### PR TITLE
update LBFGS to adapt to 0D tensor

### DIFF
--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -523,7 +523,7 @@ class LBFGS(Optimizer):
     def _add_grad(self, alpha, direction):
         offset = 0
         for p in self._params:
-            numel = reduce(lambda x, y: x * y, p.shape)
+            numel = reduce(lambda x, y: x * y, p.shape) if p.shape != [] else 1
             p = paddle.assign(
                 p.add(
                     direction[offset : offset + numel].reshape(p.shape) * alpha


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Pcard-66961
This bug occured in DeepXDE's Lorenz_inverse example.
Because 0D-tensor is allowed now, parameter could be in shape [] which will cause problem in paddle.optimizer.LBFGS API.
So update LBFGS API. Child card is DLTP-73584