### PR TITLE
[NewIR]fix new ir program translator shadow output

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -163,6 +163,11 @@ void ProgramTranslator::InsertOperationToSingleBlock(const BlockDesc& block) {
   auto& op_translator = OpTranslator::instance();
   for (auto op : block.AllOps()) {
     OpTranslateFn& fn = op_translator[op->Type()];
+    if (op->Type() == "shaddow_output") {
+      if (!param_map_.count(op->Input("x")[0])) {
+        continue;
+      }
+    }
     ir::Operation* operation = fn(ctx_, &param_map_, *op, program_);
     VLOG(10) << "[op translated][special]" << operation;
   }
@@ -180,6 +185,10 @@ void ProgramTranslator::SetParameterFromSingleBlock(const BlockDesc& block) {
         need_set_parameter_op &= (param_map_.count(var_name) != 0);
         if (need_set_parameter_op) {
           ir::OpResult defining_op_result = param_map_[var_name].value;
+          if (!defining_op_result) {
+            continue;
+          }
+
           ir::Operation* op = InsertSetParamaterOp(
               ctx_, defining_op_result, parameter_name_mappings_[var_name]);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
在动转静的模块中，反向用到的前向的变量，都需要添加shadow output op; 但是存在一些特殊的算子，OpDesc的输入是一个废弃的参数（不存在与yaml中），但是添加shadow output op 需要较大的工作量来过滤这些参数，因此在program translator做了一个检查，对于这种情况的参数，直接跳过set gradient

### Others
Pcard-67164
