### PR TITLE
[CodeStyle][CINN] fix cinn cpplint codestyle 50-55

### DIFF
--- a/paddle/cinn/common/axis.cc
+++ b/paddle/cinn/common/axis.cc
@@ -23,7 +23,7 @@
 namespace cinn {
 namespace common {
 
-const static std::vector<std::string> kAxises({
+static const std::vector<std::string> kAxises({
     "i",  // level 0
     "j",  // level 1
     "k",  // level 2

--- a/paddle/cinn/hlir/op/elementwise.cc
+++ b/paddle/cinn/hlir/op/elementwise.cc
@@ -476,7 +476,7 @@ std::shared_ptr<OpStrategy> StrategyForAssignValue(
         absl::get<std::vector<TYPE>>(value), out_type[0], tensor_name);       \
   }
 
-    if (false) {
+    if (false) {  // NOLINT
     }
     EXPAND_ATTR_TYPE(EXPAND_VALUE_TO_TENSOR)
     else {
@@ -517,7 +517,7 @@ std::vector<shape_t> InferShapeForAssignValue(
     shape.emplace_back(absl::get<std::vector<TYPE>>(value).size()); \
   }
 
-  if (false) {
+  if (false) {  // NOLINT
   }
   EXPAND_ATTR_TYPE(EXPAND_ATTR_TO_GET_SHAPE)
   else {
@@ -558,7 +558,7 @@ std::vector<Type> InferDtypeForAssignValue(
     out_type = common::type_of<TYPE>();               \
   }
 
-    if (false) {
+    if (false) {  // NOLINT
     }
     EXPAND_ATTR_TYPE(EXPAND_ATTR_TO_GET_DTYPE)
     else {

--- a/paddle/cinn/hlir/pass/check_fusion_accuracy_pass.cc
+++ b/paddle/cinn/hlir/pass/check_fusion_accuracy_pass.cc
@@ -80,8 +80,8 @@ class AssertMsg {
 
 class CheckFusionAccuracyPass {
  public:
-  CheckFusionAccuracyPass(Graph* graph_)
-      : graph_(graph_),
+  CheckFusionAccuracyPass(Graph* graph)
+      : graph_(graph),
         shape_dict_(graph_->GetMutableAttrs<ShapeDict>("infershape")),
         dtype_dict_(graph_->GetMutableAttrs<DtypeDict>("inferdtype")) {}
 

--- a/paddle/cinn/pybind/frontend.cc
+++ b/paddle/cinn/pybind/frontend.cc
@@ -935,7 +935,6 @@ void BindFrontend(pybind11::module *m) {
                  << " in CINN! Please check.";
              return self.var_model_to_program_map().at(paddle_name);
            });
-
 }  // namespace frontend
 
 #undef EXPAND_CINN_SUPPORT_TYPE

--- a/paddle/cinn/pybind/runtime.cc
+++ b/paddle/cinn/pybind/runtime.cc
@@ -193,7 +193,7 @@ void BindCinnRuntime(py::module *m) {
       .def_readwrite("flag", &cinn_buffer_t::flag)
       .def_readwrite("type", &cinn_buffer_t::type)
       .def_readwrite("dimensions", &cinn_buffer_t::dimensions)
-      //.def_readwrite("dims", &cinn_buffer_t::dims)
+      // .def_readwrite("dims", &cinn_buffer_t::dims)
       .def_readwrite("lazy", &cinn_buffer_t::lazy)
       .def_readwrite("memory_size", &cinn_buffer_t::memory_size)
       .def_readwrite("align", &cinn_buffer_t::align)
@@ -228,7 +228,7 @@ void BindCinnRuntime(py::module *m) {
   m->def("cinn_x86_device_interface", &cinn_x86_device_interface)
       .def("cinn_buffer_load_float32", &cinn_buffer_load_float32)
       .def("cinn_buffer_load_float64", &cinn_buffer_load_float64);
-  //.def("cinn_buffer_slice", &cinn_buffer_slice,
+  // .def("cinn_buffer_slice", &cinn_buffer_slice,
   //     py::return_value_policy::reference);
 
   py::class_<cinn_value_t> cinn_value(*m, "cinn_value_t");

--- a/paddle/cinn/runtime/cuda/cuda_util.cc
+++ b/paddle/cinn/runtime/cuda/cuda_util.cc
@@ -101,7 +101,8 @@ void cinn_call_cuda_kernel(void *kernel_fn,
     cinn_pod_value_t *args = static_cast<cinn_pod_value_t *>(v_args);
     for (int idx = 0; idx < num_args; ++idx) {
       if (args[idx].type_code() == ::cinn_type_code<cinn_buffer_t *>()) {
-        kernel_args.emplace_back(&((cinn_buffer_t *)(args[idx]))->memory);
+        kernel_args.emplace_back(
+            &((cinn_buffer_t *)(args[idx]))->memory);  // NOLINT
       } else {
         kernel_args.emplace_back(args[idx].data_addr());
       }

--- a/paddle/utils/variant.h
+++ b/paddle/utils/variant.h
@@ -803,6 +803,7 @@ inline constexpr T *addressof(T &arg) noexcept {
 
 template <typename T>
 inline constexpr T *addressof(const T &&) = delete;
+
 }  // namespace cpp17
 
 template <typename T>
@@ -1923,7 +1924,7 @@ class constructor : public destructor<Traits> {
                 lhs_alt, lib::forward<decltype(rhs_alt)>(rhs_alt).value);
           }
 #else
-          ctor{}
+          ctor {}
 #endif
           ,
           lhs,
@@ -2076,7 +2077,7 @@ class assignment : public copy_constructor<Traits> {
                              lib::forward<decltype(that_alt)>(that_alt).value);
           }
 #else
-          assigner<That>{this}
+          assigner<That> { this }
 #endif
           ,
           *this,
@@ -2185,7 +2186,7 @@ class impl : public copy_assignment<traits<Ts...>> {
             swap(this_alt.value, that_alt.value);
           }
 #else
-          swapper{}
+          swapper {}
 #endif
           ,
           *this,
@@ -2222,7 +2223,7 @@ class impl : public copy_assignment<traits<Ts...>> {
 #ifdef MPARK_GENERIC_LAMBDAS
         [](auto &alt) -> const std::type_info & { return typeid(alt.value); }
 #else
-        typer{}
+        typer {}
 #endif
         ,
         *this);
@@ -2812,7 +2813,7 @@ struct hash<paddle::detail::enabled_type<
                     return hash<value_type>{}(alt.value);
                   }
 #else
-                  hasher{}
+                  hasher {}
 #endif
                   ,
                   v);

--- a/paddle/utils/variant.h
+++ b/paddle/utils/variant.h
@@ -803,7 +803,6 @@ inline constexpr T *addressof(T &arg) noexcept {
 
 template <typename T>
 inline constexpr T *addressof(const T &&) = delete;
-
 }  // namespace cpp17
 
 template <typename T>
@@ -1924,7 +1923,7 @@ class constructor : public destructor<Traits> {
                 lhs_alt, lib::forward<decltype(rhs_alt)>(rhs_alt).value);
           }
 #else
-          ctor {}
+          ctor{}
 #endif
           ,
           lhs,
@@ -2077,7 +2076,7 @@ class assignment : public copy_constructor<Traits> {
                              lib::forward<decltype(that_alt)>(that_alt).value);
           }
 #else
-          assigner<That> { this }
+          assigner<That>{this}
 #endif
           ,
           *this,
@@ -2186,7 +2185,7 @@ class impl : public copy_assignment<traits<Ts...>> {
             swap(this_alt.value, that_alt.value);
           }
 #else
-          swapper {}
+          swapper{}
 #endif
           ,
           *this,
@@ -2223,7 +2222,7 @@ class impl : public copy_assignment<traits<Ts...>> {
 #ifdef MPARK_GENERIC_LAMBDAS
         [](auto &alt) -> const std::type_info & { return typeid(alt.value); }
 #else
-        typer {}
+        typer{}
 #endif
         ,
         *this);
@@ -2813,7 +2812,7 @@ struct hash<paddle::detail::enabled_type<
                     return hash<value_type>{}(alt.value);
                   }
 #else
-                  hasher {}
+                  hasher{}
 #endif
                   ,
                   v);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

* fix cinn cpplint codestyle errors about [whitespace/empty_if_body], [whitespace/comments], [whitespace/blank_line], [runtime/init], [runtime/casting], [build/storage_class]
* https://github.com/PaddlePaddle/Paddle/issues/54953
