### PR TITLE
Make embedding grad op deterministic by default

### DIFF
--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -245,7 +245,7 @@ PHI_DEFINE_EXPORTED_bool(
  */
 PHI_DEFINE_EXPORTED_int64(
     embedding_deterministic,
-    0,
+    1,
     "Whether allow using an deterministic algorithm for embedding "
     "operator. The deterministic algorithm may be slower. If "
     "it is larger than 0, the algorithm is deterministic.");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
OPs

### Description
Make embedding grad deterministic by default.