### PR TITLE
add abspath to clang-format

### DIFF
--- a/tools/codestyle/clang_format.hook
+++ b/tools/codestyle/clang_format.hook
@@ -17,4 +17,4 @@ if ! [[ $version == *"$VERSION"* ]]; then
     pip install clang-format==13.0.0
 fi
 
-clang-format $@
+$(python -c 'import os, clang_format;print(os.path.join(clang_format.__path__[0],"data/bin/clang-format"))') $@


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
get clang-format abspath before use it