### PR TITLE
【Zero_dim】support zero_dim for some prim ops part1

### DIFF
--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -554,6 +554,8 @@ def squeeze2_composite(x, axis):
     axis can only be list, not int
     """
     rank = len(x.shape)
+    if rank == 0:
+        return [assign(x), None]
     if len(axis) == 0:
         dims = set(range(rank))
     else:

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -1351,6 +1351,11 @@ class TestSqrtCompFp32(TestActivation):
         self.dtype = np.float32
 
 
+class TestSqrtComp_ZeroDim(TestSqrtComp):
+    def init_shape(self):
+        self.shape = []
+
+
 class TestRsqrt(TestActivation):
     def setUp(self):
         self.op_type = "rsqrt"
@@ -1995,7 +2000,7 @@ class TestLeakyRelu_ZeroDim(TestLeakyRelu):
         self.shape = []
 
     def if_enable_cinn(self):
-        self.enable_cinn = False
+        pass
 
 
 class TestLeakyReluAPI(unittest.TestCase):

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -577,10 +577,7 @@ class TestProdOp_ZeroDim(OpTest):
         self.public_python_api = raw_reduce_prod
         self.op_type = "reduce_prod"
         self.prim_op_type = "prim"
-        self.inputs = {'X': np.random.random([]).astype("float64")}
-        self.outputs = {'Out': self.inputs['X'].prod()}
-        self.attrs = {'dim': [], 'reduce_all': True}
-
+        self.init_inputs_and_outputs()
         # 0-D tensor doesn't support in cinn
         self.enable_cinn = False
 
@@ -594,6 +591,29 @@ class TestProdOp_ZeroDim(OpTest):
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', check_prim=True)
+
+
+class TestProdOp_ZeroDim1(TestProdOp):
+    def setUp(self):
+        self.python_api = paddle.prod
+        self.public_python_api = paddle.prod
+        self.op_type = "reduce_prod"
+        self.prim_op_type = "prim"
+        self.init_inputs_and_outputs()
+        # 0-D tensor doesn't support in cinn
+        self.enable_cinn = False
+
+    def init_inputs_and_outputs(self):
+        self.inputs = {'X': np.random.random([100]).astype("float64")}
+        self.outputs = {'Out': self.inputs['X'].prod()}
+        self.attrs = {'dim': [], 'reduce_all': True}
+
+
+class TestProdOp_ZeroDim2(TestProdOp_ZeroDim1):
+    def init_inputs_and_outputs(self):
+        self.inputs = {'X': np.random.random([5, 6, 10]).astype("float64")}
+        self.outputs = {'Out': self.inputs['X'].prod()}
+        self.attrs = {'dim': [], 'reduce_all': True}
 
 
 class TestProd6DOp(OpTest):

--- a/test/legacy_test/test_squeeze2_op.py
+++ b/test/legacy_test/test_squeeze2_op.py
@@ -100,6 +100,20 @@ class TestSqueezeOp1BF16Op(TestSqueezeOp):
         self.dtype = np.uint16
 
 
+class TestSqueezeOp_ZeroDim1(TestSqueezeOp):
+    def init_test_case(self):
+        self.ori_shape = ()
+        self.axes = (0,)
+        self.new_shape = ()
+
+
+class TestSqueezeOp_ZeroDim2(TestSqueezeOp):
+    def init_test_case(self):
+        self.ori_shape = (1, 1, 1)
+        self.axes = (0, 1, 2)
+        self.new_shape = ()
+
+
 # Correct: No axes input.
 class TestSqueezeOp2(TestSqueezeOp):
     def setUp(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66975

- 支持sqrt,squeeze,prod组合算子算子0-D语义并添加单测