### PR TITLE
Enabel memory optimize pass although MkLDNN is enabled

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -963,22 +963,8 @@ void AnalysisConfig::Update() {
 #endif
   }
 
-  // TODO(inference): When we enable memory_optimize and mkldnn, PaddleSeg model
-  // fail.
   if (enable_memory_optim_) {
-#ifdef PADDLE_WITH_MKLDNN
-    if (use_mkldnn_) {
-      enable_memory_optim_ = false;
-      LOG_FIRST_N(WARNING, 1)
-          << "It is detected that mkldnn and memory_optimize_pass are enabled "
-             "at the same time, but they are not supported yet. Currently, "
-             "memory_optimize_pass is explicitly disabled";
-    } else {
-      pass_builder()->AppendAnalysisPass("memory_optimize_pass");
-    }
-#else
     pass_builder()->AppendAnalysisPass("memory_optimize_pass");
-#endif
   }
 
   if (use_lite_) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
使用 MKLDNN 时， 允许使用内存复用pass
算子内部不能使用 sharedata 之类的API，否则会导致内存复用逻辑产生 bug，某些场景下导致内存复用中 cluster_buffer_ 中某些 buffer 指针一样从而引发计算错误。
