### PR TITLE
[clang-tidy] NO.45 enable `bugprone-unused-raii` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,7 @@ Checks: '
 -bugprone-undefined-memory-manipulation,
 -bugprone-undelegated-constructor,
 -bugprone-unhandled-self-assignment,
--bugprone-unused-raii,
+bugprone-unused-raii,
 -bugprone-unused-return-value,
 -bugprone-use-after-move,
 -bugprone-virtual-near-miss,

--- a/paddle/fluid/framework/io/crypto/aes_cipher.cc
+++ b/paddle/fluid/framework/io/crypto/aes_cipher.cc
@@ -77,7 +77,8 @@ std::string AESCipher::EncryptInternal(const std::string& plaintext,
 
   std::string ciphertext;
   m_filter->Attach(new CryptoPP::StringSink(ciphertext));
-  CryptoPP::StringSource(plaintext, true, new CryptoPP::Redirector(*m_filter));
+  CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
+  CryptoPP::StringSource(plaintext, true, filter_redirector);
   if (need_iv) {
     return iv_ + ciphertext;
   }
@@ -107,9 +108,9 @@ std::string AESCipher::DecryptInternal(const std::string& ciphertext,
   }
   std::string plaintext;
   m_filter->Attach(new CryptoPP::StringSink(plaintext));
-  CryptoPP::StringSource(ciphertext.substr(ciphertext_beg),
-                         true,
-                         new CryptoPP::Redirector(*m_filter));
+  CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
+  CryptoPP::StringSource(
+      ciphertext.substr(ciphertext_beg), true, filter_redirector);
 
   return plaintext;
 }
@@ -135,7 +136,8 @@ std::string AESCipher::AuthenticatedEncryptInternal(
 
   std::string ciphertext;
   m_filter->Attach(new CryptoPP::StringSink(ciphertext));
-  CryptoPP::StringSource(plaintext, true, new CryptoPP::Redirector(*m_filter));
+  CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
+  CryptoPP::StringSource(plaintext, true, filter_redirector);
   if (need_iv) {
     ciphertext = iv_.append(ciphertext);
   }
@@ -165,9 +167,9 @@ std::string AESCipher::AuthenticatedDecryptInternal(
   }
   std::string plaintext;
   m_filter->Attach(new CryptoPP::StringSink(plaintext));
-  CryptoPP::StringSource(ciphertext.substr(ciphertext_beg),
-                         true,
-                         new CryptoPP::Redirector(*m_filter));
+  CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
+  CryptoPP::StringSource(
+      ciphertext.substr(ciphertext_beg), true, filter_redirector);
   PADDLE_ENFORCE_EQ(
       m_filter->GetLastResult(),
       true,

--- a/paddle/fluid/pybind/generator_py.cc
+++ b/paddle/fluid/pybind/generator_py.cc
@@ -72,7 +72,7 @@ void BindGenerator(py::module* m_ptr) {
         return ostr.str();
       });
 
-  py::class_<std::mt19937_64>(m, "mt19937_64", "");
+  py::class_<std::mt19937_64>(m, "mt19937_64", "");  // NOLINT
   py::class_<phi::Generator, std::shared_ptr<phi::Generator>>(m, "Generator")
       .def("__init__",
            [](phi::Generator& self) { new (&self) phi::Generator(); })


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
NO.45 enable `bugprone-unused-raii` check

- #54073 