### PR TITLE
[clang-tidy] enable cppcoreguidelines-pro-type-reinterpret-cast check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -160,6 +160,7 @@ Checks: '
 -cppcoreguidelines-no-malloc,
 -cppcoreguidelines-pro-type-const-cast,
 -cppcoreguidelines-pro-type-member-init,
+cppcoreguidelines-pro-type-reinterpret-cast,
 -cppcoreguidelines-slicing,
 -hicpp-avoid-goto,
 -hicpp-exception-baseclass,

--- a/paddle/ir/core/op_info_impl.cc
+++ b/paddle/ir/core/op_info_impl.cc
@@ -43,13 +43,14 @@ OpInfo OpInfoImpl::Create(Dialect *dialect,
     base_ptr += interfaces_num * sizeof(InterfaceValue);
   }
   if (traits_num > 0) {
-    auto p_first_trait = reinterpret_cast<TypeId *>(base_ptr);
+    TypeId *p_first_trait = reinterpret_cast<TypeId *>(base_ptr);  // NOLINT
     memcpy(base_ptr, trait_set.data(), sizeof(TypeId) * traits_num);
     std::sort(p_first_trait, p_first_trait + traits_num);
     base_ptr += traits_num * sizeof(TypeId);
   }
   // Construct OpInfoImpl.
-  VLOG(6) << "Construct OpInfoImpl at " << reinterpret_cast<void *>(base_ptr)
+  VLOG(6) << "Construct OpInfoImpl at "
+          << reinterpret_cast<void *>(base_ptr)  // NOLINT
           << " ......";
   OpInfo op_info = OpInfo(new (base_ptr) OpInfoImpl(dialect,
                                                     op_id,
@@ -75,9 +76,9 @@ ir::IrContext *OpInfoImpl::ir_context() const {
 
 bool OpInfoImpl::HasTrait(TypeId trait_id) const {
   if (num_traits_ > 0) {
-    const TypeId *p_first_trait =
-        reinterpret_cast<const TypeId *>(reinterpret_cast<const char *>(this) -
-                                         sizeof(ir::TypeId) * num_traits_);
+    const TypeId *p_first_trait = reinterpret_cast<const TypeId *>(
+        reinterpret_cast<const char *>(this) -  // NOLINT
+        sizeof(ir::TypeId) * num_traits_);
     return std::binary_search(
         p_first_trait, p_first_trait + num_traits_, trait_id);
   }
@@ -87,8 +88,8 @@ bool OpInfoImpl::HasTrait(TypeId trait_id) const {
 bool OpInfoImpl::HasInterface(TypeId interface_id) const {
   if (num_interfaces_ > 0) {
     const InterfaceValue *p_first_interface =
-        reinterpret_cast<const InterfaceValue *>(
-            reinterpret_cast<const char *>(this) -
+        reinterpret_cast<const InterfaceValue *>(   // NOLINT
+            reinterpret_cast<const char *>(this) -  // NOLINT
             sizeof(ir::TypeId) * num_traits_ -
             sizeof(InterfaceValue) * num_interfaces_);
     return std::binary_search(p_first_interface,
@@ -101,8 +102,8 @@ bool OpInfoImpl::HasInterface(TypeId interface_id) const {
 void *OpInfoImpl::GetInterfaceImpl(TypeId interface_id) const {
   if (num_interfaces_ > 0) {
     const InterfaceValue *p_first_interface =
-        reinterpret_cast<const InterfaceValue *>(
-            reinterpret_cast<const char *>(this) -
+        reinterpret_cast<const InterfaceValue *>(   // NOLINT
+            reinterpret_cast<const char *>(this) -  // NOLINT
             sizeof(TypeId) * num_traits_ -
             sizeof(InterfaceValue) * num_interfaces_);
     size_t left = 0, right = num_interfaces_;
@@ -123,18 +124,18 @@ void *OpInfoImpl::GetInterfaceImpl(TypeId interface_id) const {
 void OpInfoImpl::Destroy() {
   VLOG(6) << "Destroy op_info impl at " << this;
   // (1) free interfaces
-  char *base_ptr = reinterpret_cast<char *>(this) -
+  char *base_ptr = reinterpret_cast<char *>(this) -  // NOLINT
                    sizeof(ir::TypeId) * num_traits_ -
                    sizeof(InterfaceValue) * num_interfaces_;
   if (num_interfaces_ > 0) {
     InterfaceValue *p_interface_val =
-        reinterpret_cast<InterfaceValue *>(base_ptr);
+        reinterpret_cast<InterfaceValue *>(base_ptr);  // NOLINT
     for (size_t i = 0; i < num_interfaces_; i++) {
       (p_interface_val + i)->~InterfaceValue();
     }
   }
   // (2) free memeory
-  VLOG(6) << "Free base_ptr " << reinterpret_cast<void *>(base_ptr);
+  VLOG(6) << "Free base_ptr " << reinterpret_cast<void *>(base_ptr);  // NOLINT
   free(base_ptr);
 }
 

--- a/paddle/ir/core/operation.cc
+++ b/paddle/ir/core/operation.cc
@@ -64,7 +64,8 @@ Operation *Operation::Create(const std::vector<ir::OpResult> &inputs,
   size_t base_size =
       result_mem_size + op_mem_size + operand_mem_size + region_mem_size;
   // 2. Malloc memory.
-  char *base_ptr = reinterpret_cast<char *>(aligned_malloc(base_size, 8));
+  char *base_ptr =
+      reinterpret_cast<char *>(aligned_malloc(base_size, 8));  // NOLINT
   // 3.1. Construct OpResults.
   for (size_t idx = num_results; idx > 0; idx--) {
     if (idx > max_inline_result_num) {
@@ -81,7 +82,7 @@ Operation *Operation::Create(const std::vector<ir::OpResult> &inputs,
       Operation(attributes, op_info, num_results, num_operands, num_regions);
   base_ptr += sizeof(Operation);
   // 3.3. Construct OpOperands.
-  if ((reinterpret_cast<uintptr_t>(base_ptr) & 0x7) != 0) {
+  if ((reinterpret_cast<uintptr_t>(base_ptr) & 0x7) != 0) {  // NOLINT
     IR_THROW("The address of OpOperandImpl must be divisible by 8.");
   }
   for (size_t idx = 0; idx < num_operands; idx++) {
@@ -90,7 +91,7 @@ Operation *Operation::Create(const std::vector<ir::OpResult> &inputs,
   }
   // 3.4. Construct Regions
   if (num_regions > 0) {
-    op->regions_ = reinterpret_cast<Region *>(base_ptr);
+    op->regions_ = reinterpret_cast<Region *>(base_ptr);  // NOLINT
     for (size_t idx = 0; idx < num_regions; idx++) {
       new (base_ptr) Region(op);
       base_ptr += sizeof(Region);
@@ -143,7 +144,8 @@ void Operation::Destroy() {
                     (num_results_ - max_inline_result_num) +
                 sizeof(detail::OpInlineResultImpl) * max_inline_result_num
           : sizeof(detail::OpInlineResultImpl) * num_results_;
-  void *aligned_ptr = reinterpret_cast<char *>(this) - result_mem_size;
+  void *aligned_ptr =
+      reinterpret_cast<char *>(this) - result_mem_size;  // NOLINT
 
   VLOG(6) << "Destroy Operation [" << name() << "]: {ptr = " << aligned_ptr
           << ", size = " << result_mem_size << "} done.";
@@ -172,17 +174,17 @@ ir::OpResult Operation::result(uint32_t index) const {
   uint32_t max_inline_idx = detail::OpResultImpl::GetMaxInlineResultIndex();
   const char *ptr =
       (index > max_inline_idx)
-          ? reinterpret_cast<const char *>(this) -
+          ? reinterpret_cast<const char *>(this) -  // NOLINT
                 (max_inline_idx + 1) * sizeof(detail::OpInlineResultImpl) -
                 (index - max_inline_idx) * sizeof(detail::OpOutlineResultImpl)
-          : reinterpret_cast<const char *>(this) -
+          : reinterpret_cast<const char *>(this) -  // NOLINT
                 (index + 1) * sizeof(detail::OpInlineResultImpl);
   if (index > max_inline_idx) {
     return ir::OpResult(
-        reinterpret_cast<const detail::OpOutlineResultImpl *>(ptr));
+        reinterpret_cast<const detail::OpOutlineResultImpl *>(ptr));  // NOLINT
   } else {
     return ir::OpResult(
-        reinterpret_cast<const detail::OpInlineResultImpl *>(ptr));
+        reinterpret_cast<const detail::OpInlineResultImpl *>(ptr));  // NOLINT
   }
 }
 
@@ -190,9 +192,11 @@ OpOperand Operation::op_operand(uint32_t index) const {
   if (index >= num_operands_) {
     IR_THROW("index exceeds OP input range.");
   }
-  const char *ptr = reinterpret_cast<const char *>(this) + sizeof(Operation) +
+  const char *ptr = reinterpret_cast<const char *>(this) +
+                    sizeof(Operation) +  // NOLINT
                     (index) * sizeof(detail::OpOperandImpl);
-  return OpOperand(reinterpret_cast<const detail::OpOperandImpl *>(ptr));
+  return OpOperand(
+      reinterpret_cast<const detail::OpOperandImpl *>(ptr));  // NOLINT
 }
 
 Value Operation::operand(uint32_t index) const {

--- a/paddle/ir/core/utils.cc
+++ b/paddle/ir/core/utils.cc
@@ -35,9 +35,10 @@ void *aligned_malloc(size_t size, size_t alignment) {
   if (mem == nullptr) {
     return nullptr;
   }
-  size_t adjust = alignment - reinterpret_cast<uint64_t>(mem) % alignment;
-  void *aligned_mem = reinterpret_cast<char *>(mem) + adjust;
-  *(reinterpret_cast<void **>(aligned_mem) - 1) = mem;
+  size_t adjust =
+      alignment - reinterpret_cast<uint64_t>(mem) % alignment;  // NOLINT
+  void *aligned_mem = reinterpret_cast<char *>(mem) + adjust;   // NOLINT
+  *(reinterpret_cast<void **>(aligned_mem) - 1) = mem;          // NOLINT
   assert(reinterpret_cast<uint64_t>(aligned_mem) % alignment == 0);
   return aligned_mem;
 #endif
@@ -50,7 +51,7 @@ void aligned_free(void *mem_ptr) {
   _aligned_free(mem_ptr);
 #else
   if (mem_ptr) {
-    free(*(reinterpret_cast<void **>(mem_ptr) - 1));
+    free(*(reinterpret_cast<void **>(mem_ptr) - 1));  // NOLINT
   }
 #endif
 }

--- a/paddle/ir/core/value.cc
+++ b/paddle/ir/core/value.cc
@@ -119,7 +119,7 @@ uint32_t OpResult::GetResultIndex() const { return impl()->GetResultIndex(); }
 
 detail::OpResultImpl *OpResult::impl() const {
   IR_ENFORCE(impl_, "Can't use impl() interface while value is null.");
-  return reinterpret_cast<detail::OpResultImpl *>(impl_);
+  return reinterpret_cast<detail::OpResultImpl *>(impl_);  // NOLINT
 }
 
 uint32_t OpResult::GetValidInlineIndex(uint32_t index) {
@@ -184,10 +184,11 @@ void OpOperandImpl::RemoveFromUdChain() {
 OpOperandImpl::~OpOperandImpl() { RemoveFromUdChain(); }
 
 uint32_t ValueImpl::index() const {
-  uint32_t index =
-      reinterpret_cast<uintptr_t>(first_use_offseted_by_index_) & 0x07;
+  uint32_t index = reinterpret_cast<uintptr_t>(first_use_offseted_by_index_) &
+                   0x07;  // NOLINT
   if (index < 6) return index;
-  return reinterpret_cast<OpOutlineResultImpl *>(const_cast<ValueImpl *>(this))
+  return reinterpret_cast<OpOutlineResultImpl *>(
+             const_cast<ValueImpl *>(this))  // NOLINT
       ->GetResultIndex();
 }
 
@@ -196,9 +197,11 @@ std::string ValueImpl::PrintUdChain() {
   result << "Value[" << this << "] -> ";
   OpOperandImpl *tmp = first_use();
   if (tmp) {
-    result << "OpOperand[" << reinterpret_cast<void *>(tmp) << "] -> ";
+    result << "OpOperand[" << reinterpret_cast<void *>(tmp)
+           << "] -> ";  // NOLINT
     while (tmp->next_use() != nullptr) {
-      result << "OpOperand[" << reinterpret_cast<void *>(tmp->next_use())
+      result << "OpOperand["
+             << reinterpret_cast<void *>(tmp->next_use())  // NOLINT
              << "] -> ";
       tmp = tmp->next_use();
     }
@@ -218,7 +221,7 @@ ir::Operation *OpResultImpl::owner() const {
   // For inline result, pointer offset index to obtain the address of op.
   if (const auto *result = ir::dyn_cast<OpInlineResultImpl>(this)) {
     result += result->GetResultIndex() + 1;
-    return reinterpret_cast<Operation *>(
+    return reinterpret_cast<Operation *>(  // NOLINT
         const_cast<OpInlineResultImpl *>(result));
   }
   // For outline result, pointer offset outline_index to obtain the address of
@@ -230,9 +233,9 @@ ir::Operation *OpResultImpl::owner() const {
   // The offset of the maximum inline result distance op is
   // GetMaxInlineResultIndex.
   const auto *inline_result =
-      reinterpret_cast<const OpInlineResultImpl *>(outline_result);
+      reinterpret_cast<const OpInlineResultImpl *>(outline_result);  // NOLINT
   inline_result += (GetMaxInlineResultIndex() + 1);
-  return reinterpret_cast<Operation *>(
+  return reinterpret_cast<Operation *>(  // NOLINT
       const_cast<OpInlineResultImpl *>(inline_result));
 }
 }  // namespace detail


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

我还不太确定是否需要引入`[cppcoreguidelines-pro-type-reinterpret-cast]`检查，下面列举的是一些讨论, @GreatV

 * https://learn.microsoft.com/zh-cn/cpp/cpp/reinterpret-cast-operator?view=msvc-170#remarks
 * https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#-type1-dont-use-reinterpret_cast
 * https://stackoverflow.com/questions/58694279/how-to-resolve-a-cppcoreguidelines-pro-type-cstyle-cast-error-in-c

任务链接:

 * https://github.com/PaddlePaddle/Paddle/issues/54073

(先不要合入)