### PR TITLE
[IR] fix assert op pd to kernel pass bug

### DIFF
--- a/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
@@ -163,7 +163,6 @@ phi::KernelKey GetKernelKey(
     const phi::Place& place,
     const std::unordered_map<ir::Value, ir::OpResult>& map_value_pair,
     dialect::OpYamlInfoParser* op_info_parser = nullptr) {
-  std::cout << op->name() << std::endl;
   if (op->name() == "pd.feed") {
     // NOTE, for now feed op don't need a kernel, so the data type from Op
     // Result the next op use base program datatype

--- a/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
@@ -163,6 +163,7 @@ phi::KernelKey GetKernelKey(
     const phi::Place& place,
     const std::unordered_map<ir::Value, ir::OpResult>& map_value_pair,
     dialect::OpYamlInfoParser* op_info_parser = nullptr) {
+  std::cout << op->name() << std::endl;
   if (op->name() == "pd.feed") {
     // NOTE, for now feed op don't need a kernel, so the data type from Op
     // Result the next op use base program datatype
@@ -309,7 +310,7 @@ phi::KernelKey GetKernelKey(
           type = input_type.dyn_cast<ir::VectorType>()[0]
                      .dyn_cast<dialect::AllocatedDenseTensorType>();
         } else {
-          type = dialect::AllocatedDenseTensorType();
+          continue;
         }
       }
 

--- a/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
@@ -305,8 +305,12 @@ phi::KernelKey GetKernelKey(
       if (input_type.isa<dialect::AllocatedDenseTensorType>()) {
         type = input_type.dyn_cast<dialect::AllocatedDenseTensorType>();
       } else if (input_type.isa<ir::VectorType>()) {
-        type = input_type.dyn_cast<ir::VectorType>()[0]
-                   .dyn_cast<dialect::AllocatedDenseTensorType>();
+        if (!input_type.dyn_cast<ir::VectorType>().empty()) {
+          type = input_type.dyn_cast<ir::VectorType>()[0]
+                     .dyn_cast<dialect::AllocatedDenseTensorType>();
+        } else {
+          type = dialect::AllocatedDenseTensorType();
+        }
       }
 
       // fake tensor here


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
assert op的输入的Vector可能是空的。此时，在choose kernel时，不需要将空Vector的类型作为choose kernel的参考输入。
Pcard-67164