### PR TITLE
[XPU] Fix linspace op do data transform error on xpu1 device when execute fall back to cpu

### DIFF
--- a/paddle/phi/api/yaml/static_ops.yaml
+++ b/paddle/phi/api/yaml/static_ops.yaml
@@ -352,8 +352,6 @@
     func : linspace
     param: [start, stop, number, dtype]
     data_type : dtype
-  data_transform :
-    skip_transform : start, stop, number
 
 - op : matmul
   args : (Tensor x, Tensor y, bool transpose_x = false, bool transpose_y = false)


### PR DESCRIPTION
### PR types
Bug fixes
### PR changes
OPs
### Description
XDNN has no implemention of linspace on XPU K200,the process of linspace infer fall back to cpu,there is a device-transform error occurs during data_transform
