### PR TITLE
[Paddle-TRT] Convert 0D tensor to 1D tensor, increase the shape tensor's number count when collecting shape

### DIFF
--- a/paddle/fluid/framework/ir/identity_op_clean_pass.cc
+++ b/paddle/fluid/framework/ir/identity_op_clean_pass.cc
@@ -21,91 +21,105 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
-class Graph;
+namespace patterns {
 
-void IdentityOpCleanPass::ApplyImpl(ir::Graph* graph) const {
-  FusePassBase::Init("identity_scale_op_clean", graph);
+// pre_op -> useless_op_in -> useless_op -> useless_op_out
+// ->
+// pre_op -> useless_op_out
+struct FindUselessOpPattern : public PatternBase {
+  FindUselessOpPattern(PDPattern* pattern, const std::string& name_scope);
 
-  // pre_op -> useless_op_in -> useless_op -> useless_op_out
-  // ->
-  // pre_op -> useless_op_out
-  GraphPatternDetector detector;
-  auto useless_op_in =
-      detector.mutable_pattern()
-          ->NewNode("useless_op_in")
-          ->assert_has_n_outputs(1)
-          ->assert_var_not_persistable()
-          ->assert_more([](Node* x) {
-            for (auto* op : x->inputs) {
-              auto op_type = op->Op()->Type();
-              if (op_type == "conditional_block" || op_type == "while") {
-                return false;
-              }
-            }
-            return true;
-          });
+  // declare operator node's name
+  PATTERN_DECL_NODE(useless_op_in);
+  PATTERN_DECL_NODE(useless_op);
+  PATTERN_DECL_NODE(useless_op_out);
+};
+
+FindUselessOpPattern::FindUselessOpPattern(PDPattern* pattern,
+                                           const std::string& name_scope)
+    : PatternBase(pattern, name_scope, name_scope) {
+  auto* useless_op_in = pattern->NewNode(useless_op_in_repr())
+                            ->assert_is_var()
+                            ->assert_var_not_persistable()
+                            ->assert_has_n_outputs(1)
+                            ->assert_more([](Node* x) {
+                              for (auto* op : x->inputs) {
+                                CHECK_EQ(op->IsOp(), true);
+                                const auto& op_type = op->Op()->Type();
+                                if (op_type == "conditional_block" ||
+                                    op_type == "while" || op_type == "feed") {
+                                  return false;
+                                }
+                              }
+                              return true;
+                            });
 
   // This useless_op must have only one input and one output!
-  auto useless_op =
-      detector.mutable_pattern()
-          ->NewNode("useless_op")
+  auto* useless_op =
+      pattern->NewNode(useless_op_repr())
+          ->assert_is_op()
           ->assert_has_n_inputs(1)
           ->assert_has_n_outputs(1)
           ->assert_more([](Node* x) {
-            if (!x->IsOp()) {
-              return false;
-            }
-            if (x->Op()->Type() == "scale") {
+            const auto& op_type = x->Op()->Type();
+            if (op_type == "scale") {
               auto scale = x->Op()->GetAttrIfExists<float>("scale");
               auto bias = x->Op()->GetAttrIfExists<float>("bias");
-              if (bias == 0 && scale == 1) {
-                return true;
-              }
-            }
-            if (x->Op()->Type() == "cast") {
+              return bias == 0.f && scale == 1.f;
+            } else if (op_type == "cast") {
               auto in_dtype = x->Op()->GetAttrIfExists<int>("in_dtype");
               auto out_dtype = x->Op()->GetAttrIfExists<int>("out_dtype");
-              if (in_dtype == out_dtype) {
-                return true;
-              }
-            }
-            if (x->Op()->Type() == "c_identity") {
+              return in_dtype == out_dtype;
+            } else if (op_type == "c_identity") {
               return true;
+            } else if (op_type == "assign") {
+              const auto& in_name = x->Op()->Input("X")[0];
+              const auto& out_name = x->Op()->Output("Out")[0];
+              return in_name == out_name;
+            } else if (op_type == "concat") {
+              return x->Op()->Input("X").size() == 1;
             }
             // you can add more cases here.
             return false;
           });
-  auto useless_op_out = detector.mutable_pattern()->NewNode("useless_op_out");
+
+  auto* useless_op_out =
+      pattern->NewNode(useless_op_out_repr())->assert_is_var();
 
   useless_op->LinksFrom({useless_op_in}).LinksTo({useless_op_out});
+}
 
-  int found_subgraph_count = 0;
+}  // namespace patterns
+
+void IdentityOpCleanPass::ApplyImpl(ir::Graph* graph) const {
+  Init(name_scope_, graph);
+
+  GraphPatternDetector gpd;
+  patterns::FindUselessOpPattern pattern(gpd.mutable_pattern(), name_scope_);
+
+  int found_count = 0;
   GraphPatternDetector::handle_t handler =
       [&](const GraphPatternDetector::subgraph_t& subgraph, Graph* graph) {
-        Node* useless_op_var = subgraph.at(useless_op);
-        Node* useless_op_in_var = subgraph.at(useless_op_in);
-        Node* useless_op_out_var = subgraph.at(useless_op_out);
-        const std::string useless_op_in_name = useless_op_in_var->Name();
-        const std::string useless_op_out_name = useless_op_out_var->Name();
+        GET_IR_NODE_FROM_SUBGRAPH(useless_op_in, useless_op_in, pattern);
+        GET_IR_NODE_FROM_SUBGRAPH(useless_op, useless_op, pattern);
+        GET_IR_NODE_FROM_SUBGRAPH(useless_op_out, useless_op_out, pattern);
+        CHECK_EQ(useless_op_in->IsVar(), true);
+        CHECK_EQ(useless_op_out->IsVar(), true);
+        CHECK_EQ(useless_op->IsOp(), true);
 
-        if (useless_op_in_var->inputs.size() != 1L) return;
-        auto pre_op_node = useless_op_in_var->inputs[0];
+        for (auto* prev_op : useless_op_in->inputs) {
+          CHECK_EQ(prev_op->IsOp(), true);
+          prev_op->Op()->RenameOutput(useless_op_in->Var()->Name(),
+                                      useless_op_out->Var()->Name());
+          IR_NODE_LINK_TO(prev_op, useless_op_out);
+        }
 
-        // Link pre_op directly to scale_out
-        auto* pre_op_desc = pre_op_node->Op();
-        IR_NODE_LINK_TO(pre_op_node, useless_op_out_var);
-        // Modify pre_op_desc
-        pre_op_desc->RenameOutput(useless_op_in_var->Name(),
-                                  useless_op_out_var->Name());
-
-        // Remove nodes in graph
-        GraphSafeRemoveNodes(graph, {useless_op_in_var, useless_op_var});
-
-        found_subgraph_count++;
+        GraphSafeRemoveNodes(graph, {useless_op_in, useless_op});
+        found_count++;
       };
 
-  detector(graph, handler);
-  AddStatis(found_subgraph_count);
+  gpd(graph, handler);
+  AddStatis(found_count);
 }
 
 }  // namespace ir

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2235,10 +2235,10 @@ void AnalysisPredictor::HookCollectShapeRangeInfo() {
 
     // We need collect value range for shape tensor for Paddle-TRT's use.
     // To be noticed, this method to identify all shape tensors is based on
-    // assumption that all shape tensors in the model have numbers <= 7.
+    // assumption that all shape tensors in the model have numbers <= 8.
     // This is a simple method to identify all shape tensors with some
     // mistakes, but it doesn't matter.
-    auto is_shape_tensor = tensor.numel() <= 7 && tensor.numel() >= 1;
+    auto is_shape_tensor = tensor.numel() <= 8 && tensor.numel() >= 1;
     if ((tensor.dtype() == phi::DataType::INT32 ||
          tensor.dtype() == phi::DataType::INT64) &&
         is_shape_tensor) {

--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -30,7 +30,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
     auto* X = engine_->GetITensor(op_desc.Input("X").front());
     nvinfer1::ITensor* Y = nullptr;
     auto* Y_v = scope.FindVar(op_desc.Input("Y").front());
-    if (Y_v) {
+    if (Y_v && !engine_->with_dynamic_shape()) {
       // Y is weight
       auto* Y_t = Y_v->GetMutable<phi::DenseTensor>();
       std::vector<int> dims_y = phi::vectorize<int>(Y_t->dims());

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -532,6 +532,11 @@ nvinfer1::ITensor *TensorRTEngine::ConvertWeight2ITensor(
   for (int64_t i = 0; i < trt_in_shape.nbDims; i++) {
     trt_in_shape.d[i] = var_dims[i];
   }
+  // Make 0-D tensor to 1-D tensor.
+  if (trt_in_shape.nbDims == 0) {
+    trt_in_shape.nbDims = 1;
+    trt_in_shape.d[0] = 1;
+  }
   // In fact , this is not always right, because we can't determine if the 0th
   // dimension is batch. Just for run chenqu's model
   if (!this->with_dynamic_shape()) {

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -524,6 +524,10 @@ class TensorRTEngine {
     for (const auto& it : runtime_input_shape) {
       auto name = it.first;
       auto input_shape = it.second;
+      // Make 0-D tensor to 1-D tensor.
+      if (input_shape.size() == 0) {
+        input_shape.push_back(1);
+      }
       bool min_change = false;
       bool max_change = false;
       std::vector<int> bak_min_shape;

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -594,6 +594,18 @@ class TensorRTEngineOp : public framework::OperatorBase {
         t.ShareDataWith(out);
       }
       auto t_shape = phi::vectorize<int64_t>(t.dims());
+
+      // This must be a zero dimension tensor.
+      // At present, we convert it to a 1D tensor to feed them into Trt.
+      if (t_shape.size() == 0) {
+        PADDLE_ENFORCE_EQ(
+            t.numel(),
+            1UL,
+            platform::errors::PreconditionNotMet(
+                "This tensor must have one element, but got %ld.", t.numel()));
+        t_shape.push_back(1);
+      }
+
       // Get index of profile 0 first, then plus binding offset
       const int bind_index =
           engine->engine()->getBindingIndex(x.c_str()) + binding_offset;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
P-card-71501
增加了paddle op到trt op转换时的shape检查；
将0维tensor处理成1维tensor，避免部分模型(grounding_dino)出错；
将shape tensor的个数上限7修改为8，以适配Grounding-SAM模型；
修改elementwise算子进入trt时的输入数据直接从tensor中查找，避免输入数据tensor的名字和其他参数名字重复导致的读取错误，同时兼容静态shape版本；