### PR TITLE
optimized group_norm

### DIFF
--- a/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
@@ -480,9 +480,9 @@ void GroupNormGradKernel(const Context& dev_ctx,
     constexpr const int vec_size = 2;
     constexpr const int acc_size = 128;
 #ifdef __HIPCC__
-    int block_size_nhwc = std::max(std::min(256, C / 2), 64);
+    int block_size_nhwc = std::max(std::min(256, (C / vec_size)), 64);
 #else
-    int block_size_nhwc = std::min(1024, C / 2);
+    int block_size_nhwc = std::min(1024, (C / vec_size));
 #endif
     dim3 grid_nhwc(((imsize + acc_size - 1) / acc_size), x_dims[0], 1);
     dim3 block_nhwc(block_size_nhwc, 1, 1);

--- a/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
@@ -38,56 +38,53 @@ __global__ void GroupNormBackwardGetMeanAndVar(const T* x,
                                                AccT* d_var,
                                                T* d_scale,
                                                T* d_bias) {
-  int gid = blockIdx.y;
-  int cid = blockIdx.x;
-  int bid = blockIdx.z;
-  int H = imsize / W;
-  int number = min(group_size, static_cast<int>(C - gid * group_size));
-  int ccid = gid * group_size + cid;
-  if (ccid >= C) return;
-  T x_scale = (flags & kHasScale) ? scale[ccid] : static_cast<T>(1);
-  T x_bias = (flags & kHasBias) ? bias[ccid] : static_cast<T>(0);
-  T x_scale_inv = static_cast<T>(0);
-  if (x_scale != static_cast<T>(0)) x_scale_inv = static_cast<T>(1.0) / x_scale;
-  AccT d_mean_data = static_cast<AccT>(0);
-  AccT d_var_data = static_cast<AccT>(0);
-  AccT d_scale_data = static_cast<AccT>(0);
-  AccT d_bias_data = static_cast<AccT>(0);
+  int hid = blockIdx.x;
+  int bid = blockIdx.y;
 
-  for (int imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
-    AccT val, dval;
+  int stride = C;
+  int cw_size = C * W;
+  int index = bid * imsize * C + hid * W * C;
 
-    int hid = imid / W;
-    int wid = imid % W;
-    val = static_cast<AccT>(x[(bid * H + hid) * W * C + wid * C + ccid]) -
-          static_cast<AccT>(x_bias);
-    dval = static_cast<AccT>(d_y[(bid * H + hid) * W * C + wid * C + ccid]);
+  for (int idx = threadIdx.x; idx < C; idx += blockDim.x) {
+    int gid = idx / group_size;
+    int ccid = idx;
 
-    d_var_data += val * dval;
-    d_mean_data += dval * static_cast<AccT>(x_scale);
+    T x_scale = (flags & kHasScale) ? scale[ccid] : static_cast<T>(1);
+    T x_bias = (flags & kHasBias) ? bias[ccid] : static_cast<T>(0);
+    T x_scale_inv = static_cast<T>(0);
+    if (x_scale != static_cast<T>(0))
+      x_scale_inv = static_cast<T>(1.0) / x_scale;
+    AccT d_mean_data = static_cast<AccT>(0);
+    AccT d_var_data = static_cast<AccT>(0);
+    AccT d_scale_data = static_cast<AccT>(0);
+    AccT d_bias_data = static_cast<AccT>(0);
 
-    val = val * static_cast<AccT>(x_scale_inv);
-    d_bias_data += dval;
-    d_scale_data += val * dval;
-  }
-  CudaAtomicAddWithWarp(&(d_mean[bid * groups + gid]),
-                        static_cast<AccT>(d_mean_data));
-  CudaAtomicAddWithWarp(&(d_var[bid * groups + gid]),
-                        static_cast<AccT>(d_var_data));
+    for (int gsid = ccid; gsid < cw_size; gsid += stride) {
+      AccT val, dval;
 
-  if (flags & kHasScale) {
-#if CUDA_VERSION >= 11070
-    phi::CudaAtomicAdd(&(d_scale[ccid]), static_cast<T>(d_scale_data));
-#else
-    CudaAtomicAddWithWarp(&(d_scale[ccid]), static_cast<T>(d_scale_data));
-#endif
-  }
-  if (flags & kHasBias) {
-#if CUDA_VERSION >= 11070
-    phi::CudaAtomicAdd(&(d_bias[ccid]), static_cast<T>(d_bias_data));
-#else
-    CudaAtomicAddWithWarp(&(d_bias[ccid]), static_cast<T>(d_bias_data));
-#endif
+      int cur_idx = index + gsid;
+      val = static_cast<AccT>(x[cur_idx]) - static_cast<AccT>(x_bias);
+      dval = static_cast<AccT>(d_y[cur_idx]);
+
+      d_var_data += val * dval;
+      d_mean_data += dval * static_cast<AccT>(x_scale);
+
+      val = val * static_cast<AccT>(x_scale_inv);
+      d_bias_data += dval;
+      d_scale_data += val * dval;
+    }
+
+    phi::CudaAtomicAdd(&(d_mean[bid * groups + gid]),
+                       static_cast<AccT>(d_mean_data));
+    phi::CudaAtomicAdd(&(d_var[bid * groups + gid]),
+                       static_cast<AccT>(d_var_data));
+
+    if (flags & kHasScale) {
+      phi::CudaAtomicAdd(&(d_scale[ccid]), static_cast<T>(d_scale_data));
+    }
+    if (flags & kHasBias) {
+      phi::CudaAtomicAdd(&(d_bias[ccid]), static_cast<T>(d_bias_data));
+    }
   }
 }
 
@@ -433,23 +430,30 @@ void GroupNormGradKernel(const Context& dev_ctx,
 
     int flags =
         (scale_data != nullptr) * kHasScale + (bias_data != nullptr) * kHasBias;
-    UNROLL_ALL_CASES(flags,
-                     GroupNormBackwardGetMeanAndVar,
-                     y_data,
-                     scale_data,
-                     bias_data,
-                     dy_data,
-                     x_dims[0],
-                     C,
-                     W,
-                     imsize,
-                     groups,
-                     group_size,
-                     epsilon,
-                     temp_mean_data,
-                     temp_var_data,
-                     d_scale_data,
-                     d_bias_data);
+#ifdef __HIPCC__
+    int block_size_nhwc = std::max(std::min(256, C), 64);
+#else
+    int block_size_nhwc = std::min(1024, C);
+#endif
+    dim3 grid_nhwc(x_dims[1], x_dims[0], 1);
+    dim3 block_nhwc(block_size_nhwc, 1, 1);
+    UNROLL_ALL_CASES_BACKWARD(flags,
+                              GroupNormBackwardGetMeanAndVar,
+                              y_data,
+                              scale_data,
+                              bias_data,
+                              dy_data,
+                              x_dims[0],
+                              C,
+                              W,
+                              imsize,
+                              groups,
+                              group_size,
+                              epsilon,
+                              temp_mean_data,
+                              temp_var_data,
+                              d_scale_data,
+                              d_bias_data);
     if (d_x_data != nullptr) {
       UNROLL_ALL_CASES(flags,
                        GroupNormBackward,

--- a/paddle/phi/kernels/gpu/group_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_kernel.cu
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/group_norm_kernel.h"
-#include <stdio.h>
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/layout.h"
@@ -595,6 +594,109 @@ void groupNormNHWCScale<T>::operator()(const GroupNormNHWCParams<T>& params,
 }
 template class groupNormNHWCScale<half>;
 
+template <typename T, typename Context>
+void GroupNormNHWCKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const paddle::optional<DenseTensor>& scale,
+                         const paddle::optional<DenseTensor>& bias,
+                         float epsilon,
+                         int groups,
+                         const std::string& data_layout_str,
+                         DenseTensor* y,
+                         DenseTensor* mean,
+                         DenseTensor* var) {
+  using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
+  GroupNormNHWCParams<T> params_;
+  params_.withSilu = false;
+
+  const auto x_dims = x.dims();
+  dev_ctx.template Alloc<T>(y);
+  const T* x_data = x.data<T>();
+  T* y_data = y->data<T>();
+  const auto scale_ptr = scale.get_ptr();
+  const auto bias_ptr = bias.get_ptr();
+  const T* scale_data = nullptr;
+  if (scale_ptr) scale_data = scale_ptr->data<T>();
+  const T* bias_data = nullptr;
+  if (bias_ptr) bias_data = bias_ptr->data<T>();
+  params_.n = x_dims[0];
+  params_.c = x_dims[3];
+  params_.h = x_dims[1];
+  params_.w = x_dims[2];
+
+  dev_ctx.template Alloc<AccT>(mean);
+  dev_ctx.template Alloc<AccT>(var);
+  auto* mean_data = mean->data<AccT>();
+  auto* var_data = var->data<AccT>();
+  params_.var_data = var_data;
+
+  int32_t cPerBlock = 320;
+  int32_t maxBlocksPerHW = 1024;
+  switch (params_.c) {
+    case 2048:
+    case 1024:
+      cPerBlock = 512;
+      break;
+    case 960:
+    case 1920:
+      cPerBlock = 480;
+      break;
+    case 512:
+    case 256:
+      cPerBlock = 256;
+      break;
+    case 128:
+      cPerBlock = 128;
+      break;
+    default:
+      cPerBlock = 320;
+  }
+  params_.groups = groups;
+  params_.cPerGroup = params_.c / params_.groups;
+  if (cPerBlock % params_.cPerGroup != 0) {
+    cPerBlock = params_.cPerGroup;
+  }
+  params_.srcX = reinterpret_cast<const T*>(x_data);
+  params_.dst = reinterpret_cast<T*>(y_data);
+
+  params_.gamma = scale_data;
+  params_.beta = bias_data;
+  params_.hw = params_.h * params_.w;
+  const int32_t blocksPerHW = findMaxDivisor(params_.hw, maxBlocksPerHW);
+  params_.hwPerBlock = divUp(params_.hw, blocksPerHW);
+  params_.cPerBlock = cPerBlock;
+  params_.hwc = params_.hw * params_.c;
+  params_.invHWC = 1.F / static_cast<float>(params_.hw * params_.cPerGroup);
+  params_.eps = epsilon;
+  auto stream = dev_ctx.stream();
+  DenseTensor redBuffer;
+  int buffer_sizes = 2 * params_.n * groups;
+  redBuffer.Resize({1, buffer_sizes});
+  params_.redBuffer = dev_ctx.template Alloc<float>(&redBuffer);
+#ifdef PADDLE_WITH_HIP
+  hipMemset(params_.redBuffer, 0, buffer_sizes * sizeof(float));
+#else
+  cudaMemset(params_.redBuffer, 0, buffer_sizes * sizeof(float));
+#endif
+  groupNormNHWCSum<T> nhwc_sum;
+  nhwc_sum(&params_, stream);
+  groupNormNHWCScale<T> nhwc_scale;
+  nhwc_scale(params_, stream);
+#ifdef PADDLE_WITH_HIP
+  phi::backends::gpu::GpuMemcpyAsync(mean_data,
+                                     params_.redBuffer,
+                                     params_.n * groups * sizeof(float),
+                                     hipMemcpyDeviceToHost,
+                                     stream);
+#else
+  phi::backends::gpu::GpuMemcpyAsync(mean_data,
+                                     params_.redBuffer,
+                                     params_.n * groups * sizeof(float),
+                                     cudaMemcpyDeviceToHost,
+                                     stream);
+#endif
+}
+
 template <typename T, typename AccT>
 __global__ void GroupNormForwardGetMeanAndVar(const T* x,
                                               int N,
@@ -947,16 +1049,16 @@ template class GroupNormDirectCUDAFunctor<half, float>;
 #endif
 
 template <typename T, typename Context>
-void GroupNormKernel(const Context& dev_ctx,
-                     const DenseTensor& x,
-                     const paddle::optional<DenseTensor>& scale,
-                     const paddle::optional<DenseTensor>& bias,
-                     float epsilon,
-                     int groups,
-                     const std::string& data_layout_str,
-                     DenseTensor* y,
-                     DenseTensor* mean,
-                     DenseTensor* var) {
+void GroupNormGeneralCaseKernel(const Context& dev_ctx,
+                                const DenseTensor& x,
+                                const paddle::optional<DenseTensor>& scale,
+                                const paddle::optional<DenseTensor>& bias,
+                                float epsilon,
+                                int groups,
+                                const std::string& data_layout_str,
+                                DenseTensor* y,
+                                DenseTensor* mean,
+                                DenseTensor* var) {
   using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
   const DataLayout data_layout = phi::StringToDataLayout(data_layout_str);
   const auto scale_ptr = scale.get_ptr();
@@ -1145,6 +1247,52 @@ void GroupNormKernel(const Context& dev_ctx,
       }
     }
   }
+}
+
+template <typename T, typename Context>
+void GroupNormKernel(const Context& dev_ctx,
+                     const DenseTensor& x,
+                     const paddle::optional<DenseTensor>& scale,
+                     const paddle::optional<DenseTensor>& bias,
+                     float epsilon,
+                     int groups,
+                     const std::string& data_layout_str,
+                     DenseTensor* y,
+                     DenseTensor* mean,
+                     DenseTensor* var) {
+  using std::is_same;
+  if (is_same<T, phi::dtype::float16>::value && data_layout_str == "NHWC") {
+    GroupNormNHWCKernel<phi::dtype::float16, Context>(dev_ctx,
+                                                      x,
+                                                      scale,
+                                                      bias,
+                                                      epsilon,
+                                                      groups,
+                                                      data_layout_str,
+                                                      y,
+                                                      mean,
+                                                      var);
+    return;
+  }
+
+#ifdef PADDLE_CUDA_BF16
+  if (is_same<T, phi::dtype::bfloat16>::value && data_layout_str == "NHWC") {
+    GroupNormNHWCKernel<phi::dtype::bfloat16, Context>(dev_ctx,
+                                                       x,
+                                                       scale,
+                                                       bias,
+                                                       epsilon,
+                                                       groups,
+                                                       data_layout_str,
+                                                       y,
+                                                       mean,
+                                                       var);
+    return;
+  }
+#endif
+
+  GroupNormGeneralCaseKernel<T, Context>(
+      dev_ctx, x, scale, bias, epsilon, groups, data_layout_str, y, mean, var);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/group_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_kernel.cu
@@ -706,28 +706,51 @@ __global__ void GroupNormForwardGetMeanAndVar(const T* x,
                                               int group_size,
                                               AccT* mean,
                                               AccT* var) {
-  int gid = blockIdx.y;
-  int cid = blockIdx.x;
-  int bid = blockIdx.z;
-  int H = imsize / W;
-  int number = min(group_size, static_cast<int>(C - gid * group_size));
-  int ccid = gid * group_size + cid;
-  if (ccid >= C) return;
+  int hid = blockIdx.x;
+  int bid = blockIdx.y;
+  int gwsize = groups * W;
   AccT x_mean = static_cast<AccT>(0);
   AccT x_var = static_cast<AccT>(0);
-  for (int imid = threadIdx.x; imid < imsize; imid += blockDim.x) {
-    AccT val;
-    int hid = imid / W;
-    int wid = imid % W;
-    val = static_cast<AccT>(x[(bid * H + hid) * W * C + wid * C + ccid]);
 
-    x_mean += val;
-    x_var += val * val;
+#ifdef __HIPCC__
+  __shared__ AccT smem_m[256];
+  __shared__ AccT smem_v[256];
+#else
+  __shared__ AccT smem_m[1024];
+  __shared__ AccT smem_v[1024];
+#endif
+
+  for (int gwid = threadIdx.x; gwid < gwsize; gwid += blockDim.x) {
+    int index_gw = bid * C * imsize + hid * C * W + gwid * group_size;
+    x_mean = static_cast<AccT>(0);
+    x_var = static_cast<AccT>(0);
+    AccT val;
+#pragma unroll
+    for (int gsid = 0; gsid < group_size; ++gsid) {
+      int index_gs = index_gw + gsid;
+      val = static_cast<AccT>(x[index_gs]);
+
+      x_mean += val;
+      x_var += val * val;
+    }
+    x_mean /= group_size * imsize;
+    x_var /= group_size * imsize;
+
+    int sid = gwid % blockDim.x;
+    smem_m[sid] = x_mean;
+    smem_v[sid] = x_var;
+    __syncthreads();
+
+    if (sid < groups) {
+      for (sid = sid + groups; sid < blockDim.x; sid += groups) {
+        x_mean += smem_m[sid];
+        x_var += smem_v[sid];
+      }
+
+      phi::CudaAtomicAdd(&mean[bid * groups + gwid % groups], x_mean);
+      phi::CudaAtomicAdd(&var[bid * groups + gwid % groups], x_var);
+    }
   }
-  x_mean /= number * imsize;
-  x_var /= number * imsize;
-  CudaAtomicAddWithWarp(&mean[bid * groups + gid], x_mean);
-  CudaAtomicAddWithWarp(&var[bid * groups + gid], x_var);
 }
 
 template <typename T, typename AccT, int flags>
@@ -783,6 +806,72 @@ __global__ void GroupNormForward(const T* x,
       y[index] = static_cast<T>(val);
     } else {
       y[(bid * H + hid) * W * C + wid * C + ccid] = static_cast<T>(val);
+    }
+  }
+}
+
+template <typename T, typename AccT, int flags, int VecSize = 2>
+__global__ void GroupNormForwardNHWC(const T* x,
+                                     const AccT* mean,
+                                     const AccT* var,
+                                     const T* scale,
+                                     const T* bias,
+                                     int N,
+                                     int C,
+                                     int W,
+                                     int imsize,
+                                     int groups,
+                                     int group_size,
+                                     AccT epsilon,
+                                     T* y,
+                                     AccT* real_var,
+                                     const DataLayout data_layout) {
+  int index = (blockIdx.x * blockDim.x + threadIdx.x) * VecSize;
+  int stride = gridDim.x * blockDim.x * VecSize;
+  int hwc_size = imsize * C;
+  int size = N * hwc_size;
+  int deal_size = blockDim.x * VecSize;
+  AccT x_value[VecSize];
+  int ng_value[VecSize];
+  int gs_value[VecSize];
+  int h_value[VecSize];
+  int rem_value[VecSize];
+
+  for (; index < size; index += stride) {
+#pragma unroll
+    for (int nx = 0; nx < VecSize; ++nx) {
+      x_value[nx] = static_cast<AccT>(x[index + nx]);
+
+      int index_nx = index + nx;
+      int index_n = index_nx / hwc_size;
+      int index_r = index_nx - index_n * hwc_size;
+      rem_value[nx] = index_r % C;
+      int index_g = rem_value[nx] / group_size;
+      ng_value[nx] = index_n * groups + index_g;
+      gs_value[nx] = rem_value[nx] - index_g * group_size;
+      h_value[nx] = index_r / (W * C);
+    }
+#pragma unroll
+    for (int nx = 0; nx < VecSize; ++nx) {
+      AccT x_mean = mean[ng_value[nx]];
+      AccT x_var = var[ng_value[nx]];
+      x_var = x_var - x_mean * x_mean;
+
+      AccT var_inv = rsqrt(x_var + epsilon);
+
+      if (gs_value[nx] == 0 && h_value[nx] == 0) {
+        real_var[ng_value[nx]] = x_var;
+      }
+
+      x_value[nx] = (x_value[nx] - x_mean) * var_inv;
+      if (flags & kHasScale) {
+        x_value[nx] *= static_cast<AccT>(scale[rem_value[nx]]);
+      }
+      if (flags & kHasBias) {
+        x_value[nx] += static_cast<AccT>(bias[rem_value[nx]]);
+      }
+
+      y[index + nx] = static_cast<T>(x_value[nx]);
     }
   }
 }
@@ -853,6 +942,13 @@ void GroupNormDirectCUDAFunctor<T, AccT>::operator()(
     cudaMemset(temp_variance, 0, sizeof(AccT) * input_ddim[0] * groups);
 #endif
 
+#ifdef __HIPCC__
+    int block_size_nhwc = std::max(std::min(256, (groups * W)), 64);
+#else
+    int block_size_nhwc = std::min(1024, (groups * W));
+#endif
+    dim3 grid_get(input_ddim[1], input_ddim[0], 1);
+    dim3 threads_get(block_size_nhwc, 1, 1);
     phi::GroupNormForwardGetMeanAndVar<T, AccT>
         <<<grid, threads, 0, stream>>>(input,
                                        input_ddim[0],
@@ -939,7 +1035,14 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
     }
   }
 
+  int flags =
+      (scale_data != nullptr) * kHasScale + (bias_data != nullptr) * kHasBias;
+
+#ifdef __HIPCC__
+  int block_size = std::max(std::min(256, imsize), 64);
+#else
   int block_size = std::min(1024, imsize);
+#endif
 
   dim3 grid(group_size, groups, x_dims[0]);
   dim3 threads(block_size, 1, 1);
@@ -963,39 +1066,71 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
           <<<grids, blocks, 0, dev_ctx.stream()>>>(
               x_data, mean_data, temp_var_data, size);
     }
+
+    UNROLL_ALL_CASES(flags,
+                     GroupNormForward,
+                     x_data,
+                     mean_data,
+                     temp_var_data,
+                     scale_data,
+                     bias_data,
+                     x_dims[0],
+                     C,
+                     W,
+                     imsize,
+                     groups,
+                     group_size,
+                     static_cast<AccT>(epsilon),
+                     y_data,
+                     var_data,
+                     data_layout);
   } else {
     set_zero_AccT(dev_ctx, mean, static_cast<AccT>(0));
     set_zero_AccT(dev_ctx, &temp_var, static_cast<AccT>(0));
+#ifdef __HIPCC__
+    int block_size_nhwc = std::max(std::min(256, (groups * W)), 64);
+#else
+    int block_size_nhwc = std::min(1024, (groups * W));
+#endif
+    dim3 grid_get(x_dims[1], x_dims[0], 1);
+    dim3 threads_get(block_size_nhwc, 1, 1);
+
     GroupNormForwardGetMeanAndVar<T, AccT>
-        <<<grid, threads, 0, dev_ctx.stream()>>>(x_data,
-                                                 x_dims[0],
-                                                 C,
-                                                 W,
-                                                 imsize,
-                                                 groups,
-                                                 group_size,
-                                                 mean_data,
-                                                 temp_var_data);
+        <<<grid_get, threads_get, 0, dev_ctx.stream()>>>(x_data,
+                                                         x_dims[0],
+                                                         C,
+                                                         W,
+                                                         imsize,
+                                                         groups,
+                                                         group_size,
+                                                         mean_data,
+                                                         temp_var_data);
+
+    int numel = x.numel();
+    constexpr const int vec_size = 2;
+    auto config =
+        phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel, vec_size);
+    int grid_nhwc = config.block_per_grid.x;
+    int block_nhwc = config.thread_per_block.x;
+
+    UNROLL_ALL_CASES_VEC(flags,
+                         GroupNormForwardNHWC,
+                         x_data,
+                         mean_data,
+                         temp_var_data,
+                         scale_data,
+                         bias_data,
+                         x_dims[0],
+                         C,
+                         W,
+                         imsize,
+                         groups,
+                         group_size,
+                         static_cast<AccT>(epsilon),
+                         y_data,
+                         var_data,
+                         data_layout);
   }
-  int flags =
-      (scale_data != nullptr) * kHasScale + (bias_data != nullptr) * kHasBias;
-  UNROLL_ALL_CASES(flags,
-                   GroupNormForward,
-                   x_data,
-                   mean_data,
-                   temp_var_data,
-                   scale_data,
-                   bias_data,
-                   x_dims[0],
-                   C,
-                   W,
-                   imsize,
-                   groups,
-                   group_size,
-                   static_cast<AccT>(epsilon),
-                   y_data,
-                   var_data,
-                   data_layout);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/gpu/group_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_kernel.cu
@@ -968,15 +968,15 @@ void GroupNormDirectCUDAFunctor<T, AccT>::operator()(
     dim3 grid_get(input_ddim[1], input_ddim[0], 1);
     dim3 threads_get(block_size_nhwc, 1, 1);
     phi::GroupNormForwardGetMeanAndVar<T, AccT>
-        <<<grid, threads, 0, stream>>>(input,
-                                       input_ddim[0],
-                                       C,
-                                       W,
-                                       image_size,
-                                       groups,
-                                       group_size,
-                                       mean,
-                                       temp_variance);
+        <<<grid_get, threads_get, 0, stream>>>(input,
+                                               input_ddim[0],
+                                               C,
+                                               W,
+                                               image_size,
+                                               groups,
+                                               group_size,
+                                               mean,
+                                               temp_variance);
 
     auto* device_ctx = static_cast<phi::GPUContext*>(
         paddle::platform::DeviceContextPool::Instance().Get(
@@ -1117,6 +1117,7 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
   } else {
     set_zero_AccT(dev_ctx, mean, static_cast<AccT>(0));
     set_zero_AccT(dev_ctx, &temp_var, static_cast<AccT>(0));
+
 #ifdef __HIPCC__
     int block_size_nhwc = std::max(std::min(256, (groups * W)), 64);
 #else

--- a/paddle/phi/kernels/gpu/group_norm_utils.h
+++ b/paddle/phi/kernels/gpu/group_norm_utils.h
@@ -47,7 +47,7 @@ enum GroupNormKernelFlags { kHasScale = 1, kHasBias = 2 };
   CHECK_CASE(2, flags, kernel_name, __VA_ARGS__)  \
   CHECK_CASE(3, flags, kernel_name, __VA_ARGS__)
 
-#define CHECK_CASE_VEC(i, flags, kernel_name, ...)                     \
+#define CHECK_CASE_VEC(i, flags, vec_size, kernel_name, ...)           \
   if (i == flags) {                                                    \
     kernel_name<T, AccT, i, vec_size>                                  \
         <<<grid_nhwc, block_nhwc, 0, dev_ctx.stream()>>>(__VA_ARGS__); \
@@ -57,11 +57,11 @@ enum GroupNormKernelFlags { kHasScale = 1, kHasBias = 2 };
 // 1 for has scale, no bias
 // 2 for no scale, has bias
 // 3 for has scale, has bias
-#define UNROLL_ALL_CASES_VEC(flags, kernel_name, ...) \
-  CHECK_CASE_VEC(0, flags, kernel_name, __VA_ARGS__)  \
-  CHECK_CASE_VEC(1, flags, kernel_name, __VA_ARGS__)  \
-  CHECK_CASE_VEC(2, flags, kernel_name, __VA_ARGS__)  \
-  CHECK_CASE_VEC(3, flags, kernel_name, __VA_ARGS__)
+#define UNROLL_ALL_CASES_VEC(flags, vec_size, kernel_name, ...) \
+  CHECK_CASE_VEC(0, flags, vec_size, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_VEC(1, flags, vec_size, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_VEC(2, flags, vec_size, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_VEC(3, flags, vec_size, kernel_name, __VA_ARGS__)
 
 template <typename T>
 __device__ __inline__ void CudaAtomicAddWithWarp(T* sum, T value) {

--- a/paddle/phi/kernels/gpu/group_norm_utils.h
+++ b/paddle/phi/kernels/gpu/group_norm_utils.h
@@ -63,22 +63,6 @@ enum GroupNormKernelFlags { kHasScale = 1, kHasBias = 2 };
   CHECK_CASE_VEC(2, flags, kernel_name, __VA_ARGS__)  \
   CHECK_CASE_VEC(3, flags, kernel_name, __VA_ARGS__)
 
-#define CHECK_CASE_BACKWARD(i, flags, kernel_name, ...)                \
-  if (i == flags) {                                                    \
-    kernel_name<T, AccT, i>                                            \
-        <<<grid_nhwc, block_nhwc, 0, dev_ctx.stream()>>>(__VA_ARGS__); \
-  }
-
-// 0 for no scale, no bias
-// 1 for has scale, no bias
-// 2 for no scale, has bias
-// 3 for has scale, has bias
-#define UNROLL_ALL_CASES_BACKWARD(flags, kernel_name, ...) \
-  CHECK_CASE_BACKWARD(0, flags, kernel_name, __VA_ARGS__)  \
-  CHECK_CASE_BACKWARD(1, flags, kernel_name, __VA_ARGS__)  \
-  CHECK_CASE_BACKWARD(2, flags, kernel_name, __VA_ARGS__)  \
-  CHECK_CASE_BACKWARD(3, flags, kernel_name, __VA_ARGS__)
-
 template <typename T>
 __device__ __inline__ void CudaAtomicAddWithWarp(T* sum, T value) {
   typedef cub::WarpReduce<T> WarpReduce;

--- a/paddle/phi/kernels/gpu/group_norm_utils.h
+++ b/paddle/phi/kernels/gpu/group_norm_utils.h
@@ -23,9 +23,9 @@ namespace cub = hipcub;
 #endif
 
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/kernels/primitive/kernel_primitives.h"
-
 namespace phi {
 
 enum GroupNormKernelFlags { kHasScale = 1, kHasBias = 2 };
@@ -46,6 +46,38 @@ enum GroupNormKernelFlags { kHasScale = 1, kHasBias = 2 };
   CHECK_CASE(1, flags, kernel_name, __VA_ARGS__)  \
   CHECK_CASE(2, flags, kernel_name, __VA_ARGS__)  \
   CHECK_CASE(3, flags, kernel_name, __VA_ARGS__)
+
+#define CHECK_CASE_VEC(i, flags, kernel_name, ...)                     \
+  if (i == flags) {                                                    \
+    kernel_name<T, AccT, i, vec_size>                                  \
+        <<<grid_nhwc, block_nhwc, 0, dev_ctx.stream()>>>(__VA_ARGS__); \
+  }
+
+// 0 for no scale, no bias
+// 1 for has scale, no bias
+// 2 for no scale, has bias
+// 3 for has scale, has bias
+#define UNROLL_ALL_CASES_VEC(flags, kernel_name, ...) \
+  CHECK_CASE_VEC(0, flags, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_VEC(1, flags, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_VEC(2, flags, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_VEC(3, flags, kernel_name, __VA_ARGS__)
+
+#define CHECK_CASE_BACKWARD(i, flags, kernel_name, ...)                \
+  if (i == flags) {                                                    \
+    kernel_name<T, AccT, i>                                            \
+        <<<grid_nhwc, block_nhwc, 0, dev_ctx.stream()>>>(__VA_ARGS__); \
+  }
+
+// 0 for no scale, no bias
+// 1 for has scale, no bias
+// 2 for no scale, has bias
+// 3 for has scale, has bias
+#define UNROLL_ALL_CASES_BACKWARD(flags, kernel_name, ...) \
+  CHECK_CASE_BACKWARD(0, flags, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_BACKWARD(1, flags, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_BACKWARD(2, flags, kernel_name, __VA_ARGS__)  \
+  CHECK_CASE_BACKWARD(3, flags, kernel_name, __VA_ARGS__)
 
 template <typename T>
 __device__ __inline__ void CudaAtomicAddWithWarp(T* sum, T value) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-70459

重写了GroupNormForwardGetMeanAndVar、GroupNormBackwardGetMeanAndVar，新增了GroupNormForwardNHWC
GroupNormForward优化前后耗时对比
![4cb34ec673104d4fb046bc88e5f80c03](https://github.com/PaddlePaddle/Paddle/assets/137985359/6f7c2e32-012b-4e06-90e5-e89d8fa373a7)
GroupNormForwardGetMeanAndVar优化前后耗时对比
![fefcb2731c98c140b596d86e80dd6f21](https://github.com/PaddlePaddle/Paddle/assets/137985359/524240c6-3b95-4e24-b552-13675e8e846b)
GroupNormBackwardGetMeanAndVar优化前后耗时对比
![6340e5ac3a65674cc68da667971a5af0](https://github.com/PaddlePaddle/Paddle/assets/137985359/c1431bb4-5cc7-4a4f-91e3-f0c37e50efac)
