### PR TITLE
[Paddle Inference]add info in memory_optimize_pass.cc

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -91,6 +91,9 @@ void MemoryOptimizePass::CollectLifeCycle(
           if (is_break) continue;
 
           auto in_shape = node->Var()->GetShape();
+          for (auto i : in_shape) {
+            CHECK_GT(i, 0);
+          }
           auto var_bytes = std::accumulate(in_shape.begin(),
                                            in_shape.end(),
                                            (int64_t)1,

--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -112,8 +112,8 @@ void MemoryOptimizePass::CollectLifeCycle(
 
     ++max_lifecycle;
   }
-  LOG(INFO) << "The whole model's persistable params are : "
-            << (persis_byte / (1 << 30)) << "GB";
+  LOG(INFO) << "The persistable params in main graph are : "
+            << (persis_byte / (1 << 20)) << "MB";
 }
 
 void MemoryOptimizePass::CollectVarMemorySize(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

P-card-71501

- 显示模型主block中不可复用的变量MB的之和
