### PR TITLE
Fix multicard bugs on ubuntu22.04

### DIFF
--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -829,9 +829,9 @@ void EagerReducer::MarkVarReady(const size_t var_index,
   const auto inside_group_index = var_locator.inside_group_index;
 
   auto &group = groups_[group_index];
-  auto &group_tensor = group.dense_tensors_[inside_group_index];
 
   if (!group.is_sparse_) {
+    auto &group_tensor = group.dense_tensors_[inside_group_index];
     const auto length = group.length_[inside_group_index];
     if (is_used_var) {
       auto *autograd_meta = tensors_[var_index].get_autograd_meta();

--- a/paddle/fluid/pybind/communication.cc
+++ b/paddle/fluid/pybind/communication.cc
@@ -79,6 +79,7 @@ void BindTCPStore(py::module *m) {
                           const std::string &key) -> py::bytes {
                          auto data = self.get(key);
                          std::string s(data.begin(), data.end());
+                         py::gil_scoped_acquire acquire;
                          return py::bytes(s);
                        },
                        py::arg("key"),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Description


#### [paddle/fluid/pybind/communication.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...eee4017:Paddle:fix_multicard_bugs_on_ubuntu22.04?expand=1#diff-61f2e43d449dedb617270b2752cd1e5608a82b2550d2924f8970fdd59c02617b)

It was observed that the creation of Python py::bytes(s) object does not correctly handle the Global Interpreter Lock (GIL). As per the [Pybind11 documentation](https://pybind11.readthedocs.io/en/stable/advanced/misc.html#common-sources-of-global-interpreter-lock-errors), the GIL should be acquired when changing the state of the Python interpreter. The existing implementation appears to function with Python 3.7 by chance, however, it fails when executed with Python 3.10. This difference in behavior points towards potential GIL handling issues.

#### [paddle/fluid/distributed/collective/reducer.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...eee4017:Paddle:fix_multicard_bugs_on_ubuntu22.04?expand=1#diff-a19fd91c843b04f4a0bfce01e7365bbde9373875d4b217a73c231fe45a24607b)

An out-of-bounds (OOB) access problem was identified when `tensor_indices_.size() == 1`, which is similar to the issue raised in #52785. The problem occurs within the [EagerReducer::InitializeGroups](https://github.com/eee4017/Paddle/blob/6f8bd38664f4b48e64f40e12eb13708a97d29772/paddle/fluid/distributed/collective/reducer.cc#L557) function. 
```
if (tensor_indices_.size() == 1 &&
    is_sparse_gradient_[tensor_indices_.front()]) {
  // process the sparse gradient. one sparse, one group
  group.dtype_ = first_var.dtype();
  group.is_sparse_ = true;
} else {
  // process the dense gradient.
  InitializeDenseGroups(tensor_indices_, &group);
}
```
If the size of `tensor_indices_` is 1 and the first index points to a sparse gradient, the `group` is marked as sparse and `InitializeDenseGroups` is not invoked. As a consequence, `group.dense_tensors_` is not populated for sparse groups. However, later in the code, there is an attempt to access `group.dense_tensors_[inside_group_index]` without verifying whether the group is sparse or not, leading to the OOB error.