### PR TITLE
Fix bugs of windows CI: skip the unit tests related to devices

### DIFF
--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -23,6 +23,10 @@ from paddle import nn
 from paddle.static import amp
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestAutoCast(AmpTestBase):
     def setUp(self):
         self._conv = paddle.nn.Conv2D(
@@ -56,6 +60,10 @@ class SimpleConvNet(nn.Layer):
         return out3
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestStaticDecorate(AmpTestBase):
     def check_results(
         self, use_amp, dtype, level, use_promote, expected_op_calls
@@ -127,6 +135,10 @@ class TestStaticDecorate(AmpTestBase):
         paddle.disable_static()
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestGradScaler(AmpTestBase):
     def test_amp_grad_scaler(self):
         model = paddle.nn.Conv2D(3, 2, 3)
@@ -154,6 +166,10 @@ class TestGradScaler(AmpTestBase):
         self.assertTrue('check_finite_and_unscale' not in op_list)
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestFp16Guard(AmpTestBase):
     def test_fp16_gurad(self):
         paddle.enable_static()

--- a/test/amp/test_amp_decorate.py
+++ b/test/amp/test_amp_decorate.py
@@ -77,6 +77,10 @@ class Model(paddle.nn.Layer):
         return x
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestAMPDecorate(unittest.TestCase):
     def check_results(self, fp32_layers=[], fp16_layers=[]):
         for idx in range(len(fp32_layers)):

--- a/test/amp/test_amp_list.py
+++ b/test/amp/test_amp_list.py
@@ -19,6 +19,10 @@ from paddle.fluid import core
 from paddle.static.amp import AutoMixedPrecisionLists, fp16_lists
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestAMPList(unittest.TestCase):
     def setUp(self):
         self.default_black_list = [

--- a/test/amp/test_amp_master_grad.py
+++ b/test/amp/test_amp_master_grad.py
@@ -35,6 +35,10 @@ class SimpleNet(paddle.nn.Layer):
     or not core.is_float16_supported(core.CUDAPlace(0)),
     "core is not complied with CUDA and not support the float16",
 )
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestMasterGrad(unittest.TestCase):
     def check_results(
         self, fp32_grads, op_list, total_steps, accumulate_batchs_num

--- a/test/amp/test_amp_promote.py
+++ b/test/amp/test_amp_promote.py
@@ -21,6 +21,10 @@ import paddle
 from paddle.static import amp
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestStaticAmpPromoteStats(AmpTestBase):
     def check_promote_results(
         self, use_amp, dtype, level, use_promote, expected_op_calls, debug_info
@@ -103,6 +107,10 @@ class TestStaticAmpPromoteStats(AmpTestBase):
         )
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestEagerAmpPromoteStats(AmpTestBase):
     def check_promote_results(
         self, dtype, level, use_promote, expected_op_calls, debug_info
@@ -172,6 +180,10 @@ class TestEagerAmpPromoteStats(AmpTestBase):
         )
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestEagerAmpPromoteSimple(AmpTestBase):
     def setUp(self):
         self._conv = paddle.nn.Conv2D(

--- a/test/legacy_test/test_optimizer.py
+++ b/test/legacy_test/test_optimizer.py
@@ -1254,6 +1254,10 @@ class TestOptimizerDtype(unittest.TestCase):
         self.check_with_dtype('float32')
 
 
+@unittest.skipIf(
+    paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0."
+)
 class TestMasterWeightSaveForFP16(unittest.TestCase):
     '''
     For Amp-O2, some optimizer(Momentum, Adam ...) will create master weights for parameters to improve the accuracy.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
### PR changes
Others

### Description
amp相关测试需要在显卡计算能力高于7.0的设备上运行，但现有windows_CI流水线的设备达不到运行要求。
