### PR TITLE
Fix random seed of test_eig_op

### DIFF
--- a/test/legacy_test/test_eig_op.py
+++ b/test/legacy_test/test_eig_op.py
@@ -281,6 +281,7 @@ class TestEigStatic(TestEigOp):
 
 class TestEigDyGraph(unittest.TestCase):
     def test_check_output_with_place(self):
+        np.random.seed(1024)
         input_np = np.random.random([3, 3]).astype('complex')
         expect_val, expect_vec = np.linalg.eig(input_np)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
`test_eig_op` and `test_eig_op_static_build` will occasionally fail due to randomness. This PR fixes the random seed. 