### PR TITLE
[DDim Decouple enforce.h] Change enforce.h->exception.h

### DIFF
--- a/paddle/phi/core/ddim.h
+++ b/paddle/phi/core/ddim.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/api/ext/exception.h"
 #include "paddle/phi/core/utils/dim.h"
 
 namespace phi {
@@ -29,23 +29,25 @@ namespace phi {
     return (callback);                         \
   }
 
-#define PADDLE_VISIT_DDIM(rank, callback)                                  \
-  switch (rank) {                                                          \
-    PADDLE_VISIT_DDIM_BASE(0, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(1, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(2, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(3, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(4, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(5, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(6, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(7, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(8, callback);                                   \
-    PADDLE_VISIT_DDIM_BASE(9, callback);                                   \
-    default:                                                               \
-      PADDLE_THROW(phi::errors::Unimplemented(                             \
-          "Invalid dimension to be accessed. Now only supports access to " \
-          "dimension 0 to 9, but received dimension is %d.",               \
-          rank));                                                          \
+#define PADDLE_VISIT_DDIM(rank, callback)                                    \
+  switch (rank) {                                                            \
+    PADDLE_VISIT_DDIM_BASE(0, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(1, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(2, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(3, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(4, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(5, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(6, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(7, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(8, callback);                                     \
+    PADDLE_VISIT_DDIM_BASE(9, callback);                                     \
+    default:                                                                 \
+      PD_THROW(                                                              \
+          "Unimplemented error. Invalid dimension to be accessed. Now only " \
+          "supports access to "                                              \
+          "dimension 0 to 9, but received dimension is ",                    \
+          rank,                                                              \
+          ".");                                                              \
   }
 
 template <typename T1, typename T2>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
APIs

### Describe
Pcard-66989

Fix the following error when `#include "paddle/phi/core/ddim.h"` in C++ level.
"enforce.h" relies on "gflags.h", but "gflags.h" has not been exposed. Hence we need to change "enforce.h" to "exception.h".

![1e8611675a682830fbb0bda8d5350998](https://user-images.githubusercontent.com/17810795/229674854-46ddd5b7-9c68-4458-9819-391f0f126d76.png)

