### PR TITLE
change dims of logsumexp in memory efficient attention infermeta

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2303,7 +2303,8 @@ void MemoryEfficientAttentionInferMeta(const MetaTensor& query,
                         "The seq length of Key, Value should be equal."));
   std::vector<int64_t> out_dims(
       {query_batch_size, query_seq_length, query_num_head, value_head_size});
-  std::vector<int64_t> logsumexp_dims({query_num_head, query_batch_size});
+  std::vector<int64_t> logsumexp_dims(
+      {query_batch_size, query_num_head, query_seq_length});
   std::vector<int64_t> seed_and_offset_dims({2});
 
   output->set_dims(phi::make_ddim(out_dims));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Description
修改memory efficient attention infermeta函数中logsumexp的维度

PCard-70444
