### PR TITLE
[PIR] fix ci error

### DIFF
--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -325,8 +325,11 @@ void BindValue(py::module *m) {
   value
       .def(
           "get_defining_op",
-          [](const Value &self) {
-            return self.dyn_cast<pir::OpResult>().owner();
+          [](const Value &self) -> pir::Operation * {
+            if (auto op_result = self.dyn_cast<pir::OpResult>()) {
+              return op_result.owner();
+            }
+            return nullptr;
           },
           return_value_policy::reference)
       .def("first_use", &Value::first_use, return_value_policy::reference)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
修复value.:get_defining_op() 替换为dyn_cast.owner（）后 value 为空的报错.

### Other
pcard-67164
