### PR TITLE
[CINN] skip timeout has setted test to avoid reset timeout

### DIFF
--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1213,10 +1213,14 @@ set(TEST_CINN_OPS
     test_assign_op
     test_flatten_contiguous_range_op)
 
-foreach(TEST_CINN_OPS ${TEST_CINN_OPS})
+foreach(TEST_CINN_OP ${TEST_CINN_OPS})
   if(WITH_CINN)
-    set_tests_properties(${TEST_CINN_OPS} PROPERTIES LABELS "RUN_TYPE=CINN")
-    set_tests_properties(${TEST_CINN_OPS} PROPERTIES TIMEOUT 200)
+    set_tests_properties(${TEST_CINN_OP} PROPERTIES LABELS "RUN_TYPE=CINN")
+
+    get_test_property(${TEST_CINN_OP} TIMEOUT ORIGIN_TIME_OUT)
+    if((NOT ${ORIGIN_TIME_OUT}) OR (${ORIGIN_TIME_OUT} LESS 200))
+      set_tests_properties(${TEST_CINN_OP} PROPERTIES TIMEOUT 200)
+    endif()
   endif()
 endforeach()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71699

防止覆盖CINN测试中某些算子已经设置了单测的timeout属性，跳过这些单测的CINN timeout 200s限制。