### PR TITLE
fix_setup.py_problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1457,10 +1457,12 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
     reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 
     for r in reqs.split():
-        installed_packages.append(re.sub("_|-", '', r.decode().split('==')[0]))
+        installed_packages.append(
+            re.sub("_|-", '', r.decode().split('==')[0]).lower()
+        )
 
     for dependency in python_dependcies_module:
-        if dependency not in installed_packages:
+        if dependency.lower() not in installed_packages:
             raise RuntimeError(missing_modules.format(dependency=dependency))
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-67010
修复setup.py中检查依赖时区分大小写的问题，如在requriements.txt中添加xlsxwriter==3.0.9，pip install -r python/requirements.txt之后，python -m  pip freeze得到的结果中显示为XlsWriter，故会报错如下：
 
![image](https://user-images.githubusercontent.com/62429225/229433242-3c8a5910-016f-4c57-b7fe-e53e186eedb7.png)
