### PR TITLE
in memory efficient attention, dropout prob must be zero when attn_bias is not none

### DIFF
--- a/python/paddle/incubate/nn/memory_efficient_attention.py
+++ b/python/paddle/incubate/nn/memory_efficient_attention.py
@@ -71,6 +71,8 @@ def memory_efficient_attention(
     query, key, value, attn_bias=None, p=0.0, scale=None, training=True
 ):
     assert type(attn_bias) in SUPPORTED_ATTN_BIAS_TYPES
+    if attn_bias is not None:
+        assert p == 0.0
     causal = isinstance(
         attn_bias,
         (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Describe
attn bias should not be specified with p=0
