### PR TITLE
Remove managed memory msg in cuda allocator

### DIFF
--- a/paddle/fluid/memory/allocation/cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_allocator.cc
@@ -70,29 +70,20 @@ phi::Allocation* CUDAAllocator::AllocateImpl(size_t size) {
         limit_size);
   }
 
-  std::string managed_memory_msg;
-  if (platform::IsGPUManagedMemoryOversubscriptionSupported(place_.device)) {
-    managed_memory_msg = string::Sprintf(
-        "If the above ways do not solve the out of memory problem, you can try "
-        "to use CUDA managed memory. The command is `export "
-        "FLAGS_use_cuda_managed_memory=true`.");
-  }
-
   PADDLE_THROW_BAD_ALLOC(platform::errors::ResourceExhausted(
       "\n\nOut of memory error on GPU %d. "
       "Cannot allocate %s memory on GPU %d, %s memory has been allocated and "
       "available memory is only %s.\n\n"
       "Please check whether there is any other process using GPU %d.\n"
       "1. If yes, please stop them, or start PaddlePaddle on another GPU.\n"
-      "2. If no, please decrease the batch size of your model. %s\n%s\n",
+      "2. If no, please decrease the batch size of your model. %s\n",
       place_.device,
       string::HumanReadableSize(size),
       place_.device,
       string::HumanReadableSize(allocated),
       string::HumanReadableSize(avail),
       place_.device,
-      err_msg,
-      managed_memory_msg));
+      err_msg));
 }
 
 }  // namespace allocation


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67003

CUDA的`managed memory`功能当前在paddle框架中未经过充分的测试和验证，不了解相关原理的用户自行使用可能给程序带来风险。其当前只局限在少数特定场景使用，不应作为框架默认推荐的解决显存不足问题的方式之一，因而本PR从显存不足的报错信息中删除用户可以尝试通过`FLAGS_use_cuda_managed_memory`来开启`managed memory`的提示。