### PR TITLE
[AMP Prim OP]support some prim ops for bf16 dtype part5

### DIFF
--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1197,7 +1197,9 @@ set(TEST_CINN_OPS
     test_scatter_nd_op
     test_strided_slice_op
     test_instance_norm_op
-    test_cumsum_op)
+    test_cumsum_op
+    test_pad_op
+    test_split_op)
 
 foreach(TEST_CINN_OPS ${TEST_CINN_OPS})
   if(WITH_CINN)

--- a/test/legacy_test/test_elementwise_min_op.py
+++ b/test/legacy_test/test_elementwise_min_op.py
@@ -127,17 +127,11 @@ class TestElementwiseMinOp_ZeroDim1(TestElementwiseOp):
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
-
 
 class TestElementwiseMinFP16Op_ZeroDim1(TestElementwiseFP16Op):
     def init_data(self):
         self.x = np.random.uniform(0.1, 1, []).astype(np.float16)
         self.y = np.random.uniform(0.1, 1, []).astype(np.float16)
-
-    def if_enable_cinn(self):
-        self.enable_cinn = False
 
 
 class TestElementwiseMinOp_ZeroDim2(TestElementwiseOp):
@@ -152,8 +146,8 @@ class TestElementwiseMinOp_ZeroDim2(TestElementwiseOp):
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
+    # def if_enable_cinn(self):
+    #     self.enable_cinn = False
 
 
 class TestElementwiseMinFP16Op_ZeroDim2(TestElementwiseFP16Op):
@@ -161,8 +155,8 @@ class TestElementwiseMinFP16Op_ZeroDim2(TestElementwiseFP16Op):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype("float16")
         self.y = np.random.uniform(0.1, 1, []).astype("float16")
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
+    # def if_enable_cinn(self):
+    #     self.enable_cinn = False
 
 
 class TestElementwiseMinOp_ZeroDim3(TestElementwiseOp):
@@ -177,8 +171,8 @@ class TestElementwiseMinOp_ZeroDim3(TestElementwiseOp):
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
+    # def if_enable_cinn(self):
+    #     self.enable_cinn = False
 
 
 class TestElementwiseMinFP16Op_ZeroDim3(TestElementwiseFP16Op):
@@ -186,8 +180,8 @@ class TestElementwiseMinFP16Op_ZeroDim3(TestElementwiseFP16Op):
         self.x = np.random.uniform(0.1, 1, []).astype("float16")
         self.y = np.random.uniform(0.1, 1, [13, 17]).astype("float16")
 
-    def if_enable_cinn(self):
-        self.enable_cinn = False
+    # def if_enable_cinn(self):
+    #     self.enable_cinn = False
 
 
 @skip_check_grad_ci(
@@ -388,7 +382,7 @@ class TestElementwiseBF16Op(OpTest):
     def test_check_grad_ingore_x(self):
         places = self._get_places()
         for place in places:
-            if type(place) is paddle.fluid.libpaddle.CPUPlace:
+            if isinstance(place, paddle.fluid.libpaddle.CPUPlace):
                 check_prim = False
             else:
                 check_prim = True
@@ -413,7 +407,7 @@ class TestElementwiseBF16Op(OpTest):
     def test_check_grad_ingore_y(self):
         places = self._get_places()
         for place in places:
-            if type(place) is paddle.fluid.libpaddle.CPUPlace:
+            if isinstance(place, paddle.fluid.libpaddle.CPUPlace):
                 check_prim = False
             else:
                 check_prim = True
@@ -436,7 +430,7 @@ class TestElementwiseBF16Op(OpTest):
             )
 
     def if_enable_cinn(self):
-        self.enable_cinn = False
+        pass
 
 
 class TestElementwiseMinBF16Op_ZeroDim1(TestElementwiseBF16Op):

--- a/test/legacy_test/test_elementwise_min_op.py
+++ b/test/legacy_test/test_elementwise_min_op.py
@@ -140,23 +140,16 @@ class TestElementwiseMinOp_ZeroDim2(TestElementwiseOp):
         self.python_api = paddle.minimum
         self.public_python_api = paddle.minimum
         self.prim_op_type = "prim"
-        self.if_enable_cinn()
         x = np.random.uniform(0.1, 1, [13, 17]).astype("float64")
         y = np.random.uniform(0.1, 1, []).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
-
-    # def if_enable_cinn(self):
-    #     self.enable_cinn = False
 
 
 class TestElementwiseMinFP16Op_ZeroDim2(TestElementwiseFP16Op):
     def init_data(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype("float16")
         self.y = np.random.uniform(0.1, 1, []).astype("float16")
-
-    # def if_enable_cinn(self):
-    #     self.enable_cinn = False
 
 
 class TestElementwiseMinOp_ZeroDim3(TestElementwiseOp):
@@ -171,17 +164,11 @@ class TestElementwiseMinOp_ZeroDim3(TestElementwiseOp):
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
-    # def if_enable_cinn(self):
-    #     self.enable_cinn = False
-
 
 class TestElementwiseMinFP16Op_ZeroDim3(TestElementwiseFP16Op):
     def init_data(self):
         self.x = np.random.uniform(0.1, 1, []).astype("float16")
         self.y = np.random.uniform(0.1, 1, [13, 17]).astype("float16")
-
-    # def if_enable_cinn(self):
-    #     self.enable_cinn = False
 
 
 @skip_check_grad_ci(

--- a/test/legacy_test/test_pad_op.py
+++ b/test/legacy_test/test_pad_op.py
@@ -100,7 +100,7 @@ def create_test_fp16(parent):
             return np.float16
 
         def test_check_grad_normal(self):
-            self.check_grad(['X'], 'Out')
+            self.check_grad(['X'], 'Out', check_prim=True)
 
     cls_name = "{}_{}".format(parent.__name__, "Fp16")
     TestPadFp16.__name__ = cls_name
@@ -238,9 +238,12 @@ class TestPadBP16Op(OpTest):
         )
         self.inputs = {'X': convert_float_to_uint16(x)}
         self.outputs = {'Out': convert_float_to_uint16(out)}
-        self.enable_cinn = False
         self.prim_op_type = "prim"
         self.public_python_api = pad_wrapper
+        self.if_enable_cinn()
+
+    def if_enable_cinn(self):
+        pass
 
     def initTestCase(self):
         self.shape = (16, 16)

--- a/test/legacy_test/test_roll_op.py
+++ b/test/legacy_test/test_roll_op.py
@@ -53,9 +53,6 @@ class TestRollOp(OpTest):
     def test_check_grad_normal(self):
         self.check_grad(['X'], 'Out', check_prim=True)
 
-    def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
-
 
 class TestRollOpCase2(TestRollOp):
     def init_dtype_type(self):

--- a/test/legacy_test/test_scatter_op.py
+++ b/test/legacy_test/test_scatter_op.py
@@ -31,6 +31,7 @@ class TestScatterOp(OpTest):
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
         self._set_dtype()
+        self.if_enable_cinn()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 50)).astype(target_dtype)
         index_np = np.array([1, 2]).astype("int32")
@@ -44,11 +45,14 @@ class TestScatterOp(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output()
 
     def test_check_grad(self):
         self.check_grad(["X", "Updates"], "Out", check_prim=True)
@@ -67,12 +71,14 @@ class TestScatterFP16Op(TestScatterOp):
 class TestScatterBF16Op(TestScatterOp):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -91,6 +97,7 @@ class TestScatterOp0(OpTest):
         self.python_api = paddle.scatter
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
+        self.if_enable_cinn()
         self._set_dtype()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 3)).astype(target_dtype)
@@ -106,11 +113,14 @@ class TestScatterOp0(OpTest):
         self.attrs = {'overwrite': True}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output()
 
     def test_check_grad(self):
         self.check_grad(["X", "Updates"], "Out", check_prim=True)
@@ -129,12 +139,14 @@ class TestScatterFP16Op0(TestScatterOp0):
 class TestScatterBF16Op0(TestScatterOp0):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -154,6 +166,7 @@ class TestScatterOp1(OpTest):
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
         self._set_dtype()
+        self.if_enable_cinn()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 3)).astype(target_dtype)
         zeros_np = np.zeros([2, 3]).astype(target_dtype)
@@ -171,11 +184,14 @@ class TestScatterOp1(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output()
 
     def test_check_grad(self):
         self.check_grad(["X", "Updates"], "Out", check_prim=True)
@@ -194,12 +210,14 @@ class TestScatterFP16Op1(TestScatterOp1):
 class TestScatterBF16Op1(TestScatterOp1):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -222,6 +240,7 @@ class TestScatterOp2(OpTest):
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
         self._set_dtype()
+        self.if_enable_cinn()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 3)).astype(target_dtype)
         index_np = np.array([1, 2]).astype("int32")
@@ -235,13 +254,16 @@ class TestScatterOp2(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=1e-3, check_prim=True)
+            self.check_output_with_place(place, atol=1e-3)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -270,6 +292,8 @@ class TestScatterFP16Op2(TestScatterOp2):
 class TestScatterBF16Op2(TestScatterOp2):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
 
@@ -283,6 +307,7 @@ class TestScatterOp3(OpTest):
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
         self._set_dtype()
+        self.if_enable_cinn()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 3)).astype(target_dtype)
         zeros_np = np.zeros([2, 3]).astype(target_dtype)
@@ -300,13 +325,16 @@ class TestScatterOp3(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=1e-3, check_prim=True)
+            self.check_output_with_place(place, atol=1e-3)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -335,6 +363,8 @@ class TestScatterFP16Op3(TestScatterOp3):
 class TestScatterBF16Op3(TestScatterOp3):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
 
@@ -345,6 +375,7 @@ class TestScatterOp4(OpTest):
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
         self._set_dtype()
+        self.if_enable_cinn()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 3)).astype(target_dtype)
         index_np = np.array([1, 2]).astype("int64")
@@ -358,11 +389,14 @@ class TestScatterOp4(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output()
 
     def test_check_grad(self):
         self.check_grad(['X', 'Updates'], 'Out', check_prim=True)
@@ -381,12 +415,14 @@ class TestScatterFP16Op4(TestScatterOp4):
 class TestScatterBF16Op4(TestScatterOp4):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -409,6 +445,7 @@ class TestScatterOp5(OpTest):
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
         self._set_dtype()
+        self.if_enable_cinn()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 3)).astype(target_dtype)
         index_np = np.array([1, 2]).astype("int64")
@@ -422,13 +459,16 @@ class TestScatterOp5(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=1e-3, check_prim=True)
+            self.check_output_with_place(place, atol=1e-3)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -457,6 +497,8 @@ class TestScatterFP16Op5(TestScatterOp5):
 class TestScatterBF16Op5(TestScatterOp5):
     def _set_dtype(self):
         self.dtype = np.uint16
+
+    def if_enable_cinn(self):
         self.enable_cinn = False
 
 
@@ -466,7 +508,7 @@ class TestScatterOp6(OpTest):
         self.python_api = paddle.scatter
         self.public_python_api = paddle.scatter
         self.prim_op_type = "prim"
-        self.enable_cinn = False
+        self.if_enable_cinn()
         self._set_dtype()
         target_dtype = "float16" if self.dtype == np.float16 else "float32"
         ref_np = np.ones((3, 50)).astype(target_dtype)
@@ -481,11 +523,14 @@ class TestScatterOp6(OpTest):
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
+    def if_enable_cinn(self):
+        pass
+
     def _set_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output()
 
     def test_check_grad(self):
         self.check_grad(["X", "Updates"], "Out", check_prim=True)
@@ -502,13 +547,16 @@ class TestScatterFP16Op6(TestScatterOp6):
     "core is not complied with CUDA and not support the bfloat16",
 )
 class TestScatterBF16Op6(TestScatterOp6):
+    def if_enable_cinn(self):
+        self.enable_cinn = False
+
     def _set_dtype(self):
         self.dtype = np.uint16
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():

--- a/test/legacy_test/test_split_op.py
+++ b/test/legacy_test/test_split_op.py
@@ -32,7 +32,6 @@ class TestSplitOp(OpTest):
         self.dtype = self.get_dtype()
         axis = 1
         if self.dtype == np.uint16:
-            self.enable_cinn = False
             x = np.random.random((4, 5, 6)).astype(np.float32)
             out = np.split(x, [2, 3], axis)
             self.inputs = {'X': convert_float_to_uint16(x)}
@@ -285,7 +284,7 @@ def create_test_bf16(parent):
 
         def test_check_grad(self):
             place = core.CUDAPlace(0)
-            self.check_grad_with_place(place, ['X'], 'out2')
+            self.check_grad_with_place(place, ['X'], 'out2', check_prim=True)
 
     cls_name = "{}_{}".format(parent.__name__, "BF16Op")
     TestSplitBF16Op.__name__ = cls_name

--- a/test/legacy_test/test_squeeze2_op.py
+++ b/test/legacy_test/test_squeeze2_op.py
@@ -16,10 +16,11 @@ import os
 import unittest
 
 import numpy as np
-from eager_op_test import OpTest
+from eager_op_test import OpTest, convert_float_to_uint16
 from test_attribute_var import UnittestBase
 
 import paddle
+from paddle.fluid import core
 from paddle.fluid.framework import Program, program_guard
 
 paddle.enable_static()
@@ -36,18 +37,31 @@ class TestSqueezeOp(OpTest):
             "Out"
         ]  # python out sig is customized output signature.
         self.init_test_case()
-        self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
+        self.init_dtype()
+        self.if_enable_cinn()
+        x = np.random.random(self.ori_shape).astype("float64")
+        xshape = np.random.random(self.ori_shape).astype("float64")
+        if hasattr(self, "dtype") and self.dtype == np.uint16:
+            x = convert_float_to_uint16(x.astype(np.float32))
+            xshape = convert_float_to_uint16(xshape.astype(np.float32))
+        self.inputs = {"X": x}
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
-            "XShape": np.random.random(self.ori_shape).astype("float64"),
+            "XShape": xshape,
         }
+
+    def if_enable_cinn(self):
+        pass
 
     def test_check_output(self):
         self.check_output(no_check_set=['XShape'], check_prim=True)
 
     def test_check_grad(self):
         self.check_grad(["X"], "Out", check_prim=True)
+
+    def init_dtype(self):
+        self.dtype = np.float64
 
     def init_test_case(self):
         self.ori_shape = (1, 3, 1, 40)
@@ -58,12 +72,32 @@ class TestSqueezeOp(OpTest):
         self.attrs = {"axes": self.axes}
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and do not support bfloat16",
+)
+class TestSqueezeOpBF16OP(TestSqueezeOp):
+    def init_dtype(self):
+        self.dtype = np.uint16
+
+
 # Correct: There is mins axis.
 class TestSqueezeOp1(TestSqueezeOp):
     def init_test_case(self):
         self.ori_shape = (1, 20, 1, 5)
         self.axes = (0, -2)
         self.new_shape = (20, 5)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and do not support bfloat16",
+)
+class TestSqueezeOp1BF16Op(TestSqueezeOp):
+    def init_dtype(self):
+        self.dtype = np.uint16
 
 
 # Correct: No axes input.
@@ -77,17 +111,40 @@ class TestSqueezeOp2(TestSqueezeOp):
             "Out"
         ]  # python out sig is customized output signature.
         self.init_test_case()
-        self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
+        self.init_dtype()
+        self.if_enable_cinn()
+        x = np.random.random(self.ori_shape).astype("float64")
+        xshape = np.random.random(self.ori_shape).astype("float64")
+        if hasattr(self, "dtype") and self.dtype == np.uint16:
+            x = convert_float_to_uint16(x.astype(np.float32))
+            xshape = convert_float_to_uint16(xshape.astype(np.float32))
+        self.inputs = {"X": x}
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
-            "XShape": np.random.random(self.ori_shape).astype("float64"),
+            "XShape": xshape,
         }
+
+    def if_enable_cinn(self):
+        pass
+
+    def init_dtype(self):
+        self.dtype = np.float64
 
     def init_test_case(self):
         self.ori_shape = (1, 20, 1, 5)
         self.axes = ()
         self.new_shape = (20, 5)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and do not support bfloat16",
+)
+class TestSqueezeOp2BF16Op(TestSqueezeOp):
+    def init_dtype(self):
+        self.dtype = np.uint16
 
 
 # Correct: Just part of axes be squeezed.
@@ -96,6 +153,16 @@ class TestSqueezeOp3(TestSqueezeOp):
         self.ori_shape = (6, 1, 5, 1, 4, 1)
         self.axes = (1, -1)
         self.new_shape = (6, 5, 1, 4)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and do not support bfloat16",
+)
+class TestSqueezeOp3BF16Op(TestSqueezeOp):
+    def init_dtype(self):
+        self.dtype = np.uint16
 
 
 class TestSqueeze2AxesTensor(UnittestBase):

--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -167,7 +167,6 @@ class TestStackBF16Op(OpTest):
         self.initParameters()
         self.op_type = 'stack'
         self.prim_op_type = "comp"
-        self.enable_cinn = False
         self.python_api = paddle.stack
         self.public_python_api = paddle.stack
         self.x = []
@@ -191,8 +190,7 @@ class TestStackBF16Op(OpTest):
         self.check_output(check_prim=True)
 
     def test_check_grad(self):
-        # concat_grad unspport bfloat16 dtype, skip check_prim
-        self.check_grad(self.get_x_names(), 'Y')
+        self.check_grad(self.get_x_names(), 'Y', check_prim=True)
 
 
 class TestStackAPIWithLoDTensorArray(unittest.TestCase):

--- a/test/legacy_test/test_tile_op.py
+++ b/test/legacy_test/test_tile_op.py
@@ -30,14 +30,17 @@ class TestTileOpRank1(OpTest):
         self.op_type = "tile"
         self.python_api = paddle.tile
         self.prim_op_type = "prim"
-        self.enable_cinn = True
         self.public_python_api = paddle.tile
         self.init_data()
+        self.if_enable_cinn()
 
         self.inputs = {'X': np.random.random(self.ori_shape).astype("float64")}
         self.attrs = {'repeat_times': self.repeat_times}
         output = np.tile(self.inputs['X'], self.repeat_times)
         self.outputs = {'Out': output}
+
+    def if_enable_cinn(self):
+        pass
 
     def init_data(self):
         self.ori_shape = [100]
@@ -52,23 +55,29 @@ class TestTileOpRank1(OpTest):
 
 class TestTileOpRank_ZeroDim1(TestTileOpRank1):
     def init_data(self):
-        self.enable_cinn = False
         self.ori_shape = []
         self.repeat_times = []
+
+    def if_enable_cinn(self):
+        self.enable_cinn = False
 
 
 class TestTileOpRank_ZeroDim2(TestTileOpRank1):
     def init_data(self):
-        self.enable_cinn = False
         self.ori_shape = []
         self.repeat_times = [2]
+
+    def if_enable_cinn(self):
+        self.enable_cinn = False
 
 
 class TestTileOpRank_ZeroDim3(TestTileOpRank1):
     def init_data(self):
-        self.enable_cinn = False
         self.ori_shape = []
         self.repeat_times = [2, 3]
+
+    def if_enable_cinn(self):
+        self.enable_cinn = False
 
 
 # with dimension expanding
@@ -240,7 +249,6 @@ class TestTileBF16OP(OpTest):
         self.__class__.op_type = self.op_type
         self.python_api = paddle.tile
         self.prim_op_type = "prim"
-        self.enable_cinn = False
         self.public_python_api = paddle.tile
         self.init_data()
         x = np.random.uniform(10, size=self.ori_shape).astype(np.float32)

--- a/test/legacy_test/test_unsqueeze2_op.py
+++ b/test/legacy_test/test_unsqueeze2_op.py
@@ -37,12 +37,16 @@ class TestUnsqueezeOp(OpTest):
             "XShape": np.random.random(self.ori_shape).astype("float64"),
         }
         self.prim_op_type = "comp"
+        self.if_enable_cinn()
+
+    def if_enable_cinn(self):
+        pass
 
     def test_check_output(self):
         self.check_output(no_check_set=["XShape"], check_prim=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_prim=True)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -90,7 +94,6 @@ class TestUnsqueezeOp_ZeroDim1(TestUnsqueezeOp):
         self.ori_shape = ()
         self.axes = (-1,)
         self.new_shape = 1
-        self.enable_cinn = False
 
 
 class TestUnsqueezeOp_ZeroDim2(TestUnsqueezeOp):
@@ -98,7 +101,6 @@ class TestUnsqueezeOp_ZeroDim2(TestUnsqueezeOp):
         self.ori_shape = ()
         self.axes = (-1, 1)
         self.new_shape = (1, 1)
-        self.enable_cinn = False
 
 
 class TestUnsqueezeOp_ZeroDim3(TestUnsqueezeOp):
@@ -106,7 +108,6 @@ class TestUnsqueezeOp_ZeroDim3(TestUnsqueezeOp):
         self.ori_shape = ()
         self.axes = (0, 1, 2)
         self.new_shape = (1, 1, 1)
-        self.enable_cinn = False
 
 
 # axes is a list(with tensor)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66975
PR改动：
- 支持elementwise_min、pad、roll、scatter、split、sequeeze2、unsequeeze2、statck、tile 组合算子 bfloat16 dtype并且添加相关单测。