### PR TITLE
use functools.wraps to restore paddle.grad parameter hint in IDE

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -609,7 +609,7 @@ dygraph_not_support = wrap_decorator(_dygraph_not_support_)
 dygraph_only = wrap_decorator(_dygraph_only_)
 static_only = wrap_decorator(_static_only_)
 fake_interface_only = wrap_decorator(_fake_interface_only_)
-non_static_only = wrap_decorator(_non_static_only_)
+non_static_only = functools.wraps(wrap_decorator(_non_static_only_))
 
 
 def _dygraph_tracer():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs 

### Describe
1. Fix no parameter hints in vscode when using `paddle.grad`

  before
  ![image](https://user-images.githubusercontent.com/23737287/230709944-1b2f19b1-fc53-4740-9187-c42948150749.png)
  after
  ![image](https://user-images.githubusercontent.com/23737287/230709931-fa31ff06-1bbf-4e3a-9ebe-88b6e91de9d9.png)
