### PR TITLE
[Function optimization] enable set_value op marker

### DIFF
--- a/paddle/fluid/operators/set_value_op.cc
+++ b/paddle/fluid/operators/set_value_op.cc
@@ -111,6 +111,7 @@ class SetValueMaker : public framework::OpProtoAndCheckerMaker {
                  framework::proto::VarType::FP32,
                  framework::proto::VarType::FP64,
                  framework::proto::VarType::FP16,
+                 framework::proto::VarType::BF16,
                  framework::proto::VarType::COMPLEX64,
                  framework::proto::VarType::COMPLEX128})
         .SetDefault(framework::proto::VarType::FP32);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
解决 set_value 算子中bf16 支持性问题。