### PR TITLE
Fix bug in cross_entropy in static mode

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -886,7 +886,6 @@ void CrossEntropyWithSoftmaxInferMeta(const MetaTensor& logits,
   auto logits_dims = logits.dims();
   auto labels_dims = label.dims();
   auto logits_rank = logits_dims.size();
-  auto labels_rank = labels_dims.size();
   PADDLE_ENFORCE_GE(axis,
                     -logits_rank,
                     phi::errors::InvalidArgument(
@@ -918,12 +917,6 @@ void CrossEntropyWithSoftmaxInferMeta(const MetaTensor& logits,
         phi::errors::InvalidArgument("Attr(axis) can only be -1 "
                                      "when not in numeric_stable_mode."));
   }
-
-  PADDLE_ENFORCE_EQ(
-      (logits_rank - 1 != labels_rank) && (logits_rank != labels_rank),
-      false,
-      phi::errors::InvalidArgument("Expected input_dims - 1 == label_dims "
-                                   "or input_dims == label_dims."));
 
   if (soft_label) {
     if (config.is_runtime || (logits_dims[axis] > 0 && labels_dims[axis] > 0)) {

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_op.py
@@ -441,6 +441,21 @@ class TestCrossEntropyOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_dtype)
 
+            def test_input_dims():
+                with paddle_static_guard():
+                    # "input_dims - 1 != label_dims and input_dims != label_dims" must be false.
+                    x3 = paddle.static.data(
+                        name='x3', shape=[-1, 3, 4, 5], dtype="int32"
+                    )
+                    lab3 = paddle.static.data(
+                        name='lab3', shape=[-1, 3, 4, 5, 6], dtype="int32"
+                    )
+                    paddle.nn.functional.cross_entropy(
+                        x3, lab3, reduction='none', use_softmax=False
+                    )
+
+            self.assertRaises(ValueError, test_input_dims)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -253,6 +253,20 @@ def fluid_softmax_with_cross_entropy(
             # Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
             #        [1.15328646])
     """
+    input_dims = len(list(logits.shape))
+    if input_dims == 0:
+        raise ValueError('The dimention of input should be larger than zero!')
+
+    label_dims = len(list(label.shape))
+    if input_dims - 1 != label_dims and input_dims != label_dims:
+        raise ValueError(
+            'Expected nput_dims - 1 = label_dims or input_dims == label_dims\
+             (got nput_dims{}, label_dims{})'.format(
+                input_dims, label_dims
+            )
+        )
+    if input_dims - 1 == label_dims:
+        label = paddle.unsqueeze(label, axis=axis)
     if in_dygraph_mode():
         if core.is_compiled_with_custom_device("npu"):
             if not soft_label:
@@ -2700,6 +2714,14 @@ def cross_entropy(
     label_dims = len(list(label.shape))
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=axis)
+
+    if input_dims - 1 != label_dims and input_dims != label_dims:
+        raise ValueError(
+            'Expected nput_dims - 1 = label_dims or input_dims == label_dims\
+             (got nput_dims{}, label_dims{})'.format(
+                input_dims, label_dims
+            )
+        )
 
     if in_dygraph_mode():
         if not soft_label:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Pcard-67001
修复[iCafe](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-69453/show),这个bug最初由[PR49333](https://github.com/PaddlePaddle/Paddle/pull/49333)引入。因为原始的`softmax_with_cross_entropy`的静态图算子一直调用的是成员函数`InferShape`所以没有暴露出来，但是[PR52515](https://github.com/PaddlePaddle/Paddle/pull/52515)采用`CrossEntropyWithSoftmaxInferMeta`来推导shape，问题就暴露出来。这里将input的dim检查重新放置到Python端。