### PR TITLE
[PIR] standardize the use of value[-5]. 

### DIFF
--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -1309,11 +1309,11 @@ void NewIRInterpreter::SolvePersisableVarNames() {
     ::pir::Value value = kv.first;
     const std::string& var_name = kv.second;
     ::pir::OpResult result = value.dyn_cast<::pir::OpResult>();
-    auto* defining_op = value.GetDefiningOp();
+    auto* defining_op = result.owner();
     if (defining_op->HasAttribute(kAttrIsPersisable)) {
-      auto is_persisables = defining_op->attribute(kAttrIsPersisable)
-                                .dyn_cast<::pir::ArrayAttribute>()
-                                .AsVector();
+      auto is_persisables =
+          defining_op->attribute<::pir::ArrayAttribute>(kAttrIsPersisable)
+              .AsVector();
       if (is_persisables[result.index()]
               .dyn_cast<::pir::BoolAttribute>()
               .data()) {

--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -27,7 +27,7 @@ OP_VJP_FORWARD_INPUT_OR_OUTPUT_TEMPLATE = """
 
 OP_VJP_FORWARD_MULTI_INPUT_TEMPLATE = """
     pir::CombineOp combine_op_obj =
-      op_obj.{input_name}().GetDefiningOp()->dyn_cast<pir::CombineOp>();
+      op_obj.{input_name}().dyn_cast<pir::OpResult>().owner()->dyn_cast<pir::CombineOp>();
     std::vector<Tensor> {input_name};
     for (size_t idx = 0; idx < combine_op_obj.inputs().size(); idx++) {{
         {input_name}.emplace_back(

--- a/paddle/fluid/pir/phi_kernel_adaptor/phi_kernel_util.cc
+++ b/paddle/fluid/pir/phi_kernel_adaptor/phi_kernel_util.cc
@@ -125,7 +125,7 @@ paddle::framework::Variable* CreateVar(
         variable_2_var_name,
     std::map<std::string, int>* var_name_2_id,
     std::vector<paddle::framework::Variable*>* variable_list) {
-  Operation* def_op = value.GetDefiningOp();
+  Operation* def_op = value.dyn_cast<OpResult>().owner();
   bool is_persisable = false;
   if (def_op->isa<::pir::SetParameterOp>()) {
     is_persisable = true;

--- a/paddle/fluid/pir/transforms/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/inplace_pass.cc
@@ -37,13 +37,14 @@ static bool CanBeDeleted(pir::Value value) {
       !value.type().isa<paddle::dialect::AllocatedSelectedRowsType>()) {
     return false;
   }
-  if (value.GetDefiningOp()->HasAttribute(kAttrIsPersisable)) {
-    return !(value.GetDefiningOp()
-                 ->attribute(kAttrIsPersisable)
-                 .dyn_cast<pir::ArrayAttribute>()
-                 .AsVector()[value.dyn_cast<pir::OpResult>().index()]
-                 .dyn_cast<pir::BoolAttribute>()
-                 .data());
+  if (auto op_result = value.dyn_cast<pir::OpResult>()) {
+    auto def_op = op_result.owner();
+    if (def_op->HasAttribute(kAttrIsPersisable)) {
+      return !(def_op->attribute<pir::ArrayAttribute>(kAttrIsPersisable)
+                   .AsVector()[op_result.index()]
+                   .dyn_cast<pir::BoolAttribute>()
+                   .data());
+    }
   }
   return true;
 }

--- a/paddle/fluid/pir/transforms/transform_general_functions.cc
+++ b/paddle/fluid/pir/transforms/transform_general_functions.cc
@@ -25,7 +25,7 @@ namespace pir {
 std::pair<std::string, pir::Parameter*> GetParameterFromValue(
     pir::Value value) {
   pir::GetParameterOp op =
-      value.GetDefiningOp()->dyn_cast<pir::GetParameterOp>();
+      value.dyn_cast<OpResult>().owner()->dyn_cast<pir::GetParameterOp>();
   PADDLE_ENFORCE_NOT_NULL(
       op,
       phi::errors::InvalidArgument(
@@ -66,7 +66,7 @@ Operation* GetDefiningOpForInput(Operation* op, uint32_t index) {
       index < op->num_operands(),
       true,
       phi::errors::InvalidArgument("Intput operand's index must be valid."));
-  return op->operand_source(index).GetDefiningOp();
+  return op->operand_source(index).dyn_cast<OpResult>().owner();
 }
 
 Operation* GetFirstUseOperationForOutput(Operation* op, uint32_t index) {

--- a/paddle/fluid/primitive/codegen/templates/rule/vjp/generated/generated_vjp.cc.j2
+++ b/paddle/fluid/primitive/codegen/templates/rule/vjp/generated/generated_vjp.cc.j2
@@ -41,7 +41,7 @@ return vjp_res;
 {% macro get_mutable_attribute(attrs, api_name) %}
   {% for i in attrs %}
     {%- if i is mutable_attribute -%}
-auto* {{i.name}}_define_op = std::static_pointer_cast<primitive::LazyTensor>({{i.name~'_'}}.impl())->value().dyn_cast<pir::OpResult>().GetDefiningOp();
+auto* {{i.name}}_define_op = std::static_pointer_cast<primitive::LazyTensor>({{i.name~'_'}}.impl())->value().dyn_cast<pir::OpResult>().owner();
       {% if i.typename is scalar %}
 if({{i.name}}_define_op->name() != "pd_op.full") {
   PADDLE_THROW(platform::errors::Unimplemented(

--- a/paddle/pir/core/attribute.h
+++ b/paddle/pir/core/attribute.h
@@ -51,6 +51,8 @@ class IR_API Attribute {
 
   bool operator!() const { return storage_ == nullptr; }
 
+  operator const void *() const { return storage_; }
+
   ///
   /// \brief Some Attribute attribute acquisition interfaces.
   ///
@@ -85,8 +87,6 @@ class IR_API Attribute {
     return pir::dyn_cast<U>(*this);
   }
 
-  friend struct std::hash<Attribute>;
-
  protected:
   const Storage *storage_{nullptr};
 };
@@ -98,7 +98,7 @@ namespace std {
 template <>
 struct hash<pir::Attribute> {
   std::size_t operator()(const pir::Attribute &obj) const {
-    return std::hash<const pir::Attribute::Storage *>()(obj.storage_);
+    return std::hash<const void *>()(obj);
   }
 };
 }  // namespace std

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -310,7 +310,7 @@ void SplitOp::PassStopGradients(OperationArgument &argument) {
       for (uint32_t i = 0; i < defining_op->num_operands(); ++i) {
         auto value = defining_op->operand_source(i);
         if (!value) continue;
-        auto *oprand_defining_op = value.GetDefiningOp();
+        auto *oprand_defining_op = value.dyn_cast<OpResult>().owner();
         if (oprand_defining_op->HasAttribute(kStopGradientAttrName)) {
           auto attrs = oprand_defining_op->attribute(kStopGradientAttrName)
                            .dyn_cast<pir::ArrayAttribute>()

--- a/paddle/pir/core/op_info.h
+++ b/paddle/pir/core/op_info.h
@@ -71,13 +71,13 @@ class IR_API OpInfo {
   template <typename InterfaceT>
   typename InterfaceT::Concept *GetInterfaceImpl() const;
 
+  operator const void *() const { return impl_; }
   void *AsOpaquePointer() const { return impl_; }
   static OpInfo RecoverFromOpaquePointer(void *pointer) {
     return OpInfo(static_cast<OpInfoImpl *>(pointer));
   }
 
   friend class OpInfoImpl;
-  friend struct std::hash<OpInfo>;
 
  private:
   explicit OpInfo(OpInfoImpl *impl) : impl_(impl) {}
@@ -105,7 +105,7 @@ namespace std {
 template <>
 struct hash<pir::OpInfo> {
   std::size_t operator()(const pir::OpInfo &obj) const {
-    return std::hash<const pir::OpInfoImpl *>()(obj.impl_);
+    return std::hash<const void *>()(obj);
   }
 };
 }  // namespace std

--- a/paddle/pir/core/type.h
+++ b/paddle/pir/core/type.h
@@ -48,7 +48,7 @@ class IR_API Type {
   Type() = default;
 
   Type(const Storage *storage)  // NOLINT
-      : storage_(const_cast<Storage *>(storage)) {}
+      : storage_(storage) {}
 
   Type(const Type &other) = default;
 
@@ -73,11 +73,7 @@ class IR_API Type {
   ///
   /// \brief Support PointerLikeTypeTraits.
   ///
-  ///
-  const void *AsOpaquePointer() const {
-    return static_cast<const void *>(storage_);
-  }
-
+  operator const void *() const { return storage_; }
   static Type RecoverFromOpaquePointer(const void *pointer) {
     return Type(reinterpret_cast<Storage *>(const_cast<void *>(pointer)));
   }
@@ -119,11 +115,6 @@ class IR_API Type {
   void Print(std::ostream &os) const;
 
   static Type Parse(std::istream &is, IrContext *ctx);
-
-  ///
-  /// \brief Enable hashing Type.
-  ///
-  friend struct std::hash<Type>;
 
   template <typename U>
   U cast() const {
@@ -189,7 +180,7 @@ namespace std {
 template <>
 struct hash<pir::Type> {
   std::size_t operator()(const pir::Type &obj) const {
-    return std::hash<const pir::Type::Storage *>()(obj.storage_);
+    return std::hash<const void *>()(obj);
   }
 };
 }  // namespace std

--- a/paddle/pir/core/type_id.h
+++ b/paddle/pir/core/type_id.h
@@ -53,6 +53,7 @@ class TypeId {
   ///
   /// \brief Support PointerLikeTypeTraits.
   ///
+  operator const void *() const { return storage_; }
   void *AsOpaquePointer() const { return storage_; }
   static TypeId RecoverFromOpaquePointer(void *pointer) {
     return TypeId(static_cast<Storage *>(pointer));
@@ -70,11 +71,6 @@ class TypeId {
   inline bool operator<(const TypeId &other) const {
     return storage_ < other.storage_;
   }
-
-  ///
-  /// \brief Enable hashing TypeId instances.
-  ///
-  friend struct std::hash<TypeId>;
 
  private:
   ///
@@ -150,7 +146,7 @@ namespace std {
 template <>
 struct hash<pir::TypeId> {
   std::size_t operator()(const pir::TypeId &obj) const {
-    return std::hash<const pir::TypeId::Storage *>()(obj.storage_);
+    return std::hash<const void *>()(obj);
   }
 };
 }  // namespace std

--- a/paddle/pir/core/value.cc
+++ b/paddle/pir/core/value.cc
@@ -52,11 +52,6 @@ void Value::set_type(pir::Type type) {
   impl_->set_type(type);
 }
 
-Operation *Value::GetDefiningOp() const {
-  if (auto result = dyn_cast<OpResult>()) return result.owner();
-  return nullptr;
-}
-
 std::string Value::PrintUdChain() {
   CHECK_VALUE_NULL_IMPL(PrintUdChain);
   return impl()->PrintUdChain();

--- a/paddle/pir/core/value.h
+++ b/paddle/pir/core/value.h
@@ -59,8 +59,6 @@ class IR_API Value {
 
   void set_type(Type type);
 
-  Operation *GetDefiningOp() const;
-
   std::string PrintUdChain();
 
   ///

--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -84,7 +84,7 @@ bool SymbolicDimMgr::LoadShapeConstraintGraph() {
   auto build_sym_product = [&](std::vector<Value> range,
                                SymbolicDimProduct& product) {
     for (Value v : range) {
-      auto definingOp = v.GetDefiningOp();
+      auto definingOp = v.dyn_cast<OpResult>().owner();
       if (auto constOp = definingOp->dyn_cast<ConstantOp>()) {
         product.factor *= constOp.value().dyn_cast<Int32Attribute>().data();
         continue;

--- a/paddle/pir/pattern_rewrite/pattern_rewrite_driver.cc
+++ b/paddle/pir/pattern_rewrite/pattern_rewrite_driver.cc
@@ -173,7 +173,8 @@ class GreedyPatternRewriteDriver : public pir::PatternRewriter {
     // that single use values often have more canonicalization opportunities.
     if (!operand || (!operand.use_empty() && !operand.HasOneUse())) return;
 
-    if (auto* def_op = operand.GetDefiningOp()) AddToWorklist(def_op);
+    if (auto* def_op = operand.dyn_cast<pir::OpResult>().owner())
+      AddToWorklist(def_op);
   }
 
   void AddOperandsToWorklist(const std::vector<pir::Value> operands) {

--- a/test/cpp/pir/core/ir_value_test.cc
+++ b/test/cpp/pir/core/ir_value_test.cc
@@ -84,10 +84,10 @@ TEST(value_test, value_test) {
   op4->Print(std::cout);
 
   // Test 1:
-  EXPECT_EQ(op1->result(0).GetDefiningOp(), op1);
-  EXPECT_EQ(op2->result(0).GetDefiningOp(), op2);
-  EXPECT_EQ(op3->result(0).GetDefiningOp(), op3);
-  EXPECT_EQ(op4->result(6).GetDefiningOp(), op4);
+  EXPECT_EQ(op1->result(0).owner(), op1);
+  EXPECT_EQ(op2->result(0).owner(), op2);
+  EXPECT_EQ(op3->result(0).owner(), op3);
+  EXPECT_EQ(op4->result(6).owner(), op4);
 
   // Test 2: op1_first_output -> op4_first_input
   pir::OpResult op1_first_output = op1->result(0);

--- a/test/cpp/pir/shape_dialect/symbolic_op_test.cc
+++ b/test/cpp/pir/shape_dialect/symbolic_op_test.cc
@@ -406,7 +406,7 @@ TEST(shape_op, dim) {
   EXPECT_EQ(dimOp.getName(), "S0");
   dimOp.setName("S1");
   EXPECT_EQ(dimOp.getName(), "S1");
-  EXPECT_EQ(res.GetDefiningOp(), dimOp.operation());
+  EXPECT_EQ(res.owner(), dimOp.operation());
   EXPECT_EQ(res.type(), pir::IndexType::get(ctx));
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
#### 规范化代码中对Value的使用[-5]。


Value分两种，OpResult和BlockArgument. 由于之前没有BlockArgument， 大家都是混用Value和OpResult， 现在有了BlockArguemnt, 需要区分Value和OpResult的使用。
在需要支持BlockArgument的地方，将原本的OpResult升级为Value，使其能够兼容BlockArgument的行为。

本pr内容：
- 移除pir::Value中的GetDefiningOp接口。
  -BlockArgument没有defining op，因此，本pr移除该接口。 对OpReusult而言，已存在功能等价的接口owner()。
- 在TypeId、Type、OpInfo中移除相应的哈希友元，新增向const void*的隐式类型转换。统一采用const void*进行哈希计算。
- 移除Type中无意义的const_cast使用。

参考pr:
- [规范化代码中对Value的使用[-1]](https://github.com/PaddlePaddle/Paddle/pull/57349)
- [规范化代码中对Value的使用[-2]](https://github.com/PaddlePaddle/Paddle/pull/55322)
- [规范化代码中对Value的使用[-3]](https://github.com/PaddlePaddle/Paddle/pull/57418)
- [规范化代码中对Value的使用[-4]](https://github.com/PaddlePaddle/Paddle/pull/57373)

### Other
Pcard-67164
