### PR TITLE
[IR] Fix gpt bug

### DIFF
--- a/paddle/fluid/ir/dialect/utils.cc
+++ b/paddle/fluid/ir/dialect/utils.cc
@@ -18,11 +18,7 @@ namespace paddle {
 namespace dialect {
 
 const std::unordered_set<std::string> LegacyOpList = {
-    "pd.fused_softmax_mask_upper_triangle",
-    "pd.fused_softmax_mask_upper_triangle_grad",
-    "pd.load_combine",
-    "pd.c_concat",
-    "pd.c_broadcast_"};
+    "pd.load_combine", "pd.c_concat", "pd.c_broadcast_"};
 
 enum class AttrType {
   UNDEFINED = 0,

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -457,7 +457,7 @@
   outputs :
     out : Out
 
-- op : check_finite_and_unscale_
+- op : check_finite_and_unscale_(check_finite_and_unscale)
   inputs :
     {x : X, scale: Scale}
   outputs :
@@ -2937,7 +2937,7 @@
   outputs :
     out : Y
 
-- op : update_loss_scaling_
+- op : update_loss_scaling_(update_loss_scaling)
   inputs :
     {x : X, found_infinite : FoundInfinite, prev_loss_scaling : PrevLossScaling, in_good_steps : InGoodSteps, in_bad_steps : InBadSteps}
   outputs :
@@ -3026,6 +3026,12 @@
     {out: Out, pivots : Pivots, infos : Infos}
   attrs:
     pivot : pivots
+
+- op: memcpy_d2h
+  inputs :
+    x : X
+  outputs :
+    out : Out
 
 - op: reindex_graph (graph_reindex)
   inputs :


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复 gpt 模型在新 IR 下执行的 bug：
- fused_softmax_mask_upper_triangle 从legacy op列表中移出，该算子在 #55769 中被规范到 phi 算子库
- 完善一些算子的映射名单
### Other
Pcard-67164
