### PR TITLE
[Custom Device]add run_check support for custom device

### DIFF
--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -110,10 +110,8 @@ def _get_default_nprocs():
         return core.get_xpu_device_count()
     elif 'cpu' in device:
         return multiprocessing.cpu_count()
-    elif 'npu' in device:
-        return core.get_custom_device_count('npu')
-    elif 'mlu' in device:
-        return core.get_custom_device_count('mlu')
+    elif device in core.get_available_custom_device():
+        return core.get_custom_device_count(device.split(":")[0])
     else:
         raise RuntimeError(
             "`paddle.distributed.spawn` does not support parallel training on device `{}` now.".format(
@@ -130,7 +128,7 @@ def _get_default_backend():
         return 'bkcl'
     elif 'cpu' in device:
         return 'gloo'
-    elif 'npu' or 'mlu' in device:
+    elif device in core.get_available_custom_device():
         return 'xccl'
     else:
         raise RuntimeError(

--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -110,6 +110,10 @@ def _get_default_nprocs():
         return core.get_xpu_device_count()
     elif 'cpu' in device:
         return multiprocessing.cpu_count()
+    elif 'npu' in device:
+        return core.get_custom_device_count('npu')
+    elif 'mlu' in device:
+        return core.get_custim_device_count('mlu')
     else:
         raise RuntimeError(
             "`paddle.distributed.spawn` does not support parallel training on device `{}` now.".format(
@@ -126,6 +130,8 @@ def _get_default_backend():
         return 'bkcl'
     elif 'cpu' in device:
         return 'gloo'
+    elif 'npu' or 'mlu' in device:
+        return 'xccl'
     else:
         raise RuntimeError(
             "`paddle.distributed.spawn` does not support parallel training on device `{}` now.".format(
@@ -275,6 +281,29 @@ def _get_subprocess_env_list(nprocs, options):
         assert (
             _get_trainers_num() == 1
         ), "CPUONLY spawn doesn't support multi-trainer"
+    elif options['backend'] == 'xccl':
+        args.selected_devices = None
+        custom_device_name = core.get_all_custom_device_type()[0]
+        env_devices = os.getenv(f"FLAGS_selected_{custom_device_name}s", None)
+        if env_devices is None or env_devices == "":
+            env_devices_list = [
+                str(x)
+                for x in range(core.get_custom_device_count(custom_device_name))
+            ]
+        else:
+            env_devices_list = env_devices.split(',')
+
+        if len(env_devices_list) < nprocs:
+            raise RuntimeError(
+                "the number of visible devices(%d) is less than the number "
+                "of spawn processes(%d), please ensure that the correct "
+                "`nprocs` argument is passed or the environment variable "
+                "`CUDA_VISIBLE_DEVICES` is correctly configured."
+                % (len(env_devices_list), nprocs)
+            )
+        args.selected_devices = ",".join(
+            [str(env_devices_list[x]) for x in range(0, nprocs)]
+        )
 
     # set other inner args
     args.node_ip = options.get('node_ip', None)

--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -113,7 +113,7 @@ def _get_default_nprocs():
     elif 'npu' in device:
         return core.get_custom_device_count('npu')
     elif 'mlu' in device:
-        return core.get_custim_device_count('mlu')
+        return core.get_custom_device_count('mlu')
     else:
         raise RuntimeError(
             "`paddle.distributed.spawn` does not support parallel training on device `{}` now.".format(

--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -298,8 +298,8 @@ def _get_subprocess_env_list(nprocs, options):
                 "the number of visible devices(%d) is less than the number "
                 "of spawn processes(%d), please ensure that the correct "
                 "`nprocs` argument is passed or the environment variable "
-                "`CUDA_VISIBLE_DEVICES` is correctly configured."
-                % (len(env_devices_list), nprocs)
+                "`FLAGS_selected_%ss` is correctly configured."
+                % (len(env_devices_list), nprocs, custom_device_name)
             )
         args.selected_devices = ",".join(
             [str(env_devices_list[x]) for x in range(0, nprocs)]

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -437,6 +437,18 @@ def _prepare_trainer_env(cluster, trainer, backend=None):
             "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
             "PADDLE_DISTRI_BACKEND": backend,  # only add here, other will be auto
         }
+    elif backend == 'xccl':
+        from paddle.framework import core
+
+        custom_device_name = core.get_all_custom_device_type()[0]
+        proc_env = {
+            f"FLAGS_selected_{custom_device_name}s": "%s"
+            % ",".join([str(g) for g in trainer.gpus]),
+            "PADDLE_TRAINER_ID": "%d" % trainer.rank,
+            "PADDLE_CURRENT_ENDPOINT": "%s" % trainer.endpoint,
+            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints()),
+        }
     else:
         raise ValueError("backend must be one of 'gloo, nccl, bkcl'")
 

--- a/python/paddle/utils/install_check.py
+++ b/python/paddle/utils/install_check.py
@@ -280,7 +280,7 @@ def run_check():
 
     try:
         if len(device_list) > 1:
-            if use_custom is True:
+            if use_custom:
                 import os
 
                 os.environ['PADDLE_DISTRI_BACKEND'] = "xccl"

--- a/python/paddle/utils/install_check.py
+++ b/python/paddle/utils/install_check.py
@@ -81,7 +81,23 @@ def _is_xpu_available():
         return False
 
 
-def _run_dygraph_single(use_cuda, use_xpu):
+def _is_custom_device_available():
+    """
+    Check whether Custom device is available.
+    """
+    try:
+        assert len(paddle.framework.core.get_available_custom_device()) > 0
+        return True
+    except Exception as e:
+        logging.warning(
+            "You are using Custom device version PaddlePaddle, but there is no Custom devices "
+            "detected on your machine. Maybe Custom devices is not set properly."
+            "\n Original Error is {}".format(e)
+        )
+        return False
+
+
+def _run_dygraph_single(use_cuda, use_xpu, use_custom, custom_device_name):
     """
     Testing the simple network in dygraph mode using one CPU/GPU/XPU.
 
@@ -94,6 +110,8 @@ def _run_dygraph_single(use_cuda, use_xpu):
         paddle.set_device('gpu')
     elif use_xpu:
         paddle.set_device('xpu')
+    elif use_custom:
+        paddle.set_device(custom_device_name)
     else:
         paddle.set_device('cpu')
     weight_attr = paddle.ParamAttr(
@@ -116,7 +134,7 @@ def _run_dygraph_single(use_cuda, use_xpu):
     opt.step()
 
 
-def _run_static_single(use_cuda, use_xpu):
+def _run_static_single(use_cuda, use_xpu, use_custom, custom_device_name):
     """
     Testing the simple network with executor running directly, using one CPU/GPU/XPU.
 
@@ -139,6 +157,8 @@ def _run_static_single(use_cuda, use_xpu):
             place = paddle.CUDAPlace(0)
         elif use_xpu:
             place = paddle.XPUPlace(0)
+        elif use_custom:
+            place = paddle.CustomPlace(custom_device_name, 0)
         else:
             place = paddle.CPUPlace()
 
@@ -229,11 +249,15 @@ def run_check():
 
     use_cuda = False
     use_xpu = False
+    use_custom = False
+    custom_device_name = None
 
     if paddle.is_compiled_with_cuda():
         use_cuda = _is_cuda_available()
     elif paddle.is_compiled_with_xpu():
         use_xpu = _is_xpu_available()
+    elif len(paddle.framework.core.get_all_custom_device_type()) == 1:
+        use_custom = _is_custom_device_available()
 
     if use_cuda:
         device_str = "GPU"
@@ -241,17 +265,25 @@ def run_check():
     elif use_xpu:
         device_str = "XPU"
         device_list = paddle.static.xpu_places()
+    elif use_custom:
+        device_str = paddle.framework.core.get_all_custom_device_type()[0]
+        custom_device_name = device_str
+        device_list = paddle.framework.core.get_available_custom_device()
     else:
         device_str = "CPU"
         device_list = paddle.static.cpu_places(device_count=1)
     device_count = len(device_list)
 
-    _run_static_single(use_cuda, use_xpu)
-    _run_dygraph_single(use_cuda, use_xpu)
+    _run_static_single(use_cuda, use_xpu, use_custom, custom_device_name)
+    _run_dygraph_single(use_cuda, use_xpu, use_custom, custom_device_name)
     print(f"PaddlePaddle works well on 1 {device_str}.")
 
     try:
         if len(device_list) > 1:
+            if use_custom is True:
+                import os
+
+                os.environ['PADDLE_DISTRI_BACKEND'] = "xccl"
             _run_parallel(device_list)
             print(
                 "PaddlePaddle works well on {} {}s.".format(

--- a/python/paddle/utils/install_check.py
+++ b/python/paddle/utils/install_check.py
@@ -242,6 +242,12 @@ def run_check():
         use_xpu = _is_xpu_available()
     elif len(paddle.framework.core.get_all_custom_device_type()) > 0:
         use_custom = True
+        if len(paddle.framework.core.get_all_custom_device_type()) > 1:
+            logging.warning(
+                "More than one kind of custom devices detected, but run check would only be executed on {}.".format(
+                    paddle.framework.core.get_all_custom_device_type()[0]
+                )
+            )
 
     if use_cuda:
         device_str = "GPU"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
为Custom Device增加run_check支持。目前仅支持单一种类的Custom Device（如只安装了昇腾NPU）。测试结果如下

> I0816 00:21:36.809013 46151 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:21:36.809063 46151 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:21:45.779037 46151 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:21:45.785408 46151 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:21:45.785624 46151 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:21:45.785661 46151 init.cc:245] CustomDevice: npu, visible devices count: 8
Running verify PaddlePaddle program ... 
I0816 00:21:46.421669 46151 program_interpreter.cc:173] New Executor is Running.
I0816 00:21:56.070345 46151 interpreter_util.cc:602] Standalone Executor is Used.
PaddlePaddle works well on 1 npu.
I0816 00:22:03.654654 47214 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.654700 47214 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.654707 47218 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.654744 47218 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.679235 47224 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.679277 47224 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.679328 47222 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.679370 47222 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.733134 47226 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.733175 47226 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.745720 47216 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.745798 47216 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.774627 47228 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.774673 47228 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:22:03.844810 47220 init.cc:239] ENV [CUSTOM_DEVICE_ROOT]=/opt/py37env/lib/python3.7/site-packages/paddle_custom_device
I0816 00:22:03.844862 47220 init.cc:145] Try loading custom device libs from: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.845295 47224 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.845419 47214 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.845582 47216 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.845983 47218 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.845981 47226 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.846091 47222 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.846371 47220 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.847659 47228 custom_device.cc:1112] Successed in loading custom runtime in lib: /opt/py37env/lib/python3.7/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0816 00:23:01.853188 47222 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.853382 47222 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.853421 47222 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.855057 47216 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.855264 47216 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.855311 47216 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.856283 47214 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.856554 47214 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.856628 47214 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.856930 47224 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.857210 47224 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.857270 47224 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.861477 47228 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.861799 47228 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.861892 47228 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.869469 47218 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.871120 47218 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.871223 47218 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.871992 47226 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.872675 47226 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.872776 47226 init.cc:245] CustomDevice: npu, visible devices count: 8
I0816 00:23:01.876528 47220 custom_kernel.cc:76] Successed in loading 325 custom kernel(s) from loaded lib(s), will be used like native ones.
I0816 00:23:01.877274 47220 init.cc:157] Finished in LoadCustomDevice with libs_path: [/opt/py37env/lib/python3.7/site-packages/paddle_custom_device]
I0816 00:23:01.877414 47220 init.cc:245] CustomDevice: npu, visible devices count: 8
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
=======================================================================
I0816 00:23:02.191779 47222 tcp_utils.cc:107] Retry to connect to 127.0.0.1:36736 while the server is not yet listening.
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
=======================================================================
I0816 00:23:02.230875 47214 tcp_utils.cc:181] The server starts to listen on IP_ANY:36736
I0816 00:23:02.231042 47214 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
=======================================================================
I0816 00:23:02.243198 47224 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
=======================================================================
I0816 00:23:02.250854 47228 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
=======================================================================
I0816 00:23:02.257926 47218 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
=======================================================================
I0816 00:23:02.268605 47216 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
=======================================================================
I0816 00:23:02.296648 47226 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
======================= Modified FLAGS detected =======================
FLAGS(name='FLAGS_npu_storage_format', current_value=True, default_value=False)
FLAGS(name='FLAGS_allocator_strategy', current_value='naive_best_fit', default_value='auto_growth')
=======================================================================
I0816 00:23:02.329967 47220 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
I0816 00:23:05.192014 47222 tcp_utils.cc:130] Successfully connected to 127.0.0.1:36736
I0816 00:23:36.681679 47659 tcp_store.cc:273] receive shutdown event and so quit from MasterDaemon run loop
PaddlePaddle works well on 8 npus.
PaddlePaddle is installed successfully! Let's start deep learning with PaddlePaddle now.