### PR TITLE
Add datatype for index_put in ops.yaml

### DIFF
--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -877,6 +877,7 @@
     func : IndexPutInferMeta
   kernel :
     func : index_put
+    data_type : x
   inplace : (x -> out)
   backward : index_put_grad
 

--- a/paddle/phi/kernels/cpu/index_put_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_grad_kernel.cc
@@ -183,7 +183,7 @@ void IndexPutGradKernel(const Context& dev_ctx,
       x.dtype(),
       value.dtype(),
       phi::errors::InvalidArgument(
-          "The data type of tensor in indices must be same to the data type "
+          "The data type of tensor value must be same to the data type "
           "of tensor x."));
   std::vector<DenseTensor> tmp_args;
   std::vector<const phi::DenseTensor*> int_indices_v =

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -102,7 +102,7 @@ void IndexPutKernel(const Context& dev_ctx,
       x.dtype(),
       value.dtype(),
       phi::errors::InvalidArgument(
-          "The data type of tensor in indices must be same to the data type "
+          "The data type of tensor value must be same to the data type "
           "of tensor x."));
   PADDLE_ENFORCE_EQ(indices.empty(),
                     false,

--- a/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
@@ -214,7 +214,7 @@ void IndexPutGradKernel(const Context& dev_ctx,
       x.dtype(),
       value.dtype(),
       phi::errors::InvalidArgument(
-          "The data type of tensor in indices must be same to the data type "
+          "The data type of tensor value must be same to the data type "
           "of tensor x."));
   std::vector<DenseTensor> tmp_args;
   std::vector<const phi::DenseTensor*> int_indices_v =

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -110,7 +110,7 @@ void IndexPutKernel(const Context& dev_ctx,
       x.dtype(),
       value.dtype(),
       phi::errors::InvalidArgument(
-          "The data type of tensor in indices must be same to the data type "
+          "The data type of tensor value must be same to the data type "
           "of tensor x."));
   PADDLE_ENFORCE_EQ(indices.empty(),
                     false,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
This PR add data_type for selecting which arg's datatype to instantiate template type T for index_put kernel
Related PR [#53652](https://github.com/PaddlePaddle/Paddle/pull/53652)