### PR TITLE
 Support tensor dump when FLAGS_check_nan_inf_level is 4

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -15,12 +15,12 @@
 #include "paddle/fluid/eager/nan_inf_utils.h"
 
 #include "paddle/fluid/framework/details/nan_inf_utils_detail.h"
+#include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/selected_rows.h"
-
-#include "paddle/phi/core/compat/convert_utils.h"
 DECLARE_int32(check_nan_inf_level);
 namespace egr {
 
@@ -102,6 +102,30 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
     } else {
       VLOG(10) << "Only DenseTensor or SelectedRows need to check, "
                << tensor_name << " is no need.";
+      return;
+    }
+    // dump data
+    if (FLAGS_check_nan_inf_level == 4) {
+      auto dir_path = paddle::framework::details::GetNanPath();
+      std::string adr_name = paddle::string::Sprintf("%d", tensor.impl());
+      std::string folder_path = dir_path + "tensor_dump/";
+      std::string mkdir_cmd = "mkdir -p " + folder_path;
+      PADDLE_ENFORCE_EQ(system(mkdir_cmd.c_str()),
+                        0,
+                        paddle::platform::errors::NotFound(
+                            "Cannot create folder %s", folder_path));
+
+      std::string str_file_name = folder_path + api_name + "_" + adr_name;
+      std::ofstream fout(str_file_name, std::ios::out | std::ios::binary);
+
+      PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                        true,
+                        paddle::platform::errors::Unavailable(
+                            "Cannot open %s to save tensor.", str_file_name));
+
+      VLOG(4) << "The dump file's path is " << str_file_name;
+      paddle::framework::SerializeToStream(fout, *dense_tensor);
+      fout.close();
       return;
     }
 

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -182,6 +182,13 @@ class TestNanInfCheckResult(unittest.TestCase):
         paddle.fluid.core.check_numerics("check_numerics", x)
         paddle.fluid.core.check_numerics("check_numerics", y)
 
+    def test_check_nan_inf_level_for_dump(self):
+        paddle.set_flags(
+            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 4}
+        )
+        if paddle.fluid.core.is_compiled_with_cuda():
+            self.check_nan_inf_level(use_cuda=True, dtype="float16")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
 Support tensor dump when FLAGS_check_nan_inf_level is 4