### PR TITLE
[clang-tidy] No.51 enable bugprone-copy-constructor-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,7 @@ Checks: '
 -bugprone-bad-signal-to-kill-thread,
 -bugprone-bool-pointer-implicit-conversion,
 -bugprone-branch-clone,
--bugprone-copy-constructor-init,
+bugprone-copy-constructor-init,
 -bugprone-dangling-handle,
 -bugprone-dynamic-static-initializers,
 -bugprone-exception-escape,

--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -52,7 +52,8 @@ DenseTensor::DenseTensor(const std::shared_ptr<phi::Allocation>& holder,
                          const DenseTensorMeta& meta)
     : meta_(meta), holder_(holder) {}
 
-DenseTensor::DenseTensor(const DenseTensor& other) : meta_(other.meta()) {
+DenseTensor::DenseTensor(const DenseTensor& other) {
+  this->meta_ = other.meta();
   holder_ = other.holder_;
   storage_properties_ =
       std::move(CopyStorageProperties(other.storage_properties_));

--- a/paddle/phi/core/sparse_coo_tensor.cc
+++ b/paddle/phi/core/sparse_coo_tensor.cc
@@ -50,9 +50,9 @@ SparseCooTensor::SparseCooTensor(DenseTensor&& non_zero_indices,
   meta_.dtype = non_zero_elements.dtype();
 }
 
-SparseCooTensor::SparseCooTensor(const SparseCooTensor& other)
-    : non_zero_indices_(other.non_zero_indices_),
-      non_zero_elements_(other.non_zero_elements_) {
+SparseCooTensor::SparseCooTensor(const SparseCooTensor& other) {
+  this->non_zero_indices_ = other.non_zero_indices_;
+  this->non_zero_elements_ = other.non_zero_elements_;
   this->coalesced_ = other.coalesced_;
   set_meta(other.meta());
 }

--- a/paddle/phi/core/sparse_csr_tensor.cc
+++ b/paddle/phi/core/sparse_csr_tensor.cc
@@ -66,10 +66,10 @@ SparseCsrTensor::SparseCsrTensor(const DenseTensor& non_zero_crows,
   meta_.dtype = non_zero_elements.dtype();
 }
 
-SparseCsrTensor::SparseCsrTensor(const SparseCsrTensor& other)
-    : non_zero_crows_(other.non_zero_crows_),
-      non_zero_cols_(other.non_zero_cols_),
-      non_zero_elements_(other.non_zero_elements_) {
+SparseCsrTensor::SparseCsrTensor(const SparseCsrTensor& other) {
+  this->non_zero_crows_ = other.non_zero_crows_;
+  this->non_zero_cols_ = other.non_zero_cols_;
+  this->non_zero_elements_ = other.non_zero_elements_;
   set_meta(other.meta());
 }
 

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -37,7 +37,8 @@ StringTensor::StringTensor(const std::shared_ptr<phi::Allocation>& holder,
                            const StringTensorMeta& meta)
     : meta_(meta), holder_(holder) {}
 
-StringTensor::StringTensor(const StringTensor& other) : meta_(other.meta()) {
+StringTensor::StringTensor(const StringTensor& other) {
+  this->meta_ = other.meta();
   holder_ = other.holder_;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
enable bugprone-copy-constructor-init

https://github.com/PaddlePaddle/Paddle/issues/54073 No.51