### PR TITLE
[Cherry-Pick] [BugFix] Fix issue-50853: CUDNN error(9), CUDNN_STATUS_NOT_SUPPORTED

### DIFF
--- a/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
@@ -131,7 +131,10 @@ void ConvElementwiseAdd2ActFusePass::ApplyImpl(ir::Graph* graph) const {
   auto* x = gpd.mutable_pattern()->NewNode("x")->AsInput()->assert_is_op_input(
       "conv2d", "Input");
 
-#if CUDNN_VERSION >= 8000
+// NOTE(liuyuanle): cudnn [8.7, 8.9 now) version has bug when act is
+// sigmoid/tanh. Ref to issue
+// https://github.com/PaddlePaddle/Paddle/issues/50853
+#if CUDNN_VERSION >= 8000 && CUDNN_VERSION < 8700
   std::unordered_set<std::string> cudnn_act_set(
       {"identity", "relu", "sigmoid", "tanh"});
 #else
@@ -154,6 +157,7 @@ void ConvElementwiseAdd2ActFusePass::ApplyImpl(ir::Graph* graph) const {
   patterns::ConvElementwiseadd2Act pattern(gpd.mutable_pattern(), pattern_name);
   pattern(x, all_act_set);
 
+  int found_count = 0;
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* g) {
     if (!IsCompat(subgraph, g)) {
@@ -220,8 +224,10 @@ void ConvElementwiseAdd2ActFusePass::ApplyImpl(ir::Graph* graph) const {
                           elementwise_add_out,
                           elementwise_add_out_1,
                           act_op});
+    found_count++;
   };
   gpd(graph, handler);
+  AddStatis(found_count);
 }
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
@@ -152,7 +152,10 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
                 ->assert_is_op_input("conv2d", "Input")
                 ->AsInput();
 
-#if CUDNN_VERSION >= 8000
+// NOTE(liuyuanle): cudnn [8.7, 8.9 now) version has bug when act is
+// sigmoid/tanh. Ref to issue
+// https://github.com/PaddlePaddle/Paddle/issues/50853
+#if CUDNN_VERSION >= 8000 && CUDNN_VERSION < 8700
   std::unordered_set<std::string> cudnn_act_set(
       {"identity", "relu", "sigmoid", "tanh"});
 #else
@@ -175,6 +178,7 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
   patterns::ConvElementwiseaddAct pattern(gpd.mutable_pattern(), pattern_name);
   pattern(x, all_act_set);
 
+  int found_count = 0;
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* g) {
     if (!IsCompat(subgraph, g)) {
@@ -226,9 +230,11 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
     GraphSafeRemoveNodes(
         graph,
         {conv_op, conv_out, elementwise_add_op, elementwise_add_out, act_op});
+    found_count++;
   };
 
   gpd(graph, handler);
+  AddStatis(found_count);
 }
 
 }  // namespace ir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
cudnnConvolutionBiasActivationForward has bug when activation is sigmoid/tanh and cudnn version is [8.7, 8.9 now)

Ref to issue: https://github.com/PaddlePaddle/Paddle/issues/50853

cherry-pick https://github.com/PaddlePaddle/Paddle/pull/55407