### PR TITLE
[AMP&OP_TEST] Fix interp test case 

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_bicubic_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bicubic_interp_v2_op.py
@@ -376,15 +376,10 @@ class TestBicubicInterpCase1FP16(TestBicubicInterpOpFP16):
         self.dtype = np.float16
 
 
-# this case will cause accuracy loss （backward:0.008773442)
-# class TestBicubicInterpCase2FP16(TestBicubicInterpOpFP16):
-#     def init_test_case(self):
-#         self.interp_method = 'bicubic'
-#         self.input_shape = [3, 3, 9, 6]
-#         self.out_h = 10
-#         self.out_w = 8
-#         self.scale = []
-#         self.align_corners = True
+class TestBicubicInterpCase2FP16(TestBicubicInterpOpFP16):
+    def init_test_case(self):
+        create_test_case2(self)
+        self.dtype = np.float16
 
 
 class TestBicubicInterpCase3FP16(TestBicubicInterpOpFP16):

--- a/python/paddle/fluid/tests/unittests/test_bicubic_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bicubic_interp_v2_op.py
@@ -104,15 +104,17 @@ def bicubic_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, (float, int)):
+    if isinstance(scale, float) or isinstance(scale, int):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, (list, tuple)):
+    elif isinstance(scale, list) or isinstance(scale, tuple):
         scale = list(map(float, scale))
     if SizeTensor is not None:
-        if not isinstance(SizeTensor, (list, tuple)):
+        if not isinstance(SizeTensor, list) and not isinstance(
+            SizeTensor, tuple
+        ):
             SizeTensor = [SizeTensor]
     return paddle._C_ops.bicubic_interp(
         x,
@@ -264,7 +266,7 @@ class TestBicubicInterpOp(OpTest):
             in_w = self.input_shape[2]
 
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -303,7 +305,7 @@ class TestBicubicInterpOp(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -424,7 +426,6 @@ class TestBicubicInterpOpBF16(OpTest):
         self.op_type = "bicubic_interp_v2"
         # NOTE(dev): some AsDispensible input is not used under imperative mode.
         # Skip check_dygraph while found them in Inputs.
-        self.check_dygraph = True
         self.dtype = np.uint16
         input_np = np.random.random(self.input_shape).astype("float32")
         scale_h = 0
@@ -465,10 +466,8 @@ class TestBicubicInterpOpBF16(OpTest):
         self.inputs = {'X': convert_float_to_uint16(input_np)}
         if self.out_size is not None:
             self.inputs['OutSize'] = self.out_size
-            self.check_dygraph = False
         if self.actual_shape is not None:
             self.inputs['OutSize'] = self.actual_shape
-            self.check_dygraph = False
 
         self.attrs = {
             'out_h': self.out_h,
@@ -487,16 +486,10 @@ class TestBicubicInterpOpBF16(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(output_np)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=self.check_dygraph, atol=1e-2)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            in_place=True,
-            check_dygraph=self.check_dygraph,
-            max_relative_error=1e-2,
-        )
+        self.check_grad(['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         create_test_case0(self)

--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_v2_op.py
@@ -121,12 +121,12 @@ def bilinear_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, (float, int)):
+    if isinstance(scale, float) or isinstance(scale, int):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, (list, tuple)):
+    elif isinstance(scale, list) or isinstance(scale, tuple):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -254,7 +254,7 @@ class TestBilinearInterpOp(OpTest):
         scale_h = 0
         scale_w = 0
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -295,7 +295,7 @@ class TestBilinearInterpOp(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -604,7 +604,7 @@ class TestBilinearInterpOpUint8(OpTest):
         ).astype("uint8")
 
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -641,7 +641,7 @@ class TestBilinearInterpOpUint8(OpTest):
             'align_mode': self.align_mode,
         }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -778,7 +778,7 @@ class TestBilinearInterpOp_attr_tensor(OpTest):
         if self.scale_by_1Dtensor:
             self.inputs['Scale'] = np.array([self.scale]).astype("float32")
         elif self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -805,7 +805,7 @@ class TestBilinearInterpOp_attr_tensor(OpTest):
         self.attrs['out_h'] = self.out_h
         self.attrs['out_w'] = self.out_w
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:

--- a/python/paddle/fluid/tests/unittests/test_linear_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linear_interp_v2_op.py
@@ -52,12 +52,12 @@ def linear_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, (float, int)):
+    if isinstance(scale, float) or isinstance(scale, int):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, (list, tuple)):
+    elif isinstance(scale, list) or isinstance(scale, tuple):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -153,7 +153,7 @@ class TestLinearInterpOp(OpTest):
             in_w = self.input_shape[1]
 
         if self.scale > 0:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -185,7 +185,7 @@ class TestLinearInterpOp(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale > 0:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 self.scale = [float(self.scale)]
             self.attrs['scale'] = self.scale
         self.outputs = {'Out': output_np}
@@ -267,7 +267,7 @@ class TestLinearInterpOpSizeTensor(TestLinearInterpOp):
             in_w = self.input_shape[1]
 
         if self.scale > 0:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -307,7 +307,7 @@ class TestLinearInterpOpSizeTensor(TestLinearInterpOp):
             'data_layout': self.data_layout,
         }
         if self.scale > 0:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]
@@ -439,7 +439,7 @@ class TestResizeLinearOpUint8(OpTest):
         input_np = np.random.random(self.input_shape).astype("uint8")
 
         if self.scale > 0:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -467,7 +467,7 @@ class TestResizeLinearOpUint8(OpTest):
             'align_mode': self.align_mode,
         }
         if self.scale > 0:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
@@ -107,12 +107,12 @@ def nearest_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, (float, int)):
+    if isinstance(scale, float) or isinstance(scale, int):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, (list, tuple)):
+    elif isinstance(scale, list) or isinstance(scale, tuple):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -302,7 +302,7 @@ class TestNearestInterpOp(OpTest):
         scale_h = 0
         scale_w = 0
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -374,7 +374,7 @@ class TestNearestInterpOp(OpTest):
                 'data_layout': self.data_layout,
             }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -445,16 +445,10 @@ class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
 
 class TestNearestInterpOpFP16(TestNearestInterpOp):
     def test_check_output(self):
-        self.check_output(check_dygraph=True, atol=1e-3)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            in_place=True,
-            check_dygraph=True,
-            max_relative_error=1e-2,
-        )
+        self.check_grad(['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         create_test_case0(self)
@@ -615,16 +609,10 @@ class TestNearestInterpOpBF16(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(output_np)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=True, atol=1e-2)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            in_place=True,
-            check_dygraph=True,
-            max_relative_error=1e-2,
-        )
+        self.check_grad(['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         create_test_case0(self)
@@ -709,7 +697,7 @@ class TestNearestInterpOpUint8(OpTest):
         ).astype("uint8")
 
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -743,7 +731,7 @@ class TestNearestInterpOpUint8(OpTest):
             'align_corners': self.align_corners,
         }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -854,7 +842,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
         if self.scale_by_1Dtensor:
             self.inputs['Scale'] = np.array([self.scale]).astype("float64")
         elif self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -881,7 +869,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
         self.attrs['out_h'] = self.out_h
         self.attrs['out_w'] = self.out_w
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_v2_op.py
@@ -120,12 +120,12 @@ def trilinear_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, (float, int)):
+    if isinstance(scale, float) or isinstance(scale, int):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, (list, tuple)):
+    elif isinstance(scale, list) or isinstance(scale, tuple):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -287,7 +287,6 @@ class TestTrilinearInterpOp(OpTest):
         self.op_type = "trilinear_interp_v2"
         # NOTE(dev): some AsDispensible input is not used under imperative mode.
         # Skip check_dygraph while found them in Inputs.
-        self.check_dygraph = True
         input_np = np.random.random(self.input_shape).astype(self.dtype)
 
         scale_w = 0
@@ -303,7 +302,7 @@ class TestTrilinearInterpOp(OpTest):
             in_w = self.input_shape[3]
 
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -354,7 +353,7 @@ class TestTrilinearInterpOp(OpTest):
             'data_layout': data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -455,16 +454,10 @@ class TestTrilinearInterpDatalayout(TestTrilinearInterpOp):
 
 class TestTrilinearInterpOpFP16(TestTrilinearInterpOp):
     def test_check_output(self):
-        self.check_output(check_dygraph=self.check_dygraph, atol=1e-3)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            in_place=True,
-            check_dygraph=self.check_dygraph,
-            max_relative_error=1e-2,
-        )
+        self.check_grad(['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         create_test_case0(self)
@@ -522,7 +515,6 @@ class TestNearestInterpOpBF16(OpTest):
         self.op_type = "trilinear_interp_v2"
         # NOTE(dev): some AsDispensible input is not used under imperative mode.
         # Skip check_dygraph while found them in Inputs.
-        self.check_dygraph = True
         self.dtype = np.uint16
         input_np = np.random.random(self.input_shape).astype("float32")
 
@@ -573,10 +565,8 @@ class TestNearestInterpOpBF16(OpTest):
         self.inputs = {'X': convert_float_to_uint16(input_np)}
         if self.out_size is not None:
             self.inputs['OutSize'] = self.out_size
-            self.check_dygraph = False
         if self.actual_shape is not None:
             self.inputs['OutSize'] = self.actual_shape
-            self.check_dygraph = False
         # c++ end treat NCDHW the same way as NCHW
         if self.data_layout == 'NCDHW':
             data_layout = 'NCHW'
@@ -601,16 +591,10 @@ class TestNearestInterpOpBF16(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(output_np)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=self.check_dygraph, atol=1e-2)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            in_place=True,
-            check_dygraph=self.check_dygraph,
-            max_relative_error=1e-2,
-        )
+        self.check_grad(['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         create_test_case0(self)
@@ -688,7 +672,7 @@ class TestTrilinearInterpOpUint8(OpTest):
         ).astype("uint8")
 
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -731,7 +715,7 @@ class TestTrilinearInterpOpUint8(OpTest):
             'align_mode': self.align_mode,
         }
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -865,7 +849,7 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         if self.scale_by_1Dtensor:
             self.inputs['Scale'] = np.array([self.scale]).astype("float32")
         elif self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -896,7 +880,7 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         self.attrs['out_h'] = self.out_h
         self.attrs['out_w'] = self.out_w
         if self.scale:
-            if isinstance(self.scale, (float, int)):
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
delete check_dygraph and use default atol,max_relative_error in test cases of interpolate API 