### PR TITLE
Fix UT: Try fixing test_the_one_ps and test_communicator_geo

### DIFF
--- a/test/legacy_test/run_server_for_communicator_geo.py
+++ b/test/legacy_test/run_server_for_communicator_geo.py
@@ -1,34 +1,37 @@
-import sys
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
-import time
-import threading
-import subprocess
-import unittest
-import numpy
+from test_communicator_geo import TestCommunicatorGeoEnd2End
 
 import paddle
-import paddle.fluid as fluid
-
-from paddle.distributed.communicator import Communicator
-import paddle.incubate.distributed.fleet.role_maker as role_maker
-from paddle.incubate.distributed.fleet.parameter_server.mode import DistributedMode
-import paddle.distributed.fleet as fleet
-
-from test_communicator_geo import TestCommunicatorGeoEnd2End
 
 paddle.enable_static()
 
 pipe_name = os.getenv("PIPE_FILE")
 
+
 class RunServer(TestCommunicatorGeoEnd2End):
     def runTest(self):
         pass
+
 
 os.environ["TRAINING_ROLE"] = "PSERVER"
 
 half_run_server = RunServer()
 with open(pipe_name, 'w') as pipe:
     pipe.write('done')
-    
+
 half_run_server.run_ut()

--- a/test/legacy_test/run_server_for_communicator_geo.py
+++ b/test/legacy_test/run_server_for_communicator_geo.py
@@ -1,0 +1,34 @@
+import sys
+import os
+
+import time
+import threading
+import subprocess
+import unittest
+import numpy
+
+import paddle
+import paddle.fluid as fluid
+
+from paddle.distributed.communicator import Communicator
+import paddle.incubate.distributed.fleet.role_maker as role_maker
+from paddle.incubate.distributed.fleet.parameter_server.mode import DistributedMode
+import paddle.distributed.fleet as fleet
+
+from test_communicator_geo import TestCommunicatorGeoEnd2End
+
+paddle.enable_static()
+
+pipe_name = os.getenv("PIPE_FILE")
+
+class RunServer(TestCommunicatorGeoEnd2End):
+    def runTest(self):
+        pass
+
+os.environ["TRAINING_ROLE"] = "PSERVER"
+
+half_run_server = RunServer()
+with open(pipe_name, 'w') as pipe:
+    pipe.write('done')
+    
+half_run_server.run_ut()

--- a/test/legacy_test/test_communicator_geo.py
+++ b/test/legacy_test/test_communicator_geo.py
@@ -25,9 +25,9 @@ from paddle import fluid
 from paddle.distributed import fleet
 from paddle.distributed.fleet.base import role_maker
 from paddle.distributed.utils.launch_utils import find_free_ports
+import tempfile
 
 paddle.enable_static()
-
 
 class TestCommunicatorGeoEnd2End(unittest.TestCase):
     def net(self):
@@ -124,51 +124,22 @@ class TestCommunicatorGeoEnd2End(unittest.TestCase):
             self.run_pserver(role, strategy)
 
     def test_communicator(self):
-        run_server_cmd = """
-
-import sys
-import os
-
-import time
-import threading
-import subprocess
-import unittest
-import numpy
-
-import paddle
-import paddle.fluid as fluid
-
-from paddle.distributed.communicator import Communicator
-import paddle.incubate.distributed.fleet.role_maker as role_maker
-from paddle.incubate.distributed.fleet.parameter_server.mode import DistributedMode
-import paddle.distributed.fleet as fleet
-
-from test_communicator_geo import TestCommunicatorGeoEnd2End
-
-paddle.enable_static()
-
-class RunServer(TestCommunicatorGeoEnd2End):
-    def runTest(self):
-        pass
-
-os.environ["TRAINING_ROLE"] = "PSERVER"
-
-half_run_server = RunServer()
-half_run_server.run_ut()
-"""
-
-        server_file = "run_server_for_communicator_geo.py"
-        with open(server_file, "w") as wb:
-            wb.write(run_server_cmd)
+        temp_dir = tempfile.TemporaryDirectory()
+        pipe_name = os.path.join(temp_dir.name, 'mypipe')
+        try:
+            os.mkfifo(pipe_name)
+        except OSError as oe:
+            print(f"Failed to create pipe: {oe}")
 
         port = find_free_ports(1).pop()
 
         os.environ["TRAINING_ROLE"] = "PSERVER"
         os.environ["PADDLE_PORT"] = str(port)
         os.environ["PADDLE_PSERVERS_IP_PORT_LIST"] = f"127.0.0.1:{port}"
+        os.environ["PIPE_FILE"] = pipe_name
 
         _python = sys.executable
-
+        server_file = "run_server_for_communicator_geo.py"
         ps_cmd = f"{_python} {server_file}"
 
         ps_proc = subprocess.Popen(
@@ -177,7 +148,8 @@ half_run_server.run_ut()
             stderr=subprocess.PIPE,
         )
 
-        time.sleep(5)
+        with open(pipe_name, 'r') as pipe:
+            start_command = pipe.read()
 
         os.environ["TRAINING_ROLE"] = "TRAINER"
 
@@ -185,9 +157,6 @@ half_run_server.run_ut()
         ps_proc.kill()
         ps_proc.wait()
         outs, errs = ps_proc.communicate()
-
-        if os.path.exists(server_file):
-            os.remove(server_file)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_communicator_geo.py
+++ b/test/legacy_test/test_communicator_geo.py
@@ -15,7 +15,7 @@
 import os
 import subprocess
 import sys
-import time
+import tempfile
 import unittest
 
 import numpy
@@ -25,9 +25,9 @@ from paddle import fluid
 from paddle.distributed import fleet
 from paddle.distributed.fleet.base import role_maker
 from paddle.distributed.utils.launch_utils import find_free_ports
-import tempfile
 
 paddle.enable_static()
+
 
 class TestCommunicatorGeoEnd2End(unittest.TestCase):
     def net(self):

--- a/test/ps/CMakeLists.txt
+++ b/test/ps/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
   list(APPEND TEST_OPS ${TEST_OP})
-  set_tests_properties(${TEST_OP} PROPERTIES TIMEOUT 50)
+  set_tests_properties(${TEST_OP} PROPERTIES TIMEOUT 120)
 endforeach()
 
 if(WITH_HETERPS AND NOT WITH_PSLIB)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description


#### `test_the_one_ps`

The `test_the_one_ps` test currently takes about 40 seconds to run on a V100 machine, just 10 seconds short of the existing 50-second timeout. To maintain the stability of our CI pipeline and accommodate any unexpected increases in execution time, it's recommended to extend this timeout.

```
677: [2023-07-07 05:13:39,322] [    INFO] launch_utils.py:1589 - Please check servers, workers, coordinator and heter_worker logs in ./ps_log/geo_cpu_log_new_the_one_ps/workerlog.*, ./ps_log/geo_cpu_log_new_the_one_ps/serverlog.* , ./ps_log/geo_cpu_log_new_the_one_ps/coordinatorlog.*, and ./ps_log/geo_cpu_log_new_the_one_ps/heterlog.*
677: INFO 2023-07-07 05:13:39,322 launch_utils.py:1589] Please check servers, workers, coordinator and heter_worker logs in ./ps_log/geo_cpu_log_new_the_one_ps/workerlog.*, ./ps_log/geo_cpu_log_new_the_one_ps/serverlog.* , ./ps_log/geo_cpu_log_new_the_one_ps/coordinatorlog.*, and ./ps_log/geo_cpu_log_new_the_one_ps/heterlog.*
677: [2023-07-07 05:13:43,790] [    INFO] launch_utils.py:1606 - all workers exit, going to finish parameter server and heter_worker.
677: INFO 2023-07-07 05:13:43,790 launch_utils.py:1606] all workers exit, going to finish parameter server and heter_worker.
677: [2023-07-07 05:13:43,790] [    INFO] launch_utils.py:1619 - all parameter server are killed
677: INFO 2023-07-07 05:13:43,790 launch_utils.py:1619] all parameter server are killed
1/1 Test #677: test_the_one_ps ..................   Passed   40.52 sec
The following tests passed:
        test_the_one_ps
100% tests passed, 0 tests failed out of 1
Total Test time (real) =  40.62 sec
```

#### `test_communicator_geo`

The `test_communicator_geo`  has demonstrated instability, resulting in occasional failures on our CI machine. This error message indicates an issue originating from the brpc library.

```
I0711 05:45:20.761823 290519 brpc_ps_client.cc:196] Client connect success:192.168.128.6:8500,
E0711 05:45:20.762519 290980 brpc_ps_client.cc:383] request cmd_id:11 failed, err:[E111]Fail to connect Socket{id=113 addr=127.0.0.1:60497} (0x0x7f8a4003c3d0): Connection refused [R1][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R2][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R3][E112]Not connected to 127.0.0.1:60497 yet, server_id=0
E0711 05:45:20.762640 290975 brpc_ps_client.cc:383] request cmd_id:25 failed, err:[E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R1][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R2][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R3][E112]Not connected to 127.0.0.1:60497 yet, server_id=0
I0711 05:45:20.762805 290519 communicator.cc:1142] InitSparse: embedding, 0
E0711 05:45:20.763376 290969 brpc_ps_client.cc:383] request cmd_id:26 failed, err:[E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R1][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R2][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R3][E112]Not connected to 127.0.0.1:60497 yet, server_id=0
E0711 05:45:20.763497 290982 brpc_ps_client.cc:383] request cmd_id:25 failed, err:[E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R1][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R2][E112]Not connected to 127.0.0.1:60497 yet, server_id=0 [R3][E112]Not connected to 127.0.0.1:60497 yet, server_id=0
test_communicator_geo failed
```

To rectify this situation, two potential fixes are proposed:

1. Currently, the unit test generates and executes a Python script at runtime using a subprocess. This is a peculiar practice since the script remains static. A simpler approach would be to pre-write the script and store it in the directory.
2. The `time.sleep(5)` command is suspected to be the source of the occasional failures on the CI machine. It's possible that this pause doesn't consistently provide sufficient time for necessary processes to complete, thereby leading to sporadic issues. To improve this, we can utilize a FIFO approach as an IPC to synchronize the two Python processes, implemented through the tempfile library.

Please review these suggested fixes to determine if they are appropriate and can be implemented to improve the stability of `test_communicator_geo`.
