### PR TITLE
Change for windows static_assert

### DIFF
--- a/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
+++ b/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
@@ -535,10 +535,11 @@ void ComputeFusedGemmEpilogueBackwardImpl(const phi::GPUContext& dev_ctx,
                                           bool use_addto_dx,
                                           bool use_addto_dy) {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  static_assert(std::is_same<DXT, T>::value || std::is_same<DXT, MT>::value,
-                "");
-  static_assert(std::is_same<DYT, T>::value || std::is_same<DYT, MT>::value,
-                "");
+  constexpr bool kIsValidDataType =
+      (std::is_same<DXT, T>::value || std::is_same<DXT, MT>::value) &&
+      (std::is_same<DYT, T>::value || std::is_same<DYT, MT>::value);
+  static_assert(kIsValidDataType, "Invalid data type");
+
   using Trait = FusedGEMMGradTrait<TransX, TransY>;
 
   if (dx) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->

Pcard-70768

- Fix `static_assert` bug in Windows CUDA 11.6 compilation. This may be the bug of msvc.