### PR TITLE
[PHI][CustomDevice] Enable CustomDevice to use CopyWithContext

### DIFF
--- a/paddle/phi/kernels/funcs/strided_memcpy.h
+++ b/paddle/phi/kernels/funcs/strided_memcpy.h
@@ -56,7 +56,8 @@ inline void CopyWithContext(const Context& ctx,
                             const Place& src_place,
                             const void* src,
                             size_t num) {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
   memory_utils::Copy(dst_place, dst, src_place, src, num, ctx.stream());
 #else
   PADDLE_THROW(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
When to use **phi::funcs::StridedMemcpyWithAxis0**
There will be an exception.
Old Code
```cpp
template <typename Context>
inline void CopyWithContext(const Context& ctx,
                            const Place& dst_place,
                            void* dst,
                            const Place& src_place,
                            const void* src,
                            size_t num) {
#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
  memory_utils::Copy(dst_place, dst, src_place, src, num, ctx.stream());
#else
  PADDLE_THROW(
      phi::errors::PreconditionNotMet("Paddle is not compiled with GPU."));
#endif
}
```
The macro only allow gpu to use **CopyWithContext / phi::funcs::StridedMemcpyWithAxis0**.
If you use custom device, you will get:
```
C++ exception with description "(PreconditionNotMet) Paddle is not compiled with GPU. (at ../third_party/paddle/include/paddle/phi/kernels/funcs/strided_memcpy.h:62)
```
So the commit is remove the limitation to allow all device to use **CopyWithContext/phi::funcs::StridedMemcpyWithAxis0**

**CopyWithContext/phi::funcs::StridedMemcpyWithAxis0**
存在无意义的限制。只允许GPU使用。
CustomDevice使用不了。
这个commit解除了这个限制。