### PR TITLE
[CINN] fix check_cinn in Optest check condition error bug

### DIFF
--- a/python/paddle/fluid/tests/unittests/eager_op_test.py
+++ b/python/paddle/fluid/tests/unittests/eager_op_test.py
@@ -497,9 +497,9 @@ class OpTest(unittest.TestCase):
     def _enable_check_cinn_test(self, place, inputs, outputs):
         # if the test not run in cuda or the paddle not compile with CINN, skip cinn test
         if (
-            core.is_compiled_with_cinn()
-            and core.is_compiled_with_cuda()
-            and isinstance(place, fluid.CUDAPlace)
+            not core.is_compiled_with_cinn()
+            or not core.is_compiled_with_cuda()
+            or not isinstance(place, fluid.CUDAPlace)
         ):
             return False
         # CINN not support bfloat16 now, skip cinn test


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66971

修复OpTest中`check_cinn`条件判断错误的bug
