### PR TITLE
Fix too many warnings about __getitem__

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -925,36 +925,49 @@ static PyObject* tensor__getitem_index_not_tensor(TensorObject* self,
   }
 
   bool set_to_1d = FLAGS_set_to_1d;
-  if (!none_axes.empty()) {
-    if (set_to_1d) {
-      // NOTE(zoooo0820): When all axes are decreased, the output will be 1-D
-      // with FLAGS_set_to_1d=True. In this case, one `None` should be pop out,
-      // otherwise the output shape will be not correct.
-      if (static_cast<int>(decrease_axis.size()) == tensor->dims().size()) {
+
+  if (set_to_1d) {
+    // NOTE(zoooo0820): When all axes are decreased, the output will be 1-D
+    // with FLAGS_set_to_1d=True. In this case, one `None` should be pop out,
+    // otherwise the output shape will be not correct.
+    if (static_cast<int>(decrease_axis.size()) == tensor->dims().size()) {
+      VLOG(0)
+          << "Warning: In Tensor '__getitem__', if the number of scalar "
+             "elements "
+             "in the index is equal to the rank of the Tensor, the output "
+             "should "
+             "be 0-D. In order to be consistent with the behavior of previous "
+             "versions, it will be processed to 1-D. But it is not correct and "
+             "will be "
+             "removed in release 2.6. "
+             "If 1-D is still wanted, please modify the index element from "
+             "scalar to slice "
+             "(e.g. 'x[i]' => 'x[i:i+1]'). ";
+      if (!none_axes.empty()) {
         none_axes.pop_back();
       }
     }
-    if (!none_axes.empty()) {
-      paddle::Tensor new_out;
-      {
-        eager_gil_scoped_release guard;
-        // Deal with cases that decrease_axes is not empty
-        // For example:
-        // # x.shape: (2,3,4)
-        // out = x[0, 0:2, None] # out.shape : (2, 1, 4)
-        for (auto& axis : none_axes) {
-          int len = 0;
-          for (int da : decrease_axis) {
-            if (da < axis) {
-              len++;
-            }
+  }
+  if (!none_axes.empty()) {
+    paddle::Tensor new_out;
+    {
+      eager_gil_scoped_release guard;
+      // Deal with cases that decrease_axes is not empty
+      // For example:
+      // # x.shape: (2,3,4)
+      // out = x[0, 0:2, None] # out.shape : (2, 1, 4)
+      for (auto& axis : none_axes) {
+        int len = 0;
+        for (int da : decrease_axis) {
+          if (da < axis) {
+            len++;
           }
-          axis -= len;
         }
-        new_out = unsqueeze_ad_func(out, none_axes);
+        axis -= len;
       }
-      return ToPyObject(new_out);
+      new_out = unsqueeze_ad_func(out, none_axes);
     }
+    return ToPyObject(new_out);
   }
 
   // the index is a list

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1067,44 +1067,61 @@ void BindImperative(py::module *m_ptr) {
              }
 
              bool set_to_1d = FLAGS_set_to_1d;
-             if (!none_axes.empty()) {
-               if (set_to_1d) {
-                 // NOTE(zoooo0820): When all axes are decreased, the output
-                 // will be 1-D with FLAGS_set_to_1d=True. In this case, one
-                 // `None` should be pop out, otherwise the output shape will be
-                 // not correct.
-                 if (static_cast<int>(decrease_axis.size()) ==
-                     tensor->dims().size()) {
+
+             if (set_to_1d) {
+               // NOTE(zoooo0820): When all axes are decreased, the output
+               // will be 1-D with FLAGS_set_to_1d=True. In this case, one
+               // `None` should be pop out, otherwise the output shape will be
+               // not correct.
+               if (static_cast<int>(decrease_axis.size()) ==
+                   tensor->dims().size()) {
+                 VLOG(0) << "Warning: In Tensor '__getitem__', if the number "
+                            "of scalar "
+                            "elements "
+                            "in the index is equal to the rank of the Tensor, "
+                            "the output "
+                            "should "
+                            "be 0-D. In order to be consistent with the "
+                            "behavior of previous "
+                            "versions, it will be processed to 1-D. But it is "
+                            "not correct and "
+                            "will be "
+                            "removed in release 2.6. "
+                            "If 1-D is still wanted, please modify the index "
+                            "element from "
+                            "scalar to slice "
+                            "(e.g. 'x[i]' => 'x[i:i+1]'). ";
+                 if (!none_axes.empty()) {
                    none_axes.pop_back();
                  }
                }
-               if (!none_axes.empty()) {
-                 // Deal with cases that decrease_axes is not empty
-                 // For example:
-                 // # x.shape: (2,3,4)
-                 // out = x[0, 0:2, None] # out.shape : (2, 1, 4)
-                 for (auto &axis : none_axes) {
-                   int len = 0;
-                   for (int da : decrease_axis) {
-                     if (da < axis) {
-                       len++;
-                     }
+             }
+             if (!none_axes.empty()) {
+               // Deal with cases that decrease_axes is not empty
+               // For example:
+               // # x.shape: (2,3,4)
+               // out = x[0, 0:2, None] # out.shape : (2, 1, 4)
+               for (auto &axis : none_axes) {
+                 int len = 0;
+                 for (int da : decrease_axis) {
+                   if (da < axis) {
+                     len++;
                    }
-                   axis -= len;
                  }
-
-                 imperative::NameVarBaseMap ins = {{"X", {out}}};
-                 framework::AttributeMap attrs = {{"axes", none_axes}};
-                 auto new_out = std::shared_ptr<imperative::VarBase>(
-                     new imperative::VarBase(tracer->GenerateUniqueName()));
-                 auto out_xshape = std::shared_ptr<imperative::VarBase>(
-                     new imperative::VarBase(tracer->GenerateUniqueName()));
-                 imperative::NameVarBaseMap outs = {{"Out", {new_out}},
-                                                    {"XShape", {out_xshape}}};
-                 tracer->TraceOp("unsqueeze2", ins, outs, std::move(attrs));
-
-                 return new_out;
+                 axis -= len;
                }
+
+               imperative::NameVarBaseMap ins = {{"X", {out}}};
+               framework::AttributeMap attrs = {{"axes", none_axes}};
+               auto new_out = std::shared_ptr<imperative::VarBase>(
+                   new imperative::VarBase(tracer->GenerateUniqueName()));
+               auto out_xshape = std::shared_ptr<imperative::VarBase>(
+                   new imperative::VarBase(tracer->GenerateUniqueName()));
+               imperative::NameVarBaseMap outs = {{"Out", {new_out}},
+                                                  {"XShape", {out_xshape}}};
+               tracer->TraceOp("unsqueeze2", ins, outs, std::move(attrs));
+
+               return new_out;
              }
 
              // the index is a list

--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -208,18 +208,6 @@ inline DDim GetDecreasedDims(const DDim slice_dims,
     if (FLAGS_set_to_1d && new_shape.size() == 0) {
       // NOTE(zoooo0820): Hack procssing to 1-D, when axes decrease to 0-D in
       // slice. This will remove in release 2.6.
-      VLOG(0)
-          << "Warning:: In Tensor '__getitem__', if the number of scalar "
-             "elements "
-             "in the index is equal to the rank of the Tensor, the output "
-             "should "
-             "be 0-D. In order to be consistent with the behavior of previous "
-             "versions, it will be processed to 1-D. But it is not correct and "
-             "will be "
-             "removed in release 2.6. "
-             "If 1-D is still wanted, please modify the index element from "
-             "scalar to slice "
-             "(e.g. 'x[i]' => 'x[i:i+1]'). ";
       new_shape.push_back(1);
     }
     decreased_dims = phi::make_ddim(new_shape);

--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -17,6 +17,7 @@ import numpy as np
 from . import unique_name
 from . import core
 import paddle
+import warnings
 
 MAX_INTEGER = 2**31 - 1
 
@@ -579,6 +580,9 @@ def _getitem_impl_(var, item):
     # otherwise the output shape will be not correct.
     set_to_1d = paddle.get_flags('FLAGS_set_to_1d')['FLAGS_set_to_1d']
     if set_to_1d and len(decrease_axes) == len(var.shape):
+        warnings.warn(
+            "Warning: In Tensor '__getitem__', if the number of scalar elements in the index is equal to the rank of the Tensor, the output should be 0-D. In order to be consistent with the behavior of previous versions, it will be processed to 1-D. But it is not correct and will be removed in release 2.6. If 1-D is still wanted, please modify the index element from scalar to slice (e.g. 'x[i]' => 'x[i:i+1]')."
+        )
         none_axes = none_axes[1:]
 
     if len(none_axes) > 0:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985
In https://github.com/PaddlePaddle/Paddle/pull/53358 , when decreased axes is same as the original shape of Tensor, the output 0-D will be hacked to 1-D and a there will be a warning. But the warning is written at function `GetDecreasedDims`, which will be called multiple times by `slice OP`. Moreover, `slice` will still be called by other OPs (e.g.`set_value`). So there  are many unexpected warnings need to be fixed (please see issue https://github.com/PaddlePaddle/Paddle/issues/53464) . 

This PR writes the warning information at `__getitem__` function to decrease the unexpected warnings.