### PR TITLE
[Zero-Dim] fix reduce all and not keep dims case

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op.cc
@@ -98,10 +98,9 @@ class __reduce_meanMaker__ : public ops::ReduceBaseOpMaker {
   virtual std::string GetOpType() const { return "Reduce reduce_mean"; }
 };
 
-DECLARE_INFER_SHAPE_FUNCTOR(
-    reduce_mean,
-    ReduceMeanInferShapeFunctor,
-    PD_INFER_META(phi::ReduceIntArrayAxisInferMetaBase));
+DECLARE_INFER_SHAPE_FUNCTOR(reduce_mean,
+                            ReduceMeanInferShapeFunctor,
+                            PD_INFER_META(phi::MeanRawInferMeta));
 
 REGISTER_OPERATOR(reduce_mean,
                   ops::ReduceBaseOp,

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -318,7 +318,7 @@ void sum_grad(const Tensor& x,
     if (!keepdim) {
       auto axis_ = std::vector<int64_t>();
       if (reduce_all) {
-        for (int64_t i = 1; i < x_dim_size; i++) {
+        for (int64_t i = 0; i < x_dim_size; i++) {
           axis_.push_back(i);
         }
       } else {

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -820,7 +820,7 @@
   args : (Tensor x, IntArray axis={}, bool keepdim=false)
   output : Tensor(out)
   infer_meta :
-    func : ReduceIntArrayAxisInferMeta
+    func : MeanInferMeta
   kernel :
     func : mean
   backward : mean_grad

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3125,22 +3125,6 @@ void ReduceInferMetaBase(const MetaTensor& x,
   out->set_layout(x.layout());
 }
 
-void ReduceIntArrayAxisInferMetaBase(const MetaTensor& x,
-                                     const IntArray& axis,
-                                     bool keep_dim,
-                                     bool reduce_all,
-                                     MetaTensor* out,
-                                     MetaConfig config) {
-  if (config.is_runtime || !axis.FromTensor()) {
-    ReduceInferMetaBase(x, axis.GetData(), keep_dim, reduce_all, out);
-  } else {
-    DDim out_dim = ReduceInferDimForIntArrayAxis(x, axis, keep_dim, reduce_all);
-    out->set_dims(out_dim);
-    out->set_dtype(x.dtype());
-    out->set_layout(x.layout());
-  }
-}
-
 void ReduceIntArrayAxisInferMeta(const MetaTensor& x,
                                  const IntArray& axis,
                                  bool keep_dim,
@@ -3151,6 +3135,23 @@ void ReduceIntArrayAxisInferMeta(const MetaTensor& x,
     reduce_all = true;
   }
   ReduceIntArrayAxisInferMetaBase(x, axis, keep_dim, reduce_all, out, config);
+}
+
+void ReduceIntArrayAxisInferMetaBase(const MetaTensor& x,
+                                     const IntArray& axis,
+                                     bool keep_dim,
+                                     bool reduce_all,
+                                     MetaTensor* out,
+                                     MetaConfig config) {
+  DDim out_dim;
+  if (config.is_runtime || !axis.FromTensor()) {
+    out_dim = ReduceInferDim(x, axis.GetData(), keep_dim, reduce_all);
+  } else {
+    out_dim = ReduceInferDimForIntArrayAxis(x, axis, keep_dim, reduce_all);
+  }
+  out->set_dims(out_dim);
+  out->set_dtype(x.dtype());
+  out->set_layout(x.layout());
 }
 
 void ReduceScatterInferMeta(const MetaTensor& x, int nranks, MetaTensor* out) {
@@ -3951,6 +3952,100 @@ void StridedSliceInferMeta(const MetaTensor& x,
       x, axes, starts, ends, strides, infer_flags, decrease_axis, out, config);
 }
 
+DDim ReduceSumMeanInferDim(const MetaTensor& x,
+                           const std::vector<int64_t>& axis,
+                           bool keep_dim,
+                           bool reduce_all) {
+  auto x_rank = x.dims().size();
+
+  std::vector<int64_t> formated_axis = axis;
+  for (size_t i = 0; i < axis.size(); ++i) {
+    if (x_rank == 0) {
+      PADDLE_ENFORCE_EQ(
+          axis[i] == 0 || axis[i] == -1,
+          true,
+          phi::errors::InvalidArgument(
+              "When input 0D Tensor, the axis can only be -1, 0, None or []"));
+    } else {
+      PADDLE_ENFORCE_LT(axis[i],
+                        x_rank,
+                        errors::InvalidArgument(
+                            "The reduce dim index %d should be in the "
+                            "range [ -dimension(X), dimension(X) ) "
+                            "which dimesion = %d. But received dim index = %d.",
+                            i,
+                            x_rank,
+                            axis[i]));
+      PADDLE_ENFORCE_GE(axis[i],
+                        -x_rank,
+                        errors::InvalidArgument(
+                            "The reduce dim index %d should be in the "
+                            "range [ -dimension(X), dimension(X) )  "
+                            "which dimesion = %d. But received dim index = %d.",
+                            i,
+                            x_rank,
+                            axis[i]));
+    }
+
+    if (axis[i] < 0) {
+      formated_axis[i] = axis[i] + x_rank;
+    }
+  }
+
+  bool full_dim = true;
+  std::set<int64_t> dims_set(formated_axis.begin(), formated_axis.end());
+  for (int64_t i = 0; i < x_rank; ++i) {
+    if (dims_set.find(i) == dims_set.end()) {
+      full_dim = false;
+      break;
+    }
+  }
+  reduce_all = reduce_all || full_dim;
+
+  std::vector<int64_t> out_dim_vector;
+  for (int64_t i = 0; i < x_rank; ++i) {
+    if (reduce_all || dims_set.find(i) != dims_set.end()) {
+      if (keep_dim) {
+        out_dim_vector.push_back(1);
+      } else {
+        continue;
+      }
+    } else {
+      out_dim_vector.push_back(x.dims().at(i));
+    }
+  }
+
+  DDim out_dim = phi::make_ddim(out_dim_vector);
+  return out_dim;
+}
+
+DDim ReduceSumMeanInferDimForIntArrayAxis(const MetaTensor& x,
+                                          const IntArray& axis,
+                                          bool keep_dim,
+                                          bool reduce_all) {
+  std::vector<int64_t> vec_axis = axis.GetData();
+  std::vector<int64_t> vec_dim;
+  if (reduce_all) {
+    if (keep_dim) {
+      vec_dim = std::vector<int64_t>(x.dims().size(), 1);
+    } else {
+      vec_dim = {};
+    }
+  } else {
+    if (keep_dim) {
+      vec_dim = std::vector<int64_t>(x.dims().size(), -1);
+    } else {
+      auto x_rank = static_cast<size_t>(x.dims().size());
+      if (vec_axis.size() > x_rank) {
+        vec_dim = {-1};
+      } else {
+        vec_dim = std::vector<int64_t>(x.dims().size() - vec_axis.size(), -1);
+      }
+    }
+  }
+  return phi::make_ddim(vec_dim);
+}
+
 /*  Why not use SumRawInferMeta directly?
     Because we need make InferMetaFunction's args follow the design of
    ops.yaml
@@ -3977,9 +4072,10 @@ void SumRawInferMeta(const MetaTensor& x,
                      MetaConfig config) {
   DDim out_dim;
   if (config.is_runtime || !axis.FromTensor()) {
-    out_dim = ReduceInferDim(x, axis.GetData(), keep_dim, reduce_all);
+    out_dim = ReduceSumMeanInferDim(x, axis.GetData(), keep_dim, reduce_all);
   } else {
-    out_dim = ReduceInferDimForIntArrayAxis(x, axis, keep_dim, reduce_all);
+    out_dim =
+        ReduceSumMeanInferDimForIntArrayAxis(x, axis, keep_dim, reduce_all);
   }
 
   DataType out_dtype;
@@ -3995,6 +4091,36 @@ void SumRawInferMeta(const MetaTensor& x,
 
   out->set_dims(out_dim);
   out->set_dtype(out_dtype);
+  out->set_layout(x.layout());
+}
+
+void MeanInferMeta(const MetaTensor& x,
+                   const IntArray& axis,
+                   bool keep_dim,
+                   MetaTensor* out,
+                   MetaConfig config) {
+  bool reduce_all = false;
+  if (axis.size() == 0) {
+    reduce_all = true;
+  }
+  MeanRawInferMeta(x, axis, keep_dim, reduce_all, out, config);
+}
+
+void MeanRawInferMeta(const MetaTensor& x,
+                      const IntArray& axis,
+                      bool keep_dim,
+                      bool reduce_all,
+                      MetaTensor* out,
+                      MetaConfig config) {
+  DDim out_dim;
+  if (config.is_runtime || !axis.FromTensor()) {
+    out_dim = ReduceSumMeanInferDim(x, axis.GetData(), keep_dim, reduce_all);
+  } else {
+    out_dim =
+        ReduceSumMeanInferDimForIntArrayAxis(x, axis, keep_dim, reduce_all);
+  }
+  out->set_dims(out_dim);
+  out->set_dtype(x.dtype());
   out->set_layout(x.layout());
 }
 

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -572,6 +572,19 @@ void SumRawInferMeta(const MetaTensor& x,
                      MetaTensor* out,
                      MetaConfig config = MetaConfig());
 
+void MeanInferMeta(const MetaTensor& x,
+                   const IntArray& axis,
+                   bool keep_dim,
+                   MetaTensor* out,
+                   MetaConfig config = MetaConfig());
+
+void MeanRawInferMeta(const MetaTensor& x,
+                      const IntArray& axis,
+                      bool keep_dim,
+                      bool reduce_all,
+                      MetaTensor* out,
+                      MetaConfig config = MetaConfig());
+
 void SvdInferMeta(const MetaTensor& x,
                   bool full_matrices,
                   MetaTensor* u,

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -89,6 +89,7 @@ PD_REGISTER_KERNEL(add_n,
                    double,
                    int,
                    phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    int64_t) {}
 
 PD_REGISTER_KERNEL(add_n_array,
@@ -99,4 +100,5 @@ PD_REGISTER_KERNEL(add_n_array,
                    double,
                    int,
                    phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    int64_t) {}

--- a/paddle/phi/kernels/funcs/selected_rows_functor.cc
+++ b/paddle/phi/kernels/funcs/selected_rows_functor.cc
@@ -395,6 +395,7 @@ template struct SelectedRowsAddToTensor<phi::CPUContext, float>;
 template struct SelectedRowsAddToTensor<phi::CPUContext, double>;
 template struct SelectedRowsAddToTensor<phi::CPUContext, int>;
 template struct SelectedRowsAddToTensor<phi::CPUContext, int64_t>;
+template struct SelectedRowsAddToTensor<phi::CPUContext, phi::dtype::float16>;
 template struct SelectedRowsAddToTensor<phi::CPUContext, phi::dtype::bfloat16>;
 
 #ifdef PADDLE_WITH_XPU

--- a/paddle/phi/kernels/funcs/unsqueeze.h
+++ b/paddle/phi/kernels/funcs/unsqueeze.h
@@ -105,19 +105,19 @@ inline DDim GetOutputSqueezeShape(const std::vector<int> squeeze_dims,
 
 inline DDim GetUnsqueezeShape(const std::vector<int64_t> unsqz_dims,
                               const DDim& in_dims) {
-  int output_size = in_dims.size() + static_cast<int>(unsqz_dims.size());
-  int cur_output_size = in_dims.size();
-  std::vector<int64_t> output_shape(output_size, 0);
+  int output_rank = in_dims.size() + static_cast<int>(unsqz_dims.size());
+  int cur_output_rank = in_dims.size();
+  std::vector<int64_t> output_shape(output_rank, 0);
 
   // Validity Check: rank range.
   PADDLE_ENFORCE_LE(
-      output_size,
+      output_rank,
       6,
       phi::errors::InvalidArgument("The output "
                                    "tensor's rank should be less than 6."));
 
   for (int axis : unsqz_dims) {
-    int cur = axis < 0 ? axis + cur_output_size + 1 : axis;
+    int cur = axis < 0 ? axis + cur_output_rank + 1 : axis;
     // Vaildity Check: the axis bound
     PADDLE_ENFORCE_GE(
         cur,
@@ -125,12 +125,12 @@ inline DDim GetUnsqueezeShape(const std::vector<int64_t> unsqz_dims,
         phi::errors::InvalidArgument("The insert dimension value should "
                                      "not be less than 0"));
     PADDLE_ENFORCE_LE(cur,
-                      cur_output_size,
+                      cur_output_rank,
                       phi::errors::InvalidArgument(
                           "The insert dimension value shoule not be larger "
                           "than the dimension size of input tensor"));
     // Move old axis, and insert new axis
-    for (int i = cur_output_size; i >= cur; --i) {
+    for (int i = cur_output_rank; i >= cur; --i) {
       if (output_shape[i] == 1) {
         // Move axis
         output_shape[i + 1] = 1;
@@ -139,11 +139,11 @@ inline DDim GetUnsqueezeShape(const std::vector<int64_t> unsqz_dims,
     }
     output_shape[cur] = 1;
     // Add the output size.
-    cur_output_size++;
+    cur_output_rank++;
   }
 
   // Make output shape
-  for (int in_idx = 0, out_idx = 0; out_idx < output_size; ++out_idx) {
+  for (int in_idx = 0, out_idx = 0; out_idx < output_rank; ++out_idx) {
     if (output_shape[out_idx] == 0) {
       output_shape[out_idx] = in_dims[in_idx++];
     }

--- a/paddle/phi/kernels/onednn/reduce_kernel_impl.h
+++ b/paddle/phi/kernels/onednn/reduce_kernel_impl.h
@@ -102,8 +102,10 @@ void ReduceKernel(const Context& dev_ctx,
     reduction_p->execute(astream, reduction_args);
     astream.wait();
 
-    out->set_mem_desc(
-        dst_memory_p->get_desc().reshape(vectorize<int64_t>(out->dims())));
+    const auto reshape_dims = out->dims().size() != 0
+                                  ? vectorize<int64_t>(out->dims())
+                                  : std::vector<int64_t>{1};
+    out->set_mem_desc(dst_memory_p->get_desc().reshape(reshape_dims));
   }
 }
 

--- a/paddle/phi/kernels/sparse/cpu/unary_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/unary_kernel.cc
@@ -30,7 +30,6 @@ void DivScalarCooKernel(const Context& dev_ctx,
                         float scalar,
                         SparseCooTensor* out) {
   EmptyLikeCooKernel<T, Context>(dev_ctx, x, out);
-
   auto eigen_out =
       phi::EigenVector<T>::Flatten(*(out->mutable_non_zero_elements()));
   auto eigen_x = phi::EigenVector<T>::Flatten(x.non_zero_elements());

--- a/python/paddle/distributed/auto_parallel/cost/base_cost.py
+++ b/python/paddle/distributed/auto_parallel/cost/base_cost.py
@@ -13,7 +13,8 @@
 # limitations under the License
 
 from collections import OrderedDict
-from functools import reduce
+
+import numpy as np
 
 import paddle
 from paddle.utils.flops import flops
@@ -807,7 +808,7 @@ class CommOpCost(OpCost):
                 factor = 8
             else:
                 raise ValueError(f"Unsupported comm dtype {dtype}")
-            comm_count = reduce(lambda x, y: x * y, shape) * factor
+            comm_count = int(np.prod(shape)) * factor
             self._comm_count = comm_count
 
         return self._comm_count

--- a/python/paddle/distributed/auto_parallel/engine.py
+++ b/python/paddle/distributed/auto_parallel/engine.py
@@ -493,7 +493,7 @@ class Engine:
             loss_indices = fetch_indices[group_idx]
             assert len(loss_indices) <= 1
             for idx in loss_indices:
-                logs["loss"] = outs[idx][0]
+                logs["loss"] = outs[idx]
             group_idx += 1
             # logging metrics
             dist_context = self._dist_contexts[mode]

--- a/python/paddle/distributed/auto_parallel/operators/common.py
+++ b/python/paddle/distributed/auto_parallel/operators/common.py
@@ -393,7 +393,7 @@ def get_data_parallel_group(dist_ctx, op, act_grad_names, rank):
 
     for var_name in act_grad_names:
         var_dim_mapping = op_dist_attr.get_input_dims_mapping(var_name)
-        # consider that the variable's shape is None
+        # consider that the variable's shape is [], which is 0D
         # TODO utilize the batch_dim attr instead of "0" in future
         batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
 

--- a/python/paddle/distributed/auto_parallel/operators/dist_default.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_default.py
@@ -159,7 +159,9 @@ class DistributedDefaultImpl0(DistributedOperatorImpl):
                 ):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         need_gradient_allreduce = True
                         break

--- a/python/paddle/distributed/auto_parallel/operators/dist_eltwise.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_eltwise.py
@@ -101,7 +101,9 @@ class DistributedElementwiseImpl0(DistributedOperatorImpl):
                 ):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         need_gradient_allreduce = True
                         break

--- a/python/paddle/distributed/auto_parallel/operators/dist_embedding.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_embedding.py
@@ -252,7 +252,7 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
             backward_op.input("Ids")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
             parallel_axis = batch_size_axis
             attrs = {"use_calc_stream": True}

--- a/python/paddle/distributed/auto_parallel/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_matmul.py
@@ -651,7 +651,7 @@ class DistributedMatmulImpl0(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -1028,7 +1028,7 @@ class DistributedMatmulImpl1(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -1365,7 +1365,7 @@ class DistributedMatmulImpl2(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -1552,7 +1552,7 @@ class DistributedMatmulV2Impl0(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -1929,7 +1929,7 @@ class DistributedMatmulV2Impl1(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -2264,7 +2264,7 @@ class DistributedMatmulV2Impl2(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -2449,7 +2449,7 @@ class DistributedMulImpl0(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -2832,7 +2832,7 @@ class DistributedMulImpl1(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1
@@ -3178,7 +3178,7 @@ class DistributedMulImpl2(DistributedOperatorImpl):
             backward_op.input("X")[0]
         )
         mesh_shape = process_mesh.shape
-        batch_size_axis = var_dim_mapping[0]
+        batch_size_axis = var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
         if (
             batch_size_axis > -1
             and mesh_shape[batch_size_axis] > 1

--- a/python/paddle/distributed/auto_parallel/operators/dist_reshape.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_reshape.py
@@ -120,7 +120,9 @@ class DistributedReshapeImpl0(DistributedOperatorImpl):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
 
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         parallel_axis = batch_size_axis
                         attrs = {"use_calc_stream": True}
@@ -377,7 +379,9 @@ class DistributedReshapeImpl1(DistributedOperatorImpl):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
 
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         parallel_axis = batch_size_axis
                         attrs = {"use_calc_stream": True}
@@ -637,7 +641,9 @@ class DistributedReshapeImpl2(DistributedOperatorImpl):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
 
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         parallel_axis = batch_size_axis
                         attrs = {"use_calc_stream": True}

--- a/python/paddle/distributed/auto_parallel/operators/dist_scale.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_scale.py
@@ -100,7 +100,9 @@ class DistributedScaleImpl(DistributedOperatorImpl):
                 ):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         need_gradient_allreduce = True
                         break

--- a/python/paddle/distributed/auto_parallel/operators/dist_softmax.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_softmax.py
@@ -94,7 +94,9 @@ class DistributedSoftmaxImpl(DistributedOperatorImpl):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
 
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         parallel_axis = batch_size_axis
                         attrs = {"use_calc_stream": True}

--- a/python/paddle/distributed/auto_parallel/operators/dist_transpose.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_transpose.py
@@ -183,7 +183,9 @@ class DistributedTranspose2Impl(DistributedOperatorImpl):
                     var_dim_mapping = dist_attr.get_input_dims_mapping(varname)
 
                     mesh_shape = process_mesh.shape
-                    batch_size_axis = var_dim_mapping[0]
+                    batch_size_axis = (
+                        var_dim_mapping[0] if len(var_dim_mapping) > 0 else -1
+                    )
                     if batch_size_axis > -1 and mesh_shape[batch_size_axis] > 1:
                         parallel_axis = batch_size_axis
                         attrs = {"use_calc_stream": True}

--- a/python/paddle/distributed/auto_parallel/utils.py
+++ b/python/paddle/distributed/auto_parallel/utils.py
@@ -1466,7 +1466,8 @@ def update_op_dims_mapping_by_default_dist_impl(dist_op):
                 ), "{} only the batch dimension (0-dim) can be sharded, but the dimension {} is sharded by {} part.".format(
                     op_desc.type(), idx, mapping
                 )
-        batch_dim_mappings.append(dims_mapping[0])
+        if len(dims_mapping) >= 1:
+            batch_dim_mappings.append(dims_mapping[0])
     for arg_name in op_desc.output_arg_names():
         serial_tensor = dist_op.get_serial_output(arg_name)
         if serial_tensor.is_parameter:
@@ -1480,7 +1481,8 @@ def update_op_dims_mapping_by_default_dist_impl(dist_op):
                     ), "{} only the batch dimension (0-dim) can be sharded, but the dimension {} is sharded by {} part.".format(
                         op_desc.type(), idx, mapping
                     )
-            batch_dim_mappings.append(dims_mapping[0])
+            if len(dims_mapping) >= 1:
+                batch_dim_mappings.append(dims_mapping[0])
         else:
             assert (
                 dims_mapping[0] == -1
@@ -1505,7 +1507,7 @@ def update_op_dims_mapping_by_default_dist_impl(dist_op):
         if serial_tensor.is_parameter:
             continue
         dims_mapping = op_dist_attr.get_input_dims_mapping(arg_name)
-        if compatible_dim_mapping != dims_mapping[0]:
+        if len(dims_mapping) >= 1 and compatible_dim_mapping != dims_mapping[0]:
             dims_mapping[0] = compatible_dim_mapping
             changed = True
     for arg_name in op_desc.output_arg_names():
@@ -1514,7 +1516,10 @@ def update_op_dims_mapping_by_default_dist_impl(dist_op):
             continue
         dims_mapping = op_dist_attr.get_output_dims_mapping(arg_name)
         if arg_name not in xshape_arg_names:
-            if compatible_dim_mapping != dims_mapping[0]:
+            if (
+                len(dims_mapping) >= 1
+                and compatible_dim_mapping != dims_mapping[0]
+            ):
                 dims_mapping[0] = compatible_dim_mapping
                 changed = True
         else:

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 
 import paddle
 from paddle import framework
@@ -94,11 +95,10 @@ class HybridParallelClipGrad:
         # global norm of distributed FP16 params_and_grads
         if len(sum_square_dist_fp16) == 0:
             global_norm_dist_fp16 = paddle.to_tensor(
-                [0.0], dtype=paddle.float32
+                np.array(0.0), dtype=paddle.float32
             )
         else:
-            global_norm_dist_fp16 = paddle.concat(sum_square_dist_fp16)
-            global_norm_dist_fp16 = paddle.sum(global_norm_dist_fp16)
+            global_norm_dist_fp16 = paddle.add_n(sum_square_dist_fp16)
             global_norm_dist_fp16 = paddle.cast(
                 global_norm_dist_fp16, dtype=paddle.float32
             )
@@ -106,11 +106,10 @@ class HybridParallelClipGrad:
         # global norm of non-distributed FP16 params_and_grads
         if len(sum_square_not_dist_fp16) == 0:
             global_norm_not_dist_fp16 = paddle.to_tensor(
-                [0.0], dtype=paddle.float32
+                np.array(0.0), dtype=paddle.float32
             )
         else:
-            global_norm_not_dist_fp16 = paddle.concat(sum_square_not_dist_fp16)
-            global_norm_not_dist_fp16 = paddle.sum(global_norm_not_dist_fp16)
+            global_norm_not_dist_fp16 = paddle.add_n(sum_square_not_dist_fp16)
             global_norm_not_dist_fp16 = paddle.cast(
                 global_norm_not_dist_fp16, dtype=paddle.float32
             )
@@ -118,11 +117,10 @@ class HybridParallelClipGrad:
         # global norm of distributed BF16 params_and_grads
         if len(sum_square_dist_bf16) == 0:
             global_norm_dist_bf16 = paddle.to_tensor(
-                [0.0], dtype=paddle.float32
+                np.array(0.0), dtype=paddle.float32
             )
         else:
-            global_norm_dist_bf16 = paddle.concat(sum_square_dist_bf16)
-            global_norm_dist_bf16 = paddle.sum(global_norm_dist_bf16)
+            global_norm_dist_bf16 = paddle.add_n(sum_square_dist_bf16)
             global_norm_dist_bf16 = paddle.cast(
                 global_norm_dist_bf16, dtype=paddle.float32
             )
@@ -130,30 +128,29 @@ class HybridParallelClipGrad:
         # global norm of non-distributed FP16 params_and_grads
         if len(sum_square_not_dist_bf16) == 0:
             global_norm_not_dist_bf16 = paddle.to_tensor(
-                [0.0], dtype=paddle.float32
+                np.array(0.0), dtype=paddle.float32
             )
         else:
-            global_norm_not_dist_bf16 = paddle.concat(sum_square_not_dist_bf16)
-            global_norm_not_dist_bf16 = paddle.sum(global_norm_not_dist_bf16)
+            global_norm_not_dist_bf16 = paddle.add_n(sum_square_not_dist_bf16)
             global_norm_not_dist_bf16 = paddle.cast(
                 global_norm_not_dist_bf16, dtype=paddle.float32
             )
 
         # global norm of distributed FP32 params_and_grads
-        global_norm_dist_fp32 = (
-            paddle.concat(sum_square_dist_fp32)
-            if len(sum_square_dist_fp32) != 0
-            else paddle.to_tensor([0.0], dtype=paddle.float32)
-        )
-        global_norm_dist_fp32 = paddle.sum(global_norm_dist_fp32)
+        if len(sum_square_dist_fp32) == 0:
+            global_norm_dist_fp32 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
+        else:
+            global_norm_dist_fp32 = paddle.add_n(sum_square_dist_fp32)
 
         # global norm of non-distributed FP32 params_and_grads
-        global_norm_not_dist_fp32 = (
-            paddle.concat(sum_square_not_dist_fp32)
-            if len(sum_square_not_dist_fp32) != 0
-            else paddle.to_tensor([0.0], dtype=paddle.float32)
-        )
-        global_norm_not_dist_fp32 = paddle.sum(global_norm_not_dist_fp32)
+        if len(sum_square_not_dist_fp32) == 0:
+            global_norm_not_dist_fp32 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
+        else:
+            global_norm_not_dist_fp32 = paddle.add_n(sum_square_not_dist_fp32)
 
         global_norm_var_dist = (
             global_norm_dist_fp16
@@ -192,14 +189,14 @@ class HybridParallelClipGrad:
         )
 
         max_global_norm = paddle.full(
-            shape=[1],
+            shape=[],
             dtype=global_norm_var_fp32.dtype,
             fill_value=self.clip_norm,
         )
         clip_var = paddle.divide(
             x=max_global_norm,
             y=paddle.maximum(x=global_norm_var_fp32, y=max_global_norm)
-            + paddle.to_tensor([1.0e-6], dtype=paddle.float32),
+            + paddle.to_tensor(np.array(1.0e-6), dtype=paddle.float32),
         )
         clip_var_fp16 = paddle.cast(clip_var, paddle.float16)
 

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py
@@ -94,59 +94,64 @@ class GroupShardedClipGrad:
 
         # global norm of non-distributed FP16 params_and_grads
         if len(sum_square_fp16) == 0:
-            global_norm_fp16 = paddle.to_tensor([0.0], dtype=paddle.float32)
+            global_norm_fp16 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
         else:
-            global_norm_fp16 = paddle.concat(sum_square_fp16)
-            global_norm_fp16 = paddle.sum(global_norm_fp16)
+            global_norm_fp16 = paddle.add_n(sum_square_fp16)
             global_norm_fp16 = paddle.cast(
                 global_norm_fp16, dtype=paddle.float32
             )
 
         # global norm of non-distributed BFP16 params_and_grads
         if len(sum_square_bfp16) == 0:
-            global_norm_bfp16 = paddle.to_tensor([0.0], dtype=paddle.float32)
+            global_norm_bfp16 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
         else:
-            global_norm_bfp16 = paddle.concat(sum_square_bfp16)
-            global_norm_bfp16 = paddle.sum(global_norm_bfp16)
+            global_norm_bfp16 = paddle.add_n(sum_square_bfp16)
             global_norm_bfp16 = paddle.cast(
                 global_norm_bfp16, dtype=paddle.float32
             )
 
         # global norm of non-distributed FP16 params_and_grads for unslice parameters
         if len(unslice_params_fp16) == 0:
-            global_unslice_fp16 = paddle.to_tensor([0.0], dtype=paddle.float32)
+            global_unslice_fp16 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
         else:
-            global_unslice_fp16 = paddle.concat(unslice_params_fp16)
-            global_unslice_fp16 = paddle.sum(global_unslice_fp16)
+            global_unslice_fp16 = paddle.add_n(unslice_params_fp16)
             global_unslice_fp16 = paddle.cast(
                 global_unslice_fp16, dtype=paddle.float32
             )
 
         # global norm of non-distributed BFP16 params_and_grads for unslice parameters
         if len(unslice_params_bfp16) == 0:
-            global_unslice_bfp16 = paddle.to_tensor([0.0], dtype=paddle.float32)
+            global_unslice_bfp16 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
         else:
-            global_unslice_bfp16 = paddle.concat(unslice_params_bfp16)
-            global_unslice_bfp16 = paddle.sum(global_unslice_bfp16)
+            global_unslice_bfp16 = paddle.add_n(unslice_params_bfp16)
             global_unslice_bfp16 = paddle.cast(
                 global_unslice_bfp16, dtype=paddle.float32
             )
 
         # global norm of non-distributed FP32 params_and_grads
-        global_norm_fp32 = (
-            paddle.concat(sum_square_fp32)
-            if len(sum_square_fp32) != 0
-            else paddle.to_tensor([0.0], dtype=paddle.float32)
-        )
-        global_norm_fp32 = paddle.sum(global_norm_fp32)
+        if len(sum_square_fp32) == 0:
+            global_norm_fp32 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
+        else:
+            global_norm_fp32 = paddle.add_n(sum_square_fp32)
 
         # global norm of non-distributed FP32 params_and_grads for unslice parameters
-        global_unslice_fp32 = (
-            paddle.concat(unslice_params_fp32)
-            if len(unslice_params_fp32) != 0
-            else paddle.to_tensor([0.0], dtype=paddle.float32)
-        )
-        global_unslice_fp32 = paddle.sum(global_unslice_fp32)
+        if len(unslice_params_fp32) == 0:
+            global_unslice_fp32 = paddle.to_tensor(
+                np.array(0.0), dtype=paddle.float32
+            )
+        else:
+            global_unslice_fp32 = paddle.add_n(unslice_params_fp32)
+
         global_unslice_var = (
             global_unslice_fp16 + global_unslice_fp32 + global_unslice_bfp16
         )
@@ -165,7 +170,7 @@ class GroupShardedClipGrad:
 
         global_norm_var = paddle.sqrt(global_norm_var + global_unslice_var)
         max_global_norm = paddle.full(
-            shape=[1], dtype=global_norm_var.dtype, fill_value=self.clip_norm
+            shape=[], dtype=global_norm_var.dtype, fill_value=self.clip_norm
         )
 
         clip_var = paddle.divide(

--- a/python/paddle/distributed/fleet/metrics/metric.py
+++ b/python/paddle/distributed/fleet/metrics/metric.py
@@ -40,7 +40,7 @@ def sum(input, scope=None, util=None):
           # in model.py
           input = paddle.cast(some_input, dtype='float32')
           cnt = paddle.sum(input)
-          global_cnt = paddle.static.create_global_var(persistable=True, dtype='float32', shape=[1], value=0)
+          global_cnt = paddle.static.create_global_var(persistable=True, dtype='float32', shape=[], value=0)
           tmp = paddle.add(cnt, global_cnt)
           paddle.assign(tmp, global_cnt)
 
@@ -80,7 +80,7 @@ def max(input, scope=None, util=None):
           # in model.py
           input = paddle.cast(some_input, dtype='float32')
           cnt = paddle.sum(input)
-          global_cnt = paddle.static.create_global_var(persistable=True, dtype='float32', shape=[1], value=0)
+          global_cnt = paddle.static.create_global_var(persistable=True, dtype='float32', shape=[], value=0)
           tmp = paddle.maximum(cnt, global_cnt)
           paddle.assign(tmp, global_cnt)
 
@@ -120,7 +120,7 @@ def min(input, scope=None, util=None):
           # in model.py
           input = paddle.cast(some_input, dtype='float32')
           cnt = paddle.sum(input)
-          global_cnt = paddle.static.create_global_var(persistable=True, dtype='float32', shape=[1], value=0)
+          global_cnt = paddle.static.create_global_var(persistable=True, dtype='float32', shape=[], value=0)
           tmp = paddle.minimum(cnt, global_cnt)
           paddle.assign(tmp, global_cnt)
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_while_op_partition.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_while_op_partition.py
@@ -206,7 +206,7 @@ def get_program():
         auto.shard_tensor(error_cost, _g_process_mesh, [None, None, None])
 
         loss = paddle.mean(error_cost)
-        auto.shard_tensor(loss, _g_process_mesh, [None])
+        auto.shard_tensor(loss, _g_process_mesh, [])
 
     return train_program, start_program, dataloader, i, loss
 

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_base.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_base.py
@@ -97,7 +97,7 @@ def check(use_cuda):
                 step += 1
                 print(
                     'iter={:.0f},cost={},acc1={}'.format(
-                        step, outs[1][0], outs[2][0]
+                        step, outs[1], outs[2][0]
                     )
                 )
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform.py
@@ -1205,7 +1205,7 @@ class TestStickBreakingTransform(unittest.TestCase):
     @param.param_func(((np.random.random(10),),))
     def test_forward_log_det_jacobian(self, x):
         self.assertEqual(
-            self._t.forward_log_det_jacobian(paddle.to_tensor(x)).shape, [1]
+            self._t.forward_log_det_jacobian(paddle.to_tensor(x)).shape, []
         )
 
 

--- a/python/paddle/fluid/tests/unittests/seresnext_test_base.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_test_base.py
@@ -49,17 +49,19 @@ class TestResnetBase(TestParallelExecutorBase):
         )
 
         if compare_separately:
-            for loss in zip(func_1_first_loss, func_2_first_loss):
-                self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
-            for loss in zip(func_1_last_loss, func_2_last_loss):
-                self.assertAlmostEqual(loss[0], loss[1], delta=delta2)
+            self.assertAlmostEqual(
+                func_1_first_loss, func_2_first_loss, delta=1e-5
+            )
+            self.assertAlmostEqual(
+                func_1_last_loss, func_2_last_loss, delta=delta2
+            )
         else:
             np.testing.assert_allclose(
                 func_1_loss_area, func_2_loss_area, rtol=delta2
             )
             self.assertAlmostEqual(
-                np.mean(func_1_first_loss), func_2_first_loss[0], delta=1e-5
+                func_1_first_loss, func_2_first_loss, delta=1e-5
             )
             self.assertAlmostEqual(
-                np.mean(func_1_last_loss), func_2_last_loss[0], delta=delta2
+                func_1_last_loss, func_2_last_loss, delta=delta2
             )

--- a/python/paddle/fluid/tests/unittests/test_argsort_op.py
+++ b/python/paddle/fluid/tests/unittests/test_argsort_op.py
@@ -24,6 +24,7 @@ from paddle.fluid.executor import Executor
 from paddle.fluid.framework import Program, grad_var_name
 
 np.random.seed(123)
+paddle.enable_static()
 
 
 class PyArgsort:
@@ -52,7 +53,7 @@ class PyArgsort:
         out = (
             np.array(self.indices, dtype=self.indices.dtype),
             np.array(self.sorted_x, dtype=self.sorted_x.dtype),
-            np.array([self.loss], dtype=self.loss.dtype),
+            np.array(self.loss, dtype=self.loss.dtype),
         )
         return out
 
@@ -178,7 +179,7 @@ class TestArgsortOpCPU(unittest.TestCase):
 
                 f[...] = o
                 dout_dfeed = (y_pos - y_neg) / (delta * 2)
-                g[...] = dout_dfeed[0]
+                g[...] = dout_dfeed
 
         return grad_list
 

--- a/python/paddle/fluid/tests/unittests/test_cond.py
+++ b/python/paddle/fluid/tests/unittests/test_cond.py
@@ -674,7 +674,7 @@ class TestCondBackward(unittest.TestCase):
                     },
                     fetch_list=[loss.name],
                 )
-                numerical_grad[0][j] = (loss_delta[0] - loss_value[0]) / delta
+                numerical_grad[0][j] = (loss_delta - loss_value) / delta
                 feed_img_delta[0][j] = feed_img[0][j]
             np.testing.assert_allclose(
                 img_grad, numerical_grad, rtol=0.05, atol=0.05

--- a/python/paddle/fluid/tests/unittests/test_cosine_embedding_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cosine_embedding_loss.py
@@ -64,7 +64,7 @@ class TestFunctionCosineEmbeddingLoss(unittest.TestCase):
             reduction='mean',
         )
         np.testing.assert_allclose(dy_result.numpy(), expected1, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         dy_result = paddle.nn.functional.cosine_embedding_loss(
             input1, input2, label, margin=0.5, reduction='sum'
@@ -78,7 +78,7 @@ class TestFunctionCosineEmbeddingLoss(unittest.TestCase):
         )
 
         np.testing.assert_allclose(dy_result.numpy(), expected2, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         dy_result = paddle.nn.functional.cosine_embedding_loss(
             input1, input2, label, margin=0.5, reduction='none'
@@ -92,7 +92,7 @@ class TestFunctionCosineEmbeddingLoss(unittest.TestCase):
         )
 
         np.testing.assert_allclose(dy_result.numpy(), expected3, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [5])
+        self.assertEqual(dy_result.shape, [5])
 
     def run_static(self, use_gpu=False):
         input1 = static.data(name='input1', shape=[5, 3], dtype='float64')
@@ -257,7 +257,7 @@ class TestClassCosineEmbeddingLoss(unittest.TestCase):
             reduction='mean',
         )
         np.testing.assert_allclose(dy_result.numpy(), expected1, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         input1_1D = paddle.to_tensor(self.input1_np_1D)
         input2_1D = paddle.to_tensor(self.input2_np_1D)

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -286,7 +286,7 @@ class TestDistRunnerBase:
                 fetch_list=[avg_cost.name],
                 feed=feeder.feed(get_data()),
             )
-            out_losses.append(loss[0])
+            out_losses.append(loss.item())
             print_to_err(type(self).__name__, "run step %d finished" % i)
         print_to_err(type(self).__name__, "trainer run finished")
         print_to_err(type(self).__name__, f"dist losses: {out_losses}")
@@ -382,7 +382,7 @@ class TestDistRunnerBase:
                 fetch_list=[avg_cost.name],
                 feed=feeder.feed(get_data()),
             )
-            out_losses.append(loss[0])
+            out_losses.append(loss.item())
             print_to_err(type(self).__name__, "run step %d finished" % i)
         print_to_err(type(self).__name__, "trainer run finished")
 
@@ -619,7 +619,7 @@ class TestDistRunnerBase:
             (loss,) = exe.run(
                 binary, fetch_list=[avg_cost.name], feed=feeder.feed(get_data())
             )
-            out_losses.append(loss[0])
+            out_losses.append(loss.item())
             print_to_err(type(self).__name__, "run step %d finished" % i)
             if lr_scheduler is not None:
                 lr_scheduler.step()

--- a/python/paddle/fluid/tests/unittests/test_eager_deletion_recurrent_op.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_deletion_recurrent_op.py
@@ -42,7 +42,7 @@ class PyRNNBase:
     def forward(self):
         for step_id in range(self.x.shape[0]):
             self.step(step_id, self.x[step_id])
-        return np.array([np.mean(self.y)])
+        return np.mean(self.y)
 
     def segment_inputs(self):
         return [self.x[i] for i in range(self.x.shape[0])]
@@ -251,7 +251,7 @@ class EagerDeletionRecurrentOpTest1(unittest.TestCase):
 
                 f[...] = o
                 dout_dfeed = (y_pos - y_neg) / (delta * 2)
-                g[...] = dout_dfeed[0]
+                g[...] = dout_dfeed
 
         return grad_list
 

--- a/python/paddle/fluid/tests/unittests/test_fetch_lod_tensor_array.py
+++ b/python/paddle/fluid/tests/unittests/test_fetch_lod_tensor_array.py
@@ -69,9 +69,10 @@ class TestFetchLoDTensorArray(unittest.TestCase):
             loss_v, array_v = exe.run(
                 binary, feed=feed_dict, fetch_list=[loss, array]
             )
-            self.assertEqual(np.array(loss_v).shape, (1,))
-            self.assertEqual(np.array(array_v[0]).shape, (batch_size, 784))
-            self.assertEqual(np.array(array_v[1]).shape, (batch_size, 1))
+            self.assertEqual(loss_v.shape, ())
+            self.assertEqual(array_v[0].shape, (batch_size, 784))
+            self.assertEqual(array_v[1].shape, (batch_size, 1))
+            self.assertEqual(array_v[2].shape, ())
             np.testing.assert_allclose(loss_v, array_v[2], rtol=1e-05)
 
     def test_fetch_lod_tensor_array(self):
@@ -81,4 +82,5 @@ class TestFetchLoDTensorArray(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_fuse_all_reduce_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_all_reduce_pass.py
@@ -78,10 +78,12 @@ class TestFuseAllReduceOpsBase(TestParallelExecutorBase):
             optimizer=optimizer,
         )
 
-        for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
-        for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
+        self.assertAlmostEqual(
+            not_fuse_op_first_loss, fuse_op_first_loss, delta=1e-6
+        )
+        self.assertAlmostEqual(
+            not_fuse_op_last_loss, fuse_op_last_loss, delta=1e-6
+        )
 
     def optimizer(self, learning_rate=1e-3):
         optimizer = fluid.optimizer.SGD(

--- a/python/paddle/fluid/tests/unittests/test_fuse_bn_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_bn_act_pass.py
@@ -98,7 +98,7 @@ class TestFuseBatchNormActPass(unittest.TestCase):
                 loss_v = exe.run(
                     binary, feed=feeder.feed(data), fetch_list=[loss]
                 )
-                loss_vals.append(loss_v[0][0])
+                loss_vals.append(loss_v[0])
 
         # open fused_bn_act_ops
         build_strategy_fused = fluid.BuildStrategy()
@@ -118,7 +118,7 @@ class TestFuseBatchNormActPass(unittest.TestCase):
                 loss_v = exe.run(
                     binary_fused, feed=feeder.feed(data), fetch_list=[loss]
                 )
-                loss_vals_fused.append(loss_v[0][0])
+                loss_vals_fused.append(loss_v[0])
 
         # check loss
         for i in range(iters):

--- a/python/paddle/fluid/tests/unittests/test_fuse_bn_add_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_bn_add_act_pass.py
@@ -216,7 +216,7 @@ class TestFusedBnAddActAPI(unittest.TestCase):
                 loss_v = exe.run(
                     binary_fused, feed={"x": x, "y": y}, fetch_list=[loss]
                 )
-                loss_vals_fused.append(loss_v[0][0])
+                loss_vals_fused.append(loss_v[0])
 
         # build_origin_program: turn off fused_bn_act_ops
         build_strategy = fluid.BuildStrategy()
@@ -234,7 +234,7 @@ class TestFusedBnAddActAPI(unittest.TestCase):
                     feed={"x": x_data[i], "y": y_data[i]},
                     fetch_list=[loss],
                 )
-                loss_vals.append(loss_v[0][0])
+                loss_vals.append(loss_v[0])
 
         # check loss
         for i in range(iters):

--- a/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
@@ -74,10 +74,12 @@ class TestMNIST(TestParallelExecutorBase):
             optimizer=_optimizer,
         )
 
-        for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
-        for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
+        self.assertAlmostEqual(
+            not_fuse_op_first_loss, fuse_op_first_loss, delta=1e-6
+        )
+        self.assertAlmostEqual(
+            not_fuse_op_last_loss, fuse_op_last_loss, delta=1e-6
+        )
 
     def test_simple_fc_with_fuse_op(self):
         self._compare_fuse_elewise_add_act_ops(simple_fc_net, DeviceType.CUDA)

--- a/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
@@ -70,10 +70,12 @@ class TestFuseOptimizationOps(TestParallelExecutorBase):
             optimizer=optimizer,
         )
 
-        for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
-        for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
+        self.assertAlmostEqual(
+            not_fuse_op_first_loss, fuse_op_first_loss, delta=1e-6
+        )
+        self.assertAlmostEqual(
+            not_fuse_op_last_loss, fuse_op_last_loss, delta=1e-6
+        )
 
     def _decorate_compare_fused_optimizer_ops(
         self, model, use_device, optimizer

--- a/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
@@ -118,10 +118,12 @@ class TestMNIST(TestParallelExecutorBase):
             optimizer=_optimizer,
         )
 
-        for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
-        for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
+        self.assertAlmostEqual(
+            not_fuse_op_first_loss, fuse_op_first_loss, delta=1e-6
+        )
+        self.assertAlmostEqual(
+            not_fuse_op_last_loss, fuse_op_last_loss, delta=1e-6
+        )
 
     def test_simple_depthwise_with_fuse_op(self):
         self._compare(simple_depthwise_net, DeviceType.CUDA)

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -152,7 +152,7 @@ class TestGradientClip(unittest.TestCase):
 
         data = next(self.train_data())
         val = exe.run(prog, feed=feeder.feed(data), fetch_list=[cost])[0]
-        self.assertEqual((1,), val.shape)
+        self.assertEqual(val.shape, ())
         self.assertFalse(np.isnan(val))
 
     def backward_and_optimize(self, cost):

--- a/python/paddle/fluid/tests/unittests/test_hinge_embedding_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_hinge_embedding_loss.py
@@ -50,7 +50,7 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
         dy_result = paddle.nn.functional.hinge_embedding_loss(input, label)
         expected = calc_hinge_embedding_loss(self.input_np, self.label_np)
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         dy_result = paddle.nn.functional.hinge_embedding_loss(
             input, label, reduction='sum'
@@ -59,7 +59,7 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
             self.input_np, self.label_np, reduction='sum'
         )
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         dy_result = paddle.nn.functional.hinge_embedding_loss(
             input, label, reduction='none'
@@ -68,7 +68,7 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
             self.input_np, self.label_np, reduction='none'
         )
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, self.shape)
+        self.assertEqual(dy_result.shape, list(self.shape))
 
     def run_static_check(self, place=paddle.CPUPlace):
         paddle.enable_static()
@@ -129,7 +129,7 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
         dy_result = hinge_embedding_loss(input, label)
         expected = calc_hinge_embedding_loss(self.input_np, self.label_np)
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         hinge_embedding_loss = paddle.nn.loss.HingeEmbeddingLoss(
             reduction='sum'
@@ -139,7 +139,7 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
             self.input_np, self.label_np, reduction='sum'
         )
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         hinge_embedding_loss = paddle.nn.loss.HingeEmbeddingLoss(
             reduction='none'
@@ -149,7 +149,7 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
             self.input_np, self.label_np, reduction='none'
         )
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, self.shape)
+        self.assertTrue(dy_result.shape, list(self.shape))
 
     def run_static_check(self, place=paddle.CPUPlace):
         paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_pass.py
@@ -80,10 +80,9 @@ class TestMNIST(TestParallelExecutorBase):
             use_device=use_device,
             use_ir_memory_optimize=True,
         )
-        for loss in zip(first_loss0, first_loss1):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
-        for loss in zip(last_loss0, last_loss1):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
+
+        self.assertAlmostEqual(first_loss0, first_loss1, delta=1e-6)
+        self.assertAlmostEqual(last_loss0, last_loss1, delta=1e-6)
 
     def test_simple_fc_net(self):
         self._compare_ir_memory_optimize(simple_fc_net, DeviceType.CPU)

--- a/python/paddle/fluid/tests/unittests/test_l1_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_l1_loss.py
@@ -31,17 +31,17 @@ class TestFunctionalL1Loss(unittest.TestCase):
         dy_result = paddle.nn.functional.l1_loss(input, label)
         expected = np.mean(np.abs(self.input_np - self.label_np))
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         dy_result = paddle.nn.functional.l1_loss(input, label, reduction='sum')
         expected = np.sum(np.abs(self.input_np - self.label_np))
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         dy_result = paddle.nn.functional.l1_loss(input, label, reduction='none')
         expected = np.abs(self.input_np - self.label_np)
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [10, 10, 5])
+        self.assertEqual(dy_result.shape, [10, 10, 5])
 
     def run_static(self, use_gpu=False):
         input = paddle.static.data(
@@ -119,19 +119,19 @@ class TestClassL1Loss(unittest.TestCase):
         dy_result = l1_loss(input, label)
         expected = np.mean(np.abs(self.input_np - self.label_np))
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         l1_loss = paddle.nn.loss.L1Loss(reduction='sum')
         dy_result = l1_loss(input, label)
         expected = np.sum(np.abs(self.input_np - self.label_np))
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [1])
+        self.assertEqual(dy_result.shape, [])
 
         l1_loss = paddle.nn.loss.L1Loss(reduction='none')
         dy_result = l1_loss(input, label)
         expected = np.abs(self.input_np - self.label_np)
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
-        self.assertTrue(dy_result.shape, [10, 10, 5])
+        self.assertEqual(dy_result.shape, [10, 10, 5])
 
     def run_static(self, use_gpu=False):
         input = paddle.static.data(

--- a/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
@@ -212,7 +212,7 @@ class TestLearningRateDecayDygraph(unittest.TestCase):
             adam_test.set_dict(opt_state)
             self.assertEqual(
                 adam_test._learning_rate.best_loss,
-                adam3._learning_rate.best_loss.numpy()[0],
+                adam3._learning_rate.best_loss.numpy(),
                 "best_loss is different before and after set_dict",
             )
             self.assertEqual(
@@ -275,7 +275,7 @@ class TestLearningRateDecayDygraph(unittest.TestCase):
                 t = lr()
 
                 np.testing.assert_allclose(
-                    t.numpy()[0].item(), right_result[i], rtol=1e-05
+                    t.numpy().item(), right_result[i], rtol=1e-05
                 )
 
             with self.assertRaises(TypeError):
@@ -342,7 +342,7 @@ class TestLearningRateDecayDygraph(unittest.TestCase):
                 right_result = step_decay(
                     epoch, learning_rate, step_size, decay_rate
                 )
-                fluid_result = scheduler().numpy()[0]
+                fluid_result = scheduler().numpy().item()
                 scheduler.epoch()
                 self.assertAlmostEqual(
                     right_result,
@@ -371,7 +371,7 @@ class TestLearningRateDecayDygraph(unittest.TestCase):
 
             for epoch in range(30):
                 right_result = lambda_decay(epoch, learning_rate, lr_lambda)
-                fluid_result = scheduler().numpy()[0]
+                fluid_result = scheduler().numpy().item()
                 scheduler.epoch()
                 self.assertAlmostEqual(
                     right_result,

--- a/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
@@ -208,7 +208,7 @@ class TestReduceOnPlateauDecay:
         self.assertEqual(
             scheduler.cooldown_counter, scheduler1.cooldown_counter
         )
-        self.assertEqual(scheduler.best.numpy()[0], scheduler1.best)
+        self.assertEqual(scheduler.best, scheduler1.best)
         self.assertEqual(scheduler.num_bad_epochs, scheduler1.num_bad_epochs)
         self.assertEqual(scheduler.last_epoch, scheduler1.last_epoch)
         self.assertEqual(scheduler.last_lr, scheduler1.last_lr)

--- a/python/paddle/fluid/tests/unittests/test_mse_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_mse_loss.py
@@ -118,7 +118,7 @@ class TestNNMseLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
-            self.assertTrue(dy_result.shape, [1])
+            self.assertEqual(dy_result.shape, ())
 
     def test_NNMseLoss_sum(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
@@ -164,7 +164,7 @@ class TestNNMseLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
-            self.assertTrue(dy_result.shape, [1])
+            self.assertEqual(dy_result.shape, ())
 
     def test_NNMseLoss_none(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
@@ -210,7 +210,7 @@ class TestNNMseLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
-            self.assertTrue(dy_result.shape, [1])
+            self.assertEqual(dy_result.shape, tuple(dim))
 
 
 class TestNNFunctionalMseLoss(unittest.TestCase):
@@ -254,7 +254,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
-            self.assertTrue(dy_result.shape, [1])
+            self.assertEqual(dy_result.shape, ())
 
     def test_NNFunctionalMseLoss_sum(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
@@ -296,7 +296,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
-            self.assertTrue(dy_result.shape, [1])
+            self.assertEqual(dy_result.shape, ())
 
     def test_NNFunctionalMseLoss_none(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
@@ -338,7 +338,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
-            self.assertTrue(dy_result.shape, [1])
+            self.assertEqual(dy_result.shape, tuple(dim))
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -42,10 +42,6 @@ class TestNanInf(unittest.TestCase):
 
         out, err = proc.communicate()
         returncode = proc.returncode
-
-        print(out)
-        print(err)
-
         # in python3, type(out+err) is 'bytes', need use encode
         assert (out + err).find(b'There are NAN or INF') != -1
 

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_run_cinn.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_run_cinn.py
@@ -110,7 +110,7 @@ def train(dot_save_dir, prefix, seed=1234):
     loss_values = []
     for step in range(iters):
         loss_v = exe.run(compiled_program, feed=feed[step], fetch_list=[loss])
-        loss_values.append(loss_v[0][0])
+        loss_values.append(loss_v[0])
     return loss_values
 
 

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_cpu.py
@@ -48,10 +48,14 @@ class TestResnetWithReduceBase(TestParallelExecutorBase):
             optimizer=seresnext_net.optimizer,
         )
 
-        for loss in zip(all_reduce_first_loss, reduce_first_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
-        for loss in zip(all_reduce_last_loss, reduce_last_loss):
-            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
+        self.assertAlmostEqual(
+            all_reduce_first_loss, reduce_first_loss, delta=1e-5
+        )
+        self.assertAlmostEqual(
+            all_reduce_last_loss,
+            reduce_last_loss,
+            delta=all_reduce_last_loss * delta2,
+        )
 
         if not use_device:
             return
@@ -86,20 +90,32 @@ class TestResnetWithReduceBase(TestParallelExecutorBase):
             enable_sequential_execution=True,
         )
 
-        for loss in zip(all_reduce_first_loss, all_reduce_first_loss_seq):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
-        for loss in zip(all_reduce_last_loss, all_reduce_last_loss_seq):
-            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
+        self.assertAlmostEqual(
+            all_reduce_first_loss, all_reduce_first_loss_seq, delta=1e-5
+        )
+        self.assertAlmostEqual(
+            all_reduce_last_loss,
+            all_reduce_last_loss_seq,
+            delta=all_reduce_last_loss * delta2,
+        )
 
-        for loss in zip(reduce_first_loss, reduce_first_loss_seq):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
-        for loss in zip(reduce_last_loss, reduce_last_loss_seq):
-            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
+        self.assertAlmostEqual(
+            reduce_first_loss, reduce_first_loss_seq, delta=1e-5
+        )
+        self.assertAlmostEqual(
+            reduce_last_loss,
+            reduce_last_loss_seq,
+            delta=reduce_last_loss * delta2,
+        )
 
-        for loss in zip(all_reduce_first_loss_seq, reduce_first_loss_seq):
-            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
-        for loss in zip(all_reduce_last_loss_seq, reduce_last_loss_seq):
-            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
+        self.assertAlmostEqual(
+            all_reduce_first_loss_seq, reduce_first_loss_seq, delta=1e-5
+        )
+        self.assertAlmostEqual(
+            all_reduce_last_loss_seq,
+            reduce_last_loss_seq,
+            delta=all_reduce_last_loss_seq * delta2,
+        )
 
 
 class TestResnetWithReduceCPU(TestResnetWithReduceBase):

--- a/python/paddle/fluid/tests/unittests/test_recurrent_op.py
+++ b/python/paddle/fluid/tests/unittests/test_recurrent_op.py
@@ -37,7 +37,7 @@ class PyRNNBase:
     def forward(self):
         for step_id in range(self.x.shape[0]):
             self.step(step_id, self.x[step_id])
-        return np.array([np.mean(self.y)])
+        return np.mean(self.y)
 
     def segment_inputs(self):
         return [self.x[i] for i in range(self.x.shape[0])]
@@ -239,7 +239,7 @@ class RecurrentOpTest1(unittest.TestCase):
 
                 f[...] = o
                 dout_dfeed = (y_pos - y_neg) / (delta * 2)
-                g[...] = dout_dfeed[0]
+                g[...] = dout_dfeed
 
         return grad_list
 

--- a/python/paddle/fluid/tests/unittests/test_resnet50_with_cinn.py
+++ b/python/paddle/fluid/tests/unittests/test_resnet50_with_cinn.py
@@ -103,7 +103,7 @@ class TestResnet50Accuracy(unittest.TestCase):
                     fetch_list=[loss],
                     return_numpy=True,
                 )
-                loss_vals.append(loss_v[0][0])
+                loss_vals.append(loss_v[0])
         return loss_vals
 
     def test_check_resnet50_accuracy(self):

--- a/python/paddle/fluid/tests/unittests/test_run_program_op.py
+++ b/python/paddle/fluid/tests/unittests/test_run_program_op.py
@@ -510,7 +510,7 @@ class TestParametersWithStopGradient(unittest.TestCase):
 
         dy_loss = self.train(to_static=False)
         st_loss = self.train(to_static=True)
-        self.assertEqual(dy_loss[0], st_loss[0])
+        self.assertEqual(dy_loss, st_loss)
 
         paddle.enable_static()
 

--- a/python/paddle/hapi/progressbar.py
+++ b/python/paddle/hapi/progressbar.py
@@ -81,8 +81,13 @@ class ProgressBar:
 
         for i, (k, val) in enumerate(values):
             if k == "loss":
-                val = val if isinstance(val, (list, np.ndarray)) else [val]
-                if isinstance(val[0], np.uint16):
+                if isinstance(val, list):
+                    scalar_val = val[0]
+                elif isinstance(val, np.ndarray):
+                    scalar_val = val.item()
+                else:
+                    scalar_val = val
+                if isinstance(scalar_val, np.uint16):
                     values[i] = ("loss", list(convert_uint16_to_float(val)))
 
         if current_num:

--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -250,7 +250,7 @@ def mean_composite(x, axis, keepdim):
         operator.mul, [x.shape[axis] for axis in axes]
     )
     norm = fill_constant(
-        shape=x.shape if len(x.shape) == 0 else [1],
+        shape=[],
         value=value_to_fill,
         dtype=sum_x.dtype,
     )

--- a/python/paddle/incubate/distributed/models/moe/grad_clip.py
+++ b/python/paddle/incubate/distributed/models/moe/grad_clip.py
@@ -142,22 +142,18 @@ class ClipGradForMOEByGlobalNorm(ClipGradBase):
 
         global_norm_var = []
         if len(sum_square_list_fp16) > 0:
-            global_norm_var_fp16 = paddle.concat(sum_square_list_fp16)
-            global_norm_var_fp16 = paddle.sum(global_norm_var_fp16)
+            global_norm_var_fp16 = paddle.add_n(sum_square_list_fp16)
             global_norm_var.append(global_norm_var_fp16.astype(sum_dtype))
         if len(sum_square_list_fp32) > 0:
-            global_norm_var_fp32 = paddle.concat(sum_square_list_fp32)
-            global_norm_var_fp32 = paddle.sum(global_norm_var_fp32)
+            global_norm_var_fp32 = paddle.add_n(sum_square_list_fp32)
             if sum_dtype == 'float32':
                 global_norm_var.append(global_norm_var_fp32)
             else:
                 global_norm_var.append(global_norm_var_fp32.astype(sum_dtype))
         if len(sum_square_list) > 0:
-            global_norm_var_fp64 = paddle.concat(sum_square_list)
-            global_norm_var_fp64 = paddle.sum(global_norm_var_fp64)
+            global_norm_var_fp64 = paddle.add_n(sum_square_list)
             global_norm_var.append(global_norm_var_fp64)
-        global_norm_var = paddle.concat(global_norm_var)
-        global_norm_var = paddle.sum(global_norm_var)
+        global_norm_var = paddle.add_n(global_norm_var)
         return global_norm_var, sum_dtype
 
     @no_grad()

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -698,7 +698,7 @@ class ClipGradByGlobalNorm(ClipGradBase):
         global_norm_var = paddle.add_n(global_norm_var)
         global_norm_var = paddle.sqrt(global_norm_var)
         max_global_norm = paddle.full(
-            shape=[1], dtype=global_norm_var.dtype, fill_value=self.clip_norm
+            shape=[], dtype=global_norm_var.dtype, fill_value=self.clip_norm
         )
 
         need_clip = False

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1331,7 +1331,7 @@ def l1_loss(input, label, reduction='mean', name=None):
         unreduced = _C_ops.abs(_C_ops.subtract(input, label))
 
         if reduction == 'mean':
-            return _C_ops.mean_all(unreduced)
+            return _C_ops.mean(unreduced, [], False)
         elif reduction == 'sum':
             return _C_ops.sum(unreduced, [], None, False)
         else:

--- a/test/autograd/test_autograd_functional_dynamic.py
+++ b/test/autograd/test_autograd_functional_dynamic.py
@@ -256,7 +256,10 @@ def jac(grad_fn, f, inputs):
             _vs = vs.copy()
             _vs[i] = _v
             _, grads = grad_fn(f, inputs, _vs)
-            d_outs = paddle.concat([d_out.flatten() for d_out in grads])
+            if isinstance(grads, typing.Sequence):
+                d_outs = paddle.concat([d_out.flatten() for d_out in grads])
+            else:
+                d_outs = grads.flatten()
             JJ_cols.append(d_outs)
     # JJ is the fully unrolled jacobian
     JJ = paddle.stack(JJ_cols)

--- a/test/autograd/test_autograd_functional_static.py
+++ b/test/autograd/test_autograd_functional_static.py
@@ -41,14 +41,14 @@ paddle.enable_static()
             'v_not_none',
             utils.reduce,
             np.random.rand(2, 3),
-            np.random.rand(1),
+            np.array(np.random.rand()),
             False,
         ),
         (
             'xs_stop_gradient',
             utils.reduce,
             np.random.rand(2, 3),
-            np.random.rand(1),
+            np.array(np.random.rand()),
             True,
         ),
         (

--- a/test/autograd/utils.py
+++ b/test/autograd/utils.py
@@ -26,10 +26,7 @@ from paddle.incubate.autograd.utils import as_tensors
 # Finite Difference Utils
 ##########################################################
 def _product(t):
-    if isinstance(t, int):
-        return t
-    else:
-        return np.product(t)
+    return int(np.product(t))
 
 
 def _get_item(t, idx):

--- a/test/contrib/test_multi_precision_fp16_train.py
+++ b/test/contrib/test_multi_precision_fp16_train.py
@@ -178,7 +178,7 @@ def train(use_pure_fp16=True, use_nesterov=False, optimizer=""):
                 (loss,) = exe.run(
                     train_program, feed=feeder.feed(data), fetch_list=[sum_cost]
                 )
-                loss_v = loss[0] if isinstance(loss, np.ndarray) else loss
+                loss_v = float(loss) if isinstance(loss, np.ndarray) else loss
                 print(
                     'PassID {:1}, Train Batch ID {:04}, train loss {:2.4}'.format(
                         pass_id, batch_id + 1, float(loss_v)

--- a/test/dygraph_to_static/seq2seq_dygraph_model.py
+++ b/test/dygraph_to_static/seq2seq_dygraph_model.py
@@ -407,7 +407,7 @@ class BaseModel(paddle.nn.Layer):
         parent_ids = []
 
         for step_idx in range(paddle.to_tensor(self.beam_max_step_num)):
-            if paddle.sum(1 - beam_finished).numpy()[0] == 0:
+            if paddle.sum(1 - beam_finished) == 0:
                 break
             step_input = self._merge_batch_beams(step_input)
             new_dec_hidden, new_dec_cell = [], []

--- a/test/dygraph_to_static/test_lac.py
+++ b/test/dygraph_to_static/test_lac.py
@@ -573,7 +573,7 @@ class TestLACModel(unittest.TestCase):
                     words, targets, length = batch
                     start_time = time.time()
                     avg_cost, crf_decode = model(words, targets, length)
-                    loss_data.append(avg_cost.numpy()[0])
+                    loss_data.append(float(avg_cost))
 
                     # backward and optimization
                     avg_cost.backward()

--- a/test/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/test/dygraph_to_static/test_mnist_pure_fp16.py
@@ -100,7 +100,7 @@ class TestPureFP16(TestMNIST):
                 scaled.backward()
                 scaler.minimize(optimizer, scaled)
 
-                loss_data.append(avg_loss.numpy()[0])
+                loss_data.append(float(avg_loss))
                 # save checkpoint
                 mnist.clear_gradients()
                 if batch_id % 2 == 0:

--- a/test/dygraph_to_static/test_reinforcement_learning.py
+++ b/test/dygraph_to_static/test_reinforcement_learning.py
@@ -176,7 +176,7 @@ def train(args, place, to_static):
                 state, reward, done, _ = env.step(action)
 
                 # log loss_probs
-                loss_data.append(loss.numpy()[0])
+                loss_data.append(float(loss))
 
                 policy.rewards.append(reward)
                 ep_reward += reward
@@ -191,7 +191,7 @@ def train(args, place, to_static):
             if i_episode % args.log_interval == 0:
                 print(
                     'Episode {}\tLast reward: {:.2f}\tAverage reward: {:.2f}\t loss_probs: {}'.format(
-                        i_episode, ep_reward, running_reward, loss.numpy()[0]
+                        i_episode, ep_reward, running_reward, float(loss)
                     )
                 )
 

--- a/test/dygraph_to_static/test_resnet_pure_fp16.py
+++ b/test/dygraph_to_static/test_resnet_pure_fp16.py
@@ -86,7 +86,7 @@ def train(to_static, build_strategy=None):
             scaler.minimize(optimizer, scaled)
             resnet.clear_gradients()
 
-            loss_data.append(avg_loss.numpy()[0])
+            loss_data.append(float(avg_loss))
             total_loss += avg_loss
             total_acc1 += acc_top1
             total_acc5 += acc_top5

--- a/test/dygraph_to_static/test_sentiment.py
+++ b/test/dygraph_to_static/test_sentiment.py
@@ -342,7 +342,7 @@ def train(args, to_static):
 
                 model.train()
                 avg_cost, prediction, acc = model(doc, label)
-                loss_data.append(avg_cost.numpy()[0])
+                loss_data.append(float(avg_cost))
 
                 avg_cost.backward()
                 sgd_optimizer.minimize(avg_cost)
@@ -358,7 +358,7 @@ def train(args, to_static):
                         "step: %d, ave loss: %f, speed: %f steps/s"
                         % (
                             batch_id,
-                            avg_cost.numpy()[0],
+                            float(avg_cost),
                             args.log_step / used_time,
                         )
                     )

--- a/test/dygraph_to_static/test_transformer.py
+++ b/test/dygraph_to_static/test_transformer.py
@@ -261,7 +261,7 @@ def train_dygraph(args, batch_generator):
                 transformer.clear_gradients()
                 if step_idx % args.print_step == 0:
                     total_avg_cost = avg_cost.numpy() * trainer_count
-                    avg_loss.append(total_avg_cost[0])
+                    avg_loss.append(float(total_avg_cost))
                     if step_idx == 0:
                         logging.info(
                             "step_idx: %d, epoch: %d, batch: %d, avg loss: %f, "

--- a/test/legacy_test/test_async_read_write.py
+++ b/test/legacy_test/test_async_read_write.py
@@ -65,7 +65,7 @@ class TestAsyncRead(unittest.TestCase):
             )
         # index data
         index_array1 = paddle.gather(self.src, self.index)
-        count_numel = paddle.sum(count).numpy()[0]
+        count_numel = paddle.sum(count).item()
         index_array2 = self.dst[count_numel : count_numel + len(self.index)]
         np.testing.assert_allclose(
             index_array1.numpy(), index_array2.numpy(), rtol=1e-05

--- a/test/prim/prim/vjp/eager/test_comp_eager_sum_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_sum_grad.py
@@ -41,7 +41,7 @@ def desired(primal, cotangent, axis, keep_dim):
 class TestSumGradComp(unittest.TestCase):
     def test_sum_grad_comp_1(self):
         self.primal = np.random.rand(10, 10)
-        self.cotangent = np.random.rand(1)
+        self.cotangent = np.array(np.random.rand())
         paddle.disable_static()
 
         np.testing.assert_allclose(

--- a/test/standalone_executor/test_standalone_cuda_graph_multi_stream.py
+++ b/test/standalone_executor/test_standalone_cuda_graph_multi_stream.py
@@ -126,7 +126,7 @@ class TestCustomStream(unittest.TestCase):
 
         for out in outs:
             for baseline, result in zip(outs[0], out):
-                self.assertEqual(baseline[0], result[0])
+                self.assertEqual(baseline, result)
 
 
 if __name__ == "__main__":

--- a/test/xpu/test_zero_dim_tensor_xpu.py
+++ b/test/xpu/test_zero_dim_tensor_xpu.py
@@ -1135,10 +1135,11 @@ class TestSundryAPI(unittest.TestCase):
             out0.numpy(),
             out1.numpy(),
         )
+        self.assertEqual(out0.shape, [])
 
         out0.retain_grads()
         out0.backward()
-        self.assertEqual(out0.grad.shape, [1])
+        self.assertEqual(out0.grad.shape, [])
         self.assertEqual(logit.grad.shape, [2, 3])
 
     def test_allclose(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Depend on https://github.com/PaddlePaddle/Paddle/pull/52739, to fix the reduce all case.
With https://github.com/PaddlePaddle/Paddle/pull/52739 changes, the output dims of reduce sum op changed from {1}  to {} for reduce_all=true and keep_dims=false case.
