### PR TITLE
Allow to keep layer_norm's weight to fp32 precision.

### DIFF
--- a/python/paddle/amp/__init__.py
+++ b/python/paddle/amp/__init__.py
@@ -20,6 +20,7 @@ from .auto_cast import FP16_WHITE_LIST  # noqa: F401
 from .auto_cast import FP16_BLACK_LIST  # noqa: F401
 from .auto_cast import PURE_FP16_WHITE_LIST  # noqa: F401
 from .auto_cast import PURE_FP16_BLACK_LIST  # noqa: F401
+from .auto_cast import _keep_layer_norm_scale_bias_to_fp32  # noqa: F401
 
 from . import grad_scaler  # noqa: F401
 from .grad_scaler import GradScaler  # noqa: F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
RT