### PR TITLE
Fix incorrect size of grid dimension in index_select

### DIFF
--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -87,7 +87,7 @@ void IndexSelectGradKernel(const Context& ctx,
   auto stream = ctx.stream();
 
   unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
-  dim3 grid_dim = dim3((numel + block_dim - 1) / block_dim);
+  dim3 grid_dim = dim3((out_nums + block_dim - 1) / block_dim);
   phi::backends::gpu::LimitGridDim(ctx, &grid_dim);
 
   phi::funcs::SetConstant<phi::GPUContext, T> index_select_grad_init;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
The `index_select_grad` OP uses incorrect size of grid dimension to run `index_select_grad_cuda` kernel.
This PR solved the `test_index_select_op` UT failure.