### PR TITLE
Fix convert directive

### DIFF
--- a/python/paddle/distribution/uniform.py
+++ b/python/paddle/distribution/uniform.py
@@ -62,33 +62,42 @@ class Uniform(distribution.Distribution):
     Examples:
         .. code-block:: python
 
-            import paddle
-            from paddle.distribution import Uniform
+            >>> import paddle
+            >>> from paddle.distribution import Uniform
+            >>> paddle.seed(2023)
 
-            # Without broadcasting, a single uniform distribution [3, 4]:
-            u1 = Uniform(low=3.0, high=4.0)
-            # 2 distributions [1, 3], [2, 4]
-            u2 = Uniform(low=[1.0, 2.0], high=[3.0, 4.0])
-            # 4 distributions
-            u3 = Uniform(low=[[1.0, 2.0], [3.0, 4.0]],
-                        high=[[1.5, 2.5], [3.5, 4.5]])
+            >>> # Without broadcasting, a single uniform distribution [3, 4]:
+            >>> u1 = Uniform(low=3.0, high=4.0)
+            >>> # 2 distributions [1, 3], [2, 4]
+            >>> u2 = Uniform(low=[1.0, 2.0], high=[3.0, 4.0])
+            >>> # 4 distributions
+            >>> u3 = Uniform(low=[[1.0, 2.0], [3.0, 4.0]],
+            ...             high=[[1.5, 2.5], [3.5, 4.5]])
+            ...
+            >>> # With broadcasting:
+            >>> u4 = Uniform(low=3.0, high=[5.0, 6.0, 7.0])
 
-            # With broadcasting:
-            u4 = Uniform(low=3.0, high=[5.0, 6.0, 7.0])
+            >>> # Complete example
+            >>> value_tensor = paddle.to_tensor([0.8], dtype="float32")
 
-            # Complete example
-            value_tensor = paddle.to_tensor([0.8], dtype="float32")
+            >>> uniform = Uniform([0.], [2.])
 
-            uniform = Uniform([0.], [2.])
+            >>> sample = uniform.sample([2])
+            >>> # a random tensor created by uniform distribution with shape: [2, 1]
+            >>> entropy = uniform.entropy()
+            >>> print(entropy)
+            Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                [0.69314718])
 
-            sample = uniform.sample([2])
-            # a random tensor created by uniform distribution with shape: [2, 1]
-            entropy = uniform.entropy()
-            # [0.6931472] with shape: [1]
-            lp = uniform.log_prob(value_tensor)
-            # [-0.6931472] with shape: [1]
-            p = uniform.probs(value_tensor)
-            # [0.5] with shape: [1]
+            >>> lp = uniform.log_prob(value_tensor)
+            >>> print(lp)
+            Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                [-0.69314718])
+
+            >>> p = uniform.probs(value_tensor)
+            >>> print(p)
+            Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                [0.50000000])
     """
 
     def __init__(self, low, high, name=None):

--- a/tools/sampcd_processor_xdoctest.py
+++ b/tools/sampcd_processor_xdoctest.py
@@ -289,7 +289,7 @@ class Xdoctester(DocTester):
 
         return test_results
 
-    def print_summary(self, test_results, whl_error):
+    def print_summary(self, test_results, whl_error=None):
         summary_success = []
         summary_failed = []
         summary_skiptest = []
@@ -298,7 +298,7 @@ class Xdoctester(DocTester):
         stdout_handler = logging.StreamHandler(stream=sys.stdout)
         logger.addHandler(stdout_handler)
         logger.info("----------------End of the Check--------------------")
-        if len(whl_error) != 0:
+        if whl_error is not None:
             logger.info("%s is not in whl.", whl_error)
             logger.info("")
             logger.info("Please check the whl package and API_PR.spec!")
@@ -329,10 +329,6 @@ class Xdoctester(DocTester):
                         summary_skiptest.append(test_result.name)
 
                     if test_result.failed:
-                        logger.info(
-                            "In addition, mistakes found in sample codes: %s",
-                            test_result.name,
-                        )
                         summary_failed.append(test_result.name)
 
                     if test_result.time > TEST_TIMEOUT:
@@ -349,16 +345,19 @@ class Xdoctester(DocTester):
                         logger.info(f'{k} - {v}s')
             if len(summary_success):
                 logger.info("%d sample codes ran success", len(summary_success))
+                logger.info('\n'.join(summary_success))
+
             if len(summary_skiptest):
                 logger.info("%d sample codes skipped", len(summary_skiptest))
-                if self.debug:
-                    logger.info('\n'.join(summary_skiptest))
+                logger.info('\n'.join(summary_skiptest))
+
             if len(summary_nocodes):
                 logger.info(
-                    "%d apis don't have sample codes", len(summary_nocodes)
+                    "%d apis could not run test or don't have sample codes",
+                    len(summary_nocodes),
                 )
-                if self.debug:
-                    logger.info('\n'.join(summary_nocodes))
+                logger.info('\n'.join(summary_nocodes))
+
             if len(summary_failed):
                 logger.info("%d sample codes ran failed", len(summary_failed))
                 logger.info('\n'.join(summary_failed))

--- a/tools/sampcd_processor_xdoctest.py
+++ b/tools/sampcd_processor_xdoctest.py
@@ -95,19 +95,13 @@ class Xdoctester(DocTester):
 
         self.directive_pattern = re.compile(
             r"""
-            (?<=(\#\s{1}))  # positive lookbehind, directive begins
-            (doctest)   # directive prefix, which should be replaced
-            (?= # positive lookahead, directive content
-                (
-                    :\s+
-                    [\+\-]
-                    (REQUIRES|SKIP)
-                    (\((env\s*:\s*(CPU|GPU|XPU|DISTRIBUTED)\s*,?\s*)+\))?
-                )
-                \s*\n+
-            )""",
+            (?<=(\#\s))     # positive lookbehind, directive begins
+            (doctest)       # directive prefix, which should be replaced
+            (?=(:\s*.*\n))  # positive lookahead, directive content
+            """,
             re.X,
         )
+
         self.directive_prefix = 'xdoctest'
 
     def convert_directive(self, docstring: str) -> str:

--- a/tools/sampcd_processor_xdoctest.py
+++ b/tools/sampcd_processor_xdoctest.py
@@ -128,8 +128,13 @@ def _patch_float_precision(digits):
 
     def _sub_number(match_obj, digits):
         match_str = match_obj.group()
+
         if 'j' in match_str or 'J' in match_str:
-            match_num = complex(match_str)
+            try:
+                match_num = complex(match_str)
+            except ValueError:
+                return match_str
+
             return (
                 str(
                     complex(
@@ -141,7 +146,10 @@ def _patch_float_precision(digits):
                 .strip(')')
             )
         else:
-            return str(round(float(match_str), digits))
+            try:
+                return str(round(float(match_str), digits))
+            except ValueError:
+                return match_str
 
     sub_number = functools.partial(_sub_number, digits=digits)
 

--- a/tools/sampcd_processor_xdoctest.py
+++ b/tools/sampcd_processor_xdoctest.py
@@ -79,6 +79,9 @@ def _patch_tensor_place():
     _check_output = checker.check_output
 
     def check_output(got, want, runstate=None):
+        if not want:  # nocover
+            return True
+
         return _check_output(
             got=pattern_tensor.sub(r'\1Place(cpu)\3', got),
             want=pattern_tensor.sub(r'\1Place(cpu)\3', want),
@@ -143,6 +146,9 @@ def _patch_float_precision(digits):
     sub_number = functools.partial(_sub_number, digits=digits)
 
     def check_output(got, want, runstate=None):
+        if not want:  # nocover
+            return True
+
         return _check_output(
             got=pattern_number.sub(sub_number, got),
             want=pattern_number.sub(sub_number, want),
@@ -298,7 +304,7 @@ class Xdoctester(DocTester):
         stdout_handler = logging.StreamHandler(stream=sys.stdout)
         logger.addHandler(stdout_handler)
         logger.info("----------------End of the Check--------------------")
-        if whl_error is not None:
+        if whl_error is not None and whl_error:
             logger.info("%s is not in whl.", whl_error)
             logger.info("")
             logger.info("Please check the whl package and API_PR.spec!")

--- a/tools/test_sampcd_processor_xdoctest.py
+++ b/tools/test_sampcd_processor_xdoctest.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 import unittest
 
@@ -38,7 +39,6 @@ class TestXdoctester(unittest.TestCase):
         self.assertEqual(doctester.style, 'freeform')
         self.assertEqual(doctester.target, 'codeblock')
         self.assertEqual(doctester.mode, 'native')
-        self.assertEqual(doctester.config['analysis'], 'auto')
 
         doctester = Xdoctester(analysis='static')
         self.assertEqual(doctester.config['analysis'], 'static')
@@ -144,7 +144,8 @@ class TestXdoctester(unittest.TestCase):
 
 
 class TestGetTestResults(unittest.TestCase):
-    def test_patch_tensor(self):
+    def test_patch_xdoctest(self):
+        # test patch tensor place
         _clear_environ()
 
         test_capacity = {'cpu'}
@@ -299,8 +300,6 @@ class TestGetTestResults(unittest.TestCase):
         self.assertTrue(tr_5.passed)
 
         # reload xdoctest.checker
-        import importlib
-
         importlib.reload(xdoctest.checker)
 
         _clear_environ()
@@ -333,6 +332,485 @@ class TestGetTestResults(unittest.TestCase):
 
         self.assertIn('cpu_to_gpu_array', tr_5.name)
         self.assertFalse(tr_5.passed)
+
+        # test patch float precision
+        # reload xdoctest.checker
+        importlib.reload(xdoctest.checker)
+
+        _clear_environ()
+
+        test_capacity = {'cpu'}
+        doctester = Xdoctester(style='freeform', target='codeblock')
+        doctester.prepare(test_capacity)
+
+        docstrings_to_test = {
+            'gpu_to_gpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+                    [0.123456780])
+
+            """,
+            'cpu_to_cpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [0.123456780])
+
+            """,
+            'gpu_to_cpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [0.123456780])
+
+            """,
+            'cpu_to_gpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+                    [0.123456780])
+            """,
+            'gpu_to_cpu_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor([[1.123456789 ,2,3], [2,3,4], [3,4,5]])
+                    >>> print(a)
+                    Tensor(shape=[3, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [[1.123456780, 2., 3.],
+                    [2., 3., 4.],
+                    [3., 4., 5.]])
+            """,
+            'cpu_to_gpu_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> a = paddle.to_tensor([[1.123456789,2,3], [2,3,4], [3,4,5]])
+                    >>> print(a)
+                    Tensor(shape=[3, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+                    [[1.123456780, 2., 3.],
+                    [2., 3., 4.],
+                    [3., 4., 5.]])
+            """,
+            'mass_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor(
+                    ... [[1.123456780, 2., -3, .3],
+                    ... [2, 3, +4., 1.2+10.34e-5j],
+                    ... [3, 5.e-3, 1e2, 3e-8]]
+                    ... )
+                    >>> # Tensor(shape=[3, 4], dtype=complex64, place=Place(gpu:0), stop_gradient=True,
+                    >>> #       [[ (1.1234568357467651+0j)                    ,
+                    >>> #          (2+0j)                                     ,
+                    >>> #         (-3+0j)                                     ,
+                    >>> #          (0.30000001192092896+0j)                   ],
+                    >>> #        [ (2+0j)                                     ,
+                    >>> #          (3+0j)                                     ,
+                    >>> #          (4+0j)                                     ,
+                    >>> #         (1.2000000476837158+0.00010340000153519213j)],
+                    >>> #        [ (3+0j)                                     ,
+                    >>> #          (0.004999999888241291+0j)                  ,
+                    >>> #          (100+0j)                                   ,
+                    >>> #          (2.999999892949745e-08+0j)                 ]])
+                    >>> print(a)
+                    Tensor(shape=[3, 4], dtype=complex64, place=Place(AAA), stop_gradient=True,
+                        [[ (1.123456+0j),
+                            (2+0j),
+                            (-3+0j),
+                            (0.3+0j)],
+                            [ (2+0j),
+                            (3+0j),
+                            (4+0j),
+                            (1.2+0.00010340j)],
+                            [ (3+0j),
+                            (0.00499999+0j),
+                            (100+0j),
+                            (2.999999e-08+0j)]])
+            """,
+            'float_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> x = [[2, 3, 4], [7, 8, 9]]
+                    >>> x = paddle.to_tensor(x, dtype='float32')
+                    >>> print(paddle.log(x))
+                    Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [[0.69314718, 1.09861231, 1.38629436],
+                        [1.94591010, 2.07944155, 2.19722462]])
+
+            """,
+            'float_array_diff': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> x = [[2, 3, 4], [7, 8, 9]]
+                    >>> x = paddle.to_tensor(x, dtype='float32')
+                    >>> print(paddle.log(x))
+                    Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+                        [[0.69314712, 1.09861221, 1.386294],
+                        [1.94591032, 2.07944156, 2.1972246]])
+
+            """,
+        }
+
+        test_results = get_test_results(doctester, docstrings_to_test)
+        self.assertEqual(len(test_results), 9)
+
+        tr_0, tr_1, tr_2, tr_3, tr_4, tr_5, tr_6, tr_7, tr_8 = test_results
+
+        self.assertIn('gpu_to_gpu', tr_0.name)
+        self.assertTrue(tr_0.passed)
+
+        self.assertIn('cpu_to_cpu', tr_1.name)
+        self.assertTrue(tr_1.passed)
+
+        self.assertIn('gpu_to_cpu', tr_2.name)
+        self.assertTrue(tr_2.passed)
+
+        self.assertIn('cpu_to_gpu', tr_3.name)
+        self.assertTrue(tr_3.passed)
+
+        self.assertIn('gpu_to_cpu_array', tr_4.name)
+        self.assertTrue(tr_4.passed)
+
+        self.assertIn('cpu_to_gpu_array', tr_5.name)
+        self.assertTrue(tr_5.passed)
+
+        self.assertIn('mass_array', tr_6.name)
+        self.assertTrue(tr_6.passed)
+
+        self.assertIn('float_array', tr_7.name)
+        self.assertTrue(tr_7.passed)
+
+        self.assertIn('float_array_diff', tr_8.name)
+        self.assertTrue(tr_8.passed)
+
+        # reload xdoctest.checker
+        importlib.reload(xdoctest.checker)
+
+        _clear_environ()
+
+        test_capacity = {'cpu'}
+        doctester = Xdoctester(
+            style='freeform', target='codeblock', patch_float_precision=False
+        )
+        doctester.prepare(test_capacity)
+
+        docstrings_to_test = {
+            'gpu_to_gpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+                    [0.123456780])
+
+            """,
+            'cpu_to_cpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [0.123456780])
+
+            """,
+            'gpu_to_cpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [0.123456780])
+
+            """,
+            'cpu_to_gpu': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> a = paddle.to_tensor(.123456789)
+                    >>> print(a)
+                    Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+                    [0.123456780])
+            """,
+            'gpu_to_cpu_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor([[1.123456789 ,2,3], [2,3,4], [3,4,5]])
+                    >>> print(a)
+                    Tensor(shape=[3, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [[1.123456780, 2., 3.],
+                    [2., 3., 4.],
+                    [3., 4., 5.]])
+            """,
+            'cpu_to_gpu_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> a = paddle.to_tensor([[1.123456789,2,3], [2,3,4], [3,4,5]])
+                    >>> print(a)
+                    Tensor(shape=[3, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+                    [[1.123456780, 2., 3.],
+                    [2., 3., 4.],
+                    [3., 4., 5.]])
+            """,
+            'mass_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('gpu')
+                    >>> a = paddle.to_tensor(
+                    ... [[1.123456780, 2., -3, .3],
+                    ... [2, 3, +4., 1.2+10.34e-5j],
+                    ... [3, 5.e-3, 1e2, 3e-8]]
+                    ... )
+                    >>> # Tensor(shape=[3, 4], dtype=complex64, place=Place(gpu:0), stop_gradient=True,
+                    >>> #       [[ (1.1234568357467651+0j)                    ,
+                    >>> #          (2+0j)                                     ,
+                    >>> #         (-3+0j)                                     ,
+                    >>> #          (0.30000001192092896+0j)                   ],
+                    >>> #        [ (2+0j)                                     ,
+                    >>> #          (3+0j)                                     ,
+                    >>> #          (4+0j)                                     ,
+                    >>> #         (1.2000000476837158+0.00010340000153519213j)],
+                    >>> #        [ (3+0j)                                     ,
+                    >>> #          (0.004999999888241291+0j)                  ,
+                    >>> #          (100+0j)                                   ,
+                    >>> #          (2.999999892949745e-08+0j)                 ]])
+                    >>> print(a)
+                    Tensor(shape=[3, 4], dtype=complex64, place=Place(AAA), stop_gradient=True,
+                        [[ (1.123456+0j),
+                            (2+0j),
+                            (-3+0j),
+                            (0.3+0j)],
+                            [ (2+0j),
+                            (3+0j),
+                            (4+0j),
+                            (1.2+0.00010340j)],
+                            [ (3+0j),
+                            (0.00499999+0j),
+                            (100+0j),
+                            (2.999999e-08+0j)]])
+            """,
+            'float_array': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> x = [[2, 3, 4], [7, 8, 9]]
+                    >>> x = paddle.to_tensor(x, dtype='float32')
+                    >>> print(paddle.log(x))
+                    Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+                    [[0.69314718, 1.09861231, 1.38629436],
+                        [1.94591010, 2.07944155, 2.19722462]])
+
+            """,
+            'float_array_diff': """
+            placeholder
+
+            Examples:
+
+                .. code-block:: python
+                    :name: code-example-1
+
+                    this is some blabla...
+
+                    >>> import paddle
+                    >>> paddle.device.set_device('cpu')
+                    >>> x = [[2, 3, 4], [7, 8, 9]]
+                    >>> x = paddle.to_tensor(x, dtype='float32')
+                    >>> print(paddle.log(x))
+                    Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+                        [[0.69314712, 1.09861221, 1.386294],
+                        [1.94591032, 2.07944156, 2.1972246]])
+
+            """,
+        }
+
+        test_results = get_test_results(doctester, docstrings_to_test)
+        self.assertEqual(len(test_results), 9)
+
+        tr_0, tr_1, tr_2, tr_3, tr_4, tr_5, tr_6, tr_7, tr_8 = test_results
+
+        self.assertIn('gpu_to_gpu', tr_0.name)
+        self.assertFalse(tr_0.passed)
+
+        self.assertIn('cpu_to_cpu', tr_1.name)
+        self.assertFalse(tr_1.passed)
+
+        self.assertIn('gpu_to_cpu', tr_2.name)
+        self.assertFalse(tr_2.passed)
+
+        self.assertIn('cpu_to_gpu', tr_3.name)
+        self.assertFalse(tr_3.passed)
+
+        self.assertIn('gpu_to_cpu_array', tr_4.name)
+        self.assertFalse(tr_4.passed)
+
+        self.assertIn('cpu_to_gpu_array', tr_5.name)
+        self.assertFalse(tr_5.passed)
+
+        self.assertIn('mass_array', tr_6.name)
+        self.assertFalse(tr_6.passed)
+
+        self.assertIn('float_array', tr_7.name)
+        self.assertTrue(tr_7.passed)
+
+        self.assertIn('float_array_diff', tr_8.name)
+        self.assertFalse(tr_8.passed)
 
     def test_run_cpu(self):
         _clear_environ()

--- a/tools/test_sampcd_processor_xdoctest.py
+++ b/tools/test_sampcd_processor_xdoctest.py
@@ -49,6 +49,11 @@ class TestXdoctester(unittest.TestCase):
         docstring_target = "# xdoctest: -SKIP\n"
         self.assertEqual(docstring_output, docstring_target)
 
+        docstring_input = '# doctest: +SKIP("skip this test...")\n'
+        docstring_output = doctester.convert_directive(docstring_input)
+        docstring_target = '# xdoctest: +SKIP("skip this test...")\n'
+        self.assertEqual(docstring_output, docstring_target)
+
         docstring_input = """
             placeholder
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

- 修改 `directive_patthern` ，能够转换含有描述的 `# doctest: +SKIP('XXX')` 
- patch xdoctest : tensor place 能够转换 Tensor 的 place，如：
  ``` python
  Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
                    [0.123456780])
  ```
  转换为

  ``` python
  Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
                    [0.123456780])
  ```
- patch xdoctest : float precision 将输出（got/want）中的数字进行统一的 round（默认digits=5），如
  ``` python
    Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
                    [0.123456780])
  ```
  与
  ``` python
    Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
                    [0.123456781])
  ```
  表示一致。

  这里没有使用 https://github.com/boisgera/numtest/blob/2.x/numtest/__init__.py 的方法，`numtest` 使用了一种近似方法，可以把 `3.1` 与 `3.14` 表示为一致。而这里修改的目的是兼容不同设备 float 的精度问题，所以统一使用 round 方法，并且兼容 complex。不需要额外的 directive。

- 修改 `print_summary` 使其打印输出 `nocodes` 的接口。
- 修改 `uniform.py` 用于验证修改后的 CI 正确性。

@SigureMo 请评审～

