### PR TITLE
fix some typos like y ... name='x'

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -7456,7 +7456,7 @@ def default_main_program():
             paddle.enable_static()
             # Sample Network:
             x = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
-            y = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
+            y = paddle.static.data(name='y', shape=[100, 100], dtype='float32')
             out = paddle.add(x, y)
 
             #print the number of blocks in the program, 1 in this case

--- a/python/paddle/ir/core.py
+++ b/python/paddle/ir/core.py
@@ -141,7 +141,7 @@ def default_main_program():
             paddle.enable_static()
             # Sample Network:
             x = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
-            y = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
+            y = paddle.static.data(name='y', shape=[100, 100], dtype='float32')
             out = paddle.add(x, y)
 
             #print the number of blocks in the program, 1 in this case

--- a/test/legacy_test/test_isclose_op.py
+++ b/test/legacy_test/test_isclose_op.py
@@ -214,7 +214,7 @@ class TestIscloseOpFp16(unittest.TestCase):
         y_data = np.random.rand(10, 10).astype('float16')
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data(shape=[10, 10], name='x', dtype='float16')
-            y = paddle.static.data(shape=[10, 10], name='x', dtype='float16')
+            y = paddle.static.data(shape=[10, 10], name='y', dtype='float16')
             out = paddle.isclose(x, y, rtol=1e-05, atol=1e-08)
             if core.is_compiled_with_cuda():
                 place = paddle.CUDAPlace(0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
fix typos likes:
```python
y = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
```
