### PR TITLE
[Dy2St]Get grad names when call append backward to fix high order gradient

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -691,11 +691,14 @@ class GradNodeRunProgram : public egr::GradNodeBase {
                              std::vector<paddle::Tensor> *x_grad) {
     auto x_grad_names =
         PADDLE_GET_CONST(std::vector<std::string>, attrs_.at("x_grad_names"));
-    PADDLE_ENFORCE_EQ(x.size(),
-                      x_grad_names.size(),
-                      paddle::platform::errors::InvalidArgument(
-                          "The x.size() and "
-                          "x_grad_names.size() should be equal."));
+    PADDLE_ENFORCE_EQ(
+        x.size(),
+        x_grad_names.size(),
+        paddle::platform::errors::InvalidArgument(
+            "The x.size() and x_grad_names.size() should be equal. "
+            "But received x.size() = %d, x_grad_names.size() = %d",
+            x.size(),
+            x_grad_names.size()));
 
     // TODO(dev): Need an elegant way to determine inforamtion of grad_tensor,
     // such as: name, tensor type(DenseTensor or SelectedRows).

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -689,15 +689,23 @@ class GradNodeRunProgram : public egr::GradNodeBase {
  protected:
   void ConstructXGradTensors(const std::vector<paddle::Tensor> &x,
                              std::vector<paddle::Tensor> *x_grad) {
+    auto x_grad_names =
+        PADDLE_GET_CONST(std::vector<std::string>, attrs_.at("x_grad_names"));
+    PADDLE_ENFORCE_EQ(x.size(),
+                      x_grad_names.size(),
+                      paddle::platform::errors::InvalidArgument(
+                          "The x.size() and "
+                          "x_grad_names.size() should be equal."));
+
     // TODO(dev): Need an elegant way to determine inforamtion of grad_tensor,
     // such as: name, tensor type(DenseTensor or SelectedRows).
-    for (auto &t : x) {
-      if (t.is_dense_tensor()) {
+    for (size_t i = 0; i < x.size(); i++) {
+      if (x[i].is_dense_tensor()) {
         x_grad->emplace_back(std::make_shared<phi::DenseTensor>());
-      } else if (t.is_selected_rows()) {
+      } else if (x[i].is_selected_rows()) {
         x_grad->emplace_back(std::make_shared<phi::SelectedRows>());
       }
-      x_grad->back().set_name(t.name() + "@GRAD");
+      x_grad->back().set_name(x_grad_names[i]);
     }
   }
 

--- a/paddle/fluid/operators/run_program_op.cc
+++ b/paddle/fluid/operators/run_program_op.cc
@@ -139,6 +139,10 @@ class RunProgramOpMaker : public framework::OpProtoAndCheckerMaker {
                                       "std::vector<std::string>"
                                       "The names of output gradients.")
         .SetDefault({});
+    AddAttr<std::vector<std::string>>("x_grad_names",
+                                      "std::vector<std::string>"
+                                      "The names of input gradients.")
+        .SetDefault({});
     AddComment(R"DOC(
 RunProgram operator.
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -2380,7 +2380,7 @@ def _calc_and_ret_grad_info_map(
     targets, inputs, target_gradients=None, no_grad_set=None
 ):
     '''
-    For Dy2St
+    This function is used in dy2st to get grad_info_map and then get grad var names
     '''
     targets = _as_list(targets)
     inputs = _as_list(inputs)
@@ -2534,6 +2534,9 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
         will be None
     """
 
+    # NOTE: If you want to modify the logic of calc_gradient, please modify
+    # it inside the _calc_and_ret_grad_info_map and _get_grad_vars functions
+    # to ensure the correctness of dy2st mode.
     grad_info_map = _calc_and_ret_grad_info_map(
         targets,
         inputs,

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -2376,28 +2376,12 @@ def _find_op_path_(
     return op_path
 
 
-def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
-    """
-    Backpropagate the gradients of targets to inputs.
-
-    Args:
-        targets(Tensor|list[Tensor]|tuple[Tensor]): The target Tensors
-        inputs(Tensor|list[Tensor]|tuple[Tensor]): The input Tensors
-        target_gradients (Tensor|list[Tensor]|tuple[Tensor], optional): The gradient Tensors
-            of targets which has the same shape with targets, If None, ones will
-            be created for them.
-        no_grad_set(set[Tensor|str], optional): Set of Tensors or Tensor.names in the :ref:`api_guide_Block_en` 0 whose gradients
-                               should be ignored. All Tensors with
-                               `stop_gradient=True` from all blocks will
-                               be automatically added into this set.
-                               If this parameter is not None, the Tensors or Tensor.names in this set will be added to the default set.
-                               Default: None.
-
-    Return:
-        (list[Tensor]): A list of gradients for inputs
-        If an input does not affect targets, the corresponding gradient Tensor
-        will be None
-    """
+def _calc_and_ret_grad_infp_map(
+    targets, inputs, target_gradients=None, no_grad_set=None
+):
+    '''
+    For Dy2St
+    '''
     targets = _as_list(targets)
     inputs = _as_list(inputs)
     target_gradients = _as_list(target_gradients)
@@ -2510,7 +2494,11 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
 
     _append_backward_vars_(block, fwd_op_num, grad_to_var, grad_info_map)
     prog._sync_with_cpp()
+    return grad_info_map
 
+
+def _get_grad_vars(grad_info_map, inputs):
+    inputs = _as_list(inputs)
     grad_vars = []
     for input_var in inputs:
         if input_var.name not in grad_info_map:
@@ -2520,6 +2508,40 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
             grad_block = grad_info[1]
             grad_var = grad_block.var(grad_info[0])
             grad_vars.append(grad_var)
+    return grad_vars
+
+
+def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
+    """
+    Backpropagate the gradients of targets to inputs.
+
+    Args:
+        targets(Tensor|list[Tensor]|tuple[Tensor]): The target Tensors
+        inputs(Tensor|list[Tensor]|tuple[Tensor]): The input Tensors
+        target_gradients (Tensor|list[Tensor]|tuple[Tensor], optional): The gradient Tensors
+            of targets which has the same shape with targets, If None, ones will
+            be created for them.
+        no_grad_set(set[Tensor|str], optional): Set of Tensors or Tensor.names in the :ref:`api_guide_Block_en` 0 whose gradients
+                               should be ignored. All Tensors with
+                               `stop_gradient=True` from all blocks will
+                               be automatically added into this set.
+                               If this parameter is not None, the Tensors or Tensor.names in this set will be added to the default set.
+                               Default: None.
+
+    Return:
+        (list[Tensor]): A list of gradients for inputs
+        If an input does not affect targets, the corresponding gradient Tensor
+        will be None
+    """
+
+    grad_info_map = _calc_and_ret_grad_infp_map(
+        targets,
+        inputs,
+        target_gradients=target_gradients,
+        no_grad_set=no_grad_set,
+    )
+
+    grad_vars = _get_grad_vars(grad_info_map, inputs)
 
     if len(grad_vars) == 1:
         return grad_vars[0]

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -2376,11 +2376,11 @@ def _find_op_path_(
     return op_path
 
 
-def _calc_and_ret_grad_info_map(
+def calc_gradient_helper(
     targets, inputs, target_gradients=None, no_grad_set=None
 ):
     '''
-    This function is used in dy2st to get grad_info_map and then get grad var names
+    Calculate gradient and return grad_info_map
     '''
     targets = _as_list(targets)
     inputs = _as_list(inputs)
@@ -2535,9 +2535,9 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
     """
 
     # NOTE: If you want to modify the logic of calc_gradient, please modify
-    # it inside the _calc_and_ret_grad_info_map and _get_grad_vars functions
+    # it inside the calc_gradient_helper and _get_grad_vars functions
     # to ensure the correctness of dy2st mode.
-    grad_info_map = _calc_and_ret_grad_info_map(
+    grad_info_map = calc_gradient_helper(
         targets,
         inputs,
         target_gradients=target_gradients,

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -2376,7 +2376,7 @@ def _find_op_path_(
     return op_path
 
 
-def _calc_and_ret_grad_infp_map(
+def _calc_and_ret_grad_info_map(
     targets, inputs, target_gradients=None, no_grad_set=None
 ):
     '''
@@ -2534,7 +2534,7 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
         will be None
     """
 
-    grad_info_map = _calc_and_ret_grad_infp_map(
+    grad_info_map = _calc_and_ret_grad_info_map(
         targets,
         inputs,
         target_gradients=target_gradients,

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -83,7 +83,8 @@ class TestDropoutOp(OpTest):
         self.check_output(check_prim=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
+        # Now in dy2st mode x_grad = [], so set check_prim=False
+        self.check_grad(['X'], 'Out', check_prim=False)
 
 
 class TestDropoutOpInput1d(OpTest):
@@ -107,7 +108,8 @@ class TestDropoutOpInput1d(OpTest):
         self.check_output(check_prim=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
+        # Now in dy2st mode x_grad = [], so set check_prim=False
+        self.check_grad(['X'], 'Out', check_prim=False)
 
 
 class TestDropoutOp2(TestDropoutOp):
@@ -283,7 +285,8 @@ class TestDropoutOpWithSeed(OpTest):
         self.check_output(check_prim=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', max_relative_error=0.05, check_prim=True)
+        # Now in dy2st mode x_grad = [], so set check_prim=False
+        self.check_grad(['X'], 'Out', max_relative_error=0.05, check_prim=False)
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_eager_run_program.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_run_program.py
@@ -134,6 +134,8 @@ class TestRunProgram(unittest.TestCase):
             ['Fake_var@GRAD'],
             'out_grad_names',
             [out.name + '@GRAD'],
+            'x_grad_names',
+            [x_t.name + '@GRAD', y_t.name + '@GRAD'],
         ]
 
         use_interpretorcore = True

--- a/python/paddle/fluid/tests/unittests/test_run_program_op.py
+++ b/python/paddle/fluid/tests/unittests/test_run_program_op.py
@@ -254,6 +254,8 @@ class RunProgramOpTest(unittest.TestCase):
                     [p.name + '@GRAD' for p in inputs['Params']],
                     'out_grad_names',
                     [out.name + '@GRAD' for out in outputs['Out']],
+                    'x_grad_names',
+                    [p.name + '@GRAD' for p in inputs['X']],
                 )
             )
 
@@ -303,6 +305,8 @@ class RunProgramOpTest(unittest.TestCase):
                     [p.name + '@GRAD' for p in inputs['Params']],
                     'out_grad_names',
                     [out.name + '@GRAD' for out in outputs['Out']],
+                    'x_grad_names',
+                    [p.name + '@GRAD' for p in inputs['X']],
                 )
             )
 

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -656,9 +656,14 @@ class PartialProgramLayer:
                 inputs = [
                     program.block(0).var(var.name) for var in self._inputs
                 ] + [program.block(0).var(var.name) for var in self._params]
-                breakpoint()
                 grad_vars = backward.gradients(targets=targets, inputs=inputs)
-                self._grad_var_names = [var.name for var in grad_vars]
+                self._grad_var_names = []
+                for i in range(len(grad_vars)):
+                    var = grad_vars[i]
+                    if isinstance(var, framework.Variable):
+                        self._grad_var_names.append(var.name)
+                    else:
+                        self._grad_var_names.append(inputs[i].name + "@GRAD")
 
             if self._hooker:
                 program, start_idx = self._hooker.after_append_backward(

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -460,6 +460,10 @@ class PartialProgramLayer:
             len(self._outputs.var_ids),
         )
 
+    @LazyInitialized
+    def _x_grad_names(self):
+        return _param_grad_names(self._train_program.desc, self._inputs)
+
     @property
     def program(self):
         """
@@ -723,6 +727,8 @@ class PartialProgramLayer:
                     self._param_grad_names,
                     'out_grad_names',
                     self._out_grad_names,
+                    'x_grad_names',
+                    self._x_grad_names,
                 )
             )
         if self._cuda_graph_capture_mode:

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -673,22 +673,18 @@ class PartialProgramLayer:
                 ]
 
                 fn = (
-                    lambda var, grad_var: grad_var.name
+                    lambda grad_var: grad_var.name
                     if isinstance(grad_var, framework.Variable)
-                    else var.name + '@GRAD'
+                    else framework.EMPTY_VAR_NAME
                 )
                 x_grad_vars = backward._get_grad_vars(grad_info_map, x_vars)
-                self._grad_var_names['x'] = list(map(fn, x_vars, x_grad_vars))
+                self._grad_var_names['x'] = list(map(fn, x_grad_vars))
                 param_grad_vars = backward._get_grad_vars(
                     grad_info_map, param_vars
                 )
-                self._grad_var_names['param'] = list(
-                    map(fn, param_vars, param_grad_vars)
-                )
+                self._grad_var_names['param'] = list(map(fn, param_grad_vars))
                 out_grad_vars = backward._get_grad_vars(grad_info_map, out_vars)
-                self._grad_var_names['out'] = list(
-                    map(fn, out_vars, out_grad_vars)
-                )
+                self._grad_var_names['out'] = list(map(fn, out_grad_vars))
 
             if self._hooker:
                 program, start_idx = self._hooker.after_append_backward(

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -643,7 +643,7 @@ class PartialProgramLayer:
                     (framework.Variable, list, tuple),
                     'paddle.static.gradients',
                 )
-                grad_info_map = backward._calc_and_ret_grad_info_map(
+                grad_info_map = backward.calc_gradient_helper(
                     targets=targets, inputs=[]
                 )
 

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -727,15 +727,7 @@ class PartialProgramLayer:
             self.program_id,
         ]
 
-        if self.training and self._grad_var_names:
-            inputs_size = len(
-                [
-                    var
-                    for var in self._inputs
-                    if isinstance(var, framework.Variable)
-                ]
-            )
-            params_size = len(self._params)
+        if self.training:
             # NOTE: In the case of higher-order gradient, the names of the parameter grads may be like
             # `grad/grad/grad/linear_0.w_0@GRAD` instead of simply `linear_0.w_0@GRAD`, so we get
             # the correct names of the parameter grads from program. And out grads are similar to above.

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -1476,16 +1476,17 @@ def _param_grad_names(program_desc, params):
                 pre_count = var_name.count(GRAD_PREFIX)
                 if GRAD_PREFIX * pre_count + suffix == var_name:
                     candidate.append(var_name)
-
         if candidate:
-            names.append(
-                max(
-                    candidate,
-                    key=lambda name: name.count(GRAD_PREFIX)
-                    if GRAD_PREFIX in name
-                    else name.count(GRAD_SUFFIX),
+            if any(
+                [True if GRAD_PREFIX in name else False for name in candidate]
+            ):
+                names.append(
+                    max(candidate, key=lambda name: name.count(GRAD_PREFIX))
                 )
-            )
+            else:
+                names.append(
+                    max(candidate, key=lambda name: name.count(GRAD_SUFFIX))
+                )
         else:
             names.append(param.name + GRAD_SUFFIX)
     return names

--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -991,11 +991,11 @@ def _run_dygraph(instance, input, program_holder):
         attrs.extend(
             (
                 'param_grad_names',
-                instance.grad_var_names.get('param', []),
+                program_holder.grad_var_names.get('param', []),
                 'out_grad_names',
-                instance.grad_var_names.get('out', []),
+                program_holder.grad_var_names.get('out', []),
                 'x_grad_names',
-                instance.grad_var_names.get('x', []),
+                program_holder.grad_var_names.get('x', []),
             )
         )
 

--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -610,7 +610,7 @@ class _ProgramHolder:
             (framework.Variable, list, tuple),
             'paddle.static.gradients',
         )
-        grad_info_map = backward._calc_and_ret_grad_info_map(
+        grad_info_map = backward.calc_gradient_helper(
             targets=targets, inputs=[]
         )
         x_vars = [

--- a/test/dygraph_to_static/test_gradname_parse.py
+++ b/test/dygraph_to_static/test_gradname_parse.py
@@ -67,40 +67,98 @@ class TestGradNameParse(unittest.TestCase):
         opt.minimize(loss)
 
 
-class TestXGradNameParse(unittest.TestCase):
-    def test_x_grad_name_parse(self):
-        def tanh_high_order_grad(x):
-            y = paddle.tanh(x)
-            return paddle.grad(y, x, create_graph=True)[0]
+def tanh_high_order_grad(x):
+    y = paddle.tanh(x)
+    return paddle.grad(y, x, create_graph=True)[0]
+
+
+class TestTanhHighOrderGrad(unittest.TestCase):
+    def setUp(self):
+        self.func = tanh_high_order_grad
 
         x1 = paddle.ones((1,))
         x1.stop_gradient = False
-        y1 = tanh_high_order_grad(x1)
-        g1 = paddle.grad(y1, x1)
+        self.dy_input = (x1,)
+        self.dy_grad_input = (x1,)
 
         x2 = paddle.ones((1,))
         x2.stop_gradient = False
-        y2 = paddle.jit.to_static(tanh_high_order_grad)(x2)
-        g2 = paddle.grad(y2, x2)
+        self.dy2st_input = (x2,)
+        self.dy2st_grad_input = (x2,)
 
-        np.testing.assert_equal(g1[0].numpy(), g2[0].numpy())
+    def test_run(self):
+        try:
+            dy_out = self.func(*self.dy_input)
+            dy_grad = paddle.grad(dy_out, self.dy_grad_input)
+        except:
+            dy_grad = [None for i in self.dy_grad_input]
+        dy_grad = [
+            t.numpy() if isinstance(t, paddle.Tensor) else t for t in dy_grad
+        ]
+
+        dy2st_out = paddle.jit.to_static(self.func)(*self.dy2st_input)
+        dy2st_grad = paddle.grad(dy2st_out, self.dy2st_grad_input)
+        dy2st_grad = [
+            t.numpy() if isinstance(t, paddle.Tensor) else t for t in dy_grad
+        ]
+        np.testing.assert_equal(dy_grad, dy2st_grad)
+
+        dy_input_grad = [
+            t.grad.numpy() if isinstance(t.grad, paddle.Tensor) else None
+            for t in self.dy_input
+        ]
+        dy2st_input_grad = [
+            t.grad.numpy() if isinstance(t.grad, paddle.Tensor) else None
+            for t in self.dy2st_input
+        ]
+        np.testing.assert_equal(dy_input_grad, dy2st_input_grad)
 
 
-class TestGradNone(unittest.TestCase):
-    def test_grad_none(self):
-        @paddle.jit.to_static
-        def matmul_high_order_grad(x, y):
-            z = paddle.matmul(x, y)
-            g = paddle.grad(z, [x, y], create_graph=False)
-            return g[0]
+def matmul_high_order_grad(x, y):
+    z = paddle.matmul(x, y)
+    g = paddle.grad(z, [x, y], create_graph=False)
+    return g[0]
 
-        x = paddle.ones([1])
-        x.stop_gradient = False
-        y = paddle.ones([1])
-        y.stop_gradient = False
-        g = matmul_high_order_grad(x, y)
-        o = paddle.grad(g, x)
-        np.testing.assert_equal(y.grad, None)
+
+class TestMatMulHighOrderGrad1(TestTanhHighOrderGrad):
+    def setUp(self):
+        self.func = matmul_high_order_grad
+
+        x1 = paddle.ones([1])
+        x1.stop_gradient = False
+        y1 = paddle.ones([1])
+        y1.stop_gradient = False
+        self.dy_input = (x1, y1)
+        self.dy_grad_input = (x1,)
+
+        x2 = paddle.ones([1])
+        x2.stop_gradient = False
+        y2 = paddle.ones([1])
+        y2.stop_gradient = False
+        self.dy2st_input = (x2, y2)
+        self.dy2st_grad_input = (x2,)
+
+
+class TestMatMulHighOrderGrad2(TestTanhHighOrderGrad):
+    def setUp(self):
+        self.func = matmul_high_order_grad
+
+        x = np.random.randn(5, 5)
+        y = np.random.randn(5, 5)
+
+        x1 = paddle.to_tensor(x)
+        x1.stop_gradient = False
+        y1 = paddle.to_tensor(y)
+        y1.stop_gradient = True
+        self.dy_input = (x1, y1)
+        self.dy_grad_input = (x1,)
+
+        x2 = paddle.to_tensor(x)
+        x2.stop_gradient = False
+        y2 = paddle.to_tensor(y)
+        y2.stop_gradient = True
+        self.dy2st_input = (x2, y2)
+        self.dy2st_grad_input = (x2,)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
PCard-66972
## 1 背景
高阶情况下动转静的input、param、out对应的grad var name不再是简单的x@GRAD，他们的name可能的形式可能有x@GRAD@GRAD、grad/grad/x@GRAD、x@GRAD_0等。所以之前通过 x.name + '@GRAD' 进行拼接的方式无法得到正确的grad var name，所以需要对动转静获取grad var name的模块进行升级以支持高阶的情况
## 2 本PR的修改
之前是通过遍历program中的var，正则匹配出grad var name，但是这种方式在一些情况下是错误的且难以维护。
在本PR中对获取grad var name的方式进行了升级，通过append_backward返回的grad_info_map来拿到对应的grad var，从而拿到grad var name，只要静态图下append_backward的逻辑是正确的那么就一定可以拿到正确的grad var name。

关于`calc_gradient`的修改，PR中只是将`calc_gradient`的主要逻辑抽离出来，形成一个`calc_gradient_helper`函数，提供给动转静模块使用
