### PR TITLE
[CodeStyle][task 5] Enable Ruff PLR1701 rule in `python/paddle/` and `test/`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ select = [
     "PLC3002",
     "PLR0206",
     "PLR0402",
-    # "PLR1701",
+    "PLR1701",
     # "PLR1711",  # Confirmation required
     "PLR1722",
     # "PLW3301",  # Confirmation required

--- a/python/paddle/base/compiler.py
+++ b/python/paddle/base/compiler.py
@@ -209,9 +209,9 @@ class CompiledProgram:
             assert scope is not None, ""
             self._local_scopes = []
 
-        assert isinstance(places, tuple) or isinstance(
-            places, list
-        ), "Currently , The places type can only be list or tuple, but the input type is {}.".format(
+        assert isinstance(
+            places, (list, tuple)
+        ), "Currently, The places type can only be list or tuple, but the input type is {}.".format(
             type(places)
         )
 

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -497,8 +497,8 @@ def _add_feed_fetch_ops(
         global_block, fetch_list, fetch_var_name, fetch_op
     ):
         for i, var in enumerate(fetch_list):
-            assert isinstance(var, Variable) or isinstance(
-                var, str
+            assert isinstance(
+                var, (Variable, str)
             ), "Wrong type for fetch_list[%s]: %s" % (i, type(var))
             global_block.append_op(
                 type=fetch_op,
@@ -666,7 +666,7 @@ def _get_program_cache_key(feed, fetch_list):
     feed_var_names = []
     if isinstance(feed, dict):
         feed_var_names = list(feed.keys())
-    elif isinstance(feed, list) or isinstance(feed, tuple):
+    elif isinstance(feed, (list, tuple)):
         for i, each in enumerate(feed):
             feed_var_names += list(each.keys())
     fetch_var_names = list(map(_to_name_str, fetch_list))
@@ -1297,11 +1297,7 @@ class Executor:
                     raise TypeError(
                         "The operator in fetch_list is not an optimize_op"
                     )
-            elif (
-                isinstance(item, Variable)
-                or isinstance(item, str)
-                or isinstance(item, str)
-            ):
+            elif isinstance(item, (Variable, str)):
                 _fetch_list.append(item)
             else:
                 raise TypeError(
@@ -1367,7 +1363,7 @@ class Executor:
         feed_names = []
         if isinstance(feed, dict):
             feed_names = list(feed.keys())
-        elif isinstance(feed, list) or isinstance(feed, tuple):
+        elif isinstance(feed, (list, tuple)):
             for i, each in enumerate(feed):
                 feed_names += list(each.keys())
 
@@ -1428,7 +1424,7 @@ class Executor:
                         % feed_name
                     )
 
-        elif isinstance(feed, list) or isinstance(feed, tuple):
+        elif isinstance(feed, (list, tuple)):
             for i, each in enumerate(feed):
                 for feed_name in list(each.keys()):
                     if not global_block.has_var(feed_name):
@@ -2807,8 +2803,8 @@ class Executor:
             global_block, fetch_list, fetch_var_name, fetch_op
         ):
             for i, var in enumerate(fetch_list):
-                assert isinstance(var, Variable) or isinstance(
-                    var, str
+                assert isinstance(
+                    var, (Variable, str)
                 ), "Wrong type for fetch_list[%s]: %s" % (i, type(var))
                 global_block.append_op(
                     type=fetch_op,

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -3434,9 +3434,7 @@ class Operator:
             self.desc.set_block_attr(name, val.desc)
         elif isinstance(val, list) and val and _all_is_type(val, Block):
             self.desc.set_blocks_attr(name, [v.desc for v in val])
-        elif isinstance(val, core.BlockDesc) or isinstance(
-            val, core.ProgramDesc
-        ):
+        elif isinstance(val, (core.BlockDesc, core.ProgramDesc)):
             self.desc.set_serialized_attr(name, val.serialize_to_string())
         else:
             self._update_desc_plain_attr(name, val)
@@ -5072,9 +5070,7 @@ class IrOpNode(IrNode):
             desc.set_block_attr(name, val.desc)
         elif isinstance(val, list) and val and _all_is_type(val, Block):
             desc.set_blocks_attr(name, [v.desc for v in val])
-        elif isinstance(val, core.BlockDesc) or isinstance(
-            val, core.ProgramDesc
-        ):
+        elif isinstance(val, (core.BlockDesc, core.ProgramDesc)):
             desc.set_serialized_attr(name, val.serialize_to_string())
         else:
             desc._set_attr(name, val)
@@ -5551,9 +5547,7 @@ class IrGraph:
             desc.set_block_attr(name, val.desc)
         elif isinstance(val, list) and val and _all_is_type(val, Block):
             desc.set_blocks_attr(name, [v.desc for v in val])
-        elif isinstance(val, core.BlockDesc) or isinstance(
-            val, core.ProgramDesc
-        ):
+        elif isinstance(val, (core.BlockDesc, core.ProgramDesc)):
             desc.set_serialized_attr(name, val.serialize_to_string())
         else:
             desc._set_attr(name, val)

--- a/python/paddle/base/layer_helper.py
+++ b/python/paddle/base/layer_helper.py
@@ -47,7 +47,7 @@ class LayerHelper(LayerHelperBase):
     def multiple_input(self, input_param_name='input'):
         inputs = self.kwargs.get(input_param_name, [])
         ret = []
-        if isinstance(inputs, list) or isinstance(inputs, tuple):
+        if isinstance(inputs, (list, tuple)):
             for inp in inputs:
                 ret.append(self.to_variable(inp))
         else:

--- a/python/paddle/base/layers/layer_function_generator.py
+++ b/python/paddle/base/layers/layer_function_generator.py
@@ -236,11 +236,7 @@ def generate_layer_fn(op_type):
         outputs = dict()
         out = kwargs.pop(_convert_(o_name), [])
         if out:
-            out_var = (
-                out[0]
-                if (isinstance(out, list) or isinstance(out, tuple))
-                else out
-            )
+            out_var = out[0] if (isinstance(out, (list, tuple))) else out
         else:
             out_var = helper.create_variable_for_type_inference(dtype=dtype)
         outputs[o_name] = [out_var]

--- a/python/paddle/base/param_attr.py
+++ b/python/paddle/base/param_attr.py
@@ -174,7 +174,7 @@ class ParamAttr:
         """
         if arg is None:
             return ParamAttr()
-        elif isinstance(arg, list) or isinstance(arg, tuple):
+        elif isinstance(arg, (list, tuple)):
             return [ParamAttr._to_attr(a) for a in arg]
         elif isinstance(arg, ParamAttr):
             return arg

--- a/python/paddle/incubate/optimizer/recompute.py
+++ b/python/paddle/incubate/optimizer/recompute.py
@@ -109,8 +109,8 @@ class RecomputeOptimizer(Optimizer):
             checkpoints, list
         ), "_checkpoints should be a list of Variable or a list of String"
         for ckpt in checkpoints:
-            assert isinstance(ckpt, str) or isinstance(
-                ckpt, Variable
+            assert isinstance(
+                ckpt, (Variable, str)
             ), "_checkpoints should be a list of Variable or a list of String"
         self._checkpoints = checkpoints
 

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -711,7 +711,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                     )
 
                 # get(timeout) will call _poll(timeout) and may raise IOError
-                if isinstance(e, queue.Empty) or isinstance(e, IOError):
+                if isinstance(e, (IOError, queue.Empty)):
                     # continue on timeout to keep getting data from queue
                     continue
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3614,9 +3614,7 @@ def reshape(x, shape, name=None):
                 out = x
             else:
                 out = _C_ops.reshape(x, new_shape)
-        elif isinstance(shape, core.eager.Tensor) or isinstance(
-            shape, paddle.ir.OpResult
-        ):
+        elif isinstance(shape, (core.eager.Tensor, paddle.ir.OpResult)):
             shape.stop_gradient = True
             out = _C_ops.reshape(x, shape)
         else:

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -772,9 +772,7 @@ class TrtLayerAutoScanTest(AutoScanTest):
                 if isinstance(threshold, float):
                     atol = threshold
                     rtol = 1e-8
-                elif isinstance(threshold, list) or isinstance(
-                    threshold, tuple
-                ):
+                elif isinstance(threshold, (list, tuple)):
                     atol = threshold[0]
                     rtol = threshold[1]
                 else:

--- a/test/legacy_test/nets.py
+++ b/test/legacy_test/nets.py
@@ -222,9 +222,7 @@ def img_conv_group(
                                                   pool_stride=2)
     """
     tmp = input
-    assert isinstance(conv_num_filter, list) or isinstance(
-        conv_num_filter, tuple
-    )
+    assert isinstance(conv_num_filter, (list, tuple))
 
     def __extend_list__(obj):
         if not hasattr(obj, '__len__'):

--- a/test/legacy_test/test_bicubic_interp_v2_op.py
+++ b/test/legacy_test/test_bicubic_interp_v2_op.py
@@ -104,12 +104,12 @@ def bicubic_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, float) or isinstance(scale, int):
+    if isinstance(scale, (float, int)):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, list) or isinstance(scale, tuple):
+    elif isinstance(scale, (list, tuple)):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -266,7 +266,7 @@ class TestBicubicInterpOp(OpTest):
             in_w = self.input_shape[2]
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -305,7 +305,7 @@ class TestBicubicInterpOp(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -433,7 +433,7 @@ class TestBicubicInterpOpBF16(OpTest):
             in_w = self.input_shape[2]
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -472,7 +472,7 @@ class TestBicubicInterpOpBF16(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:

--- a/test/legacy_test/test_bilinear_interp_v2_op.py
+++ b/test/legacy_test/test_bilinear_interp_v2_op.py
@@ -121,12 +121,12 @@ def bilinear_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, float) or isinstance(scale, int):
+    if isinstance(scale, (float, int)):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, list) or isinstance(scale, tuple):
+    elif isinstance(scale, (list, tuple)):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -254,7 +254,7 @@ class TestBilinearInterpOp(OpTest):
         scale_h = 0
         scale_w = 0
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -295,7 +295,7 @@ class TestBilinearInterpOp(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -463,7 +463,7 @@ class TestBilinearInterpOpBF16(OpTest):
         scale_h = 0
         scale_w = 0
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -504,7 +504,7 @@ class TestBilinearInterpOpBF16(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -604,7 +604,7 @@ class TestBilinearInterpOpUint8(OpTest):
         ).astype("uint8")
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -641,7 +641,7 @@ class TestBilinearInterpOpUint8(OpTest):
             'align_mode': self.align_mode,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -778,7 +778,7 @@ class TestBilinearInterpOp_attr_tensor(OpTest):
         if self.scale_by_1Dtensor:
             self.inputs['Scale'] = np.array([self.scale]).astype("float32")
         elif self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -805,7 +805,7 @@ class TestBilinearInterpOp_attr_tensor(OpTest):
         self.attrs['out_h'] = self.out_h
         self.attrs['out_w'] = self.out_w
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:

--- a/test/legacy_test/test_linear_interp_v2_op.py
+++ b/test/legacy_test/test_linear_interp_v2_op.py
@@ -52,12 +52,12 @@ def linear_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, float) or isinstance(scale, int):
+    if isinstance(scale, (float, int)):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, list) or isinstance(scale, tuple):
+    elif isinstance(scale, (list, tuple)):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -153,7 +153,7 @@ class TestLinearInterpOp(OpTest):
             in_w = self.input_shape[1]
 
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -185,7 +185,7 @@ class TestLinearInterpOp(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = [float(self.scale)]
             self.attrs['scale'] = self.scale
         self.outputs = {'Out': output_np}
@@ -267,7 +267,7 @@ class TestLinearInterpOpSizeTensor(TestLinearInterpOp):
             in_w = self.input_shape[1]
 
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -307,7 +307,7 @@ class TestLinearInterpOpSizeTensor(TestLinearInterpOp):
             'data_layout': self.data_layout,
         }
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]
@@ -377,7 +377,7 @@ class TestLinearInterpOpBF16(OpTest):
             in_w = self.input_shape[1]
 
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -409,7 +409,7 @@ class TestLinearInterpOpBF16(OpTest):
             'data_layout': self.data_layout,
         }
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = [float(self.scale)]
             self.attrs['scale'] = self.scale
         self.outputs = {'Out': convert_float_to_uint16(output_np)}
@@ -438,7 +438,7 @@ class TestResizeLinearOpUint8(OpTest):
         input_np = np.random.random(self.input_shape).astype("uint8")
 
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = float(self.scale)
             if isinstance(self.scale, list):
                 self.scale = float(self.scale[0])
@@ -466,7 +466,7 @@ class TestResizeLinearOpUint8(OpTest):
             'align_mode': self.align_mode,
         }
         if self.scale > 0:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]

--- a/test/legacy_test/test_nearest_interp_v2_op.py
+++ b/test/legacy_test/test_nearest_interp_v2_op.py
@@ -107,12 +107,12 @@ def nearest_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, float) or isinstance(scale, int):
+    if isinstance(scale, (float, int)):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, list) or isinstance(scale, tuple):
+    elif isinstance(scale, (list, tuple)):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -302,7 +302,7 @@ class TestNearestInterpOp(OpTest):
         scale_h = 0
         scale_w = 0
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -374,7 +374,7 @@ class TestNearestInterpOp(OpTest):
                 'data_layout': self.data_layout,
             }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -528,7 +528,7 @@ class TestNearestInterpOpBF16(OpTest):
         scale_h = 0
         scale_w = 0
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -600,7 +600,7 @@ class TestNearestInterpOpBF16(OpTest):
                 'data_layout': self.data_layout,
             }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -697,7 +697,7 @@ class TestNearestInterpOpUint8(OpTest):
         ).astype("uint8")
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -731,7 +731,7 @@ class TestNearestInterpOpUint8(OpTest):
             'align_corners': self.align_corners,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -849,7 +849,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
             out_h = int(self.input_shape[2] * self.scale[0])
             out_w = int(self.input_shape[3] * self.scale[1])
         elif self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -876,7 +876,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
         self.attrs['out_h'] = self.out_h
         self.attrs['out_w'] = self.out_w
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:

--- a/test/legacy_test/test_trilinear_interp_v2_op.py
+++ b/test/legacy_test/test_trilinear_interp_v2_op.py
@@ -120,12 +120,12 @@ def trilinear_interp_test(
     align_corners=True,
     align_mode=0,
 ):
-    if isinstance(scale, float) or isinstance(scale, int):
+    if isinstance(scale, (float, int)):
         scale_list = []
         for _ in range(len(x.shape) - 2):
             scale_list.append(scale)
         scale = list(map(float, scale_list))
-    elif isinstance(scale, list) or isinstance(scale, tuple):
+    elif isinstance(scale, (list, tuple)):
         scale = list(map(float, scale))
     if SizeTensor is not None:
         if not isinstance(SizeTensor, list) and not isinstance(
@@ -302,7 +302,7 @@ class TestTrilinearInterpOp(OpTest):
             in_w = self.input_shape[3]
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -353,7 +353,7 @@ class TestTrilinearInterpOp(OpTest):
             'data_layout': data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -531,7 +531,7 @@ class TestNearestInterpOpBF16(OpTest):
             in_w = self.input_shape[3]
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -582,7 +582,7 @@ class TestNearestInterpOpBF16(OpTest):
             'data_layout': data_layout,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -672,7 +672,7 @@ class TestTrilinearInterpOpUint8(OpTest):
         ).astype("uint8")
 
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -715,7 +715,7 @@ class TestTrilinearInterpOpUint8(OpTest):
             'align_mode': self.align_mode,
         }
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -849,7 +849,7 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         if self.scale_by_1Dtensor:
             self.inputs['Scale'] = np.array([self.scale]).astype("float32")
         elif self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     scale_d = scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
@@ -880,7 +880,7 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         self.attrs['out_h'] = self.out_h
         self.attrs['out_w'] = self.out_w
         if self.scale:
-            if isinstance(self.scale, float) or isinstance(self.scale, int):
+            if isinstance(self.scale, (float, int)):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:

--- a/test/legacy_test/test_unflatten.py
+++ b/test/legacy_test/test_unflatten.py
@@ -23,7 +23,7 @@ def numpy_unflatten(x, axis, shape):
     if isinstance(shape, (list, tuple)):
         if len(shape) == 0:
             raise ValueError("The input for shape cannot be empty.")
-        if isinstance(shape, list) or isinstance(shape, tuple):
+        if isinstance(shape, (list, tuple)):
             if np.min(shape) < -1:
                 raise ValueError(f"invalid shape dimension {np.min(shape)}.")
             if shape.count(-1) > 1:


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
This PR comes after the idea in https://github.com/PaddlePaddle/Paddle/issues/57367.

The purpose is to activate Ruff's `PLR1701` check.

Ruff version: `0.0.289`

What I've done:
1. Uncomment `"PLR1701",` line in `pyproject.toml`
2. Take advantage of Ruff to identify and automatically fix relevant violations.
3. Make sure no `PLR1701` violation is found after the fix.
4. Adjust one line to accomedate `black` hook (`python/paddle/base/layers/layer_function_generator.py`)
5. Make sure all local pre-commit hooks pass/skip

@gouzil
