### PR TITLE
[NewIR] Increase some log level in ir to avoid too much log

### DIFF
--- a/paddle/ir/core/op_info_impl.cc
+++ b/paddle/ir/core/op_info_impl.cc
@@ -121,7 +121,7 @@ void *OpInfoImpl::GetInterfaceImpl(TypeId interface_id) const {
 }
 
 void OpInfoImpl::Destroy() {
-  VLOG(6) << "Destroy op_info impl at " << this;
+  VLOG(10) << "Destroy op_info impl at " << this;
   // (1) free interfaces
   char *base_ptr = reinterpret_cast<char *>(this) -
                    sizeof(ir::TypeId) * num_traits_ -
@@ -134,7 +134,7 @@ void OpInfoImpl::Destroy() {
     }
   }
   // (2) free memeory
-  VLOG(6) << "Free base_ptr " << reinterpret_cast<void *>(base_ptr);
+  VLOG(10) << "Free base_ptr " << reinterpret_cast<void *>(base_ptr);
   free(base_ptr);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

提高`OpInfoImpl`析构时log的等级，避免程序结束时打印如下过长的析构log信息而冲掉命令行的其他关键调试log。
<img width="634" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/13048366/b8924e76-51ca-46b8-9359-259305dd988c">
