### PR TITLE
[PHI]Fix cub bugs when use PHI shared lib in CUDA12

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -143,10 +143,12 @@ if(WIN32)
   target_link_libraries(phi shlwapi.lib)
 endif()
 
-if(${CMAKE_CUDA_COMPILER_VERSION} GREATER 11.2)
-  # The reduce result of cub is wrong in cuda12, we workaround it by wrapping CUB/Thrust namespaces in each library:
-  # refer:https://github.com/NVIDIA/cub/issues/719
-  target_compile_definitions(phi PRIVATE CUB_WRAPPED_NAMESPACE=CUB_COMPATIBLE)
+if(WITH_GPU)
+  if(${CMAKE_CUDA_COMPILER_VERSION} GREATER 11.2)
+    # The reduce result of cub is wrong in cuda12, we workaround it by wrapping CUB/Thrust namespaces in each library:
+    # refer:https://github.com/NVIDIA/cub/issues/719
+    target_compile_definitions(phi PRIVATE CUB_WRAPPED_NAMESPACE=CUB_COMPATIBLE)
+  endif()
 endif()
 
 if(WIN32)

--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -143,6 +143,12 @@ if(WIN32)
   target_link_libraries(phi shlwapi.lib)
 endif()
 
+if(${CMAKE_CUDA_COMPILER_VERSION} GREATER 11.2)
+  # The reduce result of cub is wrong in cuda12, we workaround it by wrapping CUB/Thrust namespaces in each library:
+  # refer:https://github.com/NVIDIA/cub/issues/719
+  target_compile_definitions(phi PRIVATE CUB_WRAPPED_NAMESPACE=CUB_COMPATIBLE)
+endif()
+
 if(WIN32)
   if(WITH_SHARED_PHI)
     set_property(TARGET phi PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -144,7 +144,7 @@ if(WIN32)
 endif()
 
 if(WITH_GPU)
-  if(${CMAKE_CUDA_COMPILER_VERSION} GREATER 11.2)
+  if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.0)
     # The reduce result of cub is wrong in cuda12, we workaround it by wrapping CUB/Thrust namespaces in each library:
     # refer:https://github.com/NVIDIA/cub/issues/719
     target_compile_definitions(phi PRIVATE CUB_WRAPPED_NAMESPACE=CUB_COMPATIBLE)

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -26,6 +26,10 @@ limitations under the License. */
 #include "dnnl.hpp"  // NOLINT
 #endif
 
+#ifdef CUB_WRAPPED_NAMESPACE
+namespace cub = CUB_COMPATIBLE::cub;
+#endif
+
 namespace phi {
 
 class DenseTensorUtils;

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -68,7 +68,11 @@ struct float_bit_mask<phi::dtype::bfloat16>
 namespace cub = hipcub;
 #else
 // set cub base traits in order to handle float16
+#ifdef CUB_WRAPPED_NAMESPACE
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
@@ -78,7 +82,7 @@ struct NumericTraits<phi::dtype::bfloat16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
 };
 
-}  // namespace cub
+}  // namespace CUB_COMPATIBLE::cub
 #endif
 
 namespace phi {

--- a/paddle/phi/kernels/gpu/argsort_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_grad_kernel.cu
@@ -46,7 +46,11 @@ struct radix_key_codec_base<phi::dtype::bfloat16>
 }  // namespace rocprim
 #else
 // set cub base traits in order to handle float16
+#ifdef CUB_WRAPPED_NAMESPACE
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
@@ -55,7 +59,7 @@ template <>
 struct NumericTraits<phi::dtype::bfloat16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
 };
-}  // namespace cub
+}  // namespace CUB_COMPATIBLE::cub
 #endif
 
 namespace phi {

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -57,7 +57,11 @@ struct float_bit_mask<phi::dtype::bfloat16>
 }  // namespace rocprim
 #else
 // set cub base traits in order to handle float16
+#ifdef CUB_WRAPPED_NAMESPACE
+namespace CUB_COMPATIBLE::cub {
+#else
 namespace cub {
+#endif
 template <>
 struct NumericTraits<phi::dtype::float16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::float16> {};
@@ -66,7 +70,7 @@ template <>
 struct NumericTraits<phi::dtype::bfloat16>
     : BaseTraits<FLOATING_POINT, true, false, uint16_t, phi::dtype::bfloat16> {
 };
-}  // namespace cub
+}  // namespace CUB_COMPATIBLE::cub
 
 #endif
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复在cuda12环境下使用phi动态库，三方库cub造成的reduce精度问题