### PR TITLE
Skip fake alloc in static build for some communication OPs

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -445,7 +445,7 @@ void BuildOpFuncList(const platform::Place& place,
   // Step 1: create all ops for current block.
   CreateAllOps(block, &ops_unique);
 
-  VLOG(4) << "Static build: " << static_build;
+  VLOG(1) << "Static build: " << static_build;
 
   if (!execution_config.used_for_jit) {
     // If gc is enabled and block size > 1

--- a/paddle/fluid/framework/new_executor/interpreter/static_build.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/static_build.cc
@@ -30,6 +30,8 @@ std::set<std::string> OpsCanSkipedFakeAllocInStaticBuild = {
     "c_comm_init_multitrainer",
     "c_gen_bkcl_id",
     "c_gen_nccl_id",
+    "c_sync_calc_stream",
+    "c_sync_comm_stream",
     "c_wait_comm",
     "c_wait_compute",
     "create_double_buffer_reader",

--- a/paddle/fluid/framework/new_executor/interpreter/static_build.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/static_build.cc
@@ -19,12 +19,19 @@
 #include "paddle/fluid/operators/reader/buffered_reader.h"
 
 // These Ops is OperatorBase, but we have been handle them in static build
-std::set<std::string> OperatorBasesHandledInStaticBuild = {"depend", "read"};
+std::set<std::string> OperatorBasesHandledInStaticBuild = {"read"};
 
 std::set<std::string> OperatorBasesMustRunInStaticBuild = {
     "create_double_buffer_reader", "create_py_reader"};
 
 std::set<std::string> OpsCanSkipedFakeAllocInStaticBuild = {
+    "c_comm_init",
+    "c_comm_init_all",
+    "c_comm_init_multitrainer",
+    "c_gen_bkcl_id",
+    "c_gen_nccl_id",
+    "c_wait_comm",
+    "c_wait_compute",
     "create_double_buffer_reader",
     "create_py_reader",
     "depend",

--- a/paddle/fluid/framework/new_executor/interpreter/static_build.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/static_build.cc
@@ -19,13 +19,17 @@
 #include "paddle/fluid/operators/reader/buffered_reader.h"
 
 // These Ops is OperatorBase, but we have been handle them in static build
-std::set<std::string> OperatorBasesHandledInStaticBuild = {"read"};
+std::set<std::string> OperatorBasesHandledInStaticBuild = {"depend", "read"};
 
 std::set<std::string> OperatorBasesMustRunInStaticBuild = {
     "create_double_buffer_reader", "create_py_reader"};
 
 std::set<std::string> OpsCanSkipedFakeAllocInStaticBuild = {
-    "create_double_buffer_reader", "create_py_reader", "fetch_v2"};
+    "create_double_buffer_reader",
+    "create_py_reader",
+    "depend",
+    "fetch_v2",
+    "nop"};
 
 // Cannot static analysis these Ops' output dtype or backend because their
 // kernels have not moved to PHI yet.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->

To fix errors for new executor static build in `PaddleNLP_gpt_auto_stage3_bs128_o2_DP16-MP1-PP1_N2C16`, Card-70679 :
<img width="960" alt="a37d994d243fbcb0b941ee80e7722408" src="https://github.com/PaddlePaddle/Paddle/assets/17673696/af1339d8-c929-45ff-860b-08b7684af32d">


Skip fake alloc for the following OPs, which are unrelated to Tensor operator:
 `c_comm_init`, `c_comm_init_all`, `c_comm_init_multitrainer`, `c_gen_bkcl_id`, `c_gen_nccl_id`,     `c_sync_calc_stream`,`c_sync_comm_stream`, `c_wait_comm`, `c_wait_compute`, ` depend` and `nop`.
