### PR TITLE
fix gcc12_error

### DIFF
--- a/paddle/utils/array_ref_test.cc
+++ b/paddle/utils/array_ref_test.cc
@@ -78,7 +78,7 @@ TEST(array_ref, array_ref) {
   CHECK_EQ(drop.size(), size_t(1));
   CHECK_EQ(drop[0], 3);
 
-  paddle::array_ref<int> nums = {1, 2, 3, 4, 5, 6, 7, 8};
+  static paddle::array_ref<int> nums = {1, 2, 3, 4, 5, 6, 7, 8};
   auto front = nums.take_front(3);
   CHECK_EQ(front.size(), size_t(3));
   for (size_t i = 0; i < 3; ++i) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
Pcard-67010
修复可能使用悬空指针指向未命名的临时对象的错误，当指针指向的内存空间已被释放或不再有效的时候，gcc12就会报这个错误，我们可以使用static 延长局部变量的生命周期，直到程序运行结束以后才释放，可以避免此错误。
<!-- Describe what this PR does -->
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62429225/229308749-b334d868-b052-48ff-922b-c26a90aeaac1.png">
