### PR TITLE
[AutoTuner] Enhance etcd stability

### DIFF
--- a/python/paddle/distributed/launch/controllers/master.py
+++ b/python/paddle/distributed/launch/controllers/master.py
@@ -252,7 +252,14 @@ class ETCDMaster(Master):
 
         self.job_prefix = f'/paddle/{job_id}'
         self.heartbeat_prefix = f'{self.job_prefix}/heartbeat'
-
+        if self.ctx.is_auto_tuner_mode():
+            delete_success = False
+            while not delete_success:
+                try:
+                    self.client.delete_prefix(self.job_prefix)
+                    delete_success = True
+                except:
+                    time.sleep(1)
         lease = self.client.lease(ttl)
 
         # self.client.delete_prefix(self.job_prefix)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PCard-73218
For enhancing etcd stability, we will delete the prefix which set by auto tuner to avoid etcd internal error.