### PR TITLE
[paddle-trt] x and y 's rank should be same in trt_skip_layernorm_pass

### DIFF
--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -154,7 +154,7 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
     VLOG(4) << "handle TrtSkipLayerNorm fuse";
 
     // x and y 's rank must be same
-    if (subgraph.at(x)->V1ar()->GetShape().size() !=
+    if (subgraph.at(x)->Var()->GetShape().size() !=
         subgraph.at(y)->Var()->GetShape().size()) {
       return;
     }

--- a/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/trt_skip_layernorm_fuse_pass.cc
@@ -152,6 +152,13 @@ void TrtSkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
     }
 
     VLOG(4) << "handle TrtSkipLayerNorm fuse";
+
+    // x and y 's rank must be same
+    if (subgraph.at(x)->V1ar()->GetShape().size() !=
+        subgraph.at(y)->Var()->GetShape().size()) {
+      return;
+    }
+
     GET_IR_NODE_FROM_SUBGRAPH(elementwise, elementwise, fused_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(elementwise_out, elementwise_out, fused_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(layer_norm, layer_norm, fused_pattern);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
P-card-71501
- 修复pass错误，约束不严谨
