### PR TITLE
Add unique counter for shared memory used in DataLoader 

### DIFF
--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 
+#include <atomic>
 #include <random>
 #include <string>
 
@@ -34,12 +35,15 @@ namespace allocation {
 
 std::string GetIPCName() {
   static std::random_device rd;
+  static std::atomic<uint64_t> counter{0};
   std::string handle = "/paddle_";
 #ifdef _WIN32
   handle += std::to_string(GetCurrentProcessId());
 #else
   handle += std::to_string(getpid());
 #endif
+  handle += "_";
+  handle += counter.fetch_add(1);
   handle += "_";
   handle += std::to_string(rd());
   return handle;

--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -43,7 +43,7 @@ std::string GetIPCName() {
   handle += std::to_string(getpid());
 #endif
   handle += "_";
-  handle += counter.fetch_add(1);
+  handle += std::to_string(counter.fetch_add(1));
   handle += "_";
   handle += std::to_string(rd());
   return handle;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Add unique counter for shared memory used in DataLoader.