### PR TITLE
fix segment fault of protobuf

### DIFF
--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -45,7 +45,15 @@ def get_msg_dict(msg):
     res_dict = {}
     fields = msg.DESCRIPTOR.fields
     for f in fields:
-        res_dict[f.name] = getattr(msg, f.name)
+        v = getattr(msg, f.name)
+        # NOTE(zhiqiu): convert repeated filed to list to
+        # avoid segment fault when the process exit?
+        # WHY?
+        # I guess the type or value of protobuf item is NULL when
+        # dealloc.
+        if f.label == google.protobuf.descriptor.FieldDescriptor.LABEL_REPEATED:
+            v = list(v)
+        res_dict[f.name] = v
     return res_dict
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67009

fix segment fault of protobuf

<img width="769" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/7bc2e1db-ccbf-44e7-ba69-bd8ef92b8b15">

the call stack:
<img width="1075" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/12679c21-f735-4a7b-aaf1-d3e9dd1c787e">

