### PR TITLE
[CustomDevice] fix custom cpu unittests failure when multiple python exist in CI

### DIFF
--- a/test/custom_runtime/CMakeLists.txt
+++ b/test/custom_runtime/CMakeLists.txt
@@ -19,10 +19,12 @@ if(WITH_CUSTOM_DEVICE AND NOT WITH_GPU)
     START_BASH
     test_fleet_launch_custom_device.sh
     ENVS
+    PYTHONPATH=""
     FLAGS_allocator_strategy=naive_best_fit
     PADDLE_BINARY_DIR=${PADDLE_BINARY_DIR}
     PLUGIN_URL=${PLUGIN_URL}
-    PLUGIN_TAG=${PLUGIN_TAG})
+    PLUGIN_TAG=${PLUGIN_TAG}
+    PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE})
 
   set_tests_properties(test_custom_cpu_plugin PROPERTIES TIMEOUT 120)
   set_tests_properties(test_custom_cpu_profiler_plugin PROPERTIES TIMEOUT 120)

--- a/test/custom_runtime/test_collective_process_group_xccl.py
+++ b/test/custom_runtime/test_collective_process_group_xccl.py
@@ -15,6 +15,7 @@
 import copy
 import os
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -154,8 +155,11 @@ class TestProcessGroup(TestMultipleCustomCPU):
             && git fetch origin \
             && git checkout {} -b dev \
             && cd backends/custom_cpu \
-            && mkdir build && cd build && cmake .. && make -j8'.format(
-            self.temp_dir.name, os.getenv('PLUGIN_URL'), os.getenv('PLUGIN_TAG')
+            && mkdir build && cd build && cmake .. -DPython_EXECUTABLE={} && make -j8'.format(
+            self.temp_dir.name,
+            os.getenv('PLUGIN_URL'),
+            os.getenv('PLUGIN_TAG'),
+            sys.executable,
         )
         os.system(cmd)
 

--- a/test/custom_runtime/test_custom_cpu_plugin.py
+++ b/test/custom_runtime/test_custom_cpu_plugin.py
@@ -31,8 +31,11 @@ class TestCustomCPUPlugin(unittest.TestCase):
             && git fetch origin \
             && git checkout {} -b dev \
             && cd backends/custom_cpu \
-            && mkdir build && cd build && cmake .. && make -j8'.format(
-            self.temp_dir.name, os.getenv('PLUGIN_URL'), os.getenv('PLUGIN_TAG')
+            && mkdir build && cd build && cmake .. -DPython_EXECUTABLE={} && make -j8'.format(
+            self.temp_dir.name,
+            os.getenv('PLUGIN_URL'),
+            os.getenv('PLUGIN_TAG'),
+            sys.executable,
         )
         os.system(cmd)
 

--- a/test/custom_runtime/test_custom_cpu_profiler_plugin.py
+++ b/test/custom_runtime/test_custom_cpu_profiler_plugin.py
@@ -29,8 +29,11 @@ class TestCustomCPUProfilerPlugin(unittest.TestCase):
             && git fetch origin \
             && git checkout {} -b dev \
             && cd backends/custom_cpu \
-            && mkdir build && cd build && cmake .. && make -j8'.format(
-            self.temp_dir.name, os.getenv('PLUGIN_URL'), os.getenv('PLUGIN_TAG')
+            && mkdir build && cd build && cmake .. -DPython_EXECUTABLE={} && make -j8'.format(
+            self.temp_dir.name,
+            os.getenv('PLUGIN_URL'),
+            os.getenv('PLUGIN_TAG'),
+            sys.executable,
         )
         os.system(cmd)
 

--- a/test/custom_runtime/test_custom_cpu_to_static.py
+++ b/test/custom_runtime/test_custom_cpu_to_static.py
@@ -112,8 +112,11 @@ class TestCustomCPUPlugin(unittest.TestCase):
             && git fetch origin \
             && git checkout {} -b dev \
             && cd backends/custom_cpu \
-            && mkdir build && cd build && cmake .. && make -j8'.format(
-            self.temp_dir.name, os.getenv('PLUGIN_URL'), os.getenv('PLUGIN_TAG')
+            && mkdir build && cd build && cmake .. -DPython_EXECUTABLE={} && make -j8'.format(
+            self.temp_dir.name,
+            os.getenv('PLUGIN_URL'),
+            os.getenv('PLUGIN_TAG'),
+            sys.executable,
         )
         os.system(cmd)
 

--- a/test/custom_runtime/test_custom_op_setup.py
+++ b/test/custom_runtime/test_custom_op_setup.py
@@ -114,8 +114,8 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             self.temp_dir.name,
             os.getenv('PLUGIN_URL'),
             os.getenv('PLUGIN_TAG'),
-            self.cur_dir,
             sys.executable,
+            self.cur_dir,
         )
         os.system(cmd)
 

--- a/test/custom_runtime/test_custom_op_setup.py
+++ b/test/custom_runtime/test_custom_op_setup.py
@@ -109,12 +109,13 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             && git fetch origin \
             && git checkout {} -b dev \
             && cd backends/custom_cpu \
-            && mkdir build && cd build && cmake .. && make -j8 \
+            && mkdir build && cd build && cmake .. -DPython_EXECUTABLE={} && make -j8 \
             && cd {}'.format(
             self.temp_dir.name,
             os.getenv('PLUGIN_URL'),
             os.getenv('PLUGIN_TAG'),
             self.cur_dir,
+            sys.executable,
         )
         os.system(cmd)
 

--- a/test/custom_runtime/test_fleet_launch_custom_device.sh
+++ b/test/custom_runtime/test_fleet_launch_custom_device.sh
@@ -21,9 +21,9 @@ pushd ${temp_dir} \
 && git clone ${PLUGIN_URL} \
 && pushd PaddleCustomDevice/ \
 && git fetch origin \
-&& git checkout ${PLUGIN_TAG} -b dev \ 
+&& git checkout ${PLUGIN_TAG} -b dev \
 && pushd backends/custom_cpu \
-&& mkdir build && pushd build && cmake .. && make -j8 && popd && popd && popd && popd
+&& mkdir build && pushd build && cmake .. -DPython_EXECUTABLE=${PYTHON_EXECUTABLE} && make -j8 && popd && popd && popd && popd
 
 echo "begin test use custom_cpu"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

 fix custom cpu unittests failure when multiple python exist in CI
