### PR TITLE
【Hackathon No.52】为 Paddle dist 算子实现 float16 数据类型支持

### DIFF
--- a/paddle/phi/kernels/dist_grad_kernel.cc
+++ b/paddle/phi/kernels/dist_grad_kernel.cc
@@ -52,6 +52,10 @@ void DistGradKernel(const Context& dev_ctx,
                     float p,
                     DenseTensor* x_grad,
                     DenseTensor* y_grad) {
+  if ((!x_grad) && (!y_grad)) {
+    return;
+  }
+
   auto t = Subtract<T, Context>(dev_ctx, x, y);
   DenseTensor x_grad_tmp;
   x_grad_tmp.Resize(t.dims());
@@ -59,26 +63,32 @@ void DistGradKernel(const Context& dev_ctx,
   y_grad_tmp.Resize(t.dims());
   PNormGradKernel<T, Context>(
       dev_ctx, t, out, out_grad, p, -1, 1e-12, false, true, &x_grad_tmp);
-  ScaleKernel<T, Context>(dev_ctx, x_grad_tmp, -1.0, 0.0, false, &y_grad_tmp);
-  // do reduce, the implemetation of cpu SumKernel has bug, it changes
-  // the dims of output iternally, so we Resize x/y_grad twice.
-  auto res_x = GetReduceDims(x_grad_tmp.dims(), x.dims());
-  if (!std::get<0>(res_x).empty()) {
-    x_grad->Resize(phi::make_ddim(std::get<1>(res_x)));
-    SumKernel<T, Context>(
-        dev_ctx, x_grad_tmp, std::get<0>(res_x), x.dtype(), false, x_grad);
-    x_grad->Resize(x.dims());
-  } else {
-    x_grad->ShareBufferWith(x_grad_tmp);
+
+  if (x_grad) {
+    // do reduce, the implemetation of cpu SumKernel has bug, it changes
+    // the dims of output iternally, so we Resize x/y_grad twice.
+    auto res_x = GetReduceDims(x_grad_tmp.dims(), x.dims());
+    if (!std::get<0>(res_x).empty()) {
+      x_grad->Resize(phi::make_ddim(std::get<1>(res_x)));
+      SumKernel<T, Context>(
+          dev_ctx, x_grad_tmp, std::get<0>(res_x), x.dtype(), false, x_grad);
+      x_grad->Resize(x.dims());
+    } else {
+      x_grad->ShareBufferWith(x_grad_tmp);
+    }
   }
-  auto res_y = GetReduceDims(y_grad_tmp.dims(), y.dims());
-  if (!std::get<0>(res_y).empty()) {
-    y_grad->Resize(phi::make_ddim(std::get<1>(res_y)));
-    SumKernel<T, Context>(
-        dev_ctx, y_grad_tmp, std::get<0>(res_y), y.dtype(), false, y_grad);
-    y_grad->Resize(y.dims());
-  } else {
-    y_grad->ShareBufferWith(y_grad_tmp);
+
+  if (y_grad) {
+    ScaleKernel<T, Context>(dev_ctx, x_grad_tmp, -1.0, 0.0, false, &y_grad_tmp);
+    auto res_y = GetReduceDims(y_grad_tmp.dims(), y.dims());
+    if (!std::get<0>(res_y).empty()) {
+      y_grad->Resize(phi::make_ddim(std::get<1>(res_y)));
+      SumKernel<T, Context>(
+          dev_ctx, y_grad_tmp, std::get<0>(res_y), y.dtype(), false, y_grad);
+      y_grad->Resize(y.dims());
+    } else {
+      y_grad->ShareBufferWith(y_grad_tmp);
+    }
   }
 }
 
@@ -88,6 +98,11 @@ PD_REGISTER_KERNEL(
     dist_grad, CPU, ALL_LAYOUT, phi::DistGradKernel, float, double) {}
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-PD_REGISTER_KERNEL(
-    dist_grad, GPU, ALL_LAYOUT, phi::DistGradKernel, float, double) {}
+PD_REGISTER_KERNEL(dist_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::DistGradKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}
 #endif

--- a/paddle/phi/kernels/gpu/dist_kernel.cu
+++ b/paddle/phi/kernels/gpu/dist_kernel.cu
@@ -21,156 +21,22 @@
 #include "paddle/phi/kernels/p_norm_kernel.h"
 
 namespace phi {
-
-#define FULL_MASK 0xffffffff
-
-template <typename T>
-struct ZeroOrderFunctor {
- public:
-  __device__ T operator()(const T& x, const T& y) const {
-    return static_cast<T>((x - y) != 0);
-  }
-};
-
-template <typename T>
-struct OtherOrderFunctor {
-  explicit OtherOrderFunctor(const T& p_order) : p_order_(p_order) {}
-  __device__ T operator()(const T& x, const T& y) const {
-    return static_cast<T>(pow(abs(x - y), p_order_));
-  }
-
- private:
-  T p_order_;
-};
-
-template <typename T>
-struct PowFunctor {
-  explicit PowFunctor(const T& p_order) : p_order_(p_order) {}
-  HOSTDEVICE inline T operator()(const T x) const {
-    return static_cast<T>(pow(x, p_order_));
-  }
-  T p_order_;
-};
-
-template <typename T, typename Functor>
-__global__ void ReduceSumWithSubtract(
-    const T* x, const T* y, T* out, int64_t N, Functor func) {
-  T sum_val = 0;
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < N;
-       i += blockDim.x * gridDim.x) {
-    sum_val += func(x[i], y[i]);
-  }
-
-  __syncthreads();
-  sum_val = phi::funcs::BlockReduceSum<T>(sum_val, FULL_MASK);
-  if (threadIdx.x == 0) {
-    out[blockIdx.x] = sum_val;
-  }
-}
-
-template <typename T>
-__global__ void ReduceMaxWithSubtract(const T* x,
-                                      const T* y,
-                                      T* out,
-                                      int64_t N) {
-  T max_val = -1e10f;
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < N;
-       i += blockDim.x * gridDim.x) {
-    max_val = max(max_val, abs(x[i] - y[i]));
-  }
-
-  __syncthreads();
-  max_val = phi::funcs::BlockReduceMax<T>(max_val, FULL_MASK);
-  if (threadIdx.x == 0) {
-    out[blockIdx.x] = max_val;
-  }
-}
-
-template <typename T>
-__global__ void ReduceMinWithSubtract(const T* x,
-                                      const T* y,
-                                      T* out,
-                                      int64_t N) {
-  T min_val = 1e10f;
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < N;
-       i += blockDim.x * gridDim.x) {
-    min_val = min(min_val, abs(x[i] - y[i]));
-  }
-
-  __syncthreads();
-  min_val = phi::funcs::BlockReduceMin(min_val, FULL_MASK);
-  if (threadIdx.x == 0) {
-    out[blockIdx.x] = min_val;
-  }
-}
-
 template <typename T, typename Context>
 void DistKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const DenseTensor& y,
                 float p,
                 DenseTensor* out) {
-  DenseTensor intermediate;
-  const T* x_ptr = x.data<T>();
-  const T* y_ptr = y.data<T>();
-  T* o_ptr = dev_ctx.template Alloc<T>(out);
-  auto stream = dev_ctx.stream();
-
-  auto xdim = x.dims();
-  if (xdim == y.dims()) {  // same shape
-    auto n = x.numel();
-    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, n);
-    intermediate.Resize(phi::make_ddim({config.block_per_grid.x}));
-    T* i_ptr = dev_ctx.template Alloc<T>(&intermediate);
-
-    std::vector<int64_t> axis_dims = {static_cast<int64_t>(-1)};
-    std::vector<int> reduce_axis =
-        funcs::details::GetReduceDim(axis_dims, xdim.size(), true);
-
-    if (p == 0) {
-      ReduceSumWithSubtract<T>
-          <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
-              x_ptr, y_ptr, i_ptr, n, ZeroOrderFunctor<T>());
-      phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
-          dev_ctx, intermediate, out, kps::IdentityFunctor<T>(), reduce_axis);
-
-    } else if (p == INFINITY) {
-      ReduceMaxWithSubtract<T>
-          <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
-              x_ptr, y_ptr, i_ptr, n);
-      phi::funcs::ReduceKernel<T, T, kps::MaxFunctor, kps::IdentityFunctor<T>>(
-          dev_ctx, intermediate, out, kps::IdentityFunctor<T>(), reduce_axis);
-
-    } else if (p == -INFINITY) {
-      ReduceMinWithSubtract<T>
-          <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
-              x_ptr, y_ptr, i_ptr, n);
-
-      phi::funcs::ReduceKernel<T, T, kps::MinFunctor, kps::IdentityFunctor<T>>(
-          dev_ctx, intermediate, out, kps::IdentityFunctor<T>(), reduce_axis);
-
-    } else {
-      T p_order = static_cast<T>(p);
-      ReduceSumWithSubtract<T>
-          <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
-              x_ptr, y_ptr, i_ptr, n, OtherOrderFunctor<T>(p_order));
-      phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
-          dev_ctx, intermediate, out, kps::IdentityFunctor<T>(), reduce_axis);
-
-      const DenseTensor* tmp_norm = out;
-      std::vector<const DenseTensor*> ins = {tmp_norm};
-      std::vector<DenseTensor*> outs = {out};
-      T p_order_ = static_cast<T>(1. / p_order);
-      phi::funcs::ElementwiseKernel<T>(
-          dev_ctx, ins, &outs, PowFunctor<T>(p_order_));
-    }
-
-  } else {
-    auto t = Subtract<T, Context>(dev_ctx, x, y);
-    PNormKernel<T, Context>(dev_ctx, t, p, -1, 1e-12, false, true, out);
-  }
+  auto t = Subtract<T, Context>(dev_ctx, x, y);
+  PNormKernel<T, Context>(dev_ctx, t, p, -1, 1e-12, false, true, out);
 }
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(dist, GPU, ALL_LAYOUT, phi::DistKernel, float, double) {}
+PD_REGISTER_KERNEL(dist,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::DistKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -43,8 +43,8 @@ struct AbsMaxAndMinGradFunctor {
 template <typename T>
 struct PNormGradFunctor {
   HOSTDEVICE explicit inline PNormGradFunctor(float porder, float eps) {
-    this->porder = static_cast<T>(porder - 1.);
-    this->eps = static_cast<T>(eps);
+    this->porder = static_cast<MT>(porder - 1.);
+    this->eps = static_cast<MT>(eps);
   }
   template <typename Context,
             typename X,
@@ -59,12 +59,17 @@ struct PNormGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    dx->device(place) =
-        (*x).abs().pow(this->porder) * (*x).sign() * dy->broadcast(dim) *
-        (*y + y->constant(eps)).pow(-this->porder).broadcast(dim);
+    dx->device(place) = ((*x).template cast<MT>().abs().pow(this->porder) *
+                         (*x).template cast<MT>().sign() *
+                         (dy->broadcast(dim)).template cast<MT>() *
+                         ((*y).template cast<MT>() + this->eps)
+                             .pow(-this->porder)
+                             .broadcast(dim))
+                            .template cast<T>();
   }
-  T porder;
-  T eps;
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  MT porder;
+  MT eps;
 };
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -43,8 +43,8 @@ struct AbsMaxAndMinGradFunctor {
 template <typename T>
 struct PNormGradFunctor {
   HOSTDEVICE explicit inline PNormGradFunctor(float porder, float eps) {
-    this->porder = static_cast<MT>(porder - 1.);
-    this->eps = static_cast<MT>(eps);
+    this->porder = static_cast<T>(porder - 1.);
+    this->eps = static_cast<T>(eps);
   }
   template <typename Context,
             typename X,
@@ -59,17 +59,12 @@ struct PNormGradFunctor {
                   DY* dy,
                   const Dim& dim,
                   int size) {
-    dx->device(place) = ((*x).template cast<MT>().abs().pow(this->porder) *
-                         (*x).template cast<MT>().sign() *
-                         (dy->broadcast(dim)).template cast<MT>() *
-                         ((*y).template cast<MT>() + this->eps)
-                             .pow(-this->porder)
-                             .broadcast(dim))
-                            .template cast<T>();
+    dx->device(place) =
+        (*x).abs().pow(this->porder) * (*x).sign() * dy->broadcast(dim) *
+        (*y + y->constant(eps)).pow(-this->porder).broadcast(dim);
   }
-  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  MT porder;
-  MT eps;
+  T porder;
+  T eps;
 };
 
 template <typename T, typename Context>

--- a/python/paddle/fluid/tests/unittests/test_dist_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_op.py
@@ -193,6 +193,64 @@ class TestDistAPI(unittest.TestCase):
             np.testing.assert_allclose(dist(x_i, y_i, p), out[0], rtol=1e-05)
 
 
+class TestDistFP16OP(TestDistOp):
+    def init_data_type(self):
+        self.data_type = np.float16
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+            if core.is_float16_supported(place):
+                self.check_output_with_place(place, atol=1e-3)
+
+
+class TestDistFP16OPCase1(TestDistFP16OP):
+    def init_case(self):
+        self.x_shape = (3, 5, 5, 6)
+        self.y_shape = (5, 5, 6)
+        self.p = 1.0
+
+
+class TestDistFP16OPCase2(TestDistFP16OP):
+    def init_case(self):
+        self.x_shape = (4, 10, 10)
+        self.y_shape = (4, 10, 10)
+        self.p = 2.0
+
+
+class TestDistFP16OPCase3(TestDistFP16OP):
+    def init_case(self):
+        self.x_shape = (15, 10)
+        self.y_shape = (15, 10)
+        self.p = float("inf")
+
+
+class TestDistFP16OPCase4(TestDistFP16OP):
+    def init_case(self):
+        self.x_shape = (2, 3, 4, 5, 8)
+        self.y_shape = (3, 1, 5, 8)
+        self.p = float("-inf")
+
+
+class TestDistFP16OPCase5(TestDistFP16OP):
+    def init_case(self):
+        self.x_shape = (4, 1, 4, 8)
+        self.y_shape = (4, 1, 4, 8)
+        self.p = 1.5
+
+
+class TestDistFP16API(TestDistAPI):
+    def init_data_type(self):
+        if core.is_compiled_with_cuda() and core.is_float16_supported(
+            core.CUDAPlace(0)
+        ):
+            self.data_type = 'float16'
+        else:
+            self.data_type = (
+                'float32' if core.is_compiled_with_rocm() else 'float64'
+            )
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -706,8 +706,12 @@ def dist(x, y, p=2, name=None):
     if in_dygraph_mode():
         return _C_ops.dist(x, y, p)
 
-    check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'dist')
-    check_variable_and_dtype(y, 'dtype', ['float32', 'float64'], 'dist')
+    check_variable_and_dtype(
+        x, 'dtype', ['float16', 'float32', 'float64'], 'dist'
+    )
+    check_variable_and_dtype(
+        y, 'dtype', ['float16', 'float32', 'float64'], 'dist'
+    )
     check_type(p, 'p', (float, int), 'dist')
     helper = LayerHelper("dist", **locals())
     out = helper.create_variable_for_type_inference(x.dtype)


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
add the fp16 for `dist` op
