### PR TITLE
[BugFix] Replace include dense_tensor.h with  forward declare in phi lib

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -318,10 +318,6 @@ copy(
   DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/paddle/phi/core/)
 copy(
   inference_lib_dist
-  SRCS ${PADDLE_SOURCE_DIR}/paddle/phi/core/dense_tensor.h
-  DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/paddle/phi/core/)
-copy(
-  inference_lib_dist
   SRCS ${PADDLE_SOURCE_DIR}/paddle/fluid/platform/init_phi.h
   DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/paddle/phi/)
 copy(

--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -318,6 +318,10 @@ copy(
   DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/paddle/phi/core/)
 copy(
   inference_lib_dist
+  SRCS ${PADDLE_SOURCE_DIR}/paddle/phi/core/dense_tensor.h
+  DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/paddle/phi/core/)
+copy(
+  inference_lib_dist
   SRCS ${PADDLE_SOURCE_DIR}/paddle/fluid/platform/init_phi.h
   DSTS ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/paddle/phi/)
 copy(

--- a/paddle/fluid/framework/ir/constant_folding_pass.cc
+++ b/paddle/fluid/framework/ir/constant_folding_pass.cc
@@ -157,7 +157,7 @@ void ConstantFoldingPass::ApplyImpl(ir::Graph *graph) const {
     }
     delete local_scope;
   }
-  LOG(INFO) << folded_op_num << " Ops are folded";
+  AddStatis(folded_op_num);
 }
 
 }  // namespace ir

--- a/paddle/fluid/inference/api/demo_ci/utils.h
+++ b/paddle/fluid/inference/api/demo_ci/utils.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "paddle/extension.h"      // For pr test!
 #include "paddle_inference_api.h"  // NOLINT
 
 namespace paddle {
@@ -82,6 +83,8 @@ void CheckOutput(const std::string& referfile,
   std::getline(file, line);
   auto refer = ProcessALine(line);
   file.close();
+
+  paddle::Tensor dummy;
 
   size_t numel = output.data.length() / PaddleDtypeSize(output.dtype);
   VLOG(3) << "predictor output numel " << numel;

--- a/paddle/phi/common/tensor_ref.h
+++ b/paddle/phi/common/tensor_ref.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <sstream>
@@ -21,7 +22,6 @@
 
 #include "paddle/phi/api/ext/exception.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/core/enforce.h"
 
 namespace phi {
 
@@ -35,8 +35,7 @@ class TensorRef {
   explicit TensorRef(const DenseTensor* base) : tensor_base_(base) {}
 
   const DenseTensor* Get() const {
-    PADDLE_ENFORCE_NOT_NULL(tensor_base_,
-                            "Can not get null ptr from Tensor ref scalar");
+    assert(tensor_base_ != nullptr);
     return tensor_base_;
   }
 

--- a/paddle/phi/common/tensor_ref.h
+++ b/paddle/phi/common/tensor_ref.h
@@ -21,10 +21,11 @@
 
 #include "paddle/phi/api/ext/exception.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
 
 namespace phi {
+
+class DenseTensor;
 
 // In static model pre analysis, we can't get the data from tensor
 class TensorRef {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

copy dense_tensor.h to inference lib

fix compile error: 

![image](https://github.com/PaddlePaddle/Paddle/assets/23653004/131884e2-2840-4006-b373-2a48e2f4cbbe)

related pr: https://github.com/PaddlePaddle/Paddle/pull/55212 https://github.com/PaddlePaddle/Paddle/pull/54692

**phi目录下的修改，原则是.h里能用前向声明的就用前向声明，如果必须包含.h，则务必保证copy到inference lib里并且所有.h依赖闭环（copy逻辑在infernce_lib.cmake）**

### Others
Pcard-71500