### PR TITLE
Increase relative error of test_group_norm_op

### DIFF
--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -358,6 +358,12 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.shape = (1, 100, 4, 4)
         self.dtype = np.float16
 
+    def test_check_output(self):
+        rtol = 1e-3
+
+        place = core.CUDAPlace(0)
+        self.check_output_with_place(place, rtol=rtol)
+
 
 class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
     def setUp(self):

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -357,6 +357,26 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.attrs['epsilon'] = 0.5
         self.shape = (1, 100, 4, 4)
         self.dtype = np.float16
+        input = np.sin(np.arange(self.shape[0] * self.shape[1] * self.shape[2] * self.shape[3]))
+        input = np.transpose(input.reshape(self.shape), (0, 2, 3, 1)).astype(self.dtype)
+        scale = np.sin(np.arange(self.shape[1])).astype(self.dtype)
+        bias = np.sin(np.arange(self.shape[1])).astype(self.dtype)
+        output, mean, var = group_norm_naive(
+            input,
+            scale,
+            bias,
+            self.attrs['epsilon'],
+            self.attrs['groups'],
+            self.data_format,
+        )
+
+        self.inputs = {
+            'X': OpTest.np_dtype_to_fluid_dtype(input),
+            'Scale': OpTest.np_dtype_to_fluid_dtype(scale),
+            'Bias': OpTest.np_dtype_to_fluid_dtype(bias),
+        }
+        self.outputs = {'Y': output, 'Mean': mean, 'Variance': var}
+        self.attrs['data_layout'] = self.data_format
 
     def test_check_output(self):
         rtol = 2e-3
@@ -380,10 +400,9 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
         }
         self.compare_between_place = False
         self.init_test_case()
-
-        input = np.random.random(self.shape).astype(np.float32)
-        scale = np.random.random([self.shape[3]]).astype(np.float32)
-        bias = np.random.random([self.shape[3]]).astype(np.float32)
+        input = np.sin(np.arange(self.shape[0] * self.shape[1] * self.shape[2] * self.shape[3])).reshape(self.shape).astype(np.float32)
+        scale = np.sin(np.arange(self.shape[3])).astype(np.float32)
+        bias = np.sin(np.arange(self.shape[3])).astype(np.float32)
         output, mean, var = group_norm_naive(
             input,
             scale,

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -359,10 +359,10 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.dtype = np.float16
 
     def test_check_output(self):
-        rtol = 1e-3
-
+        rtol = 2e-3
         place = core.CUDAPlace(0)
         self.check_output_with_place(place, rtol=rtol)
+    
 
 
 class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
@@ -399,6 +399,11 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
             'Bias': convert_float_to_uint16(bias),
         }
         self.outputs = {'Y': output, 'Mean': mean, 'Variance': var}
+    
+    def test_check_output(self):
+        rtol = 2e-2
+        place = core.CUDAPlace(0)
+        self.check_output_with_place(place, rtol=rtol)
 
 
 class TestGroupNormOpBigEps1_With_NHWC(TestGroupNormOp):

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -357,8 +357,14 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.attrs['epsilon'] = 0.5
         self.shape = (1, 100, 4, 4)
         self.dtype = np.float16
-        input = np.sin(np.arange(self.shape[0] * self.shape[1] * self.shape[2] * self.shape[3]))
-        input = np.transpose(input.reshape(self.shape), (0, 2, 3, 1)).astype(self.dtype)
+        input = np.sin(
+            np.arange(
+                self.shape[0] * self.shape[1] * self.shape[2] * self.shape[3]
+            )
+        )
+        input = np.transpose(input.reshape(self.shape), (0, 2, 3, 1)).astype(
+            self.dtype
+        )
         scale = np.sin(np.arange(self.shape[1])).astype(self.dtype)
         bias = np.sin(np.arange(self.shape[1])).astype(self.dtype)
         output, mean, var = group_norm_naive(
@@ -382,7 +388,6 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         rtol = 2e-3
         place = core.CUDAPlace(0)
         self.check_output_with_place(place, rtol=rtol)
-    
 
 
 class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
@@ -400,7 +405,18 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
         }
         self.compare_between_place = False
         self.init_test_case()
-        input = np.sin(np.arange(self.shape[0] * self.shape[1] * self.shape[2] * self.shape[3])).reshape(self.shape).astype(np.float32)
+        input = (
+            np.sin(
+                np.arange(
+                    self.shape[0]
+                    * self.shape[1]
+                    * self.shape[2]
+                    * self.shape[3]
+                )
+            )
+            .reshape(self.shape)
+            .astype(np.float32)
+        )
         scale = np.sin(np.arange(self.shape[3])).astype(np.float32)
         bias = np.sin(np.arange(self.shape[3])).astype(np.float32)
         output, mean, var = group_norm_naive(
@@ -418,7 +434,7 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
             'Bias': convert_float_to_uint16(bias),
         }
         self.outputs = {'Y': output, 'Mean': mean, 'Variance': var}
-    
+
     def test_check_output(self):
         rtol = 2e-2
         place = core.CUDAPlace(0)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
Others

Pcard-71501

https://github.com/PaddlePaddle/Paddle/pull/55399这个pr 修改了group_norm算子，当数据类型是fp16或bf16，数据格式为NHWC的实现，会导致随机测试group_norm失败，所以修改测试阈值，并且，在本地测试，数据范围为n:1-3，c:1-1921，h=128，w=128，fp16和fp32单个数据相差不超过0.001953125，bf16单个数据相差不超过0.015625。
