### PR TITLE
disable dygraph test for fused_elemwise_activation_op

### DIFF
--- a/test/legacy_test/test_fused_elemwise_activation_op.py
+++ b/test/legacy_test/test_fused_elemwise_activation_op.py
@@ -92,9 +92,9 @@ def create_test_class(
             if not grad_chek:
                 return
             if self.attrs["save_intermediate_out"]:
-                self.check_grad(['X', 'Y'], ['Out'])
+                self.check_grad(['X', 'Y'], ['Out'], check_dygraph=False)
             else:
-                self.check_grad(['X', 'Y'], ['Out'])
+                self.check_grad(['X', 'Y'], ['Out'], check_dygraph=False)
 
         def test_check_grad_ingore_x(self):
             if not grad_chek:
@@ -105,6 +105,7 @@ def create_test_class(
                     ['Out'],
                     max_relative_error=0.005,
                     no_grad_set=set("X"),
+                    check_dygraph=False,
                 )
             else:
                 self.check_grad(
@@ -112,6 +113,7 @@ def create_test_class(
                     ['Out'],
                     max_relative_error=0.005,
                     no_grad_set=set("X"),
+                    check_dygraph=False,
                 )
 
         def test_check_grad_ingore_y(self):
@@ -123,6 +125,7 @@ def create_test_class(
                     ['Out'],
                     max_relative_error=0.005,
                     no_grad_set=set("Y"),
+                    check_dygraph=False,
                 )
             else:
                 self.check_grad(
@@ -130,6 +133,7 @@ def create_test_class(
                     ['Out'],
                     max_relative_error=0.005,
                     no_grad_set=set("Y"),
+                    check_dygraph=False,
                 )
 
     class TestFusedElementwiseActivationOp_scalar(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
In paddlev2.5, fused_elemwise_activation_op no longer works in dynamic graph. So, I disable dygraph test in its UT.
