### PR TITLE
[fix_bug]Add backend config to select kernel

### DIFF
--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -1108,6 +1108,7 @@
   kernel :
     func : logical_and
     data_type : x
+    backend : x
 
 - op : logical_not
   args : (Tensor x)
@@ -1117,6 +1118,7 @@
   kernel :
     func : logical_not
     data_type : x
+    backend : x
 
 - op : logical_or
   args : (Tensor x, Tensor y)
@@ -1126,6 +1128,7 @@
   kernel :
     func : logical_or
     data_type : x
+    backend : x
 
 - op : logical_xor
   args : (Tensor x, Tensor y)
@@ -1135,6 +1138,7 @@
   kernel :
     func : logical_xor
     data_type : x
+    backend : x
 
 - op : logit
   args : (Tensor x, float eps = 1e-6f)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Pcard-67001
修复logical_and、logical_or、logical_not、logical_xor缺少`x`推导backen的bug，导致[pr52451 导致detection picodet_s_320_coco_lcnet_bs64_fp16_DP 单机八卡动转静下降超5%](https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-69527/show)