### PR TITLE
delete reduce_all_ from amax_raw and amin_raw

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_amax_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_amax_op.cc
@@ -26,7 +26,7 @@ class ReduceAMaxOpMaker : public ops::ReduceBaseOpMaker {
 
 DECLARE_INFER_SHAPE_FUNCTOR(reduce_amax,
                             ReduceAMaxInferShapeFunctor,
-                            PD_INFER_META(phi::ReduceInferMetaBase));
+                            PD_INFER_META(phi::ReduceInferMeta));
 
 REGISTER_OPERATOR(
     reduce_amax,

--- a/paddle/fluid/operators/reduce_ops/reduce_amin_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_amin_op.cc
@@ -26,7 +26,7 @@ class ReduceAMinOpMaker : public ops::ReduceBaseOpMaker {
 
 DECLARE_INFER_SHAPE_FUNCTOR(reduce_amin,
                             ReduceAMinInferShapeFunctor,
-                            PD_INFER_META(phi::ReduceInferMetaBase));
+                            PD_INFER_META(phi::ReduceInferMeta));
 
 REGISTER_OPERATOR(
     reduce_amin,

--- a/paddle/phi/kernels/cpu/reduce_amax_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amax_kernel.cc
@@ -26,9 +26,8 @@ void AMaxRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MaxFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/cpu/reduce_amin_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_amin_kernel.cc
@@ -26,9 +26,8 @@ void AMinRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<CPUContext, T, phi::funcs::MinFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/kps/reduce_amax_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_amax_kernel.cu
@@ -23,9 +23,8 @@ void AMaxRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MaxFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/kps/reduce_amin_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_amin_kernel.cu
@@ -23,9 +23,8 @@ void AMinRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::MinFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/reduce_amax_kernel.cc
+++ b/paddle/phi/kernels/reduce_amax_kernel.cc
@@ -25,8 +25,7 @@ void AMaxKernel(const Context& dev_ctx,
                 const std::vector<int64_t>& dims,
                 bool keep_dim,
                 DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  AMaxRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  AMaxRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_amax_kernel.h
+++ b/paddle/phi/kernels/reduce_amax_kernel.h
@@ -23,7 +23,6 @@ void AMaxRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/reduce_amin_kernel.cc
+++ b/paddle/phi/kernels/reduce_amin_kernel.cc
@@ -25,8 +25,7 @@ void AMinKernel(const Context& dev_ctx,
                 const std::vector<int64_t>& dims,
                 bool keep_dim,
                 DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  AMinRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  AMinRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_amin_kernel.h
+++ b/paddle/phi/kernels/reduce_amin_kernel.h
@@ -23,7 +23,6 @@ void AMinRawKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const std::vector<int64_t>& dims,
                    bool keep_dim,
-                   bool reduce_all,
                    DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -85,15 +85,6 @@ KernelSignature ReduceMaxOpArgumentMapping(const ArgumentMappingContext& ctx) {
 
 KernelSignature ReduceAMaxOpArgumentMapping(const ArgumentMappingContext& ctx) {
   if (ctx.IsDenseTensorInput("X")) {
-    bool reduce_all = paddle::any_cast<bool>(ctx.Attr("reduce_all"));
-    // When ctx is InferShapeArgumentMappingContext, the reduce_all is used in
-    // InferShape, so we must return the "max_raw" KernelSignature.
-    // And the InferMeta function(i.e. ReduceInferMetaBase) is accordance with
-    // the "max_raw" KernelSignature
-    if (ctx.IsForInferShape() || reduce_all) {
-      return KernelSignature(
-          "amax_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
-    }
     return KernelSignature("amax", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
   return KernelSignature("unregistered", {}, {}, {});
@@ -117,15 +108,6 @@ KernelSignature ReduceMinOpArgumentMapping(const ArgumentMappingContext& ctx) {
 
 KernelSignature ReduceAMinOpArgumentMapping(const ArgumentMappingContext& ctx) {
   if (ctx.IsDenseTensorInput("X")) {
-    bool reduce_all = paddle::any_cast<bool>(ctx.Attr("reduce_all"));
-    // When ctx is InferShapeArgumentMappingContext, the reduce_all is used in
-    // InferShape, so we must return the "min_raw" KernelSignature.
-    // And the InferMeta function(i.e. ReduceInferMetaBase) is accordance with
-    // the "min_raw" KernelSignature
-    if (ctx.IsForInferShape() || reduce_all) {
-      return KernelSignature(
-          "amin_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
-    }
     return KernelSignature("amin", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
   return KernelSignature("unregistered", {}, {}, {});


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
reduce_all只有在dims参数为空或者长度与输入x的维度相同时值为true,因此删除输入的reduce_all后依旧可以通过dims参数来推导相应的参数值从理论上看Kernel可以无风险删除 reduce_all 参数