### PR TITLE
fix device changed in setitem-numpy case

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1313,7 +1313,7 @@ static PyObject* tensor_method__setitem_eager_tensor(TensorObject* self,
       }
     }
   } else {
-    auto self_numpy = TensorToPyArray(*self_tensor);
+    auto self_numpy = TensorToPyArray(*self_tensor, true);
     VLOG(4) << "parse_index is false";
     if (PyCheckTensor(_index)) {
       VLOG(4) << "index is tensor";

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -1635,6 +1635,20 @@ class TestSetValueInplaceLeafVar(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestSetValueIsSamePlace(unittest.TestCase):
+    def test_is_same_place(self):
+        paddle.disable_static()
+        paddle.seed(100)
+        paddle.set_device('cpu')
+        a = paddle.rand(shape=[2, 3, 4])
+        origin_place = a.place
+        a[[0, 1], 1] = 10
+        self.assertEqual(origin_place._type(), a.place._type())
+        if paddle.is_compiled_with_cuda():
+            paddle.set_device('gpu')
+        paddle.enable_static()
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985
Now there will be an unexpected device change in combined-indexing of `__setitem__`
```python
>>> import paddle
>>> paddle.set_device('cpu')
>>> a.place
Place(cpu)
>>> a[[0,1],1] = 10
>>> a.place
Place(gpu:0)
```
This may cause some downstream task error, like https://github.com/PaddlePaddle/Paddle/issues/53829

