### PR TITLE
Fix test_sparse_norm_op failure.

### DIFF
--- a/test/legacy_test/test_sparse_norm_op.py
+++ b/test/legacy_test/test_sparse_norm_op.py
@@ -100,19 +100,23 @@ class TestSparseBatchNorm(unittest.TestCase):
         else:
             bn = paddle.nn.BatchNorm3D(shape[-1], data_format=data_format)
         y = bn(x)
-        y.backward()
+        np.random.seed(5)
+        loss_data = np.random.uniform(-0.01, 0.01, y.shape).astype("float32")
+        loss = paddle.to_tensor(loss_data)
+        y.backward(loss)
 
         sp_x = paddle.to_tensor(data).to_sparse_coo(dim - 1)
         sp_x.stop_gradient = False
         sp_bn = paddle.sparse.nn.BatchNorm(shape[-1], data_format=data_format)
         sp_y = sp_bn(sp_x)
-        sp_y.backward()
+        sp_loss = loss.to_sparse_coo(dim-1)
+        sp_y.backward(sp_loss)
 
         np.testing.assert_allclose(
-            y.numpy(), sp_y.to_dense().numpy(), rtol=1e-5
+            sp_y.to_dense().numpy(), y.numpy(), rtol=1e-5
         )
         np.testing.assert_allclose(
-            x.grad.numpy(), sp_x.grad.to_dense().numpy(), rtol=1e-5
+            sp_x.grad.to_dense().numpy(), x.grad.numpy(), rtol=1e-5
         )
 
     def test_nd(self):

--- a/test/legacy_test/test_sparse_norm_op.py
+++ b/test/legacy_test/test_sparse_norm_op.py
@@ -109,7 +109,7 @@ class TestSparseBatchNorm(unittest.TestCase):
         sp_x.stop_gradient = False
         sp_bn = paddle.sparse.nn.BatchNorm(shape[-1], data_format=data_format)
         sp_y = sp_bn(sp_x)
-        sp_loss = loss.to_sparse_coo(dim-1)
+        sp_loss = loss.to_sparse_coo(dim - 1)
         sp_y.backward(sp_loss)
 
         np.testing.assert_allclose(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
card-72517

test_sparse_norm_op的case在某些cudnn版本中，sparse和dense的batch norm计算结果存在较大diff。同样的结果可以在pytorch中复现，将数据dump之后用cuda api调用cudnn计算也可以复现。因此暂时在单测中替换测试case，后续等nv有反馈后再做进一步测试。
相关issue: https://github.com/PaddlePaddle/Paddle/issues/54986