### PR TITLE
Add fused_attention, fused_feedforward, fused_gemm_epilogue to amp white_list

### DIFF
--- a/python/paddle/amp/amp_lists.py
+++ b/python/paddle/amp/amp_lists.py
@@ -23,6 +23,9 @@ FP16_WHITE_LIST = {
     'mul',
     'fake_quantize_dequantize_abs_max',
     'fake_quantize_dequantize_moving_average_abs_max',
+    'fused_gemm_epilogue',
+    'fused_attention',
+    'fused_feedforward',
 }
 
 # The set of ops that support fp16 calculation and are considered numerically-


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-70458
添加 fused_attention, fused_feedforward, fused_gemm_epilogue 到白名单
