### PR TITLE
[XPU][PHI Kernels] optimize unique & index_put

### DIFF
--- a/paddle/phi/kernels/xpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_put_kernel.cc
@@ -65,7 +65,9 @@ void XPUDealWithIndices(const Context& dev_ctx,
   }
 
   StackKernel<int64_t, Context>(dev_ctx, tmp_indices_ptr, -1, out);
-  dev_ctx.Wait();
+  if (dev_ctx.x_context()->xpu_stream) {
+    dev_ctx.Wait();
+  }
 }
 
 template <typename T, typename Context>
@@ -140,7 +142,9 @@ void IndexPutKernel(const Context& dev_ctx,
                                     index_shape,
                                     accumulate);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "index_put");
-  dev_ctx.Wait();
+  if (dev_ctx.x_context()->xpu_stream) {
+    dev_ctx.Wait();
+  }
 }
 }  // namespace phi
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
1. unique kernel：将UniqueDimFactor循环中的nonzero_count用循环外的一次reduce_all代替，避免axis_len较长时产生过多的kernel调用影响性能。
2. index_put_kernel：优化使用临时Tensor时的wait逻辑。当kernel在默认流上时由于runtime的deferred free机制能确保释放的显存不会在当前kernel执行完之前被再次分配给其他kernel，此时无需显式wait。