### PR TITLE
[CodeStyle] replace `assert np.allclose` with `np.testing.assert_allclose` and `assert np.array_equal` with `np.testing.assert_array_equal`

### DIFF
--- a/test/auto_parallel/random_control_unittest.py
+++ b/test/auto_parallel/random_control_unittest.py
@@ -86,7 +86,7 @@ class TestRandomControl(unittest.TestCase):
                 mask_tensor_remote = paddle.ones_like(mask_tensor_local)
                 dy_broadcast_helper(mask_tensor_remote)
                 if equal:
-                    assert np.array_equal(
+                    np.testing.assert_array_equal(
                         mask_tensor_remote.numpy(), mask_tensor_local.numpy()
                     )
                 else:
@@ -205,7 +205,7 @@ class TestRandomControl(unittest.TestCase):
         for i in range(7):
             mask_fw = mask_np_list[i].astype("float32")
             mask_rc = mask_np_list[i + 7].astype("float32")
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 mask_fw,
                 mask_rc,
             )

--- a/test/auto_parallel/random_control_unittest.py
+++ b/test/auto_parallel/random_control_unittest.py
@@ -90,10 +90,7 @@ class TestRandomControl(unittest.TestCase):
                         mask_tensor_remote.numpy(), mask_tensor_local.numpy()
                     )
                 else:
-                    import operator
-
-                    np.testing.assert_array_compare(
-                        operator.__ne__,
+                    assert not np.array_equal(
                         mask_tensor_remote.numpy(),
                         mask_tensor_local.numpy(),
                     )

--- a/test/auto_parallel/random_control_unittest.py
+++ b/test/auto_parallel/random_control_unittest.py
@@ -90,7 +90,10 @@ class TestRandomControl(unittest.TestCase):
                         mask_tensor_remote.numpy(), mask_tensor_local.numpy()
                     )
                 else:
-                    assert not np.array_equal(
+                    import operator
+
+                    np.testing.assert_array_compare(
+                        operator.__ne__,
                         mask_tensor_remote.numpy(),
                         mask_tensor_local.numpy(),
                     )

--- a/test/collective/fleet/dygraph_dist_save_load.py
+++ b/test/collective/fleet/dygraph_dist_save_load.py
@@ -208,7 +208,7 @@ def step_check(path1, path2):
     m1 = paddle.load(path1)
     m2 = paddle.load(path2)
     for v1, v2 in zip(m1, m2):
-        assert np.allclose(v1.numpy(), v2.numpy())
+        np.testing.assert_allclose(v1.numpy(), v2.numpy())
         print(f"value same: {v1.name}")
 
 

--- a/test/collective/fleet/dygraph_save_for_auto_infer.py
+++ b/test/collective/fleet/dygraph_save_for_auto_infer.py
@@ -267,7 +267,7 @@ def step_check(output_dir):
     m1 = np.load(p1).reshape(-1)
     m2 = np.load(p2).reshape(-1)
     try:
-        assert np.allclose(m1, m2, rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(m1, m2, rtol=1e-5, atol=1e-6)
     except:
         diff = m1 - m2
         logger.error(f"max diff{diff.max()}, min diff: {diff.min()}")

--- a/test/collective/fleet/fused_attention_pass_with_mp.py
+++ b/test/collective/fleet/fused_attention_pass_with_mp.py
@@ -234,7 +234,7 @@ class TestFusedAttentionPassWithMP(unittest.TestCase):
     def test_pass(self):
         fused_rst = self.get_rst(use_pass=True)
         non_fused_rst = self.get_rst()
-        assert np.allclose(fused_rst, non_fused_rst, atol=1e-5)
+        np.testing.assert_allclose(fused_rst, non_fused_rst, atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/hybrid_parallel_communicate_group.py
+++ b/test/collective/fleet/hybrid_parallel_communicate_group.py
@@ -58,28 +58,28 @@ class TestNewGroupAPI:
             sync_op=True,
         )
         if dp_rank == 0:
-            assert np.array_equal(result, self.tensor2)
+            np.testing.assert_array_equal(result, self.tensor2)
         elif dp_rank == 1:
-            assert np.array_equal(result, self.tensor1)
+            np.testing.assert_array_equal(result, self.tensor1)
         print("test scatter api ok")
 
         paddle.distributed.broadcast(result, src=1, group=dp_gp, sync_op=True)
-        assert np.array_equal(result, self.tensor1)
+        np.testing.assert_array_equal(result, self.tensor1)
         print("test broadcast api ok")
 
         paddle.distributed.reduce(
             result, dst=dp_src_rank, group=dp_gp, sync_op=True
         )
         if dp_rank == 0:
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 result, paddle.add(self.tensor1, self.tensor1)
             )
         elif dp_rank == 1:
-            assert np.array_equal(result, self.tensor1)
+            np.testing.assert_array_equal(result, self.tensor1)
         print("test reduce api ok")
 
         paddle.distributed.all_reduce(result, sync_op=True)
-        assert np.array_equal(
+        np.testing.assert_array_equal(
             result,
             paddle.add(paddle.add(self.tensor1, self.tensor1), self.tensor1),
         )
@@ -93,8 +93,8 @@ class TestNewGroupAPI:
         paddle.distributed.all_gather(
             result, self.tensor1, group=dp_gp, sync_op=True
         )
-        assert np.array_equal(result[0], self.tensor1)
-        assert np.array_equal(result[1], self.tensor1)
+        np.testing.assert_array_equal(result[0], self.tensor1)
+        np.testing.assert_array_equal(result[1], self.tensor1)
         print("test all_gather api ok")
 
         paddle.distributed.barrier(group=dp_gp)

--- a/test/collective/fleet/new_group.py
+++ b/test/collective/fleet/new_group.py
@@ -36,26 +36,26 @@ class TestNewGroupAPI:
             result, [self.tensor2, self.tensor1], src=0, group=gp, sync_op=True
         )
         if gp.rank == 0:
-            assert np.array_equal(result, self.tensor2)
+            np.testing.assert_array_equal(result, self.tensor2)
         elif gp.rank == 1:
-            assert np.array_equal(result, self.tensor1)
+            np.testing.assert_array_equal(result, self.tensor1)
         print("test scatter api ok")
 
         paddle.distributed.broadcast(result, src=1, group=gp, sync_op=True)
-        assert np.array_equal(result, self.tensor1)
+        np.testing.assert_array_equal(result, self.tensor1)
         print("test broadcast api ok")
 
         paddle.distributed.reduce(result, dst=0, group=gp, sync_op=True)
         if gp.rank == 0:
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 result, paddle.add(self.tensor1, self.tensor1)
             )
         elif gp.rank == 1:
-            assert np.array_equal(result, self.tensor1)
+            np.testing.assert_array_equal(result, self.tensor1)
         print("test reduce api ok")
 
         paddle.distributed.all_reduce(result, sync_op=True)
-        assert np.array_equal(
+        np.testing.assert_array_equal(
             result,
             paddle.add(paddle.add(self.tensor1, self.tensor1), self.tensor1),
         )
@@ -69,8 +69,8 @@ class TestNewGroupAPI:
         paddle.distributed.all_gather(
             result, self.tensor1, group=gp, sync_op=True
         )
-        assert np.array_equal(result[0], self.tensor1)
-        assert np.array_equal(result[1], self.tensor1)
+        np.testing.assert_array_equal(result[0], self.tensor1)
+        np.testing.assert_array_equal(result[1], self.tensor1)
         print("test all_gather api ok")
 
         paddle.distributed.barrier(group=gp)

--- a/test/collective/fleet/test_imperative_auto_mixed_precision_for_eager.py
+++ b/test/collective/fleet/test_imperative_auto_mixed_precision_for_eager.py
@@ -201,8 +201,8 @@ class TestAmpScaler(unittest.TestCase):
                 data = paddle.rand([10, 1024])
             scaler = paddle.amp.AmpScaler(init_loss_scaling=1024)
             scaled_data = scaler.scale(data)
-            self.assertEqual(
-                np.array_equal(scaled_data.numpy(), data.numpy() * 1024), True
+            np.testing.assert_array_equal(
+                scaled_data.numpy(), data.numpy() * 1024
             )
 
     def test_scale(self):

--- a/test/collective/fleet/test_mixed_precision.py
+++ b/test/collective/fleet/test_mixed_precision.py
@@ -128,12 +128,9 @@ class AMPTest(unittest.TestCase):
                     np.testing.assert_array_equal(beta_pow1_, pre_beta_pow1_)
                 else:
                     self.assertFalse(found_inf)
-
-                    assert not np.array_equal(weight_, pre_weight_)
-
-                    assert not np.array_equal(moment1_, pre_moment1_)
-
-                    assert not np.array_equal(beta_pow1_, pre_beta_pow1_)
+                    self.assertFalse(np.array_equal(weight_, pre_weight_))
+                    self.assertFalse(np.array_equal(moment1_, pre_moment1_))
+                    self.assertFalse(np.array_equal(beta_pow1_, pre_beta_pow1_))
                 pre_weight_, pre_moment1_, pre_beta_pow1_ = (
                     weight_,
                     moment1_,

--- a/test/collective/fleet/test_mixed_precision.py
+++ b/test/collective/fleet/test_mixed_precision.py
@@ -128,9 +128,21 @@ class AMPTest(unittest.TestCase):
                     np.testing.assert_array_equal(beta_pow1_, pre_beta_pow1_)
                 else:
                     self.assertFalse(found_inf)
-                    self.assertFalse(np.array_equal(weight_, pre_weight_))
-                    self.assertFalse(np.array_equal(moment1_, pre_moment1_))
-                    self.assertFalse(np.array_equal(beta_pow1_, pre_beta_pow1_))
+                    import operator
+
+                    np.testing.assert_array_compare(
+                        operator.__ne__, weight_, pre_weight_
+                    )
+                    import operator
+
+                    np.testing.assert_array_compare(
+                        operator.__ne__, moment1_, pre_moment1_
+                    )
+                    import operator
+
+                    np.testing.assert_array_compare(
+                        operator.__ne__, beta_pow1_, pre_beta_pow1_
+                    )
                 pre_weight_, pre_moment1_, pre_beta_pow1_ = (
                     weight_,
                     moment1_,

--- a/test/collective/fleet/test_mixed_precision.py
+++ b/test/collective/fleet/test_mixed_precision.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
 import unittest
 
 import numpy as np
@@ -128,17 +129,14 @@ class AMPTest(unittest.TestCase):
                     np.testing.assert_array_equal(beta_pow1_, pre_beta_pow1_)
                 else:
                     self.assertFalse(found_inf)
-                    import operator
 
                     np.testing.assert_array_compare(
                         operator.__ne__, weight_, pre_weight_
                     )
-                    import operator
 
                     np.testing.assert_array_compare(
                         operator.__ne__, moment1_, pre_moment1_
                     )
-                    import operator
 
                     np.testing.assert_array_compare(
                         operator.__ne__, beta_pow1_, pre_beta_pow1_

--- a/test/collective/fleet/test_mixed_precision.py
+++ b/test/collective/fleet/test_mixed_precision.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import operator
 import unittest
 
 import numpy as np
@@ -130,17 +129,11 @@ class AMPTest(unittest.TestCase):
                 else:
                     self.assertFalse(found_inf)
 
-                    np.testing.assert_array_compare(
-                        operator.__ne__, weight_, pre_weight_
-                    )
+                    assert not np.array_equal(weight_, pre_weight_)
 
-                    np.testing.assert_array_compare(
-                        operator.__ne__, moment1_, pre_moment1_
-                    )
+                    assert not np.array_equal(moment1_, pre_moment1_)
 
-                    np.testing.assert_array_compare(
-                        operator.__ne__, beta_pow1_, pre_beta_pow1_
-                    )
+                    assert not np.array_equal(beta_pow1_, pre_beta_pow1_)
                 pre_weight_, pre_moment1_, pre_beta_pow1_ = (
                     weight_,
                     moment1_,

--- a/test/collective/multinode/dygraph_hybrid_dp.py
+++ b/test/collective/multinode/dygraph_hybrid_dp.py
@@ -39,7 +39,7 @@ class TestDygrapgHybridDP(TestCollectiveAPIRunnerBase):
         paddle.distributed.collective.all_reduce(data_part)
         data_reduced = data_part
         data_sumed = np.sum(data, axis=0)
-        assert np.allclose(
+        np.testing.assert_allclose(
             data_sumed, data_reduced.numpy(), rtol=1e-8, atol=1e-8
         )
 

--- a/test/collective/multinode/dygraph_hybrid_dpppmp.py
+++ b/test/collective/multinode/dygraph_hybrid_dpppmp.py
@@ -197,7 +197,9 @@ class TestDygrapgHybridDPPPMP(TestCollectiveAPIRunnerBase):
 
             loss_base_arr.append(loss_base.numpy())
             loss_hybrid_arr.append(loss.numpy())
-        assert np.allclose(loss_base_arr, loss_hybrid_arr, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(
+            loss_base_arr, loss_hybrid_arr, rtol=1e-5, atol=1e-5
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/multinode/dygraph_hybrid_fp16.py
+++ b/test/collective/multinode/dygraph_hybrid_fp16.py
@@ -210,7 +210,9 @@ class TestDygraphHybridFp16(TestCollectiveAPIRunnerBase):
 
             loss_base_arr.append(loss_base.numpy())
             loss_hybrid_arr.append(loss)
-        assert np.allclose(loss_base_arr, loss_hybrid_arr, rtol=1e-3, atol=1e-3)
+        np.testing.assert_allclose(
+            loss_base_arr, loss_hybrid_arr, rtol=1e-3, atol=1e-3
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/multinode/dygraph_hybrid_recompute.py
+++ b/test/collective/multinode/dygraph_hybrid_recompute.py
@@ -186,7 +186,9 @@ class TestDygrapgHybridRecompute(TestCollectiveAPIRunnerBase):
 
             loss_base_arr.append(loss_base.numpy())
             loss_hybrid_arr.append(loss)
-        assert np.allclose(loss_base_arr, loss_hybrid_arr, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(
+            loss_base_arr, loss_hybrid_arr, rtol=1e-5, atol=1e-5
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/process_group_gloo.py
+++ b/test/collective/process_group_gloo.py
@@ -76,11 +76,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if rank == 0:
             task = pg.allreduce(tensor_x, core.ReduceOp.MAX)
             task.wait()
-            assert np.array_equal(tensor_x, max_result)
+            np.testing.assert_array_equal(tensor_x, max_result)
         else:
             task = pg.allreduce(tensor_y, core.ReduceOp.MAX)
             task.wait()
-            assert np.array_equal(tensor_y, max_result)
+            np.testing.assert_array_equal(tensor_y, max_result)
 
         print("test allreduce max api ok")
 
@@ -95,10 +95,10 @@ class TestProcessGroupFp32(unittest.TestCase):
         broadcast_result = paddle.assign(tensor_x)
         if rank == 0:
             task = pg.broadcast(tensor_x, 0)
-            assert np.array_equal(broadcast_result, tensor_x)
+            np.testing.assert_array_equal(broadcast_result, tensor_x)
         else:
             task = pg.broadcast(tensor_y, 0)
-            assert np.array_equal(broadcast_result, tensor_y)
+            np.testing.assert_array_equal(broadcast_result, tensor_y)
         print("test broadcast api ok")
 
         # test send_recv
@@ -116,11 +116,11 @@ class TestProcessGroupFp32(unittest.TestCase):
             task = pg.send(tensor_x, pg.size() - 1, True)
         elif pg.rank() == pg.size() - 1:
             task = pg.recv(tensor_y_1, 0, True)
-            assert np.array_equal(send_recv_result_1, tensor_y_1)
+            np.testing.assert_array_equal(send_recv_result_1, tensor_y_1)
 
         if pg.rank() == 0:
             task = pg.recv(tensor_x, pg.size() - 1, True)
-            assert np.array_equal(send_recv_result_2, tensor_x)
+            np.testing.assert_array_equal(send_recv_result_2, tensor_x)
         elif pg.rank() == pg.size() - 1:
             task = pg.send(tensor_y_2, 0, True)
         print("test send_recv api ok")
@@ -159,8 +159,8 @@ class TestProcessGroupFp32(unittest.TestCase):
         out_2 = paddle.slice(
             tensor_out, [0], [out_shape[0] // 2], [out_shape[0]]
         )
-        assert np.array_equal(tensor_x, out_1)
-        assert np.array_equal(tensor_y, out_2)
+        np.testing.assert_array_equal(tensor_x, out_1)
+        np.testing.assert_array_equal(tensor_y, out_2)
         print("test allgather api ok\n")
 
         # test Reduce
@@ -178,7 +178,7 @@ class TestProcessGroupFp32(unittest.TestCase):
             task = pg.reduce(tensor_y, 0)
             task.wait()
         if pg.rank() == 0:
-            assert np.array_equal(tensor_x, sum_result)
+            np.testing.assert_array_equal(tensor_x, sum_result)
         print("test reduce sum api ok\n")
 
         # test Scatter
@@ -199,9 +199,9 @@ class TestProcessGroupFp32(unittest.TestCase):
         out1 = paddle.slice(tensor_x, [0], [0], [self.shape[0]])
         out2 = paddle.slice(tensor_x, [0], [self.shape[0]], [self.shape[0] * 2])
         if pg.rank() == 0:
-            assert np.array_equal(tensor_y, out1)
+            np.testing.assert_array_equal(tensor_y, out1)
         else:
-            assert np.array_equal(tensor_y, out2)
+            np.testing.assert_array_equal(tensor_y, out2)
         print("test scatter api ok\n")
 
         # test Gather
@@ -219,7 +219,7 @@ class TestProcessGroupFp32(unittest.TestCase):
             if pg.rank() == root:
                 task = pg.gather(tensor_y[root], tensor_x, root, True)
                 task.wait()
-                assert np.array_equal(tensor_x, tensor_y)
+                np.testing.assert_array_equal(tensor_x, tensor_y)
             else:
                 task = pg.gather(tensor_y[pg.rank()], tensor_x, root, True)
                 task.wait()

--- a/test/collective/process_group_mpi.py
+++ b/test/collective/process_group_mpi.py
@@ -69,10 +69,10 @@ def test_allreduce_sum(pg, shape, dtype):
     sum_result = tensor_x + tensor_y
     if pg.rank() == 0:
         task = dist.all_reduce(tensor_x)
-        assert np.array_equal(tensor_x, sum_result)
+        np.testing.assert_array_equal(tensor_x, sum_result)
     else:
         task = dist.all_reduce(tensor_y)
-        assert np.array_equal(tensor_y, sum_result)
+        np.testing.assert_array_equal(tensor_y, sum_result)
     print("test allreduce sum api ok")
 
 
@@ -91,13 +91,13 @@ def test_allreduce_max(pg, shape, dtype):
             tensor_x, dist.ReduceOp.MAX, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_x, max_result)
+        np.testing.assert_array_equal(tensor_x, max_result)
     else:
         task = dist.all_reduce(
             tensor_y, dist.ReduceOp.MAX, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_y, max_result)
+        np.testing.assert_array_equal(tensor_y, max_result)
     print("test allreduce max api ok")
 
 
@@ -116,13 +116,13 @@ def test_allreduce_min(pg, shape, dtype):
             tensor_x, dist.ReduceOp.MIN, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_x, min_result)
+        np.testing.assert_array_equal(tensor_x, min_result)
     else:
         task = dist.all_reduce(
             tensor_y, dist.ReduceOp.MIN, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_y, min_result)
+        np.testing.assert_array_equal(tensor_y, min_result)
     print("test allreduce min api ok")
 
 
@@ -141,13 +141,13 @@ def test_allreduce_prod(pg, shape, dtype):
             tensor_x, dist.ReduceOp.PROD, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_x, prod_result)
+        np.testing.assert_array_equal(tensor_x, prod_result)
     else:
         task = dist.all_reduce(
             tensor_y, dist.ReduceOp.PROD, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_y, prod_result)
+        np.testing.assert_array_equal(tensor_y, prod_result)
     print("test allreduce prod api ok")
 
 
@@ -164,10 +164,10 @@ def test_broadcast(pg, shape, dtype):
         task = dist.broadcast(tensor_x, 0, use_calc_stream=False)
         task.synchronize()
         assert task.is_completed()
-        assert np.array_equal(broadcast_result, tensor_x)
+        np.testing.assert_array_equal(broadcast_result, tensor_x)
     else:
         task = dist.broadcast(tensor_y, 0)
-        assert np.array_equal(broadcast_result, tensor_y)
+        np.testing.assert_array_equal(broadcast_result, tensor_y)
     print("test broadcast api ok")
 
 
@@ -205,8 +205,8 @@ def test_allgather(pg, shape, dtype):
         tensor_out = paddle.concat(tensor_out_list)
     out_1 = paddle.slice(tensor_out, [0], [0], [out_shape[0] // 2])
     out_2 = paddle.slice(tensor_out, [0], [out_shape[0] // 2], [out_shape[0]])
-    assert np.array_equal(tensor_x, out_1)
-    assert np.array_equal(tensor_y, out_2)
+    np.testing.assert_array_equal(tensor_x, out_1)
+    np.testing.assert_array_equal(tensor_y, out_2)
     print("test allgather api ok\n")
 
     if pg.rank() == 0:
@@ -219,8 +219,8 @@ def test_allgather(pg, shape, dtype):
         tensor_out = paddle.concat(tensor_out_list)
     out_1 = paddle.slice(tensor_out, [0], [0], [out_shape[0] // 2])
     out_2 = paddle.slice(tensor_out, [0], [out_shape[0] // 2], [out_shape[0]])
-    assert np.array_equal(tensor_x, out_1)
-    assert np.array_equal(tensor_y, out_2)
+    np.testing.assert_array_equal(tensor_x, out_1)
+    np.testing.assert_array_equal(tensor_y, out_2)
     print("test allgather api2 ok\n")
 
 
@@ -249,9 +249,9 @@ def test_all2all(pg, shape, dtype):
     out1_2 = paddle.slice(tensor_out1, [0], [shape[0] // 2], [shape[0]])
     out2_1 = paddle.slice(tensor_out2, [0], [0], [shape[0] // 2])
     if pg.rank() == 0:
-        assert np.array_equal(out1_2.numpy(), raw_tensor_y_1.numpy())
+        np.testing.assert_array_equal(out1_2.numpy(), raw_tensor_y_1.numpy())
     else:
-        assert np.array_equal(out2_1, raw_tensor_x_2)
+        np.testing.assert_array_equal(out2_1, raw_tensor_x_2)
     print("test alltoall api ok\n")
 
     x = np.random.random(shape).astype(dtype)
@@ -277,9 +277,9 @@ def test_all2all(pg, shape, dtype):
     out1_2 = paddle.slice(tensor_out1, [0], [shape[0] // 2], [shape[0]])
     out2_1 = paddle.slice(tensor_out2, [0], [0], [shape[0] // 2])
     if pg.rank() == 0:
-        assert np.array_equal(out1_2.numpy(), raw_tensor_y_1.numpy())
+        np.testing.assert_array_equal(out1_2.numpy(), raw_tensor_y_1.numpy())
     else:
-        assert np.array_equal(out2_1, raw_tensor_x_2)
+        np.testing.assert_array_equal(out2_1, raw_tensor_x_2)
     print("test alltoall api2 ok\n")
 
 
@@ -297,7 +297,7 @@ def test_reduce_sum(pg, shape, dtype):
         task = dist.reduce(tensor_y, 0, use_calc_stream=False)
         task.wait()
     if pg.rank() == 0:
-        assert np.array_equal(tensor_x, sum_result)
+        np.testing.assert_array_equal(tensor_x, sum_result)
     print("test reduce sum api ok\n")
 
 
@@ -316,7 +316,7 @@ def test_reduce_max(pg, shape, dtype):
             tensor_x, 0, dist.ReduceOp.MAX, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_x, max_result)
+        np.testing.assert_array_equal(tensor_x, max_result)
     else:
         task = dist.reduce(
             tensor_y, 0, dist.ReduceOp.MAX, use_calc_stream=False
@@ -340,7 +340,7 @@ def test_reduce_min(pg, shape, dtype):
             tensor_x, 0, dist.ReduceOp.MIN, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_x, min_result)
+        np.testing.assert_array_equal(tensor_x, min_result)
     else:
         task = dist.reduce(
             tensor_y, 0, dist.ReduceOp.MIN, use_calc_stream=False
@@ -364,7 +364,7 @@ def test_reduce_prod(pg, shape, dtype):
             tensor_x, 0, dist.ReduceOp.PROD, use_calc_stream=False
         )
         task.wait()
-        assert np.array_equal(tensor_x, prod_result)
+        np.testing.assert_array_equal(tensor_x, prod_result)
     else:
         task = dist.reduce(
             tensor_y, 0, dist.ReduceOp.PROD, use_calc_stream=False
@@ -391,9 +391,9 @@ def test_scatter(pg, shape, dtype):
     out1 = paddle.slice(tensor_x, [0], [0], [shape[0]])
     out2 = paddle.slice(tensor_x, [0], [shape[0]], [shape[0] * 2])
     if pg.rank() == 0:
-        assert np.array_equal(tensor_y, out1)
+        np.testing.assert_array_equal(tensor_y, out1)
     else:
-        assert np.array_equal(tensor_y, out2)
+        np.testing.assert_array_equal(tensor_y, out2)
     print("test scatter api ok\n")
 
 
@@ -411,7 +411,7 @@ def test_send_recv(pg, sub_group, shape, dtype):
     elif pg.rank() == 1:
         task = dist.recv(tensor_y, 0, group=sub_group, use_calc_stream=False)
         task.wait()
-        assert np.array_equal(tensor_y, tensor_x)
+        np.testing.assert_array_equal(tensor_y, tensor_x)
 
     print("test send api ok")
 
@@ -427,7 +427,7 @@ def test_send_recv(pg, sub_group, shape, dtype):
         task = dist.send(tensor_x, 1, group=sub_group, use_calc_stream=True)
     elif pg.rank() == 1:
         task = dist.recv(tensor_y, 0, group=sub_group, use_calc_stream=True)
-        assert np.array_equal(tensor_y, tensor_x)
+        np.testing.assert_array_equal(tensor_y, tensor_x)
 
     print("test send api ok")
 

--- a/test/collective/process_group_nccl.py
+++ b/test/collective/process_group_nccl.py
@@ -64,10 +64,10 @@ class TestProcessGroupFp32(unittest.TestCase):
         sum_result = tensor_x + tensor_y
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x)
-            assert np.array_equal(tensor_x, sum_result)
+            np.testing.assert_array_equal(tensor_x, sum_result)
         else:
             task = dist.all_reduce(tensor_y)
-            assert np.array_equal(tensor_y, sum_result)
+            np.testing.assert_array_equal(tensor_y, sum_result)
 
         print("test allreduce sum api ok")
 
@@ -82,10 +82,10 @@ class TestProcessGroupFp32(unittest.TestCase):
         sum_result = tensor_x + tensor_y
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x)
-            assert np.array_equal(tensor_x, sum_result)
+            np.testing.assert_array_equal(tensor_x, sum_result)
         else:
             task = dist.all_reduce(tensor_y)
-            assert np.array_equal(tensor_y, sum_result)
+            np.testing.assert_array_equal(tensor_y, sum_result)
 
         print("test allreduce sum api with = [] ok")
 
@@ -102,11 +102,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x, dist.ReduceOp.MAX, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, max_result)
+            np.testing.assert_array_equal(tensor_x, max_result)
         else:
             task = dist.all_reduce(tensor_y, dist.ReduceOp.MAX, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, max_result)
+            np.testing.assert_array_equal(tensor_y, max_result)
 
         print("test allreduce max api ok")
 
@@ -123,11 +123,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x, dist.ReduceOp.MAX, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, max_result)
+            np.testing.assert_array_equal(tensor_x, max_result)
         else:
             task = dist.all_reduce(tensor_y, dist.ReduceOp.MAX, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, max_result)
+            np.testing.assert_array_equal(tensor_y, max_result)
 
         print("test allreduce max api with shape = [] ok")
 
@@ -144,11 +144,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x, dist.ReduceOp.MIN, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, min_result)
+            np.testing.assert_array_equal(tensor_x, min_result)
         else:
             task = dist.all_reduce(tensor_y, dist.ReduceOp.MIN, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, min_result)
+            np.testing.assert_array_equal(tensor_y, min_result)
 
         print("test allreduce min api ok")
 
@@ -165,11 +165,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x, dist.ReduceOp.MIN, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, min_result)
+            np.testing.assert_array_equal(tensor_x, min_result)
         else:
             task = dist.all_reduce(tensor_y, dist.ReduceOp.MIN, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, min_result)
+            np.testing.assert_array_equal(tensor_y, min_result)
 
         print("test allreduce min api with shape [] ok")
 
@@ -186,11 +186,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x, dist.ReduceOp.PROD, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, prod_result)
+            np.testing.assert_array_equal(tensor_x, prod_result)
         else:
             task = dist.all_reduce(tensor_y, dist.ReduceOp.PROD, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, prod_result)
+            np.testing.assert_array_equal(tensor_y, prod_result)
 
         print("test allreduce prod api ok")
 
@@ -207,11 +207,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.all_reduce(tensor_x, dist.ReduceOp.PROD, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, prod_result)
+            np.testing.assert_array_equal(tensor_x, prod_result)
         else:
             task = dist.all_reduce(tensor_y, dist.ReduceOp.PROD, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, prod_result)
+            np.testing.assert_array_equal(tensor_y, prod_result)
 
         print("test allreduce prod api with shape = [] ok")
 
@@ -229,11 +229,11 @@ class TestProcessGroupFp32(unittest.TestCase):
             task.synchronize()
             paddle.device.cuda.synchronize()
             assert task.is_completed()
-            assert np.array_equal(broadcast_result, tensor_x)
+            np.testing.assert_array_equal(broadcast_result, tensor_x)
         else:
             task = dist.broadcast(tensor_y, 0)
             paddle.device.cuda.synchronize()
-            assert np.array_equal(broadcast_result, tensor_y)
+            np.testing.assert_array_equal(broadcast_result, tensor_y)
 
         print("test broadcast api ok")
 
@@ -251,11 +251,11 @@ class TestProcessGroupFp32(unittest.TestCase):
             task.synchronize()
             paddle.device.cuda.synchronize()
             assert task.is_completed()
-            assert np.array_equal(broadcast_result, tensor_x)
+            np.testing.assert_array_equal(broadcast_result, tensor_x)
         else:
             task = dist.broadcast(tensor_y, 0)
             paddle.device.cuda.synchronize()
-            assert np.array_equal(broadcast_result, tensor_y)
+            np.testing.assert_array_equal(broadcast_result, tensor_y)
         assert tensor_y.shape == []
 
         print("test broadcast api with shape=[] ok")
@@ -298,8 +298,8 @@ class TestProcessGroupFp32(unittest.TestCase):
         out_2 = paddle.slice(
             tensor_out, [0], [out_shape[0] // 2], [out_shape[0]]
         )
-        assert np.array_equal(tensor_x, out_1)
-        assert np.array_equal(tensor_y, out_2)
+        np.testing.assert_array_equal(tensor_x, out_1)
+        np.testing.assert_array_equal(tensor_y, out_2)
         print("test allgather api ok\n")
 
         if pg.rank() == 0:
@@ -316,8 +316,8 @@ class TestProcessGroupFp32(unittest.TestCase):
         out_2 = paddle.slice(
             tensor_out, [0], [out_shape[0] // 2], [out_shape[0]]
         )
-        assert np.array_equal(tensor_x, out_1)
-        assert np.array_equal(tensor_y, out_2)
+        np.testing.assert_array_equal(tensor_x, out_1)
+        np.testing.assert_array_equal(tensor_y, out_2)
         print("test allgather api2 ok\n")
 
         # test allgather with shape = []
@@ -337,8 +337,8 @@ class TestProcessGroupFp32(unittest.TestCase):
             paddle.device.cuda.synchronize()
         out_1 = tensor_out_list[0]
         out_2 = tensor_out_list[1]
-        assert np.array_equal(tensor_x, out_1)
-        assert np.array_equal(tensor_y, out_2)
+        np.testing.assert_array_equal(tensor_x, out_1)
+        np.testing.assert_array_equal(tensor_y, out_2)
         print("test allgather api with shape [] ok\n")
 
         # test alltoall
@@ -371,9 +371,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         )
         out2_1 = paddle.slice(tensor_out2, [0], [0], [self.shape[0] // 2])
         if pg.rank() == 0:
-            assert np.array_equal(out1_2.numpy(), raw_tensor_y_1.numpy())
+            np.testing.assert_array_equal(
+                out1_2.numpy(), raw_tensor_y_1.numpy()
+            )
         else:
-            assert np.array_equal(out2_1, raw_tensor_x_2)
+            np.testing.assert_array_equal(out2_1, raw_tensor_x_2)
         print("test alltoall api ok\n")
 
         x = np.random.random(self.shape).astype(self.dtype)
@@ -404,9 +406,11 @@ class TestProcessGroupFp32(unittest.TestCase):
         )
         out2_1 = paddle.slice(tensor_out2, [0], [0], [self.shape[0] // 2])
         if pg.rank() == 0:
-            assert np.array_equal(out1_2.numpy(), raw_tensor_y_1.numpy())
+            np.testing.assert_array_equal(
+                out1_2.numpy(), raw_tensor_y_1.numpy()
+            )
         else:
-            assert np.array_equal(out2_1, raw_tensor_x_2)
+            np.testing.assert_array_equal(out2_1, raw_tensor_x_2)
         print("test alltoall api2 ok\n")
 
         # test Reduce
@@ -425,7 +429,7 @@ class TestProcessGroupFp32(unittest.TestCase):
             task.wait()
             paddle.device.cuda.synchronize()
         if pg.rank() == 0:
-            assert np.array_equal(tensor_x, sum_result)
+            np.testing.assert_array_equal(tensor_x, sum_result)
         print("test reduce sum api ok\n")
 
         # test reduce max
@@ -441,7 +445,7 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.reduce(tensor_x, 0, dist.ReduceOp.MAX, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, max_result)
+            np.testing.assert_array_equal(tensor_x, max_result)
         else:
             task = dist.reduce(tensor_y, 0, dist.ReduceOp.MAX, sync_op=False)
             task.wait()
@@ -461,7 +465,7 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.reduce(tensor_x, 0, dist.ReduceOp.MIN, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, min_result)
+            np.testing.assert_array_equal(tensor_x, min_result)
         else:
             task = dist.reduce(tensor_y, 0, dist.ReduceOp.MIN, sync_op=False)
             task.wait()
@@ -481,7 +485,7 @@ class TestProcessGroupFp32(unittest.TestCase):
         if pg.rank() == 0:
             task = dist.reduce(tensor_x, 0, dist.ReduceOp.PROD, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_x, prod_result)
+            np.testing.assert_array_equal(tensor_x, prod_result)
         else:
             task = dist.reduce(tensor_y, 0, dist.ReduceOp.PROD, sync_op=False)
             task.wait()
@@ -511,9 +515,9 @@ class TestProcessGroupFp32(unittest.TestCase):
         out1 = paddle.slice(tensor_x, [0], [0], [self.shape[0]])
         out2 = paddle.slice(tensor_x, [0], [self.shape[0]], [self.shape[0] * 2])
         if pg.rank() == 0:
-            assert np.array_equal(tensor_y, out1)
+            np.testing.assert_array_equal(tensor_y, out1)
         else:
-            assert np.array_equal(tensor_y, out2)
+            np.testing.assert_array_equal(tensor_y, out2)
         print("test scatter api ok\n")
 
         # test Scatter with shape=[]
@@ -534,9 +538,9 @@ class TestProcessGroupFp32(unittest.TestCase):
         out1 = paddle.assign(tensor_x)
         out2 = paddle.assign(tensor_x + 1)
         if pg.rank() == 0:
-            assert np.array_equal(tensor_y, out1)
+            np.testing.assert_array_equal(tensor_y, out1)
         else:
-            assert np.array_equal(tensor_y, out2), f"{tensor_y}, {out2}"
+            np.testing.assert_array_equal(tensor_y, out2)
         assert tensor_y.shape == []
         print("test scatter api with shape=[] ok\n")
 
@@ -554,7 +558,7 @@ class TestProcessGroupFp32(unittest.TestCase):
         else:
             task = dist.recv(tensor_y, 0, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, tensor_x)
+            np.testing.assert_array_equal(tensor_y, tensor_x)
 
         print("test send api ok")
 
@@ -570,7 +574,7 @@ class TestProcessGroupFp32(unittest.TestCase):
             task = dist.send(tensor_x, 1, sync_op=True)
         else:
             task = dist.recv(tensor_y, 0, sync_op=True)
-            assert np.array_equal(tensor_y, tensor_x)
+            np.testing.assert_array_equal(tensor_y, tensor_x)
 
         print("test send api ok")
 

--- a/test/collective/strategy_group.py
+++ b/test/collective/strategy_group.py
@@ -31,7 +31,7 @@ def _check_using_all_reduce(group):
     data = paddle.to_tensor([1, 2, 3])
     result = paddle.to_tensor([2, 4, 6])
     dist.all_reduce(data, group=group)
-    assert np.array_equal(data, result)
+    np.testing.assert_array_equal(data, result)
 
 
 def _check_using_send(group, dst):
@@ -43,7 +43,7 @@ def _check_using_recv(group, src):
     result = paddle.to_tensor([1, 2, 3])
     data = paddle.to_tensor([0, 0, 0])
     dist.recv(data, src=src, group=group)
-    assert np.array_equal(data, result)
+    np.testing.assert_array_equal(data, result)
 
 
 class TestStrategyGroupAPI(unittest.TestCase):

--- a/test/dygraph_to_static/test_cinn_prim.py
+++ b/test/dygraph_to_static/test_cinn_prim.py
@@ -159,7 +159,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(
-                cinn_res[i], dy_res[i], rtol=1e-6, atol=1e-6
+                cinn_res[i], dy_res[i], rtol=1e-5, atol=1e-8
             )
 
 

--- a/test/dygraph_to_static/test_cinn_prim.py
+++ b/test/dygraph_to_static/test_cinn_prim.py
@@ -159,7 +159,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(
-                cinn_res[i], dy_res[i], rtol=1e-5, atol=1e-8
+                cinn_res[i], dy_res[i], rtol=1e-6, atol=1e-6
             )
 
 

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -698,16 +698,15 @@ class TestCycleGANModel(unittest.TestCase):
         st_out = self.train(to_static=True)
         dy_out = self.train(to_static=False)
 
-        assert_func = np.allclose
+        assert_func = np.testing.assert_allclose
         # Note(Aurelius84): Because we disable BN on GPU,
         # but here we enhance the check on CPU by `np.array_equal`
         # which means the dy_out and st_out shall be exactly same.
         if not fluid.is_compiled_with_cuda():
-            assert_func = np.array_equal
+            assert_func = np.testing.assert_array_equal
 
-        self.assertTrue(
-            assert_func(dy_out, st_out),
-            msg=f"dy_out:\n {dy_out}\n st_out:\n{st_out}",
+        assert_func(
+            dy_out, st_out, err_msg=f"dy_out:\n {dy_out}\n st_out:\n{st_out}"
         )
 
 

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -705,9 +705,7 @@ class TestCycleGANModel(unittest.TestCase):
         if not fluid.is_compiled_with_cuda():
             assert_func = np.testing.assert_array_equal
 
-        assert_func(
-            dy_out, st_out, err_msg=f"dy_out:\n {dy_out}\n st_out:\n{st_out}"
-        )
+        assert_func(dy_out, st_out)
 
 
 if __name__ == "__main__":

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -698,14 +698,13 @@ class TestCycleGANModel(unittest.TestCase):
         st_out = self.train(to_static=True)
         dy_out = self.train(to_static=False)
 
-        assert_func = np.testing.assert_allclose
         # Note(Aurelius84): Because we disable BN on GPU,
         # but here we enhance the check on CPU by `np.array_equal`
         # which means the dy_out and st_out shall be exactly same.
         if not fluid.is_compiled_with_cuda():
-            assert_func = np.testing.assert_array_equal
-
-        assert_func(dy_out, st_out)
+            np.testing.assert_array_equal(dy_out, st_out)
+        else:
+            np.testing.assert_allclose(dy_out, st_out, rtol=1e-5, atol=1e-8)
 
 
 if __name__ == "__main__":

--- a/test/ir/inference/test_inference_predictor_run.py
+++ b/test/ir/inference/test_inference_predictor_run.py
@@ -119,7 +119,7 @@ class TestPredictorRunWithTensor(unittest.TestCase):
         inorder_output = self.get_inorder_output()
         disorder_output = self.get_disorder_output()
 
-        assert np.allclose(
+        np.testing.assert_allclose(
             inorder_output.numpy().flatten(), disorder_output.numpy().flatten()
         )
 

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3294,9 +3294,9 @@ class TestPow_factor_tensor(TestActivation):
                 fetch_list=[out_1, out_2, res, out_6],
             )
 
-            assert np.allclose(res_1, np.power(input, 2))
-            assert np.allclose(res_2, np.power(input, 3))
-            assert np.allclose(res_6, np.power(input, 3))
+            np.testing.assert_allclose(res_1, np.power(input, 2))
+            np.testing.assert_allclose(res_2, np.power(input, 3))
+            np.testing.assert_allclose(res_6, np.power(input, 3))
 
 
 def ref_stanh(x, scale_a=0.67, scale_b=1.7159):

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3295,13 +3295,13 @@ class TestPow_factor_tensor(TestActivation):
             )
 
             np.testing.assert_allclose(
-                res_1, np.power(input, 2), rtol=1e-6, atol=1e-6
+                res_1, np.power(input, 2), rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_2, np.power(input, 3), rtol=1e-6, atol=1e-6
+                res_2, np.power(input, 3), rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_6, np.power(input, 3), rtol=1e-6, atol=1e-6
+                res_6, np.power(input, 3), rtol=1e-5, atol=1e-8
             )
 
 

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3294,9 +3294,15 @@ class TestPow_factor_tensor(TestActivation):
                 fetch_list=[out_1, out_2, res, out_6],
             )
 
-            np.testing.assert_allclose(res_1, np.power(input, 2))
-            np.testing.assert_allclose(res_2, np.power(input, 3))
-            np.testing.assert_allclose(res_6, np.power(input, 3))
+            np.testing.assert_allclose(
+                res_1, np.power(input, 2), rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_2, np.power(input, 3), rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_6, np.power(input, 3), rtol=1e-6, atol=1e-6
+            )
 
 
 def ref_stanh(x, scale_a=0.67, scale_b=1.7159):

--- a/test/legacy_test/test_adaptive_avg_pool2d.py
+++ b/test/legacy_test/test_adaptive_avg_pool2d.py
@@ -148,15 +148,15 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
-            assert np.allclose(res_4, self.res_4_np)
+            np.testing.assert_allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -188,17 +188,17 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
                 x=x, mode="area", size=[2, 5]
             )
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            assert np.allclose(out_4.numpy(), self.res_4_np)
+            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
-            assert np.allclose(out_6.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_6.numpy(), self.res_3_np)
 
 
 class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
@@ -260,15 +260,15 @@ class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
-            assert np.allclose(res_4, self.res_4_np)
+            np.testing.assert_allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -297,15 +297,15 @@ class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
             )
             out_5 = adaptive_avg_pool(x=x)
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            assert np.allclose(out_4.numpy(), self.res_4_np)
+            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
 
 class TestOutputSizeTensor(UnittestBase):

--- a/test/legacy_test/test_adaptive_avg_pool2d.py
+++ b/test/legacy_test/test_adaptive_avg_pool2d.py
@@ -148,15 +148,21 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            np.testing.assert_allclose(res_1, self.res_1_np)
-
-            np.testing.assert_allclose(res_2, self.res_2_np)
-
-            np.testing.assert_allclose(res_3, self.res_3_np)
-
-            np.testing.assert_allclose(res_4, self.res_4_np)
-
-            np.testing.assert_allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(
+                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+            )
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -169,36 +175,38 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
             out_1 = paddle.nn.functional.adaptive_avg_pool2d(
                 x=x, output_size=[3, 3]
             )
-
             out_2 = paddle.nn.functional.adaptive_avg_pool2d(x=x, output_size=5)
-
             out_3 = paddle.nn.functional.adaptive_avg_pool2d(
                 x=x, output_size=[2, 5]
             )
-
             out_4 = paddle.nn.functional.adaptive_avg_pool2d(
                 x=x, output_size=[3, 3], data_format="NHWC"
             )
-
             out_5 = paddle.nn.functional.adaptive_avg_pool2d(
                 x=x, output_size=[None, 3]
             )
-
             out_6 = paddle.nn.functional.interpolate(
                 x=x, mode="area", size=[2, 5]
             )
 
-            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
-
-            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
-
-            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
-
-            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
-
-            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
-
-            np.testing.assert_allclose(out_6.numpy(), self.res_3_np)
+            np.testing.assert_allclose(
+                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_6.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+            )
 
 
 class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
@@ -260,15 +268,21 @@ class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            np.testing.assert_allclose(res_1, self.res_1_np)
-
-            np.testing.assert_allclose(res_2, self.res_2_np)
-
-            np.testing.assert_allclose(res_3, self.res_3_np)
-
-            np.testing.assert_allclose(res_4, self.res_4_np)
-
-            np.testing.assert_allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(
+                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+            )
 
     def test_dynamic_graph(self):
         for use_cuda in (

--- a/test/legacy_test/test_adaptive_avg_pool2d.py
+++ b/test/legacy_test/test_adaptive_avg_pool2d.py
@@ -149,19 +149,19 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
             )
 
             np.testing.assert_allclose(
-                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+                res_1, self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+                res_2, self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+                res_3, self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+                res_4, self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+                res_5, self.res_5_np, rtol=1e-5, atol=1e-8
             )
 
     def test_dynamic_graph(self):
@@ -190,22 +190,22 @@ class TestAdaptiveAvgPool2DAPI(unittest.TestCase):
             )
 
             np.testing.assert_allclose(
-                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+                out_1.numpy(), self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+                out_2.numpy(), self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+                out_3.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+                out_4.numpy(), self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+                out_5.numpy(), self.res_5_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_6.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+                out_6.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
 
 
@@ -269,19 +269,19 @@ class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
             )
 
             np.testing.assert_allclose(
-                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+                res_1, self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+                res_2, self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+                res_3, self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+                res_4, self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+                res_5, self.res_5_np, rtol=1e-5, atol=1e-8
             )
 
     def test_dynamic_graph(self):
@@ -312,19 +312,19 @@ class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
             out_5 = adaptive_avg_pool(x=x)
 
             np.testing.assert_allclose(
-                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+                out_1.numpy(), self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+                out_2.numpy(), self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+                out_3.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+                out_4.numpy(), self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+                out_5.numpy(), self.res_5_np, rtol=1e-5, atol=1e-8
             )
 
 

--- a/test/legacy_test/test_adaptive_avg_pool2d.py
+++ b/test/legacy_test/test_adaptive_avg_pool2d.py
@@ -311,15 +311,21 @@ class TestAdaptiveAvgPool2DClassAPI(unittest.TestCase):
             )
             out_5 = adaptive_avg_pool(x=x)
 
-            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
-
-            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
-
-            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
-
-            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
-
-            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(
+                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+            )
 
 
 class TestOutputSizeTensor(UnittestBase):

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -169,15 +169,21 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            np.testing.assert_allclose(res_1, self.res_1_np)
-
-            np.testing.assert_allclose(res_2, self.res_2_np)
-
-            np.testing.assert_allclose(res_3, self.res_3_np)
-
-            np.testing.assert_allclose(res_4, self.res_4_np)
-
-            np.testing.assert_allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(
+                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+            )
 
     def test_dynamic_graph(self):
         for use_cuda in (

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -170,19 +170,19 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
             )
 
             np.testing.assert_allclose(
-                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+                res_1, self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+                res_2, self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+                res_3, self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+                res_4, self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+                res_5, self.res_5_np, rtol=1e-5, atol=1e-8
             )
 
     def test_dynamic_graph(self):
@@ -216,22 +216,22 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
             )
 
             np.testing.assert_allclose(
-                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+                out_1.numpy(), self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+                out_2.numpy(), self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+                out_3.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+                out_4.numpy(), self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+                out_5.numpy(), self.res_5_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_6.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+                out_6.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
 
 
@@ -302,19 +302,19 @@ class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
             )
 
             np.testing.assert_allclose(
-                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+                res_1, self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+                res_2, self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+                res_3, self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+                res_4, self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+                res_5, self.res_5_np, rtol=1e-5, atol=1e-8
             )
 
     def test_dynamic_graph(self):
@@ -349,19 +349,19 @@ class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
             out_5 = adaptive_avg_pool(x=x)
 
             np.testing.assert_allclose(
-                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+                out_1.numpy(), self.res_1_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+                out_2.numpy(), self.res_2_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+                out_3.numpy(), self.res_3_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+                out_4.numpy(), self.res_4_np, rtol=1e-5, atol=1e-8
             )
             np.testing.assert_allclose(
-                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+                out_5.numpy(), self.res_5_np, rtol=1e-5, atol=1e-8
             )
 
 

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -169,15 +169,15 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
-            assert np.allclose(res_4, self.res_4_np)
+            np.testing.assert_allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -209,17 +209,17 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
                 x=x, mode="area", size=[2, 3, 5]
             )
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            assert np.allclose(out_4.numpy(), self.res_4_np)
+            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
-            assert np.allclose(out_6.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_6.numpy(), self.res_3_np)
 
 
 class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
@@ -288,15 +288,15 @@ class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
-            assert np.allclose(res_4, self.res_4_np)
+            np.testing.assert_allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -329,15 +329,15 @@ class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
             )
             out_5 = adaptive_avg_pool(x=x)
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            assert np.allclose(out_4.numpy(), self.res_4_np)
+            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -209,17 +209,24 @@ class TestAdaptiveAvgPool3DAPI(unittest.TestCase):
                 x=x, mode="area", size=[2, 3, 5]
             )
 
-            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
-
-            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
-
-            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
-
-            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
-
-            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
-
-            np.testing.assert_allclose(out_6.numpy(), self.res_3_np)
+            np.testing.assert_allclose(
+                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_6.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+            )
 
 
 class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
@@ -335,15 +342,21 @@ class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
             )
             out_5 = adaptive_avg_pool(x=x)
 
-            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
-
-            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
-
-            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
-
-            np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
-
-            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(
+                out_1.numpy(), self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_2.numpy(), self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_3.numpy(), self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_4.numpy(), self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                out_5.numpy(), self.res_5_np, rtol=1e-6, atol=1e-6
+            )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_adaptive_avg_pool3d.py
+++ b/test/legacy_test/test_adaptive_avg_pool3d.py
@@ -288,15 +288,21 @@ class TestAdaptiveAvgPool3DClassAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5],
             )
 
-            np.testing.assert_allclose(res_1, self.res_1_np)
-
-            np.testing.assert_allclose(res_2, self.res_2_np)
-
-            np.testing.assert_allclose(res_3, self.res_3_np)
-
-            np.testing.assert_allclose(res_4, self.res_4_np)
-
-            np.testing.assert_allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(
+                res_1, self.res_1_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_2, self.res_2_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_3, self.res_3_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_4, self.res_4_np, rtol=1e-6, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                res_5, self.res_5_np, rtol=1e-6, atol=1e-6
+            )
 
     def test_dynamic_graph(self):
         for use_cuda in (

--- a/test/legacy_test/test_adaptive_max_pool2d.py
+++ b/test/legacy_test/test_adaptive_max_pool2d.py
@@ -155,7 +155,7 @@ class TestAdaptiveMaxPool2DAPI(unittest.TestCase):
 
             np.testing.assert_allclose(res_3, self.res_3_np)
 
-            # assert np.allclose(res_4, self.res_4_np)
+            # np.testing.assert_allclose(res_4, self.res_4_np)
 
             np.testing.assert_allclose(res_5, self.res_5_np)
 
@@ -190,7 +190,7 @@ class TestAdaptiveMaxPool2DAPI(unittest.TestCase):
 
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            # assert np.allclose(out_4.numpy(), self.res_4_np)
+            # np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
@@ -261,7 +261,7 @@ class TestAdaptiveMaxPool2DClassAPI(unittest.TestCase):
 
             np.testing.assert_allclose(res_3, self.res_3_np)
 
-            # assert np.allclose(res_4, self.res_4_np)
+            # np.testing.assert_allclose(res_4, self.res_4_np)
 
             np.testing.assert_allclose(res_5, self.res_5_np)
 
@@ -297,7 +297,7 @@ class TestAdaptiveMaxPool2DClassAPI(unittest.TestCase):
 
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            # assert np.allclose(out_4.numpy(), self.res_4_np)
+            # np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 

--- a/test/legacy_test/test_adaptive_max_pool2d.py
+++ b/test/legacy_test/test_adaptive_max_pool2d.py
@@ -149,15 +149,15 @@ class TestAdaptiveMaxPool2DAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
             # assert np.allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -184,15 +184,15 @@ class TestAdaptiveMaxPool2DAPI(unittest.TestCase):
                 x=x, output_size=[None, 3]
             )
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
             # assert np.allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
 
 class TestAdaptiveMaxPool2DClassAPI(unittest.TestCase):
@@ -255,15 +255,15 @@ class TestAdaptiveMaxPool2DClassAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
             # assert np.allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -291,15 +291,15 @@ class TestAdaptiveMaxPool2DClassAPI(unittest.TestCase):
             )
             out_5 = adaptive_max_pool(x=x)
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
             # assert np.allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
 
 class TestOutDtype(unittest.TestCase):

--- a/test/legacy_test/test_adaptive_max_pool3d.py
+++ b/test/legacy_test/test_adaptive_max_pool3d.py
@@ -176,7 +176,7 @@ class TestAdaptiveMaxPool3DAPI(unittest.TestCase):
 
             np.testing.assert_allclose(res_3, self.res_3_np)
 
-            # assert np.allclose(res_4, self.res_4_np)
+            # np.testing.assert_allclose(res_4, self.res_4_np)
 
             np.testing.assert_allclose(res_5, self.res_5_np)
 
@@ -211,7 +211,7 @@ class TestAdaptiveMaxPool3DAPI(unittest.TestCase):
 
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
-            # assert np.allclose(out_4.numpy(), self.res_4_np)
+            # np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
 
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 

--- a/test/legacy_test/test_adaptive_max_pool3d.py
+++ b/test/legacy_test/test_adaptive_max_pool3d.py
@@ -170,15 +170,15 @@ class TestAdaptiveMaxPool3DAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
             # assert np.allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -205,15 +205,15 @@ class TestAdaptiveMaxPool3DAPI(unittest.TestCase):
                 x=x, output_size=[None, 3, None]
             )
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
             # assert np.allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
 
 class TestAdaptiveMaxPool3DClassAPI(unittest.TestCase):
@@ -280,15 +280,15 @@ class TestAdaptiveMaxPool3DClassAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_5],
             )
 
-            assert np.allclose(res_1, self.res_1_np)
+            np.testing.assert_allclose(res_1, self.res_1_np)
 
-            assert np.allclose(res_2, self.res_2_np)
+            np.testing.assert_allclose(res_2, self.res_2_np)
 
-            assert np.allclose(res_3, self.res_3_np)
+            np.testing.assert_allclose(res_3, self.res_3_np)
 
             #     assert np.allclose(res_4, self.res_4_np)
 
-            assert np.allclose(res_5, self.res_5_np)
+            np.testing.assert_allclose(res_5, self.res_5_np)
 
     def test_dynamic_graph(self):
         for use_cuda in (
@@ -320,15 +320,15 @@ class TestAdaptiveMaxPool3DClassAPI(unittest.TestCase):
             )
             out_5 = adaptive_max_pool(x=x)
 
-            assert np.allclose(out_1.numpy(), self.res_1_np)
+            np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
 
-            assert np.allclose(out_2.numpy(), self.res_2_np)
+            np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
 
-            assert np.allclose(out_3.numpy(), self.res_3_np)
+            np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
 
             #     assert np.allclose(out_4.numpy(), self.res_4_np)
 
-            assert np.allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
 
 
 class TestOutDtype(unittest.TestCase):

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -328,7 +328,9 @@ class TestAddMMOp5(unittest.TestCase):
             x = fluid.dygraph.to_variable(np_x)
             y = fluid.dygraph.to_variable(np_y)
             out = paddle.tensor.addmm(input, x, y)
-            assert np.allclose(np_input + np.dot(np_x, np_y), out.numpy())
+            np.testing.assert_allclose(
+                np_input + np.dot(np_x, np_y), out.numpy()
+            )
 
 
 class TestAddMMAPI(unittest.TestCase):

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -329,7 +329,7 @@ class TestAddMMOp5(unittest.TestCase):
             y = fluid.dygraph.to_variable(np_y)
             out = paddle.tensor.addmm(input, x, y)
             np.testing.assert_allclose(
-                np_input + np.dot(np_x, np_y), out.numpy()
+                np_input + np.dot(np_x, np_y), out.numpy(), rtol=1e-5, atol=1e-8
             )
 
 

--- a/test/legacy_test/test_batch_norm_op_v2.py
+++ b/test/legacy_test/test_batch_norm_op_v2.py
@@ -173,7 +173,7 @@ class TestBatchNorm(unittest.TestCase):
 
                     bn = paddle.nn.BatchNorm2D(shape[1])
                     eag_y = bn(paddle.to_tensor(x))
-                    assert np.allclose(eag_y.numpy(), y.numpy())
+                    np.testing.assert_allclose(eag_y.numpy(), y.numpy())
                 return y.numpy()
 
             def compute_v3(x, is_test, trainable_statistics):
@@ -351,10 +351,10 @@ class TestBatchNormChannelLast(unittest.TestCase):
             y.backward()
             y2.backward()
 
-            assert np.allclose(
+            np.testing.assert_allclose(
                 y.numpy().flatten(), y2.numpy().flatten(), atol=1e-5, rtol=1e-5
             )
-            assert np.allclose(
+            np.testing.assert_allclose(
                 bn1d.weight.grad.numpy().flatten(),
                 bn2d.weight.grad.numpy().flatten(),
                 atol=1e-5,

--- a/test/legacy_test/test_broadcast_to_op.py
+++ b/test/legacy_test/test_broadcast_to_op.py
@@ -66,9 +66,9 @@ class TestBroadcastToAPI(unittest.TestCase):
             },
             fetch_list=[out_1, out_2, out_3],
         )
-        assert np.array_equal(res_1, np.tile(input, (1, 1)))
-        assert np.array_equal(res_2, np.tile(input, (1, 1)))
-        assert np.array_equal(res_3, np.tile(input, (1, 1)))
+        np.testing.assert_array_equal(res_1, np.tile(input, (1, 1)))
+        np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
+        np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
 
     def test_api_fp16_gpu(self):
         if paddle.fluid.core.is_compiled_with_cuda():
@@ -101,9 +101,9 @@ class TestBroadcastToAPI(unittest.TestCase):
                     },
                     fetch_list=[out_1, out_2, out_3],
                 )
-                assert np.array_equal(res_1, np.tile(input, (1, 1)))
-                assert np.array_equal(res_2, np.tile(input, (1, 1)))
-                assert np.array_equal(res_3, np.tile(input, (1, 1)))
+                np.testing.assert_array_equal(res_1, np.tile(input, (1, 1)))
+                np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
+                np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_channel_shuffle.py
+++ b/test/legacy_test/test_channel_shuffle.py
@@ -120,8 +120,8 @@ class TestChannelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            assert np.allclose(res_1, self.out_1_np)
-            assert np.allclose(res_2, self.out_2_np)
+            np.testing.assert_allclose(res_1, self.out_1_np)
+            np.testing.assert_allclose(res_2, self.out_2_np)
 
     # same test between layer and functional in this op.
     def test_static_graph_layer(self):
@@ -160,8 +160,8 @@ class TestChannelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            assert np.allclose(res_1, out_1_np)
-            assert np.allclose(res_2, out_2_np)
+            np.testing.assert_allclose(res_1, out_1_np)
+            np.testing.assert_allclose(res_2, out_2_np)
 
     def run_dygraph(self, groups, data_format):
         n, c, h, w = 2, 9, 4, 4

--- a/test/legacy_test/test_channel_shuffle.py
+++ b/test/legacy_test/test_channel_shuffle.py
@@ -120,8 +120,8 @@ class TestChannelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            np.testing.assert_allclose(res_1, self.out_1_np)
-            np.testing.assert_allclose(res_2, self.out_2_np)
+            np.testing.assert_allclose(res_1[0], self.out_1_np)
+            np.testing.assert_allclose(res_2[0], self.out_2_np)
 
     # same test between layer and functional in this op.
     def test_static_graph_layer(self):
@@ -160,8 +160,8 @@ class TestChannelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            np.testing.assert_allclose(res_1, out_1_np)
-            np.testing.assert_allclose(res_2, out_2_np)
+            np.testing.assert_allclose(res_1[0], out_1_np)
+            np.testing.assert_allclose(res_2[0], out_2_np)
 
     def run_dygraph(self, groups, data_format):
         n, c, h, w = 2, 9, 4, 4

--- a/test/legacy_test/test_concat_op.py
+++ b/test/legacy_test/test_concat_op.py
@@ -472,9 +472,15 @@ class TestConcatAPI(unittest.TestCase):
             feed={"x_1": input_2, "x_2": input_2, "x_3": input_3},
             fetch_list=[out_1, out_2, out_3],
         )
-        assert np.array_equal(res_1, np.concatenate((input_2, input_3), axis=1))
-        assert np.array_equal(res_2, np.concatenate((input_2, input_3), axis=1))
-        assert np.array_equal(res_3, np.concatenate((input_2, input_3), axis=1))
+        np.testing.assert_array_equal(
+            res_1, np.concatenate((input_2, input_3), axis=1)
+        )
+        np.testing.assert_array_equal(
+            res_2, np.concatenate((input_2, input_3), axis=1)
+        )
+        np.testing.assert_array_equal(
+            res_3, np.concatenate((input_2, input_3), axis=1)
+        )
 
     def test_api(self):
         paddle.enable_static()
@@ -501,10 +507,18 @@ class TestConcatAPI(unittest.TestCase):
             feed={"x_1": input_2, "x_2": input_2, "x_3": input_3},
             fetch_list=[out_1, out_2, out_3, out_4],
         )
-        assert np.array_equal(res_1, np.concatenate((input_2, input_3), axis=1))
-        assert np.array_equal(res_2, np.concatenate((input_2, input_3), axis=1))
-        assert np.array_equal(res_3, np.concatenate((input_2, input_3), axis=1))
-        assert np.array_equal(res_4, np.concatenate((input_2, input_3), axis=1))
+        np.testing.assert_array_equal(
+            res_1, np.concatenate((input_2, input_3), axis=1)
+        )
+        np.testing.assert_array_equal(
+            res_2, np.concatenate((input_2, input_3), axis=1)
+        )
+        np.testing.assert_array_equal(
+            res_3, np.concatenate((input_2, input_3), axis=1)
+        )
+        np.testing.assert_array_equal(
+            res_4, np.concatenate((input_2, input_3), axis=1)
+        )
 
     def test_imperative(self):
         in1 = np.array([[1, 2, 3], [4, 5, 6]])

--- a/test/legacy_test/test_cuda_graph_partial_graph_static_run.py
+++ b/test/legacy_test/test_cuda_graph_partial_graph_static_run.py
@@ -124,7 +124,7 @@ class TestCudaGraphAttrAll(unittest.TestCase):
         x_data = np.random.random((3, 10)).astype('float32')
         cuda_graph_rst = self.run_with_cuda_graph(x_data)
         normal_run_rst = self.normal_run(x_data)
-        assert np.array_equal(cuda_graph_rst, normal_run_rst)
+        np.testing.assert_array_equal(cuda_graph_rst, normal_run_rst)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_detach.py
+++ b/test/legacy_test/test_detach.py
@@ -172,7 +172,9 @@ class Test_Detach(unittest.TestCase):
     def test_NoDetachSingle_DetachMulti(self):
         array_no_detach_single = self.no_detach_single()
         array_detach_multi = self.detach_multi()
-        assert np.array_equal(array_no_detach_single, array_detach_multi)
+        np.testing.assert_array_equal(
+            array_no_detach_single, array_detach_multi
+        )
 
 
 class TestInplace(unittest.TestCase):

--- a/test/legacy_test/test_detach.py
+++ b/test/legacy_test/test_detach.py
@@ -167,7 +167,11 @@ class Test_Detach(unittest.TestCase):
         array_no_detach_multi = self.no_detach_multi()
         array_detach_multi = self.detach_multi()
 
-        assert not np.array_equal(array_no_detach_multi, array_detach_multi)
+        import operator
+
+        np.testing.assert_array_compare(
+            operator.__ne__, array_no_detach_multi, array_detach_multi
+        )
 
     def test_NoDetachSingle_DetachMulti(self):
         array_no_detach_single = self.no_detach_single()

--- a/test/legacy_test/test_detach.py
+++ b/test/legacy_test/test_detach.py
@@ -167,11 +167,7 @@ class Test_Detach(unittest.TestCase):
         array_no_detach_multi = self.no_detach_multi()
         array_detach_multi = self.detach_multi()
 
-        import operator
-
-        np.testing.assert_array_compare(
-            operator.__ne__, array_no_detach_multi, array_detach_multi
-        )
+        assert not np.array_equal(array_no_detach_multi, array_detach_multi)
 
     def test_NoDetachSingle_DetachMulti(self):
         array_no_detach_single = self.no_detach_single()

--- a/test/legacy_test/test_egr_python_api.py
+++ b/test/legacy_test/test_egr_python_api.py
@@ -845,7 +845,7 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
 
         new_arr = np.random.rand(4, 16, 16, 32).astype('float32')
 
-        assert not np.array_equal(egr_tensor.numpy(), new_arr)
+        self.assertFalse(np.array_equal(egr_tensor.numpy(), new_arr))
 
         egr_tensor.set_value(new_arr)
         self.assertEqual(egr_tensor.stop_gradient, True)
@@ -966,7 +966,7 @@ class EagerParamBaseUsageTestCase(unittest.TestCase):
         ori_place = linear.weight.place
         new_weight = np.ones([1, 3]).astype('float32')
 
-        assert not np.array_equal(linear.weight.numpy(), new_weight)
+        self.assertFalse(np.array_equal(linear.weight.numpy(), new_weight))
 
         linear.weight.set_value(new_weight)
         np.testing.assert_array_equal(linear.weight.numpy(), new_weight)

--- a/test/legacy_test/test_egr_python_api.py
+++ b/test/legacy_test/test_egr_python_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import operator
 import unittest
 
 import numpy as np
@@ -846,9 +845,7 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
 
         new_arr = np.random.rand(4, 16, 16, 32).astype('float32')
 
-        np.testing.assert_array_compare(
-            operator.__ne__, egr_tensor.numpy(), new_arr
-        )
+        assert not np.array_equal(egr_tensor.numpy(), new_arr)
 
         egr_tensor.set_value(new_arr)
         self.assertEqual(egr_tensor.stop_gradient, True)
@@ -969,9 +966,7 @@ class EagerParamBaseUsageTestCase(unittest.TestCase):
         ori_place = linear.weight.place
         new_weight = np.ones([1, 3]).astype('float32')
 
-        np.testing.assert_array_compare(
-            operator.__ne__, linear.weight.numpy(), new_weight
-        )
+        assert not np.array_equal(linear.weight.numpy(), new_weight)
 
         linear.weight.set_value(new_weight)
         np.testing.assert_array_equal(linear.weight.numpy(), new_weight)

--- a/test/legacy_test/test_egr_python_api.py
+++ b/test/legacy_test/test_egr_python_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import operator
 import unittest
 
 import numpy as np
@@ -844,7 +845,6 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         ori_place = egr_tensor.place
 
         new_arr = np.random.rand(4, 16, 16, 32).astype('float32')
-        import operator
 
         np.testing.assert_array_compare(
             operator.__ne__, egr_tensor.numpy(), new_arr
@@ -968,7 +968,6 @@ class EagerParamBaseUsageTestCase(unittest.TestCase):
         linear = paddle.nn.Linear(1, 3)
         ori_place = linear.weight.place
         new_weight = np.ones([1, 3]).astype('float32')
-        import operator
 
         np.testing.assert_array_compare(
             operator.__ne__, linear.weight.numpy(), new_weight

--- a/test/legacy_test/test_egr_python_api.py
+++ b/test/legacy_test/test_egr_python_api.py
@@ -844,7 +844,11 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         ori_place = egr_tensor.place
 
         new_arr = np.random.rand(4, 16, 16, 32).astype('float32')
-        self.assertFalse(np.array_equal(egr_tensor.numpy(), new_arr))
+        import operator
+
+        np.testing.assert_array_compare(
+            operator.__ne__, egr_tensor.numpy(), new_arr
+        )
 
         egr_tensor.set_value(new_arr)
         self.assertEqual(egr_tensor.stop_gradient, True)
@@ -964,7 +968,11 @@ class EagerParamBaseUsageTestCase(unittest.TestCase):
         linear = paddle.nn.Linear(1, 3)
         ori_place = linear.weight.place
         new_weight = np.ones([1, 3]).astype('float32')
-        self.assertFalse(np.array_equal(linear.weight.numpy(), new_weight))
+        import operator
+
+        np.testing.assert_array_compare(
+            operator.__ne__, linear.weight.numpy(), new_weight
+        )
 
         linear.weight.set_value(new_weight)
         np.testing.assert_array_equal(linear.weight.numpy(), new_weight)

--- a/test/legacy_test/test_einsum_v2.py
+++ b/test/legacy_test/test_einsum_v2.py
@@ -581,7 +581,7 @@ class TestSimpleUndiagonal(unittest.TestCase):
         A = paddle.to_tensor(np.array([1.0, 2.0]))
         A_expect = paddle.to_tensor([[1.0, 0.0], [0.0, 2.0]])
         A_actual = paddle.einsum('i->ii', A)
-        assert np.array_equal(A_expect.numpy(), A_actual.numpy())
+        np.testing.assert_array_equal(A_expect.numpy(), A_actual.numpy())
 
 
 class TestSimpleUndiagonal2(unittest.TestCase):
@@ -595,7 +595,7 @@ class TestSimpleUndiagonal2(unittest.TestCase):
         B = paddle.to_tensor(np.array([1.0, 1.0]))
         A_expect = paddle.to_tensor([[2.0, 0.0], [0.0, 4.0]])
         A_actual = paddle.einsum('i,j->ii', A, B)
-        assert np.array_equal(A_expect.numpy(), A_actual.numpy())
+        np.testing.assert_array_equal(A_expect.numpy(), A_actual.numpy())
 
 
 class TestSimpleComplexGrad(unittest.TestCase):

--- a/test/legacy_test/test_expand_as_v2_op.py
+++ b/test/legacy_test/test_expand_as_v2_op.py
@@ -280,7 +280,7 @@ class TestExpandAsV2API(unittest.TestCase):
             feed={"x": input1, "target_tensor": input2},
             fetch_list=[out_1],
         )
-        assert np.array_equal(res_1[0], np.tile(input1, (2, 1, 1)))
+        np.testing.assert_array_equal(res_1[0], np.tile(input1, (2, 1, 1)))
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -318,9 +318,9 @@ class TestExpandV2API(unittest.TestCase):
             },
             fetch_list=[out_1, out_2, out_3],
         )
-        assert np.array_equal(res_1, np.tile(input, (1, 1)))
-        assert np.array_equal(res_2, np.tile(input, (1, 1)))
-        assert np.array_equal(res_3, np.tile(input, (1, 1)))
+        np.testing.assert_array_equal(res_1, np.tile(input, (1, 1)))
+        np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
+        np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
 
 
 class TestExpandInferShape(unittest.TestCase):

--- a/test/legacy_test/test_fill_constant_op.py
+++ b/test/legacy_test/test_fill_constant_op.py
@@ -338,14 +338,30 @@ class TestFillConstantAPI(unittest.TestCase):
             fetch_list=[out_1, out_2, out_3, out_4, out_5, out_6, out_7, out_8],
         )
 
-        assert np.array_equal(res_1, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_2, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_3, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_4, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_5, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_6, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_7, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_8, np.full([1, 2], 1.1, dtype="float32"))
+        np.testing.assert_array_equal(
+            res_1, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_2, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_3, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_4, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_5, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_6, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_7, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_8, np.full([1, 2], 1.1, dtype="float32")
+        )
 
 
 class TestFillConstantImperative(unittest.TestCase):
@@ -369,16 +385,16 @@ class TestFillConstantImperative(unittest.TestCase):
             res4 = paddle.tensor.fill_constant(
                 shape=shape, dtype='int32', value=value
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res1.numpy(), np.full([1, 2], 1.1, dtype="float32")
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res2.numpy(), np.full([1, 2], 1.1, dtype="float32")
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res3.numpy(), np.full([1, 2], 1.1, dtype="float32")
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res4.numpy(), np.full([1, 2], 88, dtype="int32")
             )
 

--- a/test/legacy_test/test_flatten_op.py
+++ b/test/legacy_test/test_flatten_op.py
@@ -90,7 +90,7 @@ class TestFlattenOpFP16(unittest.TestCase):
                         fetch_list=[y],
                     )
 
-                    assert np.array_equal(res[0].shape, [12 * 14])
+                    np.testing.assert_array_equal(res[0].shape, [12 * 14])
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_full_op.py
+++ b/test/legacy_test/test_full_op.py
@@ -74,13 +74,27 @@ class TestFullAPI(unittest.TestCase):
             fetch_list=[out_1, out_2, out_3, out_4, out_5, out_6, out_7],
         )
 
-        assert np.array_equal(res_1, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_2, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_3, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_4, np.full([1, 2], 1.2, dtype="float32"))
-        assert np.array_equal(res_5, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_6, np.full([1, 2], 1.1, dtype="float32"))
-        assert np.array_equal(res_7, np.full([1, 2], 1.1, dtype="float32"))
+        np.testing.assert_array_equal(
+            res_1, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_2, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_3, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_4, np.full([1, 2], 1.2, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_5, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_6, np.full([1, 2], 1.1, dtype="float32")
+        )
+        np.testing.assert_array_equal(
+            res_7, np.full([1, 2], 1.1, dtype="float32")
+        )
 
     def test_api_eager(self):
         with fluid.dygraph.base.guard():
@@ -134,18 +148,36 @@ class TestFullAPI(unittest.TestCase):
                 out_7, dtype=np.float32, fill_value=np.abs(1.1)
             )
 
-            assert np.array_equal(out_1, np.full([1, 2], 1.1, dtype="float32"))
-            assert np.array_equal(out_2, np.full([1, 2], 1.1, dtype="float32"))
-            assert np.array_equal(out_3, np.full([1, 2], 1.1, dtype="float32"))
-            assert np.array_equal(out_4, np.full([1, 2], 1.2, dtype="float32"))
-            assert np.array_equal(out_5, np.full([1, 2], 1.1, dtype="float32"))
-            assert np.array_equal(out_6, np.full([1, 2], 1.1, dtype="float32"))
-            assert np.array_equal(out_7, np.full([1, 2], 1.1, dtype="float32"))
-            assert np.array_equal(out_8, np.full([2], 1.1, dtype="float32"))
-            assert np.array_equal(
+            np.testing.assert_array_equal(
+                out_1, np.full([1, 2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_2, np.full([1, 2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_3, np.full([1, 2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_4, np.full([1, 2], 1.2, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_5, np.full([1, 2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_6, np.full([1, 2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_7, np.full([1, 2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
+                out_8, np.full([2], 1.1, dtype="float32")
+            )
+            np.testing.assert_array_equal(
                 out_9, np.full([2, 2, 4], 1.1, dtype="float32")
             )
-            assert np.array_equal(out_10, np.full([1, 2], 1.1, dtype="float32"))
+            np.testing.assert_array_equal(
+                out_10, np.full([1, 2], 1.1, dtype="float32")
+            )
 
 
 class TestFullOpError(unittest.TestCase):

--- a/test/legacy_test/test_fused_attention_pass.py
+++ b/test/legacy_test/test_fused_attention_pass.py
@@ -185,7 +185,9 @@ class TestFusedAttentionPass(unittest.TestCase):
     def test_pass(self):
         fused_rst = self.get_rst(use_pass=True)
         non_fused_rst = self.get_rst()
-        np.testing.assert_allclose(fused_rst, non_fused_rst)
+        np.testing.assert_allclose(
+            fused_rst, non_fused_rst, rtol=1e-5, atol=1e-8
+        )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fused_attention_pass.py
+++ b/test/legacy_test/test_fused_attention_pass.py
@@ -185,7 +185,7 @@ class TestFusedAttentionPass(unittest.TestCase):
     def test_pass(self):
         fused_rst = self.get_rst(use_pass=True)
         non_fused_rst = self.get_rst()
-        assert np.allclose(fused_rst, non_fused_rst)
+        np.testing.assert_allclose(fused_rst, non_fused_rst)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fused_feedforward_pass.py
+++ b/test/legacy_test/test_fused_feedforward_pass.py
@@ -165,7 +165,7 @@ class TestFusedFeedforwadPass(unittest.TestCase):
                         self.use_dropout_2 = use_dropout_2
                         ret_loss = self.get_value()
                         ret_loss_fused = self.get_value(use_pass=True)
-                        assert np.allclose(ret_loss, ret_loss_fused)
+                        np.testing.assert_allclose(ret_loss, ret_loss_fused)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fused_feedforward_pass.py
+++ b/test/legacy_test/test_fused_feedforward_pass.py
@@ -165,7 +165,9 @@ class TestFusedFeedforwadPass(unittest.TestCase):
                         self.use_dropout_2 = use_dropout_2
                         ret_loss = self.get_value()
                         ret_loss_fused = self.get_value(use_pass=True)
-                        np.testing.assert_allclose(ret_loss, ret_loss_fused)
+                        np.testing.assert_allclose(
+                            ret_loss, ret_loss_fused, rtol=1e-5, atol=1e-8
+                        )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -113,8 +113,12 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 data_pd = paddle.to_tensor(data.astype('float16'))
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                self.assertTrue(np.allclose(result1, expect_res1, atol=1e-5))
-                self.assertTrue(np.allclose(result2, expect_res2, atol=1e-5))
+                np.testing.assert_allclose(
+                    result1, expect_res1, rtol=1e-2, atol=1e-3
+                )
+                np.testing.assert_allclose(
+                    result2, expect_res2, rtol=1e-2, atol=1e-3
+                )
 
 
 class TestGroupNormDimException(unittest.TestCase):

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -57,23 +57,20 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
                 scale = np.array([1]).astype("float32")
                 bias = np.array([0]).astype("float32")
                 data = np.random.random(shape).astype("float32")
-                res_1 = group_norm_naive_for_general_dimension(
+                expect_res1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
                 )
-                res_2 = group_norm_naive_for_general_dimension(
+                expect_res2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
                 )
-
-                res_1 = res_1[0] if len(res_1) == 1 else res_1
-                res_2 = res_2[0] if len(res_2) == 1 else res_2
 
                 gn1 = paddle.nn.GroupNorm(num_channels=6, num_groups=6)
                 gn2 = paddle.nn.GroupNorm(num_channels=6, num_groups=2)
                 data_pd = paddle.to_tensor(data)
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                np.testing.assert_allclose(result1, res_1, atol=1e-5)
-                np.testing.assert_allclose(result2, res_2, atol=1e-5)
+                self.assertTrue(np.allclose(result1, expect_res1, atol=1e-5))
+                self.assertTrue(np.allclose(result2, expect_res2, atol=1e-5))
 
 
 class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
@@ -99,15 +96,12 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 scale = np.array([1]).astype("float32")
                 bias = np.array([0]).astype("float32")
                 data = np.random.random(shape).astype("float32")
-                res_1 = group_norm_naive_for_general_dimension(
+                expect_res1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
                 )
-                res_2 = group_norm_naive_for_general_dimension(
+                expect_res2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
                 )
-
-                res_1 = res_1[0] if len(res_1) == 1 else res_1
-                res_2 = res_2[0] if len(res_2) == 1 else res_2
 
                 gn1 = paddle.nn.GroupNorm(num_channels=6, num_groups=6)
                 gn2 = paddle.nn.GroupNorm(num_channels=6, num_groups=2)
@@ -119,8 +113,8 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 data_pd = paddle.to_tensor(data.astype('float16'))
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                np.testing.assert_allclose(result1, res_1, rtol=1e-2, atol=1e-3)
-                np.testing.assert_allclose(result2, res_2, rtol=1e-2, atol=1e-3)
+                self.assertTrue(np.allclose(result1, expect_res1, atol=1e-5))
+                self.assertTrue(np.allclose(result2, expect_res2, atol=1e-5))
 
 
 class TestGroupNormDimException(unittest.TestCase):

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -101,10 +101,13 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 data = np.random.random(shape).astype("float32")
                 res_1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
-                )[0]
+                )
                 res_2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
-                )[0]
+                )
+
+                res_1 = res_1[0] if len(res_1) == 1 else res_1
+                res_2 = res_2[0] if len(res_2) == 1 else res_2
 
                 gn1 = paddle.nn.GroupNorm(num_channels=6, num_groups=6)
                 gn2 = paddle.nn.GroupNorm(num_channels=6, num_groups=2)

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -69,8 +69,8 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
                 data_pd = paddle.to_tensor(data)
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                self.assertTrue(np.allclose(result1, expect_res1, atol=1e-5))
-                self.assertTrue(np.allclose(result2, expect_res2, atol=1e-5))
+                np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+                np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
 
 
 class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -57,20 +57,23 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
                 scale = np.array([1]).astype("float32")
                 bias = np.array([0]).astype("float32")
                 data = np.random.random(shape).astype("float32")
-                expect_res1 = group_norm_naive_for_general_dimension(
+                res_1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
-                )[0]
-                expect_res2 = group_norm_naive_for_general_dimension(
+                )
+                res_2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
-                )[0]
+                )
+
+                res_1 = res_1[0] if len(res_1) == 1 else res_1
+                res_2 = res_2[0] if len(res_2) == 1 else res_2
 
                 gn1 = paddle.nn.GroupNorm(num_channels=6, num_groups=6)
                 gn2 = paddle.nn.GroupNorm(num_channels=6, num_groups=2)
                 data_pd = paddle.to_tensor(data)
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
-                np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
+                np.testing.assert_allclose(result1, res_1, atol=1e-5)
+                np.testing.assert_allclose(result2, res_2, atol=1e-5)
 
 
 class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
@@ -96,10 +99,10 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 scale = np.array([1]).astype("float32")
                 bias = np.array([0]).astype("float32")
                 data = np.random.random(shape).astype("float32")
-                expect_res1 = group_norm_naive_for_general_dimension(
+                res_1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
                 )[0]
-                expect_res2 = group_norm_naive_for_general_dimension(
+                res_2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
                 )[0]
 
@@ -113,12 +116,8 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 data_pd = paddle.to_tensor(data.astype('float16'))
                 result1 = gn1(data_pd).numpy()
                 result2 = gn2(data_pd).numpy()
-                np.testing.assert_allclose(
-                    result1, expect_res1, rtol=1e-2, atol=1e-3
-                )
-                np.testing.assert_allclose(
-                    result2, expect_res2, rtol=1e-2, atol=1e-3
-                )
+                np.testing.assert_allclose(result1, res_1, rtol=1e-2, atol=1e-3)
+                np.testing.assert_allclose(result2, res_2, rtol=1e-2, atol=1e-3)
 
 
 class TestGroupNormDimException(unittest.TestCase):

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -59,10 +59,10 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
                 data = np.random.random(shape).astype("float32")
                 expect_res1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
-                )
+                )[0]
                 expect_res2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
-                )
+                )[0]
 
                 gn1 = paddle.nn.GroupNorm(num_channels=6, num_groups=6)
                 gn2 = paddle.nn.GroupNorm(num_channels=6, num_groups=2)
@@ -98,10 +98,10 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 data = np.random.random(shape).astype("float32")
                 expect_res1 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=6
-                )
+                )[0]
                 expect_res2 = group_norm_naive_for_general_dimension(
                     data, scale, bias, epsilon=1e-5, groups=2
-                )
+                )[0]
 
                 gn1 = paddle.nn.GroupNorm(num_channels=6, num_groups=6)
                 gn2 = paddle.nn.GroupNorm(num_channels=6, num_groups=2)

--- a/test/legacy_test/test_imperative_auto_prune.py
+++ b/test/legacy_test/test_imperative_auto_prune.py
@@ -291,8 +291,9 @@ class TestImperativeAutoPrune(unittest.TestCase):
             np.testing.assert_array_equal(
                 linear2_origin, linear2.weight.numpy()
             )
-
-            assert not np.array_equal(linear_origin, linear.weight.numpy())
+            self.assertFalse(
+                np.array_equal(linear_origin, linear.weight.numpy())
+            )
 
     def test_auto_prune9(self):
         with fluid.dygraph.guard():

--- a/test/legacy_test/test_imperative_auto_prune.py
+++ b/test/legacy_test/test_imperative_auto_prune.py
@@ -291,8 +291,10 @@ class TestImperativeAutoPrune(unittest.TestCase):
             np.testing.assert_array_equal(
                 linear2_origin, linear2.weight.numpy()
             )
-            self.assertFalse(
-                np.array_equal(linear_origin, linear.weight.numpy())
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, linear_origin, linear.weight.numpy()
             )
 
     def test_auto_prune9(self):

--- a/test/legacy_test/test_imperative_auto_prune.py
+++ b/test/legacy_test/test_imperative_auto_prune.py
@@ -291,11 +291,8 @@ class TestImperativeAutoPrune(unittest.TestCase):
             np.testing.assert_array_equal(
                 linear2_origin, linear2.weight.numpy()
             )
-            import operator
 
-            np.testing.assert_array_compare(
-                operator.__ne__, linear_origin, linear.weight.numpy()
-            )
+            assert not np.array_equal(linear_origin, linear.weight.numpy())
 
     def test_auto_prune9(self):
         with fluid.dygraph.guard():

--- a/test/legacy_test/test_imperative_layer_children.py
+++ b/test/legacy_test/test_imperative_layer_children.py
@@ -60,8 +60,8 @@ class TestLayerChildren(unittest.TestCase):
         self.ori_y1, self.ori_y2 = self.func_apply_init_weight()
 
         # compare ori dygraph and new egr
-        assert np.array_equal(self.ori_y1.numpy(), self.new_y1.numpy())
-        assert np.array_equal(self.ori_y2.numpy(), self.new_y2.numpy())
+        np.testing.assert_array_equal(self.ori_y1.numpy(), self.new_y1.numpy())
+        np.testing.assert_array_equal(self.ori_y2.numpy(), self.new_y2.numpy())
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_imperative_numpy_bridge.py
+++ b/test/legacy_test/test_imperative_numpy_bridge.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import operator
 import unittest
 import warnings
 
@@ -46,9 +45,7 @@ class TestImperativeNumpyBridge(unittest.TestCase):
             self.assertEqual(data_np[0][0], -1)
             self.assertNotEqual(var2[0][0].numpy(), -1)
 
-            np.testing.assert_array_compare(
-                operator.__ne__, var2.numpy(), data_np
-            )
+            assert not np.array_equal(var2.numpy(), data_np)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_imperative_numpy_bridge.py
+++ b/test/legacy_test/test_imperative_numpy_bridge.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
 import unittest
 import warnings
 
@@ -44,7 +45,6 @@ class TestImperativeNumpyBridge(unittest.TestCase):
             data_np[0][0] = -1
             self.assertEqual(data_np[0][0], -1)
             self.assertNotEqual(var2[0][0].numpy(), -1)
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, var2.numpy(), data_np

--- a/test/legacy_test/test_imperative_numpy_bridge.py
+++ b/test/legacy_test/test_imperative_numpy_bridge.py
@@ -44,7 +44,11 @@ class TestImperativeNumpyBridge(unittest.TestCase):
             data_np[0][0] = -1
             self.assertEqual(data_np[0][0], -1)
             self.assertNotEqual(var2[0][0].numpy(), -1)
-            self.assertFalse(np.array_equal(var2.numpy(), data_np))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, var2.numpy(), data_np
+            )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_imperative_numpy_bridge.py
+++ b/test/legacy_test/test_imperative_numpy_bridge.py
@@ -45,7 +45,7 @@ class TestImperativeNumpyBridge(unittest.TestCase):
             self.assertEqual(data_np[0][0], -1)
             self.assertNotEqual(var2[0][0].numpy(), -1)
 
-            assert not np.array_equal(var2.numpy(), data_np)
+            self.assertFalse(np.array_equal(var2.numpy(), data_np))
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_imperative_tensor_clear_gradient.py
+++ b/test/legacy_test/test_imperative_tensor_clear_gradient.py
@@ -54,7 +54,7 @@ class TestDygraphClearGradient(TestCase):
         gradient_actual = linear.weight.grad
         # expected result
         gradient_expected = np.zeros([2, 3]).astype('float64')
-        self.assertTrue(np.allclose(gradient_actual.numpy(), gradient_expected))
+        np.testing.assert_allclose(gradient_actual.numpy(), gradient_expected)
 
     @dygraph_guard
     def test_tensor_method_clear_gradient_case2(self):

--- a/test/legacy_test/test_imperative_tensor_clear_gradient.py
+++ b/test/legacy_test/test_imperative_tensor_clear_gradient.py
@@ -54,7 +54,7 @@ class TestDygraphClearGradient(TestCase):
         gradient_actual = linear.weight.grad
         # expected result
         gradient_expected = np.zeros([2, 3]).astype('float64')
-        np.testing.assert_allclose(gradient_actual.numpy(), gradient_expected)
+        self.assertTrue(np.allclose(gradient_actual.numpy(), gradient_expected))
 
     @dygraph_guard
     def test_tensor_method_clear_gradient_case2(self):

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -637,8 +637,8 @@ class TestLayer(LayerTest):
             dy_rlt = emb2(base.to_variable(inp_word))
             dy_rlt_value = dy_rlt.numpy()
 
-        np.testing.assert_allclose(static_rlt2, static_rlt)
-        np.testing.assert_allclose(dy_rlt_value, static_rlt)
+        np.testing.assert_allclose(static_rlt2[0], static_rlt)
+        np.testing.assert_allclose(dy_rlt_value[0], static_rlt)
 
         with self.dynamic_graph():
             custom_weight = np.random.randn(dict_size, 32).astype("float32")

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -452,13 +452,13 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv2d1(base.to_variable(images))
             dy_ret2 = conv2d2(base.to_variable(images))
-
             self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
 
             conv2d1_weight_np = conv2d1.weight.numpy()
             conv2d1_bias = conv2d1.bias
-
-            assert not np.array_equal(conv2d1_weight_np, conv2d2.weight.numpy())
+            self.assertFalse(
+                np.array_equal(conv2d1_weight_np, conv2d2.weight.numpy())
+            )
             conv2d2.weight.set_value(conv2d1_weight_np)
             np.testing.assert_array_equal(
                 conv2d1_weight_np, conv2d2.weight.numpy()
@@ -583,8 +583,7 @@ class TestLayer(LayerTest):
                 base.to_variable(inp_np_x), base.to_variable(inp_np_y)
             )
             dy_rlt2 = paddle.nn.functional.sigmoid(dy_rlt2)
-
-            assert not np.array_equal(dy_rlt1.numpy(), dy_rlt2.numpy())
+            self.assertFalse(np.array_equal(dy_rlt1.numpy(), dy_rlt2.numpy()))
             btp2.weight.set_value(btp1.weight.numpy())
             btp2.bias.set_value(btp1.bias)
             dy_rlt1 = btp1(
@@ -638,8 +637,8 @@ class TestLayer(LayerTest):
             dy_rlt = emb2(base.to_variable(inp_word))
             dy_rlt_value = dy_rlt.numpy()
 
-        self.assertTrue(np.allclose(static_rlt2[0], static_rlt))
-        self.assertTrue(np.allclose(dy_rlt_value[0], static_rlt))
+        np.testing.assert_allclose(static_rlt2, static_rlt)
+        np.testing.assert_allclose(dy_rlt_value, static_rlt)
 
         with self.dynamic_graph():
             custom_weight = np.random.randn(dict_size, 32).astype("float32")
@@ -652,11 +651,9 @@ class TestLayer(LayerTest):
             )
             rep1 = emb1(base.to_variable(inp_word))
             rep2 = emb2(base.to_variable(inp_word))
-
-            assert not np.array_equal(emb1.weight.numpy(), custom_weight)
+            self.assertFalse(np.array_equal(emb1.weight.numpy(), custom_weight))
             np.testing.assert_array_equal(emb2.weight.numpy(), custom_weight)
-
-            assert not np.array_equal(rep1.numpy(), rep2.numpy())
+            self.assertFalse(np.array_equal(rep1.numpy(), rep2.numpy()))
             emb2.weight.set_value(emb1.weight.numpy())
             rep2 = emb2(base.to_variable(inp_word))
             np.testing.assert_array_equal(rep1.numpy(), rep2.numpy())
@@ -757,13 +754,13 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
-
             self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
-
-            assert not np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
+            self.assertFalse(
+                np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
+            )
             conv3d2.weight.set_value(conv3d1_weight_np)
             np.testing.assert_array_equal(
                 conv3d1_weight_np, conv3d2.weight.numpy()
@@ -1008,13 +1005,13 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
-
             self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
-
-            assert not np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
+            self.assertFalse(
+                np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
+            )
             conv3d2.weight.set_value(conv3d1_weight_np)
             np.testing.assert_array_equal(
                 conv3d1_weight_np, conv3d2.weight.numpy()

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -637,8 +637,8 @@ class TestLayer(LayerTest):
             dy_rlt = emb2(base.to_variable(inp_word))
             dy_rlt_value = dy_rlt.numpy()
 
-        self.assertTrue(np.allclose(static_rlt2, static_rlt))
-        self.assertTrue(np.allclose(dy_rlt_value, static_rlt))
+        np.testing.assert_allclose(static_rlt2, static_rlt)
+        np.testing.assert_allclose(dy_rlt_value, static_rlt)
 
         with self.dynamic_graph():
             custom_weight = np.random.randn(dict_size, 32).astype("float32")

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -14,7 +14,6 @@
 
 import contextlib
 import inspect
-import operator
 import unittest
 
 import nets
@@ -454,16 +453,12 @@ class TestLayer(LayerTest):
             dy_ret1 = conv2d1(base.to_variable(images))
             dy_ret2 = conv2d2(base.to_variable(images))
 
-            np.testing.assert_array_compare(
-                operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
-            )
+            assert not np.array_equal(dy_ret1.numpy(), dy_ret2.numpy())
 
             conv2d1_weight_np = conv2d1.weight.numpy()
             conv2d1_bias = conv2d1.bias
 
-            np.testing.assert_array_compare(
-                operator.__ne__, conv2d1_weight_np, conv2d2.weight.numpy()
-            )
+            assert not np.array_equal(conv2d1_weight_np, conv2d2.weight.numpy())
             conv2d2.weight.set_value(conv2d1_weight_np)
             np.testing.assert_array_equal(
                 conv2d1_weight_np, conv2d2.weight.numpy()
@@ -589,9 +584,7 @@ class TestLayer(LayerTest):
             )
             dy_rlt2 = paddle.nn.functional.sigmoid(dy_rlt2)
 
-            np.testing.assert_array_compare(
-                operator.__ne__, dy_rlt1.numpy(), dy_rlt2.numpy()
-            )
+            assert not np.array_equal(dy_rlt1.numpy(), dy_rlt2.numpy())
             btp2.weight.set_value(btp1.weight.numpy())
             btp2.bias.set_value(btp1.bias)
             dy_rlt1 = btp1(
@@ -660,14 +653,10 @@ class TestLayer(LayerTest):
             rep1 = emb1(base.to_variable(inp_word))
             rep2 = emb2(base.to_variable(inp_word))
 
-            np.testing.assert_array_compare(
-                operator.__ne__, emb1.weight.numpy(), custom_weight
-            )
+            assert not np.array_equal(emb1.weight.numpy(), custom_weight)
             np.testing.assert_array_equal(emb2.weight.numpy(), custom_weight)
 
-            np.testing.assert_array_compare(
-                operator.__ne__, rep1.numpy(), rep2.numpy()
-            )
+            assert not np.array_equal(rep1.numpy(), rep2.numpy())
             emb2.weight.set_value(emb1.weight.numpy())
             rep2 = emb2(base.to_variable(inp_word))
             np.testing.assert_array_equal(rep1.numpy(), rep2.numpy())
@@ -769,16 +758,12 @@ class TestLayer(LayerTest):
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
 
-            np.testing.assert_array_compare(
-                operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
-            )
+            assert not np.array_equal(dy_ret1.numpy(), dy_ret2.numpy())
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
 
-            np.testing.assert_array_compare(
-                operator.__ne__, conv3d1_weight_np, conv3d2.weight.numpy()
-            )
+            assert not np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
             conv3d2.weight.set_value(conv3d1_weight_np)
             np.testing.assert_array_equal(
                 conv3d1_weight_np, conv3d2.weight.numpy()
@@ -1024,16 +1009,12 @@ class TestLayer(LayerTest):
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
 
-            np.testing.assert_array_compare(
-                operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
-            )
+            assert not np.array_equal(dy_ret1.numpy(), dy_ret2.numpy())
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
 
-            np.testing.assert_array_compare(
-                operator.__ne__, conv3d1_weight_np, conv3d2.weight.numpy()
-            )
+            assert not np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
             conv3d2.weight.set_value(conv3d1_weight_np)
             np.testing.assert_array_equal(
                 conv3d1_weight_np, conv3d2.weight.numpy()

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -645,8 +645,8 @@ class TestLayer(LayerTest):
             dy_rlt = emb2(base.to_variable(inp_word))
             dy_rlt_value = dy_rlt.numpy()
 
-        np.testing.assert_allclose(static_rlt2, static_rlt)
-        np.testing.assert_allclose(dy_rlt_value, static_rlt)
+        np.testing.assert_allclose(static_rlt2[0], static_rlt)
+        np.testing.assert_allclose(dy_rlt_value[0], static_rlt)
 
         with self.dynamic_graph():
             custom_weight = np.random.randn(dict_size, 32).astype("float32")

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import inspect
+import operator
 import unittest
 
 import nets
@@ -452,7 +453,6 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv2d1(base.to_variable(images))
             dy_ret2 = conv2d2(base.to_variable(images))
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
@@ -460,7 +460,6 @@ class TestLayer(LayerTest):
 
             conv2d1_weight_np = conv2d1.weight.numpy()
             conv2d1_bias = conv2d1.bias
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, conv2d1_weight_np, conv2d2.weight.numpy()
@@ -589,7 +588,6 @@ class TestLayer(LayerTest):
                 base.to_variable(inp_np_x), base.to_variable(inp_np_y)
             )
             dy_rlt2 = paddle.nn.functional.sigmoid(dy_rlt2)
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, dy_rlt1.numpy(), dy_rlt2.numpy()
@@ -661,13 +659,11 @@ class TestLayer(LayerTest):
             )
             rep1 = emb1(base.to_variable(inp_word))
             rep2 = emb2(base.to_variable(inp_word))
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, emb1.weight.numpy(), custom_weight
             )
             np.testing.assert_array_equal(emb2.weight.numpy(), custom_weight)
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, rep1.numpy(), rep2.numpy()
@@ -772,7 +768,6 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
@@ -780,7 +775,6 @@ class TestLayer(LayerTest):
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, conv3d1_weight_np, conv3d2.weight.numpy()
@@ -1029,7 +1023,6 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
@@ -1037,7 +1030,6 @@ class TestLayer(LayerTest):
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
-            import operator
 
             np.testing.assert_array_compare(
                 operator.__ne__, conv3d1_weight_np, conv3d2.weight.numpy()

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -453,7 +453,7 @@ class TestLayer(LayerTest):
             dy_ret1 = conv2d1(base.to_variable(images))
             dy_ret2 = conv2d2(base.to_variable(images))
 
-            assert not np.array_equal(dy_ret1.numpy(), dy_ret2.numpy())
+            self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
 
             conv2d1_weight_np = conv2d1.weight.numpy()
             conv2d1_bias = conv2d1.bias
@@ -638,8 +638,8 @@ class TestLayer(LayerTest):
             dy_rlt = emb2(base.to_variable(inp_word))
             dy_rlt_value = dy_rlt.numpy()
 
-        np.testing.assert_allclose(static_rlt2[0], static_rlt)
-        np.testing.assert_allclose(dy_rlt_value[0], static_rlt)
+        self.assertTrue(np.allclose(static_rlt2[0], static_rlt))
+        self.assertTrue(np.allclose(dy_rlt_value[0], static_rlt))
 
         with self.dynamic_graph():
             custom_weight = np.random.randn(dict_size, 32).astype("float32")
@@ -758,7 +758,7 @@ class TestLayer(LayerTest):
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
 
-            assert not np.array_equal(dy_ret1.numpy(), dy_ret2.numpy())
+            self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
@@ -1009,7 +1009,7 @@ class TestLayer(LayerTest):
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
 
-            assert not np.array_equal(dy_ret1.numpy(), dy_ret2.numpy())
+            self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -452,12 +452,18 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv2d1(base.to_variable(images))
             dy_ret2 = conv2d2(base.to_variable(images))
-            self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
+            )
 
             conv2d1_weight_np = conv2d1.weight.numpy()
             conv2d1_bias = conv2d1.bias
-            self.assertFalse(
-                np.array_equal(conv2d1_weight_np, conv2d2.weight.numpy())
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, conv2d1_weight_np, conv2d2.weight.numpy()
             )
             conv2d2.weight.set_value(conv2d1_weight_np)
             np.testing.assert_array_equal(
@@ -583,7 +589,11 @@ class TestLayer(LayerTest):
                 base.to_variable(inp_np_x), base.to_variable(inp_np_y)
             )
             dy_rlt2 = paddle.nn.functional.sigmoid(dy_rlt2)
-            self.assertFalse(np.array_equal(dy_rlt1.numpy(), dy_rlt2.numpy()))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, dy_rlt1.numpy(), dy_rlt2.numpy()
+            )
             btp2.weight.set_value(btp1.weight.numpy())
             btp2.bias.set_value(btp1.bias)
             dy_rlt1 = btp1(
@@ -651,9 +661,17 @@ class TestLayer(LayerTest):
             )
             rep1 = emb1(base.to_variable(inp_word))
             rep2 = emb2(base.to_variable(inp_word))
-            self.assertFalse(np.array_equal(emb1.weight.numpy(), custom_weight))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, emb1.weight.numpy(), custom_weight
+            )
             np.testing.assert_array_equal(emb2.weight.numpy(), custom_weight)
-            self.assertFalse(np.array_equal(rep1.numpy(), rep2.numpy()))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, rep1.numpy(), rep2.numpy()
+            )
             emb2.weight.set_value(emb1.weight.numpy())
             rep2 = emb2(base.to_variable(inp_word))
             np.testing.assert_array_equal(rep1.numpy(), rep2.numpy())
@@ -754,12 +772,18 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
-            self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
+            )
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
-            self.assertFalse(
-                np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, conv3d1_weight_np, conv3d2.weight.numpy()
             )
             conv3d2.weight.set_value(conv3d1_weight_np)
             np.testing.assert_array_equal(
@@ -1005,12 +1029,18 @@ class TestLayer(LayerTest):
             )
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
-            self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, dy_ret1.numpy(), dy_ret2.numpy()
+            )
 
             conv3d1_weight_np = conv3d1.weight.numpy()
             conv3d1_bias = conv3d1.bias
-            self.assertFalse(
-                np.array_equal(conv3d1_weight_np, conv3d2.weight.numpy())
+            import operator
+
+            np.testing.assert_array_compare(
+                operator.__ne__, conv3d1_weight_np, conv3d2.weight.numpy()
             )
             conv3d2.weight.set_value(conv3d1_weight_np)
             np.testing.assert_array_equal(

--- a/test/legacy_test/test_linspace.py
+++ b/test/legacy_test/test_linspace.py
@@ -169,7 +169,7 @@ class TestLinspaceAPI(unittest.TestCase):
             res_1, res_2, res_3 = exe.run(
                 fluid.default_main_program(), fetch_list=[out_1, out_2, out_3]
             )
-            assert np.array_equal(res_1, res_2)
+            np.testing.assert_array_equal(res_1, res_2)
 
     def test_name(self):
         with paddle_static_guard():

--- a/test/legacy_test/test_logspace.py
+++ b/test/legacy_test/test_logspace.py
@@ -179,7 +179,7 @@ class TestLogspaceAPI(unittest.TestCase):
 
         exe = paddle.static.Executor()
         res_1, res_2 = exe.run(prog, fetch_list=[out_1, out_2])
-        assert np.array_equal(res_1, res_2)
+        np.testing.assert_array_equal(res_1, res_2)
         paddle.disable_static()
 
     def test_name(self):

--- a/test/legacy_test/test_lrn_op.py
+++ b/test/legacy_test/test_lrn_op.py
@@ -371,7 +371,7 @@ class TestLocalResponseNormCAPI(unittest.TestCase):
                         fetch_list=[y],
                     )
 
-                    assert np.array_equal(res[0].shape, input.shape)
+                    np.testing.assert_array_equal(res[0].shape, input.shape)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -162,8 +162,8 @@ class TestMeshgridOp3(unittest.TestCase):
             feed={'x': input_1, 'y': input_2},
             fetch_list=[grid_x, grid_y],
         )
-        assert np.array_equal(res_1, out_1)
-        assert np.array_equal(res_2, out_2)
+        np.testing.assert_array_equal(res_1, out_1)
+        np.testing.assert_array_equal(res_2, out_2)
 
 
 class TestMeshgridOp4(unittest.TestCase):
@@ -199,8 +199,8 @@ class TestMeshgridOp4(unittest.TestCase):
             fetch_list=[grid_x, grid_y],
         )
 
-        assert np.array_equal(res_1, out_1)
-        assert np.array_equal(res_2, out_2)
+        np.testing.assert_array_equal(res_1, out_1)
+        np.testing.assert_array_equal(res_2, out_2)
 
 
 class TestMeshgridOp5(unittest.TestCase):
@@ -236,8 +236,8 @@ class TestMeshgridOp5(unittest.TestCase):
             fetch_list=[grid_x, grid_y],
         )
 
-        assert np.array_equal(res_1, out_1)
-        assert np.array_equal(res_2, out_2)
+        np.testing.assert_array_equal(res_1, out_1)
+        np.testing.assert_array_equal(res_2, out_2)
 
 
 class TestMeshgridOp6(unittest.TestCase):
@@ -262,8 +262,8 @@ class TestMeshgridOp6(unittest.TestCase):
             tensor_4 = fluid.dygraph.to_variable(input_4)
             res_3, res_4 = paddle.tensor.meshgrid(tensor_3, tensor_4)
 
-            assert np.array_equal(res_3.shape, [100, 200])
-            assert np.array_equal(res_4.shape, [100, 200])
+            np.testing.assert_array_equal(res_3.shape, [100, 200])
+            np.testing.assert_array_equal(res_4.shape, [100, 200])
 
 
 class TestMeshgridOp7(unittest.TestCase):
@@ -288,8 +288,8 @@ class TestMeshgridOp7(unittest.TestCase):
             tensor_4 = fluid.dygraph.to_variable(input_4)
             res_3, res_4 = paddle.tensor.meshgrid([tensor_3, tensor_4])
 
-            assert np.array_equal(res_3.shape, [100, 200])
-            assert np.array_equal(res_4.shape, [100, 200])
+            np.testing.assert_array_equal(res_3.shape, [100, 200])
+            np.testing.assert_array_equal(res_4.shape, [100, 200])
 
 
 class TestMeshgridOp8(unittest.TestCase):
@@ -314,8 +314,8 @@ class TestMeshgridOp8(unittest.TestCase):
             tensor_4 = fluid.dygraph.to_variable(input_4)
             res_3, res_4 = paddle.tensor.meshgrid((tensor_3, tensor_4))
 
-            assert np.array_equal(res_3.shape, [100, 200])
-            assert np.array_equal(res_4.shape, [100, 200])
+            np.testing.assert_array_equal(res_3.shape, [100, 200])
+            np.testing.assert_array_equal(res_4.shape, [100, 200])
 
 
 class TestMeshGrid_ZeroDim(TestMeshgridOp):

--- a/test/legacy_test/test_multiprocess_dataloader_dataset.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dataset.py
@@ -84,8 +84,8 @@ class TestTensorDataset(unittest.TestCase):
                 assert label.shape == [1, 1]
                 assert isinstance(input, fluid.core.eager.Tensor)
                 assert isinstance(label, fluid.core.eager.Tensor)
-                assert np.allclose(input.numpy(), input_np[i])
-                assert np.allclose(label.numpy(), label_np[i])
+                np.testing.assert_allclose(input.numpy(), input_np[i])
+                np.testing.assert_allclose(label.numpy(), label_np[i])
 
     def test_main(self):
         places = [paddle.CPUPlace()]
@@ -109,10 +109,10 @@ class TestComposeDataset(unittest.TestCase):
             input1, label1, input2, label2 = dataset[i]
             input1_t, label1_t = dataset1[i]
             input2_t, label2_t = dataset2[i]
-            assert np.allclose(input1, input1_t)
-            assert np.allclose(label1, label1_t)
-            assert np.allclose(input2, input2_t)
-            assert np.allclose(label2, label2_t)
+            np.testing.assert_allclose(input1, input1_t)
+            np.testing.assert_allclose(label1, label1_t)
+            np.testing.assert_allclose(input2, input2_t)
+            np.testing.assert_allclose(label2, label2_t)
 
 
 class TestRandomSplitApi(unittest.TestCase):
@@ -226,12 +226,12 @@ class TestChainDataset(unittest.TestCase):
 
         idx = 0
         for image, label in iter(dataset1):
-            assert np.allclose(image, samples[idx][0])
-            assert np.allclose(label, samples[idx][1])
+            np.testing.assert_allclose(image, samples[idx][0])
+            np.testing.assert_allclose(label, samples[idx][1])
             idx += 1
         for image, label in iter(dataset2):
-            assert np.allclose(image, samples[idx][0])
-            assert np.allclose(label, samples[idx][1])
+            np.testing.assert_allclose(image, samples[idx][0])
+            np.testing.assert_allclose(label, samples[idx][1])
             idx += 1
 
     def test_main(self):

--- a/test/legacy_test/test_nan_to_num_op.py
+++ b/test/legacy_test/test_nan_to_num_op.py
@@ -79,10 +79,10 @@ class TestNanToNum(unittest.TestCase):
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'X': x_np}, fetch_list=[out1, out2, out3, out4])
 
-        self.assertTrue(np.allclose(out1_np, res[0]))
-        self.assertTrue(np.allclose(out2_np, res[1]))
-        self.assertTrue(np.allclose(out3_np, res[2]))
-        self.assertTrue(np.allclose(out4_np, res[3]))
+        np.testing.assert_allclose(out1_np, res[0])
+        np.testing.assert_allclose(out2_np, res[1])
+        np.testing.assert_allclose(out3_np, res[2])
+        np.testing.assert_allclose(out4_np, res[3])
 
     def test_dygraph(self):
         paddle.disable_static(place=self.place)
@@ -97,23 +97,23 @@ class TestNanToNum(unittest.TestCase):
 
             out_tensor = paddle.nan_to_num(x_tensor)
             out_np = np_nan_to_num(x_np)
-            self.assertTrue(np.allclose(out_tensor.numpy(), out_np))
+            np.testing.assert_allclose(out_tensor.numpy(), out_np)
 
             out_tensor = paddle.nan_to_num(x_tensor, 1.0, None, None)
             out_np = np_nan_to_num(x_np, 1, None, None)
-            self.assertTrue(np.allclose(out_tensor.numpy(), out_np))
+            np.testing.assert_allclose(out_tensor.numpy(), out_np)
 
             out_tensor = paddle.nan_to_num(x_tensor, 1.0, 2.0, None)
             out_np = np_nan_to_num(x_np, 1, 2, None)
-            self.assertTrue(np.allclose(out_tensor.numpy(), out_np))
+            np.testing.assert_allclose(out_tensor.numpy(), out_np)
 
             out_tensor = paddle.nan_to_num(x_tensor, 1.0, None, -10.0)
             out_np = np_nan_to_num(x_np, 1, None, -10)
-            self.assertTrue(np.allclose(out_tensor.numpy(), out_np))
+            np.testing.assert_allclose(out_tensor.numpy(), out_np)
 
             out_tensor = paddle.nan_to_num(x_tensor, 1.0, 100.0, -10.0)
             out_np = np_nan_to_num(x_np, 1, 100, -10)
-            self.assertTrue(np.allclose(out_tensor.numpy(), out_np))
+            np.testing.assert_allclose(out_tensor.numpy(), out_np)
 
         paddle.enable_static()
 
@@ -128,7 +128,7 @@ class TestNanToNum(unittest.TestCase):
         dx = paddle.grad(y, x_tensor)[0].numpy()
 
         np_grad = np_nan_to_num_grad(x_np, np.ones_like(x_np))
-        self.assertTrue(np.allclose(np_grad, dx))
+        np.testing.assert_allclose(np_grad, dx)
 
         paddle.enable_static()
 

--- a/test/legacy_test/test_number_count_op.py
+++ b/test/legacy_test/test_number_count_op.py
@@ -65,8 +65,7 @@ class TestNumberCountAPI(unittest.TestCase):
             out = utils._number_count(x, self.upper_num)
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'x': self.x}, fetch_list=[out])
-            res = res[0] if len(res) == 1 else res
-            np.testing.assert_allclose(res, self.out)
+            assert np.allclose(res, self.out)
 
     def test_api_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_number_count_op.py
+++ b/test/legacy_test/test_number_count_op.py
@@ -65,6 +65,7 @@ class TestNumberCountAPI(unittest.TestCase):
             out = utils._number_count(x, self.upper_num)
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'x': self.x}, fetch_list=[out])
+            res = res[0] if len(res) == 1 else res
             np.testing.assert_allclose(res, self.out)
 
     def test_api_dygraph(self):

--- a/test/legacy_test/test_number_count_op.py
+++ b/test/legacy_test/test_number_count_op.py
@@ -65,13 +65,13 @@ class TestNumberCountAPI(unittest.TestCase):
             out = utils._number_count(x, self.upper_num)
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'x': self.x}, fetch_list=[out])
-            assert np.allclose(res, self.out)
+            np.testing.assert_allclose(res, self.out)
 
     def test_api_dygraph(self):
         paddle.disable_static()
         x = paddle.to_tensor(self.x)
         out = utils._number_count(x, self.upper_num)
-        assert np.allclose(out.numpy(), self.out)
+        np.testing.assert_allclose(out.numpy(), self.out)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_numel_op.py
+++ b/test/legacy_test/test_numel_op.py
@@ -120,10 +120,10 @@ class TestNumelAPI(unittest.TestCase):
                 },
                 fetch_list=[out_1, out_2],
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res_1, np.array(np.size(input_1)).astype("int64")
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res_2, np.array(np.size(input_2)).astype("int64")
             )
 
@@ -135,8 +135,8 @@ class TestNumelAPI(unittest.TestCase):
         x_2 = paddle.to_tensor(input_2)
         out_1 = paddle.numel(x_1)
         out_2 = paddle.numel(x_2)
-        assert np.array_equal(out_1.numpy().item(0), np.size(input_1))
-        assert np.array_equal(out_2.numpy().item(0), np.size(input_2))
+        np.testing.assert_array_equal(out_1.numpy().item(0), np.size(input_1))
+        np.testing.assert_array_equal(out_2.numpy().item(0), np.size(input_2))
         paddle.enable_static()
 
     def test_error(self):

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -264,16 +264,14 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 feed={"x": self.x_1_np},
                 fetch_list=out_1,
                 use_prune=True,
-            )
+            )[0]
 
             res_2 = exe.run(
                 fluid.default_main_program(),
                 feed={"x2": self.x_2_np},
                 fetch_list=out_2,
                 use_prune=True,
-            )
-            res_1 = res_1[0]
-            res_2 = res_2[0]
+            )[0]
 
             np.testing.assert_allclose(res_1, out_1_np, rtol=1e-5, atol=1e-8)
             np.testing.assert_allclose(res_2, out_2_np, rtol=1e-5, atol=1e-8)

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -272,7 +272,6 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 fetch_list=out_2,
                 use_prune=True,
             )
-            # exe.run output maybe squeeze.
             res_1 = res_1[0]
             res_2 = res_2[0]
 

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -273,8 +273,8 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
             # exe.run output maybe squeeze.
-            res_1 = res_1[0] if len(res_1) == 1 else res_1
-            res_2 = res_2[0] if len(res_2) == 1 else res_2
+            res_1 = res_1[0]
+            res_2 = res_2[0]
 
             np.testing.assert_allclose(res_1, out_1_np, rtol=1e-5, atol=1e-8)
             np.testing.assert_allclose(res_2, out_2_np, rtol=1e-5, atol=1e-8)

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -186,14 +186,14 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 feed={"x": self.x_1_np},
                 fetch_list=out_1,
                 use_prune=True,
-            )
+            )[0]
 
             res_2 = exe.run(
                 fluid.default_main_program(),
                 feed={"x2": self.x_2_np},
                 fetch_list=out_2,
                 use_prune=True,
-            )
+            )[0]
 
             np.testing.assert_allclose(res_1, self.out_1_np)
             np.testing.assert_allclose(res_2, self.out_2_np)
@@ -226,13 +226,13 @@ class TestPixelShuffleAPI(unittest.TestCase):
                     feed={"x": self.x_1_np},
                     fetch_list=out_1,
                     use_prune=True,
-                )
+                )[0]
                 res_2 = exe.run(
                     fluid.default_main_program(),
                     feed={"x2": self.x_2_np},
                     fetch_list=out_2,
                     use_prune=True,
-                )
+                )[0]
                 np.testing.assert_allclose(res_1, out_1_np)
                 np.testing.assert_allclose(res_2, out_2_np)
 
@@ -264,17 +264,17 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 feed={"x": self.x_1_np},
                 fetch_list=out_1,
                 use_prune=True,
-            )
+            )[0]
 
             res_2 = exe.run(
                 fluid.default_main_program(),
                 feed={"x2": self.x_2_np},
                 fetch_list=out_2,
                 use_prune=True,
-            )
+            )[0]
 
-            np.testing.assert_allclose(res_1, out_1_np)
-            np.testing.assert_allclose(res_2, out_2_np)
+            np.testing.assert_allclose(res_1[0], out_1_np)
+            np.testing.assert_allclose(res_2[0], out_2_np)
 
     def run_dygraph(self, up_factor, data_format):
         n, c, h, w = 2, 9, 4, 4

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -264,14 +264,16 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 feed={"x": self.x_1_np},
                 fetch_list=out_1,
                 use_prune=True,
-            )[0]
+            )
 
             res_2 = exe.run(
                 fluid.default_main_program(),
                 feed={"x2": self.x_2_np},
                 fetch_list=out_2,
                 use_prune=True,
-            )[0]
+            )
+            res_1 = res_1[0] if len(res_1) == 1 else res_1
+            res_2 = res_2[0] if len(res_2) == 1 else res_2
 
             np.testing.assert_allclose(res_1[0], out_1_np)
             np.testing.assert_allclose(res_2[0], out_2_np)

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -275,8 +275,8 @@ class TestPixelShuffleAPI(unittest.TestCase):
             res_1 = res_1[0] if len(res_1) == 1 else res_1
             res_2 = res_2[0] if len(res_2) == 1 else res_2
 
-            np.testing.assert_allclose(res_1[0], out_1_np)
-            np.testing.assert_allclose(res_2[0], out_2_np)
+            np.testing.assert_allclose(res_1, out_1_np, rtol=1e-6, atol=1e-6)
+            np.testing.assert_allclose(res_2, out_2_np, rtol=1e-6, atol=1e-6)
 
     def run_dygraph(self, up_factor, data_format):
         n, c, h, w = 2, 9, 4, 4

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -195,8 +195,8 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            assert np.allclose(res_1, self.out_1_np)
-            assert np.allclose(res_2, self.out_2_np)
+            np.testing.assert_allclose(res_1, self.out_1_np)
+            np.testing.assert_allclose(res_2, self.out_2_np)
 
     def test_api_fp16(self):
         paddle.enable_static()
@@ -233,8 +233,8 @@ class TestPixelShuffleAPI(unittest.TestCase):
                     fetch_list=out_2,
                     use_prune=True,
                 )
-                assert np.allclose(res_1, out_1_np)
-                assert np.allclose(res_2, out_2_np)
+                np.testing.assert_allclose(res_1, out_1_np)
+                np.testing.assert_allclose(res_2, out_2_np)
 
     # same test between layer and functional in this op.
     def test_static_graph_layer(self):
@@ -273,8 +273,8 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            assert np.allclose(res_1, out_1_np)
-            assert np.allclose(res_2, out_2_np)
+            np.testing.assert_allclose(res_1, out_1_np)
+            np.testing.assert_allclose(res_2, out_2_np)
 
     def run_dygraph(self, up_factor, data_format):
         n, c, h, w = 2, 9, 4, 4

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -275,8 +275,8 @@ class TestPixelShuffleAPI(unittest.TestCase):
             res_1 = res_1[0] if len(res_1) == 1 else res_1
             res_2 = res_2[0] if len(res_2) == 1 else res_2
 
-            np.testing.assert_allclose(res_1, out_1_np, rtol=1e-6, atol=1e-6)
-            np.testing.assert_allclose(res_2, out_2_np, rtol=1e-6, atol=1e-6)
+            np.testing.assert_allclose(res_1, out_1_np, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(res_2, out_2_np, rtol=1e-5, atol=1e-8)
 
     def run_dygraph(self, up_factor, data_format):
         n, c, h, w = 2, 9, 4, 4

--- a/test/legacy_test/test_pixel_shuffle_op.py
+++ b/test/legacy_test/test_pixel_shuffle_op.py
@@ -272,6 +272,7 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 fetch_list=out_2,
                 use_prune=True,
             )
+            # exe.run output maybe squeeze.
             res_1 = res_1[0] if len(res_1) == 1 else res_1
             res_2 = res_2[0] if len(res_2) == 1 else res_2
 

--- a/test/legacy_test/test_pixel_unshuffle.py
+++ b/test/legacy_test/test_pixel_unshuffle.py
@@ -225,14 +225,14 @@ class TestPixelUnshuffleAPI(unittest.TestCase):
                 feed={"x": self.x_1_np},
                 fetch_list=out_1,
                 use_prune=True,
-            )
+            )[0]
 
             res_2 = exe.run(
                 fluid.default_main_program(),
                 feed={"x2": self.x_2_np},
                 fetch_list=out_2,
                 use_prune=True,
-            )
+            )[0]
 
             np.testing.assert_allclose(res_1, self.out_1_np)
             np.testing.assert_allclose(res_2, self.out_2_np)
@@ -267,14 +267,14 @@ class TestPixelUnshuffleAPI(unittest.TestCase):
                 feed={"x": self.x_1_np},
                 fetch_list=out_1,
                 use_prune=True,
-            )
+            )[0]
 
             res_2 = exe.run(
                 fluid.default_main_program(),
                 feed={"x2": self.x_2_np},
                 fetch_list=out_2,
                 use_prune=True,
-            )
+            )[0]
 
             np.testing.assert_allclose(res_1, out_1_np)
             np.testing.assert_allclose(res_2, out_2_np)

--- a/test/legacy_test/test_pixel_unshuffle.py
+++ b/test/legacy_test/test_pixel_unshuffle.py
@@ -234,8 +234,8 @@ class TestPixelUnshuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            assert np.allclose(res_1, self.out_1_np)
-            assert np.allclose(res_2, self.out_2_np)
+            np.testing.assert_allclose(res_1, self.out_1_np)
+            np.testing.assert_allclose(res_2, self.out_2_np)
 
     # same test between layer and functional in this op.
     def test_static_graph_layer(self):
@@ -276,8 +276,8 @@ class TestPixelUnshuffleAPI(unittest.TestCase):
                 use_prune=True,
             )
 
-            assert np.allclose(res_1, out_1_np)
-            assert np.allclose(res_2, out_2_np)
+            np.testing.assert_allclose(res_1, out_1_np)
+            np.testing.assert_allclose(res_2, out_2_np)
 
     def run_dygraph(self, down_factor, data_format):
         '''run_dygraph'''

--- a/test/legacy_test/test_pool3d_api.py
+++ b/test/legacy_test/test_pool3d_api.py
@@ -391,7 +391,7 @@ class TestPool3D_API(unittest.TestCase):
                     fetch_list=[y],
                 )
 
-                assert np.array_equal(res[0].shape, [1, 2, 1, 16, 16])
+                np.testing.assert_array_equal(res[0].shape, [1, 2, 1, 16, 16])
 
     def test_static_bf16_gpu(self):
         paddle.enable_static()
@@ -421,7 +421,7 @@ class TestPool3D_API(unittest.TestCase):
                     fetch_list=[y],
                 )
 
-                assert np.array_equal(res[0].shape, [1, 2, 1, 16, 16])
+                np.testing.assert_array_equal(res[0].shape, [1, 2, 1, 16, 16])
 
 
 class TestPool3DError_API(unittest.TestCase):

--- a/test/legacy_test/test_prune.py
+++ b/test/legacy_test/test_prune.py
@@ -318,7 +318,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight = np.array(
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
-
                 self.assertFalse(
                     np.array_equal(weight_init, weight)
                 )  # weight changed
@@ -351,7 +350,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight = np.array(
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
-
                 self.assertFalse(
                     np.array_equal(weight_init, weight)
                 )  # weight changed
@@ -612,8 +610,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-
-        assert not np.array_equal(weight_without_prune, weight_expected)
+        self.assertFalse(np.array_equal(weight_without_prune, weight_expected))
 
     def test_prune_program_with_tupe_in_fetch_list(self):
         '''
@@ -677,8 +674,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-
-        assert not np.array_equal(weight_without_prune, weight_expected)
+        self.assertFalse(np.array_equal(weight_without_prune, weight_expected))
 
     def test_prune_program_partial_parameter_updated(self):
         """
@@ -734,9 +730,8 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight2 = np.array(
                     scope.find_var(w2_param_attrs.name).get_tensor()
                 )
-
-                assert not np.array_equal(
-                    weight1_init, weight1
+                self.assertFalse(
+                    np.array_equal(weight1_init, weight1)
                 )  # weight changed
                 np.testing.assert_array_equal(
                     weight2_init, weight2
@@ -800,8 +795,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-
-        assert not np.array_equal(weight_without_prune, weight_expected)
+        self.assertFalse(np.array_equal(weight_without_prune, weight_expected))
 
     def test_prune_feed_var_in_fetchlist_1(self):
         # the variable to be fed is not leaf

--- a/test/legacy_test/test_prune.py
+++ b/test/legacy_test/test_prune.py
@@ -318,8 +318,10 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight = np.array(
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
-                self.assertFalse(
-                    np.array_equal(weight_init, weight)
+                import operator
+
+                np.testing.assert_array_compare(
+                    operator.__ne__, weight_init, weight
                 )  # weight changed
 
     def test_prune_compiled_program(self):
@@ -350,8 +352,10 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight = np.array(
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
-                self.assertFalse(
-                    np.array_equal(weight_init, weight)
+                import operator
+
+                np.testing.assert_array_compare(
+                    operator.__ne__, weight_init, weight
                 )  # weight changed
 
     def test_prune_feed_without_optimizer(self):
@@ -610,7 +614,11 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-        self.assertFalse(np.array_equal(weight_without_prune, weight_expected))
+        import operator
+
+        np.testing.assert_array_compare(
+            operator.__ne__, weight_without_prune, weight_expected
+        )
 
     def test_prune_program_with_tupe_in_fetch_list(self):
         '''
@@ -674,7 +682,11 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-        self.assertFalse(np.array_equal(weight_without_prune, weight_expected))
+        import operator
+
+        np.testing.assert_array_compare(
+            operator.__ne__, weight_without_prune, weight_expected
+        )
 
     def test_prune_program_partial_parameter_updated(self):
         """
@@ -730,8 +742,10 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight2 = np.array(
                     scope.find_var(w2_param_attrs.name).get_tensor()
                 )
-                self.assertFalse(
-                    np.array_equal(weight1_init, weight1)
+                import operator
+
+                np.testing.assert_array_compare(
+                    operator.__ne__, weight1_init, weight1
                 )  # weight changed
                 np.testing.assert_array_equal(
                     weight2_init, weight2
@@ -795,7 +809,11 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-        self.assertFalse(np.array_equal(weight_without_prune, weight_expected))
+        import operator
+
+        np.testing.assert_array_compare(
+            operator.__ne__, weight_without_prune, weight_expected
+        )
 
     def test_prune_feed_var_in_fetchlist_1(self):
         # the variable to be fed is not leaf

--- a/test/legacy_test/test_prune.py
+++ b/test/legacy_test/test_prune.py
@@ -319,7 +319,9 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
 
-                assert not np.array_equal(weight_init, weight)  # weight changed
+                self.assertFalse(
+                    np.array_equal(weight_init, weight)
+                )  # weight changed
 
     def test_prune_compiled_program(self):
         program = framework.Program()
@@ -350,7 +352,9 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
 
-                assert not np.array_equal(weight_init, weight)  # weight changed
+                self.assertFalse(
+                    np.array_equal(weight_init, weight)
+                )  # weight changed
 
     def test_prune_feed_without_optimizer(self):
         program = framework.Program()

--- a/test/legacy_test/test_prune.py
+++ b/test/legacy_test/test_prune.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import contextlib
-import operator
 import unittest
 
 import numpy as np
@@ -320,9 +319,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
 
-                np.testing.assert_array_compare(
-                    operator.__ne__, weight_init, weight
-                )  # weight changed
+                assert not np.array_equal(weight_init, weight)  # weight changed
 
     def test_prune_compiled_program(self):
         program = framework.Program()
@@ -353,9 +350,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
 
-                np.testing.assert_array_compare(
-                    operator.__ne__, weight_init, weight
-                )  # weight changed
+                assert not np.array_equal(weight_init, weight)  # weight changed
 
     def test_prune_feed_without_optimizer(self):
         program = framework.Program()
@@ -614,9 +609,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
 
-        np.testing.assert_array_compare(
-            operator.__ne__, weight_without_prune, weight_expected
-        )
+        assert not np.array_equal(weight_without_prune, weight_expected)
 
     def test_prune_program_with_tupe_in_fetch_list(self):
         '''
@@ -681,9 +674,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
 
-        np.testing.assert_array_compare(
-            operator.__ne__, weight_without_prune, weight_expected
-        )
+        assert not np.array_equal(weight_without_prune, weight_expected)
 
     def test_prune_program_partial_parameter_updated(self):
         """
@@ -740,8 +731,8 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                     scope.find_var(w2_param_attrs.name).get_tensor()
                 )
 
-                np.testing.assert_array_compare(
-                    operator.__ne__, weight1_init, weight1
+                assert not np.array_equal(
+                    weight1_init, weight1
                 )  # weight changed
                 np.testing.assert_array_equal(
                     weight2_init, weight2
@@ -806,9 +797,7 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
 
-        np.testing.assert_array_compare(
-            operator.__ne__, weight_without_prune, weight_expected
-        )
+        assert not np.array_equal(weight_without_prune, weight_expected)
 
     def test_prune_feed_var_in_fetchlist_1(self):
         # the variable to be fed is not leaf

--- a/test/legacy_test/test_prune.py
+++ b/test/legacy_test/test_prune.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import operator
 import unittest
 
 import numpy as np
@@ -318,7 +319,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight = np.array(
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
-                import operator
 
                 np.testing.assert_array_compare(
                     operator.__ne__, weight_init, weight
@@ -352,7 +352,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight = np.array(
                     scope.find_var(w_param_attrs.name).get_tensor()
                 )
-                import operator
 
                 np.testing.assert_array_compare(
                     operator.__ne__, weight_init, weight
@@ -614,7 +613,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-        import operator
 
         np.testing.assert_array_compare(
             operator.__ne__, weight_without_prune, weight_expected
@@ -682,7 +680,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-        import operator
 
         np.testing.assert_array_compare(
             operator.__ne__, weight_without_prune, weight_expected
@@ -742,7 +739,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
                 weight2 = np.array(
                     scope.find_var(w2_param_attrs.name).get_tensor()
                 )
-                import operator
 
                 np.testing.assert_array_compare(
                     operator.__ne__, weight1_init, weight1
@@ -809,7 +805,6 @@ class TestExecutorRunAutoPrune(unittest.TestCase):
             )
 
         np.testing.assert_array_equal(weight_with_prune, weight_expected)
-        import operator
 
         np.testing.assert_array_compare(
             operator.__ne__, weight_without_prune, weight_expected

--- a/test/legacy_test/test_prune_gate_by_capacity_op.py
+++ b/test/legacy_test/test_prune_gate_by_capacity_op.py
@@ -62,7 +62,7 @@ def prune_gate_by_capacity(gate_idx, expert_count, n_expert, n_worker):
 def assert_allclose(output, expected, n_expert):
     c1 = count(output, n_expert)
     c2 = count(expected, n_expert)
-    assert np.allclose(c1, c2)
+    np.testing.assert_allclose(c1, c2)
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_random_routing_op.py
+++ b/test/legacy_test/test_random_routing_op.py
@@ -59,7 +59,7 @@ class TestNumberCountAPIFp32(unittest.TestCase):
         value = paddle.to_tensor(self.topk_value)
         prob = paddle.to_tensor(self.prob)
         out = utils._random_routing(x, value, prob)
-        assert np.allclose(out.numpy(), self.out)
+        np.testing.assert_allclose(out.numpy(), self.out)
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -400,10 +400,10 @@ class TestReshapeAPI(unittest.TestCase):
             fetch_list=[out_1, out_2, out_3, out_4],
         )
 
-        assert np.array_equal(res_1, input.reshape(shape))
-        assert np.array_equal(res_2, input.reshape(shape))
-        assert np.array_equal(res_3, input.reshape([5, 10]))
-        assert np.array_equal(res_4, input.reshape(shape))
+        np.testing.assert_array_equal(res_1, input.reshape(shape))
+        np.testing.assert_array_equal(res_2, input.reshape(shape))
+        np.testing.assert_array_equal(res_3, input.reshape([5, 10]))
+        np.testing.assert_array_equal(res_4, input.reshape(shape))
 
     def test_paddle_api(self):
         self._set_paddle_api()
@@ -424,9 +424,9 @@ class TestReshapeAPI(unittest.TestCase):
             shape_tensor = self.to_tensor(np.array([2, 5, 5]).astype("int32"))
             out_3 = self.reshape(x, shape=shape_tensor)
 
-        assert np.array_equal(out_1.numpy(), input.reshape(shape))
-        assert np.array_equal(out_2.numpy(), input.reshape([5, 10]))
-        assert np.array_equal(out_3.numpy(), input.reshape(shape))
+        np.testing.assert_array_equal(out_1.numpy(), input.reshape(shape))
+        np.testing.assert_array_equal(out_2.numpy(), input.reshape([5, 10]))
+        np.testing.assert_array_equal(out_3.numpy(), input.reshape(shape))
 
 
 class TestStaticReshape_(TestReshapeAPI):
@@ -448,9 +448,9 @@ class TestStaticReshape_(TestReshapeAPI):
             shape_tensor = self.to_tensor(np.array([2, 5, 5]).astype("int32"))
             out_3 = self.reshape(x, shape=shape_tensor)
 
-        assert np.array_equal(out_1.numpy(), input.reshape(shape))
-        assert np.array_equal(out_2.numpy(), input.reshape(shape))
-        assert np.array_equal(out_3.numpy(), input.reshape(shape))
+        np.testing.assert_array_equal(out_1.numpy(), input.reshape(shape))
+        np.testing.assert_array_equal(out_2.numpy(), input.reshape(shape))
+        np.testing.assert_array_equal(out_3.numpy(), input.reshape(shape))
 
 
 # Test Input Error

--- a/test/legacy_test/test_size_op.py
+++ b/test/legacy_test/test_size_op.py
@@ -83,10 +83,10 @@ class TestSizeAPI(unittest.TestCase):
                 },
                 fetch_list=[out_1, out_2],
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res_1, np.array(np.size(input_1)).astype("int64")
             )
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 res_2, np.array(np.size(input_2)).astype("int64")
             )
 
@@ -98,8 +98,8 @@ class TestSizeAPI(unittest.TestCase):
         x_2 = paddle.to_tensor(input_2)
         out_1 = paddle.numel(x_1)
         out_2 = paddle.numel(x_2)
-        assert np.array_equal(out_1.numpy().item(0), np.size(input_1))
-        assert np.array_equal(out_2.numpy().item(0), np.size(input_2))
+        np.testing.assert_array_equal(out_1.numpy().item(0), np.size(input_1))
+        np.testing.assert_array_equal(out_2.numpy().item(0), np.size(input_2))
         paddle.enable_static()
 
     def test_error(self):

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -631,13 +631,13 @@ class TestSliceAPI(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3, out_4, out_5, out_6, out_7],
             )
 
-            assert np.array_equal(res_1, input[-3:3, 0:100, 2:-1, :])
-            assert np.array_equal(res_2, input[-3:3, 0:100, :, 2:-1])
-            assert np.array_equal(res_3, input[-3:3, 0:100, :, 2:-1])
-            assert np.array_equal(res_4, input[-3:3, 0:100, 2:-1, :])
-            assert np.array_equal(res_5, input[-3:3, 0:100, 2:-1, :])
-            assert np.array_equal(res_6, input[-3:3, 0:100, :, 2:-1])
-            assert np.array_equal(res_7, input[-1, 0:100, :, 2:-1])
+            np.testing.assert_array_equal(res_1, input[-3:3, 0:100, 2:-1, :])
+            np.testing.assert_array_equal(res_2, input[-3:3, 0:100, :, 2:-1])
+            np.testing.assert_array_equal(res_3, input[-3:3, 0:100, :, 2:-1])
+            np.testing.assert_array_equal(res_4, input[-3:3, 0:100, 2:-1, :])
+            np.testing.assert_array_equal(res_5, input[-3:3, 0:100, 2:-1, :])
+            np.testing.assert_array_equal(res_6, input[-3:3, 0:100, :, 2:-1])
+            np.testing.assert_array_equal(res_7, input[-1, 0:100, :, 2:-1])
 
 
 class TestSliceApiWithTensor(unittest.TestCase):

--- a/test/legacy_test/test_sparse_conv_op.py
+++ b/test/legacy_test/test_sparse_conv_op.py
@@ -296,14 +296,16 @@ class TestSparseConv(unittest.TestCase):
         dense_out = sp_out.to_dense()
         sp_loss = dense_out.mean()
         sp_loss.backward()
-        assert np.allclose(out.numpy(), dense_out.numpy(), atol=1e-3, rtol=1e-3)
-        assert np.allclose(
+        np.testing.assert_allclose(
+            out.numpy(), dense_out.numpy(), atol=1e-3, rtol=1e-3
+        )
+        np.testing.assert_allclose(
             conv3d.weight.grad.numpy().transpose(2, 3, 4, 1, 0),
             sp_conv3d.weight.grad.numpy(),
             atol=1e-3,
             rtol=1e-3,
         )
-        assert np.allclose(
+        np.testing.assert_allclose(
             conv3d.bias.grad.numpy(),
             sp_conv3d.bias.grad.numpy(),
             atol=1e-5,

--- a/test/legacy_test/test_sparse_conv_op.py
+++ b/test/legacy_test/test_sparse_conv_op.py
@@ -94,7 +94,7 @@ class TestSparseConv(unittest.TestCase):
         )
         out.backward(out)
         out = paddle.sparse.coalesce(out)
-        assert np.array_equal(correct_out_values, out.values().numpy())
+        np.testing.assert_array_equal(correct_out_values, out.values().numpy())
 
     def test_subm_conv2d(self):
         indices = [[0, 0, 0, 0], [0, 0, 1, 2], [1, 3, 2, 3]]
@@ -126,7 +126,9 @@ class TestSparseConv(unittest.TestCase):
         y = paddle.sparse.nn.functional.subm_conv3d(
             sparse_x, weight, key='subm_conv'
         )
-        assert np.array_equal(sparse_x.indices().numpy(), y.indices().numpy())
+        np.testing.assert_array_equal(
+            sparse_x.indices().numpy(), y.indices().numpy()
+        )
 
     def test_Conv2D(self):
         # (3, non_zero_num), 3-D:(N, H, W)
@@ -223,7 +225,7 @@ class TestSparseConv(unittest.TestCase):
 
         sparse_out = subm_conv3d(sparse_input)
         # the output shape of subm_conv is same as input shape
-        assert np.array_equal(indices, sparse_out.indices().numpy())
+        np.testing.assert_array_equal(indices, sparse_out.indices().numpy())
 
         # test errors
         with self.assertRaises(ValueError):

--- a/test/legacy_test/test_sparse_copy_op.py
+++ b/test/legacy_test/test_sparse_copy_op.py
@@ -30,7 +30,7 @@ class TestSparseCopy(unittest.TestCase):
         dense_x_2 = paddle.to_tensor(np_x_2, dtype='float32')
         coo_x_2 = dense_x_2.to_sparse_coo(2)
         coo_x_2.copy_(coo_x, True)
-        assert np.array_equal(np_values, coo_x_2.values().numpy())
+        np.testing.assert_array_equal(np_values, coo_x_2.values().numpy())
 
     def test_copy_sparse_csr(self):
         np_x = [[0, 1.0, 0], [2.0, 0, 0], [0, 3.0, 0]]
@@ -42,4 +42,4 @@ class TestSparseCopy(unittest.TestCase):
         dense_x_2 = paddle.to_tensor(np_x_2, dtype='float32')
         csr_x_2 = dense_x_2.to_sparse_csr()
         csr_x_2.copy_(csr_x, True)
-        assert np.array_equal(np_values, csr_x_2.values().numpy())
+        np.testing.assert_array_equal(np_values, csr_x_2.values().numpy())

--- a/test/legacy_test/test_sparse_model.py
+++ b/test/legacy_test/test_sparse_model.py
@@ -54,13 +54,19 @@ class TestGradientAdd(unittest.TestCase):
         sparse_loss = sparse_out.values().mean()
         sparse_loss.backward(retain_graph=True)
 
-        assert np.allclose(dense_out.numpy(), sparse_out.to_dense().numpy())
-        assert np.allclose(x.grad.numpy(), sparse_x.grad.to_dense().numpy())
+        np.testing.assert_allclose(
+            dense_out.numpy(), sparse_out.to_dense().numpy()
+        )
+        np.testing.assert_allclose(
+            x.grad.numpy(), sparse_x.grad.to_dense().numpy()
+        )
 
         loss.backward()
         sparse_loss.backward()
 
-        assert np.allclose(x.grad.numpy(), sparse_x.grad.to_dense().numpy())
+        np.testing.assert_allclose(
+            x.grad.numpy(), sparse_x.grad.to_dense().numpy()
+        )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_sparse_norm_op.py
+++ b/test/legacy_test/test_sparse_norm_op.py
@@ -48,7 +48,7 @@ class TestSparseBatchNorm(unittest.TestCase):
 
         sparse_y = sparse_batch_norm(sparse_x)
         # compare the result with dense batch_norm
-        assert np.allclose(
+        np.testing.assert_allclose(
             dense_y.flatten().numpy(),
             sparse_y.values().flatten().numpy(),
             atol=1e-5,
@@ -57,7 +57,7 @@ class TestSparseBatchNorm(unittest.TestCase):
 
         # test backward
         sparse_y.backward(sparse_y)
-        assert np.allclose(
+        np.testing.assert_allclose(
             dense_x.grad.flatten().numpy(),
             sparse_x.grad.values().flatten().numpy(),
             atol=1e-5,
@@ -85,7 +85,9 @@ class TestSparseBatchNorm(unittest.TestCase):
         dense_bn = paddle.nn.BatchNorm1D(channels)
         dense_x = dense_x.reshape((-1, dense_x.shape[-1]))
         dense_out = dense_bn(dense_x)
-        assert np.allclose(dense_out.numpy(), batch_norm_out.values().numpy())
+        np.testing.assert_allclose(
+            dense_out.numpy(), batch_norm_out.values().numpy()
+        )
         # [1, 6, 6, 6, 3]
 
     def check(self, shape):
@@ -137,7 +139,7 @@ class TestSyncBatchNorm(unittest.TestCase):
             dense_sync_bn = paddle.nn.SyncBatchNorm(2)
             x = x.reshape((-1, x.shape[-1]))
             dense_hidden = dense_sync_bn(x)
-            assert np.allclose(
+            np.testing.assert_allclose(
                 sparse_hidden.values().numpy(), dense_hidden.numpy()
             )
 

--- a/test/legacy_test/test_sparse_pooling_op.py
+++ b/test/legacy_test/test_sparse_pooling_op.py
@@ -64,8 +64,10 @@ class TestMaxPool3DFunc(unittest.TestCase):
         dense_out.backward(dense_out)
 
         # compare with dense
-        assert np.allclose(dense_out.numpy(), out.numpy())
-        assert np.allclose(dense_x.grad.numpy(), self.dense_x.grad.numpy())
+        np.testing.assert_allclose(dense_out.numpy(), out.numpy())
+        np.testing.assert_allclose(
+            dense_x.grad.numpy(), self.dense_x.grad.numpy()
+        )
 
 
 class TestStride(TestMaxPool3DFunc):
@@ -111,7 +113,7 @@ class TestMaxPool3DAPI(unittest.TestCase):
         dense_out = paddle.nn.functional.max_pool3d(
             dense_x, 3, data_format='NDHWC'
         )
-        assert np.allclose(dense_out.numpy(), out.numpy())
+        np.testing.assert_allclose(dense_out.numpy(), out.numpy())
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_sparse_utils_op.py
+++ b/test/legacy_test/test_sparse_utils_op.py
@@ -330,7 +330,7 @@ class TestSparseConvert(unittest.TestCase):
         def verify(dense_x):
             sparse_x = dense_x.to_sparse_csr()
             out = sparse_x.to_dense()
-            assert np.allclose(out.numpy(), dense_x.numpy())
+            np.testing.assert_allclose(out.numpy(), dense_x.numpy())
 
         shape = np.random.randint(low=1, high=10, size=3)
         shape = list(shape)

--- a/test/legacy_test/test_sparse_utils_op.py
+++ b/test/legacy_test/test_sparse_utils_op.py
@@ -33,17 +33,17 @@ class TestSparseCreate(unittest.TestCase):
             dense_indices, dense_elements, dense_shape, stop_gradient=False
         )
         # test the to_string.py
-        assert np.array_equal(indices, coo.indices().numpy())
-        assert np.array_equal(values, coo.values().numpy())
+        np.testing.assert_array_equal(indices, coo.indices().numpy())
+        np.testing.assert_array_equal(values, coo.values().numpy())
 
     def test_create_coo_by_np(self):
         indices = [[0, 1, 2], [1, 2, 0]]
         values = [1.0, 2.0, 3.0]
         dense_shape = [3, 3]
         coo = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape)
-        assert np.array_equal(3, coo.nnz())
-        assert np.array_equal(indices, coo.indices().numpy())
-        assert np.array_equal(values, coo.values().numpy())
+        np.testing.assert_array_equal(3, coo.nnz())
+        np.testing.assert_array_equal(indices, coo.indices().numpy())
+        np.testing.assert_array_equal(values, coo.values().numpy())
 
     def test_create_csr_by_tensor(self):
         crows = [0, 2, 3, 5]
@@ -69,10 +69,10 @@ class TestSparseCreate(unittest.TestCase):
         dense_shape = [3, 4]
         csr = paddle.sparse.sparse_csr_tensor(crows, cols, values, dense_shape)
         # test the to_string.py
-        assert np.array_equal(5, csr.nnz())
-        assert np.array_equal(crows, csr.crows().numpy())
-        assert np.array_equal(cols, csr.cols().numpy())
-        assert np.array_equal(values, csr.values().numpy())
+        np.testing.assert_array_equal(5, csr.nnz())
+        np.testing.assert_array_equal(crows, csr.crows().numpy())
+        np.testing.assert_array_equal(cols, csr.cols().numpy())
+        np.testing.assert_array_equal(values, csr.values().numpy())
 
     def test_place(self):
         place = core.CPUPlace()
@@ -132,8 +132,8 @@ class TestSparseConvert(unittest.TestCase):
         values = [1.0, 2.0, 3.0, 4.0, 5.0]
         dense_x = paddle.to_tensor(x, dtype='float32', stop_gradient=False)
         out = dense_x.to_sparse_coo(2)
-        assert np.array_equal(out.indices().numpy(), indices)
-        assert np.array_equal(out.values().numpy(), values)
+        np.testing.assert_array_equal(out.indices().numpy(), indices)
+        np.testing.assert_array_equal(out.values().numpy(), values)
         # test to_sparse_coo_grad backward
         out_grad_indices = [[0, 1], [0, 1]]
         out_grad_values = [2.0, 3.0]
@@ -144,7 +144,9 @@ class TestSparseConvert(unittest.TestCase):
             stop_gradient=True,
         )
         out.backward(out_grad)
-        assert np.array_equal(dense_x.grad.numpy(), out_grad.to_dense().numpy())
+        np.testing.assert_array_equal(
+            dense_x.grad.numpy(), out_grad.to_dense().numpy()
+        )
 
     def test_coo_to_dense(self):
         indices = [[0, 0, 1, 2, 2], [1, 3, 2, 0, 1]]
@@ -168,7 +170,7 @@ class TestSparseConvert(unittest.TestCase):
             dense_tensor.backward(paddle.to_tensor(out_grad))
             # mask the out_grad by sparse_x.indices()
             correct_x_grad = [2.0, 4.0, 7.0, 9.0, 10.0]
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 correct_x_grad, sparse_x.grad.values().numpy()
             )
 
@@ -182,7 +184,7 @@ class TestSparseConvert(unittest.TestCase):
             sparse_x_cpu.retain_grads()
             dense_tensor_cpu = sparse_x_cpu.to_dense()
             dense_tensor_cpu.backward(paddle.to_tensor(out_grad))
-            assert np.array_equal(
+            np.testing.assert_array_equal(
                 correct_x_grad, sparse_x_cpu.grad.values().numpy()
             )
 
@@ -193,12 +195,12 @@ class TestSparseConvert(unittest.TestCase):
         values = [1, 2, 3, 4, 5]
         dense_x = paddle.to_tensor(x)
         out = dense_x.to_sparse_csr()
-        assert np.array_equal(out.crows().numpy(), crows)
-        assert np.array_equal(out.cols().numpy(), cols)
-        assert np.array_equal(out.values().numpy(), values)
+        np.testing.assert_array_equal(out.crows().numpy(), crows)
+        np.testing.assert_array_equal(out.cols().numpy(), cols)
+        np.testing.assert_array_equal(out.values().numpy(), values)
 
         dense_tensor = out.to_dense()
-        assert np.array_equal(dense_tensor.numpy(), x)
+        np.testing.assert_array_equal(dense_tensor.numpy(), x)
 
     def test_coo_values_grad(self):
         indices = [[0, 0, 1, 2, 2], [1, 3, 2, 0, 1]]
@@ -214,7 +216,7 @@ class TestSparseConvert(unittest.TestCase):
         out_grad = [2.0, 3.0, 5.0, 8.0, 9.0]
         # test coo_values_grad
         values_tensor.backward(paddle.to_tensor(out_grad))
-        assert np.array_equal(out_grad, sparse_x.grad.values().numpy())
+        np.testing.assert_array_equal(out_grad, sparse_x.grad.values().numpy())
         indices = [[0, 0, 1, 2, 2], [1, 3, 2, 0, 1]]
         values = [
             [1.0, 1.0],
@@ -240,7 +242,7 @@ class TestSparseConvert(unittest.TestCase):
         ]
         # test coo_values_grad
         values_tensor.backward(paddle.to_tensor(out_grad))
-        assert np.array_equal(out_grad, sparse_x.grad.values().numpy())
+        np.testing.assert_array_equal(out_grad, sparse_x.grad.values().numpy())
 
     def test_sparse_coo_tensor_grad(self):
         for device in devices:
@@ -266,7 +268,9 @@ class TestSparseConvert(unittest.TestCase):
                 )
                 sparse_x.backward(sparse_out_grad)
                 correct_values_grad = [0, 3]
-                assert np.array_equal(correct_values_grad, values.grad.numpy())
+                np.testing.assert_array_equal(
+                    correct_values_grad, values.grad.numpy()
+                )
 
                 # test the non-zero values is a vector
                 values = [[1, 1], [2, 2]]
@@ -283,7 +287,9 @@ class TestSparseConvert(unittest.TestCase):
                 )
                 sparse_x.backward(sparse_out_grad)
                 correct_values_grad = [[0, 0], [3, 3]]
-                assert np.array_equal(correct_values_grad, values.grad.numpy())
+                np.testing.assert_array_equal(
+                    correct_values_grad, values.grad.numpy()
+                )
 
     def test_sparse_coo_tensor_sorted(self):
         for device in devices:
@@ -300,10 +306,12 @@ class TestSparseConvert(unittest.TestCase):
                 sparse_x = paddle.sparse.coalesce(sparse_x)
                 indices_sorted = [[0, 1], [1, 0]]
                 values_sorted = [5.0, 1.0]
-                assert np.array_equal(
+                np.testing.assert_array_equal(
                     indices_sorted, sparse_x.indices().numpy()
                 )
-                assert np.array_equal(values_sorted, sparse_x.values().numpy())
+                np.testing.assert_array_equal(
+                    values_sorted, sparse_x.values().numpy()
+                )
 
                 # test the non-zero values is a vector
                 values = [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]
@@ -311,10 +319,12 @@ class TestSparseConvert(unittest.TestCase):
                 sparse_x = paddle.sparse.sparse_coo_tensor(indices, values)
                 sparse_x = paddle.sparse.coalesce(sparse_x)
                 values_sorted = [[5.0, 5.0], [1.0, 1.0]]
-                assert np.array_equal(
+                np.testing.assert_array_equal(
                     indices_sorted, sparse_x.indices().numpy()
                 )
-                assert np.array_equal(values_sorted, sparse_x.values().numpy())
+                np.testing.assert_array_equal(
+                    values_sorted, sparse_x.values().numpy()
+                )
 
     def test_batch_csr(self):
         def verify(dense_x):

--- a/test/legacy_test/test_split_op.py
+++ b/test/legacy_test/test_split_op.py
@@ -323,12 +323,12 @@ class TestSplitAPI(unittest.TestCase):
         )
 
         out = np.split(input_1, [2, 3], 1)
-        assert np.array_equal(res_0, out[0])
-        assert np.array_equal(res_1, out[1])
-        assert np.array_equal(res_2, out[2])
-        assert np.array_equal(res_3, out[0])
-        assert np.array_equal(res_4, out[1])
-        assert np.array_equal(res_5, out[2])
+        np.testing.assert_array_equal(res_0, out[0])
+        np.testing.assert_array_equal(res_1, out[1])
+        np.testing.assert_array_equal(res_2, out[2])
+        np.testing.assert_array_equal(res_3, out[0])
+        np.testing.assert_array_equal(res_4, out[1])
+        np.testing.assert_array_equal(res_5, out[2])
 
 
 class TestSplitOpError(unittest.TestCase):

--- a/test/legacy_test/test_strided_slice_op.py
+++ b/test/legacy_test/test_strided_slice_op.py
@@ -605,13 +605,13 @@ class TestStridedSliceAPI(unittest.TestCase):
             },
             fetch_list=[out_1, out_2, out_3, out_4, out_5, out_6, out_7],
         )
-        assert np.array_equal(res_1, input[-3:3, 0:100, 2:-1, :])
-        assert np.array_equal(res_2, input[-3:3, 0:100, :, 2:-1])
-        assert np.array_equal(res_3, input[-3:3, 0:100, :, 2:-1])
-        assert np.array_equal(res_4, input[-3:3, 0:100, 2:-1, :])
-        assert np.array_equal(res_5, input[-3:3, 0:100:2, -1:2:-1, :])
-        assert np.array_equal(res_6, input[-3:3, 0:100:2, :, -1:2:-1])
-        assert np.array_equal(res_7, input[-1, 0:100:2, :, -1:2:-1])
+        np.testing.assert_array_equal(res_1, input[-3:3, 0:100, 2:-1, :])
+        np.testing.assert_array_equal(res_2, input[-3:3, 0:100, :, 2:-1])
+        np.testing.assert_array_equal(res_3, input[-3:3, 0:100, :, 2:-1])
+        np.testing.assert_array_equal(res_4, input[-3:3, 0:100, 2:-1, :])
+        np.testing.assert_array_equal(res_5, input[-3:3, 0:100:2, -1:2:-1, :])
+        np.testing.assert_array_equal(res_6, input[-3:3, 0:100:2, :, -1:2:-1])
+        np.testing.assert_array_equal(res_7, input[-1, 0:100:2, :, -1:2:-1])
 
     def test_dygraph_op(self):
         x = paddle.zeros(shape=[3, 4, 5, 6], dtype="float32")

--- a/test/legacy_test/test_tile_op.py
+++ b/test/legacy_test/test_tile_op.py
@@ -387,9 +387,9 @@ class TestTileAPI(unittest.TestCase):
             out_2 = paddle.tile(x, repeat_times=[positive_2, 3])
             out_3 = paddle.tile(x, repeat_times=repeat_times)
 
-            assert np.array_equal(out_1.numpy(), np.tile(np_x, (2, 3)))
-            assert np.array_equal(out_2.numpy(), np.tile(np_x, (2, 3)))
-            assert np.array_equal(out_3.numpy(), np.tile(np_x, (2, 3)))
+            np.testing.assert_array_equal(out_1.numpy(), np.tile(np_x, (2, 3)))
+            np.testing.assert_array_equal(out_2.numpy(), np.tile(np_x, (2, 3)))
+            np.testing.assert_array_equal(out_3.numpy(), np.tile(np_x, (2, 3)))
 
 
 class TestTileDoubleGradCheck(unittest.TestCase):

--- a/test/legacy_test/test_unbind_op.py
+++ b/test/legacy_test/test_unbind_op.py
@@ -38,8 +38,8 @@ class TestUnbind(unittest.TestCase):
             fetch_list=[out_0, out_1],
         )
 
-        assert np.array_equal(res_1, input_1[0, 0:100])
-        assert np.array_equal(res_2, input_1[1, 0:100])
+        np.testing.assert_array_equal(res_1, input_1[0, 0:100])
+        np.testing.assert_array_equal(res_2, input_1[1, 0:100])
 
     def test_unbind_static_fp16_gpu(self):
         if paddle.fluid.core.is_compiled_with_cuda():
@@ -61,8 +61,8 @@ class TestUnbind(unittest.TestCase):
                     fetch_list=[y],
                 )
 
-                assert np.array_equal(res[0], input[0, :])
-                assert np.array_equal(res[1], input[1, :])
+                np.testing.assert_array_equal(res[0], input[0, :])
+                np.testing.assert_array_equal(res[1], input[1, :])
 
     def test_unbind_dygraph(self):
         with fluid.dygraph.guard():
@@ -96,8 +96,8 @@ class TestLayersUnbind(unittest.TestCase):
             fetch_list=[out_0, out_1],
         )
 
-        assert np.array_equal(res_1, input_1[0, 0:100])
-        assert np.array_equal(res_2, input_1[1, 0:100])
+        np.testing.assert_array_equal(res_1, input_1[0, 0:100])
+        np.testing.assert_array_equal(res_2, input_1[1, 0:100])
 
 
 class TestUnbindOp(OpTest):

--- a/test/legacy_test/test_unsqueeze2_op.py
+++ b/test/legacy_test/test_unsqueeze2_op.py
@@ -275,11 +275,11 @@ class TestUnsqueezeAPI(unittest.TestCase):
             fetch_list=[out_1, out_2, out_3, out_4, out_5],
         )
 
-        assert np.array_equal(res_1, input.reshape([3, 1, 1, 2, 5, 1]))
-        assert np.array_equal(res_2, input.reshape([3, 1, 1, 2, 5, 1]))
-        assert np.array_equal(res_3, input.reshape([3, 1, 1, 2, 5, 1]))
-        assert np.array_equal(res_4, input.reshape([3, 2, 5, 1]))
-        assert np.array_equal(res_5, input.reshape([3, 1, 1, 2, 5, 1]))
+        np.testing.assert_array_equal(res_1, input.reshape([3, 1, 1, 2, 5, 1]))
+        np.testing.assert_array_equal(res_2, input.reshape([3, 1, 1, 2, 5, 1]))
+        np.testing.assert_array_equal(res_3, input.reshape([3, 1, 1, 2, 5, 1]))
+        np.testing.assert_array_equal(res_4, input.reshape([3, 2, 5, 1]))
+        np.testing.assert_array_equal(res_5, input.reshape([3, 1, 1, 2, 5, 1]))
 
     def test_error(self):
         def test_axes_type():

--- a/test/legacy_test/test_update_loss_scaling_op.py
+++ b/test/legacy_test/test_update_loss_scaling_op.py
@@ -274,14 +274,20 @@ class TestUpdateLossScalingLayer(unittest.TestCase):
                     ],
                 )
 
-            assert np.array_equal(result_v[0], a_v)
-            assert np.array_equal(result_v[1], b_v)
-            assert np.array_equal(result_v[0], result_v[2])
-            assert np.array_equal(result_v[1], result_v[3])
-            assert np.array_equal(result_v[4], found_inf_v)
-            assert np.array_equal(result_v[5], prev_loss_scaling_v * incr_ratio)
-            assert np.array_equal(result_v[6], np.zeros_like(num_good_steps_v))
-            assert np.array_equal(result_v[7], np.zeros_like(num_bad_steps_v))
+            np.testing.assert_array_equal(result_v[0], a_v)
+            np.testing.assert_array_equal(result_v[1], b_v)
+            np.testing.assert_array_equal(result_v[0], result_v[2])
+            np.testing.assert_array_equal(result_v[1], result_v[3])
+            np.testing.assert_array_equal(result_v[4], found_inf_v)
+            np.testing.assert_array_equal(
+                result_v[5], prev_loss_scaling_v * incr_ratio
+            )
+            np.testing.assert_array_equal(
+                result_v[6], np.zeros_like(num_good_steps_v)
+            )
+            np.testing.assert_array_equal(
+                result_v[7], np.zeros_like(num_bad_steps_v)
+            )
 
     def loss_scaling_check_inf(self, use_cuda=True, scope=fluid.Scope()):
         with paddle_static_guard():
@@ -353,14 +359,20 @@ class TestUpdateLossScalingLayer(unittest.TestCase):
                         num_bad_steps,
                     ],
                 )
-            assert np.array_equal(result_v[0], np.zeros_like(a_v))
-            assert np.array_equal(result_v[1], np.zeros_like(b_v))
-            assert np.array_equal(result_v[2], np.zeros_like(a_v))
-            assert np.array_equal(result_v[3], np.zeros_like(b_v))
-            assert np.array_equal(result_v[4], found_inf_v)
-            assert np.array_equal(result_v[5], prev_loss_scaling_v * decr_ratio)
-            assert np.array_equal(result_v[6], np.zeros_like(num_good_steps_v))
-            assert np.array_equal(result_v[7], np.zeros_like(num_bad_steps_v))
+            np.testing.assert_array_equal(result_v[0], np.zeros_like(a_v))
+            np.testing.assert_array_equal(result_v[1], np.zeros_like(b_v))
+            np.testing.assert_array_equal(result_v[2], np.zeros_like(a_v))
+            np.testing.assert_array_equal(result_v[3], np.zeros_like(b_v))
+            np.testing.assert_array_equal(result_v[4], found_inf_v)
+            np.testing.assert_array_equal(
+                result_v[5], prev_loss_scaling_v * decr_ratio
+            )
+            np.testing.assert_array_equal(
+                result_v[6], np.zeros_like(num_good_steps_v)
+            )
+            np.testing.assert_array_equal(
+                result_v[7], np.zeros_like(num_bad_steps_v)
+            )
 
     def test_loss_scaling_cpu(self):
         with paddle_static_guard():

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -166,17 +166,17 @@ class TestWhereAPI(unittest.TestCase):
                             feed={'cond': self.cond, 'x': self.x, 'y': self.y},
                             fetch_list=fetch_list,
                         )
-                        assert np.array_equal(out[0], self.out)
+                        np.testing.assert_array_equal(out[0], self.out)
                         if x_stop_gradient is False:
-                            assert np.array_equal(
+                            np.testing.assert_array_equal(
                                 out[2], self.ref_x_backward(out[1])
                             )
                             if y.stop_gradient is False:
-                                assert np.array_equal(
+                                np.testing.assert_array_equal(
                                     out[3], self.ref_y_backward(out[1])
                                 )
                         elif y.stop_gradient is False:
-                            assert np.array_equal(
+                            np.testing.assert_array_equal(
                                 out[2], self.ref_y_backward(out[1])
                             )
 
@@ -202,7 +202,9 @@ class TestWhereAPI(unittest.TestCase):
                     feed={'x': x_i, 'y': y_i},
                     fetch_list=[result],
                 )
-                assert np.array_equal(out[0], np.where((x_i > 1), x_i, y_i))
+                np.testing.assert_array_equal(
+                    out[0], np.where((x_i > 1), x_i, y_i)
+                )
 
     def test_scalar(self):
         paddle.enable_static()
@@ -228,7 +230,7 @@ class TestWhereAPI(unittest.TestCase):
                     fetch_list=[result],
                 )
                 expect = np.where(cond_data, x_data, y_data)
-                assert np.array_equal(out[0], expect)
+                np.testing.assert_array_equal(out[0], expect)
 
     def __test_where_with_broadcast_static(self, cond_shape, x_shape, y_shape):
         paddle.enable_static()
@@ -262,7 +264,7 @@ class TestWhereAPI(unittest.TestCase):
                     fetch_list=[result],
                 )
                 expect = np.where(cond_data, x_data, y_data)
-                assert np.array_equal(out[0], expect)
+                np.testing.assert_array_equal(out[0], expect)
 
     def test_static_api_broadcast_1(self):
         cond_shape = [2, 4]
@@ -323,7 +325,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = fluid.dygraph.to_variable(y_i)
             cond = fluid.dygraph.to_variable(cond_i)
             out = paddle.where(cond, x, y)
-            assert np.array_equal(out.numpy(), np.where(cond_i, x_i, y_i))
+            np.testing.assert_array_equal(
+                out.numpy(), np.where(cond_i, x_i, y_i)
+            )
 
     def test_scalar(self):
         with fluid.dygraph.guard():
@@ -332,7 +336,7 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = 2.0
             cond = fluid.dygraph.to_variable(cond_i)
             out = paddle.where(cond, x, y)
-            assert np.array_equal(out.numpy(), np.where(cond_i, x, y))
+            np.testing.assert_array_equal(out.numpy(), np.where(cond_i, x, y))
 
     def __test_where_with_broadcast_dygraph(self, cond_shape, a_shape, b_shape):
         with fluid.dygraph.guard():

--- a/test/mkldnn/check_flags_mkldnn_ops_on_off.py
+++ b/test/mkldnn/check_flags_mkldnn_ops_on_off.py
@@ -54,7 +54,7 @@ def check():
         np_res = np.add(a_np, b_np)
         np_res = np.matmul(np_res, np.transpose(b_np, (0, 2, 1)))
         np_res = np.maximum(np_res, 0)
-    assert np.allclose(res1.numpy(), np_res, atol=1e-3)
+    np.testing.assert_allclose(res1.numpy(), np_res, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/test/mkldnn/check_flags_use_mkldnn.py
+++ b/test/mkldnn/check_flags_use_mkldnn.py
@@ -38,7 +38,7 @@ def check():
         a = fluid.dygraph.to_variable(a_np)
         res1 = func(a)
         res2 = np.maximum(a_np, 0)
-    assert np.array_equal(res1.numpy(), res2)
+    np.testing.assert_array_equal(res1.numpy(), res2)
 
 
 if __name__ == '__main__':

--- a/test/quantization/test_quant2_int8_mkldnn_pass.py
+++ b/test/quantization/test_quant2_int8_mkldnn_pass.py
@@ -92,7 +92,7 @@ class TestQuant2Int8MkldnnPassMul(unittest.TestCase):
             param.set(self.variables_mul["mul_weights"], self.place)
             qpass._dequantize_op_weights(graph, op_node, "Y", "Out")
 
-            assert np.allclose(
+            np.testing.assert_allclose(
                 self.scope.find_var("mul_weights").get_tensor(),
                 [
                     [

--- a/test/xpu/process_group_bkcl.py
+++ b/test/xpu/process_group_bkcl.py
@@ -86,11 +86,11 @@ class TestProcessGroupFp32(unittest.TestCase):
             # XPU don't support event query by now, so just use sync op here
             task = dist.broadcast(tensor_x, 0)
             paddle.device.xpu.synchronize()
-            assert np.array_equal(broadcast_result, tensor_x)
+            np.testing.assert_array_equal(broadcast_result, tensor_x)
         else:
             task = dist.broadcast(tensor_y, 0)
             paddle.device.xpu.synchronize()
-            assert np.array_equal(broadcast_result, tensor_y)
+            np.testing.assert_array_equal(broadcast_result, tensor_y)
 
         sys.stdout.write(f"rank {pg.rank()}: test broadcast api ok\n")
 
@@ -132,8 +132,8 @@ class TestProcessGroupFp32(unittest.TestCase):
         out_2 = paddle.slice(
             tensor_out, [0], [out_shape[0] // 2], [out_shape[0]]
         )
-        assert np.array_equal(tensor_x, out_1)
-        assert np.array_equal(tensor_y, out_2)
+        np.testing.assert_array_equal(tensor_x, out_1)
+        np.testing.assert_array_equal(tensor_y, out_2)
         sys.stdout.write(f"rank {pg.rank()}: test allgather api ok\n")
 
         if pg.rank() == 0:
@@ -150,8 +150,8 @@ class TestProcessGroupFp32(unittest.TestCase):
         out_2 = paddle.slice(
             tensor_out, [0], [out_shape[0] // 2], [out_shape[0]]
         )
-        assert np.array_equal(tensor_x, out_1)
-        assert np.array_equal(tensor_y, out_2)
+        np.testing.assert_array_equal(tensor_x, out_1)
+        np.testing.assert_array_equal(tensor_y, out_2)
         sys.stdout.write(f"rank {pg.rank()}: test allgather api2 ok\n")
 
         # test Reduce
@@ -171,8 +171,8 @@ class TestProcessGroupFp32(unittest.TestCase):
             task.wait()
             paddle.device.xpu.synchronize()
         if pg.rank() == 0:
-            assert np.array_equal(tensor_x, sum_result)
-        assert np.array_equal(tensor_y, old_tensor_y)
+            np.testing.assert_array_equal(tensor_x, sum_result)
+        np.testing.assert_array_equal(tensor_y, old_tensor_y)
         sys.stdout.write(f"rank {pg.rank()}: test reduce sum api ok\n")
 
         # test reduce_scatter
@@ -196,9 +196,9 @@ class TestProcessGroupFp32(unittest.TestCase):
             task.wait()
         paddle.device.xpu.synchronize()
         if pg.rank() == 0:
-            assert np.array_equal(need_result0, tensor_out)
+            np.testing.assert_array_equal(need_result0, tensor_out)
         else:
-            assert np.array_equal(need_result1, tensor_out)
+            np.testing.assert_array_equal(need_result1, tensor_out)
         sys.stdout.write(f"rank {pg.rank()}: test reduce_scatter sum api ok\n")
 
         # test send async api
@@ -215,7 +215,7 @@ class TestProcessGroupFp32(unittest.TestCase):
         else:
             task = dist.recv(tensor_y, 0, sync_op=False)
             task.wait()
-            assert np.array_equal(tensor_y, tensor_x)
+            np.testing.assert_array_equal(tensor_y, tensor_x)
 
         # test send sync api
         # rank 0
@@ -229,7 +229,7 @@ class TestProcessGroupFp32(unittest.TestCase):
             task = dist.send(tensor_x, 1, sync_op=True)
         else:
             task = dist.recv(tensor_y, 0, sync_op=True)
-            assert np.array_equal(tensor_y, tensor_x)
+            np.testing.assert_array_equal(tensor_y, tensor_x)
 
         # test send 0-d tensor
         # rank 0

--- a/test/xpu/test_expand_as_v2_op_xpu.py
+++ b/test/xpu/test_expand_as_v2_op_xpu.py
@@ -147,7 +147,7 @@ class TestExpandAsV2API(unittest.TestCase):
             feed={"x": x_np, "target_tensor": y_np},
             fetch_list=[out_1],
         )
-        assert np.array_equal(res_1[0], np.tile(x_np, (2, 1, 1)))
+        np.testing.assert_array_equal(res_1[0], np.tile(x_np, (2, 1, 1)))
 
 
 support_types = get_xpu_op_support_types('expand_as_v2')

--- a/test/xpu/test_expand_v2_op_xpu.py
+++ b/test/xpu/test_expand_v2_op_xpu.py
@@ -226,9 +226,9 @@ class TestExpandV2API(unittest.TestCase):
                 fetch_list=[out_1, out_2, out_3],
             )
 
-            assert np.array_equal(res_1, np.tile(input, (1, 1)))
-            assert np.array_equal(res_2, np.tile(input, (1, 1)))
-            assert np.array_equal(res_3, np.tile(input, (1, 1)))
+            np.testing.assert_array_equal(res_1, np.tile(input, (1, 1)))
+            np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
+            np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
 
 
 support_types = get_xpu_op_support_types('expand_v2')

--- a/test/xpu/test_masked_select_op_xpu.py
+++ b/test/xpu/test_masked_select_op_xpu.py
@@ -106,8 +106,7 @@ class TestMaskedSelectAPI(unittest.TestCase):
             feed={"x": np_x, "mask": np_mask},
             fetch_list=[out],
         )
-        res = res[0] if len(res) == 1 else res
-        np.testing.assert_allclose(res, np_out)
+        self.assertEqual(np.allclose(res, np_out), True)
 
 
 class TestMaskedSelectError(unittest.TestCase):

--- a/test/xpu/test_masked_select_op_xpu.py
+++ b/test/xpu/test_masked_select_op_xpu.py
@@ -106,6 +106,7 @@ class TestMaskedSelectAPI(unittest.TestCase):
             feed={"x": np_x, "mask": np_mask},
             fetch_list=[out],
         )
+        res = res[0] if len(res) == 1 else res
         np.testing.assert_allclose(res, np_out)
 
 

--- a/test/xpu/test_masked_select_op_xpu.py
+++ b/test/xpu/test_masked_select_op_xpu.py
@@ -86,7 +86,7 @@ class TestMaskedSelectAPI(unittest.TestCase):
         mask = paddle.to_tensor(np_mask)
         out = paddle.masked_select(x, mask)
         np_out = np_masked_select(np_x, np_mask)
-        self.assertEqual(np.allclose(out.numpy(), np_out), True)
+        np.testing.assert_allclose(out.numpy(), np_out)
         paddle.enable_static()
 
     def test_static_mode(self):
@@ -106,7 +106,7 @@ class TestMaskedSelectAPI(unittest.TestCase):
             feed={"x": np_x, "mask": np_mask},
             fetch_list=[out],
         )
-        self.assertEqual(np.allclose(res, np_out), True)
+        np.testing.assert_allclose(res, np_out)
 
 
 class TestMaskedSelectError(unittest.TestCase):

--- a/test/xpu/test_sparse_utils_op_xpu.py
+++ b/test/xpu/test_sparse_utils_op_xpu.py
@@ -29,17 +29,17 @@ class TestSparseCreate(unittest.TestCase):
         coo = paddle.sparse.sparse_coo_tensor(
             dense_indices, dense_elements, dense_shape, stop_gradient=False
         )
-        assert np.array_equal(indices, coo.indices().numpy())
-        assert np.array_equal(values, coo.values().numpy())
+        np.testing.assert_array_equal(indices, coo.indices().numpy())
+        np.testing.assert_array_equal(values, coo.values().numpy())
 
     def test_create_coo_by_np(self):
         indices = [[0, 1, 2], [1, 2, 0]]
         values = [1.0, 2.0, 3.0]
         dense_shape = [3, 3]
         coo = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape)
-        assert np.array_equal(3, coo.nnz())
-        assert np.array_equal(indices, coo.indices().numpy())
-        assert np.array_equal(values, coo.values().numpy())
+        np.testing.assert_array_equal(3, coo.nnz())
+        np.testing.assert_array_equal(indices, coo.indices().numpy())
+        np.testing.assert_array_equal(values, coo.values().numpy())
 
     def test_place(self):
         indices = [[0, 1], [0, 1]]

--- a/test/xpu/test_tile_op_xpu.py
+++ b/test/xpu/test_tile_op_xpu.py
@@ -219,9 +219,9 @@ class TestTileAPI(unittest.TestCase):
             out_2 = paddle.tile(x, repeat_times=[positive_2, 3])
             out_3 = paddle.tile(x, repeat_times=repeat_times)
 
-            assert np.array_equal(out_1.numpy(), np.tile(np_x, (2, 3)))
-            assert np.array_equal(out_2.numpy(), np.tile(np_x, (2, 3)))
-            assert np.array_equal(out_3.numpy(), np.tile(np_x, (2, 3)))
+            np.testing.assert_array_equal(out_1.numpy(), np.tile(np_x, (2, 3)))
+            np.testing.assert_array_equal(out_2.numpy(), np.tile(np_x, (2, 3)))
+            np.testing.assert_array_equal(out_3.numpy(), np.tile(np_x, (2, 3)))
 
 
 class TestTileAPI_ZeroDim(unittest.TestCase):

--- a/test/xpu/test_unbind_op_xpu.py
+++ b/test/xpu/test_unbind_op_xpu.py
@@ -50,8 +50,8 @@ class XPUTestUnbindOP(XPUOpTestWrapper):
                 fetch_list=[out_0, out_1],
             )
 
-            assert np.array_equal(res_1, input_1[0, 0:100])
-            assert np.array_equal(res_2, input_1[1, 0:100])
+            np.testing.assert_array_equal(res_1, input_1[0, 0:100])
+            np.testing.assert_array_equal(res_2, input_1[1, 0:100])
 
         def test_unbind_dygraph(self):
             with fluid.dygraph.guard():
@@ -89,8 +89,8 @@ class XPUTestUnbindOP(XPUOpTestWrapper):
                 fetch_list=[out_0, out_1],
             )
 
-            assert np.array_equal(res_1, input_1[0, 0:100])
-            assert np.array_equal(res_2, input_1[1, 0:100])
+            np.testing.assert_array_equal(res_1, input_1[0, 0:100])
+            np.testing.assert_array_equal(res_2, input_1[1, 0:100])
 
     class TestUnbindOp(XPUOpTest):
         def initParameters(self):

--- a/test/xpu/test_update_loss_scaling_op_xpu.py
+++ b/test/xpu/test_update_loss_scaling_op_xpu.py
@@ -174,14 +174,20 @@ class XPUTestUpdateLossScalingOp(XPUOpTestWrapper):
                         num_bad_steps,
                     ],
                 )
-            assert np.array_equal(result_v[0], a_v)
-            assert np.array_equal(result_v[1], b_v)
-            assert np.array_equal(result_v[0], result_v[2])
-            assert np.array_equal(result_v[1], result_v[3])
-            assert np.array_equal(result_v[4], found_inf_v)
-            assert np.array_equal(result_v[5], prev_loss_scaling_v * incr_ratio)
-            assert np.array_equal(result_v[6], np.zeros_like(num_good_steps_v))
-            assert np.array_equal(result_v[7], np.zeros_like(num_bad_steps_v))
+            np.testing.assert_array_equal(result_v[0], a_v)
+            np.testing.assert_array_equal(result_v[1], b_v)
+            np.testing.assert_array_equal(result_v[0], result_v[2])
+            np.testing.assert_array_equal(result_v[1], result_v[3])
+            np.testing.assert_array_equal(result_v[4], found_inf_v)
+            np.testing.assert_array_equal(
+                result_v[5], prev_loss_scaling_v * incr_ratio
+            )
+            np.testing.assert_array_equal(
+                result_v[6], np.zeros_like(num_good_steps_v)
+            )
+            np.testing.assert_array_equal(
+                result_v[7], np.zeros_like(num_bad_steps_v)
+            )
 
         def loss_scaling_check_inf(self, use_cuda=True, scope=fluid.Scope()):
             a = paddle.static.data(
@@ -252,14 +258,20 @@ class XPUTestUpdateLossScalingOp(XPUOpTestWrapper):
                         num_bad_steps,
                     ],
                 )
-            assert np.array_equal(result_v[0], np.zeros_like(a_v))
-            assert np.array_equal(result_v[1], np.zeros_like(b_v))
-            assert np.array_equal(result_v[2], np.zeros_like(a_v))
-            assert np.array_equal(result_v[3], np.zeros_like(b_v))
-            assert np.array_equal(result_v[4], found_inf_v)
-            assert np.array_equal(result_v[5], prev_loss_scaling_v * decr_ratio)
-            assert np.array_equal(result_v[6], np.zeros_like(num_good_steps_v))
-            assert np.array_equal(result_v[7], np.zeros_like(num_bad_steps_v))
+            np.testing.assert_array_equal(result_v[0], np.zeros_like(a_v))
+            np.testing.assert_array_equal(result_v[1], np.zeros_like(b_v))
+            np.testing.assert_array_equal(result_v[2], np.zeros_like(a_v))
+            np.testing.assert_array_equal(result_v[3], np.zeros_like(b_v))
+            np.testing.assert_array_equal(result_v[4], found_inf_v)
+            np.testing.assert_array_equal(
+                result_v[5], prev_loss_scaling_v * decr_ratio
+            )
+            np.testing.assert_array_equal(
+                result_v[6], np.zeros_like(num_good_steps_v)
+            )
+            np.testing.assert_array_equal(
+                result_v[7], np.zeros_like(num_bad_steps_v)
+            )
 
         def test_loss_scaling(self):
             main = fluid.Program()

--- a/test/xpu/test_where_op_xpu.py
+++ b/test/xpu/test_where_op_xpu.py
@@ -132,18 +132,18 @@ class TestXPUWhereAPI(unittest.TestCase):
                         feed={'cond': self.cond, 'x': self.x, 'y': self.y},
                         fetch_list=fetch_list,
                     )
-                    assert np.array_equal(out[0], self.out)
+                    np.testing.assert_array_equal(out[0], self.out)
 
                     if x_stop_gradient is False:
-                        assert np.array_equal(
+                        np.testing.assert_array_equal(
                             out[2], self.ref_x_backward(out[1])
                         )
                         if y.stop_gradient is False:
-                            assert np.array_equal(
+                            np.testing.assert_array_equal(
                                 out[3], self.ref_y_backward(out[1])
                             )
                     elif y.stop_gradient is False:
-                        assert np.array_equal(
+                        np.testing.assert_array_equal(
                             out[2], self.ref_y_backward(out[1])
                         )
 
@@ -165,7 +165,7 @@ class TestXPUWhereAPI(unittest.TestCase):
             out = exe.run(
                 train_prog, feed={'x': x_i, 'y': y_i}, fetch_list=[result]
             )
-            assert np.array_equal(out[0], np.where(x_i > 1, x_i, y_i))
+            np.testing.assert_array_equal(out[0], np.where(x_i > 1, x_i, y_i))
 
 
 class TestWhereDygraphAPI(unittest.TestCase):
@@ -178,7 +178,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = fluid.dygraph.to_variable(y_i)
             cond = fluid.dygraph.to_variable(cond_i)
             out = paddle.where(cond, x, y)
-            assert np.array_equal(out.numpy(), np.where(cond_i, x_i, y_i))
+            np.testing.assert_array_equal(
+                out.numpy(), np.where(cond_i, x_i, y_i)
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
https://github.com/PaddlePaddle/Paddle/issues/55348
替换了下面四种写法
- assert np.allclose(...)
- assert np.isclose(...).all()
- assert np.array_equal(...)
- assert not np.array_equal(...)

`np.testing.assert_array_compare(operator.__ne__, $$$A)` 这种写法参考了[stackoverflow](https://stackoverflow.com/questions/38506044/numpy-testing-assert-array-not-equal/38506922)

- fixes #44641
- closes #55348
