### PR TITLE
[NewIR]Fix attr type error like concat axis

### DIFF
--- a/paddle/fluid/ir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/ir/dialect/op_generator/op_build_gen.py
@@ -129,6 +129,7 @@ mutable_attribute_phi_type_maps = {
     'float': 'phi::DataType::FLOAT32',
     'std::vector<int64_t>': 'phi::DataType::INT64',
     'const std::vector<int64_t>&': 'phi::DataType::INT64',
+    'bool': 'phi::DataType::BOOL',
 }
 
 

--- a/paddle/fluid/ir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/ir/dialect/op_generator/op_gen.py
@@ -598,6 +598,19 @@ class OpInfoParser:
             if 'Scalar' in temp_type:
                 if 'data_type' in attribute_info:
                     temp_type = attribute_info['data_type']
+                op_name = self.op_yaml_item['name']
+                attr_name = attribute_info['name']
+                if (
+                    op_name not in ["isclose", "allclose"]
+                    and self.op_compat_item is not None
+                    and 'scalar' in self.op_compat_item.keys()
+                    and attr_name in self.op_compat_item['scalar'].keys()
+                    and 'data_type'
+                    in self.op_compat_item['scalar'][attr_name].keys()
+                ):
+                    temp_type = self.op_compat_item['scalar'][attr_name][
+                        'data_type'
+                    ]
             if 'IntArray' in temp_type:
                 if 'data_type' in attribute_info:
                     temp_type = "const " + attribute_info['data_type'] + "&"

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1490,6 +1490,8 @@ ir::OpResult CastPyArg2OpResult(PyObject* obj,
                                 size_t arg_pos) {
   if (PyObject_TypeCheck(obj, g_ir_opresult_pytype)) {
     return ::pybind11::handle(obj).cast<ir::OpResult>();
+  } else if (obj == nullptr || obj == Py_None) {
+    return ir::OpResult();
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "%s(): argument (position %d) must be "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- 对于concat原来生成的axis是float类型，正确的应该是int类型，在op_compat.yaml中进行了指定
```c++
// 正确的int版本的
static void Build(ir::Builder &builder, ir::OperationArgument &argument, ir::OpResult x_, int axis=0);
```

- 支持输入是OpResult是None的情况
- 处理intermediate的output，intermediate的输出不作为pd api的返回值。


Pcard-67164