### PR TITLE
Fix the timeout bug of some communication api on A100

### DIFF
--- a/test/collective/CMakeLists.txt
+++ b/test/collective/CMakeLists.txt
@@ -79,8 +79,13 @@ if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(
     test_collective_alltoall_api MODULES test_collective_alltoall_api ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
-  set_tests_properties(test_collective_alltoall_api
-                       PROPERTIES TIMEOUT "120" LABELS "RUN_TYPE=DIST")
+  if(${CUDA_ARCH_NAME} STREQUAL "Ampere")
+    set_tests_properties(test_collective_alltoall_api
+                         PROPERTIES TIMEOUT "160" LABELS "RUN_TYPE=DIST")
+  else()
+    set_tests_properties(test_collective_alltoall_api
+                         PROPERTIES TIMEOUT "120" LABELS "RUN_TYPE=DIST")
+  endif()
 endif()
 if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   bash_test_modules(
@@ -130,8 +135,13 @@ if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(
     test_collective_broadcast_api MODULES test_collective_broadcast_api ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
-  set_tests_properties(test_collective_broadcast_api
-                       PROPERTIES TIMEOUT "300" LABELS "RUN_TYPE=DIST")
+  if(${CUDA_ARCH_NAME} STREQUAL "Ampere")
+    set_tests_properties(test_collective_broadcast_api
+                         PROPERTIES TIMEOUT "360" LABELS "RUN_TYPE=DIST")
+  else()
+    set_tests_properties(test_collective_broadcast_api
+                         PROPERTIES TIMEOUT "300" LABELS "RUN_TYPE=DIST")
+  endif()
 endif()
 if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(
@@ -224,8 +234,13 @@ if((WITH_GPU OR WITH_ROCM) AND (LINUX))
     test_collective_reduce_scatter_api MODULES
     test_collective_reduce_scatter_api ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=..:${PADDLE_BINARY_DIR}/python")
-  set_tests_properties(test_collective_reduce_scatter_api
-                       PROPERTIES TIMEOUT "150" LABELS "RUN_TYPE=DIST")
+  if(${CUDA_ARCH_NAME} STREQUAL "Ampere")
+    set_tests_properties(test_collective_reduce_scatter_api
+                         PROPERTIES TIMEOUT "210" LABELS "RUN_TYPE=DIST")
+  else()
+    set_tests_properties(test_collective_reduce_scatter_api
+                         PROPERTIES TIMEOUT "150" LABELS "RUN_TYPE=DIST")
+  endif()
 endif()
 if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-67009
Fix the timeout bug of the following unit tests: test_collective_reduce_scatter, test_collective_broadcast_api, test_collective_alltoall_api on A100. This PR solves the bug by setting a larger timeout value when running on A100. The bug causes by: 1) The run time of these tests have fluctuation, sometimes it exceeds the timeout limitation.  2) On A100, each of these unit test contains one additional test case, so it takes longer run time. 
