### PR TITLE
fix: fix deformable_conv_grad op test

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -8,7 +8,7 @@ set(XPU_API_LIB_NAME "libxpuapi.so")
 set(XPU_RT_LIB_NAME "libxpurt.so")
 set(XPU_XFT_LIB_NAME "libxft.so")
 
-set(XPU_BASE_DATE "20230408")
+set(XPU_BASE_DATE "20230427")
 set(XPU_XCCL_BASE_VERSION "1.0.13")
 set(XPU_XFT_BASE_VERSION "latest")
 

--- a/test/xpu/test_deformable_conv_op_xpu.py
+++ b/test/xpu/test_deformable_conv_op_xpu.py
@@ -138,6 +138,8 @@ class XPUTestModulatedDeformableConvOp(XPUOpTestWrapper):
     class TestModulatedDeformableConvOp(XPUOpTest):
         def setUp(self):
             self.op_type = "deformable_conv"
+            # set to e-6 because of atomic add in XPU
+            self.epsilon_xpu2xpu = 0.000001
             self.dtype = self.in_type
             self.place = paddle.XPUPlace(0)
             self.init_group()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
fix deformable_conv_grad op test.
1. update XPU toolchain date, new version includes fixed op
2. modify epsilon_xpu2xpu to e-6, beacuse there are some atomic add in this op.
