### PR TITLE
[BugFix]Fix compile error in multi-cuda archs

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -183,9 +183,6 @@ if(WITH_FLASHATTN)
   add_dependencies(phi flashattn)
 endif()
 
-set(LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_SOURCE_DIR}/phi.map")
-set_target_properties(phi PROPERTIES LINK_FLAGS "${LINK_FLAGS}")
-
 set(phi_extension_header_file
     ${CMAKE_CURRENT_SOURCE_DIR}/extension.h
     CACHE INTERNAL "phi/extension.h file")

--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -105,8 +105,10 @@ else()
 endif()
 
 if(WITH_GPU)
-  add_definitions(-DCUDA_REAL_ARCHS=${NVCC_FLAGS_EXTRA_real_archs}
-  )# for backends/gpu/gpu_resources.cc
+  set_source_files_properties(
+    backends/gpu/gpu_resources.cc
+    PROPERTIES COMPILE_FLAGS
+               "-DCUDA_REAL_ARCHS=\"${NVCC_FLAGS_EXTRA_real_archs}\"")
   nv_library(
     phi ${PHI_BUILD_TYPE}
     SRCS ${PHI_SRCS}
@@ -180,6 +182,9 @@ endif()
 if(WITH_FLASHATTN)
   add_dependencies(phi flashattn)
 endif()
+
+set(LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_SOURCE_DIR}/phi.map")
+set_target_properties(phi PROPERTIES LINK_FLAGS "${LINK_FLAGS}")
 
 set(phi_extension_header_file
     ${CMAKE_CURRENT_SOURCE_DIR}/extension.h


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66980
修复PHI独立编译导致在多cuda架构下的如下编译问题：
![image](https://github.com/PaddlePaddle/Paddle/assets/29249150/b9ee14e9-407f-4e40-9b4a-dfbce1a3b260)
