### PR TITLE
[API] Expose capi in MacOS to enable GPU computing as custom device

### DIFF
--- a/paddle/phi/capi/all.h
+++ b/paddle/phi/capi/all.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 #include "paddle/phi/capi/include/c_device_context.h"

--- a/paddle/phi/capi/capi.h
+++ b/paddle/phi/capi/capi.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/common.h"
 

--- a/paddle/phi/capi/include/c_data_type.h
+++ b/paddle/phi/capi/include/c_data_type.h
@@ -14,8 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
-
+#if !defined(_WIN32)
 #include <cstdint>
 
 #include "paddle/phi/backends/device_ext.h"

--- a/paddle/phi/capi/include/c_device_context.h
+++ b/paddle/phi/capi/include/c_device_context.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 #include "paddle/phi/capi/include/c_tensor.h"

--- a/paddle/phi/capi/include/c_int_array.h
+++ b/paddle/phi/capi/include/c_int_array.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 

--- a/paddle/phi/capi/include/c_kernel_context.h
+++ b/paddle/phi/capi/include/c_kernel_context.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 #include "paddle/phi/capi/include/c_device_context.h"

--- a/paddle/phi/capi/include/c_kernel_factory.h
+++ b/paddle/phi/capi/include/c_kernel_factory.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 

--- a/paddle/phi/capi/include/c_kernel_registry.h
+++ b/paddle/phi/capi/include/c_kernel_registry.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include <vector>
 

--- a/paddle/phi/capi/include/c_place.h
+++ b/paddle/phi/capi/include/c_place.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 

--- a/paddle/phi/capi/include/c_scalar.h
+++ b/paddle/phi/capi/include/c_scalar.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 

--- a/paddle/phi/capi/include/c_tensor.h
+++ b/paddle/phi/capi/include/c_tensor.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 

--- a/paddle/phi/capi/include/common.h
+++ b/paddle/phi/capi/include/common.h
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #pragma once
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
+
+#include <type_traits>
 
 #define PD_CUSTOM_PHI_KERNEL_STATIC_ASSERT_GLOBAL_NAMESPACE(uniq_name, msg) \
   _PD_CUSTOM_PHI_KERNEL_STATIC_ASSERT_GLOBAL_NAMESPACE(uniq_name, msg)

--- a/paddle/phi/capi/include/data_type.h
+++ b/paddle/phi/capi/include/data_type.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 

--- a/paddle/phi/capi/include/kernel_registry.h
+++ b/paddle/phi/capi/include/kernel_registry.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/wrapper_base.h"
 

--- a/paddle/phi/capi/include/kernel_utils.h
+++ b/paddle/phi/capi/include/kernel_utils.h
@@ -16,7 +16,7 @@
 
 #include "paddle/phi/capi/include/common.h"
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 namespace phi {
 namespace capi {

--- a/paddle/phi/capi/include/type_utils.h
+++ b/paddle/phi/capi/include/type_utils.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include "paddle/phi/capi/include/c_data_type.h"
 #include "paddle/phi/common/data_type.h"

--- a/paddle/phi/capi/include/wrapper_base.h
+++ b/paddle/phi/capi/include/wrapper_base.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 #include <memory>
 #include <tuple>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> 
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Expose capi in MacOS to enable GPU computing as custom device. Details described [here](https://github.com/PaddlePaddle/PaddleCustomDevice/pull/485).