### PR TITLE
[XPU] fix 0-dim of ConcatFunctor.

### DIFF
--- a/paddle/phi/kernels/funcs/concat_and_split_functor.cc
+++ b/paddle/phi/kernels/funcs/concat_and_split_functor.cc
@@ -22,7 +22,8 @@ namespace funcs {
  * each dimension must be the same, except the axis dimension.
  */
 template <typename T>
-struct ConcatFunctor<phi::CPUContext, T> {
+class ConcatFunctor<phi::CPUContext, T> {
+ public:
   void operator()(const phi::CPUContext& context,
                   const std::vector<phi::DenseTensor>& input,
                   int axis,
@@ -73,7 +74,7 @@ struct ConcatFunctor<phi::CPUContext, T> {
  * each dimension must be the same, except the axis dimension.
  */
 template <typename T>
-struct SplitFunctor<phi::CPUContext, T> {
+class SplitFunctor<phi::CPUContext, T> {
  public:
   void operator()(const phi::CPUContext& context,
                   const phi::DenseTensor& input,

--- a/paddle/phi/kernels/funcs/concat_and_split_functor.cu
+++ b/paddle/phi/kernels/funcs/concat_and_split_functor.cu
@@ -620,7 +620,8 @@ void ConcatFunctorWithIndexType(const phi::GPUContext& ctx,
 }
 
 template <typename T>
-struct ConcatFunctor<phi::GPUContext, T> {
+class ConcatFunctor<phi::GPUContext, T> {
+ public:
   void operator()(const phi::GPUContext& context,
                   const std::vector<phi::DenseTensor>& input,
                   int axis,

--- a/paddle/phi/kernels/funcs/concat_and_split_functor.h
+++ b/paddle/phi/kernels/funcs/concat_and_split_functor.h
@@ -40,7 +40,8 @@ namespace funcs {
  *               [5,6]]
  */
 template <typename Context, typename T>
-struct ConcatFunctor {
+class ConcatFunctor {
+ public:
   void operator()(const Context& context,
                   const std::vector<phi::DenseTensor>& input,
                   int axis,

--- a/paddle/phi/kernels/funcs/strided_memcpy.h
+++ b/paddle/phi/kernels/funcs/strided_memcpy.h
@@ -154,6 +154,10 @@ inline void StridedMemcpyWithAxis0(
     auto out_stride = stride_numel(shape_refer[i]->dims());
     auto out = outputs->at(i);
     if (out != nullptr && out->initialized() && out->numel() > 0) {
+      // special for 0-dim
+      if (out_stride.size() == 0) {
+        out_stride = phi::make_ddim({1});
+      }
       StridedNumelCopyWithAxis<T, Context>(dev_ctx,
                                            axis,
                                            out->data<T>(),

--- a/paddle/phi/kernels/xpu/concat_and_split_functor.cc
+++ b/paddle/phi/kernels/xpu/concat_and_split_functor.cc
@@ -37,12 +37,21 @@ class ConcatFunctor<XPUContext, T> {
 
     int num = input.size();
     auto input_dims = input[0].dims();
+    // special for 0-dim shape
+    if (input_dims.size() == 0) {
+      input_dims = {1};
+    }
 
     std::vector<std::vector<int>> xdims_list(num);
     for (int i = 0; i < num; ++i) {
       std::vector<int> tmp_dims(input_dims.size());
       for (int j = 0; j < input_dims.size(); ++j) {
-        tmp_dims[j] = input[i].dims()[j];
+        auto ins_i_dims = input[i].dims();
+        // special for 0-dim shape
+        if (ins_i_dims.size() == 0) {
+          ins_i_dims = {1};
+        }
+        tmp_dims[j] = ins_i_dims[j];
       }
       xdims_list[i] = tmp_dims;
     }

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2237,7 +2237,7 @@ EOF
 set +x
         export XPU_OP_LIST_DIR=$tmp_dir
         ut_startTime_s=`date +%s`
-        test_cases=$(ctest -N -V -LE "(RUN_TYPE=DIST_KUNLUN)" | grep "_xpu" )        # cases list which would be run exclusively
+        test_cases=$(ctest -N -V -LE "(RUN_TYPE=DIST_KUNLUN)" | grep -E "_xpu|test_group$" )        # cases list which would be run exclusively
         get_quickly_disable_ut||disable_ut_quickly='disable_ut'   # indicate whether the case was in quickly disable list
         while read -r line; do
             if [[ "$line" == "" ]]; then
@@ -3545,7 +3545,7 @@ EOF
     export WITH_ONNXRUNTIME=${WITH_ONNXRUNTIME:-OFF}
     export WITH_CUDNN_FRONTEND=${WITH_CUDNN_FRONTEND:-OFF}
     export WITH_SHARED_PHI=${WITH_SHARED_PHI:-OFF}
-    
+
     if [ "$SYSTEM" == "Linux" ];then
       if [ `nproc` -gt 16 ];then
           parallel_number=$(expr `nproc` - 8)
@@ -3834,7 +3834,7 @@ EOF
     fi
     # ci will collect ccache hit rate
     collect_ccache_hits
-    
+
     if [ "$build_error" != 0 ];then
         exit 7;
     fi


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
* 类似 https://github.com/PaddlePaddle/Paddle/pull/54816 ，修复`ConcatFunctor`在输入为0-dim向量时候算不对的问题。
* 将部分`struct`统一为`class`。
* 统一各种定义，将某些`platform::XPUDeviceContext`替换为`phi::XPUContext`。
* 将`operator`下面的操作，改成直接调用`phi::funcs`下面的对应操作，删除重复的代码。
* 修改单测以喂进去0-dim的向量。
* 修改单测过滤规则，让XPU也执行`test_group`的单测。
