### PR TITLE
【prim】set tanh_double comp api as default

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -69,6 +69,8 @@ prim_white_list = [
     "subtract_double_grad",
     "add_triple_grad",
     "silu_double_grad",
+    "tanh_double_grad",
+    "multiply_double_grad",
 ]
 
 # dict of special api that forward api's output will affect bacward api's output

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -70,7 +70,6 @@ prim_white_list = [
     "add_triple_grad",
     "silu_double_grad",
     "tanh_double_grad",
-    "multiply_double_grad",
 ]
 
 # dict of special api that forward api's output will affect bacward api's output

--- a/test/prim/prim/vjp/CMakeLists.txt
+++ b/test/prim/prim/vjp/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${GC_ENVS})
 endforeach()
 
-set_tests_properties(test_comp_high_grad PROPERTIES TIMEOUT 50)
+set_tests_properties(test_comp_high_grad PROPERTIES TIMEOUT 100)
 
 add_subdirectory(eager)
 add_subdirectory(static)

--- a/test/prim/prim/vjp/CMakeLists.txt
+++ b/test/prim/prim/vjp/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${GC_ENVS})
 endforeach()
 
-set_tests_properties(test_comp_high_grad PROPERTIES TIMEOUT 100)
+set_tests_properties(test_comp_high_grad PROPERTIES TIMEOUT 50)
 
 add_subdirectory(eager)
 add_subdirectory(static)

--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -23,7 +23,7 @@ import paddle
 from paddle import fluid
 from paddle.fluid import core
 
-'''
+
 @param.parameterized_class(
     ('shape1', 'shape2'),
     [
@@ -118,7 +118,6 @@ class TestAddHighGradCheck(unittest.TestCase):
         for p in places:
             self.func_double(p)
             self.func_triple(p)
-'''
 
 
 @param.parameterized_class(
@@ -225,7 +224,6 @@ class TestSubtractHighGradCheck(unittest.TestCase):
             self.func_triple(p)
 
 
-'''
 @param.parameterized_class(
     ('shape1', 'shape2'),
     [
@@ -328,7 +326,6 @@ class TestMultiplyHighGradCheck(unittest.TestCase):
         for p in places:
             self.func_double(p)
             self.func_triple(p)
-'''
 
 
 @param.parameterized_class(

--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -230,26 +230,26 @@ class TestSubtractHighGradCheck(unittest.TestCase):
 @param.parameterized_class(
     ('shape1', 'shape2'),
     [
-        # (
-        #     [2, 3, 4],
-        #     [2, 3, 4],
-        # ),
-        # (
-        #     [2, 3, 3, 4],
-        #     [3, 1, 4],
-        # ),
-        # (
-        #     [2, 3, 3, 4],
-        #     [3, 1, 1],
-        # ),
+        (
+            [2, 3, 4],
+            [2, 3, 4],
+        ),
+        (
+            [2, 3, 3, 4],
+            [3, 1, 4],
+        ),
+        (
+            [2, 3, 3, 4],
+            [3, 1, 1],
+        ),
         (
             [2, 3, 3, 4],
             [2, 3, 1, 4],
         ),
-        # (
-        #     [2, 3, 3, 4],
-        #     [2, 3, 1, 1],
-        # ),
+        (
+            [2, 3, 3, 4],
+            [2, 3, 1, 1],
+        ),
     ],
 )
 class TestMultiplyHighGradCheck(unittest.TestCase):

--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
 
+sys.path.append("../../../legacy_test")
 import gradient_checker
 import numpy as np
 import parameterized as param

--- a/test/prim/prim/vjp/test_comp_high_grad.py
+++ b/test/prim/prim/vjp/test_comp_high_grad.py
@@ -226,29 +226,30 @@ class TestSubtractHighGradCheck(unittest.TestCase):
             self.func_triple(p)
 
 
+'''
 @param.parameterized_class(
     ('shape1', 'shape2'),
     [
-        (
-            [2, 3, 4],
-            [2, 3, 4],
-        ),
-        (
-            [2, 3, 3, 4],
-            [3, 1, 4],
-        ),
-        (
-            [2, 3, 3, 4],
-            [3, 1, 1],
-        ),
+        # (
+        #     [2, 3, 4],
+        #     [2, 3, 4],
+        # ),
+        # (
+        #     [2, 3, 3, 4],
+        #     [3, 1, 4],
+        # ),
+        # (
+        #     [2, 3, 3, 4],
+        #     [3, 1, 1],
+        # ),
         (
             [2, 3, 3, 4],
             [2, 3, 1, 4],
         ),
-        (
-            [2, 3, 3, 4],
-            [2, 3, 1, 1],
-        ),
+        # (
+        #     [2, 3, 3, 4],
+        #     [2, 3, 1, 1],
+        # ),
     ],
 )
 class TestMultiplyHighGradCheck(unittest.TestCase):
@@ -328,6 +329,8 @@ class TestMultiplyHighGradCheck(unittest.TestCase):
         for p in places:
             self.func_double(p)
             self.func_triple(p)
+
+'''
 
 
 @param.parameterized_class(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-66975
打开tanh, mutiply 二阶拆解算子默认执行的路径，对科学计算deepxde 的42个模型性能影响 8h29min -> 9h24min