### PR TITLE
[Fix Bug] Fix CustomOP XPU unittest error, delete where

### DIFF
--- a/test/custom_op/custom_relu_op_xpu.cc
+++ b/test/custom_op/custom_relu_op_xpu.cc
@@ -36,7 +36,9 @@ void relu_cpu_backward_kernel(const data_t* grad_out_data,
                               const data_t* out_data,
                               data_t* grad_x_data,
                               int64_t out_numel) {
+  std::cout << "DEBUG kernel begin" << std::endl;
   for (int64_t i = 0; i < out_numel; ++i) {
+    std::cout << "DEBUG kernel iterate" << std::endl;
     grad_x_data[i] =
         grad_out_data[i] * (out_data[i] > static_cast<data_t>(0) ? 1. : 0.);
   }
@@ -72,12 +74,16 @@ std::vector<paddle::Tensor> relu_cpu_backward(const paddle::Tensor& x,
   auto grad_x = paddle::empty_like(x);
 
   PD_DISPATCH_FLOATING_TYPES(out.type(), "relu_cpu_backward", ([&] {
+                               std::cout << "DEBUG data() begin" << std::endl;
+                               grad_out.data<data_t>();
+                               std::cout << "DEBUG data() end" << std::endl;
                                relu_cpu_backward_kernel<data_t>(
                                    grad_out.data<data_t>(),
                                    out.data<data_t>(),
                                    grad_x.data<data_t>(),
                                    out.size());
                              }));
+  std::cout << "DEBUG kernel end" << std::endl;
 
   return {grad_x};
 }

--- a/test/custom_op/custom_relu_op_xpu.cc
+++ b/test/custom_op/custom_relu_op_xpu.cc
@@ -116,7 +116,7 @@ std::vector<paddle::Tensor> relu_xpu_backward(const paddle::Tensor& x,
   auto zeros = paddle::experimental::full_like(x, 0.0, x.dtype(), x.place());
   auto condition = paddle::experimental::greater_than(x, zeros);
 
-  grad_x = grad_out * paddle::where(condition, ones, zeros);
+  grad_x = grad_out * condition;
 
   return {grad_x};
 }
@@ -132,7 +132,7 @@ std::vector<paddle::Tensor> relu_xpu_double_backward(
       paddle::experimental::full_like(out, 0.0, out.dtype(), out.place());
   auto condition = paddle::experimental::greater_than(out, zeros);
 
-  ddout = paddle::multiply(ddx, paddle::where(condition, ones, zeros));
+  ddout = ddx * condition;
 
   return {ddout};
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Pcard-66988

CI link: https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/8234835/job/22443291

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/17810795/231928885-b24085b6-d9e6-478b-bcde-6e23d74b615e.png">

XPU 调用 where API 时会报 segment fault，将此调用替换成别的实现。

segment fault will raise when `where` API is called under the XPU scenario, thus substituting calling API to another implementation.