### PR TITLE
Fix TensorRT multiclass_nms Test

### DIFF
--- a/test/ir/inference/test_trt_convert_multiclass_nms.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms.py
@@ -70,10 +70,10 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
             )
 
         def generate_scores(batch, num_boxes, num_classes):
-            return np.arange(
-                batch * num_classes * num_boxes, dtype=np.float32
+            max_value = batch * num_classes * num_boxes
+            return (1 / max_value) * np.arange(
+                max_value, dtype=np.float32
             ).reshape([batch, num_classes, num_boxes])
-            # return np.random.rand(batch, num_classes, num_boxes).astype(np.float32)
 
         for batch in [1, 2]:
             self.batch = batch


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
In multiclass_nms, the results will be arranged in order, given that the tensorrt output sequence differs from that of paddle. Errors may arise even if the selected boxes are identical but the scores do not match precisely. I believe the root of this issue lies in the score generation mechanism. Using fp16 for generating scores isn't effective since it cannot manage large figures. For instance, numbers like 4097 and 4098 in fp32 would both map to 4096 in fp16. Hence, it's essential to adjust the score generation process to ensure unique scores under fp16 precision.
