### PR TITLE
[PIR] refine shadow feed

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -1009,13 +1009,13 @@ void AddShadowFeed(
     std::unordered_map<pir::Value, pir::OpResult>* map_value_pair) {
   bool feed_op_add_shadow_feed =
       (op_item->name() == "pd_op.feed") && platform::is_gpu_place(place);
-  bool data_op_add_shadow_feed = (op_item->name() == "pd_op.data") &&
-                                 platform::is_gpu_place(place) &&
-                                 (kernel_op->attributes()
-                                      .at("place")
-                                      .dyn_cast<dialect::PlaceAttribute>()
-                                      .data()
-                                      .GetType() != phi::AllocationType::GPU);
+  bool data_op_add_shadow_feed =
+      (op_item->name() == "pd_op.data") && platform::is_gpu_place(place) &&
+      (kernel_op->attributes()
+           .at("place")
+           .dyn_cast<dialect::PlaceAttribute>()
+           .data()
+           .GetType() == phi::AllocationType::UNDEFINED);
   bool add_shadow_feed = feed_op_add_shadow_feed || data_op_add_shadow_feed;
   if (add_shadow_feed) {
     // if shadow data op place not gpu,add shadow feed op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
当Adam的beta1_pow和beta2_pow在CPU上时，被shadow feed拷贝到GPU上。而shadow feed的output作为了adam的input。而beta1_pow和beta2_pow是inplace的。这导致原始的beta1_pow和beta2_pow没有被inplace，而是shadow feed的output被inplace了。导致精度问题。
Pcard-67164