### PR TITLE
remove legacy profiler api from __all__

### DIFF
--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -19,13 +19,7 @@ import sys
 
 from paddle.utils.deprecated import deprecated
 
-__all__ = [
-    'cuda_profiler',
-    'reset_profiler',
-    'profiler',
-    'start_profiler',
-    'stop_profiler',
-]
+__all__ = []
 
 NVPROF_CONFIG = [
     "gpustarttimestamp",

--- a/python/paddle/utils/profiler.py
+++ b/python/paddle/utils/profiler.py
@@ -21,16 +21,7 @@ from ..fluid.profiler import profiler  # noqa: F401
 from ..fluid.profiler import reset_profiler, start_profiler, stop_profiler
 from .deprecated import deprecated
 
-__all__ = [  # noqa
-    'Profiler',
-    'get_profiler',
-    'ProfilerOptions',
-    'cuda_profiler',
-    'start_profiler',
-    'profiler',
-    'stop_profiler',
-    'reset_profiler',
-]
+__all__ = []
 
 
 @deprecated(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Pcard-67005

Remove `paddle.utils.profiler.*` from public api list `__all__`.
In version 2.5, code of these apis will be removed.