### PR TITLE
[IR] Fix inplace op with set_parameter op bug

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.cc
@@ -123,7 +123,7 @@ LegacyKernelInstruction::LegacyKernelInstruction(
   phi_kernel_ = new phi::Kernel(kernel_result.kernel);
   PADDLE_ENFORCE_EQ(
       phi_kernel_->IsValid(), true, "not found kernel for [%s]", kernel_name);
-  VLOG(6) << "finish process select kernel";
+  VLOG(6) << "finish process select kernel: " << kernel_name;
 
   Scope* inner_scope = local_scope == nullptr ? scope : local_scope;
 

--- a/paddle/fluid/ir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/ir/dialect/op_generator/op_gen.py
@@ -134,7 +134,7 @@ OpInfoTuple {op_name}::GetOpInfo() {{
   std::vector<paddle::dialect::OpOutputInfo> outputs = {{ {outputs} }};
   paddle::dialect::OpRunTimeInfo run_time_info = paddle::dialect::OpRunTimeInfo("{infer_meta_func}", {{"{infer_meta_param}"}}, {{"{kernel_func}"}}, {{"{kernel_param}"}}, {{"{kernel_key_dtype}"}}, {{{inplace}}}, {{{view}}});
 
-  return std::make_tuple(inputs, attributes, outputs, run_time_info);
+  return std::make_tuple(inputs, attributes, outputs, run_time_info, "{origin_op_name}");
 }}
 """
 CONSTRUCT_INPUT_INFO_TEMPLATE = """paddle::dialect::OpInputInfo("{name}", "{typename}", {optional}, {no_need_buffer}, {is_mutable_attribute})"""
@@ -1024,6 +1024,7 @@ def OpGenerator(
                 kernel_key_dtype=kernel_key_dtype,
                 inplace=inplace_str,
                 view=view_str,
+                origin_op_name=op_info.op_yaml_item['name'],
             )
 
             # generate op verify function str

--- a/paddle/fluid/ir/dialect/paddle_dialect/interface/op_yaml_info.h
+++ b/paddle/fluid/ir/dialect/paddle_dialect/interface/op_yaml_info.h
@@ -20,7 +20,8 @@
 using OpInfoTuple = std::tuple<std::vector<paddle::dialect::OpInputInfo>,
                                std::vector<paddle::dialect::OpAttributeInfo>,
                                std::vector<paddle::dialect::OpOutputInfo>,
-                               paddle::dialect::OpRunTimeInfo>;
+                               paddle::dialect::OpRunTimeInfo,
+                               std::string>;
 
 namespace paddle {
 namespace dialect {

--- a/paddle/fluid/ir/dialect/paddle_dialect/ir/pd_manual_op.cc
+++ b/paddle/fluid/ir/dialect/paddle_dialect/ir/pd_manual_op.cc
@@ -41,7 +41,7 @@ OpInfoTuple AddNOp::GetOpInfo() {
   paddle::dialect::OpRunTimeInfo run_time_info =
       OpRunTimeInfo("", {""}, {""}, {""}, {""}, {}, {});
 
-  return std::make_tuple(inputs, attributes, outputs, run_time_info);
+  return std::make_tuple(inputs, attributes, outputs, run_time_info, "add_n");
 }
 
 void AddNOp::Verify() {

--- a/paddle/fluid/ir/dialect/paddle_dialect/utils/op_yaml_info_parser.cc
+++ b/paddle/fluid/ir/dialect/paddle_dialect/utils/op_yaml_info_parser.cc
@@ -187,5 +187,9 @@ void OpYamlInfoParser::parse() {
   }
 }
 
+const std::string& OpYamlInfoParser::GetOriginOpName() const {
+  return std::get<4>(op_info_tuple_);
+}
+
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/ir/dialect/paddle_dialect/utils/op_yaml_info_parser.h
+++ b/paddle/fluid/ir/dialect/paddle_dialect/utils/op_yaml_info_parser.h
@@ -57,6 +57,8 @@ class OpYamlInfoParser {
 
   const std::string& ViewName(const std::string& out_name) const;
 
+  const std::string& GetOriginOpName() const;
+
  private:
   void parse();
   inline const std::vector<OpInputInfo>& InputInfo() const {

--- a/paddle/fluid/ir/dialect/paddle_dialect/utils/utils.cc
+++ b/paddle/fluid/ir/dialect/paddle_dialect/utils/utils.cc
@@ -18,11 +18,7 @@ namespace paddle {
 namespace dialect {
 
 const std::unordered_set<std::string> LegacyOpList = {
-    "pd.fused_softmax_mask_upper_triangle",
-    "pd.fused_softmax_mask_upper_triangle_grad",
-    "pd.load_combine",
-    "pd.c_concat",
-    "pd.load_combine"};
+    "pd.load_combine", "pd.c_concat", "pd.c_broadcast_"};
 
 enum class AttrType {
   UNDEFINED = 0,

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -744,9 +744,6 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
     }
   }
 
-  // auto& op_info =
-  // paddle::framework::OpInfoMap::Instance().Get(fluid_op_name);
-
   auto* op_info =
       paddle::framework::OpInfoMap::Instance().GetNullable(fluid_op_name);
   if (op_info == nullptr && (fluid_op_name.back() == '_')) {

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -594,13 +594,15 @@ void BuildRuntimeContext(
 
   auto& name2id = op_yaml_info.InputName2Id();
 
-  auto pd_op_name =
-      op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
-  auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with "pd.xxx"
+  std::string fluid_op_name = op_yaml_info.GetOriginOpName();
+  // auto pd_op_name =
+  //     op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
+  // auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with
+  // "pd.xxx"
 
-  if (fluid_op_name == "c_broadcast_") {
-    fluid_op_name = fluid_op_name.substr(0, fluid_op_name.length() - 1);
-  }
+  // if (fluid_op_name == "c_broadcast_") {
+  //   fluid_op_name = fluid_op_name.substr(0, fluid_op_name.length() - 1);
+  // }
 
   auto& op_normalizer = paddle::translator::OpNameNormalizer::instance();
 
@@ -674,9 +676,11 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
 
   auto& name2id = op_yaml_info.InputName2Id();
 
-  auto pd_op_name =
-      op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
-  auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with "pd.xxx"
+  std::string fluid_op_name = op_yaml_info.GetOriginOpName();
+  // auto pd_op_name =
+  //     op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
+  // auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with
+  // "pd.xxx"
 
   auto& op_normalizer = paddle::translator::OpNameNormalizer::instance();
 
@@ -748,19 +752,19 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
     }
   }
 
-  auto* op_info =
-      paddle::framework::OpInfoMap::Instance().GetNullable(fluid_op_name);
-  if (op_info == nullptr && (fluid_op_name.back() == '_')) {
-    op_info = paddle::framework::OpInfoMap::Instance().GetNullable(
-        fluid_op_name.substr(0, fluid_op_name.length() - 1));
-  }
-  PADDLE_ENFORCE_NOT_NULL(
-      op_info,
-      paddle::platform::errors::NotFound("Operator (%s) is not registered.",
-                                         fluid_op_name));
-
+  // auto* op_info =
+  //     paddle::framework::OpInfoMap::Instance().GetNullable(fluid_op_name);
+  // if (op_info == nullptr && (fluid_op_name.back() == '_')) {
+  //   op_info = paddle::framework::OpInfoMap::Instance().GetNullable(
+  //       fluid_op_name.substr(0, fluid_op_name.length() - 1));
+  // }
+  // PADDLE_ENFORCE_NOT_NULL(
+  //     op_info,
+  //     paddle::platform::errors::NotFound("Operator (%s) is not registered.",
+  //                                        fluid_op_name));
+  auto& op_info = paddle::framework::OpInfoMap::Instance().Get(fluid_op_name);
   auto ptr =
-      op_info->Creator()(fluid_op_name, in_name_map, out_name_map, attr_map);
+      op_info.Creator()(fluid_op_name, in_name_map, out_name_map, attr_map);
 
   std::shared_ptr<paddle::framework::OperatorBase> res(ptr);
   return res;

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -598,6 +598,10 @@ void BuildRuntimeContext(
       op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
   auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with "pd.xxx"
 
+  if (fluid_op_name == "c_broadcast_") {
+    fluid_op_name = fluid_op_name.substr(0, fluid_op_name.length() - 1);
+  }
+
   auto& op_normalizer = paddle::translator::OpNameNormalizer::instance();
 
   for (auto& name : vec_kernel_fn_tensor_params) {
@@ -627,7 +631,7 @@ void BuildRuntimeContext(
     ir::Value ptr = op->result(i);
 
     auto in_var_name = name_map.at(ptr);
-    VLOG(6) << "ctx->EmplaceBackInput: " << name << "\t" << in_var_name;
+    VLOG(6) << "ctx->EmplaceBackOutput: " << name << "\t" << in_var_name;
 
     PADDLE_ENFORCE_NOT_NULL(inner_scope->FindVar(in_var_name),
                             phi::errors::PreconditionNotMet(

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -80,6 +80,12 @@ void RenameData(ir::Value value,
                 std::map<std::string, int>* var_name_2_id) {
   (*value_2_var_name)[value] = new_name;
 
+  for (auto kv : (*value_2_var_name)) {
+    if (kv.second == orig_name) {
+      (*value_2_var_name)[kv.first] = new_name;
+    }
+  }
+
   for (auto kv : (*variable_2_var_name)) {
     if (kv.second == orig_name) {
       (*variable_2_var_name)[kv.first] = new_name;

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -595,14 +595,6 @@ void BuildRuntimeContext(
   auto& name2id = op_yaml_info.InputName2Id();
 
   std::string fluid_op_name = op_yaml_info.GetOriginOpName();
-  // auto pd_op_name =
-  //     op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
-  // auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with
-  // "pd.xxx"
-
-  // if (fluid_op_name == "c_broadcast_") {
-  //   fluid_op_name = fluid_op_name.substr(0, fluid_op_name.length() - 1);
-  // }
 
   auto& op_normalizer = paddle::translator::OpNameNormalizer::instance();
 
@@ -677,10 +669,6 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
   auto& name2id = op_yaml_info.InputName2Id();
 
   std::string fluid_op_name = op_yaml_info.GetOriginOpName();
-  // auto pd_op_name =
-  //     op->attributes().at("op_name").dyn_cast<ir::StrAttribute>().AsString();
-  // auto fluid_op_name = pd_op_name.substr(3);  // pd_op_name start with
-  // "pd.xxx"
 
   auto& op_normalizer = paddle::translator::OpNameNormalizer::instance();
 
@@ -752,16 +740,6 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
     }
   }
 
-  // auto* op_info =
-  //     paddle::framework::OpInfoMap::Instance().GetNullable(fluid_op_name);
-  // if (op_info == nullptr && (fluid_op_name.back() == '_')) {
-  //   op_info = paddle::framework::OpInfoMap::Instance().GetNullable(
-  //       fluid_op_name.substr(0, fluid_op_name.length() - 1));
-  // }
-  // PADDLE_ENFORCE_NOT_NULL(
-  //     op_info,
-  //     paddle::platform::errors::NotFound("Operator (%s) is not registered.",
-  //                                        fluid_op_name));
   auto& op_info = paddle::framework::OpInfoMap::Instance().Get(fluid_op_name);
   auto ptr =
       op_info.Creator()(fluid_op_name, in_name_map, out_name_map, attr_map);

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -752,8 +752,8 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
   }
   PADDLE_ENFORCE_NOT_NULL(
       op_info,
-      platform::errors::NotFound("Operator (%s) is not registered.",
-                                 fluid_op_name));
+      paddle::platform::errors::NotFound("Operator (%s) is not registered.",
+                                         fluid_op_name));
 
   auto ptr =
       op_info->Creator()(fluid_op_name, in_name_map, out_name_map, attr_map);

--- a/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/ir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -744,9 +744,22 @@ std::shared_ptr<paddle::framework::OperatorBase> BuildOperatorBase(
     }
   }
 
-  auto& op_info = paddle::framework::OpInfoMap::Instance().Get(fluid_op_name);
+  // auto& op_info =
+  // paddle::framework::OpInfoMap::Instance().Get(fluid_op_name);
+
+  auto* op_info =
+      paddle::framework::OpInfoMap::Instance().GetNullable(fluid_op_name);
+  if (op_info == nullptr && (fluid_op_name.back() == '_')) {
+    op_info = paddle::framework::OpInfoMap::Instance().GetNullable(
+        fluid_op_name.substr(0, fluid_op_name.length() - 1));
+  }
+  PADDLE_ENFORCE_NOT_NULL(
+      op_info,
+      platform::errors::NotFound("Operator (%s) is not registered.",
+                                 fluid_op_name));
+
   auto ptr =
-      op_info.Creator()(fluid_op_name, in_name_map, out_name_map, attr_map);
+      op_info->Creator()(fluid_op_name, in_name_map, out_name_map, attr_map);
 
   std::shared_ptr<paddle::framework::OperatorBase> res(ptr);
   return res;

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -639,7 +639,7 @@ ir::Operation* OpTranscriber::operator()(ir::IrContext* ctx,
   OpInputInfoList input_infos;
   OpAttributeInfoList attr_infos;
   OpOutputInfoList output_infos;
-  std::tie(input_infos, attr_infos, output_infos, std::ignore) =
+  std::tie(input_infos, attr_infos, output_infos, std::ignore, std::ignore) =
       op_info_concept->get_op_info_();
 
   this->InsertSliceOperationForInput(
@@ -755,7 +755,7 @@ struct AssignValueOpTranscriber : public OpTranscriber {
     OpInputInfoList input_infos;
     OpAttributeInfoList attr_infos;
     OpOutputInfoList output_infos;
-    std::tie(input_infos, attr_infos, output_infos, std::ignore) =
+    std::tie(input_infos, attr_infos, output_infos, std::ignore, std::ignore) =
         op_info_concept->get_op_info_();
     std::unordered_map<std::string, OpAttributeInfo> attr_info_maps;
     for (auto info : attr_infos) {
@@ -1078,7 +1078,7 @@ struct FetchOpTranscriber : public OpTranscriber {
     OpInputInfoList input_infos;
     OpAttributeInfoList attr_infos;
     OpOutputInfoList output_infos;
-    std::tie(input_infos, attr_infos, output_infos, std::ignore) =
+    std::tie(input_infos, attr_infos, output_infos, std::ignore, std::ignore) =
         op_info_concept->get_op_info_();
 
     this->InsertSliceOperationForInput(

--- a/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/ir/pattern_rewrite/pattern_rewrite_test.cc
@@ -490,7 +490,8 @@ OpInfoTuple Conv2dFusionOpTest::GetOpInfo() {
                     {},
                     {});
 
-  return std::make_tuple(inputs, attributes, outputs, run_time_info);
+  return std::make_tuple(
+      inputs, attributes, outputs, run_time_info, "conv2d_fusion_test");
 }
 
 void Conv2dFusionOpTest::Build(ir::Builder &builder,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复新IR在运行 gpt 多卡模型过程中存在的 bug，包括：
- 修复 Build Scope 过程中，inplace op + set_parameter op 同时存在导致 ir::value 与 Variable name 映射错误的 bug
- 修复 pd.c_broadcast_ 算子在 ir 下的名称与 fluid 下名称(c_broadcast)不统一导致的诸多问题

### Other
Pcard-67164
