### PR TITLE
[AMP] Add einsum to the default white_list.

### DIFF
--- a/python/paddle/amp/amp_lists.py
+++ b/python/paddle/amp/amp_lists.py
@@ -16,6 +16,7 @@
 # safe and performance-critical. These ops are always converted to fp16.
 FP16_WHITE_LIST = {
     'conv2d',
+    'einsum',
     'matmul',
     'matmul_v2',
     'max_pool2d_with_index',
@@ -87,7 +88,7 @@ FP16_EXTRA_BLACK_LIST = {
     'depthwise_conv2d',
 }
 
-BF16_WHITE_LIST = {'conv2d', 'matmul_v2'}
+BF16_WHITE_LIST = {'conv2d', 'einsum', 'matmul_v2'}
 BF16_BLACK_LIST = set()
 
 

--- a/python/paddle/static/amp/fp16_lists.py
+++ b/python/paddle/static/amp/fp16_lists.py
@@ -135,6 +135,7 @@ _only_supported_fp16_list = {'resnet_unit', 'fused_bn_add_activation'}
 
 white_list = {
     'conv2d',
+    'einsum',
     'matmul',
     'matmul_v2',
     'mul',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
einsum算子由matmul、reshape、transpose等算子拼凑而成，matmul理应加入到默认白名单中。
