### PR TITLE
[Paddle Inference] Decrease peak memory

### DIFF
--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -66,13 +66,6 @@ void NaiveExecutor::Run() {
                                 platform::NvtxRangeColor::Green);
 #endif
 
-    // According to reuse table, we share the out tensor's holder.
-    if (reuse_cache_.count(op.get())) {
-      for (auto &it : reuse_cache_[op.get()]) {
-        it.first->ShareBufferWith(*cluster_buffer_[it.second], true);
-      }
-    }
-
     op->Run(*scope_, place_);
 
     // Update the shared_holder so that only records the max one.
@@ -81,6 +74,22 @@ void NaiveExecutor::Run() {
         if (it.first->memory_size() >
             cluster_buffer_[it.second]->memory_size()) {
           cluster_buffer_[it.second] = it.first;
+          int updated_cluster_id = it.second;
+
+          // cluster_buffer_[it.second] has been updated to be a new
+          // phi::DenseTensor*, we need change all phi::DenseTensor's
+          // shared_holder in this cluster. The following two loops code looks
+          // ugly, it does work. The following two loops seem time-consuming,
+          // but once the memory reaches its peak, the cluster will not update,
+          // so it's ok.
+          for (auto op_map : reuse_cache_) {
+            // op_map.second is std::unordered_map<phi::DenseTensor*, int>.
+            for (auto &it2 : op_map.second) {
+              if (it2.second == updated_cluster_id) {
+                it2.first->ShareBufferWith(*cluster_buffer_[it2.second], true);
+              }
+            }
+          }
         }
       }
     }

--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -82,7 +82,7 @@ void NaiveExecutor::Run() {
           // ugly, it does work. The following two loops seem time-consuming,
           // but once the memory reaches its peak, the cluster will not update,
           // so it's ok.
-          for (auto op_map : reuse_cache_) {
+          for (auto &op_map : reuse_cache_) {
             // op_map.second is std::unordered_map<phi::DenseTensor*, int>.
             for (auto &it2 : op_map.second) {
               if (it2.second == updated_cluster_id) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

- Decrease peak memory
- 时刻保持一个簇里的DenseTensor共享一个buffer
- 旧的内存共享：每个簇里只有一个DenseTensor，因而时时刻刻每个簇里只有一个底层的buffer。
- 新的内存共享：每个簇里有m 个 DenseTensor，并且我们没有时时刻刻保证这m个DenseTensor共享一个buffer，尽管稳定下来后肯定会共享一个buffer。
- 因此在新的内存共享下面我们要保证： 一个簇里面的m个 DenseTensor应该要 *时时刻刻* 共享 *唯一的* 一块buffer。
- 这能很大程度上减少峰值显存。
- vae模型测试：峰值内存：16.7G -> 14.3G 
- 另外一个模型测试：6650 MB ->6115 MB
