### PR TITLE
[OpCompat] add cast and repeat_interleave in op_compat.yaml 

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -423,6 +423,8 @@
 - op : cast
   inputs :
     x : X
+  outputs :
+    out : Out
 
 - op : ceil
   backward : ceil_grad
@@ -2267,6 +2269,8 @@
     x : X
   outputs :
     out : Out
+  attrs :
+    repeats : Repeats
 
 - op : reshape (reshape2)
   backward : reshape_grad (reshape2_grad)

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -420,6 +420,10 @@
     out : Out
   drop_empty_grad : [input_grad]
 
+- op : cast
+  inputs :
+    x : X
+
 - op : ceil
   backward : ceil_grad
   inputs :
@@ -2257,6 +2261,12 @@
     out : Out
   extra :
     attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+
+- op : repeat_interleave
+  inputs :
+    x : X
+  outputs :
+    out : Out
 
 - op : reshape (reshape2)
   backward : reshape_grad (reshape2_grad)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

 * #55334

添加 cast 和 repeat_interleave 的算子参数映射