### PR TITLE
Fix paddle::Tensor usage in predictor.run, tensor should be defined instead of initialized.

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1151,10 +1151,15 @@ bool AnalysisPredictor::SetFeed(const std::vector<paddle::Tensor> &inputs,
                         feeds_.size(),
                         inputs.size()));
   for (size_t i = 0; i < inputs.size(); ++i) {
-    PADDLE_ENFORCE_EQ(inputs[i].initialized(),
+    PADDLE_ENFORCE_EQ(inputs[i].defined(),
                       true,
                       paddle::platform::errors::InvalidArgument(
-                          "The input Tensor expected to be initialized."));
+                          "The input Tensor expected to be defined."));
+    PADDLE_ENFORCE_EQ(
+        inputs[i].is_dense_tensor(),
+        true,
+        paddle::platform::errors::InvalidArgument(
+            "The input Tensor expected to be type of dense tensor."));
   }
 
   if (std::all_of(inputs.cbegin(), inputs.cend(), [&](const paddle::Tensor &t) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
predictor.run: tensor should be [defined] instead of [initialized].

![image](https://user-images.githubusercontent.com/23653004/236100023-73d79152-3ab9-40b3-b803-8f2134ae25f8.png)
