### PR TITLE
fixed a bug in bincount_kenel, which will cause miscalculation when numel is greater than 512

### DIFF
--- a/paddle/phi/kernels/gpu/bincount_kernel.cu
+++ b/paddle/phi/kernels/gpu/bincount_kernel.cu
@@ -34,13 +34,12 @@ __global__ void KernelBincount(const InputT* input,
                                const bool has_weights,
                                const T* weights,
                                OutT* output) {
-  if (!has_weights) {
-    for (int i = threadIdx.x; i < total_elements; i += blockDim.x) {
-      phi::CudaAtomicAdd(&output[input[i]], 1L);
-    }
-  } else {
-    for (int i = threadIdx.x; i < total_elements; i += blockDim.x) {
-      phi::CudaAtomicAdd(&output[input[i]], static_cast<OutT>(weights[i]));
+  int tid = blockIdx.x * blockDim.x + threadIdx;
+  if (tid < total_elements) {
+    if (!has_weights) {
+      phi::CudaAtomicAdd(&output[input[tid]], 1L);
+    } else {
+      phi::CudaAtomicAdd(&output[input[tid]], static_cast<OutT>(weights[tid]));
     }
   }
 }

--- a/paddle/phi/kernels/gpu/bincount_kernel.cu
+++ b/paddle/phi/kernels/gpu/bincount_kernel.cu
@@ -34,7 +34,7 @@ __global__ void KernelBincount(const InputT* input,
                                const bool has_weights,
                                const T* weights,
                                OutT* output) {
-  int tid = blockIdx.x * blockDim.x + threadIdx;
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid < total_elements) {
     if (!has_weights) {
       phi::CudaAtomicAdd(&output[input[tid]], 1L);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Description
As described in issue #46978，when number of elements is greater than 512 (block size greater than 1), the result of paddle.bincount is not consistent with numpy.bincount, it's because each thread is already corresponded with the input element, and the for loop is redundant.
