### PR TITLE
[PIR] op result interface name adjust.

### DIFF
--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -1314,7 +1314,7 @@ void NewIRInterpreter::SolvePersisableVarNames() {
       auto is_persisables = defining_op->attribute(kAttrIsPersisable)
                                 .dyn_cast<::pir::ArrayAttribute>()
                                 .AsVector();
-      if (is_persisables[result.GetResultIndex()]
+      if (is_persisables[result.index()]
               .dyn_cast<::pir::BoolAttribute>()
               .data()) {
         VLOG(6) << "parameter_var_names_ include: " << var_name;

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -528,7 +528,7 @@ void ProgramTranslator::SetStopGradientAttributeForAllValue(
       stop_gradients = std::vector<pir::Attribute>(
           defining_op->num_results(), pir::BoolAttribute::get(ctx_, false));
     }
-    stop_gradients[value.GetResultIndex()] =
+    stop_gradients[value.index()] =
         pir::BoolAttribute::get(ctx_, var->StopGradient());
     defining_op->set_attribute(kAttrStopGradients,
                                pir::ArrayAttribute::get(ctx_, stop_gradients));
@@ -567,7 +567,7 @@ void ProgramTranslator::SetIsPersisableAttributeForAllValue(
       is_persisable = std::vector<pir::Attribute>(
           defining_op->num_results(), pir::BoolAttribute::get(ctx_, false));
     }
-    is_persisable[value.GetResultIndex()] =
+    is_persisable[value.index()] =
         pir::BoolAttribute::get(ctx_, var->Persistable());
     defining_op->set_attribute(kAttrIsPersisable,
                                pir::ArrayAttribute::get(ctx_, is_persisable));

--- a/paddle/fluid/pir/transforms/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/inplace_pass.cc
@@ -42,7 +42,7 @@ static bool CanBeDeleted(pir::Value value) {
     return !(value.GetDefiningOp()
                  ->attribute(kAttrIsPersisable)
                  .dyn_cast<pir::ArrayAttribute>()
-                 .AsVector()[value.dyn_cast<pir::OpResult>().GetResultIndex()]
+                 .AsVector()[value.dyn_cast<pir::OpResult>().index()]
                  .dyn_cast<pir::BoolAttribute>()
                  .data());
   }

--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -368,7 +368,7 @@ bool GetOpResultBoolAttr(const OpResult &self, const std::string &attr_name) {
     auto attrs = defining_op->attribute(attr_name)
                      .dyn_cast<pir::ArrayAttribute>()
                      .AsVector();
-    return attrs[self.GetResultIndex()].dyn_cast<pir::BoolAttribute>().data();
+    return attrs[self.index()].dyn_cast<pir::BoolAttribute>().data();
   } else {
     return true;
   }
@@ -389,7 +389,7 @@ void SetOpResultBoolAttr(const OpResult &self,
         defining_op->num_results(),
         pir::BoolAttribute::get(pir::IrContext::Instance(), default_value));
   }
-  attrs[self.GetResultIndex()] =
+  attrs[self.index()] =
       pir::BoolAttribute::get(pir::IrContext::Instance(), value);
   defining_op->set_attribute(
       attr_name, pir::ArrayAttribute::get(pir::IrContext::Instance(), attrs));

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -35,7 +35,7 @@ void PassStopGradientsDefaultly(OperationArgument &argument) {  // NOLINT
                        .dyn_cast<pir::ArrayAttribute>()
                        .AsVector();
       input_stop_gradient =
-          attrs[input.GetResultIndex()].dyn_cast<pir::BoolAttribute>().data();
+          attrs[input.index()].dyn_cast<pir::BoolAttribute>().data();
     }
     if (!input_stop_gradient) {
       stop_gradient = false;
@@ -317,10 +317,9 @@ void SplitOp::PassStopGradients(OperationArgument &argument) {
           auto attrs = oprand_defining_op->attribute(kStopGradientAttrName)
                            .dyn_cast<pir::ArrayAttribute>()
                            .AsVector();
-          defaut_stop_gradients[i] =
-              attrs[value.dyn_cast<OpResult>().GetResultIndex()]
-                  .dyn_cast<pir::BoolAttribute>()
-                  .data();
+          defaut_stop_gradients[i] = attrs[value.dyn_cast<OpResult>().index()]
+                                         .dyn_cast<pir::BoolAttribute>()
+                                         .data();
         }
       }
     } else if (defining_op &&

--- a/paddle/pir/core/op_result.cc
+++ b/paddle/pir/core/op_result.cc
@@ -30,9 +30,9 @@ Operation *OpResult::owner() const {
   return IMPL_->owner();
 }
 
-uint32_t OpResult::GetResultIndex() const {
-  CHECK_OPRESULT_NULL_IMPL(GetResultIndex);
-  return IMPL_->GetResultIndex();
+uint32_t OpResult::index() const {
+  CHECK_OPRESULT_NULL_IMPL(index);
+  return IMPL_->index();
 }
 
 OpResult OpResult::dyn_cast_from(Value value) {

--- a/paddle/pir/core/op_result.h
+++ b/paddle/pir/core/op_result.h
@@ -30,7 +30,7 @@ class IR_API OpResult : public Value {
  public:
   OpResult(std::nullptr_t ptr = nullptr) : Value(ptr){};  // NOLINT
   Operation *owner() const;
-  uint32_t GetResultIndex() const;
+  uint32_t index() const;
   bool operator==(const OpResult &other) const;
 
  private:

--- a/paddle/pir/core/op_result_impl.cc
+++ b/paddle/pir/core/op_result_impl.cc
@@ -18,11 +18,11 @@
 namespace pir {
 namespace detail {
 
-uint32_t OpResultImpl::GetResultIndex() const {
+uint32_t OpResultImpl::index() const {
   if (const auto *outline_result = dyn_cast<OpOutlineResultImpl>(this)) {
-    return outline_result->GetResultIndex();
+    return outline_result->index();
   }
-  return dyn_cast<OpInlineResultImpl>(this)->GetResultIndex();
+  return dyn_cast<OpInlineResultImpl>(this)->index();
 }
 
 OpResultImpl::~OpResultImpl() { assert(use_empty()); }
@@ -30,7 +30,7 @@ OpResultImpl::~OpResultImpl() { assert(use_empty()); }
 Operation *OpResultImpl::owner() const {
   // For inline result, pointer offset index to obtain the address of op.
   if (const auto *result = dyn_cast<OpInlineResultImpl>(this)) {
-    result += result->GetResultIndex() + 1;
+    result += result->index() + 1;
     return reinterpret_cast<Operation *>(
         const_cast<OpInlineResultImpl *>(result));
   }

--- a/paddle/pir/core/op_result_impl.h
+++ b/paddle/pir/core/op_result_impl.h
@@ -38,7 +38,7 @@ class OpResultImpl : public ValueImpl {
   ///
   /// \brief Get the result index of the operation result.
   ///
-  uint32_t GetResultIndex() const;
+  uint32_t index() const;
 
   ///
   /// \brief Get the maximum number of results that can be stored inline.
@@ -67,7 +67,7 @@ class OpInlineResultImpl : public OpResultImpl {
     return value.kind() < OUTLINE_OP_RESULT_INDEX;
   }
 
-  uint32_t GetResultIndex() const { return kind(); }
+  uint32_t index() const { return kind(); }
 };
 
 ///
@@ -84,7 +84,7 @@ class OpOutlineResultImpl : public OpResultImpl {
     return value.kind() == OUTLINE_OP_RESULT_INDEX;
   }
 
-  uint32_t GetResultIndex() const { return outline_index_; }
+  uint32_t index() const { return outline_index_; }
 
   uint32_t outline_index_;
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
将 pir::OpResult::GetResultIndex 重命名为 pir::OpResult::index 。

### Other
Pcard-67164