### PR TITLE
[XPU] update xccl to 1.0.53.5.

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -12,7 +12,7 @@ set(XPU_XPTI_LIB_NAME "libxpti.so")
 if(NOT DEFINED XPU_BASE_DATE)
   set(XPU_BASE_DATE "20230620")
 endif()
-set(XPU_XCCL_BASE_VERSION "1.0.49.2")
+set(XPU_XCCL_BASE_VERSION "1.0.53.5")
 if(NOT DEFINED XPU_XFT_BASE_VERSION)
   set(XPU_XFT_BASE_VERSION "20230602")
 endif()
@@ -92,9 +92,6 @@ set(XPU_XFT_URL "${XPU_XFT_BASE_URL}/${XPU_XFT_DIR_NAME}.tar.gz")
 set(XPU_XPTI_URL
     "${XPU_XPTI_BASE_URL}/${XPU_XPTI_DIR_NAME}.tar.gz"
     CACHE STRING "" FORCE)
-set(XPU_PACK_DEPENCE_URL
-    "https://baidu-kunlun-public.su.bcebos.com/paddle_depence/pack_paddle_depence.sh"
-    CACHE STRING "" FORCE)
 set(XPU_XFT_GET_DEPENCE_URL
     "https://baidu-kunlun-public.su.bcebos.com/paddle_depence/get_xft_dependence.sh"
     CACHE STRING "" FORCE)
@@ -133,11 +130,11 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${XPU_DOWNLOAD_DIR}
   DOWNLOAD_COMMAND
     bash ${CMAKE_SOURCE_DIR}/tools/xpu/check_xpu_dependence.sh ${XPU_BASE_URL}
-    ${XPU_XCCL_BASE_URL} && wget ${XPU_PACK_DEPENCE_URL} && bash
-    pack_paddle_depence.sh ${XPU_XRE_URL} ${XPU_XRE_DIR_NAME} ${XPU_XDNN_URL}
-    ${XPU_XDNN_DIR_NAME} ${XPU_XCCL_URL} ${XPU_XCCL_DIR_NAME} && wget
-    ${XPU_XFT_GET_DEPENCE_URL} && bash get_xft_dependence.sh ${XPU_XFT_URL}
-    ${XPU_XFT_DIR_NAME} && bash
+    ${XPU_XCCL_BASE_URL} && bash
+    ${CMAKE_SOURCE_DIR}/tools/xpu/pack_paddle_depence.sh ${XPU_XRE_URL}
+    ${XPU_XRE_DIR_NAME} ${XPU_XDNN_URL} ${XPU_XDNN_DIR_NAME} ${XPU_XCCL_URL}
+    ${XPU_XCCL_DIR_NAME} && wget ${XPU_XFT_GET_DEPENCE_URL} && bash
+    get_xft_dependence.sh ${XPU_XFT_URL} ${XPU_XFT_DIR_NAME} && bash
     ${CMAKE_SOURCE_DIR}/tools/xpu/get_xpti_dependence.sh ${XPU_XPTI_URL}
     ${XPU_XPTI_DIR_NAME}
   DOWNLOAD_NO_PROGRESS 1

--- a/tools/xpu/pack_paddle_depence.sh
+++ b/tools/xpu/pack_paddle_depence.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+XRE_URL=$1
+XRE_DIR_NAME=$2
+
+XDNN_URL=$3
+XDNN_DIR_NAME=$4
+
+XCCL_URL=$5
+XCCL_DIR_NAME=$6
+
+wget --no-check-certificate ${XRE_URL} -c -q -O xre.tar.gz
+tar xvf xre.tar.gz
+
+wget --no-check-certificate ${XDNN_URL} -c -q -O xdnn.tar.gz
+tar xvf xdnn.tar.gz
+
+wget --no-check-certificate ${XCCL_URL} -c -q -O xccl.tar.gz
+tar xvf xccl.tar.gz
+
+mkdir -p xpu/include/xpu
+mkdir -p xpu/lib
+
+cp -r $XRE_DIR_NAME/include/xpu/* xpu/include/xpu/
+cp -r $XRE_DIR_NAME/so/libxpurt* xpu/lib/
+cp -r $XDNN_DIR_NAME/include/xpu/* xpu/include/xpu/
+cp -r $XDNN_DIR_NAME/so/libxpuapi.so xpu/lib/
+cp -r $XCCL_DIR_NAME/include/* xpu/include/xpu/
+cp -r $XCCL_DIR_NAME/so/* xpu/lib/


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
将XCCL依赖库升级到1.0.53.5版本。

将下载并解压XPU库的脚本，从bos上挪到tools目录下。
