### PR TITLE
[PIR]Open more dropout pir uts

### DIFF
--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -1295,7 +1295,7 @@ class OpTest(unittest.TestCase):
             return True
         for _, value in self.outputs.items():
             if not isinstance(value, (tuple, list)):
-                return False
+                continue
             for var_name, _ in value:
                 if sig_name == var_name:
                     return True

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -1340,8 +1340,11 @@ class OpTest(unittest.TestCase):
 
                 if len(fetch_list) == 0:
                     if isinstance(ret_tuple, (tuple, list)):
-                        for var in ret_tuple:
+                        assert len(ret_tuple) == len(outputs_sig)
+                        for var, output_name in zip(ret_tuple, outputs_sig):
                             if no_check_set is not None and var in no_check_set:
+                                continue
+                            if output_name not in self.outputs.keys():
                                 continue
                             if isinstance(var, list):
                                 for v in var:
@@ -1363,6 +1366,9 @@ class OpTest(unittest.TestCase):
                     ir_program, feed=feed, fetch_list=[fetch_list]
                 )
 
+                outputs_sig = [
+                    name for name in outputs_sig if name in self.outputs.keys()
+                ]
                 result = construct_output_dict_by_kernel_sig(outs, outputs_sig)
                 if hasattr(self, "python_out_sig_sub_name"):
                     for key in self.python_out_sig_sub_name.keys():

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -2393,14 +2393,10 @@ class OpTest(unittest.TestCase):
                         f"Found failed {new_ir_outs.keys()} {target_name}",
                     )
 
-            def find_imperative_expect(target_name, new_ir_outs, place):
+            def find_imperative_expect(self, target_name, new_ir_outs, place):
                 for name in new_ir_outs:
                     if name == target_name:
                         return new_ir_outs[name][0]
-                    var_list = new_ir_outs[name]
-                    for i, var in enumerate(var_list):
-                        if var.name == target_name:
-                            return new_ir_outs[name][i]
                 self.assertTrue(
                     False,
                     f"Found failed {new_ir_outs.keys()} {target_name}",
@@ -2420,7 +2416,7 @@ class OpTest(unittest.TestCase):
                 with paddle.ir.core.program_guard(
                     paddle.ir.core.default_main_program()
                 ):
-                    expect = find_imperative_expect(
+                    expect = self.find_imperative_expect(
                         target_name, self.ref_outputs, place
                     )
                     expect_t = np.array(expect)

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -191,7 +191,7 @@ class TestDropoutOp4(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=True)
+        self.check_output(check_prim=True, check_new_ir=False)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
@@ -208,7 +208,7 @@ class TestDropoutOp5(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=True)
+        self.check_output(check_prim=True, check_new_ir=False)
 
 
 class TestDropoutOp6(TestDropoutOp):
@@ -270,7 +270,7 @@ class TestDropoutOp8(OpTest):
         self.outputs = {'Out': self.inputs['X']}
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=True)
+        self.check_output(check_prim=True, check_new_ir=False)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
@@ -289,7 +289,7 @@ class TestDropoutOp9(OpTest):
         self.outputs = {'Out': self.inputs['X']}
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=True)
+        self.check_output(check_prim=True, check_new_ir=False)
 
 
 class TestDropoutOpWithSeed(OpTest):

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -191,7 +191,7 @@ class TestDropoutOp4(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=False)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
@@ -208,7 +208,7 @@ class TestDropoutOp5(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=False)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 class TestDropoutOp6(TestDropoutOp):
@@ -270,7 +270,7 @@ class TestDropoutOp8(OpTest):
         self.outputs = {'Out': self.inputs['X']}
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=False)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
@@ -289,7 +289,7 @@ class TestDropoutOp9(OpTest):
         self.outputs = {'Out': self.inputs['X']}
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=False)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 class TestDropoutOpWithSeed(OpTest):

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -124,11 +124,11 @@ class TestDropoutOpInput1d(OpTest):
         self.enable_check_static_comp = False
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
     def test_check_grad_normal(self):
         # Now in dy2st mode x_grad = [], so set check_prim=False
-        self.check_grad(['X'], 'Out', check_prim=False)
+        self.check_grad(['X'], 'Out', check_prim=False, check_new_ir=True)
 
 
 class TestDropoutOp2(TestDropoutOp):
@@ -191,7 +191,7 @@ class TestDropoutOp4(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
@@ -208,7 +208,7 @@ class TestDropoutOp5(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 class TestDropoutOp6(TestDropoutOp):
@@ -270,7 +270,7 @@ class TestDropoutOp8(OpTest):
         self.outputs = {'Out': self.inputs['X']}
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
@@ -289,7 +289,7 @@ class TestDropoutOp9(OpTest):
         self.outputs = {'Out': self.inputs['X']}
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
 
 class TestDropoutOpWithSeed(OpTest):
@@ -315,11 +315,17 @@ class TestDropoutOpWithSeed(OpTest):
         self.enable_check_static_comp = False
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
     def test_check_grad_normal(self):
         # Now in dy2st mode x_grad = [], so set check_prim=False
-        self.check_grad(['X'], 'Out', max_relative_error=0.05, check_prim=False)
+        self.check_grad(
+            ['X'],
+            'Out',
+            max_relative_error=0.05,
+            check_prim=False,
+            check_new_ir=True,
+        )
 
 
 @unittest.skipIf(
@@ -352,11 +358,11 @@ class TestFP16DropoutOp(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(
-            core.CUDAPlace(0), atol=1e-3, check_prim=True
+            core.CUDAPlace(0), atol=1e-3, check_prim=True, check_new_ir=True
         )
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_new_ir=True)
 
 
 @unittest.skipIf(
@@ -391,10 +397,10 @@ class TestBF16DropoutOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_new_ir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
+        self.check_grad(['X'], 'Out', check_prim=True, check_new_ir=True)
 
 
 class TestDropoutOpWithSeedOnCPUPlace(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Open more dropout pir uts
这里遇到了两个比较特殊的case：
- 一个是test_dropout_op.py中的TestDropoutOp4，这里的warpper会返回两个只Out和Mask，但是当is_test=True时，Mask是一个为初始化的Var，新IR下就不应该将Mask fetch出来，否则会报错
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/7f612054-dec4-4948-82dc-d32552c2f934)
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/dd730ae1-38eb-451a-8c69-a6685b74a8e4)

- 另一个是test_split_op.py中的TestSplitOp，这里的self.python_out_sig和self.outputs形式比较特殊需要处理
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/891b1cad-919f-4ab9-b563-7067818d83ad)


Pcard-67164