### PR TITLE
[Paddle-TRT] fix skiplayernorm, add trt_version check

### DIFF
--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/ir/graph_pattern_detector.h"
 #include "paddle/fluid/framework/op_version_registry.h"
+#include "paddle/fluid/inference/tensorrt/helper.h"
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -105,6 +105,16 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph, platform::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("skip_layernorm_fuse", graph);
+
+  auto trt_version = paddle::inference::tensorrt::GetTrtRuntimeVersion();
+  if (std::get<0>(trt_version) * 1000 + std::get<1>(trt_version) * 100 +
+          std::get<2>(trt_version) * 10 <
+      7200) {
+    VLOG(3) << "skip_layernorm oss plugin only available for trt version >= "
+               "7.2 Stop this pass";
+    return;
+  }
+
   int found_subgraph_count = 0;
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -109,6 +109,7 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
       graph, platform::errors::PreconditionNotMet("graph should not be null."));
   FusePassBase::Init("skip_layernorm_fuse", graph);
 
+#ifdef PADDLE_WITH_TENSORRT
   auto trt_version = paddle::inference::tensorrt::GetTrtRuntimeVersion();
   if (std::get<0>(trt_version) * 1000 + std::get<1>(trt_version) * 100 +
           std::get<2>(trt_version) * 10 <
@@ -117,7 +118,10 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
                "7.2 Stop this pass";
     return;
   }
-
+#else
+  // if no tensorrt, early stop
+  return;
+#endif
   int found_subgraph_count = 0;
 
   GraphPatternDetector gpd;

--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -18,7 +18,9 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/ir/graph_pattern_detector.h"
 #include "paddle/fluid/framework/op_version_registry.h"
+#ifdef PADDLE_WITH_TENSORRT
 #include "paddle/fluid/inference/tensorrt/helper.h"
+#endif
 
 namespace paddle {
 namespace framework {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add TensorRT version check, skip_layernorm oss plugin only available for trt version >=  7.2 