### PR TITLE
[CustomOP Python] Polish auto-gen python codes

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -1037,16 +1037,22 @@ def _generate_python_module(
 
 
 def _gen_output_content(
-    op_name, in_names, out_names, ins_map, attrs_map, inplace_reverse_idx
+    op_name,
+    in_names,
+    out_names,
+    ins_map,
+    attrs_map,
+    outs_list,
+    inplace_reverse_idx,
 ):
     # ' ' * tab space * tab number
     indent = ' ' * 4 * 2
-    dynamic_content = f"""
-{indent}res = []
+    dynamic_content = f"""res = []
 {indent}start_idx = 0"""
-    static_content = f"""
-{indent}ins = {{}}
+    static_content = f"""ins = {{}}
 {indent}ins_map = {ins_map}
+{indent}outs = {{}}
+{indent}outs_list = {outs_list}
 {indent}for key, value in ins_map.items():
 {indent}    # handle optional inputs
 {indent}    if value is not None:
@@ -1131,20 +1137,16 @@ def _custom_api_content(op_name):
         out_names,
         ins_map,
         attrs_map,
+        outs_list,
         inplace_reverse_idx,
     )
     API_TEMPLATE = textwrap.dedent(
         """
         import paddle.fluid.core as core
-        from paddle.fluid.core import Tensor
-        from paddle.fluid.framework import _dygraph_tracer, in_dygraph_mode
+        from paddle.fluid.framework import in_dygraph_mode
         from paddle.fluid.layer_helper import LayerHelper
 
         def {op_name}({params_list}):
-            # prepare inputs and outputs
-            outs = {{}}
-            outs_list = {outs_list}
-
             # The output variable's dtype use default value 'float32',
             # and the actual dtype of output variable will be inferred in runtime.
             if in_dygraph_mode():
@@ -1159,7 +1161,6 @@ def _custom_api_content(op_name):
     api_content = API_TEMPLATE.format(
         op_name=op_name,
         params_list=params_list,
-        outs_list=outs_list,
         dynamic_content=dynamic_content,
         static_content=static_content,
     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
Pcard-66988

[CustomOP Python] Polish auto-gen python codes

Code example:

```
import paddle.fluid.core as core
from paddle.fluid.framework import in_dygraph_mode
from paddle.fluid.layer_helper import LayerHelper

def custom_relu(x):
    # The output variable's dtype use default value 'float32',
    # and the actual dtype of output variable will be inferred in runtime.
    if in_dygraph_mode():
        outs = core.eager._run_custom_op("custom_relu", x)
        res = []
        start_idx = 0
        res.append(outs[start_idx])
        start_idx += 1
        return res[0] if len(res)==1 else res
    else:
        ins = {}
        ins_map = {'X' : x}
        outs = {}
        outs_list = ['Out']
        for key, value in ins_map.items():
            # handle optional inputs
            if value is not None:
                ins[key] = value
        helper = LayerHelper("custom_relu", **locals())

        outs['Out'] = helper.create_variable(dtype='float32')
        helper.append_op(type="custom_relu", inputs=ins, outputs=outs, attrs={})
        res = [outs[out_name] if out_name in outs.keys() else None for out_name in outs_list]
        return res[0] if len(res)==1 else res
```

