### PR TITLE
Add WITH_MKLDNN check into target test_save_optimized_model_pass

### DIFF
--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -174,7 +174,9 @@ if(WITH_GPU AND TENSORRT_FOUND)
   set_tests_properties(test_trt_inspector PROPERTIES TIMEOUT 60)
   set_tests_properties(test_trt_inference_predictor PROPERTIES TIMEOUT 60)
   set_tests_properties(test_trt_inference_fp16_io PROPERTIES TIMEOUT 300)
-  set_tests_properties(test_save_optimized_model_pass PROPERTIES TIMEOUT 300)
+  if(WITH_MKLDNN)
+    set_tests_properties(test_save_optimized_model_pass PROPERTIES TIMEOUT 300)
+  endif()
 
   if(WITH_NV_JETSON)
     set_tests_properties(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
The target `test_save_optimized_model_pass` is set when `WITH_MKLDNN` is `ON`.

Hence, before setting its property, we need to check option `WITH_MKLDNN` is `ON` or not.