### PR TITLE
fix some [-Wunused-function] warning

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -145,7 +145,6 @@ if(NOT WIN32)
       -Wall
       -Wextra
       -Wno-unused-parameter
-      -Wno-unused-function
       -Wno-error=array-bounds #Warning in Eigen, gcc 12.2
       -Wno-error=ignored-attributes # Warnings in Eigen, gcc 6.3
       -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -145,6 +145,7 @@ if(NOT WIN32)
       -Wall
       -Wextra
       -Wno-unused-parameter
+      -Wno-unused-function
       -Wno-error=array-bounds #Warning in Eigen, gcc 12.2
       -Wno-error=ignored-attributes # Warnings in Eigen, gcc 6.3
       -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2

--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -53,7 +53,7 @@ limitations under the License. */
 #include <string>
 #include <type_traits>
 #include <utility>
-
+#include "paddle/phi/core/macros.h"
 #if !defined(_WIN32) && !defined(PADDLE_WITH_MUSL)
 #include <execinfo.h>
 #endif

--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -226,7 +226,7 @@ struct BinaryCompareMessageConverter {
 template <>
 struct BinaryCompareMessageConverter<false> {
   template <typename T>
-  static const char* Convert(const char* expression, const T& value) {
+  static const char* Convert(const char* expression, const T& value UNUSED) {
     return expression;
   }
 };

--- a/paddle/phi/core/generator.cc
+++ b/paddle/phi/core/generator.cc
@@ -23,6 +23,12 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/core/enforce.h"
 
+static uint64_t GetRandomSeed() {
+  std::random_device rd;
+  // double has 53 bit significant, so limit uint64 to 53 bits
+  return ((((uint64_t)rd()) << 32) + rd()) & 0x1FFFFFFFFFFFFF;
+}
+
 namespace phi {
 
 const std::shared_ptr<Generator>& DefaultXPUGenerator(int64_t device_id) {

--- a/paddle/phi/core/generator.h
+++ b/paddle/phi/core/generator.h
@@ -24,11 +24,6 @@ limitations under the License. */
 #include <random>
 #include <typeinfo>
 #include <utility>
-static uint64_t GetRandomSeed() {
-  std::random_device rd;
-  // double has 53 bit significant, so limit uint64 to 53 bits
-  return ((((uint64_t)rd()) << 32) + rd()) & 0x1FFFFFFFFFFFFF;
-}
 
 namespace phi {
 

--- a/paddle/phi/core/utils/unroll_array_ops.h
+++ b/paddle/phi/core/utils/unroll_array_ops.h
@@ -15,8 +15,8 @@
 #pragma once
 #include <cstddef>
 #include <type_traits>
-
 #include "paddle/phi/core/hostdevice.h"
+#include "paddle/phi/core/macros.h"
 
 namespace phi {
 namespace detail {

--- a/paddle/phi/core/utils/unroll_array_ops.h
+++ b/paddle/phi/core/utils/unroll_array_ops.h
@@ -47,7 +47,7 @@ struct UnrollAssign {
 template <size_t kStart, size_t kEnd>
 struct UnrollAssign<kStart, kEnd, true> {
   template <typename Tin, typename Tout>
-  HOSTDEVICE inline static void Run(const Tin *d1, Tout *d2) {}
+  HOSTDEVICE inline static void Run(const Tin *d1 UNUSED, Tout *d2 UNUSED) {}
 };
 
 template <typename T, size_t kStart, size_t kEnd, bool kStop>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
 Others

### Describe
1.remove some [-Wunused-paramter] waring by adding UNUSED
2.replace a static function from .h to .cc
Pcard-67007