### PR TITLE
Optimize the memory in the case of using `pipeline` strategy and new executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/static_build.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/static_build.cc
@@ -48,6 +48,14 @@ std::set<std::string> StaticBuildBlackList = {
     "run_program" /*: to handle scope output*/,
     "sparse_sparse_coo_tensor" /*: to handle sparse output*/};
 
+// TODO(lizhiyu): This operator list is only for pipeline strategy temporarily.
+std::set<std::string> SkipCheckForPipelineTempList = {"c_broadcast",
+                                                      "c_allreduce_sum",
+                                                      "c_allgather",
+                                                      "layer_norm",
+                                                      "recv_v2",
+                                                      "reshape2_grad",
+                                                      "c_identity"};
 namespace paddle {
 namespace framework {
 namespace interpreter {
@@ -57,10 +65,17 @@ bool BlockCanBeStaticBuilt(const framework::BlockDesc& block) {
   // is_operator_base = (kernelCode >> 6) & 1
   // is_custom_op = (kernelCode >> 5) & 1
   // use_mkldnn = (kernelCode >> 4) & 1
+  // has_fluid_kernel = (kernelCode >> 3) & 1
+  // has_structed_kernel = (kernelCode >> 2) & 1
+  // need_move_to_phi = (kernelCode >> 1) & 1
   using KernelCode = int8_t;
   std::set<std::pair<std::string, KernelCode>> invalid_ops;
   for (auto& op : block.AllOps()) {
     auto op_type = op->Type();
+    if (SkipCheckForPipelineTempList.find(op_type) !=
+        SkipCheckForPipelineTempList.end()) {
+      continue;
+    }
     const framework::OpInfo& info = OpInfoMap::Instance().Get(op_type);
     auto op_base =
         info.Creator()(op_type, op->Inputs(), op->Outputs(), op->GetAttrMap());
@@ -76,14 +91,20 @@ bool BlockCanBeStaticBuilt(const framework::BlockDesc& block) {
       use_mkldnn = attr.index() == 1 ? PADDLE_GET_CONST(int, attr)
                                      : PADDLE_GET_CONST(bool, attr);
     }
-    // skip 'fluid_kernel' and 'structured_kernel' analysis temptly.
-    KernelCode kernel_code = (in_black_list << 7) + (is_operator_base << 6) +
-                             (is_custom_op << 5) + (use_mkldnn << 4);
+    bool has_fluid_kernel = OperatorWithKernel::AllOpKernels().count(op_type);
+    bool has_structured_kernel =
+        phi::KernelFactory::Instance().HasStructuredKernel(op_type);
+    bool need_move_to_phi = (has_fluid_kernel || has_structured_kernel);
+
+    KernelCode kernel_code =
+        (in_black_list << 7) + (is_operator_base << 6) + (is_custom_op << 5) +
+        (use_mkldnn << 4) + (has_fluid_kernel << 3) +
+        (has_structured_kernel << 2) + (need_move_to_phi << 1);
     if (!OpsCanSkipedFakeAllocInStaticBuild.count(op_type)) {
       if (in_black_list ||
           (is_operator_base &&
            !OperatorBasesHandledInStaticBuild.count(op_type)) ||
-          is_custom_op || use_mkldnn) {
+          is_custom_op || use_mkldnn || need_move_to_phi) {
         invalid_ops.insert(std::make_pair(op_type, kernel_code));
       }
     }
@@ -96,7 +117,10 @@ bool BlockCanBeStaticBuilt(const framework::BlockDesc& block) {
       ss << item.first << " [in_black_list = " << (item.second >> 7 & 1)
          << ", is_operator_base = " << (item.second >> 6 & 1)
          << ", is_custom_op = " << (item.second >> 5 & 1)
-         << ", use_mkldnn = " << (item.second >> 4 & 1) << "]\n";
+         << ", use_mkldnn = " << (item.second >> 4 & 1)
+         << ", has_fluid_kernel = " << (item.second >> 3 & 1)
+         << ", has_structed_kerenl = " << (item.second >> 2 & 1)
+         << ", need_move_to_phi = " << (item.second >> 1 & 1) << "]\n";
     }
     VLOG(1) << ss.str();
   }

--- a/paddle/fluid/framework/new_executor/interpreter/static_build.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/static_build.cc
@@ -96,7 +96,7 @@ bool BlockCanBeStaticBuilt(const framework::BlockDesc& block) {
       ss << item.first << " [in_black_list = " << (item.second >> 7 & 1)
          << ", is_operator_base = " << (item.second >> 6 & 1)
          << ", is_custom_op = " << (item.second >> 5 & 1)
-         << ", use_mkldnn = " << (item.second >> 4 & 1) "]\n";
+         << ", use_mkldnn = " << (item.second >> 4 & 1) << "]\n";
     }
     VLOG(1) << ss.str();
   }

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -1190,8 +1190,9 @@ void ProgramInterpreter::RecordStreamForGC(const Instruction& instr) {
 
   gpuStream_t stream =
       reinterpret_cast<const phi::GPUContext&>(instr.DeviceContext()).stream();
-  // TODO(lizhiyu): Only analyse the 'send_v2' for GPT pp strategy right now.
-  // To support all the operators for communicating in the future.
+// TODO(lizhiyu): Only analyse the 'send_v2' for GPT pp strategy right now.
+// To support all the operators for communicating in the future.
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   auto operator_base_ptr = instr.OpBase();
   if ((operator_base_ptr->Type() == "send_v2") &&
       (operator_base_ptr->Attr<bool>("use_calc_stream") == false)) {
@@ -1200,6 +1201,7 @@ void ProgramInterpreter::RecordStreamForGC(const Instruction& instr) {
                       instr.DeviceContext().GetPlace())
                  ->stream();
   }
+#endif
   auto TensorRecordStream = [&stream](phi::DenseTensor& tensor) {
     auto allocation = tensor.Holder();
     if (allocation == nullptr) {

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -30,6 +30,9 @@
 #endif
 #include "paddle/fluid/platform/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/device_manager.h"
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+#include "paddle/fluid/platform/device/gpu/nccl_helper.h"
+#endif
 
 namespace paddle {
 namespace framework {
@@ -1187,6 +1190,16 @@ void ProgramInterpreter::RecordStreamForGC(const Instruction& instr) {
 
   gpuStream_t stream =
       reinterpret_cast<const phi::GPUContext&>(instr.DeviceContext()).stream();
+  // TODO(lizhiyu): Only analyse the 'send_v2' for GPT pp strategy right now.
+  // To support all the operators for communicating in the future.
+  auto operator_base_ptr = instr.OpBase();
+  if ((operator_base_ptr->Type() == "send_v2") &&
+      (operator_base_ptr->Attr<bool>("use_calc_stream") == false)) {
+    stream = platform::NCCLCommContext::Instance()
+                 .Get(operator_base_ptr->Attr<int>("ring_id"),
+                      instr.DeviceContext().GetPlace())
+                 ->stream();
+  }
   auto TensorRecordStream = [&stream](phi::DenseTensor& tensor) {
     auto allocation = tensor.Holder();
     if (allocation == nullptr) {

--- a/paddle/fluid/framework/new_executor/program_interpreter.h
+++ b/paddle/fluid/framework/new_executor/program_interpreter.h
@@ -81,7 +81,7 @@ class ProgramInterpreter : public InterpreterBaseImpl {
     hookfuncs_ = hookfuncs;
   }
 
-  bool IsRealStaticBuild() const { return static_build_; }
+  bool IsStaticBuild() const { return static_build_; }
 
  private:
   // build graph

--- a/paddle/fluid/framework/new_executor/program_interpreter.h
+++ b/paddle/fluid/framework/new_executor/program_interpreter.h
@@ -81,6 +81,8 @@ class ProgramInterpreter : public InterpreterBaseImpl {
     hookfuncs_ = hookfuncs;
   }
 
+  bool IsRealStaticBuild() const { return static_build_; }
+
  private:
   // build graph
   void Convert(std::vector<paddle::framework::OpFuncNode>* op_func_nodes);

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -15,6 +15,7 @@
 
 #include "paddle/fluid/framework/new_executor/feed_fetch_utils.h"
 #include "paddle/fluid/framework/new_executor/interpreter/interpreter_util.h"
+#include "paddle/fluid/framework/new_executor/program_interpreter.h"
 #include "paddle/fluid/platform/profiler/event_tracing.h"
 
 #include "paddle/fluid/ir/transforms/pd_op_to_kernel_pass.h"
@@ -103,6 +104,22 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
                                             micro_batch_scopes_[micro_batch_id],
                                             execution_config));
       interpretercores_.back()->SetCopyProgram(program);
+      // NOTE(lizhiyu): Now we only check backward subprogram. After static
+      // build strategy is completely, we should
+      //                check all the program in the PP strategy.
+      if (job_type == "backward" && jobs.size() > 1) {
+        PADDLE_ENFORCE_EQ(static_cast<const ProgramInterpreter*>(
+                              interpretercores_.back()->Impl())
+                              ->IsRealStaticBuild(),
+                          true,
+                          phi::errors::InvalidArgument(
+                              "When using pipeline strategy in auto "
+                              "prarallelism with new executor, "
+                              "the backward subprogram must be builded in real "
+                              "static build mode, but it can not "
+                              "be staticly builded in this case. You can "
+                              "enable 'GLOG_v=1' to obtain log information."));
+      }
     }
   }
 }

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -110,7 +110,7 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
       if (job_type == "backward" && jobs.size() > 1) {
         PADDLE_ENFORCE_EQ(static_cast<const ProgramInterpreter*>(
                               interpretercores_.back()->Impl())
-                              ->IsRealStaticBuild(),
+                              ->IsStaticBuild(),
                           true,
                           phi::errors::InvalidArgument(
                               "When using pipeline strategy in auto "

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -33,19 +33,18 @@ from .pass_base import PassBase, PassType, register_pass
 world_process_group = get_world_process_group()
 
 
-def _remove_and_get_optimizer_op(main_program, temp_block, dist_context):
+def _remove_and_get_optimizer_op(main_program, dist_context):
     # 1 create tmp block
     # 2 mv optimizer op from global program to tmp block
     # 3 del the op from dist_context
     main_block = main_program.global_block()
+    optimize_ops_block = paddle.static.Program().global_block()
     removed_op_idx = []
-    optimize_ops_desc = []
     for idx, op in enumerate(main_block.ops):
         if is_optimize_op(op):
             # append optimizer op to tmp block
-            new_op_desc = temp_block.desc.append_op()
+            new_op_desc = optimize_ops_block.desc.append_op()
             new_op_desc.copy_from(op.desc)
-            optimize_ops_desc.append(new_op_desc)
             removed_op_idx.append(idx)
 
             # del op from dist_context
@@ -56,7 +55,7 @@ def _remove_and_get_optimizer_op(main_program, temp_block, dist_context):
         main_block._remove_op(idx, sync=False)
     main_block._sync_with_cpp()
 
-    return optimize_ops_desc
+    return optimize_ops_block
 
 
 def _get_gm_cond_var(main_program, k_steps, dist_context):
@@ -227,7 +226,7 @@ def _create_cond_block_and_update_optimizer(
     cond_var,
     new_params_to_grads: List[Tuple[Any, Any]],
     grad_to_gradient_merge: Dict[str, str],
-    optimize_ops_desc: List[Any],
+    optimize_ops_block,
     k_steps,
     avg,
 ):
@@ -254,7 +253,8 @@ def _create_cond_block_and_update_optimizer(
                 new_grad.op._set_attr(OP_ROLE_KEY, OpRole.Optimize)
 
         # append optimizer ops
-        for op_desc in optimize_ops_desc:
+        for opt_op_idx in range(optimize_ops_block.desc.op_size()):
+            op_desc = optimize_ops_block.desc.op(opt_op_idx)
             new_op_desc = cur_block.desc.append_op()
             new_op_desc.copy_from(op_desc)
 
@@ -304,11 +304,8 @@ def parse_program(
     main_program, startup_program, params_grads, k_steps, avg, dist_context
 ):
     # 1 remove optimizer_op from main_program
-    # It is wrong to use 'paddle.static.Program().global_block()' in the function '_remove_and_get_optimizer_op',
-    # because in this case, the temp_block will be deleted after the function finishes.
-    temp_block = paddle.static.Program().global_block()
-    optimize_ops_desc = _remove_and_get_optimizer_op(
-        main_program, temp_block, dist_context
+    optimize_ops_block = _remove_and_get_optimizer_op(
+        main_program, dist_context
     )
 
     # back to block 0
@@ -331,7 +328,7 @@ def parse_program(
         cond_var,
         new_params_to_grads,
         grad_to_gradient_merge,
-        optimize_ops_desc,
+        optimize_ops_block,
         k_steps,
         avg,
     )

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -230,11 +230,8 @@ def get_skip_gc_vars(program_list: List[Program]):
                 # NOTE(Ruibiao): Some vars maybe be the arguements of conditional_block op but no-need-buffer in the actual subblock, should not add them to the required_vars.
                 if op.type == "conditional_block":
                     continue
-                if (
-                    op.type == "nop" and idx == 3
-                ):  # "idx==3" means the subprogram is opt_program
-                    continue
-                if op.type == "c_sync_comm_stream" and idx == 3:
+                # NOTE(lizhiyu): In the PP, 'nop','c_sync_comm_stream' don't need to hold memory, because we have add special code for 'send_v2' when recording stream for gc.
+                if op.type == "nop" or op.type == "c_sync_comm_stream":
                     continue
                 op_info = OpInOutInfo()
                 op_info.build_info(op)

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -230,7 +230,12 @@ def get_skip_gc_vars(program_list: List[Program]):
                 # NOTE(Ruibiao): Some vars maybe be the arguements of conditional_block op but no-need-buffer in the actual subblock, should not add them to the required_vars.
                 if op.type == "conditional_block":
                     continue
-
+                if (
+                    op.type == "nop" and idx == 3
+                ):  # "idx==3" means the subprogram is opt_program
+                    continue
+                if op.type == "c_sync_comm_stream" and idx == 3:
+                    continue
                 op_info = OpInOutInfo()
                 op_info.build_info(op)
                 for arg_name in op.input_arg_names + op.output_arg_names:

--- a/python/paddle/distributed/passes/pipeline_pass_base.py
+++ b/python/paddle/distributed/passes/pipeline_pass_base.py
@@ -14,10 +14,13 @@
 
 import logging
 
+from paddle.distributed.auto_parallel.static.utils import get_logger
 from paddle.fluid import core
 
 from .pass_base import PassBase
 from .pass_utils import get_skip_gc_vars
+
+_logger = get_logger(logging.INFO)
 
 
 class PipelinePassBase(PassBase):
@@ -62,7 +65,7 @@ class PipelinePassBase(PassBase):
         type_to_gc_vars = {}
         for type, gc_var in zip(type_list, gc_vars_list):
             type_to_gc_vars[type] = gc_var
-        logging.INFO(f"The skip_gc_vars : {gc_vars_list}")
+        _logger.info(f"The skip_gc_vars : {gc_vars_list}")
 
         for job in job_list:
             job.set_skip_gc_vars(type_to_gc_vars[job.type()])

--- a/python/paddle/distributed/passes/pipeline_pass_base.py
+++ b/python/paddle/distributed/passes/pipeline_pass_base.py
@@ -66,6 +66,10 @@ class PipelinePassBase(PassBase):
         for type, gc_var in zip(type_list, gc_vars_list):
             type_to_gc_vars[type] = gc_var
         _logger.info(f"The skip_gc_vars : {gc_vars_list}")
+        if "backward" in type_to_gc_vars:
+            assert (
+                len(type_to_gc_vars["backward"]) == 0
+            ), f"When enabling pipeline parallelism stategy, the skip_gc_vars_set for backward subprogram must be empty, but it is {type_to_gc_vars['backward']}."
 
         for job in job_list:
             job.set_skip_gc_vars(type_to_gc_vars[job.type()])

--- a/python/paddle/distributed/passes/pipeline_pass_base.py
+++ b/python/paddle/distributed/passes/pipeline_pass_base.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from paddle.fluid import core
 
 from .pass_base import PassBase
@@ -60,6 +62,7 @@ class PipelinePassBase(PassBase):
         type_to_gc_vars = {}
         for type, gc_var in zip(type_list, gc_vars_list):
             type_to_gc_vars[type] = gc_var
+        logging.INFO(f"The skip_gc_vars : {gc_vars_list}")
 
         for job in job_list:
             job.set_skip_gc_vars(type_to_gc_vars[job.type()])

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass.py
@@ -50,7 +50,7 @@ class PipelineFThenBPass(PipelinePassBase):
             job_list.append(backward_job)
 
         opt_job = core.Job("optimizer")
-        opt_job.set_micro_batch_id(num_micro_batches - 1)
+        opt_job.set_micro_batch_id(0)
         job_list.append(opt_job)
         return job_list
 
@@ -106,7 +106,7 @@ class Pipeline1F1BPass(PipelinePassBase):
             backward_micro_batch_id += 1
 
         opt_job = core.Job("optimizer")
-        opt_job.set_micro_batch_id(num_micro_batches - 1)
+        opt_job.set_micro_batch_id(0)
         job_list.append(opt_job)
         return job_list
 

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass.py
@@ -50,6 +50,7 @@ class PipelineFThenBPass(PipelinePassBase):
             job_list.append(backward_job)
 
         opt_job = core.Job("optimizer")
+        opt_job.set_micro_batch_id(num_micro_batches - 1)
         job_list.append(opt_job)
         return job_list
 
@@ -105,6 +106,7 @@ class Pipeline1F1BPass(PipelinePassBase):
             backward_micro_batch_id += 1
 
         opt_job = core.Job("optimizer")
+        opt_job.set_micro_batch_id(num_micro_batches - 1)
         job_list.append(opt_job)
         return job_list
 

--- a/test/standalone_executor/test_standalone_executor_1f1b_plan.py
+++ b/test/standalone_executor/test_standalone_executor_1f1b_plan.py
@@ -74,7 +74,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             5,
             6,
             7,
-            7,
+            0,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
@@ -134,7 +134,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             5,
             6,
             7,
-            7,
+            0,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
@@ -194,7 +194,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             7,
             6,
             7,
-            7,
+            0,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
@@ -254,7 +254,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             6,
             7,
             7,
-            7,
+            0,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)

--- a/test/standalone_executor/test_standalone_executor_1f1b_plan.py
+++ b/test/standalone_executor/test_standalone_executor_1f1b_plan.py
@@ -74,7 +74,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             5,
             6,
             7,
-            0,
+            7,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
@@ -134,7 +134,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             5,
             6,
             7,
-            0,
+            7,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
@@ -194,7 +194,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             7,
             6,
             7,
-            0,
+            7,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)
@@ -254,7 +254,7 @@ class TestStandaloneExecutor1F1BPlan(unittest.TestCase):
             6,
             7,
             7,
-            0,
+            7,
         ]
         self.assertEqual(job_type_list, expect_job_type_list)
         self.assertEqual(micro_batch_id_list, expect_micro_batch_id_list)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PCard-71568
Optimize the GPU memory used in the case of using `pipeline` strategy and new executor.
1. The temporary block in the "gradient_merge pass" should be created by "paddle.static.Program().global_block()" not "main_program._crate_block()"
2. When collecting the variables to `gc`,the varibales that are used by `nop` and `c_sync_comm`  needn't to be included.
3. When  using `RecordStreamForGC` for `send_v2`, we should add extra code in the case of `use_calc_stream == false` to get the real stream.
4. The pipeline strategy with new executor depends on `static_build`.