### PR TITLE
remove reduce_all attribute for reduce_sum

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/reduce_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reduce_op.cc
@@ -42,6 +42,10 @@ class ReduceOpConverter : public OpConverter {
         PADDLE_GET_CONST(std::vector<int32_t>, op_desc.GetAttr("dim"));
     bool reduce_all = PADDLE_GET_CONST(bool, op_desc.GetAttr("reduce_all"));
 
+    if (dim.size() == 0) {
+      reduce_all = true;
+    }
+
     nvinfer1::IReduceLayer* layer = nullptr;
     if (reduce_all) {
       uint32_t reduce_dim = 0;

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3219,7 +3219,8 @@ DDim ReduceInferDim(const MetaTensor& x,
       break;
     }
   }
-  reduce_all = reduce_all || full_dim;
+  bool empty_dim = axis.size() == 0;
+  reduce_all = reduce_all || full_dim || empty_dim;
 
   std::vector<int64_t> out_dim_vector;
   for (int i = 0; i < x_rank; ++i) {

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1525,8 +1525,8 @@ def sum(x, axis=None, dtype=None, keepdim=False, name=None):
     if in_dynamic_or_pir_mode():
         return _C_ops.sum(x, axis, dtype, keepdim)
     else:
-        if axis is None:
-            axis = list(range(len(x.shape)))
+        reduce_all, axis = _get_reduce_axis_with_tensor(axis, x)
+
         attrs = {'dim': axis, 'keep_dim': keepdim}
 
         if dtype_flag:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1525,8 +1525,9 @@ def sum(x, axis=None, dtype=None, keepdim=False, name=None):
     if in_dynamic_or_pir_mode():
         return _C_ops.sum(x, axis, dtype, keepdim)
     else:
-        reduce_all, axis = _get_reduce_axis_with_tensor(axis, x)
-        attrs = {'dim': axis, 'keep_dim': keepdim, 'reduce_all': reduce_all}
+        if axis is None:
+            axis = list(range(len(x.shape)))
+        attrs = {'dim': axis, 'keep_dim': keepdim}
 
         if dtype_flag:
             attrs.update({'in_dtype': x.dtype, 'out_dtype': dtype})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
remove reduce_all attribute for reduce_sum

When axis is None, [] or full, reduce_all is True, and the logic is handled in reduce kernel, so it is no need to handle it in Python side.

Pcard-73145