### PR TITLE
[BugFix] wrong match between depend and c_allreduce_sum

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
+import os
+
 from paddle import static
 from paddle.fluid import core
 from paddle.framework import _global_flags
@@ -61,6 +63,9 @@ class RawProgramOptimizer(MetaOptimizerBase):
             )
             self.calc_comm_same_stream = (
                 user_defined_strategy._calc_comm_same_stream
+            )
+            self.sync_before_allreduce = os.environ.get(
+                'FLAGS_sync_before_allreduce', None
             )
 
     def _can_apply(self):
@@ -433,8 +438,16 @@ class RawProgramOptimizer(MetaOptimizerBase):
                     OP_ROLE_KEY: OpRole.Backward,
                 },
             )
+            if not self.calc_comm_same_stream and self.sync_before_allreduce:
+                block._insert_op_without_sync(
+                    after_idx + 1,
+                    type='c_sync_calc_stream',
+                    inputs={'X': fused_var},
+                    outputs={'Out': fused_var},
+                    attrs={OP_ROLE_KEY: OpRole.Backward},
+                )
         idx = 0
-        if not self.calc_comm_same_stream:
+        if not self.calc_comm_same_stream and not self.sync_before_allreduce:
             for i in range(len(grad_param_segments)):
                 while (
                     block.ops[idx].type != 'c_allreduce_sum'
@@ -489,6 +502,21 @@ class RawProgramOptimizer(MetaOptimizerBase):
                 },
             )
 
+        if self.calc_comm_same_stream or not self.sync_before_allreduce:
+            block._sync_with_cpp()
+            return
+
+        # insert the sync comm op
+        for idx, op in enumerate(block.ops):
+            if is_optimizer_op(op):
+                block._insert_op_without_sync(
+                    idx,
+                    type='c_sync_comm_stream',
+                    inputs={'X': fused_vars},
+                    outputs={'Out': fused_vars},
+                    attrs={'ring_id': ring_id, OP_ROLE_KEY: OpRole.Backward},
+                )
+                break
         block._sync_with_cpp()
 
     def __get_ouputs_name_to_idx(self, first_backward_idx, block):

--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -433,23 +433,14 @@ class RawProgramOptimizer(MetaOptimizerBase):
                     OP_ROLE_KEY: OpRole.Backward,
                 },
             )
-        idx = 0
-        if not self.calc_comm_same_stream:
-            for i in range(len(grad_param_segments)):
-                while (
-                    block.ops[idx].type != 'c_allreduce_sum'
-                    or fused_vars[i].name not in block.ops[idx].input_arg_names
-                ):
-                    idx += 1
-                grad_segment, param_segment = grad_param_segments[i]
-                for grad in grad_segment:
-                    block._insert_op_without_sync(
-                        idx + 1,
-                        type='depend',
-                        inputs={'X': grad, 'Dep': fused_vars[i]},
-                        outputs={'Out': grad},
-                    )
-                    idx += 1
+            if not self.calc_comm_same_stream:
+                block._insert_op_without_sync(
+                    after_idx + 1,
+                    type='c_sync_calc_stream',
+                    inputs={'X': fused_var},
+                    outputs={'Out': fused_var},
+                    attrs={OP_ROLE_KEY: OpRole.Backward},
+                )
 
         # update the outputs_name_to_idx after insertion of sync/allreduce ops
         outputs_name_to_idx = self.__get_ouputs_name_to_idx(

--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -436,14 +436,15 @@ class RawProgramOptimizer(MetaOptimizerBase):
         idx = 0
         if not self.calc_comm_same_stream:
             for i in range(len(grad_param_segments)):
-                while block.ops[idx].type != 'c_allreduce_sum':
+                op = block.ops[idx]
+                while op.type != 'c_allreduce_sum' and fused_vars[i].name not in op.input_arg_names:
                     idx += 1
                 grad_segment, param_segment = grad_param_segments[i]
                 for grad in grad_segment:
                     block._insert_op_without_sync(
                         idx + 1,
                         type='depend',
-                        inputs={'X': grad, 'Dep': fused_var},
+                        inputs={'X': grad, 'Dep': fused_vars[i]},
                         outputs={'Out': grad},
                     )
                     idx += 1

--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -437,7 +437,10 @@ class RawProgramOptimizer(MetaOptimizerBase):
         if not self.calc_comm_same_stream:
             for i in range(len(grad_param_segments)):
                 op = block.ops[idx]
-                while op.type != 'c_allreduce_sum' and fused_vars[i].name not in op.input_arg_names:
+                while (
+                    op.type != 'c_allreduce_sum'
+                    and fused_vars[i].name not in op.input_arg_names
+                ):
                     idx += 1
                 grad_segment, param_segment = grad_param_segments[i]
                 for grad in grad_segment:

--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -436,10 +436,9 @@ class RawProgramOptimizer(MetaOptimizerBase):
         idx = 0
         if not self.calc_comm_same_stream:
             for i in range(len(grad_param_segments)):
-                op = block.ops[idx]
                 while (
-                    op.type != 'c_allreduce_sum'
-                    and fused_vars[i].name not in op.input_arg_names
+                    block.ops[idx].type != 'c_allreduce_sum'
+                    or fused_vars[i].name not in block.ops[idx].input_arg_names
                 ):
                     idx += 1
                 grad_segment, param_segment = grad_param_segments[i]

--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -441,6 +441,20 @@ class RawProgramOptimizer(MetaOptimizerBase):
                     outputs={'Out': fused_var},
                     attrs={OP_ROLE_KEY: OpRole.Backward},
                 )
+        idx = 0
+        if not self.calc_comm_same_stream:
+            for i in range(len(grad_param_segments)):
+                while block.ops[idx].type != 'c_allreduce_sum':
+                    idx += 1
+                grad_segment, param_segment = grad_param_segments[i]
+                for grad in grad_segment:
+                    block._insert_op_without_sync(
+                        idx + 1,
+                        type='depend',
+                        inputs={'X': grad, 'Dep': fused_var},
+                        outputs={'Out': grad},
+                    )
+                    idx += 1
 
         # update the outputs_name_to_idx after insertion of sync/allreduce ops
         outputs_name_to_idx = self.__get_ouputs_name_to_idx(

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_raw_program_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_raw_program_optimizer.py
@@ -45,5 +45,10 @@ class TestFleetMetaOptimizerPrecision(TestDistBase):
             )
 
 
+class TestFleetMetaOptimizerPrecisionWithSync(TestFleetMetaOptimizerPrecision):
+    def need_envs(self):
+        return {'FLAGS_sync_before_allreduce': '1'}
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_raw_program_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_raw_program_optimizer.py
@@ -49,6 +49,18 @@ class TestFleetMetaOptimizerPrecisionWithSync(TestFleetMetaOptimizerPrecision):
     def need_envs(self):
         return {'FLAGS_sync_before_allreduce': '1'}
 
+    def test_dist_train(self):
+        from paddle import fluid
+
+        if fluid.core.is_compiled_with_cuda():
+            self.check_with_place(
+                "dist_fleet_raw_program_optimizer.py",
+                delta=1e-5,
+                check_error_log=True,
+                log_name=flag_name + 'with_sync',
+                need_envs=self.need_envs(),
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
Others

### Description
<!-- Describe what this PR does -->

#### Background
 在 #51989 合入后，QA反馈PaddleNLP_gpt3_bs16_fp16_DP2-MP4-PP1_N1C8打印不出日志，经排查确认是hang住了。原因是在修改时假设了所有`c_allreduce_sum`都由`RawProgramOptimizer`插入，实际并非如此。因此只能为`RawProgramOptimizer`插入的`c_allreduce_sum`建立依赖，插入`depend`算子。

#### Detail Changes
1. 修复了 #51989 中的问题，根据`fused_var`插入`depend`算子
2. 在修复后，发现PaddleNLP_gpt3_bs16_fp16_DP4-MP8-PP1性能下降10%，经分析发现在去掉 `c_sync_calc_stream`后，`NcclAllReduce` kernel执行时间上升，原因暂不明确。由于临近发版，因此采取临时修复方案，`RawProgramOptimizer`在插入通信算子时根据`FLAGS_sync_before_allreduce`采取两套不同逻辑，设置flag则遵照 #51989 之前的方案。后续查明原因后再删除这一flag。

#### Others
Card-68266