### PR TITLE
Cherry pick 0 d output

### DIFF
--- a/paddle/fluid/operators/matrix_rank_op.cc
+++ b/paddle/fluid/operators/matrix_rank_op.cc
@@ -27,7 +27,7 @@ namespace detail {
 static DDim CheckAndGetOutputDim(const DDim& dim_x) {
   auto x_vec = phi::vectorize(dim_x);
   if (x_vec.size() == 2) {
-    return phi::make_ddim({1});
+    return phi::make_ddim({});
   }
   x_vec.erase(x_vec.end() - 2, x_vec.end());
   return phi::make_ddim(x_vec);

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -72,7 +72,7 @@ static void BinarySameInputDimsCheck(const MetaTensor& x,
 static DDim CheckAndGetOutputDim(const DDim& dim_x) {
   auto x_vec = phi::vectorize(dim_x);
   if (x_vec.size() == 2) {
-    return phi::make_ddim({1});
+    return phi::make_ddim({});
   }
   x_vec.erase(x_vec.end() - 2, x_vec.end());
   return phi::make_ddim(x_vec);

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2344,7 +2344,7 @@ void MultiDotInferMeta(const std::vector<const MetaTensor*>& x,
   // If the last tensor is 1D of size n view it as a column vector (n, 1)
   if (last_dim.size() == 1) {
     last_dim = phi::make_ddim({static_cast<int>(last_dim[0]), 1});
-    out_dim = is_vector ? phi::make_ddim({1}) : phi::make_ddim({first_dim[0]});
+    out_dim = is_vector ? phi::make_ddim({}) : phi::make_ddim({first_dim[0]});
   } else {
     out_dim = is_vector ? phi::make_ddim({last_dim[1]})
                         : phi::make_ddim({first_dim[0], last_dim[1]});

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -38,7 +38,7 @@ namespace detail {
 static DDim CheckAndGetOutputDim(const DDim& dim_x) {
   auto x_vec = phi::vectorize(dim_x);
   if (x_vec.size() == 2) {
-    return phi::make_ddim({1});
+    return phi::make_ddim({});
   }
   x_vec.erase(x_vec.end() - 2, x_vec.end());
   return phi::make_ddim(x_vec);

--- a/paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h
@@ -94,7 +94,7 @@ void SlogDeterminantKernel(const Context& dev_ctx,
   std::vector<int> output_dim_vec(input_dim.begin(), input_dim.end() - 2);
   if (input_dim.size() == static_cast<size_t>(2)) {
     // when input is a two-dimension matrix, The det value is a number.
-    output_dim_vec = {1};
+    output_dim_vec = {};
   }
   output_dim_vec.insert(output_dim_vec.begin(),
                         2);  // make the output dims as same as numpy

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2080,7 +2080,7 @@ class TestSundryAPI(unittest.TestCase):
         # 3-D input
         x1 = paddle.randn([3, 3, 3])
         x1.stop_gradient = False
-        out1 = paddle.linalg.slogdet(x)
+        out1 = paddle.linalg.slogdet(x1)
         out1.retain_grads()
         out1.backward()
 
@@ -3639,16 +3639,16 @@ class TestSundryAPIStatic(unittest.TestCase):
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, fetch_list=[out])
-        self.assertEqual(res[0].shape, [2])
+        self.assertEqual(res[0].shape, (2,))
 
         # 3-D input
         x1 = paddle.randn([3, 3, 3])
         x1.stop_gradient = False
-        out1 = paddle.linalg.slogdet(x)
+        out1 = paddle.linalg.slogdet(x1)
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out])
-        self.assertEqual(res[0].shape, [2, 3])
+        res = self.exe.run(prog, fetch_list=[out1])
+        self.assertEqual(res[0].shape, (2, 3))
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2066,6 +2066,27 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(x.grad.shape, [])
         np.testing.assert_allclose(x.grad, np.array(1.0))
 
+    def test_linalg_slogdet(self):
+        # 2-D input
+        x = paddle.randn([3, 3])
+        x.stop_gradient = False
+        out = paddle.linalg.slogdet(x)
+        out.retain_grads()
+        out.backward()
+
+        self.assertTrue(out.shape, [2])
+        self.assertTrue(x.grad.shape, [3, 3])
+
+        # 3-D input
+        x1 = paddle.randn([3, 3, 3])
+        x1.stop_gradient = False
+        out1 = paddle.linalg.slogdet(x)
+        out1.retain_grads()
+        out1.backward()
+
+        self.assertTrue(out1.shape, [2, 3])
+        self.assertTrue(x1.grad.shape, [3, 3, 3])
+
 
 class TestSundryAPIStatic(unittest.TestCase):
     def setUp(self):
@@ -3608,6 +3629,26 @@ class TestSundryAPIStatic(unittest.TestCase):
 
         self.assertEqual(out1.shape, (2, 3))
         self.assertEqual(out2.shape, (2, 3))
+
+    @prog_scope
+    def test_linalg_slogdet(self):
+        # 2-D input
+        x = paddle.randn([3, 3])
+        x.stop_gradient = False
+        out = paddle.linalg.slogdet(x)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out])
+        self.assertEqual(res[0].shape, [2])
+
+        # 3-D input
+        x1 = paddle.randn([3, 3, 3])
+        x1.stop_gradient = False
+        out1 = paddle.linalg.slogdet(x)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out])
+        self.assertEqual(res[0].shape, [2, 3])
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -3630,7 +3630,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(out1.shape, (2, 3))
         self.assertEqual(out2.shape, (2, 3))
 
-    @prog_scope
+    @prog_scope()
     def test_linalg_slogdet(self):
         # 2-D input
         x = paddle.randn([3, 3])

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -3636,19 +3636,23 @@ class TestSundryAPIStatic(unittest.TestCase):
         x = paddle.randn([3, 3])
         x.stop_gradient = False
         out = paddle.linalg.slogdet(x)
+        paddle.static.append_backward(out.sum())
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out])
+        res = self.exe.run(prog, fetch_list=[out, x.grad_name])
         self.assertEqual(res[0].shape, (2,))
+        self.assertEqual(res[1].shape, (3, 3))
 
         # 3-D input
         x1 = paddle.randn([3, 3, 3])
         x1.stop_gradient = False
         out1 = paddle.linalg.slogdet(x1)
+        paddle.static.append_backward(out1.sum())
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out1])
+        res = self.exe.run(prog, fetch_list=[out1, x1.grad_name])
         self.assertEqual(res[0].shape, (2, 3))
+        self.assertEqual(res[1].shape, (3, 3, 3))
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
 Others 

### PR changes
 Others 

### Describe
Pcard-66984
Support the following api 0D output

> paddle.dist
paddle.linalg.matrix_rank
paddle.linalg.multi_dot
paddle.linalg.cond
paddle.linalg.cov
paddle.linalg.det
paddle.linalg.norm
paddle.trace

source pr:
https://github.com/PaddlePaddle/Paddle/pull/52861
https://github.com/PaddlePaddle/Paddle/pull/52857
https://github.com/PaddlePaddle/Paddle/pull/53208
