### PR TITLE
[Reshard] Support r to s of unbalanced split

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/reshard_utils.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard_utils.cc
@@ -189,5 +189,14 @@ CommContext* CreateOrGetCommContext(const DeviceContext& dev_ctx,
   return comm_context;
 }
 
+std::vector<int64_t> BalancedSplit(int64_t total_nums, int64_t num_of_pieces) {
+  std::vector<int64_t> result(num_of_pieces, total_nums / num_of_pieces);
+  int64_t remain_nums = total_nums % num_of_pieces;
+  for (int64_t i = 0; i < remain_nums; ++i) {
+    result[i] += 1;
+  }
+  return result;
+}
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/reshard_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard_utils.h
@@ -69,5 +69,10 @@ uint16_t GetMasterPort();
 
 std::shared_ptr<TCPStore> CreateOrGetGlobalTCPStore();
 
+// If given a number, balance split it to multiple pieces.
+// For example, the input value is 12, split it to 5 pieces, then return
+// {3, 3, 2, 2, 2}.
+std::vector<int64_t> BalancedSplit(int64_t total_nums, int64_t num_of_pieces);
+
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/kernels/split_kernel.h
+++ b/paddle/phi/kernels/split_kernel.h
@@ -50,31 +50,43 @@ void SplitWithNumStridedKernel(const Context& dev_ctx,
                                std::vector<DenseTensor*> out);
 
 template <typename T, typename Context>
-std::vector<DenseTensor> Split(const Context& dev_ctx,
-                               const DenseTensor& x,
-                               const IntArray& sections,
-                               const Scalar& axis) {
-  size_t out_number;
-  out_number = sections.GetData().size();
+void Split(const Context& dev_ctx,
+           const DenseTensor& x,
+           const IntArray& sections,
+           const Scalar& axis,
+           std::vector<DenseTensor>* result) {
+  size_t out_number = sections.GetData().size();
 
   std::vector<MetaTensor> out_meta;
   std::vector<MetaTensor*> out_meta_ptr;
   out_meta.reserve(out_number);
   out_meta_ptr.reserve(out_number);
-  std::vector<DenseTensor> result(out_number);
+  result->resize(out_number);
 
   for (size_t i = 0; i < out_number; ++i) {
-    out_meta.emplace_back(&result[i]);
+    out_meta.emplace_back(&result->at(i));
     out_meta_ptr.push_back(&out_meta.back());
   }
   SplitInferMeta(x, sections, axis, out_meta_ptr);
   std::vector<DenseTensor*> outs;
   outs.reserve(out_meta.size());
   for (size_t i = 0; i < out_meta.size(); ++i) {
-    outs.push_back(&result[i]);
+    outs.push_back(&result->at(i));
   }
 
   SplitKernel<T, Context>(dev_ctx, x, sections, axis, outs);
+}
+
+template <typename T, typename Context>
+std::vector<DenseTensor> Split(const Context& dev_ctx,
+                               const DenseTensor& x,
+                               const IntArray& sections,
+                               const Scalar& axis) {
+  size_t out_number = sections.GetData().size();
+  std::vector<DenseTensor> result(out_number);
+
+  Split(dev_ctx, x, sections, axis, &result);
+
   return result;
 }
 

--- a/test/cpp/auto_parallel/test_reshard_r_to_s.cc
+++ b/test/cpp/auto_parallel/test_reshard_r_to_s.cc
@@ -121,6 +121,36 @@ TEST(reshard_r_to_s, r_to_s_same_placement_cpu_1d_mesh) {
   CHECK_EQ(output->dims(), DDim({6, 2}));
 }
 
+TEST(reshard_r_to_s, r_to_s_same_placement_cpu_1d_mesh_unbalance_split) {
+  setenv("PADDLE_TRAINER_ID", "1", 1);
+
+  std::vector<int64_t> tensor_shape = {6, 8};
+  phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+  auto* context = reinterpret_cast<phi::CPUContext*>(pool.Get(phi::CPUPlace()));
+
+  std::vector<int64_t> mesh_shape = {4};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3};
+  std::vector<std::string> dim_names = {"x"};
+  ProcessMesh mesh(mesh_shape, process_ids, dim_names);
+
+  std::shared_ptr<DistTensor> input =
+      ConstructReplicatedDistCPU(context, tensor_shape, mesh);
+
+  std::shared_ptr<TensorDistAttr> out_dist_attr =
+      std::make_shared<TensorDistAttr>(tensor_shape);
+  std::vector<int64_t> out_dims_mapping = {0, -1};
+  out_dist_attr->set_dims_mapping(out_dims_mapping);
+  out_dist_attr->set_process_mesh(mesh);
+
+  RToSReshardFunction r_to_s_func;
+  std::shared_ptr<DistTensor> output =
+      r_to_s_func.Eval(context, *input, out_dist_attr);
+
+  CHECK_EQ(r_to_s_func.IsSuitable(*input, out_dist_attr), true);
+  CHECK_EQ(output->numel(), 16);
+  CHECK_EQ(output->dims(), DDim({2, 8}));
+}
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 TEST(reshard_r_to_s, r_to_s_same_placement_gpu_1d_mesh) {
   setenv("PADDLE_TRAINER_ID", "0", 0);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73145

支持Replicate到非均匀切分Shard的状态转换，以4卡为例，输入输出都是一维process_mesh，[0, 1, 2, 3]，输入为二维Replicated状态，in_tensor_shape = [6, 9]，in_dims_mapping = [-1, -1]，输出为二维Shard状态。

- 用process_mesh的0维切分输入的0维，out_dims_mapping = [0, -1]，前两个进程上有形状为[2, 9]的物理tensor，后两个进程上有形状为[1, 9]的物理tensor；
- 用process_mesh的0维切分输入的1维，out_dims_mapping = [-1, 0]，第一个进程上有形状为[6, 3]的物理tensor，后三个进程上有形状为[6, 2]的物理tensor。
