### PR TITLE
eager call all2all to avoid p2p hang in lazy init

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -337,7 +337,7 @@ class Inserter:
         """Insert send op into block at the given index."""
         op_type = 'send_v2'
         # use pair comm group
-        process_group = new_process_group([src, dst])
+        process_group = new_process_group([src, dst], group_type='p2p')
         send_op = block._insert_op(
             idx,
             type=op_type,
@@ -357,7 +357,7 @@ class Inserter:
         """Insert recv op into block at the given index."""
         op_type = 'recv_v2'
         # use pair group
-        process_group = new_process_group([src, dst])
+        process_group = new_process_group([src, dst], group_type='p2p')
         recv_op = block._insert_op(
             idx,
             type=op_type,

--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -1794,9 +1794,13 @@ class Resharder:
                 elif isinstance(op_desc, AllGatherConcatOpDesc):
                     new_process_group(op_desc.group)
                 elif isinstance(op_desc, SendOpDesc):
-                    new_process_group([op_desc.src, op_desc.dst])
+                    new_process_group(
+                        [op_desc.src, op_desc.dst], group_type='p2p'
+                    )
                 elif isinstance(op_desc, RecvOpDesc):
-                    new_process_group([op_desc.src, op_desc.dst])
+                    new_process_group(
+                        [op_desc.src, op_desc.dst], group_type='p2p'
+                    )
 
         tensor_list = []
         partition_tensor_list = []
@@ -2721,7 +2725,10 @@ class Resharder:
                                             # Ensure every rank has a global view of communicator groups for entire cluters.
                                             # When initialize communicators for pipeline parallel, every rank could
                                             # conduct a correct global synchronization.
-                                            new_process_group([item, recv_rank])
+                                            new_process_group(
+                                                [item, recv_rank],
+                                                group_type='p2p',
+                                            )
                             else:
                                 for index, tensor_process in enumerate(
                                     tensor_processes
@@ -2748,7 +2755,9 @@ class Resharder:
                                         # Ensure every rank has a global view of communicator groups for entire cluters.
                                         # When initialize communicators for pipeline parallel, every rank could
                                         # conduct a correct global synchronization.
-                                        new_process_group([item, recv_rank])
+                                        new_process_group(
+                                            [item, recv_rank], group_type='p2p'
+                                        )
 
                             cur_op_count = len(block.ops)
                             idx_offset = (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

Pcard-70448

eager call all2all to avoid p2p hang in lazy init

When use interceptor to train pipeline parallel, for example, pp0 send, and pp1 recv, the `recv` pp1 in  is not launched before until `send` ends in pp0. (Feature of interceptor's actor model, it needs `signal` to triger, and the `signal` is sended by brpc after pp0 ends.) 

However, in new version of nccl like 2.15+, Point-to-point connections for send/receive are created upon the first exchange between two ranks, and the creation need the peers to be ready. 

So, it hangs.

This pr adds all2all comunication when process group is created eagerly to avoid the hang.


