### PR TITLE
[PIR]Migrate scale/reshape/erf/greater_equal into pir

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/vjp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/vjp_interface_gen_op_list.py
@@ -52,6 +52,7 @@ vjp_interface_declare_gen_op_list = [
     'slice',
     'transpose',
     'slice_double',
+    'scale',
 ]
 vjp_interface_implementation_gen_op_list = [
     "tanh",
@@ -82,4 +83,5 @@ vjp_interface_implementation_gen_op_list = [
     'slice',
     'transpose',
     'slice_double',
+    'scale',
 ]

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -27,7 +27,7 @@ from paddle.tensor.creation import full
 from paddle.tensor.math import broadcast_shape
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
-from ..framework import LayerHelper, in_dynamic_mode
+from ..framework import LayerHelper, in_dynamic_mode, in_dynamic_or_pir_mode
 
 __all__ = []
 
@@ -630,7 +630,7 @@ def greater_equal(x, y, name=None):
             Tensor(shape=[3], dtype=bool, place=Place(cpu), stop_gradient=True,
             [True , False, True ])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.greater_equal(x, y)
     else:
         check_variable_and_dtype(

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3605,6 +3605,8 @@ def reshape(x, shape, name=None):
             for ele in shape:
                 if isinstance(ele, core.eager.Tensor):
                     new_shape.append(ele.item())
+                elif isinstance(ele, paddle.ir.OpResult):
+                    new_shape.append(-1)
                 else:
                     new_shape.append(ele)
 
@@ -3612,12 +3614,14 @@ def reshape(x, shape, name=None):
                 out = x
             else:
                 out = _C_ops.reshape(x, new_shape)
-        elif isinstance(shape, core.eager.Tensor):
+        elif isinstance(shape, core.eager.Tensor) or isinstance(
+            shape, paddle.ir.OpResult
+        ):
             shape.stop_gradient = True
             out = _C_ops.reshape(x, shape)
         else:
             raise ValueError(
-                "shape must be an instance of `list`, `tuple` or `Variable`,"
+                "shape must be an instance of `list`, `tuple` `Variable(in dygraph mode)` or `OpResult(in pir mode)`,"
                 " got '{}.'".format(type(shape))
             )
 

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -17,7 +17,7 @@ from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from .. import _C_ops
 from ..base.data_feeder import check_variable_and_dtype
-from ..framework import LayerHelper, in_dynamic_mode
+from ..framework import LayerHelper, in_dynamic_mode, in_dynamic_or_pir_mode
 from .layer_function_generator import (
     add_sample_code,
     generate_activation_fn,
@@ -1163,7 +1163,7 @@ _erf_ = generate_layer_fn('erf')
 
 
 def erf(x, name=None):
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.erf(x)
 
     locals_var = locals().copy()

--- a/test/legacy_test/test_compare_op.py
+++ b/test/legacy_test/test_compare_op.py
@@ -23,7 +23,7 @@ from paddle import base
 from paddle.base import Program, core, program_guard
 
 
-def create_test_class(op_type, typename, callback):
+def create_test_class(op_type, typename, callback, check_new_ir=False):
     class Cls(op_test.OpTest):
         def setUp(self):
             a = numpy.random.random(size=(10, 7)).astype(typename)
@@ -35,7 +35,7 @@ def create_test_class(op_type, typename, callback):
             self.op_type = op_type
 
         def test_output(self):
-            self.check_output(check_cinn=True)
+            self.check_output(check_cinn=True, check_new_ir=check_new_ir)
 
         def test_errors(self):
             paddle.enable_static()

--- a/test/legacy_test/test_erf_op.py
+++ b/test/legacy_test/test_erf_op.py
@@ -43,10 +43,10 @@ class TestErfOp(OpTest):
         return "float64"
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
+        self.check_grad(['X'], 'Out', check_prim=True, check_new_ir=True)
 
 
 class TestErfOp_ZeroDim(TestErfOp):

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -44,10 +44,10 @@ class TestReshapeOp(OpTest):
         self.infered_shape = (12, 10)
 
     def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
+        self.check_output(no_check_set=['XShape'], check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_prim=True)
+        self.check_grad(["X"], "Out", check_prim=True, check_new_ir=True)
 
 
 class TestReshapeOp_ZeroDim1(TestReshapeOp):
@@ -460,6 +460,7 @@ class TestReshapeOpError(unittest.TestCase):
         self.reshape = paddle.reshape
 
     def _test_errors(self):
+        paddle.enable_static()
         with program_guard(Program(), Program()):
             # The x type of reshape_op must be Variable.
             def test_x_type():
@@ -510,6 +511,7 @@ class TestReshapeOpError(unittest.TestCase):
                 self.reshape(x3, [-1, -2, 5])
 
             self.assertRaises(AssertionError, test_shape_3)
+        paddle.disable_static()
 
     def test_paddle_api_error(self):
         self._set_paddle_api()

--- a/test/legacy_test/test_scale_op.py
+++ b/test/legacy_test/test_scale_op.py
@@ -42,10 +42,10 @@ class TestScaleOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output(check_cinn=True)
+        self.check_output(check_cinn=True, check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_new_ir=True)
 
 
 class TestScaleOpScaleVariable(OpTest):
@@ -133,6 +133,8 @@ class TestScaleOpSelectedRows(unittest.TestCase):
 
 class TestScaleRaiseError(unittest.TestCase):
     def test_errors(self):
+        paddle.enable_static()
+
         def test_type():
             paddle.scale([10])
 
@@ -302,6 +304,7 @@ class TestScaleTripleGradCheck(unittest.TestCase):
 
 class TestScaleOpZeroNumelVariable(unittest.TestCase):
     def test_check_zero_numel_cpu(self):
+        paddle.enable_static()
         paddle.set_device('cpu')
         data = paddle.ones([0, 1])
         out = paddle.scale(data, 2)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
升级适配scale/reshape/erf/greater_equal Python API，后续进一步完善单测覆盖