### PR TITLE
Fixed a mismatch between Chinese and English documents for the CrossEntropyLoss #50424

### DIFF
--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -283,7 +283,7 @@ class CrossEntropyLoss(Layer):
 
         - **label** (Tensor)
 
-            1. If soft_label=False, the shape is
+            1. If soft_label=False, the Shape is
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
             the data type is int32, int64, float32, float64, where each value is [0, C-1].
 
@@ -302,6 +302,7 @@ class CrossEntropyLoss(Layer):
     Examples:
 
         .. code-block:: python
+          :name: code-example1
 
             >>> # hard labels
             >>> import paddle
@@ -321,6 +322,7 @@ class CrossEntropyLoss(Layer):
             5.33697682)
 
         .. code-block:: python
+          :name: code-example2
 
             >>> # soft labels
             >>> import paddle


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Description
<!-- Describe what you’ve done -->
Fixed a mismatch between Chinese and English documents for the CrossEntropyLoss.
The content of the Chinese and English documents does not match, and the Chinese document only shows one code example but there are actually two. This commit adds the :name identifier to make the Chinese document exactly copy the sample code of the English API document.
