### PR TITLE
fix fft bug in DCU

### DIFF
--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -400,7 +400,7 @@ void* GetROCFFTDsoHandle() {
 #if defined(__APPLE__) || defined(__OSX__)
   return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "librocfft.dylib");
 #else
-  return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "librocfft.so");
+  return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libhipfft.so");
 #endif
 }
 #endif


### PR DESCRIPTION
### PR types
<!-- Bug fixes -->

### PR changes
<!-- OPs -->

### Description
<!-- fix fft core dump bug in DCU，需要在dtk22.10.1环境下，运行程序前 export LD_LIBRARY_PATH= path_to_rocfft_install/lib:$LD_LIBRARY_PATH 指定新的rocfft库路径，否则会在destroyhandle时候core dump -->
