### PR TITLE
Update eval frame behavior

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -258,12 +258,20 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
       // Re-enable custom behavior
       eval_frame_callback_set(callback);
       VLOG(7) << "Start eval new frame and code.";
-      auto out = eval_custom_code(tstate, frame, code, throw_flag);
+      if (code != Py_None) {
+        auto out = eval_custom_code(tstate, frame, code, throw_flag);
+      } else {
+        auto out = eval_frame_default(tstate, frame, throw_flag);
+      }
       Py_DECREF(result);
       Py_DECREF(code);
       return out;
     } else {
-      auto out = eval_custom_code(tstate, frame, code, throw_flag);
+      if (code != Py_None) {
+        auto out = eval_custom_code(tstate, frame, code, throw_flag);
+      } else {
+        auto out = eval_frame_default(tstate, frame, throw_flag);
+      }
       // Re-enable custom behavior
       eval_frame_callback_set(callback);
       Py_DECREF(result);

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -258,19 +258,21 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
       // Re-enable custom behavior
       eval_frame_callback_set(callback);
       VLOG(7) << "Start eval new frame and code.";
-      if (code != Py_None) {
-        auto out = eval_custom_code(tstate, frame, code, throw_flag);
+      PyObject *out;
+      if (reinterpret_cast<PyObject *>(code) != Py_None) {
+        out = eval_custom_code(tstate, frame, code, throw_flag);
       } else {
-        auto out = eval_frame_default(tstate, frame, throw_flag);
+        out = eval_frame_default(tstate, frame, throw_flag);
       }
       Py_DECREF(result);
       Py_DECREF(code);
       return out;
     } else {
-      if (code != Py_None) {
-        auto out = eval_custom_code(tstate, frame, code, throw_flag);
+      PyObject *out;
+      if (reinterpret_cast<PyObject *>(code) != Py_None) {
+        out = eval_custom_code(tstate, frame, code, throw_flag);
       } else {
-        auto out = eval_frame_default(tstate, frame, throw_flag);
+        out = eval_frame_default(tstate, frame, throw_flag);
       }
       // Re-enable custom behavior
       eval_frame_callback_set(callback);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
we can now return sth like `CustomCode(None, Ture)`

### Others

PCard-66972