### PR TITLE
Add enable/disable_model_check_nan_inf op

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -759,26 +759,26 @@
     func : triu_grad
 
 - backward_op: disable_check_model_nan_inf_grad
-  forward: disable_check_model_nan_inf (Tensor x) -> Tensor(out)
-  args: (Tensor x)
-  output: Tensor(x_grad)
+  forward: disable_check_model_nan_inf (Tensor x, int flag=0) -> Tensor(out)
+  args: (Tensor out_grad, int unsetflag = 1)
+  output : Tensor(x_grad)
   infer_meta:
     func: UnchangedInferMeta
-    param : [x]
+    param : [out_grad]
   kernel:
     func: check_model_nan_inf
-    data_type: x
+    data_type: out_grad
 
 - backward_op: enable_check_model_nan_inf_grad
-  forward: enable_check_model_nan_inf (Tensor x) -> Tensor(out)
-  args: (Tensor x)
-  output: Tensor(x_grad)
+  forward: enable_check_model_nan_inf (Tensor x, int flag=1) -> Tensor(out)
+  args: (Tensor out_grad, int unsetflag = 0)
+  output : Tensor(x_grad)
   infer_meta:
     func: UnchangedInferMeta
-    param : [x]
+    param : [out_grad]
   kernel:
     func: check_model_nan_inf
-    data_type: x
+    data_type: out_grad
 
 - backward_op: unpool_grad
   forward: unpool (Tensor x, Tensor indices, int[] ksize, int[] strides, int[] padding,  IntArray output_size, str data_format) -> Tensor(out)

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -758,6 +758,28 @@
   kernel :
     func : triu_grad
 
+- backward_op: disable_check_model_nan_inf_grad
+  forward: disable_check_model_nan_inf (Tensor x) -> Tensor(out)
+  args: (Tensor x)
+  output: Tensor(x_grad)
+  infer_meta:
+    func: UnchangedInferMeta
+    param : [x]
+  kernel:
+    func: check_model_nan_inf
+    data_type: x
+
+- backward_op: enable_check_model_nan_inf_grad
+  forward: enable_check_model_nan_inf (Tensor x) -> Tensor(out)
+  args: (Tensor x)
+  output: Tensor(x_grad)
+  infer_meta:
+    func: UnchangedInferMeta
+    param : [x]
+  kernel:
+    func: check_model_nan_inf
+    data_type: x
+
 - backward_op: unpool_grad
   forward: unpool (Tensor x, Tensor indices, int[] ksize, int[] strides, int[] padding,  IntArray output_size, str data_format) -> Tensor(out)
   args: (Tensor x, Tensor indices, Tensor out, Tensor out_grad, int[] ksize, int[] strides, int[] padding, IntArray output_size, str data_format)

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -209,6 +209,16 @@
     data_type : x
   backward : depthwise_conv2d_transpose_grad
 
+- op : disable_check_model_nan_inf
+  args: (Tensor x)
+  output: Tensor(out)
+  infer_meta:
+    func: UnchangedInferMeta
+  kernel:
+    func: check_model_nan_inf
+    data_type: x
+  backward: disable_check_model_nan_inf_grad
+
 - op : distribute_fpn_proposals
   args : (Tensor fpn_rois, Tensor rois_num, int min_level, int max_level, int refer_level, int refer_scale, bool pixel_offset)
   output : Tensor[](multi_fpn_rois){max_level - min_level + 1}, Tensor[](multi_level_rois_num){max_level - min_level + 1}, Tensor(restore_index)
@@ -304,6 +314,16 @@
     param : [x, dtype]
     data_type : dtype > x
     backend : place > x
+
+- op : enable_check_model_nan_inf
+  args: (Tensor x)
+  output: Tensor(out)
+  infer_meta:
+    func: UnchangedInferMeta
+  kernel:
+    func: check_model_nan_inf
+    data_type: x
+  backward: enable_check_model_nan_inf_grad
 
 - op : equal
   args : (Tensor x, Tensor y)

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -210,10 +210,11 @@
   backward : depthwise_conv2d_transpose_grad
 
 - op : disable_check_model_nan_inf
-  args: (Tensor x)
+  args: (Tensor x, int flag = 0)
   output: Tensor(out)
   infer_meta:
     func: UnchangedInferMeta
+    param : [x]
   kernel:
     func: check_model_nan_inf
     data_type: x
@@ -316,10 +317,11 @@
     backend : place > x
 
 - op : enable_check_model_nan_inf
-  args: (Tensor x)
+  args: (Tensor x, int flag = 1)
   output: Tensor(out)
   infer_meta:
     func: UnchangedInferMeta
+    param : [x]
   kernel:
     func: check_model_nan_inf
     data_type: x

--- a/paddle/phi/kernels/cpu/debug_tools_kernel.cc
+++ b/paddle/phi/kernels/cpu/debug_tools_kernel.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/impl/debug_tools_impl.h"
+
+PD_REGISTER_KERNEL(check_model_nan_inf,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::CheckModelNanInfKernel,
+                   bool,
+                   float,
+                   double,
+                   int32_t,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/gpu/debug_tools_kernel.cu
+++ b/paddle/phi/kernels/gpu/debug_tools_kernel.cu
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/impl/debug_tools_impl.h"
+
+PD_REGISTER_KERNEL(check_model_nan_inf,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::CheckModelNanInfKernel,
+                   bool,
+                   float,
+                   double,
+                   int32_t,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   phi::dtype::complex<float>,
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -27,8 +27,8 @@ void CheckModelNanInfKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             DenseTensor* out) {
   phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
-  VLOG(4) << "Change FLAGS_check_nan_inf from " << FLAGS_check_nan_inf << " to "
-          << !FLAGS_check_nan_inf;
+  VLOG(6) << "model_check_nan_inf: Change FLAGS_check_nan_inf "
+          << FLAGS_check_nan_inf << " to " << !FLAGS_check_nan_inf;
   FLAGS_check_nan_inf = !(FLAGS_check_nan_inf);
 }
 

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -27,8 +27,8 @@ void CheckModelNanInfKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             DenseTensor* out) {
   phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
-  VLOG(4) << "Convert FLAGS_check_nan_inf from " << FLAGS_check_nan_inf
-          << " to " << !FLAGS_check_nan_inf;
+  VLOG(4) << "Change FLAGS_check_nan_inf from " << FLAGS_check_nan_inf << " to "
+          << !FLAGS_check_nan_inf;
   FLAGS_check_nan_inf = !(FLAGS_check_nan_inf);
 }
 

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -25,11 +25,12 @@ namespace phi {
 template <typename T, typename Context>
 void CheckModelNanInfKernel(const Context& dev_ctx,
                             const DenseTensor& x,
+                            int flag,
                             DenseTensor* out) {
   phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
   VLOG(6) << "model_check_nan_inf: Change FLAGS_check_nan_inf "
-          << FLAGS_check_nan_inf << " to " << !FLAGS_check_nan_inf;
-  FLAGS_check_nan_inf = !(FLAGS_check_nan_inf);
+          << FLAGS_check_nan_inf << " to " << flag;
+  FLAGS_check_nan_inf = flag;
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-
+#include "glog/logging.h"
 #include "paddle/phi/core/flags.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -27,9 +27,9 @@ void CheckModelNanInfKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             DenseTensor* out) {
   phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
-  std::cout << "1 FLAGS_check_nan_inf " << FLAGS_check_nan_inf << std::endl;
+  VLOG(4) << "Convert FLAGS_check_nan_inf from " << FLAGS_check_nan_inf
+          << " to " << !FLAGS_check_nan_inf;
   FLAGS_check_nan_inf = !(FLAGS_check_nan_inf);
-  std::cout << "2 FLAGS_check_nan_inf " << FLAGS_check_nan_inf << std::endl;
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/flags.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+
+PHI_DECLARE_bool(check_nan_inf);
+
+namespace phi {
+
+template <typename T, typename Context>
+void CheckModelNanInfKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
+                            DenseTensor* out) {
+  phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
+  std::cout << "1 FLAGS_check_nan_inf " << FLAGS_check_nan_inf << std::endl;
+  FLAGS_check_nan_inf = !(FLAGS_check_nan_inf);
+  std::cout << "2 FLAGS_check_nan_inf " << FLAGS_check_nan_inf << std::endl;
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -28,7 +28,7 @@ void CheckModelNanInfKernel(const Context& dev_ctx,
                             int flag,
                             DenseTensor* out) {
   phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
-  VLOG(6) << "Model_check_nan_inf: Change FLAGS_check_nan_inf "
+  VLOG(6) << "model_check_nan_inf: Change FLAGS_check_nan_inf "
           << FLAGS_check_nan_inf << " to " << flag;
   FLAGS_check_nan_inf = flag;
 }

--- a/paddle/phi/kernels/impl/debug_tools_impl.h
+++ b/paddle/phi/kernels/impl/debug_tools_impl.h
@@ -28,7 +28,7 @@ void CheckModelNanInfKernel(const Context& dev_ctx,
                             int flag,
                             DenseTensor* out) {
   phi::CastKernel<T>(dev_ctx, x, x.dtype(), out);
-  VLOG(6) << "model_check_nan_inf: Change FLAGS_check_nan_inf "
+  VLOG(6) << "Model_check_nan_inf: Change FLAGS_check_nan_inf "
           << FLAGS_check_nan_inf << " to " << flag;
   FLAGS_check_nan_inf = flag;
 }

--- a/python/paddle/amp/debugging.py
+++ b/python/paddle/amp/debugging.py
@@ -118,11 +118,11 @@ def check_layer_numerics(func):
             start_data.stop_gradient = False
             modified_args = list(args)  # Convert args to a mutable list
             # Set FLAGS_check_nan_inf = 1
-            modified_args[0] = _C_ops.enable_check_model_nan_inf(start_data)
+            modified_args[0] = _C_ops.enable_check_model_nan_inf(start_data, 1)
             # Call the forward function
             out_data = func(self, *modified_args, **kwargs)
             # Set FLAGS_check_nan_inf = 0
-            out = _C_ops.disable_check_model_nan_inf(out_data)
+            out = _C_ops.disable_check_model_nan_inf(out_data, 0)
             return out
         else:
             print("No elements found in args")

--- a/test/amp/test_tensor_checker.py
+++ b/test/amp/test_tensor_checker.py
@@ -118,5 +118,28 @@ class TestTensorChecker(unittest.TestCase):
                 _assert_flag(False)
 
 
+class TestCheckLayerNumerics(unittest.TestCase):
+    def test_layer_checker(self):
+        class MyLayer(paddle.nn.Layer):
+            def __init__(self, dtype):
+                super().__init__()
+                self._w = self.create_parameter([2, 3], dtype=dtype)
+                self._b = self.create_parameter([2, 3], dtype=dtype)
+
+            @paddle.amp.debugging.check_layer_numerics
+            def forward(self, x):
+                return x * self._w + self._b
+
+        # 示例调用
+        with paddle.fluid.dygraph.guard():
+            dtype = 'float32'
+            x = paddle.rand([10, 2, 3], dtype=dtype)
+            model = MyLayer(dtype)
+            loss = model(x)
+            adam = paddle.optimizer.Adam(parameters=model.parameters())
+            loss.backward()
+            adam.step()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/amp/test_tensor_checker.py
+++ b/test/amp/test_tensor_checker.py
@@ -129,8 +129,6 @@ class TestCheckLayerNumerics(unittest.TestCase):
             @paddle.amp.debugging.check_layer_numerics
             def forward(self, x):
                 return x * self._w + self._b
-
-        # 示例调用
         with paddle.fluid.dygraph.guard():
             dtype = 'float32'
             x = paddle.rand([10, 2, 3], dtype=dtype)

--- a/test/amp/test_tensor_checker.py
+++ b/test/amp/test_tensor_checker.py
@@ -129,6 +129,7 @@ class TestCheckLayerNumerics(unittest.TestCase):
             @paddle.amp.debugging.check_layer_numerics
             def forward(self, x):
                 return x * self._w + self._b
+
         with paddle.fluid.dygraph.guard():
             dtype = 'float32'
             x = paddle.rand([10, 2, 3], dtype=dtype)

--- a/test/amp/test_tensor_checker.py
+++ b/test/amp/test_tensor_checker.py
@@ -130,14 +130,13 @@ class TestCheckLayerNumerics(unittest.TestCase):
             def forward(self, x):
                 return x * self._w + self._b
 
-        with paddle.fluid.dygraph.guard():
-            dtype = 'float32'
-            x = paddle.rand([10, 2, 3], dtype=dtype)
-            model = MyLayer(dtype)
-            loss = model(x)
-            adam = paddle.optimizer.Adam(parameters=model.parameters())
-            loss.backward()
-            adam.step()
+        dtype = 'float32'
+        x = paddle.rand([10, 2, 3], dtype=dtype)
+        model = MyLayer(dtype)
+        loss = model(x)
+        adam = paddle.optimizer.Adam(parameters=model.parameters())
+        loss.backward()
+        adam.step()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->


Pcard-70458


模型AMP训练出现精度问题，通常可能是某一个模块的计算特征导致的。算子级别和模型级别的工具，都很难精准控制只检测某一个模块里面包含的前向、反向算子。因此需新增一个装饰器接口：
paddle.amp.debugging.check_layer_numerics() # 装饰器，装饰一个Layer的forward函数

功能：
* check_layer_numerics，模块（Layer）前向函数的装饰器。Layer加上装饰器后，执行过程中会检测指定Layer包含的算子的前反向计算结果。
使用场景：
* 模型太大进行模型级检测耗时太长，或者通过先验知识判定特定模块可能存在问题，则可使用该接口进行模块级检查。
本PR 新增 2个C++ 算子 以实现模块级精度检查
![image](https://github.com/PaddlePaddle/Paddle/assets/51102941/50cedce0-31bb-4b89-9812-a6d6005a3244)

