### PR TITLE
[BugFix]: Fix bugs in fused_linear_epilogue

### DIFF
--- a/paddle/fluid/operators/fused/fused_gemm_epilogue_op.cu
+++ b/paddle/fluid/operators/fused/fused_gemm_epilogue_op.cu
@@ -90,9 +90,9 @@ class FusedGemmEpilogueKernel : public framework::OpKernel<T> {
     int64_t K = trans_y ? y->dims()[1] : y->dims()[0];
     int64_t N = trans_y ? y->dims()[0] : y->dims()[1];
 
-    void* reserve_data = reserve_space ? reserve_space->data() : nullptr;
     auto fused_type =
         GetFwdFusedEpilogueType<T>(dev_ctx, activation, reserve_space);
+    void* reserve_data = reserve_space ? reserve_space->data() : nullptr;
 
     VLOG(6) << "x.shape={" << x->dims() << "}, y.shape={" << y->dims()
             << "}, out.shape={" << out->dims() << "}, M=" << M << ", N=" << N


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-67009
- Original Error: PreconditionNotMetError: Tensor holds no memory. Call Tensor::mutable_data firstly.
