### PR TITLE
remove reduce all

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -487,8 +487,8 @@
     func : fmin_grad
 
 - backward_op : frobenius_norm_grad
-  forward : frobenius_norm(Tensor x, int64_t[] axis,  bool keep_dim,  bool reduce_all) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis,  bool keep_dim,  bool reduce_all)
+  forward : frobenius_norm(Tensor x, int64_t[] axis,  bool keep_dim) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis,  bool keep_dim)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -647,7 +647,7 @@
   backward : fmin_grad
 
 - op : frobenius_norm
-  args : (Tensor x, int64_t[] axis,  bool keep_dim,  bool reduce_all)
+  args : (Tensor x, int64_t[] axis,  bool keep_dim)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMetaBase

--- a/paddle/phi/api/yaml/static_backward.yaml
+++ b/paddle/phi/api/yaml/static_backward.yaml
@@ -8,12 +8,12 @@
   invoke : assign(out_grad)
 
 - backward_op : frobenius_norm_grad
-  forward: frobenius_norm (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1)
+  forward: frobenius_norm (Tensor x, IntArray axis={0}, bool keepdim=false, int in_dtype=-1, int out_dtype=-1) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={0}, bool keepdim=false, int in_dtype=-1, int out_dtype=-1)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
   kernel :
     func : frobenius_norm_grad
-    param : [x, out, out_grad, axis, keepdim, reduce_all]
+    param : [x, out, out_grad, axis, keepdim]

--- a/paddle/phi/api/yaml/static_ops.yaml
+++ b/paddle/phi/api/yaml/static_ops.yaml
@@ -81,13 +81,13 @@
     data_type : dtype
 
 - op : frobenius_norm
-  args : (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1)
+  args : (Tensor x, IntArray axis={0}, bool keepdim=false, int in_dtype=-1, int out_dtype=-1)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMetaBase
   kernel :
     func : frobenius_norm
-    param : [x, axis, keepdim, reduce_all]
+    param : [x, axis, keepdim]
   backward : frobenius_norm_grad
 
 - op : greater_equal

--- a/paddle/phi/kernels/cpu/reduce_any_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_any_kernel.cc
@@ -26,9 +26,8 @@ void AnyRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const std::vector<int64_t>& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   phi::BoolReduceKernel<CPUContext, T, phi::funcs::AnyFunctor>(
       dev_ctx, x, dims, keep_dim, reduce_all, out);
 }

--- a/paddle/phi/kernels/frobenius_norm_grad_kernel.h
+++ b/paddle/phi/kernels/frobenius_norm_grad_kernel.h
@@ -27,6 +27,5 @@ void FrobeniusNormGradKernel(const Context& ctx,
                              const DenseTensor& dout,
                              const std::vector<int64_t>& axis,
                              bool keep_dim,
-                             bool reduce_all,
                              DenseTensor* dx);
 }  // namespace phi

--- a/paddle/phi/kernels/frobenius_norm_kernel.h
+++ b/paddle/phi/kernels/frobenius_norm_kernel.h
@@ -25,7 +25,6 @@ void FrobeniusNormKernel(const Context& ctx,
                          const DenseTensor& x,
                          const std::vector<int64_t>& axis,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* out);
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
@@ -24,9 +24,8 @@ void FrobeniusNormKernel(const Context& dev_ctx,
                          const DenseTensor& x,
                          const std::vector<int64_t>& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::AddFunctor, kps::SquareFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/impl/frobenius_norm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frobenius_norm_grad_kernel_impl.h
@@ -27,9 +27,8 @@ void FrobeniusNormGradKernel(const Context& ctx,
                              const DenseTensor& dout,
                              const std::vector<int64_t>& axis,
                              bool keep_dim,
-                             bool reduce_all,
                              DenseTensor* dx) {
-  reduce_all = recompute_reduce_all(x, axis, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, axis);
   ReduceGradKernel<Context, T, funcs::FrobeniusNormGradFunctor>(
       ctx, x, out, dout, axis, keep_dim, reduce_all, dx);
 }

--- a/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
@@ -25,9 +25,8 @@ void FrobeniusNormKernel(const Context& ctx,
                          const DenseTensor& x,
                          const std::vector<int64_t>& axis,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, axis, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, axis);
   Reduce<Context, T, funcs::FrobeniusNormFunctor>(
       ctx, x, reduce_all, axis, keep_dim, x.dtype(), out);
 }

--- a/paddle/phi/kernels/kps/reduce_any_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_any_kernel.cu
@@ -23,9 +23,8 @@ void AnyRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const std::vector<int64_t>& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::LogicalOrFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/reduce_any_kernel.cc
+++ b/paddle/phi/kernels/reduce_any_kernel.cc
@@ -25,8 +25,7 @@ void AnyKernel(const Context& dev_ctx,
                const std::vector<int64_t>& dims,
                bool keep_dim,
                DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  AnyRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  AnyRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_any_kernel.h
+++ b/paddle/phi/kernels/reduce_any_kernel.h
@@ -22,7 +22,6 @@ void AnyRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const std::vector<int64_t>& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -140,7 +140,7 @@ KernelSignature ReduceAnyOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "any_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "any_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "any_raw", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("any", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
reduce_all只有在dims参数为空或者长度与输入x的维度相同时值为true,因此删除输入的reduce_all后依旧可以通过dims参数来推导相应的参数值，从理论上看Kernel可以无风险删除 reduce_all 参数