### PR TITLE
add num_splist for flash_attn_bwd and FlashAttnUnpaddedGradKernel

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
@@ -236,11 +236,10 @@ void FlashAttnUnpaddedGradKernel(const Context& ctx,
     const int64_t total_k = k.dims()[0];
     const int64_t num_heads_k = k.dims()[1];
 
-    // TODO(umiswing): add deterministic in fa2.
-    // int num_splits = 0;  // 0 for an internal heuristic, which is optimal
-    // if (FLAGS_cudnn_deterministic) {
-    //   num_splits = 1;
-    // }
+    int num_splits = 0;  // 0 for an internal heuristic, which is optimal
+    if (FLAGS_cudnn_deterministic) {
+      num_splits = 1;
+    }
 
     // TODO(umiswing): add shape check
     PADDLE_ENFORCE_EQ(
@@ -294,6 +293,7 @@ void FlashAttnUnpaddedGradKernel(const Context& ctx,
                                             params.scale,
                                             params.causal,
                                             params.is_bf16,
+                                            num_splits,
                                             stream,
                                             params.seed,
                                             params.offset);
@@ -401,6 +401,11 @@ void FlashAttnGradKernel(const Context& ctx,
     VLOG(10) << "FlashAttn bwd seed: " << params.seed
              << ", offset: " << params.offset;
 
+    int num_splits = 0;  // 0 for an internal heuristic, which is optimal
+    if (FLAGS_cudnn_deterministic) {
+      num_splits = 1;
+    }
+
     bool succ = phi::dynload::flash_attn_bwd(dout.data(),
                                              q.data(),
                                              k.data(),
@@ -426,6 +431,7 @@ void FlashAttnGradKernel(const Context& ctx,
                                              params.scale,
                                              params.causal,
                                              params.is_bf16,
+                                             num_splits,
                                              stream,
                                              params.seed,
                                              params.offset);

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -365,6 +365,11 @@ class TestFlashAttentionWithMaskAPI(unittest.TestCase):
         out_.backward()
         np.testing.assert_allclose(out.numpy(), out_, rtol=5e-03, atol=1e-03)
 
+    def test_dot_scale_product_flag(self):
+        paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
+        self.test_dot_scale_product()
+        paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
+
 
 class TestFlashAttentionAPITest1(TestFlashAttentionAPI):
     def setUp(self):

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -323,7 +323,7 @@ class TestFlashAttentionWithMaskAPI(unittest.TestCase):
         self.dropout = 0.0
         self.causal = False
 
-    def test_dot_scale_product(self):
+    def get_out_data(self):
         # test dynamic
         paddle.disable_static()
 
@@ -363,11 +363,21 @@ class TestFlashAttentionWithMaskAPI(unittest.TestCase):
         out_ = attention_naive_with_mask(q_, k_, v_, m)
         out.backward()
         out_.backward()
+        return out, out_
+
+    def test_dot_scale_product(self):
+        out, out_ = self.get_out_data()
         np.testing.assert_allclose(out.numpy(), out_, rtol=5e-03, atol=1e-03)
 
     def test_dot_scale_product_flag(self):
         paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
-        self.test_dot_scale_product()
+
+        out1, out1_ = self.get_out_data()
+        np.testing.assert_allclose(out1.numpy(), out1_, rtol=5e-03, atol=1e-03)
+
+        out2, out2_ = self.get_out_data()
+        np.equal(out1.numpy(), out2.numpy())
+
         paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
 
 

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -310,24 +310,6 @@ class TestFlashAttentionAPI(unittest.TestCase):
         value = np.random.random(self.shape)
         out, out_, _, _, _ = self.flash_attn_compute(query, key, value)
 
-    def test_all_flag(self):
-        paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
-        query = np.random.random(self.shape)
-        key = np.random.random(self.shape)
-        value = np.random.random(self.shape)
-
-        out1, out1_, q_grad1, k_grad1, v_grad1 = self.flash_attn_compute(
-            query, key, value
-        )
-        out2, out2_, q_grad2, k_grad2, v_grad2 = self.flash_attn_compute(
-            query, key, value
-        )
-        self.assertTrue(np.equal(out1.numpy(), out2.numpy()).all())
-        self.assertTrue(np.equal(q_grad1, q_grad2).all())
-        self.assertTrue(np.equal(k_grad1, k_grad2).all())
-        self.assertTrue(np.equal(v_grad1, v_grad2).all())
-        paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
-
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
@@ -397,6 +379,24 @@ class TestFlashAttentionAPITest1(TestFlashAttentionAPI):
         self.return_softmax = False
         self.use_sdp_kernel = False
 
+    def test_all_flag(self):
+        paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
+        query = np.random.random(self.shape)
+        key = np.random.random(self.shape)
+        value = np.random.random(self.shape)
+
+        out1, out1_, q_grad1, k_grad1, v_grad1 = self.flash_attn_compute(
+            query, key, value
+        )
+        out2, out2_, q_grad2, k_grad2, v_grad2 = self.flash_attn_compute(
+            query, key, value
+        )
+        self.assertTrue(np.equal(out1.numpy(), out2.numpy()).all())
+        self.assertTrue(np.equal(q_grad1, q_grad2).all())
+        self.assertTrue(np.equal(k_grad1, k_grad2).all())
+        self.assertTrue(np.equal(v_grad1, v_grad2).all())
+        paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
+
 
 class TestFlashAttentionAPITest2(TestFlashAttentionAPI):
     def setUp(self):
@@ -431,7 +431,7 @@ class TestFlashAttentionAPITest4(TestFlashAttentionAPI):
         self.use_sdp_kernel = False
 
 
-class TestFlashAttentionAPITest5(TestFlashAttentionAPI):
+class TestFlashAttentionAPITest5(TestFlashAttentionAPITest1):
     def setUp(self):
         self.place = paddle.CUDAPlace(0)
         self.shape = (8, 1024, 16, 256)
@@ -457,7 +457,7 @@ class TestMathAttentionAPITest(TestFlashAttentionAPI):
         self.enable_mem_efficient = False
 
 
-class TestSDPAttentionAPITest(TestFlashAttentionAPI):
+class TestSDPAttentionAPITest(TestFlashAttentionAPITest1):
     def setUp(self):
         self.place = paddle.CUDAPlace(0)
         self.shape = (8, 1024, 16, 128)

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -302,13 +302,13 @@ class TestFlashAttentionAPI(unittest.TestCase):
             np.testing.assert_allclose(
                 fetches_result[0], out_, rtol=5e-03, atol=1e-03
             )
-            return out, out_, fetches_result[0]
+            return out, out_, q.grad.numpy(), k.grad.numpy(), v.grad.numpy()
 
     def test_all(self):
         query = np.random.random(self.shape)
         key = np.random.random(self.shape)
         value = np.random.random(self.shape)
-        out, out_, _ = self.flash_attn_compute(query, key, value)
+        out, out_, _, _, _ = self.flash_attn_compute(query, key, value)
 
     def test_all_flag(self):
         paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
@@ -316,14 +316,16 @@ class TestFlashAttentionAPI(unittest.TestCase):
         key = np.random.random(self.shape)
         value = np.random.random(self.shape)
 
-        out1, out1_, fetches_result1 = self.flash_attn_compute(
+        out1, out1_, q_grad1, k_grad1, v_grad1 = self.flash_attn_compute(
             query, key, value
         )
-        out2, out2_, fetches_result2 = self.flash_attn_compute(
+        out2, out2_, q_grad2, k_grad2, v_grad2 = self.flash_attn_compute(
             query, key, value
         )
         self.assertTrue(np.equal(out1.numpy(), out2.numpy()).all())
-        self.assertTrue(np.equal(fetches_result1, fetches_result2).all())
+        self.assertTrue(np.equal(q_grad1, q_grad2).all())
+        self.assertTrue(np.equal(k_grad1, k_grad2).all())
+        self.assertTrue(np.equal(v_grad1, v_grad2).all())
         paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
 
 

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -191,12 +191,16 @@ class TestFlashAttentionAPI(unittest.TestCase):
                 fetches_result[0], out_, rtol=5e-03, atol=1e-03
             )
 
-    def flash_attn_compute(self, query, key, value):
+    def test_all(self):
         print(
             f"Test case shape {self.shape} dtype {self.dtype} causal {self.causal}"
         )
         # test dynamic
         paddle.disable_static()
+
+        query = np.random.random(self.shape)
+        key = np.random.random(self.shape)
+        value = np.random.random(self.shape)
 
         q = paddle.to_tensor(
             query, place=self.place, dtype=self.dtype, stop_gradient=False
@@ -302,13 +306,6 @@ class TestFlashAttentionAPI(unittest.TestCase):
             np.testing.assert_allclose(
                 fetches_result[0], out_, rtol=5e-03, atol=1e-03
             )
-            return out, out_, q.grad.numpy(), k.grad.numpy(), v.grad.numpy()
-
-    def test_all(self):
-        query = np.random.random(self.shape)
-        key = np.random.random(self.shape)
-        value = np.random.random(self.shape)
-        out, out_, _, _, _ = self.flash_attn_compute(query, key, value)
 
 
 @unittest.skipIf(
@@ -379,24 +376,6 @@ class TestFlashAttentionAPITest1(TestFlashAttentionAPI):
         self.return_softmax = False
         self.use_sdp_kernel = False
 
-    def test_all_flag(self):
-        paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
-        query = np.random.random(self.shape)
-        key = np.random.random(self.shape)
-        value = np.random.random(self.shape)
-
-        out1, out1_, q_grad1, k_grad1, v_grad1 = self.flash_attn_compute(
-            query, key, value
-        )
-        out2, out2_, q_grad2, k_grad2, v_grad2 = self.flash_attn_compute(
-            query, key, value
-        )
-        self.assertTrue(np.equal(out1.numpy(), out2.numpy()).all())
-        self.assertTrue(np.equal(q_grad1, q_grad2).all())
-        self.assertTrue(np.equal(k_grad1, k_grad2).all())
-        self.assertTrue(np.equal(v_grad1, v_grad2).all())
-        paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
-
 
 class TestFlashAttentionAPITest2(TestFlashAttentionAPI):
     def setUp(self):
@@ -431,7 +410,7 @@ class TestFlashAttentionAPITest4(TestFlashAttentionAPI):
         self.use_sdp_kernel = False
 
 
-class TestFlashAttentionAPITest5(TestFlashAttentionAPITest1):
+class TestFlashAttentionAPITest5(TestFlashAttentionAPI):
     def setUp(self):
         self.place = paddle.CUDAPlace(0)
         self.shape = (8, 1024, 16, 256)
@@ -457,7 +436,7 @@ class TestMathAttentionAPITest(TestFlashAttentionAPI):
         self.enable_mem_efficient = False
 
 
-class TestSDPAttentionAPITest(TestFlashAttentionAPITest1):
+class TestSDPAttentionAPITest(TestFlashAttentionAPI):
     def setUp(self):
         self.place = paddle.CUDAPlace(0)
         self.shape = (8, 1024, 16, 128)

--- a/test/legacy_test/test_flash_attention_deterministic.py
+++ b/test/legacy_test/test_flash_attention_deterministic.py
@@ -20,7 +20,7 @@ import numpy as np
 
 import paddle
 import paddle.nn.functional as F
-from paddle.fluid import core
+from paddle.device import core
 from paddle.nn.functional.flash_attention import (
     flash_attention,
     scaled_dot_product_attention,
@@ -89,9 +89,6 @@ class TestFlashAttentionAPIFlag(unittest.TestCase):
         self.use_sdp_api = False
 
     def flash_attn_compute(self, query, key, value):
-        print(
-            f"Test case shape {self.shape} dtype {self.dtype} causal {self.causal}"
-        )
         # test dynamic
         paddle.disable_static()
 

--- a/test/legacy_test/test_flash_attention_deterministic.py
+++ b/test/legacy_test/test_flash_attention_deterministic.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.nn.functional as F
+from paddle.fluid import core
+from paddle.nn.functional.flash_attention import (
+    flash_attention,
+    scaled_dot_product_attention,
+)
+
+
+def get_cuda_version():
+    result = os.popen("nvcc --version").read()
+    regex = r'release (\S+),'
+    match = re.search(regex, result)
+    if match:
+        num = str(match.group(1))
+        integer, decimal = num.split('.')
+        return int(integer) * 1000 + int(float(decimal) * 10)
+    else:
+        return -1
+
+
+def attention_naive(q, k, v, causal=False):
+    qt = paddle.transpose(q, [0, 2, 1, 3])
+    kt = paddle.transpose(k, [0, 2, 1, 3])
+    vt = paddle.transpose(v, [0, 2, 1, 3])
+    scale = 1.0 / np.sqrt(q.shape[-1])
+    s = paddle.matmul(qt, paddle.transpose(kt, [0, 1, 3, 2]))
+    s = paddle.scale(s, scale)
+    p = (
+        paddle.incubate.softmax_mask_fuse_upper_triangle(s)
+        if causal
+        else F.softmax(s)
+    )
+    o = paddle.matmul(p, vt)
+    return paddle.transpose(o, [0, 2, 1, 3])
+
+
+is_sm8x = (
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] == 8
+    and paddle.device.cuda.get_device_capability()[1] >= 0
+)
+
+is_sm90 = (
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] == 9
+    and paddle.device.cuda.get_device_capability()[1] == 0
+)
+
+is_sm_supported = is_sm8x or is_sm90
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11040
+    or not is_sm_supported,
+    "core is not compiled with CUDA and cuda version need larger than or equal to 11.4"
+    "and device's compute capability must be 8.x or 90",
+)
+class TestFlashAttentionAPIFlag(unittest.TestCase):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.shape = (2, 128, 8, 16)
+        self.dtype = 'float16'
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = False
+        self.use_sdp_api = False
+
+    def flash_attn_compute(self, query, key, value):
+        print(
+            f"Test case shape {self.shape} dtype {self.dtype} causal {self.causal}"
+        )
+        # test dynamic
+        paddle.disable_static()
+
+        q = paddle.to_tensor(
+            query, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        k = paddle.to_tensor(
+            key, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        v = paddle.to_tensor(
+            value, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+
+        q_ = paddle.to_tensor(
+            query, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        k_ = paddle.to_tensor(
+            key, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        v_ = paddle.to_tensor(
+            value, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+
+        if self.use_sdp_kernel:
+            with paddle.nn.functional.sdp_kernel(
+                enable_math=self.enable_math,
+                enable_flash=self.enable_flash,
+                enable_mem_efficient=self.enable_mem_efficient,
+            ):
+                if self.use_sdp_api:
+                    out = scaled_dot_product_attention(
+                        q, k, v, None, self.dropout, self.causal
+                    )
+                else:
+                    out, _ = flash_attention(
+                        q, k, v, self.dropout, self.causal, self.return_softmax
+                    )
+
+        else:
+            out, _ = flash_attention(
+                q, k, v, self.dropout, self.causal, self.return_softmax
+            )
+        out_ = attention_naive(q_, k_, v_, self.causal)
+
+        out.backward()
+        out_.backward()
+
+        self.assertEqual(q.grad.shape, q.shape)
+        self.assertEqual(q_.grad.shape, q.shape)
+
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_.grad.numpy(), rtol=5e-03, atol=1e-03
+        )
+
+        return out, out_, q.grad.numpy(), k.grad.numpy(), v.grad.numpy()
+
+    def test_all_flag(self):
+        paddle.set_flags({'FLAGS_cudnn_deterministic': 1})
+        query = np.random.random(self.shape)
+        key = np.random.random(self.shape)
+        value = np.random.random(self.shape)
+
+        out1, out1_, q_grad1, k_grad1, v_grad1 = self.flash_attn_compute(
+            query, key, value
+        )
+
+        np.testing.assert_allclose(out1.numpy(), out1_, rtol=5e-03, atol=1e-03)
+
+        out2, out2_, q_grad2, k_grad2, v_grad2 = self.flash_attn_compute(
+            query, key, value
+        )
+        self.assertTrue(np.equal(out1.numpy(), out2.numpy()).all())
+        self.assertTrue(np.equal(q_grad1, q_grad2).all())
+        self.assertTrue(np.equal(k_grad1, k_grad2).all())
+        self.assertTrue(np.equal(v_grad1, v_grad2).all())
+        paddle.set_flags({'FLAGS_cudnn_deterministic': 0})
+
+
+class TestFlashAttentionAPIFlagTest1(TestFlashAttentionAPIFlag):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.shape = (2, 128, 8, 16)
+        self.dtype = paddle.float16
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = False
+
+
+class TestFlashAttentionAPIFlagTest2(TestFlashAttentionAPIFlag):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.shape = (8, 1024, 16, 256)
+        self.dtype = paddle.float16
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = False
+
+
+class TestSDPAttentionAPIFlagTest(TestFlashAttentionAPIFlag):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.shape = (8, 1024, 16, 128)
+        self.dtype = paddle.float16
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = True
+        self.use_sdp_api = True
+        self.enable_math = True
+        self.enable_flash = False
+        self.enable_mem_efficient = False
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-70458
llama模型参考README运行,2CI对别结果如下，loss无diff
<img width="885" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/51102941/83829661-4f74-4279-807f-4fabec8bb422">
具体数据1：
```
[    INFO] - loss: 2.00048828, learning_rate: 2.1e-06, global_step: 20, interval_runtime: 26.3106, interval_samples_per_second: 6.081193361471736, interval_steps_per_second: 0.760149170183967, epoch: 0.0014
[    INFO] - loss: 1.94342518, learning_rate: 4.1e-06, global_step: 40, interval_runtime: 18.792, interval_samples_per_second: 8.514269788523704, interval_steps_per_second: 1.064283723565463, epoch: 0.0028
[    INFO] - loss: 1.96450806, learning_rate: 6.1e-06, global_step: 60, interval_runtime: 18.8364, interval_samples_per_second: 8.494203585698061, interval_steps_per_second: 1.0617754482122577, epoch: 0.0042
[    INFO] - loss: 1.97299156, learning_rate: 8.1e-06, global_step: 80, interval_runtime: 18.7085, interval_samples_per_second: 8.552269357792328, interval_steps_per_second: 1.069033669724041, epoch: 0.0056
[    INFO] - loss: 1.97750511, learning_rate: 1e-05, global_step: 100, interval_runtime: 18.7949, interval_samples_per_second: 8.512925658562247, interval_steps_per_second: 1.064115707320281, epoch: 0.0069
[    INFO] - loss: 1.95206642, learning_rate: 1e-05, global_step: 120, interval_runtime: 18.7179, interval_samples_per_second: 8.547971573787688, interval_steps_per_second: 1.068496446723461, epoch: 0.0083
[    INFO] - loss: 1.94697475, learning_rate: 1e-05, global_step: 140, interval_runtime: 18.7172, interval_samples_per_second: 8.548273071849662, interval_steps_per_second: 1.0685341339812078, epoch: 0.0097
[    INFO] - loss: 1.96742477, learning_rate: 1e-05, global_step: 160, interval_runtime: 18.9591, interval_samples_per_second: 8.439229664237219, interval_steps_per_second: 1.0549037080296524, epoch: 0.0111
[    INFO] - loss: 1.94573994, learning_rate: 9.999e-06, global_step: 180, interval_runtime: 18.7157, interval_samples_per_second: 8.548989500870817, interval_steps_per_second: 1.0686236876088522, epoch: 0.0125
[    INFO] - loss: 1.9408371, learning_rate: 9.999e-06, global_step: 200, interval_runtime: 18.9711, interval_samples_per_second: 8.433899198356313, interval_steps_per_second: 1.0542373997945391, epoch: 0.0139
[    INFO] - loss: 1.99254551, learning_rate: 9.998e-06, global_step: 220, interval_runtime: 19.6621, interval_samples_per_second: 8.137464978509199, interval_steps_per_second: 1.0171831223136498, epoch: 0.0153
[    INFO] - loss: 1.96885376, learning_rate: 9.997e-06, global_step: 240, interval_runtime: 18.7156, interval_samples_per_second: 8.549017162948847, interval_steps_per_second: 1.0686271453686058, epoch: 0.0167
[    INFO] - loss: 1.97938385, learning_rate: 9.997e-06, global_step: 260, interval_runtime: 18.9203, interval_samples_per_second: 8.456534692087457, interval_steps_per_second: 1.0570668365109321, epoch: 0.0181
[    INFO] - loss: 1.97675762, learning_rate: 9.996e-06, global_step: 280, interval_runtime: 19.3148, interval_samples_per_second: 8.283782019454836, interval_steps_per_second: 1.0354727524318545, epoch: 0.0194
[    INFO] - loss: 1.97571411, learning_rate: 9.995e-06, global_step: 300, interval_runtime: 19.0757, interval_samples_per_second: 8.38764279200571, interval_steps_per_second: 1.0484553490007138, epoch: 0.0208
```
具体数据2：
```
[    INFO] - loss: 2.00048828, learning_rate: 2.1e-06, global_step: 20, interval_runtime: 21.0772, interval_samples_per_second: 7.591150606927911, interval_steps_per_second: 0.9488938258659889, epoch: 0.0014
[    INFO] - loss: 1.94342518, learning_rate: 4.1e-06, global_step: 40, interval_runtime: 18.8188, interval_samples_per_second: 8.502147053349322, interval_steps_per_second: 1.0627683816686653, epoch: 0.0028
[    INFO] - loss: 1.96450806, learning_rate: 6.1e-06, global_step: 60, interval_runtime: 18.8288, interval_samples_per_second: 8.497600131243356, interval_steps_per_second: 1.0622000164054195, epoch: 0.0042
[    INFO] - loss: 1.97299156, learning_rate: 8.1e-06, global_step: 80, interval_runtime: 18.7106, interval_samples_per_second: 8.551290530216257, interval_steps_per_second: 1.068911316277032, epoch: 0.0056
[    INFO] - loss: 1.97750511, learning_rate: 1e-05, global_step: 100, interval_runtime: 18.802, interval_samples_per_second: 8.509752841450895, interval_steps_per_second: 1.063719105181362, epoch: 0.0069
[    INFO] - loss: 1.95206642, learning_rate: 1e-05, global_step: 120, interval_runtime: 18.7325, interval_samples_per_second: 8.541326055744099, interval_steps_per_second: 1.0676657569680124, epoch: 0.0083
[    INFO] - loss: 1.94697475, learning_rate: 1e-05, global_step: 140, interval_runtime: 18.744, interval_samples_per_second: 8.53607879100723, interval_steps_per_second: 1.0670098488759037, epoch: 0.0097
[    INFO] - loss: 1.96742477, learning_rate: 1e-05, global_step: 160, interval_runtime: 18.9852, interval_samples_per_second: 8.427604951044907, interval_steps_per_second: 1.0534506188806134, epoch: 0.0111
[    INFO] - loss: 1.94573994, learning_rate: 9.999e-06, global_step: 180, interval_runtime: 18.7522, interval_samples_per_second: 8.532339308513075, interval_steps_per_second: 1.0665424135641344, epoch: 0.0125
[    INFO] - loss: 1.9408371, learning_rate: 9.999e-06, global_step: 200, interval_runtime: 18.9974, interval_samples_per_second: 8.42220448954145, interval_steps_per_second: 1.0527755611926812, epoch: 0.0139
[    INFO] - loss: 1.99254551, learning_rate: 9.998e-06, global_step: 220, interval_runtime: 18.7538, interval_samples_per_second: 8.531624257296887, interval_steps_per_second: 1.0664530321621108, epoch: 0.0153
[    INFO] - loss: 1.96885376, learning_rate: 9.997e-06, global_step: 240, interval_runtime: 18.7428, interval_samples_per_second: 8.536628007676303, interval_steps_per_second: 1.0670785009595378, epoch: 0.0167
[    INFO] - loss: 1.97938385, learning_rate: 9.997e-06, global_step: 260, interval_runtime: 18.8998, interval_samples_per_second: 8.465717244773764, interval_steps_per_second: 1.0582146555967205, epoch: 0.0181
[    INFO] - loss: 1.97675762, learning_rate: 9.996e-06, global_step: 280, interval_runtime: 18.7282, interval_samples_per_second: 8.543248921566835, interval_steps_per_second: 1.0679061151958544, epoch: 0.0194
[    INFO] - loss: 1.97571411, learning_rate: 9.995e-06, global_step: 300, interval_runtime: 18.7413, interval_samples_per_second: 8.537290028215388, interval_steps_per_second: 1.0671612535269235, epoch: 0.0208
```

不开确定算法的性能：
```
- loss: 2.00049, learning_rate: 2.1e-06, global_step: 20, interval_runtime: 21.3354, interval_samples_per_second: 7.499260565531818, interval_steps_per_second: 0.9374075706914773, epoch: 0.0014
- loss: 1.94349308, learning_rate: 4.1e-06, global_step: 40, interval_runtime: 18.761, interval_samples_per_second: 8.52834850825146, interval_steps_per_second: 1.0660435635314325, epoch: 0.0028
- loss: 1.96464062, learning_rate: 6.1e-06, global_step: 60, interval_runtime: 18.8037, interval_samples_per_second: 8.508971442820126, interval_steps_per_second: 1.0636214303525158, epoch: 0.0042
- loss: 1.97301292, learning_rate: 8.1e-06, global_step: 80, interval_runtime: 18.6895, interval_samples_per_second: 8.560953695414609, interval_steps_per_second: 1.0701192119268261, epoch: 0.0056
- loss: 1.97778549, learning_rate: 1e-05, global_step: 100, interval_runtime: 18.7648, interval_samples_per_second: 8.526600043709887, interval_steps_per_second: 1.065825005463736, epoch: 0.0069
- loss: 1.95245552, learning_rate: 1e-05, global_step: 120, interval_runtime: 18.7123, interval_samples_per_second: 8.550504971226191, interval_steps_per_second: 1.068813121403274, epoch: 0.0083
- loss: 1.94730988, learning_rate: 1e-05, global_step: 140, interval_runtime: 18.7294, interval_samples_per_second: 8.54271657817509, interval_steps_per_second: 1.0678395722718863, epoch: 0.0097
- loss: 1.96823559, learning_rate: 1e-05, global_step: 160, interval_runtime: 18.9585, interval_samples_per_second: 8.439481829428935, interval_steps_per_second: 1.0549352286786169, epoch: 0.0111
- loss: 1.94611969, learning_rate: 9.999e-06, global_step: 180, interval_runtime: 18.7352, interval_samples_per_second: 8.540070636271357, interval_steps_per_second: 1.0675088295339197, epoch: 0.0125
- loss: 1.9408411, learning_rate: 9.999e-06, global_step: 200, interval_runtime: 18.9657, interval_samples_per_second: 8.436264988184817, interval_steps_per_second: 1.0545331235231021, epoch: 0.0139
- loss: 1.99281082, learning_rate: 9.998e-06, global_step: 220, interval_runtime: 18.7107, interval_samples_per_second: 8.551269282269537, interval_steps_per_second: 1.0689086602836921, epoch: 0.0153
```