### PR TITLE
[CodeStyle] rollback black to 23.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
             )$
 # For Python files
 -   repo: https://github.com/psf/black.git
-    rev: 23.9.1
+    rev: 23.3.0
     hooks:
     -   id: black
         files: (.*\.(py|pyi|bzl)|BUILD|.*\.BUILD|WORKSPACE)$


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

回滚`black`到 23.3.0，因为 https://github.com/psf/black/releases/tag/23.7.0 已经 drop 3.7 支持了，而开发环境中默认仍然是 3.7 环境