### PR TITLE
[oneDNN]disable interpolate operators by default

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
@@ -69,8 +69,24 @@ inline bool FoundPhiOneDNNKernelWithCorrectDataType(
 
 bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
   if (FoundOneDNNKernelWithCorrectDataType(op) ||
-      FoundPhiOneDNNKernelWithCorrectDataType(op))
-    return true;
+      FoundPhiOneDNNKernelWithCorrectDataType(op)) {
+    // For interpolate ops, there's a little difference between Paddle and
+    // DNNL.
+    // If run DNNL interpolate ops, manual set AnalysisConfig and apply
+    // the corresponding pass.
+    const std::vector<std::string> not_default_op_types = {"bilinear_interp",
+                                                           "nearest_interp",
+                                                           "trilinear_interp",
+                                                           "bicubic_interp",
+                                                           "linear_interp",
+                                                           "bilinear_interp_v2",
+                                                           "linear_interp_v2"};
+    bool is_interpolate_op =
+        std::find(not_default_op_types.begin(),
+                  not_default_op_types.end(),
+                  op->Op()->Type()) != not_default_op_types.end();
+    return !is_interpolate_op;
+  }
   return false;
 }
 

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -363,7 +363,6 @@ void CpuPassStrategy::EnableMKLDNN() {
              "conv_transpose_eltwiseadd_bn_fuse_pass",  //
              "conv_bias_mkldnn_fuse_pass",              //
              "conv_transpose_bias_mkldnn_fuse_pass",
-             "interpolate_mkldnn_pass",
              // TODO(baoachun): Need to support 5-dimensional input.
              // "conv3d_bias_mkldnn_fuse_pass",  //
              "conv_elementwise_add_mkldnn_fuse_pass",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Should Fix #52336

#30016 implemented initial support for interpolate operators but claimed [here](https://github.com/PaddlePaddle/Paddle/pull/30016/files#diff-f984702b1eff58be962decc0ee0a0fba9cc407abfdbe8064fe4f389bed062c1aR75) that the pass should not be enabled by default. This PR is to skip the operator in `mkldnn_placement_pass` and `interpolate_mkldnn_pass` to fix the bug. We'll fix the gap and re-enable it later.