### PR TITLE
fix pylayer py39 mem leak

### DIFF
--- a/paddle/fluid/eager/pylayer/py_layer_node.h
+++ b/paddle/fluid/eager/pylayer/py_layer_node.h
@@ -31,17 +31,22 @@ namespace egr {
 class GradNodePyLayer : public GradNodeBase {
  public:
   GradNodePyLayer(PyObject* ctx,
+                  PyObject* backward_function,
                   size_t bwd_in_slot_num,
                   size_t bwd_out_slot_num)
       : GradNodeBase(bwd_in_slot_num, bwd_out_slot_num) {
     ctx_ = ctx;
+    backward_function_ = backward_function;
     name_ = "GradNodePyLayer_" + std::string(Py_TYPE(ctx_)->tp_name);
     Py_INCREF(ctx_);
+    Py_INCREF(backward_function_);
   }
 
   GradNodePyLayer(const GradNodePyLayer& other) : GradNodeBase(other) {
     this->ctx_ = other.ctx_;
     Py_INCREF(this->ctx_);
+    this->backward_function_ = other.backward_function_;
+    Py_INCREF(this->backward_function_);
     this->forward_outputs_meta_ = other.forward_outputs_meta_;
     this->forward_outputs_place_ = other.forward_outputs_place_;
   }
@@ -86,6 +91,7 @@ class GradNodePyLayer : public GradNodeBase {
 
  private:
   PyObject* ctx_{nullptr};
+  PyObject* backward_function_{nullptr};
   std::string name_{""};
   std::vector<std::vector<phi::DenseTensorMeta>> forward_outputs_meta_;
   std::vector<std::vector<paddle::platform::Place>> forward_outputs_place_;

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -150,8 +150,8 @@ PyObject* pylayer_method_apply(PyObject* cls,
   PyLayerObject* ctx = reinterpret_cast<PyLayerObject*>(
       p_pylayer_type->tp_alloc(p_pylayer_type, 0));
   if (!ctx) {
-    PADDLE_THROW(paddle::platform::errors::External(
-        pybind11::detail::error_string().c_str()));
+    PADDLE_THROW(platform::errors::Fatal(
+        "tp_alloc return null, can not new a PyObject."));
     return nullptr;
   }
 

--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -253,7 +253,7 @@ class PyLayerContext:
         self.materialize_grads = value
 
 
-class PyLayerBackward(core.eager.PyLayer, PyLayerContext):
+class PyLayerBackward(PyLayerContext):
     def backward(self, *args):
         return self._forward_cls.backward(self, *args)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Python39构造 `class PyLayerBackward(core.eager.PyLayer, PyLayerContext):`调用了 `core.eager.PyLayer` 的 `PyLayerNew`，析构是调用了`PyLayerDealloc`，但无法正常释放内存。原因未找到。
暂停通过拆分PyLayerBackward方式规避。
Pcard-71699