### PR TITLE
[Custom Device] change the dlopen flag of custom device dylibs

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -142,7 +142,7 @@ void LoadCustomDevice(const std::string &library_dir) {
   LOG(INFO) << "Try loading custom device libs from: [" << library_dir << "]";
   std::vector<std::string> libs = phi::ListAllLibraries(library_dir);
   for (const auto &lib_path : libs) {
-    auto dso_handle = dlopen(lib_path.c_str(), RTLD_NOW);
+    auto dso_handle = dlopen(lib_path.c_str(), RTLD_LAZY);
     PADDLE_ENFORCE_NOT_NULL(
         dso_handle,
         platform::errors::InvalidArgument(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修改Custom Device动态库的加载方式，由原来的RTLD_NOW改为RTLD_LAZY，这样做方便后续检查Custom Device相关软件栈版本的兼容性，可以在Custom Device自定义库中实现。

关联issue：https://github.com/PaddlePaddle/Paddle/issues/57162
