### PR TITLE
remove fused_dropout_act_bias_test for pr-ci-windows-inference update…

### DIFF
--- a/paddle/fluid/operators/fused/CMakeLists.txt
+++ b/paddle/fluid/operators/fused/CMakeLists.txt
@@ -98,16 +98,6 @@ if(WITH_GPU OR WITH_ROCM)
            generator
            memory)
     nv_test(
-      test_fused_dropout_act_bias
-      SRCS fused_dropout_act_bias_test.cu
-      DEPS tensor
-           op_registry
-           dropout_op
-           layer_norm_op
-           device_context
-           generator
-           memory)
-    nv_test(
       test_fused_layernorm_residual_dropout_bias
       SRCS fused_layernorm_residual_dropout_bias_test.cu
       DEPS tensor


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[test] fix errors in the compilation of fused_dropout_act_bias_test
