### PR TITLE
Delete reduce_all parm from amax_raw and amin_raw

### DIFF
--- a/paddle/phi/kernels/cpu/reduce_amax_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amax_kernel.cc
@@ -26,9 +26,8 @@ void AMaxRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MaxFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/cpu/reduce_amin_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amin_kernel.cc
@@ -26,9 +26,8 @@ void AMinRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MinFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/kps/reduce_amax_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_amax_kernel.cu
@@ -23,9 +23,8 @@ void AMaxRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MaxFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/kps/reduce_amin_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_amin_kernel.cu
@@ -23,9 +23,8 @@ void AMinRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MinFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/reduce_amax_kernel.cc
+++ b/paddle/phi/kernels/reduce_amax_kernel.cc
@@ -25,8 +25,7 @@ void AMaxKernel(const Context& dev_ctx,
                 const std::vector<int64_t>& dims,
                 bool keep_dim,
                 DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  AMaxRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  AMaxRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_amax_kernel.h
+++ b/paddle/phi/kernels/reduce_amax_kernel.h
@@ -23,7 +23,6 @@ void AMaxRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/reduce_amin_kernel.cc
+++ b/paddle/phi/kernels/reduce_amin_kernel.cc
@@ -25,8 +25,7 @@ void AMinKernel(const Context& dev_ctx,
                 const std::vector<int64_t>& dims,
                 bool keep_dim,
                 DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  AMinRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  AMinRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_amin_kernel.h
+++ b/paddle/phi/kernels/reduce_amin_kernel.h
@@ -23,7 +23,6 @@ void AMinRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -92,7 +92,7 @@ KernelSignature ReduceAMaxOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "max_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "amax_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "amax_raw", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("amax", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
@@ -124,7 +124,7 @@ KernelSignature ReduceAMinOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "min_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "amin_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "amin_raw", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("amin", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2563,7 +2563,7 @@ def amax(x, axis=None, keepdim=False, name=None):
             type='reduce_amax',
             inputs={'X': x},
             outputs={'Out': out},
-            attrs={'dim': axis, 'keep_dim': keepdim, 'reduce_all': reduce_all},
+            attrs={'dim': axis, 'keep_dim': keepdim},
         )
         return out
 
@@ -2673,7 +2673,7 @@ def amin(x, axis=None, keepdim=False, name=None):
             type='reduce_amin',
             inputs={'X': x},
             outputs={'Out': out},
-            attrs={'dim': axis, 'keep_dim': keepdim, 'reduce_all': reduce_all},
+            attrs={'dim': axis, 'keep_dim': keepdim},
         )
         return out
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
理论上reduce_all参数只有在dims参数为空或者长度与输入x的维度相同时为true，可以删除该参数