### PR TITLE
delete reduce_all param

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_max_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_max_op.cc
@@ -40,13 +40,12 @@ class ReduceMaxCompositeGradOpMaker : public prim::CompositeGradOpMakerBase {
     paddle::Tensor out_grad = this->GetSingleOutputGrad("Out");
     std::vector<int> axis = this->Attr<std::vector<int>>("dim");
     bool keep_dim = this->Attr<bool>("keep_dim");
-    bool reduce_all = this->Attr<bool>("reduce_all");
     paddle::Tensor x_grad_t = this->GetSingleInputGrad("X");
     paddle::Tensor* x_grad = this->GetOutputPtr(&x_grad_t);
     std::string x_grad_name = this->GetOutputName(x_grad_t);
     VLOG(6) << "Runing max_grad composite func";
     prim::max_grad<prim::DescTensor>(
-        x, out, out_grad, axis, keep_dim, reduce_all, x_grad);
+        x, out, out_grad, axis, keep_dim, x_grad);
     this->RecoverOutputName(x_grad_t, x_grad_name);
   }
 };

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -1127,7 +1127,6 @@ void max_grad(const Tensor& x,
               const Tensor& out_grad,
               const IntArray& axis,
               bool keepdim,
-              bool reduce_all,
               Tensor* x_grad) {
   if (!x_grad) {
     return;
@@ -1136,7 +1135,7 @@ void max_grad(const Tensor& x,
   std::vector<int64_t> x_dim = phi::vectorize<int64_t>(x.dims());
   int64_t axis_size = axis.size();
   int64_t x_dim_size = x_dim.size();
-  reduce_all = false;
+  bool reduce_all = false;
   if (reduce_all || axis_size == 0 || axis_size == x_dim_size) {
     reduce_all = true;
   } else {

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -602,8 +602,8 @@
     func : logcumsumexp_grad
 
 - backward_op : logsumexp_grad
-  forward : logsumexp(Tensor x, int64_t[] axis,  bool keepdim,  bool reduce_all) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis,  bool keepdim,  bool reduce_all)
+  forward : logsumexp(Tensor x, int64_t[] axis,  bool keepdim) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis,  bool keepdim)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
@@ -645,14 +645,14 @@
 
 - backward_op : max_grad
   forward: max (Tensor x,  IntArray axis={},  bool keepdim=false) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={}, bool keepdim=false, bool reduce_all=false)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={}, bool keepdim=false)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param: [x]
   kernel :
     func : max_grad
-  composite : max_grad(x, out, out_grad, axis, keepdim, reduce_all, x_grad)
+  composite : max_grad(x, out, out_grad, axis, keepdim, x_grad)
 
 - backward_op : max_pool2d_with_index_grad
   forward : max_pool2d_with_index(Tensor x, int[] kernel_size, int[] strides, int[] paddings, bool global_pooling, bool adaptive) -> Tensor(out), Tensor(mask)

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -918,7 +918,7 @@
     backend : place
 
 - op : logsumexp
-  args : (Tensor x, int64_t[] axis,  bool keepdim,  bool reduce_all)
+  args : (Tensor x, int64_t[] axis,  bool keepdim)
   output : Tensor(out)
   infer_meta :
     func : LogsumexpInferMeta

--- a/paddle/phi/kernels/cpu/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_max_kernel.cc
@@ -26,9 +26,8 @@ void MaxRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MaxFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/impl/logsumexp_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_grad_kernel_impl.h
@@ -56,11 +56,10 @@ void LogsumexpGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const std::vector<int64_t>& axis,
                          bool keepdim,
-                         bool reduce_all,
                          DenseTensor* in_grad) {
   dev_ctx.template Alloc<T>(in_grad);
 
-  reduce_all = recompute_reduce_all(in, axis, reduce_all);
+  bool reduce_all = recompute_reduce_all(in, axis);
 
   if (reduce_all) {
     auto x = phi::EigenVector<T>::Flatten(in);

--- a/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
@@ -65,11 +65,10 @@ void LogsumexpKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const std::vector<int64_t>& axis,
                      bool keepdim,
-                     bool reduce_all,
                      DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
 
-  reduce_all = recompute_reduce_all(x, axis, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, axis);
 
   auto x_dim = x.dims();
   for (int i = 0; i < x_dim.size(); i++) {

--- a/paddle/phi/kernels/impl/reduce_max_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/reduce_max_grad_kernel_impl.h
@@ -27,9 +27,8 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceGradKernel<Context, T, funcs::MaxOrMinGradFunctor>(
       dev_ctx, x, out, out_grad, dims.GetData(), keep_dim, reduce_all, x_grad);
 }

--- a/paddle/phi/kernels/kps/reduce_max_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_max_kernel.cu
@@ -23,9 +23,8 @@ void MaxRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MaxFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/logsumexp_grad_kernel.h
+++ b/paddle/phi/kernels/logsumexp_grad_kernel.h
@@ -25,7 +25,6 @@ void LogsumexpGradKernel(const Context& ctx,
                          const DenseTensor& out_grad,
                          const std::vector<int64_t>& axis,
                          bool keepdim,
-                         bool reduce_all,
                          DenseTensor* in_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/logsumexp_kernel.h
+++ b/paddle/phi/kernels/logsumexp_kernel.h
@@ -23,7 +23,6 @@ void LogsumexpKernel(const Context& ctx,
                      const DenseTensor& x,
                      const std::vector<int64_t>& axis,
                      bool keepdim,
-                     bool reduce_all,
                      DenseTensor* out);
 
 }  // namespace phi

--- a/paddle/phi/kernels/onednn/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/onednn/reduce_max_kernel.cc
@@ -22,9 +22,8 @@ void MaxRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceKernel<T, Context>(dev_ctx,
                            x,
                            dims,

--- a/paddle/phi/kernels/reduce_max_grad_kernel.h
+++ b/paddle/phi/kernels/reduce_max_grad_kernel.h
@@ -26,7 +26,6 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/reduce_max_kernel.cc
@@ -25,8 +25,7 @@ void MaxKernel(const Context& dev_ctx,
                const IntArray& dims,
                bool keep_dim,
                DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  MaxRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  MaxRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_max_kernel.h
+++ b/paddle/phi/kernels/reduce_max_kernel.h
@@ -23,7 +23,6 @@ void MaxRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/xpu/reduce_max_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_max_grad_kernel.cc
@@ -29,9 +29,8 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims_arr,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims_arr);
   auto dims = dims_arr.GetData();
 
   dev_ctx.template Alloc<T>(x_grad);

--- a/paddle/phi/kernels/xpu/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_max_kernel.cc
@@ -26,9 +26,8 @@ void MaxRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto f = [](xpu::Context* ctx,
               const T* x,

--- a/paddle/phi/ops/compat/logsumexp_sig.cc
+++ b/paddle/phi/ops/compat/logsumexp_sig.cc
@@ -20,7 +20,7 @@ KernelSignature LogsumexpGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature("logsumexp_grad",
                          {"X", "Out", "Out@GRAD"},
-                         {"axis", "keepdim", "reduce_all"},
+                         {"axis", "keepdim"},
                          {"X@GRAD"});
 }
 

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -76,7 +76,7 @@ KernelSignature ReduceMaxOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "max_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "max_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "max_raw", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("max", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
@@ -179,7 +179,7 @@ KernelSignature ReduceMaxGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature("max_grad",
                          {"X", "Out", "Out@GRAD"},
-                         {"dim", "keep_dim", "reduce_all"},
+                         {"dim", "keep_dim"},
                          {"X@GRAD"});
 }
 

--- a/test/cpp/phi/kernels/test_fused_adam_kernel.cc
+++ b/test/cpp/phi/kernels/test_fused_adam_kernel.cc
@@ -367,7 +367,7 @@ auto MaxDiff(const Context &ctx,
   diff_reduced.Resize({1});
   ctx.template Alloc<MT>(&diff_reduced);
   MaxRawKernel<MT, Context>(
-      ctx, diff, vectorize<int64_t>(x.dims()), false, true, &diff_reduced);
+      ctx, diff, vectorize<int64_t>(x.dims()), false, &diff_reduced);
 
   diff_reduced_cpu.Resize(diff_reduced.dims());
   ctx.template HostAlloc<MT>(&diff_reduced_cpu);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
reduce_all只有在dims参数为空或者长度与输入x的维度相同时值为true,因此删除输入的reduce_all后依旧可以通过dims参数来推导相应的参数值，从理论上看Kernel可以无风险删除 reduce_all 参数
