### PR TITLE
【Complex Op】fix: remove complex128 relative error constraints

### DIFF
--- a/test/legacy_test/eager_op_test.py
+++ b/test/legacy_test/eager_op_test.py
@@ -2567,14 +2567,6 @@ class OpTest(unittest.TestCase):
             numeric_grad_delta = 1e-5
             max_relative_error = 1e-7
 
-        if (
-            self.dtype == np.complex128
-            and self.op_type
-            not in op_threshold_white_list.NEED_FIX_FP64_CHECK_GRAD_THRESHOLD_OP_LIST
-        ):
-            numeric_grad_delta = 1e-5
-            max_relative_error = 1e-6
-
         cache_list = None
         if hasattr(self, "cache_name_list"):
             cache_list = self.cache_name_list

--- a/test/legacy_test/test_elementwise_div_op.py
+++ b/test/legacy_test/test_elementwise_div_op.py
@@ -538,6 +538,8 @@ class TestComplexElementwiseDivOp(OpTest):
         self.check_grad(
             ['X', 'Y'],
             'Out',
+            numeric_grad_delta=1e-5,
+            max_relative_error=1e-6,
         )
 
     def test_check_grad_ingore_x(self):
@@ -545,6 +547,8 @@ class TestComplexElementwiseDivOp(OpTest):
             ['Y'],
             'Out',
             no_grad_set=set("X"),
+            numeric_grad_delta=1e-5,
+            max_relative_error=1e-6,
         )
 
     def test_check_grad_ingore_y(self):
@@ -552,6 +556,8 @@ class TestComplexElementwiseDivOp(OpTest):
             ['X'],
             'Out',
             no_grad_set=set('Y'),
+            numeric_grad_delta=1e-5,
+            max_relative_error=1e-6,
         )
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

#54090 里为了处理 elmentwise_div_op 中 complex128 梯度误差的问题，在 eager_op_test.py 里固定了 complex128 的 numeric_grad_delta 和 max_relative_error，这会导致其他的一些 op 出现同样的梯度误差时，无法自定义 numeric_grad_delta 和 max_relative_error。

本 PR 删除了 eager_op_test.py 中对 complex128 梯度误差的固定写法