### PR TITLE
remove all content in paddle.base __all__ list

### DIFF
--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -128,40 +128,7 @@ Tensor = LoDTensor
 enable_imperative = enable_dygraph
 disable_imperative = disable_dygraph
 
-__all__ = (
-    framework.__all__
-    + executor.__all__
-    + trainer_desc.__all__
-    + lod_tensor.__all__
-    + data_feed_desc.__all__
-    + compiler.__all__
-    + backward.__all__
-    + [
-        'io',
-        'initializer',
-        'layers',
-        'dygraph',
-        'enable_dygraph',
-        'disable_dygraph',
-        'enable_imperative',
-        'disable_imperative',
-        'backward',
-        'LoDTensor',
-        'LoDTensorArray',
-        'CPUPlace',
-        'XPUPlace',
-        'CUDAPlace',
-        'CUDAPinnedPlace',
-        'IPUPlace',
-        'Tensor',
-        'ParamAttr',
-        'WeightNormParamAttr',
-        'DataFeeder',
-        'unique_name',
-        'Scope',
-        '_cuda_synchronize',
-    ]
-)
+__all__ = []
 
 
 def __bootstrap__():

--- a/python/paddle/base/backward.py
+++ b/python/paddle/base/backward.py
@@ -27,10 +27,7 @@ from . import core, log_helper, unique_name
 from .data_feeder import check_type
 from .proto import framework_pb2
 
-__all__ = [
-    'append_backward',
-    'gradients',
-]
+__all__ = []
 
 _logger = log_helper.get_logger(
     __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s'

--- a/python/paddle/base/compiler.py
+++ b/python/paddle/base/compiler.py
@@ -18,13 +18,7 @@ import warnings
 from . import core, framework
 from .framework import cpu_places, cuda_places, xpu_places
 
-__all__ = [
-    'CompiledProgram',
-    'ExecutionStrategy',
-    'BuildStrategy',
-    'IpuCompiledProgram',
-    'IpuStrategy',
-]
+__all__ = []
 
 ExecutionStrategy = core.ParallelExecutor.ExecutionStrategy
 BuildStrategy = core.ParallelExecutor.BuildStrategy

--- a/python/paddle/base/data_feed_desc.py
+++ b/python/paddle/base/data_feed_desc.py
@@ -16,7 +16,7 @@ from google.protobuf import text_format
 
 from paddle.base.proto import data_feed_pb2
 
-__all__ = ['DataFeedDesc']
+__all__ = []
 
 
 class DataFeedDesc:

--- a/python/paddle/base/data_feeder.py
+++ b/python/paddle/base/data_feeder.py
@@ -28,7 +28,7 @@ from .framework import (
     in_pir_mode,
 )
 
-__all__ = ['DataFeeder']
+__all__ = []
 
 _PADDLE_DTYPE_2_NUMPY_DTYPE = {
     core.VarDesc.VarType.BOOL: 'bool',

--- a/python/paddle/base/dataset.py
+++ b/python/paddle/base/dataset.py
@@ -20,7 +20,7 @@ from paddle.base.proto import data_feed_pb2
 from ..utils import deprecated
 from . import core
 
-__all__ = ['DatasetFactory', 'InMemoryDataset', 'QueueDataset']
+__all__ = []
 
 
 class DatasetFactory:

--- a/python/paddle/base/default_scope_funcs.py
+++ b/python/paddle/base/default_scope_funcs.py
@@ -32,14 +32,7 @@ import paddle.base.core
 
 __tl_scope__ = threading.local()
 
-__all__ = [
-    'get_cur_scope',
-    'enter_local_scope',
-    'leave_local_scope',
-    'var',
-    'find_var',
-    'scoped_function',
-]
+__all__ = []
 
 
 def get_cur_scope():

--- a/python/paddle/base/device_worker.py
+++ b/python/paddle/base/device_worker.py
@@ -14,14 +14,7 @@
 """Definition of device workers."""
 import sys
 
-__all__ = [
-    'DeviceWorker',
-    'Hogwild',
-    'DownpourSGD',
-    'Section',
-    'DownpourSGDOPT',
-    'HeterSection',
-]
+__all__ = []
 
 
 class DeviceWorker:

--- a/python/paddle/base/dygraph/__init__.py
+++ b/python/paddle/base/dygraph/__init__.py
@@ -29,4 +29,3 @@ from .tracer import Tracer
 
 
 __all__ = []
-__all__ += base.__all__

--- a/python/paddle/base/dygraph/base.py
+++ b/python/paddle/base/dygraph/base.py
@@ -28,16 +28,7 @@ from ..framework import _get_paddle_place
 from ..wrapped_decorator import signature_safe_contextmanager, wrap_decorator
 from .tracer import Tracer
 
-__all__ = [
-    'no_grad',
-    'no_grad_',
-    'grad',
-    'guard',
-    'enable_dygraph',
-    'disable_dygraph',
-    'enabled',
-    'to_variable',
-]
+__all__ = []
 
 NON_PERSISTABLE_VAR_NAME_SUFFIX = "__non_persistable"
 

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -38,7 +38,7 @@ from .incubate.checkpoint import auto_checkpoint as acp
 from .trainer_factory import FetchHandlerMonitor, TrainerFactory
 from .wrapped_decorator import signature_safe_contextmanager
 
-__all__ = ['Executor', 'global_scope', 'scope_guard']
+__all__ = []
 
 g_scope = core.Scope()
 InferNativeConfig = core.NativeConfig

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -40,32 +40,7 @@ import functools
 from .variable_index import _getitem_static, _setitem_static, _setitem_impl_
 import threading
 
-__all__ = [
-    'Program',
-    'default_startup_program',
-    'default_main_program',
-    'program_guard',
-    'name_scope',
-    'ipu_shard_guard',
-    'set_ipu_shard',
-    'cuda_places',
-    'cpu_places',
-    'xpu_places',
-    'cuda_pinned_places',
-    'in_dygraph_mode',
-    'in_pir_mode',
-    'in_dynamic_or_pir_mode',
-    'is_compiled_with_cinn',
-    'is_compiled_with_cuda',
-    'is_compiled_with_rocm',
-    'is_compiled_with_xpu',
-    'Variable',
-    'require_version',
-    'device_guard',
-    'set_flags',
-    'get_flags',
-    '_stride_in_no_check_dy2st_diff',
-]
+__all__ = []
 
 EMPTY_VAR_NAME = core.kEmptyVarName()
 TEMP_VAR_NAME = core.kTempVarName()

--- a/python/paddle/base/initializer.py
+++ b/python/paddle/base/initializer.py
@@ -16,7 +16,7 @@ import paddle
 
 from .data_feeder import check_type
 
-__all__ = ['set_global_initializer']
+__all__ = []
 
 _global_weight_initializer_ = None
 _global_bias_initializer_ = None

--- a/python/paddle/base/io.py
+++ b/python/paddle/base/io.py
@@ -16,13 +16,10 @@ import logging
 
 from paddle.base.log_helper import get_logger
 
-from . import reader
-from .reader import (  # noqa: F401
-    PyReader,
-    DataLoader,
-)
+from . import reader  # noqa: F401
+from .reader import DataLoader, PyReader  # noqa: F401
 
-__all__ = reader.__all__
+__all__ = []
 
 
 _logger = get_logger(

--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -30,7 +30,7 @@ from .framework import (
 from .initializer import _global_bias_initializer, _global_weight_initializer
 from .param_attr import ParamAttr, WeightNormParamAttr
 
-__all__ = ['LayerHelperBase']
+__all__ = []
 
 
 class LayerHelperBase:

--- a/python/paddle/base/layers/__init__.py
+++ b/python/paddle/base/layers/__init__.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import io
+from . import io  # noqa: F401
 from . import math_op_patch
 
 
 __all__ = []
-__all__ += io.__all__

--- a/python/paddle/base/layers/layer_function_generator.py
+++ b/python/paddle/base/layers/layer_function_generator.py
@@ -30,13 +30,7 @@ from ..framework import (
 from ..layer_helper import LayerHelper
 from ..proto import framework_pb2
 
-__all__ = [
-    'generate_layer_fn',
-    'generate_activation_fn',
-    'generate_inplace_fn',
-    'autodoc',
-    'templatedoc',
-]
+__all__ = []
 
 
 def _convert_(name):

--- a/python/paddle/base/lod_tensor.py
+++ b/python/paddle/base/lod_tensor.py
@@ -17,7 +17,7 @@ import numpy as np
 from . import core
 from .data_feeder import DataToLoDTensorConverter
 
-__all__ = ['create_lod_tensor', 'create_random_int_lodtensor']
+__all__ = []
 
 
 def create_lod_tensor(data, recursive_seq_lens, place):

--- a/python/paddle/base/log_helper.py
+++ b/python/paddle/base/log_helper.py
@@ -14,7 +14,7 @@
 
 import logging
 
-__all__ = ['get_logger']
+__all__ = []
 
 
 def get_logger(name, level, fmt=None):

--- a/python/paddle/base/param_attr.py
+++ b/python/paddle/base/param_attr.py
@@ -16,10 +16,7 @@ import paddle
 from paddle.base.data_feeder import check_type
 from paddle.regularizer import WeightDecayRegularizer
 
-__all__ = [
-    'ParamAttr',
-    'WeightNormParamAttr',
-]
+__all__ = []
 
 
 class ParamAttr:

--- a/python/paddle/base/reader.py
+++ b/python/paddle/base/reader.py
@@ -54,7 +54,7 @@ from .unique_name import UniqueNameGenerator
 # NOTE: [ avoid hanging & failed quickly ] These value is used in getting data from another process
 QUEUE_GET_TIMEOUT = 60
 
-__all__ = ['PyReader', 'DataLoader']
+__all__ = []
 
 data_loader_unique_name_generator = UniqueNameGenerator()
 

--- a/python/paddle/base/trainer_desc.py
+++ b/python/paddle/base/trainer_desc.py
@@ -16,14 +16,7 @@
 import os
 import sys
 
-__all__ = [
-    'TrainerDesc',
-    'MultiTrainer',
-    'DistMultiTrainer',
-    'PipelineTrainer',
-    'HeterXpuTrainer',
-    'HeterPipelineTrainer',
-]
+__all__ = []
 
 
 class TrainerDesc:

--- a/python/paddle/base/trainer_factory.py
+++ b/python/paddle/base/trainer_factory.py
@@ -43,7 +43,7 @@ from .trainer_desc import (  # noqa: F401
     PSGPUTrainer,
 )
 
-__all__ = ["TrainerFactory", "FetchHandlerMonitor"]
+__all__ = []
 
 
 class TrainerFactory:

--- a/python/paddle/base/unique_name.py
+++ b/python/paddle/base/unique_name.py
@@ -16,7 +16,7 @@ import collections
 
 from .wrapped_decorator import signature_safe_contextmanager
 
-__all__ = ['generate', 'switch', 'guard']
+__all__ = []
 
 
 class UniqueNameGenerator:

--- a/python/paddle/base/wrapped_decorator.py
+++ b/python/paddle/base/wrapped_decorator.py
@@ -16,7 +16,7 @@ import contextlib
 
 import decorator
 
-__all__ = ['wrap_decorator', 'signature_safe_contextmanager']
+__all__ = []
 
 
 def wrap_decorator(decorator_func):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67005

当前的base目录已经作为一个paddle的基础目录存在，因此其`__all__`也和其他目录一样，具备公开API的语义。 由于这部分底层函数实际上并不需要公开，`__all__`列表遗留的内容会导致错误的公开API及文档展示内容，因此需要移除。