### PR TITLE
[Do not merge] add paddle.static.setitem

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2341,7 +2341,9 @@ class Variable(metaclass=VariableMetaClass):
         return _getitem_impl_(self, item)
 
     def __setitem__(self, item, value):
-        return _setitem_impl_(self, item, value)
+        raise RuntimeError(
+            "In static mode, the __seitem__ (looks like: x[index] = value) should not be used. Please use x = paddle.static.setitem(x, index, value)"
+        )
 
     def get_value(self, scope=None):
         """

--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -615,7 +615,7 @@ def _setitem_for_tensor_array(var, item, value):
     If item is case (1), we perform paddle.tensor.array_write,
     in other cases, we raise a NotImplementedError.
     """
-    from ..framework import LayerHelper, core, _non_static_mode
+    from ..framework import core, _non_static_mode
     from .framework import Variable
 
     assert (
@@ -805,17 +805,20 @@ def _setitem_impl_(var, item, value):
 
     if paddle.fluid.framework._non_static_mode():
         var._bump_inplace_version()
-
+        output = var
+    else:
+        helper = paddle.fluid.layer_helper.LayerHelper('set_value', **locals())
+        output = helper.create_variable_for_type_inference(dtype=var.dtype)
     cur_block = default_main_program().current_block()
     cur_block.append_op(
         type="set_value",
         inputs=inputs,
-        outputs={'Out': var},
+        outputs={'Out': output},
         attrs=attrs,
         inplace_map={"Input": "Out"},
     )
 
-    return var
+    return output
 
 
 # the item is a tensor of bool

--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -37,6 +37,7 @@ from .io import set_program_state  # noqa: F401
 from ..fluid import Scope  # noqa: F401
 from .input import data  # noqa: F401
 from .input import InputSpec  # noqa: F401
+from .input import setitem  # noqa: F401
 
 from ..tensor.creation import create_parameter  # noqa: F401
 from ..tensor.creation import create_global_var  # noqa: F401
@@ -126,4 +127,5 @@ __all__ = [  # noqa
     'set_ipu_shard',
     'ctr_metric_bundle',
     'exponential_decay',
+    'setitem',
 ]

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -18,6 +18,8 @@ from paddle.fluid.data_feeder import check_type
 from paddle.fluid.framework import convert_np_dtype_to_dtype_, static_only
 from paddle.fluid.layer_helper import LayerHelper
 
+from ..fluid.variable_index import _setitem_impl_
+
 __all__ = []
 
 
@@ -342,3 +344,13 @@ class InputSpec:
 
     def __ne__(self, other):
         return not self == other
+
+
+@static_only
+def setitem(x, index, value):
+    """
+    x(Tensor): input Tensor.
+    index(Scalar|Tuple|List|Tensor): Where should be set value.
+    value(Scalar|Tensor): The value which is going to be set.
+    """
+    return _setitem_impl_(x, index, value)

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -352,5 +352,21 @@ def setitem(x, index, value):
     x(Tensor): input Tensor.
     index(Scalar|Tuple|List|Tensor): Where should be set value.
     value(Scalar|Tensor): The value which is going to be set.
+
+    [How to write index?]
+    1. ':' -> slice(),
+       (1) a[:]=v -> setitem(a, slice(None,None,None), v)
+       (2) a[1::2] -> setitem(a, slice(1,None,2), v)
+
+    2. if there are multiple indexes for axes, use TUPLE (Not LIST) to pack them.
+       (1) a[1, 2]=v -> setitem(a, (1, 2), v)
+       (2) a[[1,2],[2,3]]=v -> setitem(a, ([1,2],[2,3]), v)
+       (3) a[1,:, 3] = v -> setitem(a, (1, slice(None,None,None),3), v)
+       (4) a[1, ..., 2]=v -> setitem(a, (1, ..., 2), v)
+
+    3. You can always use TUPLE as index input， even there is only one index.
+       (1) a[Tensor([10,10])]=v -> setitem(a, (Tensor([10,10]),), v)
+       (2) a[1] = v -> setitem(a, (1,), v)
     """
+
     return _setitem_impl_(x, index, value)

--- a/python/paddle/static/nn/__init__.py
+++ b/python/paddle/static/nn/__init__.py
@@ -60,6 +60,7 @@ from .sequence_lod import sequence_reverse  # noqa: F401
 
 from .control_flow import cond
 
+
 __all__ = [  # noqa
     'fc',
     'batch_norm',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
** Just for Test **
- `__setitem__` will raise error in static mode
- add `paddle.static.setitem(x, index, value)` to support setitem in static mode.
