### PR TITLE
fix 2 bug of eager

### DIFF
--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -141,6 +141,7 @@ std::vector<paddle::Tensor> RunBackward(
   std::deque<GradNodeBase*> orig_queue;
   std::unordered_map<GradNodeBase*, std::unique_ptr<GradTensorHolder>>
       node_input_buffers_dict;
+  std::unordered_set<GradNodeBase*> visited;
   for (size_t i = 0; i < tensors.size(); i++) {
     const paddle::Tensor& tensor = tensors[i];
 
@@ -215,6 +216,10 @@ std::vector<paddle::Tensor> RunBackward(
     }
 
     // Prepare queue, potential startup_nodes
+    if (visited.count(grad_node)) {
+      continue;
+    }
+    visited.insert(grad_node);
     queue.push_back(grad_node);
   }
 

--- a/paddle/fluid/eager/pylayer/py_layer_node.cc
+++ b/paddle/fluid/eager/pylayer/py_layer_node.cc
@@ -163,7 +163,7 @@ GradNodePyLayer::operator()(
                 {paddle::pybind::UnSafeGetTensorFromPyObject(obj)});
           } else if (obj == Py_None) {
             VLOG(4) << "Got None for Tensor with pos: " << i;
-            grad_out.push_back({});
+            grad_out.push_back({paddle::Tensor()});
           } else {
             PADDLE_THROW(phi::errors::InvalidArgument(
                 "We can only support Tensor or None for backward output, "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-64703
修复两个动态图bug：
1. PyLayer在backward返回None后，grad_out添加了弄的Vector。在backward.cc中，如果Vector是空的会continue，导致None失效。修改方法为在Vector中加一个空的Tensor。
2. backward.cc，如果反向初始多个Tensor为同一个Node的输入时，Node会被执行多次。需要去重。