### PR TITLE
[Semi-Auto] Add layer_norm infer_backward rule 

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.cc
@@ -63,7 +63,6 @@ LayerNormSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 
   int begin_norm_axis = ExtractAttr<int>("begin_norm_axis", attrs);
 
-  // Step2.3.2  handle input tensor partial (TODO)
   VLOG(4) << "LayerNormSPMDRule InferForward Inputs: "
           << "x shape: [" << str_join(x_shape) << "], x_dims_mapping: ["
           << str_join(x_dims_mapping) << "]; scale shape: ["
@@ -74,9 +73,9 @@ LayerNormSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
           << begin_norm_axis << "]; ";
 
   // step1: build Einsum Notation
-  // ijk,k,k->ijk,x,x (x,scale,bias->out,mean,variance, begin_norm_axis=2, x=ij)
-  // ijkl,y(kl),y(kl)->ijkl,x(ij),x(ij) (x,scale,bias->out,mean,variance,
-  // begin_norm_axis=2, x=ij, y=kl)
+  // ijk,k,k->ijk,z,z (x,scale,bias->out,mean,variance, begin_norm_axis=2, z=ij)
+  // ijkl,y(kl),y(kl)->ijkl,z(ij),z(ij) (x,scale,bias->out,mean,variance,
+  // begin_norm_axis=2, z=ij, y=kl)
   std::string x_axes = "";
   for (auto i = 0; i < x_ndim; ++i) {
     x_axes += static_cast<char>(static_cast<int>('k') - begin_norm_axis + i);
@@ -127,8 +126,8 @@ LayerNormSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
   for (size_t i = 0; i < out_axes.size(); ++i) {
     if (i < static_cast<size_t>(begin_norm_axis)) {
       out_dims_mapping.push_back(x_dims_mapping[i]);
-      // if ijk,k,k->ijk,x,x (x,scale,bias->out,mean,variance,
-      // begin_norm_axis=2, x=ij), and the dims_mapping of input is (0,1,-1),
+      // if ijk,k,k->ijk,z,z (x,scale,bias->out,mean,variance,
+      // begin_norm_axis=2, z=ij), and the dims_mapping of input is (0,1,-1),
       // the mean and varience is sharded by dim 0 and 1,
       // which is not supported currently.
       mean_shard_dim =
@@ -173,12 +172,128 @@ LayerNormSPMDRule::InferForward(const std::vector<DistTensorSpec>& input_specs,
 
 std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
 LayerNormSPMDRule::InferBackward(
+    const std::vector<DistTensorSpec>& input_specs,
     const std::vector<DistTensorSpec>& output_specs,
     const paddle::framework::AttributeMap& attrs) {
-  PADDLE_THROW(phi::errors::Unimplemented(
-      "InferBackward of LayerNormSPMDRule is NOT implemented yet."));
+  // step0: verify input args based on layer_norm logic
+  int64_t ninputs = input_specs.size();
+  int64_t noutputs = output_specs.size();
+  PADDLE_ENFORCE_EQ(
+      ninputs,
+      3,
+      phi::errors::InvalidArgument(
+          "The size of InputSpec of layer_norm should be 3, but got [%d].",
+          ninputs));
+  PADDLE_ENFORCE_EQ(
+      noutputs,
+      3,
+      phi::errors::InvalidArgument(
+          "The size of InputSpec of layer_norm should be 3, but got [%d].",
+          noutputs));
+  VerifySpecs(output_specs, "layer_norm_backward");
 
-  return {};
+  // step1: build Einsum Notation
+  // ijk,k,k->ijk,z,z (x,scale,bias->out,mean,variance, begin_norm_axis=2, z=ij)
+  // ijkl,y(kl),y(kl)->ijkl,z(ij),z(ij) (x,scale,bias->out,mean,variance,
+  // begin_norm_axis=2, z=ij, y=kl)
+  int begin_norm_axis = ExtractAttr<int>("begin_norm_axis", attrs);
+  std::string alphabet = "ijklmnopqrstuvwxyz";
+  int x_ndim = input_specs[0].shape().size();
+  std::string x_axes = alphabet.substr(0, x_ndim);
+  // the axes after norm_axis should be replicated,
+  // so set their notation to '1'.
+  for (int i = begin_norm_axis; i < x_ndim; i++) {
+    x_axes[i] = '1';
+  }
+  std::string out_axes = x_axes;
+  std::string mean_axes(1, '1'), varience_axes(1, '1');
+  if (begin_norm_axis > 0) {
+    mean_axes[0] = out_axes[0];
+    varience_axes[0] = out_axes[0];
+  }
+  std::vector<std::string> output_axes_vec;
+  output_axes_vec.emplace_back(out_axes);
+  output_axes_vec.emplace_back(mean_axes);
+  output_axes_vec.emplace_back(varience_axes);
+
+  // step2: Sharding Propogation
+  // For the axes after norm_axis in both input and output tensors,
+  // set their dims mappings to -1. For the other axes, set input
+  // tensor's dims mapping the same as output tensor's dims mapping.
+  // step2.1 merge dims mappings of output, mean, variance.
+  std::vector<std::pair<std::string, std::vector<int64_t>>> axes_sharding_info;
+  axes_sharding_info = GetAxesDimsMappingPair(output_axes_vec, output_specs);
+  std::unordered_map<std::string, int64_t> axis_to_dim_map =
+      ShardingMergeForTensors(axes_sharding_info);
+
+  // step2.2 infer input dims mapping
+  std::vector<int64_t> input_dims_mapping =
+      GetDimsMappingForAxes(x_axes, axis_to_dim_map);
+  std::vector<TensorDistAttr> input_dist_attrs;
+  for (int64_t i = 0; i < ninputs; i++) {
+    input_dist_attrs.emplace_back(input_specs[i].dist_attr());
+  }
+  input_dist_attrs[0].set_dims_mapping(input_dims_mapping);
+  // set bias and scale to be replicated
+  input_dist_attrs[1].set_dims_mapping({-1});
+  input_dist_attrs[2].set_dims_mapping({-1});
+
+  // step2.3 update output dims mappings with merged one
+  std::vector<TensorDistAttr> output_dist_attrs;
+  for (int64_t i = 0; i < noutputs; i++) {
+    output_dist_attrs.emplace_back(output_specs[i].dist_attr());
+  }
+  std::vector<int64_t> out_dims_mapping =
+      GetDimsMappingForAxes(output_axes_vec[0], axis_to_dim_map);
+  output_dist_attrs[0].set_dims_mapping(out_dims_mapping);
+  VLOG(4) << "*********";
+  for (int64_t i = 0; i < 1; i++) {
+    VLOG(4) << "Output" << std::to_string(i) << " shape: ["
+            << str_join(output_specs[i].shape()) << "] "
+            << "Einsum Notation: " << output_axes_vec[i]
+            << " src_dims_mapping: ["
+            << str_join(output_specs[i].dims_mapping()) << "] "
+            << "dst_dims_mapping: ["
+            << str_join(output_dist_attrs[i].dims_mapping()) << "]";
+  }
+  VLOG(4) << "*********";
+  // The shape of mean and variance tensors is the product of
+  // out_shape[0:begin_norm_axis] (out_shape is output tensor's
+  // shape). So, the dims mapping of out_axes[0:begin_norm_axis]
+  // is merged to mean and variance. Now, the dims mapping is
+  // merged when only one axis is sharded. If two or more axes
+  // are sharded, the dims mapping of mean and variance are conflict,
+  // this is not supported now.
+  int64_t mean_shard_dim = -1;
+  for (int i = 0; i < begin_norm_axis; i++) {
+    mean_shard_dim =
+        ShardingMergeForAxis(mean_axes, mean_shard_dim, out_dims_mapping[i]);
+  }
+  output_dist_attrs[1].set_dims_mapping({mean_shard_dim});
+  output_dist_attrs[2].set_dims_mapping({mean_shard_dim});
+
+  VLOG(4) << "LayerNormSPMDRule InferBackward:";
+  VLOG(4) << "begin_norm_axis: " << begin_norm_axis;
+  for (int64_t i = 0; i < noutputs; i++) {
+    VLOG(4) << "Output" << std::to_string(i) << " shape: ["
+            << str_join(output_specs[i].shape()) << "] "
+            << "Einsum Notation: " << output_axes_vec[i]
+            << " src_dims_mapping: ["
+            << str_join(output_specs[i].dims_mapping()) << "] "
+            << "dst_dims_mapping: ["
+            << str_join(output_dist_attrs[i].dims_mapping()) << "]";
+  }
+
+  for (int64_t i = 0; i < ninputs; i++) {
+    VLOG(4) << "Input" << std::to_string(i) << " shape: ["
+            << str_join(input_specs[i].shape()) << "] "
+            << "Einsum Notation: " << std::string(i == 0 ? x_axes : "1")
+            << " dims_mapping: ["
+            << str_join(input_dist_attrs[i].dims_mapping()) << "]";
+  }
+  VLOG(4) << std::endl;
+
+  return {input_dist_attrs, output_dist_attrs};
 }
 
 }  // namespace auto_parallel

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.cc
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.cc
@@ -247,10 +247,9 @@ LayerNormSPMDRule::InferBackward(
   std::vector<TensorDistAttr> output_dist_attrs;
   for (int64_t i = 0; i < noutputs; i++) {
     output_dist_attrs.emplace_back(output_specs[i].dist_attr());
+    output_dist_attrs[i].set_dims_mapping(
+        GetDimsMappingForAxes(output_axes_vec[i], axis_to_dim_map));
   }
-  std::vector<int64_t> out_dims_mapping =
-      GetDimsMappingForAxes(output_axes_vec[0], axis_to_dim_map);
-  output_dist_attrs[0].set_dims_mapping(out_dims_mapping);
 
   VLOG(4) << "LayerNormSPMDRule InferBackward:";
   VLOG(4) << "begin_norm_axis: " << begin_norm_axis;

--- a/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.h
+++ b/paddle/fluid/distributed/auto_parallel/spmd_rules/layer_norm_spmd_rule.h
@@ -32,7 +32,8 @@ class LayerNormSPMDRule : public SPMDRuleBase {
                const paddle::framework::AttributeMap& attrs) override;
 
   std::pair<std::vector<TensorDistAttr>, std::vector<TensorDistAttr>>
-  InferBackward(const std::vector<DistTensorSpec>& output_specs,
+  InferBackward(const std::vector<DistTensorSpec>& input_specs,
+                const std::vector<DistTensorSpec>& output_specs,
                 const paddle::framework::AttributeMap& attrs) override;
 };
 }  // namespace auto_parallel

--- a/test/auto_parallel/spmd_rules/test_layer_norm_rule.py
+++ b/test/auto_parallel/spmd_rules/test_layer_norm_rule.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.auto_parallel.static.completion import get_spmd_rule
+from paddle.distributed.auto_parallel.static.dist_attribute import (
+    DistTensorSpec,
+    TensorDistAttr,
+)
+from paddle.distributed.fleet import auto
+
+
+class TestLayerNormSPMDRule(unittest.TestCase):
+    """
+    Unit tests for layer_norm spmd rule.
+    """
+
+    def setUp(self):
+        self.rule = get_spmd_rule("layer_norm")
+
+        x_shape = [64, 32, 1024]
+        scale_shape = [1024]
+        bias_shape = [1024]
+        process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
+
+        x_tensor_dist_attr = TensorDistAttr()
+        x_tensor_dist_attr.dims_mapping = [-1, -1, -1]
+        x_tensor_dist_attr.process_mesh = process_mesh
+        self.x_spec = DistTensorSpec(x_shape, x_tensor_dist_attr)
+
+        self.scale_spec = DistTensorSpec(self.x_spec)
+        self.bias_spec = DistTensorSpec(self.x_spec)
+        self.scale_spec.shape = scale_shape
+        self.scale_spec.set_dims_mapping([-1])
+        self.bias_spec.shape = bias_shape
+        self.bias_spec.set_dims_mapping([-1])
+
+        self.out_spec = DistTensorSpec(self.x_spec)
+        self.mean_spec = DistTensorSpec(self.x_spec)
+        self.var_spec = DistTensorSpec(self.x_spec)
+
+        self.attrs = {
+            'begin_norm_axis': 2,
+        }
+
+    def test_infer_forward(self):
+        # ijk[1, -1, -1], k[-1], k[-1] -->
+        # ijk[1, -1, -1], k[-1], k[-1], (inputs)
+        # ijk[1, -1, -1], z[1], z[1], z=ij (outputs)
+        # begin_norm_axis=2
+        self.x_spec.set_dims_mapping([1, -1, -1])
+        self.bias_spec.set_dims_mapping([-1])
+        self.scale_spec.set_dims_mapping([-1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            [self.x_spec, self.scale_spec, self.bias_spec], self.attrs
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1])
+
+        # ijk[1, 0, -1],k[0],k[0] --> error, begin_norm_axis=2
+        self.x_spec.set_dims_mapping([1, 0, -1])
+        self.scale_spec.set_dims_mapping([0])
+        self.bias_spec.set_dims_mapping([0])
+        with self.assertRaises(BaseException):
+            self.rule.infer_forward(
+                [self.x_spec, self.scale_spec, self.bias_spec], self.attrs
+            )
+
+        # ijk[0, -1, -1],y[-1],y[1] -->
+        # ijk[0, -1, -1],y[-1],y[-1], (inputs)
+        # ijk[0, -1, -1], i[0], i[0], y=jk (outputs)
+        # begin_norm_axis=1
+        self.attrs['begin_norm_axis'] = 1
+        self.x_spec.set_dims_mapping([0, -1, -1])
+        x_shape = self.x_spec.shape
+        self.scale_spec.shape = [x_shape[1] * x_shape[2]]
+        self.bias_spec.shape = [x_shape[1] * x_shape[2]]
+        self.scale_spec.set_dims_mapping([-1])
+        self.bias_spec.set_dims_mapping([1])
+
+        result_dist_attrs = self.rule.infer_forward(
+            [self.x_spec, self.scale_spec, self.bias_spec], self.attrs
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0])
+
+    def test_infer_backward(self):
+        import math
+
+        # [1, -1, -1], [1], [1] (outputs) -->
+        # [1, -1, -1], [-1], [-1], (inputs)
+        # [1, -1, -1], [1], [1] (outputs)
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [1024]
+        self.bias_spec.shape = [1024]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([1, -1, -1])
+        self.mean_spec.set_dims_mapping([1])
+        self.var_spec.set_dims_mapping([1])
+
+        result_dist_attrs = self.rule.infer_backward(
+            [self.x_spec, self.scale_spec, self.bias_spec],
+            [self.out_spec, self.mean_spec, self.var_spec],
+            self.attrs,
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [1, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1])
+
+        # [0, -1, -1], [0], [0] (outputs) -->
+        # [0, -1, -1], [-1], [-1], (inputs)
+        # [0, -1, -1], [0], [0] (outputs)
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([0, -1, -1])
+        self.mean_spec.set_dims_mapping([0])
+        self.var_spec.set_dims_mapping([0])
+
+        result_dist_attrs = self.rule.infer_backward(
+            [self.x_spec, self.scale_spec, self.bias_spec],
+            [self.out_spec, self.mean_spec, self.var_spec],
+            self.attrs,
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0])
+
+        # [-1, -1, -1], [0], [-1] (outputs) -->
+        # [0, -1, -1], [-1], [-1], (inputs)
+        # [0, -1, -1], [0], [0] (outputs)
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([-1, -1, -1])
+        self.mean_spec.set_dims_mapping([0])
+        self.var_spec.set_dims_mapping([-1])
+
+        result_dist_attrs = self.rule.infer_backward(
+            [self.x_spec, self.scale_spec, self.bias_spec],
+            [self.out_spec, self.mean_spec, self.var_spec],
+            self.attrs,
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0])
+
+        # [-1, 1, -1], [-1], [-1] (outputs) -->
+        # [-1, 1, -1], [-1], [-1], (inputs)
+        # [-1, 1, -1], [1], [1] (outputs)
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([-1, 1, -1])
+        self.mean_spec.set_dims_mapping([-1])
+        self.var_spec.set_dims_mapping([-1])
+
+        result_dist_attrs = self.rule.infer_backward(
+            [self.x_spec, self.scale_spec, self.bias_spec],
+            [self.out_spec, self.mean_spec, self.var_spec],
+            self.attrs,
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, 1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [1])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [1])
+
+        # [1, -1, -1], [0], [-1] (outputs) --> error
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([1, -1, -1])
+        self.mean_spec.set_dims_mapping([0])
+        self.var_spec.set_dims_mapping([-1])
+
+        with self.assertRaises(BaseException):
+            result_dist_attrs = self.rule.infer_backward(
+                [self.x_spec, self.scale_spec, self.bias_spec],
+                [self.out_spec, self.mean_spec, self.var_spec],
+                self.attrs,
+            )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        # [-1, 1, -1], [0], [-1] (outputs) --> error
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([-1, 1, -1])
+        self.mean_spec.set_dims_mapping([0])
+        self.var_spec.set_dims_mapping([-1])
+
+        with self.assertRaises(BaseException):
+            result_dist_attrs = self.rule.infer_backward(
+                [self.x_spec, self.scale_spec, self.bias_spec],
+                [self.out_spec, self.mean_spec, self.var_spec],
+                self.attrs,
+            )
+
+        # [0, 1, -1], [-1], [-1] (outputs) --> error
+        # begin_norm_axis=2
+        self.attrs['begin_norm_axis'] = 2
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([0, 1, -1])
+        self.mean_spec.set_dims_mapping([-1])
+        self.var_spec.set_dims_mapping([-1])
+
+        with self.assertRaises(BaseException):
+            result_dist_attrs = self.rule.infer_backward(
+                [self.x_spec, self.scale_spec, self.bias_spec],
+                [self.out_spec, self.mean_spec, self.var_spec],
+                self.attrs,
+            )
+
+        # [0, 1, -1], [-1], [-1] (outputs) -->
+        # [0, -1, -1], [-1], [-1], (inputs)
+        # [0, -1, -1], [0], [0] (outputs)
+        # begin_norm_axis=1
+        self.attrs['begin_norm_axis'] = 1
+        self.scale_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.bias_spec.shape = [
+            math.prod(self.x_spec.shape[self.attrs['begin_norm_axis'] :])
+        ]
+        self.mean_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.var_spec.shape = [
+            math.prod(self.x_spec.shape[: self.attrs['begin_norm_axis']])
+        ]
+        self.out_spec.set_dims_mapping([0, 1, -1])
+        self.mean_spec.set_dims_mapping([-1])
+        self.var_spec.set_dims_mapping([-1])
+
+        result_dist_attrs = self.rule.infer_backward(
+            [self.x_spec, self.scale_spec, self.bias_spec],
+            [self.out_spec, self.mean_spec, self.var_spec],
+            self.attrs,
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(len(result_dist_attrs), 2)
+        self.assertEqual(len(infered_input_dist_attrs), 3)
+        self.assertEqual(len(infered_output_dist_attrs), 3)
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_input_dist_attrs[1].dims_mapping, [-1])
+        self.assertEqual(infered_input_dist_attrs[2].dims_mapping, [-1])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
+        self.assertEqual(infered_output_dist_attrs[1].dims_mapping, [0])
+        self.assertEqual(infered_output_dist_attrs[2].dims_mapping, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -331,14 +331,26 @@ TEST(LayerNormSPMDRule, Ctor) {
             std::vector<int64_t>({1}));
   VLOG(4) << "test1 done.";
 
-  // ijk[1, 0, -1],k[0],k[0] --> error, begin_norm_axis=2
+  // ijk[1, 0, -1],k[0],k[0] --> ijk[1, -1, -1],z[1],z[1],
+  // begin_norm_axis=2
   x_dist_tensor_spec.set_dims_mapping({1, 0, -1});
   scale_dist_tensor_spec.set_dims_mapping({0});
   bias_dist_tensor_spec.set_dims_mapping({0});
-  EXPECT_ANY_THROW(
-      infered_dist_attrs = layer_norm_rule->InferForward(
-          {x_dist_tensor_spec, scale_dist_tensor_spec, bias_dist_tensor_spec},
-          attrs););
+  infered_dist_attrs = layer_norm_rule->InferForward(
+      {x_dist_tensor_spec, scale_dist_tensor_spec, bias_dist_tensor_spec},
+      attrs);
+  EXPECT_EQ(infered_dist_attrs.first[0].dims_mapping(),
+            std::vector<int64_t>({1, -1, -1}));
+  EXPECT_EQ(infered_dist_attrs.first[1].dims_mapping(),
+            std::vector<int64_t>({-1}));
+  EXPECT_EQ(infered_dist_attrs.first[2].dims_mapping(),
+            std::vector<int64_t>({-1}));
+  EXPECT_EQ(infered_dist_attrs.second[0].dims_mapping(),
+            std::vector<int64_t>({1, -1, -1}));
+  EXPECT_EQ(infered_dist_attrs.second[1].dims_mapping(),
+            std::vector<int64_t>({1}));
+  EXPECT_EQ(infered_dist_attrs.second[2].dims_mapping(),
+            std::vector<int64_t>({1}));
   VLOG(4) << "test2 done.";
 
   // ijk[0, -1, -1],y[-1],y[1] --> ijk[0, 1, -1], i[0], i[0], y=jk,
@@ -362,7 +374,7 @@ TEST(LayerNormSPMDRule, Ctor) {
             std::vector<int64_t>({0}));
   EXPECT_EQ(infered_dist_attrs.second[2].dims_mapping(),
             std::vector<int64_t>({0}));
-  VLOG(4) << "test2 done.";
+  VLOG(4) << "test3 done.";
 }
 
 TEST(MatmulSPMDRuleInferBackward, Ctor) {


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
Others

### Description
Pcard-70448

Add infer_backward rule for layer_norm to infer inputs' dims mappings from outputs'. 
