### PR TITLE
[FIX BUG]Delete "USE_OP_ITSELF(equal_all);\n"in CMakeLists.txt

### DIFF
--- a/paddle/fluid/operators/controlflow/CMakeLists.txt
+++ b/paddle/fluid/operators/controlflow/CMakeLists.txt
@@ -38,10 +38,8 @@ else()
   target_link_libraries(conditional_block_infer_op conditional_block_op)
 endif()
 
-file(
-  APPEND ${pybind_file}
-  "USE_OP_ITSELF(less_than);\nUSE_NO_KERNEL_OP(read_from_array);\n"
-)
+file(APPEND ${pybind_file}
+     "USE_OP_ITSELF(less_than);\nUSE_NO_KERNEL_OP(read_from_array);\n")
 file(
   APPEND ${pybind_file}
   "USE_OP_ITSELF(logical_and);\nUSE_OP_ITSELF(logical_or);\nUSE_OP_ITSELF(logical_xor);\nUSE_OP_ITSELF(logical_not);\n"

--- a/paddle/fluid/operators/controlflow/CMakeLists.txt
+++ b/paddle/fluid/operators/controlflow/CMakeLists.txt
@@ -40,13 +40,9 @@ endif()
 
 file(
   APPEND ${pybind_file}
-  "USE_OP_ITSELF(less_than);\nUSE_OP_ITSELF(equal_all);\nUSE_NO_KERNEL_OP(read_from_array);\n"
+  "USE_OP_ITSELF(less_than);\nUSE_NO_KERNEL_OP(read_from_array);\n"
 )
 file(
   APPEND ${pybind_file}
   "USE_OP_ITSELF(logical_and);\nUSE_OP_ITSELF(logical_or);\nUSE_OP_ITSELF(logical_xor);\nUSE_OP_ITSELF(logical_not);\n"
-)
-file(
-  APPEND ${pybind_file}
-  "USE_OP_ITSELF(bitwise_and);\nUSE_OP_ITSELF(bitwise_or);\nUSE_OP_ITSELF(bitwise_xor);\nUSE_OP_ITSELF(bitwise_not);\n"
 )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Pcard-67001
删除`paddle/fluid/operators/controlflow/CMakeLists.txt`中的`USE_OP_ITSELF(equal_all);\n`,解决潜在的重定义问题。