### PR TITLE
fix bug in gloo.cmake

### DIFF
--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -37,7 +37,7 @@ if(WITH_GPU)
     file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/device.cc.patch
          native_dst)
     set(GLOO_PATCH_COMMAND
-        git checkout -- . && git checkout ${GLOO_TAG} &&patch -Nd
+        git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd
         ${SOURCE_DIR}/gloo/transport/tcp < ${native_dst})
   endif()
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
在比较新的版本中，原本的 `git checkout -- . && git checkout ${GLOO_TAG} &&patch -Nd` 被识别成了
`git checkout -- . && git checkout ${GLOO_TAG} “&&patch” -Nd`，会报一个git不存在-N的参数，修改成 `git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd` 则不会有这个问题，目前只在 `gloo.cmake` 里发现了这个情况，其他的文件中不存在这个问题