### PR TITLE
[Bug Fix] fix cpu build error

### DIFF
--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -29,8 +29,9 @@
 namespace paddle {
 namespace imperative {
 
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
-    defined(PADDLE_WITH_XPU_BKCL) || defined(PADDLE_WITH_GLOO)
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) ||     \
+    defined(PADDLE_WITH_XPU_BKCL) || defined(PADDLE_WITH_GLOO) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
 // div the nranks
 void Group::DivNRanks(const platform::DeviceContext &context, int64_t nranks) {
   phi::DenseTensor *tensor =

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -44,8 +44,9 @@ class VariableWrapper;
 namespace paddle {
 namespace imperative {
 
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
-    defined(PADDLE_WITH_XPU_BKCL) || defined(PADDLE_WITH_GLOO)
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) ||     \
+    defined(PADDLE_WITH_XPU_BKCL) || defined(PADDLE_WITH_GLOO) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
 
 template <typename T>
 struct DivNRanksFunctor {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Error occurs when building develop branch only for cpu device. This PR fixes the error.
```
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc: In function ‘void paddle::pybind::BindImperative(pybind11::module*)’:
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:26: error: ‘Reducer’ is not a member of ‘paddle::imperative’
 2490 |   py::class_<imperative::Reducer, std::shared_ptr<imperative::Reducer>>(
      |                          ^~~~~~~
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:26: error: ‘Reducer’ is not a member of ‘paddle::imperative’
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:63: error: ‘Reducer’ is not a member of ‘paddle::imperative’
 2490 |   py::class_<imperative::Reducer, std::shared_ptr<imperative::Reducer>>(
      |                                                               ^~~~~~~
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:63: error: ‘Reducer’ is not a member of ‘paddle::imperative’
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:63: error: template argument 1 is invalid
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:70: error: template argument 1 is invalid
 2490 |   py::class_<imperative::Reducer, std::shared_ptr<imperative::Reducer>>(
      |                                                                      ^~
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2490:70: error: template argument 2 is invalid
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2499:25: error: ‘paddle::imperative::Reducer’ has not been declared
 2499 |            &imperative::Reducer::PrepareForBackward,
      |                         ^~~~~~~
/home/qunyang/Paddle/paddle/fluid/pybind/imperative.cc:2504:22: error: ‘AssignGroupBySize’ is not a member of ‘paddle::imperative’
 2504 |         &imperative::AssignGroupBySize,
```

