### PR TITLE
[Custom Device]fix auto_parallel.pb.h missing bug

### DIFF
--- a/paddle/phi/core/tensor_utils.h
+++ b/paddle/phi/core/tensor_utils.h
@@ -16,7 +16,9 @@ limitations under the License. */
 
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
+#ifndef PADDLE_WITH_CUSTOM_DEVICE
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
+#endif
 #include "paddle/phi/core/selected_rows.h"
 #include "paddle/phi/core/sparse_coo_tensor.h"
 #include "paddle/phi/core/sparse_csr_tensor.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
custom device编译时会报错找不到auto_parallel.pb.h，这里添加条件编译，当`PADDLE_WITH_CUSTOM_DEVICE` 时不include该头文件。本地测试结果如下：
![image](https://github.com/PaddlePaddle/Paddle/assets/50285351/79bb6ad9-d882-4506-8e87-734cdc487a7d)

相关issue https://github.com/PaddlePaddle/Paddle/issues/56750