### PR TITLE
skip flash attn ut on Hopper

### DIFF
--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -57,11 +57,13 @@ def attention_naive(q, k, v, causal=False):
 
 
 is_sm75 = (
-    paddle.device.cuda.get_device_capability()[0] == 7
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] == 7
     and paddle.device.cuda.get_device_capability()[1] == 5
 )
 is_sm8x = (
-    paddle.device.cuda.get_device_capability()[0] == 8
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] == 8
     and paddle.device.cuda.get_device_capability()[1] >= 0
 )
 is_sm_supported = is_sm75 or is_sm8x

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -56,9 +56,23 @@ def attention_naive(q, k, v, causal=False):
     return paddle.transpose(o, [0, 2, 1, 3])
 
 
+is_sm75 = (
+    paddle.device.cuda.get_device_capability()[0] == 7
+    and paddle.device.cuda.get_device_capability()[1] == 5
+)
+is_sm8x = (
+    paddle.device.cuda.get_device_capability()[0] == 8
+    and paddle.device.cuda.get_device_capability()[1] >= 0
+)
+is_sm_supported = is_sm75 or is_sm8x
+
+
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or get_cuda_version() < 11030,
-    "core is not compiled with CUDA and cuda version need larger than or equal to 11.3",
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11030
+    or not is_sm_supported,
+    "core is not compiled with CUDA and cuda version need larger than or equal to 11.3"
+    "and device's compute capability must be 7.5 or 8.x",
 )
 class TestFlashAttentionAPI(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
The `test_flash_attention.py` UT failed on H100 because flash attention is only implemented for sm75 and sm8x. Refer to [flash_attn.cpp#L293](https://github.com/PaddlePaddle/flash-attention/blob/18106c1ba0ccee81b97ca947397c08a141815a47/csrc/flash_attn/flash_attn.cpp#L293C1-L293C1)

So I skip this UT on unsupported arch.

Error message:
```
ERROR: test_all (test_flash_attention.TestFlashAttentionAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/paddle/paddle/build/python/paddle/fluid/tests/unittests/test_flash_attention.py", line 192, in test_all
    out, _ = flash_attention(
  File "/opt/paddle/paddle/build/python/paddle/nn/functional/flash_attention.py", line 83, in flash_attention
    (result_attention, result_softmax,) = _C_ops.flash_attn(
OSError: (External) `is_sm8x || is_sm75` check failed at /opt/paddle/paddle/build/third_party/flashattn/src/extern_flashattn/csrc/flash_attn/flash_attn.cpp:292 (at /opt/paddle/paddle/paddle/phi/kernels/gpu/flash_attn_kernel.cu:142)
```