### PR TITLE
Fix bugs of dropout and dropout_grad. test=kunlun.

### DIFF
--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -871,7 +871,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         }
         dense_out_trans_map = {
             'Tensor': 'phi::DenseTensor*',
-            'std::vector<Tensor>': 'std::vector<phi::DenseTensor*>&',
+            'std::vector<Tensor>': 'std::vector<phi::DenseTensor*>',
         }
         sr_input_trans_map = {
             'const Tensor&': 'const phi::SelectedRows&',


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
由于cpu端将DropoutRawKernel的第二个输出mask强制指定为uint8类型导致xpu计算与cpu不一致
