### PR TITLE
[CodeStyle] bump common hooks and remove all tabs in python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ exclude: |
 repos:
 # Common hooks
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
     -   id: check-added-large-files
     -   id: check-merge-conflict
@@ -22,7 +22,7 @@ repos:
     -   id: trailing-whitespace
         files: (.*\.(py|bzl|md|rst|c|cc|cxx|cpp|cu|h|hpp|hxx|xpu|kps|cmake|yaml|yml|hook)|BUILD|.*\.BUILD|WORKSPACE|CMakeLists\.txt)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git
-    rev: v1.1.14
+    rev: v1.5.1
     hooks:
     -   id: remove-crlf
     -   id: remove-tabs
@@ -33,11 +33,9 @@ repos:
         name: Tabs remover (Python)
         files: (.*\.(py|bzl)|BUILD|.*\.BUILD|WORKSPACE)$
         args: [--whitespaces-count, '4']
-        # Exclude the fluid directory.
-        # And exclude some unit test files that require tabs.
+        # Exclude some unit test files that require tabs.
         exclude: |
             (?x)^(
-                python/paddle/fluid/.+|
                 test/dygraph_to_static/test_error.py
             )$
 -   repo: local

--- a/python/paddle/fluid/nets.py
+++ b/python/paddle/fluid/nets.py
@@ -409,7 +409,7 @@ def scaled_dot_product_attention(
     queries, keys, values, num_heads=1, dropout_rate=0.0
 ):
     r"""
-	:api_attr: Static Graph
+    :api_attr: Static Graph
 
     This interface Multi-Head Attention using scaled dot product.
     Attention mechanism can be seen as mapping a query and a set of key-value

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -3908,7 +3908,7 @@ Lamb = LambOptimizer
 
 class ModelAverage(Optimizer):
     r"""
-	:api_attr: Static Graph
+    :api_attr: Static Graph
 
     The ModelAverage optimizer accumulates specific continuous historical parameters
     during training. The accumulated historical range can be controlled by the passed


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
- 升级 common 的 pre-commit hooks
- remove-tabs 不再 exclude 掉 fluid，因为存量只剩两个了，直接替换成空格了，这样可以保证 docstring 里没有 tab，解析时不再需要 `line.replace("\t", "    ")` 这种操作了（PaddlePaddle/docs#5941）

PCard-66962