### PR TITLE
[IR] fix getfaketensorlist bug

### DIFF
--- a/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/ir/transforms/pd_op_to_kernel_pass.cc
@@ -200,12 +200,12 @@ std::vector<std::shared_ptr<phi::TensorBase>> GetFakeTensorList(
   } else if (input_type.isa<ir::VectorType>()) {
     auto vec_inner_types = input_type.dyn_cast<ir::VectorType>().data();
     for (size_t i = 0; i < vec_inner_types.size(); ++i) {
-      if (vec_inner_types[0].isa<dialect::AllocatedDenseTensorType>()) {
+      if (vec_inner_types[i].isa<dialect::AllocatedDenseTensorType>()) {
         vec_res.push_back(build_fake_dense_tensor(
-            vec_inner_types[0].dyn_cast<dialect::AllocatedDenseTensorType>()));
-      } else if (vec_inner_types[0].isa<dialect::AllocatedSelectedRowsType>()) {
+            vec_inner_types[i].dyn_cast<dialect::AllocatedDenseTensorType>()));
+      } else if (vec_inner_types[i].isa<dialect::AllocatedSelectedRowsType>()) {
         vec_res.push_back(build_fake_selected_rows(
-            vec_inner_types[0].dyn_cast<dialect::AllocatedSelectedRowsType>()));
+            vec_inner_types[i].dyn_cast<dialect::AllocatedSelectedRowsType>()));
       }
     }
   }

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -637,7 +637,9 @@ class PartialProgramLayer:
             filter(_need_aggregation, self._outputs.tolist())
         )
         for _var in to_processed_vars:
-            _insert_aggregation_ops_for_var(target_program, _var)
+            target_program: paddle.static.Program
+            target_var = target_program.global_block().var(_var.name)
+            _insert_aggregation_ops_for_var(target_program, target_var)
 
     @switch_to_static_graph
     def _append_backward_desc(self, main_program):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
GetFakeTensorList去Tensor type时，对于vector的场景，应该去每个Tensor的type而不是第一个的

但是修改后发现新IR choose kernel失败。是由于动转静处理反向梯度聚合问题导致的。一并修复。

Pcard-67164