### PR TITLE
modify resnet_unit op for yolov5

### DIFF
--- a/paddle/fluid/eager/amp_auto_cast.h
+++ b/paddle/fluid/eager/amp_auto_cast.h
@@ -85,6 +85,12 @@ inline paddle::Tensor AmpAutoCast(const std::string& input_name,
         return input;
       }
     }
+    if (op_name == "resnet_unit") {
+      if (input_name != "X" && input_name != "FilterX" &&
+          input_name != "FilterZ") {
+        return input;
+      }
+    }
   }
   if (NeedCast(input, dst_dtype)) {
     paddle::framework::AttributeMap cast_attrs = {

--- a/paddle/fluid/operators/fused/resnet_unit_op.cc
+++ b/paddle/fluid/operators/fused/resnet_unit_op.cc
@@ -260,6 +260,7 @@ class ResNetUnitOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::string>("data_format", "").SetDefault("NHWC");
     AddAttr<bool>("fuse_add", "").SetDefault(false);
     AddAttr<bool>("has_shortcut", "").SetDefault(false);
+    AddAttr<bool>("has_dx", "wheather x need grad").SetDefault(true);
     AddAttr<bool>("use_global_stats", "").SetDefault(false);
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
@@ -303,6 +304,7 @@ class ResNetUnitGradOp : public framework::OperatorWithKernel {
 
     bool fuse_add = ctx->Attrs().Get<bool>("fuse_add");
     bool has_shortcut = ctx->Attrs().Get<bool>("has_shortcut");
+    bool has_dx = ctx->Attrs().Get<bool>("has_dx");
     if (fuse_add || has_shortcut) {
       OP_INOUT_CHECK(ctx->HasInput("Z"), "Input", "Z", "ResNetUnitGradOp");
     }
@@ -333,10 +335,12 @@ class ResNetUnitGradOp : public framework::OperatorWithKernel {
                    "ResNetUnitGradOp");
 
     // check output
-    OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("X")),
-                   "Output",
-                   framework::GradVarName("X"),
-                   "ResNetUnitGradOp");
+    if (has_dx) {
+      OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("X")),
+                     "Output",
+                     framework::GradVarName("X"),
+                     "ResNetUnitGradOp");
+    }
     OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("FilterX")),
                    "Output",
                    framework::GradVarName("FilterX"),
@@ -372,7 +376,9 @@ class ResNetUnitGradOp : public framework::OperatorWithKernel {
     const auto x_dims = ctx->GetInputDim("X");
     const auto filter_x_dims = ctx->GetInputDim("FilterX");
     const auto param_dims = ctx->GetInputDim("ScaleX");
-    ctx->SetOutputDim(framework::GradVarName("X"), x_dims);
+    if (has_dx) {
+      ctx->SetOutputDim(framework::GradVarName("X"), x_dims);
+    }
     ctx->SetOutputDim(framework::GradVarName("FilterX"), filter_x_dims);
     ctx->SetOutputDim(framework::GradVarName("ScaleX"), param_dims);
     ctx->SetOutputDim(framework::GradVarName("BiasX"), param_dims);

--- a/paddle/fluid/pybind/eager_generator.h
+++ b/paddle/fluid/pybind/eager_generator.h
@@ -275,6 +275,19 @@ std::map<std::string, std::set<std::string>> op_ins_map = {
       "Var3"}},
     {"graph_send_recv", {"X", "Src_index", "Dst_index", "Out_size"}},
     {"graph_send_ue_recv", {"X", "Y", "Src_index", "Dst_index", "Out_size"}},
+    // {"resnet_unit",
+    //  {"X",
+    //   "FilterX",
+    //   "ScaleX",
+    //   "BiasX",
+    //   "MeanX",
+    //   "VarX",
+    //   "Z",
+    //   "FilterZ",
+    //   "ScaleZ",
+    //   "BiasZ",
+    //   "MeanZ",
+    //   "VarZ"}},
 };
 
 // NOTE(zhiqiu): Like op_ins_map.
@@ -406,6 +419,19 @@ std::map<std::string, std::set<std::string>> op_outs_map = {
       "Var2Out",   "Conv3",     "SavedMean3", "SavedInvstd3", "Mean3Out",
       "Var3Out",   "MaxInput1", "MaxFilter1", "MaxInput2",    "MaxFilter2",
       "MaxInput3", "MaxFilter3"}},
+    // {"resnet_unit",
+    //  {"Y",
+    //   "BitMask",
+    //   "ConvX",
+    //   "SavedMeanX",
+    //   "SavedInvstdX",
+    //   "RunningMeanX",
+    //   "RunningVarX",
+    //   "ConvZ",
+    //   "SavedMeanZ",
+    //   "SavedInvstdZ",
+    //   "RunningMeanZ",
+    //   "RunningVarZ"}},
 };
 
 // NOTE(zhiqiu): Commonly, the outputs in auto-generated OP function are
@@ -524,6 +550,8 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
     {"group_norm", {"Mean", "Variance"}},
     {"resnet_basic_block",
      {"Mean1Out", "Var1Out", "Mean2Out", "Var2Out", "Mean3Out", "Var3Out"}},
+    {"resnet_unit",
+     {"RunningMeanX", "RunningVarX", "RunningMeanZ", "RunningVarZ"}},
 };
 
 // NOTE(pangyoki): Tensor View Strategy.

--- a/python/paddle/incubate/operators/resnet_unit.py
+++ b/python/paddle/incubate/operators/resnet_unit.py
@@ -360,7 +360,7 @@ class ResNetUnit(Layer):
             self._has_shortcut,
             self._has_dx,
             self._use_global_stats,
-            self.training,
+            not self.training,
             self._act,
         )
         return out

--- a/python/paddle/incubate/operators/resnet_unit.py
+++ b/python/paddle/incubate/operators/resnet_unit.py
@@ -45,6 +45,7 @@ def resnet_unit(
     data_format,
     fuse_add,
     has_shortcut,
+    has_dx,
     use_global_stats,
     is_test,
     act,
@@ -120,6 +121,7 @@ def resnet_unit(
         'data_format': data_format,
         'fuse_add': fuse_add,
         'has_shortcut': has_shortcut,
+        'has_dx': has_dx,
         'use_global_stats': use_global_stats,
         'is_test': is_test,
         'act_type': act,
@@ -165,6 +167,7 @@ class ResNetUnit(Layer):
         act='relu',
         fuse_add=False,
         has_shortcut=False,
+        has_dx=True,
         use_global_stats=False,
         is_test=False,
         filter_x_attr=None,
@@ -195,6 +198,7 @@ class ResNetUnit(Layer):
         self._act = act
         self._fuse_add = fuse_add
         self._has_shortcut = has_shortcut
+        self._has_dx = has_dx
         self._use_global_stats = use_global_stats
         self._is_test = is_test
 
@@ -215,8 +219,8 @@ class ResNetUnit(Layer):
         is_nchw = data_format == 'NCHW'
         # initial filter
         bn_param_dtype = fluid.core.VarDesc.VarType.FP32
+        bn_param_shape = [num_filters]
         if not is_nchw:
-            bn_param_shape = [1, 1, 1, num_filters]
             filter_x_shape = [
                 num_filters,
                 filter_size,
@@ -230,7 +234,6 @@ class ResNetUnit(Layer):
                 num_channels_z,
             ]
         else:
-            bn_param_shape = [1, num_filters, 1, 1]
             filter_x_shape = [
                 num_filters,
                 num_channels_x,
@@ -355,6 +358,7 @@ class ResNetUnit(Layer):
             self._data_format,
             self._fuse_add,
             self._has_shortcut,
+            self._has_dx,
             self._use_global_stats,
             self._is_test,
             self._act,

--- a/python/paddle/incubate/operators/resnet_unit.py
+++ b/python/paddle/incubate/operators/resnet_unit.py
@@ -47,7 +47,7 @@ def resnet_unit(
     has_shortcut,
     has_dx,
     use_global_stats,
-    is_test,
+    training,
     act,
 ):
 
@@ -123,7 +123,7 @@ def resnet_unit(
         'has_shortcut': has_shortcut,
         'has_dx': has_dx,
         'use_global_stats': use_global_stats,
-        'is_test': is_test,
+        'is_test': not training,
         'act_type': act,
     }
 
@@ -360,7 +360,7 @@ class ResNetUnit(Layer):
             self._has_shortcut,
             self._has_dx,
             self._use_global_stats,
-            self._is_test,
+            self.training,
             self._act,
         )
         return out


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
1、modify resnet_unit API for yolov5 fusion

20230420更新
1、以前的resnet_unit接口中is_test参数固定为False，eval时程序在batchnorm算子将调用train模式，不符合预期，需要修改成根据当前模式进行判断，所以使用 self.training 参数进行赋值，在eval时is_test将赋值成True，batchnorm调用infer模式
2、resnet_unit接口支持amp模式调用
