### PR TITLE
[Custom Device]add lr_ratio support of adamw for custom device

### DIFF
--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -182,7 +182,8 @@ class AdamW(Optimizer):
             if (
                 not core.is_compiled_with_cuda()
                 and not core.is_compiled_with_xpu()
-                and not core.is_compiled_with_custom_device("mlu")
+                and paddle.device.get_device()
+                not in paddle.device.get_available_custom_device()
             ):
                 raise NotImplementedError("'lr_ratio' is unimplemented in CPU.")
 

--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -182,6 +182,7 @@ class AdamW(Optimizer):
             if (
                 not core.is_compiled_with_cuda()
                 and not core.is_compiled_with_xpu()
+                and not core.is_compiled_with_custom_device("mlu")
             ):
                 raise NotImplementedError("'lr_ratio' is unimplemented in CPU.")
 

--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -182,8 +182,8 @@ class AdamW(Optimizer):
             if (
                 not core.is_compiled_with_cuda()
                 and not core.is_compiled_with_xpu()
-                and paddle.device.get_device()
-                not in paddle.device.get_available_custom_device()
+                and paddle.device.get_device().split(":")[0]
+                not in paddle.device.get_all_custom_device_type()
             ):
                 raise NotImplementedError("'lr_ratio' is unimplemented in CPU.")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Add lr_ratio support of optimizer adamw for custom device. Test result is following:
![image](https://github.com/PaddlePaddle/Paddle/assets/50285351/35410eff-80a9-4844-8882-7ebdf5304424)

不同set_device方式下paddle.get_device().split(":")[0]和paddle.device.get_all_custom_device_type()的值对比：
![d8e1b9ef70232bbd1e52fe31cad7cf7a](https://github.com/PaddlePaddle/Paddle/assets/50285351/4b2b11d5-65c0-414c-919d-6f510d1020c7)
![9bcb51573c65679b33e03f8b842b91e0](https://github.com/PaddlePaddle/Paddle/assets/50285351/dca8f92d-321f-424a-8df9-aefe6ebc92d3)
不同set_device方式下adamw优化器计算结果均与numpy一致：
![9d55fa255dba5423f103370077610fc2](https://github.com/PaddlePaddle/Paddle/assets/50285351/6f2b972b-4965-4100-864c-8e18dfad0548)
测试脚本链接 https://github.com/USTCKAY/Ascend-debug/blob/master/test_adamw.py

