### PR TITLE
fix optional template bug

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -36,7 +36,7 @@ OP_VJP_FORWARD_MULTI_INPUT_TEMPLATE = """
 
 OP_VJP_FORWARD_OPTIONAL_INPUT_TEMPLATE = """
     paddle::optional<Tensor> {input_name};
-    if (op_obj.{input_name}().type().storage()){{
+    if (op_obj.{input_name}() and op_obj.{input_name}().type().storage()){{
         {input_name} = paddle::make_optional<Tensor>(Tensor(std::make_shared<primitive::LazyTensor>(op_obj.{input_name}())));
     }}"""
 

--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -36,7 +36,7 @@ OP_VJP_FORWARD_MULTI_INPUT_TEMPLATE = """
 
 OP_VJP_FORWARD_OPTIONAL_INPUT_TEMPLATE = """
     paddle::optional<Tensor> {input_name};
-    if (op_obj.{input_name}() and op_obj.{input_name}().type().storage()){{
+    if (op_obj.{input_name}() && op_obj.{input_name}().type().storage()){{
         {input_name} = paddle::make_optional<Tensor>(Tensor(std::make_shared<primitive::LazyTensor>(op_obj.{input_name}())));
     }}"""
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
pcard-67164
fix optional template bug
添加对obj value是否为空的判断：
```py
OP_VJP_FORWARD_OPTIONAL_INPUT_TEMPLATE = """
    paddle::optional<Tensor> {input_name};
    if (op_obj.{input_name}() && op_obj.{input_name}().type().storage()){{
        {input_name} = paddle::make_optional<Tensor>(Tensor(std::make_shared<primitive::LazyTensor>(op_obj.{input_name}())));
    }}"""
```
