### PR TITLE
silu op support to use fast_swish for xpu

### DIFF
--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -378,9 +378,15 @@ struct XPUSiluGradFunctor : public funcs::BaseActivationFunctor<T> {
     const XPUType* y_grad = reinterpret_cast<const XPUType*>(dout->data<T>());
     XPUType* x_grad = reinterpret_cast<XPUType*>(dx->data<T>());
 
-    int r = xpu::swish_grad(
-        dev_ctx.x_context(), x_data, y_grad, x_grad, dx->numel());
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "swish_grad");
+    if (std::getenv("XPU_PADDLE_ACT_LUT") != nullptr) {
+      int r = xpu::fast_swish_grad(
+          dev_ctx.x_context(), x_data, y_grad, x_grad, dx->numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "fast_swish_grad");
+    } else {
+      int r = xpu::swish_grad(
+          dev_ctx.x_context(), x_data, y_grad, x_grad, dx->numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "swish_grad");
+    }
   }
 };
 

--- a/paddle/phi/kernels/xpu/activation_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_kernel.cc
@@ -333,9 +333,15 @@ struct XPUSiluFunctor : public funcs::BaseActivationFunctor<T> {
     XPUType* y_data = reinterpret_cast<XPUType*>(out->data<T>());
 
     auto xpu_context = dev_ctx.x_context();
-    int r =
-        xpu::swish(xpu_context, x_data, y_data, x.numel(), nullptr, nullptr);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "swish");
+    if (std::getenv("XPU_PADDLE_ACT_LUT") != nullptr) {
+      int r = xpu::fast_swish(
+          xpu_context, x_data, y_data, x.numel(), nullptr, nullptr);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "fast_swish");
+    } else {
+      int r =
+          xpu::swish(xpu_context, x_data, y_data, x.numel(), nullptr, nullptr);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "swish");
+    }
   }
 };
 

--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -17,6 +17,8 @@ import unittest
 
 sys.path.append('../../python/paddle/fluid/tests/unittests')
 
+import os
+
 import numpy as np
 from eager_op_test import OpTest
 from get_test_cover_info import (
@@ -105,15 +107,37 @@ class XPUTestSiluOP(XPUOpTestWrapper):
             self.outputs = {'Out': out}
             self.attrs = {'use_xpu': True}
 
+        def test_check_output(self):
+            self.set_env()
+            self.check_output_with_place(self.place)
+            self.delete_env()
+
         def test_check_grad(self):
+            self.set_env()
             self.check_grad_with_place(self.place, ['X'], 'Out')
+            self.delete_env()
 
         def init_shape(self):
             self.shape = [11, 17]
 
+        def set_env(self):
+            pass
+
+        def delete_env(self):
+            pass
+
     class TestSilu_ZeroDim(XPUTestSilu):
         def init_shape(self):
             self.shape = []
+
+    class TestSilu_LUT(XPUTestSilu):
+        def set_env(self):
+            # set "XPU_PADDLE_ACT_LUT" env to enable lut
+            os.environ['XPU_PADDLE_ACT_LUT'] = "1"
+
+        def delete_env(self):
+            if os.getenv('XPU_PADDLE_ACT_LUT'):
+                del os.environ['XPU_PADDLE_ACT_LUT']
 
 
 class TestSiluAPI(unittest.TestCase):


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
silu激活函数支持使用查表法实现的fast_swish函数，在对精度不敏感的情况下使用该函数可以提升算子性能，通过XPU_PADDLE_ACT_LUT环境变量进行控制，默认不开启。

