### PR TITLE
Fix bug of hybrid_parallel_optimizer

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -432,7 +432,9 @@ class HybridParallelOptimizer:
         # minimize does not support parameters in the form of param_group,
         # so no need use _obtain_optimizer_parameters_list
         parameter_list = (
-            parameters if parameters else self._inner_opt._parameter_list
+            parameters
+            if parameters
+            else _obtain_optimizer_parameters_list(self._inner_opt)
         )
 
         # Here sharding should use global parameter list


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Description
Fix bug of hybrid_parallel_optimizer, amp use `scaler.minimize()`, however it can't deal with group of parameter_list of dict.

card-70094
