### PR TITLE
【prim】add dygraph error code when close prim flag for op who has composite implement but no grad kernel

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1901,13 +1901,14 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
  }}
   """
             else:
-                Unavailable_log = f"""  if(trace_backward) {{
+                if self.grad_api_contents["backward_op"] not in prim_white_list:
+                    Unavailable_log = f"""  if(trace_backward) {{
     PADDLE_THROW(phi::errors::Unavailable(
     \"The Op {self.backward_api_name} doesn't have any grad\"
     \"op. If you don't intend calculating higher order\"
     \"derivatives, please set `create_graph`to False.\"));
   }}"""
-                next_grad_node_creation_str = f"""
+                    next_grad_node_creation_str = f"""
  if (!paddle::prim::PrimCommonUtils::IsEagerPrimEnabled()) {{
     {Unavailable_log}
  }}

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1905,17 +1905,19 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
                     self.grad_api_contents["backward_op"] in prim_white_list
                     or is_invoke_forward_api
                 ):
-                    Unavailable_log = f"""  if(trace_backward) {{
+
+                    next_grad_node_creation_str = f"""
+ if (!paddle::prim::PrimCommonUtils::IsEagerPrimEnabled()) {{
+    if(trace_backward) {{
     PADDLE_THROW(phi::errors::Unavailable(
     \"The Op {self.backward_api_name} doesn't have any grad\"
     \"op. If you don't intend calculating higher order\"
     \"derivatives, please set `create_graph`to False.\"));
-  }}"""
-                    next_grad_node_creation_str = f"""
- if (!paddle::prim::PrimCommonUtils::IsEagerPrimEnabled()) {{
-    {Unavailable_log}
+  }}
  }}
   """
+                else:
+                    print("&&&&&&& : ", self.grad_api_contents["backward_op"])
 
         if next_node_generator is not None:
             has_higher_order_node = True

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1916,8 +1916,6 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
   }}
  }}
   """
-                else:
-                    print("&&&&&&& : ", self.grad_api_contents["backward_op"])
 
         if next_node_generator is not None:
             has_higher_order_node = True

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1901,7 +1901,10 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
  }}
   """
             else:
-                if self.grad_api_contents["backward_op"] not in prim_white_list:
+                if (
+                    self.grad_api_contents["backward_op"] not in prim_white_list
+                    or not is_invoke_forward_api
+                ):
                     Unavailable_log = f"""  if(trace_backward) {{
     PADDLE_THROW(phi::errors::Unavailable(
     \"The Op {self.backward_api_name} doesn't have any grad\"

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1901,9 +1901,9 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
  }}
   """
             else:
-                if (
-                    self.grad_api_contents["backward_op"] not in prim_white_list
-                    or not is_invoke_forward_api
+                if not (
+                    self.grad_api_contents["backward_op"] in prim_white_list
+                    or is_invoke_forward_api
                 ):
                     Unavailable_log = f"""  if(trace_backward) {{
     PADDLE_THROW(phi::errors::Unavailable(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66975
修复动态图下，如果有组合算子但没有更高阶的非组合算子时，在不打开组合路径的情况下抛出异常。