### PR TITLE
fix 'Werror-maybe-uninitialized' compiler error in GCC 11.3

### DIFF
--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -97,7 +97,7 @@ int64_t Tensor::size() const { return impl_->numel(); }
 const phi::DDim &Tensor::dims() const { return impl_->dims(); }
 
 std::vector<int64_t> Tensor::shape() const {
-  auto dims = impl_->dims();
+  const auto &dims = impl_->dims();
   return phi::vectorize<int64_t>(dims);
 }
 

--- a/paddle/phi/kernels/funcs/sequence2batch.cc
+++ b/paddle/phi/kernels/funcs/sequence2batch.cc
@@ -26,8 +26,8 @@ class CopyMatrixRowsFunctor<phi::CPUContext, T> {
                   phi::DenseTensor* dst,
                   bool is_src_index) {
     size_t* index = index_lod.data();
-    auto src_dims = src.dims();
-    auto dst_dims = dst->dims();
+    const auto& src_dims = vectorize<int>(src.dims());
+    const auto& dst_dims = vectorize<int>(dst->dims());
     PADDLE_ENFORCE_EQ(src_dims.size(),
                       2UL,
                       phi::errors::InvalidArgument(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
fix `Werror-maybe-uninitialized` compiler error in GCC 11.3.