### PR TITLE
[XPU] Fix compilation errors of XPU plugin on multiple versions of GCC

### DIFF
--- a/paddle/phi/kernels/xpu/plugin/CMakeLists.txt
+++ b/paddle/phi/kernels/xpu/plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.10)
 
 project(xpuplugin LANGUAGES CXX)
 
@@ -62,14 +62,13 @@ message(STATUS "Build with XPU_CLANG=" ${XPU_CLANG})
 if(NOT DEFINED HOST_SYSROOT)
   set(HOST_SYSROOT $ENV{HOST_SYSROOT})
 endif()
-if(NOT HOST_SYSROOT)
-  set(HOST_SYSROOT /opt/compiler/gcc-8.2)
-endif()
-if(NOT IS_DIRECTORY ${HOST_SYSROOT})
-  message(
-    FATAL_ERROR
-      "Directory ${HOST_SYSROOT} not found, please export HOST_SYSROOT=<path_to_gcc>."
-  )
+if(HOST_SYSROOT)
+  if(NOT IS_DIRECTORY ${HOST_SYSROOT})
+    message(
+      FATAL_ERROR
+        "Directory ${HOST_SYSROOT} not found, please export HOST_SYSROOT=<path_to_gcc>."
+    )
+  endif()
 endif()
 
 if(NOT DEFINED HOST_ARCH)
@@ -89,13 +88,12 @@ endif()
 if(NOT DEFINED TOOLCHAIN_ARGS)
   set(TOOLCHAIN_ARGS $ENV{TOOLCHAIN_ARGS})
 endif()
-set(TOOLCHAIN_ARGS -isystem ${HOST_SYSROOT}/include/c++/8.2.0 -isystem
-                   /usr/include/ -isystem /usr/include/x86_64-linux-gnu)
 if(HOST_ARCH MATCHES "x86_64")
   if(TARGET_ARCH MATCHES "x86_64")
     if(EXISTS ${HOST_SYSROOT}/bin/g++)
       set(HOST_CXX ${HOST_SYSROOT}/bin/g++)
-      if(NOT EXISTS ${HOST_SYSROOT}/bin/ar)
+      set(HOST_AR ${HOST_SYSROOT}/bin/ar)
+      if(NOT EXISTS ${HOST_AR})
         # try gcc-ar
         set(HOST_AR ${HOST_SYSROOT}/bin/gcc-ar)
       endif()
@@ -105,7 +103,7 @@ if(HOST_ARCH MATCHES "x86_64")
     endif()
   endif()
   if(TARGET_ARCH MATCHES "aarch64")
-    set(TOOLCHAIN_ARGS --gcc-toolchain=${HOST_SYSROOT})
+    set(TOOLCHAIN_ARGS "${TOOLCHAIN_ARGS} --gcc-toolchain=${HOST_SYSROOT}")
     set(HOST_SYSROOT ${HOST_SYSROOT}/aarch64-linux-gnu/libc)
     set(HOST_CXX ${CMAKE_CXX_COMPILER})
     set(HOST_AR ${CMAKE_AR})
@@ -130,6 +128,7 @@ message(STATUS "Build with HOST_SYSROOT=" ${HOST_SYSROOT})
 message(STATUS "Build with HOST_CXX=" ${HOST_CXX})
 message(STATUS "Build with HOST_AR=" ${HOST_AR})
 
+separate_arguments(TOOLCHAIN_ARGS)
 # compile xpu kernel macro function
 macro(
   compile_kernel
@@ -303,9 +302,9 @@ foreach(xpu_wrapper IN LISTS xpu_wrappers)
       ${xpu_wrapper} -I${XDNN_INC_DIR} -I${XRE_INC_DIR}
       -I${CMAKE_CURRENT_SOURCE_DIR}/include -I${CMAKE_CURRENT_SOURCE_DIR}/src
       -I${CMAKE_CURRENT_SOURCE_DIR}/src/wrapper -D_GNU_SOURCE
-      -D__STDC_LIMIT_MACROS -DNDEBUG --sysroot=${HOST_SYSROOT} ${TOOLCHAIN_ARGS}
-      --target=${TARGET_ARCH} -fPIC -Werror -Wreorder -fvisibility=hidden
-      --xpu-host-only ${XPU_MF_FLAGS}
+      -D__STDC_LIMIT_MACROS -DNDEBUG ${TOOLCHAIN_ARGS} --target=${TARGET_ARCH}
+      -fPIC -Werror -Wreorder -fvisibility=hidden --xpu-host-only
+      ${XPU_MF_FLAGS}
     COMMAND
       ${CMAKE_COMMAND} -E cmake_depends "Unix Makefiles" ${CMAKE_SOURCE_DIR}
       ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}
@@ -325,9 +324,9 @@ foreach(xpu_wrapper IN LISTS xpu_wrappers)
       -I${XDNN_INC_DIR} -I${XRE_INC_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/include
       -I${CMAKE_CURRENT_SOURCE_DIR}/src
       -I${CMAKE_CURRENT_SOURCE_DIR}/src/wrapper -D_GNU_SOURCE
-      -D__STDC_LIMIT_MACROS -DNDEBUG --sysroot=${HOST_SYSROOT} ${TOOLCHAIN_ARGS}
-      --target=${TARGET_ARCH} -fPIC -Wunused-variable -Werror -Wreorder
-      -fvisibility=hidden --xpu-host-only ${HOST_XPU_FLAGS}
+      -D__STDC_LIMIT_MACROS -DNDEBUG ${TOOLCHAIN_ARGS} --target=${TARGET_ARCH}
+      -fPIC -Wunused-variable -Werror -Wreorder -fvisibility=hidden
+      --xpu-host-only ${HOST_XPU_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS wrapper_build/${wrapper_name}.wrapper.d
     COMMENT wrapper_build/${wrapper_name}.wrapper.o

--- a/paddle/phi/kernels/xpu/plugin/build.sh
+++ b/paddle/phi/kernels/xpu/plugin/build.sh
@@ -16,10 +16,10 @@
 
 set -e
 
-export XDNN_PATH=/opt/xdnn # <path_to_xdnn>
-export XRE_PATH=/opt/xre # <path_to_xre>
-export CLANG_PATH=/opt/xtdk # <path_to_xtdk>
-export HOST_SYSROOT=/opt/compiler/gcc-8.2 # <path_to_gcc>
+#export XDNN_PATH=/opt/xdnn # <path_to_xdnn>
+#export XRE_PATH=/opt/xre # <path_to_xre>
+#export CLANG_PATH=/opt/xtdk # <path_to_xtdk>
+#export HOST_SYSROOT=/opt/compiler/gcc-8.2 # <path_to_gcc>
 
 rm -rf build
 mkdir build

--- a/paddle/phi/kernels/xpu/plugin/example/CMakeLists.txt
+++ b/paddle/phi/kernels/xpu/plugin/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.10)
 
 project(example LANGUAGES CXX)
 

--- a/paddle/phi/kernels/xpu/plugin/example/build.sh
+++ b/paddle/phi/kernels/xpu/plugin/example/build.sh
@@ -16,8 +16,8 @@
 
 set -e
 
-export XDNN_PATH=/opt/xdnn # <path_to_xdnn>
-export XRE_PATH=/opt/xre # <path_to_xre>
+#export XDNN_PATH=/opt/xdnn # <path_to_xdnn>
+#export XRE_PATH=/opt/xre # <path_to_xre>
 export LINK_TYPE=static # shared/static
 
 rm -rf build

--- a/paddle/phi/kernels/xpu/plugin/example/run.sh
+++ b/paddle/phi/kernels/xpu/plugin/example/run.sh
@@ -16,10 +16,20 @@
 
 set -e
 
-XDNN_PATH=/opt/xdnn # <path_to_xdnn>
-XRE_PATH=/opt/xre # <path_to_xre>
+#XDNN_PATH=/opt/xdnn # <path_to_xdnn>
+#XRE_PATH=/opt/xre # <path_to_xre>
 
-:<<!
+if [[ "$XDNN_PATH" == "" ]] || [[ ! -d "$XDNN_PATH" ]]; then
+ echo "XDNN_PATH not set, or directory ${XDNN_PATH} not found, please export XDNN_PATH=<path_to_xdnn>."
+ exit -1
+fi
+
+if [[ "$XRE_PATH" == "" ]] || [[ ! -d "$XRE_PATH" ]]; then
+ echo "XRE_PATH not set, or directory ${XRE_PATH} not found, please export XRE_PATH=<path_to_xre>."
+ exit -1
+fi
+
+#:<<!
 export GLOG_v=0
 export XPU_VISIBLE_DEVICES=0;
 export XPUAPI_DEBUG=1;
@@ -27,9 +37,9 @@ export LD_LIBRARY_PATH=$XDNN_PATH/so:$XRE_PATH/so:$LD_LIBRARY_PATH
 
 chmod +x ./build/example
 ./build/example
-!
+#!
 
-#:<<!
+:<<!
 SSH_IP_ADDR=localhost
 SSH_PORT=9031
 SSH_USR_ID=root
@@ -46,4 +56,4 @@ sshpass -p $SSH_USR_PWD scp -v -r -o ConnectTimeout=60 -o StrictHostKeyChecking=
 sshpass -p $SSH_USR_PWD scp -v -r -o ConnectTimeout=60 -o StrictHostKeyChecking=no -P $SSH_PORT ../build/libxpuplugin.so $SSH_USR_ID@$SSH_IP_ADDR:$WORK_SPACE
 sshpass -p $SSH_USR_PWD scp -v -r -o ConnectTimeout=60 -o StrictHostKeyChecking=no -P $SSH_PORT build/example $SSH_USR_ID@$SSH_IP_ADDR:$WORK_SPACE
 sshpass -p $SSH_USR_PWD ssh -v -o ConnectTimeout=60 -o StrictHostKeyChecking=no -p $SSH_PORT $SSH_USR_ID@$SSH_IP_ADDR "cd $WORK_SPACE; ${EXPORT_ENVIRONMENT_VARIABLES} chmod +x ./example; ./example"
-#!
+!


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
1. 修复不同 GCC 版本编译 XPU wrapper 报无法找到 c++ 标准库头文件的问题。
2. 降低 CMake 版本。
3. 优化 standalone 编译脚本。
Pcard-73397
