### PR TITLE
[Debug][assert] fix softmax eigen assert error

### DIFF
--- a/paddle/phi/kernels/funcs/softmax_impl.h
+++ b/paddle/phi/kernels/funcs/softmax_impl.h
@@ -82,12 +82,12 @@ class SoftmaxEigen {
       // axis != -1, class dimension split into (axis, remain), max and sum
       // should be calculated along axis dimension
       softmax.device(*context.eigen_device()) =
-          (logits.reshape(batch_axis_remain) - logits.reshape(batch_axis_remain)
-                                                   .maximum(along_axis)
-                                                   .eval()
-                                                   .reshape(batch_one_remain)
-                                                   .broadcast(one_axis_one)
-                                                   .reshape(batch_classes))
+          (logits.reshape(batch_classes) - logits.reshape(batch_axis_remain)
+                                               .maximum(along_axis)
+                                               .eval()
+                                               .reshape(batch_one_remain)
+                                               .broadcast(one_axis_one)
+                                               .reshape(batch_classes))
               .unaryExpr(ValueClip<T>());
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->

https://github.com/PaddlePaddle/Paddle/issues/53329

现在develop能支持Debug编译了，但是有一系列问题。
使用Debug编译libpaddle_inference.so    
```
mkdir build_debug && cd build_debug
cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF
make -j16
```

当softmax CPU Kernel axis=1的时候 出现debug assert错误。

出现assert错误
位置
build_debug/third_party/eigen3/src/extern_eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorEvaluator.h:581


```cpp
  EIGEN_DEVICE_FUNC TensorEvaluator(const XprType& op, const Device& device)
    : m_device(device),
      m_functor(op.functor()),
      m_leftImpl(op.lhsExpression(), device),
      m_rightImpl(op.rhsExpression(), device)
  {
    EIGEN_STATIC_ASSERT((static_cast<int>(TensorEvaluator<LeftArgType, Device>::Layout) == static_cast<int>(TensorEvaluator<RightArgType, Device>::Layout) || internal::traits<XprType>::NumDimensions <= 1), YOU_MADE_A_PROGRAMMING_MISTAKE);
    eigen_assert(dimensions_match(m_leftImpl.dimensions(), m_rightImpl.dimensions()));
  }
```
其中
```
eigen_assert(dimensions_match(m_leftImpl.dimensions(), m_rightImpl.dimensions()));
```
报错


Log
```
[ RUN      ] API.softmax_test_axis
paddle_opencl_test: /media/wjl/D2/github/fork/Paddle/build_debug/third_party/eigen3/src/extern_eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorEvaluator.h:581: Eigen::TensorEvaluator<const Eigen::TensorCwiseBinaryOp<BinaryOp, LeftArgType, RightArgType>, Device>::TensorEvaluator(const XprType&, const Device&) [with BinaryOp = Eigen::internal::scalar_difference_op<const float, const float>; LeftArgType = const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorMap<Eigen::Tensor<const float, 2, 1, long int>, 0, Eigen::MakePointer> >; RightArgType = const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 2>, const Eigen::TensorBroadcastingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorForcedEvalOp<const Eigen::TensorReductionOp<Eigen::internal::MaxReducer<float, 0>, const Eigen::DSizes<int, 1>, const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorMap<Eigen::Tensor<const float, 2, 1, long int>, 0, Eigen::MakePointer> >, Eigen::MakePointer> > > > >; Device = Eigen::DefaultDevice; Eigen::TensorEvaluator<const Eigen::TensorCwiseBinaryOp<BinaryOp, LeftArgType, RightArgType>, Device>::XprType = Eigen::TensorCwiseBinaryOp<Eigen::internal::scalar_difference_op<const float, const float>, const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorMap<Eigen::Tensor<const float, 2, 1, long int>, 0, Eigen::MakePointer> >, const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 2>, const Eigen::TensorBroadcastingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorForcedEvalOp<const Eigen::TensorReductionOp<Eigen::internal::MaxReducer<float, 0>, const Eigen::DSizes<int, 1>, const Eigen::TensorReshapingOp<const Eigen::DSizes<int, 3>, const Eigen::TensorMap<Eigen::Tensor<const float, 2, 1, long int>, 0, Eigen::MakePointer> >, Eigen::MakePointer> > > > > >]: Assertion `dimensions_match(m_leftImpl.dimensions(), m_rightImpl.dimensions())' failed.
```

**复现代码**
```cpp
#include <memory>

#include "paddle/phi/api/include/api.h"
#include "paddle/phi/api/lib/utils/allocator.h"
#include "paddle/phi/core/dense_tensor.h"
#include "paddle/phi/core/kernel_registry.h"
int main() {

    auto x_cpu = paddle::experimental::empty({1, 17, 4, 6400}, paddle::DataType::FLOAT32, phi::CPUPlace());

    std::vector<float> mapX(x_cpu.numel());

    for (int i = 0; i < x_cpu.dims()[1]; ++i) {
        for (int j = 0; j < x_cpu.dims()[2]; ++j) {
            mapX[i * x_cpu.dims()[2] + j] = (float)rand() / (float)RAND_MAX;
        }
    }

    memcpy(x_cpu.data<float>(), mapX.data(), x_cpu.numel() * sizeof(float));

    auto out_cpu = paddle::experimental::softmax(x_cpu, 1);

    return 1;
}
```

**原因分析**
https://github.com/engineer1109/Paddle/commit/7c2ce17fbfafca53462e6c2e8fed9fac0d1d38ce
```cpp
logits.reshape(batch_axis_remain) 
```
与
```cpp
logits.reshape(batch_axis_remain).maximum(along_axis)
        .eval()
        .reshape(batch_one_remain)
        .broadcast(one_axis_one)
        .reshape(batch_classes)
```
Dimension不相等，前者是batch_axis_remain  后者是batch_classes

把前者改成是batch_classes即可修复，参考commit。
他们两者的numel是必然相等的。Release下 shape不同不影响计算。
