### PR TITLE
[Prim] Fix get var in prim when list of single tensor

### DIFF
--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -381,12 +381,13 @@ class TestStackListOfSingleTensor(unittest.TestCase):
         paddle.seed(2022)
         self.x = [paddle.randn((4, 2, 6), dtype="float32")]
 
-    def test_amp_nchw(self):
+    def test_list_single_tensor(self):
         expect = paddle.stack(self.x)
         paddle.fluid.core._set_prim_all_enabled(True)
         st_model = paddle.jit.to_static(paddle.stack)
         actual = st_model(self.x)
         np.testing.assert_allclose(expect, actual)
+        paddle.enable_static()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -375,5 +375,19 @@ class TestStackAPI_ZeroDim(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestStackListOfSingleTensor(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        paddle.seed(2022)
+        self.x = [paddle.randn((4, 2, 6), dtype="float32")]
+
+    def test_amp_nchw(self):
+        expect = paddle.stack(self.x)
+        paddle.fluid.core._set_prim_all_enabled(True)
+        st_model = paddle.jit.to_static(paddle.stack)
+        actual = st_model(self.x)
+        np.testing.assert_allclose(expect, actual)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-66975
Fix case: 
When Fix input value is list of single tensor, corresponding var value in block will be unpacked as single tensor.
