### PR TITLE
[cherry-pick] save env log for each worker (#53207)

### DIFF
--- a/python/paddle/distributed/launch/job/container.py
+++ b/python/paddle/distributed/launch/job/container.py
@@ -40,6 +40,10 @@ class Container:
         self._shell = False
 
     @property
+    def env(self):
+        return self._env
+
+    @property
     def entrypoint(self):
         return self._entrypoint
 

--- a/python/paddle/fluid/tests/unittests/test_run.py
+++ b/python/paddle/fluid/tests/unittests/test_run.py
@@ -52,7 +52,9 @@ def get_files(pth, prefix):
     return [
         f
         for f in listdir(pth)
-        if isfile(join(pth, f)) and not f.endswith('gpu.log')
+        if isfile(join(pth, f))
+        and not f.endswith('gpu.log')
+        and not f.startswith('envlog')
     ]
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Before executing a process, save the environmental variables log for each worker. The log name should be in the format of envlog.<worker_id> where <worker_id> is the ID of the worker. The content of each log file should be the same as the content of /proc/<pid>/environ for that process, where is the process ID of the worker process.
