### PR TITLE
[BugFix]Fix mac bugs when run static phi

### DIFF
--- a/test/cpp/eager/task_tests/CMakeLists.txt
+++ b/test/cpp/eager/task_tests/CMakeLists.txt
@@ -4,44 +4,85 @@ cc_test(
   DEPS eager_nan_inf_utils phi)
 
 if(NOT ((NOT WITH_PYTHON) AND ON_INFER))
-  cc_test(
+  cc_test_old(
     test_egr_task_hook
-    SRCS hook_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} eager_scale scale_node)
-  cc_test(
+    SRCS
+    hook_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    eager_scale
+    scale_node)
+  cc_test_old(
     test_egr_task_backward
-    SRCS backward_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} eager_scale scale_node)
-  cc_test(
+    SRCS
+    backward_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    eager_scale
+    scale_node)
+  cc_test_old(
     test_egr_task_grad
-    SRCS grad_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} eager_scale scale_node)
-  cc_test(
+    SRCS
+    grad_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    eager_scale
+    scale_node)
+  cc_test_old(
     test_egr_task_fwd_bwd_joint
-    SRCS fwd_bwd_joint_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} eager_scale scale_node)
-  cc_test(
+    SRCS
+    fwd_bwd_joint_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    eager_scale
+    scale_node)
+  cc_test_old(
     test_egr_task_cross_batch
-    SRCS cross_batch_accumulation_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} eager_scale scale_node)
-  cc_test(
+    SRCS
+    cross_batch_accumulation_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    eager_scale
+    scale_node)
+  cc_test_old(
     test_egr_task_hook_intermidiate
-    SRCS hook_test_intermidiate.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} dygraph_node)
-  cc_test(
+    SRCS
+    hook_test_intermidiate.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    dygraph_node)
+  cc_test_old(
     test_egr_task_autocodegen
-    SRCS generated_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps})
-  cc_test(
-    test_egr_task_tensor_utils
-    SRCS tensor_utils_test.cc
-    DEPS ${eager_deps} ${generated_deps})
-  cc_test(
-    test_egr_task_eager_utils
-    SRCS eager_utils_test.cc
-    DEPS ${eager_deps} ${generated_deps})
-  cc_test(
+    SRCS
+    generated_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps})
+  cc_test_old(test_egr_task_tensor_utils SRCS tensor_utils_test.cc DEPS
+              ${eager_deps} ${generated_deps})
+  cc_test_old(test_egr_task_eager_utils SRCS eager_utils_test.cc DEPS
+              ${eager_deps} ${generated_deps})
+  cc_test_old(
     test_egr_task_forward_autograd
-    SRCS forward_autograd_test.cc
-    DEPS ${eager_deps} ${fluid_deps} ${generated_deps} eager_scale scale_node)
+    SRCS
+    forward_autograd_test.cc
+    DEPS
+    ${eager_deps}
+    ${fluid_deps}
+    ${generated_deps}
+    eager_scale
+    scale_node)
 endif()

--- a/test/cpp/phi/api/CMakeLists.txt
+++ b/test/cpp/phi/api/CMakeLists.txt
@@ -58,14 +58,10 @@ cc_test(
   test_slice_api
   SRCS test_slice_api.cc
   DEPS ${COMMON_API_TEST_DEPS})
-cc_test(
-  test_scale_benchmark
-  SRCS test_scale_benchmark.cc
-  DEPS ${COMMON_API_TEST_DEPS})
-cc_test(
-  test_data_transform
-  SRCS test_data_transform.cc
-  DEPS ${COMMON_API_TEST_DEPS})
+cc_test_old(test_scale_benchmark SRCS test_scale_benchmark.cc DEPS
+            ${COMMON_API_TEST_DEPS})
+cc_test_old(test_data_transform SRCS test_data_transform.cc DEPS
+            ${COMMON_API_TEST_DEPS})
 cc_test(
   test_strings_empty_api
   SRCS test_strings_empty_api.cc


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66980
修复在phi静态库的条件下，MacOs出现segment fault的问题：phi编译为静态库后，使用cc_test在MacOS下进行dynamic_cast转换后会出现nullptr，cc_test主要是使用的libpaddle.so，本地已验证libpaddle.so单独链接使用（不通过cc_test使用），编译出来的单测并没有问题，故可以确定phi编译为静态库后，libpaddle.so是没有问题的，问题出在cc_test的实现当中，当前考虑到发版需要紧急修复，故先切到cc_test_old，等后续再修复cc_test中的问题