### PR TITLE
[PHI] add fused_softmax_mask and fused_softmax_mask_grad for CPU.

### DIFF
--- a/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_grad_kernel.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/softmax_grad_kernel.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusedSoftmaxMaskGradKernel(const Context& dev_ctx,
+                                const DenseTensor& out,
+                                const DenseTensor& out_grad,
+                                DenseTensor* x_grad) {
+  dev_ctx.template Alloc<T>(x_grad);
+  SoftmaxGradKernel<T, Context>(
+      dev_ctx, out, out_grad, 3, x_grad);  // axis for softmax
+}
+
+}  // namespace fusion
+}  // namespace phi
+
+PD_REGISTER_KERNEL(fused_softmax_mask_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::fusion::FusedSoftmaxMaskGradKernel,
+                   float,
+                   double) {}

--- a/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_softmax_mask_kernel.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/softmax_kernel.h"
+
+namespace phi {
+namespace fusion {
+
+template <typename T, typename Context>
+void FusedSoftmaxMaskKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
+                            const DenseTensor& mask,
+                            DenseTensor* out) {
+  auto x_dim = x.dims();
+  auto mask_dim = mask.dims();
+  auto query_seq_len = x_dim[2];
+  auto key_seq_len = x_dim[3];
+
+  PADDLE_ENFORCE_GT(query_seq_len,
+                    1,
+                    phi::errors::InvalidArgument(
+                        "Input x's second last dim must be large than 1 but "
+                        "received the second last dimension of x is %d",
+                        query_seq_len));
+
+  PADDLE_ENFORCE_EQ(key_seq_len >= 32 && key_seq_len < 8192,
+                    true,
+                    phi::errors::InvalidArgument(
+                        "Input x's last dim must be between [32, 8192) "
+                        "received the last dimension of x is %d",
+                        key_seq_len));
+
+  PADDLE_ENFORCE_EQ(mask_dim[1],
+                    1,
+                    phi::errors::InvalidArgument(
+                        "Input mask's second dim must be 1 "
+                        "received the second dimension of mask is %d",
+                        mask_dim[1]));
+
+  // dim of x and mask must be equal
+  for (size_t idx = 0; idx < 4; ++idx) {
+    if (idx == 1) continue;
+    PADDLE_ENFORCE_EQ(
+        x_dim[idx],
+        mask_dim[idx],
+        phi::errors::InvalidArgument(
+            "Input x's %dth dim should be equal with input mask's %dth dim "
+            "but "
+            "received the %dth dimension of x and mask are not equal "
+            "the %dth dim of x is %d, while the %dth dim of mask is %d.",
+            idx,
+            idx,
+            idx,
+            idx,
+            x_dim[idx],
+            idx,
+            mask_dim[idx]));
+  }
+  DenseTensor t = phi::Add<T, Context>(dev_ctx, x, mask);
+  SoftmaxKernel<T, Context>(dev_ctx, t, 3, out);  // axis for softmax
+}
+
+}  // namespace fusion
+}  // namespace phi
+
+PD_REGISTER_KERNEL(fused_softmax_mask,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::fusion::FusedSoftmaxMaskKernel,
+                   float,
+                   double) {}

--- a/test/legacy_test/test_softmax_mask_fuse_op.py
+++ b/test/legacy_test/test_softmax_mask_fuse_op.py
@@ -51,16 +51,10 @@ class TestSoftmaxMaskFuseOp(OpTest):
         self.outputs = {'Out': rst}
 
     def test_check_output(self):
-        try:
-            self.check_output_with_place(core.CPUPlace())
-        except NotImplementedError:
-            pass
+        self.check_output_with_place(core.CPUPlace())
 
     def test_check_grad(self):
-        try:
-            self.check_grad_with_place(core.CPUPlace(), ["X"], "Out")
-        except NotImplementedError:
-            pass
+        self.check_grad_with_place(core.CPUPlace(), ["X"], "Out")
 
 
 @unittest.skipIf(


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
为了在XPU下面能够使用`fused_softmax_mask`以及`fused_softmax_mask_grad`，先实现一个CPU版本。否则的话XPU单测可能会报找不到CPU实现的错误。

前向：用`Add`和`SoftmaxKernel`做组合。
反向：根据这个issue https://github.com/PaddlePaddle/Paddle/issues/55577 的讨论，直接使用`SoftmaxGradKernel`。
单测：现有版本中GPU的单测，在`CPUPlace`的地方有一个`catch`，拦截`NotImplementedError`的异常。本PR实现了CPU版本，因此可以把这里的拦截给去掉。
