### PR TITLE
offload fused_multi_transformer op's params in inference

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -1231,3 +1231,10 @@ cc_test(
   DEPS phi_utils)
 
 cc_test(convert_utils_test SRCS convert_utils_test.cc)
+
+if(WITH_GPU)
+  cc_library(
+    offload_vars_pool
+    SRCS offload_vars_pool.cc
+    DEPS op_registry phi_tensor device_context)
+endif()

--- a/paddle/fluid/framework/offload_vars_pool.cc
+++ b/paddle/fluid/framework/offload_vars_pool.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/fluid/framework/offload_vars_pool.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
+namespace paddle {
+
+namespace framework {
+
+void ResourceHolder::Alloc(size_t required_size) {
+  platform::CUDAPlace place(platform::GetCurrentDeviceId());
+  paddle::platform::DeviceContextPool& pool =
+      paddle::platform::DeviceContextPool::Instance();
+  auto* dev_ctx = static_cast<phi::GPUContext*>(pool.Get(place));
+  dev_ctx->Alloc(&tensor_, phi::DataType::FLOAT32, required_size);
+}
+
+Buffer::Buffer(size_t required_size) {
+  gpu_resource_.Alloc(required_size);
+  cudaEventCreate(&event_);
+}
+
+Buffer::~Buffer() { cudaEventDestroy(event_); }
+
+OffloadVarsPool::~OffloadVarsPool() { cudaStreamDestroy(load_stream_); }
+
+void OffloadVarsPool::Transfer(const phi::DenseTensor& src,
+                               phi::DenseTensor* dst,
+                               size_t n,
+                               cudaStream_t stream) {
+  cudaMemcpyAsync(dst->data(), src.data(), n, cudaMemcpyHostToDevice, stream);
+}
+void OffloadVarsPool::Init(
+    size_t init_size,
+    const std::list<LayerIdx2ParamsTensors>& weights_queue,
+    const std::unordered_set<size_t>& offload_layers) {
+  paddle::platform::DeviceContextPool& pool =
+      paddle::platform::DeviceContextPool::Instance();
+  platform::Place place = platform::CUDAPlace(platform::GetCurrentDeviceId());
+  auto* dev_ctx_ = static_cast<phi::GPUContext*>(pool.Get(place));
+  kernel_run_stream_ = dev_ctx_->stream();
+  cudaStreamCreateWithFlags(&load_stream_, cudaStreamNonBlocking);
+
+  buffer_nodes_.reserve(2);
+  for (size_t i = 0; i < 2u; i++) {
+    buffer_nodes_.emplace_back(init_size);
+  }
+
+  weights_queue_ = weights_queue;
+  weights_queue_cpy_ = weights_queue;
+  offload_layers_ = offload_layers;
+
+  for (auto& pair : weights_queue_) {
+    CHECK_EQ(pair.second.first.size(), pair.second.second.size());
+    for (size_t i = 0; i < pair.second.first.size(); i++) {
+      CHECK_EQ(pair.second.first[i]->numel(), pair.second.second[i]->numel());
+      CHECK_EQ(pair.second.first[i]->dtype(), pair.second.second[i]->dtype());
+    }
+  }
+
+  FillPool();
+}
+
+void OffloadVarsPool::FillPool() {
+  // fill free node
+  for (size_t i = 0; i < buffer_nodes_.size(); i++) {
+    if (weights_queue_.empty()) return;
+    if (buffer_nodes_[i].free_) {
+      LayerIdx2ParamsTensors op_params_info = weights_queue_.front();
+      weights_queue_.pop_front();
+      buffer_nodes_[i].layer_id_ = op_params_info.first;
+      cudaStreamWaitEvent(load_stream_, buffer_nodes_[i].event_, 0);
+      for (size_t j = 0; j < op_params_info.second.first.size(); j++) {
+        auto* src_tensor = op_params_info.second.first[j];
+        auto* dst_tensor = op_params_info.second.second[j];
+        dst_tensor->set_type(src_tensor->dtype());
+        dst_tensor->Resize(src_tensor->dims());
+        buffer_nodes_[i].gpu_resource_.PartionMemoryTo(
+            dst_tensor, dst_tensor->numel() * SizeOf(dst_tensor->dtype()));
+        Transfer(*src_tensor,
+                 dst_tensor,
+                 src_tensor->numel() * SizeOf(src_tensor->dtype()),
+                 load_stream_);
+      }
+      cudaEventRecord(buffer_nodes_[i].event_, load_stream_);
+      buffer_nodes_[i].free_ = false;
+      active_layers_[buffer_nodes_[i].layer_id_] = i;
+    }
+  }
+}
+}  // namespace framework
+}  // namespace paddle
+#endif

--- a/paddle/fluid/framework/offload_vars_pool.h
+++ b/paddle/fluid/framework/offload_vars_pool.h
@@ -1,0 +1,153 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef PADDLE_WITH_CUDA
+#include <list>
+
+#include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/tensor_utils.h"
+
+namespace paddle {
+
+namespace framework {
+
+using LayerIdx2ParamsTensors = std::pair<
+    size_t,
+    std::pair<std::vector<phi::DenseTensor*>, std::vector<phi::DenseTensor*>>>;
+
+struct ResourceHolder {
+  void Alloc(size_t required_size);
+
+  void InitOffset() { tensor_.set_offset(0); }
+
+  void PartionMemoryTo(phi::DenseTensor* tensor, size_t byte_size) {
+    auto& holder = phi::DenseTensorUtils::GetHolder(tensor_);
+    tensor->set_offset(tensor_.offset());
+    tensor->ResetHolder(holder);
+    tensor_.set_offset(tensor_.offset() + byte_size);
+  }
+  phi::DenseTensor tensor_;
+};
+
+struct Buffer {
+  explicit Buffer(size_t required_size);
+
+  ~Buffer();
+
+  void ResetBuffer() {
+    free_ = true;
+    gpu_resource_.InitOffset();
+  }
+
+  ResourceHolder gpu_resource_;
+  size_t layer_id_;
+  bool free_{true};
+  cudaEvent_t event_;
+};
+
+class OffloadVarsPool {
+ public:
+  ~OffloadVarsPool();
+
+  void Init(size_t init_size,
+            const std::list<LayerIdx2ParamsTensors>& weights_queue,
+            const std::unordered_set<size_t>& sched_layers);
+
+  void Transfer(const phi::DenseTensor& src,
+                phi::DenseTensor* dst,
+                size_t n,
+                cudaStream_t stream);
+
+  void FillPool();
+
+  bool IsOffloadLayer(size_t layer_idx) {
+    auto find =
+        std::find(offload_layers_.begin(), offload_layers_.end(), layer_idx);
+    return find != offload_layers_.end();
+  }
+
+  void Reset() {
+    weights_queue_ = weights_queue_cpy_;
+    FillPool();
+  }
+
+  void WaitCopyCompleted(size_t layer_idx) {
+    size_t buf_id = active_layers_[layer_idx];
+    cudaStreamWaitEvent(kernel_run_stream_, buffer_nodes_[buf_id].event_, 0);
+  }
+
+  void RecordEvent(size_t layer_idx) {
+    size_t buf_id = active_layers_[layer_idx];
+    cudaEventRecord(buffer_nodes_[buf_id].event_, kernel_run_stream_);
+    buffer_nodes_[buf_id].ResetBuffer();
+  }
+
+ public:
+  // layer id to buffer id
+  std::map<size_t, size_t> active_layers_;
+  std::vector<Buffer> buffer_nodes_;
+  cudaStream_t kernel_run_stream_;
+
+ private:
+  std::list<LayerIdx2ParamsTensors> weights_queue_;
+  std::list<LayerIdx2ParamsTensors> weights_queue_cpy_;
+  std::unordered_set<size_t> offload_layers_;
+  cudaStream_t load_stream_;
+};
+
+class OffloadVarsPoolVector {
+ public:
+  static OffloadVarsPoolVector& Instance() {
+    static OffloadVarsPoolVector instance;
+    return instance;
+  }
+
+  ~OffloadVarsPoolVector() {
+    for (auto* ptr : offload_vars_pools) delete ptr;
+  }
+
+  void Init(size_t idx,
+            size_t init_size,
+            const std::list<LayerIdx2ParamsTensors>& weights_queue,
+            const std::unordered_set<size_t>& offload_layers) {
+    if (Size() <= idx) offload_vars_pools.push_back(new OffloadVarsPool());
+
+    PADDLE_ENFORCE_GT(
+        Size(),
+        idx,
+        platform::errors::InvalidArgument(
+            "size of offload_layers_pools must be greater than "
+            "idx, but idx is %d, and size of offload_layers_pools is %d.",
+            idx,
+            Size()));
+
+    offload_vars_pools[idx]->Init(init_size, weights_queue, offload_layers);
+  }
+
+  OffloadVarsPool& Get(size_t idx) { return *offload_vars_pools[idx]; }
+
+  size_t Size() { return offload_vars_pools.size(); }
+
+ private:
+  std::vector<OffloadVarsPool*> offload_vars_pools;
+  OffloadVarsPoolVector() {
+    offload_vars_pools.push_back(new OffloadVarsPool());
+  }
+};
+}  // namespace framework
+}  // namespace paddle
+#endif

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -379,6 +379,11 @@ struct Argument {
   DECL_ARGUMENT_FIELD(enable_custom_device_mixed,
                       EnableCustomDeviceMixed,
                       bool);
+  // memory limit filed
+  DECL_ARGUMENT_FIELD(enable_offload, EnableOffLoad, bool);
+  DECL_ARGUMENT_FIELD(custom_offload_layers,
+                      CustomOffloadLayers,
+                      std::vector<int>);
 
  private:
   std::unordered_set<std::string> valid_fields_;

--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -41,8 +41,12 @@ cc_library(
        memory_optim_pass
        convert_to_mixed_precision
        inference_op_replace_pass
-       ir_graph_to_program_pass)
-
+       ir_graph_to_program_pass
+       offload_params_pass)
+cc_library(
+  offload_params_pass
+  SRCS offload_params_pass.cc
+  DEPS analysis_pass graph_to_program_pass)
 set(analysis_deps
     ${analysis_deps} analysis_passes subgraph_detector
     CACHE INTERNAL "")

--- a/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
@@ -206,6 +206,7 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToXpu(Argument *argument) {
 #endif
 
 void IrParamsSyncAmongDevicesPass::RunImpl(Argument *argument) {
+  if (argument->enable_offload_valid()) return;
   PADDLE_ENFORCE_EQ(
       argument->scope_valid(),
       true,

--- a/paddle/fluid/inference/analysis/passes/offload_params_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/offload_params_pass.cc
@@ -1,0 +1,277 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/inference/analysis/passes/offload_params_pass.h"
+
+#include <string>
+#include <unordered_set>
+
+#include "paddle/fluid/framework/framework.pb.h"
+#include "paddle/fluid/framework/ir/graph_helper.h"
+#include "paddle/fluid/framework/lod_tensor.h"
+#include "paddle/fluid/framework/offload_vars_pool.h"
+#include "paddle/fluid/framework/tensor_util.h"
+
+namespace paddle {
+namespace inference {
+namespace analysis {
+
+#ifdef PADDLE_WITH_CUDA
+constexpr int kRootBlockIndex = 0;
+
+void CopyFixedVars2GPU(const std::unordered_set<std::string> &fixed_vars,
+                       framework::Scope *scope,
+                       int device_id) {
+  for (auto var_name : fixed_vars) {
+    auto *var = scope->FindLocalVar(var_name);
+    auto *t = var->GetMutable<phi::DenseTensor>();
+    platform::Place place = platform::CUDAPlace(device_id);
+    platform::CPUPlace cpu_place;
+    phi::DenseTensor temp_tensor;
+    temp_tensor.Resize(t->dims());
+    framework::TensorCopySync(*t, cpu_place, &temp_tensor);
+    t->clear();
+    framework::TensorCopySync(temp_tensor, place, t);
+  }
+}
+
+std::list<framework::LayerIdx2ParamsTensors> CopyOffloadLayersParams2Cpu(
+    std::unordered_set<size_t> *offload_layers,
+    const std::map<size_t, std::vector<std::string>> &offload_layer_attrs,
+    std::unordered_set<std::string> *copy_completed_offload_vars,
+    const std::unordered_set<std::string> &fixed_vars,
+    framework::Scope *scope) {
+  std::list<framework::LayerIdx2ParamsTensors> weight_queue;
+  for (size_t layer : *offload_layers) {
+    framework::LayerIdx2ParamsTensors info;
+    info.first = layer;
+    for (auto var_name : offload_layer_attrs.at(layer)) {
+      if (fixed_vars.count(var_name)) continue;
+      auto *src_var = scope->GetVar(var_name);
+      CHECK(src_var->IsType<phi::DenseTensor>());
+      auto *src_tensor = src_var->GetMutable<phi::DenseTensor>();
+      framework::Variable *dst_var = nullptr;
+      phi::DenseTensor *dst_tensor = nullptr;
+      if (copy_completed_offload_vars->count(var_name)) {
+        dst_var = scope->GetVar(var_name + "_cpu");
+        dst_tensor = dst_var->GetMutable<phi::DenseTensor>();
+        info.second.first.push_back(dst_tensor);
+        info.second.second.push_back(src_tensor);
+      } else {
+        copy_completed_offload_vars->insert(var_name);
+        dst_var = scope->Var(var_name + "_cpu");
+        dst_tensor = dst_var->GetMutable<phi::DenseTensor>();
+        dst_tensor->Resize(src_tensor->dims());
+        dst_tensor->set_layout(src_tensor->layout());
+        dst_tensor->set_type(src_tensor->dtype());
+        platform::CUDAPinnedPlace cpu_pin_place;
+        framework::TensorCopySync(*src_tensor, cpu_pin_place, dst_tensor);
+        src_tensor->clear();
+        info.second.first.push_back(dst_tensor);
+        info.second.second.push_back(src_tensor);
+      }
+    }
+    if (info.second.first.size()) weight_queue.push_back(info);
+  }
+
+  offload_layers->clear();
+  for (auto &ele : weight_queue) {
+    offload_layers->insert(ele.first);
+  }
+
+  return weight_queue;
+}
+
+bool FindFusedMultiTransformerOp(framework::OpDesc *while_op,
+                                 const framework::ir::Graph &graph) {
+  auto *sub_block =
+      PADDLE_GET_CONST(framework::BlockDesc *, while_op->GetAttr("sub_block"));
+  auto sub_graph = graph.GetSubGraph(sub_block->ID());
+  CHECK(sub_graph != nullptr);
+  auto topo_order = framework::ir::TopologySortOperations(*sub_graph);
+  for (size_t i = 0; i < topo_order.size(); i++) {
+    auto &node = topo_order[i];
+    if (node->IsOp() && node->Op()->Type() == "fused_multi_transformer") {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::unordered_set<size_t> CollectOffloadLayersAndParams(
+    const std::vector<framework::ir::Node *> &block_topo_order,
+    int block_id,
+    std::map<size_t, std::vector<std::string>> *offload_layer_attrs,
+    std::unordered_set<std::string> *fixed_vars,
+    framework::Scope *scope,
+    size_t *buffer_size,
+    Argument *argument) {
+  std::unordered_set<size_t> offload_layers;
+  for (size_t i = 0; i < block_topo_order.size(); i++) {
+    auto &node = block_topo_order[i];
+    if (node->IsOp() && node->Op()->Type() == "fused_multi_transformer") {
+      node->Op()->SetAttr("offload_params", true);
+      node->Op()->SetAttr("offload_vars_pool_idx", block_id);
+
+      std::vector<std::string> qkv_w_var_names = node->Op()->Input("QKVW");
+      size_t layer_num = qkv_w_var_names.size();
+
+      std::vector<std::string> expected_offload_params{"QKVW",
+                                                       "FFN1Weight",
+                                                       "FFN2Weight",
+                                                       "OutLinearW",
+                                                       "FFN1Bias",
+                                                       "FFN2Bias",
+                                                       "FFNLnBias",
+                                                       "LnBias",
+                                                       "OutLinearBias",
+                                                       "QKVBias"};
+      std::vector<int> custom_offload_layers =
+          argument->custom_offload_layers();
+      for (size_t j = 0; j < layer_num; j++) {
+        if (custom_offload_layers.size() &&
+            std::find(custom_offload_layers.begin(),
+                      custom_offload_layers.end(),
+                      j) == custom_offload_layers.end()) {
+          continue;
+        }
+        offload_layers.insert(j);
+        size_t offload_params_size = 0;
+        for (auto offload_param : expected_offload_params) {
+          PADDLE_ENFORCE_EQ(
+              node->Op()->Input(offload_param).size(),
+              layer_num,
+              platform::errors::PreconditionNotMet(
+                  "offload_param size should be equal to layer_num"));
+          auto offload_var_name = node->Op()->Input(offload_param)[j];
+          (*offload_layer_attrs)[j].push_back(offload_var_name);
+          fixed_vars->erase(offload_var_name);
+          auto *offload_var = scope->GetVar(offload_var_name);
+          auto *offload_tensor = offload_var->GetMutable<phi::DenseTensor>();
+          offload_params_size +=
+              offload_tensor->numel() * SizeOf(offload_tensor->dtype());
+        }
+        if (offload_params_size > *buffer_size)
+          *buffer_size = offload_params_size;
+      }
+      break;
+    }
+  }
+  return offload_layers;
+}
+#endif
+
+void OffLoadParamsPass::RunImpl(Argument *argument) {
+#ifdef PADDLE_WITH_CUDA
+  PADDLE_ENFORCE_EQ(
+      argument->scope_valid(),
+      true,
+      platform::errors::PreconditionNotMet("The scope field should be valid"));
+
+  if (!argument->use_gpu()) return;
+  if (!argument->enable_offload_valid()) return;
+
+  auto &graph = argument->main_graph();
+  PADDLE_ENFORCE_EQ(argument->gpu_device_id_valid(),
+                    true,
+                    platform::errors::PreconditionNotMet(
+                        "The gpu_device_id field should be valid"));
+  auto *scope = argument->scope_ptr();
+  auto main_block_topo_order = framework::ir::TopologySortOperations(graph);
+  framework::OpDesc *while_op_with_decoder = nullptr;
+
+  std::unordered_set<std::string> fixed_vars;
+  for (auto iter = main_block_topo_order.begin();
+       iter != main_block_topo_order.end();) {
+    auto &node = *iter;
+    if (!node->IsOp()) continue;
+    for (auto *var_node : node->inputs) {
+      if (!var_node->Var()->Persistable()) continue;
+      auto var_name = var_node->Var()->Name();
+      auto *var = scope->FindLocalVar(var_name);
+      PADDLE_ENFORCE_NOT_NULL(var,
+                              platform::errors::PreconditionNotMet(
+                                  "The var should not be nullptr"));
+      if (var->IsType<phi::DenseTensor>()) {
+        fixed_vars.insert(var_name);
+      }
+      if (node->Op()->Type() == "while") {
+        if (FindFusedMultiTransformerOp(node->Op(), graph))
+          while_op_with_decoder = node->Op();
+      }
+    }
+    iter++;
+  }
+
+  std::unordered_set<std::string> copy_completed_offload_vars;
+  if (while_op_with_decoder) {
+    auto *sub_block = PADDLE_GET_CONST(
+        framework::BlockDesc *, while_op_with_decoder->GetAttr("sub_block"));
+    auto while_op_sub_graph = graph.GetSubGraph(sub_block->ID());
+    CHECK(while_op_sub_graph != nullptr);
+    auto while_block_topo_order =
+        framework::ir::TopologySortOperations(*while_op_sub_graph);
+    std::map<size_t, std::vector<std::string>> offload_decoder_layers_attrs;
+
+    size_t buffer_size = 0;
+    auto offload_decoder_layers =
+        CollectOffloadLayersAndParams(while_block_topo_order,
+                                      sub_block->ID(),
+                                      &offload_decoder_layers_attrs,
+                                      &fixed_vars,
+                                      scope,
+                                      &buffer_size,
+                                      argument);
+    if (offload_decoder_layers.size() > 0) {
+      auto weight_queue =
+          CopyOffloadLayersParams2Cpu(&offload_decoder_layers,
+                                      offload_decoder_layers_attrs,
+                                      &copy_completed_offload_vars,
+                                      fixed_vars,
+                                      scope);
+      framework::OffloadVarsPoolVector::Instance().Init(
+          sub_block->ID(), buffer_size, weight_queue, offload_decoder_layers);
+    }
+  }
+
+  std::map<size_t, std::vector<std::string>> offload_encoder_layers_attrs;
+  size_t buffer_size = 0;
+  auto offload_encoder_layers =
+      CollectOffloadLayersAndParams(main_block_topo_order,
+                                    kRootBlockIndex,
+                                    &offload_encoder_layers_attrs,
+                                    &fixed_vars,
+                                    scope,
+                                    &buffer_size,
+                                    argument);
+  if (offload_encoder_layers.size() > 0) {
+    auto weight_queue =
+        CopyOffloadLayersParams2Cpu(&offload_encoder_layers,
+                                    offload_encoder_layers_attrs,
+                                    &copy_completed_offload_vars,
+                                    fixed_vars,
+                                    scope);
+    framework::OffloadVarsPoolVector::Instance().Init(
+        kRootBlockIndex, buffer_size, weight_queue, offload_encoder_layers);
+  }
+
+  CopyFixedVars2GPU(fixed_vars, scope, argument->gpu_device_id());
+#endif
+}
+
+std::string OffLoadParamsPass::repr() const { return "offload_params_pass"; }
+
+}  // namespace analysis
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/inference/analysis/passes/offload_params_pass.h
+++ b/paddle/fluid/inference/analysis/passes/offload_params_pass.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paddle/fluid/framework/scope.h"
+#include "paddle/fluid/inference/analysis/analysis_pass.h"
+#include "paddle/fluid/platform/place.h"
+
+namespace paddle {
+namespace inference {
+namespace analysis {
+
+class OffLoadParamsPass : public AnalysisPass {
+ public:
+  void RunImpl(Argument *argument) override;
+  std::string repr() const override;
+};
+
+}  // namespace analysis
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/inference/analysis/passes/passes.cc
+++ b/paddle/fluid/inference/analysis/passes/passes.cc
@@ -21,6 +21,7 @@
 #include "paddle/fluid/inference/analysis/passes/ir_graph_to_program_pass.h"
 #include "paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.h"
 #include "paddle/fluid/inference/analysis/passes/memory_optimize_pass.h"
+#include "paddle/fluid/inference/analysis/passes/offload_params_pass.h"
 
 namespace paddle {
 namespace inference {
@@ -38,6 +39,8 @@ PassRegistry::PassRegistry() {
   passes_.emplace(
       "ir_params_sync_among_devices_pass",
       std::unique_ptr<AnalysisPass>(new IrParamsSyncAmongDevicesPass));
+  passes_.emplace("offload_params_pass",
+                  std::unique_ptr<AnalysisPass>(new OffLoadParamsPass));
   passes_.emplace("adjust_cudnn_workspace_size_pass",
                   std::unique_ptr<AnalysisPass>(new AdjustCudnnWorkSpacePass));
   passes_.emplace("inference_op_replace_pass",

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -545,6 +545,10 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(apply_optim_);
   CP_MEMBER(skip_load_params_);
 
+  // limit memory
+  CP_MEMBER(enable_offload_);
+  CP_MEMBER(custom_offload_layers_);
+
   if (use_gpu_) {
     PADDLE_ENFORCE_EQ(use_xpu_,
                       false,
@@ -1022,6 +1026,12 @@ void AnalysisConfig::Update() {
         "but did not have the option -DWITH_CUSTOM_DEVICE compiled."));
 #endif
   }
+}
+
+void AnalysisConfig::EnableOffload(std::vector<int> custom_offload_layers) {
+  enable_offload_ = true;
+  custom_offload_layers_ = custom_offload_layers;
+  Update();
 }
 
 std::string AnalysisConfig::SerializeInfoCache() {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1372,6 +1372,12 @@ void AnalysisPredictor::PrepareArgument() {
   argument_->SetEnableGPUMixed(config_.enable_gpu_mixed_);
   argument_->SetMixedPrecisionMode(static_cast<int>(
       paddle::ConvertPrecision(config_.mixed_precision_mode_)));
+
+  // offload fused_multi_transformer op params
+  if (config_.enable_offload_) {
+    argument_->SetEnableOffLoad(config_.enable_offload_);
+    argument_->SetCustomOffloadLayers(config_.custom_offload_layers_);
+  }
 }
 
 // NOTE All the members in AnalysisConfig should be copied to Argument.

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1025,6 +1025,8 @@ struct PD_INFER_DECL AnalysisConfig {
 
   void SetSkipLoadParams(bool value) { skip_load_params_ = value; }
 
+  void EnableOffload(std::vector<int> custom_offload_layers = {});
+
   ///
   /// \brief Enable use cinn compiler optimization.
   ///
@@ -1247,6 +1249,10 @@ struct PD_INFER_DECL AnalysisConfig {
   // PrepareProgram(). So we add this flag to control the process.
   bool apply_optim_{false};
   bool skip_load_params_{false};
+
+  // offload fused_multi_transformer op params
+  bool enable_offload_{false};
+  std::vector<int> custom_offload_layers_{};
 };
 
 }  // namespace paddle

--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -117,6 +117,7 @@ class PD_INFER_DECL PaddlePassBuilder {
       {"ir_graph_build_pass",
        "ir_analysis_pass",
        "ir_params_sync_among_devices_pass",
+       "offload_params_pass",
        "adjust_cudnn_workspace_size_pass",
        "inference_op_replace_pass"}};
   std::vector<std::string> passes_;

--- a/paddle/fluid/operators/fused/CMakeLists.txt
+++ b/paddle/fluid/operators/fused/CMakeLists.txt
@@ -121,7 +121,7 @@ if(WITH_GPU OR WITH_ROCM)
     op_library(fused_feedforward_op)
     # fused_attention_op
     op_library(fused_attention_op)
-    op_library(fused_multi_transformer_op)
+    op_library(fused_multi_transformer_op DEPS offload_vars_pool)
     op_library(fused_multi_transformer_int8_op)
     op_library(fused_bias_dropout_residual_layer_norm_op)
   endif()

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include "paddle/fluid/framework/offload_vars_pool.h"
 #include "paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h"
 
 namespace paddle {
@@ -23,6 +24,13 @@ template <typename T>
 class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
+    bool offload = false;
+    int offload_vars_pool_idx = -1;
+    if (ctx.HasAttr("offload_params")) {
+      offload = true;
+      offload_vars_pool_idx = ctx.Attr<int>("offload_vars_pool_idx");
+    }
+
     using U = LayerNormParamType<T>;
     auto &dev_ctx = ctx.cuda_device_context();
 
@@ -319,6 +327,17 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     }
 
     for (int i = 0; i < layers; ++i) {
+      bool is_offload_layer = framework::OffloadVarsPoolVector::Instance()
+                                  .Get(offload_vars_pool_idx)
+                                  .IsOffloadLayer(i);
+      if (offload && is_offload_layer) {
+        framework::OffloadVarsPoolVector::Instance()
+            .Get(offload_vars_pool_idx)
+            .FillPool();
+        framework::OffloadVarsPoolVector::Instance()
+            .Get(offload_vars_pool_idx)
+            .WaitCopyCompleted(i);
+      }
       // step1. layer_norm
       if (i == 0 && pre_layer_norm) {
         auto *ln_scale_data = ln_scales[i]->data<U>();
@@ -662,6 +681,10 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
         x_data = buf1->data<T>();
         std::swap(buf0, buf1);
       }
+      if (offload && is_offload_layer)
+        framework::OffloadVarsPoolVector::Instance()
+            .Get(offload_vars_pool_idx)
+            .RecordEvent(i);
     }
     if (encoder_remove_padding) {
       if (pre_layer_norm) {
@@ -680,6 +703,10 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
                              dim_embed);
       }
     }
+    if (offload)
+      framework::OffloadVarsPoolVector::Instance()
+          .Get(offload_vars_pool_idx)
+          .Reset();
   }
 };
 
@@ -689,6 +716,12 @@ template <typename T>
 class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
+    bool offload = false;
+    int offload_vars_pool_idx = -1;
+    if (ctx.HasAttr("offload_params")) {
+      offload = true;
+      offload_vars_pool_idx = ctx.Attr<int>("offload_vars_pool_idx");
+    }
     using U = LayerNormParamType<T>;
     auto &dev_ctx = ctx.cuda_device_context();
 
@@ -993,6 +1026,16 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     }
 
     for (int i = 0; i < layers; ++i) {
+      if (offload && framework::OffloadVarsPoolVector::Instance()
+                         .Get(offload_vars_pool_idx)
+                         .IsOffloadLayer(i)) {
+        framework::OffloadVarsPoolVector::Instance()
+            .Get(offload_vars_pool_idx)
+            .FillPool();
+        framework::OffloadVarsPoolVector::Instance()
+            .Get(offload_vars_pool_idx)
+            .WaitCopyCompleted(i);
+      }
       // step1. layer_norm
       if (i == 0 && pre_layer_norm) {
         auto *ln_scale_data = ln_scales[i]->data<U>();
@@ -1342,6 +1385,10 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
         x_data = buf1->data<T>();
         std::swap(buf0, buf1);
       }
+      if (offload)
+        framework::OffloadVarsPoolVector::Instance()
+            .Get(offload_vars_pool_idx)
+            .RecordEvent(i);
     }
     if (encoder_remove_padding) {
       if (pre_layer_norm) {
@@ -1360,6 +1407,10 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
                              dim_embed);
       }
     }
+    if (offload)
+      framework::OffloadVarsPoolVector::Instance()
+          .Get(offload_vars_pool_idx)
+          .Reset();
   }
 };
 

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -754,6 +754,7 @@ void BindAnalysisConfig(py::module *m) {
            [](AnalysisConfig &self, phi::CUDAStream &stream) {
              self.SetExecStream(stream.raw_stream());
            })
+      .def("enable_offload", &AnalysisConfig::EnableOffload)
 #endif
       .def("enable_xpu",
            &AnalysisConfig::EnableXpu,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Describe
针对 transformer 大模型推理的场景，对 fused_multi_transformer op 的权重数据做 offload 处理，很大幅度上能够降低大模型的显存占用，但由于 IO 速度限制，对延迟的影响也很大。

主要修改如下：

1. config增加一个接口:  **config.enable_offload()** 
可以传入一个 vector<int>数组，自定义需要 offload 特定层的 transformer，默认为空，offload 所有的 transformer layer

2. 新增一个 pass：**offload_params_pass**
当开启 enable_offload 后，会跳过 ir_params_sync_among_devices_pass，权重是否 offload 由 offload_params_pass 判断处理。 offload 的权重会放在 cpu， fixed （no offload）的权重则直接拷贝到 gpu
假设有一个 offload 的 var， scope 中则会有两个 tensor 对应这个 var， 一个是 cpu tensor， 保存着实际的权重数据，另外一个是 gpu tensor，在模型开始运行前，它是空的。
对于 fixed （no offload）var，scope 中则只有一个gpu tensor， 里面保存着实际的权重数据。

3. offload_var_pool
pool 里面有一个队列，保存着所有 offload var 的 cpu tensor 指针与对应的 gpu tensor 指针，模型运行时，cpu tensor 保存着真实的权重数据，gpu tensor 则为空，模型开始推理时，cpu tensor 里面的权重数据，则会拷贝至 gpu tensor。
gpu tensor 的显存资源从哪里来的：pool 里面有两个 Buffer， 里面 hold 显存资源，当 gpu tensor 需要显存时，便可以从 Buffer 中划取。

4. fused_multi_transformer
当开启 offload 之后，该 op 的 offload_params 属性为真，同时一个 fused_multi_transformer 对应一个属于该 op 的 offload_var_pool， pool 里保存着该 op 权重数据的 cpu tensor 和 gpu tensor。
同时该 op 运行时有一些同步操作：layer 启动之前需要等待权重数据拷贝完成


整体上，在config 中新增了一个接口，增加了一个 pass 以及 offload_var_pool，对执行器逻辑没有改动，在 fused_multi_transformer 中加了一个layer执行前后的同步操作。
 


 

