### PR TITLE
fix stride reshape inplace bug

### DIFF
--- a/paddle/phi/kernels/stride/reshape_kernel.cc
+++ b/paddle/phi/kernels/stride/reshape_kernel.cc
@@ -43,10 +43,13 @@ void ReshapeStridedKernel(const Context& dev_ctx,
     out->ResetHolder(x.Holder());
   } else {
     DenseTensor tmp;
-    tmp.set_meta(x.meta());
+    DenseTensor tmp_x = x;
+    tmp_x.Resize(x_dims);
+    tmp_x.set_strides(x_stride);
+    tmp.set_meta(tmp_x.meta());
     PD_VISIT_ALL_TYPES(x.dtype(), "ReshapeStridedKernel", ([&] {
                          phi::ContiguousKernel<data_t, Context>(
-                             dev_ctx, x, &tmp);
+                             dev_ctx, tmp_x, &tmp);
                        }));
     out->set_strides(DenseTensorMeta::calc_strides(out->dims()));
     out->set_offset(0);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
reshape在inplace时，由于infermeta时已经修改了input x的meta信息。所以导致reshape在特定场景下计算错误。
Pcard-74613