### PR TITLE
make slice/strided_slice output to view

### DIFF
--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -982,6 +982,7 @@
     func : SliceRawInferMeta
   kernel :
     func : slice
+  view : (input -> out)
   backward : slice_grad
 
 - op : softmax
@@ -1019,6 +1020,7 @@
     func : StridedSliceInferMeta
   kernel :
     func : strided_slice
+  view : (x -> out)
   backward : strided_slice_grad
 
 - op : subtract


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
**Just for testing**
output of OP `slice / strided_slice` will be view of Tensor, while  `unsqueeze` is already supported.

That means, basic indexing of `__getitem__` will output a view.