### PR TITLE
[OpenBlas version] Revert logical for xpu.

### DIFF
--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -24,8 +24,9 @@ set(CBLAS_TAG v0.3.7)
 # And why compile when gcc>8.2? Please refer to
 # https://github.com/spack/spack/issues/19932#issuecomment-733452619
 # v0.3.18 only support gcc>=8.3 or gcc>=7.4
-if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND CMAKE_CXX_COMPILER_VERSION
-                                              VERSION_GREATER 8.2)
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.2
+   AND NOT WITH_XPU)
   # We only compile with openblas 0.3.18 when gcc >= 8.3
   set(CBLAS_TAG v0.3.18)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->


xpu和openblas都在默认namespace定义了bfloat16数据结构导致编译错误，XPU下不使用openblas 0.3.18版本。

<img width="1308" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/26377421/9a9541ff-8694-4e01-88a9-a32cbd56746f">
