### PR TITLE
[generator][cmake] add pip install check

### DIFF
--- a/paddle/fluid/operators/generator/CMakeLists.txt
+++ b/paddle/fluid/operators/generator/CMakeLists.txt
@@ -27,7 +27,6 @@ function(install_py_pyyaml)
       ${PYTHON_EXECUTABLE} "-c"
       "import re, pyyaml; print(re.compile('/__init__.py.*').sub('',pyyaml.__file__))"
     RESULT_VARIABLE _pyyaml_status
-    OUTPUT_VARIABLE _pyyaml_location
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if(NOT _pyyaml_status EQUAL 0)
@@ -43,7 +42,6 @@ function(install_py_jinja2)
       ${PYTHON_EXECUTABLE} "-c"
       "import re, jinja2; print(re.compile('/__init__.py.*').sub('',jinja2.__file__))"
     RESULT_VARIABLE _jinja2_status
-    OUTPUT_VARIABLE _jinja2_location
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if(_jinja2_status EQUAL 0)
@@ -87,7 +85,6 @@ function(install_py_typing_extensions)
       ${PYTHON_EXECUTABLE} "-c"
       "import re, typing_extensions; print(re.compile('/__init__.py.*').sub('',typing_extensions.__file__))"
     RESULT_VARIABLE _te_status
-    OUTPUT_VARIABLE _te_location
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if(NOT _te_status EQUAL 0)

--- a/paddle/fluid/operators/generator/CMakeLists.txt
+++ b/paddle/fluid/operators/generator/CMakeLists.txt
@@ -21,14 +21,84 @@ if(NOT PYTHONINTERP_FOUND)
   find_package(PythonInterp REQUIRED)
 endif()
 
-# install extra dependencies
-if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U pyyaml
-                          typing-extensions>=4.1.1 jinja2==2.11.3)
-else()
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U pyyaml jinja2
-                          typing-extensions)
-endif()
+function(install_py_pyyaml)
+  execute_process(
+    COMMAND
+      ${PYTHON_EXECUTABLE} "-c"
+      "import re, pyyaml; print(re.compile('/__init__.py.*').sub('',pyyaml.__file__))"
+    RESULT_VARIABLE _pyyaml_status
+    OUTPUT_VARIABLE _pyyaml_location
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT _pyyaml_status EQUAL 0)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U pyyaml)
+  endif()
+
+endfunction()
+
+function(install_py_jinja2)
+  # check install
+  execute_process(
+    COMMAND
+      ${PYTHON_EXECUTABLE} "-c"
+      "import re, jinja2; print(re.compile('/__init__.py.*').sub('',jinja2.__file__))"
+    RESULT_VARIABLE _jinja2_status
+    OUTPUT_VARIABLE _jinja2_location
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(_jinja2_status EQUAL 0)
+    # check version
+    execute_process(
+      COMMAND ${PYTHON_EXECUTABLE} "-c"
+              "import jinja2; print(jinja2.__version__)"
+      OUTPUT_VARIABLE _jinja2_version
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
+      if(NOT _jinja2_version VERSION_LESS "2.11.3")
+        execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
+                                jinja2==2.11.3)
+      endif()
+      return()
+    endif()
+
+    if(_jinja2_version)
+      return()
+    endif()
+  endif()
+
+  if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
+                            jinja2==2.11.3)
+  else()
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U jinja2)
+  endif()
+endfunction()
+
+function(install_py_typing_extensions)
+  if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
+                            typing-extensions>=4.1.1)
+    return()
+  endif()
+
+  execute_process(
+    COMMAND
+      ${PYTHON_EXECUTABLE} "-c"
+      "import re, typing_extensions; print(re.compile('/__init__.py.*').sub('',typing_extensions.__file__))"
+    RESULT_VARIABLE _te_status
+    OUTPUT_VARIABLE _te_location
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT _te_status EQUAL 0)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
+                            typing-extensions)
+  endif()
+endfunction()
+
+install_py_pyyaml()
+install_py_jinja2()
+install_py_typing_extensions()
 
 # parse ops
 set(parsed_op_dir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
在`pip install -U` 前检查是否安装模块，以及版本是否符合要求. 来避免重复安装但网络不好的情况, 如下

```bash
-- commit: 37930a69f8
-- branch: develop
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple/
Requirement already satisfied: pyyaml in /usr/local/lib/python3.10/site-packages (6.0)
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x110400c40>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known')': /simple/pyyaml/
.........
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x11050ea70>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known')': /simple/typing-extensions/
Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/site-packages (from jinja2) (2.1.2)

[notice] A new release of pip is available: 23.1 -> 23.1.2
[notice] To update, run: python3.10 -m pip install --upgrade pip
```