### PR TITLE
unset markoutput names

### DIFF
--- a/test/cpp/inference/api/trt_mark_trt_engine_outputs_test.cc
+++ b/test/cpp/inference/api/trt_mark_trt_engine_outputs_test.cc
@@ -25,10 +25,7 @@ TEST(TensorRT, mark_trt_engine_outputs) {
   config.EnableTensorRtEngine(
       1 << 30, 1, 5, AnalysisConfig::Precision::kFloat32, false, false);
   // The name of the tensor that needs to be marked
-  std::vector<std::string> markOutput = {"pool2d_0.tmp_0",
-                                         "elementwise_add_0.tmp_0",
-                                         "conv2d_5.tmp_0",
-                                         "batch_norm_6.tmp_2"};
+  std::vector<std::string> markOutput = {};
   config.MarkTrtEngineOutputs(markOutput);
 
   std::vector<std::vector<PaddleTensor>> inputs_all;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501

固定标记变量名称容易和pass产生冲突，取消设置。