### PR TITLE
Refactor matmul grad infermeta and kernel impl

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -336,8 +336,7 @@
   args : (Tensor x, Tensor y, Tensor out_grad, bool transpose_x=false, bool transpose_y=false)
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
-    func : GeneralBinaryGradInferMeta
-    param : [x, y]
+    func : MatmulGradInferMeta
   kernel :
     func : matmul_grad
   backward : matmul_double_grad

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -300,6 +300,14 @@ void MarginCrossEntropyGradInferMeta(const MetaTensor& logits,
                                      float scale,
                                      MetaTensor* logits_grad);
 
+void MatmulGradInferMeta(const MetaTensor& x,
+                         const MetaTensor& y,
+                         const MetaTensor& out_grad,
+                         bool transpose_x,
+                         bool transpose_y,
+                         MetaTensor* x_grad,
+                         MetaTensor* y_grad);
+
 void MaxPoolWithIndexGradInferMeta(const MetaTensor& x,
                                    const MetaTensor& mask,
                                    const MetaTensor& dout,

--- a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
@@ -272,21 +272,11 @@ void MatmulGradKernel(const Context& dev_ctx,
 
     DDim dx_dims;
     if (dx) {
-      dx_dims = dx->dims();
-      if (dx_dims != x_help.dims()) {
-        dx->Resize(x_help.dims());
-      }
-
       y_conj = Conj<T>(dev_ctx, y_help);
     }
 
     DDim dy_dims;
     if (dy) {
-      dy_dims = dy->dims();
-      if (dy_dims != y_help.dims()) {
-        dy->Resize(y_help.dims());
-      }
-
       x_conj = Conj<T>(dev_ctx, x_help);
     }
 
@@ -310,17 +300,6 @@ void MatmulGradKernel(const Context& dev_ctx,
           dev_ctx, out_grad_help, false, false, y_conj, true, false, dx);
       CalcInputGrad<T>(
           dev_ctx, x_conj, true, true, out_grad_help, false, true, dy);
-    }
-
-    if (dx) {
-      if (dx_dims != x_help.dims()) {
-        dx->Resize(dx_dims);
-      }
-    }
-    if (dy) {
-      if (dy_dims != y_help.dims()) {
-        dy->Resize(dy_dims);
-      }
     }
   } else {
     // Case3: broadcast. It need cost much time to reduce sum for the
@@ -456,7 +435,6 @@ void MatmulGradKernel(const Context& dev_ctx,
         ReduceSumForMatmulGrad<Context, T>()(
             dev_ctx, dx_help, dx, dx_reduce_dims);
       }
-      dx->Resize(x.dims());
     }
     if (dy) {
       if (dy_reduce_dims.empty()) {
@@ -465,7 +443,6 @@ void MatmulGradKernel(const Context& dev_ctx,
         ReduceSumForMatmulGrad<Context, T>()(
             dev_ctx, dy_help, dy, dy_reduce_dims);
       }
-      dy->Resize(y.dims());
     }
     // Get the OutputGrad(out)
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->

Pcard-73145

Refactor matmul grad infermeta and kernel impl

Matmul算子的前向InferMeta存在错误，只能处理常规的case，在一些特殊case下没有实现正确的Shape推导，正确的Shape推导实际上是在MatmulKernel中完成的，因此当反向Matmul按照数学公式复用前向实现去推导时，结果会出现错误。单元测试中一些前向推导错误的示例如下：
```
Matmul InferMeta: X shape: [2, 1], Y shape: [100], trans_x: [0] trans_y: [1], Out Shape: [2];
Matmul InferMeta: X shape: [100], Y shape: [1, 2, 2, 2], trans_x: [1] trans_y: [0], Out Shape: [1, 2, 2];
Matmul InferMeta: X shape: [1, 3, 2], Y shape: [100], trans_x: [1] trans_y: [0], Out Shape: [1, 2];
Matmul InferMeta: X shape: [100], Y shape: [1, 1, 1], trans_x: [0] trans_y: [1], Out Shape: [1, 1];
Matmul InferMeta: X shape: [102], Y shape: [1, 2, 1], trans_x: [0] trans_y: [1], Out Shape: [1, 2];
```

在前向InferMeta正确的前提下，反向复用前向时还需要加入一些reduce操作确保shape正确，例如
```
Matmul InferMeta: X shape: [10, 2, 5], Y shape: [10, 2, 20], trans_x: [1] trans_y: [0], Out Shape: [10, 5, 20];
No broadcast - Before calc - dy_dims: 10, 5, 20, y_help dims: 5, 20, y dims: 5, 20
```