### PR TITLE
fix import error of save_inference_model API

### DIFF
--- a/python/paddle/distributed/fleet/runtime/parameter_server_runtime.py
+++ b/python/paddle/distributed/fleet/runtime/parameter_server_runtime.py
@@ -24,7 +24,6 @@ from paddle.static import (
     Variable,
     default_main_program,
     default_startup_program,
-    save_inference_model,
 )
 
 from ..base.private_helper_function import wait_server_ready
@@ -735,7 +734,7 @@ class ParameterServerRuntime(RuntimeBase):
                 raise TypeError(
                     "in fleet.save_inference_model() function, main_program must be as Program type, CompiledProgram is not allowed"
                 )
-            save_inference_model(
+            paddle.fluid.io.save_inference_model(
                 dirname,
                 feeded_var_names,
                 target_vars,
@@ -746,7 +745,7 @@ class ParameterServerRuntime(RuntimeBase):
                 export_for_deployment,
             )
         else:
-            save_inference_model(
+            paddle.fluid.io.save_inference_model(
                 dirname,
                 feeded_var_names,
                 target_vars,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
the parameter list of save_inference_model is different between fluid API and paddle.static API
in this case should use fluid API instead of paddle.static.save_inference_model
