### PR TITLE
[Custom Device] fix custom_device CopyToCpu to avoid crash

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -463,7 +463,7 @@ void Tensor::CopyToCpuImpl(T *data,
                          t_data,
                          ele_num * sizeof(T),
                          dev_ctx->stream());
-// TODO(wangran16): sync_stream
+    dev_ctx->GetStream()->Synchronize();
 #else
     PADDLE_THROW(paddle::platform::errors::InvalidArgument(
         "The analysis predictor supports CPU, GPU, NPU and XPU now."));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Cherry-pick part of the code in  https://github.com/PaddlePaddle/Paddle/pull/53220/files#diff-457c220300ee978b7acfd716fc9c411331b2edc6380ff357090b9b632dd1cfab

The async copy in CopyToCpu function at the end of the program will cause segment fault in NPU inference. This PR adds sync stream after async copy.
