### PR TITLE
Fix random failure of test_conv3d_op

### DIFF
--- a/test/legacy_test/test_conv3d_op.py
+++ b/test/legacy_test/test_conv3d_op.py
@@ -244,7 +244,7 @@ def create_test_cudnn_bf16_class(parent):
 
             self.check_grad_with_place(
                 place,
-                {'Input', 'Filter'},
+                ['Input', 'Filter'],
                 'Output',
                 user_defined_grads=[numeric_input_grads, numeric_fliter_grads],
                 check_dygraph=(not self.use_mkldnn),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
`test_conv3d_op` randomly fails because that Set traverse is in random order. If the order is not matched with the provided `user_defined_grads`, this UT will fail. This PR solves this problem by using List instead of Set.