### PR TITLE
fix qat export bug when input_spec is None

### DIFF
--- a/python/paddle/quantization/imperative/qat.py
+++ b/python/paddle/quantization/imperative/qat.py
@@ -530,7 +530,8 @@ class ImperativeQuantizeOutputs:
             model, paddle.nn.Layer
         ), "The model must be the instance of paddle.nn.Layer."
 
-        paddle.jit.to_static(model, input_spec=input_spec)
+        if input_spec:
+            paddle.jit.to_static(model, input_spec=input_spec)
         paddle.jit.save(layer=model, path=path, input_spec=input_spec, **config)
 
         is_dynamic_mode = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix qat export bug when input_spec is None. 