### PR TITLE
Remove DryRun in standalone executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -158,38 +158,6 @@ InterpreterCore::~InterpreterCore() {
 #endif
 }
 
-interpreter::CostInfo InterpreterCore::DryRun(
-    const std::vector<std::string>& feed_names,
-    const std::vector<phi::DenseTensor>& feed_tensors) {
-  SetDeviceId(place_);
-  CheckCUDAGraphBeforeRun(feed_names);
-
-  Prepare(feed_names, feed_tensors, true);
-  interpreter::CostInfo cost_info;
-  {
-    interpreter::ProfilerGuard(place_, &cost_info);
-
-    // For the program that only run once, it is no need to
-    // create work_queue, so the async_work_queue_ is created
-    // until the second step run.
-    async_work_queue_ = GetWorkQueue();
-
-    // lazy initialization of gc, do not create gc is the program only run once
-    if (!gc_) {
-      gc_ = CreateInterpreterCoreGarbageCollector(place_, vec_instruction_);
-    }
-
-    ExecuteInstructionList(vec_instruction_);
-    platform::DeviceContextPool::Instance().Get(place_)->Wait();
-  }
-
-  if (HasLocalScope()) {
-    ClearLoDTensorArrayInLocalScope();
-  }
-
-  return cost_info;
-}
-
 void InterpreterCore::RunImpl() {
   // lazy initialization of gc, do not create gc is the program only run once
   if (!gc_) {
@@ -1538,25 +1506,6 @@ void InterpreterCore::AnalyseExecuteOrderForTrace() {
           "trace_order size should be equal to dependecy_count_."));
 
   trace_execute_order_ = trace_order;
-}
-
-std::shared_ptr<InterpreterCore> CreateInterpreterCore(
-    const platform::Place& place,
-    const ProgramDesc& prog,
-    Scope* scope,
-    const std::vector<std::string>& fetch_names,
-    const interpreter::ExecutionConfig& execution_config) {
-  std::shared_ptr<InterpreterCore> core = nullptr;
-  // NOTE(Aurelius84): `AddFetch` will modify BlockDesc, so we should copy
-  // a new program.
-  auto new_prog = std::make_shared<framework::ProgramDesc>(prog);
-  auto* block = new_prog->MutableBlock(0);
-  interpreter::AddFetch(fetch_names, block);
-
-  core =
-      std::make_shared<InterpreterCore>(place, *block, scope, execution_config);
-  core->SetCopyProgram(new_prog);
-  return core;
 }
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -54,10 +54,6 @@ class InterpreterCore {
 
   ~InterpreterCore();
 
-  interpreter::CostInfo DryRun(
-      const std::vector<std::string>& feed_names,
-      const std::vector<phi::DenseTensor>& feed_tensors);
-
   paddle::framework::FetchList Run(
       const std::vector<std::string>& feed_names,
       const std::vector<phi::DenseTensor>& feed_tensors);
@@ -189,14 +185,6 @@ class InterpreterCore {
 
   InstructionSchedulingPriorityLess instruction_scheduling_priority_less;
 };
-
-std::shared_ptr<InterpreterCore> CreateInterpreterCore(
-    const platform::Place& place,
-    const ProgramDesc& prog,
-    Scope* scope,
-    const std::vector<std::string>& fetch_names = {},
-    const interpreter::ExecutionConfig& execution_config =
-        interpreter::ExecutionConfig());
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/standalone_executor.h
+++ b/paddle/fluid/framework/new_executor/standalone_executor.h
@@ -42,18 +42,12 @@ class StandaloneExecutor {
                                    const std::vector<std::string>& feed_names,
                                    const std::vector<std::string>& fetch_names);
 
-  framework::interpreter::CostInfo DryRun(
-      Scope* scope,
-      const std::vector<std::string>& feed_names,
-      const std::vector<phi::DenseTensor>& feed_tensors);
-
  private:
   std::shared_ptr<InterpreterCore> GetInterpreterCore(
       Scope* scope,
       const ProgramDesc& prog,
       const std::vector<std::string>& feed_names,
-      const std::vector<std::string>& fetch_names,
-      bool add_fetch_op);
+      const std::vector<std::string>& fetch_names);
 
   platform::Place place_;
   const ProgramDesc& prog_;

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1852,28 +1852,6 @@ All parameter, weight, gradient are variables in Paddle.
                ret = self.Run(scope, feed_names, fetch_names);
              }
              return py::cast(std::move(ret));
-           })
-      .def("dry_run",
-           [](StandaloneExecutor &self,
-              Scope *scope,
-              const std::unordered_map<std::string, py::array> &input_dict) {
-             std::vector<phi::DenseTensor> feed_tensors;
-             std::vector<std::string> feed_names;
-
-             for (auto &item : input_dict) {
-               phi::DenseTensor t;
-               SetTensorFromPyArray<platform::CPUPlace>(
-                   &t, item.second, platform::CPUPlace(), false);
-               feed_names.push_back(item.first);
-               feed_tensors.push_back(t);
-             }
-
-             framework::interpreter::CostInfo cost_info;
-             {
-               pybind11::gil_scoped_release release;
-               cost_info = self.DryRun(scope, feed_names, feed_tensors);
-             }
-             return cost_info;
            });
 
   m.def("init_gflags", framework::InitGflags);

--- a/test/cpp/new_executor/standalone_executor_test.cc
+++ b/test/cpp/new_executor/standalone_executor_test.cc
@@ -174,7 +174,9 @@ TEST(InterpreterCore, skip_gc_vars) {
   Scope scope;
 
   std::shared_ptr<InterpreterCore> startup_core =
-      CreateInterpreterCore(place, startup_prog, &scope);
+      std::make_shared<InterpreterCore>(
+          place, startup_prog.Block(0), &scope, interpreter::ExecutionConfig());
+
   startup_core->Run({}, {});
 
   std::set<std::string> skip_gc_vars = {"uniform_0.tmp_0",
@@ -191,8 +193,9 @@ TEST(InterpreterCore, skip_gc_vars) {
   interpreter::ExecutionConfig execution_config;
   execution_config.skip_gc_vars = skip_gc_vars;
 
-  std::shared_ptr<InterpreterCore> main_core = CreateInterpreterCore(
-      place, main_prog, &scope, /*fetch_names=*/{}, execution_config);
+  std::shared_ptr<InterpreterCore> main_core =
+      std::make_shared<InterpreterCore>(
+          place, main_prog.Block(0), &scope, execution_config);
 
   auto check_gc_result =
       [](Scope& scope, std::set<std::string>& vars, bool is_skip_gc) {
@@ -225,10 +228,10 @@ void TestShareWorkQueue(const ProgramDesc& prog,
   const platform::CPUPlace place = platform::CPUPlace();
 
   Scope scope;
-  std::shared_ptr<InterpreterCore> core1 =
-      CreateInterpreterCore(place, prog, &scope, fetch_names);
-  std::shared_ptr<InterpreterCore> core2 =
-      CreateInterpreterCore(place, prog, &scope, fetch_names);
+  std::shared_ptr<InterpreterCore> core1 = std::make_shared<InterpreterCore>(
+      place, prog.Block(0), &scope, interpreter::ExecutionConfig());
+  std::shared_ptr<InterpreterCore> core2 = std::make_shared<InterpreterCore>(
+      place, prog.Block(0), &scope, interpreter::ExecutionConfig());
   core2->ShareWorkQueueFrom(core1);
 
   auto run_and_check = [&feed_names, &feed_tensors, &fetch_results](


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
PCard-71568

静态图单机执行器`DryRun`功能原为支持自动并行Cost Model开发，后续自动并行实际未使用此接口实现Cost Model功能，且框架中也没有其它模块需要使用。
未使用的接口给执行器后续的维护和迭代升级带来了负担（如执行器支持流水并行多micro-batch调度，需要额外对这个接口也做升级适配），因而本PR将其移除。