### PR TITLE
[Decouple enforce.h] Move LOG from enforce.h to enforce.cc

### DIFF
--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -132,7 +132,8 @@ cc_library(
        ${MLU_CTX_DEPS}
        phi_backends
        phi_device_context
-       generator)
+       generator
+       phi_enforce)
 
 cc_library(
   collective_helper

--- a/paddle/phi/core/enforce.cc
+++ b/paddle/phi/core/enforce.cc
@@ -20,6 +20,7 @@ limitations under the License. */
 #include <vector>
 
 #include "gflags/gflags.h"
+#include "glog/logging.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/utils/blank.h"
 
@@ -162,6 +163,10 @@ std::string GetCurrentTraceBackString(bool for_signal) {
   sout << "Not support stack backtrace yet.\n";
 #endif
   return sout.str();
+}
+
+void ThrowWarnInternal(const std::string& msg) {
+  LOG(WARNING) << "WARNING :" << msg;
 }
 
 std::string SimplifyErrorTypeFormat(const std::string& str) {

--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -285,10 +285,16 @@ inline bool is_error(bool stat) { return !stat; }
     END_HANDLE_THE_ERROR                                                      \
   } while (0)
 
-#define __THROW_WARN_INTERNAL__(__MSG__)    \
-  do {                                      \
-    LOG(WARNING) << "WARNING :" << __MSG__; \
-  } while (0)
+/**
+ * [Why declare function ThrowWarnInternal instead of defining macro
+ * __THROW_WARN_INTERNAL__?]
+ * ThrowWarnInternal uses `LOG` macro to display warning message, which depends
+ * on third-party header file "logging.h". However, "logging.h" has not been
+ * exposed to site-package yet, so that error will occur when we include
+ * "enforce.h" header file. Hence, we declare function in enforce.h and define
+ * it in enforce.cc file.
+ */
+void ThrowWarnInternal(const std::string& message);
 
 /** ENFORCE EXCEPTION AND MACROS **/
 
@@ -431,7 +437,7 @@ struct EnforceNotMet : public std::exception {
       auto __message__ = ::paddle::string::Sprintf(       \
           "%s\n  [Hint: " #__VAL " should not be null.]", \
           __summary__.error_message());                   \
-      __THROW_WARN_INTERNAL__(__message__);               \
+      ThrowWarnInternal(__message__);                     \
     }                                                     \
   } while (0)
 
@@ -897,17 +903,16 @@ inline std::string build_nvidia_error_msg(ncclResult_t nccl_result) {
     }                                                        \
   } while (0)
 
-#define PADDLE_WARN_GPU_SUCCESS(COND)                        \
-  do {                                                       \
-    auto __cond__ = (COND);                                  \
-    using __CUDA_STATUS_TYPE__ = decltype(__cond__);         \
-    constexpr auto __success_type__ =                        \
-        ::phi::enforce::details::ExternalApiType<            \
-            __CUDA_STATUS_TYPE__>::kSuccess;                 \
-    if (UNLIKELY(__cond__ != __success_type__)) {            \
-      __THROW_WARN_INTERNAL__(                               \
-          ::phi::enforce::build_nvidia_error_msg(__cond__)); \
-    }                                                        \
+#define PADDLE_WARN_GPU_SUCCESS(COND)                                      \
+  do {                                                                     \
+    auto __cond__ = (COND);                                                \
+    using __CUDA_STATUS_TYPE__ = decltype(__cond__);                       \
+    constexpr auto __success_type__ =                                      \
+        ::phi::enforce::details::ExternalApiType<                          \
+            __CUDA_STATUS_TYPE__>::kSuccess;                               \
+    if (UNLIKELY(__cond__ != __success_type__)) {                          \
+      ThrowWarnInternal(::phi::enforce::build_nvidia_error_msg(__cond__)); \
+    }                                                                      \
   } while (0)
 
 #define PADDLE_ENFORCE_CUDA_LAUNCH_SUCCESS(OP)                              \
@@ -1116,16 +1121,16 @@ DEFINE_EXTERNAL_API_TYPE(ncclResult_t, ncclSuccess);
     }                                                      \
   } while (0)
 
-#define PADDLE_WARN_GPU_SUCCESS(COND)                                          \
-  do {                                                                         \
-    auto __cond__ = (COND);                                                    \
-    using __CUDA_STATUS_TYPE__ = decltype(__cond__);                           \
-    constexpr auto __success_type__ =                                          \
-        ::phi::enforce::details::ExternalApiType<                              \
-            __CUDA_STATUS_TYPE__>::kSuccess;                                   \
-    if (UNLIKELY(__cond__ != __success_type__)) {                              \
-      __THROW_WARN_INTERNAL__(::phi::enforce::build_rocm_error_msg(__cond__)); \
-    }                                                                          \
+#define PADDLE_WARN_GPU_SUCCESS(COND)                                    \
+  do {                                                                   \
+    auto __cond__ = (COND);                                              \
+    using __CUDA_STATUS_TYPE__ = decltype(__cond__);                     \
+    constexpr auto __success_type__ =                                    \
+        ::phi::enforce::details::ExternalApiType<                        \
+            __CUDA_STATUS_TYPE__>::kSuccess;                             \
+    if (UNLIKELY(__cond__ != __success_type__)) {                        \
+      ThrowWarnInternal(::phi::enforce::build_rocm_error_msg(__cond__)); \
+    }                                                                    \
   } while (0)
 
 inline void retry_sleep(unsigned millisecond) {

--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -437,7 +437,7 @@ struct EnforceNotMet : public std::exception {
       auto __message__ = ::paddle::string::Sprintf(       \
           "%s\n  [Hint: " #__VAL " should not be null.]", \
           __summary__.error_message());                   \
-      ThrowWarnInternal(__message__);                     \
+      ::phi::enforce::ThrowWarnInternal(__message__);     \
     }                                                     \
   } while (0)
 
@@ -903,16 +903,17 @@ inline std::string build_nvidia_error_msg(ncclResult_t nccl_result) {
     }                                                        \
   } while (0)
 
-#define PADDLE_WARN_GPU_SUCCESS(COND)                                      \
-  do {                                                                     \
-    auto __cond__ = (COND);                                                \
-    using __CUDA_STATUS_TYPE__ = decltype(__cond__);                       \
-    constexpr auto __success_type__ =                                      \
-        ::phi::enforce::details::ExternalApiType<                          \
-            __CUDA_STATUS_TYPE__>::kSuccess;                               \
-    if (UNLIKELY(__cond__ != __success_type__)) {                          \
-      ThrowWarnInternal(::phi::enforce::build_nvidia_error_msg(__cond__)); \
-    }                                                                      \
+#define PADDLE_WARN_GPU_SUCCESS(COND)                        \
+  do {                                                       \
+    auto __cond__ = (COND);                                  \
+    using __CUDA_STATUS_TYPE__ = decltype(__cond__);         \
+    constexpr auto __success_type__ =                        \
+        ::phi::enforce::details::ExternalApiType<            \
+            __CUDA_STATUS_TYPE__>::kSuccess;                 \
+    if (UNLIKELY(__cond__ != __success_type__)) {            \
+      ::phi::enforce::ThrowWarnInternal(                     \
+          ::phi::enforce::build_nvidia_error_msg(__cond__)); \
+    }                                                        \
   } while (0)
 
 #define PADDLE_ENFORCE_CUDA_LAUNCH_SUCCESS(OP)                              \
@@ -1121,16 +1122,17 @@ DEFINE_EXTERNAL_API_TYPE(ncclResult_t, ncclSuccess);
     }                                                      \
   } while (0)
 
-#define PADDLE_WARN_GPU_SUCCESS(COND)                                    \
-  do {                                                                   \
-    auto __cond__ = (COND);                                              \
-    using __CUDA_STATUS_TYPE__ = decltype(__cond__);                     \
-    constexpr auto __success_type__ =                                    \
-        ::phi::enforce::details::ExternalApiType<                        \
-            __CUDA_STATUS_TYPE__>::kSuccess;                             \
-    if (UNLIKELY(__cond__ != __success_type__)) {                        \
-      ThrowWarnInternal(::phi::enforce::build_rocm_error_msg(__cond__)); \
-    }                                                                    \
+#define PADDLE_WARN_GPU_SUCCESS(COND)                      \
+  do {                                                     \
+    auto __cond__ = (COND);                                \
+    using __CUDA_STATUS_TYPE__ = decltype(__cond__);       \
+    constexpr auto __success_type__ =                      \
+        ::phi::enforce::details::ExternalApiType<          \
+            __CUDA_STATUS_TYPE__>::kSuccess;               \
+    if (UNLIKELY(__cond__ != __success_type__)) {          \
+      ::phi::enforce::ThrowWarnInternal(                   \
+          ::phi::enforce::build_rocm_error_msg(__cond__)); \
+    }                                                      \
   } while (0)
 
 inline void retry_sleep(unsigned millisecond) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Pcard-66989

[Decouple enforce.h] Move LOG from enforce.h to enforce.cc

ThrowWarnInternal uses `LOG` macro to display warning message, which depends on the third-party header file "logging.h". However, "logging.h" has not been exposed to site-package yet, so that error will occur when we include "enforce.h" header file. Hence, we declare a function in enforce.h and define it in enforce.cc file.
