### PR TITLE
[Cherry-Pick]Modify eager_op_test and fix some testcasts

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/common_shape.h"
@@ -114,40 +115,42 @@ static void ElemwiseGradBroadcast1CPU(const T *x,
                                       DY_OP dy_op,
                                       T *dx,
                                       T *dy) {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
   if (is_xsize_larger) {
-    for (int i = 0; i < h; ++i) {
-      for (int j = 0; j < w; ++j) {
+    for (int j = 0; j < w; ++j) {
+      MPType sum_y = static_cast<MPType>(0);
+      for (int i = 0; i < h; ++i) {
         int x_offset = i * w + j;
         if (dx != nullptr) {
           dx[x_offset] =
               dx_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
         }
         if (dy != nullptr) {
-          T tmp = dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
-          if (i == 0) {
-            dy[j] = tmp;
-          } else {
-            dy[j] += tmp;
-          }
+          sum_y += static_cast<MPType>(
+              dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]));
         }
+      }
+      if (dy != nullptr) {
+        dy[j] = static_cast<T>(sum_y);
       }
     }
   } else {  // x.dims < y.dims, broadcast for x.
-    for (int i = 0; i < h; ++i) {
-      for (int j = 0; j < w; ++j) {
+    for (int j = 0; j < w; ++j) {
+      MPType sum_x = static_cast<MPType>(0);
+      for (int i = 0; i < h; ++i) {
         int y_offset = i * w + j;
         if (dy != nullptr) {
           dy[y_offset] =
               dy_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
         }
         if (dx != nullptr) {
-          T tmp = dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
-          if (i == 0) {
-            dx[j] = tmp;
-          } else {
-            dx[j] += tmp;
-          }
+          sum_x += static_cast<MPType>(
+              dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]));
         }
+      }
+      if (dx != nullptr) {
+        dx[j] = static_cast<T>(sum_x);
       }
     }
   }
@@ -166,9 +169,12 @@ static void ElemwiseGradBroadcast2CPU(const T *x,
                                       DY_OP dy_op,
                                       T *dx,
                                       T *dy) {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
   if (is_xsize_larger) {
-    for (int i = 0; i < pre; ++i) {
-      for (int j = 0; j < n; ++j) {
+    for (int j = 0; j < n; ++j) {
+      MPType sum_y = static_cast<MPType>(0);
+      for (int i = 0; i < pre; ++i) {
         for (int k = 0; k < post; ++k) {
           int x_offset = i * n * post + j * post + k;
           if (dx != nullptr) {
@@ -176,19 +182,19 @@ static void ElemwiseGradBroadcast2CPU(const T *x,
                 dx_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
           }
           if (dy != nullptr) {
-            T tmp = dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
-            if (i == 0 && k == 0) {
-              dy[j] = tmp;
-            } else {
-              dy[j] += tmp;
-            }
+            sum_y += static_cast<MPType>(
+                dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]));
           }
         }
       }
+      if (dy != nullptr) {
+        dy[j] = static_cast<T>(sum_y);
+      }
     }
   } else {  // x.dims < y.dims, broadcast for x.
-    for (int i = 0; i < pre; ++i) {
-      for (int j = 0; j < n; ++j) {
+    for (int j = 0; j < n; ++j) {
+      MPType sum_x = static_cast<MPType>(0);
+      for (int i = 0; i < pre; ++i) {
         for (int k = 0; k < post; ++k) {
           int y_offset = i * n * post + j * post + k;
           if (dy != nullptr) {
@@ -196,14 +202,13 @@ static void ElemwiseGradBroadcast2CPU(const T *x,
                 dy_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
           }
           if (dx != nullptr) {
-            T tmp = dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
-            if (i == 0 && k == 0) {
-              dx[j] = tmp;
-            } else {
-              dx[j] += tmp;
-            }
+            sum_x += static_cast<MPType>(
+                dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]));
           }
         }
+      }
+      if (dx != nullptr) {
+        dx[j] = static_cast<T>(sum_x);
       }
     }
   }

--- a/test/legacy_test/eager_op_test.py
+++ b/test/legacy_test/eager_op_test.py
@@ -556,11 +556,14 @@ class OpTest(unittest.TestCase):
             not in op_accuracy_white_list.NO_BF16_COMPARED_WITH_FP32_OP_LIST
         )
 
-    def enable_cal_ref_output(self):
-        self.is_calc_ref = (
+    def is_compared_with_fp32(self):
+        return (
             self.is_fp16_compared_with_fp32()
             or self.is_bf16_compared_with_fp32()
         )
+
+    def enable_cal_ref_output(self):
+        self.is_calc_ref = True
 
     def disable_cal_ref_output(self):
         self.is_calc_ref = False
@@ -710,7 +713,25 @@ class OpTest(unittest.TestCase):
                 if isinstance(self.inputs[var_name], tuple):
                     tensor.set(self.inputs[var_name][0], place)
                     if self.is_calc_ref:
-                        if self.inputs[var_name][1].dtype == np.float16:
+                        if isinstance(self.inputs[var_name][1], list):
+                            dtype = np.array(self.inputs[var_name][1]).dtype
+                            if dtype == np.float16:
+                                tensor.set_recursive_sequence_lengths(
+                                    np.array(self.inputs[var_name][1]).astype(
+                                        np.float32
+                                    )
+                                )
+                            elif dtype == np.uint16:
+                                tensor.set_recursive_sequence_lengths(
+                                    convert_uint16_to_float(
+                                        np.array(self.inputs[var_name][1])
+                                    )
+                                )
+                            else:
+                                tensor.set_recursive_sequence_lengths(
+                                    self.inputs[var_name][1]
+                                )
+                        elif self.inputs[var_name][1].dtype == np.float16:
                             tensor.set_recursive_sequence_lengths(
                                 self.inputs[var_name][1].astype(np.float32)
                             )
@@ -758,7 +779,7 @@ class OpTest(unittest.TestCase):
             self.__class__.use_xpu = True
 
         op_proto = OpProtoHolder.instance().get_op_proto(self.op_type)
-        "infer datatype from inputs and outputs for this test case"
+        # "infer datatype from inputs and outputs for this test case"
         if self.is_float16_op():
             self.dtype = np.float16
             self.__class__.dtype = self.dtype
@@ -1810,10 +1831,7 @@ class OpTest(unittest.TestCase):
             def compare_single_output_with_expect(self, name, expect):
                 actual, actual_np = self.find_actual_value(name)
                 # expect_np = expect[0] if isinstance(expect, tuple) else expect
-                if (
-                    self.op_test.is_fp16_compared_with_fp32()
-                    or self.op_test.is_bf16_compared_with_fp32()
-                ):
+                if self.op_test.is_compared_with_fp32():
                     expect, expect_np = self.find_expect_value(name)
                 else:
                     expect_np = (
@@ -1868,10 +1886,7 @@ class OpTest(unittest.TestCase):
                 )
                 self.outputs = outs
                 self.fetch_list = fetch_list
-                if (
-                    self.op_test.is_fp16_compared_with_fp32()
-                    or self.op_test.is_bf16_compared_with_fp32()
-                ):
+                if self.op_test.is_compared_with_fp32():
                     self.op_test.enable_cal_ref_output()
                     ref_outs, ref_fetch_list = self.op_test._calc_output(
                         place, no_check_set=no_check_set
@@ -1938,10 +1953,7 @@ class OpTest(unittest.TestCase):
                         place, no_check_set=no_check_set
                     )
                 self.outputs = dygraph_outs
-                if (
-                    self.op_test.is_fp16_compared_with_fp32()
-                    or self.op_test.is_bf16_compared_with_fp32()
-                ):
+                if self.op_test.is_compared_with_fp32():
                     self.op_test.enable_cal_ref_output()
                     self.is_python_api_test = True
                     self.ref_outputs = self.op_test._calc_python_api_output(
@@ -2543,10 +2555,7 @@ class OpTest(unittest.TestCase):
         if numeric_place is None:
             numeric_place = place
 
-        if user_defined_grads is None and (
-            self.is_fp16_compared_with_fp32()
-            or self.is_bf16_compared_with_fp32()
-        ):
+        if user_defined_grads is None and self.is_compared_with_fp32():
             self.enable_cal_ref_output()
             numeric_grads = self._get_gradient(
                 inputs_to_check,

--- a/test/legacy_test/test_elementwise_div_op.py
+++ b/test/legacy_test/test_elementwise_div_op.py
@@ -212,8 +212,6 @@ class TestElementwiseDivOpBF16(ElementwiseDivOp):
             check_args = [check_option['grad'], 'Out']
             check_kwargs = {
                 'no_grad_set': check_option['no_grad'],
-                'user_defined_grads': check_option['val_grad'],
-                'user_defined_grad_outputs': [self.grad_out],
                 'check_dygraph': self.check_dygraph,
             }
             if self.place is None:

--- a/test/legacy_test/test_matmul_v2_op.py
+++ b/test/legacy_test/test_matmul_v2_op.py
@@ -440,6 +440,8 @@ def create_test_bf16_class(parent, atol=0.01):
                 ['X'],
                 'Out',
                 no_grad_set={'Y'},
+                max_relative_error=3e-2,
+                atol=3e-2,
                 user_defined_grads=[numeric_grads],
                 check_cinn=self.check_cinn
                 if hasattr(self, 'check_cinn')
@@ -454,6 +456,8 @@ def create_test_bf16_class(parent, atol=0.01):
                 ['Y'],
                 'Out',
                 no_grad_set={'X'},
+                max_relative_error=3e-2,
+                atol=3e-2,
                 user_defined_grads=[numeric_grads],
                 check_cinn=self.check_cinn
                 if hasattr(self, 'check_cinn')

--- a/test/legacy_test/test_pool_max_op.py
+++ b/test/legacy_test/test_pool_max_op.py
@@ -319,7 +319,9 @@ def create_test_bf16_class(parent):
             numeric_grads = self.get_numeric_grad(place, 'X')
             if core.is_bfloat16_supported(place):
                 self.check_grad_with_place(
-                    place, {'X'}, ['Out'], user_defined_grads=[numeric_grads]
+                    place,
+                    {'X'},
+                    ['Out'],
                 )
 
     cls_name = "{}_{}".format(parent.__name__, "BF16OP")

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from eager_op_test import OpTest, paddle_static_guard
+from eager_op_test import OpTest, convert_float_to_uint16, paddle_static_guard
 
 import paddle
 from paddle.fluid import core
@@ -147,7 +147,14 @@ class TestSortedUniqueOp(TestUniqueOp):
         self.dtype = np.float64
 
     def init_config(self):
-        self.inputs = {'X': np.array([2, 3, 3, 1, 5, 3], dtype=self.dtype)}
+        if self.dtype == np.uint16:
+            self.inputs = {
+                'X': convert_float_to_uint16(
+                    np.array([2, 3, 3, 1, 5, 3], dtype=np.float32)
+                )
+            }
+        else:
+            self.inputs = {'X': np.array([2, 3, 3, 1, 5, 3], dtype=self.dtype)}
         unique, indices, inverse, count = np.unique(
             self.inputs['X'],
             return_index=True,
@@ -197,9 +204,16 @@ class TestUniqueOpAxisNone(TestUniqueOp):
         self.dtype = np.float64
 
     def init_config(self):
-        self.inputs = {
-            'X': np.random.randint(0, 100, (4, 7, 10)).astype(self.dtype)
-        }
+        if self.dtype == np.uint16:
+            self.inputs = {
+                'X': convert_float_to_uint16(
+                    np.random.randint(0, 100, (4, 7, 10)).astype(np.float32)
+                )
+            }
+        else:
+            self.inputs = {
+                'X': np.random.randint(0, 100, (4, 7, 10)).astype(self.dtype)
+            }
         unique, indices, inverse, counts = np.unique(
             self.inputs['X'],
             return_index=True,

--- a/test/white_list/op_accuracy_white_list.py
+++ b/test/white_list/op_accuracy_white_list.py
@@ -97,8 +97,5 @@ NO_FP16_COMPARED_WITH_FP32_OP_LIST = [
 
 
 NO_BF16_COMPARED_WITH_FP32_OP_LIST = [
-    'unique',
-    'fusion_gru',
-    'fusion_lstm',
     'dequantize',
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
card-72073
1. Modify the bf16 accuracy checking framework and modify the default tolerance.
2. fix the elementwise_max and elementwise_min bf16 accuracy problem .
3. fix the elementwise_div bf16 accuracy problem.
4. fix the matmul_v2 bf16 accuracy problem.
5. fix the unique bf16 accuracy problem.
6. fix the pool_max bf16 accuracy problem.
