### PR TITLE
fix parse ArrayAttribute and parse f16 type

### DIFF
--- a/paddle/pir/core/ir_printer.cc
+++ b/paddle/pir/core/ir_printer.cc
@@ -114,8 +114,7 @@ void BasicIrPrinter::PrintAttribute(Attribute attr) {
     os << "(Pointer)" << p.data();
   } else if (auto arr = attr.dyn_cast<ArrayAttribute>()) {
     const auto& vec = arr.AsVector();
-    os << "(Array)"
-       << "[";
+    os << "[";
     PrintInterleave(
         vec.begin(),
         vec.end(),

--- a/test/cpp/pir/core/TestParserText.txt
+++ b/test/cpp/pir/core/TestParserText.txt
@@ -1,6 +1,6 @@
 
 //CHECK attribute
-(Array)["  File \"train.py\", line 225, in <module>",
+["  File \"train.py\", line 225, in <module>",
 "    main(args)",
 "  File \"train.py\", line 197, in main",
 "    lr_scheduler, args.profiler_options)",
@@ -33,13 +33,13 @@ pd_op.tensor<256xf32>
 //CHECK program
 {
  (%0) = "builtin.get_parameter" () {parameter_name:"conv2d_0.w_0"} : () -> pd_op.tensor<64x3x7x7xf32>
- (%1) = "pd_op.feed" () {col:(Int32)0,is_persisable:(Array)[false],name:"data",stop_gradient:(Array)[true]} : () -> pd_op.tensor<-1x3x224x224xf32>
- (%2) = "pd_op.conv2d" (%1, %0) {data_format:"NCHW",dilations:(Array)[(Int32)1,(Int32)1],groups:(Int32)1,is_persisable:(Array)[false],padding_algorithm:"EXPLICIT",paddings:(Array)[(Int32)3,(Int32)3],stop_gradient:(Array)[false],strides:(Array)[(Int32)2,(Int32)2]} : (pd_op.tensor<-1x3x224x224xf32>, pd_op.tensor<64x3x7x7xf32>) -> pd_op.tensor<-1x64x112x112xf32>
+ (%1) = "pd_op.feed" () {col:(Int32)0,is_persisable:[false],name:"data",stop_gradient:[true]} : () -> pd_op.tensor<-1x3x224x224xf32>
+ (%2) = "pd_op.conv2d" (%1, %0) {data_format:"NCHW",dilations:[(Int32)1,(Int32)1],groups:(Int32)1,is_persisable:[false],padding_algorithm:"EXPLICIT",paddings:[(Int32)3,(Int32)3],stop_gradient:[false],strides:[(Int32)2,(Int32)2]} : (pd_op.tensor<-1x3x224x224xf32>, pd_op.tensor<64x3x7x7xf32>) -> pd_op.tensor<-1x64x112x112xf32>
 }
 //END
 
 //CHECK attribute
-(Array)[(pd_op.DataType)bool,(pd_op.DataType)float32,(pd_op.DataType)float64,
+[(pd_op.DataType)bool,(pd_op.DataType)float32,(pd_op.DataType)float64,
 (pd_op.DataType)complex64,(pd_op.DataType)complex128,(pd_op.DataType)Undefined,
 (pd_op.DataType)Undefined,(pd_op.DataType)Undefined,(pd_op.DataType)Undefined,
 (pd_op.DataType)bfloat16,(pd_op.DataType)uint8,(pd_op.DataType)uint32,(pd_op.DataType)int8,
@@ -47,18 +47,18 @@ pd_op.tensor<256xf32>
 //END
 
 //CHECK attribute
-(Array)[(pd_op.Place)Place(gpu:0),(pd_op.Place)Place(gpu_pinned),(pd_op.Place)Place(gpu_pinned),
+[(pd_op.Place)Place(gpu:0),(pd_op.Place)Place(gpu_pinned),(pd_op.Place)Place(gpu_pinned),
 (pd_op.Place)Place(xpu:0),(pd_op.Place)Place(ipu:0),(pd_op.Place)Place(:0),(pd_op.Place)Place(cpu)]
 //END
 
 //CHECK attribute
-(Array)[(pd_op.DataLayout)NHWC,(pd_op.DataLayout)STRIDED,(pd_op.DataLayout)NCHW,(pd_op.DataLayout)Undefined(AnyLayout),
+[(pd_op.DataLayout)NHWC,(pd_op.DataLayout)STRIDED,(pd_op.DataLayout)NCHW,(pd_op.DataLayout)Undefined(AnyLayout),
 (pd_op.DataLayout)ONEDNN,(pd_op.DataLayout)SPARSE_COO,(pd_op.DataLayout)SPARSE_CSR,(pd_op.DataLayout)NDHWC,(pd_op.DataLayout)NCDHW,
 (pd_op.DataLayout)PSTRING_UNION]
 //END
 
 //CHECK attribute
-(Array)[(Double)1,(Int64)0,"1"]
+[(Double)1,(Int64)0,"1"]
 //END
 
 //CHECK type
@@ -66,5 +66,13 @@ vec[bf16,f64,b,i8,u8,i16,c64,c128]
 //END
 
 //CHECK attribute
-(Array)["\"","\\"","\\\"","\t\n\r",""]
+["\"","\\"","\\\"","\t\n\r",""]
+//END
+
+//CHECK type
+f16
+//END
+
+//CHECK attribute
+[]
 //END


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
将ArrayAttribute的print形式 （Array)[Attribute,Attribute,...,]修改为[Attribute,Attribute,...,]，修复parse f16为bf16的bug。`test/cpp/pir/core/TestParserText.txt`中有例子。