### PR TITLE
[Prim] Fix none var added with op error

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1361,7 +1361,14 @@ def _append_backward_ops_(
                 for out_name in op.desc.output_arg_names():
                     grad_name_set.add(out_name)
                 continue
+            keep_var_list = []
+            if op.type in core.ops_contain_none.keys():
+                for none_var_name in core.ops_contain_none[op.type]:
+                    keep_var_list.append(op.output(none_var_name)[0])
+
             for var_name in op.desc.output_arg_names():
+                if keep_var_list and (var_name in keep_var_list):
+                    continue
                 grad_var_name = _append_grad_suffix_(var_name)
                 if grad_var_name not in grad_name_set:
                     op_desc = _create_op_desc_(

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -2503,22 +2503,13 @@ def calc_gradient_helper(
             # Some outputs of composite op are not needed and will be removed.
             # Thus, those vars should not be added with another op.
             keep_var_list = []
-            if op.type == "batch_norm":
-                use_run_stat = (
-                    op.attr("is_test") and (not op.attr("trainable_statistics"))
-                ) or op.attr("use_global_stats")
-                if use_run_stat:
-                    for none_var_name in core.ops_contain_none["batch_norm"][
-                        "eval"
-                    ]:
-                        keep_var_list.append(op.output(none_var_name)[0])
+            if op.type in core.ops_contain_none.keys():
+                values = core.ops_contain_none[op.type]
+                if isinstance(values, list):
+                    none_vars = values
                 else:
-                    for none_var_name in core.ops_contain_none["batch_norm"][
-                        "train"
-                    ]:
-                        keep_var_list.append(op.output(none_var_name)[0])
-            elif op.type in core.ops_contain_none.keys():
-                for none_var_name in core.ops_contain_none[op.type]:
+                    none_vars = values(op)
+                for none_var_name in none_vars:
                     keep_var_list.append(op.output(none_var_name)[0])
 
             for var_name in op.desc.output_arg_names():

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -460,6 +460,17 @@ def _test_use_sync(value):
 prim_config = {"forward_blacklist": set(), "composite_ops_record": set()}
 
 
+# In some case, inputs and outputs of composite op or its replaced composite rule might be None.
+# It means such arg will be no longer required in processed program by composite mechanism.
+# Therefore, such special ops should be recorded in advance and be released in args check.
+ops_contain_none = {
+    "batch_norm": ["ReserveSpace", "SavedMean", "SavedVariance"],
+    "flatten_contiguous_range": ["XShape"],
+    "squeeze2": ["XShape"],
+    "unsqueeze2": ["XShape"],
+}
+
+
 def _set_prim_forward_blacklist(ops=None):
     if ops is None:
         prim_config["forward_blacklist"] = []

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -465,14 +465,22 @@ def _test_use_sync(value):
 prim_config = {"forward_blacklist": set(), "composite_ops_record": set()}
 
 
+def _get_batch_norm_none_var(op):
+    """Some outputs of batch_norm's replaced composite rule are not needed and will be removed."""
+    use_run_stat = (
+        op.attr("is_test") and (not op.attr("trainable_statistics"))
+    ) or op.attr("use_global_stats")
+    if use_run_stat:
+        return ["ReserveSpace", "SavedMean", "SavedVariance"]
+    else:
+        return ["ReserveSpace"]
+
+
 # In some case, inputs and outputs of composite op or its replaced composite rule might be None.
 # It means such arg will be no longer required in processed program by composite mechanism.
 # Therefore, such special ops should be recorded in advance and be released in args check.
 ops_contain_none = {
-    "batch_norm": {
-        "train": ["ReserveSpace"],
-        "eval": ["ReserveSpace", "SavedMean", "SavedVariance"],
-    },
+    "batch_norm": _get_batch_norm_none_var,
     "flatten_contiguous_range": ["XShape"],
     "squeeze2": ["XShape"],
     "unsqueeze2": ["XShape"],

--- a/python/paddle/incubate/autograd/primx.py
+++ b/python/paddle/incubate/autograd/primx.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 
 import paddle
 from paddle.fluid import framework
-from paddle.fluid.core import prim_config
+from paddle.fluid.core import ops_contain_none, prim_config
 from paddle.fluid.framework import Operator, default_main_program
 from paddle.incubate.autograd.utils import as_tensors
 
@@ -548,17 +548,6 @@ def _lower(block, reverse, blacklist):
             block.desc._remove_var(var_name.encode())
             del block.vars[var_name]
     block._sync_with_cpp()
-
-
-# In some case, inputs and outputs of composite op or its replaced composite rule might be None.
-# It means such arg will be no longer required in processed program by composite mechanism.
-# Therefore, such special ops should be recorded in advance and be released in args check.
-ops_contain_none = (
-    "batch_norm",
-    "flatten_contiguous_range",
-    "squeeze2",
-    "unsqueeze2",
-)
 
 
 def _lower_composite(

--- a/test/prim/composite_ops/test_composite_batch_norm.py
+++ b/test/prim/composite_ops/test_composite_batch_norm.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from prim.composite_ops.utils import SUB_TOLERANCE
+from utils import SUB_TOLERANCE
 
 import paddle
 import paddle.nn.functional as F
@@ -489,7 +489,7 @@ class TestPrimEvalBranch(unittest.TestCase):
     def train(self, use_prim):
         core._set_prim_all_enabled(use_prim)
         paddle.seed(2022)
-        net = BatchNorm(2, act="relu", is_test=True)
+        net = BatchNorm(2, is_test=True)
         net = apply_to_static(net, False)
         out = net(self.x)
         loss = paddle.mean(out)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-66975
Some outputs of composite op are not needed and will be removed. 
Thus, those vars should not be added with another op. 
