### PR TITLE
[NewIR] elementwise_add 参数名映射修复

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -90,10 +90,15 @@
       tensor_name : EpsilonTensor
 
 - op : add (elementwise_add)
-  backward : add_grad (elementwise_add_grad)
+  backward : add_grad (elementwise_add_grad), add_double_grad (elementwise_add_grad_grad), add_triple_grad (elementwise_add_triple_grad)
+  inputs :
+    {x : X, y : Y}
+  outputs :
+    {out : Out}
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]
+  complex_promote : [X, Y]
 
 - op : add_n (sum)
   inputs:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- #55334
- #54854

添加 elementwise_add 的算子参数映射

### 修复流程简单教学：

假设你要修复的算子是 `xxx`，你要做的是，

#### 1. 首先判断是否有别名：

项目内搜索 `PD_REGISTER_BASE_KERNEL_NAME(xxx, yyy)`，如果能找到，则表明 xxx 算子的别名是 yyy，后续搜索流程则使用 yyy 来搜索，以 `elementwise_add` 为例，别名是 `add`，如果没有，则表示其没有别名。

#### 2. 配置算子映射

首先打开 `paddle/phi/api/yaml/op_compat.yaml`，全文搜索 `op : yyy`，看看能否找到，如果不能，那么先插入：

```yaml
- op : yyy (xxx)
```

如果没有别名，则直接 `- op : xxx` 即可。

#### 3. 判断算子动态参数

接下来，你需要判断这个算子的动态参数名，首先打开 `paddle/phi/api/yaml/legacy_ops.yaml` （和 `paddle/phi/api/yaml/legacy_backward.yaml`），全文搜索 `- op : yyy`。

比如 

```yaml
- op : add
  args : (Tensor x, Tensor y)
  output : Tensor(out)
  infer_meta :
    func : ElementwiseInferMeta
  kernel :
    func : add
  inplace : (x -> out)
  backward : add_grad
```

可以看到参数为 `x, y`，输出为 `out`，其余内容可以先忽略。

#### 4. 判断算子静态参数

寻找 `xxx_op.cc` 文件，如果找不到，则查找 `REGISTER_OPERATOR(xxx)` 的出现文件，随后你就可以通过里面的 `OpMaker` 判断。

如

```cpp
  void AddInputX() override {
    AddInput(
        "X",
        "(Variable), Tensor or phi::DenseTensor of any dimensions. Its dtype "
        "should be int32, int64, float32, float64.");
  }

  void AddInputY() override {
    AddInput(
        "Y",
        "(Variable), Tensor or phi::DenseTensor of any dimensions. Its dtype "
        "should be int32, int64, float32, float64.");
  }
```

可以看到其中 x、y 是对应大写等等。

#### 5. 基于动静参数配置映射

参考前面得到的参数，如果两者不同，则配置不同部分如下：

```yaml
  inputs :
    {x : X, y : Y}
```

#### 6. 配置输出参数、特殊参数等等

根据具体情况而定，不特殊说明，流程基本如上。