### PR TITLE
[xdoctest] reformat example code with google style in No.356

### DIFF
--- a/python/paddle/ir/core.py
+++ b/python/paddle/ir/core.py
@@ -125,13 +125,13 @@ def default_startup_program():
     Examples:
         .. code-block:: python
 
-            import paddle
+            >>> import paddle
 
-            paddle.enable_static()
-            x = paddle.static.data(name="x", shape=[-1, 784], dtype='float32')
-            out = paddle.static.nn.fc(name="fc", x=x, size=10, activation="relu")
-            print("main program is: {}".format(paddle.static.default_main_program()))
-            print("start up program is: {}".format(paddle.static.default_startup_program()))
+            >>> paddle.enable_static()
+            >>> x = paddle.static.data(name="x", shape=[-1, 784], dtype='float32')
+            >>> out = paddle.static.nn.fc(name="fc", x=x, size=10, activation="relu")
+            >>> print("main program is: {}".format(paddle.static.default_main_program()))
+            >>> print("start up program is: {}".format(paddle.static.default_startup_program()))
     """
     return _startup_program_
 
@@ -154,20 +154,20 @@ def default_main_program():
         Program: A ``Program`` which holding the descriptions of OPs and tensors in the network.
 
     Examples:
-        ..  code-block:: python
+        .. code-block:: python
 
-            import paddle
+            >>> import paddle
 
-            paddle.enable_static()
-            # Sample Network:
-            x = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
-            y = paddle.static.data(name='y', shape=[100, 100], dtype='float32')
-            out = paddle.add(x, y)
+            >>> paddle.enable_static()
+            >>> # Sample Network:
+            >>> x = paddle.static.data(name='x', shape=[100, 100], dtype='float32')
+            >>> y = paddle.static.data(name='y', shape=[100, 100], dtype='float32')
+            >>> out = paddle.add(x, y)
 
-            #print the number of blocks in the program, 1 in this case
-            print(paddle.static.default_main_program().num_blocks) # 1
-            #print the default_main_program
-            print(paddle.static.default_main_program())
+            >>> print the number of blocks in the program, 1 in this case
+            >>> print(paddle.static.default_main_program().num_blocks) # 1
+            >>> print the default_main_program
+            >>> print(paddle.static.default_main_program())
     """
     return _main_program_
 
@@ -224,14 +224,14 @@ def program_guard(main_program, startup_program=None):
         .. code-block:: python
             :name: code-example-1
 
-            import paddle
+            >>> import paddle
 
-            paddle.enable_static()
-            main_program = paddle.static.Program()
-            startup_program = paddle.static.Program()
-            with paddle.static.program_guard(main_program, startup_program):
-                data = paddle.static.data(name='image', shape=[None, 784, 784], dtype='float32')
-                hidden = paddle.static.nn.fc(x=data, size=10, activation='relu')
+            >>> paddle.enable_static()
+            >>> main_program = paddle.static.Program()
+            >>> startup_program = paddle.static.Program()
+            >>> with paddle.static.program_guard(main_program, startup_program):
+            ...     data = paddle.static.data(name='image', shape=[None, 784, 784], dtype='float32')
+            ...     hidden = paddle.static.nn.fc(x=data, size=10, activation='relu')
 
     Notes: The temporary :code:`Program` can be used if the user does not need
     to construct either of startup program or main program.
@@ -240,14 +240,13 @@ def program_guard(main_program, startup_program=None):
         .. code-block:: python
             :name: code-example-2
 
-            import paddle
+            >>> import paddle
 
-            paddle.enable_static()
-            main_program = paddle.static.Program()
-            # does not care about startup program. Just pass a temporary value.
-            with paddle.static.program_guard(main_program, paddle.static.Program()):
-                data = paddle.static.data(name='image', shape=[None, 784, 784], dtype='float32')
-
+            >>> paddle.enable_static()
+            >>> main_program = paddle.static.Program()
+            >>> # does not care about startup program. Just pass a temporary value.
+            >>> with paddle.static.program_guard(main_program, paddle.static.Program()):
+            ...     data = paddle.static.data(name='image', shape=[None, 784, 784], dtype='float32')
     """
     from ..base.data_feeder import check_type
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

修改如下文件的示例代码，使其通过 `xdoctest` 检查：
<html>
<body>
<!--StartFragment-->

python/paddle/ir/core.py

<!--EndFragment-->
</body>
</html>



### Related links
 
- #55629
- #55295
