### PR TITLE
【Hackathon】64.  full_batch_size_like算子 float16 单测完善

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fill_constant_batch_size_like.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_batch_size_like.py
@@ -38,11 +38,12 @@ def fill_constant_batch_size_like(
     )
 
 
-class TestFillConstatnBatchSizeLike1(OpTest):
+class TestFillConstantBatchSizeLike1(OpTest):
     # test basic
     def setUp(self):
         self.op_type = "fill_constant_batch_size_like"
         self.python_api = fill_constant_batch_size_like
+        self.init_dtype()
         self.init_data()
 
         input = np.zeros(self.shape)
@@ -59,9 +60,11 @@ class TestFillConstatnBatchSizeLike1(OpTest):
             'force_cpu': self.force_cpu,
         }
 
+    def init_dtype(self):
+        self.dtype = np.float32
+
     def init_data(self):
         self.shape = [10, 10]
-        self.dtype = np.float32
         self.value = 100
         self.input_dim_idx = 0
         self.output_dim_idx = 0
@@ -71,11 +74,16 @@ class TestFillConstatnBatchSizeLike1(OpTest):
         self.check_output()
 
 
+class TestFillConstantBatchSizeLikeFP16Op(TestFillConstantBatchSizeLike1):
+    def init_dtype(self):
+        self.dtype = np.float16
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda() or not core.supports_bfloat16(),
     "core is not compiled with CUDA or place do not support bfloat16",
 )
-class TestFillConstatnBatchSizeLikeBf16(OpTest):
+class TestFillConstantBatchSizeLikeBF16Op(OpTest):
     # test bf16
     def setUp(self):
         self.op_type = "fill_constant_batch_size_like"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
full_batch_size_like算子 float16 单测完善

![图片](https://github.com/PaddlePaddle/Paddle/assets/4617245/f8dd6128-8a03-4187-a029-1816820e8ad0)
![图片](https://github.com/PaddlePaddle/Paddle/assets/4617245/badb5a32-fdae-4dfa-b2fc-1e560ae63d3a)

fill_constant_batch_size_like 使用的是 full_batch_size_like

![图片](https://github.com/PaddlePaddle/Paddle/assets/4617245/dc746f81-cd00-4d7c-ab2e-0809e40f42aa)
float16, bfloat16已增加