### PR TITLE
fix logical op ut skip type error assert

### DIFF
--- a/paddle/phi/kernels/funcs/logical_functor.h
+++ b/paddle/phi/kernels/funcs/logical_functor.h
@@ -20,7 +20,6 @@ namespace funcs {
 #define LOGICAL_BINARY_FUNCTOR(func_name, op)                  \
   template <typename Tx, typename Ty = Tx>                     \
   struct func_name {                                           \
-    using ELEMENT_TYPE = T;                                    \
     HOSTDEVICE bool operator()(const Tx a, const Ty b) const { \
       return static_cast<bool>(a) op static_cast<bool>(b);     \
     }                                                          \

--- a/paddle/phi/kernels/funcs/logical_functor.h
+++ b/paddle/phi/kernels/funcs/logical_functor.h
@@ -17,13 +17,13 @@
 namespace phi {
 namespace funcs {
 
-#define LOGICAL_BINARY_FUNCTOR(func_name, op)                \
-  template <typename T>                                      \
-  struct func_name {                                         \
-    using ELEMENT_TYPE = T;                                  \
-    HOSTDEVICE bool operator()(const T a, const T b) const { \
-      return static_cast<bool>(a) op static_cast<bool>(b);   \
-    }                                                        \
+#define LOGICAL_BINARY_FUNCTOR(func_name, op)                  \
+  template <typename Tx, typename Ty = Tx>                     \
+  struct func_name {                                           \
+    using ELEMENT_TYPE = T;                                    \
+    HOSTDEVICE bool operator()(const Tx a, const Ty b) const { \
+      return static_cast<bool>(a) op static_cast<bool>(b);     \
+    }                                                          \
   };
 
 LOGICAL_BINARY_FUNCTOR(LogicalOrFunctor, ||)

--- a/test/legacy_test/test_logical_op.py
+++ b/test/legacy_test/test_logical_op.py
@@ -221,9 +221,7 @@ def test_type_error(unit_test, use_gpu, type_str_map):
             y = paddle.to_tensor(y)
             error_type = BaseException
         if binary_op:
-            if type_str_map['x'] != type_str_map['y'] and type_str_map[
-                'x'
-            ] not in [np.complex64, np.complex128]:
+            if type_str_map['x'] != type_str_map['y']:
                 unit_test.assertRaises(error_type, op, x=x, y=y)
             if not in_dynamic_mode():
                 error_type = TypeError


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/56323#discussion_r1303134084 This op should have thrown Exception when 1st operators = complex, 2nd operators = other type.