### PR TITLE
[clang-tidy] NO.66 enable `bugprone-integer-division`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,7 @@ Checks: '
 -bugprone-inaccurate-erase,
 -bugprone-incorrect-roundings,
 -bugprone-infinite-loop,
--bugprone-integer-division,
+bugprone-integer-division,
 -bugprone-macro-repeated-side-effects,
 -bugprone-misplaced-operator-in-strlen-in-alloc,
 -bugprone-misplaced-widening-cast,

--- a/paddle/fluid/framework/details/scope_buffered_monitor.cc
+++ b/paddle/fluid/framework/details/scope_buffered_monitor.cc
@@ -29,7 +29,7 @@ namespace paddle {
 namespace framework {
 namespace details {
 
-static constexpr double kMB = 1 / (1024 * 1024);
+static constexpr double kMB = 1.0 / (1024.0 * 1024.0);
 
 static void GetTensors(Variable *var,
                        std::unordered_set<phi::DenseTensor *> *tensor_set) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

相关链接:
 * https://clang.llvm.org/extra/clang-tidy/checks/bugprone/integer-division.html
 * #54073