### PR TITLE
DOC: typo corrected in docs of  logical_xor

### DIFF
--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -198,8 +198,8 @@ def logical_xor(x, y, out=None, name=None):
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
     Args:
-        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
-        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, int32, int64, float16, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, int32, int64, float16, float32, float64.
         out(Tensor): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 


### PR DESCRIPTION
### PR types
 Others 

### PR changes
 Docs 

### Description
This PR correct the typo in logical_xor function and Issue for this PR is here #54835
this issue is highlighted in this pic
![paddleisue1](https://github.com/PaddlePaddle/Paddle/assets/49721249/8290b3c8-2681-43f1-aa34-aa73df30f1bb)
