### PR TITLE
[IR] polish the new ir api name.

### DIFF
--- a/paddle/fluid/ir/dialect/op_gen.py
+++ b/paddle/fluid/ir/dialect/op_gen.py
@@ -70,9 +70,9 @@ op_n_attribute_declare_str = (
     "static const char *attributes_name[{attribute_num}];"
 )
 
-OP_GET_INPUT_TEMPLATE = """  ir::OpOperand {input_name}() {{ return operation()->GetOperandByIndex({input_index}); }}
+OP_GET_INPUT_TEMPLATE = """  ir::OpOperand {input_name}() {{ return operation()->operand({input_index}); }}
 """
-OP_GET_OUTPUT_TEMPLATE = """  ir::OpResult {output_name}() {{ return operation()->GetResultByIndex({output_index}); }}
+OP_GET_OUTPUT_TEMPLATE = """  ir::OpResult {output_name}() {{ return operation()->result({output_index}); }}
 """
 
 # =====================================
@@ -817,11 +817,11 @@ def GenBuildInserFullForMutableAttribute(
     build_mutable_attribute = ""
     BUILD_INTARRAY_ATTRIBUTE_TEMPLATE = """  // Generate int_array mutable attribute: {attr_name}
   paddle::dialect::FullIntArrayOp full_{attr_name}_op = builder.Build<paddle::dialect::FullIntArrayOp>({attr_name}, {phi_dtype}, phi::CPUPlace());
-  ir::OpResult {attr_name}_ = full_{attr_name}_op->GetResultByIndex(0);
+  ir::OpResult {attr_name}_ = full_{attr_name}_op->result(0);
     """
     BUILD_SCALAR_ATTRIBUTE_TEMPLATE = """  // Generate scalar mutable attribute: {attr_name}
   paddle::dialect::FullOp full_{attr_name}_op = builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{{1}}, {attr_name}, {phi_dtype}, phi::CPUPlace());
-  ir::OpResult {attr_name}_ = full_{attr_name}_op->GetResultByIndex(0);
+  ir::OpResult {attr_name}_ = full_{attr_name}_op->result(0);
     """
     for idx in range(len(op_mutable_attribute_name_list)):
         attr_name = op_mutable_attribute_name_list[idx]

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -142,7 +142,7 @@ inline ir::Operation* InsertSliceOperationForTarget(
                             {src_vec_type[defining_info.idx_in_vector]},
                             op_info);
   program->block()->push_back(operation);
-  ir::OpResult target_op_result = operation->GetResultByIndex(0);
+  ir::OpResult target_op_result = operation->result(0);
   (*param_map)[arg_name] = VariableDefiningInfo(target_op_result);
   return operation;
 }
@@ -190,7 +190,7 @@ inline ir::Operation* InsertFullOperationForAttributeInput(ir::IrContext* ctx,
     data = static_cast<float>(attr.dyn_cast<ir::BoolAttribute>().data());
     dtype = phi::DataType::BOOL;
   }
-  ir::Builder builder = ir::Builder::AtBlockEnd(ctx, program->block());
+  ir::Builder builder(ctx, program->block());
   paddle::dialect::FullOp full_op = builder.Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1}, data, dtype, phi::CPUPlace());
 
@@ -206,7 +206,7 @@ inline ir::Operation* InsertFullArrayOperationForAttributeInput(
   phi::IntArray int_array =
       attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data();
 
-  ir::Builder builder = ir::Builder::AtBlockEnd(ctx, program->block());
+  ir::Builder builder(ctx, program->block());
   paddle::dialect::FullIntArrayOp full_int_array_op =
       builder.Build<paddle::dialect::FullIntArrayOp>(
           int_array.GetData(), phi::DataType::INT64, phi::CPUPlace());
@@ -244,7 +244,7 @@ inline ir::OpResult GetAttributeAsInput(ir::IrContext* ctx,
     defining_op = InsertFullOperationForAttributeInput(ctx, program, new_attr);
   }
 
-  return defining_op->GetResultByIndex(0);
+  return defining_op->result(0);
 }
 
 inline std::vector<ir::OpResult> GenerateOperationInput(
@@ -340,7 +340,7 @@ inline std::vector<ir::OpResult> GenerateOperationInput(
     } else {
       auto* combine_op = InsertCombineOperationForTarget(
           ctx, param_map, program, legacy_input_vars);
-      op_inputs.push_back(combine_op->GetResultByIndex(0));
+      op_inputs.push_back(combine_op->result(0));
     }
   }
 
@@ -472,7 +472,7 @@ inline void RecordOpResultMapping(TranslationContext* param_map,
       VLOG(10) << "[output recording]"
                << "[" << op_desc.Type() << "]" << arg_name << " " << idx;
 
-      ir::OpResult value = operation->GetResultByIndex(idx);
+      ir::OpResult value = operation->result(idx);
       bool generated_by_vector = value.type().isa<ir::VectorType>();
       (*param_map)[arg_name] = VariableDefiningInfo(
           value, generated_by_vector, generated_by_vector ? idx_in_vector : -1);

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -122,7 +122,7 @@ void ProgramTranslator::GetParameterForSingleBlock(const BlockDesc& block) {
           ir::Operation* op =
               InsertGetParamaterOp(ctx, parameter_name_mappings[var_name]);
           program->block()->push_back(op);
-          param_map[var_name] = VariableDefiningInfo(op->GetResultByIndex(0));
+          param_map[var_name] = VariableDefiningInfo(op->result(0));
           VLOG(10) << "[op translated][get parameter]" << op;
 
           program->SetParameter(var_name, nullptr);

--- a/paddle/ir/core/builder.h
+++ b/paddle/ir/core/builder.h
@@ -31,14 +31,6 @@ class Builder {
   Builder(IrContext *context, Block *block)
       : Builder(context, block, block->end()) {}
 
-  static Builder AtBlockBegin(IrContext *context, Block *block) {
-    return Builder(context, block, block->begin());
-  }
-
-  static Builder AtBlockEnd(IrContext *context, Block *block) {
-    return Builder(context, block, block->end());
-  }
-
   IrContext *context() const { return context_; }
 
   Block *block() const { return block_; }

--- a/paddle/ir/core/ir_printer.cc
+++ b/paddle/ir/core/ir_printer.cc
@@ -198,7 +198,7 @@ void IrPrinter::PrintOpResult(Operation* op) {
   std::vector<OpResult> op_results;
   op_results.reserve(num_op_result);
   for (size_t idx = 0; idx < num_op_result; idx++) {
-    op_results.push_back(op->GetResultByIndex(idx));
+    op_results.push_back(op->result(idx));
   }
   PrintInterleave(
       op_results.begin(),
@@ -230,7 +230,7 @@ void IrPrinter::PrintOpOperands(Operation* op) {
   std::vector<Value> op_operands;
   op_operands.reserve(num_op_operands);
   for (size_t idx = 0; idx < num_op_operands; idx++) {
-    op_operands.push_back(op->GetOperandByIndex(idx).source());
+    op_operands.push_back(op->operand(idx).source());
   }
   PrintInterleave(
       op_operands.begin(),
@@ -245,9 +245,9 @@ void IrPrinter::PrintOperandsType(Operation* op) {
   std::vector<Type> op_operand_types;
   op_operand_types.reserve(num_op_operands);
   for (size_t idx = 0; idx < num_op_operands; idx++) {
-    auto op_operand = op->GetOperandByIndex(idx);
+    auto op_operand = op->operand(idx);
     if (op_operand) {
-      op_operand_types.push_back(op->GetOperandByIndex(idx).source().type());
+      op_operand_types.push_back(op->operand(idx).source().type());
     } else {
       op_operand_types.push_back(Type(nullptr));
     }
@@ -266,7 +266,7 @@ void IrPrinter::PrintOpReturnType(Operation* op) {
   std::vector<Type> op_result_types;
   op_result_types.reserve(num_op_result);
   for (size_t idx = 0; idx < num_op_result; idx++) {
-    auto op_result = op->GetResultByIndex(idx);
+    auto op_result = op->result(idx);
     if (op_result) {
       op_result_types.push_back(op_result.type());
     } else {

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -179,7 +179,7 @@ Operation::Operation(const AttributeMap &attributes,
       num_operands_(num_operands),
       num_regions_(num_regions) {}
 
-ir::OpResult Operation::GetResultByIndex(uint32_t index) const {
+ir::OpResult Operation::result(uint32_t index) const {
   if (index >= num_results_) {
     IR_THROW("index exceeds OP output range.");
   }
@@ -200,7 +200,7 @@ ir::OpResult Operation::GetResultByIndex(uint32_t index) const {
   }
 }
 
-ir::OpOperand Operation::GetOperandByIndex(uint32_t index) const {
+ir::OpOperand Operation::operand(uint32_t index) const {
   if (index >= num_operands_) {
     IR_THROW("index exceeds OP input range.");
   }

--- a/paddle/ir/core/operation.h
+++ b/paddle/ir/core/operation.h
@@ -47,10 +47,12 @@ class alignas(8) Operation final {
   void Destroy();
 
   IrContext *ir_context() const;
-  Dialect *dialect() const;
-  OpResult GetResultByIndex(uint32_t index) const;
 
-  OpOperand GetOperandByIndex(uint32_t index) const;
+  Dialect *dialect() const;
+
+  OpResult result(uint32_t index) const;
+
+  OpOperand operand(uint32_t index) const;
 
   void Print(std::ostream &os);
 

--- a/paddle/ir/pattern_rewrite/pattern_match.cc
+++ b/paddle/ir/pattern_rewrite/pattern_match.cc
@@ -88,7 +88,7 @@ RewriterBase::~RewriterBase() = default;
 //   // assert(op->num_results() == new_values.size() && "incorrect number of
 //   values to replace operation"); NotifyRootReplaced(op, new_values); bool
 //   replace_all_uses = true; for (uint32_t i = 0; i < op->num_results(); ++i) {
-//     // op->GetResultByIndex(0)
+//     // op->result(0)
 //   }
 // }
 // void RewriterBase::ReplaceOpWithIf(Operation* op,
@@ -138,7 +138,7 @@ void RewriterBase::ReplaceOpWithResultsOfAnotherOp(Operation* op,
          "replacement op doesn't match results of original op");
   // TODO(wilber): Op support results method.
   // if (op->num_results() == 1) return ReplaceOp(op,
-  // new_op->GetResultByIndex(0)); return ReplaceOp(op, new_op->GetResults());
+  // new_op->result(0)); return ReplaceOp(op, new_op->GetResults());
 }
 
 }  // namespace ir

--- a/test/cpp/ir/core/ir_exe_test.cc
+++ b/test/cpp/ir/core/ir_exe_test.cc
@@ -56,7 +56,7 @@ TEST(program_test, program) {
   ir::IrContext* ctx = ir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::PaddleDialect>();
   ir::Program program(ctx);
-  ir::Builder builder = ir::Builder::AtBlockEnd(ctx, program.block());
+  ir::Builder builder(ctx, program.block());
   ir::Block* block = program.block();
 
   // Def: A = paddle::dialect::UniformOp(std::vector<int64_t> shape,
@@ -68,9 +68,7 @@ TEST(program_test, program) {
                                                 1.0,
                                                 2,
                                                 phi::CPUPlace());
-  EXPECT_EQ(uniform1->GetResultByIndex(0)
-                .type()
-                .isa<paddle::dialect::DenseTensorType>(),
+  EXPECT_EQ(uniform1->result(0).type().isa<paddle::dialect::DenseTensorType>(),
             true);
   EXPECT_EQ(block->size(), 4u);
 
@@ -82,18 +80,15 @@ TEST(program_test, program) {
                                                 1.0,
                                                 2,
                                                 phi::CPUPlace());
-  EXPECT_EQ(uniform2->GetResultByIndex(0)
-                .type()
-                .isa<paddle::dialect::DenseTensorType>(),
+  EXPECT_EQ(uniform2->result(0).type().isa<paddle::dialect::DenseTensorType>(),
             true);
   EXPECT_EQ(block->size(), 8u);
 
   // Def: C = paddle::dialect::AddOp(ir::OpResult x_, ir::OpResult y_)
   paddle::dialect::AddOp add = builder.Build<paddle::dialect::AddOp>(
-      uniform1->GetResultByIndex(0), uniform2->GetResultByIndex(0));
-  EXPECT_EQ(
-      add->GetResultByIndex(0).type().isa<paddle::dialect::DenseTensorType>(),
-      true);
+      uniform1->result(0), uniform2->result(0));
+  EXPECT_EQ(add->result(0).type().isa<paddle::dialect::DenseTensorType>(),
+            true);
   EXPECT_EQ(block->size(), 9u);
 
   // Execute program

--- a/test/cpp/ir/core/ir_program_test.cc
+++ b/test/cpp/ir/core/ir_program_test.cc
@@ -104,13 +104,10 @@ TEST(program_test, program) {
 
   EXPECT_EQ(&program, op1->GetParentProgram());
 
-  EXPECT_EQ(op1->GetResultByIndex(0).type().dialect().id(),
-            paddle_dialect->id());
+  EXPECT_EQ(op1->result(0).type().dialect().id(), paddle_dialect->id());
   using Interface = paddle::dialect::ParameterConvertInterface;
-  Interface *a_interface = op1->GetResultByIndex(0)
-                               .type()
-                               .dialect()
-                               .GetRegisteredInterface<Interface>();
+  Interface *a_interface =
+      op1->result(0).type().dialect().GetRegisteredInterface<Interface>();
   std::shared_ptr<paddle::framework::Variable> a_var =
       a_interface->ParameterToVariable(program.GetParameter("a"));
   const phi::DenseTensor &a_tensor = a_var->Get<phi::DenseTensor>();
@@ -134,12 +131,9 @@ TEST(program_test, program) {
       ir::Operation::Create({}, op2_attribute, {dense_tensor_dtype}, op2_info);
   block->push_back(op2);
 
-  EXPECT_EQ(op2->GetResultByIndex(0).type().dialect().id(),
-            paddle_dialect->id());
-  Interface *b_interface = op2->GetResultByIndex(0)
-                               .type()
-                               .dialect()
-                               .GetRegisteredInterface<Interface>();
+  EXPECT_EQ(op2->result(0).type().dialect().id(), paddle_dialect->id());
+  Interface *b_interface =
+      op2->result(0).type().dialect().GetRegisteredInterface<Interface>();
   std::shared_ptr<paddle::framework::Variable> b_var =
       b_interface->ParameterToVariable(program.GetParameter("b"));
   const phi::DenseTensor &b_tensor = b_var->Get<phi::DenseTensor>();
@@ -158,11 +152,10 @@ TEST(program_test, program) {
       builtin_dialect->name() + "." + std::string(AddOp::name());
   ir::OpInfo op3_info = ctx->GetRegisteredOpInfo(op3_name);
   std::unordered_map<std::string, ir::Attribute> op3_attribute;
-  ir::Operation *op3 = ir::Operation::Create(
-      {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
-      op3_attribute,
-      {dense_tensor_dtype},
-      op3_info);
+  ir::Operation *op3 = ir::Operation::Create({op1->result(0), op2->result(0)},
+                                             op3_attribute,
+                                             {dense_tensor_dtype},
+                                             op3_info);
   block->push_back(op3);
 
   phi::CPUContext *dev_ctx = static_cast<phi::CPUContext *>(
@@ -186,7 +179,7 @@ TEST(program_test, program) {
 
   // (7) Def AbsOp(b)
   ir::OpInfo abs_info = ctx->GetRegisteredOpInfo("pd.abs");
-  std::vector<ir::OpResult> operands = {op1->GetResultByIndex(0)};
+  std::vector<ir::OpResult> operands = {op1->result(0)};
   std::unordered_map<std::string, ir::Attribute> abs_op_attribute;
   std::vector<ir::Type> output_types = {dense_tensor_dtype};
   ir::OperationArgument abs_argument(abs_info);
@@ -205,15 +198,14 @@ TEST(program_test, program) {
   std::unordered_map<std::string, ir::Attribute> op4_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "c")}};
 
-  ir::OperationArgument op4_argument(
-      {op3->GetResultByIndex(0)}, {}, {}, op4_info);
+  ir::OperationArgument op4_argument({op3->result(0)}, {}, {}, op4_info);
   op4_argument.AddAttributes(op4_attribute.begin(), op4_attribute.end());
   ir::Operation *op4 = ir::Operation::Create(std::move(op4_argument));
   block->push_back(op4);
 
-  EXPECT_EQ(op4->GetOperandByIndex(0).source().type().dialect().id(),
+  EXPECT_EQ(op4->operand(0).source().type().dialect().id(),
             paddle_dialect->id());
-  Interface *c_interface = op4->GetOperandByIndex(0)
+  Interface *c_interface = op4->operand(0)
                                .source()
                                .type()
                                .dialect()
@@ -274,21 +266,17 @@ TEST(program_test, slice_combine_test) {
   ir::Type output_type =
       ir::VectorType::get(ctx, std::vector<ir::Type>({fp32_dtype, fp32_dtype}));
   ir::Operation *combine_op = ir::Operation::Create(
-      {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
-      {},
-      {output_type},
-      combine_op_info);
+      {op1->result(0), op2->result(0)}, {}, {output_type}, combine_op_info);
   program.block()->push_back(combine_op);
 
   // (7) Def slice_op = SliceOp(combine_op, 0)
   std::string slice_op_name = std::string(ir::SliceOp::name());
   ir::OpInfo slice_op_info = ctx->GetRegisteredOpInfo(slice_op_name);
   ir::Attribute index_attr = ir::Int32Attribute::get(ctx, 0);
-  ir::Operation *slice_op =
-      ir::Operation::Create({combine_op->GetResultByIndex(0)},
-                            {{"index", index_attr}},
-                            {fp32_dtype},
-                            slice_op_info);
+  ir::Operation *slice_op = ir::Operation::Create({combine_op->result(0)},
+                                                  {{"index", index_attr}},
+                                                  {fp32_dtype},
+                                                  slice_op_info);
   program.block()->push_back(slice_op);
 
   // (8) Traverse Program
@@ -303,7 +291,7 @@ TEST(program_test, builder) {
 
   paddle::dialect::FullOp full_op = builder.Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{2, 2}, 1.5, phi::DataType::FLOAT32, phi::CPUPlace());
-  ir::Type full_op_output = full_op->GetResultByIndex(0).type();
+  ir::Type full_op_output = full_op->result(0).type();
   EXPECT_EQ(program.block()->size(), 1u);
   EXPECT_EQ(program.block()->back(), full_op.operation());
   EXPECT_EQ(full_op->num_operands(), 0u);

--- a/test/cpp/ir/core/ir_value_test.cc
+++ b/test/cpp/ir/core/ir_value_test.cc
@@ -54,8 +54,7 @@ TEST(value_test, value_test) {
                             ir::OpInfo());
   op2->Print(std::cout);
   // 3. Construct OP3: c = OP3(a, b);
-  std::vector<ir::OpResult> op3_inputs = {op1->GetResultByIndex(0),
-                                          op2->GetResultByIndex(0)};
+  std::vector<ir::OpResult> op3_inputs = {op1->result(0), op2->result(0)};
   std::vector<ir::Type> op3_output_types = {ir::Float32Type::get(ctx)};
   ir::Operation *op3 =
       ir::Operation::Create(op3_inputs,
@@ -64,8 +63,7 @@ TEST(value_test, value_test) {
                             ir::OpInfo());
   op3->Print(std::cout);
   // 4. Construct OP4: d, e, f, g, h, i, j = OP4(a, c);
-  std::vector<ir::OpResult> op4_inputs = {op1->GetResultByIndex(0),
-                                          op3->GetResultByIndex(0)};
+  std::vector<ir::OpResult> op4_inputs = {op1->result(0), op3->result(0)};
   std::vector<ir::Type> op4_output_types;
   for (size_t i = 0; i < 7; i++) {
     op4_output_types.push_back(ir::Float32Type::get(ctx));
@@ -78,34 +76,34 @@ TEST(value_test, value_test) {
   op4->Print(std::cout);
 
   // Test 1:
-  EXPECT_EQ(op1->GetResultByIndex(0).GetDefiningOp(), op1);
-  EXPECT_EQ(op2->GetResultByIndex(0).GetDefiningOp(), op2);
-  EXPECT_EQ(op3->GetResultByIndex(0).GetDefiningOp(), op3);
-  EXPECT_EQ(op4->GetResultByIndex(6).GetDefiningOp(), op4);
+  EXPECT_EQ(op1->result(0).GetDefiningOp(), op1);
+  EXPECT_EQ(op2->result(0).GetDefiningOp(), op2);
+  EXPECT_EQ(op3->result(0).GetDefiningOp(), op3);
+  EXPECT_EQ(op4->result(6).GetDefiningOp(), op4);
 
   // Test 2: op1_first_output -> op4_first_input
-  ir::OpResult op1_first_output = op1->GetResultByIndex(0);
-  ir::OpOperand op4_first_input = op4->GetOperandByIndex(0);
+  ir::OpResult op1_first_output = op1->result(0);
+  ir::OpOperand op4_first_input = op4->operand(0);
 
   EXPECT_EQ(op1_first_output.first_use(), op4_first_input);
-  ir::OpOperand op3_first_input = op3->GetOperandByIndex(0);
+  ir::OpOperand op3_first_input = op3->operand(0);
 
   EXPECT_EQ(op4_first_input.next_use(), op3_first_input);
   EXPECT_EQ(op3_first_input.next_use(), nullptr);
 
   // Test 3: Value iterator
-  ir::Value::use_iterator iter = op1->GetResultByIndex(0).begin();
+  ir::Value::use_iterator iter = op1->result(0).begin();
   EXPECT_EQ(iter.owner(), op4);
   ++iter;
   EXPECT_EQ(iter.owner(), op3);
 
   // destroy
-  VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
+  VLOG(0) << op1->result(0).print_ud_chain() << std::endl;
   op4->Destroy();
-  VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
+  VLOG(0) << op1->result(0).print_ud_chain() << std::endl;
   op3->Destroy();
-  VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
+  VLOG(0) << op1->result(0).print_ud_chain() << std::endl;
   op2->Destroy();
-  VLOG(0) << op1->GetResultByIndex(0).print_ud_chain() << std::endl;
+  VLOG(0) << op1->result(0).print_ud_chain() << std::endl;
   op1->Destroy();
 }

--- a/test/cpp/ir/core/phi_kernel_adaptor.h
+++ b/test/cpp/ir/core/phi_kernel_adaptor.h
@@ -54,7 +54,7 @@ void build_scope(ir::Block* block,
     int input = (*it)->num_operands();
     if (input > 0) {
       for (int i = 0; i < input; ++i) {
-        auto ptr = (*it)->GetOperandByIndex(i).source();
+        auto ptr = (*it)->operand(i).source();
         std::string name;
         if (name_map->find(ptr) != name_map->end()) {
           name = name_map->at(ptr);
@@ -72,7 +72,7 @@ void build_scope(ir::Block* block,
 
     if (out_num > 0) {
       for (int i = 0; i < out_num; ++i) {
-        ir::Value ptr = (*it)->GetResultByIndex(i);
+        ir::Value ptr = (*it)->result(i);
         std::string name;
         if (name_map->find(ptr) != name_map->end()) {
           name = name_map->at(ptr);
@@ -131,7 +131,7 @@ void build_context(ir::Operation* op,
   for (auto& t : vec_param_list) {
     if (input_index_map.count(t)) {
       // get information from input
-      ir::Value ptr = op->GetOperandByIndex(input_index_map[t]).source();
+      ir::Value ptr = op->operand(input_index_map[t]).source();
       auto in_var_name = name_map.at(ptr);
 
       if (mutable_attr_type_map.count(t)) {
@@ -180,7 +180,7 @@ void build_context(ir::Operation* op,
     }
   }
 
-  ir::Value out_ptr = op->GetResultByIndex(0);
+  ir::Value out_ptr = op->result(0);
   auto name = name_map.at(out_ptr);
 
   ctx->EmplaceBackOutput(scope->Var(name)->GetMutable<phi::DenseTensor>());
@@ -239,7 +239,7 @@ class PhiKernelAdaptor {
             (*it), name_map, scope_, &kernel_ctx, false);
         found_it->second(&kernel_ctx);
 
-        auto out_value = (*it)->GetResultByIndex(0);
+        auto out_value = (*it)->result(0);
         out_name = name_map[out_value];
       }
     }

--- a/test/cpp/ir/pass/pass_manager_test.cc
+++ b/test/cpp/ir/pass/pass_manager_test.cc
@@ -118,13 +118,10 @@ TEST(pass_manager_test, pass_manager) {
 
   EXPECT_EQ(&program, op1->GetParentProgram());
 
-  EXPECT_EQ(op1->GetResultByIndex(0).type().dialect().id(),
-            paddle_dialect->id());
+  EXPECT_EQ(op1->result(0).type().dialect().id(), paddle_dialect->id());
   using Interface = paddle::dialect::ParameterConvertInterface;
-  Interface *a_interface = op1->GetResultByIndex(0)
-                               .type()
-                               .dialect()
-                               .GetRegisteredInterface<Interface>();
+  Interface *a_interface =
+      op1->result(0).type().dialect().GetRegisteredInterface<Interface>();
   std::shared_ptr<paddle::framework::Variable> a_var =
       a_interface->ParameterToVariable(program.GetParameter("a"));
   const phi::DenseTensor &a_tensor = a_var->Get<phi::DenseTensor>();
@@ -148,12 +145,9 @@ TEST(pass_manager_test, pass_manager) {
       ir::Operation::Create({}, op2_attribute, {dense_tensor_dtype}, op2_info);
   block->push_back(op2);
 
-  EXPECT_EQ(op2->GetResultByIndex(0).type().dialect().id(),
-            paddle_dialect->id());
-  Interface *b_interface = op2->GetResultByIndex(0)
-                               .type()
-                               .dialect()
-                               .GetRegisteredInterface<Interface>();
+  EXPECT_EQ(op2->result(0).type().dialect().id(), paddle_dialect->id());
+  Interface *b_interface =
+      op2->result(0).type().dialect().GetRegisteredInterface<Interface>();
   std::shared_ptr<paddle::framework::Variable> b_var =
       b_interface->ParameterToVariable(program.GetParameter("b"));
   const phi::DenseTensor &b_tensor = b_var->Get<phi::DenseTensor>();
@@ -172,11 +166,10 @@ TEST(pass_manager_test, pass_manager) {
       builtin_dialect->name() + "." + std::string(AddOp::name());
   ir::OpInfo op3_info = ctx->GetRegisteredOpInfo(op3_name);
   std::unordered_map<std::string, ir::Attribute> op3_attribute;
-  ir::Operation *op3 = ir::Operation::Create(
-      {op1->GetResultByIndex(0), op2->GetResultByIndex(0)},
-      op3_attribute,
-      {dense_tensor_dtype},
-      op3_info);
+  ir::Operation *op3 = ir::Operation::Create({op1->result(0), op2->result(0)},
+                                             op3_attribute,
+                                             {dense_tensor_dtype},
+                                             op3_info);
   block->push_back(op3);
 
   phi::CPUContext *dev_ctx = static_cast<phi::CPUContext *>(
@@ -200,7 +193,7 @@ TEST(pass_manager_test, pass_manager) {
 
   // (7) Def AbsOp(b)
   ir::OpInfo abs_info = ctx->GetRegisteredOpInfo("pd.abs");
-  std::vector<ir::OpResult> operands = {op1->GetResultByIndex(0)};
+  std::vector<ir::OpResult> operands = {op1->result(0)};
   std::unordered_map<std::string, ir::Attribute> abs_op_attribute;
   std::vector<ir::Type> output_types = {dense_tensor_dtype};
   ir::OperationArgument abs_argument(abs_info);
@@ -219,15 +212,14 @@ TEST(pass_manager_test, pass_manager) {
   std::unordered_map<std::string, ir::Attribute> op4_attribute{
       {"parameter_name", ir::StrAttribute::get(ctx, "c")}};
 
-  ir::OperationArgument op4_argument(
-      {op3->GetResultByIndex(0)}, {}, {}, op4_info);
+  ir::OperationArgument op4_argument({op3->result(0)}, {}, {}, op4_info);
   op4_argument.AddAttributes(op4_attribute.begin(), op4_attribute.end());
   ir::Operation *op4 = ir::Operation::Create(std::move(op4_argument));
   block->push_back(op4);
 
-  EXPECT_EQ(op4->GetOperandByIndex(0).source().type().dialect().id(),
+  EXPECT_EQ(op4->operand(0).source().type().dialect().id(),
             paddle_dialect->id());
-  Interface *c_interface = op4->GetOperandByIndex(0)
+  Interface *c_interface = op4->operand(0)
                                .source()
                                .type()
                                .dialect()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

APIs

### Description
<!-- Describe what you’ve done -->
修改了api的新IR的Api名字。
将Operation的GetResultByIndex和GetOperandByIndex这两个接口考虑到使用频次较高，将其重命名为 result和operand.

### Other
Pcard-67164