### PR TITLE
[AMP] remove depthwise_conv from extra black list

### DIFF
--- a/python/paddle/amp/amp_lists.py
+++ b/python/paddle/amp/amp_lists.py
@@ -85,7 +85,6 @@ FP16_EXTRA_BLACK_LIST = {
     'lookup_table',
     'lookup_table_v2',
     'scatter',
-    'depthwise_conv2d',
 }
 
 BF16_WHITE_LIST = {'conv2d', 'einsum', 'matmul_v2'}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Description
<!-- Describe what you’ve done --> 
Pcard-70458

remove depthwise_conv from extra black list
#50940 中扩充了黑名单，depthwise_conv2d被加入到框架默认的extra black list中，原因是过去我们发现depthwise_conv2d在fp16下的性能会差于fp32。

近期在模型库的测试中发现不少模型因为该算子在默认黑名单，O2下出现了一定程度性能下降。因此本PR先将depthwise_conv2d从extra black list中移除，后续还需对该算子进行性能测试和优化。