### PR TITLE
[PIR] standardize the use of value[-2].

### DIFF
--- a/paddle/cinn/hlir/framework/new_ir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/new_ir/op_lowering_impl.cc
@@ -53,9 +53,7 @@ std::vector<ir::Tensor> CollectInputTensor(
     std::vector<ir::Tensor>* func_args,
     std::unordered_map<::pir::Value, ir::Tensor>* tensor_map) {
   std::vector<ir::Tensor> tensors;
-  for (auto& operand : op->operands()) {
-    CHECK(operand);
-    auto in_value = operand.source();
+  for (auto in_value : op->operands_source()) {
     VLOG(4) << "input tensor name: " << CompatibleInfo::ValueName(in_value);
     // NOTE(Aurelius84): Need always to create placeholder for input tensor.
     ir::Tensor tensor = details::GetTensor(in_value);
@@ -72,7 +70,7 @@ std::vector<ir::Tensor> CollectInputTensor(
   return tensors;
 }
 
-void CollectOutputInfo(const ::pir::Operation* op,
+void CollectOutputInfo(::pir::Operation* op,
                        std::vector<Type>* out_types,
                        std::vector<std::vector<int>>* out_shapes) {
   auto op_results = op->results();
@@ -359,7 +357,7 @@ std::vector<ir::Expr> OpLowererImpl::LowerOps(
 
 std::vector<ir::LoweredFunc> OpLowererImpl::DoOpLower(
     std::shared_ptr<hlir::framework::OpImpl> op_impl,
-    const ::pir::Operation* op,
+    ::pir::Operation* op,
     std::unordered_map<::pir::Value, ir::Tensor>* tensor_map,
     std::vector<ir::Tensor>* op_func_arg_tensors) {
   VLOG(4) << "Do lower with Compute, op: " << op->name();

--- a/paddle/cinn/hlir/framework/new_ir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/new_ir/op_lowering_impl.h
@@ -131,7 +131,7 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
    */
   std::vector<ir::LoweredFunc> DoOpLower(
       std::shared_ptr<hlir::framework::OpImpl> op_impl,
-      const ::pir::Operation* op,
+      ::pir::Operation* op,
       std::unordered_map<::pir::Value, ir::Tensor>* tensor_map,
       std::vector<ir::Tensor>* op_func_arg_tensors);
 

--- a/paddle/cinn/hlir/framework/new_ir/utils.cc
+++ b/paddle/cinn/hlir/framework/new_ir/utils.cc
@@ -74,8 +74,7 @@ std::vector<std::string> CompatibleInfo::InputNames(const ::pir::Operation& op,
   return names;
 }
 
-std::vector<std::string> CompatibleInfo::OutputNames(
-    const ::pir::Operation& op) {
+std::vector<std::string> CompatibleInfo::OutputNames(::pir::Operation& op) {
   std::vector<std::string> names;
   for (int i = 0; i < op.num_results(); ++i) {
     auto value = op.result(i);

--- a/paddle/cinn/hlir/framework/new_ir/utils.h
+++ b/paddle/cinn/hlir/framework/new_ir/utils.h
@@ -40,7 +40,7 @@ struct CompatibleInfo {
   static std::vector<std::string> InputNames(const ::pir::Operation& op,
                                              bool allow_duplicate = false);
 
-  static std::vector<std::string> OutputNames(const ::pir::Operation& op);
+  static std::vector<std::string> OutputNames(::pir::Operation& op);  // NOLINT
 };
 
 }  // namespace newir

--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -236,10 +236,7 @@ void BindOperation(py::module *m) {
   )DOC");
   op.def("name", &Operation::name)
       .def("get_parent_block",
-           py::overload_cast<>(&Operation::GetParent),
-           return_value_policy::reference)
-      .def("get_parent_block",
-           py::overload_cast<>(&Operation::GetParent, py::const_),
+           &Operation::GetParent,
            return_value_policy::reference)
       .def("num_operands", &Operation::num_operands)
       .def("num_results", &Operation::num_results)

--- a/paddle/pir/core/block.cc
+++ b/paddle/pir/core/block.cc
@@ -90,7 +90,7 @@ void Block::AddArgument(Type type) {
 
 bool Block::TopoOrderCheck(const OpListType &op_list) {
   std::unordered_set<Value> visited_values;
-  for (const Operation *op : op_list) {
+  for (Operation *op : op_list) {
     if (op->num_operands() > 0) {
       for (size_t i = 0; i < op->num_operands(); ++i) {
         auto operand = op->operand_source(i);

--- a/paddle/pir/core/block_argument.cc
+++ b/paddle/pir/core/block_argument.cc
@@ -29,12 +29,12 @@ namespace detail {
 class BlockArgumentImpl : public ValueImpl {
  public:
   static bool classof(const ValueImpl &value) {
-    return value.kind() == BLOCK_ARGUMENT_INDEX;
+    return value.kind() == BLOCK_ARG_IDX;
   }
 
  private:
   BlockArgumentImpl(Type type, Block *owner, uint32_t index)
-      : ValueImpl(type, BLOCK_ARGUMENT_INDEX), owner_(owner), index_(index) {}
+      : ValueImpl(type, BLOCK_ARG_IDX), owner_(owner), index_(index) {}
 
   ~BlockArgumentImpl();
   // access construction and owner

--- a/paddle/pir/core/ir_printer.cc
+++ b/paddle/pir/core/ir_printer.cc
@@ -139,7 +139,7 @@ void IrPrinter::PrintOperation(Operation* op) {
   PrintGeneralOperation(op);
 }
 
-void IrPrinter::PrintGeneralOperation(const Operation* op) {
+void IrPrinter::PrintGeneralOperation(Operation* op) {
   // TODO(lyk): add API to get opresults directly
   PrintOpResult(op);
   os << " =";
@@ -160,7 +160,7 @@ void IrPrinter::PrintGeneralOperation(const Operation* op) {
   PrintOpReturnType(op);
 }
 
-void IrPrinter::PrintFullOperation(const Operation* op) {
+void IrPrinter::PrintFullOperation(Operation* op) {
   PrintGeneralOperation(op);
   if (op->num_regions() > 0) {
     os << newline;
@@ -186,7 +186,7 @@ void IrPrinter::PrintBlock(const Block* block) {
   os << "}\n";
 }
 
-void IrPrinter::PrintValue(const Value& v) {
+void IrPrinter::PrintValue(Value v) {
   if (!v) {
     os << "<<NULL VALUE>>";
     return;
@@ -204,7 +204,7 @@ void IrPrinter::PrintValue(const Value& v) {
   os << new_name;
 }
 
-void IrPrinter::PrintOpResult(const Operation* op) {
+void IrPrinter::PrintOpResult(Operation* op) {
   os << " (";
   auto num_op_result = op->num_results();
   std::vector<OpResult> op_results;
@@ -220,7 +220,7 @@ void IrPrinter::PrintOpResult(const Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintAttributeMap(const Operation* op) {
+void IrPrinter::PrintAttributeMap(Operation* op) {
   AttributeMap attributes = op->attributes();
   std::map<std::string, Attribute, std::less<std::string>> order_attributes(
       attributes.begin(), attributes.end());
@@ -239,7 +239,7 @@ void IrPrinter::PrintAttributeMap(const Operation* op) {
   os << "}";
 }
 
-void IrPrinter::PrintOpOperands(const Operation* op) {
+void IrPrinter::PrintOpOperands(Operation* op) {
   os << " (";
   auto num_op_operands = op->num_operands();
   std::vector<Value> op_operands;
@@ -255,7 +255,7 @@ void IrPrinter::PrintOpOperands(const Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintOperandsType(const Operation* op) {
+void IrPrinter::PrintOperandsType(Operation* op) {
   auto num_op_operands = op->num_operands();
   std::vector<Type> op_operand_types;
   op_operand_types.reserve(num_op_operands);
@@ -276,7 +276,7 @@ void IrPrinter::PrintOperandsType(const Operation* op) {
   os << ")";
 }
 
-void IrPrinter::PrintOpReturnType(const Operation* op) {
+void IrPrinter::PrintOpReturnType(Operation* op) {
   auto num_op_result = op->num_results();
   std::vector<Type> op_result_types;
   op_result_types.reserve(num_op_result);

--- a/paddle/pir/core/ir_printer.h
+++ b/paddle/pir/core/ir_printer.h
@@ -51,24 +51,24 @@ class IR_API IrPrinter : public BasicIrPrinter {
   /// @brief dispatch to custom printer function or PrintGeneralOperation
   void PrintOperation(Operation* op);
   /// @brief print operation itself without its regions
-  void PrintGeneralOperation(const Operation* op);
+  void PrintGeneralOperation(Operation* op);
   /// @brief print operation and its regions
-  void PrintFullOperation(const Operation* op);
+  void PrintFullOperation(Operation* op);
 
   void PrintRegion(const Region& Region);
   void PrintBlock(const Block* block);
 
-  void PrintValue(const Value& v);
+  void PrintValue(Value v);
 
-  void PrintOpResult(const Operation* op);
+  void PrintOpResult(Operation* op);
 
-  void PrintAttributeMap(const Operation* op);
+  void PrintAttributeMap(Operation* op);
 
-  void PrintOpOperands(const Operation* op);
+  void PrintOpOperands(Operation* op);
 
-  void PrintOperandsType(const Operation* op);
+  void PrintOperandsType(Operation* op);
 
-  void PrintOpReturnType(const Operation* op);
+  void PrintOpReturnType(Operation* op);
 
  private:
   size_t cur_var_number_{0};

--- a/paddle/pir/core/op_result.cc
+++ b/paddle/pir/core/op_result.cc
@@ -47,6 +47,6 @@ bool OpResult::operator==(const OpResult &other) const {
   return impl_ == other.impl_;
 }
 
-OpResult::OpResult(const detail::OpResultImpl *impl) : Value(impl) {}
+OpResult::OpResult(detail::OpResultImpl *impl) : Value(impl) {}
 
 }  // namespace pir

--- a/paddle/pir/core/op_result.h
+++ b/paddle/pir/core/op_result.h
@@ -35,7 +35,7 @@ class IR_API OpResult : public Value {
 
  private:
   friend Operation;
-  OpResult(const detail::OpResultImpl *impl);  // NOLINT
+  OpResult(detail::OpResultImpl *impl);  // NOLINT
   // Access classof annd dyn_cast_from.
   friend Value;
   static bool classof(Value value);

--- a/paddle/pir/core/op_result_impl.cc
+++ b/paddle/pir/core/op_result_impl.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/pir/core/op_result_impl.h"
-
-#include <cassert>
+#include "paddle/pir/core/operation.h"
 
 namespace pir {
 namespace detail {
@@ -22,31 +21,31 @@ uint32_t OpResultImpl::index() const {
   if (const auto *outline_result = dyn_cast<OpOutlineResultImpl>(this)) {
     return outline_result->index();
   }
-  return dyn_cast<OpInlineResultImpl>(this)->index();
+  return static_cast<const OpInlineResultImpl *>(this)->index();
 }
 
-OpResultImpl::~OpResultImpl() { assert(use_empty()); }
+OpResultImpl::~OpResultImpl() {
+  if (!use_empty()) {
+    LOG(FATAL) << "Destoryed a op_result that is still in use. \n"
+               << "The owner op type is:" << owner()->name();
+  }
+}
 
-Operation *OpResultImpl::owner() const {
+Operation *OpResultImpl::owner() {
   // For inline result, pointer offset index to obtain the address of op.
-  if (const auto *result = dyn_cast<OpInlineResultImpl>(this)) {
+  if (auto *result = dyn_cast<OpInlineResultImpl>(this)) {
     result += result->index() + 1;
-    return reinterpret_cast<Operation *>(
-        const_cast<OpInlineResultImpl *>(result));
+    return reinterpret_cast<Operation *>(result);
   }
   // For outline result, pointer offset outline_index to obtain the address of
   // maximum inline result.
-  const OpOutlineResultImpl *outline_result =
-      (const OpOutlineResultImpl *)(this);
-  outline_result +=
-      (outline_result->outline_index_ - GetMaxInlineResultIndex());
+  auto *outline_result = static_cast<OpOutlineResultImpl *>(this);
+  outline_result += (outline_result->index() - MAX_INLINE_RESULT_IDX);
   // The offset of the maximum inline result distance op is
   // GetMaxInlineResultIndex.
-  const auto *inline_result =
-      reinterpret_cast<const OpInlineResultImpl *>(outline_result);
-  inline_result += (GetMaxInlineResultIndex() + 1);
-  return reinterpret_cast<Operation *>(
-      const_cast<OpInlineResultImpl *>(inline_result));
+  auto *inline_result = reinterpret_cast<OpInlineResultImpl *>(outline_result);
+  inline_result += OUTLINE_RESULT_IDX;
+  return reinterpret_cast<Operation *>(inline_result);
 }
 
 }  // namespace detail

--- a/paddle/pir/core/op_result_impl.h
+++ b/paddle/pir/core/op_result_impl.h
@@ -26,26 +26,19 @@ class OpResultImpl : public ValueImpl {
   using ValueImpl::ValueImpl;
 
   static bool classof(const ValueImpl &value) {
-    return value.kind() <= OUTLINE_OP_RESULT_INDEX;
+    return value.kind() <= OUTLINE_RESULT_IDX;
   }
 
   ///
   /// \brief Get the parent operation of this result.(op_ptr = value_ptr +
   /// index)
   ///
-  Operation *owner() const;
+  Operation *owner();
 
   ///
   /// \brief Get the result index of the operation result.
   ///
   uint32_t index() const;
-
-  ///
-  /// \brief Get the maximum number of results that can be stored inline.
-  ///
-  static uint32_t GetMaxInlineResultIndex() {
-    return OUTLINE_OP_RESULT_INDEX - 1;
-  }
 
   ~OpResultImpl();
 };
@@ -58,13 +51,13 @@ class OpInlineResultImpl : public OpResultImpl {
  public:
   OpInlineResultImpl(Type type, uint32_t result_index)
       : OpResultImpl(type, result_index) {
-    if (result_index > GetMaxInlineResultIndex()) {
+    if (result_index > MAX_INLINE_RESULT_IDX) {
       throw("Inline result index should not exceed MaxInlineResultIndex(5)");
     }
   }
 
   static bool classof(const ValueImpl &value) {
-    return value.kind() < OUTLINE_OP_RESULT_INDEX;
+    return value.kind() < OUTLINE_RESULT_IDX;
   }
 
   uint32_t index() const { return kind(); }
@@ -77,15 +70,15 @@ class OpInlineResultImpl : public OpResultImpl {
 class OpOutlineResultImpl : public OpResultImpl {
  public:
   OpOutlineResultImpl(Type type, uint32_t outline_index)
-      : OpResultImpl(type, OUTLINE_OP_RESULT_INDEX),
-        outline_index_(outline_index) {}
+      : OpResultImpl(type, OUTLINE_RESULT_IDX), outline_index_(outline_index) {}
 
   static bool classof(const ValueImpl &value) {
-    return value.kind() == OUTLINE_OP_RESULT_INDEX;
+    return value.kind() == OUTLINE_RESULT_IDX;
   }
 
   uint32_t index() const { return outline_index_; }
 
+ private:
   uint32_t outline_index_;
 };
 

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -26,7 +26,12 @@
 #include "paddle/pir/core/utils.h"
 
 namespace pir {
-Operation *Operation::Create(OperationArgument &&argument) {
+using detail::OpInlineResultImpl;
+using detail::OpOperandImpl;
+using detail::OpOutlineResultImpl;
+using detail::OpResultImpl;
+
+Operation *Operation::Create(const OperationArgument &argument) {
   std::vector<Value> inputs;
   for (auto op_result : argument.inputs) {
     inputs.emplace_back(op_result);
@@ -53,8 +58,7 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
   uint32_t num_results = output_types.size();
   uint32_t num_operands = inputs.size();
   uint32_t num_successors = successors.size();
-  uint32_t max_inline_result_num =
-      detail::OpResultImpl::GetMaxInlineResultIndex() + 1;
+  uint32_t max_inline_result_num = MAX_INLINE_RESULT_IDX + 1;
   size_t result_mem_size =
       num_results > max_inline_result_num
           ? sizeof(detail::OpOutlineResultImpl) *
@@ -163,13 +167,11 @@ void Operation::Destroy() {
   }
 
   // 5. Free memory.
-  uint32_t max_inline_result_num =
-      detail::OpResultImpl::GetMaxInlineResultIndex() + 1;
   size_t result_mem_size =
-      num_results_ > max_inline_result_num
+      num_results_ > OUTLINE_RESULT_IDX
           ? sizeof(detail::OpOutlineResultImpl) *
-                    (num_results_ - max_inline_result_num) +
-                sizeof(detail::OpInlineResultImpl) * max_inline_result_num
+                    (num_results_ - OUTLINE_RESULT_IDX) +
+                sizeof(detail::OpInlineResultImpl) * OUTLINE_RESULT_IDX
           : sizeof(detail::OpInlineResultImpl) * num_results_;
   void *aligned_ptr = reinterpret_cast<char *>(this) - result_mem_size;
 
@@ -195,67 +197,43 @@ Operation::Operation(const AttributeMap &attributes,
       num_regions_(num_regions),
       num_successors_(num_successors) {}
 
-pir::OpResult Operation::result(uint32_t index) const {
-  if (index >= num_results_) {
-    IR_THROW("index exceeds OP output range.");
+///
+/// \brief op ouput related public interfaces implementation
+///
+std::vector<OpResult> Operation::results() {
+  std::vector<OpResult> res;
+  for (uint32_t i = 0; i < num_results(); ++i) {
+    res.push_back(result(i));
   }
-  uint32_t max_inline_idx = detail::OpResultImpl::GetMaxInlineResultIndex();
-  const char *ptr =
-      (index > max_inline_idx)
-          ? reinterpret_cast<const char *>(this) -
-                (max_inline_idx + 1) * sizeof(detail::OpInlineResultImpl) -
-                (index - max_inline_idx) * sizeof(detail::OpOutlineResultImpl)
-          : reinterpret_cast<const char *>(this) -
-                (index + 1) * sizeof(detail::OpInlineResultImpl);
-  if (index > max_inline_idx) {
-    return pir::OpResult(
-        reinterpret_cast<const detail::OpOutlineResultImpl *>(ptr));
-  } else {
-    return pir::OpResult(
-        reinterpret_cast<const detail::OpInlineResultImpl *>(ptr));
-  }
+  return res;
 }
 
-OpOperand Operation::operand(uint32_t index) const {
-  if (index >= num_operands_) {
-    IR_THROW("index exceeds OP input range.");
+///
+/// \brief op input related public interfaces
+///
+std::vector<OpOperand> Operation::operands() {
+  std::vector<OpOperand> res;
+  for (uint32_t i = 0; i < num_operands(); ++i) {
+    res.push_back(operand(i));
   }
-  const char *ptr = reinterpret_cast<const char *>(this) + sizeof(Operation) +
-                    (index) * sizeof(detail::OpOperandImpl);
-  return OpOperand(reinterpret_cast<const detail::OpOperandImpl *>(ptr));
+  return res;
 }
-
 Value Operation::operand_source(uint32_t index) const {
-  OpOperand val = operand(index);
-  return val ? val.source() : Value();
+  auto val = op_operand_impl(index);
+  return val ? val->source() : nullptr;
 }
 
-std::string Operation::name() const {
-  auto p_name = info_.name();
-  return p_name ? p_name : "";
-}
-
-Attribute Operation::attribute(const std::string &key) const {
-  IR_ENFORCE(HasAttribute(key), "operation(%s): no attribute %s", name(), key);
-  return attributes_.at(key);
-}
-
-Region *Operation::GetParentRegion() {
-  return parent_ ? parent_->GetParent() : nullptr;
-}
-
-Operation *Operation::GetParentOp() const {
-  return parent_ ? parent_->GetParentOp() : nullptr;
-}
-
-const Program *Operation::GetParentProgram() const {
-  Operation *op = const_cast<Operation *>(this);
-  while (Operation *parent_op = op->GetParentOp()) {
-    op = parent_op;
+std::vector<Value> Operation::operands_source() const {
+  std::vector<Value> res;
+  for (uint32_t i = 0; i < num_operands(); ++i) {
+    res.push_back(operand_source(i));
   }
-  ModuleOp module_op = op->dyn_cast<ModuleOp>();
-  return module_op ? module_op.program() : nullptr;
+  return res;
 }
+
+///
+/// \brief op successor related public interfaces
+///
 BlockOperand Operation::block_operand(uint32_t index) const {
   IR_ENFORCE(index < num_successors_, "Invalid block_operand index");
   return block_operands_ + index;
@@ -263,27 +241,49 @@ BlockOperand Operation::block_operand(uint32_t index) const {
 Block *Operation::successor(uint32_t index) const {
   return block_operand(index).source();
 }
-
 void Operation::set_successor(Block *block, unsigned index) {
   IR_ENFORCE(index < num_operands_, "Invalid block_operand index");
   (block_operands_ + index)->set_source(block);
 }
 
+///
+/// \brief region related public interfaces implementation
+///
 Region &Operation::region(unsigned index) {
   IR_ENFORCE(index < num_regions_, "invalid region index");
   return regions_[index];
 }
-
 const Region &Operation::region(unsigned index) const {
   IR_ENFORCE(index < num_regions_, "invalid region index");
   return regions_[index];
 }
 
+///
+/// \brief parent related public interfaces implementation
+///
+Region *Operation::GetParentRegion() const {
+  return parent_ ? parent_->GetParent() : nullptr;
+}
+Operation *Operation::GetParentOp() const {
+  return parent_ ? parent_->GetParentOp() : nullptr;
+}
+Program *Operation::GetParentProgram() {
+  auto op = this;
+  while (Operation *parent_op = op->GetParentOp()) {
+    op = parent_op;
+  }
+  ModuleOp module_op = op->dyn_cast<ModuleOp>();
+  return module_op ? module_op.program() : nullptr;
+}
 void Operation::SetParent(Block *parent, const Block::Iterator &position) {
   parent_ = parent;
   position_ = position;
 }
 
+std::string Operation::name() const {
+  auto p_name = info_.name();
+  return p_name ? p_name : "";
+}
 void Operation::ReplaceAllUsesWith(const std::vector<Value> &values) {
   IR_ENFORCE(num_results_ == values.size(),
              "the num of result should be the same.");
@@ -306,20 +306,39 @@ void Operation::Verify() {
   }
 }
 
-std::vector<OpOperand> Operation::operands() const {
-  std::vector<OpOperand> res;
-  for (uint32_t i = 0; i < num_operands(); ++i) {
-    res.push_back(operand(i));
+int32_t Operation::ComputeOpResultOffset(uint32_t index) const {
+  if (index >= num_results_) {
+    LOG(FATAL) << "index exceeds OP op result range.";
   }
-  return res;
+  if (index < OUTLINE_RESULT_IDX) {
+    return -static_cast<int32_t>((index + 1u) * sizeof(OpInlineResultImpl));
+  }
+  constexpr uint32_t anchor = OUTLINE_RESULT_IDX * sizeof(OpInlineResultImpl);
+  index = index - MAX_INLINE_RESULT_IDX;
+  return -static_cast<int32_t>(index * sizeof(OpOutlineResultImpl) + anchor);
 }
 
-std::vector<OpResult> Operation::results() const {
-  std::vector<OpResult> res;
-  for (uint32_t i = 0; i < num_results(); ++i) {
-    res.push_back(result(i));
+int32_t Operation::ComputeOpOperandOffset(uint32_t index) const {
+  if (index >= num_operands_) {
+    LOG(FATAL) << "index exceeds OP op operand range.";
   }
-  return res;
+  return static_cast<int32_t>(index * sizeof(OpOperandImpl) +
+                              sizeof(Operation));
 }
 
+#define COMPONENT_IMPL(component_lower, componnent_upper)                     \
+  componnent_upper##Impl *Operation::component_lower##_impl(uint32_t index) { \
+    int32_t offset = Compute##componnent_upper##Offset(index);                \
+    return reinterpret_cast<componnent_upper##Impl *>(                        \
+        reinterpret_cast<char *>(this) + offset);                             \
+  }                                                                           \
+  const componnent_upper##Impl *Operation::component_lower##_impl(            \
+      uint32_t index) const {                                                 \
+    int32_t offset = Compute##componnent_upper##Offset(index);                \
+    return reinterpret_cast<const componnent_upper##Impl *>(                  \
+        reinterpret_cast<const char *>(this) + offset);                       \
+  }
+
+COMPONENT_IMPL(op_result, OpResult)
+COMPONENT_IMPL(op_operand, OpOperand)
 }  // namespace pir

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -29,6 +29,11 @@ class Program;
 class OpOperand;
 class OpResult;
 
+namespace detail {
+class OpResultImpl;
+class OpOperendImpl;
+}  // namespace detail
+
 class IR_API alignas(8) Operation final {
  public:
   ///
@@ -43,8 +48,7 @@ class IR_API alignas(8) Operation final {
                            pir::OpInfo op_info,
                            size_t num_regions = 0,
                            const std::vector<Block *> &successors = {});
-  static Operation *Create(OperationArgument &&op_argument);
-
+  static Operation *Create(const OperationArgument &op_argument);
   ///
   /// \brief Destroy the operation objects and free memory by create().
   ///
@@ -54,50 +58,70 @@ class IR_API alignas(8) Operation final {
 
   Dialect *dialect() const;
 
-  OpResult result(uint32_t index) const;
-
-  OpOperand operand(uint32_t index) const;
-
-  Value operand_source(uint32_t index) const;
-
-  uint32_t num_successors() const { return num_successors_; }
-  BlockOperand block_operand(uint32_t index) const;
-  Block *successor(uint32_t index) const;
-  void set_successor(Block *block, unsigned index);
-  bool HasSuccessors() { return num_successors_ != 0; }
-
-  /// Returns the region held by this operation at position 'index'.
-  Region &region(unsigned index);
-  const Region &region(unsigned index) const;
-  uint32_t num_regions() const { return num_regions_; }
-
-  void Print(std::ostream &os);
-
+  ///
+  /// \brief op attribute related public interfaces
+  ///
+  Attribute attribute(const std::string &key) const {
+    return attributes_.at(key);
+  }
   const AttributeMap &attributes() const { return attributes_; }
-
   template <typename T>
   T attribute(const std::string &name) {
     Attribute attr = attribute(name);
     IR_ENFORCE(attr.isa<T>(), "Attribute (%s) type is not right.", name);
     return attr.dyn_cast<T>();
   }
-
   void set_attribute(const std::string &key, Attribute value) {
     attributes_[key] = value;
   }
-
-  Attribute attribute(const std::string &key) const;
-
   bool HasAttribute(const std::string &key) const {
     return attributes_.find(key) != attributes_.end();
   }
 
-  pir::OpInfo info() const { return info_; }
-
+  ///
+  /// \brief op ouput related public interfaces
+  ///
   uint32_t num_results() const { return num_results_; }
+  OpResult result(uint32_t index) { return op_result_impl(index); }
+  std::vector<OpResult> results();
 
+  ///
+  /// \brief op input related public interfaces
+  ///
   uint32_t num_operands() const { return num_operands_; }
+  OpOperand operand(uint32_t index) { return op_operand_impl(index); }
+  std::vector<OpOperand> operands();
+  Value operand_source(uint32_t index) const;
+  std::vector<Value> operands_source() const;
 
+  ///
+  /// \brief op successor related public interfaces
+  ///
+  uint32_t num_successors() const { return num_successors_; }
+  BlockOperand block_operand(uint32_t index) const;
+  Block *successor(uint32_t index) const;
+  void set_successor(Block *block, unsigned index);
+  bool HasSuccessors() { return num_successors_ != 0; }
+
+  ///
+  /// \brief region related public interfaces
+  ///
+  uint32_t num_regions() const { return num_regions_; }
+  Region &region(unsigned index);
+  const Region &region(unsigned index) const;
+
+  ///
+  /// \brief parent related public interfaces
+  ///
+  Block *GetParent() const { return parent_; }
+  Region *GetParentRegion() const;
+  Operation *GetParentOp() const;
+  Program *GetParentProgram();
+  operator Block::Iterator() { return position_; }
+  operator Block::ConstIterator() const { return position_; }
+
+  void Print(std::ostream &os);
+  pir::OpInfo info() const { return info_; }
   std::string name() const;
 
   template <typename T>
@@ -120,28 +144,6 @@ class IR_API alignas(8) Operation final {
     return info_.HasInterface<Interface>();
   }
 
-  const Block *GetParent() const { return parent_; }
-
-  Block *GetParent() {
-    return const_cast<Block *>(
-        const_cast<const Operation *>(this)->GetParent());
-  }
-
-  Region *GetParentRegion();
-
-  Operation *GetParentOp() const;
-
-  const Program *GetParentProgram() const;
-
-  Program *GetParentProgram() {
-    return const_cast<Program *>(
-        const_cast<const Operation *>(this)->GetParentProgram());
-  }
-
-  operator Block::Iterator() { return position_; }
-
-  operator Block::ConstIterator() const { return position_; }
-
   /// Replace all uses of results of this operation with the provided 'values'.
   void ReplaceAllUsesWith(const std::vector<Value> &values);
 
@@ -153,10 +155,6 @@ class IR_API alignas(8) Operation final {
 
   void Verify();
 
-  std::vector<OpOperand> operands() const;
-
-  std::vector<OpResult> results() const;
-
  private:
   DISABLE_COPY_AND_ASSIGN(Operation);
   Operation(const AttributeMap &attribute,
@@ -165,6 +163,14 @@ class IR_API alignas(8) Operation final {
             uint32_t num_operands,
             uint32_t num_regions,
             uint32_t num_successors);
+
+  int32_t ComputeOpResultOffset(uint32_t index) const;
+  detail::OpResultImpl *op_result_impl(uint32_t index);
+  const detail::OpResultImpl *op_result_impl(uint32_t index) const;
+
+  int32_t ComputeOpOperandOffset(uint32_t index) const;
+  detail::OpOperandImpl *op_operand_impl(uint32_t index);
+  const detail::OpOperandImpl *op_operand_impl(uint32_t index) const;
 
   template <typename T, typename Enabler = void>
   struct CastUtil {

--- a/paddle/pir/core/parser/ir_parser.cc
+++ b/paddle/pir/core/parser/ir_parser.cc
@@ -207,11 +207,11 @@ void IrParser::ParseBlock(Block& block) {  // NOLINT
   ConsumeAToken("}");
 }
 
-// Operation := OpResultList ":=" Opname "(" OprandList ? ")" AttributeMap ":"
+// Operation := ValueList ":=" Opname "(" OprandList ? ")" AttributeMap ":"
 // FunctionType
 // FunctionType := "(" TypeList ")"  "->" TypeList
 Operation* IrParser::ParseOperation() {
-  std::vector<std::string> opresultindex = ParseOpResultList();
+  std::vector<std::string> value_index = ParseValueList();
   ConsumeAToken("=");
 
   OpInfo opinfo = ParseOpInfo();
@@ -232,31 +232,30 @@ Operation* IrParser::ParseOperation() {
       Operation::Create(inputs, attributeMap, type_vector, opinfo, 0);
 
   for (uint32_t i = 0; i < op->num_results(); i++) {
-    std::string key_t = opresultindex[i];
-    opresultmap[key_t] = op->result(i);
+    std::string key_t = value_index[i];
+    value_map[key_t] = op->result(i);
   }
 
   return op;
 }
 
-// OpResultList := ValueList
 // ValueList := ValueId(,ValueId)*
-std::vector<std::string> IrParser::ParseOpResultList() {
-  std::vector<std::string> opresultindex{};
+std::vector<std::string> IrParser::ParseValueList() {
+  std::vector<std::string> value_index{};
   ConsumeAToken("(");
   Token index_token = ConsumeToken();
   while (index_token.val_ != ")") {
     if (index_token.token_type_ == NULL_) {
-      opresultindex.push_back("null");
+      value_index.push_back("null");
     } else {
       std::string str = index_token.val_;
-      opresultindex.push_back(str);
+      value_index.push_back(str);
     }
     if (ConsumeToken().val_ == ")") break;
     index_token = ConsumeToken();
   }
 
-  return opresultindex;
+  return value_index;
 }
 
 // OpName := "\"" StringIdentifer "." StringIdentifer "\""
@@ -279,7 +278,7 @@ std::vector<Value> IrParser::ParseOprandList() {
       inputs.emplace_back();
     } else {
       t = ind_token.val_;
-      inputs.push_back(opresultmap[t]);
+      inputs.push_back(value_map[t]);
     }
     Token token = ConsumeToken();
     if (token.val_ == ")") {

--- a/paddle/pir/core/parser/ir_parser.h
+++ b/paddle/pir/core/parser/ir_parser.h
@@ -18,7 +18,7 @@
 #include "paddle/pir/core/parser/lexer.h"
 #include "paddle/pir/core/program.h"
 
-using OpResultMap = std::map<std::string, pir::OpResult>;
+using ValueMap = std::map<std::string, pir::Value>;
 using AttributeMap = std::unordered_map<std::string, pir::Attribute>;
 using OpAttributeInfoMap = std::map<std::string, std::string>;
 
@@ -27,7 +27,7 @@ class IrParser {
  public:
   std::unique_ptr<Lexer> lexer;
   IrContext* ctx;
-  OpResultMap opresultmap;
+  ValueMap value_map;
   std::unique_ptr<Builder> builder;
 
  public:
@@ -49,7 +49,7 @@ class IrParser {
 
   OpInfo ParseOpInfo();
 
-  std::vector<std::string> ParseOpResultList();
+  std::vector<std::string> ParseValueList();
 
   std::vector<Value> ParseOprandList();
 

--- a/paddle/pir/core/value_impl.cc
+++ b/paddle/pir/core/value_impl.cc
@@ -41,9 +41,9 @@ std::string ValueImpl::PrintUdChain() {
   return result.str();
 }
 ValueImpl::ValueImpl(Type type, uint32_t kind) {
-  if (kind > BLOCK_ARGUMENT_INDEX) {
+  if (kind > BLOCK_ARG_IDX) {
     LOG(FATAL) << "The kind of value_impl(" << kind
-               << "), is bigger than BLOCK_ARGUMENT_INDEX(7)";
+               << "), is bigger than BLOCK_ARG_IDX(7)";
   }
   type_ = type;
   first_use_offseted_by_kind_ = reinterpret_cast<OpOperandImpl *>(

--- a/paddle/pir/core/value_impl.h
+++ b/paddle/pir/core/value_impl.h
@@ -17,10 +17,11 @@
 #include "paddle/pir/core/op_operand_impl.h"
 #include "paddle/pir/core/value.h"
 
-namespace pir {
-constexpr const uint32_t OUTLINE_OP_RESULT_INDEX = 6;
-constexpr const uint32_t BLOCK_ARGUMENT_INDEX = OUTLINE_OP_RESULT_INDEX + 1;
+#define OUTLINE_RESULT_IDX 6u
+#define MAX_INLINE_RESULT_IDX (OUTLINE_RESULT_IDX - 1u)
+#define BLOCK_ARG_IDX (OUTLINE_RESULT_IDX + 1u)
 
+namespace pir {
 class Operation;
 
 namespace detail {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
#### 规范化代码中对Value的使用[-2]。


Value分两种，OpResult和BlockArgument. 由于之前没有BlockArgument， 大家都是混用Value和OpResult， 现在有了BlockArguemnt, 需要区分Value和OpResult的使用。
在需要支持BlockArgument的地方，将原本的OpResult升级为Value，使其能够兼容BlockArgument的行为。

本pr内容：
- 规范整理pir::Operation中的相关接口。
  - 将pir::Operation的部分公开接口按照attribute相关、input相关、ouput相关、successor相关、region相关、parent相关等进行了分类聚集,方便阅读。
  - 规范了部分接口的函数签名。（主要是移除或增加const限定符以及移除不合理的const_cast使用。）
- 将OpResult::GetOpResultIndex接口调整为index。
- 规范pir::Parser和pir::Printer中对OpResult的使用，调整为Value。

参考pr:
- [规范化代码中对Value的使用[-1]](https://github.com/PaddlePaddle/Paddle/pull/57349)

Todo: 
- 将pir::OperationArgument::inputs_中的类型由std::vector\<pir::OpResult\>修改为std::vector\<pir::value\>。
- 将其它Dialect中相关op的Build接口的相关参数由OpResult替换成了Value。

### Other
Pcard-67164