### PR TITLE
Disable dp_comm_overlap and sharding_comm_overlap by default

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -77,9 +77,13 @@ class PipelineParallel(MetaParallelBase):
         self._dp_comm_overlap = self._strategy.hybrid_configs[
             "pp_configs"
         ].dp_comm_overlap
+        assert not self._dp_comm_overlap, "dp_comm_overlap is not supported"
         self._sharding_comm_overlap = self._strategy.hybrid_configs[
             "pp_configs"
         ].sharding_comm_overlap
+        assert (
+            not self._sharding_comm_overlap
+        ), "sharding_comm_overlap is not supported"
         self._enable_timer = self._strategy.hybrid_configs[
             "pp_configs"
         ].enable_timer


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Disable dp_comm_overlap and sharding_comm_overlap by default.