### PR TITLE
[Dy2St] fix `func_self` maybe a callable empty list

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -339,6 +339,6 @@ def convert_call(func):
         )
         return func
 
-    if func_self:
+    if func_self is not None:
         converted_call = functools.partial(converted_call, func_self)
     return converted_call

--- a/test/dygraph_to_static/test_convert_operators.py
+++ b/test/dygraph_to_static/test_convert_operators.py
@@ -25,6 +25,11 @@ class CallNotExist(paddle.nn.Layer):
         return paddle.nn.not_exist_api
 
 
+class CallableList(list):
+    def __call__(self, x):
+        return x
+
+
 class ForwardNotExist(paddle.nn.Layer):
     def forward(self):
         return 0
@@ -50,6 +55,14 @@ class TestConvertCall(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             forward_not_exist()
+
+    def test_callable_list(self):
+        @paddle.jit.to_static
+        def callable_list(x, y):
+            callable_list = CallableList()
+            return callable_list(x) + y
+
+        self.assertEqual(callable_list(1, 2), 3)
 
 
 class TestConvertShapeCompare(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

#55482 修复 `is_unsupported` 后暴露了一个新的问题，在 PaddleNLP gpt-3 模型中有一个奇奇怪怪的 callable 对象

https://github.com/PaddlePaddle/PaddleNLP/blob/fd5739da762126f2d051ac33ae4564db5120b4d7/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/processor.py#L22-L33

大概就是这样：

```python
class MyList(list):
    def __call__(self, x):
        return x
```

而我们 `convert_call` 里直接根据 `if func_self`（即 bool）来判断其是否是 bound method，进而用 partial 绑定 self，但这里的 `func` 是 `[]`（其类型为继承自 list 的子类，无元素），因此 bool 为 False，所以就少绑定了一个参数

#55482 之前因为 `[]` 在原来的逻辑下直接跳过转写了，所以隐藏了这个 bug

### Workaround

改成 `if func_self is not None` 就好了～

PCard-66972
