### PR TITLE
support profiler Distributed Summary for CustomDevice

### DIFF
--- a/python/paddle/profiler/profiler_statistic.py
+++ b/python/paddle/profiler/profiler_statistic.py
@@ -472,7 +472,8 @@ class DistributedSummary:
                     for runtimenode in hostnode.runtime_node:
                         for devicenode in runtimenode.device_node:
                             if devicenode.type == TracerEventType.Kernel:
-                                if 'nccl' in devicenode.name.lower():
+                                kernel_name = devicenode.name.lower()
+                                if 'nccl' in kernel_name or 'xccl' in kernel_name:
                                     self.gpu_communication_range.append(
                                         (devicenode.start_ns, devicenode.end_ns)
                                     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Description
Now when using CustomDevice backends(NPU、MLU, etc) to run profiler, paddle can not print "Distributed Summary" normally.
