### PR TITLE
[IR] Fix inplace bug of add_grad cpu kernel

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -1034,7 +1034,7 @@ cc_library(
 cc_library(
   executor_cache
   SRCS executor_cache.cc
-  DEPS parallel_executor standalone_executor phi_kernel_adaptor
+  DEPS parallel_executor standalone_executor phi_kernel_adaptor pd_inplace_pass
        pd_op_to_kernel_pass ir)
 if(WITH_PSCORE)
   get_property(RPC_DEPS GLOBAL PROPERTY RPC_DEPS)

--- a/paddle/fluid/ir/transforms/inplace_pass.cc
+++ b/paddle/fluid/ir/transforms/inplace_pass.cc
@@ -328,4 +328,4 @@ std::unique_ptr<ir::Pass> CreateInplacePass() {
 
 }  // namespace ir
 
-REGISTER_PASS(inplace, InplacePass);
+REGISTER_IR_PASS(inplace, InplacePass);

--- a/paddle/ir/pass/pass_registry.h
+++ b/paddle/ir/pass/pass_registry.h
@@ -80,10 +80,10 @@ class PassRegistrar {
                 msg)
 
 // Register a new pass that can be applied on the IR.
-#define REGISTER_PASS(pass_type, pass_class)                                   \
+#define REGISTER_IR_PASS(pass_type, pass_class)                                \
   STATIC_ASSERT_PASS_GLOBAL_NAMESPACE(                                         \
       __reg_pass__##pass_type,                                                 \
-      "REGISTER_PASS must be called in global namespace");                     \
+      "REGISTER_IR_PASS must be called in global namespace");                  \
   static ::ir::PassRegistrar<pass_class> __pass_registrar_##pass_type##__(     \
       #pass_type);                                                             \
   int TouchPassRegistrar_##pass_type() {                                       \

--- a/paddle/ir/transforms/dead_code_elimination_pass.cc
+++ b/paddle/ir/transforms/dead_code_elimination_pass.cc
@@ -77,4 +77,4 @@ std::unique_ptr<Pass> CreateDeadCodeEliminationPass() {
 
 }  // namespace ir
 
-REGISTER_PASS(dead_code_elimination, DeadCodeEliminationPass);
+REGISTER_IR_PASS(dead_code_elimination, DeadCodeEliminationPass);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
优化 inplace 策略：add_grad cpu kernel 不进行 inplace，add_grad cpu kernel 的实现细节中，若 dx 与 dout 做 inplace，会清空 dx 的内存并重新分配，本质上是不可做 inplace 的，因此本 ir 在 inplace pass 中跳过 add_grad cpu kernel，详细可见：paddle/phi/kernels/funcs/elementwise_grad_base.h
### Other 
Pcard-67164
