### PR TITLE
c_allreduce use single-intput-output interface to speed up

### DIFF
--- a/paddle/fluid/operators/collective/c_allreduce_op.h
+++ b/paddle/fluid/operators/collective/c_allreduce_op.h
@@ -265,11 +265,6 @@ class CAllReduceOpCUDAKernel : public framework::OpKernel<T> {
     if (map->has(rid)) {
       // Use ProcessGroup
       distributed::ProcessGroup* pg = map->get(rid);
-      std::vector<phi::DenseTensor> in_tensor;
-      std::vector<phi::DenseTensor> out_tensor;
-      in_tensor.push_back(*in);
-      out_tensor.push_back(*out);
-
       distributed::AllreduceOptions opts;
       switch (red_type) {
         case kRedSum:
@@ -293,7 +288,7 @@ class CAllReduceOpCUDAKernel : public framework::OpKernel<T> {
               "Invalid reduce type: %d", red_type));
       }
 
-      auto task = pg->AllReduce(in_tensor, out_tensor, opts);
+      auto task = pg->AllReduce(out, *in, opts, false, true);
       task->Wait();
       return;
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Allreduce uses multi-input-output interface now, which caused gap between all_reduce kernel and other kernels.  By applying this PR, LLM inference latency can be reduced significantly. 

Pcard-71502
