### PR TITLE
[xdoctest][task 184-185] reformat example code with google style in `distributed/auto_parallel/static/*`

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/cluster_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster_v2.py
@@ -58,15 +58,14 @@ class DeviceMesh(core.DeviceMesh):
     Examples:
         .. code-block:: python
 
-            >>> # doctest: +REQUIRES(env:DISTRIBUTED)
-            >>> import paddle
-            >>> import paddle.distributed as dist
+            import paddle
+            import paddle.distributed as dist
 
-            >>> paddle.enable_static()
+            paddle.enable_static()
 
-            >>> mesh = dist.DeviceMesh([[2, 4, 5], [0, 1, 3]])
-            >>> assert mesh.shape == [2, 3]
-            >>> assert mesh.device_ids == [2, 4, 5, 0, 1, 3]
+            mesh = dist.DeviceMesh([[2, 4, 5], [0, 1, 3]])
+            assert mesh.shape == [2, 3]
+            assert mesh.device_ids == [2, 4, 5, 0, 1, 3]
 
     """
 

--- a/python/paddle/distributed/auto_parallel/static/cluster_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster_v2.py
@@ -58,14 +58,14 @@ class DeviceMesh(core.DeviceMesh):
     Examples:
         .. code-block:: python
 
-            import paddle
-            import paddle.distributed as dist
+            >>> import paddle
+            >>> import paddle.distributed as dist
 
-            paddle.enable_static()
+            >>> paddle.enable_static()
 
-            mesh = dist.DeviceMesh([[2, 4, 5], [0, 1, 3]])
-            assert mesh.shape == [2, 3]
-            assert mesh.device_ids == [2, 4, 5, 0, 1, 3]
+            >>> mesh = dist.DeviceMesh([[2, 4, 5], [0, 1, 3]])
+            >>> assert mesh.shape == [2, 3]
+            >>> assert mesh.device_ids == [2, 4, 5, 0, 1, 3]
 
     """
 

--- a/python/paddle/distributed/auto_parallel/static/cluster_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster_v2.py
@@ -58,6 +58,7 @@ class DeviceMesh(core.DeviceMesh):
     Examples:
         .. code-block:: python
 
+            >>> # doctest: +REQUIRES(env:DISTRIBUTED)
             >>> import paddle
             >>> import paddle.distributed as dist
 

--- a/python/paddle/distributed/auto_parallel/static/cluster_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster_v2.py
@@ -58,7 +58,7 @@ class DeviceMesh(core.DeviceMesh):
     Examples:
         .. code-block:: python
 
-            >>> # doctest: +SKIP('code is wrong')
+            >>> # doctest: +REQUIRES(env:DISTRIBUTED)
             >>> import paddle
             >>> import paddle.distributed as dist
 

--- a/python/paddle/distributed/auto_parallel/static/cluster_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster_v2.py
@@ -58,14 +58,15 @@ class DeviceMesh(core.DeviceMesh):
     Examples:
         .. code-block:: python
 
-            import paddle
-            import paddle.distributed as dist
+            >>> # doctest: +SKIP('code is wrong')
+            >>> import paddle
+            >>> import paddle.distributed as dist
 
-            paddle.enable_static()
+            >>> paddle.enable_static()
 
-            mesh = dist.DeviceMesh([[2, 4, 5], [0, 1, 3]])
-            assert mesh.shape == [2, 3]
-            assert mesh.device_ids == [2, 4, 5, 0, 1, 3]
+            >>> mesh = dist.DeviceMesh([[2, 4, 5], [0, 1, 3]])
+            >>> assert mesh.shape == [2, 3]
+            >>> assert mesh.device_ids == [2, 4, 5, 0, 1, 3]
 
     """
 

--- a/python/paddle/distributed/auto_parallel/static/converter.py
+++ b/python/paddle/distributed/auto_parallel/static/converter.py
@@ -101,28 +101,29 @@ class Converter:
         Examples:
             .. code-block:: python
 
-                import numpy as np
-                complete_tensors = np.arange(4).reshape([2, 2])
-                partitial_tensors = np.split(complete_tensors, 2, axis=0)
-                name = "tmp_0"
-                tensors_dict = {name: partitial_tensors}
-                strategy_1 = {
-                    name: {
-                        "process_shape": [2],
-                        "process_group": [0, 1],
-                        "dims_mapping": [0, -1]
-                    }
-                }
-                strategy_2 = {
-                    name: {
-                        "process_shape": [2],
-                        "process_group": [0, 1],
-                        "dims_mapping": [-1, -1]
-                    }
-                }
-                converter = Converter(tensors_dict, strategy_1, strategy_2)
-                result = converter.convert()
-                # the result's value is equal to `complete_tensors`
+                >>> import numpy as np
+                >>> from paddle.distributed.auto_parallel.static.converter import Converter
+                >>> complete_tensors = np.arange(4).reshape([2, 2])
+                >>> partitial_tensors = np.split(complete_tensors, 2, axis=0)
+                >>> name = "tmp_0"
+                >>> tensors_dict = {name: partitial_tensors}
+                >>> strategy_1 = {
+                ...     name: {
+                ...         "process_shape": [2],
+                ...         "process_group": [0, 1],
+                ...         "dims_mapping": [0, -1]
+                ...     }
+                ... }
+                >>> strategy_2 = {
+                ...     name: {
+                ...         "process_shape": [2],
+                ...         "process_group": [0, 1],
+                ...         "dims_mapping": [-1, -1]
+                ...     }
+                ... }
+                >>> converter = Converter(tensors_dict, strategy_1, strategy_2)
+                >>> result = converter.convert()
+                >>> # the result's value is equal to `complete_tensors`
         """
         tensors_dict = {}
         # the name which is in cur_process but not in pre_process
@@ -352,13 +353,14 @@ class Converter:
         Examples:
             .. code-block:: python
 
-                import numpy as np
-                partition_tensor_list = [(np.array([[[1.11, 1.12]]]), [[0,1],[0,1],[0,2]])]
-                tensor = np.array([[[1.13, 1.14]]])
-                partition_index = [[0,1],[0,1],[2,4]]
+                >>> import numpy as np
+                >>> partition_tensor_list = [(np.array([[[1.11, 1.12]]]), [[0,1],[0,1],[0,2]])]
+                >>> tensor = np.array([[[1.13, 1.14]]])
+                >>> partition_index = [[0,1],[0,1],[2,4]]
 
-                _merge_tensor(partition_tensor_list, tensor, partition_index)
-                # partition_tensor_list: [(np.array([[[1.11, 1.12, 1.13, 1.14]]]), [[0,1],[0,1],[0,4]])]
+                >>> _merge_tensor(partition_tensor_list, tensor, partition_index)
+                >>> print(partition_tensor_list)
+                [(np.array([[[1.11, 1.12, 1.13, 1.14]]]), [[0,1],[0,1],[0,4]])]
         """
         from .reshard import Resharder
 
@@ -416,16 +418,18 @@ class Converter:
         Examples:
             .. code-block:: python
 
-                import numpy as np
-                complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
-                rank = 2
-                complete_shape = [1, 1, 6]
-                dims_mapping = [-1, -1, 0]
-                process_shape = [3]
-                process_group = [0, 1, 2]
+                >>> import numpy as np
+                >>> from paddle.distributed.auto_parallel.static.utils import split
+                >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
+                >>> rank = 2
+                >>> complete_shape = [1, 1, 6]
+                >>> dims_mapping = [-1, -1, 0]
+                >>> process_shape = [3]
+                >>> process_group = [0, 1, 2]
 
-                sliced_tensor_list = split(complete_tensor, [[], [], [2, 4]], 3)
-                # [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
+                >>> sliced_tensor_list = split(complete_tensor, [[], [], [2, 4]], 3)
+                >>> print(sliced_tensor_list)
+                [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
         """
         sliced_tensor_list = []
         axis = len(complete_tensor.shape) - length
@@ -453,15 +457,17 @@ class Converter:
         Examples:
             .. code-block:: python
 
-                import numpy as np
-                complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
-                complete_shape = [1, 1, 6]
-                dims_mapping = [-1, -1, 0]
-                process_shape = [3]
-                process_group = [0, 1, 2]
+                >>> import numpy as np
+                >>> from paddle.distributed.auto_parallel.static.utils import _get_split_indices
+                >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
+                >>> complete_shape = [1, 1, 6]
+                >>> dims_mapping = [-1, -1, 0]
+                >>> process_shape = [3]
+                >>> process_group = [0, 1, 2]
 
-                index = _get_split_indices(complete_shape, dims_mapping, process_shape, process_group)
-                # index: [[], [], [2, 4]]
+                >>> index = _get_split_indices(complete_shape, dims_mapping, process_shape, process_group)
+                >>> print(index)
+                [[], [], [2, 4]]
         """
         from .reshard import Resharder
 
@@ -502,21 +508,23 @@ class Converter:
         Examples:
             .. code-block:: python
 
-                import numpy as np
-                complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
-                rank = 2
-                complete_shape = [1, 1, 6]
-                dims_mapping = [-1, -1, 0]
-                process_shape = [3]
-                process_group = [0, 1, 2]
+                >>> import numpy as np
+                >>> from paddle.distributed.auto_parallel.static.utils import _get_sliced_index
+                >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
+                >>> rank = 2
+                >>> complete_shape = [1, 1, 6]
+                >>> dims_mapping = [-1, -1, 0]
+                >>> process_shape = [3]
+                >>> process_group = [0, 1, 2]
 
-                slice_tensor = _slice_tensor(complete_tensor, [[], [], [2, 4]], 3)
-                # slice_tensor:
-                # [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
+                >>> slice_tensor = _slice_tensor(complete_tensor, [[], [], [2, 4]], 3)
+                >>> print(slice_tensor)
+                [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
 
-                index = _get_sliced_index(rank, complete_shape, dims_mapping
-                                                process_shape, process_group)
-                # index: 2
+                >>> index = _get_sliced_index(rank, complete_shape, dims_mapping,
+                ...                                 process_shape, process_group)
+                >>> print(index)
+                2
         """
         from .reshard import Resharder
 

--- a/python/paddle/distributed/auto_parallel/static/converter.py
+++ b/python/paddle/distributed/auto_parallel/static/converter.py
@@ -101,6 +101,7 @@ class Converter:
         Examples:
             .. code-block:: python
 
+                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
                 >>> from paddle.distributed.auto_parallel.static.converter import Converter
                 >>> complete_tensors = np.arange(4).reshape([2, 2])
@@ -353,6 +354,7 @@ class Converter:
         Examples:
             .. code-block:: python
 
+                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
                 >>> partition_tensor_list = [(np.array([[[1.11, 1.12]]]), [[0,1],[0,1],[0,2]])]
                 >>> tensor = np.array([[[1.13, 1.14]]])
@@ -418,8 +420,8 @@ class Converter:
         Examples:
             .. code-block:: python
 
+                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
-                >>> from paddle.distributed.auto_parallel.static.utils import split
                 >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
                 >>> rank = 2
                 >>> complete_shape = [1, 1, 6]
@@ -457,6 +459,7 @@ class Converter:
         Examples:
             .. code-block:: python
 
+                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
                 >>> from paddle.distributed.auto_parallel.static.utils import _get_split_indices
                 >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
@@ -508,6 +511,7 @@ class Converter:
         Examples:
             .. code-block:: python
 
+                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
                 >>> from paddle.distributed.auto_parallel.static.utils import _get_sliced_index
                 >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])

--- a/python/paddle/distributed/auto_parallel/static/converter.py
+++ b/python/paddle/distributed/auto_parallel/static/converter.py
@@ -415,27 +415,27 @@ class Converter:
     @staticmethod
     def split(complete_tensor, partition_index_list, length):
         """
-                Slice a complete tensor.
+        Slice a complete tensor.
 
-                Returns:
-                    sliced_tensor_list(list): sliced tensors with 'partition_index_list'
-        >>> # doctest: +REQUIRES(env:DISTRIBUTED)
-                Examples:
-                    .. code-block:: python
+        Returns:
+            sliced_tensor_list(list): sliced tensors with 'partition_index_list'
 
+        Examples:
+            .. code-block:: python
 
-                        >>> import numpy as np
-                        >>> from paddle.distributed.auto_parallel.static.converter import Converter
-                        >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
-                        >>> rank = 2
-                        >>> complete_shape = [1, 1, 6]
-                        >>> dims_mapping = [-1, -1, 0]
-                        >>> process_shape = [3]
-                        >>> process_group = [0, 1, 2]
+                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
+                >>> import numpy as np
+                >>> from paddle.distributed.auto_parallel.static.converter import Converter
+                >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
+                >>> rank = 2
+                >>> complete_shape = [1, 1, 6]
+                >>> dims_mapping = [-1, -1, 0]
+                >>> process_shape = [3]
+                >>> process_group = [0, 1, 2]
 
-                        >>> sliced_tensor_list = Converter.split(complete_tensor, [[], [], [2, 4]], 3)
-                        >>> print(sliced_tensor_list)
-                        [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
+                >>> sliced_tensor_list = Converter.split(complete_tensor, [[], [], [2, 4]], 3)
+                >>> print(sliced_tensor_list)
+                [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
         """
         sliced_tensor_list = []
         axis = len(complete_tensor.shape) - length

--- a/python/paddle/distributed/auto_parallel/static/converter.py
+++ b/python/paddle/distributed/auto_parallel/static/converter.py
@@ -356,13 +356,16 @@ class Converter:
 
                 >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
+                >>> import paddle
+                >>> from paddle.distributed.auto_parallel.static.converter import Converter
                 >>> partition_tensor_list = [(np.array([[[1.11, 1.12]]]), [[0,1],[0,1],[0,2]])]
                 >>> tensor = np.array([[[1.13, 1.14]]])
                 >>> partition_index = [[0,1],[0,1],[2,4]]
+                >>> complete_shape = [3, 2]
 
-                >>> _merge_tensor(partition_tensor_list, tensor, partition_index)
+                >>> Converter.merge(partition_tensor_list, tensor, partition_index, complete_shape)
                 >>> print(partition_tensor_list)
-                [(np.array([[[1.11, 1.12, 1.13, 1.14]]]), [[0,1],[0,1],[0,4]])]
+                [(array([[[1.11, 1.12, 1.13, 1.14]]]), [[0, 1], [0, 1], [0, 4]])]
         """
         from .reshard import Resharder
 
@@ -412,26 +415,27 @@ class Converter:
     @staticmethod
     def split(complete_tensor, partition_index_list, length):
         """
-        Slice a complete tensor.
+                Slice a complete tensor.
 
-        Returns:
-            sliced_tensor_list(list): sliced tensors with 'partition_index_list'
+                Returns:
+                    sliced_tensor_list(list): sliced tensors with 'partition_index_list'
+        >>> # doctest: +REQUIRES(env:DISTRIBUTED)
+                Examples:
+                    .. code-block:: python
 
-        Examples:
-            .. code-block:: python
 
-                >>> # doctest: +REQUIRES(env:DISTRIBUTED)
-                >>> import numpy as np
-                >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
-                >>> rank = 2
-                >>> complete_shape = [1, 1, 6]
-                >>> dims_mapping = [-1, -1, 0]
-                >>> process_shape = [3]
-                >>> process_group = [0, 1, 2]
+                        >>> import numpy as np
+                        >>> from paddle.distributed.auto_parallel.static.converter import Converter
+                        >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
+                        >>> rank = 2
+                        >>> complete_shape = [1, 1, 6]
+                        >>> dims_mapping = [-1, -1, 0]
+                        >>> process_shape = [3]
+                        >>> process_group = [0, 1, 2]
 
-                >>> sliced_tensor_list = split(complete_tensor, [[], [], [2, 4]], 3)
-                >>> print(sliced_tensor_list)
-                [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
+                        >>> sliced_tensor_list = Converter.split(complete_tensor, [[], [], [2, 4]], 3)
+                        >>> print(sliced_tensor_list)
+                        [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
         """
         sliced_tensor_list = []
         axis = len(complete_tensor.shape) - length
@@ -513,7 +517,7 @@ class Converter:
 
                 >>> # doctest: +REQUIRES(env:DISTRIBUTED)
                 >>> import numpy as np
-                >>> from paddle.distributed.auto_parallel.static.utils import _get_sliced_index
+                >>> from paddle.distributed.auto_parallel.static.converter import Converter
                 >>> complete_tensor = np.array([[[1.11, 1.12, 1.13, 1.14, 1.15, 1.16]]])
                 >>> rank = 2
                 >>> complete_shape = [1, 1, 6]
@@ -521,11 +525,7 @@ class Converter:
                 >>> process_shape = [3]
                 >>> process_group = [0, 1, 2]
 
-                >>> slice_tensor = _slice_tensor(complete_tensor, [[], [], [2, 4]], 3)
-                >>> print(slice_tensor)
-                [array([[[1.11, 1.12]]]), array([[[1.13, 1.14]]]), array([[[1.15, 1.16]]])]
-
-                >>> index = _get_sliced_index(rank, complete_shape, dims_mapping,
+                >>> index = Converter._get_sliced_index(rank, complete_shape, dims_mapping,
                 ...                                 process_shape, process_group)
                 >>> print(index)
                 2


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

修改如下文件的示例代码，使其通过 `xdoctest` 检查：

- `python/paddle/distributed/auto_parallel/static/cluster_v2.py`
- `python/paddle/distributed/auto_parallel/static/converter.py`
这个pr问题比较多，cluster_v2中的dist.DeviceMesh，converter的第2，3，5都有些函数没有找到对应的

预览：

- en: http://preview-paddle-pr-XXX.paddle-docs-preview.paddlepaddle.org.cn/documentation/docs/en/api/paddle/jit/XXX_en.html
- zh: http://preview-paddle-pr-XXX.paddle-docs-preview.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/jit/XXX_cn.html

### Related links
 
- #55629
- #55295

@sunzhongkai588 @SigureMo @megemini 

