### PR TITLE
refine save numpy

### DIFF
--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -298,7 +298,9 @@ def _pickle_save(obj, f, protocol):
         return (tuple, ((name, data),))
 
     def reduce_LoDTensor(self):
-        data = np.array(self._copy(paddle.CPUPlace()))
+        p = core.Place()
+        p.set_place(paddle.CPUPlace())
+        data = np.array(self._copy(p))
 
         return (eval, ('data', {'data': data}))
 
@@ -1110,7 +1112,9 @@ def load(path, **configs):
                 try:
                     tensor, _ = _load_lod_tensor(path)
                     if config.return_numpy:
-                        return np.array(tensor._copy(paddle.CPUPlace()))
+                        p = core.Place()
+                        p.set_place(paddle.CPUPlace())
+                        return np.array(tensor._copy(p))
                     else:
                         if in_dygraph_mode():
                             return _lod_tensor2varbase(tensor)

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -62,7 +62,7 @@ def _build_saved_state_dict(state_dict):
                     raise ValueError(
                         "The saved tensor is not initialized. If you used group sharded, please use save_group_sharded_model."
                     )
-                save_dict[key] = np.array(value)
+                save_dict[key] = np.array(value.cpu())
             name_table[key] = value.name
         else:
             save_dict[key] = value
@@ -91,7 +91,9 @@ def _load_state_dict_from_save_inference_model(model_path, config):
         # 3. construct state_dict
         load_param_dict = {}
         for var_name in persistable_var_dict:
-            load_param_dict[var_name] = np.array(persistable_var_dict[var_name])
+            load_param_dict[var_name] = np.array(
+                persistable_var_dict[var_name].cpu()
+            )
 
         # if *.info exists, we can recover structured_name
         var_info_filename = str(config.params_filename) + ".info"
@@ -145,7 +147,7 @@ def _load_state_dict_from_save_params(model_path):
     # 3. construct state_dict
     load_param_dict = {}
     for var in load_var_list:
-        load_param_dict[var.name] = np.array(var)
+        load_param_dict[var.name] = np.array(var.cpu())
 
     return load_param_dict
 
@@ -290,13 +292,13 @@ def _pickle_save(obj, f, protocol):
         )
 
     def reduce_varbase(self):
-        data = np.array(self)
+        data = np.array(self.cpu())
         name = self.name
 
         return (tuple, ((name, data),))
 
     def reduce_LoDTensor(self):
-        data = np.array(self)
+        data = np.array(self._copy(paddle.CPUPlace()))
 
         return (eval, ('data', {'data': data}))
 
@@ -1108,7 +1110,7 @@ def load(path, **configs):
                 try:
                     tensor, _ = _load_lod_tensor(path)
                     if config.return_numpy:
-                        return np.array(tensor)
+                        return np.array(tensor._copy(paddle.CPUPlace()))
                     else:
                         if in_dygraph_mode():
                             return _lod_tensor2varbase(tensor)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->

Pcard-74613
先将Tensor拷贝到CPU再转numpy：
numpy会拷贝Tensor的所有显存，而不是按需拷贝，导致CUDA Tensor save时间太长。
tensor.cpu会调用phi::Copy。这里如果Tensor是不连续的，会转成连续。再做按需拷贝。