### PR TITLE
fix processing logic of the arange function when dtype is empty.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_arange.py
+++ b/python/paddle/fluid/tests/unittests/test_arange.py
@@ -176,6 +176,10 @@ class TestArangeImperative(unittest.TestCase):
         for i in [x1, x2, x3, x4]:
             self.assertEqual((i.numpy() == expected_data).all(), True)
 
+        x5 = paddle.arange(start, np.array([0.5], 'float32'), step)
+        x5_expected_data = np.arange(0, 0.5, 1).astype(np.float32)
+        self.assertEqual((x5.numpy() == x5_expected_data).all(), True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_arange.py
+++ b/python/paddle/fluid/tests/unittests/test_arange.py
@@ -203,6 +203,11 @@ class TestArangeImperative(unittest.TestCase):
         x9_expected_data = np.arange(1).astype(np.int64)
         self.assertEqual((x9.numpy() == x9_expected_data).all(), True)
 
+        # [start] is float
+        x10 = paddle.arange(1.0)
+        x10_expected_data = np.arange(1).astype(np.float32)
+        self.assertEqual((x10.numpy() == x10_expected_data).all(), True)
+
         paddle.enable_static()
 
 

--- a/python/paddle/fluid/tests/unittests/test_arange.py
+++ b/python/paddle/fluid/tests/unittests/test_arange.py
@@ -170,7 +170,6 @@ class TestArangeImperative(unittest.TestCase):
         end = paddle.to_tensor(np.array([5], 'float32'))
         step = paddle.to_tensor(np.array([1], 'float32'))
         x4 = paddle.arange(start, end, step, 'int64')
-        paddle.enable_static()
 
         expected_data = np.arange(0, 5, 1).astype(np.int64)
         for i in [x1, x2, x3, x4]:
@@ -203,6 +202,8 @@ class TestArangeImperative(unittest.TestCase):
         x9 = paddle.arange(1)
         x9_expected_data = np.arange(1).astype(np.int64)
         self.assertEqual((x9.numpy() == x9_expected_data).all(), True)
+
+        paddle.enable_static()
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_arange.py
+++ b/python/paddle/fluid/tests/unittests/test_arange.py
@@ -176,11 +176,33 @@ class TestArangeImperative(unittest.TestCase):
         for i in [x1, x2, x3, x4]:
             self.assertEqual((i.numpy() == expected_data).all(), True)
 
-        x5 = paddle.arange(
-            start, paddle.to_tensor(np.array([0.5], 'float32')), step
-        )
-        x5_expected_data = np.arange(0, 0.5, 1).astype(np.float32)
+        start_float = paddle.to_tensor(np.array([0.5], 'float32'))
+        end_float = paddle.to_tensor(np.array([1.5], 'float32'))
+        step_float = paddle.to_tensor(np.array([0.5], 'float32'))
+        # all [start, end, step] is float
+        x5 = paddle.arange(start_float, end_float, step_float)
+        x5_expected_data = np.arange(0.5, 1.5, 0.5).astype(np.float32)
         self.assertEqual((x5.numpy() == x5_expected_data).all(), True)
+
+        # [start, end] is float , [step] is int
+        x6 = paddle.arange(start_float, end_float, 1)
+        x6_expected_data = np.arange(0.5, 1.5, 1).astype(np.float32)
+        self.assertEqual((x6.numpy() == x6_expected_data).all(), True)
+
+        # [start] is float , [end] is int
+        x7 = paddle.arange(start_float, 1)
+        x7_expected_data = np.arange(0.5, 1).astype(np.float32)
+        self.assertEqual((x7.numpy() == x7_expected_data).all(), True)
+
+        # [start] is float
+        x8 = paddle.arange(start_float)
+        x8_expected_data = np.arange(0.5).astype(np.float32)
+        self.assertEqual((x8.numpy() == x8_expected_data).all(), True)
+
+        # [start] is int
+        x9 = paddle.arange(1)
+        x9_expected_data = np.arange(1).astype(np.int64)
+        self.assertEqual((x9.numpy() == x9_expected_data).all(), True)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_arange.py
+++ b/python/paddle/fluid/tests/unittests/test_arange.py
@@ -176,7 +176,9 @@ class TestArangeImperative(unittest.TestCase):
         for i in [x1, x2, x3, x4]:
             self.assertEqual((i.numpy() == expected_data).all(), True)
 
-        x5 = paddle.arange(start, np.array([0.5], 'float32'), step)
+        x5 = paddle.arange(
+            start, paddle.to_tensor(np.array([0.5], 'float32')), step
+        )
         x5_expected_data = np.arange(0, 0.5, 1).astype(np.float32)
         self.assertEqual((x5.numpy() == x5_expected_data).all(), True)
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1306,10 +1306,9 @@ def arange(start=0, end=None, step=1, dtype=None, name=None):
 
     if dtype is None:
         for val in [start, end, step]:
-            if not isinstance(val, int) and isinstance(val, Variable):
-                if not paddle.to_tensor(val).is_integer():
-                    dtype = paddle.get_default_dtype()
-                    break
+            if isinstance(val, Variable) and not val.is_integer():
+                dtype = paddle.get_default_dtype()
+                break
             elif not isinstance(val, int) and not isinstance(val, Variable):
                 dtype = paddle.get_default_dtype()
                 break

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1305,12 +1305,17 @@ def arange(start=0, end=None, step=1, dtype=None, name=None):
         start = 0
 
     if dtype is None:
-        if not all(
-            paddle.to_tensor(val).is_integer() for val in [start, end, step]
-        ):
-            dtype = paddle.get_default_dtype()
-        else:
-            dtype = 'int64'
+        for val in [start, end, step]:
+            if not isinstance(val, int) and isinstance(val, Variable):
+                if not paddle.to_tensor(val).is_integer():
+                    dtype = paddle.get_default_dtype()
+                    break
+            elif not isinstance(val, int) and not isinstance(val, Variable):
+                dtype = paddle.get_default_dtype()
+                dtype = paddle.get_default_dtype()
+                break
+            else:
+                dtype = 'int64'
 
     out_shape = None
     if not in_dygraph_mode() and (

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1300,6 +1300,10 @@ def arange(start=0, end=None, step=1, dtype=None, name=None):
             # [3, 4, 5, 6]
 
     """
+    if end is None:
+        end = start
+        start = 0
+
     if dtype is None:
         if not all(
             paddle.to_tensor(val).is_integer() for val in [start, end, step]
@@ -1307,9 +1311,6 @@ def arange(start=0, end=None, step=1, dtype=None, name=None):
             dtype = paddle.get_default_dtype()
         else:
             dtype = 'int64'
-    if end is None:
-        end = start
-        start = 0
 
     out_shape = None
     if not in_dygraph_mode() and (

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -542,17 +542,27 @@ def logspace(start, stop, num, base=10.0, dtype=None, name=None):
 
 
 def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
+    def _handle_tensor_dtype(tensor, dtype):
+        if dtype:
+            if convert_dtype(dtype) != convert_dtype(tensor.dtype):
+                return tensor.astype(convert_dtype(dtype))
+        return tensor
+
+    def _handle_np_dtype(ndarray, dtype):
+        if dtype:
+            if convert_dtype(dtype) != convert_dtype(ndarray.dtype):
+                # should not ndarray.astype('uint16') directly, data bits is wrong
+                if convert_dtype(dtype) in ['uint16']:
+                    return convert_float_to_uint16(ndarray.astype('float32'))
+                else:
+                    return ndarray.astype(convert_dtype(dtype))
+
+        return ndarray
 
     if isinstance(data, np.number):  # Special case for numpy scalars
         data = np.array(data)
 
     if not isinstance(data, np.ndarray):
-
-        def _handle_dtype(data, dtype):
-            if dtype:
-                if convert_dtype(dtype) != convert_dtype(data.dtype):
-                    return data.astype(convert_dtype(dtype))
-            return data
 
         if np.isscalar(data) and not isinstance(data, str):
             data = np.array(data)
@@ -565,12 +575,12 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
                 )
         elif isinstance(data, paddle.Tensor) and not in_dygraph_mode():
             data = data._copy_to(place, False)
-            data = _handle_dtype(data, dtype)
+            data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
         elif isinstance(data, core.eager.Tensor) and in_dygraph_mode():
             data = data._copy_to(place, False)
-            data = _handle_dtype(data, dtype)
+            data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
         elif isinstance(data, (core.LoDTensor, core.Tensor)):
@@ -583,7 +593,7 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
                 data = paddle.Tensor(data)
             if not data.place._equals(place):
                 data = data._copy_to(place, False)
-            data = _handle_dtype(data, dtype)
+            data = _handle_tensor_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
         else:
@@ -607,18 +617,13 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
                         if default_type in ['float16', 'float32']
                         else 'complex128'
                     )
-                data = data.astype(default_type)
+                data = _handle_np_dtype(data, default_type)
             # Windows default type is 'int32', while Linux/Mac is 'int64'. Unify they.
             if data.dtype in ['int32']:
-                default_type = "int64"
-                data = data.astype(default_type)
+                data = data.astype("int64")
 
-    if dtype and convert_dtype(dtype) != data.dtype:
-        if convert_dtype(dtype) in ['uint16']:
-            # should not ndarray.astype('uint16') directly, data bits is wrong
-            data = convert_float_to_uint16(data.astype('float32'))
-        else:
-            data = data.astype(convert_dtype(dtype))
+    if dtype:
+        data = _handle_np_dtype(data, dtype)
 
     if _in_eager_without_dygraph_check() and isinstance(data, np.ndarray):
         return core.eager.Tensor(
@@ -641,8 +646,10 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
 
 def _to_tensor_static(data, dtype=None, stop_gradient=None):
 
-    if isinstance(data, Variable) and (dtype is None or dtype == data.dtype):
+    if isinstance(data, Variable):
         output = data
+        if dtype is not None and dtype != data.dtype:
+            output = paddle.cast(output, dtype)
     else:
         if isinstance(data, np.number):  # Special case for numpy scalars
             data = np.array(data)
@@ -651,17 +658,37 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
             if np.isscalar(data) and not isinstance(data, str):
                 data = np.array(data)
             elif isinstance(data, (list, tuple)):
-                data = np.array(data)
+                try:
+                    '''
+                    In numpy version >= 1.24.0, case like:
+                        np.array([Variable, 1, 2])
+                    is not supported, it will raise error (numpy returns an numpy array with dtype='object' in version <= 1.23.5)
 
-            if (
-                isinstance(data, np.ndarray)
-                and not dtype
-                and data.dtype != 'object'
-            ):
-                if data.dtype in ['float16', 'float32', 'float64']:
-                    data = data.astype(paddle.get_default_dtype())
-                elif data.dtype in ['int32']:
-                    data = data.astype('int64')
+                    Thus, process nested structure in except block
+                    '''
+                    data = np.array(data)
+
+                    # for numpy version <= 1.23.5
+                    if data.dtype == 'object':
+                        raise RuntimeError("Numpy get dtype `object`.")
+
+                except:
+                    to_stack_list = [None] * len(data)
+                    for idx, d in enumerate(data):
+                        to_stack_list[idx] = _to_tensor_static(
+                            d, dtype, stop_gradient
+                        )
+                    data = paddle.stack(to_stack_list)
+                    data = paddle.squeeze(data, -1)
+
+            else:
+                raise RuntimeError(
+                    f"Do not support transform type `{type(data)}` to tensor"
+                )
+
+            # fix numpy default dtype
+            if data.dtype in ['float16', 'float32', 'float64']:
+                data = data.astype(paddle.get_default_dtype())
 
         if dtype:
             target_dtype = dtype
@@ -669,24 +696,10 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
             target_dtype = data.dtype
         else:
             target_dtype = paddle.get_default_dtype()
-
         target_dtype = convert_dtype(target_dtype)
 
-        if (
-            isinstance(data, np.ndarray)
-            and len(data.shape) > 0
-            and any(isinstance(x, Variable) for x in data)
-        ):
-            to_stack_list = [None] * data.shape[0]
-            for idx, d in enumerate(data):
-                to_stack_list[idx] = _to_tensor_static(d, dtype, stop_gradient)
-            data = paddle.stack(to_stack_list)
-            data = paddle.squeeze(data, -1)
+        output = assign(data)
 
-        if not isinstance(data, Variable):
-            output = assign(data)
-        else:
-            output = data
         if convert_dtype(output.dtype) != target_dtype:
             output = paddle.cast(output, target_dtype)
 
@@ -2214,7 +2227,7 @@ def _memcpy(input, place=None, output=None):
     """
 
     The OP copies the :attr:`input` to the :attr:`output`.
-    NOTE: currently, only support CUDAPlace <-> CUDAPinnedPlace or NPUPlace <-> CPUPlace.
+    NOTE: currently, only support CUDAPlace <-> CUDAPinnedPlace.
 
     Parameters:
         input (Tensor): A tensor. Its data type supports float16, float32, float64, int32, int64, and bool.

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1312,7 +1312,6 @@ def arange(start=0, end=None, step=1, dtype=None, name=None):
                     break
             elif not isinstance(val, int) and not isinstance(val, Variable):
                 dtype = paddle.get_default_dtype()
-                dtype = paddle.get_default_dtype()
                 break
             else:
                 dtype = 'int64'

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -542,27 +542,17 @@ def logspace(start, stop, num, base=10.0, dtype=None, name=None):
 
 
 def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
-    def _handle_tensor_dtype(tensor, dtype):
-        if dtype:
-            if convert_dtype(dtype) != convert_dtype(tensor.dtype):
-                return tensor.astype(convert_dtype(dtype))
-        return tensor
-
-    def _handle_np_dtype(ndarray, dtype):
-        if dtype:
-            if convert_dtype(dtype) != convert_dtype(ndarray.dtype):
-                # should not ndarray.astype('uint16') directly, data bits is wrong
-                if convert_dtype(dtype) in ['uint16']:
-                    return convert_float_to_uint16(ndarray.astype('float32'))
-                else:
-                    return ndarray.astype(convert_dtype(dtype))
-
-        return ndarray
 
     if isinstance(data, np.number):  # Special case for numpy scalars
         data = np.array(data)
 
     if not isinstance(data, np.ndarray):
+
+        def _handle_dtype(data, dtype):
+            if dtype:
+                if convert_dtype(dtype) != convert_dtype(data.dtype):
+                    return data.astype(convert_dtype(dtype))
+            return data
 
         if np.isscalar(data) and not isinstance(data, str):
             data = np.array(data)
@@ -575,12 +565,12 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
                 )
         elif isinstance(data, paddle.Tensor) and not in_dygraph_mode():
             data = data._copy_to(place, False)
-            data = _handle_tensor_dtype(data, dtype)
+            data = _handle_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
         elif isinstance(data, core.eager.Tensor) and in_dygraph_mode():
             data = data._copy_to(place, False)
-            data = _handle_tensor_dtype(data, dtype)
+            data = _handle_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
         elif isinstance(data, (core.LoDTensor, core.Tensor)):
@@ -593,7 +583,7 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
                 data = paddle.Tensor(data)
             if not data.place._equals(place):
                 data = data._copy_to(place, False)
-            data = _handle_tensor_dtype(data, dtype)
+            data = _handle_dtype(data, dtype)
             data.stop_gradient = stop_gradient
             return data
         else:
@@ -617,13 +607,18 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
                         if default_type in ['float16', 'float32']
                         else 'complex128'
                     )
-                data = _handle_np_dtype(data, default_type)
+                data = data.astype(default_type)
             # Windows default type is 'int32', while Linux/Mac is 'int64'. Unify they.
             if data.dtype in ['int32']:
-                data = data.astype("int64")
+                default_type = "int64"
+                data = data.astype(default_type)
 
-    if dtype:
-        data = _handle_np_dtype(data, dtype)
+    if dtype and convert_dtype(dtype) != data.dtype:
+        if convert_dtype(dtype) in ['uint16']:
+            # should not ndarray.astype('uint16') directly, data bits is wrong
+            data = convert_float_to_uint16(data.astype('float32'))
+        else:
+            data = data.astype(convert_dtype(dtype))
 
     if _in_eager_without_dygraph_check() and isinstance(data, np.ndarray):
         return core.eager.Tensor(
@@ -646,10 +641,8 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
 
 def _to_tensor_static(data, dtype=None, stop_gradient=None):
 
-    if isinstance(data, Variable):
+    if isinstance(data, Variable) and (dtype is None or dtype == data.dtype):
         output = data
-        if dtype is not None and dtype != data.dtype:
-            output = paddle.cast(output, dtype)
     else:
         if isinstance(data, np.number):  # Special case for numpy scalars
             data = np.array(data)
@@ -658,37 +651,17 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
             if np.isscalar(data) and not isinstance(data, str):
                 data = np.array(data)
             elif isinstance(data, (list, tuple)):
-                try:
-                    '''
-                    In numpy version >= 1.24.0, case like:
-                        np.array([Variable, 1, 2])
-                    is not supported, it will raise error (numpy returns an numpy array with dtype='object' in version <= 1.23.5)
+                data = np.array(data)
 
-                    Thus, process nested structure in except block
-                    '''
-                    data = np.array(data)
-
-                    # for numpy version <= 1.23.5
-                    if data.dtype == 'object':
-                        raise RuntimeError("Numpy get dtype `object`.")
-
-                except:
-                    to_stack_list = [None] * len(data)
-                    for idx, d in enumerate(data):
-                        to_stack_list[idx] = _to_tensor_static(
-                            d, dtype, stop_gradient
-                        )
-                    data = paddle.stack(to_stack_list)
-                    data = paddle.squeeze(data, -1)
-
-            else:
-                raise RuntimeError(
-                    f"Do not support transform type `{type(data)}` to tensor"
-                )
-
-            # fix numpy default dtype
-            if data.dtype in ['float16', 'float32', 'float64']:
-                data = data.astype(paddle.get_default_dtype())
+            if (
+                isinstance(data, np.ndarray)
+                and not dtype
+                and data.dtype != 'object'
+            ):
+                if data.dtype in ['float16', 'float32', 'float64']:
+                    data = data.astype(paddle.get_default_dtype())
+                elif data.dtype in ['int32']:
+                    data = data.astype('int64')
 
         if dtype:
             target_dtype = dtype
@@ -696,10 +669,24 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
             target_dtype = data.dtype
         else:
             target_dtype = paddle.get_default_dtype()
+
         target_dtype = convert_dtype(target_dtype)
 
-        output = assign(data)
+        if (
+            isinstance(data, np.ndarray)
+            and len(data.shape) > 0
+            and any(isinstance(x, Variable) for x in data)
+        ):
+            to_stack_list = [None] * data.shape[0]
+            for idx, d in enumerate(data):
+                to_stack_list[idx] = _to_tensor_static(d, dtype, stop_gradient)
+            data = paddle.stack(to_stack_list)
+            data = paddle.squeeze(data, -1)
 
+        if not isinstance(data, Variable):
+            output = assign(data)
+        else:
+            output = data
         if convert_dtype(output.dtype) != target_dtype:
             output = paddle.cast(output, target_dtype)
 
@@ -1301,7 +1288,12 @@ def arange(start=0, end=None, step=1, dtype=None, name=None):
 
     """
     if dtype is None:
-        dtype = 'int64'
+        if not all(
+            paddle.to_tensor(val).is_integer() for val in [start, end, step]
+        ):
+            dtype = paddle.get_default_dtype()
+        else:
+            dtype = 'int64'
     if end is None:
         end = start
         start = 0
@@ -2222,7 +2214,7 @@ def _memcpy(input, place=None, output=None):
     """
 
     The OP copies the :attr:`input` to the :attr:`output`.
-    NOTE: currently, only support CUDAPlace <-> CUDAPinnedPlace.
+    NOTE: currently, only support CUDAPlace <-> CUDAPinnedPlace or NPUPlace <-> CPUPlace.
 
     Parameters:
         input (Tensor): A tensor. Its data type supports float16, float32, float64, int32, int64, and bool.


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
card-71012
arange API 升级，支持在start/end/step不为int，且dtype为空时，设置dtype为get_default_dtype()