### PR TITLE
[NewIR] Insert `get_parameter` only for paramters

### DIFF
--- a/paddle/fluid/framework/executor_cache.cc
+++ b/paddle/fluid/framework/executor_cache.cc
@@ -367,7 +367,7 @@ std::unique_ptr<::ir::Program> ConstructFowardIrProgram(
     }
   }
 
-  // add fetch with place op to program
+  // add data op to program
   auto *block = local_program.MutableBlock(0);
   for (auto &in_t : x) {
     auto name = in_t.name();

--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -481,9 +481,10 @@ std::string NewIRInterpreter::DebugValueInfo() {
                    platform::errors::PreconditionNotMet(
                        "var(%s) should exist in var_name_2_id_", kv.second));
     auto* var = InnerScope()->FindVar(kv.second);
-    PADDLE_ENFORCE(var != nullptr,
-                   platform::errors::PreconditionNotMet(
-                       "var(%s) should exist in var_name_2_id_", kv.second));
+    PADDLE_ENFORCE(
+        var != nullptr,
+        platform::errors::PreconditionNotMet(
+            "var(%s) should exist in scope (%p)", kv.second, InnerScope()));
     os << kv.first.impl() << " -> " << kv.second << " -> "
        << var_name_2_id_.at(kv.second) << " -> " << var << "\n";
   }

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -148,7 +148,7 @@ void ProgramTranslator::GetParameterForSingleBlock(const BlockDesc& block) {
           ir::Operation* op = InsertGetParamaterOp(ctx_, var_desc);
           program_->block()->push_back(op);
           param_map_[var_name] = VariableDefiningInfo(op->result(0));
-          VLOG(10) << "[op translated][get parameter]" << op;
+          VLOG(10) << "[op translated][get parameter]" << var_name;
 
           program_->SetParameter(var_name, nullptr);
           parameter_visited_.insert(var_name);
@@ -224,7 +224,7 @@ void ProgramTranslator::SetParameterFromSingleBlock(const BlockDesc& block) {
           insert_pos++;
 
           block->insert(insert_pos, op);
-          VLOG(10) << "[op translated][set parameter]" << op;
+          VLOG(10) << "[op translated][set parameter]" << var_name;
 
           program_->SetParameter(var_name, nullptr);
           parameter_visited_.insert(var_name);

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -143,7 +143,7 @@ void ProgramTranslator::GetParameterForSingleBlock(const BlockDesc& block) {
           var_desc = block.FindVarRecursive(var_name);
         }
 
-        bool need_get_parameter_op = is_parameter || is_unseen_variable;
+        bool need_get_parameter_op = is_parameter && is_unseen_variable;
         if (need_get_parameter_op) {
           ir::Operation* op = InsertGetParamaterOp(ctx_, var_desc);
           program_->block()->push_back(op);

--- a/paddle/fluid/ir_adaptor/translator/utils.cc
+++ b/paddle/fluid/ir_adaptor/translator/utils.cc
@@ -18,6 +18,7 @@
 
 #include "paddle/ir/core/builtin_attribute.h"
 #include "paddle/ir/core/builtin_type.h"
+#include "paddle/ir/core/utils.h"
 
 namespace paddle {
 namespace translator {
@@ -44,6 +45,16 @@ ir::Operation* InsertSliceOperationForTarget(
   ir::OpResult target_op_result = operation->result(0);
   (*param_map)[arg_name] = VariableDefiningInfo(target_op_result);
   return operation;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const std::vector<std::string>& vec_str) {
+  ir::PrintInterleave(
+      vec_str.begin(),
+      vec_str.end(),
+      [&os](std::string s) { os << s; },
+      [&os]() { os << ", "; });
+  return os;
 }
 
 }  // namespace translator

--- a/paddle/fluid/ir_adaptor/translator/utils.h
+++ b/paddle/fluid/ir_adaptor/translator/utils.h
@@ -31,5 +31,8 @@ ir::Operation* InsertSliceOperationForTarget(
     const VariableDefiningInfo& defining_info,
     const std::string& arg_name);
 
+std::ostream& operator<<(std::ostream& os,
+                         const std::vector<std::string>& vec_str);
+
 }  // namespace translator
 }  // namespace paddle

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import paddle
 from paddle.fluid import Variable, core
 from paddle.fluid.data_feeder import check_type
@@ -96,7 +98,7 @@ def data(name, shape, dtype=None, lod_level=0):
             shape[i] = -1
 
     if dtype:
-        return helper.create_global_variable(
+        out = helper.create_global_variable(
             name=name,
             shape=shape,
             dtype=dtype,
@@ -107,7 +109,7 @@ def data(name, shape, dtype=None, lod_level=0):
             need_check_feed=True,
         )
     else:
-        return helper.create_global_variable(
+        out = helper.create_global_variable(
             name=name,
             shape=shape,
             dtype=paddle.get_default_dtype(),
@@ -117,6 +119,21 @@ def data(name, shape, dtype=None, lod_level=0):
             is_data=True,
             need_check_feed=True,
         )
+
+    if os.environ.get("FLAGS_enable_new_ir_in_executor", None):
+        helper = LayerHelper('data', **locals())
+        helper.append_op(
+            type='data',
+            inputs={},
+            outputs={'out': out},
+            attrs={
+                'index': 0,
+                'dtype': 0,
+                'place': 0,
+                'name': name,
+            },
+        )
+    return out
 
 
 class InputSpec:

--- a/test/ir/new_ir/test_ir_vjp.py
+++ b/test/ir/new_ir/test_ir_vjp.py
@@ -106,7 +106,7 @@ class TestMeanVjp(unittest.TestCase):
                 .source()
                 .get_defining_op()
                 .name(),
-                "builtin.get_parameter",
+                "pd.data",
             )
             self.assertEqual(
                 grad_outs[0][0]

--- a/test/prim/new_ir_prim/test_decomp_op.py
+++ b/test/prim/new_ir_prim/test_decomp_op.py
@@ -47,7 +47,7 @@ class TestBuildOp(unittest.TestCase):
         self.assertEqual(
             op_name_list,
             [
-                'builtin.get_parameter',
+                'pd.data',
                 'pd.matmul',
                 'pd.add',
                 'pd.full_int_array',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
1. Strength the requirements for insert a `builtin.get_parameter `, now only insert for real parameters
2. For variables created by `paddle.static.data` or other apis, a `pd.data` should be inserted instead. For compatibility, we  modify the api of `paddle.static.data` when flag `FLAGS_enable_new_ir_in_executor` is set.
#### Others
Pcard-67164