### PR TITLE
Fix div error when dtype is int64 in static mode

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -419,7 +419,9 @@ def monkey_patch_variable():
             if method_name in compare_ops:
                 out = create_new_tmp_var(current_block(self), dtype="bool")
             else:
-                out = create_new_tmp_var(current_block(self), dtype=lhs_dtype)
+                out = create_new_tmp_var(
+                    current_block(self), dtype=safe_get_dtype(self)
+                )
 
             axis = -1
             if other_var.ndim > 0 and other_var.shape[0] == -1:

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -409,6 +409,12 @@ def monkey_patch_variable():
                 self = other_var
                 other_var = tmp
 
+            if (
+                op_type == "divide" or op_type == "elementwise_div"
+            ) and self.dtype in _supported_int_dtype_:
+                self = astype(self, 'float32')
+                other_var = astype(other_var, 'float32')
+
             # NOTE(zhiqiu): the output of compare operator should be bool.
             if method_name in compare_ops:
                 out = create_new_tmp_var(current_block(self), dtype="bool")

--- a/test/dygraph_to_static/test_tensor_methods.py
+++ b/test/dygraph_to_static/test_tensor_methods.py
@@ -101,5 +101,24 @@ class TestTensorSize(unittest.TestCase):
         np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-5)
 
 
+@paddle.jit.to_static
+def true_div(x, y):
+    z = x / y
+    return z
+
+
+class TestTrueDiv(unittest.TestCase):
+    def _run(self, to_static):
+        paddle.jit.enable_to_static(to_static)
+        x = paddle.to_tensor([3], dtype='int64')
+        y = paddle.to_tensor([4], dtype='int64')
+        return true_div(x, y).numpy()
+
+    def test_ture_div(self):
+        dygraph_res = self._run(to_static=False)
+        static_res = self._run(to_static=True)
+        np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-5)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
下面代码动态图返回结果是0.75，动转静(静态图)返回结果是0。正确结果应该是0.75，因为这里的除法是truediv。

```python
import paddle

@paddle.jit.to_static
def fn(x, y):
    z = x / y
    return z

x = paddle.to_tensor([3], dtype='int64')
y = paddle.to_tensor([4], dtype='int64')

out = fn(x, y)
print(out)
```

动态图的代码中将类型统一转成了float32类型，所以计算结果正确
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/bf60b6c8-2591-4a21-b192-1b85b1126206)
但是静态图variable的__truediv__方法中没有对应类型转换的代码，本PR的修改参考了老动态图varbase的truediv的代码


PCard-64703