### PR TITLE
bug fix of operator "interp_linear"

### DIFF
--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -90,7 +90,7 @@ __global__ void KeLinearInterpFw(const T* in,
 
     if (data_layout == DataLayout::kNCHW) {
       const T* in_pos =
-          &in[out_id_h * out_id_w + channel_id * in_img_size + in_img_idx];
+          &in[out_id_h * input_w + channel_id * in_img_size + in_img_idx];
       // linear interpolation
       out[out_id_h * output_w + out_id_w] =
           static_cast<T>(w2lambda * static_cast<MT>(in_pos[0]) +


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs 

### Description
According to result of benchmark test (https://github.com/PaddlePaddle/benchmark), I found that the result of forward calculation in operator "interp_linear" is wrong. And after debugging, it was found that the cause is a wrong variable name used when calculating the input vector index. Variable "out_id_w" should be "input_w". Now fixed, thank you for your time and review.

before: max_absolute_diff with cpu is 9.854e-01 (which is a completely incorrect result).
after: max_absolute_diff with cpu is less than 1e-6.
