### PR TITLE
fix pyyaml dependency check script

### DIFF
--- a/paddle/fluid/operators/generator/CMakeLists.txt
+++ b/paddle/fluid/operators/generator/CMakeLists.txt
@@ -25,7 +25,7 @@ function(install_py_pyyaml)
   execute_process(
     COMMAND
       ${PYTHON_EXECUTABLE} "-c"
-      "import re, pyyaml; print(re.compile('/__init__.py.*').sub('',pyyaml.__file__))"
+      "import re, yaml; print(re.compile('/__init__.py.*').sub('',yaml.__file__))"
     RESULT_VARIABLE _pyyaml_status
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复检测 PyYAML 是否安装的 CMake 脚本。
`import pyyaml` 应该更改为 `import yaml`，否则无论是否已经安装 PyYAML 依赖，都会重复安装该依赖。