### PR TITLE
[Reshard] Support reshard on nd mesh with same placement

### DIFF
--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -33,6 +33,7 @@
 #include "paddle/fluid/distributed/auto_parallel/spmd_rules/common.h"
 #include "paddle/fluid/distributed/auto_parallel/spmd_rules/dist_tensor_spec.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
+#include "paddle/phi/core/distributed/auto_parallel/nd_mesh_reshard_function.h"
 #include "paddle/phi/core/distributed/auto_parallel/p_to_r_reshard_function.h"
 #include "paddle/phi/core/distributed/auto_parallel/r_to_p_reshard_function.h"
 #include "paddle/phi/core/distributed/auto_parallel/r_to_s_reshard_function.h"
@@ -171,6 +172,10 @@ void BindAutoParallel(py::module *m) {
 
   py::class_<phi::distributed::SToSReshardFunction>(
       *m, "SToSReshardFunction", ReshardFunction)
+      .def(py::init<>());
+
+  py::class_<phi::distributed::SameNdMeshReshardFunction>(
+      *m, "SameNdMeshReshardFunction", ReshardFunction)
       .def(py::init<>());
 
   py::class_<ProcessMesh>(*m, "ProcessMesh")

--- a/paddle/phi/core/distributed/auto_parallel/CMakeLists.txt
+++ b/paddle/phi/core/distributed/auto_parallel/CMakeLists.txt
@@ -16,4 +16,5 @@ collect_srcs(
   s_to_r_reshard_function.cc
   r_to_p_reshard_function.cc
   p_to_r_reshard_function.cc
-  s_to_s_reshard_function.cc)
+  s_to_s_reshard_function.cc
+  nd_mesh_reshard_function.cc)

--- a/paddle/phi/core/distributed/auto_parallel/nd_mesh_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/nd_mesh_reshard_function.cc
@@ -1,0 +1,255 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/distributed/auto_parallel/nd_mesh_reshard_function.h"
+
+#include "glog/logging.h"
+#include "paddle/phi/common/int_array.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
+#include "paddle/phi/core/distributed/auto_parallel/p_to_r_reshard_function.h"
+#include "paddle/phi/core/distributed/auto_parallel/r_to_p_reshard_function.h"
+#include "paddle/phi/core/distributed/auto_parallel/r_to_s_reshard_function.h"
+#include "paddle/phi/core/distributed/auto_parallel/reshard_utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/s_to_r_reshard_function.h"
+
+namespace phi {
+namespace distributed {
+
+namespace {
+ProcessMesh GetSubProcessMesh(const ProcessMesh& mesh, int64_t axis) {
+  int64_t shape_of_axis = mesh.dim_size(axis);
+  std::vector<int64_t> shape = {shape_of_axis};
+  std::vector<std::string> dim_names = {mesh.dim_names()[axis]};
+  std::vector<int64_t> coord = GetCurRankCoordInMesh(mesh);
+
+  std::vector<int64_t> process_ids;
+  for (int64_t i = 0; i < shape_of_axis; ++i) {
+    coord[axis] = i;
+    int64_t rank = coord.back();
+    for (int64_t j = coord.size() - 2; j >= 0; --j) {
+      rank += coord[j] * mesh.dim_size(j + 1);
+    }
+    process_ids.emplace_back(rank);
+  }
+
+  ProcessMesh out_mesh(shape, process_ids, dim_names);
+  return out_mesh;
+}
+
+// Given the input two dist_attr, traversing from high-dimension axis to
+// low-dimension. Find and return the first different axis which is shard status
+// between these two. For example, the input two dims_mapping are [-1, 0, -1,
+// -1] and [-1, -1, 0, -1], the first diff shard axis is 2.
+int64_t FindFirstDiffShardAxis(const TensorDistAttr& in_dist_attr,
+                               const TensorDistAttr& out_dist_attr) {
+  const auto& in_dims_mapping = in_dist_attr.dims_mapping();
+  const auto& out_dims_mapping = out_dist_attr.dims_mapping();
+  int64_t axis = -1;
+
+  for (int64_t i = in_dims_mapping.size() - 1; i >= 0; --i) {
+    if (in_dims_mapping[i] != out_dims_mapping[i]) {
+      axis = i;
+      break;
+    }
+  }
+
+  return axis;
+}
+
+}  // namespace
+
+bool SameNdMeshReshardFunction::IsSuitable(
+    const DistTensor& in, const TensorDistAttr& out_dist_attr) {
+  bool flag = true;
+
+  flag &= (in.dist_attr().process_mesh() == out_dist_attr.process_mesh());
+  flag &= (out_dist_attr.process_mesh().ndim() > 1);
+
+  // check the input and output dims_mapping is not equal
+  flag &= in.dist_attr() != out_dist_attr;
+
+  return flag;
+}
+
+void SameNdMeshReshardFunction::Eval(phi::DeviceContext* dev_ctx,
+                                     const DistTensor& in,
+                                     const TensorDistAttr& out_dist_attr,
+                                     DistTensor* out) {
+  const auto& in_dist_attr = in.dist_attr();
+  const auto& process_mesh = out_dist_attr.process_mesh();
+
+  int64_t first_diff_axis = FindFirstDiffShardAxis(in_dist_attr, out_dist_attr);
+
+  SetValue(out, in.value());
+  SetDistProps(out, in.dims(), in_dist_attr);
+
+  // 1. change all the partial status to replicated status if needed
+  if (in_dist_attr.is_partial()) {
+    const auto& in_partial_status = in_dist_attr.partial_status();
+    const auto& out_partial_status = out_dist_attr.partial_status();
+    for (const auto& kv : in_partial_status) {
+      if (out_partial_status.count(kv.first) != 0) {
+        continue;
+      }
+      VLOG(3) << "Step1: partial axis " << kv.first;
+      // 1.1 Calculate the dist_attr after this transform
+      TensorDistAttr real_out_dist_attr(out->dist_attr());
+      real_out_dist_attr.clean_partial_dims({kv.first});
+
+      // 1.2 Calculate the process_mesh on specific axis
+      ProcessMesh sub_mesh = GetSubProcessMesh(process_mesh, kv.first);
+
+      // 1.3 Calculate the input one dim dist attr
+      TensorDistAttr in_one_dim_dist_attr(vectorize(in.dims()));
+      in_one_dim_dist_attr.set_process_mesh(sub_mesh);
+      in_one_dim_dist_attr.set_partial_status(std::vector<int64_t>{0});
+
+      // 1.4 Calculate the output one dim dist attr
+      TensorDistAttr out_one_dim_dist_attr(vectorize(in.dims()));
+      out_one_dim_dist_attr.set_process_mesh(sub_mesh);
+
+      // 1.5 Change from partial to replicated
+      SetDistProps(out, in_one_dim_dist_attr);
+
+      DistTensor tmp_result;
+      PToRReshardFunction func;
+      func.Eval(dev_ctx, *out, out_one_dim_dist_attr, &tmp_result);
+
+      // 1.6 Reset to the right dist attr
+      SetValue(out, tmp_result.value());
+      SetDistProps(out, real_out_dist_attr);
+    }
+  }
+
+  // 2. change all the shard status to replicated status
+  for (int64_t i = first_diff_axis; i >= 0; --i) {
+    int64_t in_mesh_axis = out->dist_attr().dims_mapping()[i];
+    if (in_mesh_axis != -1) {
+      VLOG(3) << "Step2: in_mesh axis " << in_mesh_axis;
+      // 2.1 Calculate the dist_attr after this transform
+      TensorDistAttr real_out_dist_attr(out->dist_attr());
+      std::vector<int64_t> real_dims_mapping =
+          real_out_dist_attr.dims_mapping();
+      real_dims_mapping[i] = -1;
+      real_out_dist_attr.set_dims_mapping(real_dims_mapping);
+
+      // 2.2 Calculate the process_mesh on specific axis
+      ProcessMesh sub_mesh = GetSubProcessMesh(process_mesh, in_mesh_axis);
+
+      // 2.3 Calculate the input one dim dist attr
+      TensorDistAttr in_one_dim_dist_attr(vectorize(in.dims()));
+      in_one_dim_dist_attr.set_process_mesh(sub_mesh);
+      std::vector<int64_t> in_one_dims_mapping =
+          in_one_dim_dist_attr.dims_mapping();
+      in_one_dims_mapping[i] = 0;
+      in_one_dim_dist_attr.set_dims_mapping(in_one_dims_mapping);
+
+      // 2.4 Calculate the output one dim dist attr
+      TensorDistAttr out_one_dim_dist_attr(vectorize(in.dims()));
+      out_one_dim_dist_attr.set_process_mesh(sub_mesh);
+
+      // 2.5 Change from shard to replicated
+      SetDistProps(out, in_one_dim_dist_attr);
+      DistTensor tmp_result;
+      SToRReshardFunction func;
+      func.Eval(dev_ctx, *out, out_one_dim_dist_attr, &tmp_result);
+
+      // 2.6 Reset to the right dist attr
+      SetValue(out, tmp_result.value());
+      SetDistProps(out, real_out_dist_attr);
+    }
+  }
+
+  // 3. Change replicated to partial
+  if (out_dist_attr.is_partial()) {
+    const auto& in_partial_status = out->dist_attr().partial_status();
+    const auto& out_partial_status = out_dist_attr.partial_status();
+    for (const auto& kv : out_partial_status) {
+      if (in_partial_status.count(kv.first) != 0) {
+        continue;
+      }
+      VLOG(3) << "Step3: Partial status mesh axis " << kv.first;
+      // 3.1 Calculate the dist_attr after this transform
+      TensorDistAttr real_out_dist_attr(out->dist_attr());
+      real_out_dist_attr.set_partial_status(std::vector<int64_t>{kv.first});
+
+      // 3.2 Calculate the process_mesh on specific axis
+      ProcessMesh sub_mesh = GetSubProcessMesh(process_mesh, kv.first);
+
+      // 3.3 Calculate the input one dim dist attr
+      TensorDistAttr in_one_dim_dist_attr(vectorize(in.dims()));
+      in_one_dim_dist_attr.set_process_mesh(sub_mesh);
+
+      // 3.4 Calculate the output one dim dist attr
+      TensorDistAttr out_one_dim_dist_attr(vectorize(in.dims()));
+      out_one_dim_dist_attr.set_process_mesh(sub_mesh);
+      out_one_dim_dist_attr.set_partial_status(std::vector<int64_t>{0});
+
+      // 3.5 Change from partial to replicated
+      DistTensor tmp_result;
+      SetDistProps(out, in_one_dim_dist_attr);
+      RToPReshardFunction func;
+      func.Eval(dev_ctx, *out, out_one_dim_dist_attr, &tmp_result);
+
+      // 3.6 Reset to the right dist attr
+      SetValue(out, tmp_result.value());
+      SetDistProps(out, real_out_dist_attr);
+    }
+  }
+
+  // 4. Change replicated to shard
+  for (int64_t i = first_diff_axis; i >= 0; --i) {
+    int64_t out_mesh_axis = out_dist_attr.dims_mapping()[i];
+    if (out_mesh_axis != -1) {
+      VLOG(3) << "Step4: out_mesh axis " << out_mesh_axis;
+      // 4.1 Calculate the dist_attr after this transform
+      TensorDistAttr real_out_dist_attr(out->dist_attr());
+      std::vector<int64_t> real_dims_mapping =
+          real_out_dist_attr.dims_mapping();
+      real_dims_mapping[i] = out_mesh_axis;
+      real_out_dist_attr.set_dims_mapping(real_dims_mapping);
+
+      // 4.2 Calculate the process_mesh on specific axis
+      ProcessMesh sub_mesh = GetSubProcessMesh(process_mesh, out_mesh_axis);
+
+      // 4.3 Calculate the input one dim dist attr
+      TensorDistAttr in_one_dim_dist_attr(vectorize(in.dims()));
+      in_one_dim_dist_attr.set_process_mesh(sub_mesh);
+
+      // 4.4 Calculate the output one dim dist attr
+      TensorDistAttr out_one_dim_dist_attr(vectorize(in.dims()));
+      out_one_dim_dist_attr.set_process_mesh(sub_mesh);
+      std::vector<int64_t> out_one_dims_mapping =
+          out_one_dim_dist_attr.dims_mapping();
+      out_one_dims_mapping[i] = 0;
+      out_one_dim_dist_attr.set_dims_mapping(out_one_dims_mapping);
+
+      // 4.5 Change from replicated to shard
+      DistTensor tmp_result;
+      SetDistProps(out, in_one_dim_dist_attr);
+      RToSReshardFunction func;
+      func.Eval(dev_ctx, *out, out_one_dim_dist_attr, &tmp_result);
+
+      // 4.6 Reset to the right dist attr
+      SetValue(out, tmp_result.value());
+      SetDistProps(out, real_out_dist_attr);
+    }
+  }
+}
+
+REGISTER_RESHARD_FUNC(SameNdMeshReshardFunction);
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/nd_mesh_reshard_function.h
+++ b/paddle/phi/core/distributed/auto_parallel/nd_mesh_reshard_function.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/distributed/auto_parallel/reshard_function.h"
+
+namespace phi {
+namespace distributed {
+
+class SameNdMeshReshardFunction final : public ReshardFunction {
+ public:
+  bool IsSuitable(const DistTensor& in,
+                  const TensorDistAttr& out_dist_attr) override;
+
+  void Eval(DeviceContext* dev_ctx,
+            const DistTensor& in,
+            const TensorDistAttr& out_dist_attr,
+            DistTensor* out) override;
+};
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/r_to_p_reshard_function.cc
@@ -54,20 +54,8 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     RESHARD_FUNCTOR(dev_ctx, Full, in.dtype(), shape, 0, GetMutableTensor(out));
   } else {
     // assign the input value to output
-    if (phi::CPUContext::classof(dev_ctx)) {
-      Assign(static_cast<const CPUContext&>(*dev_ctx),
-             in.value(),
-             GetMutableTensor(out));
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    } else if (phi::GPUContext::classof(dev_ctx)) {
-      Assign(static_cast<const GPUContext&>(*dev_ctx),
-             in.value(),
-             GetMutableTensor(out));
-#endif
-    } else {
-      PADDLE_THROW(phi::errors::Unimplemented(
-          "The assign in reshard only supported on CPU and GPU for now."));
-    }
+    RESHARD_FUNCTOR_WITHOUT_DTYPE(
+        dev_ctx, Assign, in.value(), GetMutableTensor(out));
   }
   SetDistProps(out, in.dims(), out_dist_attr);
 }

--- a/paddle/phi/core/distributed/auto_parallel/reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard_function.cc
@@ -45,6 +45,16 @@ void ReshardFunction::SetDistProps(DistTensor* tensor,
   tensor->dist_attr_ = dist_attr;
 }
 
+void ReshardFunction::SetDistProps(DistTensor* tensor,
+                                   const TensorDistAttr& dist_attr) {
+  PADDLE_ENFORCE_EQ(dist_attr.verify(vectorize(tensor->dims())),
+                    true,
+                    phi::errors::InvalidArgument(
+                        "The input dist_attr and dims are improper."));
+
+  tensor->dist_attr_ = dist_attr;
+}
+
 DenseTensor* ReshardFunction::GetMutableTensor(DistTensor* tensor) {
   return &tensor->value_;
 }

--- a/paddle/phi/core/distributed/auto_parallel/reshard_function.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard_function.h
@@ -48,6 +48,7 @@ class ReshardFunction {
   void SetDistProps(DistTensor* tensor,
                     const DDim& dims,
                     const TensorDistAttr& dist_attr);
+  void SetDistProps(DistTensor* tensor, const TensorDistAttr& dist_attr);
   DenseTensor* GetMutableTensor(DistTensor* tensor);
 };
 

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -80,6 +80,8 @@ class Context:
 
     def get_logger(self, level=logging.INFO):
         logger = logging.getLogger("LAUNCH")
+        # forbid the child logger pass on to its parent
+        logger.propagate = False
         logger.setLevel(self.args.log_level.upper() or level)
         formatter = logging.Formatter(
             fmt='%(name)s %(levelname)s %(asctime)s %(message)s'

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -100,6 +100,9 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
   py_test_modules(test_reshard_p_to_r MODULES test_reshard_p_to_r)
   set_tests_properties(test_reshard_p_to_r
                        PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
+  py_test_modules(test_reshard_nd_mesh MODULES test_reshard_nd_mesh)
+  set_tests_properties(test_reshard_nd_mesh
+                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
   py_test_modules(test_semi_auto_parallel_basic MODULES
                   test_semi_auto_parallel_basic)
   set_tests_properties(test_semi_auto_parallel_basic

--- a/test/auto_parallel/reshard_nd_mesh.py
+++ b/test/auto_parallel/reshard_nd_mesh.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle.framework import core
+
+
+class TestReshardNdMesh:
+    def __init__(self):
+        self._shape = eval(os.getenv("shape"))
+        self._dtype = os.getenv("dtype")
+        self._seeds = eval(os.getenv("seeds"))
+        self._backend = os.getenv("backend")
+        self._mesh = dist.ProcessMesh([[0], [1]], dim_names=["x", "y"])
+
+    def test_shard_partial_to_shard_replicated(self, dev_ctx):
+        paddle.seed(self._seeds)
+        value = paddle.uniform(self._shape, self._dtype)
+
+        in_shard_specs = [None for i in range(len(self._shape))]
+        in_shard_specs[0] = "y"
+        dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=in_shard_specs
+        )
+        dist_attr._set_partial_dims([0])
+        input_tensor = dist.shard_tensor(value, dist_attr=dist_attr)
+
+        # check the shape of input tensor
+        in_expected_shape = list(self._shape)
+        in_expected_shape[0] = in_expected_shape[0] // self._mesh.shape[1]
+        assert np.equal(input_tensor._local_shape, in_expected_shape).all()
+
+        # check the value of input tensor
+        in_expected_local_tensor_list = paddle.split(
+            value, num_or_sections=self._mesh.shape[1], axis=0
+        )
+        index = dist.get_rank() % self._mesh.shape[1]
+        if dist.get_rank() // self._mesh.shape[1] == 0:
+            np.testing.assert_equal(
+                input_tensor._local_value().numpy(),
+                in_expected_local_tensor_list[index].numpy(),
+            )
+        else:
+            zeros = paddle.zeros(in_expected_shape)
+            np.testing.assert_equal(
+                input_tensor._local_value().numpy(), zeros.numpy()
+            )
+
+        out_shard_specs = [None for i in range(len(self._shape))]
+        out_shard_specs[0] = "y"
+        out_dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=out_shard_specs
+        )
+
+        reshard_func = core.SameNdMeshReshardFunction()
+        assert reshard_func.is_suitable(input_tensor, out_dist_attr)
+
+        out = reshard_func.eval(dev_ctx, input_tensor, out_dist_attr)
+        np.testing.assert_equal(
+            out._local_value().numpy(),
+            in_expected_local_tensor_list[index].numpy(),
+        )
+
+    def test_shard_partial_to_replicated(self, dev_ctx):
+        paddle.seed(self._seeds)
+        value = paddle.uniform(self._shape, self._dtype)
+
+        in_shard_specs = [None for i in range(len(self._shape))]
+        in_shard_specs[0] = "y"
+        dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=in_shard_specs
+        )
+        dist_attr._set_partial_dims([0])
+        input_tensor = dist.shard_tensor(value, dist_attr=dist_attr)
+
+        # check the shape of input tensor
+        in_expected_shape = list(self._shape)
+        in_expected_shape[0] = in_expected_shape[0] // self._mesh.shape[1]
+        assert np.equal(input_tensor._local_shape, in_expected_shape).all()
+
+        # check the value of input tensor
+        in_expected_local_tensor_list = paddle.split(
+            value, num_or_sections=self._mesh.shape[1], axis=0
+        )
+        index = dist.get_rank() % self._mesh.shape[1]
+        if dist.get_rank() // self._mesh.shape[1] == 0:
+            np.testing.assert_equal(
+                input_tensor._local_value().numpy(),
+                in_expected_local_tensor_list[index].numpy(),
+            )
+        else:
+            zeros = paddle.zeros(in_expected_shape)
+            np.testing.assert_equal(
+                input_tensor._local_value().numpy(), zeros.numpy()
+            )
+
+        out_shard_specs = [None for i in range(len(self._shape))]
+        out_dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=out_shard_specs
+        )
+
+        reshard_func = core.SameNdMeshReshardFunction()
+        assert reshard_func.is_suitable(input_tensor, out_dist_attr)
+
+        out = reshard_func.eval(dev_ctx, input_tensor, out_dist_attr)
+        np.testing.assert_equal(out._local_value().numpy(), value.numpy())
+
+    def test_partial_to_partial(self, dev_ctx):
+        a = paddle.ones(self._shape)
+
+        in_shard_specs = [None for i in range(len(self._shape))]
+        out_shard_specs = [None for i in range(len(self._shape))]
+
+        dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=in_shard_specs
+        )
+        dist_attr._set_partial_dims([0])
+
+        out_dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=out_shard_specs
+        )
+        out_dist_attr._set_partial_dims([1])
+
+        input_tensor = dist.shard_tensor(a, dist_attr=dist_attr)
+
+        if dist.get_rank() // self._mesh.shape[1] == 0:
+            np.testing.assert_equal(
+                input_tensor._local_value().numpy(), a.numpy()
+            )
+        else:
+            zeros = paddle.zeros(self._shape)
+            np.testing.assert_equal(
+                input_tensor._local_value().numpy(), zeros.numpy()
+            )
+
+        reshard_func = core.SameNdMeshReshardFunction()
+        assert reshard_func.is_suitable(input_tensor, out_dist_attr)
+
+        out = reshard_func.eval(dev_ctx, input_tensor, out_dist_attr)
+
+        if dist.get_rank() % self._mesh.shape[1] == 0:
+            np.testing.assert_equal(out._local_value().numpy(), a.numpy())
+        else:
+            zeros = paddle.zeros(self._shape)
+            np.testing.assert_equal(out._local_value().numpy(), zeros.numpy())
+
+        assert np.equal(out.shape, input_tensor.shape).all()
+        assert np.equal(out._local_shape, input_tensor._local_shape).all()
+
+    def test_shard_to_shard(self, dev_ctx):
+        a = paddle.ones(self._shape)
+
+        in_shard_specs = [None for i in range(len(self._shape))]
+        in_shard_specs[1] = "y"
+
+        out_shard_specs = [None for i in range(len(self._shape))]
+        out_shard_specs[0] = "x"
+
+        dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=in_shard_specs
+        )
+
+        out_dist_attr = dist.DistAttr(
+            mesh=self._mesh, sharding_specs=out_shard_specs
+        )
+
+        input_tensor = dist.shard_tensor(a, dist_attr=dist_attr)
+
+        in_expected_shape = list(self._shape)
+        in_expected_shape[1] = in_expected_shape[1] // self._mesh.shape[1]
+        assert np.equal(input_tensor._local_shape, in_expected_shape).all()
+
+        reshard_func = core.SameNdMeshReshardFunction()
+        assert reshard_func.is_suitable(input_tensor, out_dist_attr)
+
+        out = reshard_func.eval(dev_ctx, input_tensor, out_dist_attr)
+
+        out_expected_shape = list(self._shape)
+        out_expected_shape[0] = out_expected_shape[0] // self._mesh.shape[0]
+        assert np.equal(input_tensor._local_shape, in_expected_shape).all()
+
+        assert np.equal(out.shape, input_tensor.shape).all()
+
+    def run_test_case(self):
+        if self._backend == "cpu":
+            paddle.set_device("cpu")
+            place = paddle.CPUPlace()
+        elif self._backend == "gpu":
+            place = paddle.CUDAPlace(dist.get_rank())
+
+        dev_ctx = core.DeviceContext.create(place)
+
+        self.test_partial_to_partial(dev_ctx)
+        self.test_shard_to_shard(dev_ctx)
+        self.test_shard_partial_to_shard_replicated(dev_ctx)
+        self.test_shard_partial_to_replicated(dev_ctx)
+
+
+if __name__ == '__main__':
+    TestReshardNdMesh().run_test_case()

--- a/test/auto_parallel/test_reshard_nd_mesh.py
+++ b/test/auto_parallel/test_reshard_nd_mesh.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+class TestReshardNdMesh(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(num_of_devices=2, timeout=120)
+        self._default_envs = {
+            "shape": "(12, 20, 8, 16)",
+            "dtype": "float32",
+            "seeds": "100",
+        }
+        self._changeable_envs = {
+            "backend": ["gpu", "cpu"],
+        }
+
+    def test_reshard_nd_mesh(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "reshard_nd_mesh.py",
+                user_defined_envs=envs,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73145

本PR主要支持了高维但相同mesh下不同状态间的转换，用于支持DP+MP混合并行场景。单测只为覆盖率，因为两卡不能测试全高维mesh，本地测过8卡。工作原理：

- 从后向前，找到两个dims_mapping间开始有差异的第一个tensor维度；
- 从该维度开始向前，把input中所有非replicated的维度都转换成replicated的；
  - 复用一维同mesh的状态转换函数，需要提取出需要的子ProcessMesh用来降维；
  - 降维后，为保证正确性，需要将低维dist_attr复原成高维；
- 将转换后的input按维度依次从replicated转成output需要的状态；
  - 同样复用一维同mesh的状态转换函数，需要提取出需要的子ProcessMesh用来降维；

TODO：
- 优化shard到replicated的状态转换，在低维连续转换时，可以用reshape代替split和concat；


顺便，修复高版本python下（3.9），launch的log重复打印两次的问题。