### PR TITLE
[SOT][3.11] fix eval frame for python 3.11

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -539,10 +539,12 @@ void BindEvalFrame(pybind11::module *m) {
         return obj;
       },
       py::arg("callback"));
+#if PY_VERSION_HEX >= 0x030b0000
   if (PyType_Ready(&Paddle_PyInterpreterFrameProxyType) < 0) {
     VLOG(7) << "Paddle_PyInterpreterFrameProxyType has not been ready!";
   }
   Py_INCREF(&Paddle_PyInterpreterFrameProxyType);
+#endif
 }
 
 }  // namespace pybind

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -70,7 +70,7 @@ typedef struct Paddle_PyInterpreterFrameProxy {
   static PyObject *Paddle_PyInterpreterFrameProxy_property_##name( \
       Paddle_PyInterpreterFrameProxy *self, void *closure) {       \
     Py_XINCREF(self->frame->name);                                 \
-    return reinterpret_cast<PyObject *> self->frame->name;         \
+    return reinterpret_cast<PyObject *>(self->frame->name);        \
   }
 
 #define REGISTER_PROXY_PROPERTY(name)                                       \

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -393,7 +393,7 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   // PyInterpreterFrame and causes a Segmentation Fault when Fallback to run
   // original frame. So we pass a PyInterpreterFrame to
   // _PyFrame_FastToLocalsWithError directly. But this is an internal API, so we
-  // copy lots of code from CPython project into our project.
+  // copy many code from CPython project into our project.
   if (Internal_PyFrame_FastToLocalsWithError(frame) < 0) {
 #else
   if (PyFrame_FastToLocalsWithError(frame) < 0) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

- [x] 目前 Eval Frame 会在几处根据 `PyInterpreterFrame` 创建 `PyFrameObject`，但是这样是有可能影响原来的 `PyInterpreterFrame` 的，这就导致在发生 Fallback 时，需要跑原来的 `PyInterpreterFrame`，而这个影响可能就会导致段错误，目前的 `test_tensor_dtype_in_guard` 单测就是因为这个原因，修改后已正常通过
- [x] 3.8-3.10 的 frame 就是 `PyFrameObject`，是一个 `PyObject`，因此可以直接传递给 Python 端，但 Python 3.11 不是这样的，而如果通过上面说的的方式从 `PyInterpreterFrame` 创建 `PyFrameObject` 则会产生影响，因此我们需要使用其他方式来创建一个 `PyObject` 传递给 Python 端 eval frame callback，这里创建了一个数据 Proxy 类 `PyInterpreterFrameProxy`，就是代理了其内部的 `PyInterpreterFrame`，用来间接访问 `f_code`、`f_globals`、`f_locals`、`f_builtins` 属性，我们目前只访问了这四个属性，因此不会有问题，相关参考如下：
   - https://docs.python.org/3/extending/newtypes_tutorial.html
   - https://docs.python.org/3/c-api/typeobj.html
- [x] `eval_custom_code` 中，我们会创建一个 shadow frame，在 3.8-3.10 我们会利用 `PyFrame_New` 创建 `PyFrameObject`，但这也是有问题的，这样创建的 `PyFrameObject` 会强行 complete，见 https://github.com/python/cpython/blob/17a335dd0291d09e1510157a4ebe02932ec632dd/Objects/frameobject.c#L1070 ，这会导致 `RESUME` 之前的，包括 `RESUME` 都不会跑到，其中包括了 `MAKE_CELL`，为了避免这一问题，我们需要寻找其他的创建新 Frame 的方法
- [x] 同样是 `eval_custom_code` 中，3.11 fastlocals 布局与之前版本是不一样的，通过 `co_localsplusnames` 可以获得 index -> name 的映射关系，因此利用 old 初始化 new 时候需要 `new[new_idx] = old[old_idx]`，即 `new[new_name_to_idx[old_idx_to_name[old_idx]]] = old[old_idx]`
- [x] 清理 `_custom_eval_frame` 中 callback 返回 `None` 的情况，我们现在永远只会返回 `CustomCode`

PCard-66972