### PR TITLE
[XPU] remove clip of c_softmax_with_cross_entropy op

### DIFF
--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
@@ -131,13 +131,6 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::XPUContext, T> {
       };
       phi::XPUElementwise<T, XPUType>(
           dev_ctx, logits_2d, logits_max, axis, &softmax_2d, f);
-      ret = xpu::clip<XPUType>(dev_ctx.x_context(),
-                               reinterpret_cast<XPUType*>(softmax_2d.data<T>()),
-                               reinterpret_cast<XPUType*>(softmax_2d.data<T>()),
-                               N * D,
-                               -64.,
-                               0.);
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "clip");
     }
 
     // step 3, obtain predict target
@@ -335,13 +328,6 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::XPUContext, T> {
       };
       phi::XPUElementwise<T, XPUType>(
           dev_ctx, logits_2d, logits_max, axis, &softmax_2d, f);
-      ret = xpu::clip<XPUType>(dev_ctx.x_context(),
-                               reinterpret_cast<XPUType*>(softmax_2d.data<T>()),
-                               reinterpret_cast<XPUType*>(softmax_2d.data<T>()),
-                               N * D,
-                               -64.,
-                               0.);
-      PADDLE_ENFORCE_XDNN_SUCCESS(ret, "clip");
     }
 
     // step 3, obtain predict target

--- a/test/xpu/collective_softmax_with_cross_entropy_op_xpu.py
+++ b/test/xpu/collective_softmax_with_cross_entropy_op_xpu.py
@@ -133,7 +133,7 @@ class TestCollectiveSoftmaxWithCE(TestCollectiveRunnerBase):
         # each xpu uses own half of logits
         np.random.seed(os.getpid())
         logits = np.random.uniform(
-            low=-10.0, high=10.0, size=(self.batch_size, self.local_elements)
+            low=-40.0, high=40.0, size=(self.batch_size, self.local_elements)
         ).astype(np_data_type)
         out = exe.run(
             train_prog,

--- a/test/xpu/test_collective_softmax_with_cross_entropy_xpu.py
+++ b/test/xpu/test_collective_softmax_with_cross_entropy_xpu.py
@@ -33,7 +33,7 @@ def stable_softmax(x):
     """Compute the softmax of vector x in a numerically stable way."""
     # clip to shiftx, otherwise, when calc loss with
     # log(exp(shiftx)), may get log(0)=INF
-    shiftx = (x - np.max(x)).clip(-64.0)
+    shiftx = x - np.max(x)
     exps = np.exp(shiftx)
     return exps / np.sum(exps)
 
@@ -131,13 +131,13 @@ class XPUTestCSoftmaxWithCEOP(XPUOpTestWrapper):
             # get input data for rank 0
             np.random.seed(pid0)
             input0 = np.random.uniform(
-                low=-10.0, high=10.0, size=(self.batch_size, local_elements)
+                low=-40.0, high=40.0, size=(self.batch_size, local_elements)
             ).astype(np_data_type)
 
             # get input data for rank 1
             np.random.seed(pid1)
             input1 = np.random.uniform(
-                low=-10.0, high=10.0, size=(self.batch_size, local_elements)
+                low=-40.0, high=40.0, size=(self.batch_size, local_elements)
             ).astype(np_data_type)
 
             # get combined input data


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Description
* 在`c_softmax_with_cross_entropy`算子中，原先的GPU实现是带有一个`clip`操作的。因此在 https://github.com/PaddlePaddle/Paddle/pull/52356 中，给XPU下的实现也增加了`clip`操作。
* 但是近期GPU的实现中，去掉了`clip`操作：https://github.com/PaddlePaddle/Paddle/pull/53547 ，因此本PR也跟着去掉这个操作。