### PR TITLE
[Werror][GCC9] fix -Werror=format-security

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
+++ b/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
@@ -77,8 +77,10 @@ class CustomPluginCreater : public OpConverter {
 
       // NOTE: to avoid string rewrite by iterator, deep copy here
       std::vector<char> plugin_attr_name(attr_name.length() + 1, 0);
-      snprintf(
-          plugin_attr_name.data(), attr_name.length() + 1, attr_name.c_str());
+      snprintf(plugin_attr_name.data(),
+               attr_name.length() + 1,
+               "%s",
+               attr_name.c_str());
       plugindata.name = plugin_attr_name.data();
 
       if (op_desc.GetAttrType(attr_name) == framework::proto::AttrType::INT) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

GCC9遇到如下编译Werror
```
/media/wjl/D2/github/fork/10/Paddle/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc: In member function ‘virtual void paddle::inference::tensorrt::CustomPluginCreater::operator()(const paddle::framework::proto::OpDesc&, const paddle::framework::Scope&, bool)’:
/media/wjl/D2/github/fork/10/Paddle/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc:81:77: error: format not a string literal and no format arguments [-Werror=format-security]
   81 |           plugin_attr_name.data(), attr_name.length() + 1, attr_name.c_str());
```

对于
```cpp
      snprintf(
          plugin_attr_name.data(), attr_name.length() + 1, attr_name.c_str());
```
这样是不合理的。必须有"%s"这样的字符串表达式，作为第三个参数，而不是变量attr_name.c_str() 

修改如下：
```cpp
      snprintf(plugin_attr_name.data(),
               attr_name.length() + 1,
               "%s",
               attr_name.c_str());
```

