### PR TITLE
[CustomOP Unittest] Optimize unit test, save setUp time

### DIFF
--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -195,7 +195,15 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
         paddle.seed(SEED)
         paddle.framework.random._manual_program_seed(SEED)
 
-    def test_static(self):
+    def test_all(self):
+        self._test_static()
+        self._test_dynamic()
+        self._test_static_save_and_load_inference_model()
+        self._test_static_save_and_run_inference_predictor()
+        self._test_double_grad_dynamic()
+        self._test_with_dataloader()
+
+    def _test_static(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 if device == 'cpu' and dtype == 'float16':
@@ -208,7 +216,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
                     )
                     check_output(out, pd_out, "out")
 
-    def test_dynamic(self):
+    def _test_dynamic(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 if device == 'cpu' and dtype == 'float16':
@@ -224,7 +232,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
                     check_output(out, pd_out, "out")
                     check_output(x_grad, pd_x_grad, "x_grad")
 
-    def test_static_save_and_load_inference_model(self):
+    def _test_static_save_and_load_inference_model(self):
         paddle.enable_static()
         np_data = np.random.random((1, 1, 28, 28)).astype("float32")
         np_label = np.random.random((1, 1)).astype("int64")
@@ -249,7 +257,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
                 check_output(predict, predict_infer, "predict")
         paddle.disable_static()
 
-    def test_static_save_and_run_inference_predictor(self):
+    def _test_static_save_and_run_inference_predictor(self):
         paddle.enable_static()
         np_data = np.random.random((1, 1, 28, 28)).astype("float32")
         np_label = np.random.random((1, 1)).astype("int64")
@@ -280,7 +288,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             check_output_allclose(predict, predict_infer, "predict")
         paddle.disable_static()
 
-    def test_double_grad_dynamic(self):
+    def _test_double_grad_dynamic(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 if device == 'cpu' and dtype == 'float16':
@@ -295,7 +303,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
                 check_output(out, pd_out, "out")
                 check_output(dx_grad, pd_dx_grad, "dx_grad")
 
-    def test_with_dataloader(self):
+    def _test_with_dataloader(self):
         for device in self.devices:
             paddle.set_device(device)
             # data loader


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Pcard-66988

[CustomOP Unittest] Optimize unit test, save setUp time

在 `test/custom_op/test_custom_relu_op_setup.py` 单测中，有多个单测名为 `text_xxx`，这些单测会频繁调用 `setUp` 做初始化，然而 `setUp` 函数内需要执行 `python custom_relu_setup.py install` 命令，该命令耗时较长。

本 PR 将所有单测放到 `test_all`  函数内，节省多次 `setUp` 的耗时。

Multiple `text_xxx` are put inside `test/custom_op/test_custom_relu_op_setup.py`, these unit tests will frequently call `setUp` to initialize the corresponding environment. However, the `setUp` function needs to execute the command `python custom_relu_setup.py install` and this command takes a long time.

Hence, this PR puts all unit tests inside `test_all` function to save up the running time of `setUp`.