### PR TITLE
remove need cpp14 support in complex.h

### DIFF
--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   if(WITH_MKL)
     set(FLAG_OPENMP "-fopenmp")
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 ${FLAG_OPENMP}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ${FLAG_OPENMP}")
 endif()
 
 if(WITH_GPU)

--- a/paddle/phi/common/complex.h
+++ b/paddle/phi/common/complex.h
@@ -105,16 +105,16 @@ struct PADDLE_ALIGN(sizeof(T) * 2) complex {
 
   template <typename T1 = T>
   HOSTDEVICE explicit complex(
-      const std::enable_if_t<std::is_same<T1, float>::value, complex<double>>&
-          val) {
+      const typename std::enable_if<std::is_same<T1, float>::value,
+                                    complex<double>>::type& val) {
     real = val.real;
     imag = val.imag;
   }
 
   template <typename T1 = T>
   HOSTDEVICE explicit complex(
-      const std::enable_if_t<std::is_same<T1, double>::value, complex<float>>&
-          val) {
+      const typename std::enable_if<std::is_same<T1, double>::value,
+                                    complex<float>>::type& val) {
     real = val.real;
     imag = val.imag;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

remove need cpp14 support in complex.h

尽管paddle支持cpp14编译，但对于inference lib，许多用户仍在用cpp11编译，因此，暂时不建议对外暴露的.h头文件实现中出现依赖cpp高标准特性的情况。