### PR TITLE
Throw error for NVCC lazy in 1F1B pipeline

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -242,6 +242,14 @@ class Engine:
         elif self._strategy.pipeline.enable:
             self._acc_steps = self._strategy.pipeline.accumulate_steps
 
+        if (
+            self._strategy.pipeline.enable
+            and self._strategy.pipeline.schedule_mode == "1F1B"
+        ):
+            assert (
+                os.getenv("CUDA_MODULE_LOADING") != "LAZY"
+            ), "EXP_CUDA_MODULE_LOADING_LAZY not supported in 1F1B pipeline."
+
         self.history = None
 
         paddle.framework.set_flags({'FLAGS_new_executor_sequential_run': 1})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
PCard-71568

通过`CUDA_MODULE_LOADING=LAYZ`设置NVCC layz模式，在加载kernel时可能导致不同异步流之间的操作同步执行，并在1F1B下产生定位困难的死锁问题（两个PP stage间原本应该异步执行的交叉send操作变成了同步），因而本PR在1F1B下禁用layz模式。

NV关于死锁问题的说明：https://docs.nvidia.com/cuda/cuda-c-programming-guide/lazy-loading.html?highlight=cuda_module_loading#concurrent-execution
<img width="1074" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/17673696/b72fdcf1-bfd8-4b2c-b66c-b92fb954175e">

