### PR TITLE
up index warning level

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -137,7 +137,7 @@ static PyObject* tensor_method_numpy(TensorObject* self,
     }
     if (set_to_1d) {
       // 0D Tensor hack process to 1D numpy, will remove in release 2.6
-      VLOG(0)
+      VLOG(1)
           << "Warning:: 0D Tensor cannot be used as 'Tensor.numpy()[0]' . In "
              "order to avoid this problem, "
              "0D Tensor will be changed to 1D numpy currently, but it's not "
@@ -931,7 +931,7 @@ static PyObject* tensor__getitem_index_not_tensor(TensorObject* self,
     // with FLAGS_set_to_1d=True. In this case, one `None` should be pop out,
     // otherwise the output shape will be not correct.
     if (static_cast<int>(decrease_axis.size()) == tensor->dims().size()) {
-      VLOG(0)
+      VLOG(1)
           << "Warning: In Tensor '__getitem__', if the number of scalar "
              "elements "
              "in the index is equal to the rank of the Tensor, the output "

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -137,7 +137,7 @@ static PyObject* tensor_method_numpy(TensorObject* self,
     }
     if (set_to_1d) {
       // 0D Tensor hack process to 1D numpy, will remove in release 2.6
-      VLOG(1)
+      VLOG(0)
           << "Warning:: 0D Tensor cannot be used as 'Tensor.numpy()[0]' . In "
              "order to avoid this problem, "
              "0D Tensor will be changed to 1D numpy currently, but it's not "

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1060,7 +1060,7 @@ void BindImperative(py::module *m_ptr) {
                // not correct.
                if (static_cast<int>(decrease_axis.size()) ==
                    tensor->dims().size()) {
-                 VLOG(0) << "Warning: In Tensor '__getitem__', if the number "
+                 VLOG(1) << "Warning: In Tensor '__getitem__', if the number "
                             "of scalar "
                             "elements "
                             "in the index is equal to the rank of the Tensor, "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985
For compatibility，case output 0D of API `__getitem__` is hacked to 1D and there will be a warning.

If the model code has this case, there will be too many warnings since number of iteration is large. (ref https://rpg.ifi.uzh.ch/docs/glog.html , the default GLOG_v=0 means INFO. )

This PR changes level of these two warnings to WARNING, displayed when GLOG_V=1.