### PR TITLE
[CustomOp Unittest] Fix XPU unittest, discard static backward

### DIFF
--- a/test/custom_op/test_custom_relu_op_xpu_setup.py
+++ b/test/custom_op/test_custom_relu_op_xpu_setup.py
@@ -46,9 +46,7 @@ def custom_relu_static(
     with static.scope_guard(static.Scope()):
         with static.program_guard(static.Program()):
             x = static.data(name='X', shape=[None, 8], dtype=dtype)
-            x.stop_gradient = False
             out = func(x) if use_func else paddle.nn.functional.relu(x)
-            static.append_backward(out)
 
             exe = static.Executor()
             exe.run(static.default_startup_program())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-66988

Maybe some PR introduces this bug recently, because [[CustomOP Unittest] XPU unittest only keep forward test #53021](https://github.com/PaddlePaddle/Paddle/pull/53021) can make sure all CIs passed.

Ref link: https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/8436984/job/22760246

<img width="919" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/17810795/0ab176e3-65a1-49b5-a509-2bb13bb3461e">