### PR TITLE
[Inference] Fix IR shared lib not found

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -276,7 +276,13 @@ else()
       SRCS ${paddle_phi_lib}
       DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/lib)
   endif()
-
+  if(WITH_SHARED_IR)
+    set(paddle_ir_lib ${PADDLE_BINARY_DIR}/paddle/ir/libir.*)
+    copy(
+      inference_lib_dist
+      SRCS ${paddle_ir_lib}
+      DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/lib)
+  endif()
 endif()
 
 copy(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description

ir改为动态库后，CPP API 推理找不到 libir.so

card-72344
