### PR TITLE
[NewIR] No.35 Migrate paddle.slice into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -312,7 +312,7 @@ def slice(input, axes, starts, ends):
             sliced_2 = paddle.slice(input, axes=axes, starts=[minus_3, 0, 2], ends=ends)
             # sliced_2 is input[1:3, 0:2, 2:4].
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         attrs = ()
         starts_tensor = None
         ends_tensor = None

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -67,7 +67,7 @@ class TestSliceOp(OpTest):
         self.out = self.input[1:3, 0:3, 2:4, :]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
@@ -121,7 +121,7 @@ class TestSliceZerosShapeTensor(OpTest):
         self.out = self.input[1:2]
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.CPUPlace())
+        self.check_output_with_place(paddle.CPUPlace(), check_new_ir=True)
 
 
 # 1.2 with attr(decrease)
@@ -153,7 +153,7 @@ class TestSliceOp_decs_dim(OpTest):
         self.out = self.input[1:2, 0:3, 2:4, :]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
@@ -486,7 +486,9 @@ class TestFP16(OpTest):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(
+                place, check_prim=True, check_new_ir=True
+            )
 
     def test_check_grad_normal(self):
         place = core.CUDAPlace(0)
@@ -531,7 +533,9 @@ class TestFP16_2(OpTest):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, check_prim=True)
+            self.check_output_with_place(
+                place, check_prim=True, check_new_ir=True
+            )
 
     def test_check_grad_normal(self):
         place = core.CUDAPlace(0)
@@ -571,7 +575,7 @@ class TestBF16(OpTest):
         self.infer_flags = [1, 1, 1]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(['Input'], 'Out', check_prim=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- #57097
- No.35 Migrate paddle.slice into pir
- 只有 `Situation 1: starts(list, no tensor), ends(list, no tensor)` 的单测打开了 `check_output` 的 `check_new_ir`，其他 `Situation` 的单测打开 `check_new_ir` 会报错，同时所有单测的 `check_grad` 打开 `check_new_ir` 也会报错
