### PR TITLE
[CINN] fix run cinn-ut in paddle with cinn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,13 @@ include(flags) # set paddle compile flags
 
 if(WITH_CINN)
   message(STATUS "Compile Paddle with CINN.")
+  message(
+    WARNING
+      "Enable WITH_SHARED_PHI when compiling with CINN. Force WITH_SHARED_PHI=ON."
+  )
+  set(WITH_SHARED_PHI
+      ON
+      CACHE BOOL "Enable WITH_SHARED_PHI when compiling with CINN" FORCE)
   # TODO(6clc): Use CINN_WITH_CUDNN to completely replace WITH_CUDNN in CINN.
   #             Use WITH_GPU to completely replace WITH_CUDA in CINN.
   set(WITH_MKL_CBLAS ${WITH_MKL})

--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -168,6 +168,7 @@ cinn_cc_library(
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
 if(NOT CINN_ONLY)
+  target_link_libraries(cinnapi phi)
   add_dependencies(cinnapi phi)
 endif()
 
@@ -220,6 +221,7 @@ function(gen_cinncore LINKTYPE)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
   if(NOT CINN_ONLY)
+    target_link_libraries(${CINNCORE_TARGET} phi)
     add_dependencies(${CINNCORE_TARGET} phi)
   endif()
 

--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -167,6 +167,9 @@ cinn_cc_library(
   ${jitify_deps})
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
+if(WITH_CINN)
+  add_dependencies(cinnapi phi)
+endif()
 
 target_link_libraries(cinnapi ${PYTHON_LIBRARIES})
 
@@ -216,6 +219,9 @@ function(gen_cinncore LINKTYPE)
     ginac)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
+  if(WITH_CINN)
+    add_dependencies(cinnapi phi)
+  endif()
 
   add_dependencies(${CINNCORE_TARGET} pybind)
   target_link_libraries(${CINNCORE_TARGET} ${PYTHON_LIBRARIES})

--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -220,7 +220,7 @@ function(gen_cinncore LINKTYPE)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
   if(WITH_CINN)
-    add_dependencies(cinnapi phi)
+    add_dependencies(${CINNCORE_TARGET} phi)
   endif()
 
   add_dependencies(${CINNCORE_TARGET} pybind)

--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -167,7 +167,7 @@ cinn_cc_library(
   ${jitify_deps})
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
 add_dependencies(cinnapi GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
-if(WITH_CINN)
+if(NOT CINN_ONLY)
   add_dependencies(cinnapi phi)
 endif()
 
@@ -219,7 +219,7 @@ function(gen_cinncore LINKTYPE)
     ginac)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ZLIB::ZLIB)
   add_dependencies(${CINNCORE_TARGET} GEN_LLVM_RUNTIME_IR_HEADER ${core_deps})
-  if(WITH_CINN)
+  if(NOT CINN_ONLY)
     add_dependencies(${CINNCORE_TARGET} phi)
   endif()
 

--- a/python/setup_cinn.py.in
+++ b/python/setup_cinn.py.in
@@ -139,6 +139,9 @@ if '${WITH_MKL}' == 'ON':
 if '${WITH_MKLDNN}' == 'ON':
     cinnlibs.append('${MKLDNN_SHARED_LIB}')
 
+if '${CINN_ONLY}' == 'OFF':
+    cinnlibs.append('${PHI_LIB}')
+
 if '${WITH_GPU}' == 'ON':
     cinnlibs.append('${CMAKE_BINARY_DIR}/dist/cinn/include/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh')
     cinnlibs.append('${CMAKE_BINARY_DIR}/dist/cinn/include/paddle/cinn/runtime/cuda/float16.h')

--- a/test/cinn/CMakeLists.txt
+++ b/test/cinn/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CINN_PYTHON_TEST_DIR ${CMAKE_BINARY_DIR}/test/cinn)
-set(CINN_CORE_API ${CMAKE_BINARY_DIR}/python/cinncore_api.so)
+set(CINN_CORE_API ${CMAKE_BINARY_DIR}/python/core_api.so)
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/test/__init__.py POST_BUILD

--- a/test/cinn/CMakeLists.txt
+++ b/test/cinn/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CINN_PYTHON_TEST_DIR ${CMAKE_BINARY_DIR}/test/cinn)
-set(CINN_CORE_API ${CMAKE_BINARY_DIR}/python/cinn/core_api.so)
+set(CINN_CORE_API ${CMAKE_BINARY_DIR}/python/cinncore_api.so)
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/test/__init__.py POST_BUILD
@@ -25,14 +25,14 @@ foreach(basic_test_name ${BASIC_TEST_NAMES})
     NAME ${basic_test_name}
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/${basic_test_name}.py
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endforeach()
 
 if(NOT ${WITH_GPU})
   #    ADD_TEST(NAME test_op_nn
-  #        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+  #        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
   #        python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_op_nn.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   #    )
 endif()
@@ -40,7 +40,7 @@ endif()
 if(WITH_CUDNN)
   # TODO(thisjiang): revert test_cinn_frontend after fix inference mul problem
   # ADD_TEST(NAME test_cinn_frontend
-  #     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+  #     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
   #     python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_frontend.py
   #     ${CMAKE_BINARY_DIR}/third_party/naive_mul_model
   #     ${CMAKE_BINARY_DIR}/third_party/multi_fc_model
@@ -50,20 +50,20 @@ if(WITH_CUDNN)
     NAME test_netbuilder
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_netbuilder.py "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 #ADD_TEST(NAME test_computation_python
-#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_computation.py
 #    ${CMAKE_BINARY_DIR}/third_party/naive_mul_model
 #    "${WITH_GPU}" WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 #)
 
 #ADD_TEST(NAME test_cinn_ops_check
-#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_ops.py "${WITH_GPU}"
 #    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 #)
@@ -72,7 +72,7 @@ add_test(
   NAME test_cinn_op_benchmark
   COMMAND
     ${CMAKE_COMMAND} -E env
-    PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+    PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
     python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_op_benchmark.py "${WITH_GPU}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -81,7 +81,7 @@ if(WITH_CUDNN)
     NAME test_cinn_fake_resnet
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_resnet.py
       "${CMAKE_BINARY_DIR}/third_party/resnet_model" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -90,7 +90,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_resnet18
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_resnet18.py
       "${CMAKE_BINARY_DIR}/third_party/ResNet18" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -99,7 +99,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_mobilenetV2
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_mobilenetv2.py
       "${CMAKE_BINARY_DIR}/third_party/MobileNetV2" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -108,7 +108,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_efficientnet
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_efficientnet.py
       "${CMAKE_BINARY_DIR}/third_party/EfficientNet" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -117,7 +117,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_mobilenetV1
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_mobilenetv1.py
       "${CMAKE_BINARY_DIR}/third_party/MobilenetV1" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -126,7 +126,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_resnet50
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_resnet50.py
       "${CMAKE_BINARY_DIR}/third_party/ResNet50" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -135,7 +135,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_squeezenet
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_squeezenet.py
       "${CMAKE_BINARY_DIR}/third_party/SqueezeNet" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -144,14 +144,14 @@ if(WITH_CUDNN)
     NAME test_paddle_model_convertor
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_paddle_model_convertor.py --path
       "${CMAKE_BINARY_DIR}/third_party/resnet_model"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 #ADD_TEST(NAME test_cinn_real_facedet
-#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_facedet.py "${CMAKE_BINARY_DIR}/third_party/FaceDet" "${WITH_GPU}"
 #    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 if(WITH_GPU)
@@ -166,7 +166,7 @@ if(WITH_GPU)
       NAME test_conv2d_op
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/ops/test_conv2d_op.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
@@ -181,7 +181,7 @@ if(WITH_GPU)
       NAME ${op_test_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${op_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
@@ -198,7 +198,7 @@ if(WITH_GPU)
       NAME test_mul_op_mapper
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/op_mappers/test_mul_op.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -206,7 +206,7 @@ if(WITH_GPU)
       NAME test_conv2d_op_mapper
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/op_mappers/test_conv2d_op.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
@@ -221,7 +221,7 @@ if(WITH_GPU)
       NAME "${op_mapper_test_name}_mapper"
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${op_mapper_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
@@ -242,7 +242,7 @@ if(WITH_GPU)
       NAME ${pass_test_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${pass_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
@@ -262,7 +262,7 @@ if(WITH_GPU)
       NAME ${fusion_test_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${fusion_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()

--- a/test/cinn/CMakeLists.txt
+++ b/test/cinn/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CINN_PYTHON_TEST_DIR ${CMAKE_BINARY_DIR}/test/cinn)
-set(CINN_CORE_API ${CMAKE_BINARY_DIR}/python/core_api.so)
+set(CINN_CORE_API ${CMAKE_BINARY_DIR}/python/cinn/core_api.so)
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/test/__init__.py POST_BUILD
@@ -25,14 +25,14 @@ foreach(basic_test_name ${BASIC_TEST_NAMES})
     NAME ${basic_test_name}
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/${basic_test_name}.py
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endforeach()
 
 if(NOT ${WITH_GPU})
   #    ADD_TEST(NAME test_op_nn
-  #        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+  #        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
   #        python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_op_nn.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   #    )
 endif()
@@ -40,7 +40,7 @@ endif()
 if(WITH_CUDNN)
   # TODO(thisjiang): revert test_cinn_frontend after fix inference mul problem
   # ADD_TEST(NAME test_cinn_frontend
-  #     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+  #     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
   #     python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_frontend.py
   #     ${CMAKE_BINARY_DIR}/third_party/naive_mul_model
   #     ${CMAKE_BINARY_DIR}/third_party/multi_fc_model
@@ -50,20 +50,20 @@ if(WITH_CUDNN)
     NAME test_netbuilder
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_netbuilder.py "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 #ADD_TEST(NAME test_computation_python
-#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_computation.py
 #    ${CMAKE_BINARY_DIR}/third_party/naive_mul_model
 #    "${WITH_GPU}" WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 #)
 
 #ADD_TEST(NAME test_cinn_ops_check
-#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_ops.py "${WITH_GPU}"
 #    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 #)
@@ -72,7 +72,7 @@ add_test(
   NAME test_cinn_op_benchmark
   COMMAND
     ${CMAKE_COMMAND} -E env
-    PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+    PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
     python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_op_benchmark.py "${WITH_GPU}"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -81,7 +81,7 @@ if(WITH_CUDNN)
     NAME test_cinn_fake_resnet
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_resnet.py
       "${CMAKE_BINARY_DIR}/third_party/resnet_model" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -90,7 +90,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_resnet18
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_resnet18.py
       "${CMAKE_BINARY_DIR}/third_party/ResNet18" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -99,7 +99,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_mobilenetV2
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_mobilenetv2.py
       "${CMAKE_BINARY_DIR}/third_party/MobileNetV2" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -108,7 +108,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_efficientnet
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_efficientnet.py
       "${CMAKE_BINARY_DIR}/third_party/EfficientNet" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -117,7 +117,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_mobilenetV1
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_mobilenetv1.py
       "${CMAKE_BINARY_DIR}/third_party/MobilenetV1" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -126,7 +126,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_resnet50
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_resnet50.py
       "${CMAKE_BINARY_DIR}/third_party/ResNet50" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -135,7 +135,7 @@ if(WITH_CUDNN)
     NAME test_cinn_real_squeezenet
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_squeezenet.py
       "${CMAKE_BINARY_DIR}/third_party/SqueezeNet" "${WITH_GPU}"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -144,14 +144,14 @@ if(WITH_CUDNN)
     NAME test_paddle_model_convertor
     COMMAND
       ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_paddle_model_convertor.py --path
       "${CMAKE_BINARY_DIR}/third_party/resnet_model"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
 #ADD_TEST(NAME test_cinn_real_facedet
-#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+#    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
 #    python3 ${CMAKE_CURRENT_SOURCE_DIR}/test_facedet.py "${CMAKE_BINARY_DIR}/third_party/FaceDet" "${WITH_GPU}"
 #    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 if(WITH_GPU)
@@ -166,7 +166,7 @@ if(WITH_GPU)
       NAME test_conv2d_op
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/ops/test_conv2d_op.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
@@ -181,7 +181,7 @@ if(WITH_GPU)
       NAME ${op_test_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${op_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
@@ -198,7 +198,7 @@ if(WITH_GPU)
       NAME test_mul_op_mapper
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/op_mappers/test_mul_op.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -206,7 +206,7 @@ if(WITH_GPU)
       NAME test_conv2d_op_mapper
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/op_mappers/test_conv2d_op.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
@@ -221,7 +221,7 @@ if(WITH_GPU)
       NAME "${op_mapper_test_name}_mapper"
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${op_mapper_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
@@ -242,7 +242,7 @@ if(WITH_GPU)
       NAME ${pass_test_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${pass_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
@@ -262,7 +262,7 @@ if(WITH_GPU)
       NAME ${fusion_test_name}
       COMMAND
         ${CMAKE_COMMAND} -E env
-        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
+        PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/cinn/:$ENV{PYTHONPATH}
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/${fusion_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-72423
修复Paddle With CINN 执行 python单测下op_mapper 时报gflags符号undefined问题。

当前相关Target的依赖关系如下图，因为Paddle Target同时依赖phi.so 和 cinn.so。这个两个动态库不可以同时依赖一个gflags，所以cinn.so不依赖gflags，但执行Paddle Target的时候可以使用phi.so中的gflags。

这样的依赖关系导致CINN Python UT单独使用phi.so的时候没办法找到gflags。
![image](https://github.com/PaddlePaddle/Paddle/assets/13588285/fe42944e-2753-45e9-830c-f20bea9ff158)



通用解法是将gflags转为动态库，工作量较大，考虑CINN后期有使用phi的计划，此PR将cinn.so直接依赖phi.so解决该问题。
依赖图如下。

![image](https://github.com/PaddlePaddle/Paddle/assets/13588285/74e07665-ee72-4366-9b2b-4fc91c66ce46)

