### PR TITLE
[IR] format the use of new ir api

### DIFF
--- a/paddle/fluid/ir/dialect/op_gen.py
+++ b/paddle/fluid/ir/dialect/op_gen.py
@@ -647,10 +647,10 @@ def GenBuildInputArgsStr(
     for_func_define=True,
 ):
     '''
-    Example: ir::Builder &builder, ir::OperationArgument &argument, ir::OpResult x_, phi::DataType dtype=phi::DataType::UNDEFINED, phi::Place place={}
+    Example: ir::OperationArgument &argument, ir::OpResult x_, phi::DataType dtype=phi::DataType::UNDEFINED, phi::Place place={}
     '''
-    build_args_str = "ir::Builder &builder, ir::OperationArgument &argument"
     # add inputs
+    build_args_str = "ir::OperationArgument &argument"
     if len(op_input_name_list) > 0:
         for input_name in op_input_name_list:
             build_args_str += ", ir::OpResult " + input_name + "_"

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -126,7 +126,7 @@ inline ir::Operation* InsertSliceOperationForTarget(
   ir::VectorType src_vec_type =
       defining_info.value.type().dyn_cast<ir::VectorType>();
   ir::Operation* operation =
-      ir::Operation::create({defining_info.value},
+      ir::Operation::Create({defining_info.value},
                             op_attribute_map,
                             {src_vec_type[defining_info.idx_in_vector]},
                             op_info);
@@ -153,7 +153,7 @@ inline ir::Operation* InsertCombineOperationForTarget(
   }
   ir::Type target_vec_type = ir::VectorType::get(ctx, types_in_vec);
   ir::Operation* operation =
-      ir::Operation::create(src_values, {}, {target_vec_type}, op_info);
+      ir::Operation::Create(src_values, {}, {target_vec_type}, op_info);
   program->block()->push_back(operation);
   return operation;
 }
@@ -165,7 +165,7 @@ inline ir::Operation* InsertConstantOperationForOptionalArg(
 
   ir::Type null_type = ir::Type(nullptr);
   ir::Operation* operation =
-      ir::Operation::create({}, {}, {null_type}, op_info);
+      ir::Operation::Create({}, {}, {null_type}, op_info);
   program->block()->push_back(operation);
   return operation;
 }
@@ -401,7 +401,7 @@ ir::Operation* GeneralOpHandler(ir::IrContext* ctx,
   VLOG(4) << "[general op][" << op_desc.Type() << "] preparation end.";
 
   ir::Operation* operation =
-      ir::Operation::create(op_inputs, attribute_map, op_output_types, op_info);
+      ir::Operation::Create(op_inputs, attribute_map, op_output_types, op_info);
   VLOG(4) << "[general op][" << op_desc.Type() << "] opearation creation end.";
   program->block()->push_back(operation);
 
@@ -436,7 +436,7 @@ ir::Operation* FeedOpHandler(ir::IrContext* ctx,
   };
 
   ir::Operation* operation =
-      ir::Operation::create(op_inputs, attribute_map, op_output_types, op_info);
+      ir::Operation::Create(op_inputs, attribute_map, op_output_types, op_info);
   program->block()->push_back(operation);
   RecordOpResultMapping(param_map, op_desc, operation, arg_to_idx);
 
@@ -466,7 +466,7 @@ ir::Operation* FetchOpHandler(ir::IrContext* ctx,
   };
 
   ir::Operation* operation =
-      ir::Operation::create(op_inputs, attribute_map, op_output_types, op_info);
+      ir::Operation::Create(op_inputs, attribute_map, op_output_types, op_info);
   program->block()->push_back(operation);
 
   return operation;

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -79,7 +79,7 @@ void ProgramTranslator::ExtractParameterFromSingleBlock(
         {"parameter_name", ir::StrAttribute::get(ctx, var->Name())},
     };
     ir::Type translated_var_type = type_translator[var->GetType()](ctx, *var);
-    ir::Operation* operation = ir::Operation::create(
+    ir::Operation* operation = ir::Operation::Create(
         {}, op_attribute_map, {translated_var_type}, op_info);
     program->block()->push_back(operation);
     param_map[var->Name()] =

--- a/paddle/ir/core/block.cc
+++ b/paddle/ir/core/block.cc
@@ -33,7 +33,7 @@ Block::iterator Block::insert(const_iterator iterator, Operation *op) {
 
 void Block::clear() {
   while (!empty()) {
-    ops_.back()->destroy();
+    ops_.back()->Destroy();
     ops_.pop_back();
   }
 }

--- a/paddle/ir/core/builder.cc
+++ b/paddle/ir/core/builder.cc
@@ -17,26 +17,26 @@
 #include "paddle/ir/core/value.h"
 
 namespace ir {
-Operation *Builder::insert(Operation *op) {
+/// Create an operation given the fields represented as an OperationState.
+Operation *Builder::Build(OperationArgument &&argument) {
+  return Insert(Operation::Create(std::move(argument)));
+}
+
+/// Creates an operation with the given fields.
+Operation *Builder::Build(const std::vector<OpResult> &inputs,
+                          const AttributeMap &attribute,
+                          const std::vector<Type> &output_types,
+                          OpInfo op_info) {
+  return Build(OperationArgument(inputs, attribute, output_types, op_info));
+}
+
+Operation *Builder::Insert(Operation *op) {
   if (block_) {
     block_->insert(insert_point_, op);
   } else {
     LOG(WARNING) << "Builder's Block is nullptr, insert failed.";
   }
   return op;
-}
-
-/// Create an operation given the fields represented as an OperationState.
-Operation *Builder::create(OperationArgument &&argument) {
-  return insert(Operation::create(std::move(argument)));
-}
-
-/// Creates an operation with the given fields.
-Operation *Builder::create(const std::vector<OpResult> &inputs,
-                           const AttributeMap &attribute,
-                           const std::vector<Type> &output_types,
-                           OpInfo op_info) {
-  return create(OperationArgument(inputs, attribute, output_types, op_info));
 }
 
 }  // namespace ir

--- a/paddle/ir/core/builder.h
+++ b/paddle/ir/core/builder.h
@@ -43,27 +43,27 @@ class Builder {
 
   Block *block() const { return block_; }
 
-  Operation *insert(Operation *op);
-
   /// Creates an operation given the fields represented as an OperationState.
-  Operation *create(OperationArgument &&argument);
+  Operation *Build(OperationArgument &&argument);
 
   /// Creates an operation with the given fields.
-  Operation *create(const std::vector<ir::OpResult> &inputs,
-                    const AttributeMap &attribute,
-                    const std::vector<ir::Type> &output_types,
-                    ir::OpInfo op_info);
+  Operation *Build(const std::vector<ir::OpResult> &inputs,
+                   const AttributeMap &attribute,
+                   const std::vector<ir::Type> &output_types,
+                   ir::OpInfo op_info);
 
   /// Create an operation of specific op type at the current insertion point.
   template <typename OpTy, typename... Args>
-  OpTy create(Args &&...args) {
+  OpTy Build(Args &&...args) {
     OperationArgument argument(context_->GetRegisteredOpInfo(OpTy::name()));
-    OpTy::Build(*this, argument, std::forward<Args>(args)...);
-    Operation *op = create(std::move(argument));
+    OpTy::Build(argument, std::forward<Args>(args)...);
+    Operation *op = Build(std::move(argument));
     return op->dyn_cast<OpTy>();
   }
 
  private:
+  Operation *Insert(Operation *op);
+
   IrContext *context_;
   Block *block_ = nullptr;
   // The insertion point within the list that this builder is inserting before.

--- a/paddle/ir/core/builtin_op.cc
+++ b/paddle/ir/core/builtin_op.cc
@@ -37,17 +37,17 @@ Block *ModuleOp::block() {
   return operation()->GetRegion(0).front();
 }
 
-ModuleOp ModuleOp::create(IrContext *context, Program *pointer) {
+ModuleOp ModuleOp::Create(IrContext *context, Program *pointer) {
   ir::OpInfo info = context->GetRegisteredOpInfo(name());
   OperationArgument argument(info);
   argument.AddRegion()->emplace_back();
   argument.AddAttribute("program", PointerAttribute::get(context, pointer));
-  return ModuleOp(Operation::create(std::move(argument)));
+  return ModuleOp(Operation::Create(std::move(argument)));
 }
 
-void ModuleOp::destroy() {
+void ModuleOp::Destroy() {
   if (operation()) {
-    operation()->destroy();
+    operation()->Destroy();
     *this = ModuleOp(nullptr);
   }
 }
@@ -216,8 +216,7 @@ void SliceOp::Verify(const std::vector<ir::OpResult> &inputs,
 
 const char *ConstantOp::attributes_name[attributes_num] = {"value"};
 
-void ConstantOp::Build(Builder &builder,
-                       OperationArgument &argument,
+void ConstantOp::Build(OperationArgument &argument,
                        Attribute value,
                        Type output_type) {
   argument.AddAttribute("value", value);

--- a/paddle/ir/core/builtin_op.h
+++ b/paddle/ir/core/builtin_op.h
@@ -40,8 +40,8 @@ class ModuleOp : public ir::Op<ModuleOp> {
   //
   // As the top operation, ModuleOp only support create&destroye through
   // below interface: "create"&"destroy".
-  static ModuleOp create(IrContext *context, Program *pointer);
-  void destroy();
+  static ModuleOp Create(IrContext *context, Program *pointer);
+  void Destroy();
 };
 
 ///
@@ -125,8 +125,7 @@ class ConstantOp : public Op<ConstantOp, ConstantLikeTrait> {
   static constexpr uint32_t attributes_num = 1;
   static const char *attributes_name[attributes_num];
 
-  static void Build(Builder &builder,             // NOLINT
-                    OperationArgument &argument,  // NOLINT
+  static void Build(OperationArgument &argument,  // NOLINT
                     Attribute value,
                     Type output_type);
 

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -24,8 +24,8 @@
 #include "paddle/ir/core/value_impl.h"
 
 namespace ir {
-Operation *Operation::create(OperationArgument &&argument) {
-  Operation *op = create(argument.inputs,
+Operation *Operation::Create(OperationArgument &&argument) {
+  Operation *op = Create(argument.inputs,
                          argument.attributes,
                          argument.output_types,
                          argument.info,
@@ -40,7 +40,7 @@ Operation *Operation::create(OperationArgument &&argument) {
 // Allocate the required memory based on the size and number of inputs, outputs,
 // and operators, and construct it in the order of: OpOutlineResult,
 // OpInlineResult, Operation, Operand.
-Operation *Operation::create(const std::vector<ir::OpResult> &inputs,
+Operation *Operation::Create(const std::vector<ir::OpResult> &inputs,
                              const AttributeMap &attributes,
                              const std::vector<ir::Type> &output_types,
                              ir::OpInfo op_info,
@@ -104,7 +104,7 @@ Operation *Operation::create(const std::vector<ir::OpResult> &inputs,
 
 // Call destructors for OpResults, Operation, and OpOperands in sequence, and
 // finally free memory.
-void Operation::destroy() {
+void Operation::Destroy() {
   // Deconstruct Regions.
   if (num_regions_ > 0) {
     for (size_t idx = 0; idx < num_regions_; idx++) {

--- a/paddle/ir/core/operation.h
+++ b/paddle/ir/core/operation.h
@@ -34,17 +34,17 @@ class alignas(8) Operation final {
   /// NOTE: Similar to new and delete, the destroy() and the create() need to be
   /// used in conjunction.
   ///
-  static Operation *create(const std::vector<ir::OpResult> &inputs,
+  static Operation *Create(const std::vector<ir::OpResult> &inputs,
                            const AttributeMap &attributes,
                            const std::vector<ir::Type> &output_types,
                            ir::OpInfo op_info,
                            size_t num_regions = 0);
-  static Operation *create(OperationArgument &&op_argument);
+  static Operation *Create(OperationArgument &&op_argument);
 
   ///
   /// \brief Destroy the operation objects and free memory by create().
   ///
-  void destroy();
+  void Destroy();
 
   IrContext *ir_context() const;
 

--- a/paddle/ir/core/program.cc
+++ b/paddle/ir/core/program.cc
@@ -18,12 +18,12 @@
 namespace ir {
 
 Program::Program(IrContext* context) {
-  module_ = ModuleOp::create(context, this);
+  module_ = ModuleOp::Create(context, this);
 }
 
 Program::~Program() {
   if (module_) {
-    module_.destroy();
+    module_.Destroy();
   }
 }
 

--- a/test/cpp/ir/core/ir_exe_test.cc
+++ b/test/cpp/ir/core/ir_exe_test.cc
@@ -89,7 +89,7 @@ TEST(program_test, program) {
       {"seed", seed},
       {"place", uni_place}};
   ir::Operation* op1 =
-      ir::Operation::create({}, op1_attribute, {dense_tensor_dtype}, op1_info);
+      ir::Operation::Create({}, op1_attribute, {dense_tensor_dtype}, op1_info);
 
   block->push_back(op1);
 
@@ -99,13 +99,13 @@ TEST(program_test, program) {
   ir::Attribute ten2 = ir::Int32_tAttribute::get(ctx, 3);
   std::unordered_map<std::string, ir::Attribute> op2_attribute{{"shape", ten2}};
   ir::Operation* op2 =
-      ir::Operation::create({}, op1_attribute, {dense_tensor_dtype}, op2_info);
+      ir::Operation::Create({}, op1_attribute, {dense_tensor_dtype}, op2_info);
   block->push_back(op2);
 
   // (3) Def out = AddOp(a, b)
   std::string add_op_name = std::string(paddle::dialect::AddOp::name());
   ir::OpInfo add_op_info = ctx->GetRegisteredOpInfo(add_op_name);
-  ir::Operation* add_op = ir::Operation::create(
+  ir::Operation* add_op = ir::Operation::Create(
       {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
       {},
       {dense_tensor_dtype},

--- a/test/cpp/ir/core/ir_infershape_test.cc
+++ b/test/cpp/ir/core/ir_infershape_test.cc
@@ -82,7 +82,7 @@ TEST(infershape_test, infershape_test) {
   std::vector<ir::OpResult> op_inputs = {};
   std::vector<ir::Type> op_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op =
-      ir::Operation::create(op_inputs, {}, op_output_types, op_info);
+      ir::Operation::Create(op_inputs, {}, op_output_types, op_info);
 
   InferShapeInterface interface = op->dyn_cast<InferShapeInterface>();
   phi::InferMetaContext infer_meta_ctx;

--- a/test/cpp/ir/core/ir_op_test.cc
+++ b/test/cpp/ir/core/ir_op_test.cc
@@ -175,7 +175,7 @@ TEST(op_test, op_test) {
   std::vector<ir::OpResult> op_inputs = {};
   std::vector<ir::Type> op_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op2 =
-      ir::Operation::create(op_inputs,
+      ir::Operation::Create(op_inputs,
                             CreateAttributeMap({"op2_attr1", "op2_attr2"},
                                                {"op2_attr1", "op2_attr2"}),
                             op_output_types,
@@ -187,7 +187,7 @@ TEST(op_test, op_test) {
   interface.InferShape();
   Operation2 Op2 = op2->dyn_cast<Operation2>();
   EXPECT_EQ(Op2.operation(), op2);
-  op2->destroy();
+  op2->Destroy();
 }
 
 TEST(op_test, region_test) {
@@ -201,13 +201,13 @@ TEST(op_test, region_test) {
   ir::OpInfo op2_info = ctx->GetRegisteredOpInfo(Operation2::name());
 
   ir::Operation *op1 =
-      ir::Operation::create({},
+      ir::Operation::Create({},
                             CreateAttributeMap({"op1_attr1", "op1_attr2"},
                                                {"op1_attr1", "op1_attr2"}),
                             {ir::Float32Type::get(ctx)},
                             op1_info);
   ir::Operation *op1_2 =
-      ir::Operation::create({},
+      ir::Operation::Create({},
                             CreateAttributeMap({"op1_attr1", "op1_attr2"},
                                                {"op1_attr1", "op1_attr2"}),
                             {ir::Float32Type::get(ctx)},
@@ -227,8 +227,8 @@ TEST(op_test, region_test) {
   ir::Block *block = region->front();
   block->push_front(op1);
   block->insert(block->begin(), op1_2);
-  ir::Operation *op2 = ir::Operation::create(std::move(argument));
-  op2->destroy();
+  ir::Operation *op2 = ir::Operation::Create(std::move(argument));
+  op2->Destroy();
 }
 
 TEST(op_test, module_op_death) {
@@ -240,9 +240,9 @@ TEST(op_test, module_op_death) {
   ir::AttributeMap attrs{{"program", ir::Int32_tAttribute::get(ctx, 1)}};
   std::vector<ir::Type> output_types = {ir::Float32Type::get(ctx)};
 
-  EXPECT_THROW(ir::Operation::create(inputs, {}, {}, op_info), const char *);
-  EXPECT_THROW(ir::Operation::create({}, attrs, {}, op_info), const char *);
-  EXPECT_THROW(ir::Operation::create({}, {}, output_types, op_info),
+  EXPECT_THROW(ir::Operation::Create(inputs, {}, {}, op_info), const char *);
+  EXPECT_THROW(ir::Operation::Create({}, attrs, {}, op_info), const char *);
+  EXPECT_THROW(ir::Operation::Create({}, {}, output_types, op_info),
                const char *);
 
   ir::Program program(ctx);

--- a/test/cpp/ir/core/ir_value_test.cc
+++ b/test/cpp/ir/core/ir_value_test.cc
@@ -39,7 +39,7 @@ TEST(value_test, value_test) {
   std::vector<ir::OpResult> op1_inputs = {};
   std::vector<ir::Type> op1_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op1 =
-      ir::Operation::create(op1_inputs,
+      ir::Operation::Create(op1_inputs,
                             CreateAttributeMap("op1_name", "op1_attr"),
                             op1_output_types,
                             nullptr);
@@ -48,7 +48,7 @@ TEST(value_test, value_test) {
   std::vector<ir::OpResult> op2_inputs = {};
   std::vector<ir::Type> op2_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op2 =
-      ir::Operation::create(op2_inputs,
+      ir::Operation::Create(op2_inputs,
                             CreateAttributeMap("op2_name", "op2_attr"),
                             op2_output_types,
                             nullptr);
@@ -58,7 +58,7 @@ TEST(value_test, value_test) {
                                           op2->GetResultByIndex(0)};
   std::vector<ir::Type> op3_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op3 =
-      ir::Operation::create(op3_inputs,
+      ir::Operation::Create(op3_inputs,
                             CreateAttributeMap("op3_name", "op3_attr"),
                             op3_output_types,
                             nullptr);
@@ -71,7 +71,7 @@ TEST(value_test, value_test) {
     op4_output_types.push_back(ir::Float32Type::get(ctx));
   }
   ir::Operation *op4 =
-      ir::Operation::create(op4_inputs,
+      ir::Operation::Create(op4_inputs,
                             CreateAttributeMap("op4_name", "op4_attr"),
                             op4_output_types,
                             nullptr);
@@ -101,11 +101,11 @@ TEST(value_test, value_test) {
 
   // destroy
   VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
-  op4->destroy();
+  op4->Destroy();
   VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
-  op3->destroy();
+  op3->Destroy();
   VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
-  op2->destroy();
+  op2->Destroy();
   VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
-  op1->destroy();
+  op1->Destroy();
 }

--- a/test/cpp/ir/pass/pass_manager_test.cc
+++ b/test/cpp/ir/pass/pass_manager_test.cc
@@ -107,7 +107,7 @@ TEST(pass_manager_test, pass_manager) {
   std::unordered_map<std::string, ir::Attribute> op1_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "a")}};
   ir::Operation *op1 =
-      ir::Operation::create({}, op1_attribute, {dense_tensor_dtype}, op1_info);
+      ir::Operation::Create({}, op1_attribute, {dense_tensor_dtype}, op1_info);
 
   ir::Block *block = program.block();
   block->push_back(op1);
@@ -145,7 +145,7 @@ TEST(pass_manager_test, pass_manager) {
   std::unordered_map<std::string, ir::Attribute> op2_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "b")}};
   ir::Operation *op2 =
-      ir::Operation::create({}, op2_attribute, {dense_tensor_dtype}, op2_info);
+      ir::Operation::Create({}, op2_attribute, {dense_tensor_dtype}, op2_info);
   block->push_back(op2);
 
   EXPECT_EQ(op2->GetResultByIndex(0).type().dialect().id(),
@@ -172,7 +172,7 @@ TEST(pass_manager_test, pass_manager) {
       builtin_dialect->name() + "." + std::string(AddOp::name());
   ir::OpInfo op3_info = ctx->GetRegisteredOpInfo(op3_name);
   std::unordered_map<std::string, ir::Attribute> op3_attribute;
-  ir::Operation *op3 = ir::Operation::create(
+  ir::Operation *op3 = ir::Operation::Create(
       {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
       op3_attribute,
       {dense_tensor_dtype},
@@ -207,7 +207,7 @@ TEST(pass_manager_test, pass_manager) {
   abs_argument.AddOperands(operands.begin(), operands.end());
   abs_argument.AddAttributes(abs_op_attribute.begin(), abs_op_attribute.end());
   abs_argument.AddTypes(output_types.begin(), output_types.end());
-  ir::Operation *abs_op = ir::Operation::create(std::move(abs_argument));
+  ir::Operation *abs_op = ir::Operation::Create(std::move(abs_argument));
   paddle::dialect::OpYamlInfoInterface interface =
       abs_op->dyn_cast<paddle::dialect::OpYamlInfoInterface>();
   EXPECT_EQ(std::get<0>(interface.GetOpInfo())[0].name == "x", true);
@@ -222,7 +222,7 @@ TEST(pass_manager_test, pass_manager) {
   ir::OperationArgument op4_argument(
       {op3->GetResultByIndex(0)}, {}, {}, op4_info);
   op4_argument.AddAttributes(op4_attribute.begin(), op4_attribute.end());
-  ir::Operation *op4 = ir::Operation::create(std::move(op4_argument));
+  ir::Operation *op4 = ir::Operation::Create(std::move(op4_argument));
   block->push_back(op4);
 
   EXPECT_EQ(op4->GetOperandByIndex(0).source().type().dialect().id(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

APIs

### Description
<!-- Describe what you’ve done -->

规范化新IR的接口。

- 将create、destroy、build等api的首字母大写。 
- 按照设计，Create和Build的区别在于Create的返回值需要调用者显式的destroy. 而Build的返回值则不需要。
  - 基于此原则，将ir::Builder中的Create接口修改为Build。因此Builder会自动将创建的Operation插入相应的插入点。不需要用户显式Destroy。
- 删除新Op定义中的Build函数的第一个参数Builder， 因为该函数的实现并不需要用到该参数。

### Other
Pcard-67164
