### PR TITLE
Fix bug poolop

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -1948,7 +1948,7 @@
     pool2d_double_grad : GetPoolDoubleGradExpectedKernelType
   extra :
     attrs : [bool use_mkldnn = false, bool use_quantizer = false,
-              str mkldnn_data_type = "float32", bool is_test = false, bool use_cudnn = false]
+              str mkldnn_data_type = "float32", bool is_test = false]
 
 - op : pool3d
   backward : pool3d_grad
@@ -1962,7 +1962,7 @@
     pool3d : GetPoolExpectedKernelType
     pool3d_grad : GetPoolExpectedKernelType
   extra :
-    attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+    attrs : [bool use_mkldnn = false]
 
 - op : pow
   backward : pow_grad, pow_double_grad, pow_triple_grad

--- a/paddle/phi/api/yaml/static_ops.yaml
+++ b/paddle/phi/api/yaml/static_ops.yaml
@@ -382,7 +382,7 @@
     param : [peer, dtype, out_shape]
 
 - op : pool2d
-  args : (Tensor x, IntArray kernel_size, int[] strides = {1,1}, int[] paddings = {0,0}, bool ceil_mode = false, bool exclusive = true, str data_format = "NCHW", str pooling_type = "", bool global_pooling = false, bool adaptive = false, str padding_algorithm = "EXPLICIT")
+  args : (Tensor x, IntArray kernel_size, int[] strides = {1,1}, int[] paddings = {0,0}, bool ceil_mode = false, bool exclusive = true, str data_format = "NCHW", str pooling_type = "", bool global_pooling = false, bool adaptive = false, str padding_algorithm = "EXPLICIT", bool use_cudnn = false)
   output : Tensor(out)
   infer_meta :
     func : Pool2DInferMeta
@@ -393,7 +393,7 @@
   backward : pool2d_grad
 
 - op : pool3d
-  args : (Tensor x, int[] kernel_size, int[] strides = {1,1,1}, int[] paddings = {0,0,0}, bool ceil_mode = false, bool exclusive = true, str data_format = "NCDHW", str pooling_type = "", bool global_pooling = false, bool adaptive = false, str padding_algorithm = "EXPLICIT")
+  args : (Tensor x, int[] kernel_size, int[] strides = {1,1,1}, int[] paddings = {0,0,0}, bool ceil_mode = false, bool exclusive = true, str data_format = "NCDHW", str pooling_type = "", bool global_pooling = false, bool adaptive = false, str padding_algorithm = "EXPLICIT",  bool use_cudnn = false)
   output : Tensor(out)
   infer_meta :
     func : PoolInferMeta


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-67001
修复 #54070 引起的精度问题。由于将`use_cudnn`移动到`extra`中，导致保存模型时忽略该参数，但是对比于其他算子同类参数，这个算子的区别在于：Python的接口默认`use_cudnn`是`true`,C++端的参数默认是`false`,导致动转静出现问题。
测试代码：
```
import numpy as np
import paddle

paddle.seed(33)
np.random.seed(33)


def randtool(dtype, low, high, shape):
    """
    np random tools
    """
    if dtype == "int":
        return np.random.randint(low, high, shape)

    elif dtype == "float":
        return low + (high - low) * np.random.random(shape)


class BuildClass(paddle.nn.Layer):
    """
    用于动转静的nn.Layer
    """

    def __init__(self, in_params, func):
        super(BuildClass, self).__init__()
        self.func = eval(func)(**in_params)

    def forward(self, input):
        """
        forward
        """
        x = self.func(input)
        return x


# class BuildJitFunc(paddle.nn.Layer):
#     """
#     用于动转静的nn.Layer
#     """
#
#     def __init__(self, in_params, func):
#         super(BuildJitFunc, self).__init__()
#         paddle.seed(33)
#         self.func = eval(func)
#         self._params = in_params
#
#     @paddle.jit.to_static
#     def forward(self, inputs):
#         """
#         forward
#         """
#         x = self.func(inputs, **self._params)
#         return x


func = "paddle.nn.AvgPool2D"

in_tensor = {"x": paddle.to_tensor(randtool("float", -10, 10, shape=[2, 3, 4, 4]), dtype="float32")}

in_params = {
      "kernel_size": [3, 3],
      "stride": [3, 3],
      "padding": [0, 0, 0, 0],
      "ceil_mode": True,
      "exclusive": False,
}

obj = BuildClass(in_params, func)

obj.eval()

paddle.seed(33)
dy_out = obj(in_tensor["x"])
# print("dy_out is: ", dy_out)

jit_obj = paddle.jit.to_static(obj)
print("jit_obj is created successfully !!!")

paddle.seed(33)
st_out = jit_obj(in_tensor["x"])
# print("st_out is: ", st_out)

paddle.seed(33)
paddle.jit.save(jit_obj, path="avgpool2d")

paddle.seed(33)
jit = paddle.jit.load("avgpool2d")

paddle.seed(33)
res = jit(in_tensor["x"])
# print('jit.load res: ', res)

np.testing.assert_allclose(actual=res, desired=dy_out, atol=1e-5, rtol=1e-6, equal_nan=True)

```