### PR TITLE
Delete fleet executor test

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/test/CMakeLists.txt
@@ -1,154 +1,122 @@
-get_property(paddle_lib GLOBAL PROPERTY PADDLE_LIB_NAME)
-set_source_files_properties(
-  interceptor_ping_pong_test.cc PROPERTIES COMPILE_FLAGS
-                                           ${DISTRIBUTE_COMPILE_FLAGS})
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc
-              DEPS fleet_executor ${BRPC_DEPS})
-else()
-  cc_test_old(
-    interceptor_ping_pong_test
-    SRCS
-    interceptor_ping_pong_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor)
-endif()
+# NOTE(risemeup1):The compile target of these unit tests requires occupying more than 4GB of memory,
+# which lead a intractable compilation failure issue on Coverage CI.
+# We temporarily disabled them, and will restore after all compilation issues are resolved.
 
-set_source_files_properties(
-  compute_interceptor_test.cc PROPERTIES COMPILE_FLAGS
-                                         ${DISTRIBUTE_COMPILE_FLAGS})
+# get_property(paddle_lib GLOBAL PROPERTY PADDLE_LIB_NAME)
+# set_source_files_properties(
+#   interceptor_ping_pong_test.cc PROPERTIES COMPILE_FLAGS
+#                                            ${DISTRIBUTE_COMPILE_FLAGS})
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(interceptor_ping_pong_test SRCS interceptor_ping_pong_test.cc
+#               DEPS fleet_executor ${BRPC_DEPS})
+# else()
+#   cc_test_old(
+#     interceptor_ping_pong_test
+#     SRCS
+#     interceptor_ping_pong_test.cc
+#     DEPS
+#     ${paddle_lib}
+#     python
+#     fleet_executor)
+# endif()
 
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
-              fleet_executor ${BRPC_DEPS})
-else()
-  cc_test_old(
-    compute_interceptor_test
-    SRCS
-    compute_interceptor_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor)
-endif()
+# set_source_files_properties(
+#   compute_interceptor_test.cc PROPERTIES COMPILE_FLAGS
+#                                          ${DISTRIBUTE_COMPILE_FLAGS})
 
-set_source_files_properties(
-  source_interceptor_test.cc PROPERTIES COMPILE_FLAGS
-                                        ${DISTRIBUTE_COMPILE_FLAGS})
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
-              fleet_executor ${BRPC_DEPS})
-else()
-  cc_test_old(
-    source_interceptor_test
-    SRCS
-    source_interceptor_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor)
-endif()
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
+#               fleet_executor ${BRPC_DEPS})
+# else()
+#   cc_test_old(compute_interceptor_test SRCS compute_interceptor_test.cc DEPS
+#               ${paddle_lib} python)
+# endif()
 
-set_source_files_properties(
-  sink_interceptor_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
-              fleet_executor ${BRPC_DEPS})
-else()
-  cc_test_old(
-    sink_interceptor_test
-    SRCS
-    sink_interceptor_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor)
-endif()
+# set_source_files_properties(
+#   source_interceptor_test.cc PROPERTIES COMPILE_FLAGS
+#                                         ${DISTRIBUTE_COMPILE_FLAGS})
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
+#               fleet_executor ${BRPC_DEPS})
+# else()
+#   cc_test_old(source_interceptor_test SRCS source_interceptor_test.cc DEPS
+#               ${paddle_lib} python)
+# endif()
 
-set_source_files_properties(
-  interceptor_pipeline_short_path_test.cc
-  PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(
-    interceptor_pipeline_short_path_test SRCS
-    interceptor_pipeline_short_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
-else()
-  cc_test_old(
-    interceptor_pipeline_short_path_test
-    SRCS
-    interceptor_pipeline_short_path_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor)
-endif()
+# set_source_files_properties(
+#   sink_interceptor_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
+#               fleet_executor ${BRPC_DEPS})
+# else()
+#   cc_test_old(sink_interceptor_test SRCS sink_interceptor_test.cc DEPS
+#               ${paddle_lib} python)
+# endif()
 
-set_source_files_properties(
-  interceptor_pipeline_long_path_test.cc PROPERTIES COMPILE_FLAGS
-                                                    ${DISTRIBUTE_COMPILE_FLAGS})
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(
-    interceptor_pipeline_long_path_test SRCS
-    interceptor_pipeline_long_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
-else()
-  cc_test_old(
-    interceptor_pipeline_long_path_test
-    SRCS
-    interceptor_pipeline_long_path_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor)
-endif()
+# set_source_files_properties(
+#   interceptor_pipeline_short_path_test.cc
+#   PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(
+#     interceptor_pipeline_short_path_test SRCS
+#     interceptor_pipeline_short_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
+# else()
+#   cc_test_old(interceptor_pipeline_short_path_test SRCS
+#               interceptor_pipeline_short_path_test.cc DEPS ${paddle_lib} python)
+# endif()
 
-set_source_files_properties(
-  compute_interceptor_run_op_test.cc PROPERTIES COMPILE_FLAGS
-                                                ${DISTRIBUTE_COMPILE_FLAGS})
-if(WIN32 AND WITH_TESTING)
-  cc_test_old(
-    compute_interceptor_run_op_test
-    SRCS
-    compute_interceptor_run_op_test.cc
-    DEPS
-    fleet_executor
-    naive_executor
-    fill_constant_op
-    op_registry
-    elementwise_add_op
-    scope
-    device_context
-    ${BRPC_DEPS})
-else()
-  cc_test_old(
-    compute_interceptor_run_op_test
-    SRCS
-    compute_interceptor_run_op_test.cc
-    DEPS
-    ${paddle_lib}
-    python
-    fleet_executor
-    fill_constant_op
-    elementwise_add_op)
-endif()
+# set_source_files_properties(
+#   interceptor_pipeline_long_path_test.cc PROPERTIES COMPILE_FLAGS
+#                                                     ${DISTRIBUTE_COMPILE_FLAGS})
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(
+#     interceptor_pipeline_long_path_test SRCS
+#     interceptor_pipeline_long_path_test.cc DEPS fleet_executor ${BRPC_DEPS})
+# else()
+#   cc_test_old(interceptor_pipeline_long_path_test SRCS
+#               interceptor_pipeline_long_path_test.cc DEPS ${paddle_lib} python)
+# endif()
 
-if(WITH_DISTRIBUTE AND NOT WITH_PSLIB)
-  set_source_files_properties(
-    interceptor_ping_pong_with_brpc_test.cc
-    PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-  if(WIN32 AND WITH_TESTING)
-    cc_test_old(
-      interceptor_ping_pong_with_brpc_test SRCS
-      interceptor_ping_pong_with_brpc_test.cc DEPS fleet_executor ${BRPC_DEPS})
-  else()
-    cc_test_old(
-      interceptor_ping_pong_with_brpc_test
-      SRCS
-      interceptor_ping_pong_with_brpc_test.cc
-      DEPS
-      ${paddle_lib}
-      python
-      fleet_executor)
-  endif()
-endif()
+# set_source_files_properties(
+#   compute_interceptor_run_op_test.cc PROPERTIES COMPILE_FLAGS
+#                                                 ${DISTRIBUTE_COMPILE_FLAGS})
+# if(WIN32 AND WITH_TESTING)
+#   cc_test_old(
+#     compute_interceptor_run_op_test
+#     SRCS
+#     compute_interceptor_run_op_test.cc
+#     DEPS
+#     fleet_executor
+#     naive_executor
+#     fill_constant_op
+#     op_registry
+#     elementwise_add_op
+#     scope
+#     device_context
+#     ${BRPC_DEPS})
+# else()
+#   cc_test_old(
+#     compute_interceptor_run_op_test
+#     SRCS
+#     compute_interceptor_run_op_test.cc
+#     DEPS
+#     ${paddle_lib}
+#     python
+#     fill_constant_op
+#     elementwise_add_op)
+# endif()
+
+# if(WITH_DISTRIBUTE AND NOT WITH_PSLIB)
+#   set_source_files_properties(
+#     interceptor_ping_pong_with_brpc_test.cc
+#     PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
+#   if(WIN32 AND WITH_TESTING)
+#     cc_test_old(
+#       interceptor_ping_pong_with_brpc_test SRCS
+#       interceptor_ping_pong_with_brpc_test.cc DEPS fleet_executor ${BRPC_DEPS})
+#   else()
+#     cc_test_old(
+#       interceptor_ping_pong_with_brpc_test SRCS
+#       interceptor_ping_pong_with_brpc_test.cc DEPS ${paddle_lib} python)
+#   endif()
+# endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67010
fleet_executor/test/目录下的单测编译出来的可执行文件达4.2G，导致Coverage 流水线因为内存占满出现kill -9的bug，将这些单测依赖libpaddle.so后仍然不能解决问题，因为这些单测仍然需要依赖fleet_executor，因为fleet_executor中的符号没有打进libpaddle.so，如果将fleet_exectuor打到libpaddle.so，会导致so体积和whl包体积增大，所以临时不编译这些异步执行器单测