### PR TITLE
[BugFix]Fix bugs when PaddleNLP compile with paddle_inference

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -317,6 +317,10 @@ copy(
   DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi/core/)
 copy(
   inference_lib_dist
+  SRCS ${PADDLE_SOURCE_DIR}/paddle/fluid/platform/init_phi.h
+  DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi/)
+copy(
+  inference_lib_dist
   SRCS ${PADDLE_SOURCE_DIR}/paddle/utils/any.h
   DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/utils/)
 copy(

--- a/cmake/phi_header.cmake
+++ b/cmake/phi_header.cmake
@@ -25,6 +25,9 @@ function(phi_header_path_compat TARGET_PATH)
         file(READ ${header} HEADER_CONTENT)
         string(REPLACE "paddle/phi/" "paddle/include/experimental/phi/"
                        HEADER_CONTENT "${HEADER_CONTENT}")
+        string(REPLACE "paddle/fluid/platform/"
+                       "paddle/include/experimental/phi/" HEADER_CONTENT
+                       "${HEADER_CONTENT}")
         string(REPLACE "paddle/utils/" "paddle/include/experimental/utils/"
                        HEADER_CONTENT "${HEADER_CONTENT}")
         file(WRITE ${header} "${HEADER_CONTENT}")
@@ -36,6 +39,8 @@ endfunction()
 
 phi_header_path_compat(
   ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental)
+phi_header_path_compat(
+  ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi)
 phi_header_path_compat(
   ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi/api)
 phi_header_path_compat(

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SHARED_INFERENCE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/../framework/data_feed.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../framework/data_feed_factory.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/../framework/dataset_factory.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../platform/init_phi.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/api.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/api_impl.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/analysis_predictor.cc


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-67617
修复PaddleNLP与paddle_inference联编时出现的头文件找不到的编译问题：

<img width="1207" alt="5d0656956b760b01571e041957fd399e" src="https://user-images.githubusercontent.com/29249150/228853278-85752daf-85d0-412f-a29a-946712b08825.png">

