### PR TITLE
[Dy2St] skip compare between func and module attribute to fix NumPy 1.25 error

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -121,10 +121,7 @@ def is_unsupported(func):
         for v in m.__dict__.values():
             if not callable(v):
                 continue
-            func_in_dict = func == v
-            if isinstance(func_in_dict, (list, numpy.ndarray)):
-                func_in_dict = numpy.array(func_in_dict).any()
-            if func_in_dict:
+            if func is v:
                 translator_logger.log(
                     2,
                     "Whitelist: {} is part of built-in module and does not have to be transformed.".format(

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -119,6 +119,8 @@ def is_unsupported(func):
 
     for m in BUILTIN_LIKELY_MODULES:
         for v in m.__dict__.values():
+            if not callable(v):
+                continue
             func_in_dict = func == v
             if isinstance(func_in_dict, (list, numpy.ndarray)):
                 func_in_dict = numpy.array(func_in_dict).any()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

在 NumPy 1.25 后在一些错误的比较时会直接报错[^1]，比如

```python
[[1, 2], 3] == np.bool_(False)
# NumPy 1.24
# <stdin>:1: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.

# NumPy 1.25
# ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```

原来在 NumPy 1.24 会报 Warning 的比较现在直接报错了

我们动转静的 `is_unsupported` 用于判断一个函数是否不需要转写，其实现是将所有跳过的模块所有成员与当前函数进行比较（`==` 也即 `__eq__`），而 NumPy 中包含成员 `np.False_`，由于 `np.False_` 重载了 `__eq__`，因此其比较行为是可能报错的

目前报错是发生在嵌套 `Sequential` 与 `np.False_` 比较时出现的问题，比如

```
Sequential(
  (0): Conv2d_BN(
    (c): Conv2D(3, 16, kernel_size=[3, 3], stride=[2, 2], padding=1, data_format=NCHW)
    (bn): BatchNorm2D(num_features=16, momentum=0.9, epsilon=1e-05)
  )
  (1): Hardswish()
)
```

`layer[0]` 是两层的，`layer[1]` 是一层的，其实和 `[[1, 2], 3]` 是同样的结构，在 NumPy 1.25 就会报错

### Workaround

跳过与属性的比较，只和函数比较，按理说传入的是 callable 的，那么也没有必要和非 callable 进行比较，函数比较直接 `is` 即可，下面的 `if isinstance(func_in_dict, (list, numpy.ndarray))` 看起来也是没有必要的了（和 #27631、#34246 相关）

PCard-66972

[^1]: [NumPy 1.25 Release Notes - Expired deprecations](https://numpy.org/doc/stable/release/1.25.0-notes.html#expired-deprecations)