### PR TITLE
[Fixes] Poisson NLL Loss to align with PyTorch and TensorFlow 

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1555,9 +1555,9 @@ def poisson_nll_loss(
             + 0.5 * paddle.log(2 * math.pi * label)
         )
         loss_out += paddle.where(
-            stirling_approx <= 1,
+            label > 1,
+            stirling_approx,            
             paddle.zeros_like(stirling_approx),
-            stirling_approx,
         )
     if reduction == 'mean':
         loss_out = paddle.mean(loss_out)

--- a/test/legacy_test/test_poisson_nll_loss.py
+++ b/test/legacy_test/test_poisson_nll_loss.py
@@ -51,7 +51,8 @@ def ref_poisson_nll_loss(
         stirling_approx = (
             label * np.log(label) - label + 0.5 * np.log(2 * np.pi * label)
         )
-        loss_out += np.where(stirling_approx <= 1, 0, stirling_approx)
+        loss_out += np.where(label > 1, stirling_approx, np.zeros_like(stirling_approx))
+
 
     if reduction == 'none':
         return loss_out


### PR DESCRIPTION
### PR types
 Others 

### PR changes
 Others

### Description
This commit updates the condition for adding the Stirling approximation term in Poisson NLL Loss to align with how PyTorch and TensorFlow handle it. The condition is changed from 'label <= 1' to 'label > 1' for adding the Stirling term, making the behavior consistent across frameworks.
