### PR TITLE
[PIR] standardize the use of value[-4].

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -1520,7 +1520,7 @@ struct ElementwiseTranscriber : public OpTranscriber {
           phi::DataType::INT64,
           phi::CPUPlace());
       auto y_true_shape_op = builder.Build<pir::CombineOp>(
-          std::vector<pir::OpResult>{shape_op.out(), append_shape_op.out()});
+          std::vector<pir::Value>{shape_op.out(), append_shape_op.out()});
       auto concat_op =
           builder.Build<dialect::ConcatOp>(y_true_shape_op.out(), 0);
       auto y_new_shape = concat_op.out();

--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -84,7 +84,7 @@ SPLIT_OP_TEMPLATE = """
 COMPUTE_OP_TEMPLATE = """
     paddle::dialect::{op_class_name} {op_inst_name} = APIBuilder::Instance().GetBuilder()->Build<paddle::dialect::{op_class_name}>({args});"""
 
-OP_RESULT = 'pir::OpResult'
+OP_INPUT = 'pir::Value'
 VECTOR_TYPE = 'pir::VectorType'
 INTARRAY_ATTRIBUTE = "paddle::dialect::IntArrayAttribute"
 
@@ -96,6 +96,11 @@ def get_op_class_name(op_name):
 class CodeGen:
     def __init__(self) -> None:
         self._type_map = {
+            'paddle::dialect::DenseTensorType': 'pir::Value',
+            'paddle::dialect::SelectedRowsType': 'pir::Value',
+            'pir::VectorType<paddle::dialect::DenseTensorType>': 'std::vector<pir::Value>',
+        }
+        self._ret_type_map = {
             'paddle::dialect::DenseTensorType': 'pir::OpResult',
             'paddle::dialect::SelectedRowsType': 'pir::OpResult',
             'pir::VectorType<paddle::dialect::DenseTensorType>': 'std::vector<pir::OpResult>',
@@ -160,18 +165,14 @@ class CodeGen:
                     == INTARRAY_ATTRIBUTE
                     and is_vector_mutable_attr
                 ):
-                    mutable_attr.append(f'std::vector<{OP_RESULT}> {name}')
+                    mutable_attr.append(f'std::vector<{OP_INPUT}> {name}')
                 else:
-                    mutable_attr.append(f'{OP_RESULT} {name}')
+                    mutable_attr.append(f'{OP_INPUT} {name}')
                 continue
             if with_default and default_value is not None:
                 if type in ['float', 'double']:
                     default_value = default_value.strip('"')
-                no_mutable_attr.append(
-                    '{type} {name} = {default_value}'.format(
-                        type=type, name=name, default_value=default_value
-                    )
-                )
+                no_mutable_attr.append(f'{type} {name} = {default_value}')
             else:
                 no_mutable_attr.append(f'{type} {name}')
         return ', '.join(mutable_attr + no_mutable_attr)
@@ -199,7 +200,7 @@ class CodeGen:
             return 'std::tuple<{}>'.format(
                 ', '.join(
                     [
-                        self._type_map[type]
+                        self._ret_type_map[type]
                         for type, intermediate in zip(
                             type_list, intermediate_list
                         )
@@ -209,7 +210,7 @@ class CodeGen:
             )
         elif output_num == 1:
             index = intermediate_list.index('false')
-            return self._type_map[type_list[index]]
+            return self._ret_type_map[type_list[index]]
         elif output_num == 0:
             return 'void'
 

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -48,13 +48,13 @@ def GenBuildInputArgsStr(
     attr_args_is_map=False,
 ):
     '''
-    Example: pir::Builder &builder, pir::OperationArgument &argument, pir::OpResult x_, phi::DataType dtype=phi::DataType::UNDEFINED, phi::Place place={}
+    Example: pir::Builder &builder, pir::OperationArgument &argument, pir::Value x_, phi::DataType dtype=phi::DataType::UNDEFINED, phi::Place place={}
     '''
     # add inputs
     build_args_str = "pir::Builder &builder, pir::OperationArgument &argument"
     if len(op_input_name_list) > 0:
         for input_name in op_input_name_list:
-            build_args_str += ", pir::OpResult " + input_name + "_"
+            build_args_str += ", pir::Value " + input_name + "_"
 
     if attr_args_is_map:
         build_args_str += ", pir::AttributeMap attributes"
@@ -92,7 +92,7 @@ def GenBuildInputArgsStr(
             # add mutable attributes as inputs
             if len(op_mutable_attribute_name_list) > 0:
                 for mutable_attr in op_mutable_attribute_name_list:
-                    build_args_str += ", pir::OpResult " + mutable_attr + "_"
+                    build_args_str += ", pir::Value " + mutable_attr + "_"
 
             # add non-mutable attributes
             for attr_idx in range(len(op_non_mutable_attribute_name_list)):
@@ -183,8 +183,8 @@ def GenBuildInserFullForMutableAttribute(
 
 
 def GenBuildInputs(op_input_name_list, op_mutable_attribute_name_list):
-    BUILD_INPUT_TEMPLATE = """  std::vector<pir::OpResult> argument_inputs = {{{inputs_args}}};
-  argument.AddInputs(argument_inputs.begin(), argument_inputs.end());
+    BUILD_INPUT_TEMPLATE = """  std::vector<pir::Value> argument_inputs = {{{inputs_args}}};
+  argument.AddInputs(argument_inputs);
 """
     build_input_str = '  VLOG(4) << "Builder construction inputs";\n'
     input_name_list = op_input_name_list + op_mutable_attribute_name_list
@@ -344,16 +344,11 @@ def GenBuildOutputs(
     meta_{name}.push_back(&vec_meta_{name}[i]);
   }}
  """
-
-    CREATE_INTARRAY_MUTABLE_ATTRIBUE_TEMPLATE = """  std::vector<int64_t> {name} = {name}_.owner()->dyn_cast<paddle::dialect::FullIntArrayOp>().attributes().at("value").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData(); (void){name};\n"""
-    CREATE_SCALAR_MUTABLE_ATTRIBUE_TEMPLATE = """  {dtype} {name} = {name}_.owner()->dyn_cast<paddle::dialect::FullOp>().attributes().at("value").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{dtype}>(); (void){name};\n"""
-
     CREATE_INTARRAY_MUTABLE_ATTRIBUE_WITH_UNKONW_DATA_TEMPLATE = """  phi::IntArray {name};
-  if ({name}_.owner()->info().id() == pir::TypeId::get<paddle::dialect::FullIntArrayOp>()) {{
-    {name} = std::move(phi::IntArray({name}_.owner()
+  if ({name}_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullIntArrayOp>()) {{
+    {name} = std::move(phi::IntArray({name}_.dyn_cast<pir::OpResult>().owner()
                           ->dyn_cast<paddle::dialect::FullIntArrayOp>()
-                          .attributes()
-                          .at("value")
+                          .attribute("value")
                           .dyn_cast<paddle::dialect::IntArrayAttribute>()
                           .data()
                           .GetData()));
@@ -370,14 +365,13 @@ def GenBuildOutputs(
   }}\n"""
 
     CREATE_VECTOR_INT_MUTABLE_ATTRIBUE_WITH_UNKONW_DATA_TEMPLATE = """  std::vector<int64_t> {name};
-  if ({name}_.owner()->info().id() == pir::TypeId::get<paddle::dialect::FullIntArrayOp>()) {{
-    {name} = {name}_.owner()
-                          ->dyn_cast<paddle::dialect::FullIntArrayOp>()
-                          .attributes()
-                          .at("value")
-                          .dyn_cast<paddle::dialect::IntArrayAttribute>()
-                          .data()
-                          .GetData();
+  if ({name}_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullIntArrayOp>()) {{
+    {name} = {name}_.dyn_cast<pir::OpResult>().owner()
+                    ->dyn_cast<paddle::dialect::FullIntArrayOp>()
+                    .attribute("value")
+                    .dyn_cast<paddle::dialect::IntArrayAttribute>()
+                    .data()
+                    .GetData();
   }} else if ({name}_.type().isa<pir::VectorType>()) {{
     size_t {name}_size = {name}_.type().dyn_cast<pir::VectorType>().size();
     {name} = std::vector<int64_t>({name}_size, -1);
@@ -389,11 +383,10 @@ def GenBuildOutputs(
   }}\n"""
 
     CREATE_SCALAR_MUTABLE_ATTRIBUE_WITH_UNKONW_DATA_TEMPLATE = """  phi::Scalar {name};
-  if ({name}_.owner()->info().id() == pir::TypeId::get<paddle::dialect::FullOp>()) {{
-    {name} = std::move(phi::Scalar({name}_.owner()
+  if ({name}_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullOp>()) {{
+    {name} = std::move(phi::Scalar({name}_.dyn_cast<pir::OpResult>().owner()
                                   ->dyn_cast<paddle::dialect::FullOp>()
-                                  .attributes()
-                                  .at("value")
+                                  .attribute("value")
                                   .dyn_cast<paddle::dialect::ScalarAttribute>()
                                   .data()
                                   .to<int>()));

--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -79,7 +79,7 @@ OP_VJP_STOPGRADIENT_TEMPLATE = """
     }"""
 
 OP_VJP_DEFINE_TEMPLATE = """
-std::vector<std::vector<pir::OpResult>> {op_class_name}::Vjp(pir::Operation* op, const std::vector<std::vector<pir::OpResult>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients){{
+std::vector<std::vector<pir::OpResult>> {op_class_name}::Vjp(pir::Operation* op, const std::vector<std::vector<pir::Value>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients){{
     {op_class_name} op_obj = op->dyn_cast<{op_class_name}>(); (void)op_obj;
 
     VLOG(6) << "Prepare inputs of {op_grad_name}";
@@ -254,5 +254,5 @@ def gen_exclusive_interface_str(op_info):
             "  static void InferMeta( phi::InferMetaContext *infer_meta );"
         )
     if op_info.op_phi_name[0] in vjp_interface_declare_gen_op_list:
-        exclusive_interface_str += "\n  static std::vector<std::vector<pir::OpResult>> Vjp(pir::Operation* op, const std::vector<std::vector<pir::OpResult>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients);"
+        exclusive_interface_str += "\n  static std::vector<std::vector<pir::OpResult>> Vjp(pir::Operation* op, const std::vector<std::vector<pir::Value>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients);"
     return exclusive_interface_str

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -18,7 +18,7 @@ import re
 from api_gen import (
     INTARRAY_ATTRIBUTE,
     NAMESPACE_TEMPLATE,
-    OP_RESULT,
+    OP_INPUT,
     VECTOR_TYPE,
     CodeGen,
 )
@@ -64,7 +64,7 @@ PyObject *static_api_{api_name}(PyObject *self, PyObject *args, PyObject *kwargs
         VLOG(6) << "Add {api_name} op into program";
         VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
 
-        // Get OpResult from args
+        // Get Value from args
         {inputs}
 
         // Parse Attributes
@@ -87,7 +87,7 @@ PyObject *static_api_{api_name}(PyObject *self, PyObject *args, PyObject *kwargs
         VLOG(6) << "Add {api_name} op into program";
         VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
 
-        // Get OpResult from args
+        // Get Value from args
         {inputs}
 
         // Parse Attributes
@@ -118,7 +118,7 @@ PyObject *static_api_{api_name}(PyObject *self, PyObject *args, PyObject *kwargs
         VLOG(6) << "Add {api_name} op into program";
         VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
 
-        // Get OpResult from args
+        // Get Value from args
         {inputs}
 
         // Parse Attributes
@@ -245,7 +245,7 @@ class PythonCCodeGen(CodeGen):
         ret = ''
         for i, (name, type) in enumerate(zip(name_list, type_list)):
             cast_func = (
-                'CastPyArg2VectorOfOpResult'
+                'CastPyArg2VectorOfValue'
                 if VECTOR_TYPE in type
                 else 'CastPyArg2OpResult'
             )
@@ -286,7 +286,7 @@ class PythonCCodeGen(CodeGen):
         mutable_attr_name_list = op_info.mutable_attribute_name_list
         ret = ''
         for name in mutable_attr_name_list:
-            ret += INIT_ATTRS_TEMPLATE.format(type=OP_RESULT, name=name)
+            ret += INIT_ATTRS_TEMPLATE.format(type=OP_INPUT, name=name)
 
         return ret
 
@@ -311,10 +311,10 @@ class PythonCCodeGen(CodeGen):
                     == INTARRAY_ATTRIBUTE
                 ):
                     mutable_cast_str = MUTABLE_ATTR_CAST_TEMPLATE.format(
-                        type='std::vector<pir::OpResult>',
+                        type='std::vector<pir::Value>',
                         name_=name + '_tmp',
                         name=name,
-                        cast_func='CastPyArg2VectorOfOpResult',
+                        cast_func='CastPyArg2VectorOfValue',
                         api_name=op_name,
                         index=input_size + i,
                     )

--- a/paddle/fluid/pir/dialect/operator/interface/interface.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/interface.cc
@@ -15,6 +15,24 @@
 #include "paddle/fluid/pir/dialect/operator/interface/infermeta.h"
 #include "paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h"
 #include "paddle/fluid/pir/dialect/operator/interface/vjp.h"
+namespace paddle {
+namespace dialect {
+std::vector<std::vector<pir::OpResult>> VjpInterface::Vjp(
+    pir::Operation* op,
+    const std::vector<std::vector<pir::OpResult>>& out_grads,
+    const std::vector<std::vector<bool>>& stop_gradients) {
+  std::vector<std::vector<pir::Value>> out_grads_value;
+  for (const auto& grad : out_grads) {
+    std::vector<pir::Value> grad_value;
+    for (auto op_result : grad) {
+      grad_value.emplace_back(op_result);
+    }
+    out_grads_value.emplace_back(std::move(grad_value));
+  }
+  return impl_->vjp_(op, out_grads_value, stop_gradients);
+}
+}  // namespace dialect
+}  // namespace paddle
 
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::InferMetaInterface)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::OpYamlInfoInterface)

--- a/paddle/fluid/pir/dialect/operator/interface/vjp.h
+++ b/paddle/fluid/pir/dialect/operator/interface/vjp.h
@@ -22,12 +22,12 @@ class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
   struct Concept {
     explicit Concept(std::vector<std::vector<pir::OpResult>> (*vjp)(
         pir::Operation* op,
-        const std::vector<std::vector<pir::OpResult>>& out_grads,
+        const std::vector<std::vector<pir::Value>>& out_grads,
         const std::vector<std::vector<bool>>& stop_gradients))
         : vjp_(vjp) {}
     std::vector<std::vector<pir::OpResult>> (*vjp_)(
         pir::Operation* op,
-        const std::vector<std::vector<pir::OpResult>>& out_grads,
+        const std::vector<std::vector<pir::Value>>& out_grads,
         const std::vector<std::vector<bool>>& stop_gradients);
   };
 
@@ -35,7 +35,7 @@ class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
   struct Model : public Concept {
     static std::vector<std::vector<pir::OpResult>> Vjp(
         pir::Operation* op,
-        const std::vector<std::vector<pir::OpResult>>& out_grads,
+        const std::vector<std::vector<pir::Value>>& out_grads,
         const std::vector<std::vector<bool>>& stop_gradients) {
       return ConcreteOp::Vjp(op, out_grads, stop_gradients);
     }
@@ -48,10 +48,15 @@ class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
 
   std::vector<std::vector<pir::OpResult>> Vjp(
       pir::Operation* op,
-      const std::vector<std::vector<pir::OpResult>>& out_grads,
+      const std::vector<std::vector<pir::Value>>& out_grads,
       const std::vector<std::vector<bool>>& stop_gradients) {
     return impl_->vjp_(op, out_grads, stop_gradients);
   }
+
+  std::vector<std::vector<pir::OpResult>> Vjp(
+      pir::Operation* op,
+      const std::vector<std::vector<pir::OpResult>>& out_grads,
+      const std::vector<std::vector<bool>>& stop_gradients);
 
  private:
   Concept* impl_;

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -22,13 +22,13 @@
 namespace paddle {
 namespace dialect {
 
-pir::OpResult builtin_combine(std::vector<pir::OpResult> x) {
+pir::OpResult builtin_combine(const std::vector<pir::Value>& x) {
   auto combine_op =
       APIBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(x);
   return combine_op.out();
 }
 
-pir::OpResult zeros_like(pir::OpResult x,
+pir::OpResult zeros_like(pir::Value x,
                          phi::DataType dtype,
                          const Place& place) {
   return paddle::dialect::full_like(x, 0, dtype, place);
@@ -52,14 +52,14 @@ pir::OpResult get_parameter(const std::string& name,
   return get_parameter_op.result(0);
 }
 
-void set_parameter(pir::OpResult parameter, const std::string& name) {
+void set_parameter(pir::Value parameter, const std::string& name) {
   APIBuilder::Instance().GetBuilder()->Build<pir::SetParameterOp>(parameter,
                                                                   name);
 }
 
-pir::OpResult embedding_grad(pir::OpResult x,
-                             pir::OpResult weight,
-                             pir::OpResult out_grad,
+pir::OpResult embedding_grad(pir::Value x,
+                             pir::Value weight,
+                             pir::Value out_grad,
                              int64_t padding_idx,
                              bool sparse) {
   if (weight.type().isa<paddle::dialect::DenseTensorType>()) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -23,9 +23,9 @@
 namespace paddle {
 namespace dialect {
 
-pir::OpResult builtin_combine(std::vector<pir::OpResult> x);
+pir::OpResult builtin_combine(const std::vector<pir::Value>& x);
 
-pir::OpResult zeros_like(pir::OpResult x,
+pir::OpResult zeros_like(pir::Value x,
                          phi::DataType dtype = phi::DataType::UNDEFINED,
                          const Place& place = {});
 
@@ -33,11 +33,11 @@ pir::OpResult get_parameter(const std::string& name,
                             phi::DataType dtype,
                             const std::vector<int64_t>& shape);
 
-void set_parameter(pir::OpResult parameter, const std::string& name);
+void set_parameter(pir::Value parameter, const std::string& name);
 
-pir::OpResult embedding_grad(pir::OpResult x,
-                             pir::OpResult weight,
-                             pir::OpResult out_grad,
+pir::OpResult embedding_grad(pir::Value x,
+                             pir::Value weight,
+                             pir::Value out_grad,
                              int64_t padding_idx = -1,
                              bool sparse = false);
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -45,7 +45,7 @@ class AddNOp : public pir::Op<AddNOp, OpYamlInfoInterface, InferMetaInterface> {
   static OpInfoTuple GetOpInfo();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult inputs);
+                    pir::Value inputs);
 
   void Verify();
   pir::Value inputs() { return operand_source(0); }
@@ -65,7 +65,7 @@ class AddN_Op : public pir::Op<AddN_Op,
   static OpInfoTuple GetOpInfo();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult inputs_);
+                    pir::Value inputs_);
 
   void Verify();
   pir::Value inputs() { return operand_source(0); }
@@ -85,7 +85,7 @@ class AddNWithKernelOp : public pir::Op<AddNWithKernelOp,
   static OpInfoTuple GetOpInfo();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult inputs_);
+                    pir::Value inputs_);
 
   void Verify();
   pir::Value inputs() { return operand_source(0); }
@@ -107,9 +107,9 @@ class FusedGemmEpilogueOp
 
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult x_,
-                    pir::OpResult y_,
-                    pir::OpResult bias_,
+                    pir::Value x_,
+                    pir::Value y_,
+                    pir::Value bias_,
                     pir::AttributeMap attributes);
   void Verify();
   pir::Value x() { return operand_source(0); }
@@ -134,10 +134,10 @@ class FusedGemmEpilogueGradOp
 
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult x_,
-                    pir::OpResult y_,
-                    pir::OpResult reserve_space_,
-                    pir::OpResult out_grad_,
+                    pir::Value x_,
+                    pir::Value y_,
+                    pir::Value reserve_space_,
+                    pir::Value out_grad_,
                     pir::AttributeMap attributes);
   void Verify();
   pir::Value x() { return operand_source(0); }
@@ -160,12 +160,12 @@ class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
   static OpInfoTuple GetOpInfo();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult x_,
+                    pir::Value x_,
                     float axis = 0);
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult out_grad_,
-                    pir::OpResult axis_);
+                    pir::Value out_grad_,
+                    pir::Value axis_);
 
   void Verify();
   pir::Value out_grad() { return operand_source(0); }
@@ -182,7 +182,7 @@ class IfOp : public pir::Op<IfOp> {
   static constexpr uint32_t attributes_num = 0;
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult cond,
+                    pir::Value cond,
                     std::vector<pir::Type> &&output_types);
   pir::Value cond() { return operand_source(0); }
   pir::Block *true_block();

--- a/paddle/fluid/pir/transforms/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/constant_folding_pass.cc
@@ -137,7 +137,7 @@ class ConstantFoldingPattern : public pir::RewritePattern {
     pir::Builder builder = pir::Builder(ir_context(), program->block());
 
     // prepare op inputs
-    std::vector<pir::OpResult> op_inputs;
+    std::vector<pir::Value> op_inputs;
     for (uint32_t i = 0; i < op->num_operands(); i++) {
       PADDLE_ENFORCE_EQ(
           op->operand_source(i).type().isa<paddle::dialect::DenseTensorType>(),

--- a/paddle/fluid/primitive/codegen/templates/backend/generated/generated_static_backend.cc.j2
+++ b/paddle/fluid/primitive/codegen/templates/backend/generated/generated_static_backend.cc.j2
@@ -20,23 +20,23 @@ template <>
 {%- macro prepare_ir_api_inputs(inputs)-%}
   {%- for input in inputs -%}
     {% if input.typename=='Tensor[]' and not input.optional %}
-std::vector<pir::OpResult> {{input.name}}_res({{input.name}}.size());
+std::vector<pir::Value> {{input.name}}_res({{input.name}}.size());
 std::transform({{input.name}}.begin(), {{input.name}}.end(), {{input.name}}_res.begin(), [](const Tensor& t) {
-  return std::static_pointer_cast<LazyTensor>(t.impl())->value().dyn_cast<pir::OpResult>();
+  return std::static_pointer_cast<LazyTensor>(t.impl())->value();
 });
     {% elif input.typename=='Tensor[]' and input.optional %}
-std::vector<pir::OpResult> {{input.name}}_res({{input.name}}.size());
+std::vector<pir::Value> {{input.name}}_res({{input.name}}.size());
 if({{input.name}}) {
   std::transform({{input.name}}.get().begin(), {{input.name}}.get().end(), {{input.name}}_res.begin(), [](const Tensor& t) {
-    return std::static_pointer_cast<LazyTensor>(t.impl())->value().dyn_cast<pir::OpResult>();
+    return std::static_pointer_cast<LazyTensor>(t.impl())->value();
   });
 }
     {% elif input.typename=='Tensor' and not input.optional %}
-pir::OpResult {{input.name}}_res = std::static_pointer_cast<LazyTensor>({{input.name}}.impl())->value().dyn_cast<pir::OpResult>();
+pir::Value {{input.name}}_res = std::static_pointer_cast<LazyTensor>({{input.name}}.impl())->value();
     {% else %}
-pir::OpResult {{input.name}}_res;
+pir::Value {{input.name}}_res;
 if({{input.name}}) {
-  {{input.name}}_res = std::static_pointer_cast<LazyTensor>({{input.name}}.get().impl())->value().dyn_cast<pir::OpResult>();
+  {{input.name}}_res = std::static_pointer_cast<LazyTensor>({{input.name}}.get().impl())->value();
 }
     {% endif %}
   {% endfor %}

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1534,17 +1534,17 @@ pir::OpResult CastPyArg2OpResult(PyObject* obj,
   }
 }
 
-std::vector<pir::OpResult> CastPyArg2VectorOfOpResult(
-    PyObject* obj, const std::string& op_type, size_t arg_pos) {
-  std::vector<pir::OpResult> result_list;
+std::vector<pir::Value> CastPyArg2VectorOfValue(PyObject* obj,
+                                                const std::string& op_type,
+                                                size_t arg_pos) {
+  std::vector<pir::Value> value_list;
   if (PyList_Check(obj)) {
     Py_ssize_t len = PyList_Size(obj);
     PyObject* item = nullptr;
     for (Py_ssize_t i = 0; i < len; i++) {
       item = PyList_GetItem(obj, i);
       if (PyObject_TypeCheck(item, g_ir_opresult_pytype)) {
-        result_list.emplace_back(
-            ::pybind11::handle(item).cast<pir::OpResult>());
+        value_list.emplace_back(::pybind11::handle(item).cast<pir::OpResult>());
       } else if (item == Py_None) {
         continue;
       } else {
@@ -1563,8 +1563,7 @@ std::vector<pir::OpResult> CastPyArg2VectorOfOpResult(
     for (Py_ssize_t i = 0; i < len; i++) {
       item = PyTuple_GetItem(obj, i);
       if (PyObject_TypeCheck(item, g_ir_opresult_pytype)) {
-        result_list.emplace_back(
-            ::pybind11::handle(item).cast<pir::OpResult>());
+        value_list.emplace_back(::pybind11::handle(item).cast<pir::OpResult>());
       } else if (item == Py_None) {
         continue;
       } else {
@@ -1578,7 +1577,7 @@ std::vector<pir::OpResult> CastPyArg2VectorOfOpResult(
       }
     }
   } else if (PyObject_TypeCheck(obj, g_ir_opresult_pytype)) {
-    return {::pybind11::handle(obj).cast<pir::OpResult>()};
+    return {::pybind11::handle(obj).cast<pir::Value>()};
   } else if (obj == Py_None) {
     return {};
   } else {
@@ -1589,7 +1588,7 @@ std::vector<pir::OpResult> CastPyArg2VectorOfOpResult(
         arg_pos + 1,
         ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
   }
-  return result_list;
+  return value_list;
 }
 
 paddle::experimental::Scalar CastPyArg2Scalar(PyObject* obj,

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -79,8 +79,9 @@ std::vector<float> CastPyArg2VectorOfFloat(PyObject* obj, size_t arg_pos);
 pir::OpResult CastPyArg2OpResult(PyObject* obj,
                                  const std::string& op_type,
                                  size_t arg_pos);
-std::vector<pir::OpResult> CastPyArg2VectorOfOpResult(
-    PyObject* obj, const std::string& op_type, size_t arg_pos);
+std::vector<pir::Value> CastPyArg2VectorOfValue(PyObject* obj,
+                                                const std::string& op_type,
+                                                size_t arg_pos);
 std::vector<std::vector<size_t>> CastPyArg2VectorOfVectorOfSize_t(
     PyObject* obj, size_t arg_pos);
 framework::proto::VarType::Type CastPyArg2ProtoType(PyObject* obj,

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -96,14 +96,13 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
       auto static_api_out = paddle::dialect::full(shape, value, dtype, place);
       return ToPyObject(static_api_out);
     } else {
-      pir::OpResult shape;
-      pir::OpResult value;
+      pir::Value shape, value;
 
       if (PyObject_CheckIROpResult(shape_obj)) {
         shape = CastPyArg2OpResult(shape_obj, "full", 0);
       } else if (PyObject_CheckIRVectorOfOpResult(shape_obj)) {
-        std::vector<pir::OpResult> shape_tmp =
-            CastPyArg2VectorOfOpResult(shape_obj, "full", 0);
+        std::vector<pir::Value> shape_tmp =
+            CastPyArg2VectorOfValue(shape_obj, "full", 0);
         shape = paddle::dialect::stack(shape_tmp, 0);
       } else {
         std::vector<int64_t> shape_tmp = CastPyArg2Longs(shape_obj, "full", 0);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -697,16 +697,14 @@ void BindVjp(pybind11::module *m) {
          const std::vector<std::vector<pir::OpResult>> &out_grads,
          const std::vector<std::vector<bool>> &stop_gradients) {
         py::list res;
-        pir::IrContext *ctx = pir::IrContext::Instance();
-        pir::OpInfo fwd_op_info = ctx->GetRegisteredOpInfo(fwd_op.name());
-        auto vjp_interface_impl =
-            fwd_op_info.GetInterfaceImpl<paddle::dialect::VjpInterface>();
-        if (vjp_interface_impl == nullptr) {
-          PADDLE_THROW(phi::errors::InvalidArgument(
-              "The vjp function is not registered in %s op ", fwd_op.name()));
-        }
+        paddle::dialect::VjpInterface vjp_interface =
+            fwd_op.dyn_cast<paddle::dialect::VjpInterface>();
+        PADDLE_ENFORCE(
+            vjp_interface,
+            phi::errors::InvalidArgument(
+                "The vjp function is not registered in %s op ", fwd_op.name()));
         std::vector<std::vector<pir::OpResult>> vjp_res =
-            vjp_interface_impl->vjp_(&fwd_op, out_grads, stop_gradients);
+            vjp_interface.Vjp(&fwd_op, out_grads, stop_gradients);
         PADDLE_ENFORCE_EQ(
             stop_gradients.size(),
             vjp_res.size(),

--- a/paddle/pir/core/builder.cc
+++ b/paddle/pir/core/builder.cc
@@ -25,7 +25,7 @@ Operation *Builder::Build(const OperationArgument &argument) {
 }
 
 /// Creates an operation with the given fields.
-Operation *Builder::Build(const std::vector<OpResult> &inputs,
+Operation *Builder::Build(const std::vector<Value> &inputs,
                           const AttributeMap &attribute,
                           const std::vector<Type> &output_types,
                           OpInfo op_info) {

--- a/paddle/pir/core/builder.h
+++ b/paddle/pir/core/builder.h
@@ -97,9 +97,9 @@ class Builder {
   IR_API Operation *Build(const OperationArgument &argument);
 
   /// Creates an operation with the given fields.
-  IR_API Operation *Build(const std::vector<pir::OpResult> &inputs,
+  IR_API Operation *Build(const std::vector<Value> &inputs,
                           const AttributeMap &attribute,
-                          const std::vector<pir::Type> &output_types,
+                          const std::vector<Type> &output_types,
                           pir::OpInfo op_info);
 
   /// Create an operation of specific op type at the current insertion point.

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -25,9 +25,9 @@ const char *ModuleOp::attributes_name[attributes_num] = {"program"};  // NOLINT
 void PassStopGradientsDefaultly(OperationArgument &argument) {  // NOLINT
   VLOG(4) << "Builder construction stop gradient for OpResults.";
   bool stop_gradient = true;
-  for (auto &input : argument.inputs) {
-    if (input.Value::impl() == nullptr) continue;
-
+  for (auto value : argument.inputs) {
+    auto input = value.dyn_cast<OpResult>();
+    if (!input) continue;
     auto *defining_op = input.owner();
     bool input_stop_gradient = true;
     if (defining_op->HasAttribute(kStopGradientAttrName)) {
@@ -138,7 +138,7 @@ const char *SetParameterOp::attributes_name[attributes_num] = {  // NOLINT
 
 void SetParameterOp::Build(Builder &builder,             // NOLINT
                            OperationArgument &argument,  // NOLINT
-                           OpResult parameter,
+                           Value parameter,
                            const std::string &name) {
   argument.AddInput(parameter);
   argument.AddAttribute(attributes_name[0],
@@ -161,7 +161,7 @@ void SetParameterOp::Verify() const {
 
 void CombineOp::Build(Builder &builder,
                       OperationArgument &argument,
-                      const std::vector<pir::OpResult> &inputs) {
+                      const std::vector<Value> &inputs) {
   argument.inputs = inputs;
   if (inputs.size() == 0) {
     argument.output_types.emplace_back(pir::Type());
@@ -209,7 +209,7 @@ const char *SliceOp::attributes_name[attributes_num] = {"index"};  // NOLINT
 
 void SliceOp::Build(Builder &builder,
                     OperationArgument &argument,
-                    const pir::OpResult &input,
+                    Value input,
                     int index) {
   argument.inputs = {input};
   argument.output_types.emplace_back(input.type()
@@ -221,8 +221,7 @@ void SliceOp::Build(Builder &builder,
 void SliceOp::PassStopGradients(OperationArgument &argument, int index) {
   std::vector<pir::Attribute> outs_stop_gradient(
       1, pir::BoolAttribute::get(pir::IrContext::Instance(), true));
-  auto &input = argument.inputs[0];
-  if (input.Value::impl() != nullptr) {
+  if (auto input = argument.inputs[0].dyn_cast<pir::OpResult>()) {
     auto *defining_op = input.owner();
     if (defining_op && defining_op->isa<CombineOp>()) {
       IR_ENFORCE(defining_op->HasAttribute(kStopGradientAttrName),
@@ -286,7 +285,7 @@ void SliceOp::Verify() const {
 
 void SplitOp::Build(Builder &builder,
                     OperationArgument &argument,
-                    const pir::OpResult &input) {
+                    Value input) {
   argument.inputs = {input};
   for (size_t idx = 0; idx < input.type().dyn_cast<pir::VectorType>().size();
        ++idx) {
@@ -299,8 +298,7 @@ void SplitOp::Build(Builder &builder,
 
 void SplitOp::PassStopGradients(OperationArgument &argument) {
   std::vector<bool> defaut_stop_gradients(argument.output_types.size(), true);
-  auto &input = argument.inputs[0];
-  if (input.Value::impl() != nullptr) {
+  if (auto input = argument.inputs[0].dyn_cast<OpResult>()) {
     auto *defining_op = input.owner();
     if (defining_op && defining_op->isa<CombineOp>()) {
       IR_ENFORCE(argument.output_types.size(),

--- a/paddle/pir/core/builtin_op.h
+++ b/paddle/pir/core/builtin_op.h
@@ -74,7 +74,7 @@ class IR_API SetParameterOp : public pir::Op<SetParameterOp> {
   static const char *attributes_name[attributes_num];
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    OpResult parameter,
+                    Value parameter,
                     const std::string &name);
   void Verify() const;
 };
@@ -94,7 +94,7 @@ class IR_API CombineOp : public pir::Op<CombineOp> {
 
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const std::vector<pir::OpResult> &inputs);
+                    const std::vector<Value> &inputs);
 
   void Verify() const;
   std::vector<pir::Value> inputs() {
@@ -122,7 +122,7 @@ class IR_API SliceOp : public pir::Op<SliceOp> {
 
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const pir::OpResult &input,
+                    Value input,
                     int index);
 
   void Verify() const;
@@ -148,16 +148,16 @@ class IR_API SplitOp : public pir::Op<SplitOp> {
 
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
-                    const pir::OpResult &input);
+                    Value input);
 
   void Verify() const;
   pir::Value input() { return operand_source(0); }
-  std::vector<pir::OpResult> outputs() {
-    std::vector<pir::OpResult> outputs;
+  std::vector<OpResult> outputs() {
+    std::vector<OpResult> res;
     for (uint32_t idx = 0; idx < num_results(); idx++) {
-      outputs.push_back(result(static_cast<int>(idx)));
+      res.push_back(result(idx));
     }
-    return outputs;
+    return res;
   }
 
  private:

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -32,11 +32,7 @@ using detail::OpOutlineResultImpl;
 using detail::OpResultImpl;
 
 Operation *Operation::Create(const OperationArgument &argument) {
-  std::vector<Value> inputs;
-  for (auto op_result : argument.inputs) {
-    inputs.emplace_back(op_result);
-  }
-  return Create(inputs,
+  return Create(argument.inputs,
                 argument.attributes,
                 argument.output_types,
                 argument.info,

--- a/paddle/pir/core/operation_utils.h
+++ b/paddle/pir/core/operation_utils.h
@@ -34,7 +34,7 @@ using AttributeMap = std::unordered_map<std::string, Attribute>;
 // This represents an operation arguments in an combined form, suitable for use
 // with the builder APIs.
 struct OperationArgument {
-  std::vector<OpResult> inputs;
+  std::vector<Value> inputs;
   AttributeMap attributes;
   std::vector<Type> output_types;
   OpInfo info;
@@ -44,22 +44,20 @@ struct OperationArgument {
  public:
   OperationArgument(IrContext* ir_context, const std::string& name);
   explicit OperationArgument(OpInfo info) : info(info) {}
-  OperationArgument(const std::vector<OpResult>& operands,
+  OperationArgument(const std::vector<Value>& inputs,
                     const AttributeMap& attributes,
                     const std::vector<Type>& types,
                     OpInfo info,
                     size_t num_regions = 0,
                     const std::vector<Block*> successors = {})
-      : inputs(operands),
+      : inputs(inputs),
         attributes(attributes),
         output_types(types),
         info(info),
         num_regions(num_regions),
         successors(successors) {}
 
-  void AddInput(Value input) {
-    inputs.emplace_back(input.dyn_cast<OpResult>());
-  }
+  void AddInput(Value input) { inputs.emplace_back(input); }
 
   template <class InputIt>
   void AddInputs(InputIt first, InputIt last);

--- a/test/cpp/pir/core/ir_region_test.cc
+++ b/test/cpp/pir/core/ir_region_test.cc
@@ -40,7 +40,7 @@ TEST(region, erase_op_test) {
       builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
 
   // (6) Def c = CombineOp(a, b)
-  builder.Build<pir::CombineOp>(std::vector<pir::OpResult>{a, b});
+  builder.Build<pir::CombineOp>(std::vector<pir::Value>{a, b});
 
   // Test pir::Block::erase
   pir::Block* block = program.block();

--- a/test/cpp/prim/test_vjp.cc
+++ b/test/cpp/prim/test_vjp.cc
@@ -59,7 +59,7 @@ TEST(VJP, TanhBackwardTest) {
       std::vector<int64_t>{1}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
 
   std::vector<std::vector<bool>> stop_gradients{{false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op3.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op3.out()}};
 
   pir::OpInfo op2_info = ctx->GetRegisteredOpInfo("pd_op.tanh");
   auto tanh_vjp_interface_impl =
@@ -114,7 +114,7 @@ TEST(VJP, Tanh_BackwardTest) {
       std::vector<int64_t>{1}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
 
   std::vector<std::vector<bool>> stop_gradients{{false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op3.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op3.out()}};
 
   pir::OpInfo op2_info = ctx->GetRegisteredOpInfo("pd_op.tanh_");
   auto tanh_vjp_interface_impl =
@@ -169,7 +169,7 @@ TEST(VJP, MeanBackwardTest) {
       std::vector<int64_t>{}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
 
   std::vector<std::vector<bool>> stop_gradients{{false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op3.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op3.out()}};
 
   pir::OpInfo op2_info = ctx->GetRegisteredOpInfo("pd_op.mean");
   auto mean_vjp_interface_impl =
@@ -219,7 +219,7 @@ TEST(VJP, ConcatBackwardTest) {
       paddle::dialect::APIBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1, 2}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
-  std::vector<pir::OpResult> combine_input{{op1.out(), op1.out()}};
+  std::vector<pir::Value> combine_input{{op1.out(), op1.out()}};
   pir::CombineOp op2 = builder->Build<pir::CombineOp>(combine_input);
   paddle::dialect::ConcatOp op3 =
       builder->Build<paddle::dialect::ConcatOp>(op2.out(), 0);
@@ -227,7 +227,7 @@ TEST(VJP, ConcatBackwardTest) {
   paddle::dialect::FullOp op4 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{2, 2}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
   std::vector<std::vector<bool>> stop_gradients{{false, false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op4.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op4.out()}};
   pir::OpInfo op2_info = ctx->GetRegisteredOpInfo("pd_op.concat");
   auto concat_vjp_interface_impl =
       op2_info.GetInterfaceImpl<paddle::dialect::VjpInterface>();
@@ -291,7 +291,7 @@ TEST(VJP, AddBackwardTest) {
       std::vector<int64_t>{1}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
 
   std::vector<std::vector<bool>> stop_gradients{{false}, {false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op4.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op4.out()}};
 
   pir::OpInfo op3_info = ctx->GetRegisteredOpInfo("pd_op.add");
   auto add_vjp_interface_impl =
@@ -356,7 +356,7 @@ TEST(VJP, Add_BackwardTest) {
       std::vector<int64_t>{1}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
 
   std::vector<std::vector<bool>> stop_gradients{{false}, {false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op4.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op4.out()}};
 
   pir::OpInfo op3_info = ctx->GetRegisteredOpInfo("pd_op.add_");
   auto add_inplace_vjp_interface_impl =
@@ -422,7 +422,7 @@ TEST(VJP, SplitBackwardTest) {
       std::vector<int64_t>{1, 2}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
 
   std::vector<std::vector<bool>> stop_gradients{{false}};
-  std::vector<std::vector<pir::OpResult>> out_grads{{op3.result(0), op4.out()}};
+  std::vector<std::vector<pir::Value>> out_grads{{op3.result(0), op4.out()}};
   pir::OpInfo op2_info = ctx->GetRegisteredOpInfo("pd_op.split");
 
   auto concat_vjp_interface_impl =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
#### 规范化代码中对Value的使用[-4]。


Value分两种，OpResult和BlockArgument. 由于之前没有BlockArgument， 大家都是混用Value和OpResult， 现在有了BlockArguemnt, 需要区分Value和OpResult的使用。
在需要支持BlockArgument的地方，将原本的OpResult升级为Value，使其能够兼容BlockArgument的行为。

本pr内容：
- 将pir::OperationArgument::inputs_中的类型由std::vector\<pir::OpResult\>修改为std::vector\<pir::value\>。
- 将所有Dialect中相关op的Build接口的相关参数由OpResult替换成了Value。

参考pr:
- [规范化代码中对Value的使用[-1]](https://github.com/PaddlePaddle/Paddle/pull/57349)
- [规范化代码中对Value的使用[-2]](https://github.com/PaddlePaddle/Paddle/pull/55322)
- [规范化代码中对Value的使用[-3]](https://github.com/PaddlePaddle/Paddle/pull/57418)

### Other
Pcard-67164