### PR TITLE
[Cherry-Pick] Fix bug in log_softmax kernel when lastdim is larger than 100000

### DIFF
--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -499,8 +499,7 @@ __global__ void KeMatrixSoftmaxForward(T* softmax, const T* src, int dim_size) {
 
   // write data to softmax_output according to the LogMode
   if (LogMode) {
-    LogSoftmaxForwardFunctor<AccT, T> reduction(thread_max,
-                                                std::log(thread_exp));
+    LogSoftmaxForwardFunctor<AccT, T> reduction(thread_max, thread_exp);
     if (input_align_shift == output_align_shift) {
       ThreadVecWriteVec<LogSoftmaxForwardFunctor, T, AccT, VecSize>(
           batch_output, batch_input, dim_size, input_align_shift, reduction);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->

Fix bug in log_softmax kernel when lastdim is larger than 100000

There is an unexpected `log` in the calculation

Cherry-Pick: #53654 