### PR TITLE
link C++ tests to libpaddle.so

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
@@ -1,62 +1,105 @@
+get_property(paddle_lib GLOBAL PROPERTY PADDLE_LIB_NAME)
 set_source_files_properties(
   interceptor_ping_pong_test.cc PROPERTIES COMPILE_FLAGS
                                            ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc DEPS
-            fleet_executor ${BRPC_DEPS})
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc
+              DEPS fleet_executor ${BRPC_DEPS})
+else()
+  cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc
+              DEPS ${paddle_lib} python)
+endif()
 
 set_source_files_properties(
   compute_interceptor_test.cc PROPERTIES COMPILE_FLAGS
                                          ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
-            fleet_executor ${BRPC_DEPS})
+
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
+              fleet_executor ${BRPC_DEPS})
+else()
+  cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
+              ${paddle_lib} python)
+endif()
 
 set_source_files_properties(
   source_interceptor_test.cc PROPERTIES COMPILE_FLAGS
                                         ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
-            fleet_executor ${BRPC_DEPS})
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
+              fleet_executor ${BRPC_DEPS})
+else()
+  cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
+              ${paddle_lib} python)
+endif()
 
 set_source_files_properties(
   sink_interceptor_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
-            fleet_executor ${BRPC_DEPS})
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
+              fleet_executor ${BRPC_DEPS})
+else()
+  cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
+              ${paddle_lib} python)
+endif()
 
 set_source_files_properties(
   interceptor_pipeline_short_path_test.cc
   PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(
-  interceptor_pipeline_short_path_test SRCS
-  interceptor_pipeline_short_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(
+    interceptor_pipeline_short_path_test SRCS
+    interceptor_pipeline_short_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
+else()
+  cc_test_old(interceptor_pipeline_short_path_test SRCS
+              interceptor_pipeline_short_path_test.cc DEPS ${paddle_lib} python)
+endif()
 
 set_source_files_properties(
   interceptor_pipeline_long_path_test.cc PROPERTIES COMPILE_FLAGS
                                                     ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(
-  interceptor_pipeline_long_path_test SRCS
-  interceptor_pipeline_long_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(
+    interceptor_pipeline_long_path_test SRCS
+    interceptor_pipeline_long_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
+else()
+  cc_test_old(interceptor_pipeline_long_path_test SRCS
+              interceptor_pipeline_long_path_test.cc DEPS ${paddle_lib} python)
+endif()
 
 set_source_files_properties(
   compute_interceptor_run_op_test.cc PROPERTIES COMPILE_FLAGS
                                                 ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test_old(
-  compute_interceptor_run_op_test
-  SRCS
-  compute_interceptor_run_op_test.cc
-  DEPS
-  fleet_executor
-  naive_executor
-  fill_constant_op
-  op_registry
-  elementwise_add_op
-  scope
-  device_context
-  ${BRPC_DEPS})
+if(WIN32 AND WITH_TESTING)
+  cc_test_old(
+    compute_interceptor_run_op_test
+    SRCS
+    compute_interceptor_run_op_test.cc
+    DEPS
+    fleet_executor
+    naive_executor
+    fill_constant_op
+    op_registry
+    elementwise_add_op
+    scope
+    device_context
+    ${BRPC_DEPS})
+else()
+  cc_test_old(compute_interceptor_run_op_test SRCS
+              compute_interceptor_run_op_test.cc DEPS ${paddle_lib} python)
+endif()
 
 if(WITH_DISTRIBUTE AND NOT WITH_PSLIB)
   set_source_files_properties(
     interceptor_ping_pong_with_brpc_test.cc
     PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-  cc_test_old(
-    interceptor_ping_pong_with_brpc_test SRCS
-    interceptor_ping_pong_with_brpc_test.cc DEPS fleet_executor ${BRPC_DEPS})
+  if(WIN32 AND WITH_TESTING)
+    cc_test_old(
+      interceptor_ping_pong_with_brpc_test SRCS
+      interceptor_ping_pong_with_brpc_test.cc DEPS fleet_executor ${BRPC_DEPS})
+  else()
+    cc_test_old(
+      interceptor_ping_pong_with_brpc_test SRCS
+      interceptor_ping_pong_with_brpc_test.cc DEPS ${paddle_lib} python)
+  endif()
 endif()

--- a/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
@@ -39,8 +39,14 @@ if(WIN32 AND WITH_TESTING)
   cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
               fleet_executor ${BRPC_DEPS})
 else()
-  cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
-              ${paddle_lib} python)
+  cc_test_old(
+    sink_interceptor_test
+    SRCS
+    sink_interceptor_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 set_source_files_properties(

--- a/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
@@ -6,8 +6,14 @@ if(WIN32 AND WITH_TESTING)
   cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc
               DEPS fleet_executor ${BRPC_DEPS})
 else()
-  cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc
-              DEPS ${paddle_lib} python)
+  cc_test_old(
+    interceptor_ping_pong_test
+    SRCS
+    interceptor_ping_pong_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 set_source_files_properties(
@@ -18,8 +24,14 @@ if(WIN32 AND WITH_TESTING)
   cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
               fleet_executor ${BRPC_DEPS})
 else()
-  cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
-              ${paddle_lib} python)
+  cc_test_old(
+    compute_interceptor_test
+    SRCS
+    compute_interceptor_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 set_source_files_properties(
@@ -29,8 +41,14 @@ if(WIN32 AND WITH_TESTING)
   cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
               fleet_executor ${BRPC_DEPS})
 else()
-  cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
-              ${paddle_lib} python)
+  cc_test_old(
+    source_interceptor_test
+    SRCS
+    source_interceptor_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 set_source_files_properties(
@@ -57,8 +75,14 @@ if(WIN32 AND WITH_TESTING)
     interceptor_pipeline_short_path_test SRCS
     interceptor_pipeline_short_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
 else()
-  cc_test_old(interceptor_pipeline_short_path_test SRCS
-              interceptor_pipeline_short_path_test.cc DEPS ${paddle_lib} python)
+  cc_test_old(
+    interceptor_pipeline_short_path_test
+    SRCS
+    interceptor_pipeline_short_path_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 set_source_files_properties(
@@ -69,8 +93,14 @@ if(WIN32 AND WITH_TESTING)
     interceptor_pipeline_long_path_test SRCS
     interceptor_pipeline_long_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
 else()
-  cc_test_old(interceptor_pipeline_long_path_test SRCS
-              interceptor_pipeline_long_path_test.cc DEPS ${paddle_lib} python)
+  cc_test_old(
+    interceptor_pipeline_long_path_test
+    SRCS
+    interceptor_pipeline_long_path_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 set_source_files_properties(
@@ -105,7 +135,12 @@ if(WITH_DISTRIBUTE AND NOT WITH_PSLIB)
       interceptor_ping_pong_with_brpc_test.cc DEPS fleet_executor ${BRPC_DEPS})
   else()
     cc_test_old(
-      interceptor_ping_pong_with_brpc_test SRCS
-      interceptor_ping_pong_with_brpc_test.cc DEPS ${paddle_lib} python)
+      interceptor_ping_pong_with_brpc_test
+      SRCS
+      interceptor_ping_pong_with_brpc_test.cc
+      DEPS
+      ${paddle_lib}
+      python
+      fleet_executor)
   endif()
 endif()

--- a/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
@@ -128,7 +128,9 @@ else()
     DEPS
     ${paddle_lib}
     python
-    fleet_executor)
+    fleet_executor
+    fill_constant_op
+    elementwise_add_op)
 endif()
 
 if(WITH_DISTRIBUTE AND NOT WITH_PSLIB)

--- a/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
@@ -121,8 +121,14 @@ if(WIN32 AND WITH_TESTING)
     device_context
     ${BRPC_DEPS})
 else()
-  cc_test_old(compute_interceptor_run_op_test SRCS
-              compute_interceptor_run_op_test.cc DEPS ${paddle_lib} python)
+  cc_test_old(
+    compute_interceptor_run_op_test
+    SRCS
+    compute_interceptor_run_op_test.cc
+    DEPS
+    ${paddle_lib}
+    python
+    fleet_executor)
 endif()
 
 if(WITH_DISTRIBUTE AND NOT WITH_PSLIB)

--- a/test/cpp/fluid/mkldnn/CMakeLists.txt
+++ b/test/cpp/fluid/mkldnn/CMakeLists.txt
@@ -1,3 +1,4 @@
+get_property(paddle_lib GLOBAL PROPERTY PADDLE_LIB_NAME)
 cc_test(
   test_mkldnn_op_inplace
   SRCS test_mkldnn_op_inplace.cc
@@ -41,33 +42,7 @@ cc_test(
   test_mkldnn_caching
   SRCS test_mkldnn_caching.cc
   DEPS ${TEST_MKLDNN_CACHING_DEPS})
-if(WITH_CINN)
-  cc_test_old(
-    test_mkldnn_op_nhwc
-    SRCS
-    test_mkldnn_op_nhwc.cc
-    DEPS
-    fleet_executor
-    conditional_block_op
-    standalone_executor
-    executor
-    recurrent_op_helper
-    cinn_compiler
-    recurrent_op
-    op_registry
-    generated_static_op
-    crop_op
-    activation_op
-    generated_op
-    generated_static_op
-    phi
-    transpose_op
-    fused_transpose_op
-    scope
-    device_context
-    enforce
-    python)
-else()
+if(WIN32 AND WITH_TESTING)
   cc_test_old(
     test_mkldnn_op_nhwc
     SRCS
@@ -91,4 +66,7 @@ else()
     scope
     device_context
     enforce)
+else()
+  cc_test_old(test_mkldnn_op_nhwc SRCS test_mkldnn_op_nhwc.cc DEPS
+              ${paddle_lib} python)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67010
临时解决方案：
将5个4.2G的c++单测link到libpaddle.so(windows)除外，从而缓解Coverage流水线编译时link单测打满内存的bug，待 (https://github.com/PaddlePaddle/Paddle/pull/56630) 合入之后，打通windows 上C++单测link到libpaddle.dll
