### PR TITLE
[CustomOP] delete experimental namespace of sigmoid

### DIFF
--- a/paddle/phi/api/ext/tensor_compat.h
+++ b/paddle/phi/api/ext/tensor_compat.h
@@ -135,6 +135,7 @@ using experimental::selu;
 using experimental::send_u_recv;
 using experimental::send_ue_recv;
 using experimental::send_uv;
+using experimental::sigmoid;
 using experimental::sign;
 using experimental::silu;
 using experimental::sin;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
OPs

### Description
Pcard-66988

Call sigmoid by `paddle::sigmoid` instead of `paddle::experimental::sigmoid` under the custom operator scenario.
