### PR TITLE
add log for memory stats

### DIFF
--- a/paddle/phi/kernels/impl/einsum_grad_impl.h
+++ b/paddle/phi/kernels/impl/einsum_grad_impl.h
@@ -152,7 +152,7 @@ void EinsumGradKernel(const Context& dev_ctx,
   if (x.size() == 1) {  // Unary
     auto splits = paddle::string::split_string(equation, "->");
     auto left = splits[0];
-    right = splits[1].substr(1);
+    right = splits[1];
     auto new_equation = right + "->" + gather_labels_except_reduction(left);
     auto new_operands = std::vector<const DenseTensor*>();
     new_operands.push_back(&out_grad);
@@ -171,8 +171,7 @@ void EinsumGradKernel(const Context& dev_ctx,
     auto splits = paddle::string::split_string(equation, "->");
     auto left = splits[0];
     auto ops = paddle::string::split_string(left, ",");
-    right = splits[1].substr(1);
-
+    right = splits[1];
     auto equation_for_A =
         ops[1] + "," + right + "->" + gather_labels_except_reduction(ops[0]);
     auto equation_for_B =

--- a/paddle/phi/kernels/impl/einsum_impl.h
+++ b/paddle/phi/kernels/impl/einsum_impl.h
@@ -326,19 +326,16 @@ inline static void ParseEinsumEquation(
     std::vector<int>* output_dims,
     std::string* right,
     std::vector<std::string>* input_strs) {
-  VLOG(5) << "Start ParseEinsumEquation";
+  VLOG(5) << "Start ParseEinsumEquation " << equation;
   auto results = paddle::string::split_string(equation, "->");
   auto left = results[0];
   ReplaceEllipsis(left);
-  *right = results[1].substr(1);
+  *right = results[1];
   ReplaceEllipsis(*right);
   auto op_labels = paddle::string::split_string(left, ",");
-  // split_string("i,") -> ["i"], we push back a "".
+  // split_string("i,") -> ["i", ""], we push back a "".
   // split_string("->") -> [], we push back a "".
-  if (op_labels.size() == 0)
-    op_labels.push_back("");
-  else if (left[left.size() - 1] == ',')
-    op_labels.push_back("");
+  if (op_labels.size() == 0) op_labels.push_back("");
   std::for_each(op_labels.begin(), op_labels.end(), ReplaceEllipsis);
   GlobalInfo(op_labels, *right, labeltype, all_labels);
   InferLabelShape(op_labels, inputs, labelshape, ellipsis_dims, broadcast_dims);

--- a/paddle/utils/string/string_helper.h
+++ b/paddle/utils/string/string_helper.h
@@ -130,9 +130,7 @@ std::vector<T> split_string(const std::string& str, const std::string& delim) {
     pre_pos = pos + delim.size();
   }
   tmp_str.assign(str, pre_pos, str.length() - pre_pos);
-  if (!tmp_str.empty()) {
-    res_list.push_back(tmp_str);
-  }
+  res_list.push_back(tmp_str);
   return res_list;
 }
 

--- a/paddle/utils/string/string_helper.h
+++ b/paddle/utils/string/string_helper.h
@@ -127,7 +127,7 @@ std::vector<T> split_string(const std::string& str, const std::string& delim) {
   while ((pos = str.find(delim, pre_pos)) != std::string::npos) {
     tmp_str.assign(str, pre_pos, pos - pre_pos);
     res_list.push_back(tmp_str);
-    pre_pos = pos + 1;
+    pre_pos = pos + delim.size();
   }
   tmp_str.assign(str, pre_pos, str.length() - pre_pos);
   if (!tmp_str.empty()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66978
- add log for memory stats
- fix split_string when delim is more that one characters

example：
<img width="1076" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/ee4d61f5-ac62-454d-a98e-e25ce0ca6773">
