### PR TITLE
Support 0 d output for release/2.5

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -990,7 +990,7 @@ void DistInferMeta(const MetaTensor& x,
                         "The Input(Y) has not been initialized properly. The "
                         "shape of Input(Y) = [%s].",
                         y_dims));
-  out->set_dims({1});
+  out->set_dims(phi::make_ddim({}));
   out->set_dtype(x.dtype());
 }
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -72,7 +72,7 @@ static void BinarySameInputDimsCheck(const MetaTensor& x,
 static DDim CheckAndGetOutputDim(const DDim& dim_x) {
   auto x_vec = phi::vectorize(dim_x);
   if (x_vec.size() == 2) {
-    return phi::make_ddim({1});
+    return phi::make_ddim({});
   }
   x_vec.erase(x_vec.end() - 2, x_vec.end());
   return phi::make_ddim(x_vec);

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2344,7 +2344,7 @@ void MultiDotInferMeta(const std::vector<const MetaTensor*>& x,
   // If the last tensor is 1D of size n view it as a column vector (n, 1)
   if (last_dim.size() == 1) {
     last_dim = phi::make_ddim({static_cast<int>(last_dim[0]), 1});
-    out_dim = is_vector ? phi::make_ddim({1}) : phi::make_ddim({first_dim[0]});
+    out_dim = is_vector ? phi::make_ddim({}) : phi::make_ddim({first_dim[0]});
   } else {
     out_dim = is_vector ? phi::make_ddim({last_dim[1]})
                         : phi::make_ddim({first_dim[0], last_dim[1]});

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -38,7 +38,7 @@ namespace detail {
 static DDim CheckAndGetOutputDim(const DDim& dim_x) {
   auto x_vec = phi::vectorize(dim_x);
   if (x_vec.size() == 2) {
-    return phi::make_ddim({1});
+    return phi::make_ddim({});
   }
   x_vec.erase(x_vec.end() - 2, x_vec.end());
   return phi::make_ddim(x_vec);

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2764,9 +2764,6 @@ void PNormInferMeta(const MetaTensor& x,
     for (int i = 0; i < x_dim.size(); ++i) {
       if (i != axis) reduce_dims.emplace_back(x_dim[i]);
     }
-    if (reduce_dims.size() == 0) {
-      reduce_dims.emplace_back(1);
-    }
 
     x_dim[axis] = 1;
   }

--- a/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_grad_kernel_impl.h
@@ -90,10 +90,10 @@ void DeterminantGradKernel(const Context& dev_ctx,
             " input tensor's, but here differ %d",
             input_dims_size - out_grad.dims().size()));
   } else if (input_dims_size == 2) {
-    // input dims size 2 and grad dims size 1 is possible
+    // input dims size 2 and grad dims size 0 is possible
     PADDLE_ENFORCE_EQ(
         out_grad.dims().size(),
-        1,
+        0,
         phi::errors::InvalidArgument(
             "The grad tensor of det dims size should be 2 less than"
             " input tensor's, but here differ %d",

--- a/paddle/phi/kernels/impl/determinant_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_kernel_impl.h
@@ -116,7 +116,7 @@ void DeterminantKernel(const Context& dev_ctx,
     out->Resize(output_dims);
   } else {
     // when input is a two-dimension matrix, The det value is a number.
-    out->Resize({1});
+    out->Resize(phi::make_ddim({}));
   }
   VLOG(10) << "output dim:" << out->dims();
 }

--- a/paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h
@@ -94,7 +94,7 @@ void SlogDeterminantKernel(const Context& dev_ctx,
   std::vector<int> output_dim_vec(input_dim.begin(), input_dim.end() - 2);
   if (input_dim.size() == static_cast<size_t>(2)) {
     // when input is a two-dimension matrix, The det value is a number.
-    output_dim_vec = {1};
+    output_dim_vec = {};
   }
   output_dim_vec.insert(output_dim_vec.begin(),
                         2);  // make the output dims as same as numpy

--- a/python/paddle/fluid/tests/unittests/test_pairwise_distance.py
+++ b/python/paddle/fluid/tests/unittests/test_pairwise_distance.py
@@ -22,10 +22,6 @@ from paddle import fluid
 
 def np_pairwise_distance(x, y, p=2.0, epsilon=1e-6, keepdim=False):
     distance = np.linalg.norm(x - y + epsilon, ord=p, axis=-1, keepdims=keepdim)
-    # Paddle currently has not supported for 0-d Tensors, so even if keep_dim is False,
-    # and neither x nor y is batched, a Tensor of shape (1, ) is returned
-    if distance.ndim == 0:
-        distance = np.expand_dims(distance, axis=0)
     return distance
 
 

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2080,7 +2080,7 @@ class TestSundryAPI(unittest.TestCase):
         # 3-D input
         x1 = paddle.randn([3, 3, 3])
         x1.stop_gradient = False
-        out1 = paddle.linalg.slogdet(x)
+        out1 = paddle.linalg.slogdet(x1)
         out1.retain_grads()
         out1.backward()
 
@@ -3639,16 +3639,16 @@ class TestSundryAPIStatic(unittest.TestCase):
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, fetch_list=[out])
-        self.assertEqual(res[0].shape, [2])
+        self.assertEqual(res[0].shape, (2,))
 
         # 3-D input
         x1 = paddle.randn([3, 3, 3])
         x1.stop_gradient = False
-        out1 = paddle.linalg.slogdet(x)
+        out1 = paddle.linalg.slogdet(x1)
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out])
-        self.assertEqual(res[0].shape, [2, 3])
+        res = self.exe.run(prog, fetch_list=[out1])
+        self.assertEqual(res[0].shape, (2, 3))
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2066,6 +2066,27 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(x.grad.shape, [])
         np.testing.assert_allclose(x.grad, np.array(1.0))
 
+    def test_linalg_slogdet(self):
+        # 2-D input
+        x = paddle.randn([3, 3])
+        x.stop_gradient = False
+        out = paddle.linalg.slogdet(x)
+        out.retain_grads()
+        out.backward()
+
+        self.assertTrue(out.shape, [2])
+        self.assertTrue(x.grad.shape, [3, 3])
+
+        # 3-D input
+        x1 = paddle.randn([3, 3, 3])
+        x1.stop_gradient = False
+        out1 = paddle.linalg.slogdet(x)
+        out1.retain_grads()
+        out1.backward()
+
+        self.assertTrue(out1.shape, [2, 3])
+        self.assertTrue(x1.grad.shape, [3, 3, 3])
+
 
 class TestSundryAPIStatic(unittest.TestCase):
     def setUp(self):
@@ -3608,6 +3629,26 @@ class TestSundryAPIStatic(unittest.TestCase):
 
         self.assertEqual(out1.shape, (2, 3))
         self.assertEqual(out2.shape, (2, 3))
+
+    @prog_scope
+    def test_linalg_slogdet(self):
+        # 2-D input
+        x = paddle.randn([3, 3])
+        x.stop_gradient = False
+        out = paddle.linalg.slogdet(x)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out])
+        self.assertEqual(res[0].shape, [2])
+
+        # 3-D input
+        x1 = paddle.randn([3, 3, 3])
+        x1.stop_gradient = False
+        out1 = paddle.linalg.slogdet(x)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out])
+        self.assertEqual(res[0].shape, [2, 3])
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -3630,7 +3630,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(out1.shape, (2, 3))
         self.assertEqual(out2.shape, (2, 3))
 
-    @prog_scope
+    @prog_scope()
     def test_linalg_slogdet(self):
         # 2-D input
         x = paddle.randn([3, 3])

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -3636,19 +3636,23 @@ class TestSundryAPIStatic(unittest.TestCase):
         x = paddle.randn([3, 3])
         x.stop_gradient = False
         out = paddle.linalg.slogdet(x)
+        paddle.static.append_backward(out.sum())
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out])
+        res = self.exe.run(prog, fetch_list=[out, x.grad_name])
         self.assertEqual(res[0].shape, (2,))
+        self.assertEqual(res[1].shape, (3, 3))
 
         # 3-D input
         x1 = paddle.randn([3, 3, 3])
         x1.stop_gradient = False
         out1 = paddle.linalg.slogdet(x1)
+        paddle.static.append_backward(out1.sum())
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out1])
+        res = self.exe.run(prog, fetch_list=[out1, x1.grad_name])
         self.assertEqual(res[0].shape, (2, 3))
+        self.assertEqual(res[1].shape, (3, 3, 3))
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2238,6 +2238,187 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(b.grad.shape, [4, 5])
         self.assertEqual(c.grad.shape, [5])
 
+    def test_linalg_norm(self):
+        # 1D input, p = fro ,axis = None, using reduceInferMeta
+        x_1 = paddle.arange(24, dtype="float32") - 12
+        x_1.stop_gradient = False
+        # using frobenius_norm, depends on reduce inferMeta support 0d output
+        # out_1 = paddle.linalg.norm(x_1)
+        # out_1.retain_grads()
+        # out_1.backward()
+
+        # self.assertEqual(out_1.shape, [])
+        # self.assertTrue(x_1.grad.shape, [24])
+
+        # 1D input, p = 1 ,axis = None,
+        # using p_nrom, as_vector = True
+        x_2 = paddle.arange(24, dtype="float32") - 12
+        x_2.stop_gradient = False
+        out_2 = paddle.linalg.norm(x_2, p=1)
+        out_2.retain_grads()
+        out_2.backward()
+
+        self.assertEqual(out_2.shape, [1])
+        self.assertEqual(x_2.grad.shape, [24])
+
+        # 1D input, p = 1 ,axis = 0,
+        # using p_nrom, as_vector = False
+        x_2_p = paddle.arange(24, dtype="float32") - 12
+        x_2_p.stop_gradient = False
+        out_2_p = paddle.linalg.norm(x_2_p, p=1, axis=0)
+        out_2_p.retain_grads()
+        out_2_p.backward()
+
+        self.assertEqual(out_2_p.shape, [])
+        self.assertEqual(x_2_p.grad.shape, [24])
+
+        # 1D input, p = fro ,axis = 0,
+        # using p_nrom, as_vector = False
+        x_2_fro = paddle.arange(24, dtype="float32") - 12
+        x_2_fro.stop_gradient = False
+        out_2_fro = paddle.linalg.norm(x_2_fro, p="fro", axis=0)
+        out_2_fro.retain_grads()
+        out_2_fro.backward()
+
+        self.assertEqual(out_2_fro.shape, [])
+        self.assertEqual(x_2_fro.grad.shape, [24])
+
+        # 2D input, p = 1, axis = [0, 1]
+        # using p_matrix_norm ,depends on abs, pow, sum
+        # x_3 = x_2.reshape([4, 6])
+        # x_3.stop_gradient = False
+        # out_3 = paddle.linalg.norm(x_3, p = 1, axis=[0,1])
+        # out_3.retain_grads()
+        # out_3.backward()
+
+        # self.assertEqual(out_3.shape, [])
+        # self.assertEqual(x_3.grad.shape, [4, 6])
+
+        # 2D input, p = 1, axis = None
+        # using p_matrix_norm, depends on paddle.sum
+        # x_4 = x_2.reshape([4, 6])
+        # out_4 = paddle.linalg.norm(x_4)
+        # out_4.retain_grads()
+        # out_4.backward()
+
+        # self.assertEqual(out_4.shape, [])
+        # self.assertEqual(x_4.grad.shape, [4, 6])
+
+        # 2D input, p = inf, axis = None
+        # using p_matrix_norm, depends on paddle.max, paddle.min
+        # x_5 = x_2.reshape([4, 6])
+        # out_5 = paddle.linalg.norm(x_5)
+        # out_5.retain_grads()
+        # out_5.backward()
+
+        # self.assertEqual(out_5.shape, [])
+        # self.assertEqual(x_5.grad.shape, [4, 6])
+
+        # 2D input, p = -inf, axis = [0, 1]
+        # using inf_norm, depends on paddle.max, paddle.min, paddle.abs
+        # x_6 = x_2.reshape([4, 6])
+        # out_6 = paddle.linalg.norm(x_6, p = -float("inf"), axis = [0, 1])
+        # out_6.retain_grads()
+        # out_6.backward()
+
+        # self.assertEqual(out_6.shape, [])
+        # self.assertEqual(x_6.grad.shape, [4, 6])
+
+    def test_cov(self):
+        xt = paddle.randn((3, 4))
+        xt.stop_gradient = False
+        xt_1 = paddle.randn((12,))
+        xt_1.stop_gradient = False
+
+        xt_out = paddle.linalg.cov(xt)
+        xt_out.retain_grads()
+        xt_out.backward()
+        self.assertEqual(xt_out.shape, [3, 3])
+        self.assertEqual(xt.grad.shape, [3, 4])
+
+        xt_1_out = paddle.linalg.cov(xt_1)
+        xt_1.retain_grads()
+        xt_1_out.backward()
+        self.assertEqual(xt_1_out.shape, [])
+        self.assertEqual(xt_1.grad.shape, [12])
+
+    def test_det(self):
+        xt = paddle.randn([3, 3, 3])
+        xt.stop_gradient = False
+        xt_1 = paddle.randn([3, 3])
+        xt_1.stop_gradient = False
+
+        xt_out = paddle.linalg.det(xt)
+        xt.retain_grads()
+        xt_out.backward()
+        self.assertEqual(xt_out.shape, [3])
+        self.assertEqual(xt.grad.shape, [3, 3, 3])
+
+        xt_1_out = paddle.linalg.det(xt_1)
+        xt_1.retain_grads()
+        xt_1_out.backward()
+        self.assertEqual(xt_1_out.shape, [])
+        self.assertEqual(xt_1.grad.shape, [3, 3])
+
+    def test_dist(self):
+        x = paddle.to_tensor([[3, 3], [3, 3]], dtype="float32")
+        y = paddle.to_tensor([[3, 3], [3, 1]], dtype="float32")
+        x.stop_gradient = False
+        y.stop_gradient = False
+        out = paddle.dist(x, y, 0)
+        out.backward()
+
+        self.assertEqual(out.shape, [])
+        np.testing.assert_allclose(out, np.array(1))
+        self.assertEqual(x.grad.shape, [2, 2])
+        self.assertEqual(y.grad.shape, [2, 2])
+
+    def test_cond(self):
+        pass
+        # def assert_shape(out):
+        #     self.assertEqual(out.shape, [])
+
+        # x = paddle.to_tensor([[1.0, 0, -1], [0, 1, 0], [1, 0, 1]])
+        # x.stop_gradient = False
+        # p = 2 : use paddle.sum, paddle.max, paddle.min
+        # out = paddle.linalg.cond(x)
+        # assert_shape(out)
+
+        # p = fro : use paddle.sum
+        # out_fro = paddle.linalg.cond(x, p='fro')
+        # assert_shape(out_fro)
+
+        # p = nuc : use paddle.sum, paddle.max, paddle.min
+        # out_nuc = paddle.linalg.cond(x, p='nuc')
+        # assert_shape(out_nuc)
+
+        # p in (-1, 1) : use paddle.sum, paddle.max, paddle.min
+        # out_1 = paddle.linalg.cond(x, p=1)
+        # assert_shape(out_1)
+        # out_minus_1 = paddle.linalg.cond(x, p=-1)
+        # assert_shape(out_minus_1)
+
+        # p in (-2, 2) :use paddle.max, paddle.min
+        # out_2 = paddle.linalg.cond(x, p=2)
+        # assert_shape(out_2)
+        # out_minus_2 = paddle.linalg.cond(x, p=-2)
+        # assert_shape(out_minus_2)
+
+        # p in (-inf, inf):use paddle.sum, paddle.max, paddle.min
+        # out_inf = paddle.linalg.cond(x, p=float("inf"))
+        # assert_shape(out_inf)
+        # out_minus_inf = paddle.linalg.cond(x, p=-float("inf"))
+        # assert_shape(out_minus_inf)
+        # out_minus_inf.backward()
+        # self.assertTrue(x.grad.shape, [3, 3])
+
+        # a = paddle.randn([2, 4, 4])
+        # a.stop_gradient = False
+        # a_cond_fro = paddle.linalg.cond(a, p='fro')
+        # a_cond_fro.backward()
+        # self.assertEqual(len(a_cond_fro.shape), 1)
+        # self.assertEqual(a.grad.shape, [2, 4, 4])
+
 
 class TestSundryAPIStatic(unittest.TestCase):
     def setUp(self):
@@ -3936,6 +4117,156 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[1].shape, (4,))
         self.assertEqual(res[2].shape, (4, 5))
         self.assertEqual(res[3].shape, (5,))
+
+    @prog_scope()
+    def test_linalg_norm(self):
+        # 1D input, p = fro ,axis = None, using reduceInferMeta
+        x_1 = paddle.arange(24, dtype="float32") - 12
+        x_1.stop_gradient = False
+        # using frobenius_norm, depends on reduce inferMeta support 0d output
+        # out_1 = paddle.linalg.norm(x_1)
+        # out_1.retain_grads()
+        # out_1.backward()
+
+        # self.assertEqual(out_1.shape, [])
+        # self.assertTrue(x_1.grad.shape, [24])
+
+        # 1D input, p = 1 ,axis = None,
+        # using p_nrom, as_vector = True
+        x_2 = paddle.arange(24, dtype="float32") - 12
+        x_2.stop_gradient = False
+        out_2 = paddle.linalg.norm(x_2, p=1)
+        paddle.static.append_backward(out_2.sum())
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out_2, x_2.grad_name])
+        self.assertEqual(res[0].shape, (1,))
+        self.assertEqual(res[1].shape, (24,))
+
+        # 1D input, p = 1 ,axis = 0,
+        # using p_nrom, as_vector = False
+        x_2_p = paddle.arange(24, dtype="float32") - 12
+        x_2_p.stop_gradient = False
+        out_2_p = paddle.linalg.norm(x_2_p, p=1, axis=0)
+        paddle.static.append_backward(out_2_p.sum())
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out_2_p, x_2_p.grad_name])
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, (24,))
+
+        # 1D input, p = fro ,axis = 0,
+        # using p_nrom, as_vector = False
+        x_2_fro = paddle.arange(24, dtype="float32") - 12
+        x_2_fro.stop_gradient = False
+        out_2_fro = paddle.linalg.norm(x_2_fro, p="fro", axis=0)
+        paddle.static.append_backward(out_2_fro.sum())
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out_2_fro, x_2_fro.grad_name])
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, (24,))
+
+        # 2D input, p = 1, axis = [0, 1]
+        # using p_matrix_norm ,depends on abs, pow, sum
+        # x_3 = x_2.reshape([4, 6])
+        # x_3.stop_gradient = False
+        # out_3 = paddle.linalg.norm(x_3, p = 1, axis=[0,1])
+        # out_3.retain_grads()
+        # out_3.backward()
+
+        # self.assertEqual(out_3.shape, [])
+        # self.assertEqual(x_3.grad.shape, [4, 6])
+
+        # 2D input, p = 1, axis = None
+        # using p_matrix_norm, depends on paddle.sum
+        # x_4 = x_2.reshape([4, 6])
+        # out_4 = paddle.linalg.norm(x_4)
+        # out_4.retain_grads()
+        # out_4.backward()
+
+        # self.assertEqual(out_4.shape, [])
+        # self.assertEqual(x_4.grad.shape, [4, 6])
+
+        # 2D input, p = inf, axis = None
+        # using p_matrix_norm, depends on paddle.max, paddle.min
+        # x_5 = x_2.reshape([4, 6])
+        # out_5 = paddle.linalg.norm(x_5)
+        # out_5.retain_grads()
+        # out_5.backward()
+
+        # self.assertEqual(out_5.shape, [])
+        # self.assertEqual(x_5.grad.shape, [4, 6])
+
+        # 2D input, p = -inf, axis = [0, 1]
+        # using inf_norm, depends on paddle.max, paddle.min, paddle.abs
+        # x_6 = x_2.reshape([4, 6])
+        # out_6 = paddle.linalg.norm(x_6, p = -float("inf"), axis = [0, 1])
+        # out_6.retain_grads()
+        # out_6.backward()
+
+        # self.assertEqual(out_6.shape, [])
+        # self.assertEqual(x_6.grad.shape, [4, 6])
+
+    @prog_scope()
+    def test_cov(self):
+        xt_1 = paddle.randn((12,))
+        xt_1.stop_gradient = False
+
+        out = paddle.linalg.cov(xt_1)
+        paddle.static.append_backward(out)
+
+        prog = paddle.static.default_main_program()
+
+        res = self.exe.run(prog, fetch_list=[out, xt_1.grad_name])
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, (12,))
+
+    @prog_scope()
+    def test_det(self):
+        xt_1 = paddle.randn((3, 3))
+        xt_1.stop_gradient = False
+
+        out = paddle.linalg.det(xt_1)
+        paddle.static.append_backward(out.sum())
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out, xt_1.grad_name])
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, (3, 3))
+
+    @prog_scope()
+    def test_dist(self):
+        x = paddle.to_tensor([[3, 3], [3, 3]], dtype="float32")
+        y = paddle.to_tensor([[3, 3], [3, 1]], dtype="float32")
+        x.stop_gradient = False
+        y.stop_gradient = False
+        out = paddle.dist(x, y)
+        paddle.static.append_backward(out)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out, x.grad_name, y.grad_name])
+
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, (2, 2))
+        self.assertEqual(res[1].shape, (2, 2))
+        np.testing.assert_array_equal(res[0], np.array(2).astype(np.float32))
+
+    @prog_scope()
+    def test_cond(self):
+        pass
+        # use paddle.sum, paddle.max, paddle.min
+        # x = paddle.to_tensor([[1.0, 0, -1], [0, 1, 0], [1, 0, 1]])
+        # x.stop_gradient = False
+        # out = paddle.linalg.cond(x)
+        # paddle.static.append_backward(out)
+
+        # prog = paddle.static.default_main_program()
+        # res = self.exe.run(prog, fetch_list=[out, x.grad_name])
+
+        # self.assertTrue(res[0].shape, ())
+        # self.assertTrue(res[1].shape, (3, 3))
+        # np.testing.assert_allclose(out, np.array(1.41421342))
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
 Others

### Describe
Pcard-66984
Support the following api 0D output

> paddle.dist
paddle.linalg.cond
paddle.linalg.cov
paddle.linalg.det
paddle.linalg.norm
paddle.trace

source pr:
https://github.com/PaddlePaddle/Paddle/pull/52861
https://github.com/PaddlePaddle/Paddle/pull/52857
