### PR TITLE
[Semi-Auto] Add replicated infer_backward rule

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/common.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/common.cc
@@ -34,7 +34,8 @@ SPMDRuleBase::InferForward(const std::vector<DistTensorSpec>& input_specs,
 }
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-SPMDRuleBase::InferBackward(const std::vector<DistTensorSpec>& output_specs,
+SPMDRuleBase::InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                            const std::vector<DistTensorSpec>& output_specs,
                             const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(
       phi::errors::Unimplemented("InferBackward should be called from a "

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/common.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/common.h
@@ -60,7 +60,8 @@ class SPMDRuleBase {
   // 1. The first vector: the merged DistAttr of output tensors.
   // 2. The infered DistAttr of Input tensors.
   virtual std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs);
 
   template <typename T>

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/common.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/common.h
@@ -144,7 +144,8 @@ GetAxesDimsMappingPair(const std::vector<std::string>& tensor_axes,
 // its dims mapping to -1.
 std::vector<int64_t> GetDimsMappingForAxes(
     const std::string& axes,
-    const std::unordered_map<std::string, int64_t>& axis_to_dim_map);
+    const std::unordered_map<std::string, int64_t>& axis_to_dim_map,
+    const bool unsharded_miss_axis = false);
 
 // The static map that stores and initializes all the registered SPMD rules.
 class SPMDRuleMap {

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/cross_entropy_with_softmax_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/cross_entropy_with_softmax_spmd_rule.cc
@@ -172,6 +172,7 @@ CrossEntropyWithSoftmaxSPMDRule::InferForward(
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 CrossEntropyWithSoftmaxSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& output_specs,
     const std::vector<DistTensorSpec>& input_specs,
     const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/cross_entropy_with_softmax_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/cross_entropy_with_softmax_spmd_rule.h
@@ -27,7 +27,8 @@ class CrossEntropyWithSoftmaxSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/dim_trans.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/dim_trans.cc
@@ -214,7 +214,8 @@ DimTrans* GetDimTrans(DimTrans* dim_trans,
     for (int64_t i = 1, n = inputs.size(); i < n; i++) {
       DimTrans* input = inputs[i];
       if (input->type() == DimTrans::Type::INPUTDIM) {
-        (*shardable)[i].assign(nmesh, false);
+        InputDim* inputdim = dynamic_cast<InputDim*>(input);
+        (*shardable)[inputdim->input_dim()].assign(nmesh, false);
       }
 
       GetDimTrans(input,

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/elementwise_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/elementwise_spmd_rule.cc
@@ -127,6 +127,7 @@ ElementwiseSPMDRule::InferForward(
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 ElementwiseSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& input_specs,
     const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/elementwise_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/elementwise_spmd_rule.h
@@ -32,7 +32,8 @@ class ElementwiseSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/embedding_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/embedding_spmd_rule.cc
@@ -156,8 +156,10 @@ EmbeddingSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 }
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-EmbeddingSPMDRule::InferBackward(const std::vector<DistTensorSpec>& input_specs,
-                                 const paddle::framework::AttributeMap& attrs) {
+EmbeddingSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& input_specs,
+    const std::vector<DistTensorSpec>& output_specs,
+    const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(
       "InferBackward of EmbeddingSPMDRule is NOT implemented yet."));
 }

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/embedding_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/embedding_spmd_rule.h
@@ -33,7 +33,8 @@ class EmbeddingSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.cc
@@ -173,6 +173,7 @@ LayerNormSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 LayerNormSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& input_specs,
     const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.h
@@ -32,7 +32,8 @@ class LayerNormSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/matmul_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/matmul_spmd_rule.cc
@@ -214,7 +214,8 @@ TensorDistAttr GetInferedDistAttr(
 }
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-MatmulSPMDRule::InferBackward(const std::vector<DistTensorSpec>& output_specs,
+MatmulSPMDRule::InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                              const std::vector<DistTensorSpec>& output_specs,
                               const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(
       "InferBackward of MatmulSPMDRule is NOT implemented yet."));

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/matmul_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/matmul_spmd_rule.h
@@ -39,7 +39,8 @@ class MatmulSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/reduction_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/reduction_spmd_rule.cc
@@ -120,6 +120,7 @@ ReductionSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 ReductionSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& input_specs,
     const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/reduction_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/reduction_spmd_rule.h
@@ -32,7 +32,8 @@ class ReductionSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/replicated_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/replicated_spmd_rule.cc
@@ -41,6 +41,7 @@ ReplicatedSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 ReplicatedSPMDRule::InferBackward(
     const std::vector<DistTensorSpec>& input_specs,
+    const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(
       "InferBackward of ReplicatedSPMDRule is NOT implemented yet."));

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/replicated_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/replicated_spmd_rule.cc
@@ -23,19 +23,19 @@ using phi::distributed::auto_parallel::str_join;
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 ReplicatedSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
                                  const paddle::framework::AttributeMap& attrs) {
-  std::vector<TensorDistAttr> intput_dist_attrs;
+  std::vector<TensorDistAttr> input_dist_attrs;
   std::vector<TensorDistAttr> output_dist_attrs;
-  intput_dist_attrs.reserve(input_specs.size());
+  input_dist_attrs.reserve(input_specs.size());
 
   for (auto& input_spec : input_specs) {
-    intput_dist_attrs.push_back(ReplicatedOnMesh(input_spec.dist_attr()));
+    input_dist_attrs.push_back(ReplicatedOnMesh(input_spec.dist_attr()));
   }
 
   // TODO(ljz): we need to know num of output and size of each output before
   // generate the excat replicasted dist tensor attr for the current op.
   // here we just assume that only one output tensor and has the same size as
   // the first input tensor.
-  return {intput_dist_attrs, {ReplicatedOnMesh(input_specs[0].dist_attr())}};
+  return {input_dist_attrs, {ReplicatedOnMesh(input_specs[0].dist_attr())}};
 }
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
@@ -43,8 +43,19 @@ ReplicatedSPMDRule::InferBackward(
     const std::vector<DistTensorSpec>& input_specs,
     const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
-  PADDLE_THROW(phi::errors::Unimplemented(
-      "InferBackward of ReplicatedSPMDRule is NOT implemented yet."));
+  std::vector<TensorDistAttr> input_dist_attrs;
+  std::vector<TensorDistAttr> output_dist_attrs;
+  input_dist_attrs.reserve(input_specs.size());
+  output_dist_attrs.reserve(output_specs.size());
+
+  for (const DistTensorSpec& input_spec : input_specs) {
+    input_dist_attrs.emplace_back(ReplicatedOnMesh(input_spec.dist_attr()));
+  }
+  for (const DistTensorSpec& output_spec : output_specs) {
+    output_dist_attrs.emplace_back(ReplicatedOnMesh(output_spec.dist_attr()));
+  }
+
+  return {input_dist_attrs, output_dist_attrs};
 }
 
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/replicated_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/replicated_spmd_rule.h
@@ -33,7 +33,8 @@ class ReplicatedSPMDRule : public SPMDRuleBase {
   // The dims_mapping of ALL TensorDistAttrs would be repeat of "-1"
   // (unsharded).
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/reshape_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/reshape_spmd_rule.cc
@@ -212,7 +212,6 @@ paddle::distributed::auto_parallel::ReshapeSPMDRule::InferBackward(
       phi::errors::InvalidArgument("The size of OutputSpec in reshape must "
                                    "be equal to 1, but got [%d].",
                                    noutputs));
-  VerifySpecs(input_specs, "reshape");
   VerifySpecs(output_specs, "reshape");
 
   // step1: build the transformation from the output shape

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/reshape_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/reshape_spmd_rule.h
@@ -32,7 +32,8 @@ class ReshapeSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/softmax_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/softmax_spmd_rule.cc
@@ -106,7 +106,8 @@ SoftmaxSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 }
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-SoftmaxSPMDRule::InferBackward(const std::vector<DistTensorSpec>& input_specs,
+SoftmaxSPMDRule::InferBackward(const std::vector<DistTensorSpec>& output_specs,
+                               const std::vector<DistTensorSpec>& input_specs,
                                const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(
       "InferBackward of SoftmaxSPMDRule is NOT implemented yet."));

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/softmax_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/softmax_spmd_rule.h
@@ -32,7 +32,8 @@ class SoftmaxSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/split_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/split_spmd_rule.cc
@@ -113,7 +113,8 @@ SplitSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 }
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-SplitSPMDRule::InferBackward(const std::vector<DistTensorSpec>& output_specs,
+SplitSPMDRule::InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                             const std::vector<DistTensorSpec>& output_specs,
                              const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(
       "InferBackward of SplitPMDRule is NOT implemented yet."));

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/split_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/split_spmd_rule.h
@@ -32,7 +32,8 @@ class SplitSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/transpose_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/transpose_spmd_rule.cc
@@ -90,6 +90,7 @@ TransposeSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 TransposeSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& input_specs,
     const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
   PADDLE_THROW(phi::errors::Unimplemented(

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/transpose_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/transpose_spmd_rule.h
@@ -32,7 +32,8 @@ class TransposeSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/test/auto_parallel/spmd_rules/test_reshape_rule.py
+++ b/test/auto_parallel/spmd_rules/test_reshape_rule.py
@@ -246,9 +246,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [1, 72, 48, 4, 6] (input --> output)
         # dims_mapping: [-1, -1, -1, -1, -1] --> [-1, -1, -1, -1], [-1, -1, -1, -1, -1] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [1, 72, 48, 4, 6], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [1, 72, 48, 4, 6]
         self.output_dist_tensor_spec.set_dims_mapping([-1, -1, -1, -1, -1])
         result_dist_attrs = self.rule.infer_backward(
             [self.x_dist_tensor_spec],
@@ -267,9 +265,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [1, 72, 48, 4, 6] (input --> output)
         # dims_mapping: [-1, 1, -1, 0, -1] --> [1, -1, -1, 0] [-1, 1, -1, 0, -1] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [1, 72, 48, 4, 6], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [1, 72, 48, 4, 6]
         self.output_dist_tensor_spec.set_dims_mapping([-1, 1, -1, 0, -1])
         result_dist_attrs = self.rule.infer_backward(
             [self.x_dist_tensor_spec],
@@ -288,9 +284,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [3, 24, 6, 8, 24] (input --> output)
         # dims_mapping: [1, -1, -1, -1, 0] --> [1, -1, -1, 0], [1, -1, -1, -1, 0] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [3, 24, 6, 8, 24], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [3, 24, 6, 8, 24]
         self.output_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1, 0])
 
         result_dist_attrs = self.rule.infer_backward(
@@ -310,9 +304,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [3, 24, 6, 8, 24] (input --> output)
         # dims_mapping: [-1, -1, 0, -1, 1] --> [-1, -1, 0, 1], [-1, -1, 0, -1, 1] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [3, 24, 6, 8, 24], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [3, 24, 6, 8, 24]
         self.output_dist_tensor_spec.set_dims_mapping([-1, -1, 0, -1, 1])
 
         result_dist_attrs = self.rule.infer_backward(
@@ -332,9 +324,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [6, 12, 48, 24] (intput --> output)
         # dims_mapping: [-1, -1, 0, 1] --> [-1, -1, 0, 1], [-1, -1, 0, 1] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [6, 12, 48, 24], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [6, 12, 48, 24]
         self.output_dist_tensor_spec.set_dims_mapping([-1, -1, 0, 1])
         result_dist_attrs = self.rule.infer_backward(
             [self.x_dist_tensor_spec],
@@ -353,9 +343,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [72, 3, 16, 24] (intput --> output)
         # dims_mapping: [0, 1, -1, -1] --> [0, -1, 1, -1], [0, 1, -1, -1] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [72, 3, 16, 24], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [72, 3, 16, 24]
         self.output_dist_tensor_spec.set_dims_mapping([0, 1, -1, -1])
         result_dist_attrs = self.rule.infer_backward(
             [self.x_dist_tensor_spec],
@@ -374,9 +362,7 @@ class TestReshapeSPMDRule(unittest.TestCase):
 
         # shape: [6, 12, 48, 24] --> [72, 3, 16, 24] (intput --> output)
         # dims_mapping: [1, -1, -1, -1] --> [1, -1, -1, -1], [1, -1, -1, -1] (output --> input, output)
-        self.output_dist_tensor_spec = DistTensorSpec(
-            [72, 3, 16, 24], output_tensor_dist_attr
-        )
+        self.output_dist_tensor_spec.shape = [72, 3, 16, 24]
         self.output_dist_tensor_spec.set_dims_mapping([1, -1, -1, -1])
         result_dist_attrs = self.rule.infer_backward(
             [self.x_dist_tensor_spec],


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
Others

### Description
Pcard-70448

Add infer backward SPMD rule for replicated. It sets the values of inputs' dims mappings to -1.
