### PR TITLE
[NewIR]Part-1: Add CinnJitInstruction for interpreter

### DIFF
--- a/paddle/cinn/hlir/framework/CMakeLists.txt
+++ b/paddle/cinn/hlir/framework/CMakeLists.txt
@@ -24,9 +24,9 @@ gather_srcs(
 # TODO(Aurelius84): new_ir_compiler depends on pd_dialect and could
 # not found under CINN_ONLY mode
 if(NOT CINN_ONLY)
-  cinn_cc_library(new_ir_compiler SRCS new_ir_compiler.cc DEPS cinncore
+  cinn_cc_library(new_ir_compiler SRCS new_ir_compiler.cc DEPS cinnapi
                   pd_dialect)
-  cinn_cc_library(convert_to_dialect SRCS convert_to_dialect.cc DEPS cinncore
+  cinn_cc_library(convert_to_dialect SRCS convert_to_dialect.cc DEPS cinnapi
                   cinn_dialect)
 endif()
 

--- a/paddle/cinn/hlir/framework/instruction.h
+++ b/paddle/cinn/hlir/framework/instruction.h
@@ -130,10 +130,11 @@ class Instruction {
     }
   }
 
-  int size() { return fn_ptrs_.size(); }
+  int size() const { return fn_ptrs_.size(); }
 
   std::string DumpInstruction() const;
 
+  const std::string& function_name() const { return function_name_; }
   const std::vector<std::vector<std::string>>& GetInArgs() const {
     return in_args_;
   }

--- a/paddle/cinn/hlir/framework/new_ir_compiler.cc
+++ b/paddle/cinn/hlir/framework/new_ir_compiler.cc
@@ -15,7 +15,6 @@
 #include "paddle/cinn/hlir/framework/new_ir_compiler.h"
 
 #include <absl/types/variant.h>
-#include "paddle/cinn/common/context.h"
 #include "paddle/cinn/hlir/framework/op_strategy.h"
 #include "paddle/cinn/lang/lower.h"
 #include "paddle/cinn/lang/placeholder.h"

--- a/paddle/fluid/framework/new_executor/instruction/CMakeLists.txt
+++ b/paddle/fluid/framework/new_executor/instruction/CMakeLists.txt
@@ -3,3 +3,10 @@ cc_library(
   SRCS instruction_base.cc phi_kernel_instruction.cc
        legacy_kernel_instruction.cc instruction_util.cc
   DEPS phi framework_proto)
+
+if(WITH_CINN AND NOT CINN_ONLY)
+  cc_library(
+    cinn_jit_instruction
+    SRCS cinn_jit_instruction.cc
+    DEPS phi cinnapi cinn_dialect)
+endif()

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -1,0 +1,118 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h"
+
+#include "paddle/cinn/hlir/dialect/jit_kernel_op.h"
+#include "paddle/cinn/hlir/dialect/runtime_dialect.h"
+#include "paddle/cinn/hlir/framework/instruction.h"
+#include "paddle/fluid/framework/paddle2cinn/transform_type.h"
+
+namespace paddle {
+namespace framework {
+
+// TODO(Aurelius84): Think deeply what's the responsibility is it.
+// Currently it assumes CinnLaunchContext role.
+class JitContext {
+ public:
+  cinn_buffer_t* GetCinnBufferOfVar(const std::string& name) {
+    auto res = paddle2argument_.find(name);
+    PADDLE_ENFORCE_NE(
+        res,
+        paddle2argument_.end(),
+        platform::errors::NotFound(
+            "Variable(%s) not found in compilation result", name));
+    return static_cast<cinn_buffer_t*>(res->second);
+  }
+
+  // NOTE(Aurelius84): Before running each instruction, we should share Tensor
+  // memory from paddle scope with cinn_buffer_t from cinn scope including
+  // inputs and outputs.
+  void ShareMemToCinn(const std::string& var_name,
+                      const phi::Place& place,
+                      Scope* scope) {
+    cinn_buffer_t* buffer = GetCinnBufferOfVar(var_name);
+    auto* tensor = scope->GetVar(var_name)->GetMutable<phi::DenseTensor>();
+    // TODO(Aurelius84): Maybe we should consider to unify the Scope
+    // structure between paddle and cinn, so that we don't need to develop
+    // the glue code.
+    buffer->memory = reinterpret_cast<uint8_t*>(tensor->mutable_data(
+        place, paddle2cinn::TransToPaddleDataType(buffer->type)));
+  }
+
+  // TODO(Aurelius84): Add logic to parse stream for different device.
+  void* GetStream() { return nullptr; }
+
+ private:
+  // because a cinn_pod_value_t does not own a cinn_buffer_t object,
+  // an extra stroage is necessary to keep those objects and they can
+  // not be released until the runtime program finish execution.
+  std::vector<std::unique_ptr<cinn_buffer_t>> hold_buffers_;
+  // this map saves all execution arguments with their cinn names as key,
+  // and it is passed to the Execute interface of a cinn runtime program.
+  std::map<std::string, cinn_pod_value_t> name2argument_;
+  // this map saves all execution arguments with paddle variables as key,
+  // this map conbine name2argument_ and paddle2cinn_varmap_
+  std::map<std::string, cinn_pod_value_t> paddle2argument_;
+};
+
+// TODO(Aurelius84): Impl should hold JitContext instance to
+// deliver the device context for 'instr->Run' and responsible
+// to deal with inner buffer_t shareing between framework::Scope
+// and cinn::Scope.
+class CinnJitInstruction::Impl {
+  using Instruction = cinn::hlir::framework::Instruction;
+
+ public:
+  explicit Impl(Instruction* instr) : instr_(instr) {}
+  // TODO(Aurelus84): Support to specify name2podargs and stream arguments.
+  void Run() {
+    PADDLE_ENFORCE_NOT_NULL(
+        instr_, platform::errors::NotFound("instr_ should not be NULL"));
+    instr_->Run(/*name2podargs=*/nullptr,
+                false,
+                /*stream=*/nullptr,
+                /*use_cache=*/true);
+  }
+  const Instruction* pointer() const { return instr_; }
+
+ private:
+  Instruction* instr_{nullptr};
+};
+
+CinnJitInstruction::CinnJitInstruction(size_t id,
+                                       const platform::Place& place,
+                                       ::ir::Operation* op,
+                                       Scope* scope)
+    : InstructionBase(id, place) {
+  // TODO(Aurelius84): We shall simplify members of JitKernelOp to make it
+  // only hold related function ptrs. Impl is the real runtime data structure
+  // responsible to construct hlir::framework::Instruction.
+  auto jit_kernel_op = op->dyn_cast<cinn::dialect::JitKernelOp>();
+  impl_ = std::make_shared<Impl>(jit_kernel_op.instruction());
+}
+
+void CinnJitInstruction::Run() {
+  VLOG(6) << "Run cinn jit_kernel_op : " << Name();
+  impl_->Run();
+}
+
+const std::string& CinnJitInstruction::Name() const {
+  // TODO(Aurelius84): Consider the case for instrucitons constaning
+  // multipule function ptrs and function names.
+  return impl_->pointer()->function_name();
+}
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/fluid/framework/new_executor/instruction/instruction_base.h"
+
+namespace ir {
+class Operation;
+}
+
+namespace paddle {
+namespace framework {
+class Scope;
+
+class CinnJitInstruction : public InstructionBase {
+ public:
+  CinnJitInstruction(size_t id,
+                     const platform::Place& place,
+                     ::ir::Operation* op,
+                     Scope* scope);
+
+  // TODO(Aurelius84): Only implement core interface and need implement GC and
+  // Event logic.
+  void Run() override;
+
+  const std::string& Name() const override;
+
+ private:
+  class Impl;
+  std::shared_ptr<Impl> impl_{nullptr};
+};
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/new_executor/interpreter/CMakeLists.txt
+++ b/paddle/fluid/framework/new_executor/interpreter/CMakeLists.txt
@@ -34,6 +34,10 @@ set(INTERPRETER_DEPS
     ${DEVICE_EVENT_LIBS}
     glog)
 
+if(WITH_CINN AND NOT CINN_ONLY)
+  set(INTERPRETER_DEPS ${INTERPRETER_DEPS} cinn_jit_instruction)
+endif()
+
 cc_library(
   interpreter
   SRCS ${INTERPRETER_SRCS}

--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -36,7 +36,9 @@
 #include "paddle/fluid/platform/flags.h"
 #include "paddle/phi/backends/device_manager.h"
 
+#ifdef PADDLE_WITH_CINN
 #include "paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h"
+#endif
 #include "paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.h"
 #include "paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.h"
 #include "paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.h"
@@ -462,9 +464,11 @@ void NewIRInterpreter::BuildInstruction() {
                                                    var_name_2_id_,
                                                    variable_2_var_name_));
       }
+#ifdef PADDLE_WITH_CINN
     } else if (op->dialect()->name() == "cinn") {
       vec_instruction_base_.emplace_back(
           std::make_unique<CinnJitInstruction>(op_idx++, place_, op, scope_));
+#endif
     } else {
       PADDLE_THROW(platform::errors::Unimplemented(
           "Now only support pd_kernel and cinn dialect."));

--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -36,6 +36,7 @@
 #include "paddle/fluid/platform/flags.h"
 #include "paddle/phi/backends/device_manager.h"
 
+#include "paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h"
 #include "paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.h"
 #include "paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.h"
 #include "paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.h"
@@ -461,9 +462,12 @@ void NewIRInterpreter::BuildInstruction() {
                                                    var_name_2_id_,
                                                    variable_2_var_name_));
       }
+    } else if (op->dialect()->name() == "cinn") {
+      vec_instruction_base_.emplace_back(
+          std::make_unique<CinnJitInstruction>(op_idx++, place_, op, scope_));
     } else {
       PADDLE_THROW(platform::errors::Unimplemented(
-          "Now only support pd or pd_kernel dialect."));
+          "Now only support pd_kernel and cinn dialect."));
     }
   }
 }

--- a/test/cpp/ir/cinn/CMakeLists.txt
+++ b/test/cpp/ir/cinn/CMakeLists.txt
@@ -11,4 +11,14 @@ if(WITH_TESTING AND WITH_CINN)
     gtest
     glog)
   set_tests_properties(test_new_ir_compiler PROPERTIES LABELS "RUN_TYPE=CINN")
+
+  cc_test_old(
+    test_jit_instruction
+    SRCS
+    jit_instruction_test.cc
+    DEPS
+    interpreter
+    new_ir_compiler
+    convert_to_dialect)
+  set_tests_properties(test_jit_instruction PROPERTIES LABELS "RUN_TYPE=CINN")
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
see:https://github.com/PaddlePaddle/Paddle/issues/56880

**NOTE：** 此为CINN 接入执行器的最初步的 PR，后续模块支持见后续PR。

+ 新增了 `CinnJitInstruction` 承接Interpreter 运行时 InstructionBase 的派生类角色
+ 新增了 `Impl` 主要负担具体的成员和实现
+ 新增了 `JitContext` 承担 `CinnLaunchContext` 的角色，在下个PR 体现
+ 添加了一个简单的单测