### PR TITLE
[phi] mv sequence_pool to phi - Step 1 : sequence_pooling_test

### DIFF
--- a/paddle/fluid/operators/math/CMakeLists.txt
+++ b/paddle/fluid/operators/math/CMakeLists.txt
@@ -40,10 +40,6 @@ cc_test(
   SRCS vol2col_test.cc
   DEPS vol2col)
 cc_test(
-  sequence_pooling_test
-  SRCS sequence_pooling_test.cc
-  DEPS sequence_pooling)
-cc_test(
   beam_search_test
   SRCS beam_search_test.cc
   DEPS beam_search)

--- a/test/cpp/phi/kernels/CMakeLists.txt
+++ b/test/cpp/phi/kernels/CMakeLists.txt
@@ -105,3 +105,8 @@ cc_test(
   sequence_padding_test
   SRCS sequence_padding_test.cc
   DEPS sequence_padding)
+
+cc_test(
+  sequence_pooling_test
+  SRCS sequence_pooling_test.cc
+  DEPS sequence_pooling)

--- a/test/cpp/phi/kernels/sequence_pooling_test.cc
+++ b/test/cpp/phi/kernels/sequence_pooling_test.cc
@@ -14,7 +14,7 @@ limitations under the License. */
 
 #include <gtest/gtest.h>
 
-#include "paddle/phi/kernels/funcs/sequence_pooling.h"
+#include "paddle/fluid/operators/math/sequence_pooling.h"
 
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/common/place.h"
@@ -78,7 +78,7 @@ void TestSequencePoolingSum(const DeviceContext &context,
   }
 
   // call functor
-  phi::funcs::SequencePoolGradFunctor<DeviceContext, T>()(
+  paddle::operators::math::SequencePoolGradFunctor<DeviceContext, T>()(
       context, "SUM", out_grad, &in_grad);
 
   if (place == phi::CPUPlace()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

将 `sequence_pool` 迁移至 `phi`

 * 将 `sequence_pooling_test` 迁移至新的单测目录 (此pr)
 * 迁移 `SequencePoolFunctor` 至 `phi/kernels/funcs/`, 并且迁移 `sequence_pool_op` #52750
 * 迁移 `sequence_pool_grad_op` #52680

相关issues
 * https://github.com/PaddlePaddle/Paddle/issues/52395