### PR TITLE
Bugfix, CUB regression in CUDA 12.2

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/common/common.cuh
+++ b/paddle/fluid/inference/tensorrt/plugin/common/common.cuh
@@ -32,8 +32,10 @@ __device__ inline float rsqrt(const float& x) {
   return rsqrtf(x);
 }
 
-__device__ inline kv_float operator+(const kv_float& a, const kv_float& b) {
+namespace cub {
+__host__ __device__ inline kv_float operator+(const kv_float& a, const kv_float& b) {
   return kv_float(a.key + b.key, a.value + b.value);
+}
 }
 
 // Half Operations


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Fix issue #55016. It was a compiler regression caused by the use of a global `operator+`.