### PR TITLE
[cherry-pick] fix static promote (#53439)

### DIFF
--- a/test/amp/test_amp_list.py
+++ b/test/amp/test_amp_list.py
@@ -50,9 +50,10 @@ class TestAMPList(unittest.TestCase):
         self.check_if_op_not_in_list(
             self.custom_white_list, amp_list.black_list
         )
-        self.check_if_op_not_in_list(
-            self.custom_white_list, amp_list.unsupported_list
-        )
+        if paddle.amp.is_float16_supported():
+            self.check_if_op_not_in_list(
+                self.custom_white_list, amp_list.black_list
+            )
 
     def test_eager(self):
         if not paddle.amp.is_float16_supported():

--- a/test/amp/test_amp_promote.py
+++ b/test/amp/test_amp_promote.py
@@ -48,7 +48,6 @@ class TestAMPPromote(AmpTestBase):
 
         max_iters = 2
         x_fp32 = np.random.random(size=[1, 1, 6, 6]).astype("float32")
-        print(main_program)
         losses_o1 = self.run_program(
             main_program,
             startup_program,

--- a/test/amp/test_model_cast_to_bf16.py
+++ b/test/amp/test_model_cast_to_bf16.py
@@ -265,18 +265,20 @@ class TestProgramBF16(AmpTestBase):
 
         amp.debugging.collect_operator_stats(main_program)
         op_stats_list = amp.debugging._get_op_stats_list(main_program)
+        expected_fp32_calls = {"lookup_table_v2": 1}
         expected_bf16_calls = {
             "matmul_v2": 1,
             "elementwise_add": 1,
             "dropout": 1,
             "lookup_table_v2": 0,
-            "squared_l2_norm": 2,
-            "adamw": 2,
+            "squared_l2_norm": 3,
+            "adamw": 3,
         }
         self._check_optimizer(
             main_program,
             expected_bf16_calls["matmul_v2"]
-            + expected_bf16_calls["elementwise_add"],
+            + expected_bf16_calls["elementwise_add"]
+            + expected_fp32_calls["lookup_table_v2"],
         )
         self._check_op_calls(op_stats_list[0], expected_bf16_calls)
 

--- a/test/contrib/test_image_classification_fp16.py
+++ b/test/contrib/test_image_classification_fp16.py
@@ -318,7 +318,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         amp_lists = paddle.static.amp.AutoMixedPrecisionLists()
@@ -331,7 +334,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         # 1. w={'exp}, b=None
@@ -348,7 +354,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         # 2. w={'tanh'}, b=None
@@ -365,7 +374,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         # 3. w={'lstm'}, b=None
@@ -381,7 +393,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         # 4. w=None, b={'conv2d'}
@@ -400,7 +415,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         # 5. w=None, b={'tanh'}
@@ -419,7 +437,10 @@ class TestImageClassification(unittest.TestCase):
             copy.copy(paddle.static.amp.fp16_lists.white_list)
             | paddle.static.amp.fp16_lists._only_supported_fp16_list
         )
-        black_list = copy.copy(paddle.static.amp.fp16_lists.black_list)
+        black_list = copy.copy(
+            paddle.static.amp.fp16_lists.black_list
+            | paddle.static.amp.fp16_lists._extra_black_list
+        )
         gray_list = copy.copy(paddle.static.amp.fp16_lists.gray_list)
 
         # 6. w=None, b={'lstm'}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Description
<!-- Describe what you’ve done -->  fix static promote

将因性能有问题而放入unsupprot_list中的算子放入黑名单中，以保证在O2模式下，只有3种场景权重会保持fp32：
- 算子不支持fp16
- 不在fp16-guard下
- 特殊算子bn等需要保持fp32权重

一些模型中可能存在某些算子权重被后续在白名单中的算子使用，权重的名字同时在keep_fp32_var_names和to_fp16_var_names中，可能会导致权重var.dtype和存储的数据的dtype不同。解决方案：如果var在keep_fp32_var_names中，那么将从to_fp16_var_names移除

该场景在transformer模型中存在，修复以下报错问题
![image](https://user-images.githubusercontent.com/26615455/235107461-62cf99be-196a-430f-8d4a-2f53b79b12b2.png)
