### PR TITLE
Print info for each layer in TRT inspector to avoid log being too long

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -870,8 +870,10 @@ void TensorRTEngine::GetEngineInfo() {
       infer_engine_->createEngineInspector());
   auto *infer_context = context();
   infer_inspector->setExecutionContext(infer_context);
-  LOG(INFO) << infer_inspector->getEngineInformation(
-      nvinfer1::LayerInformationFormat::kJSON);
+  for (int i = 0; i < infer_engine_->getNbLayers(); ++i) {
+    LOG(INFO) << infer_inspector->getLayerInformation(
+        i, nvinfer1::LayerInformationFormat::kJSON);
+  }
   LOG(INFO) << "====== engine info end ======";
 #else
   LOG(INFO) << "Inspector needs TensorRT version 8.2 and after.";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others


### Description
<!-- Describe what you’ve done -->
Paddle-TRT inspector will show the information of all layers in the engine by one `LOG(INFO)` call.
It may result in logger string buffer overflow (some information may not be shown).
This PR makes inspector print information one `LOG(INFO)` per layer to avoid the problem above.