### PR TITLE
fix RecordStreamForGC nullptr exception

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -1197,6 +1197,9 @@ void InterpreterCore::RecordStreamForGC(const Instruction& instr) {
       instr.KernelType() != OpFuncType::kGpuAsync) {
     return;
   }
+  if (instr.DeviceContext().GetPlace() == phi::CustomPlace()) {
+    return;
+  }
   platform::RecordEvent record(
       "RecordStreamForGC", platform::TracerEventType::UserDefined, 10);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

某种情况下，同时打开GPU和CUSTOM_DEVICE的编译选项
```
cmake .. -DWITH_GPU=ON -DWITH_CUSTOM_DEVICE=ON -DWITH_TENSORRT=ON
```
使用Custom Device进行推理。
会出现空指针的异常。
```
I0613 13:41:04.066522 3527536 interpretercore.cc:237] New Executor is Running.
I0613 13:41:04.432148 3527536 conditional_block_op.cc:98] [ControlFlow][ConditionalBlock] New Executor is Running.
W0613 13:41:04.549906 3528349 interpretercore.cc:1022] memcpy_h2d raises an exception paddle::PD_Exception, the gpu stream is nullptr.
  [/media/wjl/D2/github/fork/Paddle/paddle/phi/backends/gpu/gpu_context.cc:324]
W0613 13:41:04.552162 3527536 operator.cc:804] while raises an exception std::exception, std::exception
terminate called after throwing an instance of 'std::exception'
  what():  std::exception
```
原因是 [paddle/fluid/framework/new_executor/interpretercore.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...engineer1109:Paddle:fixstream#diff-d17098a61ffb111a5d8beac6c14cf4e7af1ef4cdf96e840f4c5d059a6a8d7a63)
RecordStreamForGC 这个函数里
有这样一行代码
```
 gpuStream_t stream =
      reinterpret_cast<const phi::GPUContext&>(instr.DeviceContext()).stream();
```
不管是GPUContext还是CustomContext 都会执行。

目前仅在这个模型下发现这个问题。
链接: https://pan.baidu.com/s/1CSqbKXVlT1gwIyCkAkDBJg?pwd=twk5 提取码: twk5
修复补丁确认可以修复。
