### PR TITLE
speedup eager_legacy_trace_op

### DIFF
--- a/python/paddle/fluid/dygraph/tracer.py
+++ b/python/paddle/fluid/dygraph/tracer.py
@@ -90,6 +90,10 @@ name_mapping = {
     # }
 }
 
+core_ops_args_info = _legacy_C_ops.get_core_ops_args_info()
+core_ops_args_type_info = _legacy_C_ops.get_core_ops_args_type_info()
+core_ops_returns_info = _legacy_C_ops.get_core_ops_returns_info()
+
 
 class Tracer(core.Tracer):
     """
@@ -119,10 +123,6 @@ class Tracer(core.Tracer):
         inplace_map=None,
     ):
         function_ptr = _legacy_C_ops.__dict__[op_type]
-
-        core_ops_args_info = _legacy_C_ops.get_core_ops_args_info()
-        core_ops_args_type_info = _legacy_C_ops.get_core_ops_args_type_info()
-        core_ops_returns_info = _legacy_C_ops.get_core_ops_returns_info()
 
         op_args = core_ops_args_info[op_type]
         op_args_type = core_ops_args_type_info[op_type]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-64703
eager_legacy_trace_op每次都读取全量的算子签名，这个是非常耗时的。会导致通过traceop走中间态性能差。
本PR修复该问题。