### PR TITLE
[PIR] fix ci error.

### DIFF
--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -450,7 +450,12 @@ void BindOpResult(py::module *m) {
            })
       .def("__hash__",
            [](OpResult &self) { return std::hash<pir::Value>{}(self); })
-      .def("get_defining_op", &OpResult::owner, return_value_policy::reference)
+      .def(
+          "get_defining_op",
+          [](const OpResult &self) -> pir::Operation * {
+            return self ? self.owner() : nullptr;
+          },
+          return_value_policy::reference)
       .def_property_readonly(
           "block",
           [](OpResult &self) { return self.owner()->GetParent(); },


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
修复OpResult.:get_defining_op() 替换为owner（）后 ,  impl为空的报错.

### Other
pcard-67164