### PR TITLE
Fix the parameter check error in rmsprop_kernel_xpu.

### DIFF
--- a/paddle/phi/kernels/xpu/rmsprop_kernel.cc
+++ b/paddle/phi/kernels/xpu/rmsprop_kernel.cc
@@ -41,12 +41,6 @@ void RmspropDenseKernel(const Context& dev_ctx,
                         DenseTensor* mean_grad_out,
                         DenseTensor* master_param_outs) {
   // copy learning_rate to cpu
-  PADDLE_ENFORCE_EQ(
-      learning_rate.dims().size(),
-      1,
-      errors::InvalidArgument("learining rate should have dimension = 1."
-                              " But received learning rate dim [%s] ",
-                              learning_rate.dims().size()));
   T learning_rate_cpu = 0.0f;
   memory_utils::Copy(CPUPlace(),
                      static_cast<void*>(&learning_rate_cpu),


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
某些特殊的情况会导致learning_rate参数的meta的数据为：meta: is_scalar = 0, dims = , dtype = float32, layout = NCHW, lod = {}, offset = 0，但由于本身是标量，所以还是有值的，且cpu、gpu的kernel也不会对该参数的dim做检查，故去除此参数检查限制。
