### PR TITLE
rename Scalar related utility functions

### DIFF
--- a/paddle/fluid/framework/attribute.cc
+++ b/paddle/fluid/framework/attribute.cc
@@ -130,13 +130,13 @@ Attribute GetAttrValue(const proto::OpDesc::Attr& attr_desc) {
     }
 
     case proto::AttrType::SCALAR: {
-      return make_scalar_from_proto(attr_desc.scalar());
+      return MakeScalarFromProto(attr_desc.scalar());
     }
 
     case proto::AttrType::SCALARS: {
       std::vector<paddle::experimental::Scalar> val(attr_desc.scalars_size());
       for (int i = 0; i < attr_desc.scalars_size(); ++i) {
-        val[i] = make_scalar_from_proto(attr_desc.scalars(i));
+        val[i] = MakeScalarFromProto(attr_desc.scalars(i));
       }
       return val;
     }
@@ -170,7 +170,7 @@ Attribute GetAttrValue(const proto::VarDesc::Attr& attr_desc) {
   return paddle::blank();
 }
 
-paddle::experimental::Scalar make_scalar_from_proto(const proto::Scalar& v) {
+paddle::experimental::Scalar MakeScalarFromProto(const proto::Scalar& v) {
   auto data_type = v.type();
   switch (data_type) {
     case proto::Scalar_Type_BOOLEAN:
@@ -192,7 +192,7 @@ paddle::experimental::Scalar make_scalar_from_proto(const proto::Scalar& v) {
   return paddle::experimental::Scalar();
 }
 
-proto::Scalar make_scalar_proto(const paddle::experimental::Scalar& v) {
+proto::Scalar MakeScalarProto(const paddle::experimental::Scalar& v) {
   proto::Scalar s;
   auto data_type = v.dtype();
   switch (data_type) {
@@ -243,7 +243,7 @@ proto::Scalar make_scalar_proto(const paddle::experimental::Scalar& v) {
   return s;
 }
 
-paddle::experimental::Scalar make_scalar_from_attribute(const Attribute& v) {
+paddle::experimental::Scalar MakeScalarFromAttribute(const Attribute& v) {
   auto attr_type = static_cast<proto::AttrType>(v.index() - 1);
   switch (attr_type) {
     case proto::AttrType::SCALAR:
@@ -266,7 +266,7 @@ paddle::experimental::Scalar make_scalar_from_attribute(const Attribute& v) {
   }
 }
 
-std::vector<paddle::experimental::Scalar> make_scalars_from_attribute(
+std::vector<paddle::experimental::Scalar> MakeScalarsFromAttribute(
     const Attribute& v) {
   auto attr_type = static_cast<proto::AttrType>(v.index() - 1);
   switch (attr_type) {
@@ -313,9 +313,9 @@ void CanonicalizeScalarAttrs(const proto::OpProto& op_proto,
       continue;  // VAR& VARS are not proper attribute
     }
     if (attr_type == proto::AttrType::SCALAR) {
-      it->second = Attribute(make_scalar_from_attribute(it->second));
+      it->second = Attribute(MakeScalarFromAttribute(it->second));
     } else if (attr_type == proto::AttrType::SCALARS) {
-      it->second = Attribute(make_scalars_from_attribute(it->second));
+      it->second = Attribute(MakeScalarsFromAttribute(it->second));
     }
   }
 }

--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -349,10 +349,10 @@ class AttrReader {
   const AttributeMap* default_attrs_;
 };
 
-paddle::experimental::Scalar make_scalar_from_proto(const proto::Scalar& v);
-proto::Scalar make_scalar_proto(const paddle::experimental::Scalar& v);
-paddle::experimental::Scalar make_scalar_from_attribute(const Attribute& v);
-std::vector<paddle::experimental::Scalar> make_scalars_from_attribute(
+paddle::experimental::Scalar MakeScalarFromProto(const proto::Scalar& v);
+proto::Scalar MakeScalarProto(const paddle::experimental::Scalar& v);
+paddle::experimental::Scalar MakeScalarFromAttribute(const Attribute& v);
+std::vector<paddle::experimental::Scalar> MakeScalarsFromAttribute(
     const Attribute& v);
 void CanonicalizeScalarAttrs(const proto::OpProto& op_proto,
                              AttributeMap* attrs);

--- a/paddle/fluid/framework/attribute_test.cc
+++ b/paddle/fluid/framework/attribute_test.cc
@@ -200,91 +200,91 @@ TEST(Attribute, ProtoAttrToAttribute_scalar) {
       paddle::experimental::Scalar(std::complex<double>(42.1, 42.1));
 
   auto proto_scalar_bool = new paddle::framework::proto::Scalar;
-  *proto_scalar_bool = paddle::framework::make_scalar_proto(s_bool);
+  *proto_scalar_bool = paddle::framework::MakeScalarProto(s_bool);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_bool);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_int8 = new paddle::framework::proto::Scalar;
-  *proto_scalar_int8 = paddle::framework::make_scalar_proto(s_int8);
+  *proto_scalar_int8 = paddle::framework::MakeScalarProto(s_int8);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_int8);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_int16 = new paddle::framework::proto::Scalar;
-  *proto_scalar_int16 = paddle::framework::make_scalar_proto(s_int16);
+  *proto_scalar_int16 = paddle::framework::MakeScalarProto(s_int16);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_int16);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_int32 = new paddle::framework::proto::Scalar;
-  *proto_scalar_int32 = paddle::framework::make_scalar_proto(s_int32);
+  *proto_scalar_int32 = paddle::framework::MakeScalarProto(s_int32);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_int32);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_int64 = new paddle::framework::proto::Scalar;
-  *proto_scalar_int64 = paddle::framework::make_scalar_proto(s_int64);
+  *proto_scalar_int64 = paddle::framework::MakeScalarProto(s_int64);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_int64);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_uint8 = new paddle::framework::proto::Scalar;
-  *proto_scalar_uint8 = paddle::framework::make_scalar_proto(s_uint8);
+  *proto_scalar_uint8 = paddle::framework::MakeScalarProto(s_uint8);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_uint8);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_uint16 = new paddle::framework::proto::Scalar;
-  *proto_scalar_uint16 = paddle::framework::make_scalar_proto(s_uint16);
+  *proto_scalar_uint16 = paddle::framework::MakeScalarProto(s_uint16);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_uint16);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_uint32 = new paddle::framework::proto::Scalar;
-  *proto_scalar_uint32 = paddle::framework::make_scalar_proto(s_uint32);
+  *proto_scalar_uint32 = paddle::framework::MakeScalarProto(s_uint32);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_uint32);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_uint64 = new paddle::framework::proto::Scalar;
-  *proto_scalar_uint64 = paddle::framework::make_scalar_proto(s_uint64);
+  *proto_scalar_uint64 = paddle::framework::MakeScalarProto(s_uint64);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_uint64);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_float16 = new paddle::framework::proto::Scalar;
-  *proto_scalar_float16 = paddle::framework::make_scalar_proto(s_float16);
+  *proto_scalar_float16 = paddle::framework::MakeScalarProto(s_float16);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_float16);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_bfloat16 = new paddle::framework::proto::Scalar;
-  *proto_scalar_bfloat16 = paddle::framework::make_scalar_proto(s_bfloat16);
+  *proto_scalar_bfloat16 = paddle::framework::MakeScalarProto(s_bfloat16);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_bfloat16);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_float = new paddle::framework::proto::Scalar;
-  *proto_scalar_float = paddle::framework::make_scalar_proto(s_float);
+  *proto_scalar_float = paddle::framework::MakeScalarProto(s_float);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_float);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_double = new paddle::framework::proto::Scalar;
-  *proto_scalar_double = paddle::framework::make_scalar_proto(s_double);
+  *proto_scalar_double = paddle::framework::MakeScalarProto(s_double);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_double);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_cfloat = new paddle::framework::proto::Scalar;
-  *proto_scalar_cfloat = paddle::framework::make_scalar_proto(s_cfloat);
+  *proto_scalar_cfloat = paddle::framework::MakeScalarProto(s_cfloat);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_cfloat);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
 
   auto proto_scalar_cdouble = new paddle::framework::proto::Scalar;
-  *proto_scalar_cdouble = paddle::framework::make_scalar_proto(s_cdouble);
+  *proto_scalar_cdouble = paddle::framework::MakeScalarProto(s_cdouble);
   proto_attr_scalar.set_allocated_scalar(proto_scalar_cdouble);
   ASSERT_EQ(AttrTypeID(paddle::framework::GetAttrValue(proto_attr_scalar)),
             paddle::framework::proto::SCALAR);
@@ -302,7 +302,7 @@ TEST(Attribute, ProtoAttrToAttribute_scalars) {
   std::vector<paddle::framework::proto::Scalar> proto_scalars;
   proto_scalars.reserve(scalars.size());
   for (const auto &item : scalars) {
-    proto_scalars.emplace_back(paddle::framework::make_scalar_proto(item));
+    proto_scalars.emplace_back(paddle::framework::MakeScalarProto(item));
   }
   paddle::framework::VectorToRepeated(proto_scalars,
                                       proto_attr_scalars.mutable_scalars());
@@ -310,8 +310,8 @@ TEST(Attribute, ProtoAttrToAttribute_scalars) {
             paddle::framework::proto::SCALARS);
 }
 
-TEST(Attribute, make_scalar_from_attribute) {
-  using paddle::framework::make_scalar_from_attribute;
+TEST(Attribute, MakeScalarFromAttribute) {
+  using paddle::framework::MakeScalarFromAttribute;
   auto s_bool = true;
   auto s_int32 = static_cast<int32_t>(42.1);
   auto s_int64 = static_cast<int64_t>(42.1);
@@ -321,22 +321,22 @@ TEST(Attribute, make_scalar_from_attribute) {
 
   auto s_scalar = paddle::experimental::Scalar(42.1);
 
-  ASSERT_EQ(make_scalar_from_attribute(paddle::framework::Attribute(s_bool)),
+  ASSERT_EQ(MakeScalarFromAttribute(paddle::framework::Attribute(s_bool)),
             paddle::experimental::Scalar(s_bool));
-  ASSERT_EQ(make_scalar_from_attribute(paddle::framework::Attribute(s_int32)),
+  ASSERT_EQ(MakeScalarFromAttribute(paddle::framework::Attribute(s_int32)),
             paddle::experimental::Scalar(s_int32));
-  ASSERT_EQ(make_scalar_from_attribute(paddle::framework::Attribute(s_int64)),
+  ASSERT_EQ(MakeScalarFromAttribute(paddle::framework::Attribute(s_int64)),
             paddle::experimental::Scalar(s_int64));
-  ASSERT_EQ(make_scalar_from_attribute(paddle::framework::Attribute(s_float)),
+  ASSERT_EQ(MakeScalarFromAttribute(paddle::framework::Attribute(s_float)),
             paddle::experimental::Scalar(s_float));
-  ASSERT_EQ(make_scalar_from_attribute(paddle::framework::Attribute(s_double)),
+  ASSERT_EQ(MakeScalarFromAttribute(paddle::framework::Attribute(s_double)),
             paddle::experimental::Scalar(s_double));
-  ASSERT_EQ(make_scalar_from_attribute(paddle::framework::Attribute(s_scalar)),
+  ASSERT_EQ(MakeScalarFromAttribute(paddle::framework::Attribute(s_scalar)),
             s_scalar);
 }
 
-TEST(Attribute, make_scalars_from_attribute) {
-  using paddle::framework::make_scalars_from_attribute;
+TEST(Attribute, MakeScalarsFromAttribute) {
+  using paddle::framework::MakeScalarsFromAttribute;
   std::vector<bool> v_bool(4, true);
   std::vector<int> v_int(4, 42);
   std::vector<int64_t> v_int64(4, 42);
@@ -345,23 +345,18 @@ TEST(Attribute, make_scalars_from_attribute) {
   std::vector<paddle::experimental::Scalar> v_scalar(
       4, paddle::experimental::Scalar(std::complex<float>(42.1, 42.1)));
 
-  ASSERT_EQ(
-      make_scalars_from_attribute(paddle::framework::Attribute(v_bool))[0],
-      paddle::experimental::Scalar(v_bool[0]));
+  ASSERT_EQ(MakeScalarsFromAttribute(paddle::framework::Attribute(v_bool))[0],
+            paddle::experimental::Scalar(v_bool[0]));
 
-  ASSERT_EQ(make_scalars_from_attribute(paddle::framework::Attribute(v_int))[0],
+  ASSERT_EQ(MakeScalarsFromAttribute(paddle::framework::Attribute(v_int))[0],
             paddle::experimental::Scalar(v_int[0]));
-  ASSERT_EQ(
-      make_scalars_from_attribute(paddle::framework::Attribute(v_int64))[0],
-      paddle::experimental::Scalar(v_int64[0]));
+  ASSERT_EQ(MakeScalarsFromAttribute(paddle::framework::Attribute(v_int64))[0],
+            paddle::experimental::Scalar(v_int64[0]));
 
-  ASSERT_EQ(
-      make_scalars_from_attribute(paddle::framework::Attribute(v_float))[0],
-      paddle::experimental::Scalar(v_float[0]));
-  ASSERT_EQ(
-      make_scalars_from_attribute(paddle::framework::Attribute(v_double))[0],
-      paddle::experimental::Scalar(v_double[0]));
-  ASSERT_EQ(
-      make_scalars_from_attribute(paddle::framework::Attribute(v_scalar))[0],
-      v_scalar[0]);
+  ASSERT_EQ(MakeScalarsFromAttribute(paddle::framework::Attribute(v_float))[0],
+            paddle::experimental::Scalar(v_float[0]));
+  ASSERT_EQ(MakeScalarsFromAttribute(paddle::framework::Attribute(v_double))[0],
+            paddle::experimental::Scalar(v_double[0]));
+  ASSERT_EQ(MakeScalarsFromAttribute(paddle::framework::Attribute(v_scalar))[0],
+            v_scalar[0]);
 }

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -935,7 +935,7 @@ struct SetAttrDescVisitor {
   void operator()(const std::string &v) const { attr_->set_s(v); }
   void operator()(const paddle::experimental::Scalar &v) const {
     auto *s = new proto::Scalar;
-    *s = make_scalar_proto(v);
+    *s = MakeScalarProto(v);
     attr_->set_allocated_scalar(s);
   }
 
@@ -995,7 +995,7 @@ struct SetAttrDescVisitor {
     std::vector<proto::Scalar> scalars;
     scalars.reserve(v.size());
     for (const auto &item : v) {
-      scalars.emplace_back(make_scalar_proto(item));
+      scalars.emplace_back(MakeScalarProto(item));
     }
     VectorToRepeated(scalars, attr_->mutable_scalars());
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Rename Scalar related utility functions(use CamelCase). Refer to https://github.com/PaddlePaddle/Paddle/pull/51984 for details

NOTE: The attempt to move `libpaddle.Scalar` related utility functions to paddle.framework would cause circular dependency. So it is not included in this pull request.

Pcard-66983 card-68840