### PR TITLE
fix data load error in static mode

### DIFF
--- a/python/paddle/io/dataloader/worker.py
+++ b/python/paddle/io/dataloader/worker.py
@@ -384,7 +384,7 @@ def _worker_loop(
                     tensor_list = [
                         numpy2lodtensor(b)
                         if isinstance(b, np.ndarray)
-                        else b.value().get_tensor()
+                        else b.get_tensor()
                         for b in batch
                     ]
                     out_queue.put((idx, tensor_list, structure))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Method `value()` is only supported in dynamic mode and that leads to error in static mode. Since `value()` just return the input as output, so it can be deleted to support static mode.
https://github.com/PaddlePaddle/Paddle/blob/6a2db618c6d188e185ecd902f014c0c72fd010b3/python/paddle/fluid/dygraph/tensor_patch_methods.py#L801
This PR is to solve https://github.com/PaddlePaddle/Paddle/issues/55362