### PR TITLE
[MEA] fix mea get pad no default return bug

### DIFF
--- a/paddle/phi/kernels/funcs/get_pad_lse.cu.h
+++ b/paddle/phi/kernels/funcs/get_pad_lse.cu.h
@@ -91,6 +91,8 @@ phi::DenseTensor get_pad_lse(const phi::GPUContext& dev_ctx,
     ViewSliceHelper<T><<<grid, block, 0, dev_ctx.stream()>>>(
         in_data, stride, in_dim[2], out_second_dim);
     return *lse;
+  } else {
+    return *lse;
   }
 }
 }  // namespace funcs


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
Fix function get_pad_lse has no default return bug. 
This bug leads to `Segmentation fault` error in Memory Effecient Attention.

Pcard-72052
