### PR TITLE
[AutoParallel] Rename default spmd rules

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/default_data_parallel.cc
+++ b/paddle/phi/infermeta/spmd_rules/default_data_parallel.cc
@@ -35,7 +35,7 @@ std::vector<int64_t> GetDefaultDataParallelDimsmapping(
 
 ////////////////// InferMeta(Contains SPMD) Functions //////////////////
 
-SpmdInfo DefaultDataParallelSpmdInferForward(
+SpmdInfo DefaultDataParallelInferSpmd(
     const std::vector<const DistMetaTensor*>& ins,
     const std::vector<const DistMetaTensor*>& outs) {
   // step1: Build Einsum Notation for input tensor's batch axis
@@ -97,7 +97,7 @@ SpmdInfo DefaultDataParallelSpmdInferForward(
 
   return {dst_input_dist_attrs, output_dist_attrs};
 }
-SpmdInfo DefaultDataParallelSpmdInferBackward(
+SpmdInfo DefaultDataParallelInferSpmdReverse(
     const std::vector<const DistMetaTensor*>& ins,
     const std::vector<const DistMetaTensor*>& outs) {
   // step1: Build Einsum Notation for input tensor's batch axis

--- a/paddle/phi/infermeta/spmd_rules/default_data_parallel.h
+++ b/paddle/phi/infermeta/spmd_rules/default_data_parallel.h
@@ -38,27 +38,26 @@ namespace distributed {
  * inferfw & inferbw) to support any kind of op.
  *
  */
-SpmdInfo DefaultDataParallelSpmdInferForward(
+SpmdInfo DefaultDataParallelInferSpmd(
     const std::vector<const DistMetaTensor*>& ins,
     const std::vector<const DistMetaTensor*>& outs);
 
-SpmdInfo DefaultDataParallelSpmdInferBackward(
+SpmdInfo DefaultDataParallelInferSpmdReverse(
     const std::vector<const DistMetaTensor*>& ins,
     const std::vector<const DistMetaTensor*>& outs);
 
 // For phi api
 template <typename... Args>
-SpmdInfo PhiDefaultDataParallelSpmdInferForward(const Args&... args) {
-  return detail::PhiSpmdVariadicArgumentParser<
-             DefaultDataParallelSpmdInferForward>()
+SpmdInfo VariadicDefaultDataParallelInferSpmd(const Args&... args) {
+  return detail::VariadicSpmdRuleArgumentParser<DefaultDataParallelInferSpmd>()
       .apply(args...)
       .InferForward();
 }
 
 template <typename... Args>
-SpmdInfo PhiDefaultDataParallelSpmdInferBackward(const Args&... args) {
-  return detail::PhiSpmdVariadicArgumentParser<
-             DefaultDataParallelSpmdInferBackward>()
+SpmdInfo VariadicDefaultDataParallelInferSpmdReverse(const Args&... args) {
+  return detail::VariadicSpmdRuleArgumentParser<
+             DefaultDataParallelInferSpmdReverse>()
       .apply(args...)
       .InferBackward();
 }

--- a/paddle/phi/infermeta/spmd_rules/replicated.cc
+++ b/paddle/phi/infermeta/spmd_rules/replicated.cc
@@ -32,9 +32,8 @@ std::vector<int64_t> GetReplicatedDimsmapping(const int ndim) {
 }
 
 ////////////////// InferMeta(Contains SPMD) Functions //////////////////
-SpmdInfo ReplicatedSpmdInferForward(
-    const std::vector<const DistMetaTensor*>& ins,
-    const std::vector<const DistMetaTensor*>& outs) {
+SpmdInfo ReplicatedInferSpmd(const std::vector<const DistMetaTensor*>& ins,
+                             const std::vector<const DistMetaTensor*>& outs) {
   // step1: Build Einsum Notation for input tensor's batch axis
   int64_t ninputs = ins.size();
   int64_t noutputs = outs.size();
@@ -83,7 +82,7 @@ SpmdInfo ReplicatedSpmdInferForward(
   return {dst_input_dist_attrs, output_dist_attrs};
 }
 
-SpmdInfo ReplicatedSpmdInferBackward(
+SpmdInfo ReplicatedInferSpmdReverse(
     const std::vector<const DistMetaTensor*>& ins,
     const std::vector<const DistMetaTensor*>& outs) {
   // step1: Build Einsum Notation for input tensor's batch axis

--- a/paddle/phi/infermeta/spmd_rules/replicated.h
+++ b/paddle/phi/infermeta/spmd_rules/replicated.h
@@ -34,25 +34,24 @@ namespace distributed {
  * inferfw & inferbw) to support any kind of op.
  *
  */
-SpmdInfo ReplicatedSpmdInferForward(
-    const std::vector<const DistMetaTensor*>& ins,
-    const std::vector<const DistMetaTensor*>& outs);
+SpmdInfo ReplicatedInferSpmd(const std::vector<const DistMetaTensor*>& ins,
+                             const std::vector<const DistMetaTensor*>& outs);
 
-SpmdInfo ReplicatedSpmdInferBackward(
+SpmdInfo ReplicatedInferSpmdReverse(
     const std::vector<const DistMetaTensor*>& ins,
     const std::vector<const DistMetaTensor*>& outs);
 
 // For phi api
 template <typename... Args>
-SpmdInfo PhiReplicatedSpmdInferForward(const Args&... args) {
-  return detail::PhiSpmdVariadicArgumentParser<ReplicatedSpmdInferForward>()
+SpmdInfo VariadicReplicatedInferSpmd(const Args&... args) {
+  return detail::VariadicSpmdRuleArgumentParser<ReplicatedInferSpmd>()
       .apply(args...)
       .InferForward();
 }
 
 template <typename... Args>
-SpmdInfo PhiReplicatedSpmdInferBackward(const Args&... args) {
-  return detail::PhiSpmdVariadicArgumentParser<ReplicatedSpmdInferBackward>()
+SpmdInfo VariadicReplicatedInferSpmdReverse(const Args&... args) {
+  return detail::VariadicSpmdRuleArgumentParser<ReplicatedInferSpmdReverse>()
       .apply(args...)
       .InferBackward();
 }

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -48,14 +48,14 @@ PD_REGISTER_SPMD_RULE(matmul,
 // default data parallel rule
 PD_REGISTER_SPMD_RULE(
     unsqueeze,
-    PD_INFER_SPMD(phi::distributed::DefaultDataParallelSpmdInferForward),
-    PD_INFER_SPMD(phi::distributed::DefaultDataParallelSpmdInferBackward));
+    PD_INFER_SPMD(phi::distributed::DefaultDataParallelInferSpmd),
+    PD_INFER_SPMD(phi::distributed::DefaultDataParallelInferSpmdReverse));
 
 // replicated rule /* for unitest */
 PD_REGISTER_SPMD_RULE(
     replicated,
-    PD_INFER_SPMD(phi::distributed::ReplicatedSpmdInferForward),
-    PD_INFER_SPMD(phi::distributed::ReplicatedSpmdInferBackward));
+    PD_INFER_SPMD(phi::distributed::ReplicatedInferSpmd),
+    PD_INFER_SPMD(phi::distributed::ReplicatedInferSpmdReverse));
 
 }  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/infermeta/spmd_rules/utils.h
+++ b/paddle/phi/infermeta/spmd_rules/utils.h
@@ -94,11 +94,10 @@ using SpmdFn = SpmdInfo (*)(const std::vector<const DistMetaTensor*>& ins,
 
 namespace detail {
 template <SpmdFn Fn>
-struct PhiSpmdVariadicArgumentParser
-    : public ArgsIterator<PhiSpmdVariadicArgumentParser<Fn>> {
+struct VariadicSpmdRuleArgumentParser
+    : public ArgsIterator<VariadicSpmdRuleArgumentParser<Fn>> {
   std::vector<const DistMetaTensor*> inputs;
   std::vector<const DistMetaTensor*> outputs;
-  std::vector<phi::Attribute> attrs;
 
   // deal with inputs
   void operator()(const DistMetaTensor& x) { inputs.emplace_back(&x); }
@@ -107,11 +106,6 @@ struct PhiSpmdVariadicArgumentParser
     for (auto t : x) {
       inputs.emplace_back(t);
     }
-  }
-
-  template <typename AttrType>
-  void operator()(AttrType x) {
-    attrs.emplace_back(x);
   }
 
   // deal with outputs
@@ -123,15 +117,9 @@ struct PhiSpmdVariadicArgumentParser
     }
   }
 
-  SpmdInfo InferForward() {
-    return Fn(inputs, outputs);
-    // return Fn(inputs, outputs, attrs);
-  }
+  SpmdInfo InferForward() { return Fn(inputs, outputs); }
 
-  SpmdInfo InferBackward() {
-    return Fn(inputs, outputs);
-    // return Fn(inputs, outputs, attrs);
-  }
+  SpmdInfo InferBackward() { return Fn(inputs, outputs); }
 };
 }  // namespace detail
 }  // namespace distributed

--- a/test/cpp/auto_parallel/spmd_rule_test.cc
+++ b/test/cpp/auto_parallel/spmd_rule_test.cc
@@ -496,10 +496,10 @@ TEST(ReplicatedSPMDRule, Ctor) {
   // 2 inputs 2 outputs
   // call in vector arguments format
   auto infered_dist_attrs_st =
-      phi::distributed::ReplicatedSpmdInferForward({&x, &y}, {&out1, &out2});
+      phi::distributed::ReplicatedInferSpmd({&x, &y}, {&out1, &out2});
   // call in variadic arguments format
   auto infered_dist_attrs_dy =
-      phi::distributed::PhiReplicatedSpmdInferForward(x, y, &out1, &out2);
+      phi::distributed::VariadicReplicatedInferSpmd(x, y, &out1, &out2);
 
   size_t input_size = 2;
   size_t output_size = 2;
@@ -527,10 +527,10 @@ TEST(ReplicatedSPMDRule, Ctor) {
   // 3 inputs 1 outputs
   // call in vector arguments format
   infered_dist_attrs_st =
-      phi::distributed::ReplicatedSpmdInferForward({&x, &y, &out1}, {&out2});
+      phi::distributed::ReplicatedInferSpmd({&x, &y, &out1}, {&out2});
   // call in variadic arguments format
   infered_dist_attrs_dy =
-      phi::distributed::PhiReplicatedSpmdInferForward(x, y, out1, &out2);
+      phi::distributed::VariadicReplicatedInferSpmd(x, y, out1, &out2);
 
   input_size = 3;
   output_size = 1;
@@ -554,10 +554,10 @@ TEST(ReplicatedSPMDRule, Ctor) {
   // 1 inputs 3 outputs backward
   // call in vector arguments format
   infered_dist_attrs_st =
-      phi::distributed::ReplicatedSpmdInferBackward({&x}, {&y, &out1, &out2});
+      phi::distributed::ReplicatedInferSpmdReverse({&x}, {&y, &out1, &out2});
   // call in variadic arguments format
   infered_dist_attrs_dy =
-      phi::distributed::PhiReplicatedSpmdInferBackward(x, &y, &out1, &out2);
+      phi::distributed::VariadicReplicatedInferSpmdReverse(x, &y, &out1, &out2);
 
   input_size = 1;
   output_size = 3;
@@ -621,11 +621,10 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
   // 2 inputs 2 outputs, batch axis sharding is propagatd while other axes are
   // replicatd call in vector arguments format
   auto infered_dist_attrs_st =
-      phi::distributed::DefaultDataParallelSpmdInferForward({&x, &y},
-                                                            {&out1, &out2});
+      phi::distributed::DefaultDataParallelInferSpmd({&x, &y}, {&out1, &out2});
   // call in variadic arguments format
   auto infered_dist_attrs_dy =
-      phi::distributed::PhiDefaultDataParallelSpmdInferForward(
+      phi::distributed::VariadicDefaultDataParallelInferSpmd(
           x, y, &out1, &out2);
 
   size_t input_size = 2;
@@ -653,11 +652,11 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
 
   // 1 inputs 3 outputs, batch axis is un-sharded
   // call in vector arguments format
-  infered_dist_attrs_st = phi::distributed::DefaultDataParallelSpmdInferForward(
-      {&x}, {&y, &out1, &out2});
+  infered_dist_attrs_st =
+      phi::distributed::DefaultDataParallelInferSpmd({&x}, {&y, &out1, &out2});
   // call in variadic arguments format
   infered_dist_attrs_dy =
-      phi::distributed::PhiDefaultDataParallelSpmdInferForward(
+      phi::distributed::VariadicDefaultDataParallelInferSpmd(
           x, &y, &out1, &out2);
 
   input_size = 1;
@@ -689,11 +688,11 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
                                           out1_dist_attr);
 
   EXPECT_ANY_THROW(infered_dist_attrs_st =
-                       phi::distributed::DefaultDataParallelSpmdInferForward(
+                       phi::distributed::DefaultDataParallelInferSpmd(
                            {&x, &y, &out1}, {&out2}));
   // call in variadic arguments format
   EXPECT_ANY_THROW(infered_dist_attrs_dy =
-                       phi::distributed::PhiDefaultDataParallelSpmdInferForward(
+                       phi::distributed::VariadicDefaultDataParallelInferSpmd(
                            x, y, out1, &out2));
 
   VLOG(4) << "test3 done." << std::endl << std::endl << std::endl;
@@ -707,12 +706,11 @@ TEST(DefaultDataParallelSPMDRule, Ctor) {
   out2 = phi::distributed::DistMetaTensor(phi::make_ddim(out2_shape),
                                           out2_dist_attr);
 
-  infered_dist_attrs_st =
-      phi::distributed::DefaultDataParallelSpmdInferBackward({&x, &y},
-                                                             {&out1, &out2});
+  infered_dist_attrs_st = phi::distributed::DefaultDataParallelInferSpmdReverse(
+      {&x, &y}, {&out1, &out2});
   // call in variadic arguments format
   infered_dist_attrs_dy =
-      phi::distributed::PhiDefaultDataParallelSpmdInferBackward(
+      phi::distributed::VariadicDefaultDataParallelInferSpmdReverse(
           x, y, &out1, &out2);
 
   input_size = 2;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->

Pcard-73145

[AutoParallel] Rename default spmd rules

切分规则按之间讨论的，命名风格改为
- XXXInferSpmd
- XXXInferSpmdReverse

对于PHI使用的规则，尽可能也不用PHI来用区分，不好说将来会不会在PHI之外也用到，因此还是根据接口自身的语义，相比一般的添加Variadic的前缀来区分