### PR TITLE
Optimize the overhead for all_elementwise case in BroadcastKernel.

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -74,14 +74,13 @@ struct BroadcastTypeClassifier {
   void InitBroadcastConfigs(const std::vector<const DenseTensor *> &ins,
                             std::vector<DenseTensor *> *outs,
                             int axis) {
+#ifdef PADDLE_WITH_XPU_KP
     const auto dims_simplifier =
         BroadcastDimsSimplifier(ins, (*outs)[0]->dims(), axis);
     if (VLOG_IS_ON(6)) {
       DimsSimplifiedLogger<int64_t>::Log(
           ins, outs, dims_simplifier, "BroadcastKernel");
     }
-
-#ifdef PADDLE_WITH_XPU_KP
     configs[0] = kps::details::BroadcastConfig(dims_simplifier.out_dims,
                                                dims_simplifier.in_dims[0],
                                                dims_simplifier.in_dims[1],
@@ -92,6 +91,12 @@ struct BroadcastTypeClassifier {
                                                dims_simplifier.rank);
 #else
     if (!all_elementwise) {
+      const auto dims_simplifier =
+          BroadcastDimsSimplifier(ins, (*outs)[0]->dims(), axis);
+      if (VLOG_IS_ON(6)) {
+        DimsSimplifiedLogger<int64_t>::Log(
+            ins, outs, dims_simplifier, "BroadcastKernel");
+      }
       for (int i = 0; i < Arity; ++i) {
         // if data shape is[m, n], then you should set data_dim = {n, m}
         // eg: out's shape [3, 45, 1]. then out_dims = {1, 45, 3}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
Pcard-70459

https://github.com/PaddlePaddle/Paddle/pull/57064 导致推理模型报如下错误：
```
I0912 13:12:32.448268 18931 engine.cc:284] Run Paddle-TRT Dynamic Shape mode.
W0912 13:12:40.775367 18931 helper.h:127] TensorRT was linked against cuBLAS/cuBLAS LT 11.5.1 but loaded cuBLAS/cuBLAS LT 11.4.1
W0912 13:12:40.780050 18931 helper.h:127] Detected invalid timing cache, setup a local cache instead
I0912 13:15:00.076458 18931 elementwiseadd_transpose_op_plugin.cu:189] TRT Plugin DataType selected. elementwiseadd_transpose-->fp32
I0912 13:15:00.076504 18931 elementwiseadd_transpose_op_plugin.cu:193] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.076745 18931 elementwiseadd_transpose_op_plugin.cu:189] TRT Plugin DataType selected. elementwiseadd_transpose-->fp32
I0912 13:15:00.076756 18931 elementwiseadd_transpose_op_plugin.cu:193] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.076972 18931 elementwiseadd_transpose_op_plugin.cu:189] TRT Plugin DataType selected. elementwiseadd_transpose-->fp32
I0912 13:15:00.076978 18931 elementwiseadd_transpose_op_plugin.cu:193] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.077176 18931 elementwiseadd_transpose_op_plugin.cu:189] TRT Plugin DataType selected. elementwiseadd_transpose-->fp32
I0912 13:15:00.077183 18931 elementwiseadd_transpose_op_plugin.cu:193] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.077526 18931 elementwiseadd_transpose_op_plugin.cu:214] TRT Plugin DataType selected. elementwiseadd_transpose-->fp16
I0912 13:15:00.077536 18931 elementwiseadd_transpose_op_plugin.cu:219] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.077734 18931 elementwiseadd_transpose_op_plugin.cu:214] TRT Plugin DataType selected. elementwiseadd_transpose-->fp16
I0912 13:15:00.077742 18931 elementwiseadd_transpose_op_plugin.cu:219] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.077937 18931 elementwiseadd_transpose_op_plugin.cu:214] TRT Plugin DataType selected. elementwiseadd_transpose-->fp16
I0912 13:15:00.077944 18931 elementwiseadd_transpose_op_plugin.cu:219] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.078140 18931 elementwiseadd_transpose_op_plugin.cu:214] TRT Plugin DataType selected. elementwiseadd_transpose-->fp16
I0912 13:15:00.078146 18931 elementwiseadd_transpose_op_plugin.cu:219] TRT Plugin format selected. elementwiseadd_transpose-->kLINEAR
I0912 13:15:00.078447 18931 elementwiseadd_transpose_op_plugin.cu:214] TRT Plugin DataType selected. elementwiseadd_transpose-->fp16
I0912 13:15:00.078456 18931 elementwiseadd_transpose_op_plugin.cu:242] TRT Plugin format selected. elementwiseadd_transpose-->kHWC8
terminate called after throwing an instance of 'phi::enforce::EnforceNotMet'
  what():  (InvalidArgument) The 1-th dimension of input tensor is expected to be equal with the 1-th dimension of output tensor 64 or 1, but received 3136. The input's shape is {1, 3136, 64}, the output's shape is {1, 64, 56, 56}. (at ../paddle/phi/kernels/funcs/dims_simplifier.h:126)

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::AnalysisPredictor::ZeroCopyRun()
1   paddle::framework::NaiveExecutor::Run()
2   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, phi::Place const&)
3   paddle::operators::TensorRTEngineOp::RunImpl(paddle::framework::Scope const&, phi::Place const&) const
4   paddle::operators::TensorRTEngineOp::PrepareTRTEngine(paddle::framework::Scope const&, paddle::inference::tensorrt::TensorRTEngine*) const
5   paddle::inference::tensorrt::OpConverter::ConvertBlockToTRTEngine(paddle::framework::BlockDesc*, paddle::framework::Scope const&, std::vector<std::string, std::allocator<std::string > > const&, std::unordered_set<std::string, std::hash<std::string >, std::equal_to<std::string >, std::allocator<std::string > > const&, std::vector<std::string, std::allocator<std::string > > const&, paddle::inference::tensorrt::TensorRTEngine*)
6   paddle::inference::tensorrt::TensorRTEngine::FreezeNetwork()
7   paddle::inference::tensorrt::plugin::ElementwiseAddTransposePluginDynamic::enqueue(nvinfer1::PluginTensorDesc const*, nvinfer1::PluginTensorDesc const*, void const* const*, void* const*, void*, CUstream_st*)
8   void phi::AddCudaFunctor<phi::dtype::float16, phi::GPUContext>(phi::GPUContext const&, phi::DenseTensor const&, phi::DenseTensor const&, int, phi::DenseTensor*)

----------------------
Error Message Summary:
----------------------
FatalError: `Process abort signal` is detected by the operating system.
  [TimeInfo: *** Aborted at 1694524500 (unix time) try "date -d @1694524500" if you are using GNU date ***]
  [SignalInfo: *** SIGABRT (@0x49f3) received by PID 18931 (TID 0x7f5981715740) from PID 18931 ***]
```

报错位置对应代码如下：
![image](https://github.com/PaddlePaddle/Paddle/assets/12538138/d2d6b04c-5c63-4299-8328-793d745a46df)

报错原因为，AddKernel的2个输入shape一样，都为`{1, 3136, 64}`，但是输出的shape为`{1, 64, 56, 56}`。BroadcastKernel实现内部，在输入shape相同时，没有对输出shape进行比较。实际上，这里应该是输出shape设置的不对。
