### PR TITLE
[Fix Patch Error] Fix patch error in cmake

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -51,9 +51,10 @@ if(CMAKE_COMPILER_IS_GNUCC)
   if(GCC_VERSION GREATER_EQUAL "12.0")
     file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/eigen/Complex.h.patch
          complex_header)
+    # See: [Why calling some `git` commands before `patch`?]
     set(EIGEN_PATCH_COMMAND
-        patch -Nd ${EIGEN_SOURCE_DIR}/Eigen/src/Core/arch/SSE/ <
-        ${complex_header})
+        git checkout -- . && git checkout ${EIGEN_TAG} && patch -Nd
+        ${EIGEN_SOURCE_DIR}/Eigen/src/Core/arch/SSE/ < ${complex_header})
   endif()
 endif()
 

--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -37,8 +37,9 @@ if(WITH_GPU)
                                                   VERSION_GREATER 12.0)
     file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/device.cc.patch
          native_dst)
-    set(GLOO_PATCH_COMMAND patch -d ${GLOO_SOURCE_DIR}/gloo/transport/tcp <
-                           ${native_dst})
+    set(GLOO_PATCH_COMMAND
+        git checkout -- . && git checkout ${GLOO_TAG} &&patch -Nd
+        ${GLOO_SOURCE_DIR}/gloo/transport/tcp < ${native_dst})
   endif()
 endif()
 
@@ -54,9 +55,11 @@ if(CMAKE_COMPILER_IS_GNUCC)
          native_dst)
     file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/types.h.patch
          types_header)
+    # See: [Why calling some `git` commands before `patch`?]
     set(GLOO_PATCH_COMMAND
-        patch -Nd ${GLOO_SOURCE_DIR}/gloo/transport/tcp < ${native_dst} &&
-        patch -Nd ${GLOO_SOURCE_DIR}/gloo/ < ${types_header})
+        git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd
+        ${GLOO_SOURCE_DIR}/gloo/transport/tcp < ${native_dst} && patch -Nd
+        ${GLOO_SOURCE_DIR}/gloo/ < ${types_header})
   endif()
 endif()
 include_directories(${GLOO_INCLUDE_DIR})

--- a/cmake/external/gtest.cmake
+++ b/cmake/external/gtest.cmake
@@ -66,8 +66,10 @@ endif()
 if(NOT WIN32 AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 12.0)
   file(TO_NATIVE_PATH
        ${PADDLE_SOURCE_DIR}/patches/gtest/gtest-death-test.cc.patch native_src)
-  set(GTEST_PATCH_COMMAND patch -Nd ${GTEST_SOURCE_DIR}/googletest/src <
-                          ${native_src})
+  # See: [Why calling some `git` commands before `patch`?]
+  set(GTEST_PATCH_COMMAND
+      git checkout -- . && git checkout ${GTEST_TAG} && patch -Nd
+      ${GTEST_SOURCE_DIR}/googletest/src < ${native_src})
 endif()
 if(WIN32)
   ExternalProject_Add(

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -25,8 +25,13 @@ set(PYBIND_PATCH_COMMAND "")
 if(NOT WIN32)
   file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/pybind/cast.h.patch
        native_dst)
-  set(PYBIND_PATCH_COMMAND patch -d ${PYBIND_INCLUDE_DIR}/pybind11 <
-                           ${native_dst})
+  # Note: [Why calling some `git` commands before `patch`?]
+  # Paddle's CI uses cache to accelarate the make process. However, error might raise when patch codes in two scenarios:
+  # 1. Patch to the wrong version: the tag version of CI's cache falls behind PYBIND_TAG, use `git checkout ${PYBIND_TAG}` to solve this.
+  # 2. Patch twice: the tag version of cache == PYBIND_TAG, but patch has already applied to cache.
+  set(PYBIND_PATCH_COMMAND
+      git checkout -- . && git checkout ${PYBIND_TAG} && patch -Nd
+      ${PYBIND_INCLUDE_DIR}/pybind11 < ${native_dst})
 endif()
 
 ExternalProject_Add(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-66988

**背景**：CI 开启 cache 的场景下，patch 代码时会报错。不开启 cache 可以正常编译。
<img width="938" alt="image" src="https://user-images.githubusercontent.com/17810795/234194514-243e9953-f026-4b47-8a49-37c9b715a8f7.png">

**分析**：cache 的编译产物有两种可能：1. cache 内的 third_party TAG_VERSION 与最新 cmake 中的 TAG_VERSION 不一致；2. cache 内已经打过 patch。这两种可能都会导致 patch 失败。

**解决**：在 `PATCH_COMMAND` 前使用 git 命令，将 cache 里的 third_party 代码复原。

Ref: https://cmake.org/cmake/help/latest/module/ExternalProject.html

<img width="794" alt="image" src="https://user-images.githubusercontent.com/17810795/234195053-1d5e16cb-eec2-4034-afb9-d47d4d85c766.png">

[Why calling some `git` commands before `patch`?]
Paddle's CI uses cache to accelarate the make process. However, error might raise when patch codes in two scenarios:
1. Patch to the wrong version: the tag version of CI's cache falls behind PYBIND_TAG, use `git checkout ${PYBIND_TAG}` to solve this.
2. Patch twice: the tag version of cache == PYBIND_TAG, but patch has already applied to cache.
Hence, we need to use git command to restore the code changes in the CI's cache.