### PR TITLE
[NewIR]Remove framework_proto DEPS in pd_dialect

### DIFF
--- a/paddle/fluid/ir/dialect/CMakeLists.txt
+++ b/paddle/fluid/ir/dialect/CMakeLists.txt
@@ -52,8 +52,7 @@ file(GLOB PD_DIALECT_SRCS "*.cc")
 cc_library(
   pd_dialect
   SRCS ${PD_DIALECT_SRCS} ${op_source_file}
-  DEPS framework_proto
-       phi
+  DEPS phi
        phi_utils
        pd_interface
        pd_trait


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

根据 @Aurelius84  的建议，尝试移除了 pd_dialect 对 framework_proto 的编译依赖(*^▽^*)

![image](https://github.com/PaddlePaddle/Paddle/assets/141831089/ac231e57-f4ea-4092-84b6-678633988de2)
