### PR TITLE
[CINN] add paddle2cinn visible variables api

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/cinn_compiler.h
+++ b/paddle/fluid/framework/paddle2cinn/cinn_compiler.h
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "cinn/common/target.h"
 #include "paddle/fluid/framework/ir/graph.h"

--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -188,6 +188,14 @@ void CinnLaunchContext::BuildVarNameMap(
           cinn2paddle_varmap_.size()));
 }
 
+std::unordered_set<std::string> CinnLaunchContext::GetVisibleVarNames() const {
+  std::unordered_set<std::string> remain_var_names;
+  for (const auto& pair : paddle2cinn_varmap_) {
+    remain_var_names.insert(this->RedirectVarName(pair.first));
+  }
+  return remain_var_names;
+}
+
 void CinnLaunchContext::UpdateCapturedEnv(const framework::Scope& scope,
                                           const platform::Place& place) {
   if (std::addressof(scope) == cached_scope_ &&
@@ -547,7 +555,8 @@ framework::InterpreterCore* CinnLaunchContext::InitializeInterpreterCore(
   return interpreter_core_.get();
 }
 
-std::string CinnLaunchContext::RedirectVarName(const std::string& var_name) {
+std::string CinnLaunchContext::RedirectVarName(
+    const std::string& var_name) const {
   auto pos = var_name.find(InplaceOutSuffix);
   if (pos == std::string::npos) {
     return var_name;

--- a/paddle/fluid/operators/cinn/cinn_launch_context.h
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.h
@@ -97,12 +97,14 @@ class CinnLaunchContext {
   }
 
   // Redirect the name of a Paddle variable to the orignal if it was inplaced
-  std::string RedirectVarName(const std::string& var_name);
+  std::string RedirectVarName(const std::string& var_name) const;
 
   // Return internal variable names list
   const std::unordered_set<std::string>& GetInternalVarNames() const {
     return internal_var_names_;
   }
+
+  std::unordered_set<std::string> GetVisibleVarNames() const;
 
   // Finalize all execution arguments and return the name->argument map
   const std::map<std::string, cinn_pod_value_t>& FinalizeArguments() const {

--- a/paddle/fluid/operators/cinn/cinn_launch_op.h
+++ b/paddle/fluid/operators/cinn/cinn_launch_op.h
@@ -133,6 +133,11 @@ class CinnLaunchOpKernel : public framework::OpKernel<T> {
           end_t - start_t);
       VLOG(1) << "Ends to compile at thread " << std::this_thread::get_id()
               << " , time cost : " << time_sec.count() << " ms";
+
+      const auto& visible_names =
+          cinn_compiled_object.launch_context->GetVisibleVarNames();
+      VLOG(1) << "These CINN variable can visible by Paddle: "
+              << string::join_strings(visible_names, ", ");
     }
     details::DebugCinnCompiledResult(cinn_compiled_object);
     auto* launch_context = cinn_compiled_object.launch_context.get();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71699

暴露`GetVisibleVarNames`接口，用于打印CINN融合后Paddle可见的变量列表