### PR TITLE
[Paddle Inference]support collectshape in run([input1, input2....])

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1095,6 +1095,10 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
   }
 #endif
 
+  if (config_.shape_range_info_collected()) {
+    HookCollectShapeRangeInfo();
+  }
+
   // Run the inference program
   // if share variables, we need not create variables
   executor_->Run();
@@ -1158,6 +1162,10 @@ bool AnalysisPredictor::Run(const std::vector<paddle::Tensor> &inputs,
             << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
   }
 #endif
+
+  if (config_.shape_range_info_collected()) {
+    HookCollectShapeRangeInfo();
+  }
 
   // Run the inference program
   // if share variables, we need not create variables


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->


P-card-71501

支持在使用这种API的case下，支持收集shape
outputs = predictor.run([input_dict[name] for name in input_names])



