### PR TITLE
[BugFix] fix random fail of test_bilinear_interp_v2_op

### DIFF
--- a/test/legacy_test/eager_op_test.py
+++ b/test/legacy_test/eager_op_test.py
@@ -1211,13 +1211,14 @@ class OpTest(unittest.TestCase):
             return
 
         set_flags({"FLAGS_enable_new_ir_in_executor": True})
-
+        new_scope = paddle.static.Scope()
         executor = Executor(place)
         ir_outs = executor.run(
             program,
             feed=feed_map,
             fetch_list=fetch_list,
             return_numpy=False,
+            scope=new_scope,
         )
         assert len(outs) == len(
             ir_outs

--- a/test/legacy_test/eager_op_test.py
+++ b/test/legacy_test/eager_op_test.py
@@ -1213,8 +1213,15 @@ class OpTest(unittest.TestCase):
         set_flags({"FLAGS_enable_new_ir_in_executor": True})
         new_scope = paddle.static.Scope()
         executor = Executor(place)
+        new_program = None
+        if isinstance(program, paddle.static.CompiledProgram):
+            new_program = fluid.CompiledProgram(
+                program._program, build_strategy=program._build_strategy
+            )
+        else:
+            new_program = program.clone()
         ir_outs = executor.run(
-            program,
+            new_program,
             feed=feed_map,
             fetch_list=fetch_list,
             return_numpy=False,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
`test_bilinear_interp_v2_op` seems will failed randomly because of same name variable in global scope.

#### Others
Pcard-67164