### PR TITLE
[CustomDevice] remove the constraint of ignore_idnex in  c_softmax_with_cross_entropy

### DIFF
--- a/paddle/fluid/operators/custom_device_common_op_registry.cc
+++ b/paddle/fluid/operators/custom_device_common_op_registry.cc
@@ -320,12 +320,6 @@ class CSoftmaxWithCrossEntropyOpCustomDeviceKernel
       auto loss_dims = loss->dims();
 
       const int64_t ignore_index = ctx.Attr<int64_t>("ignore_index");
-      PADDLE_ENFORCE_LT(ignore_index,
-                        0,
-                        platform::errors::InvalidArgument(
-                            "When SoftmaxWithCrossEntropy run on CustomDevice, "
-                            "ignore_index should be <=0, however it's %ld",
-                            ignore_index));
       const int rid = ctx.Attr<int>("ring_id");
       const int rank = ctx.Attr<int>("rank");
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
remove the constraint of ignore_idnex in  c_softmax_with_cross_entropy