### PR TITLE
[NewIR]Refine IrPrinter and basic Concept Interface for const Object

### DIFF
--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -37,7 +37,12 @@ namespace pybind {
 void BindProgram(py::module *m) {
   py::class_<Program> program(*m, "Program");
   program.def("parameters_num", &Program::parameters_num)
-      .def("block", &Program::block, return_value_policy::reference)
+      .def("block",
+           py::overload_cast<>(&Program::block),
+           return_value_policy::reference)
+      .def("block",
+           py::overload_cast<>(&Program::block, py::const_),
+           return_value_policy::reference)
       .def("print", [](Program &self) {
         std::ostringstream print_stream;
         self.Print(print_stream);

--- a/paddle/ir/core/builtin_op.cc
+++ b/paddle/ir/core/builtin_op.cc
@@ -22,7 +22,7 @@ namespace ir {
 
 const char *ModuleOp::attributes_name[attributes_num] = {"program"};
 
-Program *ModuleOp::program() const {
+Program *ModuleOp::program() {
   const AttributeMap &attr = this->attributes();
   auto iter = attr.find("program");
   if (iter == attr.end() || !iter->second) return nullptr;
@@ -30,7 +30,7 @@ Program *ModuleOp::program() const {
       iter->second.dyn_cast<PointerAttribute>().data());
 }
 
-Block *ModuleOp::block() const {
+Block *ModuleOp::block() {
   assert(operation() != nullptr);
   assert(operation()->num_regions() == 1);
   assert(operation()->region(0).size() == 1);

--- a/paddle/ir/core/builtin_op.cc
+++ b/paddle/ir/core/builtin_op.cc
@@ -22,7 +22,7 @@ namespace ir {
 
 const char *ModuleOp::attributes_name[attributes_num] = {"program"};
 
-Program *ModuleOp::program() {
+Program *ModuleOp::program() const {
   const AttributeMap &attr = this->attributes();
   auto iter = attr.find("program");
   if (iter == attr.end() || !iter->second) return nullptr;
@@ -30,7 +30,7 @@ Program *ModuleOp::program() {
       iter->second.dyn_cast<PointerAttribute>().data());
 }
 
-Block *ModuleOp::block() {
+Block *ModuleOp::block() const {
   assert(operation() != nullptr);
   assert(operation()->num_regions() == 1);
   assert(operation()->region(0).size() == 1);
@@ -52,7 +52,7 @@ void ModuleOp::Destroy() {
   }
 }
 
-void ModuleOp::Verify() {
+void ModuleOp::Verify() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: ModuleOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
@@ -79,7 +79,7 @@ void GetParameterOp::Build(Builder &builder,
   argument.output_types.emplace_back(type);
 }
 
-void GetParameterOp::Verify() {
+void GetParameterOp::Verify() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: GetParameterOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
@@ -105,7 +105,7 @@ void SetParameterOp::Build(Builder &builder,             // NOLINT
   argument.AddAttribute(attributes_name[0],
                         ir::StrAttribute::get(builder.ir_context(), name));
 }
-void SetParameterOp::Verify() {
+void SetParameterOp::Verify() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: SetParameterOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 1, "The size of outputs must be equal to 1.");
@@ -132,7 +132,7 @@ void CombineOp::Build(Builder &builder,
       ir::VectorType::get(builder.ir_context(), inputs_type));
 }
 
-void CombineOp::Verify() {
+void CombineOp::Verify() const {
   // outputs.size() == 1
   IR_ENFORCE(num_results() == 1u, "The size of outputs must be equal to 1.");
 
@@ -162,7 +162,7 @@ void CombineOp::Verify() {
 }
 
 const char *SliceOp::attributes_name[attributes_num] = {"index"};
-void SliceOp::Verify() {
+void SliceOp::Verify() const {
   // inputs.size() == 1
   auto input_size = num_operands();
   IR_ENFORCE(
@@ -217,13 +217,13 @@ void ConstantOp::Build(Builder &builder,
   argument.output_types.push_back(output_type);
 }
 
-void ConstantOp::Verify() {
+void ConstantOp::Verify() const {
   IR_ENFORCE(num_operands() == 0, "The size of inputs must be equal to 0.");
   IR_ENFORCE(num_results() == 1, "The size of outputs must be equal to 1.");
   IR_ENFORCE(attributes().count("value") > 0, "must has value attribute");
 }
 
-Attribute ConstantOp::value() { return attributes().at("value"); }
+Attribute ConstantOp::value() const { return attributes().at("value"); }
 
 }  // namespace ir
 

--- a/paddle/ir/core/builtin_op.h
+++ b/paddle/ir/core/builtin_op.h
@@ -31,8 +31,8 @@ class IR_API ModuleOp : public ir::Op<ModuleOp> {
   static constexpr uint32_t attributes_num = 1;
   static const char *attributes_name[attributes_num];
   void Verify() const;
-  Program *program() const;
-  Block *block() const;
+  Program *program();
+  Block *block();
 
   //
   // As the top operation, ModuleOp only support create&destroye through

--- a/paddle/ir/core/builtin_op.h
+++ b/paddle/ir/core/builtin_op.h
@@ -55,7 +55,7 @@ class IR_API GetParameterOp : public ir::Op<GetParameterOp> {
                     OperationArgument &argument,  // NOLINT
                     const std::string &name,
                     Type type);
-  void Verify();
+  void Verify() const;
 };
 
 ///

--- a/paddle/ir/core/builtin_op.h
+++ b/paddle/ir/core/builtin_op.h
@@ -30,9 +30,9 @@ class IR_API ModuleOp : public ir::Op<ModuleOp> {
   static const char *name() { return "builtin.module"; }
   static constexpr uint32_t attributes_num = 1;
   static const char *attributes_name[attributes_num];
-  void Verify();
-  Program *program();
-  Block *block();
+  void Verify() const;
+  Program *program() const;
+  Block *block() const;
 
   //
   // As the top operation, ModuleOp only support create&destroye through
@@ -72,7 +72,7 @@ class IR_API SetParameterOp : public ir::Op<SetParameterOp> {
                     OperationArgument &argument,  // NOLINT
                     OpResult parameter,
                     const std::string &name);
-  void Verify();
+  void Verify() const;
 };
 
 ///
@@ -92,7 +92,7 @@ class IR_API CombineOp : public ir::Op<CombineOp> {
                     OperationArgument &argument,  // NOLINT
                     const std::vector<ir::OpResult> &inputs);
 
-  void Verify();
+  void Verify() const;
 };
 
 ///
@@ -107,7 +107,7 @@ class IR_API SliceOp : public ir::Op<SliceOp> {
   static constexpr uint32_t attributes_num = 1;
 
   static const char *attributes_name[attributes_num];
-  void Verify();
+  void Verify() const;
 };
 
 class IR_API ConstantLikeTrait : public OpTraitBase<ConstantLikeTrait> {
@@ -132,9 +132,9 @@ class IR_API ConstantOp : public Op<ConstantOp, ConstantLikeTrait> {
                     Attribute value,
                     Type output_type);
 
-  void Verify();
+  void Verify() const;
 
-  Attribute value();
+  Attribute value() const;
 };
 
 }  // namespace ir

--- a/paddle/ir/core/dialect.h
+++ b/paddle/ir/core/dialect.h
@@ -145,8 +145,8 @@ class IR_API Dialect {
     IR_THROW("dialect has no registered attribute printing hook");
   }
 
-  virtual void PrintOperation(Operation *op,
-                              IrPrinter &printer) const;  // NOLINT
+  virtual void PrintOperation(const Operation *op,
+                              const IrPrinter &printer) const;  // NOLINT
 
  private:
   Dialect(const Dialect &) = delete;

--- a/paddle/ir/core/dialect.h
+++ b/paddle/ir/core/dialect.h
@@ -146,7 +146,7 @@ class IR_API Dialect {
   }
 
   virtual void PrintOperation(const Operation *op,
-                              const IrPrinter &printer) const;  // NOLINT
+                              IrPrinter &printer) const;  // NOLINT
 
  private:
   Dialect(const Dialect &) = delete;

--- a/paddle/ir/core/ir_printer.cc
+++ b/paddle/ir/core/ir_printer.cc
@@ -33,7 +33,7 @@ namespace {
 constexpr char newline[] = "\n";
 }  // namespace
 
-void BasicIrPrinter::PrintType(Type type) {
+void BasicIrPrinter::PrintType(Type type) const {
   if (!type) {
     os << "<<NULL TYPE>>";
     return;
@@ -78,7 +78,7 @@ void BasicIrPrinter::PrintType(Type type) {
   }
 }
 
-void BasicIrPrinter::PrintAttribute(Attribute attr) {
+void BasicIrPrinter::PrintAttribute(Attribute attr) const {
   if (!attr) {
     os << "<#AttrNull>";
     return;
@@ -115,7 +115,7 @@ void BasicIrPrinter::PrintAttribute(Attribute attr) {
   }
 }
 
-void IrPrinter::PrintProgram(Program* program) {
+void IrPrinter::PrintProgram(const Program* program) const {
   auto top_level_op = program->module_op();
   for (size_t i = 0; i < top_level_op->num_regions(); ++i) {
     auto& region = top_level_op->region(i);
@@ -123,7 +123,7 @@ void IrPrinter::PrintProgram(Program* program) {
   }
 }
 
-void IrPrinter::PrintOperation(Operation* op) {
+void IrPrinter::PrintOperation(const Operation* op) const {
   if (auto* dialect = op->dialect()) {
     dialect->PrintOperation(op, *this);
     return;
@@ -132,7 +132,7 @@ void IrPrinter::PrintOperation(Operation* op) {
   PrintGeneralOperation(op);
 }
 
-void IrPrinter::PrintGeneralOperation(Operation* op) {
+void IrPrinter::PrintGeneralOperation(const Operation* op) const {
   // TODO(lyk): add API to get opresults directly
   PrintOpResult(op);
   os << " =";
@@ -153,7 +153,7 @@ void IrPrinter::PrintGeneralOperation(Operation* op) {
   PrintOpReturnType(op);
 }
 
-void IrPrinter::PrintFullOperation(Operation* op) {
+void IrPrinter::PrintFullOperation(const Operation* op) const {
   PrintOperation(op);
   if (op->num_regions() > 0) {
     os << newline;
@@ -164,14 +164,14 @@ void IrPrinter::PrintFullOperation(Operation* op) {
   }
 }
 
-void IrPrinter::PrintRegion(const Region& region) {
+void IrPrinter::PrintRegion(const Region& region) const {
   for (auto it = region.begin(); it != region.end(); ++it) {
     auto* block = *it;
     PrintBlock(block);
   }
 }
 
-void IrPrinter::PrintBlock(Block* block) {
+void IrPrinter::PrintBlock(const Block* block) const {
   os << "{\n";
   for (auto it = block->begin(); it != block->end(); ++it) {
     PrintOperation(*it);
@@ -180,7 +180,7 @@ void IrPrinter::PrintBlock(Block* block) {
   os << "}\n";
 }
 
-void IrPrinter::PrintValue(Value v) {
+void IrPrinter::PrintValue(const Value& v) const {
   if (!v) {
     os << "<<NULL VALUE>>";
     return;
@@ -198,7 +198,7 @@ void IrPrinter::PrintValue(Value v) {
   os << new_name;
 }
 
-void IrPrinter::PrintOpResult(Operation* op) {
+void IrPrinter::PrintOpResult(const Operation* op) const {
   os << " (";
   auto num_op_result = op->num_results();
   std::vector<OpResult> op_results;
@@ -214,7 +214,7 @@ void IrPrinter::PrintOpResult(Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintAttributeMap(Operation* op) {
+void IrPrinter::PrintAttributeMap(const Operation* op) const {
   os << " {";
 
   PrintInterleave(
@@ -230,7 +230,7 @@ void IrPrinter::PrintAttributeMap(Operation* op) {
   os << "}";
 }
 
-void IrPrinter::PrintOpOperands(Operation* op) {
+void IrPrinter::PrintOpOperands(const Operation* op) const {
   os << " (";
   auto num_op_operands = op->num_operands();
   std::vector<Value> op_operands;
@@ -246,7 +246,7 @@ void IrPrinter::PrintOpOperands(Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintOperandsType(Operation* op) {
+void IrPrinter::PrintOperandsType(const Operation* op) const {
   auto num_op_operands = op->num_operands();
   std::vector<Type> op_operand_types;
   op_operand_types.reserve(num_op_operands);
@@ -267,7 +267,7 @@ void IrPrinter::PrintOperandsType(Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintOpReturnType(Operation* op) {
+void IrPrinter::PrintOpReturnType(const Operation* op) const {
   auto num_op_result = op->num_results();
   std::vector<Type> op_result_types;
   op_result_types.reserve(num_op_result);
@@ -286,16 +286,17 @@ void IrPrinter::PrintOpReturnType(Operation* op) {
       [this]() { this->os << ", "; });
 }
 
-void Dialect::PrintOperation(Operation* op, IrPrinter& printer) const {
+void Dialect::PrintOperation(const Operation* op,
+                             const IrPrinter& printer) const {
   printer.PrintGeneralOperation(op);
 }
 
-void Program::Print(std::ostream& os) {
+void Program::Print(std::ostream& os) const {
   IrPrinter printer(os);
   printer.PrintProgram(this);
 }
 
-void Operation::Print(std::ostream& os) {
+void Operation::Print(std::ostream& os) const {
   IrPrinter printer(os);
   printer.PrintFullOperation(this);
 }

--- a/paddle/ir/core/ir_printer.cc
+++ b/paddle/ir/core/ir_printer.cc
@@ -286,7 +286,7 @@ void IrPrinter::PrintOpReturnType(const Operation* op) {
       [this]() { this->os << ", "; });
 }
 
-void Dialect::PrintOperation(const Operation* op, IrPrinter& printer) {
+void Dialect::PrintOperation(const Operation* op, IrPrinter& printer) const {
   printer.PrintGeneralOperation(op);
 }
 

--- a/paddle/ir/core/ir_printer.cc
+++ b/paddle/ir/core/ir_printer.cc
@@ -33,7 +33,7 @@ namespace {
 constexpr char newline[] = "\n";
 }  // namespace
 
-void BasicIrPrinter::PrintType(Type type) const {
+void BasicIrPrinter::PrintType(Type type) {
   if (!type) {
     os << "<<NULL TYPE>>";
     return;
@@ -78,7 +78,7 @@ void BasicIrPrinter::PrintType(Type type) const {
   }
 }
 
-void BasicIrPrinter::PrintAttribute(Attribute attr) const {
+void BasicIrPrinter::PrintAttribute(Attribute attr) {
   if (!attr) {
     os << "<#AttrNull>";
     return;
@@ -115,7 +115,7 @@ void BasicIrPrinter::PrintAttribute(Attribute attr) const {
   }
 }
 
-void IrPrinter::PrintProgram(const Program* program) const {
+void IrPrinter::PrintProgram(const Program* program) {
   auto top_level_op = program->module_op();
   for (size_t i = 0; i < top_level_op->num_regions(); ++i) {
     auto& region = top_level_op->region(i);
@@ -123,7 +123,7 @@ void IrPrinter::PrintProgram(const Program* program) const {
   }
 }
 
-void IrPrinter::PrintOperation(const Operation* op) const {
+void IrPrinter::PrintOperation(const Operation* op) {
   if (auto* dialect = op->dialect()) {
     dialect->PrintOperation(op, *this);
     return;
@@ -132,7 +132,7 @@ void IrPrinter::PrintOperation(const Operation* op) const {
   PrintGeneralOperation(op);
 }
 
-void IrPrinter::PrintGeneralOperation(const Operation* op) const {
+void IrPrinter::PrintGeneralOperation(const Operation* op) {
   // TODO(lyk): add API to get opresults directly
   PrintOpResult(op);
   os << " =";
@@ -153,7 +153,7 @@ void IrPrinter::PrintGeneralOperation(const Operation* op) const {
   PrintOpReturnType(op);
 }
 
-void IrPrinter::PrintFullOperation(const Operation* op) const {
+void IrPrinter::PrintFullOperation(const Operation* op) {
   PrintOperation(op);
   if (op->num_regions() > 0) {
     os << newline;
@@ -164,14 +164,14 @@ void IrPrinter::PrintFullOperation(const Operation* op) const {
   }
 }
 
-void IrPrinter::PrintRegion(const Region& region) const {
+void IrPrinter::PrintRegion(const Region& region) {
   for (auto it = region.begin(); it != region.end(); ++it) {
     auto* block = *it;
     PrintBlock(block);
   }
 }
 
-void IrPrinter::PrintBlock(const Block* block) const {
+void IrPrinter::PrintBlock(const Block* block) {
   os << "{\n";
   for (auto it = block->begin(); it != block->end(); ++it) {
     PrintOperation(*it);
@@ -180,7 +180,7 @@ void IrPrinter::PrintBlock(const Block* block) const {
   os << "}\n";
 }
 
-void IrPrinter::PrintValue(const Value& v) const {
+void IrPrinter::PrintValue(const Value& v) {
   if (!v) {
     os << "<<NULL VALUE>>";
     return;
@@ -198,7 +198,7 @@ void IrPrinter::PrintValue(const Value& v) const {
   os << new_name;
 }
 
-void IrPrinter::PrintOpResult(const Operation* op) const {
+void IrPrinter::PrintOpResult(const Operation* op) {
   os << " (";
   auto num_op_result = op->num_results();
   std::vector<OpResult> op_results;
@@ -214,7 +214,7 @@ void IrPrinter::PrintOpResult(const Operation* op) const {
   os << ")";
 }
 
-void IrPrinter::PrintAttributeMap(const Operation* op) const {
+void IrPrinter::PrintAttributeMap(const Operation* op) {
   os << " {";
 
   PrintInterleave(
@@ -230,7 +230,7 @@ void IrPrinter::PrintAttributeMap(const Operation* op) const {
   os << "}";
 }
 
-void IrPrinter::PrintOpOperands(const Operation* op) const {
+void IrPrinter::PrintOpOperands(const Operation* op) {
   os << " (";
   auto num_op_operands = op->num_operands();
   std::vector<Value> op_operands;
@@ -246,7 +246,7 @@ void IrPrinter::PrintOpOperands(const Operation* op) const {
   os << ")";
 }
 
-void IrPrinter::PrintOperandsType(const Operation* op) const {
+void IrPrinter::PrintOperandsType(const Operation* op) {
   auto num_op_operands = op->num_operands();
   std::vector<Type> op_operand_types;
   op_operand_types.reserve(num_op_operands);
@@ -267,7 +267,7 @@ void IrPrinter::PrintOperandsType(const Operation* op) const {
   os << ")";
 }
 
-void IrPrinter::PrintOpReturnType(const Operation* op) const {
+void IrPrinter::PrintOpReturnType(const Operation* op) {
   auto num_op_result = op->num_results();
   std::vector<Type> op_result_types;
   op_result_types.reserve(num_op_result);
@@ -286,8 +286,7 @@ void IrPrinter::PrintOpReturnType(const Operation* op) const {
       [this]() { this->os << ", "; });
 }
 
-void Dialect::PrintOperation(const Operation* op,
-                             const IrPrinter& printer) const {
+void Dialect::PrintOperation(const Operation* op, IrPrinter& printer) {
   printer.PrintGeneralOperation(op);
 }
 

--- a/paddle/ir/core/ir_printer.h
+++ b/paddle/ir/core/ir_printer.h
@@ -32,9 +32,9 @@ class BasicIrPrinter {
  public:
   explicit BasicIrPrinter(std::ostream& os) : os(os) {}
 
-  void PrintType(Type type);
+  void PrintType(Type type) const;
 
-  void PrintAttribute(Attribute attr);
+  void PrintAttribute(Attribute attr) const;
 
  public:
   std::ostream& os;
@@ -46,33 +46,33 @@ class IR_API IrPrinter : public BasicIrPrinter {
 
   /// @brief print program
   /// @param program
-  void PrintProgram(Program* program);
+  void PrintProgram(const Program* program) const;
 
   /// @brief dispatch to custom printer function or PrintGeneralOperation
-  void PrintOperation(Operation* op);
+  void PrintOperation(const Operation* op) const;
   /// @brief print operation itself without its regions
-  void PrintGeneralOperation(Operation* op);
+  void PrintGeneralOperation(const Operation* op) const;
   /// @brief print operation and its regions
-  void PrintFullOperation(Operation* op);
+  void PrintFullOperation(const Operation* op) const;
 
-  void PrintRegion(const Region& Region);
-  void PrintBlock(Block* block);
+  void PrintRegion(const Region& Region) const;
+  void PrintBlock(const Block* block) const;
 
-  void PrintValue(Value v);
+  void PrintValue(const Value& v) const;
 
-  void PrintOpResult(Operation* op);
+  void PrintOpResult(const Operation* op) const;
 
-  void PrintAttributeMap(Operation* op);
+  void PrintAttributeMap(const Operation* op) const;
 
-  void PrintOpOperands(Operation* op);
+  void PrintOpOperands(const Operation* op) const;
 
-  void PrintOperandsType(Operation* op);
+  void PrintOperandsType(const Operation* op) const;
 
-  void PrintOpReturnType(Operation* op);
+  void PrintOpReturnType(const Operation* op) const;
 
  private:
-  size_t cur_var_number_{0};
-  std::unordered_map<const void*, std::string> aliases_;
+  mutable size_t cur_var_number_{0};
+  mutable std::unordered_map<const void*, std::string> aliases_;
 };
 
 }  // namespace ir

--- a/paddle/ir/core/ir_printer.h
+++ b/paddle/ir/core/ir_printer.h
@@ -32,9 +32,9 @@ class BasicIrPrinter {
  public:
   explicit BasicIrPrinter(std::ostream& os) : os(os) {}
 
-  void PrintType(Type type) const;
+  void PrintType(Type type);
 
-  void PrintAttribute(Attribute attr) const;
+  void PrintAttribute(Attribute attr);
 
  public:
   std::ostream& os;
@@ -46,33 +46,33 @@ class IR_API IrPrinter : public BasicIrPrinter {
 
   /// @brief print program
   /// @param program
-  void PrintProgram(const Program* program) const;
+  void PrintProgram(const Program* program);
 
   /// @brief dispatch to custom printer function or PrintGeneralOperation
-  void PrintOperation(const Operation* op) const;
+  void PrintOperation(const Operation* op);
   /// @brief print operation itself without its regions
-  void PrintGeneralOperation(const Operation* op) const;
+  void PrintGeneralOperation(const Operation* op);
   /// @brief print operation and its regions
-  void PrintFullOperation(const Operation* op) const;
+  void PrintFullOperation(const Operation* op);
 
-  void PrintRegion(const Region& Region) const;
-  void PrintBlock(const Block* block) const;
+  void PrintRegion(const Region& Region);
+  void PrintBlock(const Block* block);
 
-  void PrintValue(const Value& v) const;
+  void PrintValue(const Value& v);
 
-  void PrintOpResult(const Operation* op) const;
+  void PrintOpResult(const Operation* op);
 
-  void PrintAttributeMap(const Operation* op) const;
+  void PrintAttributeMap(const Operation* op);
 
-  void PrintOpOperands(const Operation* op) const;
+  void PrintOpOperands(const Operation* op);
 
-  void PrintOperandsType(const Operation* op) const;
+  void PrintOperandsType(const Operation* op);
 
-  void PrintOpReturnType(const Operation* op) const;
+  void PrintOpReturnType(const Operation* op);
 
  private:
-  mutable size_t cur_var_number_{0};
-  mutable std::unordered_map<const void*, std::string> aliases_;
+  size_t cur_var_number_{0};
+  std::unordered_map<const void*, std::string> aliases_;
 };
 
 }  // namespace ir

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -222,7 +222,7 @@ Program *Operation::GetParentProgram() {
   return module_op ? module_op.program() : nullptr;
 }
 
-Region &Operation::region(unsigned index) {
+Region &Operation::region(unsigned index) const {
   assert(index < num_regions_ && "invalid region index");
   return regions_[index];
 }

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -222,7 +222,12 @@ Program *Operation::GetParentProgram() {
   return module_op ? module_op.program() : nullptr;
 }
 
-Region &Operation::region(unsigned index) const {
+Region &Operation::region(unsigned index) {
+  assert(index < num_regions_ && "invalid region index");
+  return regions_[index];
+}
+
+const Region &Operation::region(unsigned index) const {
   assert(index < num_regions_ && "invalid region index");
   return regions_[index];
 }

--- a/paddle/ir/core/operation.h
+++ b/paddle/ir/core/operation.h
@@ -58,9 +58,9 @@ class IR_API alignas(8) Operation final {
   Value operand(uint32_t index) const;
 
   /// Returns the region held by this operation at position 'index'.
-  Region &region(unsigned index);
+  Region &region(unsigned index) const;
 
-  void Print(std::ostream &os);
+  void Print(std::ostream &os) const;
 
   const AttributeMap &attributes() const { return attributes_; }
 

--- a/paddle/ir/core/operation.h
+++ b/paddle/ir/core/operation.h
@@ -58,7 +58,8 @@ class IR_API alignas(8) Operation final {
   Value operand(uint32_t index) const;
 
   /// Returns the region held by this operation at position 'index'.
-  Region &region(unsigned index) const;
+  Region &region(unsigned index);
+  const Region &region(unsigned index) const;
 
   void Print(std::ostream &os) const;
 

--- a/paddle/ir/core/program.h
+++ b/paddle/ir/core/program.h
@@ -48,17 +48,17 @@ class IR_API Program {
   ~Program();
   size_t parameters_num() const { return parameters_.size(); }
 
-  ModuleOp module_op() { return module_; }
+  ModuleOp module_op() const { return module_; }
 
-  void Print(std::ostream& os);
+  void Print(std::ostream& os) const;
 
-  Block* block() { return module_.block(); }
+  Block* block() const { return module_.block(); }
 
   Parameter* GetParameter(const std::string& name) const;
   void SetParameter(const std::string& name,
                     std::unique_ptr<Parameter>&& parameter);
 
-  ParameterMap& parameters() { return parameters_; }
+  ParameterMap& parameters() const { return parameters_; }
   void set_parameters(ParameterMap&& parameters) {
     parameters_ = std::move(parameters);
   }

--- a/paddle/ir/core/program.h
+++ b/paddle/ir/core/program.h
@@ -52,13 +52,14 @@ class IR_API Program {
 
   void Print(std::ostream& os) const;
 
-  Block* block() const { return module_.block(); }
+  Block* block() { return module_.block(); }
+  const Block* block() const { return module_op().block(); }
 
-  Parameter* GetParameter(const std::string& name) const;
+  Parameter* GetParameter(const std::string& name);
   void SetParameter(const std::string& name,
                     std::unique_ptr<Parameter>&& parameter);
 
-  ParameterMap& parameters() const { return parameters_; }
+  ParameterMap& parameters() { return parameters_; }
   void set_parameters(ParameterMap&& parameters) {
     parameters_ = std::move(parameters);
   }

--- a/paddle/ir/core/program.h
+++ b/paddle/ir/core/program.h
@@ -55,7 +55,7 @@ class IR_API Program {
   Block* block() { return module_.block(); }
   const Block* block() const { return module_op().block(); }
 
-  Parameter* GetParameter(const std::string& name);
+  Parameter* GetParameter(const std::string& name) const;
   void SetParameter(const std::string& name,
                     std::unique_ptr<Parameter>&& parameter);
 

--- a/test/cpp/ir/core/ir_op_test.cc
+++ b/test/cpp/ir/core/ir_op_test.cc
@@ -155,7 +155,7 @@ class TestDialect : public ir::Dialect {
   }
   static const char *name() { return "test"; }
 
-  void PrintOperation(ir::Operation *op,
+  void PrintOperation(const ir::Operation *op,
                       ir::IrPrinter &printer) const override {
     printer.PrintOpResult(op);
     printer.os << " =";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

Pcard-67164

- [x] 规范了组件的部分接口，解决 const 对象无法使用部分接口的问题
- [ ]  待规范IrPrinter的接口参数，部分是`const*`，部分是`const&`，有待统一为`const &`
- [x]  从严格规范上来讲，此PR的部分改动仍然需要进一步优化，如下样例：（此处移除了部分不合适的接口）


```python
class IR_API ModuleOp : public ir::Op<ModuleOp> {
 
   // 此处支持的 const 语义并不规范
   Program *program() const;
   Block *block() const;

  // 规范的语义应该是
  Program *program();   // <---- 非const对象返回非const
  Block *block();

  const Program *program() const;  // <--- const 对象返回const
  const Block *block() const;

};

```
