### PR TITLE
optimize softmax_mask_fuse

### DIFF
--- a/paddle/fluid/eager/amp_auto_cast.h
+++ b/paddle/fluid/eager/amp_auto_cast.h
@@ -75,6 +75,10 @@ inline paddle::Tensor AmpAutoCast(const std::string& input_name,
       input_name != "X") {
     return input;
   }
+  if (op_name == "fused_softmax_mask" && input_name == "Mask" &&
+      input.dtype() == phi::DataType::FLOAT32) {
+    return input;
+  }
   if (dst_dtype == phi::DataType::FLOAT16) {
     if (op_name == "run_program") {
       return input;

--- a/test/legacy_test/test_softmax_mask_fuse_op.py
+++ b/test/legacy_test/test_softmax_mask_fuse_op.py
@@ -81,6 +81,27 @@ class TestSoftmaxMaskFuseOp0(OpTest):
 @unittest.skipIf(
     not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
 )
+class TestSoftmaxMaskFuseOp01(OpTest):
+    def setUp(self):
+        self.op_type = "fused_softmax_mask"
+        self.python_api = paddle.incubate.softmax_mask_fuse
+        x = np.random.random((1, 1, 8, 32)).astype("float16")
+        mask = np.random.randint(0, 2, (1, 1, 8, 32)).astype("float32")
+        mask_input = np.where(mask == 1, -10000.0, mask)
+        self.inputs = {'X': x, 'Mask': mask_input}
+        rst = _get_softmax(x, mask_input)
+        self.outputs = {'Out': rst}
+
+    def test_check_output(self):
+        self.check_output_with_place(core.CUDAPlace(0))
+
+    def test_check_grad(self):
+        self.check_grad_with_place(core.CUDAPlace(0), ["X"], "Out")
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestDropoutBiasFuseOp3(unittest.TestCase):
     def test_static_result(self):
         with fluid.program_guard(fluid.Program(), fluid.Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization 

### PR changes
OPs

### Description
由于实际cuda kernel计算中会强制将x和mask转换为fp32，所以在不损失精度的情况下，增加支持x dtype为float16, mask为float32的情况，来避免mask在组网/框架内的cast，提升softmax_mask的性能