### PR TITLE
[CodeStyle][ruff] update ruff v0.0.287 and fix F401

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     -   id: flake8
         args: ["--config=.flake8"]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.272
+    rev: v0.0.287
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,25 @@ ignore = [
     "UP015",
     # It will cause the performance regression on python3.10
     "UP038",
+
+    "F403", # Open Later
+    "F522", # Open Later
+    "F811", # Open Later
+    "F821", # Open Later
+    "C408", # Open Later
+    "C403", # Open Later
+    "C405", # Open Later
+    "C417", # Open Later
+    "C411", # Open Later
+    "C416", # Open Later
+    "UP032", # Open Later
+    "UP015", # Open Later
+    "UP018", # Open Later
+    "UP031", # Open Later
+    "UP030", # Open Later
+    "UP028", # Open Later
+    "UP034", # Open Later
+    "UP004", # Open Later
 ]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,14 @@ select = [
 
     # NumPy-specific rules
     "NPY001",
+    # "NPY003",
 
     # Bugbear
     "B002",
     "B003",
     "B004",
+    # "B006", # To be confirmed
+    # "B007",
     "B009",
     "B010",
     "B011",
@@ -69,6 +72,10 @@ select = [
     "PLC3002",
     "PLR0206",
     "PLR0402",
+    # "PLR1701",
+    # "PLR1711",
+    # "PLR1722",
+    # "PLW3301",
 ]
 unfixable = [
     "NPY001"

--- a/python/paddle/base/compiler.py
+++ b/python/paddle/base/compiler.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import multiprocessing
-import os
 import sys
 import warnings
 from . import framework
-from .framework import _get_paddle_place, _get_paddle_place_list
+from .framework import _get_paddle_place, _get_paddle_place_list  # noqa: F401
 from .framework import cuda_places, cpu_places, xpu_places
 from . import core
 

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -17,7 +17,6 @@ import sys
 import os
 import warnings
 import platform
-import logging
 
 has_paddle_dy_lib = False
 
@@ -280,34 +279,45 @@ try:
     libpaddle.LoDTensor = libpaddle.Tensor
 
     from .libpaddle import *
-    from .libpaddle import __doc__, __file__, __name__, __package__
-    from .libpaddle import __unittest_throw_exception__
-    from .libpaddle import _append_python_callable_object_and_return_id
-    from .libpaddle import _cleanup, _Scope
-    from .libpaddle import _get_use_default_grad_op_desc_maker_ops
-    from .libpaddle import _get_all_register_op_kernels
-    from .libpaddle import _get_registered_phi_kernels
-    from .libpaddle import _is_program_version_supported
-    from .libpaddle import _set_eager_deletion_mode
-    from .libpaddle import _get_eager_deletion_vars
-    from .libpaddle import _set_fuse_parameter_group_size
-    from .libpaddle import _set_fuse_parameter_memory_size
-    from .libpaddle import _is_dygraph_debug_enabled
-    from .libpaddle import _dygraph_debug_level
-    from .libpaddle import _switch_tracer
+    from .libpaddle import (
+        __doc__,
+        __file__,
+        __name__,
+        __package__,
+    )  # noqa: F401
+    from .libpaddle import __unittest_throw_exception__  # noqa: F401
+    from .libpaddle import (
+        _append_python_callable_object_and_return_id,
+    )  # noqa: F401
+    from .libpaddle import _cleanup, _Scope  # noqa: F401
+    from .libpaddle import _get_use_default_grad_op_desc_maker_ops  # noqa: F401
+    from .libpaddle import _get_all_register_op_kernels  # noqa: F401
+    from .libpaddle import _get_registered_phi_kernels  # noqa: F401
+    from .libpaddle import _is_program_version_supported  # noqa: F401
+    from .libpaddle import _set_eager_deletion_mode  # noqa: F401
+    from .libpaddle import _get_eager_deletion_vars  # noqa: F401
+    from .libpaddle import _set_fuse_parameter_group_size  # noqa: F401
+    from .libpaddle import _set_fuse_parameter_memory_size  # noqa: F401
+    from .libpaddle import _is_dygraph_debug_enabled  # noqa: F401
+    from .libpaddle import _dygraph_debug_level  # noqa: F401
+    from .libpaddle import _switch_tracer  # noqa: F401
     from .libpaddle import _set_paddle_lib_path
-    from .libpaddle import _create_loaded_parameter
-    from .libpaddle import _cuda_synchronize
-    from .libpaddle import _test_enforce_gpu_success
-    from .libpaddle import _is_compiled_with_heterps
-    from .libpaddle import _promote_types_if_complex_exists
-    from .libpaddle import _set_cached_executor_build_strategy
-    from .libpaddle import _device_synchronize
-    from .libpaddle import _xpu_device_synchronize
-    from .libpaddle import _get_current_stream
-    from .libpaddle import _Profiler, _ProfilerResult, _RecordEvent
-    from .libpaddle import _set_current_stream
-    from .libpaddle import _get_phi_kernel_name
+    from .libpaddle import _create_loaded_parameter  # noqa: F401
+    from .libpaddle import _cuda_synchronize  # noqa: F401
+    from .libpaddle import _test_enforce_gpu_success  # noqa: F401
+    from .libpaddle import _is_compiled_with_heterps  # noqa: F401
+    from .libpaddle import _promote_types_if_complex_exists  # noqa: F401
+    from .libpaddle import _set_cached_executor_build_strategy  # noqa: F401
+    from .libpaddle import _device_synchronize  # noqa: F401
+    from .libpaddle import _xpu_device_synchronize  # noqa: F401
+    from .libpaddle import _get_current_stream  # noqa: F401
+    from .libpaddle import (
+        _Profiler,
+        _ProfilerResult,
+        _RecordEvent,
+    )  # noqa: F401
+    from .libpaddle import _set_current_stream  # noqa: F401
+    from .libpaddle import _get_phi_kernel_name  # noqa: F401
 
     # prim controller flags
     from .libpaddle import __set_bwd_prim_enabled
@@ -317,31 +327,33 @@ try:
     from .libpaddle import __set_all_prim_enabled
     from .libpaddle import _is_eager_prim_enabled
     from .libpaddle import __set_eager_prim_enabled
-    from .libpaddle import _set_prim_target_grad_name
-    from .libpaddle import _add_skip_comp_ops
+    from .libpaddle import _set_prim_target_grad_name  # noqa: F401
+    from .libpaddle import _add_skip_comp_ops  # noqa: F401
     from .libpaddle import _set_bwd_prim_blacklist
-    from .libpaddle import _remove_skip_comp_ops
+    from .libpaddle import _remove_skip_comp_ops  # noqa: F401
 
     # custom devivce
-    from .libpaddle import _get_current_custom_device_stream
-    from .libpaddle import _set_current_custom_device_stream
-    from .libpaddle import _synchronize_custom_device
-    from .libpaddle import CustomDeviceStream
-    from .libpaddle import CustomDeviceEvent
+    from .libpaddle import _get_current_custom_device_stream  # noqa: F401
+    from .libpaddle import _set_current_custom_device_stream  # noqa: F401
+    from .libpaddle import _synchronize_custom_device  # noqa: F401
+    from .libpaddle import CustomDeviceStream  # noqa: F401
+    from .libpaddle import CustomDeviceEvent  # noqa: F401
 
     if sys.platform != 'win32':
-        from .libpaddle import _set_process_pids
-        from .libpaddle import _erase_process_pids
-        from .libpaddle import _set_process_signal_handler
-        from .libpaddle import _throw_error_if_process_failed
-        from .libpaddle import _convert_to_tensor_list
-        from .libpaddle import _array_to_share_memory_tensor
-        from .libpaddle import _cleanup_mmap_fds
-        from .libpaddle import _remove_tensor_list_mmap_fds
-        from .libpaddle import _set_max_memory_map_allocation_pool_size
+        from .libpaddle import _set_process_pids  # noqa: F401
+        from .libpaddle import _erase_process_pids  # noqa: F401
+        from .libpaddle import _set_process_signal_handler  # noqa: F401
+        from .libpaddle import _throw_error_if_process_failed  # noqa: F401
+        from .libpaddle import _convert_to_tensor_list  # noqa: F401
+        from .libpaddle import _array_to_share_memory_tensor  # noqa: F401
+        from .libpaddle import _cleanup_mmap_fds  # noqa: F401
+        from .libpaddle import _remove_tensor_list_mmap_fds  # noqa: F401
+        from .libpaddle import (
+            _set_max_memory_map_allocation_pool_size,
+        )  # noqa: F401
 
     # CINN
-    from .libpaddle import is_run_with_cinn
+    from .libpaddle import is_run_with_cinn  # noqa: F401
 
 except Exception as e:
     if has_paddle_dy_lib:

--- a/python/paddle/base/data_feeder.py
+++ b/python/paddle/base/data_feeder.py
@@ -14,8 +14,6 @@
 
 from . import core
 import numpy as np
-import os
-import multiprocessing
 import warnings
 import struct
 
@@ -23,7 +21,7 @@ from .framework import (
     Variable,
     default_main_program,
     in_dygraph_mode,
-    _current_expected_place,
+    _current_expected_place,  # noqa: F401
 )
 from .framework import _cpu_num, _cuda_ids
 

--- a/python/paddle/base/device_worker.py
+++ b/python/paddle/base/device_worker.py
@@ -623,7 +623,6 @@ class Section(DeviceWorker):
         Args:
             trainer_desc(TrainerDesc): a TrainerDesc object
         """
-        from google.protobuf import text_format
         from . import core
 
         trainer_desc.device_worker_name = "SectionWorker"
@@ -671,8 +670,6 @@ class HeterSection(DeviceWorker):
         Args:
             trainer_desc(TrainerDesc): a TrainerDesc object
         """
-        from google.protobuf import text_format
-        from . import core
 
         trainer_desc.device_worker_name = "HeterSectionWorker"
         heter_pipeline_opt = self._program._heter_pipeline_opt

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 from .. import core
-from ..framework import (
+from ..framework import (  # noqa: F401
     Variable,
     convert_np_dtype_to_dtype_,
     in_dygraph_mode,
 )
-from ..framework import _create_tensor as framework_create_tensor
-from ..layers.layer_function_generator import OpProtoHolder
-from . import no_grad
-from .. import framework
+from ..framework import _create_tensor as framework_create_tensor  # noqa: F401
+from ..layers.layer_function_generator import OpProtoHolder  # noqa: F401
+from . import no_grad  # noqa: F401
+from .. import framework  # noqa: F401
 
 import numpy as np
-import warnings
 from paddle import _C_ops, _legacy_C_ops
 
 _supported_int_dtype_ = [

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -15,7 +15,6 @@
 import inspect
 import numpy as np
 import warnings
-import weakref
 import sys
 
 import paddle
@@ -23,7 +22,7 @@ from .. import framework
 from ..framework import convert_np_dtype_to_dtype_
 from .. import core
 from .. import unique_name
-from ..framework import (
+from ..framework import (  # noqa: F401
     Variable,
     Parameter,
     _getitem_static,
@@ -32,8 +31,8 @@ from ..framework import (
     EagerParamBase,
     in_dygraph_mode,
 )
-from .base import switch_to_static_graph
-from .math_op_patch import monkey_patch_math_tensor
+from .base import switch_to_static_graph  # noqa: F401
+from .math_op_patch import monkey_patch_math_tensor  # noqa: F401
 from paddle.base.data_feeder import (
     convert_uint16_to_float,
     _PADDLE_DTYPE_2_NUMPY_DTYPE,
@@ -41,9 +40,9 @@ from paddle.base.data_feeder import (
 import paddle.utils.deprecated as deprecated
 import paddle.profiler as profiler
 from paddle.profiler.utils import in_profiler_mode
-from paddle import _C_ops, _legacy_C_ops
-from paddle.device import get_all_custom_device_type
-from paddle.base.framework import _global_flags
+from paddle import _C_ops, _legacy_C_ops  # noqa: F401
+from paddle.device import get_all_custom_device_type  # noqa: F401
+from paddle.base.framework import _global_flags  # noqa: F401
 
 _grad_scalar = None
 

--- a/python/paddle/base/dygraph/tracer.py
+++ b/python/paddle/base/dygraph/tracer.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
-
-import numpy as np
 
 from paddle.base import core
 from paddle.base import framework

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -14,7 +14,6 @@
 
 import logging
 import os
-import multiprocessing
 import sys
 import warnings
 import numpy as np
@@ -42,7 +41,7 @@ from .trainer_factory import FetchHandlerMonitor
 import copy
 from . import framework
 from .incubate.checkpoint import auto_checkpoint as acp
-from .compiler import _prune_feed_ops
+from .compiler import _prune_feed_ops  # noqa: F401
 
 from functools import lru_cache
 

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -14,9 +14,7 @@
 
 import textwrap
 import collections
-from collections import defaultdict
 from collections.abc import Iterable
-import contextlib
 from .wrapped_decorator import signature_safe_contextmanager, wrap_decorator
 import os
 import re
@@ -28,9 +26,8 @@ import numpy as np
 import subprocess
 import multiprocessing
 import sys
-import logging
 
-from .proto import framework_pb2, data_feed_pb2
+from .proto import framework_pb2
 
 from . import core
 from . import unique_name

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -26,6 +26,7 @@ import numpy as np
 import subprocess
 import multiprocessing
 import sys
+import logging  # noqa: F401
 
 from .proto import framework_pb2
 

--- a/python/paddle/base/incubate/checkpoint/auto_checkpoint.py
+++ b/python/paddle/base/incubate/checkpoint/auto_checkpoint.py
@@ -14,13 +14,10 @@
 
 import sys
 import logging
-import hashlib
 import json
 import os
 import time
-import collections
-from threading import Thread, current_thread
-from contextlib import contextmanager
+from threading import current_thread
 
 from paddle.base import unique_name, compiler
 from .checkpoint_saver import SerializableBase, CheckpointSaver, PaddleModel

--- a/python/paddle/base/initializer.py
+++ b/python/paddle/base/initializer.py
@@ -12,21 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-import functools
-from . import framework
-from . import core
-from .framework import (
+from . import framework  # noqa: F401
+from . import core  # noqa: F401
+from .framework import (  # noqa: F401
     in_dygraph_mode,
     default_main_program,
     _current_expected_place,
 )
-from .framework import program_guard
-import numpy as np
-from .core import VarDesc
-from . import unique_name
-from .data_feeder import check_variable_and_dtype, check_type, check_dtype
-from paddle import _C_ops, _legacy_C_ops
+from .framework import program_guard  # noqa: F401
+from .core import VarDesc  # noqa: F401
+from . import unique_name  # noqa: F401
+from .data_feeder import (
+    check_variable_and_dtype,
+    check_type,
+    check_dtype,
+)  # noqa: F401
+from paddle import _C_ops, _legacy_C_ops  # noqa: F401
 import paddle
 
 __all__ = ['set_global_initializer']

--- a/python/paddle/base/io.py
+++ b/python/paddle/base/io.py
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import errno
-import warnings
 import logging
-import pickle
-import contextlib
-from functools import reduce
-import sys
-from io import BytesIO
 
-import numpy as np
-import math
-import paddle
-from paddle.base import layers
-from paddle.base.executor import Executor, global_scope
-from paddle.base.framework import (
+import numpy as np  # noqa: F401
+from paddle.base import layers  # noqa: F401
+from paddle.base.executor import Executor, global_scope  # noqa: F401
+from paddle.base.framework import (  # noqa: F401
     Program,
     Parameter,
     default_main_program,
@@ -37,7 +27,7 @@ from paddle.base.framework import (
     dygraph_not_support,
     static_only,
 )
-from paddle.reader import (
+from paddle.reader import (  # noqa: F401
     cache,
     map_readers,
     buffered,
@@ -49,15 +39,15 @@ from paddle.reader import (
     xmap_readers,
     multiprocess_reader,
 )
-from .wrapped_decorator import signature_safe_contextmanager
-from paddle.base.compiler import CompiledProgram
-from paddle.base.log_helper import get_logger
-from . import reader
-from . import unique_name
-from .reader import *
-from . import core
-from paddle.utils import deprecated
-from paddle.base.framework import static_only
+from .wrapped_decorator import signature_safe_contextmanager  # noqa: F401
+from paddle.base.compiler import CompiledProgram  # noqa: F401
+from paddle.base.log_helper import get_logger  # noqa: F401
+from . import reader  # noqa: F401
+from . import unique_name  # noqa: F401
+from .reader import *  # noqa: F401
+from . import core  # noqa: F401
+from paddle.utils import deprecated  # noqa: F401
+from paddle.base.framework import static_only  # noqa: F401
 
 __all__ = reader.__all__
 

--- a/python/paddle/base/layer_helper.py
+++ b/python/paddle/base/layer_helper.py
@@ -18,12 +18,10 @@ from .framework import (
     Parameter,
     dtype_is_floating,
     in_dygraph_mode,
-    OpProtoHolder,
     _global_flags,
 )
 from . import unique_name
 from .param_attr import ParamAttr
-from . import core
 
 from .layer_helper_base import LayerHelperBase
 from .dygraph_utils import _append_activation_in_dygraph

--- a/python/paddle/base/layers/layer_function_generator.py
+++ b/python/paddle/base/layers/layer_function_generator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import re
-import functools
 import warnings
 import string
 

--- a/python/paddle/base/reader.py
+++ b/python/paddle/base/reader.py
@@ -17,26 +17,20 @@ import sys
 import numpy as np
 import threading
 import paddle
-import time
-import copy
 
 from .framework import (
     Program,
-    Variable,
     program_guard,
     default_main_program,
     default_startup_program,
     in_dygraph_mode,
-    cpu_places,
     _current_expected_place,
 )
 from .executor import global_scope
 from .data_feeder import DataFeeder, BatchedTensorProvider
 from .multiprocess_utils import (
-    multiprocess_queue_set,
     CleanupFuncRegistrar,
     _cleanup_mmap,
-    _cleanup,
     _set_SIGCHLD_handler,
 )
 from .layers.io import (
@@ -51,9 +45,7 @@ import logging
 import warnings
 
 ### Dygraph DataLoader configs ###
-import os
 import multiprocessing
-import signal
 
 import queue
 

--- a/python/paddle/base/trainer_desc.py
+++ b/python/paddle/base/trainer_desc.py
@@ -305,8 +305,6 @@ class TrainerDesc:
         )
 
     def _desc(self):
-        from google.protobuf import text_format
-
         return self.proto_desc.SerializeToString()
 
     def __str__(self):

--- a/python/paddle/base/trainer_factory.py
+++ b/python/paddle/base/trainer_factory.py
@@ -25,22 +25,11 @@ local_logger = get_logger(
 
 from .trainer_desc import (
     MultiTrainer,
-    DistMultiTrainer,
-    PipelineTrainer,
-    HeterXpuTrainer,
-    PSGPUTrainer,
-    HeterPipelineTrainer,
 )
 from .device_worker import (
     Hogwild,
-    DownpourSGD,
-    DownpourLite,
-    Section,
-    DownpourSGDOPT,
-    HeterSection,
 )
 from .framework import Variable
-from multiprocessing import Process, Manager
 
 __all__ = ["TrainerFactory", "FetchHandlerMonitor"]
 

--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import numpy as np
 from . import unique_name
 from . import core
@@ -373,7 +372,6 @@ def _setitem_for_tensor_array(var, item, value):
         from paddle.jit.dy2static.variable_trans_func import (
             to_static_variable,
         )
-        from paddle import cast
         from paddle.tensor import array_write
 
         item = paddle.cast(to_static_variable(item), dtype='int64')

--- a/test/legacy_test/test_math_op_patch.py
+++ b/test/legacy_test/test_math_op_patch.py
@@ -14,7 +14,6 @@
 
 import unittest
 
-import numpy
 import numpy as np
 from decorator_helper import prog_scope
 

--- a/test/legacy_test/test_rnn_cell_api.py
+++ b/test/legacy_test/test_rnn_cell_api.py
@@ -15,7 +15,6 @@
 import sys
 import unittest
 
-import numpy
 import numpy as np
 
 sys.path.append("../../test/rnn")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

## 第一阶段

### 存量统计

升级`ruff` 至 v0.0.287 并新增检查

```bash
ruff --select UP . --statistics
873	UP032	[*] Use f-string instead of `format` call
172	UP015	[*] Unnecessary open mode parameters
 43	UP018	[*] Unnecessary `bool` call (rewrite as a literal)
  7	UP028	[*] Replace `yield` over `for` loop with `yield from`
  1	UP004	[*] Class `Event` inherits from `object`
```

```bash
ruff --select PL . --statistics
2506	PLR2004	[ ] Magic value used in comparison, consider replacing -0.5 with a constant variable
1662	PLR0913	[ ] Too many arguments to function call (10 > 5)
 565	PLR0912	[ ] Too many branches (13 > 12)
 539	PLR0915	[ ] Too many statements (100 > 50)
 366	PLW2901	[ ] Outer `for` loop variable `i` overwritten by inner `for` loop target
 281	PLR1714	[ ] Consider merging multiple comparisons. Use a `set` if the elements are hashable.
 254	PLR5501	[ ] Use `elif` instead of `else` then `if`, to reduce indentation
 204	PLW0603	[ ] Using the global statement to update `CATEGORIES_DICT` is discouraged
 140	PLR1711	[*] Useless `return` statement at end of function
 105	PLW0602	[ ] Using global for `API_DEV_SPEC_FN` but no assignment is done
  51	PLR1701	[*] Merge `isinstance` calls: `isinstance(ckpt, (Variable, str))`
  49	PLR0911	[ ] Too many return statements (10 > 6)
  26	PLW1508	[ ] Invalid type for environment variable default; expected `str` or `None`
  23	PLW0127	[ ] Self-assignment of variable `_startup`
  14	PLR0124	[ ] Name compared with itself, consider replacing `H != H`
  13	PLC0208	[ ] Use a sequence type instead of a `set` when iterating over values
   6	PLW1510	[ ] `subprocess.run` without explicit `check` argument
   5	PLR0133	[ ] Two constants compared in a comparison, consider replacing `10 > 5`
   5	PLW0129	[ ] Asserting on a non-empty string literal will always pass
   3	PLW1509	[ ] `preexec_fn` argument is unsafe when using threads
   2	PLR1722	[*] Use `sys.exit()` instead of `quit`
   2	PLW0120	[ ] `else` clause on loop without a `break` statement; remove the `else` and de-indent all the code inside it
   2	PLW3301	[*] Nested `min` calls can be flattened
```

```bash
ruff --select B . --statistics
863	B007	[*] Loop control variable `alignment` not used within loop body
233	B006	[*] Do not use mutable data structures for argument defaults
177	B028	[ ] No explicit `stacklevel` keyword argument found
129	B023	[ ] Function definition does not bind loop variable `K`
 72	B904	[ ] Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
 23	B008	[ ] Do not perform function call `DistributedStrategy` in argument defaults
 15	B017	[ ] `assertRaises(BaseException)` should be considered evil
 10	B026	[ ] Star-arg unpacking after a keyword argument is strongly discouraged
  8	B005	[ ] Using `.strip()` with multi-character strings is misleading the reader
  3	B027	[ ] `AlgorithmBase.collect_model_info` is an empty method in an abstract base class, but has no abstract decorator
  3	B033	[ ] Sets should not contain duplicate item `"multiply_grad"`
  1	B024	[ ] `FLClientBase` is an abstract base class, but it has no abstract methods
```

### tracking issue

| 序号 |   错误码   | 存量  | 认领人 | 完成 PR |
|:--:|:-------:|:---:|:---:|:-----:|
| 1  |  UP032  | 983 |     |       |
| 2  |  B007   | 863 |     |       |
| 3  |  UP015  | 175 |     |       |
| 4  | PLR1711 | 140 |     |       |
| 5  | NPY003  | 64  |     |       |
| 6  | PLR1701 | 51  |     |       |
| 7  |  UP018  | 43  |     |       |
| 8  |  UP031  | 33  |     |       |
| 9  |  C408   | 28  |     |       |
| 10 |  UP030  | 23  |     |       |
| 11 |  F403   | 11  |     |       |
| 12 |  UP028  | 11  |     |       |
| 13 |  F522   |  5  |     |       |
| 14 |  F811   |  4  |     |       |
| 15 |  C403   |  3  |     |       |
| 16 |  UP034  |  3  |     |       |
| 17 |  C405   |  2  |     |       |
| 18 |  C417   |  2  |     |       |
| 19 | PLR1722 |  2  |     |       |
| 20 | PLW3301 |  2  |     |       |
| 21 |  F821   |  1  |     |       |
| 22 |  C411   |  1  |     |       |
| 23 |  C416   |  1  |     |       |
| 24 |  UP004  |  1  |     |       |


`B006` 需要单独确认是否添加[B006 mutable-argument-default](https://beta.ruff.rs/docs/rules/mutable-argument-default/)

> **Note**
> 
> 在新增检查的同时需要同时删除 `exclude` 中的 `./python/paddle/base/**` 选项
> 做完后需在 `ignore` 中删除序号, 或者在 `select` 中删除注释

## 第二阶段

删除 `exclude` 中的 `./python/paddle/base/**` 选项, 并修复已存在的所有检查

| 序号 |   错误码   | 存量  | 认领人 | 完成 PR |
|:--:|:-------:|:---:|:---:|:-----:|
| 1  |  F401   | 163 |     |       |
| 2  |  B017   | 15  |     |       |
| 3  |  B010   |  4  |     |       |
| 4  |  B011   |  2  |     |       |
| 5  | PLR0402 |  2  |     |       |
| 6  |  B004   |  1  |     |       |
| 7  |  B009   |  1  |     |       |
| 8  |  B016   |  1  |     |       |
| 9  |  B019   |  1  |     |       |
| 10 | PLC0414 |  1  |     |       |


## 相关文档

* https://github.com/PaddlePaddle/community/blob/master/rfcs/CodeStyle/20230305_introducing_ruff.md
* #51524

## 常用命令
```bash
# 安装 ruff v0.0.287
pip install ruff==0.0.287
# 本 rule 自动修复方案不合适，因此仅仅跑一下（不加 `--fix`），之后手动修复
ruff --select NPY003 .
# 手动修复中...
```