### PR TITLE
fix auto mixed precision pass related to tensorrt_engine op

### DIFF
--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -479,7 +479,9 @@ void AutoMixedPrecisionPass::UpdateOpPrecision() const {
         auto op_type = op_node->Op()->Type();
 
         if (GetOpOriginalType(op_type) == "fetch") continue;
-        if (op_node->Op()->HasAttr("sub_block")) continue;
+        if (op_node->Op()->HasAttr("sub_block") &&
+            GetOpOriginalType(op_type) != "tensorrt_engine")
+          continue;
 
         for (auto* var_node : op_node->outputs) {
           CHECK_EQ(var_node->IsVar(), true);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

fix auto mixed precision pass related to tensorrt_engine op.
tensorrt_engine没有sub_block这个attr，但是
![159985204cad3b40a02828eda6d4d191](https://github.com/PaddlePaddle/Paddle/assets/23653004/b032b2a0-d4c9-4799-9c85-a77b93f1758b)
会判定为true，why?