### PR TITLE
Fix GetIPCName() bug

### DIFF
--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -43,7 +43,7 @@ std::string GetIPCName() {
   handle += std::to_string(getpid());
 #endif
   handle += "_";
-  handle += counter.fetch_add(1);
+  handle += std::to_string(counter.fetch_add(1));
   handle += "_";
   handle += std::to_string(rd());
   return handle;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix GetIPCName() bug with missing `std::to_string`.