### PR TITLE
[ONEDNN] fix int8 resnet50 accuracy by disabling inplace

### DIFF
--- a/paddle/fluid/inference/api/mkldnn_quantizer.cc
+++ b/paddle/fluid/inference/api/mkldnn_quantizer.cc
@@ -177,6 +177,10 @@ void AnalysisPredictor::MkldnnQuantizer::CalculateScalesForOpOutputs(
       if (compute_scale) {
         CalculateSingleScale(
             op->Type(), output.first, var_name, *var_tensor, is_unsigned);
+        VLOG(6) << "CalculateScalesForOpOutputs --> var_name: " << var_name
+                << ", var_tensor data ptr: " << var_tensor->data<float>()
+                << ", is unsigned: " << is_unsigned
+                << ", scales: " << scales_[var_name].second.data<double>()[0];
       }
     }
   }

--- a/paddle/phi/kernels/onednn/conv_function.h
+++ b/paddle/phi/kernels/onednn/conv_function.h
@@ -37,10 +37,6 @@ static dnnl::memory::data_type GetDstType(
     if (force_fp32_output) {
       dst_dt = dnnl::memory::data_type::f32;
     }
-    if (fuse_residual_conn && residual_param) {
-      auto residual_dt = funcs::ToOneDNNDataType(residual_param->dtype());
-      if (dst_dt != residual_dt) dst_dt = residual_dt;
-    }
   } else {
     if (!force_fp32_output && is_bfloat16) {
       dst_dt = dnnl::memory::data_type::bf16;
@@ -97,6 +93,7 @@ void ComputeFP32(const OneDNNContext& dev_ctx,
                                                              input,
                                                              filter,
                                                              bias,
+                                                             residual_param,
                                                              strides,
                                                              paddings,
                                                              padding_algorithm,
@@ -113,13 +110,8 @@ void ComputeFP32(const OneDNNContext& dev_ctx,
         auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
         auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
             filter, groups, is_conv3d, is_test);
-        std::shared_ptr<dnnl::memory> dst_memory_p;
-        if (fuse_residual_conn) {
-          dst_memory_p =
-              handler.AcquireDstMemoryWithResidual(output, residual_param);
-        } else {
-          dst_memory_p = handler.template AcquireDstMemory<T_out>(output);
-        }
+        std::shared_ptr<dnnl::memory> dst_memory_p =
+            handler.template AcquireDstMemory<T_out>(output);
 
         auto conv_p = handler.AcquireForwardPrimitive();
         std::unordered_map<int, dnnl::memory> args = {
@@ -131,6 +123,13 @@ void ComputeFP32(const OneDNNContext& dev_ctx,
           auto bias_memory_p =
               handler.AcquireBiasMemoryWithReorder(bias, is_test);
           args.insert({DNNL_ARG_BIAS, *bias_memory_p});
+        }
+
+        if (fuse_residual_conn) {
+          auto residual_memory_p =
+              handler.AcquireResidualMemory(residual_param);
+          args.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP((int)0) | DNNL_ARG_SRC_1,
+                       *residual_memory_p});
         }
 
         auto& astream = OneDNNContext::tls().get_stream();
@@ -161,10 +160,6 @@ void ComputeINT8(const OneDNNContext& dev_ctx,
   const auto& onednn_engine = dev_ctx.GetEngine();
   const bool is_conv3d = strides.size() == 3U;
 
-  bool unsigned_output =
-      (fuse_activation == "relu" || fuse_activation == "relu6");
-  bool need_s8_to_u8 = false;
-
   PADDLE_ENFORCE_NE(
       is_conv3d,
       true,
@@ -185,6 +180,7 @@ void ComputeINT8(const OneDNNContext& dev_ctx,
                                                              input,
                                                              filter,
                                                              bias,
+                                                             residual_param,
                                                              strides,
                                                              paddings,
                                                              padding_algorithm,
@@ -213,25 +209,8 @@ void ComputeINT8(const OneDNNContext& dev_ctx,
         auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
             filter, groups, false, true, scale_weights_data, mask_reorder);
 
-        std::shared_ptr<dnnl::memory> dst_memory_p;
-        if (fuse_residual_conn) {
-          PADDLE_ENFORCE_EQ(
-              output->dims(),
-              residual_param->dims(),
-              phi::errors::InvalidArgument(
-                  "Output and elementwise parameter need to have the "
-                  "same dimension sizes, but got output's dimension = %d"
-                  " and residual param's dimension =%d .",
-                  output->dims().size(),
-                  residual_param->dims().size()));
-          dst_memory_p =
-              handler.AcquireDstMemoryWithResidual(output, residual_param);
-          need_s8_to_u8 = (funcs::OneDNNGetDataType<T_out>() ==
-                           dnnl::memory::data_type::s8) &&
-                          unsigned_output;
-        } else {
-          dst_memory_p = handler.template AcquireDstMemory<T_out>(output);
-        }
+        std::shared_ptr<dnnl::memory> dst_memory_p =
+            handler.template AcquireDstMemory<T_out>(output);
 
         auto conv_p = handler.AcquireForwardPrimitive();
 
@@ -265,13 +244,25 @@ void ComputeINT8(const OneDNNContext& dev_ctx,
           args.insert({DNNL_ARG_BIAS, *bias_memory_p});
         }
 
+        if (fuse_residual_conn) {
+          PADDLE_ENFORCE_EQ(
+              output->dims(),
+              residual_param->dims(),
+              phi::errors::InvalidArgument(
+                  "Output and elementwise parameter need to have the "
+                  "same dimension sizes, but got output's dimension = %d"
+                  " and residual param's dimension =%d .",
+                  output->dims().size(),
+                  residual_param->dims().size()));
+          auto residual_memory_p =
+              handler.AcquireResidualMemory(residual_param);
+          args.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP((int)0) | DNNL_ARG_SRC_1,
+                       *residual_memory_p});
+        }
+
         auto& astream = OneDNNContext::tls().get_stream();
         conv_p->execute(astream, args);
         astream.wait();
-
-        if (need_s8_to_u8) {
-          dev_ctx.Alloc<uint8_t>(output);
-        }
 
         output->set_mem_desc(dst_memory_p->get_desc());
       }));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
oneDNN conv kernel will enable inplace for conv+residual fusion, which means share the same memory between output tensor and residuan param tensor. This is an optimization to reduce memory footprint and improve performance. But it's not always allowed to do this optimization. For example, two typical scenarios that inplace optimization can't be performed:
- When MkldnnQuantizer calibrates the f32 model.  MkldnnQuantizer will run f32 model first, save all intermediate tensors and then calculate scales for each tensor. If inplace enabled, multiple tensors will share same memory, and the calculated scales will be wrong.
```
I0407 02:46:14.437359 61316 mkldnn_quantizer.cc:180] CalculateScalesForOpOutputs --> var_name: batch_norm_4.tmp_2, var_tensor data ptr: 0x7f774f5c7000, is unsigned: 0, scales: 0.452599
I0407 02:46:23.268147 61316 mkldnn_quantizer.cc:180] CalculateScalesForOpOutputs --> var_name: elementwise_add_0, var_tensor data ptr: 0x7f774f5c7000, is unsigned: 1, scales: 0.452599
I0407 02:46:25.497138 61316 mkldnn_quantizer.cc:180] CalculateScalesForOpOutputs --> var_name: batch_norm_5.tmp_2, var_tensor data ptr: 0x7f774a935000, is unsigned: 1, scales: 0.762081
I0407 02:46:27.782670 61316 mkldnn_quantizer.cc:180] CalculateScalesForOpOutputs --> var_name: batch_norm_6.tmp_2, var_tensor data ptr: 0x7f7745ca3000, is unsigned: 1, scales: 0.543725
I0407 02:46:36.622802 61316 mkldnn_quantizer.cc:180] CalculateScalesForOpOutputs --> var_name: elementwise_add_1, var_tensor data ptr: 0x7f774f5c7000, is unsigned: 1, scales: 0.452599
```
- When the input tensor has other to-be-ran consumers. Inside kernel, we can't know whether the input has other to-be-ran consumers or not, so basically, it's not safe to always do inplace.

In this PR, we disabled the inplace optimization for onednn conv kernel. by replacing post-sum to post-binary_add. For int8 cases, post-binary_add doesn't support scale, so we use the following transformation to convert that scale to a div and a mul post-op. And the div can be folded to output scales.
```
dst = conv + sum_scale * residual  ==> dst = sum_scale * (conv / sum_scale + residual)
```
Beyond above change, we also don't force conv-sum output dtype to residual dtype anymore, which also help to improve accuracy and reduce s8 to u8 reorder overhead.

The acc and perf are measured by using API UT: analyzer_int8_image_classification_tester.

100 samples from imagenet val

  |   | Before   fix |   | After   fix |  
-- | -- | -- | -- | -- | --
model | Data   type | Acc   @top1 | FPS (4   cores, 50 bs) | Acc   @top1 | FPS (4   cores, 50 bs)
resnet50 | Int8 | 0.7900 | 110.6617 | 0.8100 | 114.6621
resnet50 | Fp32 | 0.8100 | 49.2413 | 0.8100 | 44.4158
mobilenetv2 | Int8 | 0.7500 | 225.0028 | 0.7400 | 240.5564
mobilenetv2 | Fp32 | 0.7300 | 148.4617 | 0.7300 | 148.6830


2000 samples from imagenet val

  |   | Before   fix |   | After   fix |  
-- | -- | -- | -- | -- | --
model | Data   type | Acc   @top1 | FPS (4   cores, 50 bs) | Acc   @top1 | FPS (4   cores, 50 bs)
resnet50 | Int8 | 0.7495 | 142.4420 | 0.7505 | 156.2931
resnet50 | Fp32 | 0.7495 | 56.8059 | 0.7495 | 55.0029
mobilenetv2 | Int8 | 0.7015 | 440.4986 | 0.7025 | 438.6604
mobilenetv2 | Fp32 | 0.7060 | 271.9890 | 0.7060 | 263.4630


