### PR TITLE
add skip_group for  topology.

### DIFF
--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -146,6 +146,7 @@ class DistributedStrategy:
             self.strategy.sync_nccl_allreduce = bool(_global_flags()[key])
 
         self.hybrid_parallel_order = ['dp', 'pp', 'sharding', 'mp']
+        self.hybrid_parallel_skip_group = []
         self.sync_param_name = ["embedding", "layer_norm", ".b_"]
 
         self.__lock_attr = True
@@ -1694,6 +1695,10 @@ class DistributedStrategy:
         if "order" in hybrid_config:
             self.hybrid_parallel_order = hybrid_config["order"]
             hybrid_config.pop('order')
+
+        if "skip_group" in hybrid_config:
+            self.hybrid_parallel_skip_group = hybrid_config["skip_group"]
+            hybrid_config.pop("skip_group")
 
         check_configs_key(
             self.strategy.hybrid_configs, hybrid_config, "hybrid_configs"

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -429,7 +429,10 @@ class Fleet:
             hybrid_group_names=hybrid_group_names, dims=dims
         )
 
-        self._hcg = tp.HybridCommunicateGroup(self._topology)
+        self._hcg = tp.HybridCommunicateGroup(
+            self._topology,
+            skip_group=self._user_defined_strategy.hybrid_parallel_skip_group,
+        )
 
         if self.mp_degree > 1:
             tensor_parallel_configs = (

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_layers.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_layers.py
@@ -123,8 +123,22 @@ class TestDistTraning(unittest.TestCase):
             "dp_degree": 1,
             "mp_degree": self.model_parallel_size,
             "pp_degree": 1,
+            "skip_group": ["dp", "pp", "sharding", "check"],
         }
         fleet.init(is_collective=True, strategy=strategy)
+        hcg = fleet.get_hybrid_communicate_group()
+        assert (
+            hcg.get_data_parallel_group() is None
+        ), f"dp group should skip, but created {hcg.get_data_parallel_group()}"
+        assert (
+            hcg.get_pipe_parallel_group() is None
+        ), f"pp group should skip, but created {hcg.get_pipe_parallel_group()}"
+        assert (
+            hcg.get_sharding_parallel_group() is None
+        ), f"sharding group should skip, but created {hcg.get_sharding_parallel_group()}"
+        assert (
+            hcg.get_check_parallel_group() is None
+        ), f"check group should skip, but created {hcg.get_check_parallel_group()}"
 
     def test_column_parallel_layer(self):
         set_random_seed(1024)

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_distributed_strategy.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_distributed_strategy.py
@@ -129,6 +129,18 @@ class TestStrategyConfig(unittest.TestCase):
             strategy.hybrid_parallel_order, ['sharding', 'mp', 'dp', 'pp']
         )
 
+    def test_hybrid_parallel_configs_skip_group(self):
+        strategy = paddle.distributed.fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 2,
+            "pp_degree": 4,
+            "skip_group": ['sharding', 'mp', 'dp', 'pp'],
+        }
+        self.assertEqual(
+            strategy.hybrid_parallel_skip_group, ['sharding', 'mp', 'dp', 'pp']
+        )
+
     def test_localsgd(self):
         strategy = paddle.distributed.fleet.DistributedStrategy()
         strategy.localsgd = True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
add skip_group for  topology to skip creating groups.
```
strategy.hybrid_configs = {
            "dp_degree": 1,
            "mp_degree": 2,
            "pp_degree": 1,
            "mp_configs": {
                "sync_param": False,
                "sync_grad": False,
                "sync_moment": False,
            },
            "skip_group": ["dp", "sharding", "pp", "check"],
        }
fleet.init(is_collective=True, strategy=strategy)
```