### PR TITLE
[Paddle Inference]Enhance the shape check of embedding_eltwise_layernorm_fuse_pass

### DIFF
--- a/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass.cc
@@ -307,11 +307,44 @@ int EmbeddingEltwiseLayerNormFusePass::BuildFusion(
 
     std::vector<std::string> ids;
     std::vector<std::string> embs;
+
+    auto ids0_shape = start_pattern_in_nodes[i][0].first->Var()->GetShape();
+
     for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
+      auto ids_shape = start_pattern_in_nodes[i][iter].first->Var()->GetShape();
+      if (ids_shape.size() != ids0_shape.size()) {
+        VLOG(3) << "Shape check failed, ids'rank are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+        return fusion_count;
+      } else {
+        for (size_t j = 0; j < ids_shape.size(); ++j) {
+          if (ids_shape[j] != ids0_shape[j]) {
+            VLOG(3)
+                << "Shape check failed, ids.shape[i] are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+            return fusion_count;
+          }
+        }
+      }
       ids.push_back(start_pattern_in_nodes[i][iter].first->Name());
       embs.push_back(start_pattern_in_nodes[i][iter].second->Name());
     }
     for (size_t iter = 0; iter < js.size(); ++iter) {
+      auto ids_shape = inner_pattern_ins[js[iter]].first->Var()->GetShape();
+      if (ids_shape.size() != ids0_shape.size()) {
+        VLOG(3) << "Shape check failed, ids'rank are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+        return fusion_count;
+      } else {
+        for (size_t j = 0; j < ids_shape.size(); ++j) {
+          if (ids_shape[j] != ids0_shape[j]) {
+            VLOG(3)
+                << "Shape check failed, ids.shape[i] are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+            return fusion_count;
+          }
+        }
+      }
       ids.push_back(inner_pattern_ins[js[iter]].first->Name());
       embs.push_back(inner_pattern_ins[js[iter]].second->Name());
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Enhance the shape check: embedding_eltwise_layernorm_fuse_pass, don't support broadcast
![image](https://github.com/PaddlePaddle/Paddle/assets/27151961/75fe397b-b25d-4fa7-914a-be03de19d19d)