### PR TITLE
[Paddle Inference] Fix cuda version constrait of nvcc_lazy to 11.8

### DIFF
--- a/cmake/experiments/cuda_module_loading_lazy.cmake
+++ b/cmake/experiments/cuda_module_loading_lazy.cmake
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # this file contains experimental build options for lazy cuda module loading
-# cuda moduel lazy loading is supported by CUDA 11.7+
-# this experiment option makes Paddle supports lazy loading before CUDA 11.7.
+# cuda moduel lazy loading is supported by CUDA 11.8+
+# this experiment option makes Paddle supports lazy loading before CUDA 11.8.
 
 if(LINUX)
   if(NOT ON_INFER)
@@ -27,8 +27,8 @@ if(LINUX)
     message("EXP_CUDA_MODULE_LOADING_LAZY only works with GPU")
     return()
   endif()
-  if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.7")
-    message("cuda 11.7+ already support lazy module loading")
+  if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.8")
+    message("cuda 11.8+ already support lazy module loading")
     return()
   endif()
   if(${CUDA_VERSION} VERSION_LESS "12.0" AND ${CMAKE_CXX_COMPILER_VERSION}
@@ -38,7 +38,7 @@ if(LINUX)
   endif()
 
   message(
-    "for cuda before 11.7, libcudart.so must be used for the lazy module loading trick to work, instead of libcudart_static.a"
+    "for cuda before 11.8, libcudart.so must be used for the lazy module loading trick to work, instead of libcudart_static.a"
   )
   set(CUDA_USE_STATIC_CUDA_RUNTIME
       OFF

--- a/tools/nvcc_lazy.sh
+++ b/tools/nvcc_lazy.sh
@@ -44,11 +44,11 @@ echo "  nvcc \"\$@\"" >> $1
 echo "  exit 0" >> $1
 echo "fi" >> $1
 echo -e >> $1
-echo "# check nvcc version, if nvcc >= 11.7, just run nvcc itself" >> $1
+echo "# check nvcc version, if nvcc >= 11.8, just run nvcc itself" >> $1
 echo "CUDA_VERSION=\$(nvcc --version | grep -oP '(?<=V)\d*\.\d*')" >> $1
 echo "CUDA_VERSION_MAJOR=\${CUDA_VERSION%.*}" >> $1
 echo "CUDA_VERSION_MINOR=\${CUDA_VERSION#*.}" >> $1
-echo "if (( CUDA_VERSION_MAJOR > 11 || (CUDA_VERSION_MAJOR == 11 && CUDA_VERSION_MINOR >= 7) )); then" >> $1
+echo "if (( CUDA_VERSION_MAJOR > 11 || (CUDA_VERSION_MAJOR == 11 && CUDA_VERSION_MINOR >= 8) )); then" >> $1
 echo "  nvcc \"\$@\"" >> $1
 echo "  exit" >> $1
 echo "fi" >> $1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Fix cuda version constrait of nvcc_lazy to 11.8