### PR TITLE
fix: support str_value of Scalar is bool dtype

### DIFF
--- a/paddle/phi/common/scalar.h
+++ b/paddle/phi/common/scalar.h
@@ -110,6 +110,12 @@ class ScalarBase {
       data_.f64 = -std::numeric_limits<double>::infinity();
     } else if (str_value == "nan") {
       data_.f64 = std::numeric_limits<double>::quiet_NaN();
+    } else if (str_value == "True") {
+      dtype_ = DataType::BOOL;
+      data_.b = true;
+    } else if (str_value == "Fasle") {
+      dtype_ = DataType::BOOL;
+      data_.b = false;
     } else {
       // NOTE(chenfeiyu): to support subnormal floating point number
       // std::stod cannot handle subnormal values


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
部分接口的`str_value`可以接受bool类型，例如：`fill_constant_batch_size_like`。原代码会导致bool类型的单测执行结果错误。
![image](https://github.com/PaddlePaddle/Paddle/assets/31957460/9f9552a0-8bf3-4396-bdfb-154446b17739)

复现单测如下（来源于[PaddleCustomDevice](https://github.com/PaddlePaddle/PaddleCustomDevice/blob/a872bc34ebbc270d41c82f00faaee60c679b40e0/backends/npu/tests/unittests/test_fill_constant_batch_size_like_op_npu.py#L4)）：
```python
class TestFillConstantBatchSizeLike(OpTest):
    def setUp(self):
        self.op_type = "fill_constant_batch_size_like"
        self.init_shape()
        self.init_value()
        self.init_dtype()
        self.init_force_cpu()
        self.init_dim_idx()

        self.inputs = {"Input": np.random.random(self.input_shape).astype("float32")}
        self.attrs = {
            "shape": self.shape,
            "value": self.value,
            "str_value": self.str_value,
            "dtype": self.dtype,
            "force_cpu": self.force_cpu,
            "input_dim_idx": self.input_dim_idx,
            "output_dim_idx": self.output_dim_idx,
        }
        self.outputs = {
            "Out": np.full(self.output_shape, self.output_value, self.output_dtype)
        }

    def init_shape(self):
        self.input_shape = [4, 5]
        self.shape = [123, 92]
        self.output_shape = (4, 92)

    def init_value(self):
        self.value = True
        self.str_value = "True"
        self.output_value = True

    def init_dtype(self):
        self.dtype = core.VarDesc.VarType.FP32
        self.output_dtype = np.float32

    def init_force_cpu(self):
        self.force_cpu = False

    def init_dim_idx(self):
        self.input_dim_idx = 0
        self.output_dim_idx = 0

    def test_check_output(self):
        self.check_output()

```