### PR TITLE
Enable FLAGS_new_executor_micro_batching

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -2415,6 +2415,7 @@ def use_new_executor():
         'FLAGS_new_executor_micro_batching', None
     )
     return new_executor_micro_batching in [
+        None,
         1,
         '1',
         True,

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -64,9 +64,15 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
                   test_pass_generation_pipeline)
   set_tests_properties(test_pass_generation_pipeline
                        PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 50)
+  set_tests_properties(
+    test_pass_generation_pipeline
+    PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
   py_test_modules(test_pass_1F1B MODULES test_pass_1F1B)
   set_tests_properties(test_pass_1F1B PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE"
                                                  TIMEOUT 50)
+  set_tests_properties(
+    test_pass_1F1B PROPERTIES ENVIRONMENT
+                              "FLAGS_new_executor_micro_batching=False")
   py_test_modules(test_auto_tuner MODULES test_auto_tuner)
   set_tests_properties(test_auto_tuner PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE"
                                                   TIMEOUT 100)

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -702,7 +702,7 @@ if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
     LABELS
     "RUN_TYPE=DIST"
     ENVS
-    "PADDLE_DIST_UT_PORT=21272;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python;FLAGS_new_executor_micro_batching=False"
+    "PADDLE_DIST_UT_PORT=21272;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
   )
   set_tests_properties(test_ir_pass_pipeline PROPERTIES TIMEOUT "240")
 endif()

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -702,7 +702,7 @@ if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
     LABELS
     "RUN_TYPE=DIST"
     ENVS
-    "PADDLE_DIST_UT_PORT=21272;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
+    "PADDLE_DIST_UT_PORT=21272;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python;FLAGS_new_executor_micro_batching=False"
   )
   set_tests_properties(test_ir_pass_pipeline PROPERTIES TIMEOUT "240")
 endif()
@@ -950,4 +950,7 @@ if((WITH_GPU) AND (LINUX))
   )
   set_tests_properties(test_dygraph_save_for_auto_infer
                        PROPERTIES TIMEOUT "300" LABELS "RUN_TYPE=DIST")
+  set_tests_properties(
+    test_dygraph_save_for_auto_infer
+    PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
 endif()

--- a/test/collective/fleet/test_ir_pass_pipeline.py
+++ b/test/collective/fleet/test_ir_pass_pipeline.py
@@ -19,7 +19,10 @@ import test_pipeline
 
 class TestPipelineWithIRPass(test_pipeline.TestPipeline):
     def need_envs(self):
-        return {'FLAGS_apply_pass_to_program': '1'}
+        return {
+            'FLAGS_apply_pass_to_program': '1',
+            'FLAGS_new_executor_micro_batching': '0',
+        }
 
 
 if __name__ == '__main__':

--- a/test/collective/fleet/test_pipeline.py
+++ b/test/collective/fleet/test_pipeline.py
@@ -33,7 +33,7 @@ class TestPipeline(TestDistBase):
         self._nccl_comm_num = 1
 
     def need_envs(self):
-        return {'FLAGS_new_executor_micro_batching': '0'}
+        return {"FLAGS_new_executor_micro_batching": "0"}
 
     def test_dist_train(self):
         if fluid.core.is_compiled_with_cuda():
@@ -65,7 +65,10 @@ class TestPipeline(TestDistBase):
                 "pipeline_mnist_one_device.py",
                 check_error_log=True,
                 log_name=flag_name,
-                need_envs={"PADDLE_MANUAL_PIPELINE_STAGE": "0"},
+                need_envs={
+                    "PADDLE_MANUAL_PIPELINE_STAGE": "0",
+                    "FLAGS_new_executor_micro_batching": "0",
+                },
             )
 
 

--- a/test/collective/fleet/test_pipeline.py
+++ b/test/collective/fleet/test_pipeline.py
@@ -33,7 +33,7 @@ class TestPipeline(TestDistBase):
         self._nccl_comm_num = 1
 
     def need_envs(self):
-        return {}
+        return {'FLAGS_new_executor_micro_batching': '0'}
 
     def test_dist_train(self):
         if fluid.core.is_compiled_with_cuda():

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1436,27 +1436,15 @@ py_test_modules(test_stride MODULES test_stride ENVS
 
 set_tests_properties(test_slice_op_with_stride PROPERTIES TIMEOUT 300)
 
-# These UTs are specially designed for FleetExecutor
-set_tests_properties(
-  test_fleet_executor PROPERTIES ENVIRONMENT
-                                 "FLAGS_new_executor_micro_batching=False")
-set_tests_properties(
-  test_fleet_executor_origin_scheduler
-  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
-set_tests_properties(
-  test_fleet_executor_with_task_nodes
-  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
-set_tests_properties(
-  test_pass_1F1B PROPERTIES ENVIRONMENT
-                            "FLAGS_new_executor_micro_batching=False")
-set_tests_properties(
-  test_pass_generation_pipeline
-  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
-
-# TODO(Ruibiao): These UTs require fixing DataLoader issues to run in Standalone Executor.
-set_tests_properties(
-  test_dygraph_save_for_auto_infer
-  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
-set_tests_properties(
-  test_ir_pass_pipeline PROPERTIES ENVIRONMENT
+if((WITH_ROCM OR WITH_GPU) AND NOT WIN32)
+  # These UTs are specially designed for FleetExecutor
+  set_tests_properties(
+    test_fleet_executor PROPERTIES ENVIRONMENT
                                    "FLAGS_new_executor_micro_batching=False")
+  set_tests_properties(
+    test_fleet_executor_origin_scheduler
+    PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
+  set_tests_properties(
+    test_fleet_executor_with_task_nodes
+    PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
+endif()

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1435,3 +1435,28 @@ py_test_modules(test_stride MODULES test_stride ENVS
                 FLAGS_use_stride_kernel=true)
 
 set_tests_properties(test_slice_op_with_stride PROPERTIES TIMEOUT 300)
+
+# These UTs are specially designed for FleetExecutor
+set_tests_properties(
+  test_fleet_executor PROPERTIES ENVIRONMENT
+                                 "FLAGS_new_executor_micro_batching=False")
+set_tests_properties(
+  test_fleet_executor_origin_scheduler
+  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
+set_tests_properties(
+  test_fleet_executor_with_task_nodes
+  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
+set_tests_properties(
+  test_pass_1F1B PROPERTIES ENVIRONMENT
+                            "FLAGS_new_executor_micro_batching=False")
+set_tests_properties(
+  test_pass_generation_pipeline
+  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
+
+# TODO(Ruibiao): These UTs require fixing DataLoader issues to run in Standalone Executor.
+set_tests_properties(
+  test_dygraph_save_for_auto_infer
+  PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
+set_tests_properties(
+  test_ir_pass_pipeline PROPERTIES ENVIRONMENT
+                                   "FLAGS_new_executor_micro_batching=False")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
PCard-71568

当前新执行器StandaloneExecutor已完成流水并行场景的支持，经过单机和两机PP场景下不同混合并行配置的测试，精度与异步流水执行器（FleetExecutor）完全对齐，性能和显存均有不同幅度的领先。

本PR开启FLAGS_new_executor_micro_batching，将静半流水并行场景使用的执行器从FleetExecutor默认切换为StandaloneExecutor。

有部分CI单测是专门用来测试FleetExecutor的，另有部分单测Dataloader仍使用旧的from_generator接口（该接口新执行器已不支持），这些单测暂时保持FLASG关闭。
