### PR TITLE
Bugfix, fast layer norm, OOB

### DIFF
--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -220,8 +220,7 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
     if (col < cols) {
       phi::Load<ScaleT, VecSize>(gamma_ptr + col * VecSize, &gamma[it]);
       phi::Load<ScaleT, VecSize>(beta_ptr + col * VecSize, &beta[it]);
-    }
-    else {
+    } else {
       gamma[it] = Vec_scale{};
       beta[it] = Vec_scale{};
     }
@@ -234,9 +233,9 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
 #pragma unroll
     for (int it = 0, col = c; it < LDGS; it++) {
       if (col < cols) {
-        phi::Load<T, VecSize>(x_ptr + row * ELTS_PER_ROW + col * VecSize, &x[it]);
-      }
-      else {
+        phi::Load<T, VecSize>(x_ptr + row * ELTS_PER_ROW + col * VecSize,
+                              &x[it]);
+      } else {
         x[it] = Vec{};
       }
       col += THREADS_PER_ROW;
@@ -336,7 +335,8 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
 #pragma unroll
     for (int it = 0, col = c; it < LDGS; it++) {
       if (col < cols) {
-        phi::Store<T, VecSize>(x[it], y_ptr + row * ELTS_PER_ROW + col * VecSize);
+        phi::Store<T, VecSize>(x[it],
+                               y_ptr + row * ELTS_PER_ROW + col * VecSize);
       }
       col += THREADS_PER_ROW;
     }

--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -217,8 +217,14 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
   Vec_scale beta[LDGS];
 #pragma unroll
   for (int it = 0, col = c; it < LDGS; it++) {
-    phi::Load<ScaleT, VecSize>(gamma_ptr + col * VecSize, &gamma[it]);
-    phi::Load<ScaleT, VecSize>(beta_ptr + col * VecSize, &beta[it]);
+    if (col < cols) {
+      phi::Load<ScaleT, VecSize>(gamma_ptr + col * VecSize, &gamma[it]);
+      phi::Load<ScaleT, VecSize>(beta_ptr + col * VecSize, &beta[it]);
+    }
+    else {
+      gamma[it] = Vec_scale{};
+      beta[it] = Vec_scale{};
+    }
     col += THREADS_PER_ROW;
   }
 
@@ -227,7 +233,12 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
     Vec x[LDGS];
 #pragma unroll
     for (int it = 0, col = c; it < LDGS; it++) {
-      phi::Load<T, VecSize>(x_ptr + row * ELTS_PER_ROW + col * VecSize, &x[it]);
+      if (col < cols) {
+        phi::Load<T, VecSize>(x_ptr + row * ELTS_PER_ROW + col * VecSize, &x[it]);
+      }
+      else {
+        x[it] = Vec{};
+      }
       col += THREADS_PER_ROW;
     }
     U xf[LDGS * VecSize];
@@ -324,7 +335,9 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fast_ln_fwd_kernel(
 
 #pragma unroll
     for (int it = 0, col = c; it < LDGS; it++) {
-      phi::Store<T, VecSize>(x[it], y_ptr + row * ELTS_PER_ROW + col * VecSize);
+      if (col < cols) {
+        phi::Store<T, VecSize>(x[it], y_ptr + row * ELTS_PER_ROW + col * VecSize);
+      }
       col += THREADS_PER_ROW;
     }
   }

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -578,7 +578,8 @@ void LayerNormKernel(const Context &dev_ctx,
                                    VecSize,                                  \
                                    WARPS_M,                                  \
                                    WARPS_N,                                  \
-                                   BYTES_PER_LDG>                            \
+                                   BYTES_PER_LDG,                            \
+                                   feature_size>                             \
         <<<grid, THREADS_PER_CTA, 0, stream>>>(                              \
             batch_size,                                                      \
             feature_size,                                                    \

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -605,8 +605,7 @@ void LayerNormKernel(const Context &dev_ctx,
   if ((feature_size >= 768 && feature_size <= 2048 && feature_size % 256 == 0 ||
        feature_size == 4096) &&
       scale != nullptr && bias != nullptr) {
-    // can_call_fast_kernel = true;
-    can_call_fast_kernel = false;
+    can_call_fast_kernel = true;
   }
 
   if (can_call_fast_kernel) {

--- a/test/legacy_test/test_layer_norm_op.py
+++ b/test/legacy_test/test_layer_norm_op.py
@@ -515,8 +515,13 @@ class TestLayerNormOp(unittest.TestCase):
         self.use_cudnn = True
 
     def __assert_close(self, tensor, np_array, msg, atol=1e-4):
-        np.testing.assert_allclose(np.array(tensor).flatten(), np_array.flatten(),
-            rtol=1e-3, atol=atol, err_msg=msg)
+        np.testing.assert_allclose(
+            np.array(tensor).flatten(),
+            np_array.flatten(),
+            rtol=1e-3,
+            atol=atol,
+            err_msg=msg,
+        )
 
     def check_forward_backward(
         self,

--- a/test/legacy_test/test_layer_norm_op.py
+++ b/test/legacy_test/test_layer_norm_op.py
@@ -515,7 +515,8 @@ class TestLayerNormOp(unittest.TestCase):
         self.use_cudnn = True
 
     def __assert_close(self, tensor, np_array, msg, atol=1e-4):
-        self.assertTrue(np.allclose(np.array(tensor), np_array, atol=atol), msg)
+        np.testing.assert_allclose(np.array(tensor).flatten(), np_array.flatten(),
+            rtol=1e-3, atol=atol, err_msg=msg)
 
     def check_forward_backward(
         self,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Fix issue #55352.
1. `fast_ln_fwd_kernel` was disabled by accident in PaddlePaddle 2.4, so it was never tested before.
2. `fast_ln_fwd_kernel` actually has out-of-bounds access bug. This patch fixes it.
3. According to #44641, replace `self.assertTrue` with `np.testing.assert_allclose`