### PR TITLE
[ROCM]fix bfloat16 to float error!

### DIFF
--- a/paddle/phi/common/bfloat16.h
+++ b/paddle/phi/common/bfloat16.h
@@ -157,7 +157,9 @@ struct PADDLE_ALIGN(2) bfloat16 {
     uint16_t temp = x;
     uint16_t* temp_ptr = reinterpret_cast<uint16_t*>(&temp);
     res = *temp_ptr;
-    return res;
+    // return res;
+    res = res << 16;
+    return *reinterpret_cast<float*>(&res);
 #else
 #ifdef PADDLE_CUDA_BF16
     return __bfloat162float(*reinterpret_cast<const __nv_bfloat16*>(&x));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
在rocm环境下，bfloat16数据格式转换为float数据类型会报错，bfloat16_test单元测试失败。这个提交修复这个问题
