### PR TITLE
[cherry-pick] remove c++14 assert and remove include tensor.h in phi

### DIFF
--- a/cmake/phi_header.cmake
+++ b/cmake/phi_header.cmake
@@ -52,6 +52,16 @@ phi_header_path_compat(
 phi_header_path_compat(
   ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi/core)
 
+# NOTE(liuyuanle): In inference lib, no need include paddle/utils/pybind.h, so we delete this.
+file(READ
+     ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/extension.h
+     HEADER_CONTENT)
+string(REGEX REPLACE "#if !defined\\(PADDLE_ON_INFERENCE\\).*#endif" ""
+                     HEADER_CONTENT "${HEADER_CONTENT}")
+file(WRITE
+     ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/extension.h
+     "${HEADER_CONTENT}")
+
 # In order to be compatible with the original behavior, the header file name needs to be changed
 file(RENAME
      ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/extension.h

--- a/cmake/phi_header.cmake
+++ b/cmake/phi_header.cmake
@@ -17,21 +17,24 @@ set(PADDLE_INFERENCE_INSTALL_DIR
 
 function(phi_header_path_compat TARGET_PATH)
   message(STATUS "phi header path compat processing: ${TARGET_PATH}")
-  file(GLOB HEADERS "${TARGET_PATH}/*" "*.h")
-  foreach(header ${HEADERS})
-    if(${header} MATCHES ".*.h$")
-      file(READ ${header} HEADER_CONTENT)
-      string(REPLACE "paddle/phi/" "paddle/include/experimental/phi/"
-                     HEADER_CONTENT "${HEADER_CONTENT}")
-      string(REPLACE "paddle/fluid/platform/"
-                     "paddle/include/experimental/phi/" HEADER_CONTENT
-                     "${HEADER_CONTENT}")
-      string(REPLACE "paddle/utils/" "paddle/include/experimental/utils/"
-                     HEADER_CONTENT "${HEADER_CONTENT}")
-      file(WRITE ${header} "${HEADER_CONTENT}")
-      message(STATUS "phi header path compat processing complete: ${header}")
-    endif()
-  endforeach()
+  string(FIND ${TARGET_PATH} "experimental" pos)
+  if(pos GREATER 1)
+    file(GLOB HEADERS "${TARGET_PATH}/*" "*.h")
+    foreach(header ${HEADERS})
+      if(${header} MATCHES ".*.h$")
+        file(READ ${header} HEADER_CONTENT)
+        string(REPLACE "paddle/phi/" "paddle/include/experimental/phi/"
+                       HEADER_CONTENT "${HEADER_CONTENT}")
+        string(REPLACE "paddle/fluid/platform/"
+                       "paddle/include/experimental/phi/" HEADER_CONTENT
+                       "${HEADER_CONTENT}")
+        string(REPLACE "paddle/utils/" "paddle/include/experimental/utils/"
+                       HEADER_CONTENT "${HEADER_CONTENT}")
+        file(WRITE ${header} "${HEADER_CONTENT}")
+        message(STATUS "phi header path compat processing complete: ${header}")
+      endif()
+    endforeach()
+  endif()
 endfunction()
 
 phi_header_path_compat(
@@ -48,7 +51,6 @@ phi_header_path_compat(
   ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi/common)
 phi_header_path_compat(
   ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/phi/core)
-phi_header_path_compat(${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/)
 
 # In order to be compatible with the original behavior, the header file name needs to be changed
 file(RENAME

--- a/paddle/extension.h
+++ b/paddle/extension.h
@@ -16,8 +16,8 @@ limitations under the License. */
 
 // All paddle apis in C++ frontend
 #include "paddle/phi/api/all.h"
-// Python bindings for the C++ frontend (includes Python.h)
 #if !defined(PADDLE_ON_INFERENCE) && !defined(PADDLE_NO_PYTHON)
+// Python bindings for the C++ frontend (includes Python.h)
 #include "paddle/utils/pybind.h"
 #endif
 // For initialization of DeviceContextPool and MemoryMethod

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -56,7 +56,7 @@
 #include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/place.h"
 #include "paddle/fluid/platform/profiler.h"
-#include "paddle/phi/api/ext/op_meta_info.h"
+#include "paddle/phi/api/include/tensor.h"
 #include "paddle/phi/common/backend.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -266,7 +266,6 @@ GpuPassStrategy::GpuPassStrategy() : PassStrategy({}) {
         "transpose_flatten_concat_fuse_pass",  //
         "conv2d_fusion_layout_transfer_pass",  //
         "auto_mixed_precision_pass",           //
-        "delete_cast_op_pass",                 //
         "inplace_op_var_pass",                 // should be the last pass.
   });
 

--- a/paddle/fluid/inference/api/paddle_tensor.h
+++ b/paddle/fluid/inference/api/paddle_tensor.h
@@ -21,12 +21,14 @@
 
 #include "paddle_infer_declare.h"  // NOLINT
 
-#include "paddle/phi/api/include/tensor.h"  // expose paddle::Tensor
-
 #ifdef PADDLE_WITH_ONNXRUNTIME
 #include "onnxruntime_c_api.h"    // NOLINT
 #include "onnxruntime_cxx_api.h"  // NOLINT
 #endif
+
+namespace paddle {
+class Tensor;
+}
 
 namespace paddle_infer {
 

--- a/paddle/fluid/platform/init_phi.h
+++ b/paddle/fluid/platform/init_phi.h
@@ -11,8 +11,11 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
+
 #pragma once
+
 #include "paddle/phi/api/include/dll_decl.h"
+
 namespace paddle {
 
 class PADDLE_API InitPhi {

--- a/paddle/phi/api/all.h
+++ b/paddle/phi/api/all.h
@@ -14,10 +14,6 @@ limitations under the License. */
 
 #pragma once
 
-#if !defined(_MSC_VER) && __cplusplus < 201402L
-#error C++14 or later compatible compiler is required to use Paddle.
-#endif
-
 #ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX  // msvc max/min macro conflict with std::min/max


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[cherry-pick #53050](https://github.com/PaddlePaddle/Paddle/pull/53050) remove c++14 assert and remove include tensor.h in phi