### PR TITLE
[XPU] support approximate for gelu activation.

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -8,7 +8,7 @@ set(XPU_API_LIB_NAME "libxpuapi.so")
 set(XPU_RT_LIB_NAME "libxpurt.so")
 set(XPU_XFT_LIB_NAME "libxft.so")
 
-set(XPU_BASE_DATE "20230529")
+set(XPU_BASE_DATE "20230602")
 set(XPU_XCCL_BASE_VERSION "1.0.49.2")
 set(XPU_XFT_BASE_VERSION "latest")
 

--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -377,6 +377,19 @@ class XPUTestGeluOP(XPUOpTestWrapper):
             self.outputs = {'Out': out}
             self.attrs = {"approximate": approximate, 'use_xpu': True}
 
+    class XPUTestGeluApproximate(TestActivationOPBase):
+        def set_case(self):
+            self.op_type = "gelu"
+            self.dtype = self.in_type
+
+            approximate = True
+            x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
+            out = gelu(x, approximate)
+
+            self.inputs = {'X': x}
+            self.outputs = {'Out': out}
+            self.attrs = {"approximate": approximate, 'use_xpu': True}
+
 
 support_types = get_xpu_op_support_types('gelu')
 for stype in support_types:

--- a/test/xpu/test_rnn_op_xpu.py
+++ b/test/xpu/test_rnn_op_xpu.py
@@ -11,9 +11,13 @@
 # limitations under the License.
 
 import random
+import sys
 import unittest
 
 import numpy as np
+
+sys.path.append('../rnn')
+
 from convert import get_params_for_net
 from get_test_cover_info import (
     XPUOpTestWrapper,


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
* 给`gelu`算子，增加对`approximate`参数的支持。
* 更新XDNN依赖到20230602，需要用到里面新增的`approximate_gelu_grad`函数。
* 顺便修了 https://github.com/PaddlePaddle/Paddle/pull/53235 引入的一个单测路径依赖问题。
