### PR TITLE
[Debug][Werror]error: control reaches end of non-void function [-Werror=return-type]

### DIFF
--- a/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h
+++ b/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h
@@ -405,15 +405,6 @@ class CompositeGradOpMakerBase {
       }
     }
     return input_grads;
-    PADDLE_ENFORCE_LE(
-        var_names.size(),
-        1UL,
-        platform::errors::Unavailable(
-            "BUG from operator developer:"
-            " for input argument with a list of variables, "
-            " drop_empty_grad is not allowed because it makes"
-            " the correspondence bewteen a variable and its gradient"
-            " ambiguous."));
   }
 
   std::vector<framework::VarDesc*> MultiOutputGrad(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Debug模式下编译
[Paddle/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h ](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h)Werror错误
```
In file included from /media/wjl/D2/github/fork/Paddle/paddle/fluid/framework/details/op_registry.h:35,
                 from /media/wjl/D2/github/fork/Paddle/paddle/fluid/framework/op_registry.h:31,
                 from /media/wjl/D2/github/fork/Paddle/paddle/fluid/operators/concat_op.h:21,
                 from /media/wjl/D2/github/fork/Paddle/paddle/fluid/operators/concat_op.cc:15:
/media/wjl/D2/github/fork/Paddle/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h: In member function ‘std::vector<paddle::framework::VarDesc*> paddle::prim::CompositeGradOpMakerBase::MultiInputGrad(const string&) const’:
/media/wjl/D2/github/fork/Paddle/paddle/fluid/prim/utils/static/composite_grad_desc_maker.h:417:3: error: control reaches end of non-void function [-Werror=return-type]
  417 |   }
      |   ^
```
```
  std::vector<framework::VarDesc*> MultiInputGrad(
      const std::string& name) const {
    std::vector<std::string> ret_val;
    std::vector<framework::VarDesc*> input_grads;
    auto var_names = this->MultiForwardInputVarName(name);
    ret_val.reserve(var_names.size());
    std::transform(var_names.begin(),
                   var_names.end(),
                   std::back_inserter(ret_val),
                   [this](const std::string& fwd_var_name) -> std::string {
                     auto g_name = framework::GradVarName(fwd_var_name);
                     if (no_grad_set_.empty() || !no_grad_set_.count(g_name)) {
                       (*this->grad_to_var_)[g_name] = fwd_var_name;
                       return g_name;
                     } else {
                       return framework::kEmptyVarName;
                     }
                   });
    for (const auto& name : ret_val) {
      if (original_block_->HasVar(name)) {
        // Copy Var from original block to active block, or create a new one.
        CopyVarFromOrig(name);
        input_grads.emplace_back(
            StaticCompositeContext::Instance().GetBlock()->FindVar(name));
      } else {
        input_grads.emplace_back(
            StaticCompositeContext::Instance().GetBlock()->Var(name));
      }
    }
    return input_grads;
    PADDLE_ENFORCE_LE(
        var_names.size(),
        1UL,
        platform::errors::Unavailable(
            "BUG from operator developer:"
            " for input argument with a list of variables, "
            " drop_empty_grad is not allowed because it makes"
            " the correspondence bewteen a variable and its gradient"
            " ambiguous."));
  }
```
原因return下面有多余的语句。 
这个是cmake .. -DCMAKE_BUILD_TYPE=Debug 时出现
https://github.com/PaddlePaddle/Paddle/issues/53313