### PR TITLE
[PIR] standardize the use of value[-1].

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -134,7 +134,7 @@ inline pir::Operation* InsertCombineOperationForTarget(
   std::string combine_op_name(pir::CombineOp::name());
   pir::OpInfo op_info = ctx->GetRegisteredOpInfo(combine_op_name);
 
-  std::vector<pir::OpResult> src_values;
+  std::vector<pir::Value> src_values;
   std::vector<pir::Type> types_in_vec;
   for (const auto& arg_name : args) {
     auto defining_info = param_map->at(arg_name);
@@ -299,7 +299,7 @@ pir::OpResult OpTranscriber::GetAttributeAsInput(
   return defining_op->result(0);
 }
 
-std::vector<pir::OpResult> OpTranscriber::GenerateOperationInput(
+std::vector<pir::Value> OpTranscriber::GenerateOperationInput(
     pir::IrContext* ctx,
     TranslationContext* param_map,
     const OpDesc& op_desc,
@@ -314,7 +314,7 @@ std::vector<pir::OpResult> OpTranscriber::GenerateOperationInput(
 
   VLOG(10) << "[op:" << op_desc.Type() << "][input] start";
 
-  std::vector<pir::OpResult> op_inputs;
+  std::vector<pir::Value> op_inputs;
 
   for (const auto& info : input_infos) {
     if (auto special_handler = this->GetSpecialInputHandlers(info.name)) {
@@ -779,7 +779,7 @@ struct AssignValueOpTranscriber : public OpTranscriber {
 
     VLOG(10) << "[op assign_value] attribute translation done";
 
-    std::vector<pir::OpResult> op_inputs = {};
+    std::vector<pir::Value> op_inputs = {};
 
     OpOutputMapping arg_to_idx;
     OpOutputTypeList op_output_types;
@@ -904,7 +904,7 @@ struct FeedOpTranscriber : public OpTranscriber {
     return attribute_map;
   }
 
-  std::vector<pir::OpResult> GenerateOperationInput(
+  std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,
       const OpDesc& op_desc,
@@ -942,7 +942,7 @@ struct DataOpTranscriber : public FeedOpTranscriber {
 };
 
 struct SplitOpTranscriber : public OpTranscriber {
-  std::vector<pir::OpResult> GenerateOperationInput(
+  std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,
       const OpDesc& op_desc,
@@ -953,7 +953,7 @@ struct SplitOpTranscriber : public OpTranscriber {
 
     VLOG(10) << "[op:split][input] start";
 
-    std::vector<pir::OpResult> op_inputs;
+    std::vector<pir::Value> op_inputs;
     // process first input
     auto x_input_vars = op_desc.Input("X");
     IR_ENFORCE(x_input_vars.size() == 1, "x input of split MUST be a tensor");
@@ -1085,7 +1085,7 @@ struct ShadowOutputOpTranscriber : public OpTranscriber {
                              pir::Program* program) override {
     auto op_info = ctx->GetRegisteredOpInfo(pir::SetParameterOp::name());
 
-    std::vector<pir::OpResult> op_inputs;
+    std::vector<pir::Value> op_inputs;
     auto legacy_input_vars = op_desc.Input("x", true);
 
     auto defining_info = (*param_map)[legacy_input_vars[0]];
@@ -1163,7 +1163,7 @@ struct FillConstant2FullTranscriber : public OpTranscriber {
     return op_info;
   }
 
-  std::vector<pir::OpResult> GenerateOperationInput(
+  std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,
       const OpDesc& op_desc,
@@ -1245,14 +1245,14 @@ struct FillConstant2FullWithTensorTranscriber : public OpTranscriber {
     return op_info;
   }
 
-  std::vector<pir::OpResult> GenerateOperationInput(
+  std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,
       const OpDesc& op_desc,
       const std::string& normalized_op_name,
       const OpInputInfoList& input_infos,
       pir::Program* program) override {
-    std::vector<pir::OpResult> op_inputs;
+    std::vector<pir::Value> op_inputs;
     if (op_desc.HasInput("ShapeTensor", true) &&
         op_desc.Input("ShapeTensor", true).size() > 0) {
       auto shape_tensor_vars = op_desc.Input("ShapeTensor", true);
@@ -1409,7 +1409,7 @@ struct ReduceOpTranscriber : public OpTranscriber {
 };
 
 struct ElementwiseTranscriber : public OpTranscriber {
-  std::vector<pir::OpResult> GenerateOperationInput(
+  std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,
       const OpDesc& op_desc,

--- a/paddle/fluid/ir_adaptor/translator/op_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.h
@@ -66,7 +66,7 @@ struct OpTranscriber {
 
  public:
   virtual pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx, const OpDesc& op_desc);
-  virtual std::vector<pir::OpResult> GenerateOperationInput(
+  virtual std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,
       const OpDesc& op_desc,

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -718,7 +718,7 @@ void HandleForSpecialOp(
     HandleForIfOp(place, op_item, block, ctx, map_op_pair, map_value_pair);
     return;
   }
-  std::vector<pir::OpResult> vec_inputs;
+  std::vector<pir::Value> vec_inputs;
   std::vector<pir::Type> op_output_types;
   if (op_item->name() == "builtin.combine") {
     // Copy op inputs
@@ -754,8 +754,7 @@ void HandleForSpecialOp(
 
         if (new_in.type().isa<pir::VectorType>()) {
           auto vec_types = new_in.type().dyn_cast<pir::VectorType>().data();
-          auto index = op_item->attributes()
-                           .at("index")
+          auto index = op_item->attribute("index")
                            .dyn_cast<pir::Int32Attribute>()
                            .data();
           op_output_types.push_back(vec_types[index]);
@@ -899,7 +898,7 @@ std::vector<pir::Type> BuildOpOutputType(pir::Operation* op_item,
   return op_output_types;
 }
 
-std::vector<pir::OpResult> BuildOpInputList(
+std::vector<pir::Value> BuildOpInputList(
     pir::Operation* op_item,
     const std::string& kernel_fn_str,
     const phi::KernelKey& kernel_key,
@@ -913,7 +912,7 @@ std::vector<pir::OpResult> BuildOpInputList(
     return {};
   }
 
-  std::vector<pir::OpResult> vec_inputs;
+  std::vector<pir::Value> vec_inputs;
 
   for (size_t i = 0; i < op_item->num_operands(); ++i) {
     auto cur_in = op_item->operand_source(i);
@@ -981,7 +980,7 @@ std::vector<pir::OpResult> BuildOpInputList(
         auto pre_define_op = cur_in.GetDefiningOp();
 
         if (pre_define_op->name() == "builtin.combine") {
-          std::vector<pir::OpResult> inner_inputs;
+          std::vector<pir::Value> inner_inputs;
           std::vector<pir::Type> types_in_vec;
           bool is_trans = false;
           for (size_t j = 0; j < pre_define_op->num_operands(); ++j) {
@@ -1155,7 +1154,7 @@ std::string GetKernelFnStr(const OpYamlInfoParser* op_info_parser,
 pir::Operation* BuildPhiKernelOp(
     const std::string& kernel_fn_str,
     const phi::KernelKey& kernel_key,
-    const std::vector<pir::OpResult>& vec_inputs,
+    const std::vector<pir::Value>& vec_inputs,
     const std::vector<pir::Type>& op_output_types,
     pir::Operation* op_item,
     pir::Block* block,

--- a/paddle/pir/core/op_result.cc
+++ b/paddle/pir/core/op_result.cc
@@ -47,12 +47,6 @@ bool OpResult::operator==(const OpResult &other) const {
   return impl_ == other.impl_;
 }
 
-// OpResult::OpResult(const detail::OpResultImpl *impl) : Value(impl) {}
-
-uint32_t OpResult::GetValidInlineIndex(uint32_t index) {
-  uint32_t max_inline_index =
-      pir::detail::OpResultImpl::GetMaxInlineResultIndex();
-  return index <= max_inline_index ? index : max_inline_index;
-}
+OpResult::OpResult(const detail::OpResultImpl *impl) : Value(impl) {}
 
 }  // namespace pir

--- a/paddle/pir/core/op_result.h
+++ b/paddle/pir/core/op_result.h
@@ -28,18 +28,14 @@ class OpResultImpl;
 ///
 class IR_API OpResult : public Value {
  public:
-  OpResult() = default;
+  OpResult(std::nullptr_t ptr = nullptr) : Value(ptr){};  // NOLINT
   Operation *owner() const;
   uint32_t GetResultIndex() const;
   bool operator==(const OpResult &other) const;
-  // OpResult(const detail::OpResultImpl *impl);  // NOLINT
-
-  // This func will remove in next pr.
-  OpResult(const detail::ValueImpl *impl) : Value(impl) {}  // NOLINT
 
  private:
   friend Operation;
-  static uint32_t GetValidInlineIndex(uint32_t index);
+  OpResult(const detail::OpResultImpl *impl);  // NOLINT
   // Access classof annd dyn_cast_from.
   friend Value;
   static bool classof(Value value);

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -27,7 +27,11 @@
 
 namespace pir {
 Operation *Operation::Create(OperationArgument &&argument) {
-  return Create(argument.inputs,
+  std::vector<Value> inputs;
+  for (auto op_result : argument.inputs) {
+    inputs.emplace_back(op_result);
+  }
+  return Create(inputs,
                 argument.attributes,
                 argument.output_types,
                 argument.info,
@@ -38,7 +42,7 @@ Operation *Operation::Create(OperationArgument &&argument) {
 // Allocate the required memory based on the size and number of inputs, outputs,
 // and operators, and construct it in the order of: OpOutlineResult,
 // OpInlineResult, Operation, operand.
-Operation *Operation::Create(const std::vector<pir::OpResult> &inputs,
+Operation *Operation::Create(const std::vector<Value> &inputs,
                              const AttributeMap &attributes,
                              const std::vector<Type> &output_types,
                              pir::OpInfo op_info,
@@ -89,7 +93,7 @@ Operation *Operation::Create(const std::vector<pir::OpResult> &inputs,
     IR_THROW("The address of OpOperandImpl must be divisible by 8.");
   }
   for (size_t idx = 0; idx < num_operands; idx++) {
-    new (base_ptr) detail::OpOperandImpl(inputs[idx].impl_, op);
+    new (base_ptr) detail::OpOperandImpl(inputs[idx], op);
     base_ptr += sizeof(detail::OpOperandImpl);
   }
   // 3.4. Construct BlockOperands.

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -37,7 +37,7 @@ class IR_API alignas(8) Operation final {
   /// NOTE: Similar to new and delete, the destroy() and the create() need to be
   /// used in conjunction.
   ///
-  static Operation *Create(const std::vector<pir::OpResult> &inputs,
+  static Operation *Create(const std::vector<pir::Value> &inputs,
                            const AttributeMap &attributes,
                            const std::vector<pir::Type> &output_types,
                            pir::OpInfo op_info,

--- a/paddle/pir/core/operation_utils.h
+++ b/paddle/pir/core/operation_utils.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <memory>
 #include "paddle/pir/core/attribute.h"
 #include "paddle/pir/core/op_info.h"
@@ -56,11 +57,28 @@ struct OperationArgument {
         num_regions(num_regions),
         successors(successors) {}
 
-  /// Add Operand.
+  // Will be deleted in the next pr.
   void AddOperand(OpResult operand) { inputs.emplace_back(operand); }
 
+  void AddInput(Value input) {
+    inputs.emplace_back(input.dyn_cast<OpResult>());
+  }
+
+  // Will be deleted in the next pr.
   template <class InputIt>
   void AddOperands(InputIt first, InputIt last);
+
+  template <class InputIt>
+  void AddInputs(InputIt first, InputIt last);
+
+  void AddInputs(std::initializer_list<Value> value_list) {
+    AddInputs(std::begin(value_list), std::end(value_list));
+  }
+
+  template <class ValueContainer>
+  void AddInputs(const ValueContainer& value_container) {
+    AddInputs(std::begin(value_container), std::end(value_container));
+  }
 
   /// Add Output.
   void AddOutput(Type type) { output_types.emplace_back(type); }
@@ -87,6 +105,14 @@ void OperationArgument::AddOperands(InputIt first, InputIt last) {
     inputs.emplace_back(*first++);
   }
 }
+
+template <class InputIt>
+void OperationArgument::AddInputs(InputIt first, InputIt last) {
+  while (first != last) {
+    AddInput(*first++);
+  }
+}
+
 template <class InputIt>
 void OperationArgument::AddOutputs(InputIt first, InputIt last) {
   while (first != last) {

--- a/paddle/pir/core/parser/ir_parser.cc
+++ b/paddle/pir/core/parser/ir_parser.cc
@@ -216,7 +216,7 @@ Operation* IrParser::ParseOperation() {
 
   OpInfo opinfo = ParseOpInfo();
 
-  std::vector<OpResult> inputs = ParseOprandList();
+  std::vector<Value> inputs = ParseOprandList();
 
   pir::AttributeMap attributeMap = ParseAttributeMap();
 
@@ -269,14 +269,14 @@ OpInfo IrParser::ParseOpInfo() {
 
 // OprandList := ValueList
 // ValueList := ValueId(,ValueId)*
-std::vector<OpResult> IrParser::ParseOprandList() {
+std::vector<Value> IrParser::ParseOprandList() {
   ConsumeAToken("(");
-  std::vector<OpResult> inputs{};
+  std::vector<Value> inputs{};
   Token ind_token = ConsumeToken();
   while (ind_token.val_ != ")") {
     std::string t = "";
     if (ind_token.token_type_ == NULL_) {
-      inputs.push_back(GetNullValue());
+      inputs.emplace_back();
     } else {
       t = ind_token.val_;
       inputs.push_back(opresultmap[t]);
@@ -325,12 +325,6 @@ std::vector<Type> IrParser::ParseTypeList() {
     ConsumeAToken(",");
   }
   return type_vector;
-}
-
-OpResult IrParser::GetNullValue() {
-  Value* v = new Value{nullptr};
-  OpResult* opresult = static_cast<OpResult*>(v);
-  return *opresult;
 }
 
 Attribute Attribute::Parse(std::istream& is, IrContext* ctx) {

--- a/paddle/pir/core/parser/ir_parser.h
+++ b/paddle/pir/core/parser/ir_parser.h
@@ -51,13 +51,11 @@ class IrParser {
 
   std::vector<std::string> ParseOpResultList();
 
-  std::vector<OpResult> ParseOprandList();
+  std::vector<Value> ParseOprandList();
 
   AttributeMap ParseAttributeMap();
 
   std::vector<Type> ParseTypeList();
-
-  OpResult GetNullValue();
 
   Type ParseType();
 

--- a/paddle/pir/dialect/shape/ir/shape_op.cc
+++ b/paddle/pir/dialect/shape/ir/shape_op.cc
@@ -35,74 +35,67 @@ void SymbolicDim::Build(Builder &builder,
                         bool knownNegativeOne,
                         bool knownNonSizeOne,
                         bool knownNonSizeZero) {
-  pir::Attribute attr_sym_name =
-      pir::StrAttribute::get(pir::IrContext::Instance(), sym_name);
+  Attribute attr_sym_name = StrAttribute::get(IrContext::Instance(), sym_name);
   argument.AddAttribute("sym_name", attr_sym_name);
-  pir::Attribute attr_value =
-      pir::Int64Attribute::get(pir::IrContext::Instance(), value);
+  Attribute attr_value = Int64Attribute::get(IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
-  pir::Attribute attr_knownNonNegative =
-      pir::BoolAttribute::get(pir::IrContext::Instance(), knownNonNegative);
+  Attribute attr_knownNonNegative =
+      BoolAttribute::get(IrContext::Instance(), knownNonNegative);
   argument.AddAttribute("knownNonNegative", attr_knownNonNegative);
-  pir::Attribute attr_knownNegativeOne =
-      pir::BoolAttribute::get(pir::IrContext::Instance(), knownNegativeOne);
+  Attribute attr_knownNegativeOne =
+      BoolAttribute::get(IrContext::Instance(), knownNegativeOne);
   argument.AddAttribute("knownNegativeOne", attr_knownNegativeOne);
-  pir::Attribute attr_knownNonSizeOne =
-      pir::BoolAttribute::get(pir::IrContext::Instance(), knownNonSizeOne);
+  Attribute attr_knownNonSizeOne =
+      BoolAttribute::get(IrContext::Instance(), knownNonSizeOne);
   argument.AddAttribute("knownNonSizeOne", attr_knownNonSizeOne);
-  pir::Attribute attr_knownNonSizeZero =
-      pir::BoolAttribute::get(pir::IrContext::Instance(), knownNonSizeZero);
+  Attribute attr_knownNonSizeZero =
+      BoolAttribute::get(IrContext::Instance(), knownNonSizeZero);
   argument.AddAttribute("knownNonSizeZero", attr_knownNonSizeZero);
 }
 
 const std::string SymbolicDim::getSymName() {
-  return attribute<pir::StrAttribute>("sym_name").AsString();
+  return attribute<StrAttribute>("sym_name").AsString();
 }
 int64_t SymbolicDim::getValue() {
-  return attribute<pir::Int64Attribute>("value").data();
+  return attribute<Int64Attribute>("value").data();
 }
 bool SymbolicDim::getKnownNonNegative() {
-  return attribute<pir::BoolAttribute>("knownNonNegative").data();
+  return attribute<BoolAttribute>("knownNonNegative").data();
 }
 bool SymbolicDim::getKnownNegativeOne() {
-  return attribute<pir::BoolAttribute>("knownNegativeOne").data();
+  return attribute<BoolAttribute>("knownNegativeOne").data();
 }
 bool SymbolicDim::getKnownNonSizeOne() {
-  return attribute<pir::BoolAttribute>("knownNonSizeOne").data();
+  return attribute<BoolAttribute>("knownNonSizeOne").data();
 }
 bool SymbolicDim::getKnownNonSizeZero() {
-  return attribute<pir::BoolAttribute>("knownNonSizeZero").data();
+  return attribute<BoolAttribute>("knownNonSizeZero").data();
 }
 
 void SymbolicDim::updateSymName(std::string attrValue) {
   operation()->set_attribute(
-      "sym_name",
-      pir::StrAttribute::get(pir::IrContext::Instance(), attrValue));
+      "sym_name", StrAttribute::get(IrContext::Instance(), attrValue));
 }
 void SymbolicDim::updateValue(int64_t attrValue) {
   operation()->set_attribute(
-      "value", pir::Int64Attribute::get(pir::IrContext::Instance(), attrValue));
+      "value", Int64Attribute::get(IrContext::Instance(), attrValue));
 }
 
 void SymbolicDim::updateKnownNonNegative(bool attrValue) {
   operation()->set_attribute(
-      "knownNonNegative",
-      pir::BoolAttribute::get(pir::IrContext::Instance(), attrValue));
+      "knownNonNegative", BoolAttribute::get(IrContext::Instance(), attrValue));
 }
 void SymbolicDim::updateKnownNegativeOne(bool attrValue) {
   operation()->set_attribute(
-      "knownNegativeOne",
-      pir::BoolAttribute::get(pir::IrContext::Instance(), attrValue));
+      "knownNegativeOne", BoolAttribute::get(IrContext::Instance(), attrValue));
 }
 void SymbolicDim::updateKnownNonSizeOne(bool attrValue) {
   operation()->set_attribute(
-      "knownNonSizeOne",
-      pir::BoolAttribute::get(pir::IrContext::Instance(), attrValue));
+      "knownNonSizeOne", BoolAttribute::get(IrContext::Instance(), attrValue));
 }
 void SymbolicDim::updateKnownNonSizeZero(bool attrValue) {
   operation()->set_attribute(
-      "knownNonSizeZero",
-      pir::BoolAttribute::get(pir::IrContext::Instance(), attrValue));
+      "knownNonSizeZero", BoolAttribute::get(IrContext::Instance(), attrValue));
 }
 
 bool SymbolicDim::IsDynamic() {
@@ -140,20 +133,18 @@ const char *DimOp::attributes_name[attributes_num] = {"name"};  // NOLINT
 void DimOp::Build(Builder &builder,
                   OperationArgument &argument,
                   const std::string &name) {
-  pir::Attribute attr_name =
-      pir::StrAttribute::get(pir::IrContext::Instance(), name);
+  Attribute attr_name = StrAttribute::get(IrContext::Instance(), name);
   argument.AddAttribute("name", attr_name);
-  argument.output_types.emplace_back(
-      pir::IndexType::get(pir::IrContext::Instance()));
+  argument.output_types.emplace_back(IndexType::get(IrContext::Instance()));
 }
 
 const std::string DimOp::getName() {
-  return attribute<pir::StrAttribute>("name").AsString();
+  return attribute<StrAttribute>("name").AsString();
 }
 
 void DimOp::setName(std::string attrName) {
   operation()->set_attribute(
-      "name", pir::StrAttribute::get(pir::IrContext::Instance(), attrName));
+      "name", StrAttribute::get(IrContext::Instance(), attrName));
 }
 
 const char *TieProductEqualOp::attributes_name[attributes_num] = {
@@ -163,43 +154,41 @@ void TieProductEqualOp::Build(Builder &builder,
                               OperationArgument &argument,
                               int64_t lhs_len,
                               int64_t rhs_len,
-                              const std::vector<pir::OpResult> &inputs) {
-  pir::Attribute attr_lhs_len =
-      pir::Int64Attribute::get(pir::IrContext::Instance(), lhs_len);
+                              const std::vector<Value> &inputs) {
+  Attribute attr_lhs_len = Int64Attribute::get(IrContext::Instance(), lhs_len);
   argument.AddAttribute("lhs_len", attr_lhs_len);
-  pir::Attribute attr_rhs_len =
-      pir::Int64Attribute::get(pir::IrContext::Instance(), rhs_len);
+  Attribute attr_rhs_len = Int64Attribute::get(IrContext::Instance(), rhs_len);
   argument.AddAttribute("rhs_len", attr_rhs_len);
-  argument.inputs = inputs;
+  argument.AddInputs(inputs);
 }
 
 void TieProductEqualOp::Build(Builder &builder,
                               OperationArgument &argument,
-                              const std::vector<pir::OpResult> &lhs,
-                              const std::vector<pir::OpResult> &rhs) {
-  pir::Attribute attr_lhs_len =
-      pir::Int64Attribute::get(pir::IrContext::Instance(), lhs.size());
+                              const std::vector<Value> &lhs,
+                              const std::vector<Value> &rhs) {
+  Attribute attr_lhs_len =
+      Int64Attribute::get(IrContext::Instance(), lhs.size());
   argument.AddAttribute("lhs_len", attr_lhs_len);
-  pir::Attribute attr_rhs_len =
-      pir::Int64Attribute::get(pir::IrContext::Instance(), rhs.size());
+  Attribute attr_rhs_len =
+      Int64Attribute::get(IrContext::Instance(), rhs.size());
   argument.AddAttribute("rhs_len", attr_rhs_len);
 
-  argument.inputs = lhs;
-  argument.inputs.insert(argument.inputs.end(), rhs.begin(), rhs.end());
+  argument.AddInputs(lhs);
+  argument.AddInputs(rhs);
 }
 
-std::vector<pir::Value> TieProductEqualOp::getLhs() {
-  int64_t lhs_len = attribute<pir::Int64Attribute>("lhs_len").data();
-  std::vector<pir::Value> res;
+std::vector<Value> TieProductEqualOp::getLhs() {
+  int64_t lhs_len = attribute<Int64Attribute>("lhs_len").data();
+  std::vector<Value> res;
   for (uint32_t idx = 0; idx < lhs_len; idx++) {
     res.push_back(operand_source(idx));
   }
   return res;
 }
-std::vector<pir::Value> TieProductEqualOp::getRhs() {
-  int64_t lhs_len = attribute<pir::Int64Attribute>("lhs_len").data();
-  int64_t rhs_len = attribute<pir::Int64Attribute>("rhs_len").data();
-  std::vector<pir::Value> res;
+std::vector<Value> TieProductEqualOp::getRhs() {
+  int64_t lhs_len = attribute<Int64Attribute>("lhs_len").data();
+  int64_t rhs_len = attribute<Int64Attribute>("rhs_len").data();
+  std::vector<Value> res;
   for (uint32_t idx = 0; idx < rhs_len; idx++) {
     res.push_back(operand_source(lhs_len + idx));
   }
@@ -211,23 +200,21 @@ const char *TieShapeOp::attributes_name[attributes_num] = {
 
 void TieShapeOp::Build(Builder &builder,
                        OperationArgument &argument,
-                       const pir::OpResult &input) {
-  argument.inputs = {input};
+                       Value input) {
+  argument.AddInput(input);
 }
 void TieShapeOp::Build(Builder &builder,             // NOLINT
                        OperationArgument &argument,  // NOLINT
-                       const pir::OpResult &input,
-                       const std::vector<pir::OpResult> &dims) {
-  argument.inputs = {input};
-  for (auto &dim : dims) {
-    argument.inputs.push_back(dim);
-  }
+                       Value input,
+                       const std::vector<Value> &dims) {
+  argument.AddInput(input);
+  argument.AddInputs(dims);
 }
 
-pir::Value TieShapeOp::getValue() { return operand_source(0); }
+Value TieShapeOp::getValue() { return operand_source(0); }
 
-std::vector<pir::Value> TieShapeOp::getShapeDimIndexes() {
-  std::vector<pir::Value> res;
+std::vector<Value> TieShapeOp::getShapeDimIndexes() {
+  std::vector<Value> res;
   for (uint32_t i = 1; i < num_operands(); i++) {
     res.push_back(operand_source(i));
   }
@@ -238,39 +225,36 @@ void FuncOp::Build(Builder &builder, OperationArgument &argument) {
   argument.num_regions = 1;
 }
 
-pir::Block *FuncOp::block() {
-  pir::Region &region = (*this)->region(0);
+Block *FuncOp::block() {
+  Region &region = (*this)->region(0);
   if (region.empty()) region.emplace_back();
   return region.front();
 }
 
 void TensorDimOp::Build(Builder &builder,
                         OperationArgument &argument,
-                        const pir::OpResult &source,
-                        const pir::OpResult &index) {
-  argument.inputs = {source, index};
-  argument.output_types.emplace_back(
-      pir::IndexType::get(pir::IrContext::Instance()));
+                        Value source,
+                        Value index) {
+  argument.AddInputs({source, index});
+  argument.output_types.emplace_back(IndexType::get(IrContext::Instance()));
 }
 
 void TensorDimOp::Build(Builder &builder,
                         OperationArgument &argument,
-                        const pir::OpResult &source,
+                        Value source,
                         int64_t index) {
-  pir::OpResult indexValue =
+  OpResult indexValue =
       builder
-          .Build<pir::ConstantOp>(
-              pir::Int64Attribute::get(pir::IrContext::Instance(), 2),
-              pir::IndexType::get(pir::IrContext::Instance()))
+          .Build<ConstantOp>(Int64Attribute::get(IrContext::Instance(), 2),
+                             IndexType::get(IrContext::Instance()))
           ->result(0);
-  argument.inputs = {source, indexValue};
-  argument.output_types.emplace_back(
-      pir::IndexType::get(pir::IrContext::Instance()));
+  argument.AddInputs({source, indexValue});
+  argument.output_types.emplace_back(IndexType::get(IrContext::Instance()));
 }
 
-pir::Value TensorDimOp::getSource() { return operand_source(0); }
+Value TensorDimOp::getSource() { return operand_source(0); }
 
-pir::Value TensorDimOp::getIndex() { return operand_source(1); }
+Value TensorDimOp::getIndex() { return operand_source(1); }
 }  // namespace dialect
 }  // namespace pir
 

--- a/paddle/pir/dialect/shape/ir/shape_op.h
+++ b/paddle/pir/dialect/shape/ir/shape_op.h
@@ -91,11 +91,11 @@ class IR_API TieProductEqualOp : public Op<TieProductEqualOp> {
                     OperationArgument &argument,  // NOLINT
                     int64_t lhs_len,
                     int64_t rhs_len,
-                    const std::vector<pir::OpResult> &inputs);
+                    const std::vector<Value> &inputs);
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const std::vector<pir::OpResult> &lhs,
-                    const std::vector<pir::OpResult> &rhs);
+                    const std::vector<Value> &lhs,
+                    const std::vector<Value> &rhs);
   std::vector<pir::Value> getLhs();
   std::vector<pir::Value> getRhs();
   void Verify() {}
@@ -111,15 +111,14 @@ class IR_API TieShapeOp : public Op<TieShapeOp> {
 
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const pir::OpResult &input);
+                    pir::Value input);
 
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const pir::OpResult &input,
-                    const std::vector<pir::OpResult> &dims);
-
-  pir::Value getValue();
-  std::vector<pir::Value> getShapeDimIndexes();
+                    Value input,
+                    const std::vector<Value> &dims);
+  Value getValue();
+  std::vector<Value> getShapeDimIndexes();
   void Verify() {}
 };
 
@@ -147,15 +146,15 @@ class IR_API TensorDimOp : public Op<TensorDimOp> {
 
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const pir::OpResult &source,
-                    const pir::OpResult &index);
+                    Value source,
+                    Value index);
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const pir::OpResult &source,
+                    Value source,
                     int64_t index);
-  pir::Value getIndex();
-  pir::Value getSource();
-  pir::OpResult out() { return result(0); }
+  Value getIndex();
+  Value getSource();
+  OpResult out() { return result(0); }
   void Verify() {}
 };
 

--- a/paddle/pir/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/dialect/shape/transforms/shape_optimization_pass.cc
@@ -23,12 +23,12 @@
 
 namespace {
 
-bool InsertTieShapeOnValue(pir::OpResult value,
+bool InsertTieShapeOnValue(pir::Value value,
                            pir::Builder& builder) {  // NOLINT
   auto ty = value.type().dyn_cast<paddle::dialect::DenseTensorType>();
 
   if (!ty || ty.dims().size() == 0) return true;
-  std::vector<pir::OpResult> dimSizes;
+  std::vector<pir::Value> dimSizes;
   for (int64_t dim = 0, rank = ty.dims().size(); dim < rank; ++dim) {
     auto dimOp = builder.Build<pir::dialect::TensorDimOp>(value, dim);
     dimSizes.push_back(dimOp.out());

--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -586,7 +586,7 @@ bool SymbolicDimMgr::SaveShapeConstraintGraph() {
 
   Builder builder = Builder(m_->ir_context(), funcOp.block());
   auto build_operands = [&](const SymbolicDimProduct& prod) {
-    std::vector<OpResult> values;
+    std::vector<Value> values;
 
     if (prod.factor != 1) {
       values.push_back(

--- a/test/cpp/pir/core/ir_infershape_test.cc
+++ b/test/cpp/pir/core/ir_infershape_test.cc
@@ -83,7 +83,7 @@ TEST(infershape_test, infershape_test) {
   std::string op_name = OperationTest::name();
   pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_name);
 
-  std::vector<pir::OpResult> op_inputs = {};
+  std::vector<pir::Value> op_inputs = {};
   std::vector<pir::Type> op_output_types = {pir::Float32Type::get(ctx)};
   pir::Operation *op =
       pir::Operation::Create(op_inputs, {}, op_output_types, op_info);

--- a/test/cpp/pir/core/ir_op_test.cc
+++ b/test/cpp/pir/core/ir_op_test.cc
@@ -104,13 +104,11 @@ class Operation1 : public pir::Op<Operation1> {
   }
   static void Build(const pir::Builder &builder,
                     pir::OperationArgument &argument) {  // NOLINT
-    std::vector<pir::OpResult> inputs = {};
     std::vector<pir::Type> output_types = {
         pir::Float32Type::get(builder.ir_context())};
     std::unordered_map<std::string, pir::Attribute> attributes =
         CreateAttributeMap({"op1_attr1", "op1_attr2"},
                            {"op1_attr1", "op1_attr2"});
-    argument.AddOperands(inputs.begin(), inputs.end());
     argument.AddOutputs(output_types.begin(), output_types.end());
     argument.AddAttributes(attributes.begin(), attributes.end());
   }
@@ -192,7 +190,7 @@ TEST(op_test, op_test) {
   EXPECT_EQ(op2_info.HasInterface<InferShapeInterface>(), true);
 
   // (3) Test uses for op.
-  std::vector<pir::OpResult> op_inputs = {};
+  std::vector<pir::Value> op_inputs = {};
   std::vector<pir::Type> op_output_types = {pir::Float32Type::get(ctx)};
   pir::Operation *op2 =
       pir::Operation::Create(op_inputs,
@@ -263,7 +261,7 @@ TEST(op_test, module_op_death) {
   pir::IrContext *ctx = pir::IrContext::Instance();
   pir::OpInfo op_info = ctx->GetRegisteredOpInfo(pir::ModuleOp::name());
 
-  std::vector<pir::OpResult> inputs{pir::OpResult()};
+  std::vector<pir::Value> inputs{pir::Value()};
   pir::AttributeMap attrs{{"program", pir::Int32Attribute::get(ctx, 1)}};
   std::vector<pir::Type> output_types = {pir::Float32Type::get(ctx)};
 

--- a/test/cpp/pir/core/ir_value_test.cc
+++ b/test/cpp/pir/core/ir_value_test.cc
@@ -36,7 +36,7 @@ pir::AttributeMap CreateAttributeMap(std::string attribute_name,
 TEST(value_test, value_test) {
   pir::IrContext *ctx = pir::IrContext::Instance();
   // 1. Construct OP1: a = OP1()
-  std::vector<pir::OpResult> op1_inputs = {};
+  std::vector<pir::Value> op1_inputs = {};
   std::vector<pir::Type> op1_output_types = {pir::Float32Type::get(ctx)};
   pir::Operation *op1 =
       pir::Operation::Create(op1_inputs,
@@ -47,7 +47,7 @@ TEST(value_test, value_test) {
   pir::OpResult a = op1->result(0);
   EXPECT_TRUE(a.use_empty());
   // 2. Construct OP2: b = OP2();
-  std::vector<pir::OpResult> op2_inputs = {};
+  std::vector<pir::Value> op2_inputs = {};
   std::vector<pir::Type> op2_output_types = {pir::Float32Type::get(ctx)};
   pir::Operation *op2 =
       pir::Operation::Create(op2_inputs,
@@ -58,7 +58,7 @@ TEST(value_test, value_test) {
   pir::OpResult b = op2->result(0);
   EXPECT_TRUE(b.use_empty());
   // 3. Construct OP3: c = OP3(a, b);
-  std::vector<pir::OpResult> op3_inputs{a, b};
+  std::vector<pir::Value> op3_inputs{a, b};
   std::vector<pir::Type> op3_output_types = {pir::Float32Type::get(ctx)};
   pir::Operation *op3 =
       pir::Operation::Create(op3_inputs,
@@ -71,7 +71,7 @@ TEST(value_test, value_test) {
   op3->Print(std::cout);
   pir::OpResult c = op3->result(0);
   // 4. Construct OP4: d, e, f, g, h, i, j = OP4(a, c);
-  std::vector<pir::OpResult> op4_inputs = {a, c};
+  std::vector<pir::Value> op4_inputs = {a, c};
   std::vector<pir::Type> op4_output_types;
   for (size_t i = 0; i < 7; i++) {
     op4_output_types.push_back(pir::Float32Type::get(ctx));

--- a/test/cpp/pir/shape_dialect/constraint_pass_test.cc
+++ b/test/cpp/pir/shape_dialect/constraint_pass_test.cc
@@ -59,7 +59,7 @@ pir::Operation *CreateDenseTensorOp(
     const phi::DDim &dims,
     const std::vector<std::string> &attribute_names,
     const std::vector<std::string> &attributes) {
-  std::vector<pir::OpResult> op_inputs = {};
+  std::vector<pir::Value> op_inputs = {};
   pir::Type fp32_dtype = pir::Float32Type::get(ctx);
   phi::DataLayout data_layout = phi::DataLayout::NCHW;
   phi::LoD lod = {{0, 1, 2}};

--- a/test/cpp/pir/shape_dialect/symbolic_op_test.cc
+++ b/test/cpp/pir/shape_dialect/symbolic_op_test.cc
@@ -45,7 +45,7 @@ pir::Operation *CreateDenseTensorOp(
     const phi::DDim &dims,
     const std::vector<std::string> &attribute_names,
     const std::vector<std::string> &attributes) {
-  std::vector<pir::OpResult> op_inputs = {};
+  std::vector<pir::Value> op_inputs = {};
   pir::Type fp32_dtype = pir::Float32Type::get(ctx);
   phi::DataLayout data_layout = phi::DataLayout::NCHW;
   phi::LoD lod = {{0, 1, 2}};
@@ -219,29 +219,29 @@ TEST(assist_struct_test, symbolic_dim_mgr_complex) {
 
   // Mark S1 == S2.
   builder.Build<pir::dialect::TieProductEqualOp>(
-      2, 2, std::vector<pir::OpResult>{constant, dimOpS1, dimOpS2, constant});
+      2, 2, std::vector<pir::Value>{constant, dimOpS1, dimOpS2, constant});
   // Mark S0 * S1 == S2 * S3, For check S0 == S3.
   builder.Build<pir::dialect::TieProductEqualOp>(
-      2, 2, std::vector<pir::OpResult>{dimOpS0, dimOpS1, dimOpS2, dimOpS3});
+      2, 2, std::vector<pir::Value>{dimOpS0, dimOpS1, dimOpS2, dimOpS3});
   // Mark S4 * S0 * S1 == S2 * S3 * S5, For check S4 == S5.
   builder.Build<pir::dialect::TieProductEqualOp>(
       3,
       3,
-      std::vector<pir::OpResult>{
+      std::vector<pir::Value>{
           dimOpS4, dimOpS0, dimOpS1, dimOpS2, dimOpS3, dimOpS5});
   // For check S6 == C10 * C20.
   builder.Build<pir::dialect::TieProductEqualOp>(
-      1, 2, std::vector<pir::OpResult>{dimOpS6, dimOpC10, dimOpC20});
+      1, 2, std::vector<pir::Value>{dimOpS6, dimOpC10, dimOpC20});
   // Mark C10 * S0 * S1 == S2 * S3 * S7, for check C10 == S7.
   builder.Build<pir::dialect::TieProductEqualOp>(
       3,
       3,
-      std::vector<pir::OpResult>{
+      std::vector<pir::Value>{
           dimOpC10, dimOpS0, dimOpS1, dimOpS2, dimOpS3, dimOpS7});
 
   // For unsimplify product case: S8 * S9 == S10 * S11
   builder.Build<pir::dialect::TieProductEqualOp>(
-      2, 2, std::vector<pir::OpResult>{dimOpS8, dimOpS9, dimOpS10, dimOpS11});
+      2, 2, std::vector<pir::Value>{dimOpS8, dimOpS9, dimOpS10, dimOpS11});
 
   auto op = CreateDenseTensorOp(ctx,
                                 {pir::ShapedTypeInterface::kDynamic,
@@ -427,7 +427,7 @@ TEST(shape_op, tie_product_equal) {
       builder.Build<pir::dialect::TieProductEqualOp>(
           2,
           3,
-          std::vector<pir::OpResult>{dimOp0, dimOp1, dimOp2, dimOp3, dimOp4});
+          std::vector<pir::Value>{dimOp0, dimOp1, dimOp2, dimOp3, dimOp4});
 
   std::vector<pir::Value> lhs = tie_product_equal.getLhs();
   std::vector<pir::Value> rhs = tie_product_equal.getRhs();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
规范化代码中对Value的使用[-1]。

Value分两种，OpResult和BlockArgument. 由于之前没有BlockArgument， 大家都是混用Value和OpResult， 现在有了BlockArguemnt, 需要区分Value和OpResult的使用。

本pr内容：
- 将pri::Operation::Create接口中的输入参数由std::vector\<pir::OpResult\>修改为std::vector\<pir::value\>。
并同步修改了对pir::Operation::Create接口的调用。
- 将shape dialect中相关op的Build接口的相关参数由OpResult替换成了Value。

Todo: 
- 将pir::OperationArgument::inputs_中的类型由std::vector\<pir::OpResult\>修改为std::vector\<pir::value\>。
- 将其它Dialect中相关op的Build接口的相关参数由OpResult替换成了Value。
## Other
Pcard-67164
