### PR TITLE
[Pir] delete support mutable attribute for pow

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -125,6 +125,14 @@ class CodeGen:
                 op_compat_item = op_compat_parser.get_compat(
                     op['forward']['name']
                 )
+
+            if (
+                op_compat_item is not None
+                and op_compat_item['op'] == "pow"
+                and 'scalar' in op_compat_item
+            ):
+                op_compat_item = op_compat_item.pop('scalar')
+
             op_info_items.append(OpInfoParser(op, op_compat_item))
         return op_info_items
 

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -847,7 +847,11 @@ def OpGenerator(
         ):
             op_compat_item = op_compat_parser.get_compat(op['forward']['name'])
 
-        if op_compat_item['op'] == "pow" and 'scalar' in op_compat_item:
+        if (
+            op_compat_item is not None
+            and op_compat_item['op'] == "pow"
+            and 'scalar' in op_compat_item
+        ):
             op_compat_item = op_compat_item.pop('scalar')
 
         op_info_items[op['name']] = OpInfoParser(op, op_compat_item)

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -846,6 +846,10 @@ def OpGenerator(
             and 'forward' in op
         ):
             op_compat_item = op_compat_parser.get_compat(op['forward']['name'])
+
+        if op_compat_item['op'] == "pow" and 'scalar' in op_compat_item:
+            op_compat_item = op_compat_item.pop('scalar')
+
         op_info_items[op['name']] = OpInfoParser(op, op_compat_item)
     # (3) CodeGen: Traverse op_info_items and generate
     ops_name_list = []  # all op class name store in this list

--- a/paddle/fluid/primitive/codegen/gen.py
+++ b/paddle/fluid/primitive/codegen/gen.py
@@ -288,7 +288,7 @@ def extend_compat_info(apis, compats):
                 backward_apis.append(apis_dict[backward_op_name])
         support_tensor_attrs_names = []
         compat_attrs_data_type = {}
-        if 'scalar' in compat_item:
+        if 'scalar' in compat_item and compat_item['op'] != "pow":
             for attr_name, attr_info in compat_item['scalar'].items():
                 if (
                     'support_tensor' in attr_info

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2151,10 +2151,6 @@
     out : Out
   attrs :
     y : factor
-  scalar :
-    y :
-      data_type : float
-      tensor_name : FactorTensor
 
 - op : prelu
   backward : prelu_grad

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2151,6 +2151,10 @@
     out : Out
   attrs :
     y : factor
+  scalar :
+    y :
+      data_type : float
+      tensor_name : FactorTensor
 
 - op : prelu
   backward : prelu_grad

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3587,33 +3587,7 @@ class TestPow_ZeroDim(TestPow):
         self.shape = []
 
 
-class TestPow_factor_tensor(TestActivation):
-    def setUp(self):
-        self.op_type = "pow"
-        self.python_api = paddle.pow
-        self.enable_cinn = False
-        self.init_dtype()
-
-        np.random.seed(1024)
-        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
-        out = np.power(x, 3)
-
-        self.inputs = {
-            'X': OpTest.np_dtype_to_base_dtype(x),
-            'FactorTensor': np.array([3.0]).astype(self.dtype),
-        }
-
-        self.attrs = {}
-        self.outputs = {'Out': out}
-
-    def test_check_output(self):
-        self.check_output()
-
-    def test_check_grad(self):
-        if self.dtype == np.float16:
-            return
-        self.check_grad(['X'], 'Out')
-
+class TestPow_API(TestActivation):
     def test_api(self):
         with paddle.base.framework._static_guard():
             input = np.random.uniform(1, 2, [11, 17]).astype("float32")
@@ -4525,7 +4499,7 @@ create_test_act_fp16_class(TestLog10)
 create_test_act_fp16_class(TestLog1p)
 create_test_act_fp16_class(TestSquare)
 create_test_act_fp16_class(TestPow, check_prim=True)
-create_test_act_fp16_class(TestPow_factor_tensor)
+create_test_act_fp16_class(TestPow_API)
 create_test_act_fp16_class(TestSTanh)
 create_test_act_fp16_class(TestSoftplus)
 create_test_act_fp16_class(TestSoftsign)
@@ -4656,7 +4630,7 @@ create_test_act_bf16_class(TestLog10)
 create_test_act_bf16_class(TestLog1p)
 create_test_act_bf16_class(TestSquare)
 create_test_act_bf16_class(TestPow, check_prim=True)
-create_test_act_bf16_class(TestPow_factor_tensor)
+create_test_act_bf16_class(TestPow_API)
 create_test_act_bf16_class(TestSTanh)
 create_test_act_bf16_class(TestSoftplus)
 create_test_act_bf16_class(TestSoftsign)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
删除 Pow 算子对可变 attribute 的支持，如果输入 y 是一个 tensor，将直接调用 elementwise_pow
Pcard-67164