### PR TITLE
remove reduce_all params

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_prod_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_prod_op.cc
@@ -44,7 +44,6 @@ class ReduceProdCompositeGradOpMaker : public prim::CompositeGradOpMakerBase {
     // get attr
     std::vector<int> axis = this->Attr<std::vector<int>>("dim");
     bool keep_dim = this->Attr<bool>("keep_dim");
-    bool reduce_all = this->Attr<bool>("reduce_all");
 
     // get output
     paddle::Tensor x_grad_t = this->GetSingleInputGrad("X");
@@ -57,7 +56,7 @@ class ReduceProdCompositeGradOpMaker : public prim::CompositeGradOpMakerBase {
     VLOG(6) << "Runing prod_grad composite func";
     // call composite backward func
     prim::prod_grad<prim::DescTensor>(
-        x, out, out_grad, axis, keep_dim, reduce_all, x_grad);
+        x, out, out_grad, axis, keep_dim, x_grad);
     // recover output name
     this->RecoverOutputName(x_grad_t, x_grad_name);
   }

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -1075,13 +1075,12 @@ void prod_grad(const Tensor& x,
                const Tensor& out_grad,
                const IntArray& axis,
                bool keep_dim,
-               bool reduce_all,
                Tensor* x_grad) {
+  bool reduce_all = false;
   if (x_grad) {
     std::vector<int64_t> x_dim = phi::vectorize<int64_t>(x.dims());
     int64_t axis_size = axis.size();
     int64_t x_dim_size = x_dim.size();
-    reduce_all = false;
     if (reduce_all || axis_size == 0 || axis_size == x_dim_size) {
       reduce_all = true;
     } else {

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -694,14 +694,14 @@
     func : mean_all_grad
 
 - backward_op : mean_double_grad
-  forward: mean_grad (Tensor x, Tensor grad_out, IntArray axis={},  bool keepdim=false, bool reduce_all = false) -> Tensor(grad_x)
+  forward: mean_grad (Tensor x, Tensor grad_out, IntArray axis={},  bool keepdim=false) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray axis={},  bool keepdim=false)
   output : Tensor(grad_out_grad)
   invoke : mean(grad_x_grad, axis, keepdim)
 
 - backward_op : mean_grad
   forward: mean (Tensor x,  IntArray axis={},  bool keepdim=false) -> Tensor(out)
-  args : (Tensor x, Tensor out_grad, IntArray axis={},  bool keepdim=false, bool reduce_all=false)
+  args : (Tensor x, Tensor out_grad, IntArray axis={},  bool keepdim=false)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
@@ -713,7 +713,7 @@
 
 - backward_op : min_grad
   forward: min (Tensor x,  IntArray axis={},  bool keepdim=false) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={}, bool keepdim=false, bool reduce_all=false)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={}, bool keepdim=false)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
@@ -867,15 +867,15 @@
     param : [x, out, out_grad, kernel_size, strides, paddings, ceil_mode, exclusive, data_format, pooling_type, global_pooling, adaptive, padding_algorithm]
 
 - backward_op : prod_grad
-  forward : prod (Tensor x, IntArray dims, bool keep_dim, bool reduce_all) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray dims,  bool keep_dim, bool reduce_all)
+  forward : prod (Tensor x, IntArray dims, bool keep_dim) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray dims,  bool keep_dim)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
   kernel :
     func : prod_grad
-  composite: prod_grad(x, out, out_grad, dims, keep_dim, reduce_all, x_grad)
+  composite: prod_grad(x, out, out_grad, dims, keep_dim, x_grad)
 
 - backward_op : psroi_pool_grad
   forward : psroi_pool (Tensor x, Tensor boxes, Tensor boxes_num, int pooled_height, int pooled_width, int output_channels, float spatial_scale) -> Tensor(out)
@@ -1108,21 +1108,21 @@
   inplace : (out_grad -> x_grad)
 
 - backward_op : sum_double_grad
-  forward : sum_grad (Tensor x, Tensor grad_out, IntArray axis, bool keepdim, bool reduce_all=false) -> Tensor(grad_x)
+  forward : sum_grad (Tensor x, Tensor grad_out, IntArray axis, bool keepdim) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray axis={}, bool keepdim=false)
   output : Tensor(grad_out_grad)
   invoke : sum(grad_x_grad, axis, grad_x_grad.dtype(), keepdim)
 
 - backward_op : sum_grad
   forward : sum (Tensor x, IntArray axis={}, DataType dtype=DataType::UNDEFINED, bool keepdim=false) -> Tensor(out)
-  args : (Tensor x, Tensor out_grad, IntArray axis, bool keepdim, bool reduce_all=false)
+  args : (Tensor x, Tensor out_grad, IntArray axis, bool keepdim)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
   kernel :
     func : sum_grad
-  composite : sum_grad(x, out_grad, axis, keepdim, reduce_all, x_grad)
+  composite : sum_grad(x, out_grad, axis, keepdim, x_grad)
   no_need_buffer : x
   backward : sum_double_grad
 

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -1197,7 +1197,7 @@
     func : prior_box
 
 - op : prod
-  args : (Tensor x, IntArray dims, bool keep_dim, bool reduce_all)
+  args : (Tensor x, IntArray dims, bool keep_dim)
   output : Tensor
   infer_meta :
     func : ReduceIntArrayAxisInferMetaBase

--- a/paddle/phi/kernels/cpu/identity_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/identity_loss_grad_kernel.cc
@@ -32,7 +32,7 @@ void IdentityLossGradKernel(const Context& dev_ctx,
     case 0:
       // sum
       phi::ReduceSumGradKernel<T>(
-          dev_ctx, x, out_grad, std::vector<int64_t>{0}, false, true, x_grad);
+          dev_ctx, x, out_grad, std::vector<int64_t>{0}, false, x_grad);
       break;
     case 1:
       // mean

--- a/paddle/phi/kernels/cpu/identity_loss_kernel.cc
+++ b/paddle/phi/kernels/cpu/identity_loss_kernel.cc
@@ -31,7 +31,7 @@ void IdentityLossKernel(const Context& dev_ctx,
     case 0:
       // sum
       phi::SumRawKernel<T>(
-          dev_ctx, x, phi::IntArray({0}), false, true, out->dtype(), out);
+          dev_ctx, x, phi::IntArray({0}), false, out->dtype(), out);
       break;
     case 1:
       // mean

--- a/paddle/phi/kernels/cpu/prod_kernel.cc
+++ b/paddle/phi/kernels/cpu/prod_kernel.cc
@@ -26,9 +26,8 @@ void ProdKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const IntArray& dims,
                 bool keep_dim,
-                bool reduce_all,
                 DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::ProdFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/cpu/reduce_mean_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_mean_grad_kernel.cc
@@ -26,9 +26,8 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const IntArray& dims,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceGradKernel<Context, T, funcs::MeanGradFunctor, true>(dev_ctx,
                                                              x,
                                                              paddle::none,

--- a/paddle/phi/kernels/cpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_mean_kernel.cc
@@ -26,9 +26,8 @@ void MeanRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MeanFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/cpu/reduce_min_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_min_kernel.cc
@@ -26,9 +26,8 @@ void MinRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MinFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/cpu/reduce_sum_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_sum_grad_kernel.cc
@@ -28,9 +28,8 @@ void ReduceSumGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceGradKernel<Context, T, funcs::SumGradFunctor, true>(dev_ctx,
                                                             x,
                                                             paddle::none,

--- a/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_sum_kernel.cc
@@ -26,12 +26,12 @@ void SumRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();
   }
+  bool reduce_all = recompute_reduce_all(x, dims);
   phi::Reduce<CPUContext, T, phi::funcs::SumFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
 }

--- a/paddle/phi/kernels/gpu/reduce_mean_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_mean_grad_kernel.cu
@@ -27,9 +27,8 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const IntArray& dims,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   // get reduce_dim and reduce_num for reduce_mean_grad
   int dim_size = x.dims().size();
   std::vector<int> reduce_dims =

--- a/paddle/phi/kernels/gpu/reduce_sum_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_sum_grad_kernel.cu
@@ -27,9 +27,8 @@ void ReduceSumGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   // get reduce_dim for reduce_mean_grad
   int dim_size = x.dims().size();
   std::vector<int> reduce_dims =

--- a/paddle/phi/kernels/impl/prod_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/prod_grad_kernel_impl.h
@@ -28,9 +28,8 @@ void ProdGradKernel(const Context& dev_ctx,
                     const DenseTensor& out_grad,
                     const IntArray& dims,
                     bool keep_dim,
-                    bool reduce_all,
                     DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceGradKernel<Context, T, funcs::ProdGradFunctor>(
       dev_ctx, x, out, out_grad, dims.GetData(), keep_dim, reduce_all, x_grad);
 }

--- a/paddle/phi/kernels/impl/reduce_min_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/reduce_min_grad_kernel_impl.h
@@ -27,9 +27,8 @@ void ReduceMinGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceGradKernel<Context, T, funcs::MaxOrMinGradFunctor>(
       dev_ctx, x, out, out_grad, dims.GetData(), keep_dim, reduce_all, x_grad);
 }

--- a/paddle/phi/kernels/kps/prod_kernel.cu
+++ b/paddle/phi/kernels/kps/prod_kernel.cu
@@ -23,9 +23,8 @@ void ProdKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const IntArray& dims,
                 bool keep_dim,
-                bool reduce_all,
                 DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MulFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/kps/reduce_mean_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_mean_kernel.cu
@@ -23,9 +23,8 @@ void MeanRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out, true);

--- a/paddle/phi/kernels/kps/reduce_min_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_min_kernel.cu
@@ -23,9 +23,8 @@ void MinRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MinFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/kps/reduce_sum_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_sum_kernel.cu
@@ -77,10 +77,9 @@ void SumRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();
   }

--- a/paddle/phi/kernels/onednn/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/onednn/reduce_mean_kernel.cc
@@ -22,9 +22,8 @@ void MeanRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceKernel<T, Context>(dev_ctx,
                            x,
                            dims,

--- a/paddle/phi/kernels/onednn/reduce_min_kernel.cc
+++ b/paddle/phi/kernels/onednn/reduce_min_kernel.cc
@@ -22,9 +22,8 @@ void MinRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceKernel<T, Context>(dev_ctx,
                            x,
                            dims,

--- a/paddle/phi/kernels/onednn/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/onednn/reduce_sum_kernel.cc
@@ -22,10 +22,9 @@ void SumRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   ReduceKernel<T, Context>(dev_ctx,
                            x,
                            dims,

--- a/paddle/phi/kernels/prod_grad_kernel.h
+++ b/paddle/phi/kernels/prod_grad_kernel.h
@@ -26,6 +26,5 @@ void ProdGradKernel(const Context& dev_ctx,
                     const DenseTensor& out_grad,
                     const IntArray& dims,
                     bool keep_dim,
-                    bool reduce_all,
                     DenseTensor* x_grad);
 }  // namespace phi

--- a/paddle/phi/kernels/prod_kernel.cc
+++ b/paddle/phi/kernels/prod_kernel.cc
@@ -25,8 +25,7 @@ void ProdInferKernel(const Context& dev_ctx,
                      const IntArray& dims,
                      bool keep_dim,
                      DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  ProdKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  ProdKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/prod_kernel.h
+++ b/paddle/phi/kernels/prod_kernel.h
@@ -23,7 +23,6 @@ void ProdKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const IntArray& dims,
                 bool keep_dim,
-                bool reduce_all,
                 DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/reduce_mean_grad_kernel.h
+++ b/paddle/phi/kernels/reduce_mean_grad_kernel.h
@@ -25,7 +25,6 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const IntArray& dims,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/reduce_mean_kernel.cc
@@ -25,8 +25,7 @@ void MeanKernel(const Context& dev_ctx,
                 const IntArray& dims,
                 bool keep_dim,
                 DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  MeanRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  MeanRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_mean_kernel.h
+++ b/paddle/phi/kernels/reduce_mean_kernel.h
@@ -24,7 +24,6 @@ void MeanRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/reduce_min_grad_kernel.h
+++ b/paddle/phi/kernels/reduce_min_grad_kernel.h
@@ -26,7 +26,6 @@ void ReduceMinGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_min_kernel.cc
+++ b/paddle/phi/kernels/reduce_min_kernel.cc
@@ -25,13 +25,7 @@ void MinKernel(const Context& dev_ctx,
                const IntArray& dims,
                bool keep_dim,
                DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  PADDLE_ENFORCE_GT(
-      x.numel(),
-      0,
-      errors::InvalidArgument("Zero-size tensor to reduction operation minimum "
-                              "which has no identity."));
-  MinRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  MinRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_min_kernel.h
+++ b/paddle/phi/kernels/reduce_min_kernel.h
@@ -24,7 +24,6 @@ void MinRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/reduce_sum_grad_kernel.h
+++ b/paddle/phi/kernels/reduce_sum_grad_kernel.h
@@ -25,7 +25,6 @@ void ReduceSumGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/reduce_sum_kernel.cc
@@ -26,9 +26,8 @@ void SumKernel(const Context& dev_ctx,
                DataType out_dtype,
                bool keep_dim,
                DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
   SumRawKernel<T, Context>(
-      dev_ctx, x, dims, keep_dim, reduce_all, out_dtype, out);
+      dev_ctx, x, dims, keep_dim, out_dtype, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_sum_kernel.h
+++ b/paddle/phi/kernels/reduce_sum_kernel.h
@@ -24,7 +24,6 @@ void SumRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out);
 

--- a/paddle/phi/kernels/xpu/prod_kernel.cc
+++ b/paddle/phi/kernels/xpu/prod_kernel.cc
@@ -26,9 +26,8 @@ void ProdKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const IntArray& dims,
                 bool keep_dim,
-                bool reduce_all,
                 DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   using XPUType = typename XPUTypeTrait<T>::Type;
 
   auto f = [](xpu::Context* ctx,

--- a/paddle/phi/kernels/xpu/reduce_mean_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_grad_kernel.cc
@@ -28,10 +28,9 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
                           const DenseTensor& out_grad,
                           const IntArray& dims_arr,
                           bool keep_dim,
-                          bool reduce_all,
                           DenseTensor* x_grad) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims_arr);
   dev_ctx.template Alloc<T>(x_grad);
   const XPUType* dy_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
 

--- a/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_kernel.cc
@@ -26,9 +26,8 @@ void MeanRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const IntArray& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto f = [](xpu::Context* ctx,
               const T* x,

--- a/paddle/phi/kernels/xpu/reduce_min_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_min_grad_kernel.cc
@@ -29,9 +29,8 @@ void ReduceMinGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims_arr,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
-  reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims_arr);
   auto dims = dims_arr.GetData();
 
   dev_ctx.template Alloc<T>(x_grad);

--- a/paddle/phi/kernels/xpu/reduce_min_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_min_kernel.cc
@@ -26,9 +26,8 @@ void MinRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   using XPUType = typename XPUTypeTrait<T>::Type;
 
   auto f = [](xpu::Context* ctx,

--- a/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
@@ -25,10 +25,9 @@ void ReduceSumGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& dims_arr,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* x_grad) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-  reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims_arr);
   auto dims = dims_arr.GetData();
   dev_ctx.template Alloc<XPUType>(x_grad);
   const auto* out_data = out_grad.data<XPUType>();

--- a/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_kernel.cc
@@ -25,12 +25,12 @@ void SumRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const IntArray& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DataType out_dtype,
                   DenseTensor* out) {
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();
   }
+  bool reduce_all = recompute_reduce_all(x, dims);
   XPUReduce<Context, T, phi::SumFunctor>(
       dev_ctx, x, dims.GetData(), keep_dim, reduce_all, out_dtype, out);
 }

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -26,7 +26,7 @@ KernelSignature ReduceSumOpArgumentMapping(const ArgumentMappingContext& ctx) {
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature("sum_raw",
                              {"X"},
-                             {"dim", "keep_dim", "reduce_all", "out_dtype"},
+                             {"dim", "keep_dim", "out_dtype"},
                              {"Out"});
     }
     return KernelSignature(
@@ -44,7 +44,7 @@ KernelSignature ReduceMeanOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "mean_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "mean_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "mean_raw", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("mean", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
@@ -60,7 +60,7 @@ KernelSignature ReduceProdOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "max_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "prod", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "prod", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("prod_infer", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
@@ -108,7 +108,7 @@ KernelSignature ReduceMinOpArgumentMapping(const ArgumentMappingContext& ctx) {
     // the "min_raw" KernelSignature
     if (ctx.IsForInferShape() || reduce_all) {
       return KernelSignature(
-          "min_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
+          "min_raw", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }
     return KernelSignature("min", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
@@ -163,7 +163,7 @@ KernelSignature ReduceSumGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature("sum_grad",
                          {"X", "Out@GRAD"},
-                         {"dim", "keep_dim", "reduce_all"},
+                         {"dim", "keep_dim"},
                          {"X@GRAD"});
 }
 
@@ -171,7 +171,7 @@ KernelSignature ReduceMeanGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature("mean_grad",
                          {"X", "Out@GRAD"},
-                         {"dim", "keep_dim", "reduce_all"},
+                         {"dim", "keep_dim"},
                          {"X@GRAD"});
 }
 
@@ -195,7 +195,7 @@ KernelSignature ReduceMinGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature("min_grad",
                          {"X", "Out", "Out@GRAD"},
-                         {"dim", "keep_dim", "reduce_all"},
+                         {"dim", "keep_dim"},
                          {"X@GRAD"});
 }
 
@@ -211,7 +211,7 @@ KernelSignature ReduceProdGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature("prod_grad",
                          {"X", "Out", "Out@GRAD"},
-                         {"dim", "keep_dim", "reduce_all"},
+                         {"dim", "keep_dim"},
                          {"X@GRAD"});
 }
 

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -53,12 +53,7 @@ KernelSignature ReduceMeanOpArgumentMapping(const ArgumentMappingContext& ctx) {
 
 KernelSignature ReduceProdOpArgumentMapping(const ArgumentMappingContext& ctx) {
   if (ctx.IsDenseTensorInput("X")) {
-    bool reduce_all = paddle::any_cast<bool>(ctx.Attr("reduce_all"));
-    // When ctx is InferShapeArgumentMappingContext, the reduce_all is used in
-    // InferShape, so we must return the "max_raw" KernelSignature.
-    // And the InferMeta function(i.e. ReduceInferMetaBase) is accordance with
-    // the "max_raw" KernelSignature
-    if (ctx.IsForInferShape() || reduce_all) {
+    if (ctx.IsForInferShape()) {
       return KernelSignature(
           "prod", {"X"}, {"dim", "keep_dim"}, {"Out"});
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
reduce_all只有在dims参数为空或者长度与输入x的维度相同时值为true,因此删除输入的reduce_all后依旧可以通过dims参数来推导相应的参数值，从理论上看Kernel可以无风险删除 reduce_all 参数