### PR TITLE
Remove namespace for dist_attr and process_mesh

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/dist_attr.h
+++ b/paddle/fluid/distributed/auto_parallel/dist_attr.h
@@ -40,6 +40,10 @@ class VarDesc;
 }  // namespace framework
 
 namespace distributed {
+
+using phi::distributed::ProcessMesh;
+using phi::distributed::TensorDistAttr;
+
 namespace auto_parallel {
 
 using framework::BlockDesc;
@@ -48,8 +52,6 @@ using framework::ProgramDesc;
 using framework::VarDesc;
 
 using phi::distributed::auto_parallel::OperatorDistAttrProto;
-using phi::distributed::auto_parallel::ProcessMesh;
-using phi::distributed::auto_parallel::TensorDistAttr;
 
 constexpr const char* kDefault = "default";
 

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/dist_tensor_spec.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/dist_tensor_spec.h
@@ -19,10 +19,10 @@ limitations under the License. */
 
 namespace paddle {
 namespace distributed {
-namespace auto_parallel {
+using phi::distributed::ProcessMesh;
+using phi::distributed::TensorDistAttr;
 
-using phi::distributed::auto_parallel::ProcessMesh;
-using phi::distributed::auto_parallel::TensorDistAttr;
+namespace auto_parallel {
 
 /**
  * A unified data class for inferring distributed attributes

--- a/paddle/fluid/eager/grad_tensor_holder.cc
+++ b/paddle/fluid/eager/grad_tensor_holder.cc
@@ -99,8 +99,7 @@ void GradTensorHolder::CopyValueFromTensor(size_t slot_id,
         auto dist_tensor = std::make_shared<phi::distributed::DistTensor>(
             dense_temp,
             dense_temp->meta(),
-            std::make_shared<
-                phi::distributed::auto_parallel::TensorDistAttr>());
+            std::make_shared<phi::distributed::TensorDistAttr>());
         temp.set_impl(dist_tensor);
         buffer_[slot_id][rank] = temp;
 #endif

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -28,7 +28,7 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-using phi::distributed::auto_parallel::TensorDistAttr;
+using phi::distributed::TensorDistAttr;
 
 // convert between std::vector and protobuf repeated.
 template <typename T>

--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -40,21 +40,21 @@ namespace paddle {
 namespace pybind {
 
 using paddle::distributed::auto_parallel::DistTensorSpec;
+using paddle::distributed::auto_parallel::kDefault;
 using paddle::distributed::auto_parallel::OperatorDistAttr;
 using paddle::distributed::auto_parallel::SPMDRuleBase;
 using paddle::distributed::auto_parallel::SPMDRuleMap;
 using paddle::framework::OpDesc;
 using paddle::framework::VarDesc;
+using phi::distributed::ProcessMesh;
+using phi::distributed::TensorDistAttr;
 using phi::distributed::auto_parallel::Device;
 using phi::distributed::auto_parallel::DeviceCapability;
 using phi::distributed::auto_parallel::DeviceMesh;
 using phi::distributed::auto_parallel::DistributedMapper;
-using phi::distributed::auto_parallel::kDefault;
 using phi::distributed::auto_parallel::Link;
 using phi::distributed::auto_parallel::LinkCapability;
 using phi::distributed::auto_parallel::Machine;
-using phi::distributed::auto_parallel::ProcessMesh;
-using phi::distributed::auto_parallel::TensorDistAttr;
 
 PyTypeObject *g_tensor_dist_attr_pytype = nullptr;
 

--- a/paddle/fluid/pybind/eager.cc
+++ b/paddle/fluid/pybind/eager.cc
@@ -46,7 +46,7 @@ limitations under the License. */
 #include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 using phi::distributed::DistTensor;
-using phi::distributed::auto_parallel::TensorDistAttr;
+using phi::distributed::TensorDistAttr;
 #endif
 
 namespace paddle {
@@ -737,7 +737,7 @@ Tensor is the basic data structure in PaddlePaddle. There are some ways to creat
  * ** zero_copy: bool,
  * ** name: std::string,
  * ** stop_gradient: bool,
- * ** dist_attr: phi::distributed::auto_parallel::TensorDistAttr)
+ * ** dist_attr: phi::distributed::TensorDistAttr)
  * 4.
  * def __init__ (
  * ** value: ndarray)
@@ -751,7 +751,7 @@ Tensor is the basic data structure in PaddlePaddle. There are some ways to creat
  * ** tensor: Tensor,
  * ** place: paddle::platform::Place,
  * ** name: std::string,
- * ** dist_attr: phi::distributed::auto_parallel::TensorDistAttr)
+ * ** dist_attr: phi::distributed::TensorDistAttr)
  * 7. (multi-place) (should have at least one parameter, one parameter similar
  * to case 5, zero parameter equals to case 1.)
  * def __init__ (

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -546,7 +546,7 @@ platform::Place CastPyArg2Place(PyObject* obj, ssize_t arg_pos) {
 }
 
 #ifdef PADDLE_WITH_DISTRIBUTE
-using phi::distributed::auto_parallel::TensorDistAttr;
+using phi::distributed::TensorDistAttr;
 std::shared_ptr<TensorDistAttr> CastPyArg2DistAttr(PyObject* obj,
                                                    ssize_t arg_pos) {
   if (PyObject_IsInstance(
@@ -891,8 +891,7 @@ PyObject* ToPyObject(const phi::distributed::DistTensor* value) {
   return obj.ptr();
 }
 
-PyObject* ToPyObject(
-    const phi::distributed::auto_parallel::TensorDistAttr* value) {
+PyObject* ToPyObject(const phi::distributed::TensorDistAttr* value) {
   auto obj = ::pybind11::cast(value, py::return_value_policy::reference);
   obj.inc_ref();
   return obj.ptr();

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -121,8 +121,7 @@ PyObject* ToPyObject(const platform::Place& value);
 PyObject* ToPyObject(const phi::DenseTensor* value);
 #ifdef PADDLE_WITH_DISTRIBUTE
 PyObject* ToPyObject(const phi::distributed::DistTensor* value);
-PyObject* ToPyObject(
-    const phi::distributed::auto_parallel::TensorDistAttr* value);
+PyObject* ToPyObject(const phi::distributed::TensorDistAttr* value);
 #endif
 PyObject* ToPyObject(const phi::SelectedRows* value);
 PyObject* ToPyObject(const paddle::framework::proto::VarType::Type& dtype);
@@ -314,8 +313,8 @@ paddle::DataType CastPyArg2DataTypeDirectly(PyObject* obj,
                                             ssize_t arg_pos);
 
 #ifdef PADDLE_WITH_DISTRIBUTE
-std::shared_ptr<phi::distributed::auto_parallel::TensorDistAttr>
-CastPyArg2DistAttr(PyObject* obj, ssize_t arg_pos);
+std::shared_ptr<phi::distributed::TensorDistAttr> CastPyArg2DistAttr(
+    PyObject* obj, ssize_t arg_pos);
 #endif
 
 paddle::optional<paddle::Tensor> GetOptionalTensorFromArgs(

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -44,8 +44,8 @@ PyTypeObject *g_blockdesc_pytype = nullptr;
 namespace pd = paddle::framework;
 namespace jit = paddle::jit;
 
+using paddle::distributed::TensorDistAttr;
 using paddle::distributed::auto_parallel::OperatorDistAttr;
-using paddle::distributed::auto_parallel::TensorDistAttr;
 
 template <typename T>
 static pybind11::bytes SerializeMessage(

--- a/paddle/phi/api/lib/api_gen_utils.cc
+++ b/paddle/phi/api/lib/api_gen_utils.cc
@@ -491,8 +491,7 @@ phi::distributed::DistTensor* SetKernelDistOutput(Tensor* out) {
     if (out->impl() == nullptr) {
       auto dense_t = std::make_shared<phi::DenseTensor>();
       // TODO(chenweihang): polish code, dist_attr is null now
-      auto dist_attr =
-          std::make_shared<phi::distributed::auto_parallel::TensorDistAttr>();
+      auto dist_attr = std::make_shared<phi::distributed::TensorDistAttr>();
       auto dist_t = std::make_shared<phi::distributed::DistTensor>(
           dense_t, phi::DenseTensorMeta(), dist_attr);
       out->set_impl(dist_t);

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
@@ -22,7 +22,8 @@ limitations under the License. */
 
 namespace phi {
 namespace distributed {
-namespace auto_parallel {
+using phi::distributed::auto_parallel::str_join;
+using phi::distributed::auto_parallel::TensorDistAttrProto;
 
 // partial is not allow annotated by user by now.
 std::vector<std::string> TensorDistAttr::fields_{
@@ -343,6 +344,5 @@ std::string TensorDistAttr::partial_status_string() const {
   return partial_status_str;
 }
 
-}  // namespace auto_parallel
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.h
@@ -30,9 +30,6 @@ limitations under the License. */
 
 namespace phi {
 namespace distributed {
-namespace auto_parallel {
-
-constexpr const char* kDefault = "default";
 
 class TensorDistAttr {
  public:
@@ -125,9 +122,9 @@ class TensorDistAttr {
   // in partial-support-stage-I partial will always be a runtime attribute,
   // there is not need to serialize it. support the partial serialization in
   // future partial-support-stage-II.
-  void from_proto(const TensorDistAttrProto& proto);
+  void from_proto(const auto_parallel::TensorDistAttrProto& proto);
 
-  TensorDistAttrProto to_proto() const;
+  auto_parallel::TensorDistAttrProto to_proto() const;
 
   std::string serialize_to_string();
 
@@ -157,6 +154,5 @@ inline bool operator!=(const TensorDistAttr& lhs, const TensorDistAttr& rhs) {
   return !operator==(lhs, rhs);
 }
 
-}  // namespace auto_parallel
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
@@ -22,11 +22,7 @@ namespace phi {
 class DenseTensorUtils;
 
 namespace distributed {
-
-namespace auto_parallel {
 class TensorDistAttr;
-}
-using auto_parallel::TensorDistAttr;
 
 class DistTensor final
     : public phi::TensorBase,

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
@@ -12,15 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
+
 #include <algorithm>
 #include <iterator>
 
-#include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
 #include "paddle/phi/core/distributed/auto_parallel/utils.h"
 
 namespace phi {
 namespace distributed {
-namespace auto_parallel {
+
+using phi::distributed::auto_parallel::has_duplicates;
+using phi::distributed::auto_parallel::ProcessMeshProto;
+using phi::distributed::auto_parallel::str_join;
 
 ProcessMesh::ProcessMesh(const std::vector<int64_t> &shape,
                          const std::vector<int64_t> &process_ids,
@@ -129,6 +133,5 @@ bool operator==(const ProcessMesh &lhs, const ProcessMesh &rhs) {
   return true;
 }
 
-}  // namespace auto_parallel
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.h
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.h
@@ -27,7 +27,6 @@ limitations under the License. */
 
 namespace phi {
 namespace distributed {
-namespace auto_parallel {
 
 class ProcessMesh {
  public:
@@ -48,7 +47,7 @@ class ProcessMesh {
   int64_t ndim() const { return shape_.size(); }
 
   int64_t dim_size(int64_t dim) const {
-    int64_t cdim = canonical_dim(dim, shape_.size());
+    int64_t cdim = auto_parallel::canonical_dim(dim, shape_.size());
     return shape_[cdim];
   }
 
@@ -68,8 +67,8 @@ class ProcessMesh {
   // ProcessMesh from_string(const std::string& mesh_str);
   std::string to_string() const;
 
-  static ProcessMesh from_proto(const ProcessMeshProto& proto);
-  ProcessMeshProto to_proto() const;
+  static ProcessMesh from_proto(const auto_parallel::ProcessMeshProto& proto);
+  auto_parallel::ProcessMeshProto to_proto() const;
 
  private:
   std::vector<int64_t> shape_;
@@ -88,6 +87,5 @@ inline bool operator!=(const ProcessMesh& lhs, const ProcessMesh& rhs) {
   return !operator==(lhs, rhs);
 }
 
-}  // namespace auto_parallel
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/reshard_function.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard_function.h
@@ -19,12 +19,9 @@ namespace phi {
 class DeviceContext;
 
 namespace distributed {
-namespace auto_parallel {
-class TensorDistAttr;
-}  // namespace auto_parallel
 
 class DistTensor;
-using auto_parallel::TensorDistAttr;
+class TensorDistAttr;
 
 class ReshardFunction {
  public:

--- a/paddle/phi/core/distributed/auto_parallel/reshard_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard_utils.h
@@ -27,13 +27,7 @@ class DeviceContext;
 
 namespace distributed {
 class CommContext;
-
-namespace auto_parallel {
-
 class ProcessMesh;
-}  // namespace auto_parallel
-
-using auto_parallel::ProcessMesh;
 
 bool IsDimsMappingShard(const std::vector<int64_t>& dims_mapping);
 

--- a/test/cpp/auto_parallel/dist_attr_test.cc
+++ b/test/cpp/auto_parallel/dist_attr_test.cc
@@ -17,11 +17,11 @@ limitations under the License. */
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 
+#include "paddle/fluid/distributed/auto_parallel/dist_attr.h"
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/framework/var_desc.h"
-#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
 
 namespace phi {
 namespace distributed {
@@ -127,7 +127,8 @@ TEST(DistAttr, ctor) {
   EXPECT_EQ(out_dist_attr.verify(get_tensor_shape(out)), true);
 
   OperatorDistAttr mul_dist_attr(*op);
-  EXPECT_EQ(mul_dist_attr.impl_type(), kDefault);
+  EXPECT_EQ(mul_dist_attr.impl_type(),
+            paddle::distributed::auto_parallel::kDefault);
   EXPECT_EQ(mul_dist_attr.impl_idx(), 0);
   EXPECT_EQ(mul_dist_attr.is_recompute(), false);
   EXPECT_EQ(mul_dist_attr.is_annotated("process_mesh"), false);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73145

将DistAttr和ProcessMesh移动到phi::distributed的namespace下