### PR TITLE
Fix Gloo ut in CUDA 12

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_gloo.cc
+++ b/paddle/fluid/distributed/collective/process_group_gloo.cc
@@ -48,7 +48,7 @@ namespace distributed {
       func<double>(__VA_ARGS__);             \
       break;                                 \
     case phi::DataType::FLOAT16:             \
-      func<gloo::float16>(__VA_ARGS__);      \
+      func<float16>(__VA_ARGS__);            \
       break;                                 \
     case phi::DataType::INT32:               \
       func<int32_t>(__VA_ARGS__);            \
@@ -73,7 +73,7 @@ namespace distributed {
       func<double>(args);                    \
       break;                                 \
     case phi::DataType::FLOAT16:             \
-      func<gloo::float16>(args);             \
+      func<float16>(args);                   \
       break;                                 \
     case phi::DataType::INT32:               \
       func<int32_t>(args);                   \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-67009

Fix Gloo ut in CUDA 12, A100. This PR replaces `gloo::float16` with `phi::dtype::float16`.