### PR TITLE
Fix drop_last during evaluation for hapi.Model.fit

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1922,7 +1922,7 @@ class Model:
 
         if eval_data is not None and isinstance(eval_data, Dataset):
             eval_sampler = DistributedBatchSampler(
-                eval_data, batch_size=eval_batch_size
+                eval_data, batch_size=eval_batch_size, drop_last=drop_last,
             )
             eval_loader = DataLoader(
                 eval_data,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->

Currently, it will do 'drop last' for eval data even if `model.fit(drop_last=False)`
