### PR TITLE
fix bugs when using cast<int64_t, int32_t> in xpu/cross_entropy kerne…

### DIFF
--- a/paddle/phi/kernels/xpu/cross_entropy_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/cross_entropy_grad_kernel.cc
@@ -54,16 +54,25 @@ void CrossEntropyWithSoftmaxGradKernel(const Context& dev_ctx,
           d);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "soft_softmax_with_cross_entropy_grad");
     } else {
-      xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-      int* labels_int_ptr_l3 =
-          RAII_GUARD.alloc_l3_or_gm<int32_t>(labels.numel());
-      PADDLE_ENFORCE_XDNN_NOT_NULL(labels_int_ptr_l3);
+      int* labels_int_ptr_l3 = nullptr;
+      if (labels.dtype() == DataType::INT32) {
+        labels_int_ptr_l3 = const_cast<int*> labels.data<int32_t>();
+      } else if (labels.dtype() == DataType::INT64) {
+        xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+        labels_int_ptr_l3 = RAII_GUARD.alloc_l3_or_gm<int32_t>(labels.numel());
+        PADDLE_ENFORCE_XDNN_NOT_NULL(labels_int_ptr_l3);
 
-      r = xpu::cast<int64_t, int32_t>(dev_ctx.x_context(),
-                                      labels.data<int64_t>(),
-                                      labels_int_ptr_l3,
-                                      labels.numel());
-      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+        r = xpu::cast<int64_t, int32_t>(dev_ctx.x_context(),
+                                        labels.data<int64_t>(),
+                                        labels_int_ptr_l3,
+                                        labels.numel());
+        PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      } else {
+        // TODO(lilujia): other data types should be handled
+        errors::Unimplemented(
+            ("cross_entropy does not support data types other than int32 and "
+             "int64"));
+      }
 
       r = xpu::hard_softmax_with_cross_entropy_grad<XPUType, int>(
           dev_ctx.x_context(),
@@ -113,15 +122,26 @@ void CrossEntropyWithSoftmaxGradKernel(const Context& dev_ctx,
           t);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "soft_softmax_with_cross_entropy_grad");
     } else {
-      int* labels_int_ptr_l3 =
-          RAII_GUARD.alloc_l3_or_gm<int32_t>(labels.numel());
-      PADDLE_ENFORCE_XDNN_NOT_NULL(labels_int_ptr_l3);
+      int* labels_int_ptr_l3 = nullptr;
+      if (labels.dtype() == DataType::INT32) {
+        labels_int_ptr_l3 = const_cast<int*> labels.data<int32_t>();
+      } else if (labels.dtype() == DataType::INT64) {
+        xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+        labels_int_ptr_l3 = RAII_GUARD.alloc_l3_or_gm<int32_t>(labels.numel());
+        PADDLE_ENFORCE_XDNN_NOT_NULL(labels_int_ptr_l3);
 
-      r = xpu::cast<int64_t, int32_t>(dev_ctx.x_context(),
-                                      labels.data<int64_t>(),
-                                      labels_int_ptr_l3,
-                                      labels.numel());
-      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+        r = xpu::cast<int64_t, int32_t>(dev_ctx.x_context(),
+                                        labels.data<int64_t>(),
+                                        labels_int_ptr_l3,
+                                        labels.numel());
+        PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      } else {
+        // TODO(lilujia): other data types should be handled
+        errors::Unimplemented(
+            ("cross_entropy does not support data types other than int32 and "
+             "int64"));
+      }
+
       r = xpu::hard_softmax_with_cross_entropy_grad<XPUType, int>(
           dev_ctx.x_context(),
           reinterpret_cast<const XPUType*>(loss_grad.data<T>()),

--- a/paddle/phi/kernels/xpu/cross_entropy_kernel.cc
+++ b/paddle/phi/kernels/xpu/cross_entropy_kernel.cc
@@ -133,15 +133,24 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
                                          axis == rank - 1 ? d : t);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "soft_cross_entropy");
   } else {
-    DenseTensor labels_int32;
-    int* labels_int_ptr_l3 = RAII_GUARD.alloc_l3_or_gm<int32_t>(labels.numel());
-    PADDLE_ENFORCE_XDNN_NOT_NULL(labels_int_ptr_l3);
+    int* labels_int_ptr_l3 = nullptr;
+    if (labels.dtype() == DataType::INT32) {
+      labels_int_ptr_l3 = const_cast<int32_t*> labels.data<int32_t>();
+    } else if (labels.dtype() == DataType::INT64) {
+      labels_int_ptr_l3 = RAII_GUARD.alloc_l3_or_gm<int32_t>(labels.numel());
+      PADDLE_ENFORCE_XDNN_NOT_NULL(labels_int_ptr_l3);
 
-    r = xpu::cast<int64_t, int32_t>(dev_ctx.x_context(),
-                                    labels.data<int64_t>(),
-                                    labels_int_ptr_l3,
-                                    labels.numel());
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::cast<int64_t, int32_t>(dev_ctx.x_context(),
+                                      labels.data<int64_t>(),
+                                      labels_int_ptr_l3,
+                                      labels.numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+    } else {
+      // TODO(lilujia): other data types should be handled
+      errors::Unimplemented(
+          ("cross_entropy does not support data types other than int32 and "
+           "int64"));
+    }
 
     r = xpu::hard_cross_entropy<XPUType, int32_t>(
         dev_ctx.x_context(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Description
Fix bugs when using cast<int64_t, int32_t> in xpu/cross_entropy kernels, *test=kunlun
