### PR TITLE
[NewIR] add method to check_unregistered_ops in `paddle dialect`

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -245,66 +245,6 @@ inline ir::OpResult GetAttributeAsInput(ir::IrContext* ctx,
 
 }  // namespace
 
-/// @brief This class is used to translate a OpDesc, it's a functor class and
-/// should have no non-static data member, since we expected it's stateless.
-struct OpTranscriber {
- public:
-  virtual ~OpTranscriber() = default;
-
- public:
-  virtual ir::Operation* operator()(ir::IrContext* ctx,
-                                    TranslationContext* param_map,
-                                    const OpDesc& op_desc,
-                                    ir::Program* program);
-
- public:
-  virtual ir::OpInfo LoopkUpOpInfo(ir::IrContext* ctx, const OpDesc& op_desc);
-  virtual std::vector<ir::OpResult> GenerateOperationInput(
-      ir::IrContext* ctx,
-      TranslationContext* param_map,
-      const OpDesc& op_desc,
-      const std::string& normalized_op_name,
-      const OpInputInfoList& input_infos,
-      ir::Program* program);
-  virtual std::tuple<OpOutputTypeList, OpOutputMapping> GenerateOperationOutput(
-      ir::IrContext* ctx,
-      const OpDesc& op_desc,
-      const OpOutputInfoList& output_infos);
-  virtual void HandleNonexistentAttribute(ir::IrContext*,
-                                          ir::AttributeMap* attribute_map,
-                                          const OpAttributeInfo& info) {
-    auto& attribute_translator = AttributeTranslator::instance();
-    (*attribute_map)[info.name] =
-        attribute_translator(info.type_name, paddle::framework::Attribute());
-  }
-  virtual ir::AttributeMap TranslateOpAttribute(
-      ir::IrContext* ctx,
-      const std::string& normalized_op_name,
-      const OpAttributeInfoList& op_attr_infos,
-      const OpDesc& op_desc);
-
-  virtual void RecordOpResultMapping(ir::IrContext* ctx,
-                                     TranslationContext* param_map,
-                                     const OpDesc& op_desc,
-                                     ir::Operation* operation,
-                                     const OpOutputMapping& arg_to_idx);
-
- public:
-  virtual InputHandlerFn GetSpecialInputHandlers(
-      const std::string& input_name) {
-    return nullptr;
-  }
-  virtual AttributeHandlerFn GetSpecialAttributeHandlers(
-      const std::string& input_name) {
-    return nullptr;
-  }
-  virtual void InsertSliceOperationForInput(ir::IrContext* ctx,
-                                            TranslationContext* param_map,
-                                            const OpDesc& op_desc,
-                                            const OpInputInfoList& input_infos,
-                                            ir::Program* program);
-};
-
 ir::OpInfo OpTranscriber::LoopkUpOpInfo(ir::IrContext* ctx,
                                         const OpDesc& op_desc) {
   std::string target_op_name =
@@ -622,6 +562,14 @@ ir::AttributeMap OpTranscriber::TranslateOpAttribute(
   }
 
   return attribute_map;
+}
+
+void OpTranscriber::HandleNonexistentAttribute(ir::IrContext*,
+                                               ir::AttributeMap* attribute_map,
+                                               const OpAttributeInfo& info) {
+  auto& attribute_translator = AttributeTranslator::instance();
+  (*attribute_map)[info.name] =
+      attribute_translator(info.type_name, paddle::framework::Attribute());
 }
 
 void OpTranscriber::RecordOpResultMapping(ir::IrContext* ctx,

--- a/paddle/fluid/ir_adaptor/translator/op_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.h
@@ -20,6 +20,7 @@
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/var_desc.h"
+#include "paddle/fluid/ir/dialect/paddle_dialect/interface/op_yaml_info.h"
 #include "paddle/fluid/ir_adaptor/translator/program_translator.h"
 #include "paddle/ir/core/ir_context.h"
 #include "paddle/ir/core/operation.h"
@@ -28,6 +29,84 @@
 
 namespace paddle {
 namespace translator {
+
+/// @brief This class is used to translate a OpDesc, it's a functor class and
+/// should have no non-static data member, since we expected it's stateless.
+struct OpTranscriber {
+ public:
+  virtual ~OpTranscriber() = default;
+
+ public:
+  using IdxInOp = size_t;
+  using IdxInVector = size_t;
+  using ResultIdx = std::tuple<IdxInOp, IdxInVector>;
+  using OpDesc = paddle::framework::OpDesc;
+  using OpOutputTypeList = std::vector<ir::Type>;
+  using OpOutputMapping = std::unordered_map<std::string, ResultIdx>;
+  using OpInputInfo = dialect::OpInputInfo;
+  using OpInputInfoList = std::vector<dialect::OpInputInfo>;
+  using OpAttributeInfo = dialect::OpAttributeInfo;
+  using OpAttributeInfoList = std::vector<dialect::OpAttributeInfo>;
+  using OpOutputInfo = dialect::OpOutputInfo;
+  using OpOutputInfoList = std::vector<dialect::OpOutputInfo>;
+  using InputHandlerFn = std::function<ir::OpResult(ir::IrContext*,
+                                                    TranslationContext*,
+                                                    const OpDesc&,
+                                                    const std::string&,
+                                                    const OpInputInfo&,
+                                                    ir::Program*)>;
+  using AttributeHandlerFn = std::function<ir::Attribute(
+      ir::IrContext*, const OpDesc&, const OpAttributeInfo&)>;
+
+ public:
+  virtual ir::Operation* operator()(ir::IrContext* ctx,
+                                    TranslationContext* param_map,
+                                    const OpDesc& op_desc,
+                                    ir::Program* program);
+
+ public:
+  virtual ir::OpInfo LoopkUpOpInfo(ir::IrContext* ctx, const OpDesc& op_desc);
+  virtual std::vector<ir::OpResult> GenerateOperationInput(
+      ir::IrContext* ctx,
+      TranslationContext* param_map,
+      const OpDesc& op_desc,
+      const std::string& normalized_op_name,
+      const OpInputInfoList& input_infos,
+      ir::Program* program);
+  virtual std::tuple<OpOutputTypeList, OpOutputMapping> GenerateOperationOutput(
+      ir::IrContext* ctx,
+      const OpDesc& op_desc,
+      const OpOutputInfoList& output_infos);
+  virtual void HandleNonexistentAttribute(ir::IrContext*,
+                                          ir::AttributeMap* attribute_map,
+                                          const OpAttributeInfo& info);
+  virtual ir::AttributeMap TranslateOpAttribute(
+      ir::IrContext* ctx,
+      const std::string& normalized_op_name,
+      const OpAttributeInfoList& op_attr_infos,
+      const OpDesc& op_desc);
+
+  virtual void RecordOpResultMapping(ir::IrContext* ctx,
+                                     TranslationContext* param_map,
+                                     const OpDesc& op_desc,
+                                     ir::Operation* operation,
+                                     const OpOutputMapping& arg_to_idx);
+
+ public:
+  virtual InputHandlerFn GetSpecialInputHandlers(
+      const std::string& input_name) {
+    return nullptr;
+  }
+  virtual AttributeHandlerFn GetSpecialAttributeHandlers(
+      const std::string& input_name) {
+    return nullptr;
+  }
+  virtual void InsertSliceOperationForInput(ir::IrContext* ctx,
+                                            TranslationContext* param_map,
+                                            const OpDesc& op_desc,
+                                            const OpInputInfoList& input_infos,
+                                            ir::Program* program);
+};
 
 class OpTranslator {
  public:
@@ -60,6 +139,10 @@ class OpTranslator {
     } else {
       return special_handlers[op_type];
     }
+  }
+
+  bool HasSpecialHandler(const std::string& op_type) {
+    return special_handlers.count(op_type) != 0;
   }
 };
 

--- a/paddle/fluid/ir_adaptor/translator/utils.h
+++ b/paddle/fluid/ir_adaptor/translator/utils.h
@@ -15,7 +15,9 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
+#include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/ir_adaptor/translator/program_translator.h"
 #include "paddle/ir/core/ir_context.h"
 #include "paddle/ir/core/operation.h"
@@ -33,6 +35,9 @@ ir::Operation* InsertSliceOperationForTarget(
 
 std::ostream& operator<<(std::ostream& os,
                          const std::vector<std::string>& vec_str);
+
+std::vector<std::string> CheckUnregisteredOperation(
+    ir::IrContext* ctx, const framework::ProgramDesc& legacy_program);
 
 }  // namespace translator
 }  // namespace paddle

--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -30,6 +30,7 @@
 #include "paddle/fluid/ir/dialect/paddle_dialect/ir/pd_type.h"
 #include "paddle/fluid/ir/dialect/paddle_dialect/utils/utils.h"
 #include "paddle/fluid/ir_adaptor/translator/translate.h"
+#include "paddle/fluid/ir_adaptor/translator/utils.h"
 #include "paddle/ir/core/block.h"
 #include "paddle/ir/core/builtin_attribute.h"
 #include "paddle/ir/core/program.h"
@@ -431,6 +432,21 @@ void BindUtils(pybind11::module *m) {
                 print(newir_program)
 
       )DOC");
+  m->def(
+      "check_unregistered_ops",
+      [](const framework::ProgramDesc &legacy_program) {
+        ir::IrContext *ctx = ir::IrContext::Instance();
+        return paddle::translator::CheckUnregisteredOperation(ctx,
+                                                              legacy_program);
+      },
+      R"DOC(
+      Check unregistered operators in paddle dialect.
+
+      Args:
+        legacy_program (ProgramDesc): The Fluid Program that need checked.
+      Returns:
+        list[str] : List of unregistered operators in paddle dialect, the name is expressed by origin op name.
+    )DOC");
 }
 
 void BindNewIR(pybind11::module *module) {

--- a/python/paddle/ir/__init__.py
+++ b/python/paddle/ir/__init__.py
@@ -27,6 +27,7 @@ from paddle.fluid.libpaddle.ir import (
     set_insertion_point,
     reset_insertion_point_to_start,
     reset_insertion_point_to_end,
+    check_unregistered_ops,
 )  # noqa: F401
 
 from . import core

--- a/test/ir/new_ir/test_special_op_translator.py
+++ b/test/ir/new_ir/test_special_op_translator.py
@@ -336,7 +336,6 @@ class TestCheckUnregisteredOp(unittest.TestCase):
             y, h = cell(x, prev_h)
 
         ops = ir.check_unregistered_ops(main_program.desc)
-        print(ops)
         assert len(ops) == 0
 
 

--- a/test/ir/new_ir/test_special_op_translator.py
+++ b/test/ir/new_ir/test_special_op_translator.py
@@ -325,5 +325,20 @@ class TestShadowOutputSlice(unittest.TestCase):
         l = ir.translate_to_new_ir(main_program.desc)
 
 
+class TestCheckUnregisteredOp(unittest.TestCase):
+    def test_program(self):
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program):
+            x = paddle.randn((4, 16))
+            prev_h = paddle.randn((4, 32))
+
+            cell = paddle.nn.SimpleRNNCell(16, 32)
+            y, h = cell(x, prev_h)
+
+        ops = ir.check_unregistered_ops(main_program.desc)
+        print(ops)
+        assert len(ops) == 0
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
This PR adds a method to check unregistered ops in paddle dialect. 
Example:
```
main_program = paddle.static.Program()
with paddle.static.program_guard(main_program):
    x = paddle.randn((4, 16))
    prev_h = paddle.randn((4, 32))

    cell = paddle.nn.SimpleRNNCell(16, 32)
    y, h = cell(x, prev_h)

ops = ir.check_unregistered_ops(main_program.desc)
assert len(ops) == 0
```
#### Others
Pcard-67164