### PR TITLE
[xdoctest] reformat example code with google style in No.339-No.343

### DIFF
--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -262,8 +262,8 @@ def monkey_patch_variable():
                 >>> import paddle
                 >>> import paddle.base as base
                 >>> paddle.enable_static()
-                >>> startup_prog = base.Program()
-                >>> main_prog = base.Program()
+                >>> startup_prog = paddle.static.Program()
+                >>> main_prog = paddle.static.Program()
                 >>> with base.program_guard(startup_prog, main_prog):
                 ...     original_variable = paddle.static.data(name = "new_variable", shape=[2,2], dtype='float32')
                 ...     new_variable = original_variable.astype('int64')
@@ -422,7 +422,7 @@ def monkey_patch_variable():
                 >>> x = paddle.static.data(name='x', shape=[3, 2, 1])
                 >>> # print the dimension of the Variable
                 >>> print(x.ndimension())
-                <bound method monkey_patch_variable.<locals>.<lambda> of var x : LOD_TENSOR.shape(3, 2, 1).dtype(float32).stop_gradient(True)>
+                3
         """
         return len(self.shape)
 
@@ -444,7 +444,7 @@ def monkey_patch_variable():
                 >>> x = paddle.static.data(name='x', shape=[3, 2, 1])
                 >>> # print the dimension of the Variable
                 >>> print(x.dim())
-                <bound method monkey_patch_variable.<locals>.<lambda> of var x : LOD_TENSOR.shape(3, 2, 1).dtype(float32).stop_gradient(True)>
+                3
         """
         return len(self.shape)
 

--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -76,15 +76,15 @@ class LayerHelperBase:
 
         Examples:
 
-         .. code-block:: python
+            .. code-block:: python
 
-            import numpy as np
-            import paddle.fluid as fluid
+                >>> import numpy as np
+                >>> import paddle.fluid as fluid
 
-            with fluid.dygraph.guard():
-                x = np.ones([2, 2], np.float32)
-                y = fluid.dygraph.to_variable(x)
-
+                >>> with fluid.dygraph.guard():
+                ...     x = np.ones([2, 2], np.float32)
+                ...     y = fluid.dygraph.to_variable(x)
+                ...
         """
         if isinstance(value, np.ndarray):
             return core.eager.Tensor(

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -147,11 +147,11 @@ def monkey_patch_variable():
 
             .. code-block:: python
 
-                import paddle
-                paddle.enable_static()
+                >>> import paddle
+                >>> paddle.enable_static()
 
-                x = paddle.static.data(name="x", shape=[2,2], dtype='float32')
-                y = x.cpu()
+                >>> x = paddle.static.data(name="x", shape=[2,2], dtype='float32')
+                >>> y = x.cpu()
         """
         block = current_block(self)
         tmp_name = unique_tmp_name()
@@ -194,12 +194,12 @@ def monkey_patch_variable():
 
             .. code-block:: python
 
-                import paddle
-                paddle.enable_static()
+                >>> import paddle
+                >>> paddle.enable_static()
 
-                x = paddle.static.data(name="x", shape=[2,2], dtype='float32')
-                y = x.cpu()
-                z = y.cuda()
+                >>> x = paddle.static.data(name="x", shape=[2,2], dtype='float32')
+                >>> y = x.cpu()
+                >>> z = y.cuda()
         """
         if device_id is not None:
             warnings.warn("device_id is not supported, and it will be ignored.")
@@ -258,30 +258,34 @@ def monkey_patch_variable():
             In Static Graph Mode:
 
             .. code-block:: python
-                import paddle
-                import paddle.fluid as fluid
-                paddle.enable_static()
-                startup_prog = fluid.Program()
-                main_prog = fluid.Program()
-                with fluid.program_guard(startup_prog, main_prog):
-                    original_variable = paddle.static.data(name = "new_variable", shape=[2,2], dtype='float32')
-                    new_variable = original_variable.astype('int64')
-                    print("new var's dtype is: {}".format(new_variable.dtype))
+                >>> import paddle
+                >>> import paddle.fluid as fluid
+                >>> paddle.enable_static()
+                >>> startup_prog = fluid.Program()
+                >>> main_prog = fluid.Program()
+                >>> with fluid.program_guard(startup_prog, main_prog):
+                ...     original_variable = paddle.static.data(name = "new_variable", shape=[2,2], dtype='float32')
+                ...     new_variable = original_variable.astype('int64')
+                ...     print("new var's dtype is: {}".format(new_variable.dtype))
+                ...
+                new var's dtype is: paddle.int64
 
             In Dygraph Mode:
 
             .. code-block:: python
 
-                import paddle.fluid as fluid
-                import numpy as np
+                >>> import paddle.fluid as fluid
+                >>> import numpy as np
 
-                x = np.ones([2, 2], np.float32)
-                with fluid.dygraph.guard():
-                    original_variable = fluid.dygraph.to_variable(x)
-                    print("original var's dtype is: {}, numpy dtype is {}".format(original_variable.dtype, original_variable.numpy().dtype))
-                    new_variable = original_variable.astype('int64')
-                    print("new var's dtype is: {}, numpy dtype is {}".format(new_variable.dtype, new_variable.numpy().dtype))
-
+                >>> x = np.ones([2, 2], np.float32)
+                >>> with fluid.dygraph.guard():
+                ...     original_variable = fluid.dygraph.to_variable(x)
+                ...     print("original var's dtype is: {}, numpy dtype is {}".format(original_variable.dtype, original_variable.numpy().dtype))
+                ...     new_variable = original_variable.astype('int64')
+                ...     print("new var's dtype is: {}, numpy dtype is {}".format(new_variable.dtype, new_variable.numpy().dtype))
+                ...
+                original var's dtype is: paddle.float32, numpy dtype is float32
+                new var's dtype is: paddle.int64, numpy dtype is int64
         """
         block = current_block(self)
         out = create_new_tmp_var(block, dtype)
@@ -387,14 +391,15 @@ def monkey_patch_variable():
         Examples:
             .. code-block:: python
 
-                import paddle
+                >>> import paddle
 
-                paddle.enable_static()
+                >>> paddle.enable_static()
 
-                # create a static Variable
-                x = paddle.static.data(name='x', shape=[3, 2, 1])
-                # print the dimension of the Variable
-                print(x.ndim)
+                >>> # create a static Variable
+                >>> x = paddle.static.data(name='x', shape=[3, 2, 1])
+                >>> # print the dimension of the Variable
+                >>> print(x.ndim)
+                3
         """
         return len(self.shape)
 
@@ -408,14 +413,15 @@ def monkey_patch_variable():
         Examples:
             .. code-block:: python
 
-                import paddle
+                >>> import paddle
 
-                paddle.enable_static()
+                >>> paddle.enable_static()
 
-                # create a static Variable
-                x = paddle.static.data(name='x', shape=[3, 2, 1])
-                # print the dimension of the Variable
-                print(x.ndimension)
+                >>> # create a static Variable
+                >>> x = paddle.static.data(name='x', shape=[3, 2, 1])
+                >>> # print the dimension of the Variable
+                >>> print(x.ndimension)
+                <bound method monkey_patch_variable.<locals>.<lambda> of var x : LOD_TENSOR.shape(3, 2, 1).dtype(float32).stop_gradient(True)>
         """
         return len(self.shape)
 
@@ -429,14 +435,15 @@ def monkey_patch_variable():
         Examples:
             .. code-block:: python
 
-                import paddle
+                >>> import paddle
 
-                paddle.enable_static()
+                >>> paddle.enable_static()
 
-                # create a static Variable
-                x = paddle.static.data(name='x', shape=[3, 2, 1])
-                # print the dimension of the Variable
-                print(x.dim)
+                >>> # create a static Variable
+                >>> x = paddle.static.data(name='x', shape=[3, 2, 1])
+                >>> # print the dimension of the Variable
+                >>> print(x.dim)
+                <bound method monkey_patch_variable.<locals>.<lambda> of var x : LOD_TENSOR.shape(3, 2, 1).dtype(float32).stop_gradient(True)>
         """
         return len(self.shape)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
修改如下文件的示例代码为新的格式，并通过 xdoctest 检查：
- python/paddle/fluid/io.py
- python/paddle/fluid/layer_helper_base.py 
- python/paddle/fluid/layers/control_flow.py 
- python/paddle/fluid/layers/learning_rate_scheduler.py
- python/paddle/fluid/layers/math_op_patch.py

其中：
- io.py没有涉及到sample code；
- python/paddle/fluid/layers/control_flow.py  已经被迁移到 python/paddle/static/nn/control_flow.py；
- learning_rate_scheduler.py已经被删除

@sunzhongkai588 @SigureMo @megemini
- https://github.com/PaddlePaddle/Paddle/issues/55629








<br class="Apple-interchange-newline">
