### PR TITLE
enable setting double attribute into opdesc

### DIFF
--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -372,7 +372,7 @@ void BindOpDesc(pybind11::module *m) {
       .def("_set_int32_attr", &pd::OpDesc::SetPlainAttr<int>)
       .def("_set_int64_attr", &pd::OpDesc::SetPlainAttr<int64_t>)
       .def("_set_float32_attr", &pd::OpDesc::SetPlainAttr<float>)
-      //  .def("_set_float64_attr", &pd::OpDesc::SetPlainAttr<double>)
+      .def("_set_float64_attr", &pd::OpDesc::SetPlainAttr<double>)
       .def("_set_str_attr", &pd::OpDesc::SetPlainAttr<std::string>)
 
       .def("_set_bools_attr", &pd::OpDesc::SetPlainAttr<std::vector<bool>>)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
enable setting double attribute into opdesc

Support for double attribute in OpDesc was introduced in https://github.com/PaddlePaddle/Paddle/pull/45390, but never used by an operator in use.

Seting double attribute is enabled here to fully support double attributes.

Pcard-66983
