### PR TITLE
[StandaloneExe] add strategy force_sequential_run

### DIFF
--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -270,7 +270,8 @@ inline std::ostream &operator<<(std::ostream &os,
   os << "fuse_gemm_epilogue_: " << strategy.fuse_gemm_epilogue_ << std::endl;
   os << "fused_attention_: " << strategy.fused_attention_ << std::endl;
   os << "fused_feedforward_: " << strategy.fused_feedforward_ << std::endl;
-  os << "fused_feedforward_: " << strategy.force_sequential_run_ << std::endl;
+  os << "force_sequential_run_: " << strategy.force_sequential_run_
+     << std::endl;
   os << "mkldnn_enabled_op_types_: ";
   for (auto str : strategy.mkldnn_enabled_op_types_) {
     os << str << ", ";

--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -135,6 +135,7 @@ struct BuildStrategy {
   bool fuse_adamw_{false};
   // Fused feed forward
   bool fused_feedforward_{false};
+  bool force_sequential_run{false};
 
   // mkldnn_enabled_op_types specify the operator type list to
   // use MKLDNN acceleration. It is null in default, means
@@ -269,6 +270,7 @@ inline std::ostream &operator<<(std::ostream &os,
   os << "fuse_gemm_epilogue_: " << strategy.fuse_gemm_epilogue_ << std::endl;
   os << "fused_attention_: " << strategy.fused_attention_ << std::endl;
   os << "fused_feedforward_: " << strategy.fused_feedforward_ << std::endl;
+  os << "fused_feedforward_: " << strategy.force_sequential_run << std::endl;
   os << "mkldnn_enabled_op_types_: ";
   for (auto str : strategy.mkldnn_enabled_op_types_) {
     os << str << ", ";

--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -135,7 +135,7 @@ struct BuildStrategy {
   bool fuse_adamw_{false};
   // Fused feed forward
   bool fused_feedforward_{false};
-  bool force_sequential_run{false};
+  bool force_sequential_run_{false};
 
   // mkldnn_enabled_op_types specify the operator type list to
   // use MKLDNN acceleration. It is null in default, means
@@ -270,7 +270,7 @@ inline std::ostream &operator<<(std::ostream &os,
   os << "fuse_gemm_epilogue_: " << strategy.fuse_gemm_epilogue_ << std::endl;
   os << "fused_attention_: " << strategy.fused_attention_ << std::endl;
   os << "fused_feedforward_: " << strategy.fused_feedforward_ << std::endl;
-  os << "fused_feedforward_: " << strategy.force_sequential_run << std::endl;
+  os << "fused_feedforward_: " << strategy.force_sequential_run_ << std::endl;
   os << "mkldnn_enabled_op_types_: ";
   for (auto str : strategy.mkldnn_enabled_op_types_) {
     os << str << ", ";

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -126,7 +126,6 @@ message BuildStrategy {
   optional string debug_graphviz_path = 17;
   optional bool fused_attention = 18 [ default = false];
   optional bool fused_feedforward = 19 [ default = false];
-  optional bool force_sequential_run = 20 [ default = false];
 }
 
 message ExecutionStrategy {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -126,6 +126,7 @@ message BuildStrategy {
   optional string debug_graphviz_path = 17;
   optional bool fused_attention = 18 [ default = false];
   optional bool fused_feedforward = 19 [ default = false];
+  optional bool force_sequential_run = 20 [ default = false];
 }
 
 message ExecutionStrategy {

--- a/paddle/fluid/pybind/parallel_executor.cc
+++ b/paddle/fluid/pybind/parallel_executor.cc
@@ -760,6 +760,31 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
                         build_strategy.fused_feedforward = True
                      )DOC")
       .def_property(
+          "force_sequential_run",
+          [](const BuildStrategy &self) { return self.force_sequential_run_; },
+          [](BuildStrategy &self, bool b) {
+            PADDLE_ENFORCE_NE(self.IsFinalized(),
+                              true,
+                              platform::errors::PreconditionNotMet(
+                                  "BuildStrategy has been finlaized, cannot be "
+                                  "configured again."));
+            self.force_sequential_run_ = b;
+          },
+          R"DOC((bool, optional): force_sequential_run is used to let the `StandaloneExecutor` run ops by the
+          order of `ProgramDesc`. Default is False.
+
+                Examples:
+                    .. code-block:: python
+
+                        import paddle
+                        import paddle.static as static
+
+                        paddle.enable_static()
+
+                        build_strategy = static.BuildStrategy()
+                        build_strategy.fused_feedforward = True
+                     )DOC")
+      .def_property(
           "fuse_bn_act_ops",
           [](const BuildStrategy &self) { return self.fuse_bn_act_ops_; },
           [](BuildStrategy &self, bool b) {

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1619,7 +1619,10 @@ class Executor:
                     else program._graph
                 )
                 build_strategy = compiled_program._build_strategy
-                if build_strategy.force_sequential_run:
+                if (
+                    build_strategy is not None
+                    and build_strategy.force_sequential_run
+                ):
                     schedule_flag = [
                         'FLAGS_new_executor_serial_run',
                         'FLAGS_new_executor_sequential_run',

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1609,16 +1609,6 @@ class Executor:
                 )
             feed = self._update_feed(program, feed)
 
-            program, new_exe = self._executor_cache.get_program_and_executor(
-                program,
-                feed,
-                fetch_list,
-                feed_var_name,
-                fetch_var_name,
-                self.place,
-                scope,
-            )
-
             stored_flag = {}
             if isinstance(program, compiler.CompiledProgram) or isinstance(
                 program._graph, compiler.CompiledProgram
@@ -1631,11 +1621,26 @@ class Executor:
                 build_strategy = compiled_program._build_strategy
                 if build_strategy.force_sequential_run:
                     schedule_flag = [
-                        "FLAGS_new_executor_serial_run",
-                        "FLAGS_new_executor_sequential_run",
+                        'FLAGS_new_executor_serial_run',
+                        'FLAGS_new_executor_sequential_run',
                     ]
-                    stored_flag = {f: os.getenv(f, None) for f in schedule_flag}
-                    set_flags({f: "true" for f in schedule_flag})
+                    for flag in schedule_flag:
+                        value = os.getenv(flag, False)
+                        if isinstance(value, str):
+                            value = value.lower()
+                            value = True if value == 'true' else False
+                        stored_flag[flag] = bool(value)
+                    set_flags({f: True for f in schedule_flag})
+
+            program, new_exe = self._executor_cache.get_program_and_executor(
+                program,
+                feed,
+                fetch_list,
+                feed_var_name,
+                fetch_var_name,
+                self.place,
+                scope,
+            )
 
             self._feed_data(program, feed, feed_var_name, scope)
             if hasattr(program, 'lr_scheduler'):

--- a/test/standalone_executor/test_standalone_sequentail_run.py
+++ b/test/standalone_executor/test_standalone_sequentail_run.py
@@ -20,12 +20,6 @@ import paddle
 
 
 class TestStandaloneExecutor(unittest.TestCase):
-    def setUp(self):
-        seed = 100
-
-        paddle.seed(seed)
-        np.random.seed(seed)
-
     def build_program(self):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
@@ -38,6 +32,9 @@ class TestStandaloneExecutor(unittest.TestCase):
         return main_program, startup_program, [c]
 
     def run_program(self, force_sequential_run=False):
+        seed = 100
+        paddle.seed(seed)
+        np.random.seed(seed)
         main, startup, outs = self.build_program()
         build_strategy = paddle.static.BuildStrategy()
         build_strategy.force_sequential_run = force_sequential_run

--- a/test/standalone_executor/test_standalone_sequentail_run.py
+++ b/test/standalone_executor/test_standalone_sequentail_run.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestStandaloneExecutor(unittest.TestCase):
+    def setUp(self):
+        seed = 100
+
+        paddle.seed(seed)
+        np.random.seed(seed)
+
+    def build_program(self):
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            a = paddle.static.data(name="data", shape=[2, 2], dtype='float32')
+            b = paddle.ones([2, 2]) * 2
+            t = paddle.static.nn.fc(a, 2)
+            c = t + b
+
+        return main_program, startup_program, [c]
+
+    def run_program(self, force_sequential_run=False):
+        main, startup, outs = self.build_program()
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.force_sequential_run = force_sequential_run
+        compiled_program = paddle.static.CompiledProgram(
+            main, build_strategy=build_strategy
+        )
+
+        exe = paddle.static.Executor()
+        scope = paddle.static.Scope()
+        with paddle.static.scope_guard(scope):
+            exe.run(startup)
+            data = np.ones([2, 2], dtype="float32")
+            ret = exe.run(
+                compiled_program,
+                feed={"data": data},
+                fetch_list=[v.name for v in outs],
+            )
+            return ret
+
+    def test_result(self):
+        paddle.enable_static()
+        ret1 = self.run_program(True)
+        ret2 = self.run_program(False)
+        np.testing.assert_array_equal(ret1, ret2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add a new `BuildStrategy`: `force_sequential_run`, which will let the operations run by the order in the `Program`.

#### Other
Pcard-67004