### PR TITLE
[API Enhancement] No.6 support single `int` input in UpsamplingNearest2D and UpsamplingBilinear2D

### DIFF
--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -656,6 +656,8 @@ class UpsamplingNearest2D(Layer):
         self, size=None, scale_factor=None, data_format='NCHW', name=None
     ):
         super().__init__()
+        if isinstance(size, int):
+            size = [size, size]
         self.size = size
         self.scale_factor = scale_factor
         self.data_format = data_format
@@ -742,6 +744,8 @@ class UpsamplingBilinear2D(Layer):
         self, size=None, scale_factor=None, data_format='NCHW', name=None
     ):
         super().__init__()
+        if isinstance(size, int):
+            size = [size, size]
         self.size = size
         self.scale_factor = scale_factor
         self.data_format = data_format

--- a/test/legacy_test/test_imperative_layers.py
+++ b/test/legacy_test/test_imperative_layers.py
@@ -116,11 +116,19 @@ class TestLayerPrint(unittest.TestCase):
             str(module), 'UpsamplingNearest2D(size=[12, 12], data_format=NCHW)'
         )
 
+        module = nn.UpsamplingNearest2D(size=12)
+        self.assertEqual(
+            str(module), 'UpsamplingNearest2D(size=[12, 12], data_format=NCHW)'
+        )
+
         module = nn.UpsamplingBilinear2D(size=[12, 12])
         self.assertEqual(
             str(module), 'UpsamplingBilinear2D(size=[12, 12], data_format=NCHW)'
         )
-
+        module = nn.UpsamplingBilinear2D(size=12)
+        self.assertEqual(
+            str(module), 'UpsamplingBilinear2D(size=[12, 12], data_format=NCHW)'
+        )
         module = nn.Bilinear(in1_features=5, in2_features=4, out_features=1000)
         self.assertEqual(
             str(module),

--- a/test/legacy_test/test_imperative_layers.py
+++ b/test/legacy_test/test_imperative_layers.py
@@ -125,10 +125,12 @@ class TestLayerPrint(unittest.TestCase):
         self.assertEqual(
             str(module), 'UpsamplingBilinear2D(size=[12, 12], data_format=NCHW)'
         )
+
         module = nn.UpsamplingBilinear2D(size=12)
         self.assertEqual(
             str(module), 'UpsamplingBilinear2D(size=[12, 12], data_format=NCHW)'
         )
+
         module = nn.Bilinear(in1_features=5, in2_features=4, out_features=1000)
         self.assertEqual(
             str(module),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/55883 No.6
The docs will be modify after CI passing