### PR TITLE
fix cinn version path

### DIFF
--- a/python/setup_cinn.py.in
+++ b/python/setup_cinn.py.in
@@ -109,7 +109,7 @@ with_mkl        = '%(with_mkl)s'
             'istaged': is_taged(),
             'with_mkl': '${WITH_MKL}'})
 
-write_version_py(filename='${CINN_BINARY_DIR}/python/cinn/version/info.py')
+write_version_py(filename='${CMAKE_BINARY_DIR}/python/cinn/version/info.py')
 
 if sys.platform != 'win32':
     @contextmanager


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
cinn python dir should be located at `${CMAKE_BINARY_DIR}/python/cinn` instead of `${CINN_BINARY_DIR}/python/cinn/version/info.py`
