### PR TITLE
Print the forward's stack when backward op has nan/inf and FLAGS_check_nan_inf_level = 0 

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
@@ -60,19 +60,7 @@ paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
     egr::CheckTensorHasNanOrInf("add_n", api_result);
-    std::string filename = __FILE__;
-    std::string line = std::to_string(__LINE__);
-    std::string function_name = __FUNCTION__;
-    forward_trace = filename + " " + line + " " + function_name + "\n";
-    forward_trace =
-        egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
-    try {
-      PADDLE_ENFORCE(
-          false,
-          "add_n's backward has nan/inf, please check the data of backward op");
-    } catch (std::exception& e) {
-      egr::Controller::Instance().SetOpPythonStackStr(forward_trace);
-    }
+    forward_trace = egr::Controller::Instance().GetPythonStack();
   }
 
   // Get Outputs

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/add_n_fwd_func.cc
@@ -56,14 +56,14 @@ paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
           << "add_n_ad_func";
   auto api_result = paddle::experimental::add_n(x);
 
-  std::string filename = __FILE__;
-  std::string line = std::to_string(__LINE__);
-  std::string function_name = __FUNCTION__;
-  std::string forward_trace =
-      filename + " " + line + " " + function_name + "\n";
+  std::string forward_trace = "";
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
     egr::CheckTensorHasNanOrInf("add_n", api_result);
+    std::string filename = __FILE__;
+    std::string line = std::to_string(__LINE__);
+    std::string function_name = __FUNCTION__;
+    forward_trace = filename + " " + line + " " + function_name + "\n";
     forward_trace =
         egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
     try {
@@ -100,7 +100,9 @@ paddle::Tensor add_n_ad_func(const std::vector<paddle::Tensor>& x) {
         std::shared_ptr<AddNGradNodeFinal>(new AddNGradNodeFinal(1, 1));
 
     // Set forward's stack
-    grad_node->SetForwardTrace(forward_trace);
+    if (FLAGS_check_nan_inf) {
+      grad_node->SetForwardTrace(forward_trace);
+    }
 
     // SetAttributes if needed
 

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -114,19 +114,7 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
     egr::CheckTensorHasNanOrInf("conv2d", api_result);
-    std::string filename = __FILE__;
-    std::string line = std::to_string(__LINE__);
-    std::string function_name = __FUNCTION__;
-    forward_trace = filename + " " + line + " " + function_name + "\n";
-    forward_trace =
-        egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
-    try {
-      PADDLE_ENFORCE(false,
-                     "conv2d's backward has nan/inf, please check the data of "
-                     "backward op");
-    } catch (std::exception& e) {
-      egr::Controller::Instance().SetOpPythonStackStr(forward_trace);
-    }
+    forward_trace = egr::Controller::Instance().GetPythonStack();
   }
 
   // Get Outputs

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -110,9 +110,23 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
                                                  dilations,
                                                  groups,
                                                  data_format);
+  std::string filename = __FILE__;
+  std::string line = std::to_string(__LINE__);
+  std::string function_name = __FUNCTION__;
+  std::string forward_trace =
+      filename + " " + line + " " + function_name + "\n";
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
     egr::CheckTensorHasNanOrInf("conv2d", api_result);
+    forward_trace =
+        egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
+    try {
+      PADDLE_ENFORCE(false,
+                     "conv2d's backward has nan/inf, please check the data of "
+                     "backward op");
+    } catch (std::exception& e) {
+      egr::Controller::Instance().SetOpPythonStackStr(forward_trace);
+    }
   }
 
   // Get Outputs
@@ -138,6 +152,10 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
     // Node Construction
     auto grad_node =
         std::shared_ptr<Conv2dGradNodeFinal>(new Conv2dGradNodeFinal(1, 2));
+
+    // Set forward's stack
+    grad_node->SetForwardTrace(forward_trace);
+
     // SetAttributes if needed
     grad_node->SetAttributestrides(strides);
     grad_node->SetAttributepaddings(paddings);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -110,14 +110,14 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
                                                  dilations,
                                                  groups,
                                                  data_format);
-  std::string filename = __FILE__;
-  std::string line = std::to_string(__LINE__);
-  std::string function_name = __FUNCTION__;
-  std::string forward_trace =
-      filename + " " + line + " " + function_name + "\n";
+  std::string forward_trace = "";
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
     egr::CheckTensorHasNanOrInf("conv2d", api_result);
+    std::string filename = __FILE__;
+    std::string line = std::to_string(__LINE__);
+    std::string function_name = __FUNCTION__;
+    forward_trace = filename + " " + line + " " + function_name + "\n";
     forward_trace =
         egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
     try {
@@ -154,7 +154,9 @@ paddle::Tensor conv2d_ad_func(const paddle::Tensor& input,
         std::shared_ptr<Conv2dGradNodeFinal>(new Conv2dGradNodeFinal(1, 2));
 
     // Set forward's stack
-    grad_node->SetForwardTrace(forward_trace);
+    if (FLAGS_check_nan_inf) {
+      grad_node->SetForwardTrace(forward_trace);
+    }
 
     // SetAttributes if needed
     grad_node->SetAttributestrides(strides);

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -175,6 +175,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
   std::string forward_trace = "";
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
+    egr::CheckTensorHasNanOrInf("sync_batch_norm_", api_result);
     forward_trace = egr::Controller::Instance().GetPythonStack();
   }
 

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -172,14 +172,15 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
                                              data_layout,
                                              use_global_stats,
                                              trainable_statistics);
+  std::string forward_trace = "";
   // Check NaN and Inf if needed
-  std::string filename = __FILE__;
-  std::string line = std::to_string(__LINE__);
-  std::string function_name = __FUNCTION__;
-  std::string forward_trace =
-      filename + " " + line + " " + function_name + "\n";
   if (FLAGS_check_nan_inf) {
     egr::CheckTensorHasNanOrInf("sync_batch_norm_", api_result);
+    std::string filename = __FILE__;
+    std::string line = std::to_string(__LINE__);
+    std::string function_name = __FUNCTION__;
+    std::string forward_trace =
+        filename + " " + line + " " + function_name + "\n";
     forward_trace =
         egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
     try {
@@ -242,7 +243,9 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
         std::shared_ptr<SyncBatchNormGradNode>(new SyncBatchNormGradNode(6, 5));
 
     // Set forward's stack
-    grad_node->SetForwardTrace(forward_trace);
+    if (FLAGS_check_nan_inf) {
+      grad_node->SetForwardTrace(forward_trace);
+    }
 
     egr::Controller::Instance().PushBackForceSequentialNodes(grad_node.get());
     // SetAttributes if needed

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/sync_batch_norm_fwd_func.cc
@@ -175,21 +175,7 @@ sync_batch_norm__ad_func(const paddle::Tensor& x,
   std::string forward_trace = "";
   // Check NaN and Inf if needed
   if (FLAGS_check_nan_inf) {
-    egr::CheckTensorHasNanOrInf("sync_batch_norm_", api_result);
-    std::string filename = __FILE__;
-    std::string line = std::to_string(__LINE__);
-    std::string function_name = __FUNCTION__;
-    std::string forward_trace =
-        filename + " " + line + " " + function_name + "\n";
-    forward_trace =
-        egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
-    try {
-      PADDLE_ENFORCE(
-          false,
-          "add_n's backward has nan/inf, please check the data of backward op");
-    } catch (std::exception& e) {
-      egr::Controller::Instance().SetOpPythonStackStr(forward_trace);
-    }
+    forward_trace = egr::Controller::Instance().GetPythonStack();
   }
 
   // Get Outputs

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -74,6 +74,12 @@ class Controller {
 
   void EnableLayoutAutoTune() { tracer_->EnableLayoutAutoTune(); }
 
+  void SetOpPythonStackStr(std::string stack_str) {
+    tracer_->SetOpPythonStackStr(stack_str);
+  }
+
+  std::string GetOpPythonStackStr() { return tracer_->GetOpPythonStackStr(); }
+
   bool HasGrad() const { return tracer_->HasGrad(); }
   void SetHasGrad(bool has_grad) { tracer_->SetHasGrad(has_grad); }
   std::string GenerateUniqueName(std::string key = "eager_in_tmp") {

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -74,11 +74,11 @@ class Controller {
 
   void EnableLayoutAutoTune() { tracer_->EnableLayoutAutoTune(); }
 
-  void SetOpPythonStackStr(std::string stack_str) {
-    tracer_->SetOpPythonStackStr(stack_str);
+  void SetPythonStack(std::string stack_str) {
+    tracer_->SetPythonStack(stack_str);
   }
 
-  std::string GetOpPythonStackStr() { return tracer_->GetOpPythonStackStr(); }
+  std::string GetPythonStack() { return tracer_->GetPythonStack(); }
 
   bool HasGrad() const { return tracer_->HasGrad(); }
   void SetHasGrad(bool has_grad) { tracer_->SetHasGrad(has_grad); }

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -492,17 +492,7 @@ CHECK_NAN_AND_INF_TEMPLATE_FORWARD = """
   std::string forward_trace ="";
   if (FLAGS_check_nan_inf) {{
       egr::CheckTensorHasNanOrInf("{}", {});
-      std::string filename = __FILE__;
-      std::string line = std::to_string(__LINE__);
-      std::string function_name = __FUNCTION__;
-      forward_trace = filename+" " + line+" "+function_name+"\\n";
-      forward_trace = egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
-      try{{
-       PADDLE_ENFORCE(false,
-               "{}'s backward has nan/inf, please check the data of backward op");
-      }} catch(std::exception& e) {{
-         egr::Controller::Instance().SetOpPythonStackStr(forward_trace);
-      }}
+      forward_trace = egr::Controller::Instance().GetPythonStack();
   }}
 """
 
@@ -1463,7 +1453,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
 
         # Check Nan and Inf
         check_nan_inf_str = CHECK_NAN_AND_INF_TEMPLATE_FORWARD.format(
-            function_name, "api_result", function_name
+            function_name, "api_result"
         )
 
         # Get Outputs

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -297,7 +297,9 @@ FORWARD_BODY_TEMPLATE = """  if(require_any_grad) {{
     // Node Construction
 {}
     // Set for forward trace
-{}
+  if (FLAGS_check_nan_inf) {{
+  {}
+  }}
     // SetAttributes if needed
 {}
     // Set TensorWrappers for Forward Inputs if needed
@@ -487,12 +489,13 @@ CHECK_BACKWARD_INPLACE_TEMPLATE = """
   }}"""
 
 CHECK_NAN_AND_INF_TEMPLATE_FORWARD = """
-  std::string filename = __FILE__;
-  std::string line = std::to_string(__LINE__);
-  std::string function_name = __FUNCTION__;
-  std::string forward_trace = filename+" " + line+" "+function_name+"\\n";
+  std::string forward_trace ="";
   if (FLAGS_check_nan_inf) {{
       egr::CheckTensorHasNanOrInf("{}", {});
+      std::string filename = __FILE__;
+      std::string line = std::to_string(__LINE__);
+      std::string function_name = __FUNCTION__;
+      forward_trace = filename+" " + line+" "+function_name+"\\n";
       forward_trace = egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
       try{{
        PADDLE_ENFORCE(false,

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -496,7 +496,7 @@ CHECK_NAN_AND_INF_TEMPLATE_FORWARD = """
       forward_trace = egr::Controller::Instance().GetOpPythonStackStr() + forward_trace;
       try{{
        PADDLE_ENFORCE(false,
-               "{} backward has nan/inf, please check the data of backward op");
+               "{}'s backward has nan/inf, please check the data of backward op");
       }} catch(std::exception& e) {{
          egr::Controller::Instance().SetOpPythonStackStr(forward_trace);
       }}

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -122,20 +122,24 @@ NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});"
 
 
 FUNCTION_SET_DEVICE_TEMPLATE = """{}    if (paddle::platform::is_gpu_place(place)) {{
+     std::string filename = __FILE__;
+     std::string line= std::to_string(__LINE__);
+     std::string function_name = __FUNCTION__;
      pybind11::gil_scoped_acquire gil;
      PyObject* mod = PyImport_ImportModule("traceback");
      PyObject *traceback_list= PyObject_CallMethod(mod, "format_stack", "");
      std::string str ="";
-    for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
-        PyObject* line = PyList_GetItem(traceback_list, i);
-        str += py::str(PyUnicode_AsUTF8(line));
-    }}
-    std::cout << str << std::endl;
-    for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
-        PyObject* line = PyList_GetItem(traceback_list, i);
-        const char* line_str = PyUnicode_AsUTF8(line);
-        std::cout << line_str << std::endl;
-    }}
+     for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
+         PyObject* line = PyList_GetItem(traceback_list, i);
+         str += py::str(PyUnicode_AsUTF8(line));
+     }}
+     std::string last = str + filename +" " + line + " " + function_name+"\\n";
+     egr::Controller::Instance().SetOpPythonStackStr(last);
+    //for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
+    //    PyObject* line = PyList_GetItem(traceback_list, i);
+    //    const char* line_str = PyUnicode_AsUTF8(line);
+    //    std::cout << line_str << std::endl;
+    //}}
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -122,6 +122,20 @@ NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});"
 
 
 FUNCTION_SET_DEVICE_TEMPLATE = """{}    if (paddle::platform::is_gpu_place(place)) {{
+     pybind11::gil_scoped_acquire gil;
+     PyObject* mod = PyImport_ImportModule("traceback");
+     PyObject *traceback_list= PyObject_CallMethod(mod, "format_stack", "");
+     std::string str ="";
+    for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
+        PyObject* line = PyList_GetItem(traceback_list, i);
+        str += py::str(PyUnicode_AsUTF8(line));
+    }}
+    std::cout << str << std::endl;
+    for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
+        PyObject* line = PyList_GetItem(traceback_list, i);
+        const char* line_str = PyUnicode_AsUTF8(line);
+        std::cout << line_str << std::endl;
+    }}
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -121,8 +121,10 @@ static PyObject * eager_api_{}(PyObject *self, PyObject *args, PyObject *kwargs)
 NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});"
 
 
-FUNCTION_SET_DEVICE_TEMPLATE = """{}    if (paddle::platform::is_gpu_place(place)) {{
-      SetPythonStack();
+FUNCTION_SET_DEVICE_TEMPLATE = """{}
+    LOG(INFO)<<"this is SetPythonStack";
+    SetPythonStack();
+    if (paddle::platform::is_gpu_place(place)) {{
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -122,19 +122,21 @@ NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});"
 
 
 FUNCTION_SET_DEVICE_TEMPLATE = """{}    if (paddle::platform::is_gpu_place(place)) {{
-     std::string filename = __FILE__;
-     std::string line= std::to_string(__LINE__);
-     std::string function_name = __FUNCTION__;
-     pybind11::gil_scoped_acquire gil;
-     PyObject* mod = PyImport_ImportModule("traceback");
-     PyObject *traceback_list= PyObject_CallMethod(mod, "format_stack", "");
-     std::string str ="";
-     for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
-         PyObject* line = PyList_GetItem(traceback_list, i);
-         str += py::str(PyUnicode_AsUTF8(line));
-     }}
-     std::string last = str + filename +" " + line + " " + function_name+"\\n";
-     egr::Controller::Instance().SetOpPythonStackStr(last);
+     if (FLAGS_check_nan_inf){{
+       std::string filename = __FILE__;
+       std::string line= std::to_string(__LINE__);
+       std::string function_name = __FUNCTION__;
+       pybind11::gil_scoped_acquire gil;
+       PyObject* mod = PyImport_ImportModule("traceback");
+       PyObject *traceback_list= PyObject_CallMethod(mod, "format_stack", "");
+       std::string str ="";
+       for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
+           PyObject* line = PyList_GetItem(traceback_list, i);
+           str += py::str(PyUnicode_AsUTF8(line));
+       }}
+       std::string last = str + filename +" " + line + " " + function_name+"\\n";
+       egr::Controller::Instance().SetOpPythonStackStr(last);
+      }}
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;
@@ -183,7 +185,7 @@ PYTHON_C_WRAPPER_TEMPLATE = """
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/eager/amp_utils.h"
 #include "paddle/fluid/eager/eager_amp_auto_cast.h"
-
+DECLARE_bool(check_nan_inf);
 namespace paddle {{
 namespace pybind {{
 

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -122,21 +122,7 @@ NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});"
 
 
 FUNCTION_SET_DEVICE_TEMPLATE = """{}    if (paddle::platform::is_gpu_place(place)) {{
-     if (FLAGS_check_nan_inf){{
-       std::string filename = __FILE__;
-       std::string line= std::to_string(__LINE__);
-       std::string function_name = __FUNCTION__;
-       pybind11::gil_scoped_acquire gil;
-       PyObject* mod = PyImport_ImportModule("traceback");
-       PyObject *traceback_list= PyObject_CallMethod(mod, "format_stack", "");
-       std::string str ="";
-       for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
-           PyObject* line = PyList_GetItem(traceback_list, i);
-           str += py::str(PyUnicode_AsUTF8(line));
-       }}
-       std::string last = str + filename +" " + line + " " + function_name+"\\n";
-       egr::Controller::Instance().SetOpPythonStackStr(last);
-      }}
+      SetPythonStack();
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;
@@ -185,7 +171,6 @@ PYTHON_C_WRAPPER_TEMPLATE = """
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/eager/amp_utils.h"
 #include "paddle/fluid/eager/eager_amp_auto_cast.h"
-DECLARE_bool(check_nan_inf);
 namespace paddle {{
 namespace pybind {{
 

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -135,11 +135,6 @@ FUNCTION_SET_DEVICE_TEMPLATE = """{}    if (paddle::platform::is_gpu_place(place
      }}
      std::string last = str + filename +" " + line + " " + function_name+"\\n";
      egr::Controller::Instance().SetOpPythonStackStr(last);
-    //for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {{
-    //    PyObject* line = PyList_GetItem(traceback_list, i);
-    //    const char* line_str = PyUnicode_AsUTF8(line);
-    //    std::cout << line_str << std::endl;
-    //}}
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::backends::gpu::SetDeviceId(place.device);
       VLOG(4) <<"CurrentDeviceId: " << phi::backends::gpu::GetCurrentDeviceId() << " from " << (int)place.device;

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -292,11 +292,9 @@ class GradNodeBase {
     is_tensor_wrappers_cleared_ = is_tensor_wrappers_cleared;
   }
 
-  void SetForwardTrace(std::string backward_trace) {
-    backward_trace_ = backward_trace;
-  }
+  void SetForwardTrace(std::string trace) { forward_trace_ = trace; }
 
-  std::string GetForwardTrace() { return backward_trace_; }
+  std::string GetForwardTrace() { return forward_trace_; }
 
  private:
   // bwd_out_meta_ is used to record Grad output info for backward
@@ -323,8 +321,8 @@ class GradNodeBase {
   bool need_complex_to_real_ = false;
 
   bool is_tensor_wrappers_cleared_ = false;
-  // The trace of backward function
-  std::string backward_trace_ = "";
+  // The trace of forward function
+  std::string forward_trace_ = "";
 };
 
 }  // namespace egr

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -292,6 +292,18 @@ class GradNodeBase {
     is_tensor_wrappers_cleared_ = is_tensor_wrappers_cleared;
   }
 
+  void SetForwardTrace(std::string backward_trace) {
+    backward_trace_ = backward_trace;
+  }
+
+  std::string GetForwardTrace() {
+    if (backward_trace_.size()) {
+      std::cout << " GetForwardOpBlock is false"
+                << std::endl;  // <<backward_trace_<<std::endl;
+    }
+    return backward_trace_;
+  }
+
  private:
   // bwd_out_meta_ is used to record Grad output info for backward
   paddle::small_vector<std::vector<GradSlotMeta>, kSlotSmallVectorSize>
@@ -317,6 +329,8 @@ class GradNodeBase {
   bool need_complex_to_real_ = false;
 
   bool is_tensor_wrappers_cleared_ = false;
+  // The trace of backward function
+  std::string backward_trace_ = "";
 };
 
 }  // namespace egr

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -296,13 +296,7 @@ class GradNodeBase {
     backward_trace_ = backward_trace;
   }
 
-  std::string GetForwardTrace() {
-    if (backward_trace_.size()) {
-      std::cout << " GetForwardOpBlock is false"
-                << std::endl;  // <<backward_trace_<<std::endl;
-    }
-    return backward_trace_;
-  }
+  std::string GetForwardTrace() { return backward_trace_; }
 
  private:
   // bwd_out_meta_ is used to record Grad output info for backward

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -34,6 +34,7 @@ struct DebugTools {
   DebugTools() {}
   std::string path = "";
 };
+
 static DebugTools debug_nan_inf;
 
 void SetNanInfDebugPath(const std::string& nan_inf_path) {
@@ -162,6 +163,17 @@ void TensorCheckerVisitor<phi::CPUContext>::apply(
   std::string cpu_hint_str =
       GetCpuHintString<T>(op_type, var_name, tensor.place());
   CheckNanInfCpuImpl(tensor.data<T>(), tensor.numel(), cpu_hint_str);
+  // try {
+  //      PADDLE_THROW(platform::errors::InvalidArgument(
+  //        "asfasdfasd Cannot find the dimension of in this device mesh."));
+  // } catch (...) {
+  //    std::exception_ptr  current_exception = std::current_exception();
+  //    try {
+  //    } catch (...){
+  //      LOG(WARNING) << "Tasdfa Catch raises an unknown exception";
+  //      std::rethrow_exception(current_exception);
+  //    }
+  // }
 }
 
 template <>

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -34,7 +34,6 @@ struct DebugTools {
   DebugTools() {}
   std::string path = "";
 };
-
 static DebugTools debug_nan_inf;
 
 void SetNanInfDebugPath(const std::string& nan_inf_path) {

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -163,17 +163,6 @@ void TensorCheckerVisitor<phi::CPUContext>::apply(
   std::string cpu_hint_str =
       GetCpuHintString<T>(op_type, var_name, tensor.place());
   CheckNanInfCpuImpl(tensor.data<T>(), tensor.numel(), cpu_hint_str);
-  // try {
-  //      PADDLE_THROW(platform::errors::InvalidArgument(
-  //        "asfasdfasd Cannot find the dimension of in this device mesh."));
-  // } catch (...) {
-  //    std::exception_ptr  current_exception = std::current_exception();
-  //    try {
-  //    } catch (...){
-  //      LOG(WARNING) << "Tasdfa Catch raises an unknown exception";
-  //      std::rethrow_exception(current_exception);
-  //    }
-  // }
 }
 
 template <>

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -37,7 +37,7 @@ DECLARE_string(tracer_mkldnn_ops_off);
 
 namespace paddle {
 namespace imperative {
-thread_local std::string Tracer::op_python_stack_str_ = "";
+thread_local std::string Tracer::python_stack_ = "";
 
 thread_local bool Tracer::enable_program_desc_tracing_ = false;
 

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -37,6 +37,7 @@ DECLARE_string(tracer_mkldnn_ops_off);
 
 namespace paddle {
 namespace imperative {
+thread_local std::string Tracer::op_python_stack_str_ = "";
 
 thread_local bool Tracer::enable_program_desc_tracing_ = false;
 

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -199,10 +199,8 @@ class Tracer {
     use_layout_autotune_ = false;
     return false;
   }
-  void SetOpPythonStackStr(std::string stack_str) {
-    op_python_stack_str_ = stack_str;
-  }
-  std::string GetOpPythonStackStr() { return op_python_stack_str_; }
+  void SetPythonStack(std::string stack_str) { python_stack_ = stack_str; }
+  std::string GetPythonStack() { return python_stack_; }
   phi::KernelSignature GetExpectedKernelSignature(
       const std::string& type,
       const NameTensorMap& ins,
@@ -218,7 +216,7 @@ class Tracer {
   std::unique_ptr<UniqueNameGenerator> generator_;
   platform::Place expected_place_;
   GarbageCollectorMap gcs_;
-  static thread_local std::string op_python_stack_str_;
+  static thread_local std::string python_stack_;
   static thread_local bool enable_program_desc_tracing_;
   static thread_local bool use_layout_autotune_;
   static thread_local bool has_grad_;

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -199,7 +199,10 @@ class Tracer {
     use_layout_autotune_ = false;
     return false;
   }
-
+  void SetOpPythonStackStr(std::string stack_str) {
+    op_python_stack_str_ = stack_str;
+  }
+  std::string GetOpPythonStackStr() { return op_python_stack_str_; }
   phi::KernelSignature GetExpectedKernelSignature(
       const std::string& type,
       const NameTensorMap& ins,
@@ -215,6 +218,7 @@ class Tracer {
   std::unique_ptr<UniqueNameGenerator> generator_;
   platform::Place expected_place_;
   GarbageCollectorMap gcs_;
+  static thread_local std::string op_python_stack_str_;
   static thread_local bool enable_program_desc_tracing_;
   static thread_local bool use_layout_autotune_;
   static thread_local bool has_grad_;

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -38,6 +38,7 @@ limitations under the License. */
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
+DECLARE_bool(check_nan_inf);
 
 namespace paddle {
 namespace pybind {
@@ -214,6 +215,24 @@ std::string CastPyArg2AttrString(PyObject* obj, ssize_t arg_pos) {
 std::shared_ptr<imperative::VarBase> CastPyArg2VarBase(PyObject* obj,
                                                        ssize_t arg_pos) {
   return py::cast<std::shared_ptr<imperative::VarBase>>(obj);
+}
+
+void SetPythonStack() {
+  if (FLAGS_check_nan_inf) {
+    std::string filename = __FILE__;
+    std::string line = std::to_string(__LINE__);
+    std::string function_name = __FUNCTION__;
+    pybind11::gil_scoped_acquire gil;
+    PyObject* mod = PyImport_ImportModule("traceback");
+    PyObject* traceback_list = PyObject_CallMethod(mod, "format_stack", "");
+    std::string str = "";
+    for (Py_ssize_t i = 0; i < PyList_Size(traceback_list); i++) {
+      PyObject* line = PyList_GetItem(traceback_list, i);
+      str += py::str(PyUnicode_AsUTF8(line));
+    }
+    std::string last = str + egr::Controller::Instance().GetPythonStack();
+    egr::Controller::Instance().SetPythonStack(last);
+  }
 }
 
 std::shared_ptr<jit::Function> CastPyArg2JitFunction(PyObject* obj,

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -219,9 +219,6 @@ std::shared_ptr<imperative::VarBase> CastPyArg2VarBase(PyObject* obj,
 
 void SetPythonStack() {
   if (FLAGS_check_nan_inf) {
-    std::string filename = __FILE__;
-    std::string line = std::to_string(__LINE__);
-    std::string function_name = __FUNCTION__;
     pybind11::gil_scoped_acquire gil;
     PyObject* mod = PyImport_ImportModule("traceback");
     PyObject* traceback_list = PyObject_CallMethod(mod, "format_stack", "");

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -79,6 +79,7 @@ std::vector<std::string> CastPyArg2VectorOfString(PyObject* obj,
                                                   ssize_t arg_pos);
 std::shared_ptr<jit::Function> CastPyArg2JitFunction(PyObject* obj,
                                                      ssize_t arg_pos);
+void SetPythonStack();
 
 PyObject* ToPyObject(int value);
 PyObject* ToPyObject(uint32_t value);

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_backward_stack.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_backward_stack.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import paddle
+
+
+def main():
+    paddle.disable_static()
+    paddle.set_flags({"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 0})
+    cpu_place = paddle.CPUPlace()
+    x = paddle.to_tensor([1, 0.0, 3], stop_gradient=False, place=cpu_place)
+    y = paddle.to_tensor([0.2, 0.0, 0.5], place=cpu_place)
+    z = paddle.pow(x, y)
+    paddle.autograd.backward([z])
+    paddle.enable_static()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_backward_stack.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_backward_stack.py
@@ -17,14 +17,12 @@ import paddle
 
 
 def main():
-    paddle.disable_static()
     paddle.set_flags({"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 0})
     cpu_place = paddle.CPUPlace()
     x = paddle.to_tensor([1, 0.0, 3], stop_gradient=False, place=cpu_place)
     y = paddle.to_tensor([0.2, 0.0, 0.5], place=cpu_place)
     z = paddle.pow(x, y)
     paddle.autograd.backward([z])
-    paddle.enable_static()
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -78,6 +78,13 @@ class TestCheckSkipEnv(TestNanInf):
 
 
 class TestNanInfCheckResult(unittest.TestCase):
+    def setUp(self):
+        self._python_interp = sys.executable
+        if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
+            self._python_interp += " -m coverage run --branch -p"
+
+        self.env = os.environ.copy()
+
     def generate_inputs(self, shape, dtype="float32"):
         data = np.random.random(size=shape).astype(dtype)
         # [-10, 10)
@@ -140,6 +147,25 @@ class TestNanInfCheckResult(unittest.TestCase):
         _check_num_nan_inf(use_cuda=False)
         if paddle.fluid.core.is_compiled_with_cuda():
             _check_num_nan_inf(use_cuda=True)
+
+    def test_check_stack(self):
+        self._python_interp += " check_nan_inf_backward_stack.py"
+        cmd = self._python_interp
+        proc = subprocess.Popen(
+            cmd.split(" "),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+        )
+
+        out, err = proc.communicate()
+        returncode = proc.returncode
+
+        print(out)
+        print(err)
+
+        # in python3, type(out+err) is 'bytes', need use encode
+        assert (out + err).find(b' z = paddle.pow(x, y)') != -1
 
     def check_nan_inf_level(self, use_cuda, dtype):
         shape = [8, 8]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

新增nan_inf检查工具反向op调用栈打印的支持，效果如下：
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/51102941/230844539-7dbbca30-2c0d-406a-a1bc-562d9a72ae0c.png">
