### PR TITLE
[NewExe] update run checks of standalone executor

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1585,8 +1585,6 @@ class Executor:
             program = pruned_program
 
         def _can_use_interpreter_core(program, place):
-            if core.is_compiled_with_mlu():
-                return False
 
             compiled = isinstance(
                 program, compiler.CompiledProgram

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1606,28 +1606,6 @@ class Executor:
                     )
                     return False
 
-                # Unsupported case 2: async mode
-                if (
-                    compiled_program._build_strategy is not None
-                    and compiled_program._build_strategy.async_mode
-                ):
-                    warnings.warn(
-                        "Standalone executor is not used for async mode",
-                        UserWarning,
-                    )
-                    return False
-
-                # Unsupported case 3: CUDA Graph
-                if (
-                    compiled_program._build_strategy is not None
-                    and compiled_program._build_strategy.allow_cuda_graph_capture
-                    and not _is_cuda_graph_enable_standalone_executor()
-                ):
-                    warnings.warn(
-                        "Standalone executor is not used for CUDA Graph when FLAGS_CUDA_GRAPH_USE_STANDALONE_EXECUTOR=0",
-                        UserWarning,
-                    )
-                    return False
             return True
 
         if self._enable_interpreter_core and _can_use_interpreter_core(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Delete the following checks which are used to decide whether use `StandaloneExecutor` or not:
1. `core.is_compiled_with_mlu()`: mlu related code is moved to `PaddleCustomDevice` now, this line has no effect
2. `async_mode`: added in #45599 and `StandaloneExecutor` now supports those unit tests
3. `allow_cuda_graph_capture`: `StandaloneExecutor` now supports this case

#### Others
Pcard-67004