### PR TITLE
[XPU] fix unittest of shape op.

### DIFF
--- a/paddle/phi/kernels/selected_rows/shape_kernel.cc
+++ b/paddle/phi/kernels/selected_rows/shape_kernel.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/shape_kernel.h"
@@ -65,6 +66,23 @@ PD_REGISTER_KERNEL(shape_sr,
                    double,
                    phi::dtype::complex<float>,
                    phi::dtype::complex<double>) {
+  kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
+  kernel->OutputAt(0).SetBackend(phi::Backend::CPU);
+  kernel->OutputAt(0).SetDataType(phi::DataType::INT32);
+}
+#endif
+
+#if defined(PADDLE_WITH_XPU)
+PD_REGISTER_KERNEL(shape_sr,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::sr::ShapeKernel,
+                   bool,
+                   int,
+                   int64_t,
+                   float,
+                   double,
+                   phi::dtype::float16) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->OutputAt(0).SetBackend(phi::Backend::CPU);
   kernel->OutputAt(0).SetDataType(phi::DataType::INT32);


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
`shape`算子在`selected_rows`下面缺少XPU的注册。之前没有踩上，而在这个PR https://github.com/PaddlePaddle/Paddle/pull/54221 修改了算子的注册方式，会导致XPU下面的单测跑不过。但是XPU单测脚本有bug（用另外的PR处理），导致明明单测挂了却没有拦住。
本PR追加了注册，让`test_shape_op_xpu`单测能正常跑过。
