### PR TITLE
fix ccache print information

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3153,7 +3153,7 @@ function collect_ccache_hits() {
     ccache_version=$(ccache -V | grep "ccache version" | awk '{print $3}')
     echo "$ccache_version"
     if [[ $ccache_version == 4* ]] ; then
-        rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
+        rate=$(ccache -s | grep "Hits" | awk 'NR==1 {print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
         echo "ccache hit rate: ${rate}%"
     else
         rate=$(ccache -s | grep 'cache hit rate' | awk '{print $4}')

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3149,8 +3149,9 @@ function exec_samplecode_test() {
 
 
 function collect_ccache_hits() {
-    rate=$(ccache -s | grep 'cache hit rate' | awk '{print $4}')
-    echo "ccache hit rate: ${rate}%"
+    ccache -s
+    rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
+    echo "ccache hit rate: ${rate}"
     echo "ipipe_log_param_Ccache_Hit_Rate: ${rate}%" >> ${PADDLE_ROOT}/build/build_summary.txt
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3153,7 +3153,6 @@ function collect_ccache_hits() {
     ccache_version=$(ccache -V | grep "ccache version" | awk '{print $3}')
     echo "$ccache_version"
     if [[ $ccache_version == 4* ]] ; then
-        
         rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
         echo "ccache hit rate: ${rate}%"
     else

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3151,13 +3151,16 @@ function exec_samplecode_test() {
 function collect_ccache_hits() {
     ccache -s
     ccache_version=$(ccache -V | grep "ccache version" | awk '{print $3}')
-    if [ ${ccache_version} != "4.8.2" ] ; then
-        rate=$(ccache -s | grep 'cache hit rate' | awk '{print $4}')
+    echo "$ccache_version"
+    if [[ $ccache_version == 4* ]] ; then
+        
+        rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
         echo "ccache hit rate: ${rate}%"
     else
-        rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
+        rate=$(ccache -s | grep 'cache hit rate' | awk '{print $4}')
         echo "ccache hit rate: ${rate}"
     fi
+
     echo "ipipe_log_param_Ccache_Hit_Rate: ${rate}%" >> ${PADDLE_ROOT}/build/build_summary.txt
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3150,8 +3150,14 @@ function exec_samplecode_test() {
 
 function collect_ccache_hits() {
     ccache -s
-    rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
-    echo "ccache hit rate: ${rate}"
+    ccache_version=$(ccache -V | grep "ccache version" | awk '{print $3}')
+    if [ ${ccache_version} != "4.8.2" ] ; then
+        rate=$(ccache -s | grep 'cache hit rate' | awk '{print $4}')
+        echo "ccache hit rate: ${rate}%"
+    else
+        rate=$(ccache -s | grep "Hits" | awk '{print $5}' | cut -d '(' -f2 | cut -d ')' -f1)
+        echo "ccache hit rate: ${rate}"
+    fi
     echo "ipipe_log_param_Ccache_Hit_Rate: ${rate}%" >> ${PADDLE_ROOT}/build/build_summary.txt
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
ccache升级到最新4.x之后，ccache -s 显示如下，和原来低版本显示的不一样，导致ci日志看不到ccache命中率
![image](https://github.com/PaddlePaddle/Paddle/assets/62429225/ed5032ab-3443-4485-ab6f-66faa32528e1)
