### PR TITLE
【Eager】fix multiply double grad error

### DIFF
--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -552,19 +552,18 @@ void MultiplyDoubleGradKernel(const Context& dev_ctx,
       }
     }
   } else {
-    if (dx && dy) {
-      phi::funcs::ElemwiseGradCompute<Context, T, MulGradDX<T>, MulGradDY<T>>(
-          dev_ctx,
-          ddx_safe,
-          ddy_safe,
-          dout,
-          dout,
-          axis,
-          dx,
-          dy,
-          MulGradDX<T>(),
-          MulGradDY<T>());
-    }
+    VLOG(3) << "Calculating here with dx: " << dx << ", dy: " << dy;
+    phi::funcs::ElemwiseGradCompute<Context, T, MulGradDX<T>, MulGradDY<T>>(
+        dev_ctx,
+        ddx_safe,
+        ddy_safe,
+        dout,
+        dout,
+        axis,
+        dx,
+        dy,
+        MulGradDX<T>(),
+        MulGradDY<T>());
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Pcard-66975
This PR fix multiply double grad kernel can't calculate dx, dy without ddout