### PR TITLE
Fixed the bug of kernel_signature in the api.cc.

### DIFF
--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -871,7 +871,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         }
         dense_out_trans_map = {
             'Tensor': 'phi::DenseTensor*',
-            'std::vector<Tensor>': 'std::vector<phi::DenseTensor*>&',
+            'std::vector<Tensor>': 'std::vector<phi::DenseTensor*>',
         }
         sr_input_trans_map = {
             'const Tensor&': 'const phi::SelectedRows&',


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Description
当phi kernel的输出为std::vector<DenseTensor*>类型时，函数指针kernel_signature中指定类型为std::vector<DenseTensor*>&（引用传递），kernel参数类型为std::vector<DenseTensor*> (按值传递)，这会导致kernel_out在执行完函数kernel_fn后被clear掉。

