### PR TITLE
【new ir】add __eq__ and __hash__ to compare opresult and value

### DIFF
--- a/paddle/ir/core/value.cc
+++ b/paddle/ir/core/value.cc
@@ -122,6 +122,15 @@ detail::OpResultImpl *OpResult::impl() const {
   return reinterpret_cast<detail::OpResultImpl *>(impl_);
 }
 
+bool OpResult::operator==(const OpResult &other) const {
+  return impl_ == other.impl_;
+}
+
+detail::ValueImpl *OpResult::value_impl() const {
+  IR_ENFORCE(impl_, "Can't use value_impl() interface while value is null.");
+  return impl_;
+}
+
 uint32_t OpResult::GetValidInlineIndex(uint32_t index) {
   uint32_t max_inline_index =
       ir::detail::OpResultImpl::GetMaxInlineResultIndex();

--- a/paddle/ir/core/value.h
+++ b/paddle/ir/core/value.h
@@ -192,7 +192,11 @@ class IR_API OpResult : public Value {
 
   uint32_t GetResultIndex() const;
 
+  bool operator==(const OpResult &other) const;
+
   friend Operation;
+
+  detail::ValueImpl *value_impl() const;
 
  private:
   static uint32_t GetValidInlineIndex(uint32_t index);
@@ -209,4 +213,5 @@ struct hash<ir::Value> {
     return std::hash<const ir::detail::ValueImpl *>()(obj.impl_);
   }
 };
+
 }  // namespace std

--- a/test/ir/new_ir/test_ir_pybind.py
+++ b/test/ir/new_ir/test_ir_pybind.py
@@ -84,12 +84,26 @@ class TestPybind(unittest.TestCase):
         matmul_op.result(0).set_stop_gradient(True)
         self.assertEqual(matmul_op.result(0).get_stop_gradient(), True)
 
+        # test opresult hash
         result_set = set()
         for opresult in matmul_op.results():
             result_set.add(opresult)
-
-        # self.assertTrue(add_op.operands()[0].source() in result_set)
-        # self.assertEqual(add_op.operands_source()[0] , matmul_op.results()[0],)
+        # test opresult hash and hash(opresult) == hash(operesult)
+        self.assertTrue(add_op.operands()[0].source() in result_set)
+        # test value hash and hash(value) == hash(operesult)
+        self.assertTrue(add_op.operands_source()[0] in result_set)
+        # test value == value
+        self.assertEqual(
+            add_op.operands_source()[0], add_op.operands_source()[0]
+        )
+        # test value == opresult
+        self.assertEqual(add_op.operands_source()[0], matmul_op.results()[0])
+        # test opresult == value
+        self.assertEqual(
+            add_op.operands()[0].source(), add_op.operands_source()[0]
+        )
+        # test opresult == opresult
+        self.assertEqual(add_op.operands()[0].source(), matmul_op.results()[0])
 
         self.assertEqual(
             tanh_op.operands()[0].source().get_defining_op().name(), "pd.add"
@@ -100,10 +114,6 @@ class TestPybind(unittest.TestCase):
             tanh_op.operands()[0].source().get_defining_op().name(), "pd.matmul"
         )
 
-        self.assertEqual(
-            tanh_op.operands()[0].source().get_defining_op(),
-            tanh_op.operands_source()[0].get_defining_op(),
-        )
         self.assertEqual(add_op.result(0).use_empty(), True)
 
     def test_type(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-67164

增加opresult 结构和 value 结构判等方法__eq__; __hash__，使得指向相同地址的opresult 和 value 在python端可以判断正确（==, is, value in opresult_set)