### PR TITLE
Fix unnecessary synchronized memcpy in hybrid parallel training

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -14,8 +14,6 @@
 
 import os
 
-import numpy as np
-
 import paddle
 from paddle import framework
 from paddle.autograd import no_grad
@@ -125,65 +123,56 @@ class HybridParallelClipGrad:
                     elif g.dtype == paddle.float32:
                         sum_square_not_dist_fp32.append(sum_square)
 
+        def async_add_n(var_list):
+            return paddle.stack(var_list).sum()
+
         # global norm of distributed FP16 params_and_grads
         if len(sum_square_dist_fp16) == 0:
-            global_norm_dist_fp16 = paddle.to_tensor(
-                np.array(0.0), dtype=paddle.float32
-            )
+            global_norm_dist_fp16 = paddle.zeros((1,), dtype=paddle.float32)
         else:
-            global_norm_dist_fp16 = paddle.add_n(sum_square_dist_fp16)
+            global_norm_dist_fp16 = async_add_n(sum_square_dist_fp16)
             global_norm_dist_fp16 = paddle.cast(
                 global_norm_dist_fp16, dtype=paddle.float32
             )
 
         # global norm of non-distributed FP16 params_and_grads
         if len(sum_square_not_dist_fp16) == 0:
-            global_norm_not_dist_fp16 = paddle.to_tensor(
-                np.array(0.0), dtype=paddle.float32
-            )
+            global_norm_not_dist_fp16 = paddle.zeros((1,), dtype=paddle.float32)
         else:
-            global_norm_not_dist_fp16 = paddle.add_n(sum_square_not_dist_fp16)
+            global_norm_not_dist_fp16 = async_add_n(sum_square_not_dist_fp16)
             global_norm_not_dist_fp16 = paddle.cast(
                 global_norm_not_dist_fp16, dtype=paddle.float32
             )
 
         # global norm of distributed BF16 params_and_grads
         if len(sum_square_dist_bf16) == 0:
-            global_norm_dist_bf16 = paddle.to_tensor(
-                np.array(0.0), dtype=paddle.float32
-            )
+            global_norm_dist_bf16 = paddle.zeros((1,), dtype=paddle.float32)
         else:
-            global_norm_dist_bf16 = paddle.add_n(sum_square_dist_bf16)
+            global_norm_dist_bf16 = async_add_n(sum_square_dist_bf16)
             global_norm_dist_bf16 = paddle.cast(
                 global_norm_dist_bf16, dtype=paddle.float32
             )
 
         # global norm of non-distributed FP16 params_and_grads
         if len(sum_square_not_dist_bf16) == 0:
-            global_norm_not_dist_bf16 = paddle.to_tensor(
-                np.array(0.0), dtype=paddle.float32
-            )
+            global_norm_not_dist_bf16 = paddle.zeros((1,), dtype=paddle.float32)
         else:
-            global_norm_not_dist_bf16 = paddle.add_n(sum_square_not_dist_bf16)
+            global_norm_not_dist_bf16 = async_add_n(sum_square_not_dist_bf16)
             global_norm_not_dist_bf16 = paddle.cast(
                 global_norm_not_dist_bf16, dtype=paddle.float32
             )
 
         # global norm of distributed FP32 params_and_grads
         if len(sum_square_dist_fp32) == 0:
-            global_norm_dist_fp32 = paddle.to_tensor(
-                np.array(0.0), dtype=paddle.float32
-            )
+            global_norm_dist_fp32 = paddle.zeros((1,), dtype=paddle.float32)
         else:
-            global_norm_dist_fp32 = paddle.add_n(sum_square_dist_fp32)
+            global_norm_dist_fp32 = async_add_n(sum_square_dist_fp32)
 
         # global norm of non-distributed FP32 params_and_grads
         if len(sum_square_not_dist_fp32) == 0:
-            global_norm_not_dist_fp32 = paddle.to_tensor(
-                np.array(0.0), dtype=paddle.float32
-            )
+            global_norm_not_dist_fp32 = paddle.zeros((1,), dtype=paddle.float32)
         else:
-            global_norm_not_dist_fp32 = paddle.add_n(sum_square_not_dist_fp32)
+            global_norm_not_dist_fp32 = async_add_n(sum_square_not_dist_fp32)
 
         global_norm_var_dist = (
             global_norm_dist_fp16
@@ -210,7 +199,7 @@ class HybridParallelClipGrad:
         clip_var = paddle.divide(
             x=max_global_norm,
             y=paddle.maximum(x=global_norm_var_fp32, y=max_global_norm)
-            + paddle.to_tensor(np.array(1.0e-6), dtype=paddle.float32),
+            + paddle.full(shape=[], dtype=paddle.float32, fill_value=1.0e-6),
         )
         clip_var_fp16 = paddle.cast(clip_var, paddle.float16)
 
@@ -322,7 +311,7 @@ class HybridParallelOptimizer:
             paddle.distributed.all_reduce(
                 sync_var, group=mp_group, sync_op=True
             )
-            sync_var.scale_(1.0 / mp_group.nranks)
+            sync_var.multiply_(1.0 / mp_group.nranks)
 
     def _filter_fn(self, param, strategy):
         p_name = param.name

--- a/python/paddle/distributed/fleet/utils/hybrid_parallel_util.py
+++ b/python/paddle/distributed/fleet/utils/hybrid_parallel_util.py
@@ -130,7 +130,7 @@ def _broadcast_data_help(data, shape, dtype, hcg):
     src_rank = hcg.get_model_parallel_group_src_rank()
     mp_rank = hcg.get_model_parallel_rank()
 
-    shape_gpu = paddle.to_tensor(shape, dtype="int32")
+    shape_gpu = shape._copy_to(data.place, False)
     paddle.distributed.broadcast(
         shape_gpu, src=src_rank, group=model_parallel_group, sync_op=True
     )
@@ -192,7 +192,7 @@ def broadcast_input_data(hcg, *inputs, **kwargs):
                     v_gpu = v._copy_to(place, True)
                     v._clear_data()
                     v_gpu._share_buffer_to(v)
-                _broadcast_data_help(v, v.shape, v.dtype, hcg)
+                _broadcast_data_help(v, paddle.shape(v), v.dtype, hcg)
         else:
             _broadcast_object_list_help(v, hcg)
 
@@ -203,7 +203,7 @@ def broadcast_input_data(hcg, *inputs, **kwargs):
                     v_gpu = v._copy_to(place, True)
                     v._clear_data()
                     v_gpu._share_buffer_to(v)
-                _broadcast_data_help(v, v.shape, v.dtype, hcg)
+                _broadcast_data_help(v, paddle.shape(v), v.dtype, hcg)
             kwargs[k] = v
         else:
             kwargs[k] = _broadcast_object_list_help(v, hcg)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
When training GPT model using PaddleNLP, there are some unnecessary synchronized `cudaMemcpy`. These copy operations come from various sources: GradClip, AdamW optimizer and input broadcasting in TP. Such synchronization results in GPU bubbles, which harms the GPU utilization. 

This PR removes the unnecessary synchronized `cudaMemcpy`. This optimization brings **1.6%** E2E speedup in GPT-5B model training.