### PR TITLE
add odd rules for getting kernels

### DIFF
--- a/tools/get_op_list.py
+++ b/tools/get_op_list.py
@@ -55,10 +55,28 @@ def get_model_ops(model_file, ops_set):
 
 def get_model_phi_kernels(ops_set):
     phi_set = set()
+    phi_raw_list = [
+        "add",
+        "subtract",
+        "multiply",
+        "multiply_sr",
+        "divide",
+        "maximum",
+        "minimum",
+        "remainder",
+        "floor_divide",
+        "elementwise_pow",
+    ]
+    phi_odd_dist = {"batch_norm": "batch_norm_infer"}
     for op in ops_set:
         print(op)
-        print(_get_phi_kernel_name(op))
-        phi_set.add(_get_phi_kernel_name(op))
+        phi_kernel = _get_phi_kernel_name(op)
+        print(phi_kernel)
+        phi_set.add(phi_kernel)
+        if phi_kernel in phi_raw_list:
+            phi_set.add(phi_kernel + "_raw")
+        if phi_kernel in phi_odd_dist.keys():
+            phi_set.add(phi_odd_dist[phi_kernel])
 
     return phi_set
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501

模型算子裁剪功能（#47046, #47047, #54760)存在一些特殊的kernel很难设置相应的匹配规则，因而用硬编码的方式写在 get_op_list.py 中