### PR TITLE
fix cuda compile error

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -58,7 +58,8 @@ function(detect_installed_gpus out_variable)
       "}\n")
 
     execute_process(
-      COMMAND "${CUDA_NVCC_EXECUTABLE}" "--run" "${cufile}"
+      COMMAND "${CUDA_NVCC_EXECUTABLE}" "-ccbin=${CMAKE_C_COMPILER}" "--run"
+              "${cufile}"
       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles/"
       RESULT_VARIABLE nvcc_res
       OUTPUT_VARIABLE nvcc_out


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-67010
修复QA发版切换ninja编译报错的bug，主要是因为cmake在运行AutoDetectCuda文件时需要通过-ccbin指定host编译器所在路径 
![686467c09150f4903c2772aa598d3468](https://user-images.githubusercontent.com/62429225/230887149-2d4000e5-9b74-4dbf-ad75-faaec1e68a1e.png)

