### PR TITLE
replace PIL deprecated constant

### DIFF
--- a/python/paddle/utils/image_util.py
+++ b/python/paddle/utils/image_util.py
@@ -30,7 +30,12 @@ def resize_image(img, target_size):
     resized_size = int(round(img.size[0] * percent)), int(
         round(img.size[1] * percent)
     )
-    img = img.resize(resized_size, Image.ANTIALIAS)
+    try:
+        # For Pillow >= 9.1.0
+        LANCZOS = Image.Resampling.LANCZOS
+    except AttributeError:
+        LANCZOS = Image.LANCZOS
+    img = img.resize(resized_size, LANCZOS)
     return img
 
 

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -30,7 +30,7 @@ try:
         'lanczos': Image.Resampling.LANCZOS,
         'hamming': Image.Resampling.HAMMING,
     }
-except:
+except AttributeError:
     _pil_interp_from_str = {
         'nearest': Image.NEAREST,
         'bilinear': Image.BILINEAR,

--- a/test/cpp/inference/api/full_pascalvoc_test_preprocess.py
+++ b/test/cpp/inference/api/full_pascalvoc_test_preprocess.py
@@ -44,10 +44,16 @@ TAR_TARGETHASH = "b6e924de25625d8de591ea690078ad9f"
 TEST_LIST_KEY = "VOCdevkit/VOC2007/ImageSets/Main/test.txt"
 BIN_FULLSIZE = 5348678856
 
+try:
+    # For Pillow >= 9.1.0
+    LANCZOS = Image.Resampling.LANCZOS
+except AttributeError:
+    LANCZOS = Image.LANCZOS
+
 
 def preprocess(img):
     img_width, img_height = img.size
-    img = img.resize((RESIZE_W, RESIZE_H), Image.ANTIALIAS)
+    img = img.resize((RESIZE_W, RESIZE_H), LANCZOS)
     img = np.array(img)
     # HWC to CHW
     if len(img.shape) == 3:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #42307，Pillow 9.1.0 弃用了部分 constants[^1]，只不过当时还只是报 warning，按照计划，2023-07-01 新发布的 Pillow 10.0.0 已经将相关 constants 移除了，部分单测已经报错，PR-CI-Windows-Inference 会挂掉，比如 https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/8695702/job/23153220

<img width="882" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/38436475/2c0ceafc-7074-43e9-93dd-8f0c8c982805">

PCard-66962

[^1]: 详情见 [Pillow 9.1.0 release notes](https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html)