### PR TITLE
[PaddleInference] Fix llm inference dy2static error

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -1458,7 +1458,7 @@ void FusedBiasActInferMeta(const MetaTensor& x,
   auto token_num = x_dims[0];
   auto dim = x_dims[1];
 
-  if (!config.is_runtime) {
+  if (config.is_runtime) {
     PADDLE_ENFORCE_GT(
         x_dims[0],
         0,

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -418,6 +418,9 @@ class _SaveLoadConfig:
         # when need to save a prune model, use input_names_after_prune to specify the inputs left after pruning
         self.input_names_after_prune = None
 
+        # in the scene of llm-inference, prunning program can cause unexpectable result, an option to skip prune is necessary
+        self.skip_prune_program = False
+
     @property
     def output_spec(self):
         return self._output_spec
@@ -497,6 +500,7 @@ def _parse_save_configs(configs):
         "clip_extra",
         "skip_forward",
         "input_names_after_prune",
+        "skip_prune_program",
     ]
 
     # input check
@@ -517,6 +521,7 @@ def _parse_save_configs(configs):
     inner_config.input_names_after_prune = configs.get(
         "input_names_after_prune", None
     )
+    inner_config.skip_prune_program = configs.get("skip_prune_program", False)
 
     return inner_config
 
@@ -1259,6 +1264,7 @@ def save(layer, path, input_spec=None, **configs):
                 executor=Executor(_current_expected_place()),
                 program=concrete_program.main_program.clone(),
                 clip_extra=configs.clip_extra,
+                skip_prune_program=configs.skip_prune_program,
             )
 
         if combine_params:

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -187,7 +187,7 @@ def append_fetch_ops(
         )
 
 
-def normalize_program(program, feed_vars, fetch_vars):
+def normalize_program(program, feed_vars, fetch_vars, skip_prune_program=False):
     """
 
     Normalize/Optimize a program according to feed_vars and fetch_vars.
@@ -277,9 +277,10 @@ def normalize_program(program, feed_vars, fetch_vars):
     copy_program.desc.flush()
 
     feed_var_names = [var.name for var in feed_vars]
-    copy_program = copy_program._prune_with_input(
-        feeded_var_names=feed_var_names, targets=fetch_vars
-    )
+    if not skip_prune_program:
+        copy_program = copy_program._prune_with_input(
+            feeded_var_names=feed_var_names, targets=fetch_vars
+        )
     copy_program = copy_program._inference_optimize(prune_read_op=True)
     fetch_var_names = [var.name for var in fetch_vars]
     prepend_feed_ops(copy_program, feed_var_names)
@@ -568,7 +569,9 @@ def save_inference_model(
 
     program = _get_valid_program(kwargs.get('program', None))
     clip_extra = kwargs.get('clip_extra', True)
-    program = normalize_program(program, feed_vars, fetch_vars)
+    program = normalize_program(
+        program, feed_vars, fetch_vars, kwargs.get('skip_prune_program', False)
+    )
 
     # serialize and save program
     legacy_format = kwargs.get('legacy_format', False)

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -187,7 +187,7 @@ def append_fetch_ops(
         )
 
 
-def normalize_program(program, feed_vars, fetch_vars, skip_prune_program=False):
+def normalize_program(program, feed_vars, fetch_vars, **kwargs):
     """
 
     Normalize/Optimize a program according to feed_vars and fetch_vars.
@@ -196,6 +196,8 @@ def normalize_program(program, feed_vars, fetch_vars, skip_prune_program=False):
         program(Program): Specify a program you want to optimize.
         feed_vars(Tensor | list[Tensor]): Variables needed by inference.
         fetch_vars(Tensor | list[Tensor]): Variables returned by inference.
+        kwargs: Supported keys including ``skip_prune_program``.
+            - skip_prune_program(bool): whether to skip prunning program. Defaults to False.
 
     Returns:
         Program: Normalized/Optimized program.
@@ -277,6 +279,8 @@ def normalize_program(program, feed_vars, fetch_vars, skip_prune_program=False):
     copy_program.desc.flush()
 
     feed_var_names = [var.name for var in feed_vars]
+
+    skip_prune_program = kwargs.get('skip_prune_program', False)
     if not skip_prune_program:
         copy_program = copy_program._prune_with_input(
             feeded_var_names=feed_var_names, targets=fetch_vars
@@ -570,7 +574,10 @@ def save_inference_model(
     program = _get_valid_program(kwargs.get('program', None))
     clip_extra = kwargs.get('clip_extra', True)
     program = normalize_program(
-        program, feed_vars, fetch_vars, kwargs.get('skip_prune_program', False)
+        program,
+        feed_vars,
+        fetch_vars,
+        skip_prune_program=kwargs.get('skip_prune_program', False),
     )
 
     # serialize and save program


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
1. Fix condition error in FusedBiasActInferMeta when converting dygraph to static graph
2. Add option named 'skip_prune_program' in `save_inference_model` API to allow users to skip prune program, which can avoid some dy2static errors 

Pcard-71502