### PR TITLE
[IR&PASS] add conv + elementwise_add fuse pattern

### DIFF
--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -54,8 +54,8 @@
 #include "paddle/fluid/ir/interface/op_yaml_info.h"
 #include "paddle/ir/core/op_base.h"
 #include "paddle/phi/api/lib/utils/allocator.h"
-#include "paddle/phi/infermeta/multiary.h"
 #include "paddle/phi/core/meta_tensor.h"
+#include "paddle/phi/infermeta/multiary.h"
 
 // Define op1.
 class Operation1 : public ir::Op<Operation1> {
@@ -506,7 +506,7 @@ class Conv2dFusionOp
                             false,
                             false,
                             &meta_out,
-                            MetaConfig());
+                            phi::MetaConfig());
 
     std::vector<ir::Type> argument_outputs;
     ir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(

--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -363,7 +363,7 @@ class Conv2dFusionOp
                     ir::OperationArgument &argument,
                     ir::OpResult input_,
                     ir::OpResult filter_,
-                    ir::Value bias_,
+                    ir::OpResult bias_,
                     ir::AttributeMap attributes) {
     std::vector<int> strides;
     for (size_t i = 0;
@@ -571,7 +571,7 @@ class Conv2dAddFusePattern
     ir::Value add_input = op.x();
     IR_ENFORCE(add_input == conv2d_out);
 
-    ir::Value bias = op.y();
+    auto bias = op->result(1);
 
     rewriter.SetInsertionPoint(conv2d_op);
 

--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -359,7 +359,7 @@ class Conv2dFusionOp
   static const char *attributes_name[6];
   static constexpr uint32_t attributes_num = 6;
   static OpInfoTuple GetOpInfo();
-  static void Build(ir::Builder *builder,
+  static void Build(ir::Builder &builder,
                     ir::OperationArgument &argument,
                     ir::OpResult input_,
                     ir::OpResult filter_,

--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -356,12 +356,7 @@ class Conv2dFusionOp
  public:
   using Op::Op;
   static const char *name() { return "pd.conv2d_fusion"; }
-  static const char *attributes_name[6] = {"strides",
-                                           "paddings",
-                                           "padding_algorithm",
-                                           "dilations",
-                                           "groups",
-                                           "data_format"};
+  static const char *attributes_name[6];
   static constexpr uint32_t attributes_num = 6;
   static OpInfoTuple GetOpInfo();
   static void Build(ir::Builder &builder,

--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -356,7 +356,12 @@ class Conv2dFusionOp
  public:
   using Op::Op;
   static const char *name() { return "pd.conv2d_fusion"; }
-  static const char *attributes_name[6];
+  static const char *attributes_name[6] = {"strides",
+                                           "paddings",
+                                           "padding_algorithm",
+                                           "dilations",
+                                           "groups",
+                                           "data_format"};
   static constexpr uint32_t attributes_num = 6;
   static OpInfoTuple GetOpInfo();
   static void Build(ir::Builder &builder,
@@ -572,13 +577,15 @@ class Conv2dAddFusePattern
     IR_ENFORCE(add_input == conv2d_out);
 
     auto bias = op->result(1);
+    auto attributes = conv2d_op.attributes();
 
     rewriter.SetInsertionPoint(conv2d_op);
 
     auto conv2d_fuse_op = rewriter.Build<paddle::dialect::Conv2dFusionOp>(
         ir::GetDefiningOpForInput<0>(conv2d_op)->result(0),
         conv2d_filter_result,
-        bias);
+        bias,
+        attributes);
     rewriter.ReplaceOp(op, {conv2d_fuse_op.out()});
     return true;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71500

1. 在新 IR/PASS 体系下添加 conv2d + batch_norm fuse pattern demo
2. pass前后支持验证ir的正确性