### PR TITLE
Optimize the calling logic of the cast and cast_grad kernels to reduce compilation size

### DIFF
--- a/paddle/phi/kernels/gpu/cast_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cast_grad_kernel.cu
@@ -26,7 +26,7 @@ void CastGradKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const DenseTensor& out_grad,
                     DenseTensor* x_grad) {
-  CastKernel<T, Context>(dev_ctx, out_grad, x->dtype(), x_grad);
+  CastKernel<T, Context>(dev_ctx, out_grad, x.dtype(), x_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/cast_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cast_grad_kernel.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/cast_grad_kernel.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/visit_type.h"
@@ -25,10 +26,7 @@ void CastGradKernel(const Context& dev_ctx,
                     const DenseTensor& x,
                     const DenseTensor& out_grad,
                     DenseTensor* x_grad) {
-  PD_VISIT_ALL_TYPES(x.dtype(), "CastCUDAKernelImpl", ([&] {
-                       CastCUDAKernelImpl<T, data_t>(
-                           dev_ctx, out_grad, x_grad->dtype(), x_grad);
-                     }));
+  CastKernel<T, Context>(dev_ctx, out_grad, x->dtype(), x_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/cast_impl.h
+++ b/paddle/phi/kernels/gpu/cast_impl.h
@@ -41,21 +41,15 @@ void CastCUDAKernelImpl(const GPUContext& dev_ctx,
       dev_ctx, inputs, &outputs, CastFunctor<InT, OutT>());
 }
 
-template <typename InT, typename OutT>
-void CastInplaceCUDAKernelImpl(const GPUContext& dev_ctx,
-                               const DenseTensor& x,
-                               DataType out_dtype,
-                               DenseTensor* out) {
-  std::vector<const DenseTensor*> inputs;
-  std::vector<DenseTensor*> outputs;
-  // inplace case
-  auto x_origin = x;
-  inputs.emplace_back(&x_origin);
-  outputs.emplace_back(out);
-  dev_ctx.Alloc<OutT>(out);
-  out->set_type(out_dtype);
-  phi::funcs::ElementwiseKernel<OutT>(
-      dev_ctx, inputs, &outputs, CastFunctor<InT, OutT>());
+template <typename InT>
+void CastCUDAKernel(const GPUContext& dev_ctx,
+                    const DenseTensor& x,
+                    DataType out_dtype,
+                    DenseTensor* out) {
+  PD_VISIT_ALL_TYPES(out_dtype, "CastCUDAKernelImpl", ([&] {
+                       CastCUDAKernelImpl<InT, data_t>(
+                           dev_ctx, x, out_dtype, out);
+                     }));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/cast_kernel.cu
+++ b/paddle/phi/kernels/gpu/cast_kernel.cu
@@ -17,7 +17,6 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/gpu/cast_impl.h"
-
 namespace phi {
 
 template <typename T, typename Context>
@@ -26,18 +25,12 @@ void CastKernel(const Context& dev_ctx,
                 DataType out_dtype,
                 DenseTensor* out) {
   if (out->IsSharedWith(x)) {
-    PD_VISIT_ALL_TYPES(out_dtype, "CastInplaceCUDAKernelImpl", ([&] {
-                         CastInplaceCUDAKernelImpl<T, data_t>(
-                             dev_ctx, x, out_dtype, out);
-                       }));
+    auto x_origin = x;
+    CastCUDAKernel<T>(dev_ctx, x_origin, out_dtype, out);
   } else {
-    PD_VISIT_ALL_TYPES(out_dtype, "CastCUDAKernelImpl", ([&] {
-                         CastCUDAKernelImpl<T, data_t>(
-                             dev_ctx, x, out_dtype, out);
-                       }));
+    CastCUDAKernel<T>(dev_ctx, x, out_dtype, out);
   }
 }
-
 }  // namespace phi
 
 #define PTEN_REGISTER_CAST_CUDA_BASE_TYPE(op_name, ...)        \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-70459
compile test 4.1
体积变化： 
<img width="817" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/51102941/cc870206-b4f2-40a2-afb6-e888504c22e3">
