### PR TITLE
[AMP OP&Test] Support fp16&bf16 in reduce_max

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -173,8 +173,8 @@ struct MaxOrMinGradFunctor {
                   const Dim& dim,
                   int size) {
     auto equals = (*x) == y->broadcast(dim);
-    auto ones = dx->constant(1.0f);
-    auto zeros = dx->constant(0.0f);
+    auto ones = dx->constant(1);
+    auto zeros = dx->constant(0);
     // If there are multiple minimum or maximum elements, the subgradient of
     // each is the set [0, 1], and we pass gradient to all of them here.
     dx->device(place) = dy->broadcast(dim).reshape(x->dimensions()) *

--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -173,8 +173,8 @@ struct MaxOrMinGradFunctor {
                   const Dim& dim,
                   int size) {
     auto equals = (*x) == y->broadcast(dim);
-    auto ones = dx->constant(1);
-    auto zeros = dx->constant(0);
+    auto ones = dx->constant(1.0f);
+    auto zeros = dx->constant(0.0f);
     // If there are multiple minimum or maximum elements, the subgradient of
     // each is the set [0, 1], and we pass gradient to all of them here.
     dx->device(place) = dy->broadcast(dim).reshape(x->dimensions()) *

--- a/paddle/phi/kernels/gpu/reduce_max_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_max_grad_kernel.cu
@@ -25,4 +25,6 @@ PD_REGISTER_KERNEL(max_grad,
                    float,
                    double,
                    int,
-                   int64_t) {}
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/reduce_max_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_max_grad_kernel.cu
@@ -35,9 +35,6 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
   auto dims_data = dims.GetData();
   reduce_all = recompute_reduce_all(x, dims_data, reduce_all);
 
-  // get reduce_dim
-  int dim_size = x.dims().size();
-
   // make equal_out
   phi::DenseTensor* equal_out = new phi::DenseTensor();
   equal_out->Resize(x.dims());

--- a/paddle/phi/kernels/kps/reduce_max_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_max_kernel.cu
@@ -36,6 +36,14 @@ void MaxRawKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_XPU_KP
 PD_REGISTER_KERNEL(max_raw, KPS, ALL_LAYOUT, phi::MaxRawKernel, float) {}
 #else
-PD_REGISTER_KERNEL(
-    max_raw, KPS, ALL_LAYOUT, phi::MaxRawKernel, float, double, int, int64_t) {}
+PD_REGISTER_KERNEL(max_raw,
+                   KPS,
+                   ALL_LAYOUT,
+                   phi::MaxRawKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
 #endif

--- a/paddle/phi/kernels/reduce_max_kernel.cc
+++ b/paddle/phi/kernels/reduce_max_kernel.cc
@@ -34,7 +34,20 @@ void MaxKernel(const Context& dev_ctx,
 PD_REGISTER_KERNEL(
     max, CPU, ALL_LAYOUT, phi::MaxKernel, float, double, int, int64_t) {}
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUDA)
+PD_REGISTER_KERNEL(max,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::MaxKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
+#endif
+
+#if defined(PADDLE_WITH_HIP)
 PD_REGISTER_KERNEL(
     max, GPU, ALL_LAYOUT, phi::MaxKernel, float, double, int, int64_t) {}
 #endif

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -251,18 +251,6 @@ class TestMaxOp(OpTest):
             only_check_prim=True,
         )
 
-    def test_raise_error(self):
-        if core.is_compiled_with_cuda():
-            self.inputs = {'X': np.random.random((5, 6, 10)).astype("float16")}
-            place = core.CUDAPlace(0)
-            with self.assertRaises(RuntimeError) as cm:
-                self.check_output_with_place(place)
-            error_msg = str(cm.exception).split("\n")[-2].strip().split(".")[0]
-            self.assertEqual(
-                error_msg,
-                "NotFoundError: The kernel (reduce_max) with key (GPU, Undefined(AnyLayout), float16) is not found and GPU kernel cannot fallback to CPU one",
-            )
-
 
 class TestMaxOp_ZeroDim(OpTest):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
@@ -300,13 +288,19 @@ class TestMaxOp_FP32(OpTest):
         self.prim_op_type = "prim"
         self.python_api = paddle.max
         self.public_python_api = paddle.max
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype("float32")}
+        self.init_dtype()
+        if self.dtype == np.uint16:
+            x = np.random.random((5, 6, 10)).astype(np.float32)
+            self.inputs = {'X': convert_float_to_uint16(x)}
+        else:
+            x = np.random.random((5, 6, 10)).astype(self.dtype)
+            self.inputs = {'X': x}
         self.attrs = {'dim': [-1], 'keep_dim': True}
-        self.outputs = {
-            'Out': self.inputs['X'].max(
-                axis=tuple(self.attrs['dim']), keepdims=True
-            )
-        }
+        out = x.max(axis=tuple(self.attrs['dim']), keepdims=True)
+        if self.dtype == np.uint16:
+            self.outputs = {'Out': convert_float_to_uint16(out)}
+        else:
+            self.outputs = {'Out': out}
 
     def test_check_output(self):
         self.check_output()
@@ -319,6 +313,24 @@ class TestMaxOp_FP32(OpTest):
             check_prim=True,
             only_check_prim=True,
         )
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+
+class TestMaxOp_FP16(TestMaxOp_FP32):
+    def init_dtype(self):
+        self.dtype = np.float16
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA or not support the bfloat16",
+)
+class TestMaxOp_BF16(OpTest):
+    def init_dtype(self):
+        self.dtype = np.uint16
 
 
 @skip_check_grad_ci(

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -332,6 +332,19 @@ class TestMaxOp_BF16(OpTest):
     def init_dtype(self):
         self.dtype = np.uint16
 
+    def test_check_output(self):
+        self.check_output_with_place(core.CUDAPlace(0))
+
+    def test_check_grad(self):
+        # only composite op support gradient check of reduce_max
+        self.check_grad_with_place(
+            core.CUDAPlace(0),
+            ['X'],
+            'Out',
+            check_prim=True,
+            only_check_prim=True,
+        )
+
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -280,7 +280,7 @@ class TestMaxOp_ZeroDim(OpTest):
         )
 
 
-class TestMaxOp_FP32(OpTest):
+class TestMaxFP32Op(OpTest):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
     def setUp(self):
@@ -318,7 +318,7 @@ class TestMaxOp_FP32(OpTest):
         self.dtype = np.float32
 
 
-class TestMaxOp_FP16(TestMaxOp_FP32):
+class TestMaxFP16Op(TestMaxFP32Op):
     def init_dtype(self):
         self.dtype = np.float16
 
@@ -328,7 +328,7 @@ class TestMaxOp_FP16(TestMaxOp_FP32):
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
     "core is not compiled with CUDA or not support the bfloat16",
 )
-class TestMaxOp_BF16(OpTest):
+class TestMaxBF16Op(TestMaxFP32Op):
     def init_dtype(self):
         self.dtype = np.uint16
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2348,7 +2348,10 @@ def max(x, axis=None, keepdim=False, name=None):
         reduce_all, axis = _get_reduce_axis_with_tensor(axis, x)
         helper = LayerHelper('max', **locals())
         check_variable_and_dtype(
-            x, 'x', ['float32', 'float64', 'int32', 'int64'], 'max'
+            x,
+            'x',
+            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64'],
+            'max',
         )
         if not isinstance(axis, Variable) and paddle.utils._contain_var(axis):
             axis = paddle.utils._convert_to_tensor_list(axis)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
reduce_max支持float16和bfloat16数据类型，并补充相应单测。
#52822 Reopen