### PR TITLE
[PHI]Fix cub bugs when use PHI shared lib in CUDA12

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -5,6 +5,12 @@ endif()
 #(risemeup1) note: CMake 3.18 needs to specify the value of CMAKE_CUDA_ARCHITECTURES，otherwise a large number of warnings may appear in cmake
 set(CMAKE_CUDA_ARCHITECTURES OFF)
 
+if(${CMAKE_CUDA_COMPILER_VERSION} GREATER 11.2)
+  # The reduce result of cub is wrong in cuda12, we workaround it by wrapping CUB/Thrust namespaces in each library:
+  # refer:https://github.com/NVIDIA/cub/issues/719
+  add_definitions(-DCUB_WRAPPED_NAMESPACE=CUB_COMPATIBLE)
+endif()
+
 if(WITH_NV_JETSON)
   add_definitions(-DWITH_NV_JETSON)
   set(paddle_known_gpu_archs "53 62 72")

--- a/paddle/fluid/inference/tensorrt/plugin/common/common.cuh
+++ b/paddle/fluid/inference/tensorrt/plugin/common/common.cuh
@@ -20,6 +20,10 @@
 #include "cublas_v2.h"
 #include "paddle/fluid/platform/device_context.h"
 
+#if CUDA_VERSION >= 11020
+  namespace cub = CUB_COMPATIBLE::cub;
+#endif
+
 using kv_float = cub::KeyValuePair<float, float>;
 using kv_half = cub::KeyValuePair<half, half>;
 using kv_half2 = cub::KeyValuePair<half2, half2>;
@@ -32,7 +36,11 @@ __device__ inline float rsqrt(const float& x) {
   return rsqrtf(x);
 }
 
+#if CUDA_VERSION >= 11020
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 __host__ __device__ inline kv_float operator+(const kv_float& a, const kv_float& b) {
   return kv_float(a.key + b.key, a.value + b.value);
 }

--- a/paddle/fluid/inference/tensorrt/plugin/transformer_input_output_convert_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/transformer_input_output_convert_plugin.cu
@@ -19,6 +19,10 @@ limitations under the License. */
 #include "cub/cub.cuh"
 #include "paddle/fluid/inference/tensorrt/plugin/transformer_input_output_convert_plugin.h"
 
+#if CUDA_VERSION >= 11020
+namespace cub = CUB_COMPATIBLE::cub;
+#endif
+
 namespace paddle {
 namespace inference {
 namespace tensorrt {

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -26,6 +26,10 @@ limitations under the License. */
 #include "dnnl.hpp"  // NOLINT
 #endif
 
+#if CUDA_VERSION >= 11020
+namespace cub = CUB_COMPATIBLE::cub;
+#endif
+
 namespace phi {
 
 class DenseTensorUtils;

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -68,7 +68,11 @@ struct float_bit_mask<phi::dtype::bfloat16>
 namespace cub = hipcub;
 #else
 // set cub base traits in order to handle float16
+#if CUDA_VERSION >= 11020
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
@@ -78,7 +82,7 @@ struct NumericTraits<phi::dtype::bfloat16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
 };
 
-}  // namespace cub
+}  // namespace CUB_COMPATIBLE::cub
 #endif
 
 namespace phi {

--- a/paddle/phi/kernels/gpu/argsort_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_grad_kernel.cu
@@ -46,7 +46,11 @@ struct radix_key_codec_base<phi::dtype::bfloat16>
 }  // namespace rocprim
 #else
 // set cub base traits in order to handle float16
+#if CUDA_VERSION >= 11020
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
@@ -55,7 +59,7 @@ template <>
 struct NumericTraits<phi::dtype::bfloat16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
 };
-}  // namespace cub
+}  // namespace CUB_COMPATIBLE::cub
 #endif
 
 namespace phi {

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -57,7 +57,11 @@ struct float_bit_mask<phi::dtype::bfloat16>
 }  // namespace rocprim
 #else
 // set cub base traits in order to handle float16
+#if CUDA_VERSION >= 11020
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
@@ -66,7 +70,7 @@ template <>
 struct NumericTraits<phi::dtype::bfloat16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
 };
-}  // namespace cub
+}  // namespace CUB_COMPATIBLE::cub
 
 #endif
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复在cuda12环境下使用phi动态库，三方库cub造成的reduce精度问题