### PR TITLE
[CustomDevice] Add lacking custom device C Api

### DIFF
--- a/paddle/fluid/inference/capi_exp/pd_common.h
+++ b/paddle/fluid/inference/capi_exp/pd_common.h
@@ -66,8 +66,11 @@ typedef int8_t PD_Bool;
 PD_ENUM(PD_PrecisionType){
     PD_PRECISION_FLOAT32 = 0, PD_PRECISION_INT8, PD_PRECISION_HALF};
 
-PD_ENUM(PD_PlaceType){
-    PD_PLACE_UNK = -1, PD_PLACE_CPU, PD_PLACE_GPU, PD_PLACE_XPU};
+PD_ENUM(PD_PlaceType){PD_PLACE_UNK = -1,
+                      PD_PLACE_CPU,
+                      PD_PLACE_GPU,
+                      PD_PLACE_XPU,
+                      PD_PLACE_CUSTOM};
 
 PD_ENUM(PD_DataType){
     PD_DATA_UNK = -1,

--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -193,6 +193,29 @@ int32_t PD_ConfigNpuDeviceId(__pd_keep PD_Config* pd_config) {
   CHECK_AND_CONVERT_PD_CONFIG;
   return config->npu_device_id();
 }
+
+void PD_ConfigEnableCustomDevice(__pd_keep PD_Config* pd_config,
+                                 char* device_type,
+                                 int32_t device_id) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  config->EnableCustomDevice(device_type, device_id);
+}
+PD_Bool PD_ConfigUseCustomDevice(__pd_keep PD_Config* pd_config) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  return config->use_custom_device();
+}
+int32_t PD_ConfigCustomDeviceId(__pd_keep PD_Config* pd_config) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  return config->custom_device_id();
+}
+char* PD_ConfigCustomDeviceType(__pd_keep PD_Config* pd_config) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  auto device_type_str = config->custom_device_type();
+  char* c = reinterpret_cast<char*>(malloc(device_type_str.length() + 1));
+  snprintf(c, device_type_str.length() + 1, "%s", device_type_str.c_str());
+  return c;
+}
+
 int32_t PD_ConfigMemoryPoolInitSizeMb(__pd_keep PD_Config* pd_config) {
   CHECK_AND_CONVERT_PD_CONFIG;
   return config->memory_pool_init_size_mb();

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -254,6 +254,34 @@ PADDLE_CAPI_EXPORT extern int32_t PD_ConfigXpuDeviceId(
 PADDLE_CAPI_EXPORT extern int32_t PD_ConfigNpuDeviceId(
     __pd_keep PD_Config* pd_config);
 ///
+/// \brief Turn on custome device.
+///
+/// \param[in] pd_config config
+/// \param[in] device_type device type
+/// \param[in] device_id device_id the custome device card to use.
+///
+PADDLE_CAPI_EXPORT extern void PD_ConfigEnableCustomDevice(
+    __pd_keep PD_Config* pd_config, char* device_type, int32_t device_id);
+///
+/// \brief A boolean state telling whether the custom device is turned on.
+///
+/// \param[in] pd_onfig config
+/// \return Whether the custom device is turned on.
+///
+PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigUseCustomDevice(
+    __pd_keep PD_Config* pd_config);
+///
+/// \brief Get the custom device id.
+///
+/// \return int The custom device id.
+///
+PADDLE_CAPI_EXPORT extern int32_t custom_device_id(__pd_keep PD_Config* pd_config);
+/// \brief Get the custom device type.
+///
+/// \return string The custom device type.
+///
+PADDLE_CAPI_EXPORT extern char* custom_device_type(__pd_keep PD_Config* pd_config);
+///
 /// \brief Get the initial size in MB of the GPU memory pool.
 ///
 /// \param[in] pd_onfig config

--- a/paddle/fluid/inference/capi_exp/pd_utils.cc
+++ b/paddle/fluid/inference/capi_exp/pd_utils.cc
@@ -221,6 +221,8 @@ PlaceType CvtToCxxPlaceType(PD_PlaceType place_type) {
       return PlaceType::kGPU;
     case PD_PLACE_XPU:
       return PlaceType::kXPU;
+    case PD_PLACE_CUSTOM:
+      return PlaceType::kCUSTOM;
     default:
       PADDLE_THROW(paddle::platform::errors::InvalidArgument(
           "Unsupport paddle place type %d.", place_type));
@@ -236,6 +238,8 @@ PD_PlaceType CvtFromCxxPlaceType(PlaceType place_type) {
       return PD_PLACE_GPU;
     case PlaceType::kXPU:
       return PD_PLACE_XPU;
+    case PD_PLACE_CUSTOM:
+      return PlaceType::kCUSTOM;
     default:
       return PD_PLACE_UNK;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

[paddle/fluid/inference/capi_exp/pd_common.h](https://github.com/PaddlePaddle/Paddle/compare/develop...Kelly-Zhe:Paddle:paddle_capi_custom_device?expand=1#diff-e2c8f59e7813c202dc997bbe04d877028cb2c1d413ef80811e4fa6dfd94831a3)
[paddle/fluid/inference/capi_exp/pd_config.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...Kelly-Zhe:Paddle:paddle_capi_custom_device?expand=1#diff-7c995a45e8a4f40733fdea501c8cc026a286439c6190217755f89bf9c107d68f)

Paddle一直缺少CAPI对Custom Device的接口。
这个PR补充了CAPI的枚举，EnableCustomDevice的相关C接口。
某些App开发，需要强制C接口编程，例如ffmpeg。
