### PR TITLE
[PIR]split opresult&opoperand from value.cc.

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -18,7 +18,7 @@
 
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
-#include "paddle/pir/core/value.h"
+#include "paddle/pir/core/op_result.h"
 
 namespace paddle {
 namespace dialect {

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -37,7 +37,7 @@ typedef SSIZE_T ssize_t;
 #include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 #include "paddle/phi/core/selected_rows.h"
-#include "paddle/pir/core/value.h"
+#include "paddle/pir/core/op_result.h"
 #include "paddle/utils/pybind.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"

--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -334,7 +334,7 @@ void BindValue(py::module *m) {
       .def("__eq__", &Value::operator==)
       .def("__eq__",
            [](Value &self, OpResult &other) {
-             return self.impl() == other.value_impl();
+             return self.impl() == other.Value::impl();
            })
       .def("__hash__",
            [](const Value &self) { return std::hash<pir::Value>{}(self); });
@@ -405,7 +405,7 @@ void BindOpResult(py::module *m) {
   op_result.def("__eq__", &OpResult::operator==)
       .def("__eq__",
            [](OpResult &self, Value &other) {
-             return self.value_impl() == other.impl();
+             return self.Value::impl() == other.impl();
            })
       .def("__hash__",
            [](OpResult &self) {

--- a/paddle/pir/core/op_base.h
+++ b/paddle/pir/core/op_base.h
@@ -17,6 +17,7 @@
 
 #include "paddle/pir/core/enforce.h"
 #include "paddle/pir/core/interface_support.h"
+#include "paddle/pir/core/op_result.h"
 #include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/utils.h"
 

--- a/paddle/pir/core/op_operand.cc
+++ b/paddle/pir/core/op_operand.cc
@@ -1,0 +1,70 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "paddle/pir/core/op_operand.h"
+#include "paddle/pir/core/enforce.h"
+#include "paddle/pir/core/op_operand_impl.h"
+
+#define CHECK_NULL_IMPL(class_name, func_name)                  \
+  IR_ENFORCE(impl_,                                             \
+             "impl_ pointer is null when call func:" #func_name \
+             " , in class: " #class_name ".")
+
+#define CHECK_OPOPEREND_NULL_IMPL(func_name) \
+  CHECK_NULL_IMPL(OpOpernad, func_name)
+
+namespace pir {
+
+OpOperand::OpOperand(const detail::OpOperandImpl *impl)
+    : impl_(const_cast<detail::OpOperandImpl *>(impl)) {}
+
+OpOperand &OpOperand::operator=(const OpOperand &rhs) {
+  impl_ = rhs.impl_;
+  return *this;
+}
+
+OpOperand &OpOperand::operator=(const detail::OpOperandImpl *impl) {
+  if (this->impl_ == impl) return *this;
+  impl_ = const_cast<detail::OpOperandImpl *>(impl);
+  return *this;
+}
+OpOperand::operator bool() const { return impl_ && impl_->source(); }
+
+OpOperand OpOperand::next_use() const {
+  CHECK_OPOPEREND_NULL_IMPL(next_use);
+  return impl_->next_use();
+}
+
+Value OpOperand::source() const {
+  CHECK_OPOPEREND_NULL_IMPL(source);
+  return impl_->source();
+}
+
+Type OpOperand::type() const { return source().type(); }
+
+void OpOperand::set_source(Value value) {
+  CHECK_OPOPEREND_NULL_IMPL(set_source);
+  impl_->set_source(value);
+}
+
+Operation *OpOperand::owner() const {
+  CHECK_OPOPEREND_NULL_IMPL(owner);
+  return impl_->owner();
+}
+
+void OpOperand::RemoveFromUdChain() {
+  CHECK_OPOPEREND_NULL_IMPL(RemoveFromUdChain);
+  return impl_->RemoveFromUdChain();
+}
+
+}  // namespace pir

--- a/paddle/pir/core/op_operand.h
+++ b/paddle/pir/core/op_operand.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/pir/core/dll_decl.h"
+
+namespace pir {
+class Operation;
+class Value;
+class Type;
+
+namespace detail {
+class OpOperandImpl;
+}  // namespace detail
+
+///
+/// \brief OpOperand class represents the op_operand of operation. This class
+/// only provides interfaces, for specific implementation, see Impl class.
+///
+class IR_API OpOperand {
+ public:
+  OpOperand() = default;
+
+  OpOperand(const OpOperand &other) = default;
+
+  OpOperand(const detail::OpOperandImpl *impl);  // NOLINT
+
+  OpOperand &operator=(const OpOperand &rhs);
+
+  OpOperand &operator=(const detail::OpOperandImpl *impl);
+
+  bool operator==(const OpOperand &other) const { return impl_ == other.impl_; }
+
+  bool operator!=(const OpOperand &other) const { return !operator==(other); }
+
+  bool operator!() const { return impl_ == nullptr; }
+
+  operator bool() const;
+
+  OpOperand next_use() const;
+
+  Value source() const;
+
+  Type type() const;
+
+  void set_source(Value value);
+
+  Operation *owner() const;
+
+  void RemoveFromUdChain();
+
+  friend Operation;
+
+ private:
+  detail::OpOperandImpl *impl_{nullptr};
+};
+}  // namespace pir

--- a/paddle/pir/core/op_operand_impl.cc
+++ b/paddle/pir/core/op_operand_impl.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "paddle/pir/core/op_operand_impl.h"
+#include "paddle/pir/core/value_impl.h"
+
+namespace pir {
+namespace detail {
+
+pir::Operation *OpOperandImpl::owner() const { return owner_; }
+
+pir::detail::OpOperandImpl *OpOperandImpl::next_use() { return next_use_; }
+
+pir::Value OpOperandImpl::source() const { return source_; }
+
+void OpOperandImpl::set_source(Value source) {
+  RemoveFromUdChain();
+  if (!source) {
+    return;
+  }
+  source_ = source;
+  InsertToUdChain();
+}
+
+OpOperandImpl::OpOperandImpl(pir::Value source, pir::Operation *owner)
+    : source_(source), owner_(owner) {
+  if (!source) {
+    return;
+  }
+  InsertToUdChain();
+}
+
+void OpOperandImpl::InsertToUdChain() {
+  prev_use_addr_ = source_.impl()->first_use_addr();
+  next_use_ = source_.impl()->first_use();
+  if (next_use_) {
+    next_use_->prev_use_addr_ = &next_use_;
+  }
+  source_.impl()->set_first_use(this);
+}
+
+void OpOperandImpl::RemoveFromUdChain() {
+  if (!source_) return;
+  if (!prev_use_addr_) return;
+  if (prev_use_addr_ == source_.impl()->first_use_addr()) {
+    /// NOTE: In ValueImpl, first_use_offseted_by_index_ use lower three bits
+    /// storage index information, so need to be updated using the set_first_use
+    /// method here.
+    source_.impl()->set_first_use(next_use_);
+  } else {
+    *prev_use_addr_ = next_use_;
+  }
+  if (next_use_) {
+    next_use_->prev_use_addr_ = prev_use_addr_;
+  }
+  next_use_ = nullptr;
+  prev_use_addr_ = nullptr;
+  source_ = nullptr;
+}
+
+OpOperandImpl::~OpOperandImpl() { RemoveFromUdChain(); }
+
+}  // namespace detail
+}  // namespace pir

--- a/paddle/pir/core/op_operand_impl.h
+++ b/paddle/pir/core/op_operand_impl.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "paddle/pir/core/value.h"
+
+namespace pir {
+
+class Operation;
+
+namespace detail {
+///
+/// \brief OpOperandImpl
+///
+class OpOperandImpl {
+ public:
+  Operation *owner() const;
+
+  OpOperandImpl *next_use();
+
+  Value source() const;
+
+  void set_source(Value value);
+
+  /// Remove this op_operand from the current use list.
+  void RemoveFromUdChain();
+
+  ~OpOperandImpl();
+
+  friend Operation;
+
+ private:
+  OpOperandImpl(Value source, Operation *owner);
+
+  // Insert self to the UD chain holded by source_;
+  // It is not safe. So set private.
+  void InsertToUdChain();
+
+  Value source_;
+
+  OpOperandImpl *next_use_ = nullptr;
+
+  OpOperandImpl **prev_use_addr_ = nullptr;
+
+  Operation *const owner_ = nullptr;
+};
+
+}  // namespace detail
+}  // namespace pir

--- a/paddle/pir/core/op_result.cc
+++ b/paddle/pir/core/op_result.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "paddle/pir/core/op_result.h"
+#include "paddle/pir/core/enforce.h"
+#include "paddle/pir/core/op_result_impl.h"
+
+#define CHECK_NULL_IMPL(class_name, func_name)                  \
+  IR_ENFORCE(impl_,                                             \
+             "impl_ pointer is null when call func:" #func_name \
+             " , in class: " #class_name ".")
+
+#define CHECK_OPRESULT_NULL_IMPL(func_name) CHECK_NULL_IMPL(OpResult, func_name)
+
+namespace pir {
+
+// OpResult
+bool OpResult::classof(Value value) {
+  return value && pir::isa<detail::OpResultImpl>(value.impl());
+}
+
+Operation *OpResult::owner() const {
+  CHECK_OPRESULT_NULL_IMPL(owner);
+  return impl()->owner();
+}
+
+uint32_t OpResult::GetResultIndex() const {
+  CHECK_OPRESULT_NULL_IMPL(GetResultIndex);
+  return impl()->GetResultIndex();
+}
+
+detail::OpResultImpl *OpResult::impl() const {
+  return reinterpret_cast<detail::OpResultImpl *>(impl_);
+}
+
+bool OpResult::operator==(const OpResult &other) const {
+  return impl_ == other.impl_;
+}
+
+uint32_t OpResult::GetValidInlineIndex(uint32_t index) {
+  uint32_t max_inline_index =
+      pir::detail::OpResultImpl::GetMaxInlineResultIndex();
+  return index <= max_inline_index ? index : max_inline_index;
+}
+
+}  // namespace pir

--- a/paddle/pir/core/op_result.h
+++ b/paddle/pir/core/op_result.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/pir/core/value.h"
+namespace pir {
+
+namespace detail {
+class OpResultImpl;
+}  // namespace detail
+
+///
+/// \brief OpResult class represents the value defined by a result of operation.
+/// This class only provides interfaces, for specific implementation, see Impl
+/// class.
+///
+class IR_API OpResult : public Value {
+ public:
+  using Value::Value;
+
+  static bool classof(Value value);
+
+  Operation *owner() const;
+
+  uint32_t GetResultIndex() const;
+
+  bool operator==(const OpResult &other) const;
+
+  friend Operation;
+
+  detail::OpResultImpl *impl() const;
+
+ private:
+  static uint32_t GetValidInlineIndex(uint32_t index);
+};
+
+}  // namespace pir

--- a/paddle/pir/core/op_result_impl.cc
+++ b/paddle/pir/core/op_result_impl.cc
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "paddle/pir/core/op_result_impl.h"
+
+#include <cassert>
+
+namespace pir {
+namespace detail {
+
+uint32_t OpResultImpl::GetResultIndex() const {
+  if (const auto *outline_result = dyn_cast<OpOutlineResultImpl>(this)) {
+    return outline_result->GetResultIndex();
+  }
+  return dyn_cast<OpInlineResultImpl>(this)->GetResultIndex();
+}
+
+OpResultImpl::~OpResultImpl() { assert(use_empty()); }
+
+Operation *OpResultImpl::owner() const {
+  // For inline result, pointer offset index to obtain the address of op.
+  if (const auto *result = dyn_cast<OpInlineResultImpl>(this)) {
+    result += result->GetResultIndex() + 1;
+    return reinterpret_cast<Operation *>(
+        const_cast<OpInlineResultImpl *>(result));
+  }
+  // For outline result, pointer offset outline_index to obtain the address of
+  // maximum inline result.
+  const OpOutlineResultImpl *outline_result =
+      (const OpOutlineResultImpl *)(this);
+  outline_result +=
+      (outline_result->outline_index_ - GetMaxInlineResultIndex());
+  // The offset of the maximum inline result distance op is
+  // GetMaxInlineResultIndex.
+  const auto *inline_result =
+      reinterpret_cast<const OpInlineResultImpl *>(outline_result);
+  inline_result += (GetMaxInlineResultIndex() + 1);
+  return reinterpret_cast<Operation *>(
+      const_cast<OpInlineResultImpl *>(inline_result));
+}
+
+}  // namespace detail
+}  // namespace pir

--- a/paddle/pir/core/op_result_impl.h
+++ b/paddle/pir/core/op_result_impl.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/pir/core/value_impl.h"
+
+namespace pir {
+namespace detail {
+///
+/// \brief OpResultImpl is the implementation of an operation result.
+///
+class OpResultImpl : public ValueImpl {
+ public:
+  using ValueImpl::ValueImpl;
+
+  static bool classof(const ValueImpl &value) {
+    return value.kind() <= OUTLINE_OP_RESULT_INDEX;
+  }
+
+  ///
+  /// \brief Get the parent operation of this result.(op_ptr = value_ptr +
+  /// index)
+  ///
+  Operation *owner() const;
+
+  ///
+  /// \brief Get the result index of the operation result.
+  ///
+  uint32_t GetResultIndex() const;
+
+  ///
+  /// \brief Get the maximum number of results that can be stored inline.
+  ///
+  static uint32_t GetMaxInlineResultIndex() {
+    return OUTLINE_OP_RESULT_INDEX - 1;
+  }
+
+  ~OpResultImpl();
+};
+
+///
+/// \brief OpInlineResultImpl is the implementation of an operation result whose
+/// index <= 5.
+///
+class OpInlineResultImpl : public OpResultImpl {
+ public:
+  OpInlineResultImpl(Type type, uint32_t result_index)
+      : OpResultImpl(type, result_index) {
+    if (result_index > GetMaxInlineResultIndex()) {
+      throw("Inline result index should not exceed MaxInlineResultIndex(5)");
+    }
+  }
+
+  static bool classof(const OpResultImpl &value) {
+    return value.kind() < OUTLINE_OP_RESULT_INDEX;
+  }
+
+  uint32_t GetResultIndex() const { return kind(); }
+};
+
+///
+/// \brief OpOutlineResultImpl is the implementation of an operation result
+/// whose index > 5.
+///
+class OpOutlineResultImpl : public OpResultImpl {
+ public:
+  OpOutlineResultImpl(Type type, uint32_t outline_index)
+      : OpResultImpl(type, OUTLINE_OP_RESULT_INDEX),
+        outline_index_(outline_index) {}
+
+  static bool classof(const OpResultImpl &value) {
+    return value.kind() == OUTLINE_OP_RESULT_INDEX;
+  }
+
+  uint32_t GetResultIndex() const { return outline_index_; }
+
+  uint32_t outline_index_;
+};
+
+}  // namespace detail
+}  // namespace pir

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -19,11 +19,11 @@
 #include "paddle/pir/core/dialect.h"
 #include "paddle/pir/core/enforce.h"
 #include "paddle/pir/core/op_info.h"
+#include "paddle/pir/core/op_result_impl.h"
 #include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/program.h"
 #include "paddle/pir/core/region.h"
 #include "paddle/pir/core/utils.h"
-#include "paddle/pir/core/value_impl.h"
 
 namespace pir {
 Operation *Operation::Create(OperationArgument &&argument) {

--- a/paddle/pir/core/operation_utils.h
+++ b/paddle/pir/core/operation_utils.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include "paddle/pir/core/attribute.h"
 #include "paddle/pir/core/op_info.h"
+#include "paddle/pir/core/op_result.h"
 #include "paddle/pir/core/region.h"
 #include "paddle/pir/core/type.h"
 #include "paddle/pir/core/value.h"

--- a/paddle/pir/core/value.cc
+++ b/paddle/pir/core/value.cc
@@ -17,6 +17,8 @@
 #include <cstddef>
 
 #include "paddle/pir/core/enforce.h"
+#include "paddle/pir/core/op_operand.h"
+#include "paddle/pir/core/op_result.h"
 #include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/value_impl.h"
 
@@ -25,59 +27,10 @@
              "impl_ pointer is null when call func:" #func_name \
              " , in class: " #class_name ".")
 
-#define CHECK_OPOPEREND_NULL_IMPL(func_name) \
-  CHECK_NULL_IMPL(OpOpernad, func_name)
-
 #define CHECK_VALUE_NULL_IMPL(func_name) CHECK_NULL_IMPL(Value, func_name)
 
-#define CHECK_OPRESULT_NULL_IMPL(func_name) CHECK_NULL_IMPL(OpResult, func_name)
 namespace pir {
 
-// Operand
-OpOperand::OpOperand(const detail::OpOperandImpl *impl)
-    : impl_(const_cast<detail::OpOperandImpl *>(impl)) {}
-
-OpOperand &OpOperand::operator=(const OpOperand &rhs) {
-  if (this == &rhs) return *this;
-  impl_ = rhs.impl_;
-  return *this;
-}
-
-OpOperand &OpOperand::operator=(const detail::OpOperandImpl *impl) {
-  if (this->impl_ == impl) return *this;
-  impl_ = const_cast<detail::OpOperandImpl *>(impl);
-  return *this;
-}
-OpOperand::operator bool() const { return impl_ && impl_->source(); }
-
-OpOperand OpOperand::next_use() const {
-  CHECK_OPOPEREND_NULL_IMPL(next_use);
-  return impl_->next_use();
-}
-
-Value OpOperand::source() const {
-  CHECK_OPOPEREND_NULL_IMPL(source);
-  return impl_->source();
-}
-
-Type OpOperand::type() const { return source().type(); }
-
-void OpOperand::set_source(Value value) {
-  CHECK_OPOPEREND_NULL_IMPL(set_source);
-  impl_->set_source(value);
-}
-
-Operation *OpOperand::owner() const {
-  CHECK_OPOPEREND_NULL_IMPL(owner);
-  return impl_->owner();
-}
-
-void OpOperand::RemoveFromUdChain() {
-  CHECK_OPOPEREND_NULL_IMPL(RemoveFromUdChain);
-  return impl_->RemoveFromUdChain();
-}
-
-// Value
 Value::Value(const detail::ValueImpl *impl)
     : impl_(const_cast<detail::ValueImpl *>(impl)) {}
 
@@ -113,9 +66,7 @@ std::string Value::PrintUdChain() {
   return impl()->PrintUdChain();
 }
 
-Value::UseIterator Value::use_begin() const {
-  return pir::OpOperand(first_use());
-}
+Value::UseIterator Value::use_begin() const { return OpOperand(first_use()); }
 
 Value::UseIterator Value::use_end() const { return Value::UseIterator(); }
 
@@ -153,148 +104,4 @@ void Value::ReplaceAllUsesWith(Value new_value) const {
   }
 }
 
-// OpResult
-bool OpResult::classof(Value value) {
-  return value && pir::isa<detail::OpResultImpl>(value.impl());
-}
-
-Operation *OpResult::owner() const {
-  CHECK_OPRESULT_NULL_IMPL(owner);
-  return impl()->owner();
-}
-
-uint32_t OpResult::GetResultIndex() const {
-  CHECK_OPRESULT_NULL_IMPL(GetResultIndex);
-  return impl()->GetResultIndex();
-}
-
-detail::OpResultImpl *OpResult::impl() const {
-  return reinterpret_cast<detail::OpResultImpl *>(impl_);
-}
-
-bool OpResult::operator==(const OpResult &other) const {
-  return impl_ == other.impl_;
-}
-
-detail::ValueImpl *OpResult::value_impl() const {
-  IR_ENFORCE(impl_, "Can't use value_impl() interface while value is null.");
-  return impl_;
-}
-
-uint32_t OpResult::GetValidInlineIndex(uint32_t index) {
-  uint32_t max_inline_index =
-      pir::detail::OpResultImpl::GetMaxInlineResultIndex();
-  return index <= max_inline_index ? index : max_inline_index;
-}
-
-// details
-namespace detail {
-pir::Operation *OpOperandImpl::owner() const { return owner_; }
-
-pir::detail::OpOperandImpl *OpOperandImpl::next_use() { return next_use_; }
-
-pir::Value OpOperandImpl::source() const { return source_; }
-
-void OpOperandImpl::set_source(Value source) {
-  RemoveFromUdChain();
-  if (!source) {
-    return;
-  }
-  source_ = source;
-  InsertToUdChain();
-}
-
-OpOperandImpl::OpOperandImpl(pir::Value source, pir::Operation *owner)
-    : source_(source), owner_(owner) {
-  if (!source) {
-    return;
-  }
-  InsertToUdChain();
-}
-
-void OpOperandImpl::InsertToUdChain() {
-  prev_use_addr_ = source_.impl()->first_use_addr();
-  next_use_ = source_.impl()->first_use();
-  if (next_use_) {
-    next_use_->prev_use_addr_ = &next_use_;
-  }
-  source_.impl()->set_first_use(this);
-}
-
-void OpOperandImpl::RemoveFromUdChain() {
-  if (!source_) return;
-  if (!prev_use_addr_) return;
-  if (prev_use_addr_ == source_.impl()->first_use_addr()) {
-    /// NOTE: In ValueImpl, first_use_offseted_by_index_ use lower three bits
-    /// storage index information, so need to be updated using the set_first_use
-    /// method here.
-    source_.impl()->set_first_use(next_use_);
-  } else {
-    *prev_use_addr_ = next_use_;
-  }
-  if (next_use_) {
-    next_use_->prev_use_addr_ = prev_use_addr_;
-  }
-  next_use_ = nullptr;
-  prev_use_addr_ = nullptr;
-  source_ = nullptr;
-}
-
-OpOperandImpl::~OpOperandImpl() { RemoveFromUdChain(); }
-
-uint32_t ValueImpl::index() const {
-  uint32_t index =
-      reinterpret_cast<uintptr_t>(first_use_offseted_by_index_) & 0x07;
-  if (index < 6) return index;
-  return reinterpret_cast<OpOutlineResultImpl *>(const_cast<ValueImpl *>(this))
-      ->GetResultIndex();
-}
-
-std::string ValueImpl::PrintUdChain() {
-  std::stringstream result;
-  result << "Value[" << this << "] -> ";
-  OpOperandImpl *tmp = first_use();
-  if (tmp) {
-    result << "OpOperand[" << reinterpret_cast<void *>(tmp) << "] -> ";
-    while (tmp->next_use() != nullptr) {
-      result << "OpOperand[" << reinterpret_cast<void *>(tmp->next_use())
-             << "] -> ";
-      tmp = tmp->next_use();
-    }
-  }
-  result << "nullptr";
-  return result.str();
-}
-
-uint32_t OpResultImpl::GetResultIndex() const {
-  if (const auto *outline_result = pir::dyn_cast<OpOutlineResultImpl>(this)) {
-    return outline_result->GetResultIndex();
-  }
-  return pir::dyn_cast<OpInlineResultImpl>(this)->GetResultIndex();
-}
-
-OpResultImpl::~OpResultImpl() { assert(use_empty()); }
-
-pir::Operation *OpResultImpl::owner() const {
-  // For inline result, pointer offset index to obtain the address of op.
-  if (const auto *result = pir::dyn_cast<OpInlineResultImpl>(this)) {
-    result += result->GetResultIndex() + 1;
-    return reinterpret_cast<Operation *>(
-        const_cast<OpInlineResultImpl *>(result));
-  }
-  // For outline result, pointer offset outline_index to obtain the address of
-  // maximum inline result.
-  const OpOutlineResultImpl *outline_result =
-      (const OpOutlineResultImpl *)(this);
-  outline_result +=
-      (outline_result->outline_index_ - GetMaxInlineResultIndex());
-  // The offset of the maximum inline result distance op is
-  // GetMaxInlineResultIndex.
-  const auto *inline_result =
-      reinterpret_cast<const OpInlineResultImpl *>(outline_result);
-  inline_result += (GetMaxInlineResultIndex() + 1);
-  return reinterpret_cast<Operation *>(
-      const_cast<OpInlineResultImpl *>(inline_result));
-}
-}  // namespace detail
 }  // namespace pir

--- a/paddle/pir/core/value.h
+++ b/paddle/pir/core/value.h
@@ -15,60 +15,16 @@
 #pragma once
 
 #include "paddle/pir/core/cast_utils.h"
+#include "paddle/pir/core/op_operand.h"
 #include "paddle/pir/core/type.h"
 #include "paddle/pir/core/use_iterator.h"
 
 namespace pir {
 class Operation;
-class Value;
 
 namespace detail {
-class OpOperandImpl;
 class ValueImpl;
-class OpResultImpl;
 }  // namespace detail
-
-///
-/// \brief OpOperand class represents the op_operand of operation. This class
-/// only provides interfaces, for specific implementation, see Impl class.
-///
-class IR_API OpOperand {
- public:
-  OpOperand() = default;
-
-  OpOperand(const OpOperand &other) = default;
-
-  OpOperand(const detail::OpOperandImpl *impl);  // NOLINT
-
-  OpOperand &operator=(const OpOperand &rhs);
-
-  OpOperand &operator=(const detail::OpOperandImpl *impl);
-
-  bool operator==(const OpOperand &other) const { return impl_ == other.impl_; }
-
-  bool operator!=(const OpOperand &other) const { return !operator==(other); }
-
-  bool operator!() const { return impl_ == nullptr; }
-
-  operator bool() const;
-
-  OpOperand next_use() const;
-
-  Value source() const;
-
-  Type type() const;
-
-  void set_source(Value value);
-
-  Operation *owner() const;
-
-  void RemoveFromUdChain();
-
-  friend Operation;
-
- private:
-  detail::OpOperandImpl *impl_{nullptr};
-};
 
 ///
 /// \brief Value class represents the SSA value in the IR system. This class
@@ -137,32 +93,6 @@ class IR_API Value {
 
  protected:
   detail::ValueImpl *impl_{nullptr};
-};
-
-///
-/// \brief OpResult class represents the value defined by a result of operation.
-/// This class only provides interfaces, for specific implementation, see Impl
-/// class.
-///
-class IR_API OpResult : public Value {
- public:
-  using Value::Value;
-
-  static bool classof(Value value);
-
-  Operation *owner() const;
-
-  uint32_t GetResultIndex() const;
-
-  bool operator==(const OpResult &other) const;
-
-  friend Operation;
-
-  detail::ValueImpl *value_impl() const;
-  detail::OpResultImpl *impl() const;
-
- private:
-  static uint32_t GetValidInlineIndex(uint32_t index);
 };
 
 }  // namespace pir

--- a/paddle/pir/core/value_impl.cc
+++ b/paddle/pir/core/value_impl.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "paddle/pir/core/value_impl.h"
+
+namespace pir {
+
+namespace detail {
+void ValueImpl::set_first_use(OpOperandImpl *first_use) {
+  uint32_t offset = kind();
+  first_use_offseted_by_index_ = reinterpret_cast<OpOperandImpl *>(
+      reinterpret_cast<uintptr_t>(first_use) + offset);
+  VLOG(4) << "The index of this value is " << offset
+          << ". Offset and set first use: " << first_use << " -> "
+          << first_use_offseted_by_index_ << ".";
+}
+
+std::string ValueImpl::PrintUdChain() {
+  std::stringstream result;
+  result << "Value[" << this << "] -> ";
+  OpOperandImpl *tmp = first_use();
+  if (tmp) {
+    result << "OpOperand[" << reinterpret_cast<void *>(tmp) << "] -> ";
+    while (tmp->next_use() != nullptr) {
+      result << "OpOperand[" << reinterpret_cast<void *>(tmp->next_use())
+             << "] -> ";
+      tmp = tmp->next_use();
+    }
+  }
+  result << "nullptr";
+  return result.str();
+}
+ValueImpl::ValueImpl(Type type, uint32_t index) {
+  if (index > OUTLINE_OP_RESULT_INDEX) {
+    throw("The value of index must not exceed 6");
+  }
+  type_ = type;
+  first_use_offseted_by_index_ = reinterpret_cast<OpOperandImpl *>(
+      reinterpret_cast<uintptr_t>(nullptr) + index);
+  VLOG(4) << "Construct a ValueImpl whose's index is " << index
+          << ". The offset first_use address is: "
+          << first_use_offseted_by_index_;
+}
+
+}  // namespace detail
+}  // namespace pir

--- a/paddle/pir/core/value_impl.h
+++ b/paddle/pir/core/value_impl.h
@@ -14,50 +14,14 @@
 
 #pragma once
 
+#include "paddle/pir/core/op_operand_impl.h"
 #include "paddle/pir/core/value.h"
 
 namespace pir {
 static const uint32_t OUTLINE_OP_RESULT_INDEX = 6;
-
 class Operation;
 
 namespace detail {
-///
-/// \brief OpOperandImpl
-///
-class OpOperandImpl {
- public:
-  pir::Operation *owner() const;
-
-  pir::detail::OpOperandImpl *next_use();
-
-  pir::Value source() const;
-
-  void set_source(Value value);
-
-  /// Remove this op_operand from the current use list.
-  void RemoveFromUdChain();
-
-  ~OpOperandImpl();
-
-  friend pir::Operation;
-
- private:
-  OpOperandImpl(pir::Value source, pir::Operation *owner);
-
-  // Insert self to the UD chain holded by source_;
-  // It is not safe. So set private.
-  void InsertToUdChain();
-
-  pir::detail::OpOperandImpl *next_use_ = nullptr;
-
-  pir::detail::OpOperandImpl **prev_use_addr_ = nullptr;
-
-  pir::Value source_;
-
-  pir::Operation *const owner_ = nullptr;
-};
-
 ///
 /// \brief ValueImpl is the base class of all derived Value classes such as
 /// OpResultImpl. This class defines all the information and usage interface in
@@ -71,28 +35,16 @@ class alignas(8) ValueImpl {
   ///
   /// \brief Interface functions of "type_" attribute.
   ///
-  pir::Type type() const { return type_; }
+  Type type() const { return type_; }
 
-  void set_type(pir::Type type) { type_ = type; }
-
-  ///
-  /// \brief Interface functions of "first_use_offseted_by_index_" attribute.
-  ///
-  uint32_t index() const;
+  void set_type(Type type) { type_ = type; }
 
   OpOperandImpl *first_use() const {
     return reinterpret_cast<OpOperandImpl *>(
         reinterpret_cast<uintptr_t>(first_use_offseted_by_index_) & (~0x07));
   }
 
-  void set_first_use(OpOperandImpl *first_use) {
-    uint32_t offset = index();
-    first_use_offseted_by_index_ = reinterpret_cast<OpOperandImpl *>(
-        reinterpret_cast<uintptr_t>(first_use) + offset);
-    VLOG(4) << "The index of this value is " << offset
-            << ". Offset and set first use: " << first_use << " -> "
-            << first_use_offseted_by_index_ << ".";
-  }
+  void set_first_use(OpOperandImpl *first_use);
 
   OpOperandImpl **first_use_addr() { return &first_use_offseted_by_index_; }
 
@@ -104,26 +56,23 @@ class alignas(8) ValueImpl {
 
   std::string PrintUdChain();
 
+  ///
+  /// \brief Interface functions of "first_use_offseted_by_index_" attribute.
+  ///
+  uint32_t kind() const {
+    return reinterpret_cast<uintptr_t>(first_use_offseted_by_index_) & 0x07;
+  }
+
  protected:
   ///
   /// \brief Only can be constructed by derived classes such as OpResultImpl.
   ///
-  explicit ValueImpl(pir::Type type, uint32_t index) {
-    if (index > OUTLINE_OP_RESULT_INDEX) {
-      throw("The value of index must not exceed 6");
-    }
-    type_ = type;
-    first_use_offseted_by_index_ = reinterpret_cast<OpOperandImpl *>(
-        reinterpret_cast<uintptr_t>(nullptr) + index);
-    VLOG(4) << "Construct a ValueImpl whose's index is " << index
-            << ". The offset first_use address is: "
-            << first_use_offseted_by_index_;
-  }
+  ValueImpl(Type type, uint32_t index);
 
   ///
   /// \brief Attribute1: Type of value.
   ///
-  pir::Type type_;
+  Type type_;
 
   ///
   /// \brief Attribute2/3: Record the UD-chain of value and index.
@@ -137,74 +86,6 @@ class alignas(8) ValueImpl {
   OpOperandImpl *first_use_offseted_by_index_ = nullptr;
 };
 
-///
-/// \brief OpResultImpl is the implementation of an operation result.
-///
-class alignas(8) OpResultImpl : public ValueImpl {
- public:
-  using ValueImpl::ValueImpl;
-
-  static bool classof(const ValueImpl &value) { return true; }
-
-  ///
-  /// \brief Get the parent operation of this result.(op_ptr = value_ptr +
-  /// index)
-  ///
-  pir::Operation *owner() const;
-
-  ///
-  /// \brief Get the result index of the operation result.
-  ///
-  uint32_t GetResultIndex() const;
-
-  ///
-  /// \brief Get the maximum number of results that can be stored inline.
-  ///
-  static uint32_t GetMaxInlineResultIndex() {
-    return OUTLINE_OP_RESULT_INDEX - 1;
-  }
-
-  ~OpResultImpl();
-};
-
-///
-/// \brief OpInlineResultImpl is the implementation of an operation result whose
-/// index <= 5.
-///
-class OpInlineResultImpl : public OpResultImpl {
- public:
-  OpInlineResultImpl(pir::Type type, uint32_t result_index)
-      : OpResultImpl(type, result_index) {
-    if (result_index > GetMaxInlineResultIndex()) {
-      throw("Inline result index should not exceed MaxInlineResultIndex(5)");
-    }
-  }
-
-  static bool classof(const OpResultImpl &value) {
-    return value.index() < OUTLINE_OP_RESULT_INDEX;
-  }
-
-  uint32_t GetResultIndex() const { return index(); }
-};
-
-///
-/// \brief OpOutlineResultImpl is the implementation of an operation result
-/// whose index > 5.
-///
-class OpOutlineResultImpl : public OpResultImpl {
- public:
-  OpOutlineResultImpl(pir::Type type, uint32_t outline_index)
-      : OpResultImpl(type, OUTLINE_OP_RESULT_INDEX),
-        outline_index_(outline_index) {}
-
-  static bool classof(const OpResultImpl &value) {
-    return value.index() >= OUTLINE_OP_RESULT_INDEX;
-  }
-
-  uint32_t GetResultIndex() const { return outline_index_; }
-
-  uint32_t outline_index_;
-};
-
 }  // namespace detail
+
 }  // namespace pir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others 

### Description
<!-- Describe what you’ve done -->
将OpResult、OpOperand、OpResultImpl、OpOperandImpl从value.cc以及value.h中抽出来，单独成文件。
方便BlockArgument的开发。

在PIR开发初期，由于只有OpResult， 没有BlockArgument。而且Value、OpResult、OpOperand的接口较为简单，因此将三者放在了同一个文件value.cc里。考虑到BlockArguemnt的开发，会让Value和OpResult的区别趋于明显。因此，本pr对value.cc进行拆分。

###Others
pcard-67164