### PR TITLE
[CustomDevice]fix == error with place

### DIFF
--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -1150,7 +1150,8 @@ void NewIRInterpreter::RecordStreamForGC(const Instruction& instr) {
       instr.KernelType() != OpFuncType::kGpuAsync) {
     return;
   }
-  if (instr.DeviceContext().GetPlace() == phi::CustomPlace()) {
+  if (instr.DeviceContext().GetPlace().GetType() ==
+      phi::AllocationType::CUSTOM) {
     return;
   }
   platform::RecordEvent record(

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -1136,7 +1136,8 @@ void ProgramInterpreter::RecordStreamForGC(const Instruction& instr) {
     return;
   }
 
-  if (instr.DeviceContext().GetPlace() == phi::CustomPlace()) {
+  if (instr.DeviceContext().GetPlace().GetType() ==
+      phi::AllocationType::CUSTOM) {
     return;
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/54606
我之前这个PR里提交的判断GetPlace() 是否为CustomDevice的代码存在问题
```cpp
instr.DeviceContext().GetPlace() == phi::CustomPlace()
```
phi::Place == 的重载是比较HashCode的数值
自定义的Custom类型HashCode数值与默认的phi::CustomPlace() 不一样
这种比较方式是不正确的。


追加的修正方案
```cpp
instr.DeviceContext().GetPlace().GetType() == phi::AllocationType::CUSTOM
```
才能正确判断GetPlace()是否为CustomDevice