### PR TITLE
【PaddlePaddle Hackathon 4 No.44】为 Paddle 优化 logsumexp op 在 GPU 上的计算性能

### DIFF
--- a/paddle/phi/kernels/gpu/logsumexp_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_kernel.cu
@@ -83,9 +83,6 @@ void LogsumexpKernel(const Context& dev_ctx,
       keeped_outdim_vec.push_back(xdim[i]);
     }
   }
-  if (outdim_vec.size() == 0) {
-    outdim_vec.push_back(1);
-  }
 
   auto outdim = phi::make_ddim(outdim_vec);
   auto keeped_outdim = phi::make_ddim(keeped_outdim_vec);

--- a/paddle/phi/kernels/gpu/logsumexp_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,12 +14,106 @@
 
 #include "paddle/phi/kernels/logsumexp_kernel.h"
 
-#include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/logsumexp_kernel_impl.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_subtract_kernel.h"
+#include "paddle/phi/kernels/funcs/activation_functor.h"
+#include "paddle/phi/kernels/funcs/elementwise_base.h"
+#include "paddle/phi/kernels/gpu/reduce.h"
 
 using float16 = phi::dtype::float16;
+
+namespace phi {
+
+template <typename T>
+struct LogCUDAFunctor {
+  HOSTDEVICE inline T operator()(const T x) const { return std::log(x); }
+};
+
+template <>
+struct LogCUDAFunctor<float16> {
+  HOSTDEVICE inline float16 operator()(const float16 x) const {
+    auto x_ = static_cast<float>(x);
+    return static_cast<float16>(std::log(x_));
+  }
+};
+
+template <typename T, typename Context>
+void LogsumexpKernel(const Context& dev_ctx,
+                     const DenseTensor& x,
+                     const std::vector<int64_t>& axis,
+                     bool keepdim,
+                     bool reduce_all,
+                     DenseTensor* out) {
+  auto* in_x = &x;
+  auto* out_y = out;
+  auto xdim = in_x->dims();
+  for (size_t i = 0; i < xdim.size(); i++)
+    PADDLE_ENFORCE_LT(0,
+                      xdim[i],
+                      errors::InvalidArgument(
+                          "The dims of Input(X) should be greater than 0."));
+
+  reduce_all = recompute_reduce_all(x, axis, reduce_all);
+  std::vector<int64_t> outdim_vec, keeped_outdim_vec;
+  std::vector<int> axis_vec;
+  for (auto i : axis) {
+    auto v = i >= 0 ? i : i + xdim.size();
+    axis_vec.push_back(v);
+  }
+  if (axis.size() == 0 || reduce_all) {
+    for (size_t i = 0; i < xdim.size(); i++) {
+      axis_vec.push_back(i);
+    }
+  }
+  for (size_t i = 0; i < xdim.size(); i++) {
+    bool flag = false;
+    for (auto v : axis_vec) {
+      if (v == i) {
+        flag = true;
+        break;
+      }
+    }
+    if (flag) {
+      keeped_outdim_vec.push_back(1);
+      if (keepdim) outdim_vec.push_back(1);
+    } else {
+      outdim_vec.push_back(xdim[i]);
+      keeped_outdim_vec.push_back(xdim[i]);
+    }
+  }
+  if (outdim_vec.size() == 0) {
+    outdim_vec.push_back(1);
+  }
+
+  auto outdim = phi::make_ddim(outdim_vec);
+  auto keeped_outdim = phi::make_ddim(keeped_outdim_vec);
+  out->Resize(outdim);
+  dev_ctx.template Alloc<T>(out_y);
+
+  DenseTensor max_x;
+  max_x.Resize(outdim);
+  dev_ctx.template Alloc<T>(&max_x);
+
+  phi::funcs::ReduceKernel<T, T, kps::MaxFunctor, kps::IdentityFunctor<T>>(
+      dev_ctx, *in_x, &max_x, kps::IdentityFunctor<T>(), axis_vec);
+
+  max_x.Resize(keeped_outdim);
+  DenseTensor temp_x = Subtract<T, Context>(dev_ctx, *in_x, max_x);
+  phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::ExpFunctor<T>>(
+      dev_ctx, temp_x, out_y, kps::ExpFunctor<T>(), axis_vec);
+
+  const std::vector<const DenseTensor*> inputs = {out_y};
+  std::vector<DenseTensor*> outputs = {&temp_x};
+  phi::funcs::ElementwiseKernel<T>(
+      dev_ctx, inputs, &outputs, LogCUDAFunctor<T>());
+  temp_x.Resize(outdim);
+  out->Resize(outdim);
+  phi::AddKernel<T, Context>(dev_ctx, temp_x, max_x, out);
+}
+
+}  // namespace phi
 
 PD_REGISTER_KERNEL(
     logsumexp, GPU, ALL_LAYOUT, phi::LogsumexpKernel, float, double, float16) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

目前 Paddle 内 logsumexp OP 的 GPU 计算调用了 eigen，性能较差，有较大的提升空间。

设计文档：https://github.com/PaddlePaddle/community/blob/master/rfcs/OPs-Perf/20220305_logsumexp_op_optimization.md

- 开发环境
  -  Nvidia  GTX 1060
  -  CUDA11.2, cuDNN 8
 
- 测试环境
  - Tesla V100
  -  CUDA11.2, cuDNN 8

当前 `logsumexp` 前向性能如下所示（1000次运行取平均值）：
| Case No. | device | input_shape | input_type | origin Paddle Perf(ms) |
|---|---|---|---|---|
| 1 | Tesla V100 | [64L, 64L] | float32 | 0.05317 | 
| 2 | Tesla V100 | [1024L, 512L] | float32 | 0.72666 |
| 3 | Tesla V100 | [64L, 64L] | float16 | 0.052309 |
| 4 | Tesla V100 | [1024L, 512L] | float16 | 0.721384 |

PyTorch 中 logsumexp 前向性能如下所示（1000次运行取平均值）：
| Case No. | device | input_shape | input_type | PyTorch Perf(ms) | diff with original Paddle|
|---|---|---|---|---|---|
| 1 | Tesla V100 | [64L, 64L] | float32 | 0.030523 | faster than 74.2% |
| 2 | Tesla V100 | [1024L, 512L] | float32 | 0.038930 | faster than 1766.6% |
| 3 | Tesla V100 | [64L, 64L] | float16 | 0.031530 | faster than 65.9% |
| 4 | Tesla V100 | [1024L, 512L] | float16 | 0.037380 | faster than 1845.9% |

当前前向性能如下（1000次运行取平均值） ：
| Case No. | device | input_shape | input_type | New Paddle Perf(ms) | diff with original Paddle | diff with PyTorch | 
|---|---|---|---|---|---|---|
| 1 | Tesla V100 | [64L, 64L] | float32 | 0.016674 | faster than 218.9% | faster than 83.1% |
| 2 | Tesla V100 | [1024L, 512L] | float32 | 0.027571 | faster than 2535.6% | faster than 41.2% |
| 3 | Tesla V100 | [64L, 64L] | float16 | 0.017113 | faster than 205.7% | faster than 84.2% |
| 4 | Tesla V100 | [1024L, 512L] | float16 | 0.027820 | faster than 2493.0% | faster than 34.4% |