### PR TITLE
Remove old dataloader in ut

### DIFF
--- a/test/contrib/test_image_classification_fp16.py
+++ b/test/contrib/test_image_classification_fp16.py
@@ -497,12 +497,6 @@ class TestAmpWithNonIterableDataLoader(unittest.TestCase):
                 label = paddle.static.data(
                     name='label', shape=[-1, 1], dtype='int64'
                 )
-                py_reader = fluid.io.DataLoader.from_generator(
-                    feed_list=[image, label],
-                    capacity=4,
-                    iterable=False,
-                    use_double_buffer=False,
-                )
 
                 net = vgg16_bn_drop(image)
                 logits = paddle.static.nn.fc(

--- a/test/contrib/test_multi_precision_fp16_train.py
+++ b/test/contrib/test_multi_precision_fp16_train.py
@@ -283,12 +283,6 @@ class TestAmpWithNonIterableDataLoader(unittest.TestCase):
                 label = paddle.static.data(
                     name='label', shape=[-1, 1], dtype='int64'
                 )
-                py_reader = fluid.io.DataLoader.from_generator(
-                    feed_list=[image, label],
-                    capacity=4,
-                    iterable=False,
-                    use_double_buffer=False,
-                )
                 zero_var = paddle.tensor.fill_constant(
                     shape=[1], dtype='int64', value=0
                 )

--- a/test/dygraph_to_static/test_resnet.py
+++ b/test/dygraph_to_static/test_resnet.py
@@ -220,6 +220,27 @@ def reader_decorator(reader):
     return __reader__
 
 
+class TransedFlowerDataSet(paddle.io.Dataset):
+    def __init__(self, flower_data, length):
+        self.img = []
+        self.label = []
+        self.flower_data = flower_data()
+        self._generate(length)
+
+    def _generate(self, length):
+        for i, data in enumerate(self.flower_data):
+            if i >= length:
+                break
+            self.img.append(data[0])
+            self.label.append(data[1])
+
+    def __getitem__(self, idx):
+        return self.img[idx], self.label[idx]
+
+    def __len__(self):
+        return len(self.img)
+
+
 class ResNetHelper:
     def __init__(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -243,15 +264,13 @@ class ResNetHelper:
             paddle.seed(SEED)
             paddle.framework.random._manual_program_seed(SEED)
 
-            train_reader = paddle.batch(
+            dataset = TransedFlowerDataSet(
                 reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
-                batch_size=batch_size,
-                drop_last=True,
+                batch_size * (10 + 1),
             )
-            data_loader = fluid.io.DataLoader.from_generator(
-                capacity=5, iterable=True
+            data_loader = paddle.io.DataLoader(
+                dataset, batch_size=batch_size, drop_last=True
             )
-            data_loader.set_sample_list_generator(train_reader)
 
             resnet = ResNet()
             if to_static:
@@ -315,8 +334,6 @@ class ResNetHelper:
                                 resnet.state_dict(),
                                 self.dy_state_dict_save_path + '.pdparams',
                             )
-                        # avoid dataloader throw abort signaal
-                        data_loader._reset()
                         break
 
         return total_loss.numpy()

--- a/test/dygraph_to_static/test_simnet.py
+++ b/test/dygraph_to_static/test_simnet.py
@@ -74,7 +74,7 @@ vocab = fake_vocabulary()
 
 
 class FakeReaderProcessor:
-    def __init__(self, args, vocab):
+    def __init__(self, args, vocab, length):
         self.vocab = vocab
         self.seq_len = args.seq_len
         self.sample_size = args.fake_sample_size
@@ -86,6 +86,10 @@ class FakeReaderProcessor:
             self.data_samples.append(
                 np.array([query, pos_title, neg_title]).astype(np.int64)
             )
+        self.query = []
+        self.pos_title = []
+        self.neg_title = []
+        self._init_data(length)
 
     def get_reader(self, mode, epoch=0):
         def reader_with_pairwise():
@@ -95,8 +99,25 @@ class FakeReaderProcessor:
 
         return reader_with_pairwise
 
+    def _init_data(self, length):
+        reader = self.get_reader("train", epoch=args.epoch)()
+        for i, yield_data in enumerate(reader):
+            if i >= length:
+                break
+            self.query.append(yield_data[0])
+            self.pos_title.append(yield_data[1])
+            self.neg_title.append(yield_data[2])
 
-simnet_process = FakeReaderProcessor(args, vocab)
+    def __getitem__(self, idx):
+        return self.query[idx], self.pos_title[idx], self.neg_title[idx]
+
+    def __len__(self):
+        return len(self.query)
+
+
+simnet_process = FakeReaderProcessor(
+    args, vocab, args.batch_size * (args.epoch + 1)
+)
 
 
 def train(conf_dict, to_static):
@@ -133,14 +154,8 @@ def train(conf_dict, to_static):
         global_step = 0
         losses = []
 
-        train_loader = fluid.io.DataLoader.from_generator(
-            capacity=16, return_list=True, iterable=True, use_double_buffer=True
-        )
-        get_train_examples = simnet_process.get_reader(
-            "train", epoch=args.epoch
-        )
-        train_loader.set_sample_list_generator(
-            paddle.batch(get_train_examples, batch_size=args.batch_size), place
+        train_loader = paddle.io.DataLoader(
+            simnet_process, batch_size=args.batch_size, places=[place]
         )
 
         for left, pos_right, neg_right in train_loader():

--- a/test/dygraph_to_static/test_simnet.py
+++ b/test/dygraph_to_static/test_simnet.py
@@ -73,7 +73,7 @@ def fake_vocabulary():
 vocab = fake_vocabulary()
 
 
-class FakeReaderProcessor:
+class FakeReaderProcessor(paddle.io.Dataset):
     def __init__(self, args, vocab, length):
         self.vocab = vocab
         self.seq_len = args.seq_len

--- a/test/dygraph_to_static/transformer_util.py
+++ b/test/dygraph_to_static/transformer_util.py
@@ -303,6 +303,90 @@ class InputField:
             )
 
 
+class TransedWMT16TrainDataSet(paddle.io.Dataset):
+    def __init__(self, data_reader, length):
+        self.src_word = []
+        self.src_pos = []
+        self.src_slf_attn_bias = []
+        self.trg_word = []
+        self.trg_pos = []
+        self.trg_slf_attn_bias = []
+        self.trg_src_attn_bias = []
+        self.lbl_word = []
+        self.lbl_weight = []
+
+        self.reader = data_reader()
+        self._generate(length)
+
+    def _generate(self, length):
+        for i, data in enumerate(self.reader):
+            if i >= length:
+                break
+            self.src_word.append(data[0])
+            self.src_pos.append(data[1])
+            self.src_slf_attn_bias.append(data[2])
+            self.trg_word.append(data[3])
+            self.trg_pos.append(data[4])
+            self.trg_slf_attn_bias.append(data[5])
+            self.trg_src_attn_bias.append(data[6])
+            self.lbl_word.append(data[7])
+            self.lbl_weight.append(data[8])
+
+    def __getitem__(self, idx):
+        return (
+            self.src_word[idx],
+            self.src_pos[idx],
+            self.src_slf_attn_bias[idx],
+            self.trg_word[idx],
+            self.trg_pos[idx],
+            self.trg_slf_attn_bias[idx],
+            self.trg_src_attn_bias[idx],
+            self.lbl_word[idx],
+            self.lbl_weight[idx],
+        )
+
+    def __len__(self):
+        return len(self.src_word)
+
+
+class TransedWMT16TestDataSet(paddle.io.Dataset):
+    def __init__(self, data_reader, length):
+        self.src_word = []
+        self.src_pos = []
+        self.src_slf_attn_bias = []
+        self.trg_word = []
+        self.trg_pos = []
+        self.trg_slf_attn_bias = []
+        self.trg_src_attn_bias = []
+        self.lbl_word = []
+        self.lbl_weight = []
+
+        self.reader = data_reader()
+        self._generate(length)
+
+    def _generate(self, length):
+        for i, data in enumerate(self.reader):
+            if i >= length:
+                break
+            self.src_word.append(data[0])
+            self.src_pos.append(data[1])
+            self.src_slf_attn_bias.append(data[2])
+            self.trg_word.append(data[3])
+            self.trg_slf_attn_bias.append(data[4])
+
+    def __getitem__(self, idx):
+        return (
+            self.src_word[idx],
+            self.src_pos[idx],
+            self.src_slf_attn_bias[idx],
+            self.trg_word[idx],
+            self.trg_slf_attn_bias[idx],
+        )
+
+    def __len__(self):
+        return len(self.src_word)
+
+
 def load(program, model_path, executor=None, var_list=None):
     """
     To load python2 saved models in python3.

--- a/test/prim/model/test_resnet_cinn.py
+++ b/test/prim/model/test_resnet_cinn.py
@@ -157,8 +157,6 @@ def run(model, data_loader, optimizer, mode):
                 )
             )
             if batch_id >= end_step:
-                # avoid dataloader throw abort signaal
-                data_loader._reset()
                 break
     print(losses)
     return losses

--- a/test/prim/model/test_resnet_cinn.py
+++ b/test/prim/model/test_resnet_cinn.py
@@ -71,6 +71,27 @@ def reader_decorator(reader):
     return __reader__
 
 
+class TransedFlowerDataSet(paddle.io.Dataset):
+    def __init__(self, flower_data, length):
+        self.img = []
+        self.label = []
+        self.flower_data = flower_data()
+        self._generate(length)
+
+    def _generate(self, length):
+        for i, data in enumerate(self.flower_data):
+            if i >= length:
+                break
+            self.img.append(data[0])
+            self.label.append(data[1])
+
+    def __getitem__(self, idx):
+        return self.img[idx], self.label[idx]
+
+    def __len__(self):
+        return len(self.img)
+
+
 def optimizer_setting(parameter_list=None):
     optimizer = fluid.optimizer.Momentum(
         learning_rate=base_lr,
@@ -153,13 +174,13 @@ def train(to_static, enable_prim, enable_cinn):
     paddle.framework.random._manual_program_seed(SEED)
     fluid.core._set_prim_all_enabled(enable_prim)
 
-    train_reader = paddle.batch(
+    dataset = TransedFlowerDataSet(
         reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
-        batch_size=batch_size,
-        drop_last=True,
+        batch_size * (10 + 1),
     )
-    data_loader = fluid.io.DataLoader.from_generator(capacity=5, iterable=True)
-    data_loader.set_sample_list_generator(train_reader)
+    data_loader = paddle.io.DataLoader(
+        dataset, batch_size=batch_size, drop_last=True
+    )
 
     resnet = resnet50(False)
     if to_static:

--- a/test/prim/model/test_resnet_prim.py
+++ b/test/prim/model/test_resnet_prim.py
@@ -157,8 +157,6 @@ def run(model, data_loader, optimizer, mode):
                 )
             )
             if batch_id >= end_step:
-                # avoid dataloader throw abort signaal
-                data_loader._reset()
                 break
     print(losses)
     return losses

--- a/test/prim/model/test_resnet_prim.py
+++ b/test/prim/model/test_resnet_prim.py
@@ -71,6 +71,27 @@ def reader_decorator(reader):
     return __reader__
 
 
+class TransedFlowerDataSet(paddle.io.Dataset):
+    def __init__(self, flower_data, length):
+        self.img = []
+        self.label = []
+        self.flower_data = flower_data()
+        self._generate(length)
+
+    def _generate(self, length):
+        for i, data in enumerate(self.flower_data):
+            if i >= length:
+                break
+            self.img.append(data[0])
+            self.label.append(data[1])
+
+    def __getitem__(self, idx):
+        return self.img[idx], self.label[idx]
+
+    def __len__(self):
+        return len(self.img)
+
+
 def optimizer_setting(parameter_list=None):
     optimizer = fluid.optimizer.Momentum(
         learning_rate=base_lr,
@@ -153,13 +174,13 @@ def train(to_static, enable_prim, enable_cinn):
     paddle.framework.random._manual_program_seed(SEED)
     fluid.core._set_prim_all_enabled(enable_prim)
 
-    train_reader = paddle.batch(
+    dataset = TransedFlowerDataSet(
         reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
-        batch_size=batch_size,
-        drop_last=True,
+        batch_size * (10 + 1),
     )
-    data_loader = fluid.io.DataLoader.from_generator(capacity=5, iterable=True)
-    data_loader.set_sample_list_generator(train_reader)
+    data_loader = paddle.io.DataLoader(
+        dataset, batch_size=batch_size, drop_last=True
+    )
 
     resnet = resnet50(False)
     if to_static:

--- a/test/prim/model/test_resnet_prim_cinn.py
+++ b/test/prim/model/test_resnet_prim_cinn.py
@@ -156,8 +156,6 @@ def run(model, data_loader, optimizer, mode):
                 )
             )
             if batch_id >= end_step:
-                # avoid dataloader throw abort signaal
-                data_loader._reset()
                 break
     print(losses)
     return losses

--- a/test/prim/model/test_resnet_prim_cinn.py
+++ b/test/prim/model/test_resnet_prim_cinn.py
@@ -70,6 +70,27 @@ def reader_decorator(reader):
     return __reader__
 
 
+class TransedFlowerDataSet(paddle.io.Dataset):
+    def __init__(self, flower_data, length):
+        self.img = []
+        self.label = []
+        self.flower_data = flower_data()
+        self._generate(length)
+
+    def _generate(self, length):
+        for i, data in enumerate(self.flower_data):
+            if i >= length:
+                break
+            self.img.append(data[0])
+            self.label.append(data[1])
+
+    def __getitem__(self, idx):
+        return self.img[idx], self.label[idx]
+
+    def __len__(self):
+        return len(self.img)
+
+
 def optimizer_setting(parameter_list=None):
     optimizer = fluid.optimizer.Momentum(
         learning_rate=base_lr,
@@ -152,13 +173,13 @@ def train(to_static, enable_prim, enable_cinn):
     paddle.framework.random._manual_program_seed(SEED)
     fluid.core._set_prim_all_enabled(enable_prim)
 
-    train_reader = paddle.batch(
+    dataset = TransedFlowerDataSet(
         reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
-        batch_size=batch_size,
-        drop_last=True,
+        batch_size * (10 + 1),
     )
-    data_loader = fluid.io.DataLoader.from_generator(capacity=5, iterable=True)
-    data_loader.set_sample_list_generator(train_reader)
+    data_loader = paddle.io.DataLoader(
+        dataset, batch_size=batch_size, drop_last=True
+    )
 
     resnet = resnet50(False)
     if to_static:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67005

remove old version DataLoader (created by `from_generator`)  in UT and replace it with 2.0 version `paddle.io.DataLoader`.

There are still some case cannot be replaced, which will be removed after DataLoader upgrade.
- unit test case in Distrubuted Training.
- unit test case in Executor, which use non-iterable DataLoader.
- unit test for old version DataLoader (will be moved with the DataLoader code)

