### PR TITLE
[0D-Tensor] Support elementwise_add

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.cc
@@ -94,13 +94,8 @@ FeedInfoMap CinnGraphSymbolization::GetFeedInfoMapFromInput() const {
       feed_map[feed_name] = utils::GetCinnFeedInfoFromTensor(*tensor);
     }
 
-    PADDLE_ENFORCE_NE(
-        feed_map[feed_name].shape.size(),
-        0UL,
-        platform::errors::PreconditionNotMet(
-            "The input variable %s's tensor shape cannot be empty,"
-            "we need the variable's dtype and shape from tensor.",
-            feed_name.c_str()));
+    VLOG_IF(4, feed_map[feed_name].shape.size() == 0UL)
+        << "Shape is empty, Create 0D-Tensor for " << feed_name;
   }
   return feed_map;
 }

--- a/paddle/fluid/framework/paddle2cinn/cinn_zero_tensor_trick_pass.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_zero_tensor_trick_pass.cc
@@ -58,6 +58,40 @@ void CinnZeroTensorTrickPass::ApplyImpl(ir::Graph* graph) const {
     }
   }
 
+  // CINN ops in this white list support 0D-Tensor
+  const std::unordered_set<std::string> white_op_list{"elementwise_add"};
+  std::unordered_set<std::string> white_tensor_name;
+  // enable white_op_list only when graph_node_size = 1, which means single op
+  // test
+  int graph_node_size = 0;
+  for (const ir::Node* n : graph->Nodes()) {
+    if (n->IsOp()) {
+      graph_node_size++;
+      VLOG(6) << "Graph has op node " << n->Op()->Type();
+      if (white_op_list.find(n->Op()->Type()) != white_op_list.end()) {
+        for (const ir::Node* var : n->inputs) {
+          white_tensor_name.insert(var->Var()->Name());
+
+          std::vector<int64_t> shape = var->Var()->GetShape();
+          if (shape.empty()) {
+            VLOG(6) << "input var " << var->Name()
+                    << " dims is empty, keep it's 0D-Tensor status";
+          }
+        }
+        for (const ir::Node* var : n->outputs) {
+          white_tensor_name.insert(var->Var()->Name());
+
+          std::vector<int64_t> shape = var->Var()->GetShape();
+          if (shape.empty()) {
+            VLOG(6) << "output var " << var->Name()
+                    << " dims is empty, keep it's 0D-Tensor status";
+          }
+        }
+      }
+    }
+  }
+  VLOG(6) << "Graph has " << graph_node_size << " op node";
+
   for (const ir::Node* n : graph->Nodes()) {
     if (n->IsOp() && op_cases_fix_attr.count(n->Op()->Type())) {
       if (n->Op()->HasAttr("shape")) {
@@ -85,6 +119,11 @@ void CinnZeroTensorTrickPass::ApplyImpl(ir::Graph* graph) const {
     }
     if (n->IsVar()) {
       if (n->Var() && n->Var()->GetType() == proto::VarType::LOD_TENSOR) {
+        if (graph_node_size == 1 && white_tensor_name.find(n->Var()->Name()) !=
+                                        white_tensor_name.end()) {
+          VLOG(6) << "Keep 0D-Tensor status of var " << n->Var()->Name();
+          continue;
+        }
         std::vector<int64_t> shape = n->Var()->GetShape();
         if (shape.empty()) {
           shape.push_back(1);

--- a/paddle/fluid/framework/paddle2cinn/cinn_zero_tensor_trick_pass_test.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_zero_tensor_trick_pass_test.cc
@@ -27,7 +27,7 @@ TEST(CinnZeroTensorTrickPass, basic) {
   ir::Layers layers;
   auto* x = layers.data("x", {});
   auto* y = layers.data("y", {3, 4});
-  auto* add_out_0 = layers.elementwise_add(x, y, nullptr, 0);
+  auto* add_out_0 = layers.mul(x, y, nullptr, 0);
   std::unique_ptr<ir::Graph> graph(new ir::Graph(layers.main_program()));
   auto pass = ir::PassRegistry::Instance().Get("cinn_zero_tensor_trick_pass");
   VLOG(3) << DebugString(graph);
@@ -43,7 +43,7 @@ TEST(CinnZeroTensorTrickPass, basic) {
             shape.empty(),
             false,
             platform::errors::PreconditionNotMet(
-                "The shape of elementwise_add should not be empty after fuse"));
+                "The shape of mul should not be empty after fuse"));
       }
     }
   }

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -123,18 +123,12 @@ class TestElementwiseAddOp_ZeroDim2(TestElementwiseAddOp_ZeroDim1):
         self.y = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
         self.out = np.add(self.x, self.y)
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
-
 
 class TestElementwiseAddOp_ZeroDim3(TestElementwiseAddOp_ZeroDim1):
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
         self.y = np.random.uniform(0.1, 1, []).astype(self.dtype)
         self.out = np.add(self.x, self.y)
-
-    def if_enable_cinn(self):
-        self.enable_cinn = False
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -116,9 +116,6 @@ class TestElementwiseAddOp_ZeroDim1(TestElementwiseAddOp):
         self.y = np.random.uniform(0.1, 1, []).astype(self.dtype)
         self.out = np.add(self.x, self.y)
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
-
 
 class TestElementwiseAddOp_ZeroDim2(TestElementwiseAddOp_ZeroDim1):
     def init_input_output(self):
@@ -126,12 +123,18 @@ class TestElementwiseAddOp_ZeroDim2(TestElementwiseAddOp_ZeroDim1):
         self.y = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
         self.out = np.add(self.x, self.y)
 
+    def if_enable_cinn(self):
+        self.enable_cinn = False
+
 
 class TestElementwiseAddOp_ZeroDim3(TestElementwiseAddOp_ZeroDim1):
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
         self.y = np.random.uniform(0.1, 1, []).astype(self.dtype)
         self.out = np.add(self.x, self.y)
+
+    def if_enable_cinn(self):
+        self.enable_cinn = False
 
 
 @unittest.skipIf(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
Pcard-71127

**Main change:**
1. [0D-Tensor] Support elementwise_add
2. `cinn_zero_tensor_trick_pass.cc` creates a white list, ops in this list will keep 0D-Tensor to verify the accuracy of 0D-Tensor ops in CINN.

Ref link: 
- https://github.com/PaddlePaddle/CINN/pull/1428
- https://github.com/PaddlePaddle/CINN/pull/1449
- Link to the first PR: #53382