### PR TITLE
[XPU] fix bug on XPUPlace and AllGather

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -381,7 +381,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
                                                      phi::AllocationType::XPU);
   return Collective(
       out_tensor,
-      in_tensor,
+      in_tensor_maybe_partial,
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -349,6 +349,7 @@ from .framework import IPUPlace  # noqa: F401
 from .framework import CUDAPlace  # noqa: F401
 from .framework import CUDAPinnedPlace  # noqa: F401
 from .framework import CustomPlace  # noqa: F401
+from .framework import XPUPlace  # noqa: F401
 
 from .autograd import grad  # noqa: F401
 from .autograd import no_grad  # noqa: F401
@@ -380,7 +381,6 @@ from .device import is_compiled_with_cinn  # noqa: F401
 from .device import is_compiled_with_cuda  # noqa: F401
 from .device import is_compiled_with_rocm  # noqa: F401
 from .device import is_compiled_with_custom_device  # noqa: F401
-from .device import XPUPlace  # noqa: F401
 
 # high-level api
 from .hapi import Model  # noqa: F401

--- a/python/paddle/framework/__init__.py
+++ b/python/paddle/framework/__init__.py
@@ -25,6 +25,7 @@ from ..fluid.core import IPUPlace  # noqa: F401
 from ..fluid.core import CUDAPlace  # noqa: F401
 from ..fluid.core import CUDAPinnedPlace  # noqa: F401
 from ..fluid.core import CustomPlace  # noqa: F401
+from ..fluid.core import XPUPlace  # noqa: F401
 
 from ..fluid import core  # noqa: F401
 from ..fluid.dygraph import base, to_variable


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
本PR修复以下两个问题：

1、`AllGather`函数的传参不对。

2、python端的`XPUPlace`有问题，例如下面的代码和执行结果：

```
>>> paddle.CUDAPlace
<class 'paddle.fluid.libpaddle.CUDAPlace'>
>>> paddle.CPUPlace
<class 'paddle.fluid.libpaddle.CPUPlace'>
>>> paddle.XPUPlace
<function XPUPlace at 0x7ff0bf9abe60>
```

以及，调用`paddle.device.synchronize()`的时候会报错：

```
>>> paddle.device.synchronize()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/dist-packages/paddle/device/__init__.py", line 905, in synchronize
    elif paddle.is_compiled_with_xpu() and isinstance(place, paddle.XPUPlace):
TypeError: isinstance() arg 2 must be a type or tuple of types
```
