### PR TITLE
Delete the keyword WITH_ASCEND_INT64 in configure.cmake and CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,6 @@ option(NEW_RELEASE_ALL
        OFF)
 option(NEW_RELEASE_JIT
        "PaddlePaddle next-level release strategy for backup jit package" OFF)
-option(WITH_ASCEND_INT64 "Compile with int64 kernel for ascend NPU" OFF)
 option(WITH_POCKETFFT "Compile with pocketfft support" ON)
 option(WITH_RECORD_BUILDTIME
        "Compile PaddlePaddle with record all targets build time" OFF)

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -93,6 +93,10 @@ if(WITH_BOX_PS)
   add_definitions(-DPADDLE_WITH_BOX_PS)
 endif()
 
+if(WITH_ASCEND)
+  add_definitions(-DPADDLE_WITH_ASCEND)
+endif()
+
 if(WITH_XPU)
   message(STATUS "Compile with XPU!")
   add_definitions(-DPADDLE_WITH_XPU)

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -93,10 +93,6 @@ if(WITH_BOX_PS)
   add_definitions(-DPADDLE_WITH_BOX_PS)
 endif()
 
-if(WITH_ASCEND_INT64)
-  add_definitions(-DPADDLE_WITH_ASCEND_INT64)
-endif()
-
 if(WITH_XPU)
   message(STATUS "Compile with XPU!")
   add_definitions(-DPADDLE_WITH_XPU)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#52319 