### PR TITLE
[CustomOP Unittest] Polish unit test of custom operator, kCPU->CPU

### DIFF
--- a/test/custom_op/attr_test_op.cc
+++ b/test/custom_op/attr_test_op.cc
@@ -132,7 +132,7 @@ std::vector<paddle::Tensor> AttrTestForward(
     std::vector<float> float_vec_attr,
     std::vector<int64_t> int64_vec_attr,
     std::vector<std::string> str_vec_attr) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -173,7 +173,7 @@ std::vector<paddle::Tensor> AttrTestBackward(
     int int_attr,
     const std::vector<float>& float_vec_attr,
     const std::vector<std::string>& str_vec_attr) {
-  auto grad_x = paddle::Tensor(paddle::PlaceType::kCPU, grad_out.shape());
+  auto grad_x = paddle::empty_like(grad_out);
 
   PD_DISPATCH_FLOATING_TYPES(grad_out.type(), "assign_cpu_kernel", ([&] {
                                assign_cpu_kernel<data_t>(
@@ -198,7 +198,7 @@ std::vector<paddle::Tensor> ConstAttrTestForward(
     const std::vector<float>& float_vec_attr,
     const std::vector<int64_t>& int64_vec_attr,
     const std::vector<std::string>& str_vec_attr) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -239,7 +239,7 @@ std::vector<paddle::Tensor> ConstAttrTestBackward(
     const int& int_attr,
     const std::vector<float>& float_vec_attr,
     const std::vector<std::string>& str_vec_attr) {
-  auto grad_x = paddle::Tensor(paddle::PlaceType::kCPU, grad_out.shape());
+  auto grad_x = paddle::empty_like(grad_out);
 
   PD_DISPATCH_FLOATING_TYPES(grad_out.type(), "assign_cpu_kernel", ([&] {
                                assign_cpu_kernel<data_t>(

--- a/test/custom_op/context_pool_test_op.cc
+++ b/test/custom_op/context_pool_test_op.cc
@@ -17,9 +17,7 @@
 #include "paddle/extension.h"
 #include "paddle/phi/backends/context_pool.h"
 
-#define CHECK_INPUT(x)                                         \
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
-           #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
 
 std::vector<paddle::Tensor> ContextPoolTest(const paddle::Tensor& x) {
   // 1. test cpu context

--- a/test/custom_op/context_pool_test_op.cc
+++ b/test/custom_op/context_pool_test_op.cc
@@ -17,8 +17,9 @@
 #include "paddle/extension.h"
 #include "paddle/phi/backends/context_pool.h"
 
-#define CHECK_INPUT(x) \
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x)                                         \
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
+           #x " must be a CPU Tensor.")
 
 std::vector<paddle::Tensor> ContextPoolTest(const paddle::Tensor& x) {
   // 1. test cpu context

--- a/test/custom_op/custom_concat_op.cc
+++ b/test/custom_op/custom_concat_op.cc
@@ -17,8 +17,9 @@
 #include "concat_and_split.h"  // NOLINT
 #include "paddle/extension.h"
 
-#define CHECK_INPUT(x) \
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x)                                         \
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
+           #x " must be a CPU Tensor.")
 
 int64_t ComputeAxis(int64_t axis, int64_t rank) {
   PD_CHECK(axis >= -rank && axis < rank,

--- a/test/custom_op/custom_concat_op.cc
+++ b/test/custom_op/custom_concat_op.cc
@@ -17,9 +17,7 @@
 #include "concat_and_split.h"  // NOLINT
 #include "paddle/extension.h"
 
-#define CHECK_INPUT(x)                                         \
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
-           #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
 
 int64_t ComputeAxis(int64_t axis, int64_t rank) {
   PD_CHECK(axis >= -rank && axis < rank,

--- a/test/custom_op/custom_conj_op.cc
+++ b/test/custom_op/custom_conj_op.cc
@@ -18,8 +18,9 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_INPUT(x) \
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x)                                         \
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
+           #x " must be a CPU Tensor.")
 
 template <typename data_t>
 using EnableComplex = typename std::enable_if<

--- a/test/custom_op/custom_conj_op.cc
+++ b/test/custom_op/custom_conj_op.cc
@@ -18,9 +18,7 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_INPUT(x)                                         \
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
-           #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
 
 template <typename data_t>
 using EnableComplex = typename std::enable_if<

--- a/test/custom_op/custom_inplace.cc
+++ b/test/custom_op/custom_inplace.cc
@@ -52,7 +52,8 @@ void relu_backward_kernel(const data_t* out_data,
 }
 
 void AddForward(paddle::Tensor& x, const paddle::Tensor& y) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "AddForward", ([&] {
@@ -63,8 +64,10 @@ void AddForward(paddle::Tensor& x, const paddle::Tensor& y) {  // NOLINT
 std::vector<paddle::Tensor> AddBackward(const paddle::Tensor& x,
                                         const paddle::Tensor& y,
                                         paddle::Tensor& out_grad) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
-  PD_CHECK(y.place() == paddle::PlaceType::kCPU, "y must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
+  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
+           "y must be a CPU Tensor.");
 
   paddle::Tensor y_grad = paddle::empty(x.shape(), x.dtype(), x.place());
 
@@ -92,7 +95,8 @@ PD_BUILD_GRAD_OP(custom_add)
 // out[i] = x[i] + y
 void AddVectorForward(std::vector<paddle::Tensor>& x,  // NOLINT
                       const paddle::Tensor& y) {
-  PD_CHECK(y.place() == paddle::PlaceType::kCPU, "y must be a CPU Tensor.");
+  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
+           "y must be a CPU Tensor.");
 
   PD_DISPATCH_FLOATING_TYPES(y.type(), "AddVectorForward", ([&] {
                                for (size_t i = 0; i < x.size(); ++i) {
@@ -109,9 +113,10 @@ std::vector<paddle::Tensor> AddVectorBackward(
     const std::vector<paddle::Tensor>& x,
     const paddle::Tensor& y,
     std::vector<paddle::Tensor>& out_grad) {  // NOLINT
-  PD_CHECK(x[0].place() == paddle::PlaceType::kCPU,
+  PD_CHECK(x[0].place().GetType() == paddle::AllocationType::CPU,
            "x[0] must be a CPU Tensor.");
-  PD_CHECK(y.place() == paddle::PlaceType::kCPU, "y must be a CPU Tensor.");
+  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
+           "y must be a CPU Tensor.");
   PD_CHECK(x.size() == out_grad.size(),
            "x must have the same size as out_grad.");
 
@@ -145,8 +150,10 @@ void MultiInplaceForward(paddle::Tensor& x,  // NOLINT
                          const paddle::Tensor& y,
                          paddle::Tensor& a,  // NOLINT
                          const paddle::Tensor& b) {
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
-  PD_CHECK(a.place() == paddle::PlaceType::kCPU, "a must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
+  PD_CHECK(a.place().GetType() == paddle::AllocationType::CPU,
+           "a must be a CPU Tensor.");
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "MultiInplaceForward", ([&] {
@@ -162,10 +169,14 @@ std::vector<paddle::Tensor> MultiInplaceBackward(
     const paddle::Tensor& a,
     const paddle::Tensor& b,
     paddle::Tensor& outab_grad) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
-  PD_CHECK(y.place() == paddle::PlaceType::kCPU, "y must be a CPU Tensor.");
-  PD_CHECK(a.place() == paddle::PlaceType::kCPU, "a must be a CPU Tensor.");
-  PD_CHECK(b.place() == paddle::PlaceType::kCPU, "b must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
+  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
+           "y must be a CPU Tensor.");
+  PD_CHECK(a.place().GetType() == paddle::AllocationType::CPU,
+           "a must be a CPU Tensor.");
+  PD_CHECK(b.place().GetType() == paddle::AllocationType::CPU,
+           "b must be a CPU Tensor.");
 
   paddle::Tensor y_grad = paddle::empty(x.shape(), x.dtype(), x.place());
   paddle::Tensor b_grad = paddle::empty(a.shape(), a.dtype(), a.place());
@@ -200,7 +211,8 @@ PD_BUILD_GRAD_OP(custom_multi_inplace)
     .SetKernelFn(PD_KERNEL(MultiInplaceBackward));
 
 void ReluForwardInplace(paddle::Tensor& x) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
 
   PD_DISPATCH_FLOATING_TYPES(x.type(), "ReluForward", ([&] {
                                relu_forward_kernel<data_t>(x.data<data_t>(),
@@ -211,7 +223,8 @@ void ReluForwardInplace(paddle::Tensor& x) {  // NOLINT
 void ReluBackwardInplace(const paddle::Tensor& x,
                          const paddle::Tensor& out,
                          paddle::Tensor& grad_out) {  // NOLINT
-  PD_CHECK(out.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(out.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
 
   PD_DISPATCH_FLOATING_TYPES(
       grad_out.type(), "ReluBackward", ([&] {

--- a/test/custom_op/custom_inplace.cc
+++ b/test/custom_op/custom_inplace.cc
@@ -18,6 +18,8 @@
 
 #include "paddle/extension.h"
 
+#define CHECK_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
+
 template <typename data_t>
 void add_data_pointer(const data_t* x_data, data_t* out_data, int64_t numel) {
   for (size_t i = 0; i < numel; ++i) {
@@ -52,8 +54,7 @@ void relu_backward_kernel(const data_t* out_data,
 }
 
 void AddForward(paddle::Tensor& x, const paddle::Tensor& y) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "AddForward", ([&] {
@@ -64,10 +65,8 @@ void AddForward(paddle::Tensor& x, const paddle::Tensor& y) {  // NOLINT
 std::vector<paddle::Tensor> AddBackward(const paddle::Tensor& x,
                                         const paddle::Tensor& y,
                                         paddle::Tensor& out_grad) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
-  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
-           "y must be a CPU Tensor.");
+  CHECK_INPUT(x);
+  CHECK_INPUT(y);
 
   paddle::Tensor y_grad = paddle::empty(x.shape(), x.dtype(), x.place());
 
@@ -95,8 +94,7 @@ PD_BUILD_GRAD_OP(custom_add)
 // out[i] = x[i] + y
 void AddVectorForward(std::vector<paddle::Tensor>& x,  // NOLINT
                       const paddle::Tensor& y) {
-  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
-           "y must be a CPU Tensor.");
+  CHECK_INPUT(y);
 
   PD_DISPATCH_FLOATING_TYPES(y.type(), "AddVectorForward", ([&] {
                                for (size_t i = 0; i < x.size(); ++i) {
@@ -113,10 +111,8 @@ std::vector<paddle::Tensor> AddVectorBackward(
     const std::vector<paddle::Tensor>& x,
     const paddle::Tensor& y,
     std::vector<paddle::Tensor>& out_grad) {  // NOLINT
-  PD_CHECK(x[0].place().GetType() == paddle::AllocationType::CPU,
-           "x[0] must be a CPU Tensor.");
-  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
-           "y must be a CPU Tensor.");
+  CHECK_INPUT(x[0]);
+  CHECK_INPUT(y);
   PD_CHECK(x.size() == out_grad.size(),
            "x must have the same size as out_grad.");
 
@@ -150,10 +146,8 @@ void MultiInplaceForward(paddle::Tensor& x,  // NOLINT
                          const paddle::Tensor& y,
                          paddle::Tensor& a,  // NOLINT
                          const paddle::Tensor& b) {
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
-  PD_CHECK(a.place().GetType() == paddle::AllocationType::CPU,
-           "a must be a CPU Tensor.");
+  CHECK_INPUT(x);
+  CHECK_INPUT(a);
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "MultiInplaceForward", ([&] {
@@ -169,14 +163,10 @@ std::vector<paddle::Tensor> MultiInplaceBackward(
     const paddle::Tensor& a,
     const paddle::Tensor& b,
     paddle::Tensor& outab_grad) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
-  PD_CHECK(y.place().GetType() == paddle::AllocationType::CPU,
-           "y must be a CPU Tensor.");
-  PD_CHECK(a.place().GetType() == paddle::AllocationType::CPU,
-           "a must be a CPU Tensor.");
-  PD_CHECK(b.place().GetType() == paddle::AllocationType::CPU,
-           "b must be a CPU Tensor.");
+  CHECK_INPUT(x);
+  CHECK_INPUT(y);
+  CHECK_INPUT(a);
+  CHECK_INPUT(b);
 
   paddle::Tensor y_grad = paddle::empty(x.shape(), x.dtype(), x.place());
   paddle::Tensor b_grad = paddle::empty(a.shape(), a.dtype(), a.place());
@@ -211,8 +201,7 @@ PD_BUILD_GRAD_OP(custom_multi_inplace)
     .SetKernelFn(PD_KERNEL(MultiInplaceBackward));
 
 void ReluForwardInplace(paddle::Tensor& x) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
 
   PD_DISPATCH_FLOATING_TYPES(x.type(), "ReluForward", ([&] {
                                relu_forward_kernel<data_t>(x.data<data_t>(),
@@ -223,8 +212,7 @@ void ReluForwardInplace(paddle::Tensor& x) {  // NOLINT
 void ReluBackwardInplace(const paddle::Tensor& x,
                          const paddle::Tensor& out,
                          paddle::Tensor& grad_out) {  // NOLINT
-  PD_CHECK(out.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(out);
 
   PD_DISPATCH_FLOATING_TYPES(
       grad_out.type(), "ReluBackward", ([&] {

--- a/test/custom_op/custom_optional.cc
+++ b/test/custom_op/custom_optional.cc
@@ -18,6 +18,8 @@
 
 #include "paddle/extension.h"
 
+#define CHECK_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
+
 template <typename data_t>
 void add_one_pointer(const data_t* x_data, data_t* out_data, int64_t numel) {
   for (size_t i = 0; i < numel; ++i) {
@@ -45,8 +47,7 @@ if (y) {
 std::vector<paddle::Tensor> AddForward(
     const paddle::Tensor& x,
     const paddle::optional<paddle::Tensor>& y) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
   paddle::Tensor out = paddle::empty(x.shape(), x.dtype(), x.place());
 
   if (y) {
@@ -86,8 +87,7 @@ std::vector<paddle::Tensor> AddBackward(
     const paddle::Tensor& x,
     const paddle::optional<paddle::Tensor>& y,
     const paddle::Tensor& out_grad) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   if (y) {
@@ -120,8 +120,7 @@ if (y) {
 std::vector<paddle::Tensor> AddVectorForward(
     const paddle::Tensor& x,
     const paddle::optional<std::vector<paddle::Tensor>>& y) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
   paddle::Tensor out = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -170,8 +169,7 @@ std::vector<paddle::Tensor> AddVectorBackward(
     const paddle::Tensor& x,
     const paddle::optional<std::vector<paddle::Tensor>>& y,
     const paddle::Tensor& out_grad) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
 
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 
@@ -212,8 +210,7 @@ if (y) {
 std::vector<paddle::Tensor> AddOptionalInplaceForward(
     const paddle::Tensor& x,
     paddle::optional<paddle::Tensor>& y) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
   paddle::Tensor outX = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -257,8 +254,7 @@ std::vector<paddle::Tensor> AddOptionalInplaceBackward(
     const paddle::optional<paddle::Tensor>& y,
     const paddle::Tensor& outx_grad,
     paddle::optional<paddle::Tensor>& outy_grad) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
 
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 
@@ -319,8 +315,7 @@ if (y) {
 std::vector<paddle::Tensor> AddOptionalInplaceVectorForward(
     const paddle::Tensor& x,
     paddle::optional<std::vector<paddle::Tensor>>& y) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
   paddle::Tensor outX = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -366,8 +361,7 @@ std::vector<paddle::Tensor> AddOptionalInplaceVectorBackward(
     const paddle::optional<std::vector<paddle::Tensor>>& y,
     const paddle::Tensor& outx_grad,
     paddle::optional<std::vector<paddle::Tensor>>& outy_grad) {  // NOLINT
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
-           "x must be a CPU Tensor.");
+  CHECK_INPUT(x);
 
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 

--- a/test/custom_op/custom_optional.cc
+++ b/test/custom_op/custom_optional.cc
@@ -45,7 +45,8 @@ if (y) {
 std::vector<paddle::Tensor> AddForward(
     const paddle::Tensor& x,
     const paddle::optional<paddle::Tensor>& y) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
   paddle::Tensor out = paddle::empty(x.shape(), x.dtype(), x.place());
 
   if (y) {
@@ -85,7 +86,8 @@ std::vector<paddle::Tensor> AddBackward(
     const paddle::Tensor& x,
     const paddle::optional<paddle::Tensor>& y,
     const paddle::Tensor& out_grad) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   if (y) {
@@ -118,7 +120,8 @@ if (y) {
 std::vector<paddle::Tensor> AddVectorForward(
     const paddle::Tensor& x,
     const paddle::optional<std::vector<paddle::Tensor>>& y) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
   paddle::Tensor out = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -167,7 +170,8 @@ std::vector<paddle::Tensor> AddVectorBackward(
     const paddle::Tensor& x,
     const paddle::optional<std::vector<paddle::Tensor>>& y,
     const paddle::Tensor& out_grad) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
 
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 
@@ -208,7 +212,8 @@ if (y) {
 std::vector<paddle::Tensor> AddOptionalInplaceForward(
     const paddle::Tensor& x,
     paddle::optional<paddle::Tensor>& y) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
   paddle::Tensor outX = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -252,7 +257,8 @@ std::vector<paddle::Tensor> AddOptionalInplaceBackward(
     const paddle::optional<paddle::Tensor>& y,
     const paddle::Tensor& outx_grad,
     paddle::optional<paddle::Tensor>& outy_grad) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
 
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 
@@ -313,7 +319,8 @@ if (y) {
 std::vector<paddle::Tensor> AddOptionalInplaceVectorForward(
     const paddle::Tensor& x,
     paddle::optional<std::vector<paddle::Tensor>>& y) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
   paddle::Tensor outX = paddle::zeros(x.shape(), x.dtype(), x.place());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -359,7 +366,8 @@ std::vector<paddle::Tensor> AddOptionalInplaceVectorBackward(
     const paddle::optional<std::vector<paddle::Tensor>>& y,
     const paddle::Tensor& outx_grad,
     paddle::optional<std::vector<paddle::Tensor>>& outy_grad) {  // NOLINT
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, "x must be a CPU Tensor.");
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU,
+           "x must be a CPU Tensor.");
 
   paddle::Tensor x_grad = paddle::zeros(x.shape(), x.dtype(), x.place());
 

--- a/test/custom_op/custom_relu_op.cc
+++ b/test/custom_op/custom_relu_op.cc
@@ -128,9 +128,9 @@ std::vector<paddle::Tensor> ReluBackward(const paddle::Tensor& x,
 
 std::vector<paddle::Tensor> ReluDoubleBackward(const paddle::Tensor& out,
                                                const paddle::Tensor& ddx) {
-  if (out.place().GetType() == paddle::AllocationType::CPU) {
+  if (out.is_cpu()) {
     return relu_cpu_double_backward(out, ddx);
-  } else if (out.place().GetType() == paddle::AllocationType::GPU) {
+  } else if (out.is_gpu()) {
     return relu_cuda_double_backward(out, ddx);
   } else {
     PD_THROW("Not implemented.");
@@ -179,9 +179,9 @@ std::vector<paddle::Tensor> relu_cuda_backward_without_x(
 
 std::vector<paddle::Tensor> ReluBackwardWithoutX(
     const paddle::Tensor& out, const paddle::Tensor& grad_out) {
-  if (out.place().GetType() == paddle::AllocationType::CPU) {
+  if (out.is_cpu()) {
     return relu_cpu_backward_without_x(out, grad_out);
-  } else if (out.place().GetType() == paddle::AllocationType::GPU) {
+  } else if (out.is_gpu()) {
     return relu_cuda_backward_without_x(out, grad_out);
   } else {
     PD_THROW("Not implemented.");
@@ -235,9 +235,9 @@ void relu_cuda_backward_out(const paddle::Tensor& x,
                             paddle::Tensor* grad_x);
 
 void ReluForwardOut(const paddle::Tensor& x, paddle::Tensor* out) {
-  if (x.place().GetType() == paddle::AllocationType::CPU) {
+  if (x.is_cpu()) {
     return relu_cpu_forward_out(x, out);
-  } else if (x.place().GetType() == paddle::AllocationType::GPU) {
+  } else if (x.is_gpu()) {
     return relu_cuda_forward_out(x, out);
   } else {
     PD_THROW("Not implemented.");
@@ -248,9 +248,9 @@ void ReluBackwardOut(const paddle::Tensor& x,
                      const paddle::Tensor& out,
                      const paddle::Tensor& grad_out,
                      paddle::Tensor* grad_x) {
-  if (x.place().GetType() == paddle::AllocationType::CPU) {
+  if (x.is_cpu()) {
     return relu_cpu_backward_out(x, out, grad_out, grad_x);
-  } else if (x.place().GetType() == paddle::AllocationType::GPU) {
+  } else if (x.is_gpu()) {
     return relu_cuda_backward_out(x, out, grad_out, grad_x);
   } else {
     PD_THROW("Not implemented.");

--- a/test/custom_op/custom_relu_op.cc
+++ b/test/custom_op/custom_relu_op.cc
@@ -128,9 +128,9 @@ std::vector<paddle::Tensor> ReluBackward(const paddle::Tensor& x,
 
 std::vector<paddle::Tensor> ReluDoubleBackward(const paddle::Tensor& out,
                                                const paddle::Tensor& ddx) {
-  if (out.place() == paddle::PlaceType::kCPU) {
+  if (out.place().GetType() == paddle::AllocationType::CPU) {
     return relu_cpu_double_backward(out, ddx);
-  } else if (out.place() == paddle::PlaceType::kGPU) {
+  } else if (out.place().GetType() == paddle::AllocationType::GPU) {
     return relu_cuda_double_backward(out, ddx);
   } else {
     PD_THROW("Not implemented.");
@@ -179,9 +179,9 @@ std::vector<paddle::Tensor> relu_cuda_backward_without_x(
 
 std::vector<paddle::Tensor> ReluBackwardWithoutX(
     const paddle::Tensor& out, const paddle::Tensor& grad_out) {
-  if (out.place() == paddle::PlaceType::kCPU) {
+  if (out.place().GetType() == paddle::AllocationType::CPU) {
     return relu_cpu_backward_without_x(out, grad_out);
-  } else if (out.place() == paddle::PlaceType::kGPU) {
+  } else if (out.place().GetType() == paddle::AllocationType::GPU) {
     return relu_cuda_backward_without_x(out, grad_out);
   } else {
     PD_THROW("Not implemented.");
@@ -235,9 +235,9 @@ void relu_cuda_backward_out(const paddle::Tensor& x,
                             paddle::Tensor* grad_x);
 
 void ReluForwardOut(const paddle::Tensor& x, paddle::Tensor* out) {
-  if (x.place() == paddle::PlaceType::kCPU) {
+  if (x.place().GetType() == paddle::AllocationType::CPU) {
     return relu_cpu_forward_out(x, out);
-  } else if (x.place() == paddle::PlaceType::kGPU) {
+  } else if (x.place().GetType() == paddle::AllocationType::GPU) {
     return relu_cuda_forward_out(x, out);
   } else {
     PD_THROW("Not implemented.");
@@ -248,9 +248,9 @@ void ReluBackwardOut(const paddle::Tensor& x,
                      const paddle::Tensor& out,
                      const paddle::Tensor& grad_out,
                      paddle::Tensor* grad_x) {
-  if (x.place() == paddle::PlaceType::kCPU) {
+  if (x.place().GetType() == paddle::AllocationType::CPU) {
     return relu_cpu_backward_out(x, out, grad_out, grad_x);
-  } else if (x.place() == paddle::PlaceType::kGPU) {
+  } else if (x.place().GetType() == paddle::AllocationType::GPU) {
     return relu_cuda_backward_out(x, out, grad_out, grad_x);
   } else {
     PD_THROW("Not implemented.");

--- a/test/custom_op/custom_relu_op_xpu.cc
+++ b/test/custom_op/custom_relu_op_xpu.cc
@@ -161,7 +161,7 @@ std::vector<paddle::Tensor> ReluBackward(const paddle::Tensor& x,
 
 std::vector<paddle::Tensor> ReluDoubleBackward(const paddle::Tensor& out,
                                                const paddle::Tensor& ddx) {
-  if (out.place().GetType() == paddle::AllocationType::CPU) {
+  if (out.is_cpu()) {
     return relu_cpu_double_backward(out, ddx);
   } else if (out.place().GetType() == phi::AllocationType::XPU) {
     return relu_xpu_double_backward(out, ddx);

--- a/test/custom_op/custom_relu_op_xpu.cc
+++ b/test/custom_op/custom_relu_op_xpu.cc
@@ -161,7 +161,7 @@ std::vector<paddle::Tensor> ReluBackward(const paddle::Tensor& x,
 
 std::vector<paddle::Tensor> ReluDoubleBackward(const paddle::Tensor& out,
                                                const paddle::Tensor& ddx) {
-  if (out.place() == paddle::PlaceType::kCPU) {
+  if (out.place().GetType() == paddle::AllocationType::CPU) {
     return relu_cpu_double_backward(out, ddx);
   } else if (out.place().GetType() == phi::AllocationType::XPU) {
     return relu_xpu_double_backward(out, ddx);

--- a/test/custom_op/custom_simple_slice_op.cc
+++ b/test/custom_op/custom_simple_slice_op.cc
@@ -17,8 +17,9 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_INPUT(x) \
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x)                                         \
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
+           #x " must be a CPU Tensor.")
 
 std::vector<paddle::Tensor> SimpleSliceFunction(const paddle::Tensor& x,
                                                 int64_t begin_index,

--- a/test/custom_op/custom_simple_slice_op.cc
+++ b/test/custom_op/custom_simple_slice_op.cc
@@ -17,9 +17,7 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_INPUT(x)                                         \
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
-           #x " must be a CPU Tensor.")
+#define CHECK_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
 
 std::vector<paddle::Tensor> SimpleSliceFunction(const paddle::Tensor& x,
                                                 int64_t begin_index,

--- a/test/custom_op/custom_tanh_op.cc
+++ b/test/custom_op/custom_tanh_op.cc
@@ -18,9 +18,7 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_CPU_INPUT(x)                                     \
-  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
-           #x " must be a CPU Tensor.")
+#define CHECK_CPU_INPUT(x) PD_CHECK(x.is_cpu(), #x " must be a CPU Tensor.")
 
 template <typename data_t>
 void tanh_cpu_forward_kernel(const data_t* x_data,

--- a/test/custom_op/custom_tanh_op.cc
+++ b/test/custom_op/custom_tanh_op.cc
@@ -18,8 +18,9 @@
 
 #include "paddle/extension.h"
 
-#define CHECK_CPU_INPUT(x) \
-  PD_CHECK(x.place() == paddle::PlaceType::kCPU, #x " must be a CPU Tensor.")
+#define CHECK_CPU_INPUT(x)                                     \
+  PD_CHECK(x.place().GetType() == paddle::AllocationType::CPU, \
+           #x " must be a CPU Tensor.")
 
 template <typename data_t>
 void tanh_cpu_forward_kernel(const data_t* x_data,

--- a/test/custom_op/dispatch_test_op.cc
+++ b/test/custom_op/dispatch_test_op.cc
@@ -27,7 +27,7 @@ void assign_cpu_kernel(const data_t* x_data,
 }
 
 std::vector<paddle::Tensor> DispatchTestInterger(const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_INTEGRAL_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -45,7 +45,7 @@ PD_BUILD_OP(dispatch_test_integer)
 
 std::vector<paddle::Tensor> DispatchTestFloatAndInteger(
     const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_AND_INTEGRAL_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -62,7 +62,7 @@ PD_BUILD_OP(dispatch_test_float_and_integer)
     .SetKernelFn(PD_KERNEL(DispatchTestFloatAndInteger));
 
 std::vector<paddle::Tensor> DispatchTestComplex(const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_COMPLEX_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -80,7 +80,7 @@ PD_BUILD_OP(dispatch_test_complex)
 
 std::vector<paddle::Tensor> DispatchTestFloatAndComplex(
     const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -98,7 +98,7 @@ PD_BUILD_OP(dispatch_test_float_and_complex)
 
 std::vector<paddle::Tensor> DispatchTestFloatAndIntegerAndComplex(
     const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_AND_INTEGRAL_AND_COMPLEX_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -115,7 +115,7 @@ PD_BUILD_OP(dispatch_test_float_and_integer_and_complex)
     .SetKernelFn(PD_KERNEL(DispatchTestFloatAndIntegerAndComplex));
 
 std::vector<paddle::Tensor> DispatchTestFloatAndHalf(const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_AND_HALF_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {

--- a/test/custom_op/multi_out_test_op.cc
+++ b/test/custom_op/multi_out_test_op.cc
@@ -34,7 +34,7 @@ void fill_constant_cpu_kernel(data_t* out_data, int64_t x_numel, data_t value) {
 }
 
 std::vector<paddle::Tensor> MultiOutCPU(const paddle::Tensor& x) {
-  auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto out = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_TYPES(
       x.type(), "assign_cpu_kernel", ([&] {
@@ -43,13 +43,13 @@ std::vector<paddle::Tensor> MultiOutCPU(const paddle::Tensor& x) {
       }));
 
   // fake multi output: Fake_float64 with float64 dtype
-  auto fake_float64 = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto fake_float64 = paddle::empty_like(x);
 
   fill_constant_cpu_kernel<double>(
       fake_float64.mutable_data<double>(x.place()), x.size(), 0.);
 
   // fake multi output: ZFake_int32 with int32 dtype
-  auto zfake_int32 = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
+  auto zfake_int32 = paddle::empty_like(x);
 
   fill_constant_cpu_kernel<int32_t>(
       zfake_int32.mutable_data<int32_t>(x.place()), x.size(), 1);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
Pcard-66988

[CustomOP Unittest] Polish unit test of custom operator, kCPU->CPU

`paddle::PlaceType::kCPU` 在未来将被废弃，本 PR 对自定义算子中所有涉及到 `paddle::PlaceType::kCPU` 的调用，进行等价替换。当外部用户参考单测进行实现时，屏蔽掉 `kCPU` 的概念，从而减轻未来删除 `kCPU` 的负担。

`paddle::PlaceType::kCPU` will be deprecated in the future, this PR finishes the equivalent substitution of calling `paddle::PlaceType::kCPU` within the custom operator scenario. When external users refer to unit tests for implementation, this PR masks the concept of kCPU, thereby relieving the burden of future deletion of kCPU.