### PR TITLE
【Hackathon No61】add bf16 for mode

### DIFF
--- a/paddle/phi/kernels/gpu/mode_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/mode_grad_kernel.cu
@@ -15,6 +15,8 @@
 #include "paddle/phi/kernels/mode_grad_kernel.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
@@ -89,4 +91,6 @@ PD_REGISTER_KERNEL(mode_grad,
                    float,
                    double,
                    int32_t,
-                   int64_t) {}
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/mode_kernel.cu
+++ b/paddle/phi/kernels/gpu/mode_kernel.cu
@@ -15,6 +15,8 @@
 #include "paddle/phi/kernels/mode_kernel.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
@@ -129,7 +131,15 @@ void ModeKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    mode, GPU, ALL_LAYOUT, phi::ModeKernel, float, double, int32_t, int64_t) {
+PD_REGISTER_KERNEL(mode,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::ModeKernel,
+                   float,
+                   double,
+                   int32_t,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {
   kernel->OutputAt(1).SetDataType(phi::DataType::INT64);
 }

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -154,64 +154,64 @@ class TestModeFP16Op(OpTest):
             )
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA"
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
-)
-class TestModeBF16Op(OpTest):
-    def init_args(self):
-        self.axis = 1
+# @unittest.skipIf(
+#     not core.is_compiled_with_cuda(),
+#     "core is not compiled with CUDA"
+#     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+# )
+# class TestModeBF16Op(OpTest):
+#     def init_args(self):
+#         self.axis = 1
 
-    def setUp(self):
-        self.op_type = "mode"
-        self.python_api = paddle.mode
-        self.dtype = np.uint16
-        self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
-        self.init_args()
-        self.input_data = convert_uint16_to_float(
-            convert_float_to_uint16(self.input_data)
-        )
+#     def setUp(self):
+#         self.op_type = "mode"
+#         self.python_api = paddle.mode
+#         self.dtype = np.uint16
+#         self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
+#         self.init_args()
+#         self.input_data = convert_uint16_to_float(
+#             convert_float_to_uint16(self.input_data)
+#         )
 
-        self.inputs = {'X': convert_float_to_uint16(self.input_data)}
-        self.attrs = {'axis': self.axis}
-        output, indices = cal_mode(self.input_data, axis=self.axis)
+#         self.inputs = {'X': convert_float_to_uint16(self.input_data)}
+#         self.attrs = {'axis': self.axis}
+#         output, indices = cal_mode(self.input_data, axis=self.axis)
 
-        self.outputs = {
-            'Out': convert_float_to_uint16(output),
-            'Indices': indices,
-        }
-        self.init_numeric_grads()
+#         self.outputs = {
+#             'Out': convert_float_to_uint16(output),
+#             'Indices': indices,
+#         }
+#         self.init_numeric_grads()
 
-    def init_numeric_grads(self):
-        self.grad = np.zeros(self.input_data.shape).astype(np.float32)
-        in_dims = list(range(self.grad.ndim))
-        a_view = np.transpose(
-            self.grad,
-            in_dims[: self.axis] + in_dims[self.axis + 1 :] + [self.axis],
-        )
-        idx = np.array(self.outputs['Indices']).flatten()
-        inds = np.ndindex(a_view.shape[:-1])
-        for i, ind in enumerate(inds):
-            a_view[ind][idx[i]] = 1 / np.prod(self.outputs['Indices'].shape)
-        self.grad = np.transpose(
-            a_view,
-            in_dims[: self.axis] + in_dims[-1:] + in_dims[self.axis : -1],
-        )
+#     def init_numeric_grads(self):
+#         self.grad = np.zeros(self.input_data.shape).astype(np.float32)
+#         in_dims = list(range(self.grad.ndim))
+#         a_view = np.transpose(
+#             self.grad,
+#             in_dims[: self.axis] + in_dims[self.axis + 1 :] + [self.axis],
+#         )
+#         idx = np.array(self.outputs['Indices']).flatten()
+#         inds = np.ndindex(a_view.shape[:-1])
+#         for i, ind in enumerate(inds):
+#             a_view[ind][idx[i]] = 1 / np.prod(self.outputs['Indices'].shape)
+#         self.grad = np.transpose(
+#             a_view,
+#             in_dims[: self.axis] + in_dims[-1:] + in_dims[self.axis : -1],
+#         )
 
-    def test_check_output(self):
-        paddle.enable_static()
-        place = core.CUDAPlace(0)
-        if core.is_bfloat16_supported(place):
-            self.check_output_with_place(place)
+#     def test_check_output(self):
+#         paddle.enable_static()
+#         place = core.CUDAPlace(0)
+#         if core.is_bfloat16_supported(place):
+#             self.check_output_with_place(place)
 
-    def test_check_grad(self):
-        paddle.enable_static()
-        place = core.CUDAPlace(0)
-        if core.is_bfloat16_supported(place):
-            self.check_grad_with_place(
-                place, {'X'}, 'Out', user_defined_grads=[self.grad]
-            )
+#     def test_check_grad(self):
+#         paddle.enable_static()
+#         place = core.CUDAPlace(0)
+#         if core.is_bfloat16_supported(place):
+#             self.check_grad_with_place(
+#                 place, {'X'}, 'Out', user_defined_grads=[self.grad]
+#             )
 
 
 class TestModeOpLastdim(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -64,9 +64,10 @@ def cal_mode(a, axis, keepdim=False):
 class TestModeOp(OpTest):
     def init_args(self):
         self.axis = 1
+        self.input_shape = (2, 64, 1)
 
     def init_input_data(self):
-        self.input_data = np.random.rand(2, 64, 1).astype(self.dtype)
+        self.input_data = np.random.rand(*self.input_shape).astype(self.dtype)
         self.inputs = {'X': self.input_data}
 
     def init_dtype(self):
@@ -130,34 +131,16 @@ class TestModeFP16Op(TestModeOp):
     def init_dtype(self):
         self.dtype = np.float16
 
-    def test_check_output(self):
-        paddle.enable_static()
-        place = core.CUDAPlace(0)
-        if core.is_float16_supported(place):
-            self.check_output_with_place(place)
-
-    def test_check_grad(self):
-        paddle.enable_static()
-        place = core.CUDAPlace(0)
-        grad = self.init_numeric_grads()
-
-        if core.is_float16_supported(place):
-            self.check_grad_with_place(
-                place, {'X'}, 'Out', user_defined_grads=[grad]
-            )
-
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
-    "core is not compiled with CUDA and not support the bfloat16",
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
 )
 class TestModeBF16Op(TestModeOp):
     def init_dtype(self):
         self.dtype = np.uint16
 
     def init_input_data(self):
-        self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
+        self.input_data = np.random.rand(*self.input_shape).astype(np.float32)
         self.input_data = convert_uint16_to_float(
             convert_float_to_uint16(self.input_data)
         )
@@ -183,6 +166,7 @@ class TestModeBF16Op(TestModeOp):
 class TestModeOpLastdim(TestModeOp):
     def init_args(self):
         self.axis = -1
+        self.input_shape = (2, 1, 1, 2, 30)
 
 
 @unittest.skipIf(
@@ -191,6 +175,7 @@ class TestModeOpLastdim(TestModeOp):
 class TestModeFP16OpLastdim(TestModeFP16Op):
     def init_args(self):
         self.axis = -1
+        self.input_shape = (2, 1, 1, 2, 30)
 
 
 @unittest.skipIf(
@@ -199,6 +184,7 @@ class TestModeFP16OpLastdim(TestModeFP16Op):
 class TestModeBF16OpLastdim(TestModeBF16Op):
     def init_args(self):
         self.axis = -1
+        self.input_shape = (2, 1, 1, 2, 30)
 
 
 class TestModeOpKernels(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -133,8 +133,7 @@ class TestModeFP16Op(TestModeOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA"
+    not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
     "core is not compiled with CUDA and not support the bfloat16",
 )

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -154,64 +154,65 @@ class TestModeFP16Op(OpTest):
             )
 
 
-# @unittest.skipIf(
-#     not core.is_compiled_with_cuda(),
-#     "core is not compiled with CUDA"
-#     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
-# )
-# class TestModeBF16Op(OpTest):
-#     def init_args(self):
-#         self.axis = 1
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and not support the bfloat16",
+)
+class TestModeBF16Op(OpTest):
+    def init_args(self):
+        self.axis = 1
 
-#     def setUp(self):
-#         self.op_type = "mode"
-#         self.python_api = paddle.mode
-#         self.dtype = np.uint16
-#         self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
-#         self.init_args()
-#         self.input_data = convert_uint16_to_float(
-#             convert_float_to_uint16(self.input_data)
-#         )
+    def setUp(self):
+        self.op_type = "mode"
+        self.__class__.op_type = "mode"
+        self.python_api = paddle.mode
+        self.dtype = np.uint16
+        self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
+        self.init_args()
+        self.input_data = convert_uint16_to_float(
+            convert_float_to_uint16(self.input_data)
+        )
 
-#         self.inputs = {'X': convert_float_to_uint16(self.input_data)}
-#         self.attrs = {'axis': self.axis}
-#         output, indices = cal_mode(self.input_data, axis=self.axis)
+        self.inputs = {'X': convert_float_to_uint16(self.input_data)}
+        self.attrs = {'axis': self.axis}
+        output, indices = cal_mode(self.input_data, axis=self.axis)
 
-#         self.outputs = {
-#             'Out': convert_float_to_uint16(output),
-#             'Indices': indices,
-#         }
-#         self.init_numeric_grads()
+        self.outputs = {
+            'Out': convert_float_to_uint16(output),
+            'Indices': indices,
+        }
+        self.init_numeric_grads()
 
-#     def init_numeric_grads(self):
-#         self.grad = np.zeros(self.input_data.shape).astype(np.float32)
-#         in_dims = list(range(self.grad.ndim))
-#         a_view = np.transpose(
-#             self.grad,
-#             in_dims[: self.axis] + in_dims[self.axis + 1 :] + [self.axis],
-#         )
-#         idx = np.array(self.outputs['Indices']).flatten()
-#         inds = np.ndindex(a_view.shape[:-1])
-#         for i, ind in enumerate(inds):
-#             a_view[ind][idx[i]] = 1 / np.prod(self.outputs['Indices'].shape)
-#         self.grad = np.transpose(
-#             a_view,
-#             in_dims[: self.axis] + in_dims[-1:] + in_dims[self.axis : -1],
-#         )
+    def init_numeric_grads(self):
+        self.grad = np.zeros(self.input_data.shape).astype(np.float32)
+        in_dims = list(range(self.grad.ndim))
+        a_view = np.transpose(
+            self.grad,
+            in_dims[: self.axis] + in_dims[self.axis + 1 :] + [self.axis],
+        )
+        idx = np.array(self.outputs['Indices']).flatten()
+        inds = np.ndindex(a_view.shape[:-1])
+        for i, ind in enumerate(inds):
+            a_view[ind][idx[i]] = 1 / np.prod(self.outputs['Indices'].shape)
+        self.grad = np.transpose(
+            a_view,
+            in_dims[: self.axis] + in_dims[-1:] + in_dims[self.axis : -1],
+        )
 
-#     def test_check_output(self):
-#         paddle.enable_static()
-#         place = core.CUDAPlace(0)
-#         if core.is_bfloat16_supported(place):
-#             self.check_output_with_place(place)
+    def test_check_output(self):
+        place = core.CUDAPlace(0)
+        paddle.enable_static()
+        if core.is_bfloat16_supported(place):
+            self.check_output_with_place(place)
 
-#     def test_check_grad(self):
-#         paddle.enable_static()
-#         place = core.CUDAPlace(0)
-#         if core.is_bfloat16_supported(place):
-#             self.check_grad_with_place(
-#                 place, {'X'}, 'Out', user_defined_grads=[self.grad]
-#             )
+    def test_check_grad(self):
+        place = core.CUDAPlace(0)
+        paddle.enable_static()
+        if core.is_bfloat16_supported(place):
+            self.check_grad_with_place(
+                place, {'X'}, 'Out', user_defined_grads=[self.grad]
+            )
 
 
 class TestModeOpLastdim(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -69,7 +69,6 @@ class TestModeOp(OpTest):
         self.op_type = "mode"
         self.python_api = paddle.mode
         self.dtype = np.float64
-        np.random.seed(666)
         self.input_data = np.random.rand(2, 64, 1)
         self.init_args()
         self.inputs = {'X': self.input_data}
@@ -114,8 +113,9 @@ class TestModeFP16Op(OpTest):
         self.op_type = "mode"
         self.python_api = paddle.mode
         self.dtype = np.float16
-        np.random.seed(666)
-        self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
+        self.input_data = (
+            np.random.rand(2, 64, 1).astype(np.float16).astype(np.float32)
+        )
         self.init_args()
         self.inputs = {'X': self.input_data.astype(self.dtype)}
         self.attrs = {'axis': self.axis}
@@ -165,10 +165,8 @@ class TestModeBF16Op(OpTest):
         self.op_type = "mode"
         self.python_api = paddle.mode
         self.dtype = np.uint16
-        np.random.seed(6666)
-        self.input_data = np.random.rand(2, 64, 1)
+        self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
         self.init_args()
-        self.input_data = self.input_data.astype(np.float32)
         self.input_data = convert_uint16_to_float(
             convert_float_to_uint16(self.input_data)
         )

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -133,7 +133,10 @@ class TestModeFP16Op(TestModeOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA"
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and not support the bfloat16",
 )
 class TestModeBF16Op(TestModeOp):
     def init_dtype(self):

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -195,7 +195,10 @@ class TestModeBF16Op(OpTest):
         place = core.CUDAPlace(0)
         paddle.enable_static()
         grad = init_numeric_grads(
-            self.input_data.shape, self.outputs['Indices'], self.axis
+            self.input_data.shape,
+            self.outputs['Indices'],
+            self.axis,
+            np.float32,
         )
         if core.is_bfloat16_supported(place):
             self.check_grad_with_place(
@@ -203,7 +206,7 @@ class TestModeBF16Op(OpTest):
             )
 
 
-class TestModeOpLastdim(OpTest):
+class TestModeOpLastdim(TestModeOp):
     def init_args(self):
         self.axis = -1
 
@@ -217,20 +220,6 @@ class TestModeOpLastdim(OpTest):
         self.attrs = {'axis': self.axis}
         output, indices = cal_mode(self.input_data, axis=self.axis)
         self.outputs = {'Out': output, 'Indices': indices}
-
-    def test_check_output(self):
-        paddle.enable_static()
-        self.check_output()
-
-    def test_check_grad(self):
-        paddle.enable_static()
-        grad = init_numeric_grads(
-            self.input_data.shape,
-            self.outputs['Indices'],
-            self.axis,
-            np.float64,
-        )
-        self.check_grad({'X'}, 'Out', user_defined_grads=[grad])
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -155,7 +155,9 @@ class TestModeFP16Op(OpTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA"
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
 )
 class TestModeBF16Op(OpTest):
     def init_args(self):

--- a/python/paddle/fluid/tests/unittests/test_mode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mode_op.py
@@ -61,46 +61,57 @@ def cal_mode(a, axis, keepdim=False):
     return modes, indexes
 
 
-def init_numeric_grads(input_shape, out_indices, axis, dtype):
-    if axis < 0:
-        axis = len(input_shape) + axis
-    grad = np.zeros(input_shape).astype(dtype)
-    in_dims = list(range(grad.ndim))
-    if axis == len(input_shape) - 1:
-        a_view = grad
-    else:
-        a_view = np.transpose(
-            grad,
-            in_dims[:axis] + in_dims[axis + 1 :] + [axis],
-        )
-    idx = np.array(out_indices).flatten()
-    inds = np.ndindex(a_view.shape[:-1])
-    for i, ind in enumerate(inds):
-        a_view[ind][idx[i]] = 1 / np.prod(out_indices.shape)
-    if axis == len(input_shape) - 1:
-        grad = a_view
-    else:
-        grad = np.transpose(
-            a_view,
-            in_dims[:axis] + in_dims[-1:] + in_dims[axis:-1],
-        )
-    return grad
-
-
 class TestModeOp(OpTest):
     def init_args(self):
         self.axis = 1
 
+    def init_input_data(self):
+        self.input_data = np.random.rand(2, 64, 1).astype(self.dtype)
+        self.inputs = {'X': self.input_data}
+
+    def init_dtype(self):
+        self.dtype = np.float64
+
     def setUp(self):
         self.op_type = "mode"
         self.python_api = paddle.mode
-        self.dtype = np.float64
-        self.input_data = np.random.rand(2, 64, 1)
+        self.init_dtype()
         self.init_args()
-        self.inputs = {'X': self.input_data}
+        self.init_input_data()
         self.attrs = {'axis': self.axis}
         output, indices = cal_mode(self.input_data, axis=self.axis)
         self.outputs = {'Out': output, 'Indices': indices}
+
+    def init_numeric_grads(self):
+        if self.axis < 0:
+            axis = len(self.input_data.shape) + self.axis
+        else:
+            axis = self.axis
+        if self.dtype == np.float64:
+            dtype = np.float64
+        else:
+            dtype = np.float32
+        grad = np.zeros(self.input_data.shape).astype(dtype)
+        in_dims = list(range(grad.ndim))
+        if axis == len(self.input_data.shape) - 1:
+            a_view = grad
+        else:
+            a_view = np.transpose(
+                grad,
+                in_dims[:axis] + in_dims[axis + 1 :] + [axis],
+            )
+        idx = np.array(self.outputs['Indices']).flatten()
+        inds = np.ndindex(a_view.shape[:-1])
+        for i, ind in enumerate(inds):
+            a_view[ind][idx[i]] = 1 / np.prod(self.outputs['Indices'].shape)
+        if axis == len(self.input_data.shape) - 1:
+            grad = a_view
+        else:
+            grad = np.transpose(
+                a_view,
+                in_dims[:axis] + in_dims[-1:] + in_dims[axis:-1],
+            )
+        return grad
 
     def test_check_output(self):
         paddle.enable_static()
@@ -108,32 +119,16 @@ class TestModeOp(OpTest):
 
     def test_check_grad(self):
         paddle.enable_static()
-        grad = init_numeric_grads(
-            self.input_data.shape,
-            self.outputs['Indices'],
-            self.axis,
-            np.float64,
-        )
+        grad = self.init_numeric_grads()
         self.check_grad({'X'}, 'Out', user_defined_grads=[grad])
 
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
 )
-class TestModeFP16Op(OpTest):
-    def init_args(self):
-        self.axis = 1
-
-    def setUp(self):
-        self.op_type = "mode"
-        self.python_api = paddle.mode
+class TestModeFP16Op(TestModeOp):
+    def init_dtype(self):
         self.dtype = np.float16
-        self.input_data = np.random.rand(2, 64, 1).astype(np.float16)
-        self.init_args()
-        self.inputs = {'X': self.input_data.astype(self.dtype)}
-        self.attrs = {'axis': self.axis}
-        output, indices = cal_mode(self.input_data, axis=self.axis)
-        self.outputs = {'Out': output, 'Indices': indices}
 
     def test_check_output(self):
         paddle.enable_static()
@@ -144,12 +139,7 @@ class TestModeFP16Op(OpTest):
     def test_check_grad(self):
         paddle.enable_static()
         place = core.CUDAPlace(0)
-        grad = init_numeric_grads(
-            self.input_data.shape,
-            self.outputs['Indices'],
-            self.axis,
-            np.float32,
-        )
+        grad = self.init_numeric_grads()
 
         if core.is_float16_supported(place):
             self.check_grad_with_place(
@@ -162,28 +152,16 @@ class TestModeFP16Op(OpTest):
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
     "core is not compiled with CUDA and not support the bfloat16",
 )
-class TestModeBF16Op(OpTest):
-    def init_args(self):
-        self.axis = 1
-
-    def setUp(self):
-        self.op_type = "mode"
-        self.__class__.op_type = "mode"
-        self.python_api = paddle.mode
+class TestModeBF16Op(TestModeOp):
+    def init_dtype(self):
         self.dtype = np.uint16
+
+    def init_input_data(self):
         self.input_data = np.random.rand(2, 64, 1).astype(np.float32)
-        self.init_args()
         self.input_data = convert_uint16_to_float(
             convert_float_to_uint16(self.input_data)
         )
-
         self.inputs = {'X': convert_float_to_uint16(self.input_data)}
-        self.attrs = {'axis': self.axis}
-        output, indices = cal_mode(self.input_data, axis=self.axis)
-        self.outputs = {
-            'Out': convert_float_to_uint16(output),
-            'Indices': indices,
-        }
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
@@ -194,12 +172,8 @@ class TestModeBF16Op(OpTest):
     def test_check_grad(self):
         place = core.CUDAPlace(0)
         paddle.enable_static()
-        grad = init_numeric_grads(
-            self.input_data.shape,
-            self.outputs['Indices'],
-            self.axis,
-            np.float32,
-        )
+        grad = self.init_numeric_grads()
+
         if core.is_bfloat16_supported(place):
             self.check_grad_with_place(
                 place, {'X'}, 'Out', user_defined_grads=[grad]
@@ -210,17 +184,6 @@ class TestModeOpLastdim(TestModeOp):
     def init_args(self):
         self.axis = -1
 
-    def setUp(self):
-        self.op_type = "mode"
-        self.python_api = paddle.mode
-        self.dtype = np.float64
-        self.input_data = np.random.rand(2, 1, 1, 2, 30)
-        self.init_args()
-        self.inputs = {'X': self.input_data}
-        self.attrs = {'axis': self.axis}
-        output, indices = cal_mode(self.input_data, axis=self.axis)
-        self.outputs = {'Out': output, 'Indices': indices}
-
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
@@ -229,17 +192,6 @@ class TestModeFP16OpLastdim(TestModeFP16Op):
     def init_args(self):
         self.axis = -1
 
-    def setUp(self):
-        self.op_type = "mode"
-        self.python_api = paddle.mode
-        self.dtype = np.float16
-        self.input_data = np.random.rand(2, 1, 1, 2, 30).astype(np.float16)
-        self.init_args()
-        self.inputs = {'X': self.input_data.astype(self.dtype)}
-        self.attrs = {'axis': self.axis}
-        output, indices = cal_mode(self.input_data, axis=self.axis)
-        self.outputs = {'Out': output, 'Indices': indices}
-
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
@@ -247,23 +199,6 @@ class TestModeFP16OpLastdim(TestModeFP16Op):
 class TestModeBF16OpLastdim(TestModeBF16Op):
     def init_args(self):
         self.axis = -1
-
-    def setUp(self):
-        self.op_type = "mode"
-        self.python_api = paddle.mode
-        self.dtype = np.uint16
-        self.input_data = np.random.rand(2, 1, 1, 2, 30).astype(np.float32)
-        self.init_args()
-        self.input_data = convert_uint16_to_float(
-            convert_float_to_uint16(self.input_data)
-        )
-        self.inputs = {'X': convert_float_to_uint16(self.input_data)}
-        self.attrs = {'axis': self.axis}
-        output, indices = cal_mode(self.input_data, axis=self.axis)
-        self.outputs = {
-            'Out': convert_float_to_uint16(output),
-            'Indices': indices,
-        }
 
 
 class TestModeOpKernels(unittest.TestCase):


### PR DESCRIPTION
### PR types
Others 

### PR changes
 APIs

### Description
为mode算子添加fp16,bf16支持并添加单测
改动说明：
1. 原先单测中out计算函数_mode1D不正确,导致众数计算结果都会说序列第一个,但由于原先input中重复值概率很小，因此未检测到。
2. 对于众数bf16类型的计算结果测试，需要对输入对齐到精度损失后的input，例如input为[1.231,1.242,1.243],dtype=float32，计算众数，结果可以为1.231,index=0，而对bf16测试时,对input进行fp32 to uint16转换后,再转回，input精度损失后假设为[1.23,1.24,1.24]，众数计算结果应为1.24,index=1，不应与原本fp32的结果进行对照检测，因此对input 进行了fp32 to uint16, uint16  to fp32的精度损失转换。
3. 众数的反向计算采用默认数值微分的方式会有误，故采用了user_defined_grads