### PR TITLE
[Paddle-TRT] revert to paddle op when matrix_multiply cannot enter into paddle-trt

### DIFF
--- a/paddle/fluid/framework/ir/trt_map_ops_to_matrix_multiply_pass.cc
+++ b/paddle/fluid/framework/ir/trt_map_ops_to_matrix_multiply_pass.cc
@@ -58,10 +58,10 @@ void TrtMapOpsToMatrixMultiplyPass::ApplyImpl(ir::Graph* graph) const {
     GET_IR_NODE_FROM_SUBGRAPH(ops, ops, mul_matmul_matmul_v2);
     GET_IR_NODE_FROM_SUBGRAPH(ops_out, ops_out, mul_matmul_matmul_v2);
     auto op_desc = ops->Op();
+    op_desc->SetAttr("original_type", op_desc->Type());
     op_desc->SetType("matrix_multiply");
 
     // OpDesc original_desc(*(ops->Op()));
-    op_desc->SetAttr("original_type", ops->Op()->Type());
 
     if (op_desc->HasAttr("transpose_X") || op_desc->HasAttr("trans_x")) {
       if (op_desc->HasAttr("transpose_X")) {

--- a/paddle/fluid/framework/ir/trt_map_ops_to_matrix_multiply_pass.cc
+++ b/paddle/fluid/framework/ir/trt_map_ops_to_matrix_multiply_pass.cc
@@ -60,6 +60,7 @@ void TrtMapOpsToMatrixMultiplyPass::ApplyImpl(ir::Graph* graph) const {
     auto op_desc = ops->Op();
     op_desc->SetAttr("original_type", op_desc->Type());
     op_desc->SetType("matrix_multiply");
+    ops->RenameOp("matrix_multiply");
 
     // OpDesc original_desc(*(ops->Op()));
 

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -224,6 +224,16 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
           ->SetAllNodesLowerToTrt(use_cuda_graph);
     }
   }
+
+  // some ops are only implemented in paddle-trt,
+  // but not in paddle ,we should revert it.
+  for (auto *op_node : framework::ir::TopologyVarientSort(
+           *graph, static_cast<framework::ir::SortKind>(0))) {
+    if (op_node->Op()->Type() == "matrix_multiply") {
+      op_node->Op()->SetType(
+          op_node->Op()->GetAttrIfExists<std::string>("original_type"));
+    }
+  }
 }
 
 std::string GenerateEngineKey(const std::set<std::string> &engine_inputs,

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -235,6 +235,7 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
       LOG(WARNING) << "matrix_multiply can't enter into paddle-trt,"
                    << "we will revert to " << origin_type;
       op_node->Op()->SetType(origin_type);
+      op_node->RenameOp(origin_type);
     }
   }
 }

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -230,8 +230,11 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
   for (auto *op_node : framework::ir::TopologyVarientSort(
            *graph, static_cast<framework::ir::SortKind>(0))) {
     if (op_node->Op()->Type() == "matrix_multiply") {
-      op_node->Op()->SetType(
-          op_node->Op()->GetAttrIfExists<std::string>("original_type"));
+      auto origin_type =
+          op_node->Op()->GetAttrIfExists<std::string>("original_type");
+      LOG(WARNING) << "matrix_multiply can't enter into paddle-trt,"
+                   << "we will revert to " << origin_type;
+      op_node->Op()->SetType(origin_type);
     }
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
revert to paddle op when matrix_multiply cannot enter into paddle-trt