### PR TITLE
[IR] Add op compat info for grad op

### DIFF
--- a/paddle/fluid/ir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/ir/dialect/op_generator/op_gen.py
@@ -137,6 +137,14 @@ DEFINE_OP_TYPE_ID = """
 IR_DEFINE_EXPLICIT_TYPE_ID({op_name})
 """
 
+scalar_type_maps = {
+    'int': 'ir::Int32Attribute',
+    'int64_t': 'ir::Int64Attribute',
+    'float': 'ir::FloatAttribute',
+    'dobule': 'ir::DoubleAttribute',
+    'bool': 'ir::BoolAttribute',
+}
+
 
 def to_phi_and_fluid_op_name(op_item):
     # Templat: - op : phi_name (fluid_name)
@@ -150,13 +158,14 @@ def to_phi_and_fluid_op_name(op_item):
         return phi_name, fluid_name
 
 
-scalar_type_maps = {
-    'int': 'ir::Int32Attribute',
-    'int64_t': 'ir::Int64Attribute',
-    'float': 'ir::FloatAttribute',
-    'dobule': 'ir::DoubleAttribute',
-    'bool': 'ir::BoolAttribute',
-}
+def to_phi_and_fluid_grad_op_name(op_item):
+    # Templat: sum_grad (reduce_sum_grad), sum_double_grad
+    rtn = []
+    all_names = op_item.split(', ')
+    for name in all_names:
+        backward_phi_name, backward_fluid_name = to_phi_and_fluid_op_name(name)
+        rtn.append([backward_phi_name, backward_fluid_name])
+    return rtn
 
 
 # =====================================
@@ -170,9 +179,16 @@ class OpCompatParser:
 
     def get_compat(self, op_name):
         for compat in self.ops_compat:
-            phi_name, fluid_name = to_phi_and_fluid_op_name(compat['op'])
-            if op_name == phi_name:
+            forward_phi_name, forward_fluid_name = to_phi_and_fluid_op_name(
+                compat['op']
+            )
+            if op_name == forward_phi_name:
                 return compat
+            elif 'backward' in compat.keys():
+                bkw_names = to_phi_and_fluid_grad_op_name(compat['backward'])
+                for name in bkw_names:
+                    if op_name == name[0]:
+                        return compat
         return None
 
 

--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -114,17 +114,17 @@ def OpNameNormalizerInitialization(
             insert_new_mutable_attributes(
                 legacy_name, op_compat_item["int_array"]
             )
+            for backward_op in legacy_backward_op_names:
+                insert_new_mutable_attributes(
+                    backward_op, op_compat_item["int_array"]
+                )
 
         if "scalar" in op_compat_item:
             insert_new_mutable_attributes(legacy_name, op_compat_item["scalar"])
-
-        if "int_array" in op_compat_item:
-            insert_new_mutable_attributes(
-                legacy_name, op_compat_item["int_array"]
-            )
-
-        if "scalar" in op_compat_item:
-            insert_new_mutable_attributes(legacy_name, op_compat_item["scalar"])
+            for backward_op in legacy_backward_op_names:
+                insert_new_mutable_attributes(
+                    backward_op, op_compat_item["scalar"]
+                )
 
     # special op mappings
     op_name_mappings["fetch_v2"] = "fetch"

--- a/test/cpp/ir/core/program_translator_test.cc
+++ b/test/cpp/ir/core/program_translator_test.cc
@@ -56,14 +56,13 @@ TEST(PaddleDialectTest, MainProgram) {
   ctx->GetOrRegisterDialect<ir::BuiltinDialect>();
   auto program = paddle::TranslateLegacyProgramToProgram(p);
 
-  size_t op_size = program->block()->size();
-  // ops.size() = op size in BlockDesc + get_parameter_op + combine op + int
-  // array op + full op
   std::stringstream ss;
   program->Print(ss);
 
-  // EXPECT_EQ(op_size,
-  //           p.Block(0).OpSize() + program->parameters_num() + 20 + 5 + 9);
+  // ops.size() = op size in BlockDesc + get_parameter_op + combine op + int
+  // array op + full op (Note: p already has a full)
+  EXPECT_EQ(program->block()->size(),
+            p.Block(0).OpSize() + program->parameters_num() + 20 + 5 + 8);
   EXPECT_GT(ss.str().size(), 0u);
 }
 

--- a/test/cpp/ir/core/program_translator_test.cc
+++ b/test/cpp/ir/core/program_translator_test.cc
@@ -59,11 +59,11 @@ TEST(PaddleDialectTest, MainProgram) {
   size_t op_size = program->block()->size();
   // ops.size() = op size in BlockDesc + get_parameter_op + combine op + int
   // array op + full op
-  EXPECT_EQ(op_size,
-            p.Block(0).OpSize() + program->parameters_num() + 20 + 3 + 8);
-
   std::stringstream ss;
   program->Print(ss);
+
+  // EXPECT_EQ(op_size,
+  //           p.Block(0).OpSize() + program->parameters_num() + 20 + 5 + 9);
   EXPECT_GT(ss.str().size(), 0u);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
在新 IR 算子定义中，为反向算子附加 op_compat 信息

### Other
Pcard-67164
