### PR TITLE
【PRIM】【PIR】fix excutor for data op in pir and support divide op prim mode

### DIFF
--- a/test/legacy_test/test_elementwise_div_op.py
+++ b/test/legacy_test/test_elementwise_div_op.py
@@ -82,6 +82,7 @@ class ElementwiseDivOp(OpTest):
 
     def if_check_prim(self):
         self.check_prim = True
+        self.check_prim_pir = True
 
     def gen_data(self, shape):
         return np.random.uniform(0.1, 1, shape)
@@ -124,6 +125,7 @@ class ElementwiseDivOp(OpTest):
                 'user_defined_grad_outputs': [self.grad_out],
                 'check_dygraph': self.check_dygraph,
                 'check_prim': self.check_prim,
+                'check_prim_pir': self.check_prim_pir,
             }
             if self.place is None:
                 self.check_grad(*check_args, **check_kwargs, check_new_ir=True)
@@ -215,6 +217,8 @@ class TestElementwiseDivOpBF16(ElementwiseDivOp):
             check_kwargs = {
                 'no_grad_set': check_option['no_grad'],
                 'check_dygraph': self.check_dygraph,
+                'check_prim': self.check_prim,
+                'check_prim_pir': self.check_prim_pir,
             }
             if self.place is None:
                 self.check_grad(*check_args, **check_kwargs, check_new_ir=True)
@@ -226,6 +230,7 @@ class TestElementwiseDivOpBF16(ElementwiseDivOp):
 
     def if_check_prim(self):
         self.check_prim = True
+        self.check_prim_pir = True
 
     def if_enable_cinn(self):
         self.enable_cinn = False
@@ -455,7 +460,11 @@ def create_test_fp16_class(parent, max_relative_error=2e-3):
                 else:
                     check_args.insert(0, self.place)
                     self.check_grad_with_place(
-                        *check_args, **check_kwargs, check_new_ir=True
+                        *check_args,
+                        **check_kwargs,
+                        check_new_ir=True,
+                        check_prim=True,
+                        check_prim_pir=True
                     )
 
     cls_name = "{}_{}".format(parent.__name__, "Fp16")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-66975
背景：
执行器在执行时会根据data op在scope中创建变量，但是会要求data op在program最前面，目前pir下data op插入不一定会插在program最前面，导致部分变量在scope中未初始化。考虑到执行器执行效率，不应该每次执行都扫描整个program根据data op去在scope中创建变量，因此需要修改data op的插入机制，让它每次都插入在program最前面。
本次PR主要完成以下工作：

- 修改data op插入方式，让其每次都插入在最后一个data op的后面
- pir下支持divide算子组合模式