### PR TITLE
[IR] add region data structure.

### DIFF
--- a/paddle/fluid/translator/op_translator.cc
+++ b/paddle/fluid/translator/op_translator.cc
@@ -110,8 +110,8 @@ inline ir::Operation* InsertSliceOperationForTarget(
       defining_info.value.type().dyn_cast<ir::VectorType>();
   ir::Operation* operation =
       ir::Operation::create({defining_info.value},
-                            {src_vec_type[defining_info.idx_in_vector]},
                             op_attribute_map,
+                            {src_vec_type[defining_info.idx_in_vector]},
                             op_info);
   program->InsertOp(operation);
   ir::OpResult target_op_result = operation->GetResultByIndex(0);
@@ -136,7 +136,7 @@ inline ir::Operation* InsertCombineOperationForTarget(
   }
   ir::Type target_vec_type = ir::VectorType::get(ctx, types_in_vec);
   ir::Operation* operation =
-      ir::Operation::create(src_values, {target_vec_type}, {}, op_info);
+      ir::Operation::create(src_values, {}, {target_vec_type}, op_info);
   program->InsertOp(operation);
   return operation;
 }
@@ -281,7 +281,7 @@ ir::Operation* GeneralOpHandler(ir::IrContext* ctx,
   std::tie(op_output_types, arg_to_idx) = GenerateOperationOutput(ctx, op_desc);
   auto op_info = LoopkUpOpInfo(ctx, op_desc);
   ir::Operation* operation =
-      ir::Operation::create(op_inputs, op_output_types, {}, op_info);
+      ir::Operation::create(op_inputs, {}, op_output_types, op_info);
   program->InsertOp(operation);
   RecordOpResultMapping(param_map, op_desc, operation, arg_to_idx);
 
@@ -299,7 +299,7 @@ ir::Operation* FeedOpHandler(ir::IrContext* ctx,
   std::tie(op_output_types, arg_to_idx) = GenerateOperationOutput(ctx, op_desc);
   auto op_info = LoopkUpOpInfo(ctx, op_desc);
   ir::Operation* operation =
-      ir::Operation::create(op_inputs, op_output_types, {}, op_info);
+      ir::Operation::create(op_inputs, {}, op_output_types, op_info);
   program->InsertOp(operation);
   RecordOpResultMapping(param_map, op_desc, operation, arg_to_idx);
 
@@ -315,7 +315,7 @@ ir::Operation* FetchOpHandler(ir::IrContext* ctx,
   OpOutputTypeList op_output_types = {};
   auto op_info = LoopkUpOpInfo(ctx, op_desc);
   ir::Operation* operation =
-      ir::Operation::create(op_inputs, op_output_types, {}, op_info);
+      ir::Operation::create(op_inputs, {}, op_output_types, op_info);
   program->InsertOp(operation);
 
   return operation;

--- a/paddle/fluid/translator/program_translator.cc
+++ b/paddle/fluid/translator/program_translator.cc
@@ -79,7 +79,7 @@ void ProgramTranslator::ExtractParameterFromSingleBlock(
     };
     ir::Type translated_var_type = type_translator[var->GetType()](ctx, *var);
     ir::Operation* operation = ir::Operation::create(
-        {}, {translated_var_type}, op_attribute_map, op_info);
+        {}, op_attribute_map, {translated_var_type}, op_info);
     program->InsertOp(operation);
     param_map[var->Name()] =
         VariableDefiningInfo(operation->GetResultByIndex(0));

--- a/paddle/ir/core/block.h
+++ b/paddle/ir/core/block.h
@@ -14,18 +14,23 @@
 
 #pragma once
 
+#include <cstddef>
 #include <list>
 #include "paddle/ir/core/operation.h"
 
 namespace ir {
+class Region;
+
 class Block {
  public:
   using iterator = std::list<Operation *>::iterator;
   using reverse_iterator = std::list<Operation *>::reverse_iterator;
+  using const_iterator = std::list<Operation *>::const_iterator;
 
   Block() = default;
   ~Block();
 
+  Region *parent() const { return parent_; }
   bool empty() const { return ops_.empty(); }
   size_t size() const { return ops_.size(); }
 
@@ -34,21 +39,22 @@ class Block {
   reverse_iterator rbegin() { return ops_.rbegin(); }
   reverse_iterator rend() { return ops_.rend(); }
 
-  Operation *back() { return ops_.back(); }
-  Operation *front() { return ops_.front(); }
-  void push_back(Operation *op) { ops_.push_back(op); }
-  void push_front(Operation *op) { ops_.push_front(op); }
-  std::list<Operation *>::iterator insert(
-      std::list<Operation *>::const_iterator iterator, Operation *op) {
-    return ops_.insert(iterator, op);
-  }
+  Operation *back() const { return ops_.back(); }
+  Operation *front() const { return ops_.front(); }
+  void push_back(Operation *op);
+  void push_front(Operation *op);
+  iterator insert(const_iterator iterator, Operation *op);
   void clear();
 
  private:
   Block(Block &) = delete;
-  void operator=(Block &) = delete;
+  Block &operator=(const Block &) = delete;
+
+  friend class Region;
+  void set_parent(Region *parent) { parent_ = parent; }
 
  private:
+  Region *parent_;              // not owned
   std::list<Operation *> ops_;  // owned
 };
 }  // namespace ir

--- a/paddle/ir/core/builder.cc
+++ b/paddle/ir/core/builder.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/ir/core/builder.h"
+#include "paddle/ir/core/region.h"
 
 namespace ir {
 Operation *Builder::insert(Operation *op) {
@@ -25,17 +26,16 @@ Operation *Builder::insert(Operation *op) {
 }
 
 /// Create an operation given the fields represented as an OperationState.
-Operation *Builder::create(const OperationArgument &argument) {
-  return insert(Operation::create(argument));
+Operation *Builder::create(OperationArgument &&argument) {
+  return insert(Operation::create(std::move(argument)));
 }
 
 /// Creates an operation with the given fields.
 Operation *Builder::create(const std::vector<ir::OpResult> &inputs,
-                           const std::vector<ir::Type> &output_types,
                            const AttributeMap &attribute,
+                           const std::vector<ir::Type> &output_types,
                            ir::OpInfo op_info) {
-  OperationArgument argument(op_info, inputs, output_types, attribute);
-  return create(argument);
+  return create(OperationArgument(inputs, attribute, output_types, op_info));
 }
 
 }  // namespace ir

--- a/paddle/ir/core/builder.h
+++ b/paddle/ir/core/builder.h
@@ -47,12 +47,12 @@ class Builder {
   Operation *insert(Operation *op);
 
   /// Creates an operation given the fields represented as an OperationState.
-  Operation *create(const OperationArgument &argument);
+  Operation *create(OperationArgument &&argument);
 
   /// Creates an operation with the given fields.
   Operation *create(const std::vector<ir::OpResult> &inputs,
-                    const std::vector<ir::Type> &output_types,
                     const AttributeMap &attribute,
+                    const std::vector<ir::Type> &output_types,
                     ir::OpInfo op_info);
 
   /// Create an operation of specific op type at the current insertion point.
@@ -60,7 +60,7 @@ class Builder {
   OpTy create(Args &&...args) {
     OperationArgument argument(context_->GetRegisteredOpInfo(OpTy::name()));
     OpTy::build(*this, argument, std::forward<Args>(args)...);
-    Operation *op = create(argument);
+    Operation *op = create(std::move(argument));
     return op->dyn_cast<OpTy>();
   }
 

--- a/paddle/ir/core/builtin_op.h
+++ b/paddle/ir/core/builtin_op.h
@@ -17,6 +17,7 @@
 #include "paddle/ir/core/op_base.h"
 
 namespace ir {
+
 ///
 /// \brief GetParameterOp: OpResult = GetParameterOp({StrAttribute,
 /// StrAttribute})

--- a/paddle/ir/core/operation_utils.cc
+++ b/paddle/ir/core/operation_utils.cc
@@ -13,19 +13,11 @@
 // limitations under the License.
 
 #include "paddle/ir/core/operation_utils.h"
+#include "paddle/ir/core/region.h"
 
 namespace ir {
-OperationArgument::OperationArgument(IrContext* ir_context, std::string name) {
-  info_ = ir_context->GetRegisteredOpInfo(name);
+OperationArgument::OperationArgument(IrContext* ir_context,
+                                     const std::string& name) {
+  info = ir_context->GetRegisteredOpInfo(name);
 }
-
-OperationArgument::OperationArgument(OpInfo info,
-                                     const std::vector<OpResult>& operands,
-                                     const std::vector<Type>& types,
-                                     const AttributeMap& named_attr)
-    : info_(info),
-      inputs_(operands),
-      output_types_(types),
-      attribute_(named_attr) {}
-
 }  // namespace ir

--- a/paddle/ir/core/region.cc
+++ b/paddle/ir/core/region.cc
@@ -12,29 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/ir/core/region.h"
 #include "paddle/ir/core/block.h"
 
 namespace ir {
-Block::~Block() { clear(); }
-void Block::push_back(Operation *op) {
-  op->set_parent(this);
-  ops_.push_back(op);
+Region::~Region() { clear(); }
+
+void Region::push_back(Block *block) {
+  block->set_parent(this);
+  blocks_.push_back(block);
+}
+void Region::push_front(Block *block) {
+  block->set_parent(this);
+  blocks_.push_front(block);
 }
 
-void Block::push_front(Operation *op) {
-  op->set_parent(this);
-  ops_.push_front(op);
+Region::iterator Region::insert(const_iterator position, Block *block) {
+  block->set_parent(this);
+  return blocks_.insert(position, block);
+}
+void Region::TakeBody(Region &&other) {
+  clear();
+  blocks_.swap(other.blocks_);
+  for (auto &block : blocks_) {
+    block->set_parent(this);
+  }
 }
 
-Block::iterator Block::insert(const_iterator iterator, Operation *op) {
-  op->set_parent(this);
-  return ops_.insert(iterator, op);
-}
-
-void Block::clear() {
+void Region::clear() {
   while (!empty()) {
-    ops_.back()->destroy();
-    ops_.pop_back();
+    delete blocks_.back();
+    blocks_.pop_back();
   }
 }
 }  // namespace ir

--- a/paddle/ir/core/region.h
+++ b/paddle/ir/core/region.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <list>
+
+namespace ir {
+
+class Block;
+class Operation;
+
+class Region {
+ public:
+  using iterator = std::list<Block *>::iterator;
+  using reverse_iterator = std::list<Block *>::reverse_iterator;
+  using const_iterator = std::list<Block *>::const_iterator;
+  ~Region();
+  Region() = default;
+
+  bool empty() const { return blocks_.empty(); }
+  size_t size() const { return blocks_.size(); }
+
+  iterator begin() { return blocks_.begin(); }
+  iterator end() { return blocks_.end(); }
+  reverse_iterator rbegin() { return blocks_.rbegin(); }
+  reverse_iterator rend() { return blocks_.rend(); }
+
+  Block *back() const { return blocks_.back(); }
+  Block *front() const { return blocks_.front(); }
+  void push_back(Block *block);
+  void push_front(Block *block);
+  iterator insert(const_iterator position, Block *block);
+  void clear();
+
+  void TakeBody(Region &&other);
+
+ private:
+  Region(Region &) = delete;
+  Region &operator=(const Region &) = delete;
+  friend class Operation;
+  explicit Region(Operation *op) : parent_(op) {}
+
+ private:
+  Operation *parent_{nullptr};  // not owned
+  std::list<Block *> blocks_;   // owned
+};
+}  // namespace ir

--- a/test/cpp/ir/core/ir_op_test.cc
+++ b/test/cpp/ir/core/ir_op_test.cc
@@ -14,12 +14,14 @@
 
 #include <gtest/gtest.h>
 
+#include "paddle/ir/core/block.h"
 #include "paddle/ir/core/builder.h"
 #include "paddle/ir/core/builtin_attribute.h"
 #include "paddle/ir/core/builtin_type.h"
 #include "paddle/ir/core/dialect.h"
 #include "paddle/ir/core/ir_context.h"
 #include "paddle/ir/core/op_base.h"
+#include "paddle/ir/core/region.h"
 
 /// \brief Define built-in Trait, derived from OpTraitBase.
 class ReadOnlyTrait : public ir::OpTraitBase<ReadOnlyTrait> {
@@ -175,9 +177,9 @@ TEST(op_test, op_test) {
   std::vector<ir::Type> op_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op2 =
       ir::Operation::create(op_inputs,
-                            op_output_types,
                             CreateAttributeMap({"op2_attr1", "op2_attr2"},
                                                {"op2_attr1", "op2_attr2"}),
+                            op_output_types,
                             op2_info);
 
   ReadOnlyTrait trait = op2->dyn_cast<ReadOnlyTrait>();
@@ -186,5 +188,46 @@ TEST(op_test, op_test) {
   interface.InferShape();
   Operation2 Op2 = op2->dyn_cast<Operation2>();
   EXPECT_EQ(Op2.operation(), op2);
+  op2->destroy();
+}
+
+TEST(op_test, region_test) {
+  // (1) Register Dialect, Operation1, Operation2 into IrContext.
+  ir::IrContext *ctx = ir::IrContext::Instance();
+  ir::Dialect *test_dialect = ctx->GetOrRegisterDialect<TestDialect>();
+  EXPECT_EQ(test_dialect != nullptr, true);
+
+  // (2) Get registered operations.
+  ir::OpInfo op1_info = ctx->GetRegisteredOpInfo(Operation1::name());
+  ir::OpInfo op2_info = ctx->GetRegisteredOpInfo(Operation2::name());
+
+  ir::Operation *op1 =
+      ir::Operation::create({},
+                            CreateAttributeMap({"op1_attr1", "op1_attr2"},
+                                               {"op1_attr1", "op1_attr2"}),
+                            {ir::Float32Type::get(ctx)},
+                            op1_info);
+  ir::Operation *op1_2 =
+      ir::Operation::create({},
+                            CreateAttributeMap({"op1_attr1", "op1_attr2"},
+                                               {"op1_attr1", "op1_attr2"}),
+                            {ir::Float32Type::get(ctx)},
+                            op1_info);
+
+  ir::OperationArgument argument(op2_info);
+  argument.attribute = CreateAttributeMap({"op2_attr1", "op2_attr2"},
+                                          {"op2_attr1", "op2_attr2"});
+  argument.output_types = {ir::Float32Type::get(ctx)};
+  argument.regions.emplace_back(std::make_unique<ir::Region>());
+  ir::Region *region = argument.regions.back().get();
+  EXPECT_EQ(region->empty(), true);
+
+  region->push_back(new ir::Block());
+  region->push_front(new ir::Block());
+  region->insert(region->begin(), new ir::Block());
+  ir::Block *block = region->front();
+  block->push_front(op1);
+  block->insert(block->begin(), op1_2);
+  ir::Operation *op2 = ir::Operation::create(std::move(argument));
   op2->destroy();
 }

--- a/test/cpp/ir/core/ir_program_test.cc
+++ b/test/cpp/ir/core/ir_program_test.cc
@@ -91,7 +91,7 @@ TEST(program_test, program) {
   std::unordered_map<std::string, ir::Attribute> op1_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "a")}};
   ir::Operation *op1 =
-      ir::Operation::create({}, {dense_tensor_dtype}, op1_attribute, op1_info);
+      ir::Operation::create({}, op1_attribute, {dense_tensor_dtype}, op1_info);
 
   program.InsertOp(op1);
 
@@ -123,7 +123,7 @@ TEST(program_test, program) {
   std::unordered_map<std::string, ir::Attribute> op2_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "b")}};
   ir::Operation *op2 =
-      ir::Operation::create({}, {dense_tensor_dtype}, op2_attribute, op2_info);
+      ir::Operation::create({}, op2_attribute, {dense_tensor_dtype}, op2_info);
   program.InsertOp(op2);
 
   EXPECT_EQ(op2->GetResultByIndex(0).type().dialect().id(),
@@ -153,8 +153,8 @@ TEST(program_test, program) {
   std::unordered_map<std::string, ir::Attribute> op3_attribute;
   ir::Operation *op3 = ir::Operation::create(
       {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
-      {dense_tensor_dtype},
       op3_attribute,
+      {dense_tensor_dtype},
       op3_info);
   program.InsertOp(op3);
 
@@ -184,7 +184,7 @@ TEST(program_test, program) {
   std::unordered_map<std::string, ir::Attribute> op4_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "c")}};
   ir::Operation *op4 = ir::Operation::create(
-      {op3->GetResultByIndex(0)}, {}, op4_attribute, op4_info);
+      {op3->GetResultByIndex(0)}, op4_attribute, {}, op4_info);
   program.InsertOp(op4);
 
   EXPECT_EQ(op4->GetOperandByIndex(0).impl()->source().type().dialect().id(),
@@ -230,7 +230,7 @@ TEST(program_test, slice_combine_test) {
   std::unordered_map<std::string, ir::Attribute> op1_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "a")}};
   ir::Operation *op1 =
-      ir::Operation::create({}, {fp32_dtype}, op1_attribute, op1_info);
+      ir::Operation::create({}, op1_attribute, {fp32_dtype}, op1_info);
   program.InsertOp(op1);
 
   // (5) Def b = GetParameterOp("b")
@@ -239,7 +239,7 @@ TEST(program_test, slice_combine_test) {
   std::unordered_map<std::string, ir::Attribute> op2_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "b")}};
   ir::Operation *op2 =
-      ir::Operation::create({}, {fp32_dtype}, op2_attribute, op2_info);
+      ir::Operation::create({}, op2_attribute, {fp32_dtype}, op2_info);
   program.InsertOp(op2);
 
   // (6) Def combine_op = CombineOp("a", "b")
@@ -249,8 +249,8 @@ TEST(program_test, slice_combine_test) {
       ir::VectorType::get(ctx, std::vector<ir::Type>({fp32_dtype, fp32_dtype}));
   ir::Operation *combine_op = ir::Operation::create(
       {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
-      {output_type},
       {},
+      {output_type},
       combine_op_info);
   program.InsertOp(combine_op);
 
@@ -260,8 +260,8 @@ TEST(program_test, slice_combine_test) {
   ir::Attribute index_attr = ir::Int32_tAttribute::get(ctx, 0);
   ir::Operation *slice_op =
       ir::Operation::create({combine_op->GetResultByIndex(0)},
-                            {fp32_dtype},
                             {{"index", index_attr}},
+                            {fp32_dtype},
                             slice_op_info);
   program.InsertOp(slice_op);
 

--- a/test/cpp/ir/core/ir_value_test.cc
+++ b/test/cpp/ir/core/ir_value_test.cc
@@ -40,8 +40,8 @@ TEST(value_test, value_test) {
   std::vector<ir::Type> op1_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op1 =
       ir::Operation::create(op1_inputs,
-                            op1_output_types,
                             CreateAttributeMap("op1_name", "op1_attr"),
+                            op1_output_types,
                             nullptr);
   VLOG(0) << op1->print();
   // 2. Construct OP2: b = OP2();
@@ -49,8 +49,8 @@ TEST(value_test, value_test) {
   std::vector<ir::Type> op2_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op2 =
       ir::Operation::create(op2_inputs,
-                            op2_output_types,
                             CreateAttributeMap("op2_name", "op2_attr"),
+                            op2_output_types,
                             nullptr);
   VLOG(0) << op2->print() << std::endl;
   // 3. Construct OP3: c = OP3(a, b);
@@ -59,8 +59,8 @@ TEST(value_test, value_test) {
   std::vector<ir::Type> op3_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op3 =
       ir::Operation::create(op3_inputs,
-                            op3_output_types,
                             CreateAttributeMap("op3_name", "op3_attr"),
+                            op3_output_types,
                             nullptr);
   VLOG(0) << op3->print() << std::endl;
   // 4. Construct OP4: d, e, f, g, h, i, j = OP4(a, c);
@@ -72,8 +72,8 @@ TEST(value_test, value_test) {
   }
   ir::Operation *op4 =
       ir::Operation::create(op4_inputs,
-                            op4_output_types,
                             CreateAttributeMap("op4_name", "op4_attr"),
+                            op4_output_types,
                             nullptr);
   VLOG(0) << op4->print() << std::endl;
 

--- a/test/cpp/pass/pass_manager_test.cc
+++ b/test/cpp/pass/pass_manager_test.cc
@@ -96,8 +96,8 @@ TEST(pass_manager_test, pass_manager_test) {
   std::vector<ir::Type> op_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op =
       ir::Operation::create(op_inputs,
-                            op_output_types,
                             CreateAttributeMap(ctx, "op1_attr1", "op1_attr1"),
+                            op_output_types,
                             op_info);
 
   // (4) Test pass manager for op.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

- 新增region数据结构
- 调整相关数据结构{Operation、OperationArgument、builder}的接口，统一按照： 输入、属性、输出、其它 的顺序进行排列。（与phi算子库一致）

### Other

Pcard-67164