### PR TITLE
[Paddle-TRT]fix bilinear_interp_v2 && some other bugs in trt 7011

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -236,8 +236,8 @@ void TensorRTEngine::FreezeNetwork() {
     LOG(INFO) << "Run Paddle-TRT Dynamic Shape mode.";
     for (int i = 0; i < max_profile_num_; i++) {
       for (auto &input : min_input_shape_) {
-#if IS_TRT_VERSION_LT(7000)
-        // trt6 will check all_of input > 0
+#if IS_TRT_VERSION_LT(7100)
+        // trt6/trt7011 will check all_of input > 0
         if (!(std::all_of(input.second.begin(),
                           input.second.end(),
                           [](int x) { return x > 0; }) &&

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -917,6 +917,10 @@ struct SimpleOpTypeSetTeller : public Teller {
     }
 
     if (op_type == "bilinear_interp_v2") {
+      // trt 7011 result in test_solov2_trt_fp32.py TRT fp32 diff
+#if IS_TRT_VERSION_LT(7100)
+      return false;
+#endif
       std::vector<std::string> attrs{"data_layout",
                                      "interp_method",
                                      "align_corners",

--- a/paddle/fluid/inference/tensorrt/plugin/elementwiseadd_transpose_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/elementwiseadd_transpose_op_plugin.cu
@@ -86,9 +86,16 @@ bool ElementwiseAddTransposePluginDynamic::supportsFormatCombination(
   }
   // output 0
   if (pos == 2) {
-    return (in.type == in_out[0].type) &&
-           (in.format == nvinfer1::TensorFormat::kLINEAR ||
-            in.format == nvinfer1::TensorFormat::kHWC8);
+    // 7.0.0.11 test_pcpvt_base_trt_fp16.py failed if support C8.
+    // Only support linear format in lower versions of TRT
+#if IS_TRT_VERSION_GE(7100)
+    bool support_format = in.format == nvinfer1::TensorFormat::kLINEAR ||
+                          in.format == nvinfer1::TensorFormat::kHWC8;
+#else
+    bool support_format = in.format == nvinfer1::TensorFormat::kLINEAR;
+#endif
+
+    return (in.type == in_out[0].type) && (support_format);
   }
 }
 void ElementwiseAddTransposePluginDynamic::configurePlugin(

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_bilinear_interp_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_bilinear_interp_v2.py
@@ -30,7 +30,10 @@ class TrtConvertBilinearInterpV2Test(TrtLayerAutoScanTest):
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
-
+        ver = paddle_infer.get_trt_compile_version()
+        # here is consistent with op_teller.cc
+        if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 7100:
+            return False
         return True
 
     def sample_program_configs(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- 7011下，对于elementwiseadd_transpose_pass，只支持linear，否则会build失败。
- 在trt7011及以下版本中禁止掉bilinear_interp_v2，因为单测有diff
- 7100以下版本会检查min/max/opt shape 值是否为负。
- [pr to release/2.4](https://github.com/PaddlePaddle/Paddle/pull/50187)
