### PR TITLE
[TRT] PrelnResidualBiasPluginDynamic Support 4D Inputs

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1598,6 +1598,22 @@ struct SimpleOpTypeSetTeller : public Teller {
                    "dropout_rate != 0, stop convert";
         return false;
       }
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+      auto x_var_name = desc.Input("X")[0];
+      auto* x_var_desc = block->FindVar(x_var_name);
+      const auto x_shape = x_var_desc->GetShape();
+      if (!(x_shape.size() == 3 || x_shape.size() == 4)) {
+        VLOG(3) << "The fused_bias_dropout_residual_layer_norm op only support "
+                   "3-D or 4-D input in "
+                   "tensorrt.";
+        return false;
+      }
     }
     if (op_type == "fused_preln_embedding_eltwise_layernorm") {
       if (!with_dynamic_shape) {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1610,8 +1610,7 @@ struct SimpleOpTypeSetTeller : public Teller {
       const auto x_shape = x_var_desc->GetShape();
       if (!(x_shape.size() == 3 || x_shape.size() == 4)) {
         VLOG(3) << "The fused_bias_dropout_residual_layer_norm op only support "
-                   "3-D or 4-D input in "
-                   "tensorrt.";
+                   "3-D or 4-D input in tensorrt.";
         return false;
       }
     }

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1598,21 +1598,6 @@ struct SimpleOpTypeSetTeller : public Teller {
                    "dropout_rate != 0, stop convert";
         return false;
       }
-      auto* block = desc.Block();
-      if (block == nullptr) {
-        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
-                   "Developers need to check whether block_desc is passed in "
-                   "the pass.";
-        return false;
-      }
-      auto x_var_name = desc.Input("X")[0];
-      auto* x_var_desc = block->FindVar(x_var_name);
-      const auto x_shape = x_var_desc->GetShape();
-      if (!(x_shape.size() == 3 || x_shape.size() == 4)) {
-        VLOG(3) << "The fused_bias_dropout_residual_layer_norm op only support "
-                   "3-D or 4-D input in tensorrt.";
-        return false;
-      }
     }
     if (op_type == "fused_preln_embedding_eltwise_layernorm") {
       if (!with_dynamic_shape) {

--- a/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
@@ -358,16 +358,25 @@ int PrelnResidualBiasPluginDynamic::enqueue(
     void *workspace,
     cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
-  int hidden = input_dims.d[2];
-  int rows_dy = input_dims.d[0] * input_dims.d[1];
-  int cols_dy = input_dims.d[2];
-  if (input_dims.nbDims == 4) {
+  int hidden;
+  int rows_temp;
+  int cols_temp;
+  if (input_dims.nbDims == 3) {
+    hidden = input_dims.d[2];
+    rows_temp = input_dims.d[0] * input_dims.d[1];
+    cols_temp = input_dims.d[2];
+  } else if (input_dims.nbDims == 4) {
     hidden = input_dims.d[3];
-    rows_dy = input_dims.d[0] * input_dims.d[1] * input_dims.d[2];
-    cols_dy = input_dims.d[3];
+    rows_temp = input_dims.d[0] * input_dims.d[1] * input_dims.d[2];
+    cols_temp = input_dims.d[3];
+  } else {
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "fused_bias_dropout_residual_layer_norm op only support 3-D or 4-D "
+        "input, but get `%d`-D.",
+        input_dims.nbDims));
   }
-  const size_t rows = static_cast<size_t>(rows_dy);  // batch * seq_length
-  const size_t cols = static_cast<size_t>(cols_dy);
+  const size_t rows = static_cast<size_t>(rows_temp);  // batch * seq_length
+  const size_t cols = static_cast<size_t>(cols_temp);
 
   auto input_type = input_desc[0].type;
   if (input_type == nvinfer1::DataType::kFLOAT) {

--- a/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
@@ -359,9 +359,15 @@ int PrelnResidualBiasPluginDynamic::enqueue(
     cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   int hidden = input_dims.d[2];
-  const size_t rows = static_cast<size_t>(
-      input_dims.d[0] * input_dims.d[1]);  // batch * seq_length
-  const size_t cols = static_cast<size_t>(input_dims.d[2]);
+  int rows_dy = input_dims.d[0] * input_dims.d[1];
+  int cols_dy = input_dims.d[2];
+  if (input_dims.nbDims == 4) {
+    hidden = input_dims.d[3];
+    rows_dy = input_dims.d[0] * input_dims.d[1] * input_dims.d[2];
+    cols_dy = input_dims.d[3];
+  }
+  const size_t rows = static_cast<size_t>(rows_dy);  // batch * seq_length
+  const size_t cols = static_cast<size_t>(cols_dy);
 
   auto input_type = input_desc[0].type;
   if (input_type == nvinfer1::DataType::kFLOAT) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
P-card-71501
Paddle-TRT PrelnResidualBiasPluginDynamic之前默认输入是3维的，现在**增加4维输入检查**，并将最后一个维度当做隐藏层。
