### PR TITLE
[XPU] using xpu::normal in gaussian kernel.

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -8,7 +8,7 @@ set(XPU_API_LIB_NAME "libxpuapi.so")
 set(XPU_RT_LIB_NAME "libxpurt.so")
 set(XPU_XFT_LIB_NAME "libxft.so")
 
-set(XPU_BASE_DATE "20230523")
+set(XPU_BASE_DATE "20230529")
 set(XPU_XCCL_BASE_VERSION "1.0.49.2")
 set(XPU_XFT_BASE_VERSION "latest")
 

--- a/paddle/phi/kernels/xpu/gelu_kernel.cc
+++ b/paddle/phi/kernels/xpu/gelu_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/gelu_kernel.h"
 
+#include "glog/logging.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/float16.h"
@@ -26,6 +27,9 @@ void GeluKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 bool approximate,
                 DenseTensor* out) {
+  if (approximate) {
+    LOG_FIRST_N(INFO, 1) << "XPU does not support gelu with approximate.";
+  }
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(out);
   int r = xpu::gelu<XPUType>(dev_ctx.x_context(),


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
* 更新XDNN依赖到最新，即20230529。
* 在`gaussian`算子里面直接调用XDNN提供的`normal`函数。
* 在`gelu`算子中，如果发现使用`approximate`参数，打印一行日志。目前XDNN有`gelu`的近似计算模式但是没有现成的算子绑定，另外没有近似的`gelu`的反向，所以这里先加个日志。

另，关于去掉的TODO：在这个PR里面 https://github.com/PaddlePaddle/Paddle/pull/54077 修改了fleet中`RNGStatesTracker`的行为，所以在多卡运行的情况下，各个卡会拿到不同的随机种子，因此不需要在算子内部进行特殊处理了。