### PR TITLE
[NewIR] add stop_gradient attribute for defining op

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -320,10 +320,6 @@ std::vector<ir::OpResult> OpTranscriber::GenerateOperationInput(
 
   std::set<std::string> yaml_input_set;
   for (const auto& info : input_infos) {
-    if (auto special_handler = this->GetSpecialInputHandlers(info.name)) {
-      continue;
-    }
-
     std::string legacy_input_name =
         op_normalizer.GetLegacyArgName(op_desc.Type(), info.name);
 
@@ -371,7 +367,6 @@ std::vector<ir::OpResult> OpTranscriber::GenerateOperationInput(
 
     std::vector<std::string> legacy_input_vars;
     // return empty OpResult if this arg is optional and not shown in OpDesc
-    // TODO(lyk): HasInput doesnot consider variadic attribute
     if (op_desc.HasInput(legacy_input_name, true)) {
       legacy_input_vars = op_desc.Input(legacy_input_name, true);
     }
@@ -428,6 +423,10 @@ std::vector<ir::OpResult> OpTranscriber::GenerateOperationInput(
 
     // if src type is Tensor
     if (!is_vector) {
+      IR_ENFORCE(legacy_input_vars.size() == 1u,
+                 "Input %s not found when parsing op %s",
+                 info.name,
+                 op_desc.Type());
       auto defining_info = (*param_map)[legacy_input_vars[0]];
       op_inputs.push_back(defining_info.value);
 

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -222,7 +222,7 @@ void ProgramTranslator::SetStopGradientAttributeForAllValue(
             << " from: " << defining_op->name();
     std::vector<ir::Attribute> stop_gradients;
     if (defining_op->HasAttribute(kAttrStopGradients)) {
-      stop_gradients = defining_op->GetAttribute(kAttrStopGradients)
+      stop_gradients = defining_op->attribute(kAttrStopGradients)
                            .dyn_cast<ir::ArrayAttribute>()
                            .data();
     } else {
@@ -231,11 +231,9 @@ void ProgramTranslator::SetStopGradientAttributeForAllValue(
     }
     stop_gradients[value.GetResultIndex()] =
         ir::BoolAttribute::get(ctx_, var->StopGradient());
-    defining_op->SetAttribute(kAttrStopGradients,
-                              ir::ArrayAttribute::get(ctx_, stop_gradients));
+    defining_op->set_attribute(kAttrStopGradients,
+                               ir::ArrayAttribute::get(ctx_, stop_gradients));
   }
-
-  // Note(lyk): Do we need to set `stop gradient` for every operation?
 }
 
 }  // namespace translator

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -24,6 +24,7 @@
 #include "paddle/fluid/ir_adaptor/translator/type_translator.h"
 #include "paddle/ir/core/attribute.h"
 #include "paddle/ir/core/block.h"
+#include "paddle/ir/core/builtin_attribute.h"
 #include "paddle/ir/core/builtin_op.h"
 #include "paddle/ir/core/builtin_type.h"
 #include "paddle/ir/core/enforce.h"
@@ -38,16 +39,18 @@ using ProgramDesc = ::paddle::framework::ProgramDesc;
 using BlockDesc = ::paddle::framework::BlockDesc;
 using VarDesc = ::paddle::framework::VarDesc;
 
+const std::unordered_set<std::string> ProgramTranslator::no_cast_var_names = {
+    "feed",
+    "fetch",
+};
+
+constexpr char kAttrStopGradients[] = "stop_gradient";
+
 ProgramTranslator::ProgramTranslator(const ProgramDesc* legacy_program,
                                      ir::Program* program)
     : legacy_program_(legacy_program), program_(program) {
   ctx_ = ir::IrContext::Instance();
 }
-
-const std::unordered_set<std::string> ProgramTranslator::no_cast_var_names = {
-    "feed",
-    "fetch",
-};
 
 void ProgramTranslator::Translate() {
   PADDLE_ENFORCE_EQ(
@@ -70,6 +73,11 @@ void ProgramTranslator::Translate() {
   for (size_t block_idx = 0; block_idx < legacy_program_->Size(); block_idx++) {
     const BlockDesc& block = legacy_program_->Block(block_idx);
     SetParameterFromSingleBlock(block);
+  }
+
+  for (size_t block_idx = 0; block_idx < legacy_program_->Size(); block_idx++) {
+    const BlockDesc& block = legacy_program_->Block(block_idx);
+    SetStopGradientAttributeForAllValue(block);
   }
 }
 
@@ -196,6 +204,38 @@ void ProgramTranslator::SetParameterFromSingleBlock(const BlockDesc& block) {
       }
     }
   }
+}
+
+void ProgramTranslator::SetStopGradientAttributeForAllValue(
+    const BlockDesc& block) {
+  // Currently we set stop gradient for operation that generated a value
+  // connected with VarDesc
+  for (const auto& [var_name, value_info] : param_map_) {
+    VLOG(10) << "[op translated][stop gradient]" << var_name;
+    VarDesc* var = block.FindVarRecursive(var_name);
+    if (var == nullptr) {
+      continue;
+    }
+    ir::OpResult value = value_info.value;
+    auto* defining_op = value.owner();
+    VLOG(8) << "[op translated][stop gradient]" << var_name
+            << " from: " << defining_op->name();
+    std::vector<ir::Attribute> stop_gradients;
+    if (defining_op->HasAttribute(kAttrStopGradients)) {
+      stop_gradients = defining_op->GetAttribute(kAttrStopGradients)
+                           .dyn_cast<ir::ArrayAttribute>()
+                           .data();
+    } else {
+      stop_gradients = std::vector<ir::Attribute>(
+          defining_op->num_results(), ir::BoolAttribute::get(ctx_, false));
+    }
+    stop_gradients[value.GetResultIndex()] =
+        ir::BoolAttribute::get(ctx_, var->StopGradient());
+    defining_op->SetAttribute(kAttrStopGradients,
+                              ir::ArrayAttribute::get(ctx_, stop_gradients));
+  }
+
+  // Note(lyk): Do we need to set `stop gradient` for every operation?
 }
 
 }  // namespace translator

--- a/paddle/fluid/ir_adaptor/translator/program_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.h
@@ -72,12 +72,13 @@ class ProgramTranslator {
   /// 2. "fetch", the output variable of fetch op
   /// However, new feed has no input and new fetch has no output
   /// So we don't handle these two vairables when
-  /// `ExtractParameterFromSingleBlock`
+  /// `Get/SetParameterFromSingleBlock`
   static const std::unordered_set<std::string> no_cast_var_names;
 
   void GetParameterForSingleBlock(const BlockDesc& block);
   void InsertOperationToSingleBlock(const BlockDesc& block);
   void SetParameterFromSingleBlock(const BlockDesc& block);
+  void SetStopGradientAttributeForAllValue(const BlockDesc& block);
 };
 
 }  // namespace translator

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -205,6 +205,15 @@ std::string Operation::name() const {
   return p_name ? p_name : "";
 }
 
+Attribute Operation::attribute(const std::string &key) const {
+  IR_ENFORCE(HasAttribute(key),
+             "operation(%s)%x: no attribute %s",
+             name(),
+             static_cast<void *>(this),
+             key);
+  return attributes_.at(key);
+}
+
 Region *Operation::GetParentRegion() const {
   return parent_ ? parent_->GetParent() : nullptr;
 }

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -206,11 +206,7 @@ std::string Operation::name() const {
 }
 
 Attribute Operation::attribute(const std::string &key) const {
-  IR_ENFORCE(HasAttribute(key),
-             "operation(%s)%x: no attribute %s",
-             name(),
-             static_cast<void *>(this),
-             key);
+  IR_ENFORCE(HasAttribute(key), "operation(%s): no attribute %s", name(), key);
   return attributes_.at(key);
 }
 

--- a/paddle/ir/core/operation.h
+++ b/paddle/ir/core/operation.h
@@ -64,13 +64,11 @@ class IR_API alignas(8) Operation final {
 
   const AttributeMap &attributes() const { return attributes_; }
 
-  void SetAttribute(const std::string &key, Attribute value) {
+  void set_attribute(const std::string &key, Attribute value) {
     attributes_[key] = value;
   }
 
-  Attribute GetAttribute(const std::string &key) const {
-    return attributes_.at(key);
-  }
+  Attribute attribute(const std::string &key) const;
 
   bool HasAttribute(const std::string &key) const {
     return attributes_.find(key) != attributes_.end();

--- a/paddle/ir/core/operation.h
+++ b/paddle/ir/core/operation.h
@@ -68,6 +68,14 @@ class IR_API alignas(8) Operation final {
     attributes_[key] = value;
   }
 
+  Attribute GetAttribute(const std::string &key) const {
+    return attributes_.at(key);
+  }
+
+  bool HasAttribute(const std::string &key) const {
+    return attributes_.find(key) != attributes_.end();
+  }
+
   ir::OpInfo info() const { return info_; }
 
   uint32_t num_results() const { return num_results_; }

--- a/test/cpp/ir/core/ir_op_test.cc
+++ b/test/cpp/ir/core/ir_op_test.cc
@@ -274,6 +274,6 @@ TEST(op_test, module_op_death) {
   EXPECT_EQ(program.module_op().program(), &program);
   EXPECT_EQ(program.module_op().ir_context(), ctx);
 
-  program.module_op()->SetAttribute("program",
-                                    ir::PointerAttribute::get(ctx, &program));
+  program.module_op()->set_attribute("program",
+                                     ir::PointerAttribute::get(ctx, &program));
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
After this op, the attribute `stop_attribute` of VarDesc will be introduced as the attribute of the defining op of the corresponding value.
The operation will be like:
```
(%432, %433, %434, %435, %436, %437) = "pd.batch_norm" (%431, %2, %4, %3, %1) {stop_gradient:array[0,1,1,1,1,1],trainable_statistics:0,use_global_stats:0,data_layout:NCHW,epsilon:1e-05,momentum:0.9,is_test:0} : (tensor<-1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> tensor<-1x64x112x112xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<64xf32>, tensor<-1xf32>
(%438) = "pd.relu" (%432) {stop_gradient:array[0]} : (tensor<-1x64x112x112xf32>) -> tensor<-1x64x112x112xf32>
```

**However, it should be noted that not all operation will have a `stop_attribute` currently.**

#### Others
Pcard-67164 