### PR TITLE
Fix setitem error in static mode

### DIFF
--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -821,14 +821,15 @@ def _setitem_impl_(var, item, value):
         inplace_map={"Input": "Out"},
     )
 
-    # map var to the new output
-    from paddle.jit.dy2static.program_translator import (
-        ProgramTranslator,
-    )
+    if not paddle.in_dynamic_mode():
+        # map var to the new output
+        from paddle.jit.dy2static.program_translator import (
+            ProgramTranslator,
+        )
 
-    ProgramTranslator.get_instance()._params_map.add(
-        cur_block.program, var.desc.id(), output
-    )
+        ProgramTranslator.get_instance()._params_map.add(
+            cur_block.program, var.desc.id(), output
+        )
 
     return output
 

--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -21,9 +21,6 @@ import warnings
 
 MAX_INTEGER = 2**31 - 1
 
-# map var to the new output
-var_dict = {}
-
 
 def is_list_tuple(index, contain_type):
     def _is_list_tuple(item):
@@ -825,7 +822,13 @@ def _setitem_impl_(var, item, value):
     )
 
     # map var to the new output
-    var_dict[var.desc.id()] = output
+    from paddle.jit.dy2static.program_translator import (
+        ProgramTranslator,
+    )
+
+    ProgramTranslator.get_instance()._params_map.add(
+        cur_block.program, var.desc.id(), output
+    )
 
     return output
 

--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -21,6 +21,9 @@ import warnings
 
 MAX_INTEGER = 2**31 - 1
 
+# map var to the new output
+var_dict = {}
+
 
 def is_list_tuple(index, contain_type):
     def _is_list_tuple(item):
@@ -807,17 +810,24 @@ def _setitem_impl_(var, item, value):
 
     if paddle.in_dynamic_mode():
         var._bump_inplace_version()
+        output = var
+    else:
+        helper = paddle.fluid.layer_helper.LayerHelper('set_value', **locals())
+        output = helper.create_variable_for_type_inference(dtype=var.dtype)
 
     cur_block = default_main_program().current_block()
     cur_block.append_op(
         type="set_value",
         inputs=inputs,
-        outputs={'Out': var},
+        outputs={'Out': output},
         attrs=attrs,
         inplace_map={"Input": "Out"},
     )
 
-    return var
+    # map var to the new output
+    var_dict[var.desc.id()] = output
+
+    return output
 
 
 # the item is a tensor of bool

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -23,6 +23,7 @@ from paddle.fluid.dygraph.base import (
 from paddle.fluid.framework import Variable, core
 from paddle.fluid.layers import control_flow
 from paddle.fluid.layers.control_flow import while_loop
+from paddle.fluid.variable_index import var_dict
 
 from .utils import (
     RETURN_NO_VALUE_VAR_NAME,
@@ -48,6 +49,11 @@ def convert_load(x):
         TODO:(@xiongkun) may run convert_load in dygraph mode, which should be fixed.
         """
         return _convert_into_variable(x)
+
+    # map var to the new output
+    if isinstance(x, paddle.fluid.framework.Variable):
+        if x.desc.id() in var_dict.keys():
+            return var_dict[x.desc.id()]
     return x
 
 

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -50,7 +50,7 @@ def convert_load(x):
         return _convert_into_variable(x)
 
     # get the new output of the var
-    if isinstance(x, Variable):
+    if in_declarative_mode() and isinstance(x, Variable):
         cur_block = default_main_program().current_block()
 
         from paddle.jit.dy2static.program_translator import ProgramTranslator

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1147,13 +1147,6 @@ class ParametersMap:
             return params[id]
         return None
 
-    def pop(self, program):
-        params = self.params_dict.get(self._program_hash(program))
-        if params is None:
-            return []
-        del self.params_dict[self._program_hash(program)]
-        return list(params)
-
     def _program_hash(self, program):
         """
         because program is not deleted while calling from_func_spec.

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1125,6 +1125,43 @@ class ParametersRecorder:
         return id(program)
 
 
+class ParametersMap:
+    def __init__(self):
+        self.params_dict = {}
+
+    @synchronized
+    def add(self, program, id, param):
+        """use the default_program as key, append param the parameter list."""
+        key = self._program_hash(program)
+        if key not in self.params_dict:
+            self.params_dict[key] = {}
+
+        params = self.params_dict[key]
+        params[id] = param
+
+    def get(self, program, id):
+        params = self.params_dict.get(self._program_hash(program))
+        if params is None:
+            return None
+        if id in params.keys():
+            return params[id]
+        return None
+
+    def pop(self, program):
+        params = self.params_dict.get(self._program_hash(program))
+        if params is None:
+            return []
+        del self.params_dict[self._program_hash(program)]
+        return list(params)
+
+    def _program_hash(self, program):
+        """
+        because program is not deleted while calling from_func_spec.
+        so it's ok to use id(program)
+        """
+        return id(program)
+
+
 class FallbackProgramLayer:
     __slots__ = [
         '_instance',
@@ -1386,6 +1423,7 @@ class ProgramTranslator:
         self._initialized = True
         self._program_cache = ProgramCache()
         self._params_recorder = ParametersRecorder()
+        self._params_map = ParametersMap()
         self.enable_to_static = True
 
     def enable(self, enable_to_static):

--- a/test/dygraph_to_static/test_setitem.py
+++ b/test/dygraph_to_static/test_setitem.py
@@ -31,7 +31,7 @@ class TestSetItemBase(unittest.TestCase):
 
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[:, 2] = x[:, 2] + 99
             return y
 
@@ -59,7 +59,7 @@ class TestSetItemBase(unittest.TestCase):
 class TestCase1(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[2] = x[2] + 99  # (2, )
             return y
 
@@ -69,7 +69,7 @@ class TestCase1(TestSetItemBase):
 class TestCase2(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[:] = x[:] + 99  # slice(None,None,None)
             return y
 
@@ -79,7 +79,7 @@ class TestCase2(TestSetItemBase):
 class TestCase3(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[1::2] = x[1::2] + 99  # slice(1,None,2)
             return y
 
@@ -89,7 +89,7 @@ class TestCase3(TestSetItemBase):
 class TestCase4(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[1, 2] = x[1, 2] + 99  # (1, 2)
             return y
 
@@ -99,7 +99,7 @@ class TestCase4(TestSetItemBase):
 class TestCase5(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[[1, 2], [2, 3]] = x[[1, 2], [2, 3]] + 99  # ([1,2],[2,3])
             return y
 
@@ -109,7 +109,7 @@ class TestCase5(TestSetItemBase):
 class TestCase6(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[1, :, 3] = x[1, :, 3] + 99  # slice(None,None,None),3)
             return y
 
@@ -119,7 +119,7 @@ class TestCase6(TestSetItemBase):
 class TestCase7(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             y[1, ..., 2] = x[1, ..., 2] + 99  # (1, ..., 2)
             return y
 
@@ -129,7 +129,7 @@ class TestCase7(TestSetItemBase):
 class TestCase8(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             index = paddle.to_tensor([1, 2], dtype="int64")
             y[index] = x[index] + 99  # Tensor([1,2])
             return y
@@ -140,7 +140,7 @@ class TestCase8(TestSetItemBase):
 class TestCase9(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 99
+            y = x + 1
             one = paddle.to_tensor(1, dtype="int64")
             two = paddle.to_tensor(2, dtype="int64")
             y[one, :, :, 2] = x[1, :, :, two] + 99  # Tensor([1]), Tensor([2])

--- a/test/dygraph_to_static/test_setitem.py
+++ b/test/dygraph_to_static/test_setitem.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestSetItemBase(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+
+    def init_data(self):
+        paddle.seed(2023)
+        x = paddle.randn([4, 8, 16, 32])
+        x.stop_gradient = False
+        return x
+
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[:, 2] = x[:, 2] + 1
+            return y
+
+        return foo
+
+    def test_case(self):
+        func = self.init_func()
+        dy_res = self.run_dygrah(func)
+        st_res = self.run_to_static(func)
+
+        for dy_out, st_out in zip(dy_res, st_res):
+            np.testing.assert_allclose(dy_out.numpy(), st_out.numpy())
+
+    def run_dygrah(self, func):
+        x = self.init_data()
+        y = func(x)
+        x_grad = paddle.grad(y, x)[0]
+        return y, x_grad
+
+    def run_to_static(self, func):
+        func = paddle.jit.to_static(func)
+        return self.run_dygrah(func)
+
+
+class TestCase1(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[2] = x[2] + 1  # (2, )
+            return y
+
+        return foo
+
+
+class TestCase2(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[:] = x[:] + 1  # slice(None,None,None)
+            return y
+
+        return foo
+
+
+class TestCase3(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[1::2] = x[1::2] + 1  # slice(1,None,2)
+            return y
+
+        return foo
+
+
+class TestCase4(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[1, 2] = x[1, 2] + 1  # (1, 2)
+            return y
+
+        return foo
+
+
+class TestCase5(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[[1, 2], [2, 3]] = x[[1, 2], [2, 3]] + 1  # ([1,2],[2,3])
+            return y
+
+        return foo
+
+
+class TestCase6(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[1, :, 3] = x[1, :, 3] + 1  # slice(None,None,None),3)
+            return y
+
+        return foo
+
+
+class TestCase7(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            y[1, ..., 2] = x[1, ..., 2] + 1  # (1, ..., 2)
+            return y
+
+        return foo
+
+
+class TestCase8(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            index = paddle.to_tensor([1, 2], dtype="int64")
+            y[index] = x[index] + 1  # Tensor([1,2])
+            return y
+
+        return foo
+
+
+class TestCase9(TestSetItemBase):
+    def init_func(self):
+        def foo(x):
+            y = x + 1
+            one = paddle.to_tensor([1], dtype="int64")
+            two = paddle.to_tensor([2], dtype="int64")
+            y[one, :, :, 2] = x[1, :, :, two] + 1  # Tensor([1]), Tensor([2])
+            return y
+
+        return foo
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/dygraph_to_static/test_setitem.py
+++ b/test/dygraph_to_static/test_setitem.py
@@ -31,8 +31,8 @@ class TestSetItemBase(unittest.TestCase):
 
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[:, 2] = x[:, 2] + 1
+            y = x + 99
+            y[:, 2] = x[:, 2] + 99
             return y
 
         return foo
@@ -59,8 +59,8 @@ class TestSetItemBase(unittest.TestCase):
 class TestCase1(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[2] = x[2] + 1  # (2, )
+            y = x + 99
+            y[2] = x[2] + 99  # (2, )
             return y
 
         return foo
@@ -69,8 +69,8 @@ class TestCase1(TestSetItemBase):
 class TestCase2(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[:] = x[:] + 1  # slice(None,None,None)
+            y = x + 99
+            y[:] = x[:] + 99  # slice(None,None,None)
             return y
 
         return foo
@@ -79,8 +79,8 @@ class TestCase2(TestSetItemBase):
 class TestCase3(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[1::2] = x[1::2] + 1  # slice(1,None,2)
+            y = x + 99
+            y[1::2] = x[1::2] + 99  # slice(1,None,2)
             return y
 
         return foo
@@ -89,8 +89,8 @@ class TestCase3(TestSetItemBase):
 class TestCase4(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[1, 2] = x[1, 2] + 1  # (1, 2)
+            y = x + 99
+            y[1, 2] = x[1, 2] + 99  # (1, 2)
             return y
 
         return foo
@@ -99,8 +99,8 @@ class TestCase4(TestSetItemBase):
 class TestCase5(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[[1, 2], [2, 3]] = x[[1, 2], [2, 3]] + 1  # ([1,2],[2,3])
+            y = x + 99
+            y[[1, 2], [2, 3]] = x[[1, 2], [2, 3]] + 99  # ([1,2],[2,3])
             return y
 
         return foo
@@ -109,8 +109,8 @@ class TestCase5(TestSetItemBase):
 class TestCase6(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[1, :, 3] = x[1, :, 3] + 1  # slice(None,None,None),3)
+            y = x + 99
+            y[1, :, 3] = x[1, :, 3] + 99  # slice(None,None,None),3)
             return y
 
         return foo
@@ -119,8 +119,8 @@ class TestCase6(TestSetItemBase):
 class TestCase7(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            y[1, ..., 2] = x[1, ..., 2] + 1  # (1, ..., 2)
+            y = x + 99
+            y[1, ..., 2] = x[1, ..., 2] + 99  # (1, ..., 2)
             return y
 
         return foo
@@ -129,9 +129,9 @@ class TestCase7(TestSetItemBase):
 class TestCase8(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
+            y = x + 99
             index = paddle.to_tensor([1, 2], dtype="int64")
-            y[index] = x[index] + 1  # Tensor([1,2])
+            y[index] = x[index] + 99  # Tensor([1,2])
             return y
 
         return foo
@@ -140,10 +140,10 @@ class TestCase8(TestSetItemBase):
 class TestCase9(TestSetItemBase):
     def init_func(self):
         def foo(x):
-            y = x + 1
-            one = paddle.to_tensor([1], dtype="int64")
-            two = paddle.to_tensor([2], dtype="int64")
-            y[one, :, :, 2] = x[1, :, :, two] + 1  # Tensor([1]), Tensor([2])
+            y = x + 99
+            one = paddle.to_tensor(1, dtype="int64")
+            two = paddle.to_tensor(2, dtype="int64")
+            y[one, :, :, 2] = x[1, :, :, two] + 99  # Tensor([1]), Tensor([2])
             return y
 
         return foo


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
in static mode, `__setitem__` will create a new Variable, so we have to map the origin var to the new Variable