### PR TITLE
fix var order in paddle.jit.save

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -1248,10 +1248,10 @@ def save(layer, path, input_spec=None, **configs):
             file_prefix = file_prefix + '.' + attr_func
         file_prefix = os.path.join(model_path, file_prefix)
         with scope_guard(scope):
-            input_vars = []
-            for var in concrete_program.main_program.clone().list_vars():
-                if var.name in input_var_names:
-                    input_vars.append(var)
+            input_vars = [
+                concrete_program.main_program.global_block().var(name)
+                for name in input_var_names
+            ]
             save_inference_model(
                 path_prefix=file_prefix,
                 feed_vars=input_vars,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -271,6 +271,7 @@ def scale(x, scale=1.0, bias=0.0, bias_after_scale=True, act=None, name=None):
             "x",
             [
                 'float16',
+                'bfloat16',
                 'uint16',
                 'float32',
                 'float64',
@@ -279,6 +280,8 @@ def scale(x, scale=1.0, bias=0.0, bias_after_scale=True, act=None, name=None):
                 'int32',
                 'int64',
                 'uint8',
+                'complex64',
+                'complex128',
             ],
             "scale",
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67005

1. 修复 https://github.com/PaddlePaddle/Paddle/pull/55345 中带来的`paddle.jit.save`阶段多个变量名顺序可能发生变化（与预期输入顺序不一致），从而导致调用`paddle.jit.load`后的执行阶段中，变量检查报错的问题。
2. 为`paddle.scale` 静态图下的类型检查增加`bfloat16/complex64/complex128`的类型支持，当前`ScaleKernel`已支持上述类型。目的是解决`paddle.jit.load`中自动添加scale时类型检查报错的问题。