### PR TITLE
fix bug in op_desc

### DIFF
--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -765,8 +765,7 @@ void OpDesc::SetAttr(const std::string &name, const Attribute &v) {
 
   attrs_ptr->operator[](name) = v;
   VLOG(10) << "op_type: " << Type() << ", attr name: " << name
-           << " , type index: "
-           << TransToPhiDataType(this->attrs_[name].index());
+           << " , type index: " << attrs_ptr->operator[](name).index();
   need_update_ = true;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix bug in op_desc

1. this->attrs_ may not contain the attr with `name`, since it can be  runtime_attr.
2. Not all attr types can be convert to PhiDataType
Pcard-64703