### PR TITLE
Make PHI compile into a static library by default

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -236,9 +236,18 @@ if(WITH_CUDNN_FRONTEND)
   add_definitions(-DPADDLE_WITH_CUDNN_FRONTEND)
 endif()
 
-set(WITH_PHI_SHARED
-    OFF
-    CACHE BOOL "" FORCE)
+# FIXME(zengjinle): do not know why MAC does not support to compile
+# libphi.a
+if(APPLE)
+  set(WITH_PHI_SHARED
+      ON
+      CACHE BOOL "" FORCE)
+else()
+  set(WITH_PHI_SHARED
+      OFF
+      CACHE BOOL "" FORCE)
+endif()
+
 if(WIN32
    OR WITH_ROCM
    OR WITH_XPU_KP

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -237,7 +237,7 @@ if(WITH_CUDNN_FRONTEND)
 endif()
 
 set(WITH_PHI_SHARED
-    ON
+    OFF
     CACHE BOOL "" FORCE)
 if(WIN32
    OR WITH_ROCM


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Pcard-67009

Make PHI compile into a static library by default.