### PR TITLE
[Paddle-Inference] Tune between cuDNN and cutlass backend  in runtime

### DIFF
--- a/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
@@ -192,7 +192,11 @@ void ConvElementwiseAdd2ActFusePass::ApplyImpl(ir::Graph* graph) const {
         base_op_desc, bias_name, bias1_name, act_op_type, act_op_out);
     framework::OpDesc new_op_desc(new_op_proto, nullptr);
     if (cutlass_can_fuse && cutlass_enable && is_fp16_precision) {
-      new_op_desc.SetAttr("use_cutlass", true);
+      new_op_desc.SetAttr("can_run_by_cutlass_backend", true);
+    }
+
+    if (cudnn_can_fuse) {
+      new_op_desc.SetAttr("can_run_by_cudnn_backend", true);
     }
 
     // Create a new node for the fused op.

--- a/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
@@ -205,7 +205,11 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
         PrepareOpDesc(base_op_desc, bias_name, act_op_type, act_op_out, alpha);
     framework::OpDesc new_op_desc(new_op_proto, nullptr);
     if (cutlass_can_fuse && cutlass_enable && is_fp16_precision) {
-      new_op_desc.SetAttr("use_cutlass", true);
+      new_op_desc.SetAttr("can_run_by_cutlass_backend", true);
+    }
+
+    if (cudnn_can_fuse) {
+      new_op_desc.SetAttr("can_run_by_cudnn_backend", true);
     }
     // Create a new node for the fused op.
     auto* new_conv_op = graph->CreateOpNode(&new_op_desc);

--- a/paddle/fluid/framework/ir/conv_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_fuse_pass.cc
@@ -126,8 +126,9 @@ void ConvElementwiseAddFusePass::ApplyImpl(ir::Graph* graph) const {
     bool cutlass_can_fuse = CutlassTeller::Instance()->CbaCanSupport(
         conv_op->Op(), scope, act_type, Get<int>("gpu_device_id"));
     if (cutlass_can_fuse && cutlass_enable && is_fp16_precision) {
-      new_op_desc.SetAttr("use_cutlass", true);
+      new_op_desc.SetAttr("can_run_by_cutlass_backend", true);
     }
+    new_op_desc.SetAttr("can_run_by_cudnn_backend", true);
 
     auto* elementwise_add_op_desc = elementwise_add_op->Op();
     auto out_threshold_attr =

--- a/paddle/fluid/framework/library_type.h
+++ b/paddle/fluid/framework/library_type.h
@@ -27,6 +27,7 @@ enum class LibraryType {
   kMKLDNN = 1,
   kCUDNN = 2,
   kKP = 3,
+  kCUTLASS = 4,
 };
 
 inline std::string LibraryTypeToString(const LibraryType& library_type) {
@@ -39,6 +40,8 @@ inline std::string LibraryTypeToString(const LibraryType& library_type) {
       return "CUDNN";
     case LibraryType::kKP:
       return "KP";
+    case LibraryType::kCUTLASS:
+      return "CUTLASS";
     default:
       PADDLE_THROW(platform::errors::Unimplemented(
           "Unknown LibraryType code (%d), only supports library type include "
@@ -58,6 +61,8 @@ inline LibraryType StringToLibraryType(const char* ctype) {
     return LibraryType::kMKLDNN;
   } else if (s == std::string("CUDNN")) {
     return LibraryType::kCUDNN;
+  } else if (s == std::string("CUTLASS")) {
+    return LibraryType::kCUTLASS;
     // To be compatible with register macro.
     // CPU, CUDA, PLAIN are same library type.
   } else if (s == std::string("KP")) {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1992,8 +1992,11 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
         BuildPhiKernelContext(*runtime_ctx, dev_ctx, impl_->getKernelContext());
         // phi_kernel_name is like conv2d_fusion, there are more than one phi
         // kernel defined on different backend,we choose a best phi kernel.
-        // please note that we have alreadly have kernel_type_.
-        // std::cout << "*kernel_type_ " <<  *kernel_type_ << std::endl;
+        // please note that we have alreadly have kernel_type_ before entering
+        // PhiKernelTune function.
+        std::cout << "*kernel_type_ " << *kernel_type_ << phi_kernel_name
+                  << std::endl;
+        // *kernel_type_ is like
         // {
         //  data_type[::paddle::platform::float16];
         //  data_layout[Undefined(AnyLayout)];

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1569,20 +1569,8 @@ bool OperatorWithKernel::CanCUTLASSBeUsed(
     const framework::ExecutionContext& ctx, phi::DataType data_type) const {
   bool use_cutlass = ctx.HasAttr("can_run_by_cutlass_backend") &&
                      ctx.Attr<bool>("can_run_by_cutlass_backend") &&
-                     paddle::platform::is_gpu_place(ctx.GetPlace());
-#if defined(PADDLE_WITH_CUDA) && defined(PADDLE_WITH_CUTLASS)
-  auto& dev_ctx = ctx.device_context<phi::GPUContext>();
-  if (use_cutlass && data_type == phi::DataType::BFLOAT16 &&
-      dev_ctx.GetComputeCapability() == 75) {
-    PADDLE_ENFORCE_EQ(
-        dev_ctx.GetComputeCapability(),
-        75,
-        phi::errors::PreconditionNotMet(
-            "Expect compute compatiblity to be less than 75, but got %d. ",
-            dev_ctx.GetComputeCapability()));
-  }
-#endif  // PADDLE_WITH_CUDA && PADDLE_WITH_CUTLASS
-
+                     paddle::platform::is_gpu_place(ctx.GetPlace()) &&
+                     data_type == phi::DataType::FLOAT16;
   return use_cutlass && this->SupportsCUTLASS(data_type);
 }
 

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -749,6 +749,7 @@ class OperatorWithKernel : public OperatorBase {
   bool SupportsMKLDNN(phi::DataType data_type) const;
 
   bool SupportsCUDNN(phi::DataType data_type) const;
+  bool SupportsCUTLASS(phi::DataType data_type) const;
 
   bool SupportsKernelType(const OpKernelType& kernel_type,
                           const ExecutionContext& exe_ctx) const;
@@ -764,6 +765,12 @@ class OperatorWithKernel : public OperatorBase {
 
   bool CanCUDNNBeUsed(const framework::ExecutionContext& ctx,
                       proto::VarType::Type data_type) const;
+
+  bool CanCUTLASSBeUsed(const framework::ExecutionContext& ctx,
+                        phi::DataType data_type) const;
+
+  bool CanCUTLASSBeUsed(const framework::ExecutionContext& ctx,
+                        proto::VarType::Type data_type) const;
 
   virtual void InferShape(InferShapeContext* ctx) const;
 
@@ -866,7 +873,14 @@ class OperatorWithKernel : public OperatorBase {
                                const std::vector<std::string>& inplace_vars,
                                const Scope& exec_scope) const;
 
+  void PhiKernelTune(const ExecutionContext& exe_ctx,
+                     const std::string& phi_kernel_name) const;
+
   OpKernelType InnerGetExpectedKernelType(const ExecutionContext& ctx) const;
+
+  OpKernelType InnerGetExpectedKernelType(
+      const ExecutionContext& ctx,
+      const framework::LibraryType library_type) const;
 
   void HandleComplexGradToRealGrad(const Scope& scope,
                                    RuntimeContext* ctx) const;

--- a/paddle/fluid/framework/phi_utils.cc
+++ b/paddle/fluid/framework/phi_utils.cc
@@ -91,6 +91,8 @@ phi::KernelKey TransOpKernelTypeToPhiKernelKey(
       break;
     case LibraryType::kKP:
       backend = phi::Backend::KPS;
+    case LibraryType::kCUTLASS:
+      backend = phi::Backend::CUTLASS;
       break;
     default:
       break;

--- a/paddle/fluid/operators/fused/conv_fusion_op.cc
+++ b/paddle/fluid/operators/fused/conv_fusion_op.cc
@@ -316,13 +316,3 @@ REGISTER_OPERATOR(
     ops::ConvOpInferVarType,
     paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
     paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
-
-// This op is used by cutlass, conv2d_fusion_cutlass is a intermediate op
-// produced by conv2d_fusion_layout_transfer_pass.
-REGISTER_OPERATOR(
-    conv2d_fusion_cutlass,
-    ops::Conv2DFusionOp,
-    ops::Conv2DFusionOpMaker,
-    ops::ConvOpInferVarType,
-    paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
-    paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);

--- a/paddle/phi/backends/gpu/gpu_context.h
+++ b/paddle/phi/backends/gpu/gpu_context.h
@@ -268,6 +268,7 @@ class PADDLE_API GPUContext : public DeviceContext,
 // and Dnn kernel function, so if we using DnnContext = GPUContext, we
 // must use different function name for cudnn kernel
 using GPUDNNContext = GPUContext;
+using CUTLASSContext = GPUContext;
 
 // KPS (Kernel PrimitiveS API) needs to exist as a kind of backend,
 // because we want to implement a KPS-based kernel and make it run

--- a/paddle/phi/common/backend.h
+++ b/paddle/phi/common/backend.h
@@ -48,7 +48,8 @@ enum class Backend : uint8_t {
   // acceleration device's backend
   GPU,
   // the third library backend
-  GPUDNN,  // cuDNN and hipDNN
+  GPUDNN,   // cuDNN and hipDNN
+  CUTLASS,  // cutlass library
 
   // various acceleration devices' backends
   XPU,  // XPU currently does not exist at the same time as CUDA
@@ -101,6 +102,9 @@ inline std::ostream& operator<<(std::ostream& os, Backend backend) {
     case Backend::GPUDNN:
       os << "GPUDNN";
       break;
+    case Backend::CUTLASS:
+      os << "CUTLASS";
+      break;
     case Backend::KPS:
       os << "KPS";
       break;
@@ -144,6 +148,8 @@ inline Backend StringToBackend(const char* backend_cstr) {
     return Backend::ONEDNN;
   } else if (s == std::string("GPUDNN")) {
     return Backend::GPUDNN;
+  } else if (s == std::string("CUTLASS")) {
+    return Backend::CUTLASS;
   } else if (s == std::string("KPS")) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     // NOTE(chenweihang) KPS is not yet a complete backend, and it still needs
@@ -180,6 +186,8 @@ inline std::string BackendToString(const Backend& backend) {
       return "ONEDNN";
     case Backend::GPUDNN:
       return "GPUDNN";
+    case Backend::CUTLASS:
+      return "CUTLASS";
     case Backend::KPS:
       return "KPS";
     case Backend::IPU:

--- a/paddle/phi/core/compat/convert_utils.cc
+++ b/paddle/phi/core/compat/convert_utils.cc
@@ -70,6 +70,7 @@ phi::Place TransToPhiPlace(const Backend& backend, bool set_device_id) {
 #endif
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     case phi::Backend::GPUDNN:
+    case phi::Backend::CUTLASS:
       return phi::GPUPlace(
           set_device_id ? phi::backends::gpu::GetCurrentDeviceId() : 0);
 #endif

--- a/paddle/phi/kernels/autotune/phi_kernel_tune.h
+++ b/paddle/phi/kernels/autotune/phi_kernel_tune.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_context.h"
+#include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/kernels/autotune/gpu_timer.h"
+
+class PhiKernelTuner {
+ public:
+  explicit PhiKernelTuner(phi::KernelContext* ctx) : ctx_(ctx) {}
+  virtual ~PhiKernelTuner() {}
+
+  void AddPhiKernel(std::unique_ptr<phi::Kernel>&& kernel) {
+    kernels_.push_back(std::forward<std::unique_ptr<phi::Kernel>>(kernel));
+  }
+
+  std::unique_ptr<phi::Kernel> Run() {
+    PADDLE_ENFORCE_GT(
+        kernels_.size(),
+        0,
+        phi::errors::InvalidArgument(
+            "kernel num must be greater than 0, now is %d", kernels_.size()));
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    PADDLE_ENFORCE_GT(
+        kernels_.size(),
+        0,
+        phi::errors::InvalidArgument(
+            "kernel num must be greater than 0, now is %d", kernels_.size()));
+    size_t best_idx = 0;
+    float min_time = std::numeric_limits<float>::max();
+
+    // Time cost test estabulished in default stream.
+    for (size_t i = 0; i < kernels_.size(); ++i) {
+      auto time = RunAndMeasureKernel(kernels_[i].get(), ctx_);
+      if (time < min_time) {
+        min_time = time;
+        best_idx = i;
+      }
+    }
+    std::cout << kernels_.size() << "kernels_.size()" << std::endl;
+    return std::move(kernels_[best_idx]);
+  }
+
+ private:
+  std::vector<std::unique_ptr<phi::Kernel>> kernels_;
+  phi::KernelContext* ctx_;
+  mutable std::mutex mutex_;
+
+  float RunAndMeasureKernel(phi::Kernel* kernel, phi::KernelContext* ctx) {
+    // Regard 1st run as warmup, judge the compare result by the time cost
+    // of rest cycles.
+    constexpr int repeats = 6;
+    phi::GpuTimer timer;
+    float time_cost = 0;
+
+    paddle::platform::DeviceContextPool& pool =
+        paddle::platform::DeviceContextPool::Instance();
+    paddle::platform::CUDAPlace place(paddle::platform::GetCurrentDeviceId());
+    auto* dev_ctx = static_cast<phi::GPUContext*>(pool.Get(place));
+
+    const auto& stream = dev_ctx->stream();
+
+    dev_ctx->Wait();
+    for (int i = 0; i < repeats; ++i) {
+      timer.Start(stream);
+      (*kernel)(ctx);
+      timer.Stop(stream);
+      auto time = timer.ElapsedTime();
+      if (i > 0) {
+        time_cost += time;
+      }
+    }
+    return time_cost;
+  }
+};

--- a/paddle/phi/kernels/fusion/cutlass/conv2d/conv2d_util.cu
+++ b/paddle/phi/kernels/fusion/cutlass/conv2d/conv2d_util.cu
@@ -289,9 +289,10 @@ int ProfileToGetBestConfig(
       min_time = elapsed_time;
       min_time_index = i;
       // debug code
-      VLOG(3) << OpType2String(op_type) << ": tactic " << i << " has max diff "
-              << conv2d_diff_gpu(params, op_type) << " compared with baseline,"
-              << "cost_time: " << elapsed_time << "ms.";
+      std::cout << OpType2String(op_type) << ": tactic " << i
+                << " has max diff " << conv2d_diff_gpu(params, op_type)
+                << " compared with baseline,"
+                << "cost_time: " << elapsed_time << "ms." << std::endl;
     }
   }
 

--- a/paddle/phi/kernels/fusion/cutlass/conv2d_fusion.cu
+++ b/paddle/phi/kernels/fusion/cutlass/conv2d_fusion.cu
@@ -29,12 +29,16 @@ void Conv2dFusionKernel(const Context& ctx,
                         const std::vector<int>& strides,
                         const std::vector<int>& paddings,
                         const std::string& padding_algorithm,
-                        int groups,
                         const std::vector<int>& dilations,
+                        int groups,
                         const std::string& data_format,
                         const std::string& activation,
+                        bool exhaustive_search,
+                        const std::vector<int>& channels,
+                        int user_workspace_size,
                         float fuse_alpha,
-                        DenseTensor* output) {
+                        DenseTensor* output,
+                        std::vector<DenseTensor*> outs) {
   ctx.template Alloc<T>(output);
   auto in_dims = x.dims();
   auto filter_dims = filter.dims();
@@ -162,8 +166,8 @@ void Conv2dFusionKernel(const Context& ctx,
 }  // namespace fusion
 }  // namespace phi
 
-PD_REGISTER_KERNEL(conv2d_fusion_cutlass,
-                   GPU,
+PD_REGISTER_KERNEL(conv2d_fusion,
+                   CUTLASS,
                    ALL_LAYOUT,
                    phi::fusion::cutlass_internal::Conv2dFusionKernel,
                    float,

--- a/paddle/phi/kernels/fusion/gpu/conv_fusion_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/conv_fusion_kernel.cu
@@ -373,6 +373,7 @@ void ConvFusionKernel(const Context& ctx,
                       bool exhaustive_search,
                       const std::vector<int>& channels,
                       int user_workspace_size,
+                      float fuse_alpha,
                       DenseTensor* output,
                       std::vector<DenseTensor*> outs) {
   auto handle = ctx.cudnn_handle();

--- a/paddle/phi/ops/compat/conv2d_sig.cc
+++ b/paddle/phi/ops/compat/conv2d_sig.cc
@@ -52,25 +52,9 @@ KernelSignature Conv2dDoubleGradOpArgumentMapping(
                           "data_format"},
                          {"DInput", "DFilter", "DDOutput"});
 }
-
-KernelSignature Conv2dFusionArgumentMapping(const ArgumentMappingContext& ctx) {
-  return KernelSignature("conv2d_fusion_cutlass",
-                         {"Input", "Filter", "Bias", "ResidualData"},
-                         {"strides",
-                          "paddings",
-                          "padding_algorithm",
-                          "groups",
-                          "dilations",
-                          "data_format",
-                          "activation",
-                          "fuse_alpha"},
-                         {"Output"});
-}
 }  // namespace phi
 
 PD_REGISTER_ARG_MAPPING_FN(conv2d, phi::Conv2dOpArgumentMapping);
-PD_REGISTER_ARG_MAPPING_FN(conv2d_fusion_cutlass,
-                           phi::Conv2dFusionArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(conv2d_grad, phi::Conv2dGradOpArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(conv2d_grad_grad,
                            phi::Conv2dDoubleGradOpArgumentMapping);

--- a/paddle/phi/ops/compat/conv_fusion_sig.cc
+++ b/paddle/phi/ops/compat/conv_fusion_sig.cc
@@ -30,6 +30,7 @@ KernelSignature ConvFusionOpArgumentMapping(const ArgumentMappingContext& ctx) {
                              "exhaustive_search",
                              "split_channels",
                              "workspace_size_MB",
+                             "fuse_alpha",
                          },
                          {"Output", "Outputs"});
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

- Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

- Others

### Description
<!-- Describe what you’ve done -->


- 该PR将 cutlass写的conv2d_fususion和cuDNN的conv2d_fusion签名相同，同时新增了cutlass backend。
- 由于 cuDNN 和 cutlass处理的case不能完全等价，因此在 pass阶段，将根据问题规模设置can_run_by_cutlass_backend 和 can_run_by_cudnn_backend 两flag 来表示可由cuDNN或可由 cutlass计算，运行时，将根据此两个flag 来进行tune，谁跑的快就执行哪个后端。

