### PR TITLE
fix trainable in Parameter

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -7170,6 +7170,8 @@ class Parameter(Variable, metaclass=ParameterMetaClass):
         )
         self.trainable = kwargs.get('trainable', True)
 
+        self.stop_gradient = not self.trainable
+
         self.optimize_attr = kwargs.get('optimize_attr', {'learning_rate': 1.0})
 
         self.regularizer = kwargs.get('regularizer', None)

--- a/test/legacy_test/test_trainable.py
+++ b/test/legacy_test/test_trainable.py
@@ -20,6 +20,8 @@ from simple_nets import init_data
 import paddle
 from paddle import fluid
 
+paddle.enable_static()
+
 
 def test_trainable():
     x = paddle.static.data(name='image', shape=[-1, 784], dtype='float32')
@@ -68,12 +70,12 @@ class TestTrainable(unittest.TestCase):
         self.check_trainable(
             test_trainable,
             feed_dict,
-            op_count={'adam': 1, 'scale': 0, 'mul_grad': 1},
+            op_count={'adam': 1, 'scale': 0, 'mul_grad': 0},
         )
         self.check_trainable(
             test_trainable,
             feed_dict,
-            op_count={'adamax': 1, 'scale': 1, 'mul_grad': 1},
+            op_count={'adamax': 1, 'scale': 1, 'mul_grad': 0},
             optimizer=paddle.optimizer.Adamax(learning_rate=0.2),
         )
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67005

In class `Parameter`, there are two flags of trainable,  `self.trainable (set by API)` and `self.stop_gradient (inherited from Variable)`.  However, these two flags are not  independent while they control the same thing. (e.g. , `self.trainable` is False, while `self.stop_gradient` is False, too)

This may cause training issues with precision.

- In `fluid.optimizer.Optimizer`, whether a Parameter is trainable is determined by `self.trainable`. https://github.com/PaddlePaddle/Paddle/blob/v2.5.1/python/paddle/fluid/optimizer.py#L1396

- In `paddle.optimizer.Optimizer`, whether  a Parameter is trainable is determined by `self.stop_gradient`. https://github.com/PaddlePaddle/Paddle/blob/v2.5.1/python/paddle/optimizer/optimizer.py#L1371

In theory they should be equivalent, but the above problem leads to different results.