### PR TITLE
Fix the calculation of y_grad in divide_backward

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -118,7 +118,7 @@ struct DivGradXYFunctor {
     // dy = - dout * out / y
     phi::Array<OutT, 2> outs;
     outs[0] = a / c;
-    outs[1] = -a * b / c;
+    outs[1] = -a * ((b / c) / c);
     return outs;
   }
 };
@@ -131,7 +131,7 @@ struct DivGradXYFunctor<ComplexType<InT>, ComplexType<OutT>> {
       const ComplexType<InT> c) {
     phi::Array<ComplexType<OutT>, 2> outs;
     ComplexType<InT> c_conj(c.real, -c.imag);
-    ComplexType<InT> out_div_c_conj((b / c).real, -(b / c).imag);
+    ComplexType<InT> out_div_c_conj(((b / c) / c).real, -((b / c) / c).imag);
     outs[0] = a / c_conj;
     outs[1] = -a * out_div_c_conj;
     return outs;
@@ -158,7 +158,7 @@ struct DivGradXFunctor<ComplexType<T>> {
 template <typename T>
 struct DivGradYFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b, const T c) const {
-    return -a * b / c;
+    return -a * ((b / c) / c);
   }
 };
 
@@ -168,7 +168,7 @@ struct DivGradYFunctor<ComplexType<T>> {
   inline HOSTDEVICE ComplexType<T> operator()(const ComplexType<T> a,
                                               const ComplexType<T> b,
                                               const ComplexType<T> c) const {
-    ComplexType<T> out_div_c_conj((b / c).real, -(b / c).imag);
+    ComplexType<T> out_div_c_conj(((b / c) / c).real, -((b / c) / c).imag);
     return -a * out_div_c_conj;
   }
 };

--- a/paddle/phi/kernels/gpu/elementwise_divide_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/elementwise_divide_grad_kernel.cu
@@ -36,7 +36,7 @@ void DivideGradKernel(const Context& dev_ctx,
                       DenseTensor* dy) {
   const auto place = dev_ctx.GetPlace();
   if (dx != nullptr && dy != nullptr) {
-    std::vector<const DenseTensor*> ins = {&dout, &out, &y};
+    std::vector<const DenseTensor*> ins = {&dout, &x, &y};
     GetGradXAndYOut<T>(dev_ctx,
                        place,
                        axis,
@@ -50,7 +50,7 @@ void DivideGradKernel(const Context& dev_ctx,
     GetGradXOrYOut<T>(
         dev_ctx, place, axis, ins, dout, dx, funcs::DivGradXFunctor<T>());
   } else if (dy != nullptr && dx == nullptr) {
-    std::vector<const DenseTensor*> ins = {&dout, &out, &y};
+    std::vector<const DenseTensor*> ins = {&dout, &x, &y};
     GetGradXOrYOut<T>(
         dev_ctx, place, axis, ins, dout, dy, funcs::DivGradYFunctor<T>());
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->

修改内容：

- 在除法`out = x / y`中，将`y`的反向公式由`dy = -dout * out / y` 改为 `dy = -dout * ((x / y) / y)`

修改原因：

- 使用result作为反向的输入，在低精度的时候本身cast之后就会存在一些精度损失，所以重新计算后才是更准确的结果

修改影响：

- 此改动可以使结果更精确且对性能影响忽略不计