### PR TITLE
Disable FLAGS_set_to_1d and force 0-D to take effect

### DIFF
--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -749,9 +749,9 @@ PHI_DEFINE_EXPORTED_int32(
  * [false]: not set 0D Tensor to 1D Numpy, close the hack
  *
  * Now, just set true by default in 2.5 transition time
- * which will be removed in future (2.6 or 2.7) .
+ * which will be removed in future (2.6) .
  */
-PHI_DEFINE_EXPORTED_bool(set_to_1d, true, "set 0D Tensor to 1D numpy");
+PHI_DEFINE_EXPORTED_bool(set_to_1d, false, "set 0D Tensor to 1D numpy");
 
 /**
  * Debug related FLAG


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

Pcard-66984

Disable FLAGS_set_to_1d and force 0D to take effect

