### PR TITLE
[XPU] use fp16 in adamw optimizer

### DIFF
--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -232,6 +232,9 @@ void DenseTensor::set_meta(const DenseTensorMeta& meta) {
   } else {
     meta_.strides = meta.strides;
   }
+#ifdef PADDLE_WITH_XPU
+  meta_.scale_value = meta.scale_value;
+#endif
 }
 
 /* @jim19930609: This interface will be further modified until we finalized the

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -392,6 +392,9 @@ DenseTensor& DenseTensor::ShareDataWith(const DenseTensor& src) {
   meta_.offset = src.meta_.offset;
   meta_.use_gpudnn = src.meta_.use_gpudnn;
   meta_.strides = src.meta_.strides;
+#ifdef PADDLE_WITH_XPU
+  meta_.scale_value = src.meta_.scale_value;
+#endif
   storage_properties_ =
       std::move(CopyStorageProperties(src.storage_properties_));
 #ifdef PADDLE_WITH_DNNL

--- a/paddle/phi/core/tensor_meta.cc
+++ b/paddle/phi/core/tensor_meta.cc
@@ -118,12 +118,20 @@ DDim DenseTensorMeta::calc_strides(const DDim& dims) {
   }
 }
 
-DenseTensorMeta::DenseTensorMeta() { use_gpudnn = true; }
+DenseTensorMeta::DenseTensorMeta() {
+  use_gpudnn = true;
+#ifdef PADDLE_WITH_XPU
+  scale_value = -1.0f;
+#endif
+}
 
 DenseTensorMeta::DenseTensorMeta(DataType dtype, const DDim& dims)
     : dims(dims), dtype(dtype) {
   strides = calc_strides(dims);
   use_gpudnn = true;
+#ifdef PADDLE_WITH_XPU
+  scale_value = -1.0f;
+#endif
 }
 
 DenseTensorMeta::DenseTensorMeta(DataType dtype,
@@ -131,6 +139,9 @@ DenseTensorMeta::DenseTensorMeta(DataType dtype,
                                  const DDim& strides)
     : dims(dims), dtype(dtype), strides(strides) {
   use_gpudnn = true;
+#ifdef PADDLE_WITH_XPU
+  scale_value = -1.0f;
+#endif
 }
 
 DenseTensorMeta::DenseTensorMeta(DataType dtype,
@@ -140,6 +151,9 @@ DenseTensorMeta::DenseTensorMeta(DataType dtype,
     : dims(dims), dtype(dtype), layout(layout), offset(offset) {
   strides = calc_strides(dims);
   use_gpudnn = true;
+#ifdef PADDLE_WITH_XPU
+  scale_value = -1.0f;
+#endif
 }
 
 DenseTensorMeta::DenseTensorMeta(DataType dtype,
@@ -150,6 +164,9 @@ DenseTensorMeta::DenseTensorMeta(DataType dtype,
     : dims(dims), dtype(dtype), layout(layout), lod(lod), offset(offset) {
   strides = calc_strides(dims);
   use_gpudnn = true;
+#ifdef PADDLE_WITH_XPU
+  scale_value = -1.0f;
+#endif
 }
 
 DenseTensorMeta::DenseTensorMeta(const DenseTensorMeta& other) {
@@ -165,6 +182,9 @@ DenseTensorMeta::DenseTensorMeta(const DenseTensorMeta& other) {
   } else {
     strides = other.strides;
   }
+#ifdef PADDLE_WITH_XPU
+  scale_value = other.scale_value;
+#endif
 }
 
 DenseTensorMeta& DenseTensorMeta::operator=(const DenseTensorMeta& other) {
@@ -180,6 +200,9 @@ DenseTensorMeta& DenseTensorMeta::operator=(const DenseTensorMeta& other) {
   } else {
     strides = other.strides;
   }
+#ifdef PADDLE_WITH_XPU
+  scale_value = other.scale_value;
+#endif
   return *this;
 }
 
@@ -197,7 +220,9 @@ DenseTensorMeta& DenseTensorMeta::operator=(  // NOLINT
   } else {
     strides = std::move(other.strides);
   }
-
+#ifdef PADDLE_WITH_XPU
+  scale_value = other.scale_value;
+#endif
   return *this;
 }
 

--- a/paddle/phi/core/tensor_meta.h
+++ b/paddle/phi/core/tensor_meta.h
@@ -82,13 +82,23 @@ struct DenseTensorMeta {
   LoD lod;
   size_t offset{0};
   DDim strides;
+
+#ifdef PADDLE_WITH_XPU
+  // for per tensor scale
+  float scale_value{-1.0f};
+#endif
 };
 
 inline bool operator==(const DenseTensorMeta& lhs, const DenseTensorMeta& rhs) {
   return (lhs.is_scalar == rhs.is_scalar) && lhs.use_gpudnn == rhs.use_gpudnn &&
          (lhs.dims == rhs.dims) && (lhs.dtype == rhs.dtype) &&
          (lhs.layout == rhs.layout) && (lhs.lod == rhs.lod) &&
+#ifdef PADDLE_WITH_XPU
+         (lhs.offset == rhs.offset) && (lhs.strides == rhs.strides) &&
+         (lhs.scale_value == rhs.scale_value);
+#else
          (lhs.offset == rhs.offset) && (lhs.strides == rhs.strides);
+#endif
 }
 
 struct StringTensorMeta {


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
`AdamW`优化器内部的`moment1`和`moment2`两个数据结构会分别占用一份和参数规模等长，并且类型是`float32`的空间。

实验发现在训练某些模型的时候，可以将这两个数据结构的类型调整成为`float16`，并且记录下来一个`scale_value`值以用来和`float32`类型之间互相转换。

目前仅在XPU下生效，通过`export xpu_adamw_moment_dtype="fp16"`来打开此功能。
