### PR TITLE
[PIR]Polish Guard policy in OpTest

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -309,7 +309,7 @@ def in_pir_mode():
 
             >>> paddle.enable_static()
             >>> with paddle.new_ir_utils.IrGuard():
-            >>>     print(paddle.framework.in_pir_mode())
+            ...     print(paddle.framework.in_pir_mode())
             True
 
     """
@@ -7768,16 +7768,6 @@ def _dygraph_guard(tracer):
     tmp_tracer = global_var._dygraph_tracer_
     global_var._dygraph_tracer_ = tracer
 
-    try:
-        yield
-    finally:
-        global_var._dygraph_tracer_ = tmp_tracer
-
-
-@signature_safe_contextmanager
-def _static_guard():
-    tmp_tracer = global_var._dygraph_tracer_
-    global_var._dygraph_tracer_ = None
     try:
         yield
     finally:

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -28,6 +28,7 @@ from prim_op_test import OpTestUtils, PrimForwardChecker, PrimGradChecker
 from testsuite import append_input_output, append_loss_ops, create_op, set_input
 
 sys.path.append("..")
+from utils import static_guard
 from white_list import (
     check_shape_white_list,
     compile_vs_runtime_white_list,
@@ -1448,7 +1449,7 @@ class OpTest(unittest.TestCase):
         for_inplace_test=None,
         check_cinn=False,
     ):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             program = Program()
             block = program.global_block()
             op = self._append_ops(block)
@@ -1624,9 +1625,7 @@ class OpTest(unittest.TestCase):
             if fwd_var_name is None:
                 fwd_var_name = arg
             fwd_var = fwd_program.global_block().vars.get(fwd_var_name)
-            assert fwd_var is not None, "{} cannot be found".format(
-                fwd_var_name
-            )
+            assert fwd_var is not None, f"{fwd_var_name} cannot be found"
             grad_var = grad_block.create_var(
                 name=arg,
                 dtype=fwd_var.dtype,
@@ -1794,7 +1793,7 @@ class OpTest(unittest.TestCase):
         Returns:
             res (tuple(outs, fetch_list, feed_map, program, op_desc)): The results of given grad_op_desc.
         """
-        with paddle.base.framework._static_guard():
+        with static_guard():
             (
                 fwd_outs,
                 fwd_fetch_list,
@@ -3369,7 +3368,7 @@ class OpTest(unittest.TestCase):
         parallel=False,
         check_cinn=False,
     ):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             prog = Program()
             scope = core.Scope()
             ir_scope = core.Scope()

--- a/test/legacy_test/prim_op_test.py
+++ b/test/legacy_test/prim_op_test.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 
 import config
 import numpy as np
+from utils import dygraph_guard, static_guard
 
 import paddle
 from paddle.autograd.ir_backward import grad as ir_grad
@@ -249,21 +250,11 @@ class PrimForwardChecker:
         self.checker_name = "PrimForwardChecker"
         self.place = place
         self.op_test = op_test
-        self.save_eager_or_static_status()
         self.init()
         self.init_checker()
 
     def init(self):
         pass
-
-    def save_eager_or_static_status(self):
-        self.eager_mode = True if in_dygraph_mode() else False
-
-    def recover_eager_or_static_status(self):
-        if self.eager_mode:
-            paddle.disable_static()
-        else:
-            paddle.enable_static()
 
     def init_checker(self):
         assert hasattr(
@@ -419,55 +410,55 @@ class PrimForwardChecker:
             if self.enable_check_static_comp:
                 self.check_static_comp()
 
-        self.recover_eager_or_static_status()
-
     def get_kernel_sig(self):
-        paddle.disable_static()
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            _,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
-        eager_tensor_outputs = self.get_eager_empty_output(stop_gradient=True)
-        kernel_sig = OpTestUtils._get_kernel_signature(
-            self.op_type,
-            eager_tensor_inputs,
-            eager_tensor_outputs,
-            attrs_outputs,
-        )
+        with dygraph_guard():
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                _,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
+            eager_tensor_outputs = self.get_eager_empty_output(
+                stop_gradient=True
+            )
+            kernel_sig = OpTestUtils._get_kernel_signature(
+                self.op_type,
+                eager_tensor_inputs,
+                eager_tensor_outputs,
+                attrs_outputs,
+            )
         return kernel_sig
 
     def get_eager_desire(self):
-        paddle.disable_static()
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            _,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
-        args = OpTestUtils.prepare_python_api_arguments(
-            self.public_python_api,
-            eager_tensor_inputs,
-            attrs_outputs,
-            self.kernel_sig,
-        )
-        inputs_sig, _, _ = self.kernel_sig
-        args = OpTestUtils.assumption_assert_and_transform(
-            args, len(inputs_sig)
-        )
-        ret = flatten(_as_list(self.public_python_api(*args)))
-        ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
-        if OpTestUtils.is_bfloat16_type(self.dtype):
-            ret = paddle.utils.map_structure(
-                lambda x: convert_uint16_to_float(x), ret
+        with dygraph_guard():
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                _,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
+            args = OpTestUtils.prepare_python_api_arguments(
+                self.public_python_api,
+                eager_tensor_inputs,
+                attrs_outputs,
+                self.kernel_sig,
             )
+            inputs_sig, _, _ = self.kernel_sig
+            args = OpTestUtils.assumption_assert_and_transform(
+                args, len(inputs_sig)
+            )
+            ret = flatten(_as_list(self.public_python_api(*args)))
+            ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
+            if OpTestUtils.is_bfloat16_type(self.dtype):
+                ret = paddle.utils.map_structure(
+                    lambda x: convert_uint16_to_float(x), ret
+                )
         return ret
 
     def get_eager_input_attr_and_inputdict(self, stop_gradient):
@@ -584,7 +575,7 @@ class PrimForwardChecker:
         # forward comp only for comp op
         if self.prim_op_type == "prim":
             return
-        with paddle.base.framework._static_guard():
+        with static_guard():
             core._set_prim_forward_enabled(self.enable_fw_comp)
             startup_program, main_program = (
                 paddle.static.Program(),
@@ -658,86 +649,90 @@ class PrimForwardChecker:
                     )
                 ),
             )
-        paddle.disable_static()
-        core._set_prim_forward_enabled(False)
+        with dygraph_guard():
+            core._set_prim_forward_enabled(False)
 
     def check_jit_comp(self):
         if self.prim_op_type == "prim":
             return
-        paddle.disable_static()
-        if type(self.place) == paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) == paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        atol = self.fw_comp_atol if self.enable_fw_comp else self.jit_comp_atol
-        rtol = self.fw_comp_rtol if self.enable_fw_comp else self.jit_comp_rtol
-        core._set_prim_forward_enabled(self.enable_fw_comp)
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            _,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
-        args = OpTestUtils.prepare_python_api_arguments(
-            self.public_python_api,
-            eager_tensor_inputs,
-            attrs_outputs,
-            self.kernel_sig,
-        )
-        inputs_sig, _, _ = self.kernel_sig
-        args = OpTestUtils.assumption_assert_and_transform(
-            args, len(inputs_sig)
-        )
-        net = PrimNet(self.public_python_api)
-        net = apply_to_static(net, False)
-        # ensure the operator not in program if check_prim is True
-        forward_ops = [
-            op.type
-            for op in net.forward.get_concrete_program(args)[1]
-            .forward_program.block(0)
-            .ops
-        ]
-        assert self.op_type not in forward_ops, (
-            "%s shouldn't appear in program when check_prim is True"
-        ) % (self.op_type)
-        ret = flatten(_as_list(net(args)))
-        ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
-        if OpTestUtils.is_bfloat16_type(self.dtype):
-            ret = paddle.utils.map_structure(
-                lambda x: convert_uint16_to_float(x), ret
+        with dygraph_guard():
+            if type(self.place) == paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) == paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            atol = (
+                self.fw_comp_atol if self.enable_fw_comp else self.jit_comp_atol
             )
-        # check jit comp forward
-        if len(ret) != len(self.eager_desire):
-            msg = (
-                "The jit comp forward api out tensor nums is different with eager forward api out tensor nums on {}."
-                'when enable_fw_comp is {}, jit comp forward api out tensor nums = {}, eager forward api out tensor nums = {}. \n'.format(
-                    str(self.place),
-                    self.enable_fw_comp,
-                    len(ret),
-                    len(self.eager_desire),
+            rtol = (
+                self.fw_comp_rtol if self.enable_fw_comp else self.jit_comp_rtol
+            )
+            core._set_prim_forward_enabled(self.enable_fw_comp)
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                _,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
+            args = OpTestUtils.prepare_python_api_arguments(
+                self.public_python_api,
+                eager_tensor_inputs,
+                attrs_outputs,
+                self.kernel_sig,
+            )
+            inputs_sig, _, _ = self.kernel_sig
+            args = OpTestUtils.assumption_assert_and_transform(
+                args, len(inputs_sig)
+            )
+            net = PrimNet(self.public_python_api)
+            net = apply_to_static(net, False)
+            # ensure the operator not in program if check_prim is True
+            forward_ops = [
+                op.type
+                for op in net.forward.get_concrete_program(args)[1]
+                .forward_program.block(0)
+                .ops
+            ]
+            assert self.op_type not in forward_ops, (
+                "%s shouldn't appear in program when check_prim is True"
+            ) % (self.op_type)
+            ret = flatten(_as_list(net(args)))
+            ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
+            if OpTestUtils.is_bfloat16_type(self.dtype):
+                ret = paddle.utils.map_structure(
+                    lambda x: convert_uint16_to_float(x), ret
                 )
-            )
-            raise RuntimeError(msg)
-        for i in range(len(ret)):
-            np.testing.assert_allclose(
-                ret[i],
-                self.eager_desire[i],
-                rtol=rtol,
-                atol=atol,
-                err_msg=(
-                    'Check jit comp forward api out failed. Mismatch between jit comp '
-                    'and eager on %s, when enable_fw_comp is %s,the forward api out tensor\'s index is : %d \n'
-                    'jit comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
-                    % (
+            # check jit comp forward
+            if len(ret) != len(self.eager_desire):
+                msg = (
+                    "The jit comp forward api out tensor nums is different with eager forward api out tensor nums on {}."
+                    'when enable_fw_comp is {}, jit comp forward api out tensor nums = {}, eager forward api out tensor nums = {}. \n'.format(
                         str(self.place),
                         self.enable_fw_comp,
-                        i,
-                        ret[i],
-                        self.eager_desire[i],
+                        len(ret),
+                        len(self.eager_desire),
                     )
-                ),
-            )
-        core._set_prim_forward_enabled(False)
-        net.forward.program_cache.clear()
+                )
+                raise RuntimeError(msg)
+            for i in range(len(ret)):
+                np.testing.assert_allclose(
+                    ret[i],
+                    self.eager_desire[i],
+                    rtol=rtol,
+                    atol=atol,
+                    err_msg=(
+                        'Check jit comp forward api out failed. Mismatch between jit comp '
+                        'and eager on %s, when enable_fw_comp is %s,the forward api out tensor\'s index is : %d \n'
+                        'jit comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
+                        % (
+                            str(self.place),
+                            self.enable_fw_comp,
+                            i,
+                            ret[i],
+                            self.eager_desire[i],
+                        )
+                    ),
+                )
+            core._set_prim_forward_enabled(False)
+            net.forward.program_cache.clear()
 
     def check_jit_comp_with_cinn(self):
         if self.prim_op_type == "prim":
@@ -749,92 +744,92 @@ class PrimForwardChecker:
             and core.is_compiled_with_cinn()
         ):
             return
-        paddle.disable_static()
-        atol = (
-            self.cinn_atol
-            if self.enable_cinn and core.is_compiled_with_cinn()
-            else self.fw_comp_atol
-        )
-        rtol = (
-            self.cinn_rtol
-            if self.enable_cinn and core.is_compiled_with_cinn()
-            else self.fw_comp_rtol
-        )
-        core._set_prim_forward_enabled(self.enable_fw_comp)
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            _,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
-        args = OpTestUtils.prepare_python_api_arguments(
-            self.public_python_api,
-            eager_tensor_inputs,
-            attrs_outputs,
-            self.kernel_sig,
-        )
-        inputs_sig, _, _ = self.kernel_sig
-        args = OpTestUtils.assumption_assert_and_transform(
-            args, len(inputs_sig)
-        )
-        net = PrimNet(self.public_python_api)
-        net = apply_to_static(
-            net, core.is_compiled_with_cinn() and self.enable_cinn
-        )
-        # check the operator not in program if check prim is True
-        forward_ops = [
-            op.type
-            for op in net.forward.get_concrete_program(args)[1]
-            .forward_program.block(0)
-            .ops
-        ]
-        assert self.op_type not in forward_ops, (
-            "%s shouldn't appear in program when check_prim is True"
-        ) % (self.op_type)
-        ret = flatten(_as_list(net(args)))
-        ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
-        if OpTestUtils.is_bfloat16_type(self.dtype):
-            ret = paddle.utils.map_structure(
-                lambda x: convert_uint16_to_float(x), ret
+        with dygraph_guard():
+            atol = (
+                self.cinn_atol
+                if self.enable_cinn and core.is_compiled_with_cinn()
+                else self.fw_comp_atol
             )
-        # check jit comp forward
-        if len(ret) != len(self.eager_desire):
-            msg = (
-                "The jit comp with cinn forward api out tensor nums is different with eager forward api out tensor nums on {}."
-                'when enable_fw_comp is {}, enable_cinn is {}, jit comp forward api out tensor nums = {}, eager forward api out tensor nums = {}. \n'.format(
-                    str(self.place),
-                    self.enable_fw_comp,
-                    core.is_compiled_with_cinn() and self.enable_cinn,
-                    len(ret),
-                    len(self.eager_desire),
+            rtol = (
+                self.cinn_rtol
+                if self.enable_cinn and core.is_compiled_with_cinn()
+                else self.fw_comp_rtol
+            )
+            core._set_prim_forward_enabled(self.enable_fw_comp)
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                _,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=True)
+            args = OpTestUtils.prepare_python_api_arguments(
+                self.public_python_api,
+                eager_tensor_inputs,
+                attrs_outputs,
+                self.kernel_sig,
+            )
+            inputs_sig, _, _ = self.kernel_sig
+            args = OpTestUtils.assumption_assert_and_transform(
+                args, len(inputs_sig)
+            )
+            net = PrimNet(self.public_python_api)
+            net = apply_to_static(
+                net, core.is_compiled_with_cinn() and self.enable_cinn
+            )
+            # check the operator not in program if check prim is True
+            forward_ops = [
+                op.type
+                for op in net.forward.get_concrete_program(args)[1]
+                .forward_program.block(0)
+                .ops
+            ]
+            assert self.op_type not in forward_ops, (
+                "%s shouldn't appear in program when check_prim is True"
+            ) % (self.op_type)
+            ret = flatten(_as_list(net(args)))
+            ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
+            if OpTestUtils.is_bfloat16_type(self.dtype):
+                ret = paddle.utils.map_structure(
+                    lambda x: convert_uint16_to_float(x), ret
                 )
-            )
-            raise RuntimeError(msg)
-        for i in range(len(ret)):
-            np.testing.assert_allclose(
-                ret[i],
-                self.eager_desire[i],
-                rtol=rtol,
-                atol=atol,
-                err_msg=(
-                    'Check jit comp with cinn forward api out failed. Mismatch between jit comp and eager on %s, '
-                    'when enable_fw_comp is %s, enable_cinn is %s, the forward api out tensor\'s index is : %d \n'
-                    'jit comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
-                    % (
+            # check jit comp forward
+            if len(ret) != len(self.eager_desire):
+                msg = (
+                    "The jit comp with cinn forward api out tensor nums is different with eager forward api out tensor nums on {}."
+                    'when enable_fw_comp is {}, enable_cinn is {}, jit comp forward api out tensor nums = {}, eager forward api out tensor nums = {}. \n'.format(
                         str(self.place),
                         self.enable_fw_comp,
                         core.is_compiled_with_cinn() and self.enable_cinn,
-                        i,
-                        ret[i],
-                        self.eager_desire[i],
+                        len(ret),
+                        len(self.eager_desire),
                     )
-                ),
-            )
-        core._set_prim_forward_enabled(False)
-        net.forward.program_cache.clear()
+                )
+                raise RuntimeError(msg)
+            for i in range(len(ret)):
+                np.testing.assert_allclose(
+                    ret[i],
+                    self.eager_desire[i],
+                    rtol=rtol,
+                    atol=atol,
+                    err_msg=(
+                        'Check jit comp with cinn forward api out failed. Mismatch between jit comp and eager on %s, '
+                        'when enable_fw_comp is %s, enable_cinn is %s, the forward api out tensor\'s index is : %d \n'
+                        'jit comp forward api out tensor:\n%s\n eager forward api out tensor:\n%s\n'
+                        % (
+                            str(self.place),
+                            self.enable_fw_comp,
+                            core.is_compiled_with_cinn() and self.enable_cinn,
+                            i,
+                            ret[i],
+                            self.eager_desire[i],
+                        )
+                    ),
+                )
+            core._set_prim_forward_enabled(False)
+            net.forward.program_cache.clear()
 
 
 class PrimGradChecker(PrimForwardChecker):
@@ -875,7 +870,6 @@ class PrimGradChecker(PrimForwardChecker):
         else:
             if self.enable_check_static_comp:
                 self.check_static_comp()
-        self.recover_eager_or_static_status()
 
     def get_output_dict(self, np_outputs, api_outputs, outputs_sig):
         assert len(api_outputs) <= len(outputs_sig), (
@@ -937,100 +931,100 @@ class PrimGradChecker(PrimForwardChecker):
         return no_grad_set
 
     def get_eager_desire(self):
-        paddle.disable_static()
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            inputs_dict,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=False)
-        args = OpTestUtils.prepare_python_api_arguments(
-            self.public_python_api,
-            eager_tensor_inputs,
-            attrs_outputs,
-            self.kernel_sig,
-        )
-        inputs_sig, _, outputs_sig = self.kernel_sig
-        if hasattr(self.op_test, "python_out_sig"):
-            outputs_sig = self.op_test.python_out_sig
-        args = OpTestUtils.assumption_assert_and_transform(
-            args, len(inputs_sig)
-        )
-        ret = _as_list(self.public_python_api(*args))
-        outputs_dict = self.get_output_dict(self.outputs, ret, outputs_sig)
-        ys = []
-        if isinstance(self.output_names, list):
-            for output_name in self.output_names:
-                ys.append(outputs_dict[output_name])
-        else:
-            ys.append(outputs_dict[self.output_names])
-        xs = []
-        if isinstance(self.inputs_to_check, list):
-            for input_name in self.inputs_to_check:
-                xs.append(inputs_dict[input_name])
-        else:
-            xs.append(inputs_dict[self.inputs_to_check])
-        vs = self.gen_eager_grad_outputs()
-        no_grad_vars = self.gen_no_grad_set(
-            var_dict={**inputs_dict, **outputs_dict}
-        )
-        ret = paddle.grad(
-            ys, xs, vs, allow_unused=True, no_grad_vars=no_grad_vars
-        )
-        ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
-        if OpTestUtils.is_bfloat16_type(self.dtype):
-            ret = paddle.utils.map_structure(
-                lambda x: convert_uint16_to_float(x), ret
+        with dygraph_guard():
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                inputs_dict,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=False)
+            args = OpTestUtils.prepare_python_api_arguments(
+                self.public_python_api,
+                eager_tensor_inputs,
+                attrs_outputs,
+                self.kernel_sig,
             )
+            inputs_sig, _, outputs_sig = self.kernel_sig
+            if hasattr(self.op_test, "python_out_sig"):
+                outputs_sig = self.op_test.python_out_sig
+            args = OpTestUtils.assumption_assert_and_transform(
+                args, len(inputs_sig)
+            )
+            ret = _as_list(self.public_python_api(*args))
+            outputs_dict = self.get_output_dict(self.outputs, ret, outputs_sig)
+            ys = []
+            if isinstance(self.output_names, list):
+                for output_name in self.output_names:
+                    ys.append(outputs_dict[output_name])
+            else:
+                ys.append(outputs_dict[self.output_names])
+            xs = []
+            if isinstance(self.inputs_to_check, list):
+                for input_name in self.inputs_to_check:
+                    xs.append(inputs_dict[input_name])
+            else:
+                xs.append(inputs_dict[self.inputs_to_check])
+            vs = self.gen_eager_grad_outputs()
+            no_grad_vars = self.gen_no_grad_set(
+                var_dict={**inputs_dict, **outputs_dict}
+            )
+            ret = paddle.grad(
+                ys, xs, vs, allow_unused=True, no_grad_vars=no_grad_vars
+            )
+            ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
+            if OpTestUtils.is_bfloat16_type(self.dtype):
+                ret = paddle.utils.map_structure(
+                    lambda x: convert_uint16_to_float(x), ret
+                )
         return ret
 
     def check_eager_comp(self):
         if self.prim_op_type == "comp":
             return
-        paddle.disable_static()
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        atol = self.rev_comp_atol
-        rtol = self.rev_comp_rtol
-        core.set_prim_eager_enabled(self.enable_rev_comp)
-        actual_ret = self.get_eager_desire()
-        # check static forward
-        if len(actual_ret) != len(self.eager_desire):
-            msg = (
-                "The eager comp grad out tensor nums is different with eager grad out tensor nums on {}."
-                'when enable_rev_comp is {}, eager comp grad api out tensor nums = {}, eager grad out tensor nums = {}. \n'.format(
-                    str(self.place),
-                    self.enable_rev_comp,
-                    len(actual_ret),
-                    len(self.eager_desire),
-                )
-            )
-            raise RuntimeError(msg)
-        for i in range(len(actual_ret)):
-            np.testing.assert_allclose(
-                actual_ret[i],
-                self.eager_desire[i],
-                rtol=atol,
-                atol=rtol,
-                err_msg=(
-                    'Check eager comp grad out failed. Mismatch between eager comp '
-                    'and eager on %s, when enable_rev_comp is %s,the eager comp grad out tensor\'s index is : %d \n'
-                    'eager comp grad out tensor:\n%s\n eager grad out tensor:\n%s\n'
-                    % (
+        with dygraph_guard():
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            atol = self.rev_comp_atol
+            rtol = self.rev_comp_rtol
+            core.set_prim_eager_enabled(self.enable_rev_comp)
+            actual_ret = self.get_eager_desire()
+            # check static forward
+            if len(actual_ret) != len(self.eager_desire):
+                msg = (
+                    "The eager comp grad out tensor nums is different with eager grad out tensor nums on {}."
+                    'when enable_rev_comp is {}, eager comp grad api out tensor nums = {}, eager grad out tensor nums = {}. \n'.format(
                         str(self.place),
                         self.enable_rev_comp,
-                        i,
-                        actual_ret[i],
-                        self.eager_desire[i],
+                        len(actual_ret),
+                        len(self.eager_desire),
                     )
-                ),
-            )
-        core.set_prim_eager_enabled(False)
+                )
+                raise RuntimeError(msg)
+            for i in range(len(actual_ret)):
+                np.testing.assert_allclose(
+                    actual_ret[i],
+                    self.eager_desire[i],
+                    rtol=atol,
+                    atol=rtol,
+                    err_msg=(
+                        'Check eager comp grad out failed. Mismatch between eager comp '
+                        'and eager on %s, when enable_rev_comp is %s,the eager comp grad out tensor\'s index is : %d \n'
+                        'eager comp grad out tensor:\n%s\n eager grad out tensor:\n%s\n'
+                        % (
+                            str(self.place),
+                            self.enable_rev_comp,
+                            i,
+                            actual_ret[i],
+                            self.eager_desire[i],
+                        )
+                    ),
+                )
+            core.set_prim_eager_enabled(False)
 
     def check_static_comp(self):
         if self.prim_op_type == "prim":
@@ -1040,7 +1034,7 @@ class PrimGradChecker(PrimForwardChecker):
             core._set_prim_backward_enabled(self.enable_rev_comp)
         atol = self.rev_comp_atol if self.enable_rev_comp else self.fw_comp_atol
         rtol = self.rev_comp_rtol if self.enable_rev_comp else self.fw_comp_rtol
-        with paddle.base.framework._static_guard():
+        with static_guard():
             startup_program, main_program = (
                 paddle.static.Program(),
                 paddle.static.Program(),
@@ -1146,146 +1140,18 @@ class PrimGradChecker(PrimForwardChecker):
             )
         core._set_prim_forward_enabled(False)
         core._set_prim_backward_enabled(False)
-        paddle.disable_static()
 
     def check_jit_comp(self):
-        paddle.disable_static()
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        if self.prim_op_type == "prim":
-            core._set_prim_backward_enabled(self.enable_rev_comp)
-        else:
-            core._set_prim_forward_enabled(self.enable_fw_comp)
-            core._set_prim_backward_enabled(self.enable_rev_comp)
-        atol = (
-            self.fw_comp_atol
-            if self.enable_fw_comp and not self.enable_rev_comp
-            else self.jit_comp_atol
-        )
-        rtol = (
-            self.fw_comp_rtol
-            if self.enable_fw_comp and not self.enable_rev_comp
-            else self.jit_comp_rtol
-        )
-        atol = self.rev_comp_atol if self.enable_rev_comp else atol
-        rtol = self.rev_comp_rtol if self.enable_rev_comp else rtol
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            inputs_dict,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=False)
-        args = OpTestUtils.prepare_python_api_arguments(
-            self.public_python_api,
-            eager_tensor_inputs,
-            attrs_outputs,
-            self.kernel_sig,
-        )
-        inputs_sig, _, outputs_sig = self.kernel_sig
-        args = OpTestUtils.assumption_assert_and_transform(
-            args, len(inputs_sig)
-        )
-        net = PrimNet(self.public_python_api)
-        net = apply_to_static(net, False)
-        # check the backward operator not in program when check_prim is True
-        ops = [
-            op.type
-            for op in net.forward.get_concrete_program(args)[1]
-            .backward_program.block(0)
-            .ops
-        ]
-        backward_op_type = self.op_type + "_grad"
-        assert backward_op_type not in ops, (
-            "%s shouldn't appear in program when check_prim is True"
-        ) % (backward_op_type)
-        out = _as_list(net(args))
-        if hasattr(self.op_test, "python_out_sig"):
-            outputs_sig = self.op_test.python_out_sig
-        outputs_dict = self.get_output_dict(self.outputs, out, outputs_sig)
-        ys = []
-        if isinstance(self.output_names, list):
-            for output_name in self.output_names:
-                ys.append(outputs_dict[output_name])
-        else:
-            ys.append(outputs_dict[self.output_names])
-        xs = []
-        if isinstance(self.inputs_to_check, list):
-            for input_name in self.inputs_to_check:
-                xs.append(inputs_dict[input_name])
-        else:
-            xs.append(inputs_dict[self.inputs_to_check])
-        vs = self.gen_eager_grad_outputs()
-        no_grad_vars = self.gen_no_grad_set(
-            var_dict={**inputs_dict, **outputs_dict}
-        )
-        ret = paddle.grad(
-            ys, xs, vs, allow_unused=True, no_grad_vars=no_grad_vars
-        )
-        ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
-        if OpTestUtils.is_bfloat16_type(self.dtype):
-            ret = paddle.utils.map_structure(
-                lambda x: convert_uint16_to_float(x), ret
-            )
-        # check jit comp grad out
-        if len(ret) != len(self.eager_desire):
-            msg = (
-                "The jit comp grad out tensor nums is different with eager grad out tensor nums on {}."
-                'when enable_fw_comp is {}, enable_rev_comp is {}, jit comp grad out tensor nums = {}, eager grad out tensor nums = {}. \n'.format(
-                    str(self.place),
-                    self.enable_fw_comp,
-                    self.enable_rev_comp,
-                    len(ret),
-                    len(self.eager_desire),
-                )
-            )
-            raise RuntimeError(msg)
-        for i in range(len(ret)):
-            np.testing.assert_allclose(
-                ret[i],
-                self.eager_desire[i],
-                rtol=rtol,
-                atol=atol,
-                err_msg=(
-                    'Check jit comp grad out failed. Mismatch between jit comp '
-                    'and eager on %s, when enable_fw_comp is %s, enable_rev_comp is %s,the grad out tensor\'s index is : %d \n'
-                    'jit comp grad out tensor:\n%s\n eager grad out out tensor:\n%s\n'
-                    % (
-                        str(self.place),
-                        self.enable_fw_comp,
-                        self.enable_rev_comp,
-                        i,
-                        ret[i],
-                        self.eager_desire[i],
-                    )
-                ),
-            )
-        core._set_prim_forward_enabled(False)
-        core._set_prim_backward_enabled(False)
-        net.forward.program_cache.clear()
-
-    def check_jit_comp_with_cinn(self):
-        # cinn doesn't support cpu place
-        if (
-            type(self.place) is paddle.base.libpaddle.CPUPlace
-            and self.enable_cinn
-            and core.is_compiled_with_cinn()
-        ):
-            return
-        paddle.disable_static()
-        if type(self.place) is paddle.base.libpaddle.CPUPlace:
-            paddle.device.set_device("cpu")
-        if type(self.place) is paddle.base.libpaddle.CUDAPlace:
-            paddle.device.set_device("gpu:0")
-        if self.prim_op_type == "prim":
-            core._set_prim_backward_enabled(self.enable_rev_comp)
-        else:
-            core._set_prim_forward_enabled(self.enable_fw_comp)
-            core._set_prim_backward_enabled(self.enable_rev_comp)
-        if self.enable_cinn and core.is_compiled_with_cinn():
-            atol = self.cinn_atol
-            rtol = self.cinn_rtol
-        else:
+        with dygraph_guard():
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            if self.prim_op_type == "prim":
+                core._set_prim_backward_enabled(self.enable_rev_comp)
+            else:
+                core._set_prim_forward_enabled(self.enable_fw_comp)
+                core._set_prim_backward_enabled(self.enable_rev_comp)
             atol = (
                 self.fw_comp_atol
                 if self.enable_fw_comp and not self.enable_rev_comp
@@ -1298,101 +1164,228 @@ class PrimGradChecker(PrimForwardChecker):
             )
             atol = self.rev_comp_atol if self.enable_rev_comp else atol
             rtol = self.rev_comp_rtol if self.enable_rev_comp else rtol
-        (
-            eager_tensor_inputs,
-            attrs_outputs,
-            inputs_dict,
-        ) = self.get_eager_input_attr_and_inputdict(stop_gradient=False)
-        args = OpTestUtils.prepare_python_api_arguments(
-            self.public_python_api,
-            eager_tensor_inputs,
-            attrs_outputs,
-            self.kernel_sig,
-        )
-        inputs_sig, _, outputs_sig = self.kernel_sig
-        args = OpTestUtils.assumption_assert_and_transform(
-            args, len(inputs_sig)
-        )
-        net = PrimNet(self.public_python_api)
-        net = apply_to_static(
-            net, core.is_compiled_with_cinn() and self.enable_cinn
-        )
-        # check the backward operator not in program when check_prim is True
-        ops = [
-            op.type
-            for op in net.forward.get_concrete_program(args)[1]
-            .backward_program.block(0)
-            .ops
-        ]
-        backward_op_type = self.op_type + "_grad"
-        assert backward_op_type not in ops, (
-            "%s shouldn't appear in program when check_prim is True"
-        ) % (backward_op_type)
-
-        out = _as_list(net(args))
-        if hasattr(self.op_test, "python_out_sig"):
-            outputs_sig = self.op_test.python_out_sig
-        outputs_dict = self.get_output_dict(self.outputs, out, outputs_sig)
-        ys = []
-        if isinstance(self.output_names, list):
-            for output_name in self.output_names:
-                ys.append(outputs_dict[output_name])
-        else:
-            ys.append(outputs_dict[self.output_names])
-        xs = []
-        if isinstance(self.inputs_to_check, list):
-            for input_name in self.inputs_to_check:
-                xs.append(inputs_dict[input_name])
-        else:
-            xs.append(inputs_dict[self.inputs_to_check])
-        vs = self.gen_eager_grad_outputs()
-        no_grad_vars = self.gen_no_grad_set(
-            var_dict={**inputs_dict, **outputs_dict}
-        )
-        ret = paddle.grad(
-            ys, xs, vs, allow_unused=True, no_grad_vars=no_grad_vars
-        )
-        ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
-        if OpTestUtils.is_bfloat16_type(self.dtype):
-            ret = paddle.utils.map_structure(
-                lambda x: convert_uint16_to_float(x), ret
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                inputs_dict,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=False)
+            args = OpTestUtils.prepare_python_api_arguments(
+                self.public_python_api,
+                eager_tensor_inputs,
+                attrs_outputs,
+                self.kernel_sig,
             )
-        # check jit comp grad out
-        if len(ret) != len(self.eager_desire):
-            msg = (
-                "The jit comp with cinn grad out tensor nums is different with eager grad out tensor nums on {}."
-                'when enable_fw_comp is {}, enable_rev_comp is {}, enable_cinn is {}, jit comp grad out tensor nums = {}, eager grad out tensor nums = {}. \n'.format(
-                    str(self.place),
-                    self.enable_fw_comp,
-                    self.enable_rev_comp,
-                    self.enable_cinn and core.is_compiled_with_cinn(),
-                    len(ret),
-                    len(self.eager_desire),
+            inputs_sig, _, outputs_sig = self.kernel_sig
+            args = OpTestUtils.assumption_assert_and_transform(
+                args, len(inputs_sig)
+            )
+            net = PrimNet(self.public_python_api)
+            net = apply_to_static(net, False)
+            # check the backward operator not in program when check_prim is True
+            ops = [
+                op.type
+                for op in net.forward.get_concrete_program(args)[1]
+                .backward_program.block(0)
+                .ops
+            ]
+            backward_op_type = self.op_type + "_grad"
+            assert backward_op_type not in ops, (
+                "%s shouldn't appear in program when check_prim is True"
+            ) % (backward_op_type)
+            out = _as_list(net(args))
+            if hasattr(self.op_test, "python_out_sig"):
+                outputs_sig = self.op_test.python_out_sig
+            outputs_dict = self.get_output_dict(self.outputs, out, outputs_sig)
+            ys = []
+            if isinstance(self.output_names, list):
+                for output_name in self.output_names:
+                    ys.append(outputs_dict[output_name])
+            else:
+                ys.append(outputs_dict[self.output_names])
+            xs = []
+            if isinstance(self.inputs_to_check, list):
+                for input_name in self.inputs_to_check:
+                    xs.append(inputs_dict[input_name])
+            else:
+                xs.append(inputs_dict[self.inputs_to_check])
+            vs = self.gen_eager_grad_outputs()
+            no_grad_vars = self.gen_no_grad_set(
+                var_dict={**inputs_dict, **outputs_dict}
+            )
+            ret = paddle.grad(
+                ys, xs, vs, allow_unused=True, no_grad_vars=no_grad_vars
+            )
+            ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
+            if OpTestUtils.is_bfloat16_type(self.dtype):
+                ret = paddle.utils.map_structure(
+                    lambda x: convert_uint16_to_float(x), ret
                 )
+            # check jit comp grad out
+            if len(ret) != len(self.eager_desire):
+                msg = (
+                    "The jit comp grad out tensor nums is different with eager grad out tensor nums on {}."
+                    'when enable_fw_comp is {}, enable_rev_comp is {}, jit comp grad out tensor nums = {}, eager grad out tensor nums = {}. \n'.format(
+                        str(self.place),
+                        self.enable_fw_comp,
+                        self.enable_rev_comp,
+                        len(ret),
+                        len(self.eager_desire),
+                    )
+                )
+                raise RuntimeError(msg)
+            for i in range(len(ret)):
+                np.testing.assert_allclose(
+                    ret[i],
+                    self.eager_desire[i],
+                    rtol=rtol,
+                    atol=atol,
+                    err_msg=(
+                        'Check jit comp grad out failed. Mismatch between jit comp '
+                        'and eager on %s, when enable_fw_comp is %s, enable_rev_comp is %s,the grad out tensor\'s index is : %d \n'
+                        'jit comp grad out tensor:\n%s\n eager grad out out tensor:\n%s\n'
+                        % (
+                            str(self.place),
+                            self.enable_fw_comp,
+                            self.enable_rev_comp,
+                            i,
+                            ret[i],
+                            self.eager_desire[i],
+                        )
+                    ),
+                )
+            core._set_prim_forward_enabled(False)
+            core._set_prim_backward_enabled(False)
+            net.forward.program_cache.clear()
+
+    def check_jit_comp_with_cinn(self):
+        # cinn doesn't support cpu place
+        if (
+            type(self.place) is paddle.base.libpaddle.CPUPlace
+            and self.enable_cinn
+            and core.is_compiled_with_cinn()
+        ):
+            return
+        with dygraph_guard():
+            if type(self.place) is paddle.base.libpaddle.CPUPlace:
+                paddle.device.set_device("cpu")
+            if type(self.place) is paddle.base.libpaddle.CUDAPlace:
+                paddle.device.set_device("gpu:0")
+            if self.prim_op_type == "prim":
+                core._set_prim_backward_enabled(self.enable_rev_comp)
+            else:
+                core._set_prim_forward_enabled(self.enable_fw_comp)
+                core._set_prim_backward_enabled(self.enable_rev_comp)
+            if self.enable_cinn and core.is_compiled_with_cinn():
+                atol = self.cinn_atol
+                rtol = self.cinn_rtol
+            else:
+                atol = (
+                    self.fw_comp_atol
+                    if self.enable_fw_comp and not self.enable_rev_comp
+                    else self.jit_comp_atol
+                )
+                rtol = (
+                    self.fw_comp_rtol
+                    if self.enable_fw_comp and not self.enable_rev_comp
+                    else self.jit_comp_rtol
+                )
+                atol = self.rev_comp_atol if self.enable_rev_comp else atol
+                rtol = self.rev_comp_rtol if self.enable_rev_comp else rtol
+            (
+                eager_tensor_inputs,
+                attrs_outputs,
+                inputs_dict,
+            ) = self.get_eager_input_attr_and_inputdict(stop_gradient=False)
+            args = OpTestUtils.prepare_python_api_arguments(
+                self.public_python_api,
+                eager_tensor_inputs,
+                attrs_outputs,
+                self.kernel_sig,
             )
-            raise RuntimeError(msg)
-        for i in range(len(ret)):
-            np.testing.assert_allclose(
-                ret[i],
-                self.eager_desire[i],
-                rtol=rtol,
-                atol=atol,
-                err_msg=(
-                    'Check jit comp with cinn grad out failed. Mismatch between jit comp with cinn '
-                    'and eager on %s, when enable_fw_comp is %s, enable_rev_comp is %s, enable_cinn is %s,'
-                    'the grad out tensor\'s index is : %d ,jit comp with cinn grad out tensor:\n%s\n eager grad out out tensor:\n%s\n'
-                    % (
+            inputs_sig, _, outputs_sig = self.kernel_sig
+            args = OpTestUtils.assumption_assert_and_transform(
+                args, len(inputs_sig)
+            )
+            net = PrimNet(self.public_python_api)
+            net = apply_to_static(
+                net, core.is_compiled_with_cinn() and self.enable_cinn
+            )
+            # check the backward operator not in program when check_prim is True
+            ops = [
+                op.type
+                for op in net.forward.get_concrete_program(args)[1]
+                .backward_program.block(0)
+                .ops
+            ]
+            backward_op_type = self.op_type + "_grad"
+            assert backward_op_type not in ops, (
+                "%s shouldn't appear in program when check_prim is True"
+            ) % (backward_op_type)
+
+            out = _as_list(net(args))
+            if hasattr(self.op_test, "python_out_sig"):
+                outputs_sig = self.op_test.python_out_sig
+            outputs_dict = self.get_output_dict(self.outputs, out, outputs_sig)
+            ys = []
+            if isinstance(self.output_names, list):
+                for output_name in self.output_names:
+                    ys.append(outputs_dict[output_name])
+            else:
+                ys.append(outputs_dict[self.output_names])
+            xs = []
+            if isinstance(self.inputs_to_check, list):
+                for input_name in self.inputs_to_check:
+                    xs.append(inputs_dict[input_name])
+            else:
+                xs.append(inputs_dict[self.inputs_to_check])
+            vs = self.gen_eager_grad_outputs()
+            no_grad_vars = self.gen_no_grad_set(
+                var_dict={**inputs_dict, **outputs_dict}
+            )
+            ret = paddle.grad(
+                ys, xs, vs, allow_unused=True, no_grad_vars=no_grad_vars
+            )
+            ret = paddle.utils.map_structure(lambda x: x.numpy(), ret)
+            if OpTestUtils.is_bfloat16_type(self.dtype):
+                ret = paddle.utils.map_structure(
+                    lambda x: convert_uint16_to_float(x), ret
+                )
+            # check jit comp grad out
+            if len(ret) != len(self.eager_desire):
+                msg = (
+                    "The jit comp with cinn grad out tensor nums is different with eager grad out tensor nums on {}."
+                    'when enable_fw_comp is {}, enable_rev_comp is {}, enable_cinn is {}, jit comp grad out tensor nums = {}, eager grad out tensor nums = {}. \n'.format(
                         str(self.place),
                         self.enable_fw_comp,
                         self.enable_rev_comp,
                         self.enable_cinn and core.is_compiled_with_cinn(),
-                        i,
-                        ret[i],
-                        self.eager_desire[i],
+                        len(ret),
+                        len(self.eager_desire),
                     )
-                ),
-            )
+                )
+                raise RuntimeError(msg)
+            for i in range(len(ret)):
+                np.testing.assert_allclose(
+                    ret[i],
+                    self.eager_desire[i],
+                    rtol=rtol,
+                    atol=atol,
+                    err_msg=(
+                        'Check jit comp with cinn grad out failed. Mismatch between jit comp with cinn '
+                        'and eager on %s, when enable_fw_comp is %s, enable_rev_comp is %s, enable_cinn is %s,'
+                        'the grad out tensor\'s index is : %d ,jit comp with cinn grad out tensor:\n%s\n eager grad out out tensor:\n%s\n'
+                        % (
+                            str(self.place),
+                            self.enable_fw_comp,
+                            self.enable_rev_comp,
+                            self.enable_cinn and core.is_compiled_with_cinn(),
+                            i,
+                            ret[i],
+                            self.eager_desire[i],
+                        )
+                    ),
+                )
 
-        core._set_prim_forward_enabled(False)
-        core._set_prim_backward_enabled(False)
-        net.forward.program_cache.clear()
+            core._set_prim_forward_enabled(False)
+            core._set_prim_backward_enabled(False)
+            net.forward.program_cache.clear()

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
 from scipy.special import erf, expit
+from utils import static_guard
 
 import paddle
 import paddle.nn.functional as F
@@ -39,7 +40,7 @@ def dynamic_guad():
 
 class TestSqrtOpError(unittest.TestCase):
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with program_guard(Program(), Program()):
                 # The input type of sqrt op must be Variable or numpy.ndarray.
                 in1 = 1
@@ -198,7 +199,7 @@ class TestExp_Complex128(TestExp_Complex64):
 
 class Test_Exp_Op_Fp16(unittest.TestCase):
     def test_api_fp16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -283,7 +284,7 @@ class TestExpm1API(unittest.TestCase):
 
     def test_static_api(self):
         def run(place):
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 with paddle.static.program_guard(paddle.static.Program()):
                     X = paddle.static.data('X', self.shape, dtype=self.dtype)
                     out = paddle.expm1(X)
@@ -323,7 +324,7 @@ class Test_Expm1_Op_Int(unittest.TestCase):
 
 class TestParameter:
     def test_out_name(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 np_x = np.array([0.1]).astype('float32').reshape((-1, 1))
                 data = paddle.static.data(
@@ -528,7 +529,7 @@ class TestSiluAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [11, 17])
                 out1 = F.silu(x)
@@ -552,7 +553,7 @@ class TestSiluAPI(unittest.TestCase):
         paddle.enable_static()
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.silu, 1)
@@ -622,7 +623,7 @@ class TestLogSigmoidAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [11, 17])
                 out1 = F.log_sigmoid(x)
@@ -646,7 +647,7 @@ class TestLogSigmoidAPI(unittest.TestCase):
         paddle.enable_static()
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.log_sigmoid, 1)
@@ -738,7 +739,7 @@ class TestTanhAPI(unittest.TestCase):
         self.tanh = F.tanh
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], self.dtype)
                 out1 = self.tanh(x)
@@ -762,7 +763,7 @@ class TestTanhAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, self.tanh, 1)
@@ -810,7 +811,7 @@ class TestAtan(TestActivation, TestParameter):
         self.check_grad(['X'], 'Out')
 
     def test_out_name(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 np_x = np.array([0.1]).astype('float32').reshape((-1, 1))
                 data = paddle.static.data(
@@ -898,7 +899,7 @@ class TestSinhAPI(unittest.TestCase):
             np.testing.assert_allclose(z, z_expected, rtol=1e-05)
 
     def test_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             test_data_shape = [11, 17]
             with base.program_guard(base.Program(), base.Program()):
                 input_x = np.random.uniform(0.1, 1, test_data_shape).astype(
@@ -938,7 +939,7 @@ class TestSinhAPI(unittest.TestCase):
 
 class TestSinhOpError(unittest.TestCase):
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with program_guard(Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, paddle.sinh, 1)
@@ -1009,7 +1010,7 @@ class TestCoshAPI(unittest.TestCase):
             np.testing.assert_allclose(z, z_expected, rtol=1e-05)
 
     def test_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             test_data_shape = [11, 17]
             with base.program_guard(base.Program(), base.Program()):
                 input_x = np.random.uniform(0.1, 1, test_data_shape).astype(
@@ -1049,7 +1050,7 @@ class TestCoshAPI(unittest.TestCase):
 
 class TestCoshOpError(unittest.TestCase):
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with program_guard(Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, paddle.cosh, 1)
@@ -1108,7 +1109,7 @@ class TestTanhshrinkAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.tanhshrink(x)
@@ -1131,7 +1132,7 @@ class TestTanhshrinkAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.tanhshrink, 1)
@@ -1209,7 +1210,7 @@ class TestHardShrinkAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out1 = F.hardshrink(x)
@@ -1239,7 +1240,7 @@ class TestHardShrinkAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.hardshrink, 1)
@@ -1275,7 +1276,7 @@ class TestHardtanhAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out1 = F.hardtanh(x)
@@ -1305,7 +1306,7 @@ class TestHardtanhAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.hardtanh, 1)
@@ -1371,7 +1372,7 @@ class TestSoftshrinkAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.softshrink(x, self.threshold)
@@ -1394,7 +1395,7 @@ class TestSoftshrinkAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.softshrink, 1)
@@ -1884,7 +1885,7 @@ class TestTanAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, out_test.numpy(), rtol=1e-05)
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [11, 17], self.dtype)
                 out = paddle.tan(x)
@@ -2268,7 +2269,7 @@ class TestReluAPI(unittest.TestCase):
         self.relu = F.relu
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out1 = self.relu(x)
@@ -2291,8 +2292,8 @@ class TestReluAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
-            with paddle.base.framework._static_guard():
+        with static_guard():
+            with static_guard():
                 with paddle.static.program_guard(paddle.static.Program()):
                     # The input type must be Variable.
                     self.assertRaises(TypeError, self.relu, 1)
@@ -2392,7 +2393,7 @@ class TestLeakyReluAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out1 = F.leaky_relu(x)
@@ -2422,7 +2423,7 @@ class TestLeakyReluAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.leaky_relu, 1)
@@ -2548,7 +2549,7 @@ class TestGELUAPI(unittest.TestCase):
         self.rev_comp_atol = 1e-8
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [11, 17], dtype="float32")
                 out1 = F.gelu(x)
@@ -2578,7 +2579,7 @@ class TestGELUAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.gelu, 1)
@@ -2674,7 +2675,7 @@ class TestRelu6API(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.relu6(x)
@@ -2697,7 +2698,7 @@ class TestRelu6API(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_base_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.relu6(x)
@@ -2707,7 +2708,7 @@ class TestRelu6API(unittest.TestCase):
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.relu6, 1)
@@ -2725,7 +2726,7 @@ class TestRelu6API(unittest.TestCase):
 
 class TestRelu6APIWarnings(unittest.TestCase):
     def test_warnings(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with warnings.catch_warnings(record=True) as context:
                 warnings.simplefilter("always")
 
@@ -2818,7 +2819,7 @@ class TestHardswishAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.hardswish(x)
@@ -2841,7 +2842,7 @@ class TestHardswishAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_base_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.hardswish(x)
@@ -2856,7 +2857,7 @@ class TestHardswishAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.hardswish, 1)
@@ -2966,7 +2967,7 @@ class TestELUAPI(unittest.TestCase):
         self.elu = F.elu
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out1 = self.elu(x)
@@ -2998,7 +2999,7 @@ class TestELUAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, self.elu, 1)
@@ -3077,7 +3078,7 @@ class TestCELUAPI(unittest.TestCase):
         self.celu = F.celu
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out1 = self.celu(x, 1.5)
@@ -3109,7 +3110,7 @@ class TestCELUAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, self.celu, 1)
@@ -3188,7 +3189,7 @@ class TestLog(TestActivation):
 
 class Test_Log_Op_Fp16(unittest.TestCase):
     def test_api_fp16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3201,7 +3202,7 @@ class Test_Log_Op_Fp16(unittest.TestCase):
                     (res,) = exe.run(fetch_list=[out])
 
     def test_api_bf16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3251,7 +3252,7 @@ class TestLog2(TestActivation):
         self.check_grad(['X'], 'Out')
 
     def test_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3298,7 +3299,7 @@ class TestLog2_Op_Int(unittest.TestCase):
         paddle.enable_static()
 
     def test_api_bf16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3348,7 +3349,7 @@ class TestLog10_Op_Int(unittest.TestCase):
         paddle.enable_static()
 
     def test_api_bf16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3363,7 +3364,7 @@ class TestLog10_Op_Int(unittest.TestCase):
 
 class TestLog10API(unittest.TestCase):
     def test_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3416,7 +3417,7 @@ class TestLog1p(TestActivation):
 
 class Test_Log1p_Op_Fp16(unittest.TestCase):
     def test_api_fp16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3441,7 +3442,7 @@ class TestLog1p_Op_Int(unittest.TestCase):
         paddle.enable_static()
 
     def test_api_bf16(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -3461,7 +3462,7 @@ class TestLog1p_ZeroDim(TestLog1p):
 
 class TestLog1pAPI(unittest.TestCase):
     def test_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program(), base.Program()):
                 input_x = np.random.uniform(0.1, 1, [11, 17]).astype("float64")
                 data_x = paddle.static.data(
@@ -3615,7 +3616,7 @@ class TestPow_factor_tensor(TestActivation):
         self.check_grad(['X'], 'Out')
 
     def test_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             input = np.random.uniform(1, 2, [11, 17]).astype("float32")
             x = paddle.static.data(name="x", shape=[11, 17], dtype="float32")
             res = paddle.static.data(
@@ -3720,7 +3721,7 @@ class TestSTanhAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', [10, 12])
                 out = paddle.stanh(x, self.scale_a, self.scale_b)
@@ -3739,7 +3740,7 @@ class TestSTanhAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_base_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('X', [10, 12], dtype="float32")
                 out = paddle.stanh(x, self.scale_a, self.scale_b)
@@ -3749,7 +3750,7 @@ class TestSTanhAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, paddle.stanh, 1)
@@ -3861,7 +3862,7 @@ class TestSoftplusAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.softplus(x, self.beta, self.threshold)
@@ -3884,7 +3885,7 @@ class TestSoftplusAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.softplus, 1)
@@ -3947,7 +3948,7 @@ class TestSoftsignAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.softsign(x)
@@ -3970,7 +3971,7 @@ class TestSoftsignAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.softsign, 1)
@@ -4038,7 +4039,7 @@ class TestThresholdedReluAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.thresholded_relu(x, self.threshold)
@@ -4061,7 +4062,7 @@ class TestThresholdedReluAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.thresholded_relu, 1)
@@ -4142,7 +4143,7 @@ class TestHardsigmoidAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.hardsigmoid(x)
@@ -4165,7 +4166,7 @@ class TestHardsigmoidAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_base_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.hardsigmoid(x, slope=0.2)
@@ -4180,7 +4181,7 @@ class TestHardsigmoidAPI(unittest.TestCase):
         np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.hardsigmoid, 1)
@@ -4246,7 +4247,7 @@ class TestSwishAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.swish(x)
@@ -4269,7 +4270,7 @@ class TestSwishAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_base_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.swish(x)
@@ -4279,7 +4280,7 @@ class TestSwishAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.swish, 1)
@@ -4346,7 +4347,7 @@ class TestMishAPI(unittest.TestCase):
         )
 
     def test_static_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out1 = F.mish(x)
@@ -4369,7 +4370,7 @@ class TestMishAPI(unittest.TestCase):
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
     def test_base_api(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.mish(x)
@@ -4379,7 +4380,7 @@ class TestMishAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, F.mish, 1)

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 import parameterized as param
 from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
+from utils import static_guard
 
 import paddle
 from paddle import _C_ops, base, static
@@ -1682,7 +1683,7 @@ class TestCompositeDropout(unittest.TestCase):
         fwd_actual = []
         rev_actual = []
         mps = []
-        with paddle.base.framework._static_guard():
+        with static_guard():
             for place in self.places:
                 paddle.seed(self.seed)
                 mp, sp = paddle.static.Program(), paddle.static.Program()

--- a/test/legacy_test/test_erf_op.py
+++ b/test/legacy_test/test_erf_op.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
 from scipy.special import erf
+from utils import static_guard
 
 import paddle
 import paddle.base.dygraph as dg
@@ -65,13 +66,13 @@ class TestErfLayer(unittest.TestCase):
         np.testing.assert_allclose(y_ref, y_test, rtol=1e-05)
 
     def test_case(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             self._test_case(base.CPUPlace())
             if base.is_compiled_with_cuda():
                 self._test_case(base.CUDAPlace(0))
 
     def test_name(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data('x', [3, 4])
                 y = paddle.erf(x, name='erf')

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -24,6 +24,7 @@ from op_test import (
     skip_check_grad_ci,
 )
 from testsuite import create_op
+from utils import static_guard
 
 import paddle
 from paddle import base
@@ -1154,7 +1155,7 @@ class TestCompositeGroupNorm(unittest.TestCase):
         if len(self.places) < 1:
             return
 
-        with paddle.base.framework._static_guard():
+        with static_guard():
             for place in self.places:
                 fwd_actual.append([])
                 rev_actual.append([])

--- a/test/legacy_test/test_instance_norm_op.py
+++ b/test/legacy_test/test_instance_norm_op.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 import parameterized as param
 from op_test import OpTest
+from utils import static_guard
 
 import paddle
 from paddle import base, nn
@@ -428,7 +429,7 @@ class TestCompositeInstanceNormNorm(unittest.TestCase):
         if len(self.places) < 1:
             return
 
-        with paddle.base.framework._static_guard():
+        with static_guard():
             for place in self.places:
                 fwd_actual.append([])
                 rev_actual.append([])

--- a/test/legacy_test/test_instance_norm_op_v2.py
+++ b/test/legacy_test/test_instance_norm_op_v2.py
@@ -17,6 +17,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
+from utils import static_guard
 
 import paddle
 from paddle import base
@@ -140,7 +141,7 @@ class TestInstanceNorm(unittest.TestCase):
             np.testing.assert_allclose(y1, y2, rtol=1e-05)
 
     def test_static(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             places = [base.CPUPlace()]
             if core.is_compiled_with_cuda() and core.op_support_gpu(
                 "instance_norm"

--- a/test/legacy_test/test_pad_op.py
+++ b/test/legacy_test/test_pad_op.py
@@ -18,6 +18,7 @@ import unittest
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
 from test_attribute_var import UnittestBase
+from utils import static_guard
 
 import paddle
 from paddle.base import Program, core, program_guard
@@ -115,7 +116,7 @@ create_test_fp16(TestCase3)
 
 class TestPadOpError(unittest.TestCase):
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with program_guard(Program(), Program()):
                 input_data = np.random.random((2, 2)).astype("float32")
 
@@ -136,7 +137,7 @@ class TestPaddingValueTensor(UnittestBase):
         self.save_path = os.path.join(self.temp_dir.name, self.path_prefix())
 
     def test_static(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             main_prog = Program()
             starup_prog = Program()
             with program_guard(main_prog, starup_prog):
@@ -196,7 +197,7 @@ class TestPaddingValueTensor2(TestPaddingValueTensor):
 
 class TestPaddingValueTensor3(unittest.TestCase):
     def test_static(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             np_x = np.random.random((16, 16)).astype('float32')
             main_prog = Program()
             starup_prog = Program()

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
+from utils import static_guard
 
 import paddle
 from paddle import base
@@ -1598,7 +1599,7 @@ class TestReduceWithDtype2(TestReduceWithDtype):
 
 class TestReduceSumOpError(unittest.TestCase):
     def test_errors(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with program_guard(Program(), Program()):
                 # The input type of reduce_sum_op must be Variable.
                 x1 = base.create_lod_tensor(

--- a/test/legacy_test/test_scatter_nd_op.py
+++ b/test/legacy_test/test_scatter_nd_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
+from utils import static_guard
 
 import paddle
 from paddle import base
@@ -324,7 +325,7 @@ class TestScatterNdOpAPI(unittest.TestCase):
     """
 
     def testcase1(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             ref1 = paddle.static.data(
                 name='ref1',
                 shape=[10, 9, 8, 1, 3],
@@ -343,7 +344,7 @@ class TestScatterNdOpAPI(unittest.TestCase):
             output1 = paddle.scatter_nd_add(ref1, index1, updates1)
 
     def testcase2(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             ref2 = paddle.static.data(
                 name='ref2',
                 shape=[10, 9, 8, 1, 3],
@@ -364,7 +365,7 @@ class TestScatterNdOpAPI(unittest.TestCase):
             )
 
     def testcase3(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             shape3 = [10, 9, 8, 1, 3]
             index3 = paddle.static.data(
                 name='index3',
@@ -379,7 +380,7 @@ class TestScatterNdOpAPI(unittest.TestCase):
             output3 = paddle.scatter_nd(index3, updates3, shape3)
 
     def testcase4(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             shape4 = [10, 9, 8, 1, 3]
             index4 = paddle.static.data(
                 name='index4',
@@ -450,7 +451,7 @@ class TestScatterNdOpAPI(unittest.TestCase):
 class TestScatterNdOpRaise(unittest.TestCase):
     def test_check_raise(self):
         def check_raise_is_test():
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 try:
                     ref5 = paddle.static.data(
                         name='ref5', shape=[-1, 3, 4, 5], dtype='float32'
@@ -471,7 +472,7 @@ class TestScatterNdOpRaise(unittest.TestCase):
 
     def test_check_raise2(self):
         with self.assertRaises(ValueError):
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 ref6 = paddle.static.data(
                     name='ref6',
                     shape=[10, 9, 8, 1, 3],
@@ -491,7 +492,7 @@ class TestScatterNdOpRaise(unittest.TestCase):
 
     def test_check_raise3(self):
         def check_raise_is_test():
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 try:
                     shape = [3, 4, 5]
                     index7 = paddle.static.data(

--- a/test/legacy_test/test_softmax_op.py
+++ b/test/legacy_test/test_softmax_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
+from utils import static_guard
 
 import paddle
 import paddle.nn.functional as F
@@ -468,7 +469,7 @@ class TestSoftmaxAPI(unittest.TestCase):
         self.softmax = F.softmax
 
     def test_static_check(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data('X', self.x_np.shape, 'float32')
                 out1 = self.softmax(x)
@@ -512,7 +513,7 @@ class TestSoftmaxAPI(unittest.TestCase):
         paddle.enable_static()
 
     def test_error(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 # The input type must be Variable.
                 self.assertRaises(TypeError, self.softmax, 1)
@@ -546,7 +547,7 @@ class TestSoftmaxAPI_ZeroDim(unittest.TestCase):
         paddle.enable_static()
 
     def test_static(self):
-        with paddle.base.framework._static_guard():
+        with static_guard():
             main_prog = base.Program()
             with base.program_guard(main_prog, base.Program()):
                 x = paddle.rand([])

--- a/test/legacy_test/utils.py
+++ b/test/legacy_test/utils.py
@@ -16,6 +16,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base.framework import _dygraph_guard
+from paddle.base.wrapped_decorator import signature_safe_contextmanager
 
 __all__ = ['DyGraphProgramDescTracerTestHelper', 'is_equal_program']
 
@@ -119,3 +120,27 @@ class DyGraphProgramDescTracerTestHelper:
 
         for v1, v2 in zip(out_dygraph, out_static_graph):
             self.unittest_obj.assertTrue(func(v1.numpy(), v2))
+
+
+@signature_safe_contextmanager
+def dygraph_guard():
+    in_dygraph_outside = paddle.base.framework.in_dygraph_mode()
+    try:
+        if not in_dygraph_outside:
+            paddle.disable_static()
+        yield
+    finally:
+        if not in_dygraph_outside:
+            paddle.enable_static()
+
+
+@signature_safe_contextmanager
+def static_guard():
+    in_dygraph_outside = paddle.base.framework.in_dygraph_mode()
+    try:
+        if in_dygraph_outside:
+            paddle.enable_static()
+        yield
+    finally:
+        if in_dygraph_outside:
+            paddle.disable_static()

--- a/test/standalone_executor/test_standalone_executor.py
+++ b/test/standalone_executor/test_standalone_executor.py
@@ -20,6 +20,7 @@ import shutil
 import unittest
 
 import numpy as np
+from utils import static_guard
 
 import paddle
 from paddle.base import core
@@ -236,7 +237,7 @@ class SwitchExecutorInterfaceWithFeed(unittest.TestCase):
         data = np.ones([2, 2], dtype="float32")
         feed = {"a": data, 'fake_input': data}
 
-        with paddle.base.framework._static_guard():
+        with static_guard():
             res = self.run_new_executor(feed)
         with paddle.base.dygraph.guard():
             gt = self.run_dygraph(feed)

--- a/test/xpu/test_pad_op_xpu.py
+++ b/test/xpu/test_pad_op_xpu.py
@@ -23,6 +23,7 @@ from get_test_cover_info import (
 )
 from op_test_xpu import XPUOpTest
 from test_attribute_var import UnittestBase
+from utils import static_guard
 
 import paddle
 from paddle.base import Program, program_guard
@@ -101,7 +102,7 @@ class XPUTestPadOp(XPUOpTestWrapper):
 
     class TestPadOpError(unittest.TestCase):
         def test_errors(self):
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 with program_guard(Program(), Program()):
                     input_data = np.random.random((2, 2)).astype("float32")
 
@@ -123,7 +124,7 @@ class XPUTestPadOp(XPUOpTestWrapper):
             )
 
         def test_static(self):
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 main_prog = Program()
                 starup_prog = Program()
                 with program_guard(main_prog, starup_prog):
@@ -182,7 +183,7 @@ class XPUTestPadOp(XPUOpTestWrapper):
 
     class TestPaddingValueTensor3(unittest.TestCase):
         def test_static(self):
-            with paddle.base.framework._static_guard():
+            with static_guard():
                 np_x = np.random.random((16, 16)).astype('float32')
                 main_prog = Program()
                 starup_prog = Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
升级OpTest中关于动静态图的guard机制，确保退出guard能够正常还原，减少开发单测由于隐形guard切换带来的各种问题