### PR TITLE
Fix arm py3.11 install paddle-bfloat

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,5 +5,5 @@ protobuf>=3.1.0, <=3.20.2 ; platform_system == "Windows"
 Pillow
 decorator
 astor
-paddle_bfloat==0.1.7
+paddle_bfloat==0.1.7 ; platform_machine != "aarch64"
 opt_einsum==3.3.0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
ARM环境中不需要安装paddle-bfloat依赖
Pcard-67012