### PR TITLE
[XPU] avoid compile issue in non-xpu env

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -133,7 +133,7 @@ ExternalProject_Add(
     pack_paddle_depence.sh ${XPU_XRE_URL} ${XPU_XRE_DIR_NAME} ${XPU_XDNN_URL}
     ${XPU_XDNN_DIR_NAME} ${XPU_XCCL_URL} ${XPU_XCCL_DIR_NAME} && wget
     ${XPU_XFT_GET_DEPENCE_URL} && bash get_xft_dependence.sh ${XPU_XFT_URL}
-    ${XPU_XFT_DIR_NAME} && bash
+    ${XPU_XFT_DIR_NAME} [ -n "$WITH_XPTI" ] && bash
     ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
     ${XPU_XPTI_DIR_NAME}
   DOWNLOAD_NO_PROGRESS 1

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -94,9 +94,6 @@ set(XPU_PACK_DEPENCE_URL
 set(XPU_XFT_GET_DEPENCE_URL
     "https://baidu-kunlun-public.su.bcebos.com/paddle_depence/get_xft_dependence.sh"
     CACHE STRING "" FORCE)
-set(XPU_XPTI_GET_DEPENCE_URL
-    "https://baidu-kunlun-public.su.bcebos.com/paddle_depence/get_xpti_dependence.sh"
-    CACHE STRING "" FORCE)
 
 set(SNAPPY_PREFIX_DIR "${THIRD_PARTY_PATH}/xpu")
 set(XPU_DOWNLOAD_DIR "${SNAPPY_PREFIX_DIR}/src/${XPU_PROJECT}")
@@ -136,8 +133,9 @@ ExternalProject_Add(
     pack_paddle_depence.sh ${XPU_XRE_URL} ${XPU_XRE_DIR_NAME} ${XPU_XDNN_URL}
     ${XPU_XDNN_DIR_NAME} ${XPU_XCCL_URL} ${XPU_XCCL_DIR_NAME} && wget
     ${XPU_XFT_GET_DEPENCE_URL} && bash get_xft_dependence.sh ${XPU_XFT_URL}
-    ${XPU_XFT_DIR_NAME} && wget ${XPU_XPTI_GET_DEPENCE_URL} && bash
-    get_xpti_dependence.sh ${XPU_XPTI_URL} ${XPU_XPTI_DIR_NAME}
+    ${XPU_XFT_DIR_NAME} && bash
+    ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
+    ${XPU_XPTI_DIR_NAME}
   DOWNLOAD_NO_PROGRESS 1
   UPDATE_COMMAND ""
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${XPU_INSTALL_ROOT}

--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -165,9 +165,9 @@ if(WITH_XPU_XFT)
   set(XPU_XFT_LIB "${XPU_LIB_DIR}/${XPU_XFT_LIB_NAME}")
 endif()
 
-if(WITH_XPU_XPTI)
+if(WITH_XPTI)
   message(STATUS "Compile with XPU XPTI!")
-  add_definitions(-DPADDLE_WITH_XPU_XPTI)
+  add_definitions(-DPADDLE_WITH_XPTI)
   set(XPU_XPTI_LIB "${XPU_LIB_DIR}/${XPU_XPTI_LIB_NAME}")
 endif()
 
@@ -182,7 +182,7 @@ else()
   target_link_libraries(xpulib ${XPU_API_LIB} ${XPU_RT_LIB})
 endif()
 
-if(WITH_XPU_XPTI)
+if(WITH_XPTI)
   target_link_libraries(xpulib ${XPU_XPTI_LIB})
 endif()
 

--- a/paddle/fluid/platform/dynload/xpti.cc
+++ b/paddle/fluid/platform/dynload/xpti.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#ifdef PADDLE_WITH_XPU
+#ifdef PADDLE_WITH_XPTI
 
 #include "paddle/fluid/platform/dynload/xpti.h"
 
@@ -28,4 +28,4 @@ XPTI_ROUTINE_EACH(DEFINE_WRAP);
 }  // namespace platform
 }  // namespace paddle
 
-#endif  // PADDLE_WITH_XPU
+#endif  // PADDLE_WITH_XPTI

--- a/paddle/fluid/platform/dynload/xpti.h
+++ b/paddle/fluid/platform/dynload/xpti.h
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
+#ifdef PADDLE_WITH_XPTI
+
 #include <xpu/xpti.h>
 
 #include <mutex>  // NOLINT
@@ -41,3 +43,5 @@ XPTI_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_XPTI_WRAP);
 }  // namespace dynload
 }  // namespace platform
 }  // namespace paddle
+
+#endif  // PADDLE_WITH_XPTI

--- a/paddle/phi/backends/dynload/xpti.cc
+++ b/paddle/phi/backends/dynload/xpti.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#ifdef PADDLE_WITH_XPU
+#ifdef PADDLE_WITH_XPTI
 
 #include "paddle/phi/backends/dynload/xpti.h"
 
@@ -29,4 +29,4 @@ XPTI_ROUTINE_EACH(DEFINE_WRAP);
 }  // namespace dynload
 }  // namespace phi
 
-#endif  // PADDLE_WITH_XPU
+#endif  // PADDLE_WITH_XPTI

--- a/paddle/phi/backends/dynload/xpti.h
+++ b/paddle/phi/backends/dynload/xpti.h
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
-#ifdef PADDLE_WITH_XPU
+#ifdef PADDLE_WITH_XPTI
 
 #include <xpu/xpti.h>
 

--- a/tools/xpu/get_xpti_dependence.sh
+++ b/tools/xpu/get_xpti_dependence.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+XPTI_URL=$1
+XPTI_DIR_NAME=$2
+
+wget --no-check-certificate ${XPTI_URL} -c -q -O xpti.tar.gz
+if [[ $? -ne 0  ]]; then
+  echo "downloading failed: ${XPTI_URL}"
+  exit 1
+else
+  echo "downloading ok: ${XPTI_URL}"
+fi
+
+tar -xvf xpti.tar.gz
+
+# xpu/include/xpu already exists
+cp -r ${XPTI_DIR_NAME}/include/* xpu/include/xpu
+# xpu/lib already exists
+cp -r ${XPTI_DIR_NAME}/so/* xpu/lib/
+# copy libxpurt.so that support klprof
+# commit fa894b83f9e2d1235564b93301265d8b55be5464 (HEAD -> trace)
+rm xpu/lib/libxpurt.so*
+cp -r ${XPTI_DIR_NAME}/runtime/libxpurt.so* xpu/lib/


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
1. add XPTI macro to avoid compile issue
2. rename macro from WITH_XPU_XPTI to WITH_XPTI
3. call get_xpti_dependency.sh only in need since this script will alter libxpurt.so