### PR TITLE
make test_lite_engine_op linked to libpaddle.so

### DIFF
--- a/test/cpp/fluid/lite/CMakeLists.txt
+++ b/test/cpp/fluid/lite/CMakeLists.txt
@@ -1,8 +1,1 @@
-cc_test_old(
-  test_lite_engine_op
-  SRCS
-  lite_engine_op_test.cc
-  DEPS
-  fleet_executor
-  lite_engine_op
-  analysis)
+cc_test(test_lite_engine_op SRCS lite_engine_op_test.cc)

--- a/test/cpp/fluid/lite/CMakeLists.txt
+++ b/test/cpp/fluid/lite/CMakeLists.txt
@@ -1,1 +1,4 @@
-cc_test(test_lite_engine_op SRCS lite_engine_op_test.cc)
+get_property(paddle_lib GLOBAL PROPERTY PADDLE_LIB_NAME)
+
+cc_test_old(test_lite_engine_op SRCS lite_engine_op_test.cc DEPS ${paddle_lib}
+            python)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67010
优化test_lite_engine_op单测可执行文件大小，改为link libpaddle.so
优化前4.2G，优化后15M