### PR TITLE
[IR&PASS] add ut for pass_infra (AnalysisManager, PreservedAnalyses)

### DIFF
--- a/paddle/ir/pass/analysis_manager.h
+++ b/paddle/ir/pass/analysis_manager.h
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -25,7 +26,6 @@
 #include "paddle/ir/core/type_name.h"
 #include "paddle/ir/pass/pass_instrumentation.h"
 #include "paddle/ir/pass/utils.h"
-#include "paddle/utils/optional.h"
 
 namespace ir {
 
@@ -149,14 +149,13 @@ class AnalysisMap {
   }
 
   template <typename AnalysisT>
-  paddle::optional<std::reference_wrapper<AnalysisT>> GetCachedAnalysis()
-      const {
+  std::optional<std::reference_wrapper<AnalysisT>> GetCachedAnalysis() const {
     auto res = analyses_.find(TypeId::get<AnalysisT>());
-    if (res == analyses_.end()) return paddle::none;
+    if (res == analyses_.end()) return std::nullopt;
     return {static_cast<AnalysisModel<AnalysisT>&>(*res->second).analysis};
   }
 
-  Operation* getOperation() const { return ir_; }
+  Operation* GetOperation() const { return ir_; }
 
   void Clear() { analyses_.clear(); }
 
@@ -257,8 +256,7 @@ class AnalysisManager {
   }
 
   template <typename AnalysisT>
-  paddle::optional<std::reference_wrapper<AnalysisT>> GetCachedAnalysis()
-      const {
+  std::optional<std::reference_wrapper<AnalysisT>> GetCachedAnalysis() const {
     return analyses_->GetCachedAnalysis<AnalysisT>();
   }
 
@@ -269,11 +267,11 @@ class AnalysisManager {
     analyses_->Invalidate(pa);
   }
 
-  void clear() { analyses_->Clear(); }
+  void Clear() { analyses_->Clear(); }
 
   PassInstrumentor* GetPassInstrumentor() const { return instrumentor_; }
 
-  Operation* GetOperation() { return analyses_->getOperation(); }
+  Operation* GetOperation() { return analyses_->GetOperation(); }
 
  private:
   AnalysisManager(detail::AnalysisMap* impl, PassInstrumentor* pi)

--- a/paddle/ir/pass/pass.h
+++ b/paddle/ir/pass/pass.h
@@ -20,7 +20,7 @@
 
 #include "paddle/ir/core/enforce.h"
 #include "paddle/ir/pass/analysis_manager.h"
-#include "paddle/utils/optional.h"
+#include "paddle/phi/core/enforce.h"
 
 namespace ir {
 
@@ -91,8 +91,7 @@ class IR_API Pass {
   AnalysisManager analysis_manager() { return pass_state().am; }
 
   detail::PassExecutionState& pass_state() {
-    IR_ENFORCE(pass_state_.is_initialized() == true,
-               "pass state was never initialized");
+    IR_ENFORCE(pass_state_.has_value() == true, "pass state has no value");
     return *pass_state_;
   }
 
@@ -101,7 +100,7 @@ class IR_API Pass {
  private:
   detail::PassInfo pass_info_;
 
-  paddle::optional<detail::PassExecutionState> pass_state_;
+  std::optional<detail::PassExecutionState> pass_state_;
 
   friend class PassManager;
   friend class detail::PassAdaptor;

--- a/paddle/ir/pattern_rewrite/frozen_rewrite_pattern_set.cc
+++ b/paddle/ir/pattern_rewrite/frozen_rewrite_pattern_set.cc
@@ -14,13 +14,13 @@
 
 #include "paddle/ir/pattern_rewrite/frozen_rewrite_pattern_set.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
 
 #include "paddle/ir/core/op_info.h"
-#include "paddle/utils/optional.h"
 
 namespace ir {
 
@@ -76,19 +76,19 @@ FrozenRewritePatternSet::FrozenRewritePatternSet(
         continue;
     }
 
-    if (paddle::optional<OpInfo> root_name = pat->root_kind()) {
+    if (std::optional<OpInfo> root_name = pat->root_kind()) {
       impl_->op_specific_native_pattern_map_[*root_name].push_back(pat.get());
       impl_->op_specific_native_patterns_.push_back(std::move(pat));
       continue;
     }
 
-    if (paddle::optional<TypeId> interface_id = pat->GetRootInterfaceID()) {
+    if (std::optional<TypeId> interface_id = pat->GetRootInterfaceID()) {
       AddToOpsWhen(
           pat, [&](OpInfo info) { return info.HasInterface(*interface_id); });
       continue;
     }
 
-    if (paddle::optional<TypeId> trait_id = pat->GetRootTraitID()) {
+    if (std::optional<TypeId> trait_id = pat->GetRootTraitID()) {
       AddToOpsWhen(pat, [&](OpInfo info) { return info.HasTrait(*trait_id); });
       continue;
     }

--- a/paddle/ir/pattern_rewrite/pattern_applicator.cc
+++ b/paddle/ir/pattern_rewrite/pattern_applicator.cc
@@ -21,20 +21,20 @@
 namespace ir {
 
 PatternApplicator::PatternApplicator(
-    const FrozenRewritePatternSet& frozen_patter_list)
-    : frozen_patter_list_(frozen_patter_list) {}
+    const FrozenRewritePatternSet& frozen_pattern_list)
+    : frozen_pattern_list_(frozen_pattern_list) {}
 
-void PatternApplicator::ApplyCostModel(CostModel model) {
+void PatternApplicator::ApplyCostModel(const CostModel& model) {
   // TODO(wilber): remove impossible patterns.
   patterns_.clear();
-  for (const auto& it : frozen_patter_list_.op_specific_native_patterns()) {
+  for (const auto& it : frozen_pattern_list_.op_specific_native_patterns()) {
     for (const RewritePattern* pattern : it.second) {
       patterns_[it.first].push_back(pattern);
     }
   }
 
   any_op_patterns_.clear();
-  for (auto& pattern : frozen_patter_list_.match_any_op_native_patterns()) {
+  for (auto& pattern : frozen_pattern_list_.match_any_op_native_patterns()) {
     any_op_patterns_.push_back(pattern.get());
   }
 
@@ -59,10 +59,11 @@ void PatternApplicator::ApplyCostModel(CostModel model) {
 
 void PatternApplicator::WalkAllPatterns(
     std::function<void(const Pattern&)> walk) {
-  for (const auto& it : frozen_patter_list_.op_specific_native_patterns())
+  for (const auto& it : frozen_pattern_list_.op_specific_native_patterns())
     for (auto* pattern : it.second) walk(*pattern);
 
-  for (auto& it : frozen_patter_list_.match_any_op_native_patterns()) walk(*it);
+  for (const auto& it : frozen_pattern_list_.match_any_op_native_patterns())
+    walk(*it);
 }
 
 bool PatternApplicator::MatchAndRewrite(

--- a/paddle/ir/pattern_rewrite/pattern_applicator.h
+++ b/paddle/ir/pattern_rewrite/pattern_applicator.h
@@ -39,7 +39,7 @@ class PatternApplicator {
                        std::function<void(const Pattern&)> on_failure = {},
                        std::function<bool(const Pattern&)> on_success = {});
 
-  void ApplyCostModel(CostModel model);
+  void ApplyCostModel(const CostModel& model);
 
   void ApplyDefaultCostModel() {
     ApplyCostModel([](const Pattern& pattern) { return pattern.benefit(); });
@@ -48,7 +48,7 @@ class PatternApplicator {
   void WalkAllPatterns(std::function<void(const Pattern&)> walk);
 
  private:
-  const FrozenRewritePatternSet& frozen_patter_list_;
+  const FrozenRewritePatternSet& frozen_pattern_list_;
   std::unordered_map<OpInfo, std::vector<const RewritePattern*>> patterns_;
   std::vector<const RewritePattern*> any_op_patterns_;
 };

--- a/paddle/ir/pattern_rewrite/pattern_match.h
+++ b/paddle/ir/pattern_rewrite/pattern_match.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <initializer_list>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -30,7 +31,6 @@
 #include "paddle/ir/core/type_id.h"
 #include "paddle/ir/core/type_name.h"
 #include "paddle/ir/core/value.h"
-#include "paddle/utils/optional.h"
 
 namespace ir {
 
@@ -72,22 +72,22 @@ class IR_API Pattern {
  public:
   const std::vector<OpInfo>& generated_ops() const { return generated_ops_; }
 
-  paddle::optional<OpInfo> root_kind() const {
+  std::optional<OpInfo> root_kind() const {
     if (root_kind_ == RootKind::OperationInfo)
       return OpInfo::RecoverFromOpaquePointer(root_val_);
-    return paddle::none;
+    return std::nullopt;
   }
 
-  paddle::optional<TypeId> GetRootInterfaceID() const {
+  std::optional<TypeId> GetRootInterfaceID() const {
     if (root_kind_ == RootKind::InterfaceId)
       return TypeId::RecoverFromOpaquePointer(root_val_);
-    return paddle::none;
+    return std::nullopt;
   }
 
-  paddle::optional<TypeId> GetRootTraitID() const {
+  std::optional<TypeId> GetRootTraitID() const {
     if (root_kind_ == RootKind::TraitId)
       return TypeId::RecoverFromOpaquePointer(root_val_);
-    return paddle::none;
+    return std::nullopt;
   }
 
   PatternBenefit benefit() const { return benefit_; }

--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -20,7 +20,7 @@
 #include "paddle/ir/core/ir_context.h"
 #include "paddle/ir/pattern_rewrite/pattern_match.h"
 
-TEST(PatternBenefit, PatternBenefit) {
+TEST(pattern_rewrite, PatternBenefit) {
   ir::PatternBenefit benefit1(1);
   EXPECT_EQ(benefit1.benefit(), 1U);
   ir::PatternBenefit benefit2(2);
@@ -95,7 +95,7 @@ class TestPatternRewrite2 : public ir::OpRewritePattern<Operation1> {
   }
 };
 
-TEST(RewritePattern, OpRewritePattern) {
+TEST(pattern_rewrite, RewritePatternSet) {
   ir::IrContext *ctx = ir::IrContext::Instance();
   ctx->GetOrRegisterDialect<ir::BuiltinDialect>();
   auto *test_dialect = ctx->GetOrRegisterDialect<TestDialect>();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

Pcard-71500

- add ut for pass_infra (AnalysisManager, PreservedAnalyses)
- use std::optional instead of  paddle::optional