### PR TITLE
remove old dataloader & generator from quantilization

### DIFF
--- a/test/quantization/test_post_training_quantization_while.py
+++ b/test/quantization/test_post_training_quantization_while.py
@@ -152,7 +152,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
     ):
         place = paddle.CPUPlace()
         exe = paddle.static.Executor(place)
-        # val_reader = paddle.dataset.mnist.train()
+
         train_dataset = paddle.vision.datasets.MNIST(
             mode='train', transform=None
         )

--- a/test/quantization/test_post_training_quantization_while.py
+++ b/test/quantization/test_post_training_quantization_while.py
@@ -29,6 +29,23 @@ random.seed(0)
 np.random.seed(0)
 
 
+class TransedMnistDataSet(paddle.io.Dataset):
+    def __init__(self, mnist_data):
+        self.mnist_data = mnist_data
+
+    def __getitem__(self, idx):
+        img = (
+            np.array(self.mnist_data[idx][0])
+            .astype('float32')
+            .reshape(1, 28, 28)
+        )
+        batch = img / 127.5 - 1.0
+        return {"x": batch}
+
+    def __len__(self):
+        return len(self.mnist_data)
+
+
 class TestPostTrainingQuantization(unittest.TestCase):
     def setUp(self):
         self.download_path = 'int8/download'
@@ -132,28 +149,30 @@ class TestPostTrainingQuantization(unittest.TestCase):
         is_optimize_model=False,
         batch_size=10,
         batch_nums=10,
-        is_data_loader=False,
     ):
         place = paddle.CPUPlace()
         exe = paddle.static.Executor(place)
-        val_reader = paddle.dataset.mnist.train()
-
-        def val_data_generator():
-            batches = []
-            for data in val_reader():
-                batches.append(data[0].reshape(1, 28, 28))
-                if len(batches) == batch_size:
-                    batches = np.asarray(batches)
-                    yield {"x": batches}
-                    batches = []
+        # val_reader = paddle.dataset.mnist.train()
+        train_dataset = paddle.vision.datasets.MNIST(
+            mode='train', transform=None
+        )
+        train_dataset = TransedMnistDataSet(train_dataset)
+        BatchSampler = paddle.io.BatchSampler(
+            train_dataset, batch_size=batch_size
+        )
+        val_data_generator = paddle.io.DataLoader(
+            train_dataset,
+            batch_sampler=BatchSampler,
+            places=paddle.static.cpu_places(),
+        )
 
         ptq = PostTrainingQuantization(
             executor=exe,
             model_dir=model_path,
             model_filename='model.pdmodel',
             params_filename='model.pdiparams',
-            sample_generator=val_reader if not is_data_loader else None,
-            data_loader=val_data_generator if is_data_loader else None,
+            sample_generator=None,
+            data_loader=val_data_generator,
             batch_size=batch_size,
             batch_nums=batch_nums,
             algo=algo,
@@ -183,7 +202,6 @@ class TestPostTrainingQuantization(unittest.TestCase):
         batch_size=10,
         infer_iterations=10,
         quant_iterations=5,
-        is_data_loader=False,
     ):
         origin_model_path = self.download_model(data_url, data_md5, model_name)
 
@@ -210,7 +228,6 @@ class TestPostTrainingQuantization(unittest.TestCase):
             is_optimize_model,
             batch_size,
             quant_iterations,
-            is_data_loader=is_data_loader,
         )
 
         print(
@@ -442,7 +459,6 @@ class TestPostTrainingAbsMaxForWhile(TestPostTrainingQuantization):
             batch_size,
             infer_iterations,
             quant_iterations,
-            is_data_loader=True,
         )
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Pcard-67005

The old verison of generated DataLoader (i.e. created by `paddle.fluid.io.DataLoader.from_generator`) will be deprecated and replaced by iterative version, (i.e. created by `paddle.io.DataLoader`). But there are still some There are still some modules dependencies on the former one. （Quantization and Auto-Parrallel).

This PR is to remove the dependencies in Quantization.  The `PostTrainingQuantization` will only accept `paddle.io.DataLoader`.