### PR TITLE
Check fluid ci

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -108,6 +108,19 @@ if [ "$inference_approve" != "" ]; then
     check_approval 1 qingqing01 heavengate
 fi
 
+filter_fluid=`git diff --name-only upstream/develop |  grep "py$" | grep "^test/"`
+filter_fluid+=" `git diff --name-only upstream/develop | grep "py$" | grep -v "^python/paddle/fluid"| grep "^python/paddle"`"
+has_fluid=`git diff -U0 upstream/$BRANCH -- $filter_fluid | grep '^\+' | grep -v '^++' | grep -E "(fluid\.)|(paddle\.fluid)"`
+if [ "${has_fluid}" != "" ]; then
+    for fluid in "${has_fluid}";
+    do
+        echo "${fluid}"
+    done
+    echo_line="You must have one RD (zoooo0820(Recommend), or jeff41404) approval for using fluid API, because fluid API is going to be removed.\n"
+    check_approval 1 zoooo0820 jeff41404
+fi
+
+
 DEV_OP_USE_DEFAULT_GRAD_MAKER_SPEC=${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_maker_DEV.spec
 PR_OP_USE_DEFAULT_GRAD_MAKER_SPEC=${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_maker_PR.spec
 ADDED_OP_USE_DEFAULT_GRAD_MAKER=`python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py ${DEV_OP_USE_DEFAULT_GRAD_MAKER_SPEC} ${PR_OP_USE_DEFAULT_GRAD_MAKER_SPEC}`


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67005

Based on  https://github.com/PaddlePaddle/Paddle/pull/48380, we try to add fluid API check in PR-CI-Static-Check for two purposes： 
- Although there is a check for modification of `python/paddle/fluid`, but we found there are some other newly added files using fluid APIs， e.g. (`test/` for unittests), blocking the migrated fluid PR.
- Similar to the above, even though the migrated fluid PR is merged as planned, there is a potential hidden conflict (between the migrated fluid PR and other PRs which using fluid APIs)

So we try to check the fluid APIs usage in `python/paddle/` and `test/`. 
