### PR TITLE
add BF16 datatype for argsort

### DIFF
--- a/paddle/phi/kernels/gpu/argsort_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_grad_kernel.cu
@@ -222,4 +222,5 @@ PD_REGISTER_KERNEL(argsort_grad,
                    double,
                    int,
                    int64_t,
-                   phi::dtype::float16) {}
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -61,6 +61,11 @@ namespace cub {
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
+
+template <>
+struct NumericTraits<phi::dtype::bfloat16>
+    : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
+};
 }  // namespace cub
 #endif
 
@@ -328,6 +333,7 @@ PD_REGISTER_KERNEL(argsort,
                    double,
                    int,
                    int64_t,
-                   phi::dtype::float16) {
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {
   kernel->OutputAt(1).SetDataType(phi::DataType::INT64);
 }

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -109,6 +109,7 @@ def argsort(x, axis=-1, descending=False, name=None):
                 'int32',
                 'int64',
                 'uint8',
+                'uint16',
             ],
             'argsort',
         )

--- a/test/legacy_test/test_argsort_op.py
+++ b/test/legacy_test/test_argsort_op.py
@@ -525,6 +525,9 @@ class TestArgsortBF16OP(OpTest):
         self.op_type = "argsort"
         self.python_api = paddle.argsort
         self.public_python_api = paddle.argsort
+        self.python_out_sig = [
+            "Out"
+        ]  # python out sig is customized output signature.
         self.dtype = np.uint16
         self.descending = False
         self.attrs = {"axis": self.axis, "descending": self.descending}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
OPs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/54871 add BF16 datatype for argsort

参考：https://github.com/PaddlePaddle/Paddle/pull/51823