### PR TITLE
fix fmha, when use cache, the first step should assign cache_kv_out

### DIFF
--- a/paddle/fluid/operators/fused/fmha_ref.h
+++ b/paddle/fluid/operators/fused/fmha_ref.h
@@ -185,6 +185,8 @@ class FMHARef {
       // out [2, bs, num_head, cache_seq_len + seq_len, head_dim]
       concat(dev_ctx_, {*cache_kv_tensor, kv_tensor}, 3, cache_kv_out_tensor);
       out_seq_len = cache_kv_out_tensor->dims()[3];
+    } else {
+      *cache_kv_out_tensor = transpose_2_out_tensor->Slice(1, 3);
     }
 
     int64_t q_size = batch_size_ * seq_len_ * num_head_ * head_dim_;

--- a/paddle/phi/kernels/fusion/gpu/fmha_ref.h
+++ b/paddle/phi/kernels/fusion/gpu/fmha_ref.h
@@ -188,6 +188,8 @@ class FMHARef {
       // out [2, bs, num_head, cache_seq_len + seq_len, head_dim]
       concat(dev_ctx_, {*cache_kv_tensor, kv_tensor}, 3, cache_kv_out_tensor);
       out_seq_len = cache_kv_out_tensor->dims()[3];
+    } else {
+      *cache_kv_out_tensor = transpose_2_out_tensor->Slice(1, 3);
     }
 
     int64_t q_size = batch_size_ * seq_len_ * num_head_ * head_dim_;

--- a/paddle/phi/kernels/fusion/gpu/fmha_ref.h
+++ b/paddle/phi/kernels/fusion/gpu/fmha_ref.h
@@ -188,8 +188,6 @@ class FMHARef {
       // out [2, bs, num_head, cache_seq_len + seq_len, head_dim]
       concat(dev_ctx_, {*cache_kv_tensor, kv_tensor}, 3, cache_kv_out_tensor);
       out_seq_len = cache_kv_out_tensor->dims()[3];
-    } else {
-      *cache_kv_out_tensor = transpose_2_out_tensor->Slice(1, 3);
     }
 
     int64_t q_size = batch_size_ * seq_len_ * num_head_ * head_dim_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
### PR changes
OPs

### Description
修复fmha_ref.h中，当使用cache时，计算第一个token的时候，传入的cache_kv_tensor是空指针，无法给cache_kv_out_tensor赋值
