### PR TITLE
remove reduce_all from amax_grad

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -72,7 +72,7 @@
 
 - backward_op : amax_grad
   forward: amax (Tensor x,  int64_t[] axis={},  bool keepdim=false) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis={},  bool keepdim=false, bool reduce_all=false)
+  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis={},  bool keepdim=false)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/kernels/cpu/reduce_amax_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amax_grad_kernel.cc
@@ -26,8 +26,8 @@ void ReduceAMaxGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const std::vector<int64_t>& dims,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad) {
+  bool reduce_all = false;
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   ReduceGradKernel<Context, T, funcs::AMaxOrAMinGradFunctor>(
       dev_ctx, x, out, out_grad, dims, keep_dim, reduce_all, x_grad);

--- a/paddle/phi/kernels/cpu/reduce_amax_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amax_grad_kernel.cc
@@ -27,8 +27,7 @@ void ReduceAMaxGradKernel(const Context& dev_ctx,
                           const std::vector<int64_t>& dims,
                           bool keep_dim,
                           DenseTensor* x_grad) {
-  bool reduce_all = false;
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceGradKernel<Context, T, funcs::AMaxOrAMinGradFunctor>(
       dev_ctx, x, out, out_grad, dims, keep_dim, reduce_all, x_grad);
 }

--- a/paddle/phi/kernels/gpu/reduce_amax_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_amax_grad_kernel.cu
@@ -26,8 +26,8 @@ void ReduceAMaxGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const std::vector<int64_t>& dims,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad) {
+  bool reduce_all = false;
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   ReduceCudaAMaxAMinGrad<T, Context>(
       dev_ctx, x, out, out_grad, dims, keep_dim, reduce_all, x_grad);

--- a/paddle/phi/kernels/gpu/reduce_amax_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_amax_grad_kernel.cu
@@ -27,8 +27,7 @@ void ReduceAMaxGradKernel(const Context& dev_ctx,
                           const std::vector<int64_t>& dims,
                           bool keep_dim,
                           DenseTensor* x_grad) {
-  bool reduce_all = false;
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceCudaAMaxAMinGrad<T, Context>(
       dev_ctx, x, out, out_grad, dims, keep_dim, reduce_all, x_grad);
 }

--- a/paddle/phi/kernels/reduce_amax_grad_kernel.h
+++ b/paddle/phi/kernels/reduce_amax_grad_kernel.h
@@ -26,7 +26,6 @@ void ReduceAMaxGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const std::vector<int64_t>& dims,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -185,10 +185,8 @@ KernelSignature ReduceMaxGradOpArgumentMapping(
 
 KernelSignature ReduceAMaxGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
-  return KernelSignature("amax_grad",
-                         {"X", "Out", "Out@GRAD"},
-                         {"dim", "keep_dim", "reduce_all"},
-                         {"X@GRAD"});
+  return KernelSignature(
+      "amax_grad", {"X", "Out", "Out@GRAD"}, {"dim", "keep_dim"}, {"X@GRAD"});
 }
 
 KernelSignature ReduceMinGradOpArgumentMapping(

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -1392,44 +1392,6 @@ class TestAllZeroError(unittest.TestCase):
             self.assertRaises(ValueError, test_0_size)
 
 
-class TestAmaxOp(OpTest):
-    """Remove Amax with subgradient from gradient check to confirm the success of CI."""
-
-    def setUp(self):
-        self.op_type = "reduce_amax"
-        self.prim_op_type = "prim"
-        self.python_api = paddle.amax
-        self.public_python_api = paddle.amax
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype("float32")}
-        self.outputs = {
-            'Out': np.amax(self.inputs['X'])
-        }
-
-    def test_check_output(self):
-        self.check_output()
-
-    def test_check_grad(self):
-        # only composite op support gradient check of amax
-        self.check_grad(
-            ['X'],
-            'Out',
-            check_prim=True,
-            only_check_prim=True,
-        )
-
-    def test_raise_error(self):
-        if core.is_compiled_with_cuda():
-            self.inputs = {'X': np.random.random((5, 6, 10)).astype("float16")}
-            place = core.CUDAPlace(0)
-            with self.assertRaises(RuntimeError) as cm:
-                self.check_output_with_place(place)
-            error_msg = str(cm.exception).split("\n")[-2].strip().split(".")[0]
-            self.assertEqual(
-                error_msg,
-                "NotFoundError: The kernel (amax) with key (GPU, Undefined(AnyLayout), float16) is not found and GPU kernel cannot fallback to CPU one",
-            )
-
-
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -1392,6 +1392,44 @@ class TestAllZeroError(unittest.TestCase):
             self.assertRaises(ValueError, test_0_size)
 
 
+class TestAmaxOp(OpTest):
+    """Remove Amax with subgradient from gradient check to confirm the success of CI."""
+
+    def setUp(self):
+        self.op_type = "amax"
+        self.prim_op_type = "prim"
+        self.python_api = paddle.amax
+        self.public_python_api = paddle.amax
+        self.inputs = {'X': np.random.random((5, 6, 10)).astype("float32")}
+        self.outputs = {
+            'Out': np.amax(self.inputs['X'])
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        # only composite op support gradient check of amax
+        self.check_grad(
+            ['X'],
+            'Out',
+            check_prim=True,
+            only_check_prim=True,
+        )
+
+    def test_raise_error(self):
+        if core.is_compiled_with_cuda():
+            self.inputs = {'X': np.random.random((5, 6, 10)).astype("float16")}
+            place = core.CUDAPlace(0)
+            with self.assertRaises(RuntimeError) as cm:
+                self.check_output_with_place(place)
+            error_msg = str(cm.exception).split("\n")[-2].strip().split(".")[0]
+            self.assertEqual(
+                error_msg,
+                "NotFoundError: The kernel (amax) with key (GPU, Undefined(AnyLayout), float16) is not found and GPU kernel cannot fallback to CPU one",
+            )
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -1396,7 +1396,7 @@ class TestAmaxOp(OpTest):
     """Remove Amax with subgradient from gradient check to confirm the success of CI."""
 
     def setUp(self):
-        self.op_type = "amax"
+        self.op_type = "reduce_amax"
         self.prim_op_type = "prim"
         self.python_api = paddle.amax
         self.public_python_api = paddle.amax


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
理论上reduce_all参数只有在dims参数为空或者长度与输入x的维度相同时为true，可以删除该参数