### PR TITLE
[Bug fix] Fix the bug of test_fused_multi_transformer_op on cuda12

### DIFF
--- a/test/legacy_test/test_fused_multi_transformer_op.py
+++ b/test/legacy_test/test_fused_multi_transformer_op.py
@@ -1412,7 +1412,9 @@ class TestFusedMultiTransformerOpPreCacheStatic1(TestFusedMultiTransformerOp):
             )
 
 
-class TestFusedMultiAttentionAPIError(unittest.TestCase):
+# Starts the name of this test with 'Z' to make this test
+# run after others. If not, it will make other tests fail.
+class ZTestFusedMultiAttentionAPIError(unittest.TestCase):
     def test_errors(self):
         def test_invalid_input_dim():
             array = np.array([1.9], dtype=np.float32)
@@ -1425,7 +1427,7 @@ class TestFusedMultiAttentionAPIError(unittest.TestCase):
         self.assertRaises(ValueError, test_invalid_input_dim)
 
 
-class TestFusedMultiTransformerAPIError(unittest.TestCase):
+class ZTestFusedMultiTransformerAPIError(unittest.TestCase):
     def test_errors(self):
         def test_invalid_input_dim():
             array = np.array([], dtype=np.float32)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-67009
Fix the bug of test_fused_multi_transformer_op on cuda12. Modify the name of testAPIError unit tests to make them run after other tests. If not, other tests will fail.
