### PR TITLE
refine paddle_flags error message about flag multiple definition

### DIFF
--- a/paddle/utils/flags_native.cc
+++ b/paddle/utils/flags_native.cc
@@ -297,8 +297,9 @@ void Flag::SetValueFromString(const std::string& value) {
 void FlagRegistry::RegisterFlag(Flag* flag) {
   auto iter = flags_.find(flag->name_);
   if (iter != flags_.end()) {
-    LOG_FLAG_FATAL_ERROR("illegal RegisterFlag, flag \"" + flag->name_ +
-                         "\" has been defined in " + iter->second->file_);
+    LOG_FLAG_FATAL_ERROR("flag multiple definition, flag \"" + flag->name_ +
+                         "\" was defined both in " + iter->second->file_ +
+                         " and " + flag->file_);
   } else {
     std::lock_guard<std::mutex> lock(mutex_);
     flags_[flag->name_] = flag;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- 修改重复注册 flag 的报错信息
- 修改后的效果：
``` bash
paddle flags error: flag multiple definition, flag "paddle_num_threads" was defined both in /home/huangjiyi/code/parallel/Paddle/paddle/phi/core/flags.cc and /home/huangjiyi/code/parallel/Paddle/paddle/utils/flags_native_test.cc (at /home/huangjiyi/code/parallel/Paddle/paddle/utils/flags_native.cc:300)
```
