### PR TITLE
fix to tensor return nested structure

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -680,8 +680,6 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
                             d, dtype, stop_gradient
                         )
                     data = paddle.stack(to_stack_list)
-                    data = paddle.squeeze(data, -1)
-
             else:
                 raise RuntimeError(
                     f"Do not support transform type `{type(data)}` to tensor"

--- a/test/dygraph_to_static/test_cpu_cuda_to_tensor.py
+++ b/test/dygraph_to_static/test_cpu_cuda_to_tensor.py
@@ -73,7 +73,7 @@ class TestToTensor1(unittest.TestCase):
         x = paddle.to_tensor([3])
         np.testing.assert_allclose(
             paddle.jit.to_static(func)(x).numpy(),
-            np.array([1, 2, 3, 4]),
+            np.array([[1], [2], [3], [4]]),
             rtol=1e-05,
         )
 

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -15,11 +15,7 @@
 import unittest
 
 import numpy
-from dygraph_to_static_util import (
-    ast_only_test,
-    dy2static_unittest,
-    sot_only_test,
-)
+from dygraph_to_static_util import dy2static_unittest
 
 import paddle
 from paddle.base import core
@@ -154,7 +150,6 @@ class TestToTensorReturnVal(unittest.TestCase):
         self.assertTrue(a.stop_gradient == b.stop_gradient)
         self.assertTrue(a.place._equals(b.place))
 
-    @ast_only_test
     def test_to_tensor_err_log(self):
         paddle.disable_static()
         x = paddle.to_tensor([3])
@@ -163,18 +158,6 @@ class TestToTensorReturnVal(unittest.TestCase):
         except Exception as e:
             self.assertTrue(
                 "Do not support transform type `<class 'dict'>` to tensor"
-                in str(e)
-            )
-
-    @sot_only_test
-    def test_to_tensor_err_log_sot(self):
-        paddle.disable_static()
-        x = paddle.to_tensor([3])
-        try:
-            a = paddle.jit.to_static(case8)(x)
-        except Exception as e:
-            self.assertTrue(
-                "Can't constructs a 'paddle.Tensor' with data type <class 'dict'>"
                 in str(e)
             )
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
fix bug when input has nested structure, to_tensor will loss struct information

### Others

PCard-66972