### PR TITLE
[Paddle Inference]Enhance the shape check of trt_embedding_eltwise_layernorm_fuse_pass,…

### DIFF
--- a/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass.cc
@@ -307,11 +307,44 @@ int EmbeddingEltwiseLayerNormFusePass::BuildFusion(
 
     std::vector<std::string> ids;
     std::vector<std::string> embs;
+
+    auto ids0_shape = start_pattern_in_nodes[i][0].first->Var()->GetShape();
+    bool flag = true;
     for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
+      auto ids_shape = start_pattern_in_nodes[i][iter].first->Var()->GetShape();
+      if (ids_shape.size() != ids0_shape.size()) {
+        VLOG(3) << "Shape check failed, ids'rank are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+        flag = false;
+      } else {
+        for (size_t j = 0; j < ids_shape.size(); ++j) {
+          if (ids_shape[j] != ids0_shape[j]) {
+            VLOG(3)
+                << "Shape check failed, ids.shape[i] are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+            flag = false;
+          }
+        }
+      }
       ids.push_back(start_pattern_in_nodes[i][iter].first->Name());
       embs.push_back(start_pattern_in_nodes[i][iter].second->Name());
     }
     for (size_t iter = 0; iter < js.size(); ++iter) {
+      auto ids_shape = inner_pattern_ins[js[iter]].first->Var()->GetShape();
+      if (ids_shape.size() != ids0_shape.size()) {
+        VLOG(3) << "Shape check failed, ids'rank are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+        flag = false;
+      } else {
+        for (size_t j = 0; j < ids_shape.size(); ++j) {
+          if (ids_shape[j] != ids0_shape[j]) {
+            VLOG(3)
+                << "Shape check failed, ids.shape[i] are not all equal, stop "
+                   "embedding_eltwise_layernorm_fuse_pass.";
+            flag = false;
+          }
+        }
+      }
       ids.push_back(inner_pattern_ins[js[iter]].first->Name());
       embs.push_back(inner_pattern_ins[js[iter]].second->Name());
     }
@@ -322,66 +355,70 @@ int EmbeddingEltwiseLayerNormFusePass::BuildFusion(
                  "inputs with lookup_table_v2";
       return fusion_count;
     }
+    if (flag) {
+      OpDesc new_op_desc;
+      new_op_desc.SetType("fused_embedding_eltwise_layernorm");
+      new_op_desc.SetInput("Ids", ids);
+      new_op_desc.SetInput("Embs", embs);
+      new_op_desc.SetInput("WordId", {ids[0]});
+      new_op_desc.SetInput("PosId", {ids[1]});
+      if (ids.size() > 2) {
+        new_op_desc.SetInput("SentId", {ids[2]});
+      }
 
-    OpDesc new_op_desc;
-    new_op_desc.SetType("fused_embedding_eltwise_layernorm");
-    new_op_desc.SetInput("Ids", ids);
-    new_op_desc.SetInput("Embs", embs);
-    new_op_desc.SetInput("WordId", {ids[0]});
-    new_op_desc.SetInput("PosId", {ids[1]});
-    if (ids.size() > 2) {
-      new_op_desc.SetInput("SentId", {ids[2]});
+      new_op_desc.SetInput("WordEmbedding", {embs[0]});
+      new_op_desc.SetInput("PosEmbedding", {embs[1]});
+      if (embs.size() > 2) {
+        new_op_desc.SetInput("SentEmbedding", {embs[2]});
+      }
+
+      new_op_desc.SetInput("Bias", {end_pattern_biases[k]->Name()});
+      new_op_desc.SetInput("Scale", {end_pattern_scales[k]->Name()});
+      new_op_desc.SetOutput("Out", {end_pattern_out[k]->Name()});
+      new_op_desc.SetAttr("epsilon",
+                          end_patter_layernorms[k]->Op()->GetAttr("epsilon"));
+
+      if (end_patter_layernorms[k]->Op()->HasAttr("out_threshold")) {
+        new_op_desc.SetAttr("enable_int8", true);
+        new_op_desc.SetAttr(
+            "out_threshold",
+            end_patter_layernorms[k]->Op()->GetAttr("out_threshold"));
+      }
+
+      auto* embedding_eltwise_layernorm = graph->CreateOpNode(&new_op_desc);
+
+      for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
+        IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].first,
+                        embedding_eltwise_layernorm);
+        IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].second,
+                        embedding_eltwise_layernorm);
+      }
+      for (size_t iter = 0; iter < js.size(); ++iter) {
+        IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].first,
+                        embedding_eltwise_layernorm);
+        IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].second,
+                        embedding_eltwise_layernorm);
+      }
+      IR_NODE_LINK_TO(end_pattern_biases[k], embedding_eltwise_layernorm);
+      IR_NODE_LINK_TO(end_pattern_scales[k], embedding_eltwise_layernorm);
+      IR_NODE_LINK_TO(embedding_eltwise_layernorm, end_pattern_out[k]);
+
+      // Remove unneeded nodes.
+      std::unordered_set<const Node*> marked_nodes;
+      marked_nodes.insert(start_pattern_remove_nodes[i].begin(),
+                          start_pattern_remove_nodes[i].end());
+      marked_nodes.insert(end_pattern_remove_nodes[k].begin(),
+                          end_pattern_remove_nodes[k].end());
+      for (size_t iter = 0; iter < js.size(); ++iter) {
+        marked_nodes.insert(inner_pattern_remove_nodes[js[iter]].begin(),
+                            inner_pattern_remove_nodes[js[iter]].end());
+      }
+      GraphSafeRemoveNodes(graph, marked_nodes);
+      ++fusion_count;
+    } else {
+      VLOG(3) << "Shape check failed, stop "
+                 "embedding_eltwise_layernorm_fuse_pass.";
     }
-
-    new_op_desc.SetInput("WordEmbedding", {embs[0]});
-    new_op_desc.SetInput("PosEmbedding", {embs[1]});
-    if (embs.size() > 2) {
-      new_op_desc.SetInput("SentEmbedding", {embs[2]});
-    }
-
-    new_op_desc.SetInput("Bias", {end_pattern_biases[k]->Name()});
-    new_op_desc.SetInput("Scale", {end_pattern_scales[k]->Name()});
-    new_op_desc.SetOutput("Out", {end_pattern_out[k]->Name()});
-    new_op_desc.SetAttr("epsilon",
-                        end_patter_layernorms[k]->Op()->GetAttr("epsilon"));
-
-    if (end_patter_layernorms[k]->Op()->HasAttr("out_threshold")) {
-      new_op_desc.SetAttr("enable_int8", true);
-      new_op_desc.SetAttr(
-          "out_threshold",
-          end_patter_layernorms[k]->Op()->GetAttr("out_threshold"));
-    }
-
-    auto* embedding_eltwise_layernorm = graph->CreateOpNode(&new_op_desc);
-
-    for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
-      IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].first,
-                      embedding_eltwise_layernorm);
-      IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].second,
-                      embedding_eltwise_layernorm);
-    }
-    for (size_t iter = 0; iter < js.size(); ++iter) {
-      IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].first,
-                      embedding_eltwise_layernorm);
-      IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].second,
-                      embedding_eltwise_layernorm);
-    }
-    IR_NODE_LINK_TO(end_pattern_biases[k], embedding_eltwise_layernorm);
-    IR_NODE_LINK_TO(end_pattern_scales[k], embedding_eltwise_layernorm);
-    IR_NODE_LINK_TO(embedding_eltwise_layernorm, end_pattern_out[k]);
-
-    // Remove unneeded nodes.
-    std::unordered_set<const Node*> marked_nodes;
-    marked_nodes.insert(start_pattern_remove_nodes[i].begin(),
-                        start_pattern_remove_nodes[i].end());
-    marked_nodes.insert(end_pattern_remove_nodes[k].begin(),
-                        end_pattern_remove_nodes[k].end());
-    for (size_t iter = 0; iter < js.size(); ++iter) {
-      marked_nodes.insert(inner_pattern_remove_nodes[js[iter]].begin(),
-                          inner_pattern_remove_nodes[js[iter]].end());
-    }
-    GraphSafeRemoveNodes(graph, marked_nodes);
-    ++fusion_count;
   }
 
   return fusion_count;

--- a/paddle/fluid/framework/ir/trt_embedding_eltwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_embedding_eltwise_layernorm_fuse_pass.cc
@@ -311,68 +311,105 @@ int TrtEmbeddingEltwiseLayerNormFusePass::BuildFusion(
 
     std::vector<std::string> ids;
     std::vector<std::string> embs;
+
+    auto ids0_shape = start_pattern_in_nodes[i][0].first->Var()->GetShape();
+    bool flag = true;
     for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
+      auto ids_shape = start_pattern_in_nodes[i][iter].first->Var()->GetShape();
+      if (ids_shape.size() != ids0_shape.size()) {
+        VLOG(3) << "Shape check failed, ids'rank are not all equal, stop "
+                   "trt_embedding_eltwise_layernorm_fuse_pass.";
+        flag = false;
+      } else {
+        for (size_t j = 0; j < ids_shape.size(); ++j) {
+          if (ids_shape[j] != ids0_shape[j]) {
+            VLOG(3)
+                << "Shape check failed, ids.shape[i] are not all equal, stop "
+                   "trt_embedding_eltwise_layernorm_fuse_pass.";
+            flag = false;
+          }
+        }
+      }
       ids.push_back(start_pattern_in_nodes[i][iter].first->Name());
       embs.push_back(start_pattern_in_nodes[i][iter].second->Name());
     }
     for (size_t iter = 0; iter < js.size(); ++iter) {
+      auto ids_shape = inner_pattern_ins[js[iter]].first->Var()->GetShape();
+      if (ids_shape.size() != ids0_shape.size()) {
+        VLOG(3) << "Shape check failed, ids'rank are not all equal, stop "
+                   "trt_embedding_eltwise_layernorm_fuse_pass.";
+        flag = false;
+      } else {
+        for (size_t j = 0; j < ids_shape.size(); ++j) {
+          if (ids_shape[j] != ids0_shape[j]) {
+            VLOG(3)
+                << "Shape check failed, ids.shape[i] are not all equal, stop "
+                   "trt_embedding_eltwise_layernorm_fuse_pass.";
+            flag = false;
+          }
+        }
+      }
       ids.push_back(inner_pattern_ins[js[iter]].first->Name());
       embs.push_back(inner_pattern_ins[js[iter]].second->Name());
     }
 
-    OpDesc new_op_desc(end_patter_layernorms[0]->Op()->Block());
-    new_op_desc.SetType("fused_embedding_eltwise_layernorm");
-    new_op_desc.SetInput("Ids", ids);
-    new_op_desc.SetInput("Embs", embs);
-    if (use_varseqlen && pos_id != "" && mask_id != "") {
-      new_op_desc.SetInput("PosId", {pos_id});
-      new_op_desc.SetInput("MaskId", {mask_id});
-    }
-    new_op_desc.SetInput("Bias", {end_pattern_biases[k]->Name()});
-    new_op_desc.SetInput("Scale", {end_pattern_scales[k]->Name()});
-    new_op_desc.SetOutput("Out", {end_pattern_out[k]->Name()});
-    new_op_desc.SetAttr("epsilon",
-                        end_patter_layernorms[k]->Op()->GetAttr("epsilon"));
+    if (flag) {
+      OpDesc new_op_desc(end_patter_layernorms[0]->Op()->Block());
+      new_op_desc.SetType("fused_embedding_eltwise_layernorm");
+      new_op_desc.SetInput("Ids", ids);
+      new_op_desc.SetInput("Embs", embs);
+      if (use_varseqlen && pos_id != "" && mask_id != "") {
+        new_op_desc.SetInput("PosId", {pos_id});
+        new_op_desc.SetInput("MaskId", {mask_id});
+      }
+      new_op_desc.SetInput("Bias", {end_pattern_biases[k]->Name()});
+      new_op_desc.SetInput("Scale", {end_pattern_scales[k]->Name()});
+      new_op_desc.SetOutput("Out", {end_pattern_out[k]->Name()});
+      new_op_desc.SetAttr("epsilon",
+                          end_patter_layernorms[k]->Op()->GetAttr("epsilon"));
 
-    if (end_patter_layernorms[k]->Op()->HasAttr("out_threshold")) {
-      new_op_desc.SetAttr("enable_int8", true);
-      new_op_desc.SetAttr(
-          "out_threshold",
-          end_patter_layernorms[k]->Op()->GetAttr("out_threshold"));
-    }
+      if (end_patter_layernorms[k]->Op()->HasAttr("out_threshold")) {
+        new_op_desc.SetAttr("enable_int8", true);
+        new_op_desc.SetAttr(
+            "out_threshold",
+            end_patter_layernorms[k]->Op()->GetAttr("out_threshold"));
+      }
 
-    auto* embedding_eltwise_layernorm = graph->CreateOpNode(&new_op_desc);
+      auto* embedding_eltwise_layernorm = graph->CreateOpNode(&new_op_desc);
 
-    for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
-      IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].first,
-                      embedding_eltwise_layernorm);
-      IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].second,
-                      embedding_eltwise_layernorm);
-    }
-    for (size_t iter = 0; iter < js.size(); ++iter) {
-      IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].first,
-                      embedding_eltwise_layernorm);
-      IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].second,
-                      embedding_eltwise_layernorm);
-    }
-    IR_NODE_LINK_TO(end_pattern_biases[k], embedding_eltwise_layernorm);
-    IR_NODE_LINK_TO(end_pattern_scales[k], embedding_eltwise_layernorm);
-    IR_NODE_LINK_TO(embedding_eltwise_layernorm, end_pattern_out[k]);
+      for (size_t iter = 0; iter < start_pattern_in_nodes[i].size(); ++iter) {
+        IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].first,
+                        embedding_eltwise_layernorm);
+        IR_NODE_LINK_TO(start_pattern_in_nodes[i][iter].second,
+                        embedding_eltwise_layernorm);
+      }
+      for (size_t iter = 0; iter < js.size(); ++iter) {
+        IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].first,
+                        embedding_eltwise_layernorm);
+        IR_NODE_LINK_TO(inner_pattern_ins[js[iter]].second,
+                        embedding_eltwise_layernorm);
+      }
+      IR_NODE_LINK_TO(end_pattern_biases[k], embedding_eltwise_layernorm);
+      IR_NODE_LINK_TO(end_pattern_scales[k], embedding_eltwise_layernorm);
+      IR_NODE_LINK_TO(embedding_eltwise_layernorm, end_pattern_out[k]);
 
-    // Remove unneeded nodes.
-    std::unordered_set<const Node*> marked_nodes;
-    marked_nodes.insert(start_pattern_remove_nodes[i].begin(),
-                        start_pattern_remove_nodes[i].end());
-    marked_nodes.insert(end_pattern_remove_nodes[k].begin(),
-                        end_pattern_remove_nodes[k].end());
-    for (size_t iter = 0; iter < js.size(); ++iter) {
-      marked_nodes.insert(inner_pattern_remove_nodes[js[iter]].begin(),
-                          inner_pattern_remove_nodes[js[iter]].end());
+      // Remove unneeded nodes.
+      std::unordered_set<const Node*> marked_nodes;
+      marked_nodes.insert(start_pattern_remove_nodes[i].begin(),
+                          start_pattern_remove_nodes[i].end());
+      marked_nodes.insert(end_pattern_remove_nodes[k].begin(),
+                          end_pattern_remove_nodes[k].end());
+      for (size_t iter = 0; iter < js.size(); ++iter) {
+        marked_nodes.insert(inner_pattern_remove_nodes[js[iter]].begin(),
+                            inner_pattern_remove_nodes[js[iter]].end());
+      }
+      GraphSafeRemoveNodes(graph, marked_nodes);
+      ++fusion_count;
+    } else {
+      VLOG(3) << "Shape check failed, stop "
+                 "trt_embedding_eltwise_layernorm_fuse_pass.";
     }
-    GraphSafeRemoveNodes(graph, marked_nodes);
-    ++fusion_count;
   }
-
   return fusion_count;
 }
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -2567,7 +2567,7 @@ struct SimpleOpTypeSetTeller : public Teller {
         return false;
       }
     }
-    if (op_type == "lookup_table") {
+    if (op_type == "lookup_table" || op_type == "lookup_table_v2") {
       if (!with_dynamic_shape) {
         VLOG(3) << "the lookup_table does not support "
                    "static shape yet";

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -210,8 +210,8 @@ if(WITH_GPU AND TENSORRT_FOUND)
     set_tests_properties(test_merge_layernorm_fuse_pass PROPERTIES TIMEOUT 180)
     set_tests_properties(test_skip_merge_layernorm_fuse_pass PROPERTIES TIMEOUT
                                                                         180)
-    set_tests_properties(test_emb_eltwise_layernorm_fuse_pass PROPERTIES TIMEOUT
-                                                                         120)
+    set_tests_properties(test_trt_emb_eltwise_layernorm_fuse_pass
+                         PROPERTIES TIMEOUT 180)
 
     set_tests_properties(test_fc_fuse_pass PROPERTIES TIMEOUT 240)
     set_tests_properties(test_reverse_roll_fuse_pass PROPERTIES TIMEOUT 120)

--- a/test/ir/inference/test_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_emb_eltwise_layernorm_fuse_pass.py
@@ -48,27 +48,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
         # is_distributed only support False
         if program_config.ops[0].attrs['is_distributed']:
             return False
-
-        # axis only support -1 and the last dim.
-        if program_config.ops[3].attrs['axis'] not in [-1, 2]:
-            return False
-
-        if not (
-            program_config.ops[5].attrs['epsilon'] >= 0
-            and program_config.ops[5].attrs['epsilon'] <= 0.001
-        ):
-            return False
-
-        if program_config.ops[5].attrs['begin_norm_axis'] != 2:
-            return False
-
-        # input check
-        if (
-            program_config.weights['embedding_weight1'].shape[1]
-            != program_config.weights['layer_norm_scale'].shape[0]
-        ):
-            return False
-
         return True
 
     def sample_program_config(self, draw):

--- a/test/ir/inference/test_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_emb_eltwise_layernorm_fuse_pass.py
@@ -41,19 +41,10 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
     '''
 
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
-        # is_sparse is only support False
-        if program_config.ops[0].attrs['is_sparse']:
-            return False
-
-        # is_distributed only support False
-        if program_config.ops[0].attrs['is_distributed']:
-            return False
         return True
 
     def sample_program_config(self, draw):
-        is_sparse = draw(st.booleans())
-        is_distributed = draw(st.booleans())
-        padding_idx = draw(st.integers())
+        padding_idx = -1
         axis = -1
         op_type = draw(st.sampled_from(['lookup_table', 'lookup_table_v2']))
         epsilon = draw(st.floats(min_value=0.0001, max_value=0.001))
@@ -95,8 +86,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
 
         attrs = [
             {
-                'is_sparse': is_sparse,
-                'is_distributed': is_distributed,
                 'padding_idx': padding_idx,
                 'op_type': op_type,
             },
@@ -114,8 +103,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             inputs={"Ids": ["input_data1"], "W": ["embedding_weight1"]},
             outputs={"Out": ["embedding_output1"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -124,8 +111,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             inputs={"Ids": ["input_data2"], "W": ["embedding_weight2"]},
             outputs={"Out": ["embedding_output2"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -134,8 +119,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             inputs={"Ids": ["input_data3"], "W": ["embedding_weight3"]},
             outputs={"Out": ["embedding_output3"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -248,39 +231,9 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
     '''
 
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
-        # is_sparse is only support False
-        if program_config.ops[0].attrs['is_sparse']:
-            return False
-
-        # is_distributed only support False
-        if program_config.ops[0].attrs['is_distributed']:
-            return False
-
-        # axis only support -1 and the last dim.
-        if program_config.ops[3].attrs['axis'] not in [-1, 2]:
-            return False
-
-        if not (
-            program_config.ops[5].attrs['epsilon'] >= 0
-            and program_config.ops[5].attrs['epsilon'] <= 0.001
-        ):
-            return False
-
-        if program_config.ops[5].attrs['begin_norm_axis'] != 2:
-            return False
-
-        # input check
-        if (
-            program_config.weights['embedding_weight1'].shape[1]
-            != program_config.weights['layer_norm_scale'].shape[0]
-        ):
-            return False
-
         return True
 
     def sample_program_config(self, draw):
-        is_sparse = False
-        is_distributed = False
         padding_idx = 0
         axis = -1
         op_type = draw(st.sampled_from(['lookup_table', 'lookup_table_v2']))
@@ -351,8 +304,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
 
         attrs = [
             {
-                'is_sparse': is_sparse,
-                'is_distributed': is_distributed,
                 'padding_idx': padding_idx,
                 'op_type': op_type,
             },
@@ -370,8 +321,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             inputs={"Ids": ["input_data1"], "W": ["embedding_weight1"]},
             outputs={"Out": ["embedding_output1"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -380,8 +329,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             inputs={"Ids": ["input_data2"], "W": ["embedding_weight2"]},
             outputs={"Out": ["embedding_output2"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -390,8 +337,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             inputs={"Ids": ["input_data3"], "W": ["embedding_weight3"]},
             outputs={"Out": ["embedding_output3"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )

--- a/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
@@ -50,27 +50,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
         # is_distributed only support False
         if program_config.ops[0].attrs['is_distributed']:
             return False
-
-        # axis only support -1 and the last dim.
-        if program_config.ops[3].attrs['axis'] not in [-1, 2]:
-            return False
-
-        if not (
-            program_config.ops[5].attrs['epsilon'] >= 0
-            and program_config.ops[5].attrs['epsilon'] <= 0.001
-        ):
-            return False
-
-        if program_config.ops[5].attrs['begin_norm_axis'] != 2:
-            return False
-
-        # input check
-        if (
-            program_config.weights['embedding_weight1'].shape[1]
-            != program_config.weights['layer_norm_scale'].shape[0]
-        ):
-            return False
-
         return True
 
     def sample_program_config(self, draw):

--- a/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
@@ -43,19 +43,10 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
     '''
 
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
-        # is_sparse is only support False
-        if program_config.ops[0].attrs['is_sparse']:
-            return False
-
-        # is_distributed only support False
-        if program_config.ops[0].attrs['is_distributed']:
-            return False
         return True
 
     def sample_program_config(self, draw):
-        is_sparse = draw(st.booleans())
-        is_distributed = draw(st.booleans())
-        padding_idx = draw(st.integers())
+        padding_idx = -1
         axis = -1
         op_type = draw(st.sampled_from(['lookup_table', 'lookup_table_v2']))
         epsilon = draw(st.floats(min_value=0.0001, max_value=0.001))
@@ -97,8 +88,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
 
         attrs = [
             {
-                'is_sparse': is_sparse,
-                'is_distributed': is_distributed,
                 'padding_idx': padding_idx,
                 'op_type': op_type,
             },
@@ -116,8 +105,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             inputs={"Ids": ["input_data1"], "W": ["embedding_weight1"]},
             outputs={"Out": ["embedding_output1"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -126,8 +113,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             inputs={"Ids": ["input_data2"], "W": ["embedding_weight2"]},
             outputs={"Out": ["embedding_output2"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -136,8 +121,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             inputs={"Ids": ["input_data3"], "W": ["embedding_weight3"]},
             outputs={"Out": ["embedding_output3"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -294,40 +277,10 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
     '''
 
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
-        # is_sparse is only support False
-        if program_config.ops[0].attrs['is_sparse']:
-            return False
-
-        # is_distributed only support False
-        if program_config.ops[0].attrs['is_distributed']:
-            return False
-
-        # axis only support -1 and the last dim.
-        if program_config.ops[3].attrs['axis'] not in [-1, 2]:
-            return False
-
-        if not (
-            program_config.ops[5].attrs['epsilon'] >= 0
-            and program_config.ops[5].attrs['epsilon'] <= 0.001
-        ):
-            return False
-
-        if program_config.ops[5].attrs['begin_norm_axis'] != 2:
-            return False
-
-        # input check
-        if (
-            program_config.weights['embedding_weight1'].shape[1]
-            != program_config.weights['layer_norm_scale'].shape[0]
-        ):
-            return False
-
         return True
 
     def sample_program_config(self, draw):
-        is_sparse = False
-        is_distributed = False
-        padding_idx = 0
+        padding_idx = -1
         axis = -1
         op_type = draw(st.sampled_from(['lookup_table', 'lookup_table_v2']))
         epsilon = 0.0001
@@ -397,8 +350,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
 
         attrs = [
             {
-                'is_sparse': is_sparse,
-                'is_distributed': is_distributed,
                 'padding_idx': padding_idx,
                 'op_type': op_type,
             },
@@ -416,8 +367,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             inputs={"Ids": ["input_data1"], "W": ["embedding_weight1"]},
             outputs={"Out": ["embedding_output1"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -426,8 +375,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             inputs={"Ids": ["input_data2"], "W": ["embedding_weight2"]},
             outputs={"Out": ["embedding_output2"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )
@@ -436,8 +383,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             inputs={"Ids": ["input_data3"], "W": ["embedding_weight3"]},
             outputs={"Out": ["embedding_output3"]},
             attrs={
-                'is_sparse': attrs[0]['is_sparse'],
-                'is_distributed': attrs[0]['is_distributed'],
                 'padding_idx': attrs[0]['padding_idx'],
             },
         )

--- a/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
@@ -102,7 +102,7 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
 
         def generate_weight1(attrs):
             # set embedding weight by attrs
-            return np.random.uniform(0.1, 0.1, attrs['weight_size']).astype(
+            return np.random.uniform(0.05, 0.05, attrs['weight_size']).astype(
                 np.float32
             )
 
@@ -402,7 +402,7 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
 
         def generate_weight1(attrs):
             # set embedding weight by attrs
-            return np.random.uniform(0.1, 0.5, attrs['weight_size']).astype(
+            return np.random.uniform(0.05, 0.1, attrs['weight_size']).astype(
                 np.float32
             )
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Pcard-71501
- Enhance the shape check: trt_embedding_eltwise_layernorm_fuse_pass, don't support broadcast
- Enhance the shape check: embedding_eltwise_layernorm_fuse_pass, don't support broadcast

![image](https://github.com/PaddlePaddle/Paddle/assets/27151961/75fe397b-b25d-4fa7-914a-be03de19d19d)

- fix test for trt_embedding_eltwise_layernorm_fuse_pass, embedding_eltwise_layernorm_fuse_pass