### PR TITLE
[XPU] Fix matmul + elementwise_add + bn + act fusion that elementwise_add has branch

### DIFF
--- a/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
@@ -128,6 +128,9 @@ FcXPUPattern::FcXPUPattern(PDPattern* pattern,
     add_out = pattern->NewNode(add_out_repr())
                   ->assert_is_op_output("elementwise_add", "Out")
                   ->assert_var_not_persistable();
+    if (with_bn_ || !act_type_.empty()) {
+      add_out->assert_has_n_outputs(1);
+    }
     add->LinksFrom({mul_out, bias}).LinksTo({add_out});
   } else {
     add_out = mul_out;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Fix matmul + elementwise_add + bn + act fuse bug，when elementwise_add has branch，can not fuse bn or act
