### PR TITLE
[Unittest Stream] Fix unittest, change raw_stream->GetStream()

### DIFF
--- a/test/custom_runtime/custom_op.cc
+++ b/test/custom_runtime/custom_op.cc
@@ -199,7 +199,7 @@ std::vector<paddle::Tensor> StreamForward(const paddle::Tensor& x) {
   auto dev_ctx =
       paddle::experimental::DeviceContextPool::Instance().Get(x.place());
   auto custom_ctx = static_cast<const phi::CustomContext*>(dev_ctx);
-  void* stream = custom_ctx->stream();
+  std::shared_ptr<phi::stream::Stream> stream = custom_ctx->GetStream();
 
   PD_CHECK(stream != nullptr);
   std::cout << "Check stream != nullptr successfully" << std::endl;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Pcard-66988

[Unittest Stream] Fix unit test, change raw_stream->GetStream()

py3 测试环境从 `cuda11 + python3.7` 升级到 `cuda12 + python3.9` 后，自定义算子获取自定义设备 stream 的单测会报错。
用户调用 `stream()` 时会返回 nullptr，需要将改函数修改为 `GetStream()`，从而避免这个问题。
后续如果需要获取 `raw_stream`，需要先调用 `set_stream`

**Background**
py3 environment upgrade from `cuda11 + python3.7` to `cuda12 + python3.9`

**Reason**
`custom_ctx->stream()` might return nullptr when raw_stream has not been initialized yet.
Change `stream()` to `GetStream()` to fix this.

Afterward, users may need to `set_stream` before calling `raw_stream`.