### PR TITLE
[NewIR]Emplace back empty type when vector is empty

### DIFF
--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -126,12 +126,16 @@ void CombineOp::Build(Builder &builder,
                       OperationArgument &argument,
                       const std::vector<pir::OpResult> &inputs) {
   argument.inputs = inputs;
-  std::vector<pir::Type> inputs_type(inputs.size());
-  for (size_t idx = 0; idx < inputs.size(); ++idx) {
-    inputs_type[idx] = inputs[idx].type();
+  if (inputs.size() == 0) {
+    argument.output_types.emplace_back(pir::Type());
+  } else {
+    std::vector<pir::Type> inputs_type(inputs.size());
+    for (size_t idx = 0; idx < inputs.size(); ++idx) {
+      inputs_type[idx] = inputs[idx].type();
+    }
+    argument.output_types.emplace_back(
+        pir::VectorType::get(builder.ir_context(), inputs_type));
   }
-  argument.output_types.emplace_back(
-      pir::VectorType::get(builder.ir_context(), inputs_type));
 }
 
 void CombineOp::Verify() const {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[NewIR]Emplace back empty type when vector is empty

Pcard-67164