### PR TITLE
No need to insert 1-scale op when paddle.static.save_inference_model() is called.

### DIFF
--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -253,14 +253,9 @@ def normalize_program(program, feed_vars, fetch_vars):
             )
             break
 
-    # fix the bug that the activation op's output as target will be pruned.
-    # will affect the inference performance.
-    # TODO(Superjomn) add an IR pass to remove 1-scale op.
     with program_guard(program):
         uniq_fetch_vars = []
         for i, var in enumerate(fetch_vars):
-            if var.dtype != paddle.bool:
-                var = paddle.scale(var, 1.0, name=f"save_infer_model/scale_{i}")
             uniq_fetch_vars.append(var)
         fetch_vars = uniq_fetch_vars
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
paddle.static.save_inference_model 接口被调用时，会自动在模型每个输出加一个 1-scale op。而相关代码已在 fluid.io.save_inference_model() 中移除，参考修复 PR https://github.com/PaddlePaddle/Paddle/pull/36119 https://github.com/PaddlePaddle/Paddle/pull/35730
