### PR TITLE
【CINN】Fix simplifyBlockMutator backtrace logic

### DIFF
--- a/paddle/cinn/optim/ir_simplify.cc
+++ b/paddle/cinn/optim/ir_simplify.cc
@@ -299,6 +299,9 @@ struct SimplifyBlocksMutator : public ir::IRMutator<> {
       *expr = node->stmts[0];
       Visit(expr, expr);
     } else {
+      for (auto& s : node->stmts) {
+        Visit(&s, &s);
+      }
       std::vector<Expr> stmts;
       for (auto& s : node->stmts) {
         if (s.As<ir::Block>()) {
@@ -308,7 +311,6 @@ struct SimplifyBlocksMutator : public ir::IRMutator<> {
             stmts.push_back(inner_stmt);
           }
         } else {
-          IRMutator<>::Visit(&s, &s);
           stmts.push_back(s);
         }
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
card-72718
This PR fix Backward Tracing logic of SimplifyBlockMutator