### PR TITLE
fix paddle namespace conflict when using paddle_flags

### DIFF
--- a/paddle/fluid/distributed/ps/service/heter_client.cc
+++ b/paddle/fluid/distributed/ps/service/heter_client.cc
@@ -85,7 +85,7 @@ void HeterClient::CreateClient2XpuConnection() {
     xpu_channels_[i].reset(new brpc::Channel());
     if (xpu_channels_[i]->Init(xpu_list_[i].c_str(), "", &options) != 0) {
       VLOG(0) << "HeterClient channel init fail. Try Again";
-      auto ip_port = ::paddle::string::Split(xpu_list_[i], ':');
+      auto ip_port = paddle::string::Split(xpu_list_[i], ':');
       std::string ip = ip_port[0];
       int port = std::stoi(ip_port[1]);
       std::string int_ip_port = GetIntTypeEndpoint(ip, port);
@@ -100,7 +100,7 @@ void HeterClient::CreateClient2XpuConnection() {
     if (previous_xpu_channels_[i]->Init(
             previous_xpu_list_[i].c_str(), "", &options) != 0) {
       VLOG(0) << "HeterClient channel init fail. Try Again";
-      auto ip_port = ::paddle::string::Split(previous_xpu_list_[i], ':');
+      auto ip_port = paddle::string::Split(previous_xpu_list_[i], ':');
       std::string ip = ip_port[0];
       int port = std::stoi(ip_port[1]);
       std::string int_ip_port = GetIntTypeEndpoint(ip, port);
@@ -167,13 +167,13 @@ void HeterClient::SendAndRecvAsync(
     // int idx = 1;  // for test
     // LOG(INFO) << "xpu_channels_ size: " << xpu_channels_.size();
     // channel = xpu_channels_[idx].get();  // 为了适配 send_and_recv op
-    // ::paddle::distributed::PsService_Stub stub(channel);
+    // paddle::distributed::PsService_Stub stub(channel);
     // stub.SendToSwitch(&closure->cntl, &request, &closure->response,
     // closure); fut.wait();
     VLOG(4) << "calling switch service done";
     return;
   }
-  ::paddle::distributed::PsService_Stub stub(channel);
+  paddle::distributed::PsService_Stub stub(channel);
   stub.SendAndRecvVariable(
       &closure->cntl, &request, &closure->response, closure);
 }
@@ -181,11 +181,11 @@ void HeterClient::SendAndRecvAsync(
 std::future<int32_t> HeterClient::SendCmd(
     uint32_t table_id, int cmd_id, const std::vector<std::string>& params) {
   size_t request_call_num = xpu_channels_.size();
-  ::paddle::distributed::DownpourBrpcClosure* closure =
-      new ::paddle::distributed::DownpourBrpcClosure(
+  paddle::distributed::DownpourBrpcClosure* closure =
+      new paddle::distributed::DownpourBrpcClosure(
           request_call_num, [request_call_num, cmd_id](void* done) {
             int ret = 0;
-            auto* closure = (::paddle::distributed::DownpourBrpcClosure*)done;
+            auto* closure = (paddle::distributed::DownpourBrpcClosure*)done;
             for (size_t i = 0; i < request_call_num; ++i) {
               if (closure->check_response(i, cmd_id) != 0) {
                 ret = -1;
@@ -204,7 +204,7 @@ std::future<int32_t> HeterClient::SendCmd(
     for (const auto& param : params) {
       closure->request(i)->add_params(param);
     }
-    ::paddle::distributed::PsService_Stub rpc_stub(xpu_channels_[i].get());
+    paddle::distributed::PsService_Stub rpc_stub(xpu_channels_[i].get());
     closure->cntl(i)->set_timeout_ms(
         FLAGS_pserver_timeout_ms);  // cmd msg don't limit timeout for save/load
     rpc_stub.service(
@@ -270,7 +270,7 @@ int HeterClient::Send(const platform::DeviceContext& ctx,
   }
   brpc::Channel* channel = send_switch_channels_[0].get();
   // brpc::Channel* channel = xpu_channels_[0].get();
-  ::paddle::distributed::PsService_Stub stub(channel);
+  paddle::distributed::PsService_Stub stub(channel);
   stub.SendToSwitch(&closure->cntl, &request, &closure->ps_response, closure);
 
   VLOG(4) << "waiting SendToSwitch response result......";
@@ -317,7 +317,7 @@ int HeterClient::Send(int group_id,
     send_switch_channels_.push_back(xpu_channels_[0]);
   }
   brpc::Channel* channel = send_switch_channels_[0].get();
-  ::paddle::distributed::PsService_Stub stub(channel);
+  paddle::distributed::PsService_Stub stub(channel);
   stub.SendToSwitch(&closure->cntl, &request, &closure->ps_response, closure);
   fut.wait();
   delete closure;
@@ -362,7 +362,7 @@ int HeterClient::Recv(const platform::DeviceContext& ctx,
     recv_switch_channels_.push_back(xpu_channels_[1]);
   }
   brpc::Channel* channel = recv_switch_channels_[0].get();
-  ::paddle::distributed::PsService_Stub stub(channel);
+  paddle::distributed::PsService_Stub stub(channel);
   stub.RecvFromSwitch(&closure->cntl, &request, &closure->response, closure);
   fut.wait();
   VLOG(4) << "RecvFromSwitch done";
@@ -412,7 +412,7 @@ int HeterClient::Recv(int group_id,
     recv_switch_channels_.push_back(xpu_channels_[0]);
   }
   brpc::Channel* channel = recv_switch_channels_[0].get();
-  ::paddle::distributed::PsService_Stub stub(channel);
+  paddle::distributed::PsService_Stub stub(channel);
   stub.RecvFromSwitch(&closure->cntl, &request, &closure->response, closure);
   fut.wait();
   VLOG(4) << "RecvFromSwitch done";

--- a/paddle/phi/core/flags.h
+++ b/paddle/phi/core/flags.h
@@ -59,24 +59,20 @@
 #else  // PADDLE_WITH_GFLAGS
 
 #define PHI_DECLARE_VARIABLE(type, shorttype, name) \
-  namespace paddle {                                \
-  namespace flags {                                 \
+  namespace paddle_flags {                          \
   extern PHI_IMPORT_FLAG type FLAGS_##name;         \
   }                                                 \
-  }                                                 \
-  using paddle::flags::FLAGS_##name
+  using paddle_flags::FLAGS_##name
 
 #define PHI_DEFINE_VARIABLE(type, shorttype, name, default_value, description) \
-  namespace paddle {                                                           \
-  namespace flags {                                                            \
+  namespace paddle_flags {                          \
   static const type FLAGS_##name##_default = default_value;                    \
   PHI_EXPORT_FLAG type FLAGS_##name = default_value;                           \
   /* Register FLAG */                                                          \
   static ::paddle::flags::FlagRegisterer flag_##name##_registerer(             \
       #name, description, __FILE__, &FLAGS_##name##_default, &FLAGS_##name);   \
   }                                                                            \
-  }                                                                            \
-  using paddle::flags::FLAGS_##name
+  using paddle_flags::FLAGS_##name
 
 #endif
 

--- a/paddle/phi/core/flags.h
+++ b/paddle/phi/core/flags.h
@@ -65,7 +65,7 @@
   using paddle_flags::FLAGS_##name
 
 #define PHI_DEFINE_VARIABLE(type, shorttype, name, default_value, description) \
-  namespace paddle_flags {                          \
+  namespace paddle_flags {                                                     \
   static const type FLAGS_##name##_default = default_value;                    \
   PHI_EXPORT_FLAG type FLAGS_##name = default_value;                           \
   /* Register FLAG */                                                          \

--- a/paddle/utils/flags_native.h
+++ b/paddle/utils/flags_native.h
@@ -74,12 +74,10 @@ void PrintAllFlagHelp(bool to_file = false,
 
 // ----------------------------DECLARE FLAGS----------------------------
 #define PD_DECLARE_VARIABLE(type, name) \
-  namespace paddle {                    \
-  namespace flags {                     \
+  namespace paddle_flags {              \
   extern type FLAGS_##name;             \
   }                                     \
-  }                                     \
-  using paddle::flags::FLAGS_##name
+  using paddle_flags::FLAGS_##name
 
 #define PD_DECLARE_bool(name) PD_DECLARE_VARIABLE(bool, name)
 #define PD_DECLARE_int32(name) PD_DECLARE_VARIABLE(int32_t, name)
@@ -105,16 +103,14 @@ class FlagRegisterer {
 
 // ----------------------------DEFINE FLAGS----------------------------
 #define PD_DEFINE_VARIABLE(type, name, default_value, description)           \
-  namespace paddle {                                                         \
-  namespace flags {                                                          \
+  namespace paddle_flags {                                                   \
   static const type FLAGS_##name##_default = default_value;                  \
   type FLAGS_##name = default_value;                                         \
   /* Register FLAG */                                                        \
   static ::paddle::flags::FlagRegisterer flag_##name##_registerer(           \
       #name, description, __FILE__, &FLAGS_##name##_default, &FLAGS_##name); \
   }                                                                          \
-  }                                                                          \
-  using paddle::flags::FLAGS_##name
+  using paddle_flags::FLAGS_##name
 
 #define PD_DEFINE_bool(name, val, txt) PD_DEFINE_VARIABLE(bool, name, val, txt)
 #define PD_DEFINE_int32(name, val, txt) \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- 修复 #56256 中引入在一些使用了 paddle_flags 的文件中无法正确解析 paddle 命名空间的问题

上述问题的原因在 `paddle::xxx` 命名空间下定义或者声明了 FLAG，比如：

https://github.com/PaddlePaddle/Paddle/blob/e2af9d569af56ae3b450b633fc5fedade3c4299e/paddle/fluid/distributed/ps/service/heter_client.cc#L20-L23

在对该文件进行宏展开预处理后，会得到：

``` C++
namespace paddle {
namespace distributed {
namespace paddle { namespace flags { static const int32_t FLAGS_heter_world_size_default = 100; int32_t FLAGS_heter_world_size = 100; static ::paddle::flags::FlagRegisterer flag_heter_world_size_registerer( "heter_world_size", "group size", "/home/huangjiyi/code/develop/Paddle/paddle/fluid/distributed/ps/service/heter_client.cc", &FLAGS_heter_world_size_default, &FLAGS_heter_world_size); } } using paddle_flags::FLAGS_heter_world_size;
namespace paddle { namespace flags { static const int32_t FLAGS_switch_send_recv_timeout_s_default = 600; int32_t FLAGS_switch_send_recv_timeout_s = 600; static ::paddle::flags::FlagRegisterer flag_switch_send_recv_timeout_s_registerer( "switch_send_recv_timeout_s", "switch_send_recv_timeout_s", "/home/huangjiyi/code/develop/Paddle/paddle/fluid/distributed/ps/service/heter_client.cc", &FLAGS_switch_send_recv_timeout_s_default, &FLAGS_switch_send_recv_timeout_s); } } using paddle_flags::FLAGS_switch_send_recv_timeout_s;
```

相当于在 `paddle::distributed` 命名空间下又定义了一个 `paddle` 命名空间，这样的话后续该文件在 `paddle::distributed` 命名空间下的 `paddle::xxx` 用法都会被解析成 `paddle::distributed::paddle::xxx`

#### 更底层的原因
在编译的过程中，需要对 `paddle::xxx` 用法进行解析，需要先找到符号 `paddle` 的声明或定义，由于 `paddle` 是一个非限定名称（没有前缀`::`），因此查找过程的顺序是：先在当前命名空间 `paddle::distributed` 进行查找，如果没找到就在上一层命名空间进行找，直到找完全局命名空间，ref: https://en.cppreference.com/w/cpp/language/unqualified_lookup

在上面的例子中，由于在 `paddle::distributed` 命名空间下使用 `PD_DEFINE_int32` 会定义一个 `paddle` 命名空间，编译器在解析后续的 `paddle` 名称时会先找到 `paddle::distributed::paddle`，从而所有 `paddle::xxx` 用法都会被解析成 `paddle::distributed::paddle::xxx`，然后编译器再进一步按照限定名称查找这些用法的声明或者定义，最后没找到报错：
``` bash
/Paddle/paddle/fluid/distributed/ps/service/heter_client.cc:432:15: error: ‘paddle::distributed::paddle::framework’ has not been declared
  432 | using paddle::framework::TransToProtoVarType;
      |               ^~~~~~~~~
```

#### Solution
- 更换 FLAGS 定义的命名空间
- 这个 PR 只将之前改的一个文件改回来了以说明这个问题已经解决了，所以没改其他文件