### PR TITLE
【PaddlePaddle Hackathon 4 No.33】为 Paddle 优化 Histogram op 在 GPU 上的计算性能

### DIFF
--- a/paddle/phi/kernels/gpu/histogram_kernel.cu
+++ b/paddle/phi/kernels/gpu/histogram_kernel.cu
@@ -107,7 +107,7 @@ __global__ void KernelMinMax(const T* input,
       }
       if (min_ptr[0] == max_ptr[0]) {
         min_ptr[0] = min_ptr[0] - 1;
-        max_ptr[0] = max_ptr[0] - 1;
+        max_ptr[0] = max_ptr[0] + 1;
       }
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what this PR does -->
当前Paddle采用自主编写的CUDA Kernel执行Histogram的核心计算部分，但是在确定直方图边界时使用Eigen进行计算，存在一定的优化空间
设计文档：https://github.com/PaddlePaddle/community/blob/master/rfcs/OPs-Perf/20230328_histogram_op_optimization.md

* 开发环境
   1. 设备：Tesla V100
   2. 环境：CUDA11.2，cuDNN 8

* 优化方法
   *  关键是使用__global__ kernel的方式实现了KernelMinMax，加速Histogram确定直方图边界的计算部分，从而提高Histogram算子在GPU上的计算性能。

完成优化后，Paddle与优化前的Paddle的性能对比效果:
| Case No. | device| input_shape | input_type | bins | min | max |Paddle Perf(ms) |old Paddle Perf(ms) |diff|
|---|---|---|---|---|---|---|---|---|---|
| 1 | Tesla V100 | [16, 64] | int32   | 100 | 0 | 0 | 0.01176 |0.09403|faster than 699.57% |
| 2 | Tesla V100 | [16, 64] | int64   | 100 | 0 | 0 | 0.01179 |0.13624|faster than 1055.56%|
| 3 | Tesla V100 | [16, 64] | float32 | 100 | 0 | 0 |0.01117 |0.01889|faster than 69.11%|

完成优化后，Paddle与Pytorch的性能对比效果如下:
| Case No. | device| input_shape | input_type | bins | min | max |Paddle Perf(ms) |Pytorch Perf(ms) |diff|
|---|---|---|---|---|---|---|---|---|---|
| 1 | Tesla V100 | [16, 64] | int32   | 100 | 0 | 0 | 0.01176  |0.02255|faster than 91.75%|
| 2 | Tesla V100 | [16, 64] | int64   | 100 | 0 | 0 | 0.01179 |0.03424|faster than 190.42%|
| 3 | Tesla V100 | [16, 64] | float32 | 100 | 0 | 0 | 0.01117 |0.02250|faster than 101.43%|

针对三种不同case, 优化后的性能有不同程度的提升。