### PR TITLE
Change gpu_time_diff default value in tools/check_op_benchmark_result.py

### DIFF
--- a/tools/check_op_benchmark_result.py
+++ b/tools/check_op_benchmark_result.py
@@ -74,7 +74,7 @@ def check_speed_result(case_name, develop_data, pr_data, pr_result):
         gpu_time_diff = (pr_gpu_time - develop_gpu_time) / develop_gpu_time
         gpu_time_diff_str = "{:.5f}".format(gpu_time_diff * 100)
     else:
-        gpu_time_diff = None
+        gpu_time_diff = 0
         gpu_time_diff_str = ""
 
     pr_total_time = pr_data.get("total")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
tools/check_op_benchmark_result.py
如果 gpu_time_diff = None
执行到 return gpu_time_diff > 0.05 时有异常