### PR TITLE
Fix random seed of test_lu_op

### DIFF
--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -195,6 +195,7 @@ class TestLUAPI(unittest.TestCase):
                 np_dtype = np.float32
             elif dtype == "float64":
                 np_dtype = np.float64
+            np.random.seed(1024)
             a = np.random.rand(*shape).astype(np_dtype)
             m = a.shape[-2]
             n = a.shape[-1]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
`test_lu_op` fails occasionally due to randomness. We fix the random seed in this PR.