### PR TITLE
[CINN] Fix instance_norm for CINN

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_instance_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_instance_norm_op.py
@@ -125,7 +125,6 @@ class TestInstanceNormOp(OpTest):
             'SavedMean': ref_mean_np,
             'SavedVariance': ref_var_np,
         }
-        self.enable_cinn = False
 
     def test_check_output(self):
         self.check_output(check_prim=True)
@@ -165,6 +164,8 @@ class TestInstanceNormFP64(TestInstanceNormOp):
         self.mean_np, self.var_np = _cal_mean_variance(
             self.x_np, self.epsilon, mean_shape
         )
+        self.cinn_atol = 1e-13
+        self.cinn_rtol = 1e-13
         self.fw_comp_rtol = 1e-14
         self.fw_comp_atol = 1e-14
         self.rev_comp_rtol = 1e-13
@@ -667,7 +668,7 @@ class TestCompositeInstanceNormNorm(unittest.TestCase):
                 stop_gradient=False,
             )
             net = PrimGroupNorm(self.num_channels, scale_, bias_)
-            net = apply_to_static(net, False)
+            net = apply_to_static(net, True)
             output = net(input_)
             grad = paddle.grad(output, input_)
             fwd_actual.append(output.numpy())

--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -192,7 +192,7 @@ def instancenorm_composite(x, scale, bias, epsilon):
     var_tmp1 = difference * difference
     variance = mean(var_tmp1, axis=axis, keepdim=True)
     var_tmp3 = variance + epsilon
-    sqrt_var = pow(var_tmp3, full([], 0.5, dtype=var_tmp3.dtype))
+    sqrt_var = pow(var_tmp3, full([1], 0.5, dtype=var_tmp3.dtype))
     out = difference / sqrt_var
 
     if scale is not None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Pcard-66971
修复instance_norm算子单测在CINN执行错误的问题。

具体问题单测如下：

1. `TestInstanceNormOp `, `TestCompositeInstanceNormNorm`, `TestInstanceNormCase1 `由于 instance_norm 算子拆分时使用full接口创建了0D Tensor，CINN目前不支持0D Tensor因此报错，改为1D Tensor后问题解决。
2. `TestInstanceNormFP64 ` 由于单测精度阈值较高导致CINN反向结果未满足精度要求，将cinn_atol和cinn_rtol改为1e-13后测试通过。



