### PR TITLE
fix KeyError when delte idx from task_infos

### DIFF
--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -752,7 +752,8 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                     batch.reraise()
 
                 if idx == self._rcvd_idx:
-                    del self._task_infos[idx]
+                    if idx in self._task_infos:
+                        del self._task_infos[idx]
                     self._structure_infos.append(structure)
                     return batch
                 else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
Pcard-71594

num_workers > 0 训练过程中经常出现如下报错
![image](https://github.com/PaddlePaddle/Paddle/assets/23737287/3e375e2f-3137-47dc-ab69-33b7eb909c72)

- 已有相关问题（未解决）：#41635
- 问题定位：在 `_task_infos` 中尝试删除 `idx` 时，`idx` 并不存在于 `task_infos` 中，从而引起 `KeyError`
- 解决方法：暂时采用比较简单的解决方法，在 `del` 之前加一个 if 判断（但这不是最好的解决办法，因为 pytorch 代码类似，但应该不会出现这种问题，猜测是 `_task_infos` 这个变量在多线程的情况下有隐蔽问题导致）
