### PR TITLE
[ROCM] fix profiler compilation error on dtk23.04

### DIFF
--- a/cmake/cupti.cmake
+++ b/cmake/cupti.cmake
@@ -4,7 +4,7 @@ endif()
 
 if(WITH_ROCM)
   set(CUPTI_ROOT
-      "${ROCM_PATH}/CUPTI"
+      "${ROCM_PATH}/cuda/extras/CUPTI"
       CACHE PATH "CUPTI ROOT")
 else()
   set(CUPTI_ROOT
@@ -52,6 +52,10 @@ find_library(
 get_filename_component(CUPTI_LIBRARY_PATH ${CUPTI_LIBRARY} DIRECTORY)
 if(CUPTI_INCLUDE_DIR AND CUPTI_LIBRARY)
   set(CUPTI_FOUND ON)
+  if(WITH_ROCM)
+    include_directories(${ROCM_PATH}/cuda/include)
+    add_definitions(-D__CUDA_HIP_PLATFORM_AMD__)
+  endif()
 else()
   set(CUPTI_FOUND OFF)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
fix profiler compilation error on dtk23.04
