### PR TITLE
Add c_embedding forward compat op.

### DIFF
--- a/paddle/phi/ops/compat/c_embedding_sig.cc
+++ b/paddle/phi/ops/compat/c_embedding_sig.cc
@@ -26,11 +26,9 @@ KernelSignature CEmbeddingGradOpArgumentMapping(
                          {"start_index"},
                          {"W@GRAD"});
 }
-
 }  // namespace phi
 
-PD_REGISTER_ARG_MAPPING_FN(c_embedding,
-                           phi::CEmbeddingOpArgumentMapping);
+PD_REGISTER_ARG_MAPPING_FN(c_embedding, phi::CEmbeddingOpArgumentMapping);
 
 PD_REGISTER_ARG_MAPPING_FN(c_embedding_grad,
                            phi::CEmbeddingGradOpArgumentMapping);

--- a/paddle/phi/ops/compat/c_embedding_sig.cc
+++ b/paddle/phi/ops/compat/c_embedding_sig.cc
@@ -15,6 +15,9 @@
 #include "paddle/phi/core/compat/op_utils.h"
 
 namespace phi {
+KernelSignature CEmbeddingOpArgumentMapping(const ArgumentMappingContext& ctx) {
+  return KernelSignature("c_embedding", {"W", "Ids"}, {"start_index"}, {"Out"});
+}
 
 KernelSignature CEmbeddingGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {

--- a/paddle/phi/ops/compat/c_embedding_sig.cc
+++ b/paddle/phi/ops/compat/c_embedding_sig.cc
@@ -29,5 +29,8 @@ KernelSignature CEmbeddingGradOpArgumentMapping(
 
 }  // namespace phi
 
+PD_REGISTER_ARG_MAPPING_FN(c_embedding,
+                           phi::CEmbeddingOpArgumentMapping);
+
 PD_REGISTER_ARG_MAPPING_FN(c_embedding_grad,
                            phi::CEmbeddingGradOpArgumentMapping);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Description
PCard-70444.
Fix bug of PR [52169](https://github.com/PaddlePaddle/Paddle/pull/56129). Add c_embedding forward compat op, which support `paddle._legacy_C_ops.c_embedding`
