### PR TITLE
fix paddle.nonzero when as_tuple=True

### DIFF
--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -381,7 +381,7 @@ def nonzero(x, as_tuple=False):
     of `input`. Given a n-Dimensional `input` tensor with shape [x_1, x_2, ..., x_n], If
     as_tuple is False, we can get a output tensor with shape [z, n], where `z` is the
     number of all non-zero elements in the `input` tensor. If as_tuple is True, we can get
-    a 1-D tensor tuple of length `n`, and the shape of each 1-D tensor is [z, 1].
+    a 1-D tensor tuple of length `n`, and the shape of each 1-D tensor is [z].
 
     Args:
         x (Tensor): The input tensor variable.
@@ -408,12 +408,9 @@ def nonzero(x, as_tuple=False):
             out_z1_tuple = paddle.nonzero(x1, as_tuple=True)
             for out in out_z1_tuple:
                 print(out)
-            #[[0]
-            # [1]
-            # [2]]
-            #[[0]
-            # [1]
-            # [2]]
+            #[0, 1, 2]
+            #[0, 1, 2]
+
             out_z2 = paddle.nonzero(x2)
             print(out_z2)
             #[[1]
@@ -421,8 +418,7 @@ def nonzero(x, as_tuple=False):
             out_z2_tuple = paddle.nonzero(x2, as_tuple=True)
             for out in out_z2_tuple:
                 print(out)
-            #[[1]
-            # [3]]
+            #[1, 3]
 
     """
     list_out = []
@@ -632,9 +628,8 @@ def where(condition, x=None, y=None, name=None):
 
             out = paddle.where(x>1)
             print(out)
-            #out: (Tensor(shape=[2, 1], dtype=int64, place=CPUPlace, stop_gradient=True,
-            #            [[2],
-            #             [3]]),)
+            #out: (Tensor(shape=[2], dtype=int64, place=CPUPlace, stop_gradient=True,
+            #            [2, 3]),)
     """
     if np.isscalar(x):
         x = paddle.full([1], x, np.array([x]).dtype.name)

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -460,14 +460,8 @@ def nonzero(x, as_tuple=False):
 
     if not as_tuple:
         return outs
-    elif rank == 1:
-        return (outs,)
     else:
-        for i in range(rank):
-            list_out.append(
-                paddle.slice(outs, axes=[1], starts=[i], ends=[i + 1])
-            )
-        return tuple(list_out)
+        return tuple(paddle.unbind(outs, 1))
 
 
 def sort(x, axis=-1, descending=False, name=None):

--- a/test/legacy_test/test_nonzero_api.py
+++ b/test/legacy_test/test_nonzero_api.py
@@ -82,6 +82,7 @@ class TestNonZeroAPI(unittest.TestCase):
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
     def test_dygraph_api(self):
+        paddle.disable_static()
         data_x = np.array([[True, False], [False, True]])
         x = paddle.to_tensor(data_x)
         z = paddle.nonzero(x)

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -395,12 +395,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = paddle.where(x)
             self.assertEqual(type(y), tuple)
             self.assertEqual(len(y), 2)
-            z = paddle.concat(list(y), axis=1)
             exe = fluid.Executor(fluid.CPUPlace())
-            (res,) = exe.run(
-                feed={'x': data}, fetch_list=[z.name], return_numpy=False
-            )
-        expect_out = np.array([[0, 0], [1, 1]])
+            res = exe.run(feed={'x': data}, fetch_list=y, return_numpy=False)
+        expect_out = np.where(data)
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
         data = np.array([True, True, False])
         with program_guard(Program(), Program()):
@@ -409,12 +406,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = paddle.where(x)
             self.assertEqual(type(y), tuple)
             self.assertEqual(len(y), 1)
-            z = paddle.concat(list(y), axis=1)
             exe = fluid.Executor(fluid.CPUPlace())
-            (res,) = exe.run(
-                feed={'x': data}, fetch_list=[z.name], return_numpy=False
-            )
-        expect_out = np.array([[0], [1]])
+            res = exe.run(feed={'x': data}, fetch_list=y, return_numpy=False)
+        expect_out = np.where(data)
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Pcard-64703

`paddle.nonzero(x, as_tuple=True)`  should return a tuple with 1-D Tensor. However, currently it returns a tuple with 2-D Tensor, shape of which is [N, 1]. 


`paddle.where(condition)` is same with `paddle.nonzero(condition, as_tuple=True)`, which is fixed,  too.
