### PR TITLE
Fix fused_attention_op and fused_feedforward_op bugs in xpu

### DIFF
--- a/paddle/phi/kernels/fusion/xpu/fused_feedforward_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_feedforward_grad_kernel.cc
@@ -529,7 +529,7 @@ void FusedFeedForwardGradKernel(
 }  // namespace fusion
 }  // namespace phi
 
-PD_REGISTER_KERNEL(fused_feedward_grad,
+PD_REGISTER_KERNEL(fused_feedforward_grad,
                    XPU,
                    ALL_LAYOUT,
                    phi::fusion::FusedFeedForwardGradKernel,

--- a/paddle/phi/kernels/fusion/xpu/fused_feedforward_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_feedforward_grad_kernel.cc
@@ -478,7 +478,7 @@ void FusedFeedForwardGradKernel(
                                      dropout2_fix_seed,
                                      nullptr,
                                      dropout2_seed_val);
-
+  dev_ctx.template Alloc<T>(d_x);
   dev_ctx.template Alloc<float>(d_ln_scale);
   dev_ctx.template Alloc<float>(d_ln_bias);
   dev_ctx.template Alloc<T>(d_linear1_bias);

--- a/paddle/phi/kernels/fusion/xpu/fused_feedforward_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_feedforward_kernel.cc
@@ -377,7 +377,7 @@ void FusedFeedForwardKernel(const Context& dev_ctx,
 }  // namespace fusion
 }  // namespace phi
 
-PD_REGISTER_KERNEL(fused_feedward,
+PD_REGISTER_KERNEL(fused_feedforward,
                    XPU,
                    ALL_LAYOUT,
                    phi::fusion::FusedFeedForwardKernel,

--- a/paddle/phi/kernels/xpu/fused_attention_kernel.cc
+++ b/paddle/phi/kernels/xpu/fused_attention_kernel.cc
@@ -181,12 +181,12 @@ void FusedAttentionKernel(const Context &dev_ctx,
   float *ln_mean_ptr =
       (ln_mean == nullptr)
           ? (nullptr)
-          : reinterpret_cast<float *>(dev_ctx.template Alloc<T>(ln_mean));
+          : reinterpret_cast<float *>(dev_ctx.template Alloc<float>(ln_mean));
 
   float *ln_var_ptr =
       (ln_var == nullptr)
           ? (nullptr)
-          : reinterpret_cast<float *>(dev_ctx.template Alloc<T>(ln_var));
+          : reinterpret_cast<float *>(dev_ctx.template Alloc<float>(ln_var));
 
   XPUTypeT *ln_out_ptr =
       (ln_out == nullptr)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->

Pcard-67003

修复因昆仑CI监控不完善（只测编译不测单测）导致PR https://github.com/PaddlePaddle/Paddle/pull/53011 和 https://github.com/PaddlePaddle/Paddle/pull/53196 引入xpu算子bug的问题，影响单测：`test_fused_attention_op_xpu`、`test_fused_feedforward_op_xpu`。

**CI后续改进：**
昆仑CI `PR-CI-kunlun-R200-test`已有单测问题修复后，观察后续运行是否稳定，然后开required。
开required后观察是否有任务积压（因xpu单测测试机器资源较少），若有积压则考虑先关xpu覆盖率（保障能跑过，比覆盖率更重要一些）。