### PR TITLE
fix the bug of quanting matmul

### DIFF
--- a/python/paddle/static/quantization/post_training_quantization.py
+++ b/python/paddle/static/quantization/post_training_quantization.py
@@ -701,8 +701,10 @@ class PostTrainingQuantization:
                     in self.quant_config.activation_quant_operation_types
                     or is_conv1d_quant
                 ):
-                    if op_type == 'matmul_v2' and op.attr('trans_y'):
-                        op_type += '_trans_y'
+                    trans_y = (op_type == 'matmul_v2') and op.op().attr(
+                        'trans_y'
+                    )
+                    op_type = op_type + '_trans_y' if trans_y else op_type
                     collect_var_name(
                         utils._get_op_input_var_names(op),
                         persistable_var_names,

--- a/python/paddle/static/quantization/post_training_quantization.py
+++ b/python/paddle/static/quantization/post_training_quantization.py
@@ -701,6 +701,8 @@ class PostTrainingQuantization:
                     in self.quant_config.activation_quant_operation_types
                     or is_conv1d_quant
                 ):
+                    if op_type == 'matmul_v2' and op.attr('trans_y'):
+                        op_type += '_trans_y'
                     collect_var_name(
                         utils._get_op_input_var_names(op),
                         persistable_var_names,

--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -1173,7 +1173,9 @@ class QuantizationFreezePass:
                     # Quantize weight and restore
                     if self._round_type == 'round':
                         param_v = self._load_var(input_arg_name)
-                        quant_axis = op_node.op().attr('quant_axis')
+                        quant_axis = 0
+                        if op_node.op().has_attr('quant_axis'):
+                            quant_axis = op_node.op().attr('quant_axis')
                         if input_arg_name not in self._quantized_ops:
                             self._quantized_ops.add(input_arg_name)
                             quantized_param_v = utils.quant_tensor(

--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -347,8 +347,10 @@ class QuantizationTransformPass:
                         quant_type == 'channel_wise_abs_max'
                     ):  # Weight quantization
                         op_type = op.name()
-                        if op_type == 'matmul_v2' and op.op().attr('trans_y'):
-                            op_type += '_trans_y'
+                        trans_y = (op_type == 'matmul_v2') and op.op().attr(
+                            'trans_y'
+                        )
+                        op_type = op_type + '_trans_y' if trans_y else op_type
                         quant_axis = (
                             1
                             if op_type in utils._channelwise_quant_axis1_ops
@@ -2591,8 +2593,10 @@ class QuantizationTransformPassV2(QuantizationTransformPass):
                 if quant_type == 'channel_wise_abs_max':  # Weight quantization
                     channel_wise = True
                     op_type = op.name()
-                    if op_type == 'matmul_v2' and op.op().attr('trans_y'):
-                        op_type += '_trans_y'
+                    trans_y = (op_type == 'matmul_v2') and op.op().attr(
+                        'trans_y'
+                    )
+                    op_type = op_type + '_trans_y' if trans_y else op_type
                     quant_axis = (
                         1
                         if op_type in utils._channelwise_quant_axis1_ops

--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -86,20 +86,6 @@ def _is_input_all_not_persistable(graph, op_node):
     return is_input_all_not_persistable
 
 
-def _check_grandchild_op_node(op_node, grandchild_op_name):
-    '''
-    Check whether the fake_quant node has a grandchild op node named
-    grandchild_op_name.
-    '''
-    for out1_var_node in op_node.outputs:
-        for out1_op_node in out1_var_node.outputs:
-            for out2_var_node in out1_op_node.outputs:
-                for out2_op_node in out2_var_node.outputs:
-                    if out2_op_node.name() == grandchild_op_name:
-                        return True
-    return False
-
-
 class QuantizationTransformPass:
     """
     Quantize the ops that have weights. Add quant and dequant ops for
@@ -360,9 +346,12 @@ class QuantizationTransformPass:
                     if (
                         quant_type == 'channel_wise_abs_max'
                     ):  # Weight quantization
+                        op_type = op.name()
+                        if op_type == 'matmul_v2' and op.op().attr('trans_y'):
+                            op_type += '_trans_y'
                         quant_axis = (
                             1
-                            if op.name() in utils._channelwise_quant_axis1_ops
+                            if op_type in utils._channelwise_quant_axis1_ops
                             else 0
                         )
                         (
@@ -1184,13 +1173,7 @@ class QuantizationFreezePass:
                     # Quantize weight and restore
                     if self._round_type == 'round':
                         param_v = self._load_var(input_arg_name)
-                        if any(
-                            _check_grandchild_op_node(op_node, op)
-                            for op in utils._channelwise_quant_axis1_ops
-                        ):
-                            quant_axis = 1
-                        else:
-                            quant_axis = 0
+                        quant_axis = op_node.op().attr('quant_axis')
                         if input_arg_name not in self._quantized_ops:
                             self._quantized_ops.add(input_arg_name)
                             quantized_param_v = utils.quant_tensor(
@@ -2605,9 +2588,12 @@ class QuantizationTransformPassV2(QuantizationTransformPass):
                 channel_wise = False
                 if quant_type == 'channel_wise_abs_max':  # Weight quantization
                     channel_wise = True
+                    op_type = op.name()
+                    if op_type == 'matmul_v2' and op.op().attr('trans_y'):
+                        op_type += '_trans_y'
                     quant_axis = (
                         1
-                        if op.name() in utils._channelwise_quant_axis1_ops
+                        if op_type in utils._channelwise_quant_axis1_ops
                         else 0
                     )
                 insert_quant_pass = InsertQuantizeLinear(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复了当matmul内置transpose时（trans_y=True）的量化错误。

如下图所示，修改前：当matmul开启 transpose_y = True 的时候，其输出dequant op 的scale维度会和输出tensor的维度不匹配。
<img width="462" alt="image" src="https://user-images.githubusercontent.com/41366441/231409095-a9564cde-62e4-4820-bfdd-a610ea8334b8.png">
<img width="486" alt="image" src="https://user-images.githubusercontent.com/41366441/231409926-d5d56e17-f055-46b3-843b-2938f93a3c52.png">

