### PR TITLE
[Dygraph] Fix split_tensor of dp_pp_comm_overlap

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/utils.py
@@ -20,6 +20,7 @@ import paddle
 from paddle import _legacy_C_ops
 from paddle.distributed.parallel import _split_tensors
 from paddle.fluid import core
+from paddle.framework import base as imperative_base
 
 __all__ = []
 
@@ -165,6 +166,7 @@ class FusedAllReduceBuffer:
         if self._all_params_checked_in:
             self._fused_allreduce_grads()
 
+    @imperative_base.no_grad
     def _fused_allreduce_grads(self):
         assert self._all_params_checked_in
         flattened_vars = []
@@ -188,6 +190,7 @@ class FusedAllReduceBuffer:
                 )
             )
 
+    @imperative_base.no_grad
     def scale_and_split_grads(self):
         for task in self._tasks:
             task.wait()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[Dygraph] Fix split_tensor of dp_pp_comm_overlap. (card-70853)

修复case：

PP+DP策略下，通信overlap性能优化策略会在未使用main_grad机制的场景中报下图中的错误

<img width="1358" alt="d4e92c29cc6e075fc26fdb1387f18a6f" src="https://github.com/PaddlePaddle/Paddle/assets/86215757/ee553fe0-1c9f-4c9d-b5d0-2fd3970aa6d7">

原因是训练中某些参数的梯度的 `stop_gradient` 为 `False`（高阶微分需要）；框架机制中保障叶子结点不能使用 `inplace` API，除非叶子结点的 `stop_gradient` 为 `True`。

解决方式是让梯度的 `inplace` 操作在 `no_grad` 环境下完成。