### PR TITLE
[FlashAttention] Add test_flash_attention_deterministic to ci gpups.

### DIFF
--- a/tools/gpups_test.sh
+++ b/tools/gpups_test.sh
@@ -47,6 +47,7 @@ parallel_list="^init_phi_test$|\
 ^test_dist_fleet_ps12$|\
 ^test_executor_feed_non_tensor$|\
 ^test_flash_attention$|\
+^test_flash_attention_deterministic$|\
 ^test_fused_adam_op$|\
 ^test_fused_attention_no_dropout$|\
 ^test_fused_attention_op$|\


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-70459

Add test_flash_attention_deterministic to ci-gpups