### PR TITLE
【CINN】fix bug of test_pad_op for cinn

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -1949,15 +1949,15 @@ void pad_grad(const Tensor& input,
     size_t rank = input.dims().size();
     auto out_dims = out_grad.dims();
 
-    std::vector<int> starts(rank, 0);
+    std::vector<int64_t> starts(rank, 0);
     std::vector<int64_t> ends(rank, 0);
     std::vector<int64_t> axes(rank, 0);
     std::vector<int64_t> infer_flags(rank, 1);
     std::vector<int64_t> decrease_axis({});
     for (size_t i = 0; i < rank; ++i) {
-      starts.push_back(static_cast<int>(paddings[2 * i]));
-      ends.push_back(static_cast<int64_t>(out_dims[i] - paddings[2 * i + 1]));
-      axes.push_back(i);
+      starts[i] = static_cast<int64_t>(paddings[2 * i]);
+      ends[i] = static_cast<int64_t>(out_dims[i] - paddings[2 * i + 1]);
+      axes[i] = i;
     }
     auto out_tmp =
         slice<T>(out_grad, axes, starts, ends, infer_flags, decrease_axis);

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -51,7 +51,6 @@ class TestPadOp(OpTest):
         }
         self.prim_op_type = "prim"
         self.public_python_api = pad_wrapper
-        self.enable_cinn = False
 
     def get_dtype(self):
         return np.float64


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
Pcard-66971

修复`pad`算子单测在CINN执行错误的问题。
错误原因为`pad_grad`反向算子组合逻辑中实现代码存在Bug，本PR对此Bug进行了修复。