### PR TITLE
[CustomOP] InferDtypeFn supports attrs

### DIFF
--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -643,36 +643,72 @@ struct InferShapeFuncImpl<Return (*)(Args...), impl_fn> {
 // Record Op Infer dtype core function
 using InferDtypeFunc = std::vector<DataType> (*)(
     const std::vector<DataType>& input_dtypes,
-    const std::vector<std::vector<DataType>>& vec_input_dtypes);
+    const std::vector<std::vector<DataType>>& vec_input_dtypes,
+    const std::vector<paddle::any>& attrs);
 
-#define PD_SPECIALIZE_InferDtypeCallHelper_TO_DTYPE(input_type)              \
+#define PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPE(input_type)     \
+  template <typename... Tail>                                        \
+  struct InferDtypeCallHelper<input_type, Tail...> {                 \
+    template <int in_idx,                                            \
+              int vec_in_idx,                                        \
+              int attr_idx,                                          \
+              typename... PreviousArgs>                              \
+    static Return InferDtype(                                        \
+        const std::vector<DataType>& input_dtypes,                   \
+        const std::vector<std::vector<DataType>>& vec_input_dtypes,  \
+        const std::vector<paddle::any>& attrs,                       \
+        const PreviousArgs&... pargs) {                              \
+      input_type arg = input_dtypes[in_idx];                         \
+      return InferDtypeCallHelper<Tail...>::                         \
+          template InferDtype<in_idx + 1, vec_in_idx, attr_idx>(     \
+              input_dtypes, vec_input_dtypes, attrs, pargs..., arg); \
+    }                                                                \
+  }
+
+#define PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPES(input_type)    \
+  template <typename... Tail>                                        \
+  struct InferDtypeCallHelper<input_type, Tail...> {                 \
+    template <int in_idx,                                            \
+              int vec_in_idx,                                        \
+              int attr_idx,                                          \
+              typename... PreviousArgs>                              \
+    static Return InferDtype(                                        \
+        const std::vector<DataType>& input_dtypes,                   \
+        const std::vector<std::vector<DataType>>& vec_input_dtypes,  \
+        const std::vector<paddle::any>& attrs,                       \
+        const PreviousArgs&... pargs) {                              \
+      input_type arg = vec_input_dtypes[vec_in_idx];                 \
+      return InferDtypeCallHelper<Tail...>::                         \
+          template InferDtype<in_idx, vec_in_idx + 1, attr_idx>(     \
+              input_dtypes, vec_input_dtypes, attrs, pargs..., arg); \
+    }                                                                \
+  }
+
+#define PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(attr_type)               \
   template <typename... Tail>                                                \
-  struct InferDtypeCallHelper<input_type, Tail...> {                         \
-    template <int in_idx, int vec_in_idx, typename... PreviousArgs>          \
+  struct InferDtypeCallHelper<attr_type, Tail...> {                          \
+    template <int in_idx,                                                    \
+              int vec_in_idx,                                                \
+              int attr_idx,                                                  \
+              typename... PreviousArgs>                                      \
     static Return InferDtype(                                                \
         const std::vector<DataType>& input_dtypes,                           \
         const std::vector<std::vector<DataType>>& vec_input_dtypes,          \
+        const std::vector<paddle::any>& attrs,                               \
         const PreviousArgs&... pargs) {                                      \
-      input_type arg = input_dtypes[in_idx];                                 \
-      return InferDtypeCallHelper<Tail...>::template InferDtype<in_idx + 1,  \
-                                                                vec_in_idx>( \
-          input_dtypes, vec_input_dtypes, pargs..., arg);                    \
+      try {                                                                  \
+        attr_type arg = paddle::any_cast<attr_type>(attrs[attr_idx]);        \
+        return InferDtypeCallHelper<Tail...>::                               \
+            template InferDtype<in_idx, vec_in_idx, attr_idx + 1>(           \
+                input_dtypes, vec_input_dtypes, attrs, pargs..., arg);       \
+      } catch (paddle::bad_any_cast&) {                                      \
+        PD_THROW(                                                            \
+            "Attribute cast error in custom operator InferDtypeFn. "         \
+            "Expected " #attr_type                                           \
+            " value. InferDtypeFn's attribute list must be exactly same as " \
+            "Forward KernelFn's attribute list");                            \
+      }                                                                      \
     }                                                                        \
-  }
-
-#define PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPES(input_type)   \
-  template <typename... Tail>                                       \
-  struct InferDtypeCallHelper<input_type, Tail...> {                \
-    template <int in_idx, int vec_in_idx, typename... PreviousArgs> \
-    static Return InferDtype(                                       \
-        const std::vector<DataType>& input_dtypes,                  \
-        const std::vector<std::vector<DataType>>& vec_input_dtypes, \
-        const PreviousArgs&... pargs) {                             \
-      input_type arg = vec_input_dtypes[vec_in_idx];                \
-      return InferDtypeCallHelper<Tail...>::                        \
-          template InferDtype<in_idx, vec_in_idx + 1>(              \
-              input_dtypes, vec_input_dtypes, pargs..., arg);       \
-    }                                                               \
   }
 
 template <typename F, F f>
@@ -682,35 +718,39 @@ template <typename Return, typename... Args, Return (*impl_fn)(Args...)>
 struct InferDtypeFuncImpl<Return (*)(Args...), impl_fn> {
   static Return InferDtype(
       const std::vector<DataType>& input_dtypes,
-      const std::vector<std::vector<DataType>>& vec_input_dtypes) {
-    return InferDtypeCallHelper<Args..., TypeTag<int>>::template InferDtype<0,
-                                                                            0>(
-        input_dtypes, vec_input_dtypes);
+      const std::vector<std::vector<DataType>>& vec_input_dtypes,
+      const std::vector<paddle::any>& attrs) {
+    return InferDtypeCallHelper<Args..., TypeTag<int>>::
+        template InferDtype<0, 0, 0>(input_dtypes, vec_input_dtypes, attrs);
   }
 
  private:
   template <typename... RemainingArgs>
   struct InferDtypeCallHelper;
 
-  PD_SPECIALIZE_InferDtypeCallHelper_TO_DTYPE(const DataType&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPE(const DataType&);
   PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPES(const std::vector<DataType>&);
 
   template <typename... Tail>
   struct InferDtypeCallHelper<const paddle::optional<DataType>&, Tail...> {
-    template <int in_idx, int vec_in_idx, typename... PreviousArgs>
+    template <int in_idx,
+              int vec_in_idx,
+              int attr_idx,
+              typename... PreviousArgs>
     static Return InferDtype(
         const std::vector<DataType>& input_dtypes,
         const std::vector<std::vector<DataType>>& vec_input_dtypes,
+        const std::vector<paddle::any>& attrs,
         const PreviousArgs&... pargs) {
       const DataType& arg = input_dtypes[in_idx];
       if (arg == DataType::UNDEFINED) {
-        return InferDtypeCallHelper<Tail...>::template InferDtype<in_idx + 1,
-                                                                  vec_in_idx>(
-            input_dtypes, vec_input_dtypes, pargs..., paddle::none);
+        return InferDtypeCallHelper<Tail...>::
+            template InferDtype<in_idx + 1, vec_in_idx, attr_idx>(
+                input_dtypes, vec_input_dtypes, attrs, pargs..., paddle::none);
       } else {
-        return InferDtypeCallHelper<Tail...>::template InferDtype<in_idx + 1,
-                                                                  vec_in_idx>(
-            input_dtypes, vec_input_dtypes, pargs..., arg);
+        return InferDtypeCallHelper<Tail...>::
+            template InferDtype<in_idx + 1, vec_in_idx, attr_idx>(
+                input_dtypes, vec_input_dtypes, attrs, pargs..., arg);
       }
     }
   };
@@ -718,36 +758,65 @@ struct InferDtypeFuncImpl<Return (*)(Args...), impl_fn> {
   template <typename... Tail>
   struct InferDtypeCallHelper<const paddle::optional<std::vector<DataType>>&,
                               Tail...> {
-    template <int in_idx, int vec_in_idx, typename... PreviousArgs>
+    template <int in_idx,
+              int vec_in_idx,
+              int attr_idx,
+              typename... PreviousArgs>
     static Return InferDtype(
         const std::vector<DataType>& input_dtypes,
         const std::vector<std::vector<DataType>>& vec_input_dtypes,
+        const std::vector<paddle::any>& attrs,
         const PreviousArgs&... pargs) {
       const std::vector<DataType>& arg = vec_input_dtypes[vec_in_idx];
       if (arg.empty()) {
         return InferDtypeCallHelper<Tail...>::
-            template InferDtype<in_idx, vec_in_idx + 1>(
-                input_dtypes, vec_input_dtypes, pargs..., paddle::none);
+            template InferDtype<in_idx, vec_in_idx + 1, attr_idx>(
+                input_dtypes, vec_input_dtypes, attrs, pargs..., paddle::none);
       } else {
         return InferDtypeCallHelper<Tail...>::
-            template InferDtype<in_idx, vec_in_idx + 1>(
-                input_dtypes, vec_input_dtypes, pargs..., arg);
+            template InferDtype<in_idx, vec_in_idx + 1, attr_idx>(
+                input_dtypes, vec_input_dtypes, attrs, pargs..., arg);
       }
     }
   };
 
-  // NOTE(chenweihang): Used to be compatible with the 2.0.1 released
+  // NOTE(HongyuJia): Used to be compatible with the 2.0.1 released
   // interface, and will be deprecated in the future
-  PD_SPECIALIZE_InferDtypeCallHelper_TO_DTYPE(DataType);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPE(DataType);
   PD_SPECIALIZE_InferDtypeCallHelper_FOR_DTYPES(std::vector<DataType>);
+
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(bool);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(int);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(float);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(int64_t);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const std::string&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const std::vector<int>&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const std::vector<float>&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const std::vector<int64_t>&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const std::vector<std::string>&);
+
+  // NOTE(HongyuJia): Used to be compatible with the 2.0.1 released
+  // interface, and will be deprecated in the future
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const bool&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const int&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const float&);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(const int64_t&);
+
+  // NOTE(HongyuJia): Used to be compatible with the 2.1 released
+  // interface, but not recommended
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(std::string);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(std::vector<int>);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(std::vector<float>);
+  PD_SPECIALIZE_InferDtypeCallHelper_FOR_ATTR(std::vector<std::string>);
 
   // end: base template
   template <typename T>
   struct InferDtypeCallHelper<TypeTag<T>> {
-    template <int in_idx, int vec_in_idx>
+    template <int in_idx, int vec_in_idx, int attr_idx>
     static Return InferDtype(
         const std::vector<DataType>& input_dtypes,
         const std::vector<std::vector<DataType>>& vec_input_dtypes,
+        const std::vector<paddle::any>& attrs,
         const Args&... args) {
       return impl_fn(args...);
     }

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -506,13 +506,6 @@ OpMetaInfoBuilder& OpMetaInfoBuilder::SetInferShapeFn(InferShapeFunc func) {
 }
 
 OpMetaInfoBuilder& OpMetaInfoBuilder::SetInferDtypeFn(InferDtypeFunc func) {
-  PADDLE_ENFORCE_EQ(
-      index_,
-      0UL,
-      phi::errors::Unimplemented(
-          "Currently, the InferDtypeFn setting of Grad Op is not supported, "
-          "And backward Tensor `X@GRAD` will use the dtype of forward Tensor "
-          "`X` by default."));
   info_ptr_->SetInferDtypeFn(std::forward<InferDtypeFunc>(func));
   return *this;
 }

--- a/test/custom_op/CMakeLists.txt
+++ b/test/custom_op/CMakeLists.txt
@@ -40,6 +40,7 @@ if(WITH_TESTING)
   py_test(test_multi_out_jit SRCS test_multi_out_jit.py)
   py_test(test_custom_attrs_jit SRCS test_custom_attrs_jit.py)
   py_test(test_custom_cast_op_jit SRCS test_custom_cast_op_jit.py)
+  set_tests_properties(test_custom_cast_op_jit PROPERTIES TIMEOUT 180)
   py_test(test_custom_concat SRCS test_custom_concat.py)
   set_tests_properties(
     test_custom_concat PROPERTIES ENVIRONMENT

--- a/test/custom_op/CMakeLists.txt
+++ b/test/custom_op/CMakeLists.txt
@@ -39,6 +39,7 @@ if(WITH_TESTING)
   py_test(test_dispatch_jit SRCS test_dispatch_jit.py)
   py_test(test_multi_out_jit SRCS test_multi_out_jit.py)
   py_test(test_custom_attrs_jit SRCS test_custom_attrs_jit.py)
+  py_test(test_custom_cast_op_jit SRCS test_custom_cast_op_jit.py)
   py_test(test_custom_concat SRCS test_custom_concat.py)
   set_tests_properties(
     test_custom_concat PROPERTIES ENVIRONMENT

--- a/test/custom_op/custom_cast_op.cc
+++ b/test/custom_op/custom_cast_op.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <vector>
+
+#include "paddle/extension.h"
+
+paddle::DataType ConvertDtype(const std::string& data_type) {
+  if (data_type == "float16") {
+    return paddle::DataType::FLOAT16;
+  } else if (data_type == "float32") {
+    return paddle::DataType::FLOAT32;
+  } else if (data_type == "float64") {
+    return paddle::DataType::FLOAT64;
+  } else {
+    PD_THROW("DataType Not Supported.");
+  }
+}
+
+std::vector<paddle::Tensor> CastForward(const paddle::Tensor& x,
+                                        const std::string& data_type) {
+  return {paddle::experimental::cast(x, ConvertDtype(data_type))};
+}
+
+std::vector<paddle::DataType> CastForwardInferDtype(
+    const paddle::DataType& input_dtype, const std::string& data_type) {
+  return {ConvertDtype(data_type)};
+}
+
+std::vector<paddle::Tensor> CastBackward(const paddle::Tensor& grad_out,
+                                         const std::string& data_type) {
+  return {paddle::experimental::cast(grad_out, ConvertDtype(data_type))};
+}
+
+std::vector<paddle::DataType> CastBackwardInferDtype(
+    const paddle::DataType& grad_out_dtype, const std::string& data_type) {
+  return {ConvertDtype(data_type)};
+}
+
+PD_BUILD_OP(custom_cast)
+    .Inputs({"X"})
+    .Attrs({"data_type: std::string"})
+    .Outputs({"Out"})
+    .SetKernelFn(PD_KERNEL(CastForward))
+    .SetInferDtypeFn(PD_INFER_DTYPE(CastForwardInferDtype));
+
+PD_BUILD_GRAD_OP(custom_cast)
+    .Inputs({paddle::Grad("Out")})
+    .Attrs({"data_type: std::string"})
+    .Outputs({paddle::Grad("X")})
+    .SetKernelFn(PD_KERNEL(CastBackward))
+    .SetInferDtypeFn(PD_INFER_DTYPE(CastBackwardInferDtype));

--- a/test/custom_op/test_custom_cast_op_jit.py
+++ b/test/custom_op/test_custom_cast_op_jit.py
@@ -37,15 +37,9 @@ if os.name == 'nt' and os.path.isfile(file):
     cmd = f'del {file}'
     run_cmd(cmd, True)
 
-# Compile and load custom op Just-In-Time.
-# custom_relu_op_dup.cc is only used for multi ops test,
-# not a new op, if you want to test only one op, remove this
-# source file
-sources = ['custom_cast_op.cc']
-
 custom_module = load(
     name='custom_cast_module_jit',
-    sources=sources,
+    sources=['custom_cast_op.cc'],
     extra_include_paths=paddle_includes,  # add for Coverage CI
     extra_library_paths=paddle_libraries,
     extra_cxx_cflags=extra_cc_args,  # test for cc flags

--- a/test/custom_op/test_custom_cast_op_jit.py
+++ b/test/custom_op/test_custom_cast_op_jit.py
@@ -99,27 +99,16 @@ def custom_cast_static(device, dtype, np_x):
 class TestCustomCastOp(unittest.TestCase):
     def setUp(self):
         self.dtypes = ['float32', 'float64']
-        if paddle.is_compiled_with_cuda():
-            self.dtypes.append('float16')
-        self.devices = ['cpu']
-        if paddle.is_compiled_with_cuda():
-            self.devices.append('gpu')
 
     def test_static(self):
-        for device in self.devices:
-            for dtype in self.dtypes:
-                if device == 'cpu' and dtype == 'float16':
-                    continue
-                x = np.random.uniform(-1, 1, [4, 8]).astype("float32")
-                custom_cast_static(device, dtype, x)
+        for dtype in self.dtypes:
+            x = np.random.uniform(-1, 1, [4, 8]).astype("float32")
+            custom_cast_static('cpu', dtype, x)
 
     def test_dynamic(self):
-        for device in self.devices:
-            for dtype in self.dtypes:
-                if device == 'cpu' and dtype == 'float16':
-                    continue
-                x = np.random.uniform(-1, 1, [4, 8]).astype("float32")
-                custom_cast_dynamic(device, dtype, x)
+        for dtype in self.dtypes:
+            x = np.random.uniform(-1, 1, [4, 8]).astype("float32")
+            custom_cast_dynamic('cpu', dtype, x)
 
 
 if __name__ == '__main__':

--- a/test/custom_op/test_custom_cast_op_jit.py
+++ b/test/custom_op/test_custom_cast_op_jit.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import numpy as np
+from utils import (
+    extra_cc_args,
+    extra_nvcc_args,
+    paddle_includes,
+    paddle_libraries,
+)
+
+import paddle
+from paddle import static
+from paddle.utils.cpp_extension import get_build_directory, load
+from paddle.utils.cpp_extension.extension_utils import run_cmd
+
+# Because Windows don't use docker, the shared lib already exists in the
+# cache dir, it will not be compiled again unless the shared lib is removed.
+file = '{}\\custom_cast_module_jit\\custom_cast_module_jit.pyd'.format(
+    get_build_directory()
+)
+if os.name == 'nt' and os.path.isfile(file):
+    cmd = f'del {file}'
+    run_cmd(cmd, True)
+
+# Compile and load custom op Just-In-Time.
+# custom_relu_op_dup.cc is only used for multi ops test,
+# not a new op, if you want to test only one op, remove this
+# source file
+sources = ['custom_cast_op.cc']
+
+custom_module = load(
+    name='custom_cast_module_jit',
+    sources=sources,
+    extra_include_paths=paddle_includes,  # add for Coverage CI
+    extra_library_paths=paddle_libraries,
+    extra_cxx_cflags=extra_cc_args,  # test for cc flags
+    extra_cuda_cflags=extra_nvcc_args,  # test for nvcc flags
+    verbose=True,
+)
+
+
+def custom_cast_dynamic(device, dtype, np_x):
+    paddle.set_device(device)
+
+    x = paddle.to_tensor(np_x, dtype="float32")
+    x.stop_gradient = False
+
+    out = custom_module.custom_cast(x, dtype)
+    out.stop_gradient = False
+
+    out.backward()
+
+    assert str(out.dtype).split(".")[-1] == dtype
+    assert str(x.grad.dtype).split(".")[-1] == dtype
+
+
+def custom_cast_static(device, dtype, np_x):
+    paddle.enable_static()
+    paddle.set_device(device)
+
+    with static.scope_guard(static.Scope()):
+        with static.program_guard(static.Program()):
+            x = static.data(name='X', shape=[None, 8], dtype="float32")
+            x.stop_gradient = False
+            out = custom_module.custom_cast(x, dtype)
+            static.append_backward(out)
+
+            exe = static.Executor()
+            exe.run(static.default_startup_program())
+            # in static graph mode, x data has been covered by out
+            out_v, x_grad_v = exe.run(
+                static.default_main_program(),
+                feed={'X': np_x},
+                fetch_list=[out.name, x.name + "@GRAD"],
+            )
+
+            assert x_grad_v[0].dtype == dtype
+            assert out_v[0].dtype == dtype
+
+    paddle.disable_static()
+    return out_v
+
+
+class TestCustomCastOp(unittest.TestCase):
+    def setUp(self):
+        self.dtypes = ['float32', 'float64']
+        if paddle.is_compiled_with_cuda():
+            self.dtypes.append('float16')
+        self.devices = ['cpu']
+        if paddle.is_compiled_with_cuda():
+            self.devices.append('gpu')
+
+    def test_static(self):
+        for device in self.devices:
+            for dtype in self.dtypes:
+                if device == 'cpu' and dtype == 'float16':
+                    continue
+                x = np.random.uniform(-1, 1, [4, 8]).astype("float32")
+                custom_cast_static(device, dtype, x)
+
+    def test_dynamic(self):
+        for device in self.devices:
+            for dtype in self.dtypes:
+                if device == 'cpu' and dtype == 'float16':
+                    continue
+                x = np.random.uniform(-1, 1, [4, 8]).astype("float32")
+                custom_cast_dynamic(device, dtype, x)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-66988

自定义算子机制不断拓宽框架二次开发的边界，团队内外对自定义算子机制提出了一项新的需求：`InferDtypeFn` 支持传入 Attributes，利用 Attribute 控制输出 Tensor 的数据类型，输出 Tensor 的类型不必强制来自于输入 Tensor（可参考 `cast` 算子），本 PR 提供此机制

The custom operator mechanism continues to broaden the boundaries of the secondary development of the framework. A new requirement has been put forward for the custom operator mechanism both inside and outside the team: `InferDtypeFn` supports passing in Attributes, using Attributes to control the data type of the output Tensor, and the data type of the output Tensor does not have to be forced to come from the input Tensor (refer to `cast` operator), this PR provides this mechanism
