### PR TITLE
Refine interface of hlir::framework::Instruction

### DIFF
--- a/paddle/cinn/hlir/framework/instruction.cc
+++ b/paddle/cinn/hlir/framework/instruction.cc
@@ -365,7 +365,7 @@ void Instruction::Run(
   //   }
 }
 
-std::string Instruction::DumpInstruction() {
+std::string Instruction::DumpInstruction() const {
   std::stringstream ss;
   ss << "Instruction {" << std::endl;
   for (size_t i = 0; i < fn_names_.size(); ++i) {

--- a/paddle/cinn/hlir/framework/instruction.h
+++ b/paddle/cinn/hlir/framework/instruction.h
@@ -132,13 +132,17 @@ class Instruction {
 
   int size() { return fn_ptrs_.size(); }
 
-  std::string DumpInstruction();
+  std::string DumpInstruction() const;
 
-  std::vector<std::vector<std::string>> GetInArgs() { return in_args_; }
-  std::vector<std::vector<std::string>> GetOutArgs() { return out_args_; }
+  const std::vector<std::vector<std::string>>& GetInArgs() const {
+    return in_args_;
+  }
+  const std::vector<std::vector<std::string>>& GetOutArgs() const {
+    return out_args_;
+  }
   void ClearInArgs() { in_args_.clear(); }
   void ClearOutArgs() { out_args_.clear(); }
-  std::vector<std::string> GetFnNames() { return fn_names_; }
+  const std::vector<std::string>& GetFnNames() const { return fn_names_; }
   void AddInArgs(const std::vector<std::string>& in_args) {
     in_args_.push_back(in_args);
   }

--- a/paddle/cinn/hlir/framework/program.cc
+++ b/paddle/cinn/hlir/framework/program.cc
@@ -140,9 +140,9 @@ void Program::Export(const std::vector<std::string>& persistent_vars,
   int instplaceholder = writeplaceholder(4 * 3, insnum, f);
   int findex = 0;
   for (auto& ins : instrs_) {
-    auto in_args = ins->GetInArgs();
-    auto out_args = ins->GetOutArgs();
-    auto fn_names = ins->GetFnNames();
+    auto& in_args = ins->GetInArgs();
+    auto& out_args = ins->GetOutArgs();
+    auto& fn_names = ins->GetFnNames();
     for (int i = 0; i < fn_names.size(); i++, findex++) {
       std::vector<std::string> all_args(in_args[i].begin(), in_args[i].end());
       all_args.insert(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
+ `DumpInstruction` 函数没有修改成员变量，应该用 const 修饰
+  `GetInArgs`、`GetOutArgs`等三个函数有两处可以优化：①用 const 修饰 ② 返回引用，避免copy