### PR TITLE
[NewIR]Add more gen api

### DIFF
--- a/paddle/fluid/ir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/ir/dialect/op_generator/op_gen.py
@@ -259,7 +259,7 @@ class OpInfoParser:
             'bool': ['ir::BoolAttribute', 'bool'],
             'bool[]': [
                 'ir::ArrayAttribute<ir::BoolAttribute>',
-                'const std::vecot<bool>&',
+                'const std::vector<bool>&',
             ],
             'str': ['ir::StrAttribute', 'const std::string&'],
             'str[]': [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- 为了不再阻塞其他工作，添加部分自动生成的API
- 本PR中支持了多返回值API的生成，下面是reshape API的生成
```
std::tuple<ir::OpResult, ir::OpResult> reshape(ir::OpResult x, const std::vector<int64_t>& shape);

std::tuple<ir::OpResult, ir::OpResult> reshape(ir::OpResult x, const std::vector<int64_t>& shape){
    paddle::dialect::ReshapeOp reshape_op = APIBuilder::Instance().GetBuilder()->Build<paddle::dialect::ReshapeOp>(x, shape);
    return std::make_tuple(reshape_op.result(0), reshape_op.result(1));
}
```
- 对于split类的API，需要等待builtin中的SliceOp完善后才能够生成
- 下个PR预计会打开所有API的自动生成，或者有一个黑名单，只有少部分API不生成

Pcard-67164