### PR TITLE
[Cherry-Pick] Fix bug of block desc. (#53163)

### DIFF
--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -313,7 +313,13 @@ void BlockDesc::MoveFrom(BlockDesc *block) {
       } else if (attr_type == proto::AttrType::BLOCK) {
         ProgramDesc *program = block->Program();
         std::vector<framework::BlockDesc *> old_block_desc;
-        for (int i = 0; i < program->Proto()->blocks_size(); ++i) {
+        // NOTE(GhostScreaming): don't use program->proto()->blocks_size(),
+        // previous assignment of new Variable in vars_ use std::move,
+        // which makes 'var_ptr' which holded by 'block' a nullptr.
+        // block->Program()->proto() will calls Flush() at firtst,
+        // a null var_ptr will cause segmentation fault.
+        int block_size = static_cast<int>(program->Size());
+        for (int i = 0; i < block_size; ++i) {
           // record all block desc's ptr from origin block's program
           old_block_desc.emplace_back(program->MutableBlock(i));
         }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Description
Fix bug of `BlockDesc::MoveFrom()`. It's used to rebuild `main_program_desc` from `ProgramDesc` modified by Fusion Pass. As some fused operators need to create new Variables in modified `ProgramDesc`, `MoveFrom` function uses `std::move()` function to move these VarDesc to `main_program_desc`. As a result, their pointers holded by modified `ProgramDesc`  become nullptr. When call `block()->Program()->proto()` function, it will call `ProgramDesc::Flush()` function at first, which may cause a segmentation fault.
