### PR TITLE
Increase absolute error of test_group_norm_op

### DIFF
--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -357,13 +357,16 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.attrs['epsilon'] = 0.5
         self.shape = (1, 100, 4, 4)
         self.dtype = np.float16
-        
+
     def test_check_output(self):
         rtol = 2e-3
         atol = 2e-3
         inplace_atol = 2e-3
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, rtol=rtol, atol=atol, inplace_atol=inplace_atol)
+        self.check_output_with_place(
+            place, rtol=rtol, atol=atol, inplace_atol=inplace_atol
+        )
+
 
 class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
     def setUp(self):

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -357,38 +357,13 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.attrs['epsilon'] = 0.5
         self.shape = (1, 100, 4, 4)
         self.dtype = np.float16
-        input = np.sin(
-            np.arange(
-                self.shape[0] * self.shape[1] * self.shape[2] * self.shape[3]
-            )
-        )
-        input = np.transpose(input.reshape(self.shape), (0, 2, 3, 1)).astype(
-            self.dtype
-        )
-        scale = np.sin(np.arange(self.shape[1])).astype(self.dtype)
-        bias = np.sin(np.arange(self.shape[1])).astype(self.dtype)
-        output, mean, var = group_norm_naive(
-            input,
-            scale,
-            bias,
-            self.attrs['epsilon'],
-            self.attrs['groups'],
-            self.data_format,
-        )
-
-        self.inputs = {
-            'X': OpTest.np_dtype_to_fluid_dtype(input),
-            'Scale': OpTest.np_dtype_to_fluid_dtype(scale),
-            'Bias': OpTest.np_dtype_to_fluid_dtype(bias),
-        }
-        self.outputs = {'Y': output, 'Mean': mean, 'Variance': var}
-        self.attrs['data_layout'] = self.data_format
-
+        
     def test_check_output(self):
         rtol = 2e-3
+        atol = 2e-3
+        inplace_atol = 2e-3
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, rtol=rtol)
-
+        self.check_output_with_place(place, rtol=rtol, atol=atol, inplace_atol=inplace_atol)
 
 class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
     def setUp(self):


### PR DESCRIPTION
### PR types

Bug fixes
### PR changes
OPs

### Description
Pcard-71501
https://github.com/PaddlePaddle/Paddle/pull/55399%E8%BF%99%E4%B8%AApr 修改了group_norm算子，当数据类型是fp16或bf16，数据格式为NHWC的实现，会导致随机测试group_norm失败，所以修改测试绝对误差阈值，并且，在本地测试，数据范围为n:1-3，c:1-1921，h=128，w=128，fp16和fp32单个数据相差不超过0.001953125，bf16单个数据相差不超过0.015625。
