### PR TITLE
[inference]update SplitLayerNormPass, fix bias and scale of LayerNorm shared by multi OP

### DIFF
--- a/paddle/fluid/framework/ir/split_layernorm_to_math_ops_pass.cc
+++ b/paddle/fluid/framework/ir/split_layernorm_to_math_ops_pass.cc
@@ -425,7 +425,14 @@ void SplitLayerNormPass::ApplyImpl(Graph* graph) const {
     IR_NODE_LINK_TO(new_bias_node, elementwise_add1_node);
     IR_NODE_LINK_TO(elementwise_add1_node, layer_norm_out);
 
-    GraphSafeRemoveNodes(g, {layer_norm_op, layer_norm_bias, layer_norm_scale});
+    std::unordered_set<const Node*> nodes2rm = {};
+    nodes2rm.insert(layer_norm_op);
+    if (layer_norm_bias->outputs.size() <= 1UL)
+      nodes2rm.insert(layer_norm_bias);
+    if (layer_norm_scale->outputs.size() <= 1UL)
+      nodes2rm.insert(layer_norm_scale);
+
+    GraphSafeRemoveNodes(g, nodes2rm);
     found_layer_norm_count++;
   };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- Fix bias and scale shared by multi OP in SplitLayerNormPass. This error may occur in models such as DINO and PETR.
<img width="726" alt="93ed2d314ccd6c670c27c4864f84363d" src="https://github.com/PaddlePaddle/Paddle/assets/1312389/37812c3c-d1ce-4cb5-a49e-c6716f799365">
