### PR TITLE
[cherry-pick] Fix core dumped in training when check_nan_inf=1

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -114,7 +114,9 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
 
 void CheckTensorHasNanOrInf(const std::string& api_name,
                             const paddle::optional<Tensor>& tensor) {
-  CheckTensorHasNanOrInf(api_name, tensor.get());
+  if (tensor) {
+    CheckTensorHasNanOrInf(api_name, *tensor);
+  }
 }
 
 void CheckTensorHasNanOrInf(const std::string& api_name,
@@ -168,7 +170,7 @@ void CheckTensorHasNanOrInf(
     const std::string& api_name,
     const paddle::optional<std::vector<Tensor>>& tensors) {
   if (tensors) {
-    CheckTensorHasNanOrInf(api_name, tensors.get());
+    CheckTensorHasNanOrInf(api_name, *tensors);
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复优化器精度检查bug
<img width="734" alt="image" src="https://user-images.githubusercontent.com/51102941/236765843-16a71d34-1331-4498-9e68-e06a29a5fef4.png">
