### PR TITLE
[Paddle  Inference] rename vars in subgraph

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/subgraph_util.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/subgraph_util.cc
@@ -166,7 +166,7 @@ void RenameAndGetOutputs(
       for (int k = 0; k < in_var->arguments_size(); k++) {  // all the arguments
         const std::string arg_value = in_var->arguments(k);
         const std::string arg_value_with_id =
-            arg_value + std::to_string(var2id[arg_value]);
+            RenameVarBeUnique(arg_value, std::to_string(var2id[arg_value]));
         if (input_names_with_id.count(arg_value_with_id)) {
           replaced_names.push_back(arg_value);
           if (graph_var_map.count(arg_value)) {
@@ -214,7 +214,7 @@ void RenameAndGetOutputs(
       for (int k = 0; k < out_var->arguments_size(); k++) {
         const std::string arg_value = out_var->arguments(k);
         const std::string arg_value_with_id =
-            arg_value + std::to_string(var2id[arg_value]);
+            RenameVarBeUnique(arg_value, std::to_string(var2id[arg_value]));
         if (graph_var_map.count(arg_value)) {
           add_block_var(arg_value, arg_value_with_id);
         }
@@ -229,6 +229,11 @@ void RenameAndGetOutputs(
       }
     }
   }
+}
+
+std::string RenameVarBeUnique(std::string original_var_name,
+                              std::string var_id) {
+  return original_var_name + "_subgraph_" + var_id;
 }
 
 }  // namespace analysis

--- a/paddle/fluid/inference/analysis/ir_passes/subgraph_util.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/subgraph_util.cc
@@ -199,7 +199,8 @@ void RenameAndGetOutputs(
           PADDLE_GET_CONST(std::vector<int>, op_desc.GetAttr("paddings"));
       if (same_hierarchy_conv2d_num_map[input_var_name] > 0) {
         (*output_names_with_id)
-            .insert(out_var_name + std::to_string(var2id[out_var_name]));
+            .insert(RenameVarBeUnique(out_var_name,
+                                      std::to_string(var2id[out_var_name])));
         (*output_names).insert(out_var_name);
       } else if (filter_shape[2] == 1 && filter_shape[3] == 1 &&
                  strides[0] == 1 && strides[1] == 1 && paddings[0] == 0 &&

--- a/paddle/fluid/inference/analysis/ir_passes/subgraph_util.h
+++ b/paddle/fluid/inference/analysis/ir_passes/subgraph_util.h
@@ -62,6 +62,11 @@ void RenameAndGetOutputs(
     const std::unordered_map<std::string, framework::ir::Node *> &graph_var_map,
     bool trt_and_not_int8 = false);
 
+// When fuse some ops into one subgraph, we need to rename all vars within this
+// subgraph (excluding the inputs and outputs of the subgraph) to a unique name.
+std::string RenameVarBeUnique(std::string original_var_name,
+                              std::string var_id);
+
 }  // namespace analysis
 }  // namespace inference
 }  // namespace paddle

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -325,7 +325,8 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
   // The node->inputs contains input tensors and parameters.
   for (auto *x : node->inputs) {
     input_names.insert(x->Name());
-    input_names_with_id.insert(x->Name() + std::to_string(x->id()));
+    input_names_with_id.insert(
+        RenameVarBeUnique(x->Name(), std::to_string(x->id())));
     if (std::count(graph_params.begin(), graph_params.end(), x->Name()) > 0) {
       parameters.push_back(x->Name());
     }
@@ -355,7 +356,8 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
   // https://github.com/PaddlePaddle/Paddle/pull/53184
   for (auto *n : graph->Nodes()) {
     if (n->IsVar() && input_names.count(n->Name())) {
-      input_names_with_id.insert(n->Name() + std::to_string(n->id()));
+      input_names_with_id.insert(
+          RenameVarBeUnique(n->Name(), std::to_string(n->id())));
     }
   }
 
@@ -407,7 +409,8 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
 
   for (auto *x : node->outputs) {
     output_names.insert(x->Name());
-    output_names_with_id.insert(x->Name() + std::to_string(x->id()));
+    output_names_with_id.insert(
+        RenameVarBeUnique(x->Name(), std::to_string(x->id())));
     origin_name_output_rank[x->Name()] = x->Var()->GetShape().size();
     trt_outputs.insert(x);
     map_origin_outputs_dtype[x->Name()] =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->


Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

P-card-71501

- 降低了 子图内var的重命名和模型权重名相碰撞的概率，但没有根本上避免碰撞

- 之前将子图内的var重命名的方法是：orinal_name + var_id，因为var_id是整个模型唯一的，因此这种方式是唯一的，但是我们是不把权重重命名的，因此可能造成var重命名后和权重的名字碰撞了，这不好。
- 这里改成 orinal_name + \_subgraph_ + var_id，尽管不能根本上避免碰撞，但是能降低好多概率。

