### PR TITLE
[AutoParallel] fix supplement_explicit_dependencies when amp-o2

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -1369,6 +1369,10 @@ def is_prim_op(op):
     return op.type.endswith("_p")
 
 
+def is_comm_op(op):
+    return op.has_attr("ring_id")
+
+
 def get_loss_op(block):
     loss_ops = []
     for op in block.ops:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-70448
- fix supplement_explicit_dependencies pass when amp-o2 is on
- The check_finite_and_unscale dep op cannot be comm op