### PR TITLE
[BUG] fix BF16 bug of float/int/long/index Tensor

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -114,21 +114,27 @@ def monkey_patch_math_tensor():
         ), "only one element variable can be converted to float."
         tensor = var.value().get_tensor()
         assert tensor._is_initialized(), "variable's tensor is not initialized"
-        return float(np.array(var).flatten()[0])
+        if var.dtype == core.VarDesc.VarType.BF16:
+            var = var.astype('float32')
+        return float(np.array(var))
 
     def _long_(var):
         numel = np.prod(var.shape)
         assert numel == 1, "only one element variable can be converted to long."
         tensor = var.value().get_tensor()
         assert tensor._is_initialized(), "variable's tensor is not initialized"
-        return int(np.array(var).flatten()[0])
+        if var.dtype == core.VarDesc.VarType.BF16:
+            var = var.astype('float32')
+        return int(np.array(var))
 
     def _int_(var):
         numel = np.prod(var.shape)
         assert numel == 1, "only one element variable can be converted to int."
         tensor = var.value().get_tensor()
         assert tensor._is_initialized(), "variable's tensor is not initialized"
-        return int(np.array(var).flatten()[0])
+        if var.dtype == core.VarDesc.VarType.BF16:
+            var = var.astype('float32')
+        return int(np.array(var))
 
     def _len_(var):
         assert var.ndim > 0, "len() of a 0-D tensor is wrong"
@@ -146,7 +152,9 @@ def monkey_patch_math_tensor():
         ), "only one element variable can be converted to python index."
         tensor = var.value().get_tensor()
         assert tensor._is_initialized(), "variable's tensor is not initialized"
-        return int(np.array(var).flatten()[0])
+        if var.dtype == core.VarDesc.VarType.BF16:
+            var = var.astype('float32')
+        return int(np.array(var))
 
     @property
     def _ndim_(var):

--- a/test/legacy_test/test_math_op_patch_var_base.py
+++ b/test/legacy_test/test_math_op_patch_var_base.py
@@ -242,6 +242,11 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             self.assertTrue(int(a) == 100)
             self.assertTrue(int(a) == 100)
 
+        a = paddle.to_tensor(1000000.0, dtype='bfloat16')
+        self.assertTrue(float(a) == 999424.0)
+        self.assertTrue(int(a) == 999424)
+        self.assertTrue(int(a) == 999424)
+
     def test_len(self):
         a_np = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         with fluid.dygraph.guard():
@@ -259,6 +264,16 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             self.assertTrue(list1[var1] == 3)
             str1 = "just test"
             self.assertTrue(str1[var1] == 's')
+
+        var1 = paddle.to_tensor(2.0, dtype='bfloat16')
+        i_tmp = 0
+        for i in range(var1):
+            self.assertTrue(i == i_tmp)
+            i_tmp = i_tmp + 1
+        list1 = [1, 2, 3, 4, 5]
+        self.assertTrue(list1[var1] == 3)
+        str1 = "just test"
+        self.assertTrue(str1[var1] == 's')
 
     def test_np_left_mul(self):
         with fluid.dygraph.guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->

Pcard-73362

修复BFLOAT16 Tensor使用float/int/long/index时返回的bug，由于先调用Tensor.numpy()将类型转为np.uint16，此时数据会出错。