### PR TITLE
Remove the test of fluid StepDecay in set_lr_scheduler

### DIFF
--- a/test/legacy_test/test_imperative_optimizer_v2.py
+++ b/test/legacy_test/test_imperative_optimizer_v2.py
@@ -688,10 +688,6 @@ class TestOptimizerLearningRate(unittest.TestCase):
             lr = adam.get_lr()
             np.testing.assert_allclose(lr, 0.5, rtol=1e-06, atol=0.0)
 
-            with self.assertRaises(TypeError):
-                scheduler_var = paddle.fluid.dygraph.StepDecay(0.5, step_size=3)
-                adam.set_lr_scheduler(scheduler_var)
-
 
 class TestImperativeMomentumOptimizer(TestImperativeOptimizerBase):
     def get_optimizer_dygraph(self, parameter_list):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72425
the fluid version of learning rate is or will be removed, so the unit test of set_lr_scheduler no longer needs to test it.
<img width="974" alt="4c5ee7a27c5109572763193562ac53fa" src="https://github.com/PaddlePaddle/Paddle/assets/118182234/c5b56028-5ab6-4408-a84d-e62ed7069a73">
