### PR TITLE
[3rd-party] update openBLAS to fix compile error on Raptor Lake

### DIFF
--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -19,7 +19,7 @@ set(CBLAS_INSTALL_DIR ${THIRD_PARTY_PATH}/install/openblas)
 set(CBLAS_SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/openblas)
 set(CBLAS_TAG v0.3.7)
 
-# OpenBLAS support Raptor Lake v0.3.22
+# OpenBLAS support Raptor Lake from v0.3.22
 if(UNIX
    AND NOT APPLE
    AND NOT WITH_ROCM

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -19,15 +19,11 @@ set(CBLAS_INSTALL_DIR ${THIRD_PARTY_PATH}/install/openblas)
 set(CBLAS_SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/openblas)
 set(CBLAS_TAG v0.3.7)
 
-# Why use v0.3.18?  The IDG business line encountered a random openblas error,
-# which can be resolved after upgrading openblas.
-# And why compile when gcc>8.2? Please refer to
-# https://github.com/spack/spack/issues/19932#issuecomment-733452619
-# v0.3.18 only support gcc>=8.3 or gcc>=7.4
-if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.2
+# OpenBLAS support Raptor Lake v0.3.22
+if(UNIX
+   AND NOT APPLE
+   AND NOT WITH_ROCM
    AND NOT WITH_XPU)
-  # We only compile with openblas 0.3.18 when gcc >= 8.3
   set(CBLAS_TAG v0.3.23)
 endif()
 

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -28,7 +28,7 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.2
    AND NOT WITH_XPU)
   # We only compile with openblas 0.3.18 when gcc >= 8.3
-  set(CBLAS_TAG v0.3.18)
+  set(CBLAS_TAG v0.3.23)
 endif()
 
 if(APPLE AND WITH_ARM)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
https://github.com/xianyi/OpenBLAS/blob/394a9fbafe9010b76a2615c562204277a956eb52/Changelog.txt#L54
https://github.com/xianyi/OpenBLAS/blob/394a9fbafe9010b76a2615c562204277a956eb52/Changelog.txt#L17

OpenBLAS 0.3.22 开始支持Raptor Lake，当前 0.3.18 版本不能在 Xeon 4th CPU上编译（当`WITH_MKL=OFF`时）。
