### PR TITLE
[AMP] Polish the documentation of check_numerics. test=document_fix

### DIFF
--- a/python/paddle/amp/debugging.py
+++ b/python/paddle/amp/debugging.py
@@ -276,8 +276,12 @@ def check_numerics(
         debug_mode(paddle.amp.debugging.DebugMode, optional): The mode of debugging to be used. Default is DebugMode.CHECK_NAN_INF_AND_ABORT.
 
     Returns:
-        stats(Tensor): The output stats tensor stores the number of NaNs, Infs and zeros of input tensor. The shape is [3] and dtype is int64.
-        values(Tensor): The output values tensor stores the maximum, minimum and mean value of input tensor. The shape is [3] and dtype is float.
+        (Tensor, Tensor): A tuple of tensors containing
+
+            - **stats** (Tensor): Returns the number of NaNs, Infs and zeros of input tensor.
+                                  The shape is [3] and dtype is int64.
+            - **values** (Tensor): Returns the maximum, minimum and mean value of input tensor.
+                                   The shape is [3] and dtype is float.
 
     Examples:
 

--- a/python/paddle/amp/debugging.py
+++ b/python/paddle/amp/debugging.py
@@ -278,10 +278,8 @@ def check_numerics(
     Returns:
         (Tensor, Tensor): A tuple of tensors containing
 
-            - **stats** (Tensor): Returns the number of NaNs, Infs and zeros of input tensor.
-                                  The shape is [3] and dtype is int64.
-            - **values** (Tensor): Returns the maximum, minimum and mean value of input tensor.
-                                   The shape is [3] and dtype is float.
+        - **stats** (Tensor): Returns the number of NaNs, Infs and zeros of input tensor. The shape is [3] and dtype is int64.
+        - **values** (Tensor): Returns the maximum, minimum and mean value of input tensor. The shape is [3] and dtype is float.
 
     Examples:
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Description
<!-- Describe what you’ve done -->
Pcard-70458

修复check_numerics英文文档返回值的格式。

![image](https://github.com/PaddlePaddle/Paddle/assets/12538138/06451ffa-f602-4523-8c7d-cadf8c5e38f9)
