### PR TITLE
[LAUNCH] save env log for each worker

### DIFF
--- a/python/paddle/distributed/launch/controllers/controller.py
+++ b/python/paddle/distributed/launch/controllers/controller.py
@@ -65,6 +65,7 @@ class ControllerBase:
         if len(self.pod.containers) > 0:
             self.ctx.logger.debug(self.pod.containers[0])
 
+        self.save_pod_env()
         self.ctx.status.run()
         self.pod.deploy()
 
@@ -254,6 +255,37 @@ class Controller(ControllerBase):
         try:
             os.makedirs(os.path.dirname(f), exist_ok=True)
             with open(f, 'a+') as fd:
+                if fd.tell() == 0:
+                    fd.write(str(os.environ))
+                    fd.write("\n")
                 fd.write(str(info))
+                fd.write("\n")
         except Exception as e:
             self.ctx.logger.error(f"save log failed because {e}")
+
+    def save_pod_env(self):
+        assert (
+            len(self.pod.containers) + len(self.pod.init_containers) > 0
+        ), "No container in the pod"
+
+        if not self.ctx.args.log_dir:
+            return
+
+        for c in self.pod.init_containers:
+            self._save_container_env(c, is_init=True)
+
+        for c in self.pod.containers:
+            self._save_container_env(c)
+
+    def _save_container_env(self, container, is_init=False):
+        f = os.path.join(
+            self.ctx.args.log_dir,
+            f'envlog.{container.rank}',
+        )
+        try:
+            os.makedirs(os.path.dirname(f), exist_ok=True)
+            with open(f, 'w') as fd:
+                for k, v in sorted(container.env.items()):
+                    fd.write(str(f"{k}={v}\n"))
+        except Exception as e:
+            self.ctx.logger.error(f"save pod env log failed because {e}")

--- a/python/paddle/distributed/launch/controllers/controller.py
+++ b/python/paddle/distributed/launch/controllers/controller.py
@@ -280,7 +280,9 @@ class Controller(ControllerBase):
     def _save_container_env(self, container, is_init=False):
         f = os.path.join(
             self.ctx.args.log_dir,
-            f'envlog.{container.rank}',
+            f'envlog.init.{container.rank}'
+            if is_init
+            else f'envlog.{container.rank}',
         )
         try:
             os.makedirs(os.path.dirname(f), exist_ok=True)

--- a/python/paddle/distributed/launch/job/container.py
+++ b/python/paddle/distributed/launch/job/container.py
@@ -40,6 +40,10 @@ class Container:
         self._shell = False
 
     @property
+    def env(self):
+        return self._env
+
+    @property
     def entrypoint(self):
         return self._entrypoint
 

--- a/python/paddle/fluid/tests/unittests/test_run.py
+++ b/python/paddle/fluid/tests/unittests/test_run.py
@@ -52,7 +52,9 @@ def get_files(pth, prefix):
     return [
         f
         for f in listdir(pth)
-        if isfile(join(pth, f)) and not f.endswith('gpu.log')
+        if isfile(join(pth, f))
+        and not f.endswith('gpu.log')
+        and not f.startswith('envlog')
     ]
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Before executing a process, save the environmental variables log for each worker. The log name should be in the format of `envlog.<worker_id>` where <worker_id> is the ID of the worker. The content of each log file should be the same as the content of `/proc/<pid>/environ` for that process, where <pid> is the process ID of the worker process.
