### PR TITLE
[Inference] jit.save() remove useless renaming process

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_static_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load.py
@@ -1652,7 +1652,7 @@ class TestSaveLoadInferenceModel(unittest.TestCase):
             self.assertEqual(feed_target_names, ['x'])
             self.assertEqual(fetch_targets[0].shape, (10, 10))
             ops = [op.type for op in inference_program.block(0).ops]
-            self.assertEqual(ops, ['feed', 'elementwise_add', 'scale', 'fetch'])
+            self.assertEqual(ops, ['feed', 'elementwise_add', 'fetch'])
 
 
 if __name__ == '__main__':

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -198,7 +198,7 @@ def normalize_program(program, feed_vars, fetch_vars):
     #                                name="save_infer_model/scale_{}".format(i))
     #         uniq_fetch_vars.append(var)
     #     fetch_vars = uniq_fetch_vars
-    # TODO(vivienfanghuagood) maybe these codes is not needed 
+    # TODO(vivienfanghuagood) maybe these codes is not needed
 
     # serialize program
     copy_program = program.clone()

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -189,15 +189,16 @@ def normalize_program(program, feed_vars, fetch_vars):
     # fix the bug that the activation op's output as target will be pruned.
     # will affect the inference performance.
     # TODO(Superjomn) add an IR pass to remove 1-scale op.
-    with program_guard(program):
-        uniq_fetch_vars = []
-        for i, var in enumerate(fetch_vars):
-            if var.dtype != paddle.bool:
-                var = layers.scale(var,
-                                   1.,
-                                   name="save_infer_model/scale_{}".format(i))
-            uniq_fetch_vars.append(var)
-        fetch_vars = uniq_fetch_vars
+    # with program_guard(program):
+    #     uniq_fetch_vars = []
+    #     for i, var in enumerate(fetch_vars):
+    #         if var.dtype != paddle.bool:
+    #             var = layers.scale(var,
+    #                                1.,
+    #                                name="save_infer_model/scale_{}".format(i))
+    #         uniq_fetch_vars.append(var)
+    #     fetch_vars = uniq_fetch_vars
+    # TODO(vivienfanghuagood) maybe these codes is not needed 
 
     # serialize program
     copy_program = program.clone()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-71500
去除当 jit.save() 时无意义的对结果重修改的逻辑。