### PR TITLE
Reduce the use of skipIf for bfloat16 tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/eager_op_test.py
+++ b/python/paddle/fluid/tests/unittests/eager_op_test.py
@@ -2094,6 +2094,15 @@ class OpTest(unittest.TestCase):
                     return []
             else:
                 return []
+        if self.dtype == np.uint16 or self.dtype == "uint16":
+            if (
+                core.is_compiled_with_cuda()
+                and core.is_bfloat16_supported(core.CUDAPlace(0))
+                and core.op_support_gpu(self.op_type)
+            ):
+                return [core.CUDAPlace(0)]
+            else:
+                return []
         places = [fluid.CPUPlace()]
         cpu_only = self._cpu_only if hasattr(self, '_cpu_only') else False
         if (

--- a/python/paddle/fluid/tests/unittests/test_lgamma_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lgamma_op.py
@@ -20,7 +20,6 @@ from eager_op_test import OpTest, convert_float_to_uint16
 from scipy import special
 
 import paddle
-from paddle.fluid import core
 
 paddle.enable_static()
 
@@ -65,11 +64,6 @@ class TestLgammaFP16Op(TestLgammaOp):
         self.check_grad(['X'], 'Out')
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
-    "core is not compiled with CUDA or not support bfloat16",
-)
 class TestLgammaBF16Op(OpTest):
     def setUp(self):
         self.op_type = 'lgamma'
@@ -85,11 +79,10 @@ class TestLgammaBF16Op(OpTest):
         self.outputs = {'Out': convert_float_to_uint16(result)}
 
     def test_check_output(self):
-        # After testing, bfloat16 needs to set the parameter place
-        self.check_output_with_place(core.CUDAPlace(0))
+        self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad_with_place(core.CUDAPlace(0), ['X'], 'Out')
+        self.check_grad(['X'], 'Out')
 
 
 class TestLgammaOpApi(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -17,7 +17,7 @@ import unittest
 import gradient_checker
 import numpy as np
 from decorator_helper import prog_scope
-from eager_op_test import OpTest, convert_float_to_uint16
+from eager_op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
 
 import paddle
 from paddle import fluid
@@ -313,6 +313,7 @@ class TestTransposeFP16Op(OpTest):
         self.axis = (1, 0)
 
 
+@skip_check_grad_ci(reason='The check_grad is not currently implemented')
 class TestTransposeBF16Op(OpTest):
     def setUp(self):
         self.init_op_type()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
减少bfloat16测试用例中unittest.skipIf的使用
