### PR TITLE
[AutoParallel] keep lr_sheduler same bewteen executor and engine

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/callbacks.py
+++ b/python/paddle/distributed/auto_parallel/static/callbacks.py
@@ -171,14 +171,14 @@ class LRSchedulerAuto(LRScheduler):
 
         if self.by_step and self.train_step % self.acc_step == 0:
             if (
-                self.model._optimizer
-                and hasattr(self.model._optimizer, '_learning_rate')
+                self.model.optimizer
+                and hasattr(self.model.optimizer, '_learning_rate')
                 and isinstance(
-                    self.model._optimizer._learning_rate,
+                    self.model.optimizer._learning_rate,
                     paddle.optimizer.lr.LRScheduler,
                 )
             ):
-                self.model._optimizer._learning_rate.step()
+                self.model.optimizer._learning_rate.step()
 
 
 class History(Callback):

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -970,7 +970,9 @@ class Engine:
             save_dir=save_dir,
             verbose=verbose,
             metrics=self._metrics_name(),
-            acc_step=self._acc_steps,
+            acc_step=1
+            if self._strategy.pipeline.enable
+            else self._acc_steps,  # lr update once every local batch
         )
 
         cbks.on_begin('train')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-70448
- Deepcopy optimizer will copy learning_rate at the same time but it would cause a difference of learning_rate between executor and engine.
    - excutor: program._lr_scheduler()
    - engine: engine.optimizer._learning_rate()