### PR TITLE
[XPU][PHI Kernels] add int_with_ll quantization for conv kernels

### DIFF
--- a/paddle/phi/kernels/xpu/conv_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_grad_kernel.cc
@@ -107,7 +107,7 @@ void ConvGradKernel(const Context& dev_ctx,
     }
   }
   int fccal_type = FCCalcType<XPUT>();
-  if (fccal_type == 1) {
+  if (fccal_type == XPUFCCalcType::FC_INT32) {
     int r = xpu::conv2d_grad<XPUT, XPUT, XPUT, int>(dev_ctx.x_context(),
                                                     input_data,
                                                     filter_data_ptr,
@@ -132,7 +132,7 @@ void ConvGradKernel(const Context& dev_ctx,
                                                     is_nchw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d_grad");
 
-  } else if (fccal_type == 2) {
+  } else if (fccal_type == XPUFCCalcType::FC_FLOAT) {
     int r = xpu::conv2d_grad<XPUT, XPUT, XPUT, float>(dev_ctx.x_context(),
                                                       input_data,
                                                       filter_data_ptr,
@@ -157,6 +157,31 @@ void ConvGradKernel(const Context& dev_ctx,
                                                       is_nchw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d_grad");
 
+  } else if (fccal_type == XPUFCCalcType::FC_INT32_WITH_LL) {
+    int r =
+        xpu::conv2d_grad<XPUT, XPUT, XPUT, int_with_ll_t>(dev_ctx.x_context(),
+                                                          input_data,
+                                                          filter_data_ptr,
+                                                          output_grad_data,
+                                                          input_grad_data,
+                                                          filter_grad_data_ptr,
+                                                          batch_size,
+                                                          img_c,
+                                                          img_h,
+                                                          img_w,
+                                                          f,
+                                                          ksize,
+                                                          strides,
+                                                          paddings,
+                                                          dilations,
+                                                          groups,
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          is_nchw);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d_grad");
   } else {
     int r = xpu::conv2d_grad<XPUT, XPUT, XPUT, int16_t>(dev_ctx.x_context(),
                                                         input_data,
@@ -305,7 +330,7 @@ void Conv3DGradKernel(const Context& dev_ctx,
     }
   }
   int fccal_type = FCCalcType<XPUT>();
-  if (fccal_type == 1) {
+  if (fccal_type == XPUFCCalcType::FC_INT32) {
     int r = xpu::conv3d_grad<XPUT, XPUT, XPUT, int>(dev_ctx.x_context(),
                                                     input_data,
                                                     filter_data_ptr,
@@ -330,7 +355,7 @@ void Conv3DGradKernel(const Context& dev_ctx,
                                                     nullptr,
                                                     is_ncdhw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv3d_grad");
-  } else if (fccal_type == 2) {
+  } else if (fccal_type == XPUFCCalcType::FC_FLOAT) {
     int r = xpu::conv3d_grad<XPUT, XPUT, XPUT, float>(dev_ctx.x_context(),
                                                       input_data,
                                                       filter_data_ptr,
@@ -354,6 +379,32 @@ void Conv3DGradKernel(const Context& dev_ctx,
                                                       nullptr,
                                                       nullptr,
                                                       is_ncdhw);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv3d_grad");
+  } else if (fccal_type == XPUFCCalcType::FC_INT32_WITH_LL) {
+    int r =
+        xpu::conv3d_grad<XPUT, XPUT, XPUT, int_with_ll_t>(dev_ctx.x_context(),
+                                                          input_data,
+                                                          filter_data_ptr,
+                                                          output_grad_data,
+                                                          input_grad_data,
+                                                          filter_grad_data_ptr,
+                                                          batch_size,
+                                                          img_c,
+                                                          img_d,
+                                                          img_h,
+                                                          img_w,
+                                                          f,
+                                                          ksize,
+                                                          strides,
+                                                          paddings,
+                                                          dilations,
+                                                          groups,
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          nullptr,
+                                                          is_ncdhw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv3d_grad");
   } else {
     int r = xpu::conv3d_grad<XPUT, XPUT, XPUT, int16_t>(dev_ctx.x_context(),

--- a/paddle/phi/kernels/xpu/conv_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_kernel.cc
@@ -89,7 +89,7 @@ void ConvKernel(const Context& dev_ctx,
   }
 
   int fccal_type = FCCalcType<XPUT>();
-  if (fccal_type == 1) {
+  if (fccal_type == XPUFCCalcType::FC_INT32) {
     int r = xpu::conv2d<XPUT, XPUT, XPUT, int>(dev_ctx.x_context(),
                                                input_data,
                                                filter_data_ptr,
@@ -109,7 +109,7 @@ void ConvKernel(const Context& dev_ctx,
                                                nullptr,
                                                is_nchw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d");
-  } else if (fccal_type == 2) {
+  } else if (fccal_type == XPUFCCalcType::FC_FLOAT) {
     int r = xpu::conv2d<XPUT, XPUT, XPUT, float>(dev_ctx.x_context(),
                                                  input_data,
                                                  filter_data_ptr,
@@ -128,6 +128,26 @@ void ConvKernel(const Context& dev_ctx,
                                                  nullptr,
                                                  nullptr,
                                                  is_nchw);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d");
+  } else if (fccal_type == XPUFCCalcType::FC_INT32_WITH_LL) {
+    int r = xpu::conv2d<XPUT, XPUT, XPUT, int_with_ll_t>(dev_ctx.x_context(),
+                                                         input_data,
+                                                         filter_data_ptr,
+                                                         output_data,
+                                                         batch_size,
+                                                         img_c,
+                                                         img_h,
+                                                         img_w,
+                                                         f,
+                                                         ksize,
+                                                         strides,
+                                                         paddings,
+                                                         dilations,
+                                                         groups,
+                                                         nullptr,
+                                                         nullptr,
+                                                         nullptr,
+                                                         is_nchw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d");
   } else {
     int r = xpu::conv2d<XPUT, XPUT, XPUT, int16_t>(dev_ctx.x_context(),
@@ -239,7 +259,7 @@ void Conv3DKernel(const Context& dev_ctx,
   }
 
   int fccal_type = FCCalcType<XPUT>();
-  if (fccal_type == 1) {
+  if (fccal_type == XPUFCCalcType::FC_INT32) {
     int r = xpu::conv3d<XPUT, XPUT, XPUT, int>(dev_ctx.x_context(),
                                                input_data,
                                                filter_data_ptr,
@@ -260,7 +280,7 @@ void Conv3DKernel(const Context& dev_ctx,
                                                nullptr,
                                                is_ncdhw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv3d");
-  } else if (fccal_type == 2) {
+  } else if (fccal_type == XPUFCCalcType::FC_FLOAT) {
     int r = xpu::conv3d<XPUT, XPUT, XPUT, float>(dev_ctx.x_context(),
                                                  input_data,
                                                  filter_data_ptr,
@@ -282,6 +302,27 @@ void Conv3DKernel(const Context& dev_ctx,
                                                  is_ncdhw);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv3d");
 
+  } else if (fccal_type == XPUFCCalcType::FC_INT32_WITH_LL) {
+    int r = xpu::conv3d<XPUT, XPUT, XPUT, int_with_ll_t>(dev_ctx.x_context(),
+                                                         input_data,
+                                                         filter_data_ptr,
+                                                         output_data,
+                                                         batch_size,
+                                                         img_c,
+                                                         img_d,
+                                                         img_h,
+                                                         img_w,
+                                                         f,
+                                                         ksize,
+                                                         strides,
+                                                         paddings,
+                                                         dilations,
+                                                         groups,
+                                                         nullptr,
+                                                         nullptr,
+                                                         nullptr,
+                                                         is_ncdhw);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv3d");
   } else {
     int r = xpu::conv3d<XPUT, XPUT, XPUT, int16_t>(dev_ctx.x_context(),
                                                    input_data,

--- a/paddle/phi/kernels/xpu/conv_transpose_kernel.cc
+++ b/paddle/phi/kernels/xpu/conv_transpose_kernel.cc
@@ -122,6 +122,31 @@ void Conv2dTransposeKernel(const Context& ctx,
         nullptr,
         true);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d_transpose_v2");
+  } else if (fccal_type == XPUFCCalcType::FC_INT32_WITH_LL) {
+    // xpu::conv2d_transpose_v2 do not support int_with_ll now
+    // use xpu::conv2d_transpose
+    int img_yh = static_cast<int>(x.dims()[2]);
+    int img_yw = static_cast<int>(x.dims()[3]);
+    int r = xpu::conv2d_transpose<XPUT, XPUT, XPUT, int_with_ll_t>(
+        ctx.x_context(),
+        reinterpret_cast<const XPUT*>(x.data<T>()),
+        reinterpret_cast<const XPUT*>(filter.data<T>()),
+        reinterpret_cast<XPUT*>(out->data<T>()),
+        batch_size,
+        img_yc,
+        img_yh,
+        img_yw,
+        img_xc,
+        ksize,
+        strides,
+        paddings_,
+        dilations_,
+        groups,
+        nullptr,
+        nullptr,
+        nullptr,
+        true);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "conv2d_transpose");
   } else {
     int r = xpu::conv2d_transpose_v2<XPUT, XPUT, XPUT, int16_t>(
         ctx.x_context(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
1. 为xpu卷积相关kernel添加int_with_ll量化支持，主要包括以下kernel:
    a. conv2d
    b. conv2d_grad
    c. conv3d
    d. conv3d_grad
    e. conv2d_tranpose
2. conv2d_tranpose_v2 api目前暂不支持int_with_ll量化，对该量化方式调用xpu::conv2d_transpose，但用户自己指定output_size时（极少数情况），可能与该api算出的维度不一致（可参考单测中的[XPUTestConv2DTransposeOp.TestWithEvenUpsample](https://github.com/PaddlePaddle/Paddle/blob/f8d021466e7c49fb44f98ef83b02218ade4f43da/test/xpu/test_conv2d_transpose_op_xpu.py#L281)），因此对该情况禁用int_with_ll量化。
3. deformable conv前向及反向算子不支持int_with_ll量化
4. conv2d_transpose_grad的int_with_ll支持已在前序PR中实现。 https://github.com/PaddlePaddle/Paddle/pull/54802