### PR TITLE
delete reduce_all from frobenius_norm

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -476,8 +476,8 @@
     func : fmin_grad
 
 - backward_op : frobenius_norm_grad
-  forward : frobenius_norm(Tensor x, int64_t[] axis,  bool keep_dim,  bool reduce_all) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis,  bool keep_dim,  bool reduce_all)
+  forward : frobenius_norm(Tensor x, int64_t[] axis,  bool keep_dim) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, int64_t[] axis,  bool keep_dim)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -607,7 +607,7 @@
   args : (Tensor x, int64_t[] axis,  bool keep_dim)
   output : Tensor(out)
   infer_meta :
-    func : ReduceInferMetaBase
+    func : ReduceInferMeta
   kernel :
     func : frobenius_norm
   backward : frobenius_norm_grad

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -604,7 +604,7 @@
   backward : fmin_grad
 
 - op : frobenius_norm
-  args : (Tensor x, int64_t[] axis,  bool keep_dim,  bool reduce_all)
+  args : (Tensor x, int64_t[] axis,  bool keep_dim)
   output : Tensor(out)
   infer_meta :
     func : ReduceInferMetaBase

--- a/paddle/phi/api/yaml/static_backward.yaml
+++ b/paddle/phi/api/yaml/static_backward.yaml
@@ -23,12 +23,12 @@
   no_need_buffer : weight
 
 - backward_op : frobenius_norm_grad
-  forward: frobenius_norm (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1) -> Tensor(out)
-  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1)
+  forward: frobenius_norm (Tensor x, IntArray axis={0}, bool keepdim=false, int in_dtype=-1, int out_dtype=-1) -> Tensor(out)
+  args : (Tensor x, Tensor out, Tensor out_grad, IntArray axis={0}, bool keepdim=false, int in_dtype=-1, int out_dtype=-1)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
     param : [x]
   kernel :
     func : frobenius_norm_grad
-    param : [x, out, out_grad, axis, keepdim, reduce_all]
+    param : [x, out, out_grad, axis, keepdim]

--- a/paddle/phi/api/yaml/static_ops.yaml
+++ b/paddle/phi/api/yaml/static_ops.yaml
@@ -126,13 +126,13 @@
     data_type : dtype
 
 - op : frobenius_norm
-  args : (Tensor x, IntArray axis={0}, bool keepdim=false, bool reduce_all=false, int in_dtype=-1, int out_dtype=-1)
+  args : (Tensor x, IntArray axis={0}, bool keepdim=false, int in_dtype=-1, int out_dtype=-1)
   output : Tensor(out)
   infer_meta :
-    func : ReduceInferMetaBase
+    func : ReduceInferMeta
   kernel :
     func : frobenius_norm
-    param : [x, axis, keepdim, reduce_all]
+    param : [x, axis, keepdim]
   backward : frobenius_norm_grad
 
 - op : gaussian

--- a/paddle/phi/kernels/frobenius_norm_grad_kernel.h
+++ b/paddle/phi/kernels/frobenius_norm_grad_kernel.h
@@ -27,6 +27,5 @@ void FrobeniusNormGradKernel(const Context& ctx,
                              const DenseTensor& dout,
                              const std::vector<int64_t>& axis,
                              bool keep_dim,
-                             bool reduce_all,
                              DenseTensor* dx);
 }  // namespace phi

--- a/paddle/phi/kernels/frobenius_norm_kernel.h
+++ b/paddle/phi/kernels/frobenius_norm_kernel.h
@@ -25,7 +25,6 @@ void FrobeniusNormKernel(const Context& ctx,
                          const DenseTensor& x,
                          const std::vector<int64_t>& axis,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* out);
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/frobenius_norm_kernel.cu
@@ -24,9 +24,8 @@ void FrobeniusNormKernel(const Context& dev_ctx,
                          const DenseTensor& x,
                          const std::vector<int64_t>& dims,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, dims);
   auto out_dtype = x.dtype();
   phi::Reduce<T, kps::AddFunctor, kps::SquareFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);

--- a/paddle/phi/kernels/impl/frobenius_norm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frobenius_norm_grad_kernel_impl.h
@@ -27,9 +27,8 @@ void FrobeniusNormGradKernel(const Context& ctx,
                              const DenseTensor& dout,
                              const std::vector<int64_t>& axis,
                              bool keep_dim,
-                             bool reduce_all,
                              DenseTensor* dx) {
-  reduce_all = recompute_reduce_all(x, axis, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, axis);
   ReduceGradKernel<Context, T, funcs::FrobeniusNormGradFunctor>(
       ctx, x, out, dout, axis, keep_dim, reduce_all, dx);
 }

--- a/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/frobenius_norm_kernel_impl.h
@@ -25,9 +25,8 @@ void FrobeniusNormKernel(const Context& ctx,
                          const DenseTensor& x,
                          const std::vector<int64_t>& axis,
                          bool keep_dim,
-                         bool reduce_all,
                          DenseTensor* out) {
-  reduce_all = recompute_reduce_all(x, axis, reduce_all);
+  bool reduce_all = recompute_reduce_all(x, axis);
   Reduce<Context, T, funcs::FrobeniusNormFunctor>(
       ctx, x, reduce_all, axis, keep_dim, x.dtype(), out);
 }

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -145,7 +145,6 @@ special_op_attrs = {
     "amax": [{"reduce_all": False}],
     "amin": [{"reduce_all": False}],
     "any": [{"reduce_all": False}],
-    "frobenius_norm": [{"reduce_all": False}],
     "logsumexp": [{"reduce_all": False}],
     "reduce_max": [{"reduce_all": False}],
     "reduce_min": [{"reduce_all": False}],

--- a/python/paddle/fluid/tests/unittests/test_norm_all.py
+++ b/python/paddle/fluid/tests/unittests/test_norm_all.py
@@ -80,7 +80,7 @@ def numpy_frobenius_norm(x, axis=None, keepdims=False):
     return r
 
 
-def frobenius_norm(x, dim, keep_dim, reduce_all):
+def frobenius_norm(x, dim, keep_dim):
     return paddle.linalg.norm(x, p='fro', axis=dim, keepdim=keep_dim)
 
 

--- a/python/paddle/fluid/tests/unittests/test_norm_all.py
+++ b/python/paddle/fluid/tests/unittests/test_norm_all.py
@@ -92,12 +92,10 @@ class TestFrobeniusNormOp(OpTest):
         self.init_dtype()
         x = (np.random.random(self.shape) + 1.0).astype(self.dtype)
         norm = numpy_frobenius_norm(x, self.axis, self.keepdim)
-        self.reduce_all = len(self.axis) == len(self.shape)
         self.inputs = {'X': x}
         self.attrs = {
             'dim': list(self.axis),
             'keep_dim': self.keepdim,
-            'reduce_all': self.reduce_all,
         }
         self.outputs = {'Out': norm}
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -369,11 +369,9 @@ def norm(x, p='fro', axis=None, keepdim=False, name=None):
             )
 
         if in_dygraph_mode():
-            if dim is None:
-                return _C_ops.frobenius_norm(input, [], keepdim, True)
             return _C_ops.frobenius_norm(input, dim, keepdim, False)
         else:
-            attrs = {'dim': dim, 'keep_dim': keepdim, 'reduce_all': False}
+            attrs = {'dim': dim, 'keep_dim': keepdim}
             if dim is None:
                 attrs['reduce_all'] = True
             check_variable_and_dtype(

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -369,11 +369,9 @@ def norm(x, p='fro', axis=None, keepdim=False, name=None):
             )
 
         if in_dygraph_mode():
-            return _C_ops.frobenius_norm(input, dim, keepdim, False)
+            return _C_ops.frobenius_norm(input, dim, keepdim)
         else:
             attrs = {'dim': dim, 'keep_dim': keepdim}
-            if dim is None:
-                attrs['reduce_all'] = True
             check_variable_and_dtype(
                 input, 'input', ['float32', 'float64'], 'frobenius_norm'
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
reduce_all只有在dims参数为空或者长度与输入x的维度相同时值为true,因此删除输入的reduce_all后依旧可以通过dims参数来推导相应的参数值从理论上看Kernel可以无风险删除 reduce_all 参数