### PR TITLE
[BugFix]Fix cuda12 bugs

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -237,5 +237,5 @@ if(WITH_CUDNN_FRONTEND)
 endif()
 
 if(WITH_SHARED_PHI)
-  add_definitions(-DPHI_SHARED)
+  add_definitions(-DPADDLE_WITH_SHARED_PHI)
 endif()

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -40,22 +40,6 @@ PADDLE_DEFINE_EXPORTED_bool(enable_rpc_profiler,
 
 DEFINE_bool(enable_record_memory, false, "enable memory recorder");
 
-#if defined(_WIN32) && defined(PHI_SHARED)
-phi::ProfilerState phi::ProfilerHelper::g_state = phi::ProfilerState::kDisabled;
-bool phi::ProfilerHelper::g_enable_nvprof_hook = false;
-thread_local uint64_t phi::ProfilerHelper::g_thread_id;
-uint32_t phi::ProfilerHelper::g_next_thread_id = 0;
-std::mutex phi::ProfilerHelper::g_all_event_lists_mutex;
-std::list<std::shared_ptr<phi::EventList<phi::Event>>>
-    phi::ProfilerHelper::g_all_event_lists;
-thread_local std::shared_ptr<phi::EventList<phi::Event>>
-    phi::ProfilerHelper::g_event_list;
-std::list<std::shared_ptr<phi::EventList<phi::MemEvent>>>
-    phi::ProfilerHelper::g_all_mem_event_lists;
-thread_local std::shared_ptr<phi::EventList<phi::MemEvent>>
-    phi::ProfilerHelper::g_mem_event_list;
-std::mutex phi::ProfilerHelper::g_all_mem_event_lists_mutex;
-#endif
 namespace paddle {
 namespace platform {
 

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1029,6 +1029,14 @@ void ReduceKernel(const KPDevice& dev_ctx,
   constexpr bool kIsTxFP16 = std::is_same<Tx, phi::dtype::float16>::value;
   constexpr bool kIsTxBF16 = std::is_same<Tx, phi::dtype::bfloat16>::value;
   bool use_cub_reduce = config.reduce_num == numel && !kIsTxFP16 && !kIsTxBF16;
+  // NOTE(zhiqiu): hot fix
+  // cuda 12.0 + cub got wrong result in some shapes when build phi with shared
+  // library. For example, paddle.sum(paddle.ones([1024,100],
+  // dtype=paddle.float32)) is expected to 102400, but got 0.
+#if PADDLE_WITH_SHARED_PHI && CUDA_VERSION >= 12000
+  use_cub_reduce = false;
+#endif
+
 #ifndef PADDLE_WITH_XPU_KP
   if (use_cub_reduce) {
     if (is_mean) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
在Cuda12 + cub的环境下，PHI编译为动态库调用cub的reduce接口后产生了数据为0的结果，该PR临时修复这个问题