### PR TITLE
remove advanced_check for Variable in slice

### DIFF
--- a/python/paddle/fluid/dygraph/tensor_patch_methods.py
+++ b/python/paddle/fluid/dygraph/tensor_patch_methods.py
@@ -734,13 +734,6 @@ def monkey_patch_tensor():
         for slice_item in item:
             if isinstance(slice_item, (list, np.ndarray, Variable)):
                 return True
-            elif isinstance(slice_item, slice):
-                if (
-                    isinstance(slice_item.start, Variable)
-                    or isinstance(slice_item.stop, Variable)
-                    or isinstance(slice_item.step, Variable)
-                ):
-                    return True
 
         return False
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985

修复`setitem`中使用了包含Variable类型指定slice中start/end/step的场景，存在性能下降的问题

在此前，`__getitem__`将上述场景分发到了python侧处理但`__setitem__`不是。当前支持联合索引的PR中合并了`__getitem__`和`__setitem__`关于基础索引/高级索引的分类检查，导致`__setitem__`在上述场景中被分发到Python侧处理，造成性能下降。但从语义上，该场景仍然属于基础索引场景，可以在Cpp侧处理，并且Cpp侧也支持处理该场景。  因此针对索引中出现的slice类型，不再区分其内容是否是Variable