### PR TITLE
【complex op】 No.34 add complex support for dot

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1117,13 +1117,31 @@ def dot(x, y, name=None):
         check_variable_and_dtype(
             x,
             'x',
-            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'],
+            [
+                'float16',
+                'uint16',
+                'float32',
+                'float64',
+                'int32',
+                'int64',
+                'complex64',
+                'complex128',
+            ],
             op_type,
         )
         check_variable_and_dtype(
             y,
             'y',
-            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'],
+            [
+                'float16',
+                'uint16',
+                'float32',
+                'float64',
+                'int32',
+                'int64',
+                'complex64',
+                'complex128',
+            ],
             op_type,
         )
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1080,8 +1080,8 @@ def dot(x, y, name=None):
        is the batch dimension, which means that the vectors of multiple batches are dotted.
 
     Parameters:
-        x(Tensor): 1-D or 2-D ``Tensor``. Its dtype should be ``float32``, ``float64``, ``int32``, ``int64``
-        y(Tensor): 1-D or 2-D ``Tensor``. Its dtype soulde be ``float32``, ``float64``, ``int32``, ``int64``
+        x(Tensor): 1-D or 2-D ``Tensor``. Its dtype should be ``float32``, ``float64``, ``int32``, ``int64``, ``complex64``, ``complex128``
+        y(Tensor): 1-D or 2-D ``Tensor``. Its dtype soulde be ``float32``, ``float64``, ``int32``, ``int64``, ``complex64``, ``complex128``
         name(str, optional): Name of the output. Default is None. It's used to print debug info for developers. Details: :ref:`api_guide_Name`
 
     Returns:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1117,13 +1117,13 @@ def dot(x, y, name=None):
         check_variable_and_dtype(
             x,
             'x',
-            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64'],
+            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'],
             op_type,
         )
         check_variable_and_dtype(
             y,
             'y',
-            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64'],
+            ['float16', 'uint16', 'float32', 'float64', 'int32', 'int64', 'complex64', 'complex128'],
             op_type,
         )
 

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -186,23 +186,27 @@ class TestComplex64DotOp(DotOp):
     def init_dtype(self):
         self.dtype = np.complex64
 
-    def init_shape(self):
-        self.shape = 100
-
     def init_input_output(self):
-        self.init_shape()
+        shape = 100
         self.x = (
-            np.random.random(self.shape) + 1j * np.random.random(self.shape)
+            np.random.random(shape) + 1j * np.random.random(shape)
         ).astype(self.dtype)
         self.y = (
-            np.random.random(self.shape) + 1j * np.random.random(self.shape)
+            np.random.random(shape) + 1j * np.random.random(shape)
         ).astype(self.dtype)
         self.out = np.dot(self.x, self.y).astype(self.dtype)
 
 
 class TestComplex64DotOp2D(TestComplex64DotOp):
-    def init_shape(self):
-        self.shape = (100, 100)
+    def init_input_output(self):
+        shape = (2, 100)
+        self.x = (
+            np.random.random(shape) + 1j * np.random.random(shape)
+        ).astype(self.dtype)
+        self.y = (
+            np.random.random(shape) + 1j * np.random.random(shape)
+        ).astype(self.dtype)
+        self.out = np.diag(np.dot(self.x, self.y.T)).reshape(-1)
 
 
 class TestComplex128DotOp(TestComplex64DotOp):

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -185,13 +185,17 @@ class TestDygraph(unittest.TestCase):
 class TestComplex64DotOp(DotOp):
     def init_dtype(self):
         self.dtype = np.complex64
-        
+
     def init_shape(self):
         self.shape = 100
 
     def init_input_output(self):
-        self.x = (np.random.random(self.shape) + 1j * np.random.random(self.shape)).astype(self.dtype)
-        self.y = (np.random.random(self.shape) + 1j * np.random.random(self.shape)).astype(self.dtype)
+        self.x = (
+            np.random.random(self.shape) + 1j * np.random.random(self.shape)
+        ).astype(self.dtype)
+        self.y = (
+            np.random.random(self.shape) + 1j * np.random.random(self.shape)
+        ).astype(self.dtype)
         self.out = np.dot(self.x, self.y).astype(self.dtype)
 
 

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -182,102 +182,27 @@ class TestDygraph(unittest.TestCase):
             )
 
 
-class TestComplexDotOp(OpTest):
-    def setUp(self):
-        self.op_type = "dot"
-        self.python_api = paddle.dot
-        self.init_base_dtype()
-        self.init_input_output()
-
-        self.inputs = {
-            'X': OpTest.np_dtype_to_fluid_dtype(self.x),
-            'Y': OpTest.np_dtype_to_fluid_dtype(self.y),
-        }
-        self.outputs = {'Out': self.out}
-
-    def init_base_dtype(self):
-        self.dtype = np.float64
+class TestComplex64DotOp(DotOp):
+    def init_dtype(self):
+        self.dtype = np.complex64
+        
+    def init_shape(self):
+        self.shape = 100
 
     def init_input_output(self):
-        self.x = np.random.random(100).astype(
-            self.dtype
-        ) + 1j * np.random.random(100).astype(self.dtype)
-        self.y = np.random.random(100).astype(
-            self.dtype
-        ) + 1j * np.random.random(100).astype(self.dtype)
-        self.out = np.dot(self.x, self.y)
-
-    def test_check_output(self):
-        self.check_output()
-
-    def test_check_grad_normal(self):
-        self.check_grad(
-            ['X', 'Y'],
-            'Out',
-        )
-
-    def test_check_grad_ingore_x(self):
-        self.check_grad(
-            ['Y'],
-            'Out',
-            no_grad_set=set("X"),
-        )
-
-    def test_check_grad_ingore_y(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            no_grad_set=set('Y'),
-        )
+        self.x = (np.random.random(self.shape) + 1j * np.random.random(self.shape)).astype(self.dtype)
+        self.y = (np.random.random(self.shape) + 1j * np.random.random(self.shape)).astype(self.dtype)
+        self.out = np.dot(self.x, self.y).astype(self.dtype)
 
 
-class TestComplexDotOp2D(OpTest):
-    def setUp(self):
-        self.op_type = "dot"
-        self.python_api = paddle.dot
-        self.init_base_dtype()
-        self.init_input_output()
+class TestComplex64DotOp2D(TestComplex64DotOp):
+    def init_shape(self):
+        self.shape = (100, 100)
 
-        self.inputs = {
-            'X': OpTest.np_dtype_to_fluid_dtype(self.x),
-            'Y': OpTest.np_dtype_to_fluid_dtype(self.y),
-        }
-        self.outputs = {'Out': self.out}
 
-    def init_base_dtype(self):
-        self.dtype = np.float64
-
-    def init_input_output(self):
-        self.x = np.random.random((2, 100)).astype(
-            self.dtype
-        ) + 1j * np.random.random((2, 100)).astype(self.dtype)
-        self.y = np.random.random((2, 100)).astype(
-            self.dtype
-        ) + 1j * np.random.random((2, 100)).astype(self.dtype)
-        self.out = np.diag(np.dot(self.x, self.y.T)).reshape(-1)
-
-    def test_check_output(self):
-        self.check_output()
-
-    def test_check_grad_normal(self):
-        self.check_grad(
-            ['X', 'Y'],
-            'Out',
-        )
-
-    def test_check_grad_ingore_x(self):
-        self.check_grad(
-            ['Y'],
-            'Out',
-            no_grad_set=set("X"),
-        )
-
-    def test_check_grad_ingore_y(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            no_grad_set=set('Y'),
-        )
+class TestComplex128DotOp(TestComplex64DotOp):
+    def init_dtype(self):
+        self.dtype = np.complex128
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -190,6 +190,7 @@ class TestComplex64DotOp(DotOp):
         self.shape = 100
 
     def init_input_output(self):
+        self.init_shape()
         self.x = (
             np.random.random(self.shape) + 1j * np.random.random(self.shape)
         ).astype(self.dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- #56145

改动：
- op dot 的前向及反向 kernel 已经支持复数类型，无需改动
- 在 dot api 的类型校验中增加了复数
- 改写 op dot 的复数单测
