### PR TITLE
[CINN]fix bug in cinn stack op_mapper

### DIFF
--- a/paddle/cinn/frontend/op_mappers/paddle/concat.cc
+++ b/paddle/cinn/frontend/op_mappers/paddle/concat.cc
@@ -101,7 +101,7 @@ void StackOpMapper(const paddle::cpp::OpDesc& op_desc,
       << "The axis of stack should >= 0 and < rank(x) + 1! Please check.";
 
   // N * [A, B] with axis=0 --> [N, A, B]; N * [A, B] with axis=1 --> [A, N, B];
-  cinn::utils::ShapeType new_shape(concat_out->shape);
+  cinn::utils::ShapeType new_shape(xs.front()->shape);
   new_shape.insert(new_shape.begin() + axis, xs.size());
 
   auto out = ctx.Builder()->Reshape(concat_out, new_shape);

--- a/test/cinn/op_mappers/test_stack_op.py
+++ b/test/cinn/op_mappers/test_stack_op.py
@@ -52,5 +52,10 @@ class TestStackOp(OpMapperTest):
         self.check_outputs_and_grads()
 
 
+class TestStackOpAxisNegative(TestStackOp):
+    def set_op_attrs(self):
+        return {"axis": -1}
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
pcard-72718
fix bug in cinn stack op_mapper, the output shape is wrong when axis < 0 
