### PR TITLE
Remove DataLoader.from_generator timeout settings

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -67,7 +67,7 @@ import signal
 import queue
 
 # NOTE: [ avoid hanging & failed quickly ] These value is used in getting data from another process
-QUEUE_GET_TIMEOUT = 60
+QUEUE_GET_TIMEOUT = None
 
 __all__ = ['PyReader', 'DataLoader', 'default_collate_fn']
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Remove the timeout settings of `DataLoader.from_generator`.