### PR TITLE
Add set layout in TransposeGradInferMeta

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4500,6 +4500,7 @@ void TransposeGradInferMeta(const MetaTensor& x,
   }
 
   TransposeInferMeta(x, reversed_axis, out);
+  out->set_layout(static_cast<DataLayout>(x.layout()));
 }
 
 void UnbindInferMeta(const MetaTensor& x,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
给transpose OP反向添加layout设置，保证输出layout与输入layout保持一致

