### PR TITLE
Fix event info bug in StreamAnalyzer

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
@@ -346,7 +346,6 @@ void analyse_event_info_for_two_instructions<Instruction>(
 
   if (has_data_dependency<Instruction, std::string>(
           instructions[cur_instr_id], instructions[next_instr_id]) ||
-      !run_type_info[next_instr_id][DownstreamRunType::kEventRun].empty() ||
       instructions[next_instr_id]->OpBase()->Type() == "depend") {
     waiter_instr_ids->insert(next_instr_id);
     return;
@@ -406,7 +405,6 @@ void analyse_event_info_for_two_instructions<
 
   if (has_data_dependency<paddle::framework::InstructionBase, ir::Value>(
           instructions[cur_instr_id], instructions[next_instr_id]) ||
-      !run_type_info[next_instr_id][DownstreamRunType::kEventRun].empty() ||
       instructions[next_instr_id]->Name() == "pd.depend") {
     waiter_instr_ids->insert(next_instr_id);
     return;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
PCard-71568
去除`StreamAnalyzer`中对依赖`op1 -> op2`在op2下游无需要同步的算子时经验性插入的同步操作，该策略用于多流同步分析时提前终止以降低图遍历复杂度，但这种策略在某些case下显得过于保守，容易引入冗余的同步操作，从而导致预期外的性能开销。本PR将其删除。
