### PR TITLE
fix paddle-trt bug when encounter inplace var + weight share condition.

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -299,6 +299,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
   // var may have the same name but not have the same id.
   // e.g., var(batch_norm2d_0.w_1) may have id: 10, 13, 25.... in a graph.
   // so we must find all the var_name+id.
+  // https://github.com/PaddlePaddle/Paddle/pull/53184
   for (auto *n : graph->Nodes()) {
     if (n->IsVar() && input_names.count(n->Name())) {
       input_names_with_id.insert(n->Name() + std::to_string(n->id()));

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -296,6 +296,15 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
     }
   }
 
+  // var may have the same name but not have the same id.
+  // e.g., var(batch_norm2d_0.w_1) may have id: 10, 13, 25.... in a graph.
+  // so we must find all the var_name+id.
+  for (auto *n : graph->Nodes()) {
+    if (n->IsVar() && input_names.count(n->Name())) {
+      input_names_with_id.insert(n->Name() + std::to_string(n->id()));
+    }
+  }
+
   auto model_precision =
       static_cast<phi::DataType>(Get<int>("model_precision"));
   auto mixed_black_list =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
**背景：** paddle的IR表示中存在算子的输入输出相同的情况，但trt不支持这种类型的ir，因此在很早之前paddle-trt内部对var进行了改名处理（var->var+id，如batch_norm2d_0.w_1（如果id为13）-> batch_norm2d_0.w_113）能够有效的规避由于IR的不规范导致的问题。
此外模型中有时会遇到权重共享的情况，如一个weight是多个算子的输入，如下图的两个batch_norm所示，其`batch_norm2d_0.w_1 `被共享。
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/26377421/233622219-ba2e2848-047e-49e7-af53-ef5feb8cb0cf.png">

我们发现在graph ir中，`batch_norm2d_0.w_1`的var在graph内部出现了多次，但其不是唯一的，内部存在了多个var（name一致但id不一致）：
- var(name= batch_norm2d_0.w_1, id=10)
- var(name= batch_norm2d_0.w_1, id=13)
- var(name= batch_norm2d_0.w_1, id=25)

由于graph内部相同的var有多个不同的表示，paddle-trt的改名逻辑没有处理这种情况，导致op_desc被错误的修改，如第二个batch_norm的Mean输入`batch_norm2d_0.w_1`被错误的改成了`batch_norm2d_0.w_113`导致Scope FindVar过程失败挂出，该pr并未从根本解决此问题，仅修改改名逻辑规避了Scope FindVar出错的情况。