### PR TITLE
[XPU] Fix delete_repeated_ops_pass, fix multiclass_nms3

### DIFF
--- a/paddle/fluid/framework/ir/delete_repeated_ops_pass.cc
+++ b/paddle/fluid/framework/ir/delete_repeated_ops_pass.cc
@@ -122,6 +122,10 @@ void DeleteRepeatedOpsPass::DeleteRepeatedOps(
                      Graph* graph) {
     VLOG(4) << "handle DeleteRepeatedOps";
     GET_IR_NODE_FROM_SUBGRAPH(in_var, in_var, pattern);
+    // in_var node may be deleted by the previous detected subgraph
+    if (graph->Nodes().count(in_var) == 0) {
+      return;
+    }
 
     std::vector<std::string> invalid_out_ops{
         "while", "conditional_block", "fetch"};

--- a/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
@@ -59,10 +59,18 @@ void MultiClassNMSKernel(const Context& ctx,
   rois_num_vec.clear();
   if (is_lod) {
     if (has_rois_num) {
+      phi::DenseTensor rois_num_host;
+      rois_num_host.Resize(rois_num.get_ptr()->dims());
+      ctx.template HostAlloc<int>(&rois_num_host);
+      phi::Copy(ctx,
+                *rois_num.get_ptr(),
+                rois_num_host.place(),
+                false,
+                &rois_num_host);
       n = rois_num.get_ptr()->numel();
       for (int i = 0; i < n; i++) {
-        rois_num_vec.push_back(rois_num.get_ptr()->data<int>()[i]);
-        boxes_count += rois_num.get_ptr()->data<int>()[i];
+        rois_num_vec.push_back(rois_num_host.data<int>()[i]);
+        boxes_count += rois_num_host.data<int>()[i];
       }
     } else {
       auto lod = bboxes.lod().back();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
- fix delete_repeated_ops_pass: in_var may be deleted by previous deteted subgraph
- fix multiclass_nms3: input rois_num is on xpu