### PR TITLE
[CustomDevice] update check_finite_and_unscale

### DIFF
--- a/python/paddle/static/amp/amp_nn.py
+++ b/python/paddle/static/amp/amp_nn.py
@@ -54,14 +54,6 @@ def check_finite_and_unscale(x, scale, name=None, float_status=None):
         )
 
     inputs = {'X': x, 'Scale': scale}
-    if core.is_compiled_with_custom_device('npu'):
-        check_variable_and_dtype(
-            float_status,
-            "float_status",
-            ['float16', 'float32'],
-            'check_finite_and_unscale',
-        )
-        inputs['FloatStatus'] = float_status
     outputs = {'Out': x, 'FoundInfinite': found_inf}
     helper.append_op(
         type='check_finite_and_unscale', inputs=inputs, outputs=outputs


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Build-in npu has been deleted in Paddle and custom_npu check_finite_and_unscale kernel no longer takes float_status as the input. So, this PR deletes related code. 