### PR TITLE
[xdoctest] reformat example code with google style in No.284-285

### DIFF
--- a/python/paddle/incubate/nn/loss.py
+++ b/python/paddle/incubate/nn/loss.py
@@ -49,10 +49,10 @@ def identity_loss(x, reduction="none"):
 
         .. code-block:: python
 
-            import paddle
-            paddle.enable_static()
-            loss = paddle.static.data(name="loss", shape=[-1, 1], dtype="float32")
-            out = paddle.incubate.identity_loss(loss, reduction=1)
+            >>> import paddle
+            >>> paddle.enable_static()
+            >>> loss = paddle.static.data(name="loss", shape=[-1, 1], dtype="float32")
+            >>> out = paddle.incubate.identity_loss(loss, reduction=1)
     """
     if isinstance(reduction, str):
         reduction = {"sum": 0, "mean": 1, "none": 2}.get(reduction.lower())

--- a/python/paddle/incubate/operators/graph_khop_sampler.py
+++ b/python/paddle/incubate/operators/graph_khop_sampler.py
@@ -70,17 +70,17 @@ def graph_khop_sampler(
     Examples:
         .. code-block:: python
 
-            import paddle
+            >>> import paddle
 
-            row = [3, 7, 0, 9, 1, 4, 2, 9, 3, 9, 1, 9, 7]
-            colptr = [0, 2, 4, 5, 6, 7, 9, 11, 11, 13, 13]
-            nodes = [0, 8, 1, 2]
-            sample_sizes = [2, 2]
-            row = paddle.to_tensor(row, dtype="int64")
-            colptr = paddle.to_tensor(colptr, dtype="int64")
-            nodes = paddle.to_tensor(nodes, dtype="int64")
+            >>> row = [3, 7, 0, 9, 1, 4, 2, 9, 3, 9, 1, 9, 7]
+            >>> colptr = [0, 2, 4, 5, 6, 7, 9, 11, 11, 13, 13]
+            >>> nodes = [0, 8, 1, 2]
+            >>> sample_sizes = [2, 2]
+            >>> row = paddle.to_tensor(row, dtype="int64")
+            >>> colptr = paddle.to_tensor(colptr, dtype="int64")
+            >>> nodes = paddle.to_tensor(nodes, dtype="int64")
 
-            edge_src, edge_dst, sample_index, reindex_nodes = paddle.incubate.graph_khop_sampler(row, colptr, nodes, sample_sizes, False)
+            >>> edge_src, edge_dst, sample_index, reindex_nodes = paddle.incubate.graph_khop_sampler(row, colptr, nodes, sample_sizes, False)
 
     """
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

修改如下文件的示例代码，使其通过 `xdoctest` 检查：
loss.py
graph_khop_sampler.py

### Related links
 
- #55629
- #55295
