### PR TITLE
[AutoParallel] Simplify DistTensor namespace path

### DIFF
--- a/paddle/fluid/pybind/eager.cc
+++ b/paddle/fluid/pybind/eager.cc
@@ -45,7 +45,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_DISTRIBUTE
 #include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
-using phi::distributed::auto_parallel::DistTensor;
+using phi::distributed::DistTensor;
 using phi::distributed::auto_parallel::TensorDistAttr;
 #endif
 

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -801,8 +801,8 @@ static PyObject* tensor_method_get_underline_tensor(TensorObject* self,
     return ToPyObject(tensor);
   } else if (self->tensor.is_dist_tensor()) {
 #ifdef PADDLE_WITH_DISTRIBUTE
-    auto* tensor = static_cast<phi::distributed::auto_parallel::DistTensor*>(
-        self->tensor.impl().get());
+    auto* tensor =
+        static_cast<phi::distributed::DistTensor*>(self->tensor.impl().get());
     VLOG(6) << "dist tensor: " << tensor->defined();
     return ToPyObject(tensor);
 #else

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -164,9 +164,8 @@ PyObject* tensor_properties_get_dist_attr(TensorObject* self, void* closure) {
   EAGER_TRY
   if (self->tensor.is_dist_tensor()) {
 #ifdef PADDLE_WITH_DISTRIBUTE
-    phi::distributed::auto_parallel::DistTensor* dist_tensor =
-        static_cast<phi::distributed::auto_parallel::DistTensor*>(
-            self->tensor.impl().get());
+    phi::distributed::DistTensor* dist_tensor =
+        static_cast<phi::distributed::DistTensor*>(self->tensor.impl().get());
     return ToPyObject(dist_tensor->dist_attr().get());
 #else
     RETURN_PY_NONE

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -859,7 +859,7 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
 }
 
 #ifdef PADDLE_WITH_DISTRIBUTE
-PyObject* ToPyObject(const phi::distributed::auto_parallel::DistTensor* value) {
+PyObject* ToPyObject(const phi::distributed::DistTensor* value) {
   auto obj = ::pybind11::cast(value, py::return_value_policy::reference);
   obj.inc_ref();
   return obj.ptr();

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -113,7 +113,7 @@ PyObject* ToPyObject(const std::vector<std::vector<paddle::Tensor>>& value,
 PyObject* ToPyObject(const platform::Place& value);
 PyObject* ToPyObject(const phi::DenseTensor* value);
 #ifdef PADDLE_WITH_DISTRIBUTE
-PyObject* ToPyObject(const phi::distributed::auto_parallel::DistTensor* value);
+PyObject* ToPyObject(const phi::distributed::DistTensor* value);
 PyObject* ToPyObject(
     const phi::distributed::auto_parallel::TensorDistAttr* value);
 #endif

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -1025,7 +1025,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
 #endif
 
 #ifdef PADDLE_WITH_DISTRIBUTE
-  using phi::distributed::auto_parallel::DistTensor;
+  using phi::distributed::DistTensor;
   py::class_<DistTensor>(m, "DistTensor")
       .def(
           "get_tensor",

--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -133,7 +133,7 @@ bool Tensor::is_dense_tensor() const {
 }
 bool Tensor::is_dist_tensor() const {
 #ifdef PADDLE_WITH_DISTRIBUTE
-  return phi::distributed::auto_parallel::DistTensor::classof(impl_.get());
+  return phi::distributed::DistTensor::classof(impl_.get());
 #else
   return false;
 #endif

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -30,9 +30,7 @@ namespace phi {
 
 class DenseTensorUtils;
 namespace distributed {
-namespace auto_parallel {
 class DistTensor;
-}  // namespace auto_parallel
 }  // namespace distributed
 
 /// \brief The Dense tensor stores values in a contiguous sequential block
@@ -186,7 +184,7 @@ class DenseTensor : public TensorBase,
 
  private:
   friend class DenseTensorUtils;
-  friend class phi::distributed::auto_parallel::DistTensor;
+  friend class phi::distributed::DistTensor;
 
  protected:
   DenseTensorMeta meta_;

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
@@ -16,7 +16,6 @@
 
 namespace phi {
 namespace distributed {
-namespace auto_parallel {
 
 void* DistTensor::AllocateFrom(Allocator* allocator,
                                DataType dtype,
@@ -59,6 +58,5 @@ void DistTensor::set_meta(const DenseTensorMeta& meta) {
   meta_ = meta;
 }
 
-}  // namespace auto_parallel
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
@@ -18,9 +18,7 @@
 #include "paddle/phi/core/dense_tensor.h"
 
 namespace phi {
-
 namespace distributed {
-namespace auto_parallel {
 
 class TensorDistAttr;
 
@@ -125,6 +123,5 @@ class DistTensor final
   std::unique_ptr<DenseTensor> value_{nullptr};
 };
 
-}  // namespace auto_parallel
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
@@ -20,7 +20,10 @@
 namespace phi {
 namespace distributed {
 
+namespace auto_parallel {
 class TensorDistAttr;
+}
+using auto_parallel::TensorDistAttr;
 
 class DistTensor final
     : public phi::TensorBase,

--- a/paddle/phi/core/utils/type_info.cc
+++ b/paddle/phi/core/utils/type_info.cc
@@ -56,8 +56,7 @@ template class TypeInfoTraits<phi::DeviceContext, CPUContext>;
 template class TypeInfoTraits<phi::DeviceContext, CustomContext>;
 
 #ifdef PADDLE_WITH_DISTRIBUTE
-template class TypeInfoTraits<phi::TensorBase,
-                              phi::distributed::auto_parallel::DistTensor>;
+template class TypeInfoTraits<phi::TensorBase, phi::distributed::DistTensor>;
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->

Pcard-73145

[AutoParallel] Simplify DistTensor namespace path

去掉不必要的namespace路径，目前auto_parallel的namespace路径太深，代码冗长，不便于开发

TODO：后续去掉auto_parallel的namespace