### PR TITLE
【测试用，无需 review】try decoupe batch_norm and sync_batch_norm

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -114,7 +114,7 @@ void BatchNormOp::InferShape(framework::InferShapeContext *ctx) const {
   VLOG(4) << ctx->IsRunMKLDNNKernel();
   VLOG(4) << data_layout;
   const int64_t C =
-      ((ctx->IsRunMKLDNNKernel() == true) || (data_layout == DataLayout::kNCHW)
+      ((ctx->IsRunMKLDNNKernel() == true) && (data_layout == DataLayout::kNCHW)
            ? x_dims[1]
            : x_dims[x_dims.size() - 1]);
 

--- a/paddle/fluid/operators/batch_norm_op.h
+++ b/paddle/fluid/operators/batch_norm_op.h
@@ -49,11 +49,6 @@ class BatchNormOp : public framework::OperatorWithKernel {
  protected:
   phi::KernelKey GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override;
-
-  phi::KernelKey GetKernelTypeForVar(
-      const std::string& var_name,
-      const phi::DenseTensor& tensor,
-      const phi::KernelKey& expected_kernel_type) const override;
 };
 
 class BatchNormGradOp : public framework::OperatorWithKernel {
@@ -64,11 +59,6 @@ class BatchNormGradOp : public framework::OperatorWithKernel {
  protected:
   phi::KernelKey GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override;
-
-  phi::KernelKey GetKernelTypeForVar(
-      const std::string& var_name,
-      const phi::DenseTensor& tensor,
-      const phi::KernelKey& expected_kernel_type) const override;
 };
 
 class BatchNormDoubleGradOp : public framework::OperatorWithKernel {

--- a/paddle/fluid/operators/inplace_abn_op.cu
+++ b/paddle/fluid/operators/inplace_abn_op.cu
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/inplace_abn_op.h"
-#include "paddle/fluid/operators/batch_norm_op.h"
 #include "paddle/fluid/operators/sync_batch_norm_utils.h"
 #include "paddle/phi/kernels/batch_norm_grad_kernel.h"
 #include "paddle/phi/kernels/batch_norm_kernel.h"

--- a/paddle/phi/core/infermeta_utils.cc
+++ b/paddle/phi/core/infermeta_utils.cc
@@ -128,10 +128,13 @@ const AttrType& InferMetaContext::AttrAt(size_t idx) const {
   try {
     return paddle::get<AttrType>(attrs_.at(idx));
   } catch (paddle::bad_variant_access const& e) {
-    PADDLE_THROW(phi::errors::InvalidArgument(
-        "Attribute cast error in InferMeta Context, the expected attribute "
-        "type is `%s`.",
-        std::type_index(typeid(AttrType)).name()));
+    PADDLE_THROW(
+        phi::errors::InvalidArgument("Attribute [%d] cast error in InferMeta "
+                                     "Context, the expected attribute "
+                                     "type is `%s`, but received `%s`.",
+                                     idx,
+                                     std::type_index(typeid(AttrType)).name(),
+                                     attrs_.at(idx).type().name()));
   }
 }
 

--- a/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/batch_norm_grad_kernel.h"
 
 #include "paddle/phi/backends/onednn/onednn_reuse.h"
+#include "paddle/phi/core/compat/get_kerneltype_forvar_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {
@@ -116,9 +117,37 @@ void BatchNormGradKernel(const Context& dev_ctx,
                                      bias_grad);
 }
 
+phi::KernelKey BatchNormGradGetKernelTypeForVar(
+    const GetKernelTypeForVarContext* ctx) {
+  const std::string& var_name = ctx->GetVarName();
+  const phi::DenseTensor& tensor = ctx->GetTensor();
+  const phi::KernelKey& expected_kernel_type = ctx->GetKernelKey();
+
+  // Only input require reshaping, weights and
+  // bias are having shape in NCHW order
+  if (((var_name == "X") || (var_name == "Y@GRAD")) &&
+      (expected_kernel_type.layout() == phi::DataLayout::ONEDNN) &&
+      (tensor.layout() != phi::DataLayout::ONEDNN)) {
+    auto attrs = ctx->GetAttrs();
+    auto it = attrs.find("data_layout");
+    const std::string data_layout = PADDLE_GET_CONST(std::string, it->second);
+    auto dl = phi::StringToDataLayout(data_layout);
+    // Some models may have intentionally set "AnyLayout" for pool
+    // op. Treat this as NCHW (default data_format value)
+    if (dl != phi::DataLayout::kAnyLayout) {
+      return phi::KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
+    }
+  }
+
+  return phi::KernelKey(
+      tensor.place(), tensor.layout(), expected_kernel_type.dtype());
+}
+
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    batch_norm_grad, OneDNN, ONEDNN, phi::BatchNormGradKernel, float) {}
+    batch_norm_grad, OneDNN, ONEDNN, phi::BatchNormGradKernel, float) {
+  kernel->get_kerneltype_forvar_fn_ = phi::BatchNormGradGetKernelTypeForVar;
+}
 PD_REGISTER_KERNEL(
     batch_norm_grad_raw, OneDNN, ONEDNN, phi::BatchNormGradRawKernel, float) {}

--- a/paddle/phi/kernels/onednn/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/batch_norm_kernel.h"
 
 #include "paddle/phi/backends/onednn/onednn_reuse.h"
+#include "paddle/phi/core/compat/get_kerneltype_forvar_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
@@ -140,8 +141,36 @@ void BatchNormInferKernel(const Context &dev_ctx,
                               /*reserve_space=*/nullptr);
 }
 
+phi::KernelKey BatchNormGetKernelTypeForVar(
+    const GetKernelTypeForVarContext *ctx) {
+  const std::string &var_name = ctx->GetVarName();
+  const phi::DenseTensor &tensor = ctx->GetTensor();
+  const phi::KernelKey &expected_kernel_type = ctx->GetKernelKey();
+
+  // Only input require reshaping, weights and
+  // bias are having shape in NCHW order
+  if ((var_name == "X") &&
+      (expected_kernel_type.layout() == phi::DataLayout::ONEDNN) &&
+      (tensor.layout() != phi::DataLayout::ONEDNN)) {
+    auto attrs = ctx->GetAttrs();
+    auto it = attrs.find("data_layout");
+    const std::string data_layout = PADDLE_GET_CONST(std::string, it->second);
+    auto dl = phi::StringToDataLayout(data_layout);
+    // Some models may have intentionally set "AnyLayout" for pool
+    // op. Treat this as NCHW (default data_format value)
+    if (dl != phi::DataLayout::kAnyLayout) {
+      return phi::KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
+    }
+  }
+
+  return phi::KernelKey(
+      tensor.place(), tensor.layout(), expected_kernel_type.dtype());
+}
+
 }  // namespace phi
 
-PD_REGISTER_KERNEL(batch_norm, OneDNN, ONEDNN, phi::BatchNormKernel, float) {}
+PD_REGISTER_KERNEL(batch_norm, OneDNN, ONEDNN, phi::BatchNormKernel, float) {
+  kernel->get_kerneltype_forvar_fn_ = phi::BatchNormGetKernelTypeForVar;
+}
 PD_REGISTER_KERNEL(
     batch_norm_infer, OneDNN, ONEDNN, phi::BatchNormInferKernel, float) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
尝试解耦合 batch_norm 和 sync_batch_norm，以解决自动生成问题。

- 参考 #53816

- [ ] 下沉 `GetKernelTypeForVar`
- [ ] 分离 `GetExpectedKernelType`
- [ ] 支持 `BatchNorm` 自动生成
- [ ] 支持 `SyncBatchNorm` 自动生成