### PR TITLE
add informata for strided grad kernel

### DIFF
--- a/paddle/phi/kernels/stride/diagonal_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/diagonal_grad_kernel.cc
@@ -36,6 +36,11 @@ void DiagonalGradStridedKernel(const Context& dev_ctx,
                            dev_ctx, *in_grad, 0, in_grad);
                      }));
   DenseTensor tmp;
+  tmp.set_layout(out_grad.layout());
+  tmp.set_lod(out_grad.lod());
+  tmp.set_type(out_grad.dtype());
+  tmp.Resize(out_grad.dims());
+
   DiagonalStridedKernel<Context>(dev_ctx, *in_grad, offset, axis1, axis2, &tmp);
   PD_VISIT_ALL_TYPES(out_grad.dtype(), "DiagonalGradStridedKernel", ([&] {
                        phi::StridedCopyKernel<data_t, Context>(

--- a/paddle/phi/kernels/stride/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/index_select_grad_kernel.cc
@@ -34,6 +34,11 @@ void IndexSelectGradStridedKernel(const Context& dev_ctx,
                            dev_ctx, *x_grad, 0, x_grad);
                      }));
   DenseTensor tmp;
+  tmp.set_layout(out_grad.layout());
+  tmp.set_lod(out_grad.lod());
+  tmp.set_type(out_grad.dtype());
+  tmp.Resize(out_grad.dims());
+
   IndexSelectStridedKernel<Context>(dev_ctx, *x_grad, index, dim, &tmp);
   PD_VISIT_ALL_TYPES(out_grad.dtype(), "IndexSelectGradStridedKernel", ([&] {
                        phi::StridedCopyKernel<data_t, Context>(

--- a/paddle/phi/kernels/stride/strided_slice_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/strided_slice_grad_kernel.cc
@@ -38,6 +38,10 @@ void StridedSliceRawGradStridedKernel(const Context& dev_ctx,
                            dev_ctx, *x_grad, 0, x_grad);
                      }));
   DenseTensor tmp;
+  tmp.set_layout(out_grad.layout());
+  tmp.set_lod(out_grad.lod());
+  tmp.set_type(out_grad.dtype());
+  tmp.Resize(out_grad.dims());
   StridedSliceRawStridedKernel<Context>(dev_ctx,
                                         *x_grad,
                                         axes,

--- a/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
@@ -40,6 +40,11 @@ void TensorUnfoldGradKernel(const Context& dev_ctx,
                        }));
   }
   DenseTensor tmp;
+  tmp.set_layout(out_grad.layout());
+  tmp.set_lod(out_grad.lod());
+  tmp.set_type(out_grad.dtype());
+  tmp.Resize(out_grad.dims());
+
   TensorUnfoldKernel<Context>(dev_ctx, *input_grad, axis, size, step, &tmp);
   PD_VISIT_ALL_TYPES(out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
                        phi::StridedCopyKernel<data_t, Context>(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
很多stride反向kernel会调用前向的stride kernel。会声明一个DenseTensor tmp，但是没有为tmp做infermata。会引发异常。
Pcard-71699