### PR TITLE
worker processes won't hang when any other of workers is already done

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -457,6 +457,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
 
         for i in range(self._num_workers):
             indices_queue = multiprocessing.Queue()
+            indices_queue.cancel_join_thread()
             self._indices_queues.append(indices_queue)
             worker = multiprocessing.Process(
                 target=_worker_loop,

--- a/python/paddle/fluid/dataloader/worker.py
+++ b/python/paddle/fluid/dataloader/worker.py
@@ -398,3 +398,6 @@ def _worker_loop(
     finally:
         if use_shared_memory:
             _cleanup_mmap()
+    if done_event.is_set():
+        out_queue.cancel_join_thread()
+        out_queue.close()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->

If data length for each worker process is not same，once the worker with the shortest data length is done, other workers still wait the done worker to join the thread, which will cause the process hang. 

We fix this bug by canceling the done worker to join thread.