### PR TITLE
slove issue-52842

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -139,13 +139,6 @@ if(NOT APPLE
   set(LINK_FLAGS
       "-Wl,--version-script ${CMAKE_CURRENT_SOURCE_DIR}/paddle_inference.map")
 
-  # temporarily fix brpc double link issue(52842)
-  if(WITH_INFERENCE_API_TEST
-     AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-     AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 10.4)
-    set(LINK_FLAGS "${LINK_FLAGS} -Wl,-Bsymbolic")
-  endif()
-
   set_target_properties(paddle_inference_shared PROPERTIES LINK_FLAGS
                                                            "${LINK_FLAGS}")
   # check symbol hidden


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
ref to https://github.com/PaddlePaddle/Paddle/issues/52842

1. -Wl,-Bsymbolic 存在副作用，会导致目标中的相关实例被初始化两次，相关单测运行报错，这个PR将其移除。
2. 我分析真正导致inference单测（如test_analyzer_ner）报错的原因是，inference单测链接了inference.so，分析后发现是inference.so对暴露符号有限制，而推理单测使用符号较广泛，不能够只依赖inference.so来获取符号，所以会间接获取paddle内部静态库来进行链接，导致出现动态库和静态库同时链接单测出现该问题。
3. 通过编译单测相关的cmake选项命令判断，跳过inference.so的符号限制，这样inference.so就能满足inference单测的需求，不会间接获取paddle内部静态库来进行链接，从而不会导致issue中的brpc被链接两次的报错。
![image](https://github.com/PaddlePaddle/Paddle/assets/23653004/8a40bb48-6eeb-4faf-ad0b-4a0ce0eb2770)
这个判断逻辑在当前dev 最新commit已存在，因此这个PR没有添加。
