### PR TITLE
fix bug on case with gpu driver but no gpu

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cuda_info.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_info.cc
@@ -64,7 +64,12 @@ static int GetGPUDeviceCountImpl() {
     }
   }
   int count;
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetDeviceCount(&count));
+  status = cudaGetDeviceCount(&count);
+  if (status != cudaSuccess) {
+    VLOG(2) << "You have gpu driver and cuda installed, but the machine not "
+               "has any gpu card.";
+    count = 0;
+  }
   return count;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501

case：设置了cuda和gpu驱动的环境变量，但无gpu设备，此时cpu模式跑不通
本PR修正了该case的bug

