### PR TITLE
[CINN] Fix test_dot_merger segmentation fault

### DIFF
--- a/paddle/cinn/ir/tensor.cc
+++ b/paddle/cinn/ir/tensor.cc
@@ -554,11 +554,14 @@ ir::Tensor _Tensor_::Reshape(const std::vector<Expr> &shape,
 
   {
     int32_t this_num_elements = 1;
-    for (auto &e : this->shape)
+    for (auto &e : this->shape) {
       this_num_elements = this_num_elements * e.as_int32();
+    }
 
     int32_t num_elements = 1;
-    for (auto &e : shape) num_elements = num_elements * e.as_int32();
+    for (auto &e : shape) {
+      num_elements = num_elements * e.as_int32();
+    }
 
     CHECK_EQ(this_num_elements, num_elements) << "number of elements mismatch.";
   }

--- a/paddle/cinn/ir/tensor.cc
+++ b/paddle/cinn/ir/tensor.cc
@@ -553,14 +553,14 @@ ir::Tensor _Tensor_::Reshape(const std::vector<Expr> &shape,
   auto selft = Tensor(const_cast<ir::_Tensor_ *>(this));
 
   {
-    Expr this_num_elements = Expr(1);
-    for (auto &e : this->shape) this_num_elements = this_num_elements * e;
+    int32_t this_num_elements = 1;
+    for (auto &e : this->shape)
+      this_num_elements = this_num_elements * e.as_int32();
 
-    Expr num_elements = Expr(1);
-    for (auto &e : shape) num_elements = num_elements * e;
+    int32_t num_elements = 1;
+    for (auto &e : shape) num_elements = num_elements * e.as_int32();
 
-    CHECK(MathIsZero(this_num_elements - num_elements))
-        << "number of elements mismatch";
+    CHECK_EQ(this_num_elements, num_elements) << "number of elements mismatch.";
   }
 
   n->name = Context::Global().NewName(name + "_reshape");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Pcard-72511

`test_dot_merger`和`test_dot_merger_pass`在CI和本地环境中会随机出现`segmentation fault`错误，导致单测随机挂，经排查后发现是`ginac`库相关的问题，现避免使用`MathIsZero`绕过

<img width="953" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/32707008/62aa68d6-1d9a-41ad-bc68-a586070997ee">

