### PR TITLE
[IR] Fix pd.feed bug in ir BuildScope

### DIFF
--- a/paddle/fluid/ir/interface/op_yaml_info_parser.cc
+++ b/paddle/fluid/ir/interface/op_yaml_info_parser.cc
@@ -89,7 +89,7 @@ const std::map<std::string, int>& OpYamlInfoParser::InputName2Id() const {
 }
 
 const std::map<std::string, int>& OpYamlInfoParser::OutputName2Id() const {
-  return input_name2id_;
+  return output_name2id_;
 }
 
 bool OpYamlInfoParser::HasInplace(const std::string& out_name) const {

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -199,9 +199,21 @@ void HandleForSpecialOp(
 
     int index =
         op->attributes().at("col").dyn_cast<ir::Int32Attribute>().data();
+    std::string name =
+        op->attributes().at("name").dyn_cast<ir::StrAttribute>().AsString();
+    paddle::framework::Variable* var = inner_scope->FindVar(name);
 
     auto feed_var_name = "feed_" + std::to_string(index);
     value_2_var_name->emplace(value, feed_var_name);
+    variable_2_var_name->emplace(var, feed_var_name);
+    auto id = var_name_2_id->size();
+    var_name_2_id->emplace(feed_var_name, id);
+    variable_list->push_back(var);
+    PADDLE_ENFORCE_EQ(
+        variable_list->size(),
+        var_name_2_id->size(),
+        paddle::platform::errors::InvalidArgument(
+            "The size of variable_list and var_name_2_id map should be equal"));
   }
 
   if (op_name == "pd.feed_with_place") {

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -351,6 +351,9 @@ void HandleForInplaceOp(
 
   for (size_t i = 0; i < op->num_results(); ++i) {
     ir::Value value = op->result(i);
+    if (value.type().storage() == nullptr) {
+      continue;
+    }
     std::string value_name = yaml_parser.OutputNames()[i];
     if (yaml_parser.HasInplace(value_name)) {
       std::string inplace_name = yaml_parser.InplaceName(value_name);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复 ir BuildScope 在处理 feed 算子时，value_2_var_name、variable_2_var_name、var_name_2_id、variable_list 数据存储不一致问题
### Others
Pcard-67164