### PR TITLE
【CINN】Move ir_verify from namespace optim to ir_utils

### DIFF
--- a/paddle/cinn/backends/codegen_c.cc
+++ b/paddle/cinn/backends/codegen_c.cc
@@ -38,7 +38,7 @@ using cinn::common::float16;
 const char *kCKeywordRestrict = "__restrict__";
 
 void CodeGenC::Compile(const ir::Module &module, const Outputs &outputs) {
-  ir::IrVerify(Expr(module));
+  ir::ir_utils::IrVerify(Expr(module));
 
   if (!outputs.c_header_name.empty()) {
     auto source = Compile(module, OutputKind::CHeader);

--- a/paddle/cinn/backends/codegen_cuda_dev.cc
+++ b/paddle/cinn/backends/codegen_cuda_dev.cc
@@ -56,7 +56,7 @@ std::string CodeGenCUDA_Dev::Compile(const ir::Module &module, bool for_nvrtc) {
 
 void CodeGenCUDA_Dev::Compile(const ir::Module &module,
                               const Outputs &outputs) {
-  ir::IrVerify(Expr(module));
+  ir::ir_utils::IrVerify(Expr(module));
 
   CodeGenC::inline_builtin_codes_ = false;
   if (!outputs.c_header_name.empty()) {

--- a/paddle/cinn/backends/llvm/codegen_llvm.cc
+++ b/paddle/cinn/backends/llvm/codegen_llvm.cc
@@ -790,7 +790,7 @@ llvm::Value *CodeGenLLVM::Visit(const ir::Call *op) {
 llvm::Value *CodeGenLLVM::Visit(const ir::_Module_ *op) {
   {
     Expr body_to_verify(&Reference(op));
-    ir::IrVerify(body_to_verify);
+    ir::ir_utils::IrVerify(body_to_verify);
   }
 
   for (auto &fn : op->functions) {

--- a/paddle/cinn/ir/test/ir_verify_test.cc
+++ b/paddle/cinn/ir/test/ir_verify_test.cc
@@ -18,12 +18,14 @@
 
 #include "paddle/cinn/ir/op/ir_operators.h"
 
-namespace cinn::ir {
-
+namespace cinn {
+namespace ir {
+namespace ir_utils {
 TEST(IrVerify, basic) {
   Expr a(1);
   Expr b(1);
   IrVerify(a + b);
 }
-
-}  // namespace cinn::ir
+}  // namespace ir_utils
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/ir/utils/ir_verify.cc
+++ b/paddle/cinn/ir/utils/ir_verify.cc
@@ -17,7 +17,10 @@
 #include "paddle/cinn/ir/utils/ir_mutator.h"
 #include "paddle/cinn/ir/utils/ir_printer.h"
 
-namespace cinn::ir {
+namespace cinn {
+namespace ir {
+namespace ir_utils {
+namespace {
 
 struct IrVerifyVisitor : public ir::IRMutator<> {
   using ir::IRMutator<>::Visit;
@@ -30,10 +33,11 @@ struct IrVerifyVisitor : public ir::IRMutator<> {
   NODETY_FORALL(__)
 #undef __
 };
-
+}  // namespace
 void IrVerify(Expr e) {
   IrVerifyVisitor visitor;
   visitor.Visit(&e, &e);
 }
-
-}  // namespace cinn::ir
+}  // namespace ir_utils
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/ir/utils/ir_verify.h
+++ b/paddle/cinn/ir/utils/ir_verify.h
@@ -15,8 +15,11 @@
 #pragma once
 #include "paddle/cinn/ir/ir.h"
 
-namespace cinn::ir {
+namespace cinn {
+namespace ir {
+namespace ir_utils {
 
 void IrVerify(Expr e);
-
-}  // namespace cinn::ir
+}  // namespace ir_utils
+}  // namespace ir
+}  // namespace cinn


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR move ir_verify from namespace optim to ir_utils