### PR TITLE
Isolate DenseTensor::set_type and DenseTensor::set_layout from header file

### DIFF
--- a/paddle/phi/core/selected_rows.cc
+++ b/paddle/phi/core/selected_rows.cc
@@ -23,4 +23,10 @@ SelectedRows::SelectedRows(const std::vector<int64_t>& rows,
 SelectedRows::SelectedRows()
     : impl_(std::make_shared<phi::SelectedRowsImpl>()) {}
 
+void SelectedRows::set_type(const DataType dtype) { impl_->set_type(dtype); }
+
+void SelectedRows::set_layout(const DataLayout layout) {
+  impl_->set_layout(layout);
+}
+
 }  // namespace phi

--- a/paddle/phi/core/selected_rows.h
+++ b/paddle/phi/core/selected_rows.h
@@ -139,13 +139,17 @@ class SelectedRows : public TensorBase,
   /// \return The data type of the tensor.
   DataType dtype() const noexcept override { return impl_->dtype(); }
 
-  void set_type(const DataType dtype) { impl_->set_type(dtype); }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_type(const DataType dtype);
+#endif
 
   /// \brief Returns the data layout of the tensor.
   /// \return The data layout of the tensor.
   DataLayout layout() const noexcept override { return impl_->layout(); }
 
-  void set_layout(const DataLayout layout) { impl_->set_layout(layout); }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_layout(const DataLayout layout);
+#endif
 
   /// \brief Returns the data place of the tensor.
   /// \return The data place of the tensor.

--- a/paddle/phi/core/selected_rows_impl.cc
+++ b/paddle/phi/core/selected_rows_impl.cc
@@ -208,4 +208,13 @@ void SelectedRowsImpl::Get(const phi::DenseTensor& ids,
     }
   }
 }
+
+void SelectedRowsImpl::set_type(const DataType dtype) {
+  value_->set_type(dtype);
+}
+
+void SelectedRowsImpl::set_layout(const DataLayout layout) {
+  value_->set_layout(layout);
+}
+
 }  // namespace phi

--- a/paddle/phi/core/selected_rows_impl.h
+++ b/paddle/phi/core/selected_rows_impl.h
@@ -159,13 +159,17 @@ class SelectedRowsImpl {
   /// \return The data type of the tensor.
   DataType dtype() const noexcept { return value_->dtype(); }
 
-  void set_type(const DataType dtype) { value_->set_type(dtype); }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_type(const DataType dtype);
+#endif
 
   /// \brief Returns the data layout of the tensor.
   /// \return The data layout of the tensor.
   DataLayout layout() const noexcept { return value_->layout(); }
 
-  void set_layout(const DataLayout layout) { value_->set_layout(layout); }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_layout(const DataLayout layout);
+#endif
 
   /// \brief Returns the data place of the tensor.
   /// \return The data place of the tensor.

--- a/paddle/phi/core/sparse_coo_tensor.cc
+++ b/paddle/phi/core/sparse_coo_tensor.cc
@@ -84,6 +84,12 @@ int64_t SparseCooTensor::nnz() const {
   }
 }
 
+void SparseCooTensor::set_type(const DataType dtype) { meta_.dtype = dtype; }
+
+void SparseCooTensor::set_layout(const DataLayout layout) {
+  meta_.layout = layout;
+}
+
 void SparseCooTensor::Resize(const DDim& dense_dims,
                              const int64_t sparse_dim,
                              const int64_t non_zero_num) {

--- a/paddle/phi/core/sparse_coo_tensor.h
+++ b/paddle/phi/core/sparse_coo_tensor.h
@@ -104,13 +104,18 @@ class SparseCooTensor : public TensorBase,
   /// \brief Returns the data type of the tensor.
   /// \return The data type of the tensor.
   DataType dtype() const noexcept override { return meta_.dtype; }
-  void set_type(const DataType dtype) { meta_.dtype = dtype; }
+
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_type(const DataType dtype);
+#endif
 
   /// \brief Returns the data layout of the tensor.
   /// \return The data layout of the tensor.
   DataLayout layout() const noexcept override { return meta_.layout; }
 
-  void set_layout(const DataLayout layout) { meta_.layout = layout; }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_layout(const DataLayout layout);
+#endif
 
   /// \brief Returns the data place of the tensor.
   /// \return The data place of the tensor.

--- a/paddle/phi/core/sparse_csr_tensor.cc
+++ b/paddle/phi/core/sparse_csr_tensor.cc
@@ -88,6 +88,12 @@ void* SparseCsrTensor::AllocateFrom(Allocator* allocator,
       allocator, dtype, requested_size, fake_alloc);
 }
 
+void SparseCsrTensor::set_type(const DataType dtype) { meta_.dtype = dtype; }
+
+void SparseCsrTensor::set_layout(const DataLayout layout) {
+  meta_.layout = layout;
+}
+
 void SparseCsrTensor::Resize(const DDim& dense_dims,
                              const int64_t non_zero_num) {
   PADDLE_ENFORCE(this->initialized(),

--- a/paddle/phi/core/sparse_csr_tensor.h
+++ b/paddle/phi/core/sparse_csr_tensor.h
@@ -110,13 +110,17 @@ class SparseCsrTensor : public TensorBase,
   /// \return The data type of the tensor.
   DataType dtype() const noexcept override { return meta_.dtype; }
 
-  void set_type(const DataType dtype) { meta_.dtype = dtype; }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_type(const DataType dtype);
+#endif
 
   /// \brief Returns the data layout of the tensor.
   /// \return The data layout of the tensor.
   DataLayout layout() const noexcept override { return meta_.layout; }
 
-  void set_layout(const DataLayout layout) { meta_.layout = layout; }
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
+  void set_layout(const DataLayout layout);
+#endif
 
   /// \brief Returns the data place of the tensor.
   /// \return The data place of the tensor.

--- a/paddle/phi/core/tensor_array.h
+++ b/paddle/phi/core/tensor_array.h
@@ -65,11 +65,15 @@ class TensorArray : public TensorBase,
 
   DataType dtype() const override;
 
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
   void set_type(const DataType dtype);
+#endif
 
   DataLayout layout() const override;
 
+#ifndef PADDLE_WITH_CUSTOM_KERNEL
   void set_layout(const DataLayout layout);
+#endif
 
   /// \brief This overrided function is not used in TensorArray.
   bool valid() const override;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
Pcard-67003
Fix https://github.com/PaddlePaddle/Paddle/issues/52583

DenseTensor的set_type和set_layout接口当前通过PADDLE_WITH_CUSTOM_KERNEL屏蔽，不对第三方插件暴露。

PR https://github.com/PaddlePaddle/Paddle/pull/51149 在sparse_coo_tensor、sparse_csr_tensor和selected_rows头文件中使用这两个接口导致第三方插件编译报错：
![0954e5f19839e49ec169450359d89d2f](https://user-images.githubusercontent.com/17673696/230338126-0c8a6158-0920-4f82-a010-661c8c78d1d3.png)

本PR修复此问题，将对DenseTensor的set_type和set_layout接口调用移动到.cc文件中，不在.h头文件中使用。
同时，因set_type和set_layout接口是否要暴露给第三方插件使用仍在讨论中，本PR使用PADDLE_WITH_CUSTOM_KERNEL宏暂时对sparse_coo_tensor、sparse_csr_tensor和selected_rows等class的接口也进行屏蔽，对齐DenseTensor的屏蔽行为。