### PR TITLE
[inference]conv_fusion support bias's rank equal to input's rank

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/conv_fusion_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/conv_fusion_kernel.cu
@@ -130,9 +130,9 @@ class CudnnConvDescManager {
     XXH64_hash_t hash_key = XXH64_digest(state);
     XXH64_freeState(state);
 
-    if (1 || !cudnn_conv_cache_.count(hash_key)) {
+    if (!cudnn_conv_cache_.count(hash_key)) {
       std::lock_guard<std::mutex> lock(cache_mutex_);
-      if (1 || !cudnn_conv_cache_.count(hash_key)) {
+      if (!cudnn_conv_cache_.count(hash_key)) {
         cudnn_conv_cache_[hash_key] = CudnnCacheInfo();
         cudnn_conv_cache_[hash_key].x_desc =
             GetTensorDescInfo(input_dims, input_dtype, format);
@@ -140,11 +140,6 @@ class CudnnConvDescManager {
             GetFilterDescInfo(filter_dims, input_dtype, format);
         cudnn_conv_cache_[hash_key].o_desc =
             GetTensorDescInfo(output_dims, input_dtype, format);
-        std::cout << "conv_fusion: bias dim ";
-        for (auto& it : bias_dims) {
-          std::cout << it << ", ";
-        }
-        std::cout << std::endl;
         cudnn_conv_cache_[hash_key].b_desc =
             GetTensorDescInfo(bias_dims, input_dtype, format);
         cudnn_conv_cache_[hash_key].conv_desc =
@@ -204,9 +199,9 @@ class CudnnConvDescManager {
     XXH64_hash_t hash_key = XXH64_digest(state);
     XXH64_freeState(state);
 
-    if (1 || !conv_attr_cache_.count(hash_key)) {
+    if (!conv_attr_cache_.count(hash_key)) {
       std::lock_guard<std::mutex> lock(attr_mutex_);
-      if (1 || !conv_attr_cache_.count(hash_key)) {
+      if (!conv_attr_cache_.count(hash_key)) {
         ConvAttrCacheInfo cache;
         auto paddings = paddings_t;
         auto dilations = dilations_t;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
Pcard-71501
<!-- Describe what you’ve done -->
- conv_fusion support bias's rank equal to input's rank, caused by https://github.com/PaddlePaddle/Paddle/pull/51486

bias will be reshaped on the develop branck, while 2.4.2 will not.
![5634e17cabead030ee0dd5df41b8f0bc](https://github.com/PaddlePaddle/Paddle/assets/1312389/87908ca3-9312-411c-bdf2-d35a633921fa)

<img width="959" alt="89d297ec5e3826f61c7e22bce064d59f" src="https://github.com/PaddlePaddle/Paddle/assets/1312389/dfac59a1-f45d-4894-a884-c8d83261290f">
