### PR TITLE
[Cherry-pick 2.5][Zero-Dim] paddle.static.data, squeeze, unbind, unstack, gather_nd and einsum support 0D

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3761,6 +3761,9 @@ void SqueezeInferMeta(const MetaTensor& x,
   if (!config.is_runtime && axes.FromTensor()) {
     // compile time infershape, set all elements to -1.
     int output_size = x.dims().size() - axes.GetData().size();
+    if (x.dims().size() == 0 && output_size == -1) {
+      output_size = 0;
+    }
     std::vector<int64_t> vec_out_dims(output_size, -1);
     out->set_dims(phi::make_ddim(vec_out_dims));
   } else {

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -580,7 +580,7 @@ def _as_lodtensor(data, place, dtype=None):
             else dtype
         )
         if np.isscalar(data):
-            data = np.array([data]).astype(dtype)
+            data = np.array(data).astype(dtype)
         elif isinstance(data, (list, tuple)):
             data = np.array(data)
             if data.dtype == np.object_:

--- a/python/paddle/fluid/tests/unittests/test_compare_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_op.py
@@ -96,7 +96,7 @@ def create_paddle_case(op_type, callback):
                 paddle.enable_static()
                 with program_guard(Program(), Program()):
                     x = paddle.static.data(name='x', shape=[4], dtype='int64')
-                    y = paddle.static.data(name='y', shape=[1], dtype='int64')
+                    y = paddle.static.data(name='y', shape=[], dtype='int64')
                     op = eval("paddle.%s" % (self.op_type))
                     out = op(x, y)
                     exe = fluid.Executor(self.place)

--- a/python/paddle/fluid/tests/unittests/test_data.py
+++ b/python/paddle/fluid/tests/unittests/test_data.py
@@ -31,6 +31,16 @@ class TestApiStaticDataError(unittest.TestCase):
             x3 = paddle.static.data(name="x3", shape=[2, 25])
             self.assertEqual(x3.dtype, core.VarDesc.VarType.FP64)
 
+    def test_0D(self):
+        with program_guard(Program(), Program()):
+            x1 = paddle.static.data(name="x1_0D", shape=[])
+            self.assertEqual(x1.dtype, core.VarDesc.VarType.FP32)
+            x2 = paddle.static.data(name="x2_0D", shape=(), dtype="bool")
+            self.assertEqual(x2.dtype, core.VarDesc.VarType.BOOL)
+            paddle.set_default_dtype("float64")
+            x3 = paddle.static.data(name="x3_0D", shape=[])
+            self.assertEqual(x3.dtype, core.VarDesc.VarType.FP64)
+
     def test_error(self):
         with program_guard(Program(), Program()):
 

--- a/python/paddle/fluid/tests/unittests/test_data.py
+++ b/python/paddle/fluid/tests/unittests/test_data.py
@@ -37,9 +37,6 @@ class TestApiStaticDataError(unittest.TestCase):
             self.assertEqual(x1.dtype, core.VarDesc.VarType.FP32)
             x2 = paddle.static.data(name="x2_0D", shape=(), dtype="bool")
             self.assertEqual(x2.dtype, core.VarDesc.VarType.BOOL)
-            paddle.set_default_dtype("float64")
-            x3 = paddle.static.data(name="x3_0D", shape=[])
-            self.assertEqual(x3.dtype, core.VarDesc.VarType.FP64)
 
     def test_error(self):
         with program_guard(Program(), Program()):

--- a/python/paddle/fluid/tests/unittests/test_deg2rad.py
+++ b/python/paddle/fluid/tests/unittests/test_deg2rad.py
@@ -67,7 +67,7 @@ class TestDeg2radAPI2(TestDeg2radAPI):
     # Test input data type is int
     def setUp(self):
         self.x_np = 180
-        self.x_shape = [1]
+        self.x_shape = []
         self.out_np = np.pi
         self.x_dtype = 'int64'
 

--- a/python/paddle/fluid/tests/unittests/test_deg2rad.py
+++ b/python/paddle/fluid/tests/unittests/test_deg2rad.py
@@ -66,8 +66,8 @@ class TestDeg2radAPI(unittest.TestCase):
 class TestDeg2radAPI2(TestDeg2radAPI):
     # Test input data type is int
     def setUp(self):
-        self.x_np = 180
-        self.x_shape = []
+        self.x_np = [180]
+        self.x_shape = [1]
         self.out_np = np.pi
         self.x_dtype = 'int64'
 

--- a/python/paddle/fluid/tests/unittests/test_executor_feed_non_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_feed_non_tensor.py
@@ -22,7 +22,7 @@ from paddle import fluid
 
 class TestExecutor(unittest.TestCase):
     def net(self):
-        lr = paddle.static.data(name="lr", shape=[1], dtype='float32')
+        lr = paddle.static.data(name="lr", shape=[], dtype='float32')
         x = paddle.static.data(name="x", shape=[None, 1], dtype='float32')
         y = paddle.static.data(name="y", shape=[None, 1], dtype='float32')
         y_predict = paddle.static.nn.fc(x, size=1)

--- a/python/paddle/fluid/tests/unittests/test_gcd.py
+++ b/python/paddle/fluid/tests/unittests/test_gcd.py
@@ -25,8 +25,8 @@ paddle.enable_static()
 
 class TestGcdAPI(unittest.TestCase):
     def setUp(self):
-        self.x_np = 12
-        self.y_np = 20
+        self.x_np = [12]
+        self.y_np = [20]
         self.x_shape = [1]
         self.y_shape = [1]
 
@@ -81,14 +81,14 @@ class TestGcdAPI3(TestGcdAPI):
     def setUp(self):
         self.x_np = 0
         self.y_np = 20
-        self.x_shape = [1]
-        self.y_shape = [1]
+        self.x_shape = []
+        self.y_shape = []
 
 
 class TestGcdAPI4(TestGcdAPI):
     def setUp(self):
-        self.x_np = 0
-        self.y_np = 0
+        self.x_np = [0]
+        self.y_np = [0]
         self.x_shape = [1]
         self.y_shape = [1]
 
@@ -97,5 +97,5 @@ class TestGcdAPI5(TestGcdAPI):
     def setUp(self):
         self.x_np = 12
         self.y_np = -20
-        self.x_shape = [1]
-        self.y_shape = [1]
+        self.x_shape = []
+        self.y_shape = []

--- a/python/paddle/fluid/tests/unittests/test_lcm.py
+++ b/python/paddle/fluid/tests/unittests/test_lcm.py
@@ -27,8 +27,8 @@ class TestLcmAPI(unittest.TestCase):
     def setUp(self):
         self.x_np = 12
         self.y_np = 20
-        self.x_shape = [1]
-        self.y_shape = [1]
+        self.x_shape = []
+        self.y_shape = []
 
     def test_static_graph(self):
         startup_program = fluid.Program()
@@ -81,14 +81,14 @@ class TestLcmAPI3(TestLcmAPI):
     def setUp(self):
         self.x_np = 0
         self.y_np = 20
-        self.x_shape = [1]
-        self.y_shape = [1]
+        self.x_shape = []
+        self.y_shape = []
 
 
 class TestLcmAPI4(TestLcmAPI):
     def setUp(self):
-        self.x_np = 0
-        self.y_np = 0
+        self.x_np = [0]
+        self.y_np = [0]
         self.x_shape = [1]
         self.y_shape = [1]
 
@@ -97,5 +97,5 @@ class TestLcmAPI5(TestLcmAPI):
     def setUp(self):
         self.x_np = 12
         self.y_np = -20
-        self.x_shape = [1]
-        self.y_shape = [1]
+        self.x_shape = []
+        self.y_shape = []

--- a/python/paddle/fluid/tests/unittests/test_put_along_axis_op.py
+++ b/python/paddle/fluid/tests/unittests/test_put_along_axis_op.py
@@ -141,7 +141,7 @@ class TestPutAlongAxisAPI(unittest.TestCase):
         self.place = [paddle.CPUPlace()]
         self.axis = 0
         self.value_np = 99.0
-        self.value_shape = [1]
+        self.value_shape = []
         self.x_feed = copy.deepcopy(self.x_np)
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
@@ -240,7 +240,7 @@ class TestPutAlongAxisAPICase2(TestPutAlongAxisAPI):
         self.place = [paddle.CPUPlace()]
         self.axis = 0
         self.value_np = 99.0
-        self.value_shape = [1]
+        self.value_shape = []
         self.x_feed = copy.deepcopy(self.x_np)
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
@@ -258,7 +258,7 @@ class TestPutAlongAxisAPICase3(TestPutAlongAxisAPI):
         self.place = [paddle.CPUPlace()]
         self.axis = 0
         self.value_np = 99.0
-        self.value_shape = [1]
+        self.value_shape = []
         self.x_feed = copy.deepcopy(self.x_np)
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))

--- a/python/paddle/fluid/tests/unittests/test_rad2deg.py
+++ b/python/paddle/fluid/tests/unittests/test_rad2deg.py
@@ -65,8 +65,8 @@ class TestRad2degAPI(unittest.TestCase):
 
 class TestRad2degAPI2(TestRad2degAPI):
     def setUp(self):
-        self.x_np = np.pi / 2
-        self.x_shape = []
+        self.x_np = [np.pi / 2]
+        self.x_shape = [1]
         self.out_np = 90
         self.x_dtype = 'float32'
 

--- a/python/paddle/fluid/tests/unittests/test_rad2deg.py
+++ b/python/paddle/fluid/tests/unittests/test_rad2deg.py
@@ -66,7 +66,7 @@ class TestRad2degAPI(unittest.TestCase):
 class TestRad2degAPI2(TestRad2degAPI):
     def setUp(self):
         self.x_np = np.pi / 2
-        self.x_shape = [1]
+        self.x_shape = []
         self.out_np = 90
         self.x_dtype = 'float32'
 
@@ -84,7 +84,7 @@ class TestRad2degAPI3(TestRad2degAPI):
     # Test input data type is int
     def setUp(self):
         self.x_np = 1
-        self.x_shape = [1]
+        self.x_shape = []
         self.out_np = 180 / np.pi
         self.x_dtype = 'int64'
 

--- a/python/paddle/fluid/tests/unittests/test_rad2deg.py
+++ b/python/paddle/fluid/tests/unittests/test_rad2deg.py
@@ -83,8 +83,8 @@ class TestRad2degAPI2(TestRad2degAPI):
 class TestRad2degAPI3(TestRad2degAPI):
     # Test input data type is int
     def setUp(self):
-        self.x_np = 1
-        self.x_shape = []
+        self.x_np = [1]
+        self.x_shape = [1]
         self.out_np = 180 / np.pi
         self.x_dtype = 'int64'
 

--- a/python/paddle/fluid/tests/unittests/test_trapezoid.py
+++ b/python/paddle/fluid/tests/unittests/test_trapezoid.py
@@ -83,7 +83,7 @@ class TestTrapezoidAPI(unittest.TestCase):
                     )
                 if self.dx is not None:
                     dx = paddle.static.data(
-                        name="dx", shape=[1], dtype='float32'
+                        name="dx", shape=[], dtype='float32'
                     )
 
                 exe = paddle.static.Executor(place)

--- a/python/paddle/fluid/tests/unittests/test_unbind_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unbind_op.py
@@ -29,7 +29,7 @@ class TestUnbind(unittest.TestCase):
         x_1 = paddle.static.data(shape=[2, 3], dtype='float32', name='x_1')
         [out_0, out_1] = tensor.unbind(input=x_1, axis=0)
         input_1 = np.random.random([2, 3]).astype("float32")
-        axis = paddle.static.data(shape=[1], dtype='int32', name='axis')
+        axis = paddle.static.data(shape=[], dtype='int32', name='axis')
         exe = fluid.Executor(place=fluid.CPUPlace())
 
         [res_1, res_2] = exe.run(
@@ -87,7 +87,7 @@ class TestLayersUnbind(unittest.TestCase):
         x_1 = paddle.static.data(shape=[2, 3], dtype='float32', name='x_1')
         [out_0, out_1] = paddle.unbind(input=x_1, axis=0)
         input_1 = np.random.random([2, 3]).astype("float32")
-        axis = paddle.static.data(shape=[1], dtype='int32', name='axis')
+        axis = paddle.static.data(shape=[], dtype='int32', name='axis')
         exe = fluid.Executor(place=fluid.CPUPlace())
 
         [res_1, res_2] = exe.run(

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4306,8 +4306,8 @@ class TestSundryAPIStatic(unittest.TestCase):
                 "x2": np.array(100.5, dtype='float32'),
             },
             fetch_list=[
-                x1.grad_name,
-                x2.grad_name,
+                x1.name,
+                x2.name,
             ],
         )
         self.assertEqual(res[0].shape, [])

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4130,14 +4130,14 @@ class TestSundryAPIStatic(unittest.TestCase):
         out1 = paddle.unstack(x1, 0)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out1])
-        self.assertEqual(res[0][0].shape, ())
+        self.assertEqual(res[0].shape, ())
 
         x2 = paddle.full([2], 2, 'float32')
         out2 = paddle.unstack(x2, 0)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out2])
-        self.assertEqual(res[0][0].shape, ())
-        self.assertEqual(res[0][1].shape, ())
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, ())
 
     @prog_scope()
     def test_unbind(self):
@@ -4145,14 +4145,14 @@ class TestSundryAPIStatic(unittest.TestCase):
         out1 = paddle.unbind(x1, 0)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out1])
-        self.assertEqual(res[0][0].shape, ())
+        self.assertEqual(res[0].shape, ())
 
         x2 = paddle.full([2], 2, 'float32')
         out2 = paddle.unbind(x2, 0)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out2])
-        self.assertEqual(res[0][0].shape, ())
-        self.assertEqual(res[0][1].shape, ())
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, ())
 
     @prog_scope()
     def test_maseked_select(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -1631,8 +1631,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_array_equal(out1, expect1)
-        np.testing.assert_array_equal(out2, expect2)
+        np.testing.assert_allclose(out1, expect1, rtol=1e-05)
+        np.testing.assert_allclose(out2, expect2, rtol=1e-05)
 
     def test_einsum_V2(self):
         os.environ['FLAGS_new_einsum'] = "1"
@@ -1652,8 +1652,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_array_equal(out1, expect1)
-        np.testing.assert_array_equal(out2, expect2)
+        np.testing.assert_allclose(out1, expect1, rtol=1e-05)
+        np.testing.assert_allclose(out2, expect2, rtol=1e-05)
 
     def test_scatter_1D(self):
         x = paddle.to_tensor([1.0, 3.0, 5.0, 7.0, 9.0], stop_gradient=False)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4297,8 +4297,6 @@ class TestSundryAPIStatic(unittest.TestCase):
     def test_static_data(self):
         x1 = paddle.static.data(name="x1", shape=[])
         x2 = paddle.static.data(name="x2", shape=(), dtype="bool")
-        paddle.set_default_dtype("float64")
-        x3 = paddle.static.data(name="x3", shape=[])
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(
@@ -4306,12 +4304,10 @@ class TestSundryAPIStatic(unittest.TestCase):
             fetch_list=[
                 x1,
                 x2,
-                x3,
             ],
         )
         self.assertEqual(res[0].shape, [])
         self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, [])
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4294,6 +4294,26 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, (3, 4, 2))
 
     @prog_scope()
+    def test_static_data(self):
+        x1 = paddle.static.data(name="x1", shape=[])
+        x2 = paddle.static.data(name="x2", shape=(), dtype="bool")
+        paddle.set_default_dtype("float64")
+        x3 = paddle.static.data(name="x3", shape=[])
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(
+            prog,
+            fetch_list=[
+                x1,
+                x2,
+                x3,
+            ],
+        )
+        self.assertEqual(res[0].shape, [])
+        self.assertEqual(res[1].shape, ())
+        self.assertEqual(res[2].shape, [])
+
+    @prog_scope()
     def test_prelu(self):
         x1 = paddle.full([], 1.0, 'float32')
         x1.stop_gradient = False

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4303,7 +4303,7 @@ class TestSundryAPIStatic(unittest.TestCase):
             prog,
             feed={
                 "x1": np.array(1.0, dtype='float32'),
-                "x2": np.array(100.5, dtype='float32'),
+                "x2": 100.5,
             },
             fetch_list=[
                 x1.name,
@@ -4313,7 +4313,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], np.array(1.0))
         self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[1], np.array(100.5))
+        self.assertEqual(res[1], 100.5)
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4310,7 +4310,7 @@ class TestSundryAPIStatic(unittest.TestCase):
                 x2.name,
             ],
         )
-        self.assertEqual(res[0].shape, [])
+        self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], np.array(1.0))
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[1], np.array(100.5))

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4296,7 +4296,7 @@ class TestSundryAPIStatic(unittest.TestCase):
     @prog_scope()
     def test_static_data(self):
         x1 = paddle.static.data(name="x1", shape=[])
-        x2 = paddle.static.data(name="x2", shape=())
+        x2 = paddle.static.data(name="x2", shape=[])
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4311,9 +4311,9 @@ class TestSundryAPIStatic(unittest.TestCase):
             ],
         )
         self.assertEqual(res[0].shape, [])
-        np.testing.assert_allclose(res[0], np.array(1.0))
+        self.assertEqual(res[0], np.array(1.0))
         self.assertEqual(res[1].shape, ())
-        np.testing.assert_allclose(res[1], np.array(True))
+        self.assertEqual(res[1], np.array(True))
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4296,8 +4296,6 @@ class TestSundryAPIStatic(unittest.TestCase):
     @prog_scope()
     def test_static_data(self):
         x1 = paddle.static.data(name="x1", shape=[])
-        x2 = paddle.static.data(name="x2", shape=[])
-
         prog = paddle.static.default_main_program()
         res = self.exe.run(
             prog,
@@ -4311,18 +4309,22 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], np.array(1.0))
 
+        x2 = paddle.static.data(name="x2", shape=[])
+        x3 = paddle.static.data(name="x3", shape=[])
+        y = x2 + x3
         prog = paddle.static.default_main_program()
         res = self.exe.run(
             prog,
             feed={
                 "x2": 100.5,
+                "x3": 200.5,
             },
             fetch_list=[
-                x2.name,
+                y.name,
             ],
         )
         self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[0], 100.5)
+        self.assertEqual(res[0], 301.0)
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4295,7 +4295,7 @@ class TestSundryAPIStatic(unittest.TestCase):
 
     @prog_scope()
     def test_static_data(self):
-        x1 = paddle.static.data(name="x1", shape=[])
+        x1 = paddle.static.data(name="x1", shape=[1])
         x2 = paddle.static.data(name="x2", shape=(), dtype="bool")
 
         prog = paddle.static.default_main_program()

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -1631,8 +1631,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_allclose(out1, expect1, rtol=1e-04)
-        np.testing.assert_allclose(out2, expect2, rtol=1e-04)
+        np.testing.assert_allclose(out1, expect1, rtol=1e-03)
+        np.testing.assert_allclose(out2, expect2, rtol=1e-03)
 
     def test_einsum_V2(self):
         os.environ['FLAGS_new_einsum'] = "1"
@@ -1652,8 +1652,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_allclose(out1, expect1, rtol=1e-04)
-        np.testing.assert_allclose(out2, expect2, rtol=1e-04)
+        np.testing.assert_allclose(out1, expect1, rtol=1e-03)
+        np.testing.assert_allclose(out2, expect2, rtol=1e-03)
 
     def test_scatter_1D(self):
         x = paddle.to_tensor([1.0, 3.0, 5.0, 7.0, 9.0], stop_gradient=False)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2342,7 +2342,7 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(x1.grad.shape, [])
 
         x2 = paddle.full([], 3)
-        x3 = paddle.full([], 0, dtype='int32')
+        x3 = paddle.full([1], 0, dtype='int32')
         x2.stop_gradient = False
         x2.retain_grads()
         out2 = paddle.squeeze(x2, axis=x3)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4295,19 +4295,25 @@ class TestSundryAPIStatic(unittest.TestCase):
 
     @prog_scope()
     def test_static_data(self):
-        x1 = paddle.static.data(name="x1", shape=[1])
+        x1 = paddle.static.data(name="x1", shape=[])
         x2 = paddle.static.data(name="x2", shape=(), dtype="bool")
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(
             prog,
+            feed={
+                "x1": np.array(1.0, dtype='float32'),
+                "x2": np.array(True, dtype='bool'),
+            },
             fetch_list=[
-                x1,
-                x2,
+                x1.grad_name,
+                x2.grad_name,
             ],
         )
         self.assertEqual(res[0].shape, [])
+        np.testing.assert_allclose(res[0], np.array(1.0))
         self.assertEqual(res[1].shape, ())
+        np.testing.assert_allclose(res[1], np.array(True))
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -1631,8 +1631,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_allclose(out1, expect1, rtol=1e-05)
-        np.testing.assert_allclose(out2, expect2, rtol=1e-05)
+        np.testing.assert_allclose(out1, expect1, rtol=1e-04)
+        np.testing.assert_allclose(out2, expect2, rtol=1e-04)
 
     def test_einsum_V2(self):
         os.environ['FLAGS_new_einsum'] = "1"
@@ -1652,8 +1652,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_allclose(out1, expect1, rtol=1e-05)
-        np.testing.assert_allclose(out2, expect2, rtol=1e-05)
+        np.testing.assert_allclose(out1, expect1, rtol=1e-04)
+        np.testing.assert_allclose(out2, expect2, rtol=1e-04)
 
     def test_scatter_1D(self):
         x = paddle.to_tensor([1.0, 3.0, 5.0, 7.0, 9.0], stop_gradient=False)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4146,18 +4146,14 @@ class TestSundryAPIStatic(unittest.TestCase):
 
     @prog_scope()
     def test_unstack(self):
-        x1 = paddle.full([], 0, 'float32')
-        x1.stop_gradient = False
+        x1 = paddle.full([1], 0, 'float32')
         out1 = paddle.unstack(x1, 0)
-        paddle.static.append_backward(out1)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out1])
         self.assertEqual(res[0][0].shape, ())
 
         x2 = paddle.full([2], 2, 'float32')
-        x2.stop_gradient = False
         out2 = paddle.unstack(x2, 0)
-        paddle.static.append_backward(out2)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out2])
         self.assertEqual(res[0][0].shape, ())
@@ -4165,18 +4161,14 @@ class TestSundryAPIStatic(unittest.TestCase):
 
     @prog_scope()
     def test_unbind(self):
-        x1 = paddle.full([], 0, 'float32')
-        x1.stop_gradient = False
+        x1 = paddle.full([1], 0, 'float32')
         out1 = paddle.unbind(x1, 0)
-        paddle.static.append_backward(out1)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out1])
         self.assertEqual(res[0][0].shape, ())
 
         x2 = paddle.full([2], 2, 'float32')
-        x2.stop_gradient = False
         out2 = paddle.unbind(x2, 0)
-        paddle.static.append_backward(out2)
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, feed={}, fetch_list=[out2])
         self.assertEqual(res[0][0].shape, ())
@@ -4204,16 +4196,6 @@ class TestSundryAPIStatic(unittest.TestCase):
         x1.stop_gradient = False
         out1 = paddle.squeeze(x1, axis=0)
         paddle.static.append_backward(out1.sum())
-        prog = paddle.static.default_main_program()
-        res = self.exe.run(
-            prog,
-            fetch_list=[
-                out1,
-                x1.grad_name,
-            ],
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
 
         x2 = paddle.full([], 3)
         x3 = paddle.full([], 0, dtype='int32')
@@ -4225,12 +4207,16 @@ class TestSundryAPIStatic(unittest.TestCase):
         res = self.exe.run(
             prog,
             fetch_list=[
+                out1,
                 out2,
+                x1.grad_name,
                 x2.grad_name,
             ],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
+        self.assertEqual(res[2].shape, ())
+        self.assertEqual(res[3].shape, ())
 
     @prog_scope()
     def test_unsqueeze(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4303,17 +4303,26 @@ class TestSundryAPIStatic(unittest.TestCase):
             prog,
             feed={
                 "x1": np.array(1.0, dtype='float32'),
-                "x2": 100.5,
             },
             fetch_list=[
                 x1.name,
-                x2.name,
             ],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], np.array(1.0))
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[1], 100.5)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(
+            prog,
+            feed={
+                "x2": 100.5,
+            },
+            fetch_list=[
+                x2.name,
+            ],
+        )
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[0], 100.5)
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -3429,7 +3429,7 @@ class TestSundryAPIStatic(unittest.TestCase):
     def test_gather_nd(self):
         x1 = paddle.full([10], 1.0, 'float32')
         x1.stop_gradient = False
-        x2 = paddle.to_tensor([2, 3], 1.0, 'float32')
+        x2 = paddle.full([2, 3], 1.0, 'float32')
         x2.stop_gradient = False
 
         index1 = paddle.full([1], 1, 'int64')

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4147,40 +4147,40 @@ class TestSundryAPIStatic(unittest.TestCase):
     @prog_scope()
     def test_unstack(self):
         x1 = paddle.full([], 0, 'float32')
-        x2 = paddle.full([2], 2, 'float32')
         x1.stop_gradient = False
-        x2.stop_gradient = False
-        [out] = paddle.unstack(x1, 0)
-        paddle.static.append_backward(out)
-        [out2_1, out2_2] = paddle.unstack(x2, 0)
-        paddle.static.append_backward(out2_1)
-        paddle.static.append_backward(out2_2)
-
+        out1 = paddle.unstack(x1, 0)
+        paddle.static.append_backward(out1)
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, feed={}, fetch_list=[out, out2_1, out2_2])
+        res = self.exe.run(prog, feed={}, fetch_list=[out1])
+        self.assertEqual(res[0][0].shape, ())
 
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, ())
+        x2 = paddle.full([2], 2, 'float32')
+        x2.stop_gradient = False
+        out2 = paddle.unstack(x2, 0)
+        paddle.static.append_backward(out2)
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, feed={}, fetch_list=[out2])
+        self.assertEqual(res[0][0].shape, ())
+        self.assertEqual(res[0][1].shape, ())
 
     @prog_scope()
     def test_unbind(self):
         x1 = paddle.full([], 0, 'float32')
-        x2 = paddle.full([2], 2, 'float32')
         x1.stop_gradient = False
-        x2.stop_gradient = False
-        [out] = paddle.unbind(x1, 0)
-        paddle.static.append_backward(out)
-        [out2_1, out2_2] = paddle.unstack(x2, 0)
-        paddle.static.append_backward(out2_1)
-        paddle.static.append_backward(out2_2)
-
+        out1 = paddle.unbind(x1, 0)
+        paddle.static.append_backward(out1)
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, feed={}, fetch_list=[out, out2_1, out2_2])
+        res = self.exe.run(prog, feed={}, fetch_list=[out1])
+        self.assertEqual(res[0][0].shape, ())
 
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, ())
+        x2 = paddle.full([2], 2, 'float32')
+        x2.stop_gradient = False
+        out2 = paddle.unbind(x2, 0)
+        paddle.static.append_backward(out2)
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, feed={}, fetch_list=[out2])
+        self.assertEqual(res[0][0].shape, ())
+        self.assertEqual(res[0][1].shape, ())
 
     @prog_scope()
     def test_maseked_select(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2270,52 +2270,32 @@ class TestSundryAPI(unittest.TestCase):
     def test_unstack(self):
         x1 = paddle.full([1], 0)
         x2 = paddle.full([2], 2)
-        x1.retain_grads()
-        x2.retain_grads()
-        x1.stop_gradient = False
-        x2.stop_gradient = False
+
         [out1] = paddle.unstack(x1, 0)
-        out1.retain_grads()
-        out1.backward()
         [out2_1, out2_2] = paddle.unstack(x2, 0)
-        out2_1.retain_grads()
-        out2_1.backward()
-        out2_2.retain_grads()
-        out2_2.backward()
+
         self.assertEqual(out1.shape, [])
         self.assertEqual(out1.numpy(), 0)
-        self.assertEqual(out1.grad.shape, [])
+
         self.assertEqual(out2_1.shape, [])
         self.assertEqual(out2_1.numpy(), 2)
-        self.assertEqual(out2_1.grad.shape, [])
         self.assertEqual(out2_2.shape, [])
         self.assertEqual(out2_2.numpy(), 2)
-        self.assertEqual(out2_2.grad.shape, [])
 
     def test_unbind(self):
         x1 = paddle.full([1], 0)
         x2 = paddle.full([2], 2)
-        x1.retain_grads()
-        x2.retain_grads()
-        x1.stop_gradient = False
-        x2.stop_gradient = False
+
         [out1] = paddle.unbind(x1, 0)
-        out1.retain_grads()
-        out1.backward()
         [out2_1, out2_2] = paddle.unbind(x2, 0)
-        out2_1.retain_grads()
-        out2_1.backward()
-        out2_2.retain_grads()
-        out2_2.backward()
+
         self.assertEqual(out1.shape, [])
         self.assertEqual(out1.numpy(), 0)
-        self.assertEqual(out1.grad.shape, [])
+
         self.assertEqual(out2_1.shape, [])
         self.assertEqual(out2_1.numpy(), 2)
-        self.assertEqual(out2_1.grad.shape, [])
         self.assertEqual(out2_2.shape, [])
         self.assertEqual(out2_2.numpy(), 2)
-        self.assertEqual(out2_2.grad.shape, [])
 
     def test_maseked_select(self):
         x = paddle.rand([])

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4296,14 +4296,14 @@ class TestSundryAPIStatic(unittest.TestCase):
     @prog_scope()
     def test_static_data(self):
         x1 = paddle.static.data(name="x1", shape=[])
-        x2 = paddle.static.data(name="x2", shape=(), dtype="bool")
+        x2 = paddle.static.data(name="x2", shape=())
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(
             prog,
             feed={
                 "x1": np.array(1.0, dtype='float32'),
-                "x2": np.array(True, dtype='bool'),
+                "x2": np.array(100.5, dtype='float32'),
             },
             fetch_list=[
                 x1.grad_name,
@@ -4313,7 +4313,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, [])
         self.assertEqual(res[0], np.array(1.0))
         self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[1], np.array(True))
+        self.assertEqual(res[1], np.array(100.5))
 
     @prog_scope()
     def test_prelu(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2267,6 +2267,48 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out1.shape, [2, 3, 12, 12])
         self.assertEqual(input_x.grad.shape, [2, 3, 6, 6])
 
+    def test_unstack(self):
+        x1 = paddle.full([1], 0)
+        x2 = paddle.full([2], 2)
+        x1.retain_grads()
+        x2.retain_grads()
+        x1.stop_gradient = False
+        x2.stop_gradient = False
+        out1 = paddle.unstack(x1, 0)
+        out1.retain_grads()
+        out1.backward()
+        [out2_1, out2_2] = paddle.unstack(x2, 0)
+        self.assertEqual(out1.shape, [])
+        self.assertEqual(out1.numpy(), 0)
+        self.assertEqual(out1.grad.shape, [])
+        self.assertEqual(out2_1.shape, [])
+        self.assertEqual(out2_1.numpy(), 2)
+        self.assertEqual(out2_1.grad.shape, [])
+        self.assertEqual(out2_2.shape, [])
+        self.assertEqual(out2_2.numpy(), 2)
+        self.assertEqual(out2_2.grad.shape, [])
+
+    def test_unbind(self):
+        x1 = paddle.full([1], 0)
+        x2 = paddle.full([2], 2)
+        x1.retain_grads()
+        x2.retain_grads()
+        x1.stop_gradient = False
+        x2.stop_gradient = False
+        out1 = paddle.unbind(x1, 0)
+        out1.retain_grads()
+        out1.backward()
+        [out2_1, out2_2] = paddle.unstack(x2, 0)
+        self.assertEqual(out1.shape, [])
+        self.assertEqual(out1.numpy(), 0)
+        self.assertEqual(out1.grad.shape, [])
+        self.assertEqual(out2_1.shape, [])
+        self.assertEqual(out2_1.numpy(), 2)
+        self.assertEqual(out2_1.grad.shape, [])
+        self.assertEqual(out2_2.shape, [])
+        self.assertEqual(out2_2.numpy(), 2)
+        self.assertEqual(out2_2.grad.shape, [])
+
     def test_maseked_select(self):
         x = paddle.rand([])
         x.stop_gradient = False
@@ -2280,6 +2322,23 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(y.grad.shape, [1])
         self.assertEqual(x.grad.shape, [])
         self.assertEqual(x.grad.numpy(), 1)
+
+    def test_squeeze(self):
+        x1 = paddle.full([], 2)
+        x1.stop_gradient = False
+        x1.retain_grads()
+        out1 = paddle.squeeze(x1, axis=0)
+        out1.retain_grads()
+        out1.backward()
+        self.assertEqual(out1.shape, [])
+        self.assertEqual(x1.grad.shape, [])
+
+        x2 = paddle.full([], 0, dtype='int32')
+        out2 = paddle.squeeze(x1, axis=x2)
+        out2.retain_grads()
+        out2.backward()
+        self.assertEqual(out2.shape, [])
+        self.assertEqual(x1.grad.shape, [])
 
     def test_unsqueeze(self):
         x1 = paddle.full([], 2)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -1618,8 +1618,10 @@ class TestSundryAPI(unittest.TestCase):
         x = paddle.rand([5])
         # sum
         out1 = paddle.einsum('i->', x)
+        expect1 = np.einsum('i->', x)
         # dot
         out2 = paddle.einsum('i,i->', x, x)
+        expect2 = np.einsum('i,i->', x, x)
 
         out1.retain_grads()
         out2.retain_grads()
@@ -1629,16 +1631,18 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_array_equal(out1, np.array(3.0))
-        np.testing.assert_array_equal(out2, np.array(5.0))
+        np.testing.assert_array_equal(out1, expect1)
+        np.testing.assert_array_equal(out2, expect2)
 
     def test_einsum_V2(self):
         os.environ['FLAGS_new_einsum'] = "1"
         x = paddle.rand([5])
         # sum
         out1 = paddle.einsum('i->', x)
+        expect1 = np.einsum('i->', x)
         # dot
         out2 = paddle.einsum('i,i->', x, x)
+        expect2 = np.einsum('i,i->', x, x)
 
         out1.retain_grads()
         out2.retain_grads()
@@ -1648,8 +1652,8 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out1.shape, [])
         self.assertEqual(out2.shape, [])
-        np.testing.assert_array_equal(out1, np.einsum('i->', x))
-        np.testing.assert_array_equal(out2, np.einsum('i,i->', x, x))
+        np.testing.assert_array_equal(out1, expect1)
+        np.testing.assert_array_equal(out2, expect2)
 
     def test_scatter_1D(self):
         x = paddle.to_tensor([1.0, 3.0, 5.0, 7.0, 9.0], stop_gradient=False)
@@ -3425,7 +3429,7 @@ class TestSundryAPIStatic(unittest.TestCase):
     def test_gather_nd(self):
         x1 = paddle.full([10], 1.0, 'float32')
         x1.stop_gradient = False
-        x2 = paddle.to_tensor([2, 3], 1.0, stop_gradient=False)
+        x2 = paddle.to_tensor([2, 3], 1.0, 'float32')
         x2.stop_gradient = False
 
         index1 = paddle.full([1], 1, 'int64')

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2321,12 +2321,14 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out1.shape, [])
         self.assertEqual(x1.grad.shape, [])
 
-        x2 = paddle.full([], 0, dtype='int32')
-        out2 = paddle.squeeze(x1, axis=x2)
+        x2 = paddle.full([1, 1], 1, dtype='int32')
+        x2.stop_gradient = False
+        x2.retain_grads()
+        out2 = paddle.squeeze(x2, axis=[0, 1])
         out2.retain_grads()
         out2.backward()
         self.assertEqual(out2.shape, [])
-        self.assertEqual(x1.grad.shape, [])
+        self.assertEqual(x2.grad.shape, [1, 1])
 
     def test_unsqueeze(self):
         x1 = paddle.full([], 2)
@@ -4177,10 +4179,9 @@ class TestSundryAPIStatic(unittest.TestCase):
         out1 = paddle.squeeze(x1, axis=0)
         paddle.static.append_backward(out1.sum())
 
-        x2 = paddle.full([], 3)
-        x3 = paddle.full([], 0, dtype='int32')
+        x2 = paddle.full([1, 1], 1, dtype='int32')
         x2.stop_gradient = False
-        out2 = paddle.squeeze(x2, axis=x3)
+        out2 = paddle.squeeze(x2, axis=[0, 1])
         paddle.static.append_backward(out2.sum())
 
         prog = paddle.static.default_main_program()
@@ -4196,7 +4197,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
-        self.assertEqual(res[3].shape, ())
+        self.assertEqual(res[3].shape, (1, 1))
 
     @prog_scope()
     def test_unsqueeze(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -2341,14 +2341,15 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out1.shape, [])
         self.assertEqual(x1.grad.shape, [])
 
-        x2 = paddle.full([1, 1], 1, dtype='int32')
+        x2 = paddle.full([], 3)
+        x3 = paddle.full([], 0, dtype='int32')
         x2.stop_gradient = False
         x2.retain_grads()
-        out2 = paddle.squeeze(x2, axis=[0, 1])
+        out2 = paddle.squeeze(x2, axis=x3)
         out2.retain_grads()
         out2.backward()
         self.assertEqual(out2.shape, [])
-        self.assertEqual(x2.grad.shape, [1, 1])
+        self.assertEqual(x2.grad.shape, [])
 
     def test_unsqueeze(self):
         x1 = paddle.full([], 2)
@@ -4213,9 +4214,10 @@ class TestSundryAPIStatic(unittest.TestCase):
         out1 = paddle.squeeze(x1, axis=0)
         paddle.static.append_backward(out1.sum())
 
-        x2 = paddle.full([1, 1], 1, dtype='int32')
+        x2 = paddle.full([], 3)
+        x3 = paddle.full([], 0, dtype='int32')
         x2.stop_gradient = False
-        out2 = paddle.squeeze(x2, axis=[0, 1])
+        out2 = paddle.squeeze(x2, axis=x3)
         paddle.static.append_backward(out2.sum())
 
         prog = paddle.static.default_main_program()
@@ -4231,7 +4233,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, ())
-        self.assertEqual(res[3].shape, (1, 1))
+        self.assertEqual(res[3].shape, ())
 
     @prog_scope()
     def test_unsqueeze(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -4204,6 +4204,16 @@ class TestSundryAPIStatic(unittest.TestCase):
         x1.stop_gradient = False
         out1 = paddle.squeeze(x1, axis=0)
         paddle.static.append_backward(out1.sum())
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(
+            prog,
+            fetch_list=[
+                out1,
+                x1.grad_name,
+            ],
+        )
+        self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[1].shape, ())
 
         x2 = paddle.full([], 3)
         x3 = paddle.full([], 0, dtype='int32')
@@ -4215,16 +4225,12 @@ class TestSundryAPIStatic(unittest.TestCase):
         res = self.exe.run(
             prog,
             fetch_list=[
-                out1,
                 out2,
-                x1.grad_name,
                 x2.grad_name,
             ],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, ())
-        self.assertEqual(res[3].shape, ())
 
     @prog_scope()
     def test_unsqueeze(self):

--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -966,8 +966,8 @@ def einsum(equation, *operands):
 
             # dot
             print(paddle.einsum('i,i->', x, x))
-            # Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
-            #   [1.45936954])
+            # Tensor(shape=[], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
+            #   1.45936954)
 
             # outer
             print(paddle.einsum("i,j->ij", x, y))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/52775
https://github.com/PaddlePaddle/Paddle/pull/52843
https://github.com/PaddlePaddle/Paddle/pull/53175
