### PR TITLE
Reduce the workspace for TRT index_select UT

### DIFF
--- a/test/ir/inference/test_trt_convert_index_select.py
+++ b/test/ir/inference/test_trt_convert_index_select.py
@@ -187,7 +187,7 @@ class TrtConvertIndexSelectTest(TrtLayerAutoScanTest):
         yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-3
 
     def test(self):
-        self.trt_param.workspace_size = 1 << 60
+        self.trt_param.workspace_size = 1 << 10
         self.run_test()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
UT `test_trt_convert_index_select` sets too large workspace for TensorRT.

This MR changes the workspace from `1 << 60` to `1 << 10`.