### PR TITLE
[PIR] Add check before fetch attr in map

### DIFF
--- a/paddle/fluid/framework/op_call_stack_test.cc
+++ b/paddle/fluid/framework/op_call_stack_test.cc
@@ -44,6 +44,7 @@ TEST(OpCallStack, InsertCallStackInfo) {
     stack_test_vec.emplace_back(stack_test_str);
     attr_map["op_callstack"] = stack_test_vec;
     paddle::framework::InsertCallStackInfo("test", attr_map, &exception);
+    paddle::framework::InsertCallStackInfo("test", stack_test_vec, &exception);
     std::string ex_msg = exception.what();
     EXPECT_TRUE(ex_msg.find(stack_test_str) != std::string::npos);
     EXPECT_TRUE(ex_msg.find("[operator < test > error]") != std::string::npos);

--- a/paddle/fluid/framework/op_call_stack_test.cc
+++ b/paddle/fluid/framework/op_call_stack_test.cc
@@ -44,7 +44,6 @@ TEST(OpCallStack, InsertCallStackInfo) {
     stack_test_vec.emplace_back(stack_test_str);
     attr_map["op_callstack"] = stack_test_vec;
     paddle::framework::InsertCallStackInfo("test", attr_map, &exception);
-    paddle::framework::InsertCallStackInfo("test", stack_test_vec, &exception);
     std::string ex_msg = exception.what();
     EXPECT_TRUE(ex_msg.find(stack_test_str) != std::string::npos);
     EXPECT_TRUE(ex_msg.find("[operator < test > error]") != std::string::npos);

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -669,21 +669,36 @@ def gen_build_func_str(
     )
 
     GET_ATTRIBUTES_FROM_MAP_TEMPLATE = """
+  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
+    phi::errors::NotFound(
+        "{op_name} is expected for '{attribute_name}' Attribute"));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
     GET_STR_ATTRIBUTES_FROM_MAP_TEMPLATE = """
+  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
+    phi::errors::NotFound(
+        "{op_name} is expected for '{attribute_name}' Attribute"));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
     GET_ARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
+  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
+    phi::errors::NotFound(
+        "{op_name} is expected for '{attribute_name}' Attribute"));
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
     {attribute_name}.push_back(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).dyn_cast<{inner_type}>().{data_name}());
   }}
 """
     GET_INTARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
+  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
+    phi::errors::NotFound(
+        "{op_name} is expected for '{attribute_name}' Attribute"));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
     GET_SCALAR_ATTRIBUTE_FROM_MAP_TEMPLATE = """
+  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
+    phi::errors::NotFound(
+        "{op_name} is expected for '{attribute_name}' Attribute"));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """
 

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -669,36 +669,41 @@ def gen_build_func_str(
     )
 
     GET_ATTRIBUTES_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
-    phi::errors::NotFound(
-        "'{attribute_name}' Attribute is expected for {op_name}. "));
+  PADDLE_ENFORCE(
+      attributes.find("{attribute_name}") != attributes.end(),
+      phi::errors::NotFound(
+          "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
     GET_STR_ATTRIBUTES_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
-    phi::errors::NotFound(
-        "'{attribute_name}' Attribute is expected for {op_name}. "));
+  PADDLE_ENFORCE(
+      attributes.find("{attribute_name}") != attributes.end(),
+      phi::errors::NotFound(
+          "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
     GET_ARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
-    phi::errors::NotFound(
-        "'{attribute_name}' Attribute is expected for {op_name}. "));
+  PADDLE_ENFORCE(
+      attributes.find("{attribute_name}") != attributes.end(),
+      phi::errors::NotFound(
+          "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
     {attribute_name}.push_back(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).dyn_cast<{inner_type}>().{data_name}());
   }}
 """
     GET_INTARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
-    phi::errors::NotFound(
-        "'{attribute_name}' Attribute is expected for {op_name}. "));
+  PADDLE_ENFORCE(
+      attributes.find("{attribute_name}") != attributes.end(),
+      phi::errors::NotFound(
+          "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
     GET_SCALAR_ATTRIBUTE_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
-    phi::errors::NotFound(
-        "'{attribute_name}' Attribute is expected for {op_name}. "));
+  PADDLE_ENFORCE(
+      attributes.find("{attribute_name}") != attributes.end(),
+      phi::errors::NotFound(
+          "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """
 

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -721,6 +721,7 @@ def gen_build_func_str(
                     data_name = "AsString"
                 get_attributes_str += (
                     GET_ARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE.format(
+                        op_name=op_class_name,
                         attr_type=attr_type,
                         attribute_name=op_attribute_name_list[idx],
                         inner_type=inner_type,
@@ -733,6 +734,7 @@ def gen_build_func_str(
             ):
                 get_attributes_str += (
                     GET_INTARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE.format(
+                        op_name=op_class_name,
                         attr_type=attr_type,
                         attribute_name=op_attribute_name_list[idx],
                     )
@@ -743,6 +745,7 @@ def gen_build_func_str(
             ):
                 get_attributes_str += (
                     GET_SCALAR_ATTRIBUTE_FROM_MAP_TEMPLATE.format(
+                        op_name=op_class_name,
                         attr_type=attr_type,
                         attribute_name=op_attribute_name_list[idx],
                     )
@@ -750,6 +753,7 @@ def gen_build_func_str(
             elif "pir::StrAttribute" in op_attribute_type_list[idx]:
                 get_attributes_str += (
                     GET_STR_ATTRIBUTES_FROM_MAP_TEMPLATE.format(
+                        op_name=op_class_name,
                         attr_type=attr_type,
                         attribute_name=op_attribute_name_list[idx],
                         attr_ir_type=op_attribute_type_list[idx],
@@ -757,6 +761,7 @@ def gen_build_func_str(
                 )
             else:
                 get_attributes_str += GET_ATTRIBUTES_FROM_MAP_TEMPLATE.format(
+                    op_name=op_class_name,
                     attr_type=attr_type,
                     attribute_name=op_attribute_name_list[idx],
                     attr_ir_type=op_attribute_type_list[idx],

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -671,19 +671,19 @@ def gen_build_func_str(
     GET_ATTRIBUTES_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{attribute_name} Attribute is expected for {op_name}. "));
+        "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
     GET_STR_ATTRIBUTES_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{attribute_name} Attribute is expected for {op_name}. "));
+        "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
     GET_ARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{attribute_name} Attribute is expected for {op_name}. "));
+        "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
     {attribute_name}.push_back(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).dyn_cast<{inner_type}>().{data_name}());
@@ -692,13 +692,13 @@ def gen_build_func_str(
     GET_INTARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{attribute_name} Attribute is expected for {op_name}. "));
+        "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
     GET_SCALAR_ATTRIBUTE_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{attribute_name} Attribute is expected for {op_name}. "));
+        "'{attribute_name}' Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """
 

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -671,19 +671,19 @@ def gen_build_func_str(
     GET_ATTRIBUTES_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{op_name} is expected for '{attribute_name}' Attribute"));
+        "{attribute_name} Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
     GET_STR_ATTRIBUTES_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{op_name} is expected for '{attribute_name}' Attribute"));
+        "{attribute_name} Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
     GET_ARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{op_name} is expected for '{attribute_name}' Attribute"));
+        "{attribute_name} Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
     {attribute_name}.push_back(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).dyn_cast<{inner_type}>().{data_name}());
@@ -692,13 +692,13 @@ def gen_build_func_str(
     GET_INTARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{op_name} is expected for '{attribute_name}' Attribute"));
+        "{attribute_name} Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
     GET_SCALAR_ATTRIBUTE_FROM_MAP_TEMPLATE = """
   PADDLE_ENFORCE(attributes.find("{attribute_name}") != attributes.end(),
     phi::errors::NotFound(
-        "{op_name} is expected for '{attribute_name}' Attribute"));
+        "{attribute_name} Attribute is expected for {op_name}. "));
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -455,17 +455,20 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
                                 pir::OpResult y_,
                                 pir::OpResult bias_,
                                 pir::AttributeMap attributes) {
-  PADDLE_ENFORCE(attributes.find("trans_x") != attributes.end(),
+  PADDLE_ENFORCE(
+      attributes.find("trans_x") != attributes.end(),
       phi::errors::NotFound(
           "'trans_x' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
-  PADDLE_ENFORCE(attributes.find("trans_y") != attributes.end(),
+  PADDLE_ENFORCE(
+      attributes.find("trans_y") != attributes.end(),
       phi::errors::NotFound(
           "'trans_y' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
-  PADDLE_ENFORCE(attributes.find("activation") != attributes.end(),
+  PADDLE_ENFORCE(
+      attributes.find("activation") != attributes.end(),
       phi::errors::NotFound(
           "'activation' Attribute is expected for FusedGemmEpilogueOp"));
   std::string activation =
@@ -706,19 +709,21 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
                                     pir::OpResult reserve_space_,
                                     pir::OpResult out_grad_,
                                     pir::AttributeMap attributes) {
-  PADDLE_ENFORCE(attributes.find("trans_x") != attributes.end(),
+  PADDLE_ENFORCE(
+      attributes.find("trans_x") != attributes.end(),
       phi::errors::NotFound(
           "'trans_x' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
-  PADDLE_ENFORCE(attributes.find("trans_y") != attributes.end(),
+  PADDLE_ENFORCE(
+      attributes.find("trans_y") != attributes.end(),
       phi::errors::NotFound(
           "'trans_y' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
-  PADDLE_ENFORCE(attributes.find("activation_grad") != attributes.end(),
-      phi::errors::NotFound(
-          "'activation_grad' Attribute is expected for"
+  PADDLE_ENFORCE(
+      attributes.find("activation_grad") != attributes.end(),
+      phi::errors::NotFound("'activation_grad' Attribute is expected for"
                "FusedGemmEpilogueGradOp"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -455,10 +455,19 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
                                 pir::OpResult y_,
                                 pir::OpResult bias_,
                                 pir::AttributeMap attributes) {
+  PADDLE_ENFORCE(attributes.find("trans_x") != attributes.end(),
+      phi::errors::NotFound(
+          "FusedGemmEpilogueOp is expected for 'trans_x' Attribute"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
+  PADDLE_ENFORCE(attributes.find("trans_y") != attributes.end(),
+      phi::errors::NotFound(
+          "FusedGemmEpilogueOp is expected for 'trans_y' Attribute"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
+  PADDLE_ENFORCE(attributes.find("activation") != attributes.end(),
+      phi::errors::NotFound(
+          "FusedGemmEpilogueOp is expected for 'activation' Attribute"));
   std::string activation =
       attributes.at("activation").dyn_cast<pir::StrAttribute>().AsString();
 
@@ -697,10 +706,19 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
                                     pir::OpResult reserve_space_,
                                     pir::OpResult out_grad_,
                                     pir::AttributeMap attributes) {
+  PADDLE_ENFORCE(attributes.find("trans_x") != attributes.end(),
+      phi::errors::NotFound(
+          "FusedGemmEpilogueGradOp is expected for 'trans_x' Attribute"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
+  PADDLE_ENFORCE(attributes.find("trans_y") != attributes.end(),
+      phi::errors::NotFound(
+          "FusedGemmEpilogueGradOp is expected for 'trans_y' Attribute"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
+  PADDLE_ENFORCE(attributes.find("activation_grad") != attributes.end(),
+      phi::errors::NotFound(
+          "FusedGemmEpilogueGradOp is expected for 'activation_grad' Attribute"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -718,8 +718,8 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
 
   PADDLE_ENFORCE(attributes.find("activation_grad") != attributes.end(),
       phi::errors::NotFound(
-          "'activation_grad' Attribute is expected for" +
-              "FusedGemmEpilogueGradOp"));
+          "'activation_grad' Attribute is expected for"
+               "FusedGemmEpilogueGradOp"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -724,7 +724,7 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
   PADDLE_ENFORCE(
       attributes.find("activation_grad") != attributes.end(),
       phi::errors::NotFound("'activation_grad' Attribute is expected for"
-               "FusedGemmEpilogueGradOp"));
+                            "FusedGemmEpilogueGradOp"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -457,17 +457,17 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
                                 pir::AttributeMap attributes) {
   PADDLE_ENFORCE(attributes.find("trans_x") != attributes.end(),
       phi::errors::NotFound(
-          "FusedGemmEpilogueOp is expected for 'trans_x' Attribute"));
+          "'trans_x' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(attributes.find("trans_y") != attributes.end(),
       phi::errors::NotFound(
-          "FusedGemmEpilogueOp is expected for 'trans_y' Attribute"));
+          "'trans_y' Attribute is expected for FusedGemmEpilogueOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(attributes.find("activation") != attributes.end(),
       phi::errors::NotFound(
-          "FusedGemmEpilogueOp is expected for 'activation' Attribute"));
+          "'activation' Attribute is expected for FusedGemmEpilogueOp"));
   std::string activation =
       attributes.at("activation").dyn_cast<pir::StrAttribute>().AsString();
 
@@ -708,17 +708,18 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
                                     pir::AttributeMap attributes) {
   PADDLE_ENFORCE(attributes.find("trans_x") != attributes.end(),
       phi::errors::NotFound(
-          "FusedGemmEpilogueGradOp is expected for 'trans_x' Attribute"));
+          "'trans_x' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_x = attributes.at("trans_x").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(attributes.find("trans_y") != attributes.end(),
       phi::errors::NotFound(
-          "FusedGemmEpilogueGradOp is expected for 'trans_y' Attribute"));
+          "'trans_y' Attribute is expected for FusedGemmEpilogueGradOp"));
   bool trans_y = attributes.at("trans_y").dyn_cast<pir::BoolAttribute>().data();
 
   PADDLE_ENFORCE(attributes.find("activation_grad") != attributes.end(),
       phi::errors::NotFound(
-          "FusedGemmEpilogueGradOp is expected for 'activation_grad' Attribute"));
+          "'activation_grad' Attribute is expected for" +
+              "FusedGemmEpilogueGradOp"));
   std::string activation_grad =
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Pcard-67164

在Op的Build过程中，当attributes中没有对应key时会直接抛出Map::at()的错误，但是不会提示到具体出错的行。本PR添加强制检查，提前抛出异常，方便问题定位。