### PR TITLE
recovery launch devices in test_pass_sharding

### DIFF
--- a/test/auto_parallel/test_pass_sharding.py
+++ b/test/auto_parallel/test_pass_sharding.py
@@ -36,6 +36,8 @@ class TestShardingPass(unittest.TestCase):
             + [
                 "-m",
                 "paddle.distributed.launch",
+                "--devices",
+                "0,1",
                 "--log_dir",
                 tmp_dir.name,
                 launch_model_path,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-70448
- recovery launch devices in test_pass_sharding