### PR TITLE
[Bug-fix] fix bug of Tensor.item() when CUDAPinnedPlace

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -976,7 +976,14 @@ static PyObject* tensor__getitem_from_offset(TensorObject* self,
                                              PyObject* args,
                                              PyObject* kwargs) {
   EAGER_TRY
-  auto ptr = static_cast<phi::DenseTensor*>(self->tensor.impl().get());
+  phi::DenseTensor* ptr = nullptr;
+  if (self->tensor.is_selected_rows()) {
+    auto* selected_rows =
+        static_cast<phi::SelectedRows*>(self->tensor.impl().get());
+    ptr = static_cast<phi::DenseTensor*>(selected_rows->mutable_value());
+  } else {
+    ptr = static_cast<phi::DenseTensor*>(self->tensor.impl().get());
+  }
   PADDLE_ENFORCE_NOT_NULL(ptr,
                           platform::errors::InvalidArgument(
                               "%s is not a DenseTensor.", self->tensor.name()));

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -276,7 +276,8 @@ T TensorGetElement(const phi::DenseTensor &self, size_t offset) {
                         "The offset exceeds the size of tensor."));
 
   T b = static_cast<T>(0);
-  if (platform::is_cpu_place(self.place())) {
+  if (platform::is_cpu_place(self.place()) ||
+      platform::is_cuda_pinned_place(self.place())) {
     b = self.data<T>()[offset];
   } else if (platform::is_xpu_place(self.place())) {
 #ifdef PADDLE_WITH_XPU

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -168,7 +168,7 @@ class TestVarBase(unittest.TestCase):
                 self.assertEqual(x_array.dtype, x.numpy().dtype)
                 np.testing.assert_array_equal(x_array, x.numpy())
 
-                x = paddle.to_tensor(1.0)
+                x = paddle.to_tensor(1.0, place=place)
                 self.assertEqual(x.item(), 1.0)
                 self.assertTrue(isinstance(x.item(), float))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
card-68733

fix bug of Tensor.item() when CUDAPinnedPlace, it always return 0 and not read data correctly.
