### PR TITLE
make variable_length_memory_efficient_attention supports mask_broadcast_head

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/default_fmha_grouped.h
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/default_fmha_grouped.h
@@ -77,8 +77,7 @@ template <
     int KeysPerBlock_,
     bool SingleValueIteration_,
     GroupScheduleMode GroupScheduleMode_,
-    bool AddMask,
-    bool MaskBroadcastRow>
+    bool AddMask>
 struct DefaultFMHAGrouped {
   using scalar_t = scalar_t_;
   using accum_t = float;
@@ -92,7 +91,6 @@ struct DefaultFMHAGrouped {
   using ArchTag = ArchTag_;
   static bool const kIsAligned = isAligned_;
   static bool const kAddMask = AddMask;
-  static bool const kMaskBroadcastRow = MaskBroadcastRow;
   static bool const kSingleValueIteration = SingleValueIteration_;
   static int const kKeysPerBlock = KeysPerBlock_;
   static bool const kMaskIsAligned = maskIsAligned_;
@@ -288,7 +286,6 @@ struct DefaultFMHAGrouped {
                                          SingleValueIteration_,
                                          GroupScheduleMode_,
                                          AddMask,
-                                         MaskBroadcastRow,
                                          maskIsAligned_>;
 };
 

--- a/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention.cu
+++ b/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention.cu
@@ -65,10 +65,11 @@ void MultiHeadAttentionVariableForwardKernel(
   if (mask) {
     // [B, 1, S, D]
     auto mask_tensor = mask.get();
+    int64_t mask_num_heads = mask_tensor.dims()[1];
     params.ldm = mask_tensor.dims()[3];
     params.ElementM = mask_tensor.dims()[2] * mask_tensor.dims()[3];
     params.mask_ptr = mask_tensor.data();
-    params.mask_broadcast_row = false;
+    params.mask_broadcast_head = mask_num_heads == 1 ? true : false;
   }
 
   bool kernel_launched = false;
@@ -82,10 +83,6 @@ void MultiHeadAttentionVariableForwardKernel(
       return;
     }
     if (!mask && KernelType::kAddMask) {
-      return;
-    }
-    if (KernelType::kMaskBroadcastRow) {
-      // not support mask_broad_cast
       return;
     }
     if (mask && reinterpret_cast<uintptr_t>(params.mask_ptr) % 16 == 0 &&


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-71502
make variable_length_memory_efficient_attention supports mask_broadcast_heads