### PR TITLE
Optimize the implemention of several operators to decrease the compiled size.

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -40,22 +40,11 @@ struct AddFunctor {
   inline HOSTDEVICE T operator()(const T a, const T b) const { return a + b; }
 };
 template <typename T>
-struct InverseAddFunctor {
-  inline HOSTDEVICE T operator()(const T a, const T b) const { return b + a; }
-};
+using InverseAddFunctor = AddFunctor<T>;
 
-// Float32Bfloat16Add
-template <typename T>
-struct Float32Bfloat16AddFunctor {
-  inline HOSTDEVICE T operator()(const T x, const phi::bfloat16 y) {
-    return x + static_cast<T>(y);
-  }
-};
-
-// Float32Float16Add
-template <typename T>
-struct Float32Float16AddFunctor {
-  inline HOSTDEVICE T operator()(const T x, const phi::float16 y) {
+template <typename T, typename Ty = T>
+struct MultiPrecisionAddFunctor {
+  inline HOSTDEVICE T operator()(const T x, const Ty y) const {
     return x + static_cast<T>(y);
   }
 };
@@ -82,15 +71,7 @@ struct MultiplyFunctor<bool> {
   }
 };
 template <typename T>
-struct InverseMultiplyFunctor {
-  inline HOSTDEVICE T operator()(const T a, const T b) const { return b * a; }
-};
-template <>
-struct InverseMultiplyFunctor<bool> {
-  inline HOSTDEVICE bool operator()(const bool a, const bool b) const {
-    return b && a;
-  }
-};
+using InverseMultiplyFunctor = MultiplyFunctor<T>;
 
 template <typename T>
 struct IsZeroFunctor {

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -21,21 +21,26 @@
 
 namespace phi {
 
-template <typename T, size_t Rank>
-__global__ void flip_cuda_kernel(const int64_t N,
-                                 const T* in_data,
-                                 T* out_data,
-                                 phi::Array<int64_t, Rank> shape,
-                                 phi::Array<int64_t, Rank> stride,
-                                 phi::Array<int, Rank> flip_dims,
-                                 int flip_dims_size) {
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= N) {
+template <typename T>
+__global__ void FlipCudaKernel(const T* in_data,
+                               T* out_data,
+                               phi::Array<int64_t, DDim::kMaxRank> shape,
+                               phi::Array<int64_t, DDim::kMaxRank> stride,
+                               phi::Array<int, DDim::kMaxRank> flip_dims,
+                               const int rank,
+                               const int64_t numel,
+                               const int flip_dims_size) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
+  if (idx >= numel) {
     return;
   }
 
-  int cur_indices = idx, rem = 0, dst_offset = 0;
-  for (int i = 0; i < Rank; ++i) {
+  int64_t cur_indices = idx;
+  int64_t rem = 0;
+  int64_t dst_offset = 0;
+  for (int i = 0; i < rank; ++i) {
     int64_t temp = cur_indices;
     cur_indices = cur_indices / stride[i];
     rem = temp - cur_indices * stride[i];
@@ -51,91 +56,48 @@ __global__ void flip_cuda_kernel(const int64_t N,
   out_data[idx] = in_data[dst_offset];
 }
 
-template <typename T, typename Context, size_t N>
-void LaunchFlipCudaKernel(const Context& dev_ctx,
-                          const DenseTensor& x,
-                          const std::vector<int>& axis,
-                          DenseTensor* out) {
-  auto* in_data = x.data<T>();
-  auto* out_data = dev_ctx.template Alloc<T>(out);
-
-  auto x_dims = x.dims();
-  const int total_dims = x_dims.size();
-  const int64_t numel = x.numel();
-  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
-  auto x_stride = phi::stride(x_dims);
-
-  phi::Array<int64_t, N> stride_a;
-  phi::Array<int64_t, N> shape_a;
-  phi::Array<int, N> flip_dims_a;
-  size_t flip_dims_size = axis.size();
-
-  for (size_t idx = 0; idx < N; ++idx) {
-    stride_a[idx] = x_stride[idx];
-    shape_a[idx] = x_dims[idx];
-    flip_dims_a[idx] = idx < flip_dims_size ? axis[idx] : 0;
-  }
-
-  for (size_t i = 0; i < flip_dims_a.size(); ++i) {
-    if (flip_dims_a[i] < 0) {
-      flip_dims_a[i] += total_dims;
-    }
-  }
-  flip_cuda_kernel<T, N>
-      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
-          numel,
-          in_data,
-          out_data,
-          shape_a,
-          stride_a,
-          flip_dims_a,
-          flip_dims_size);
-}
-
 template <typename T, typename Context>
 void FlipKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const std::vector<int>& axis,
                 DenseTensor* out) {
-  const size_t total_dims = x.dims().size();
-  switch (total_dims) {
-    case 0:
-      LaunchFlipCudaKernel<T, Context, 0>(dev_ctx, x, axis, out);
-      break;
-    case 1:
-      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
-      break;
-    case 2:
-      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
-      break;
-    case 3:
-      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
-      break;
-    case 4:
-      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
-      break;
-    case 5:
-      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
-      break;
-    case 6:
-      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
-      break;
-    case 7:
-      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
-      break;
-    case 8:
-      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
-      break;
-    case 9:
-      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
-      break;
-    default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "dims of input tensor should be less than 10, But received"
-          "%d",
-          x.dims().size()));
+  auto* in_data = x.data<T>();
+  auto* out_data = dev_ctx.template Alloc<T>(out);
+
+  auto x_dims = x.dims();
+  const int rank = x_dims.size();
+  const int64_t numel = x.numel();
+
+  size_t flip_dims_size = axis.size();
+  auto x_stride = phi::stride(x_dims);
+
+  phi::Array<int64_t, DDim::kMaxRank> stride_array;
+  phi::Array<int64_t, DDim::kMaxRank> shape_array;
+  phi::Array<int, DDim::kMaxRank> flip_dims_array;
+
+  for (int i = 0; i < rank; ++i) {
+    stride_array[i] = x_stride[i];
+    shape_array[i] = x_dims[i];
+    if (i < flip_dims_size) {
+      flip_dims_array[i] = axis[i] < 0 ? axis[i] + rank : axis[i];
+    } else {
+      flip_dims_array[i] = 0;
+    }
   }
+
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  FlipCudaKernel<T>
+      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
+          in_data,
+          out_data,
+          shape_array,
+          stride_array,
+          flip_dims_array,
+          rank,
+          numel,
+          flip_dims_size);
 }
+
 }  // namespace phi
 
 PD_REGISTER_KERNEL(flip,

--- a/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
@@ -24,20 +24,23 @@
 
 namespace phi {
 
-template <typename T, size_t Rank>
-__global__ void set_zero_cuda_kernel(const int64_t N,
-                                     int64_t** indices,
-                                     phi::Array<int64_t, Rank> stride,
-                                     phi::Array<int64_t, Rank> shape,
-                                     T* out) {
-  int64_t idx = threadIdx.x + blockDim.x * blockIdx.x;
-  int64_t cur_ix = 0;
-
-  if (idx >= N) {
+template <typename T>
+__global__ void SetZeroCudaKernel(int64_t** indices,
+                                  phi::Array<int64_t, DDim::kMaxRank> stride,
+                                  phi::Array<int64_t, DDim::kMaxRank> shape,
+                                  const int rank,
+                                  const int64_t numel,
+                                  T* out) {
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x);
+  if (idx >= numel) {
     return;
   }
+
+  int64_t cur_ix = 0;
   int64_t offset = 0;
-  for (int i = 0; i < Rank; ++i) {
+  for (int i = 0; i < rank; ++i) {
     cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
     if (cur_ix < 0) {
       cur_ix += shape[i];
@@ -48,21 +51,25 @@ __global__ void set_zero_cuda_kernel(const int64_t N,
   *(out + offset) = 0;
 }
 
-template <typename T, size_t Rank>
-__global__ void index_put_grad_cuda_kernel(const int64_t N,
-                                           const T* out_grad,
-                                           int64_t** indices,
-                                           phi::Array<int64_t, Rank> stride,
-                                           phi::Array<int64_t, Rank> shape,
-                                           T* value_grad) {
-  int64_t idx = threadIdx.x + blockDim.x * blockIdx.x;
-  int64_t cur_ix = 0;
-
-  if (idx >= N) {
+template <typename T>
+__global__ void IndexPutGradCudaKernel(
+    const T* out_grad,
+    int64_t** indices,
+    phi::Array<int64_t, DDim::kMaxRank> stride,
+    phi::Array<int64_t, DDim::kMaxRank> shape,
+    const int rank,
+    const int64_t numel,
+    T* value_grad) {
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x);
+  if (idx >= numel) {
     return;
   }
+
+  int64_t cur_ix = 0;
   int64_t offset = 0;
-  for (int i = 0; i < Rank; ++i) {
+  for (int i = 0; i < rank; ++i) {
     cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
     if (cur_ix < 0) {
       cur_ix += shape[i];
@@ -73,12 +80,13 @@ __global__ void index_put_grad_cuda_kernel(const int64_t N,
   *(value_grad + idx) = *(out_grad + offset);
 }
 
-template <typename T, typename Context, size_t Rank>
+template <typename T, typename Context>
 void LaunchIndexPutGradCudaKernel(
     const Context& dev_ctx,
     const std::vector<const DenseTensor*>& indices,
     const DenseTensor& out_grad,
-    bool accumulate,
+    const int rank,
+    const bool accumulate,
     DenseTensor* value_grad,
     DenseTensor* x_grad) {
   if (x_grad) {
@@ -87,43 +95,41 @@ void LaunchIndexPutGradCudaKernel(
       T* x_grad_data = x_grad->data<T>();
 
       auto x_grad_dims = x_grad->dims();
-      const int64_t numel = indices[0]->numel();
-      auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
       auto x_grad_stride = phi::stride(x_grad_dims);
 
-      phi::Array<int64_t, Rank> stride_a;
-      phi::Array<int64_t, Rank> shape_a;
-
-      for (size_t idx = 0; idx < Rank; ++idx) {
-        stride_a[idx] = x_grad_stride[idx];
-        shape_a[idx] = x_grad_dims[idx];
+      phi::Array<int64_t, DDim::kMaxRank> stride_array;
+      phi::Array<int64_t, DDim::kMaxRank> shape_array;
+      for (int i = 0; i < rank; ++i) {
+        stride_array[i] = x_grad_stride[i];
+        shape_array[i] = x_grad_dims[i];
       }
 
+      const int64_t numel = indices[0]->numel();
       auto pd_indices =
           funcs::GetDevicePointerArray<int64_t, Context>(dev_ctx, indices);
-      set_zero_cuda_kernel<T, Rank><<<config.block_per_grid,
-                                      config.thread_per_block,
-                                      0,
-                                      dev_ctx.stream()>>>(
-          numel, pd_indices, stride_a, shape_a, x_grad_data);
+      auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+      SetZeroCudaKernel<T><<<config.block_per_grid,
+                             config.thread_per_block,
+                             0,
+                             dev_ctx.stream()>>>(
+          pd_indices, stride_array, shape_array, rank, numel, x_grad_data);
     }
   }
 
   auto out_grad_dims = out_grad.dims();
-  const int64_t numel = indices[0]->numel();
-  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto out_grad_stride = phi::stride(out_grad_dims);
 
-  phi::Array<int64_t, Rank> stride_a;
-  phi::Array<int64_t, Rank> shape_a;
-
-  for (size_t idx = 0; idx < Rank; ++idx) {
-    stride_a[idx] = out_grad_stride[idx];
-    shape_a[idx] = out_grad_dims[idx];
+  phi::Array<int64_t, DDim::kMaxRank> stride_array;
+  phi::Array<int64_t, DDim::kMaxRank> shape_array;
+  for (int i = 0; i < rank; ++i) {
+    stride_array[i] = out_grad_stride[i];
+    shape_array[i] = out_grad_dims[i];
   }
 
+  const int64_t numel = indices[0]->numel();
   auto pd_indices =
       funcs::GetDevicePointerArray<int64_t, Context>(dev_ctx, indices);
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
 
   if (value_grad) {
     if (value_grad->numel() == 1) {
@@ -133,16 +139,16 @@ void LaunchIndexPutGradCudaKernel(
       T* tmp_value_grad_data = dev_ctx.template Alloc<T>(&tmp_value_grad);
       auto out_grad_data = out_grad.data<T>();
 
-      index_put_grad_cuda_kernel<T, Rank>
-          <<<config.block_per_grid,
-             config.thread_per_block,
-             0,
-             dev_ctx.stream()>>>(numel,
-                                 out_grad_data,
-                                 pd_indices,
-                                 stride_a,
-                                 shape_a,
-                                 tmp_value_grad_data);
+      IndexPutGradCudaKernel<T><<<config.block_per_grid,
+                                  config.thread_per_block,
+                                  0,
+                                  dev_ctx.stream()>>>(out_grad_data,
+                                                      pd_indices,
+                                                      stride_array,
+                                                      shape_array,
+                                                      rank,
+                                                      numel,
+                                                      tmp_value_grad_data);
 
       std::vector<int> v_dims(tmp_value_grad.dims().size());
       std::iota(v_dims.begin(), v_dims.end(), 0);
@@ -157,11 +163,16 @@ void LaunchIndexPutGradCudaKernel(
       T* value_grad_data = dev_ctx.template Alloc<T>(value_grad);
       auto out_grad_data = out_grad.data<T>();
 
-      index_put_grad_cuda_kernel<T, Rank><<<config.block_per_grid,
-                                            config.thread_per_block,
-                                            0,
-                                            dev_ctx.stream()>>>(
-          numel, out_grad_data, pd_indices, stride_a, shape_a, value_grad_data);
+      IndexPutGradCudaKernel<T><<<config.block_per_grid,
+                                  config.thread_per_block,
+                                  0,
+                                  dev_ctx.stream()>>>(out_grad_data,
+                                                      pd_indices,
+                                                      stride_array,
+                                                      shape_array,
+                                                      rank,
+                                                      numel,
+                                                      value_grad_data);
     } else {
       DenseTensor tmp_value_grad(value_grad->dtype());
       tmp_value_grad.Resize(indices[0]->dims());
@@ -169,16 +180,16 @@ void LaunchIndexPutGradCudaKernel(
       T* tmp_value_grad_data = dev_ctx.template Alloc<T>(&tmp_value_grad);
       auto out_grad_data = out_grad.data<T>();
 
-      index_put_grad_cuda_kernel<T, Rank>
-          <<<config.block_per_grid,
-             config.thread_per_block,
-             0,
-             dev_ctx.stream()>>>(numel,
-                                 out_grad_data,
-                                 pd_indices,
-                                 stride_a,
-                                 shape_a,
-                                 tmp_value_grad_data);
+      IndexPutGradCudaKernel<T><<<config.block_per_grid,
+                                  config.thread_per_block,
+                                  0,
+                                  dev_ctx.stream()>>>(out_grad_data,
+                                                      pd_indices,
+                                                      stride_array,
+                                                      shape_array,
+                                                      rank,
+                                                      numel,
+                                                      tmp_value_grad_data);
 
       std::vector<int64_t> after_dims = phi::vectorize(tmp_value_grad.dims());
       std::vector<int64_t> before_dims = phi::vectorize(value_grad->dims());
@@ -234,7 +245,6 @@ void IndexPutGradKernel(const Context& dev_ctx,
     return;
   }
 
-  const size_t total_dims = x.dims().size();
   auto bd_dim = funcs::BroadCastTensorsDims(int_indices_v);
 
   std::vector<int64_t> res_dim_v(phi::vectorize(bd_dim));
@@ -256,37 +266,9 @@ void IndexPutGradKernel(const Context& dev_ctx,
                                      bd_dim,
                                      &res_dim_v);
 
-  switch (total_dims) {
-    case 1:
-      LaunchIndexPutGradCudaKernel<T, Context, 1>(
-          dev_ctx, res_indices_v, out_grad, accumulate, value_grad, x_grad);
-      break;
-    case 2:
-      LaunchIndexPutGradCudaKernel<T, Context, 2>(
-          dev_ctx, res_indices_v, out_grad, accumulate, value_grad, x_grad);
-      break;
-    case 3:
-      LaunchIndexPutGradCudaKernel<T, Context, 3>(
-          dev_ctx, res_indices_v, out_grad, accumulate, value_grad, x_grad);
-      break;
-    case 4:
-      LaunchIndexPutGradCudaKernel<T, Context, 4>(
-          dev_ctx, res_indices_v, out_grad, accumulate, value_grad, x_grad);
-      break;
-    case 5:
-      LaunchIndexPutGradCudaKernel<T, Context, 5>(
-          dev_ctx, res_indices_v, out_grad, accumulate, value_grad, x_grad);
-      break;
-    case 6:
-      LaunchIndexPutGradCudaKernel<T, Context, 6>(
-          dev_ctx, res_indices_v, out_grad, accumulate, value_grad, x_grad);
-      break;
-    default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "dims of input tensor should be less than 7, But received"
-          "%d",
-          x.dims().size()));
-  }
+  const int rank = x.dims().size();
+  LaunchIndexPutGradCudaKernel<T, Context>(
+      dev_ctx, res_indices_v, out_grad, rank, accumulate, value_grad, x_grad);
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -21,24 +21,27 @@
 
 namespace phi {
 
-template <typename T, size_t Rank>
-__global__ void index_put_cuda_kernel(const int64_t N,
-                                      const T* x,
-                                      const T* vals,
-                                      int64_t** indices,
-                                      phi::Array<int64_t, Rank> stride,
-                                      phi::Array<int64_t, Rank> shape,
-                                      int64_t is_single_val_tensor,
-                                      bool accumulate,
-                                      T* out) {
-  int64_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+template <typename T>
+__global__ void IndexPutCudaKernel(const T* x,
+                                   const T* vals,
+                                   int64_t** indices,
+                                   phi::Array<int64_t, DDim::kMaxRank> stride,
+                                   phi::Array<int64_t, DDim::kMaxRank> shape,
+                                   const int rank,
+                                   const int64_t numel,
+                                   const int64_t is_single_val_tensor,
+                                   const bool accumulate,
+                                   T* out) {
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x);
   int64_t cur_ix = 0;
 
-  if (idx >= N) {
+  if (idx >= numel) {
     return;
   }
   int64_t offset = 0;
-  for (int i = 0; i < Rank; ++i) {
+  for (int i = 0; i < rank; ++i) {
     cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
     if (cur_ix < 0) {
       cur_ix += shape[i];
@@ -53,7 +56,7 @@ __global__ void index_put_cuda_kernel(const int64_t N,
   }
 }
 
-template <typename T, typename Context, size_t Rank>
+template <typename T, typename Context>
 void LaunchIndexPutCudaKernel(const Context& dev_ctx,
                               const DenseTensor& x,
                               const std::vector<const DenseTensor*>& indices,
@@ -62,38 +65,39 @@ void LaunchIndexPutCudaKernel(const Context& dev_ctx,
                               DenseTensor* out) {
   auto* x_data = x.data<T>();
   auto* val_data = value.data<T>();
+
   bool is_initialized = out->initialized();
   T* out_data = dev_ctx.template Alloc<T>(out);
-
   if (!is_initialized) {
     phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   }
 
   auto x_dims = x.dims();
-  const int64_t numel = indices[0]->numel();
-  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  const int rank = x_dims.size();
   auto x_stride = phi::stride(x_dims);
 
-  phi::Array<int64_t, Rank> stride_a;
-  phi::Array<int64_t, Rank> shape_a;
-
-  for (size_t idx = 0; idx < Rank; ++idx) {
-    stride_a[idx] = x_stride[idx];
-    shape_a[idx] = x_dims[idx];
+  phi::Array<int64_t, DDim::kMaxRank> stride_array;
+  phi::Array<int64_t, DDim::kMaxRank> shape_array;
+  for (int i = 0; i < rank; ++i) {
+    stride_array[i] = x_stride[i];
+    shape_array[i] = x_dims[i];
   }
 
   int64_t is_single_val_tensor = (value.numel() == 1) ? 0 : INT64_MAX;
-
+  const int64_t numel = indices[0]->numel();
   auto pd_indices =
       funcs::GetDevicePointerArray<int64_t, Context>(dev_ctx, indices);
-  index_put_cuda_kernel<T, Rank>
+
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  IndexPutCudaKernel<T>
       <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
-          numel,
           x_data,
           val_data,
           pd_indices,
-          stride_a,
-          shape_a,
+          stride_array,
+          shape_array,
+          rank,
+          numel,
           is_single_val_tensor,
           accumulate,
           out_data);
@@ -124,7 +128,6 @@ void IndexPutKernel(const Context& dev_ctx,
     }
     return;
   }
-  const size_t total_dims = x.dims().size();
   auto bd_dim = funcs::BroadCastTensorsDims(int_indices_v);
 
   std::vector<int64_t> res_dim_v(phi::vectorize(bd_dim));
@@ -158,37 +161,8 @@ void IndexPutKernel(const Context& dev_ctx,
     ptr_value = &value;
   }
 
-  switch (total_dims) {
-    case 1:
-      LaunchIndexPutCudaKernel<T, Context, 1>(
-          dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
-      break;
-    case 2:
-      LaunchIndexPutCudaKernel<T, Context, 2>(
-          dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
-      break;
-    case 3:
-      LaunchIndexPutCudaKernel<T, Context, 3>(
-          dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
-      break;
-    case 4:
-      LaunchIndexPutCudaKernel<T, Context, 4>(
-          dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
-      break;
-    case 5:
-      LaunchIndexPutCudaKernel<T, Context, 5>(
-          dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
-      break;
-    case 6:
-      LaunchIndexPutCudaKernel<T, Context, 6>(
-          dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
-      break;
-    default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "dims of input tensor should be less than 7, But received"
-          "%d",
-          x.dims().size()));
-  }
+  LaunchIndexPutCudaKernel<T, Context>(
+      dev_ctx, x, res_indices_v, *ptr_value, accumulate, out);
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/gpu/roll_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roll_grad_kernel.cu
@@ -22,8 +22,6 @@
 
 namespace phi {
 
-using phi::PADDLE_CUDA_NUM_THREADS;
-
 template <typename T, typename Context>
 void RollGradKernel(const Context& dev_ctx,
                     const DenseTensor& x,
@@ -31,23 +29,23 @@ void RollGradKernel(const Context& dev_ctx,
                     const IntArray& shifts,
                     const std::vector<int64_t>& axis,
                     DenseTensor* x_grad) {
-  auto* in_data = out_grad.data<T>();
-  T* out_data = dev_ctx.template Alloc<T>(x_grad);
-  int64_t numel = out_grad.numel();
-  auto stream = dev_ctx.stream();
+  auto* out_grad_data = out_grad.data<T>();
+  T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
 
   auto shifts_data = shifts.GetData();
-  size_t nums = shifts_data.size();
+  int rank = shifts_data.size();
+
+  int64_t numel = out_grad.numel();
   auto input_dim = out_grad.dims();
   auto stride_dim = phi::stride(input_dim);
 
-  std::vector<int64_t> strides(nums), sizes(nums);
+  std::vector<int64_t> strides(rank), sizes(rank);
   if (axis.size() == 0) {
     strides[0] = 1;
     sizes[0] = numel;
     shifts_data[0] = ((-shifts_data[0]) % numel + numel) % numel;
   } else {
-    for (size_t i = 0; i < nums; i++) {
+    for (int i = 0; i < rank; i++) {
       int dim = axis[i] >= 0 ? axis[i] : axis[i] + input_dim.size();
       int64_t size = input_dim[dim];
       if (size != 0) {
@@ -58,22 +56,14 @@ void RollGradKernel(const Context& dev_ctx,
     }
   }
 
-  switch (nums) {
-    CALL_ROLL_CUDA_KERNEL(1);
-    CALL_ROLL_CUDA_KERNEL(2);
-    CALL_ROLL_CUDA_KERNEL(3);
-    CALL_ROLL_CUDA_KERNEL(4);
-    CALL_ROLL_CUDA_KERNEL(5);
-    CALL_ROLL_CUDA_KERNEL(6);
-    CALL_ROLL_CUDA_KERNEL(7);
-    CALL_ROLL_CUDA_KERNEL(8);
-    CALL_ROLL_CUDA_KERNEL(9);
-    default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "shifts.size() should be less than 10, But received shifts.size() "
-          "= %d",
-          shifts_data.size()));
-  }
+  LaunchRollKernel<T, Context>(dev_ctx,
+                               out_grad_data,
+                               x_grad_data,
+                               rank,
+                               numel,
+                               shifts_data,
+                               strides,
+                               sizes);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/roll_kernel.cu
+++ b/paddle/phi/kernels/gpu/roll_kernel.cu
@@ -23,8 +23,6 @@
 
 namespace phi {
 
-using phi::PADDLE_CUDA_NUM_THREADS;
-
 template <typename T, typename Context>
 void RollKernel(const Context& dev_ctx,
                 const DenseTensor& x,
@@ -33,22 +31,21 @@ void RollKernel(const Context& dev_ctx,
                 DenseTensor* out) {
   auto* in_data = x.data<T>();
   T* out_data = dev_ctx.template Alloc<T>(out);
-  int64_t numel = x.numel();
-  auto stream = dev_ctx.stream();
 
   auto shifts_data = shifts.GetData();
+  int rank = shifts_data.size();
 
-  size_t nums = shifts_data.size();
+  int64_t numel = x.numel();
   auto input_dim = x.dims();
   auto stride_dim = phi::stride(input_dim);
 
-  std::vector<int64_t> strides(nums), sizes(nums);
+  std::vector<int64_t> strides(rank), sizes(rank);
   if (axis.size() == 0) {
     strides[0] = 1;
     sizes[0] = numel;
     shifts_data[0] = (shifts_data[0] % numel + numel) % numel;
   } else {
-    for (size_t i = 0; i < nums; i++) {
+    for (int i = 0; i < rank; i++) {
       int dim = axis[i] >= 0 ? axis[i] : axis[i] + input_dim.size();
       int64_t size = input_dim[dim];
 
@@ -60,22 +57,8 @@ void RollKernel(const Context& dev_ctx,
     }
   }
 
-  switch (nums) {
-    CALL_ROLL_CUDA_KERNEL(1);
-    CALL_ROLL_CUDA_KERNEL(2);
-    CALL_ROLL_CUDA_KERNEL(3);
-    CALL_ROLL_CUDA_KERNEL(4);
-    CALL_ROLL_CUDA_KERNEL(5);
-    CALL_ROLL_CUDA_KERNEL(6);
-    CALL_ROLL_CUDA_KERNEL(7);
-    CALL_ROLL_CUDA_KERNEL(8);
-    CALL_ROLL_CUDA_KERNEL(9);
-    default:
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "shifts.size() should be less than 10, But received shifts.size() "
-          "= %d",
-          shifts_data.size()));
-  }
+  LaunchRollKernel<T, Context>(
+      dev_ctx, in_data, out_data, rank, numel, shifts_data, strides, sizes);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/roll_kernel_impl.h
+++ b/paddle/phi/kernels/gpu/roll_kernel_impl.h
@@ -22,23 +22,25 @@ namespace phi {
 
 using phi::PADDLE_CUDA_NUM_THREADS;
 
-template <typename T, size_t Rank>
+template <typename T>
 __global__ void RollCudaKernel(const T* input,
                                T* output,
-                               int64_t N,
-                               phi::Array<int64_t, Rank> shifts,
-                               phi::Array<int64_t, Rank> strides,
-                               phi::Array<int64_t, Rank> sizes) {
-  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= N) {
+                               const int rank,
+                               const int64_t numel,
+                               phi::Array<int64_t, DDim::kMaxRank> shifts,
+                               phi::Array<int64_t, DDim::kMaxRank> strides,
+                               phi::Array<int64_t, DDim::kMaxRank> sizes) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) +
+      static_cast<int64_t>(threadIdx.x);
+  if (idx >= numel) {
     return;
   }
 
   int64_t output_idx = idx;
   int64_t new_dim_idx = 0;
 
-#pragma unroll
-  for (size_t i = 0; i < Rank; i++) {
+  for (size_t i = 0; i < rank; i++) {
     new_dim_idx = (output_idx / strides[i]) % sizes[i] + shifts[i];
     if (new_dim_idx >= sizes[i]) {
       output_idx += (shifts[i] - sizes[i]) * strides[i];
@@ -49,22 +51,33 @@ __global__ void RollCudaKernel(const T* input,
   output[output_idx] = input[idx];
 }
 
-#define CALL_ROLL_CUDA_KERNEL(N)                                            \
-  case N: {                                                                 \
-    phi::Array<int64_t, N> _strides;                                        \
-    phi::Array<int64_t, N> _shifts;                                         \
-    phi::Array<int64_t, N> _sizes;                                          \
-    for (size_t idx = 0; idx < N; ++idx) {                                  \
-      _strides[idx] = strides[idx];                                         \
-      _shifts[idx] = shifts_data[idx];                                      \
-      _sizes[idx] = sizes[idx];                                             \
-    }                                                                       \
-    RollCudaKernel<T, N>                                                    \
-        <<<(numel + PADDLE_CUDA_NUM_THREADS - 1) / PADDLE_CUDA_NUM_THREADS, \
-           PADDLE_CUDA_NUM_THREADS,                                         \
-           0,                                                               \
-           stream>>>(in_data, out_data, numel, _shifts, _strides, _sizes);  \
-    break;                                                                  \
+template <typename T, typename Context>
+void LaunchRollKernel(const Context& dev_ctx,
+                      const T* input,
+                      T* output,
+                      const int rank,
+                      const int64_t numel,
+                      const std::vector<int64_t> shifts,
+                      const std::vector<int64_t> strides,
+                      const std::vector<int64_t> sizes) {
+  using phi::PADDLE_CUDA_NUM_THREADS;
+
+  phi::Array<int64_t, DDim::kMaxRank> strides_array;
+  phi::Array<int64_t, DDim::kMaxRank> shifts_array;
+  phi::Array<int64_t, DDim::kMaxRank> sizes_array;
+  for (int i = 0; i < rank; ++i) {
+    strides_array[i] = strides[i];
+    shifts_array[i] = shifts[i];
+    sizes_array[i] = sizes[i];
   }
+
+  auto stream = dev_ctx.stream();
+  RollCudaKernel<T>
+      <<<(numel + PADDLE_CUDA_NUM_THREADS - 1) / PADDLE_CUDA_NUM_THREADS,
+         PADDLE_CUDA_NUM_THREADS,
+         0,
+         stream>>>(
+          input, output, rank, numel, shifts_array, strides_array, sizes_array);
+}
 
 }  // namespace phi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
Pcard-70459

本PR的工作包括：
1. CPU一些二元计算需要使用`InverseFunctor`，在计算满足交换律时，可以使用`using InverseAddFunctor = AddFunctor<T>;`别名，而不是定义新的`Functor`，编译出来的静态库大小可减少2M
2. flip、rooll & roll_grad、index_put & index_put_grad 的Kernel实现中使用了Rank作为模板，会导致算子产生比较大的二进制文件，实际上Rank作为模板与否，并不会影响算子的性能。故改写了这几个算子，从模板中移除Rank，编译出来的静态库大小可减少4M