### PR TITLE
delete reduce_all from any_raw

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_any_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_any_op.cc
@@ -30,7 +30,7 @@ class OpBase;
 
 DECLARE_INFER_SHAPE_FUNCTOR(reduce_any,
                             ReduceAnyInferShapeFunctor,
-                            PD_INFER_META(phi::ReduceInferMetaBase));
+                            PD_INFER_META(phi::ReduceInferMeta));
 
 class ReduceAnyOpMaker : public ops::ReduceBaseOpMaker {
  protected:

--- a/paddle/phi/kernels/cpu/reduce_any_kernel.cc
+++ b/paddle/phi/kernels/cpu/reduce_any_kernel.cc
@@ -26,9 +26,8 @@ void AnyRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const std::vector<int64_t>& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   phi::BoolReduceKernel<CPUContext, T, phi::funcs::AnyFunctor>(
       dev_ctx, x, dims, keep_dim, reduce_all, out);
 }

--- a/paddle/phi/kernels/kps/reduce_any_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_any_kernel.cu
@@ -23,9 +23,8 @@ void AnyRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const std::vector<int64_t>& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::LogicalOrFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/reduce_any_kernel.cc
+++ b/paddle/phi/kernels/reduce_any_kernel.cc
@@ -25,8 +25,7 @@ void AnyKernel(const Context& dev_ctx,
                const std::vector<int64_t>& dims,
                bool keep_dim,
                DenseTensor* out) {
-  bool reduce_all = recompute_reduce_all(x, dims);
-  AnyRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, out);
+  AnyRawKernel<T>(dev_ctx, x, dims, keep_dim, out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/reduce_any_kernel.h
+++ b/paddle/phi/kernels/reduce_any_kernel.h
@@ -22,7 +22,6 @@ void AnyRawKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   const std::vector<int64_t>& dims,
                   bool keep_dim,
-                  bool reduce_all,
                   DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/ops/compat/reduce_sig.cc
+++ b/paddle/phi/ops/compat/reduce_sig.cc
@@ -133,15 +133,6 @@ KernelSignature ReduceAMinOpArgumentMapping(const ArgumentMappingContext& ctx) {
 
 KernelSignature ReduceAnyOpArgumentMapping(const ArgumentMappingContext& ctx) {
   if (ctx.IsDenseTensorInput("X")) {
-    bool reduce_all = paddle::any_cast<bool>(ctx.Attr("reduce_all"));
-    // When ctx is InferShapeArgumentMappingContext, the reduce_all is used in
-    // InferShape, so we must return the "any_raw" KernelSignature.
-    // And the InferMeta function(i.e. ReduceInferMetaBase) is accordance with
-    // the "any_raw" KernelSignature
-    if (ctx.IsForInferShape() || reduce_all) {
-      return KernelSignature(
-          "any_raw", {"X"}, {"dim", "keep_dim", "reduce_all"}, {"Out"});
-    }
     return KernelSignature("any", {"X"}, {"dim", "keep_dim"}, {"Out"});
   }
   return KernelSignature("unregistered", {}, {}, {});

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -627,7 +627,6 @@ class TestAnyOp(OpTest):
         self.python_api = paddle.any
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
         self.outputs = {'Out': self.inputs['X'].any()}
-        self.attrs = {'reduce_all': True}
 
     def test_check_output(self):
         self.check_output()
@@ -639,7 +638,7 @@ class TestAnyOp_ZeroDim(OpTest):
         self.op_type = "reduce_any"
         self.inputs = {'X': np.random.randint(0, 2, []).astype("bool")}
         self.outputs = {'Out': self.inputs['X'].any()}
-        self.attrs = {'dim': [], 'reduce_all': True}
+        self.attrs = {'dim': []}
 
     def test_check_output(self):
         self.check_output()
@@ -654,7 +653,7 @@ class TestAny8DOp(OpTest):
                 "bool"
             )
         }
-        self.attrs = {'reduce_all': True, 'dim': (3, 5, 4)}
+        self.attrs = {'dim': (3, 5, 4)}
         self.outputs = {'Out': self.inputs['X'].any(axis=self.attrs['dim'])}
 
     def test_check_output(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
reduce_all只有在dims参数为空或者长度与输入x的维度相同时值为true,因此删除输入的reduce_all后依旧可以通过dims参数来推导相应的参数值从理论上看Kernel可以无风险删除 reduce_all 参数