### PR TITLE
change use_custom_device in eager_op_test from method to variable

### DIFF
--- a/python/paddle/fluid/tests/unittests/eager_op_test.py
+++ b/python/paddle/fluid/tests/unittests/eager_op_test.py
@@ -1522,7 +1522,7 @@ class OpTest(unittest.TestCase):
         core._set_prim_all_enabled(False)
         core.set_prim_eager_enabled(False)
 
-        if hasattr(self, "use_custom_device") and self.use_custom_device():
+        if hasattr(self, "use_custom_device") and self.use_custom_device:
             check_dygraph = False
 
         def find_imperative_actual(target_name, dygraph_outs, place):
@@ -2069,7 +2069,7 @@ class OpTest(unittest.TestCase):
         if self.is_xpu_op():
             self.__class__.use_xpu = True
 
-        if hasattr(self, "use_custom_device") and self.use_custom_device():
+        if hasattr(self, "use_custom_device") and self.use_custom_device:
             check_dygraph = False
 
         places = self._get_places()
@@ -2232,7 +2232,7 @@ class OpTest(unittest.TestCase):
         only_check_prim=False,
         atol=1e-5,
     ):
-        if hasattr(self, "use_custom_device") and self.use_custom_device():
+        if hasattr(self, "use_custom_device") and self.use_custom_device:
             check_dygraph = False
 
         self._check_grad_helper()
@@ -2271,7 +2271,7 @@ class OpTest(unittest.TestCase):
         numeric_place=None,
         atol=1e-5,
     ):
-        if hasattr(self, "use_custom_device") and self.use_custom_device():
+        if hasattr(self, "use_custom_device") and self.use_custom_device:
             check_dygraph = False
 
         core._set_prim_all_enabled(False)
@@ -2492,7 +2492,7 @@ class OpTest(unittest.TestCase):
         no_grad_set=None,
         check_dygraph=True,
     ):
-        if hasattr(self, "use_custom_device") and self.use_custom_device():
+        if hasattr(self, "use_custom_device") and self.use_custom_device:
             check_dygraph = False
 
         with fluid.dygraph.base.guard(place=place):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Custom Device的单测中use_custom_device是作为成员变量存在的，将eager_op_test.py中的self.use_custom_device从方法成员改为成员变量，可以减少Custom Device适配的代码改动。