### PR TITLE
Adjust unittest test_layer_convert_dtype.py

### DIFF
--- a/test/amp/test_layer_convert_dtype.py
+++ b/test/amp/test_layer_convert_dtype.py
@@ -127,7 +127,7 @@ class TestSupportedTypeInfo(unittest.TestCase):
         res = paddle.amp.is_float16_supported('cpu')
         self.assertEqual(res, False)
         res = paddle.amp.is_bfloat16_supported('cpu')
-        self.assertEqual(res, True)
+        self.assertEqual(res, core.supports_bfloat16())
 
     def test_gpu_fp16_supported(self):
         res = paddle.amp.is_float16_supported()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复单测test_layer_convert_dtype.py中的默认值，原因是PR-CI-Windows中编译的paddle不支持bf16。所以将默认值True更正为core.supports_bfloat16()。