### PR TITLE
Multi slice shouldn't be delete if decrease_axis different in delete_repeated_ops_pass. 

### DIFF
--- a/paddle/fluid/framework/ir/delete_repeated_ops_pass.cc
+++ b/paddle/fluid/framework/ir/delete_repeated_ops_pass.cc
@@ -151,6 +151,8 @@ std::string GenSliceAttrKey(OpDesc* slice_op_desc) {
   auto starts = slice_op_desc->GetAttrIfExists<std::vector<int>>("starts");
   auto ends = slice_op_desc->GetAttrIfExists<std::vector<int>>("ends");
   auto axes = slice_op_desc->GetAttrIfExists<std::vector<int>>("axes");
+  auto decrease_axis =
+      slice_op_desc->GetAttrIfExists<std::vector<int>>("decrease_axis");
   attr_key += "starts_";
   for (auto start : starts) {
     attr_key += std::to_string(start) + "_";
@@ -161,6 +163,10 @@ std::string GenSliceAttrKey(OpDesc* slice_op_desc) {
   }
   attr_key += "axes_";
   for (auto axis : axes) {
+    attr_key += std::to_string(axis) + "_";
+  }
+  attr_key += "decrease_axis_";
+  for (auto axis : decrease_axis) {
     attr_key += std::to_string(axis) + "_";
   }
   return attr_key;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
当slice 的 decrease_axis 属性不同时，slice 不能被消除。
