### PR TITLE
add IndexPutGradInfermeta to fix backward error in static-mode

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -1092,8 +1092,7 @@
   args : (Tensor x, Tensor[] indices, Tensor value, Tensor out_grad, bool accumulate=false)
   output : Tensor(x_grad), Tensor(value_grad)
   infer_meta :
-    func : GeneralBinaryGradInferMeta
-    param : [x, value]
+    func : IndexPutGradInferMeta
   kernel :
     func : index_put_grad
     data_type : out_grad

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -1203,17 +1203,17 @@ void IndexAddGradInferMeta(const MetaTensor& index,
 }
 
 void IndexPutGradInferMeta(const MetaTensor& x,
-                            const std::vector<const MetaTensor*>& indices,
+                           const std::vector<const MetaTensor*>& indices,
                            const MetaTensor& value,
                            const MetaTensor& out_grad,
                            bool accumulate,
                            MetaTensor* x_grad,
                            MetaTensor* value_grad) {
   if (x_grad) {
-      x_grad -> share_meta(x);
+    x_grad->share_meta(x);
   }
   if (value_grad) {
-      value_grad -> share_meta(value);
+    value_grad->share_meta(value);
   }
 }
 

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -1202,6 +1202,21 @@ void IndexAddGradInferMeta(const MetaTensor& index,
   }
 }
 
+void IndexPutGradInferMeta(const MetaTensor& x,
+                            const std::vector<const MetaTensor*>& indices,
+                           const MetaTensor& value,
+                           const MetaTensor& out_grad,
+                           bool accumulate,
+                           MetaTensor* x_grad,
+                           MetaTensor* value_grad) {
+  if (x_grad) {
+      x_grad -> share_meta(x);
+  }
+  if (value_grad) {
+      value_grad -> share_meta(value);
+  }
+}
+
 void FusedRopeGradInferMeta(const MetaTensor& dout_q,
                             const MetaTensor& dout_k,
                             const MetaTensor& dout_v,

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -468,7 +468,7 @@ void IndexAddGradInferMeta(const MetaTensor& index,
                            MetaTensor* add_tensor_grad);
 
 void IndexPutGradInferMeta(const MetaTensor& x,
-                            const std::vector<const MetaTensor*>& indices,
+                           const std::vector<const MetaTensor*>& indices,
                            const MetaTensor& value,
                            const MetaTensor& out_grad,
                            bool accumulate,

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -467,4 +467,11 @@ void IndexAddGradInferMeta(const MetaTensor& index,
                            MetaTensor* x_grad,
                            MetaTensor* add_tensor_grad);
 
+void IndexPutGradInferMeta(const MetaTensor& x,
+                            const std::vector<const MetaTensor*>& indices,
+                           const MetaTensor& value,
+                           const MetaTensor& out_grad,
+                           bool accumulate,
+                           MetaTensor* x_grad,
+                           MetaTensor* value_grad);
 }  // namespace phi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Card-73285
Since the auto-generated code  is different between dynamic and static mode, Grad OP `index_put_grad` works fine in dynamic mode but raises error in static mode.
```
I0720 12:47:08.784021  8805 op_call_stack.cc:62] InvalidArgumentError: shape of value can't not be broadcast to shape of x[indices] (at /paddle/Paddle/paddle/phi/kernels/funcs/index_put_utils.h:286)
Traceback (most recent call last):
  File "test_index_put_grad.py", line 50, in <module>
    res = exe.run(fetch_list=[z, x.grad_name, value.grad_name])
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/executor.py", line 1444, in run
    use_prune=use_prune,
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/executor.py", line 1669, in _run_impl
    ret = new_exe.run(list(feed.keys()), return_numpy)
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/executor.py", line 684, in run
    tensors = self._new_exe.run(feed_names)._move_to_list()
ValueError: In user code:

    File "test_index_put_grad.py", line 44, in <module>
      z  = paddle.index_put(y, (index1,), value)
    File "/usr/local/lib/python3.7/dist-packages/paddle/tensor/manipulation.py", line 4918, in index_put
      attrs={'accumulate': accumulate},
    File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/layer_helper.py", line 45, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/framework.py", line 4033, in append_op
      attrs=kwargs.get("attrs", None),
    File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/framework.py", line 2795, in __init__
      for frame in traceback.extract_stack():

    InvalidArgumentError: shape of value can't not be broadcast to shape of x[indices] (at /paddle/Paddle/paddle/phi/kernels/funcs/index_put_utils.h:286)
      [operator < index_put_grad > error]
```

The essence of the problem is in `GeneralBinaryGradInferMeta `, the second input (indices[0]) is used incorrectly in the static graph mode, resulting in error size of `value_grad`.  This PR fixes this by adding `IndexPutGradInferMeta`.