### PR TITLE
Fix error in docstring for flatten function

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1499,7 +1499,7 @@ def flatten(x, start_axis=0, stop_axis=-1, name=None):
             end_axis = 2
 
           We get:
-            Out.shape = (3, 1000 * 100, 2)
+            Out.shape = (3, 100 * 100, 4)
 
         Case 2:
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Docs

### Description
<!-- Describe what you’ve done -->
Flatten function docstring initially displayed output shape as (3, 1000 * 100, 2) instead of he correct (3, 100 * 100, 4). This was a misleading case for the function