### PR TITLE
remove_diag_embed_to_creation

### DIFF
--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -777,35 +777,42 @@ class SimpleRNNCell(RNNCellBase):
                 )
             )
         std = 1.0 / math.sqrt(hidden_size)
-        if weight_ih_attr is False:
+        if weight_ih_attr is not False:
+            self.weight_ih = self.create_parameter(
+                (hidden_size, input_size),
+                weight_ih_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+        else:
             self.weight_ih = self.create_parameter(
                 (hidden_size, input_size),
                 None,
                 default_initializer=I.Constant(1.0),
             )
             self.weight_ih.stop_gradient = True
-        else:
-            self.weight_ih = self.create_parameter(
-                (hidden_size, input_size),
-                weight_ih_attr,
+
+        if weight_hh_attr is not False:
+            self.weight_hh = self.create_parameter(
+                (hidden_size, hidden_size),
+                weight_hh_attr,
                 default_initializer=I.Uniform(-std, std),
             )
-
-        if weight_hh_attr is False:
+        else:
             self.weight_hh = self.create_parameter(
                 (hidden_size, hidden_size),
                 None,
                 default_initializer=I.Constant(1.0),
             )
             self.weight_hh.stop_gradient = True
-        else:
-            self.weight_hh = self.create_parameter(
-                (hidden_size, hidden_size),
-                weight_hh_attr,
+
+        if bias_ih_attr is not False:
+            self.bias_ih = self.create_parameter(
+                (hidden_size,),
+                bias_ih_attr,
+                is_bias=True,
                 default_initializer=I.Uniform(-std, std),
             )
-
-        if bias_ih_attr is False:
+        else:
             self.bias_ih = self.create_parameter(
                 (hidden_size,),
                 None,
@@ -813,15 +820,15 @@ class SimpleRNNCell(RNNCellBase):
                 default_initializer=I.Constant(0.0),
             )
             self.bias_ih.stop_gradient = True
-        else:
-            self.bias_ih = self.create_parameter(
+
+        if bias_hh_attr is not False:
+            self.bias_hh = self.create_parameter(
                 (hidden_size,),
-                bias_ih_attr,
+                bias_hh_attr,
                 is_bias=True,
                 default_initializer=I.Uniform(-std, std),
             )
-
-        if bias_hh_attr is False:
+        else:
             self.bias_hh = self.create_parameter(
                 (hidden_size,),
                 None,
@@ -829,13 +836,6 @@ class SimpleRNNCell(RNNCellBase):
                 default_initializer=I.Constant(0.0),
             )
             self.bias_hh.stop_gradient = True
-        else:
-            self.bias_hh = self.create_parameter(
-                (hidden_size,),
-                bias_hh_attr,
-                is_bias=True,
-                default_initializer=I.Uniform(-std, std),
-            )
 
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -972,34 +972,40 @@ class LSTMCell(RNNCellBase):
                 )
             )
         std = 1.0 / math.sqrt(hidden_size)
-        if weight_ih_attr is False:
+        if weight_ih_attr is not False:
+            self.weight_ih = self.create_parameter(
+                (4 * hidden_size, input_size),
+                weight_ih_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+        else:
             self.weight_ih = self.create_parameter(
                 (4 * hidden_size, input_size),
                 None,
                 default_initializer=I.Constant(1.0),
             )
             self.weight_ih.stop_gradient = True
-        else:
-            self.weight_ih = self.create_parameter(
-                (4 * hidden_size, input_size),
-                weight_ih_attr,
+        if weight_hh_attr is not False:
+            self.weight_hh = self.create_parameter(
+                (4 * hidden_size, hidden_size),
+                weight_hh_attr,
                 default_initializer=I.Uniform(-std, std),
             )
-        if weight_hh_attr is False:
+        else:
             self.weight_hh = self.create_parameter(
                 (4 * hidden_size, hidden_size),
                 None,
                 default_initializer=I.Constant(1.0),
             )
             self.weight_hh.stop_gradient = True
-        else:
-            self.weight_hh = self.create_parameter(
-                (4 * hidden_size, hidden_size),
-                weight_hh_attr,
-                default_initializer=I.Uniform(-std, std),
+        if bias_ih_attr is not False:
+            self.bias_ih = self.create_parameter(
+                (4 * hidden_size,),
+                bias_ih_attr,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
             )
-
-        if bias_ih_attr is False:
+        else:
             self.bias_ih = self.create_parameter(
                 (4 * hidden_size,),
                 None,
@@ -1007,15 +1013,14 @@ class LSTMCell(RNNCellBase):
                 default_initializer=I.Uniform(-std, std),
             )
             self.bias_ih.stop_gradient = True
-        else:
-            self.bias_ih = self.create_parameter(
+        if bias_hh_attr is not False:
+            self.bias_hh = self.create_parameter(
                 (4 * hidden_size,),
-                bias_ih_attr,
+                bias_hh_attr,
                 is_bias=True,
                 default_initializer=I.Constant(0.0),
             )
-
-        if bias_hh_attr is False:
+        else:
             self.bias_hh = self.create_parameter(
                 (4 * hidden_size,),
                 None,
@@ -1023,13 +1028,6 @@ class LSTMCell(RNNCellBase):
                 default_initializer=I.Uniform(-std, std),
             )
             self.bias_hh.stop_gradient = True
-        else:
-            self.bias_hh = self.create_parameter(
-                (4 * hidden_size,),
-                bias_hh_attr,
-                is_bias=True,
-                default_initializer=I.Constant(0.0),
-            )
 
         self.hidden_size = hidden_size
         self.input_size = input_size
@@ -1167,34 +1165,41 @@ class GRUCell(RNNCellBase):
                 )
             )
         std = 1.0 / math.sqrt(hidden_size)
-        if weight_ih_attr is False:
+        if weight_ih_attr is not False:
+            self.weight_ih = self.create_parameter(
+                (3 * hidden_size, input_size),
+                weight_ih_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+        else:
             self.weight_ih = self.create_parameter(
                 (3 * hidden_size, input_size),
                 None,
                 default_initializer=I.Constant(1.0),
             )
             self.weight_ih.stop_gradient = True
-        else:
-            self.weight_ih = self.create_parameter(
-                (3 * hidden_size, input_size),
-                weight_ih_attr,
+        if weight_hh_attr is not False:
+            self.weight_hh = self.create_parameter(
+                (3 * hidden_size, hidden_size),
+                weight_hh_attr,
                 default_initializer=I.Uniform(-std, std),
             )
-        if weight_hh_attr is False:
+        else:
             self.weight_hh = self.create_parameter(
                 (3 * hidden_size, hidden_size),
                 None,
                 default_initializer=I.Constant(1.0),
             )
             self.weight_hh.stop_gradient = True
-        else:
-            self.weight_hh = self.create_parameter(
-                (3 * hidden_size, hidden_size),
-                weight_hh_attr,
-                default_initializer=I.Uniform(-std, std),
-            )
 
-        if bias_ih_attr is False:
+        if bias_ih_attr is not False:
+            self.bias_ih = self.create_parameter(
+                (3 * hidden_size,),
+                bias_ih_attr,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
+        else:
             self.bias_ih = self.create_parameter(
                 (3 * hidden_size,),
                 None,
@@ -1202,15 +1207,15 @@ class GRUCell(RNNCellBase):
                 default_initializer=I.Uniform(-std, std),
             )
             self.bias_ih.stop_gradient = True
-        else:
-            self.bias_ih = self.create_parameter(
+
+        if bias_hh_attr is not False:
+            self.bias_hh = self.create_parameter(
                 (3 * hidden_size,),
-                bias_ih_attr,
+                bias_hh_attr,
                 is_bias=True,
                 default_initializer=I.Constant(0.0),
             )
-
-        if bias_hh_attr is False:
+        else:
             self.bias_hh = self.create_parameter(
                 (3 * hidden_size,),
                 None,
@@ -1218,13 +1223,6 @@ class GRUCell(RNNCellBase):
                 default_initializer=I.Uniform(-std, std),
             )
             self.bias_hh.stop_gradient = True
-        else:
-            self.bias_hh = self.create_parameter(
-                (3 * hidden_size,),
-                bias_hh_attr,
-                is_bias=True,
-                default_initializer=I.Constant(0.0),
-            )
 
         self.hidden_size = hidden_size
         self.input_size = input_size

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -1003,14 +1003,14 @@ class LSTMCell(RNNCellBase):
                 (4 * hidden_size,),
                 bias_ih_attr,
                 is_bias=True,
-                default_initializer=I.Constant(0.0),
+                default_initializer=I.Uniform(-std, std),
             )
         else:
             self.bias_ih = self.create_parameter(
                 (4 * hidden_size,),
                 None,
                 is_bias=True,
-                default_initializer=I.Uniform(-std, std),
+                default_initializer=I.Constant(0.0),
             )
             self.bias_ih.stop_gradient = True
         if bias_hh_attr is not False:
@@ -1018,14 +1018,14 @@ class LSTMCell(RNNCellBase):
                 (4 * hidden_size,),
                 bias_hh_attr,
                 is_bias=True,
-                default_initializer=I.Constant(0.0),
+                default_initializer=I.Uniform(-std, std),
             )
         else:
             self.bias_hh = self.create_parameter(
                 (4 * hidden_size,),
                 None,
                 is_bias=True,
-                default_initializer=I.Uniform(-std, std),
+                default_initializer=I.Constant(0.0),
             )
             self.bias_hh.stop_gradient = True
 
@@ -1195,14 +1195,14 @@ class GRUCell(RNNCellBase):
         if bias_ih_attr is not False:
             self.bias_ih = self.create_parameter(
                 (3 * hidden_size,),
-                None,
+                bias_ih_attr,
                 is_bias=True,
                 default_initializer=I.Uniform(-std, std),
             )
         else:
             self.bias_ih = self.create_parameter(
                 (3 * hidden_size,),
-                bias_ih_attr,
+                None,
                 is_bias=True,
                 default_initializer=I.Constant(0.0),
             )
@@ -1211,14 +1211,14 @@ class GRUCell(RNNCellBase):
         if bias_hh_attr is not False:
             self.bias_hh = self.create_parameter(
                 (3 * hidden_size,),
-                None,
+                bias_hh_attr,
                 is_bias=True,
                 default_initializer=I.Uniform(-std, std),
             )
         else:
             self.bias_hh = self.create_parameter(
                 (3 * hidden_size,),
-                bias_hh_attr,
+                None,
                 is_bias=True,
                 default_initializer=I.Constant(0.0),
             )

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -777,28 +777,65 @@ class SimpleRNNCell(RNNCellBase):
                 )
             )
         std = 1.0 / math.sqrt(hidden_size)
-        self.weight_ih = self.create_parameter(
-            (hidden_size, input_size),
-            weight_ih_attr,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.weight_hh = self.create_parameter(
-            (hidden_size, hidden_size),
-            weight_hh_attr,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.bias_ih = self.create_parameter(
-            (hidden_size,),
-            bias_ih_attr,
-            is_bias=True,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.bias_hh = self.create_parameter(
-            (hidden_size,),
-            bias_hh_attr,
-            is_bias=True,
-            default_initializer=I.Uniform(-std, std),
-        )
+        if weight_ih_attr is False:
+            self.weight_ih = self.create_parameter(
+                (hidden_size, input_size),
+                None,
+                default_initializer=I.Constant(1.0),
+            )
+            self.weight_ih.stop_gradient = True
+        else:
+            self.weight_ih = self.create_parameter(
+                (hidden_size, input_size),
+                weight_ih_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+
+        if weight_hh_attr is False:
+            self.weight_hh = self.create_parameter(
+                (hidden_size, hidden_size),
+                None,
+                default_initializer=I.Constant(1.0),
+            )
+            self.weight_hh.stop_gradient = True
+        else:
+            self.weight_hh = self.create_parameter(
+                (hidden_size, hidden_size),
+                weight_hh_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+
+        if bias_ih_attr is False:
+            self.bias_ih = self.create_parameter(
+                (hidden_size,),
+                None,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
+            self.bias_ih.stop_gradient = True
+        else:
+            self.bias_ih = self.create_parameter(
+                (hidden_size,),
+                bias_ih_attr,
+                is_bias=True,
+                default_initializer=I.Uniform(-std, std),
+            )
+
+        if bias_hh_attr is False:
+            self.bias_hh = self.create_parameter(
+                (hidden_size,),
+                None,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
+            self.bias_hh.stop_gradient = True
+        else:
+            self.bias_hh = self.create_parameter(
+                (hidden_size,),
+                bias_hh_attr,
+                is_bias=True,
+                default_initializer=I.Uniform(-std, std),
+            )
 
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -935,28 +972,64 @@ class LSTMCell(RNNCellBase):
                 )
             )
         std = 1.0 / math.sqrt(hidden_size)
-        self.weight_ih = self.create_parameter(
-            (4 * hidden_size, input_size),
-            weight_ih_attr,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.weight_hh = self.create_parameter(
-            (4 * hidden_size, hidden_size),
-            weight_hh_attr,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.bias_ih = self.create_parameter(
-            (4 * hidden_size,),
-            bias_ih_attr,
-            is_bias=True,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.bias_hh = self.create_parameter(
-            (4 * hidden_size,),
-            bias_hh_attr,
-            is_bias=True,
-            default_initializer=I.Uniform(-std, std),
-        )
+        if weight_ih_attr is False:
+            self.weight_ih = self.create_parameter(
+                (4 * hidden_size, input_size),
+                None,
+                default_initializer=I.Constant(1.0),
+            )
+            self.weight_ih.stop_gradient = True
+        else:
+            self.weight_ih = self.create_parameter(
+                (4 * hidden_size, input_size),
+                weight_ih_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+        if weight_hh_attr is False:
+            self.weight_hh = self.create_parameter(
+                (4 * hidden_size, hidden_size),
+                None,
+                default_initializer=I.Constant(1.0),
+            )
+            self.weight_hh.stop_gradient = True
+        else:
+            self.weight_hh = self.create_parameter(
+                (4 * hidden_size, hidden_size),
+                weight_hh_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+
+        if bias_ih_attr is False:
+            self.bias_ih = self.create_parameter(
+                (4 * hidden_size,),
+                None,
+                is_bias=True,
+                default_initializer=I.Uniform(-std, std),
+            )
+            self.bias_ih.stop_gradient = True
+        else:
+            self.bias_ih = self.create_parameter(
+                (4 * hidden_size,),
+                bias_ih_attr,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
+
+        if bias_hh_attr is False:
+            self.bias_hh = self.create_parameter(
+                (4 * hidden_size,),
+                None,
+                is_bias=True,
+                default_initializer=I.Uniform(-std, std),
+            )
+            self.bias_hh.stop_gradient = True
+        else:
+            self.bias_hh = self.create_parameter(
+                (4 * hidden_size,),
+                bias_hh_attr,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
 
         self.hidden_size = hidden_size
         self.input_size = input_size
@@ -1094,28 +1167,64 @@ class GRUCell(RNNCellBase):
                 )
             )
         std = 1.0 / math.sqrt(hidden_size)
-        self.weight_ih = self.create_parameter(
-            (3 * hidden_size, input_size),
-            weight_ih_attr,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.weight_hh = self.create_parameter(
-            (3 * hidden_size, hidden_size),
-            weight_hh_attr,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.bias_ih = self.create_parameter(
-            (3 * hidden_size,),
-            bias_ih_attr,
-            is_bias=True,
-            default_initializer=I.Uniform(-std, std),
-        )
-        self.bias_hh = self.create_parameter(
-            (3 * hidden_size,),
-            bias_hh_attr,
-            is_bias=True,
-            default_initializer=I.Uniform(-std, std),
-        )
+        if weight_ih_attr is False:
+            self.weight_ih = self.create_parameter(
+                (3 * hidden_size, input_size),
+                None,
+                default_initializer=I.Constant(1.0),
+            )
+            self.weight_ih.stop_gradient = True
+        else:
+            self.weight_ih = self.create_parameter(
+                (3 * hidden_size, input_size),
+                weight_ih_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+        if weight_hh_attr is False:
+            self.weight_hh = self.create_parameter(
+                (3 * hidden_size, hidden_size),
+                None,
+                default_initializer=I.Constant(1.0),
+            )
+            self.weight_hh.stop_gradient = True
+        else:
+            self.weight_hh = self.create_parameter(
+                (3 * hidden_size, hidden_size),
+                weight_hh_attr,
+                default_initializer=I.Uniform(-std, std),
+            )
+
+        if bias_ih_attr is False:
+            self.bias_ih = self.create_parameter(
+                (3 * hidden_size,),
+                None,
+                is_bias=True,
+                default_initializer=I.Uniform(-std, std),
+            )
+            self.bias_ih.stop_gradient = True
+        else:
+            self.bias_ih = self.create_parameter(
+                (3 * hidden_size,),
+                bias_ih_attr,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
+
+        if bias_hh_attr is False:
+            self.bias_hh = self.create_parameter(
+                (3 * hidden_size,),
+                None,
+                is_bias=True,
+                default_initializer=I.Uniform(-std, std),
+            )
+            self.bias_hh.stop_gradient = True
+        else:
+            self.bias_hh = self.create_parameter(
+                (3 * hidden_size,),
+                bias_hh_attr,
+                is_bias=True,
+                default_initializer=I.Constant(0.0),
+            )
 
         self.hidden_size = hidden_size
         self.input_size = input_size

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -1195,32 +1195,32 @@ class GRUCell(RNNCellBase):
         if bias_ih_attr is not False:
             self.bias_ih = self.create_parameter(
                 (3 * hidden_size,),
-                bias_ih_attr,
+                None,
                 is_bias=True,
-                default_initializer=I.Constant(0.0),
+                default_initializer=I.Uniform(-std, std),
             )
         else:
             self.bias_ih = self.create_parameter(
                 (3 * hidden_size,),
-                None,
+                bias_ih_attr,
                 is_bias=True,
-                default_initializer=I.Uniform(-std, std),
+                default_initializer=I.Constant(0.0),
             )
             self.bias_ih.stop_gradient = True
 
         if bias_hh_attr is not False:
             self.bias_hh = self.create_parameter(
                 (3 * hidden_size,),
-                bias_hh_attr,
+                None,
                 is_bias=True,
-                default_initializer=I.Constant(0.0),
+                default_initializer=I.Uniform(-std, std),
             )
         else:
             self.bias_hh = self.create_parameter(
                 (3 * hidden_size,),
-                None,
+                bias_hh_attr,
                 is_bias=True,
-                default_initializer=I.Uniform(-std, std),
+                default_initializer=I.Constant(0.0),
             )
             self.bias_hh.stop_gradient = True
 

--- a/test/rnn/convert.py
+++ b/test/rnn/convert.py
@@ -18,15 +18,17 @@ import paddle
 def convert_params_for_cell(np_cell, paddle_cell):
     state = np_cell.parameters
     for k, v in paddle_cell.named_parameters():
-        v.set_value(state[k])
+        if k in state:
+            v.set_value(state[k])
 
 
 def convert_params_for_cell_static(np_cell, paddle_cell, place):
     state = np_cell.parameters
     for k, v in paddle_cell.named_parameters():
-        scope = paddle.static.global_scope()
-        tensor = scope.find_var(v.name).get_tensor()
-        tensor.set(state[k], place)
+        if k in state:
+            scope = paddle.static.global_scope()
+            tensor = scope.find_var(v.name).get_tensor()
+            tensor.set(state[k], place)
 
 
 def convert_params_for_net(np_net, paddle_net):

--- a/test/rnn/convert.py
+++ b/test/rnn/convert.py
@@ -18,17 +18,15 @@ import paddle
 def convert_params_for_cell(np_cell, paddle_cell):
     state = np_cell.parameters
     for k, v in paddle_cell.named_parameters():
-        if k in state:
-            v.set_value(state[k])
+        v.set_value(state[k])
 
 
 def convert_params_for_cell_static(np_cell, paddle_cell, place):
     state = np_cell.parameters
     for k, v in paddle_cell.named_parameters():
-        if k in state:
-            scope = paddle.static.global_scope()
-            tensor = scope.find_var(v.name).get_tensor()
-            tensor.set(state[k], place)
+        scope = paddle.static.global_scope()
+        tensor = scope.find_var(v.name).get_tensor()
+        tensor.set(state[k], place)
 
 
 def convert_params_for_net(np_net, paddle_net):

--- a/test/rnn/rnn_numpy.py
+++ b/test/rnn/rnn_numpy.py
@@ -70,8 +70,8 @@ class SimpleRNNCell(LayerMixin):
             self.parameters['bias_ih'] = self.bias_ih
             self.parameters['bias_hh'] = self.bias_hh
         else:
-            self.bias_ih = None
-            self.bias_hh = None
+            self.bias_ih = np.zeros(hidden_size)
+            self.bias_hh = np.zeros(hidden_size)
 
     def init_state(self, inputs, batch_dim_index=0):
         batch_size = inputs.shape[batch_dim_index]
@@ -116,8 +116,8 @@ class GRUCell(LayerMixin):
             self.parameters['bias_ih'] = self.bias_ih
             self.parameters['bias_hh'] = self.bias_hh
         else:
-            self.bias_ih = None
-            self.bias_hh = None
+            self.bias_ih = np.zeros(3 * hidden_size)
+            self.bias_hh = np.zeros(3 * hidden_size)
 
     def init_state(self, inputs, batch_dim_index=0):
         batch_size = inputs.shape[batch_dim_index]
@@ -168,8 +168,8 @@ class LSTMCell(LayerMixin):
             self.parameters['bias_ih'] = self.bias_ih
             self.parameters['bias_hh'] = self.bias_hh
         else:
-            self.bias_ih = None
-            self.bias_hh = None
+            self.bias_ih = np.zeros(4 * hidden_size)
+            self.bias_hh = np.zeros(4 * hidden_size)
 
     def init_state(self, inputs, batch_dim_index=0):
         batch_size = inputs.shape[batch_dim_index]

--- a/test/rnn/rnn_numpy.py
+++ b/test/rnn/rnn_numpy.py
@@ -38,12 +38,14 @@ class SimpleRNNCell(LayerMixin):
         self,
         input_size,
         hidden_size,
+        weight=True,
         bias=True,
         nonlinearity="RNN_TANH",
         dtype="float64",
     ):
         self.input_size = input_size
         self.hidden_size = hidden_size
+        self.weight = weight
         self.bias = bias
         if nonlinearity == 'RNN_TANH':
             self.nonlinearity = np.tanh
@@ -52,12 +54,16 @@ class SimpleRNNCell(LayerMixin):
 
         self.parameters = {}
         std = 1.0 / math.sqrt(hidden_size)
-        self.weight_ih = np.random.uniform(
-            -std, std, (hidden_size, input_size)
-        ).astype(dtype)
-        self.weight_hh = np.random.uniform(
-            -std, std, (hidden_size, hidden_size)
-        ).astype(dtype)
+        if weight:
+            self.weight_ih = np.random.uniform(
+                -std, std, (hidden_size, input_size)
+            ).astype(dtype)
+            self.weight_hh = np.random.uniform(
+                -std, std, (hidden_size, hidden_size)
+            ).astype(dtype)
+        else:
+            self.weight_ih = np.ones((hidden_size, input_size)).astype(dtype)
+            self.weight_hh = np.ones((hidden_size, hidden_size)).astype(dtype)
         self.parameters['weight_ih'] = self.weight_ih
         self.parameters['weight_hh'] = self.weight_hh
         if bias:
@@ -92,18 +98,29 @@ class SimpleRNNCell(LayerMixin):
 
 
 class GRUCell(LayerMixin):
-    def __init__(self, input_size, hidden_size, bias=True, dtype="float64"):
+    def __init__(
+        self, input_size, hidden_size, weight=True, bias=True, dtype="float64"
+    ):
         self.input_size = input_size
         self.hidden_size = hidden_size
+        self.weight = weight
         self.bias = bias
         self.parameters = {}
         std = 1.0 / math.sqrt(hidden_size)
-        self.weight_ih = np.random.uniform(
-            -std, std, (3 * hidden_size, input_size)
-        ).astype(dtype)
-        self.weight_hh = np.random.uniform(
-            -std, std, (3 * hidden_size, hidden_size)
-        ).astype(dtype)
+        if weight:
+            self.weight_ih = np.random.uniform(
+                -std, std, (3 * hidden_size, input_size)
+            ).astype(dtype)
+            self.weight_hh = np.random.uniform(
+                -std, std, (3 * hidden_size, hidden_size)
+            ).astype(dtype)
+        else:
+            self.weight_ih = np.ones((3 * hidden_size, input_size)).astype(
+                dtype
+            )
+            self.weight_hh = np.ones((3 * hidden_size, hidden_size)).astype(
+                dtype
+            )
         self.parameters['weight_ih'] = self.weight_ih
         self.parameters['weight_hh'] = self.weight_hh
         if bias:
@@ -144,18 +161,29 @@ class GRUCell(LayerMixin):
 
 
 class LSTMCell(LayerMixin):
-    def __init__(self, input_size, hidden_size, bias=True, dtype="float64"):
+    def __init__(
+        self, input_size, hidden_size, weight=True, bias=True, dtype="float64"
+    ):
         self.input_size = input_size
         self.hidden_size = hidden_size
+        self.weight = weight
         self.bias = bias
         self.parameters = {}
         std = 1.0 / math.sqrt(hidden_size)
-        self.weight_ih = np.random.uniform(
-            -std, std, (4 * hidden_size, input_size)
-        ).astype(dtype)
-        self.weight_hh = np.random.uniform(
-            -std, std, (4 * hidden_size, hidden_size)
-        ).astype(dtype)
+        if weight:
+            self.weight_ih = np.random.uniform(
+                -std, std, (4 * hidden_size, input_size)
+            ).astype(dtype)
+            self.weight_hh = np.random.uniform(
+                -std, std, (4 * hidden_size, hidden_size)
+            ).astype(dtype)
+        else:
+            self.weight_ih = np.ones((4 * hidden_size, input_size)).astype(
+                dtype
+            )
+            self.weight_hh = np.ones((4 * hidden_size, hidden_size)).astype(
+                dtype
+            )
         self.parameters['weight_ih'] = self.weight_ih
         self.parameters['weight_hh'] = self.weight_hh
         if bias:

--- a/test/rnn/rnn_numpy.py
+++ b/test/rnn/rnn_numpy.py
@@ -67,11 +67,11 @@ class SimpleRNNCell(LayerMixin):
             self.bias_hh = np.random.uniform(-std, std, (hidden_size,)).astype(
                 dtype
             )
-            self.parameters['bias_ih'] = self.bias_ih
-            self.parameters['bias_hh'] = self.bias_hh
         else:
-            self.bias_ih = np.zeros(hidden_size)
-            self.bias_hh = np.zeros(hidden_size)
+            self.bias_ih = np.zeros(hidden_size).astype(dtype)
+            self.bias_hh = np.zeros(hidden_size).astype(dtype)
+        self.parameters['bias_ih'] = self.bias_ih
+        self.parameters['bias_hh'] = self.bias_hh
 
     def init_state(self, inputs, batch_dim_index=0):
         batch_size = inputs.shape[batch_dim_index]
@@ -113,11 +113,11 @@ class GRUCell(LayerMixin):
             self.bias_hh = np.random.uniform(
                 -std, std, (3 * hidden_size)
             ).astype(dtype)
-            self.parameters['bias_ih'] = self.bias_ih
-            self.parameters['bias_hh'] = self.bias_hh
         else:
-            self.bias_ih = np.zeros(3 * hidden_size)
-            self.bias_hh = np.zeros(3 * hidden_size)
+            self.bias_ih = np.zeros(3 * hidden_size).astype(dtype)
+            self.bias_hh = np.zeros(3 * hidden_size).astype(dtype)
+        self.parameters['bias_ih'] = self.bias_ih
+        self.parameters['bias_hh'] = self.bias_hh
 
     def init_state(self, inputs, batch_dim_index=0):
         batch_size = inputs.shape[batch_dim_index]
@@ -165,11 +165,11 @@ class LSTMCell(LayerMixin):
             self.bias_hh = np.random.uniform(
                 -std, std, (4 * hidden_size)
             ).astype(dtype)
-            self.parameters['bias_ih'] = self.bias_ih
-            self.parameters['bias_hh'] = self.bias_hh
         else:
-            self.bias_ih = np.zeros(4 * hidden_size)
-            self.bias_hh = np.zeros(4 * hidden_size)
+            self.bias_ih = np.zeros(4 * hidden_size).astype(dtype)
+            self.bias_hh = np.zeros(4 * hidden_size).astype(dtype)
+        self.parameters['bias_ih'] = self.bias_ih
+        self.parameters['bias_hh'] = self.bias_hh
 
     def init_state(self, inputs, batch_dim_index=0):
         batch_size = inputs.shape[batch_dim_index]

--- a/test/rnn/test_rnn_cells.py
+++ b/test/rnn/test_rnn_cells.py
@@ -24,8 +24,9 @@ from rnn_numpy import GRUCell, LSTMCell, SimpleRNNCell
 
 
 class TestSimpleRNNCell(unittest.TestCase):
-    def __init__(self, bias=True, place="cpu"):
+    def __init__(self, weight=True, bias=True, place="cpu"):
         super().__init__(methodName="runTest")
+        self.weight = weight
         self.bias = bias
         self.place = (
             paddle.CPUPlace() if place == "cpu" else paddle.CUDAPlace(0)
@@ -33,9 +34,14 @@ class TestSimpleRNNCell(unittest.TestCase):
 
     def setUp(self):
         paddle.disable_static(self.place)
-        rnn1 = SimpleRNNCell(16, 32, bias=self.bias)
+        rnn1 = SimpleRNNCell(16, 32, weight=self.weight, bias=self.bias)
         rnn2 = paddle.nn.SimpleRNNCell(
-            16, 32, bias_ih_attr=self.bias, bias_hh_attr=self.bias
+            16,
+            32,
+            weight_ih_attr=self.weight,
+            weight_hh_attr=self.weight,
+            bias_ih_attr=self.bias,
+            bias_hh_attr=self.bias,
         )
         convert_params_for_cell(rnn1, rnn2)
 
@@ -76,8 +82,9 @@ class TestSimpleRNNCell(unittest.TestCase):
 
 
 class TestGRUCell(unittest.TestCase):
-    def __init__(self, bias=True, place="cpu"):
+    def __init__(self, weight=True, bias=True, place="cpu"):
         super().__init__(methodName="runTest")
+        self.weight = weight
         self.bias = bias
         self.place = (
             paddle.CPUPlace() if place == "cpu" else paddle.CUDAPlace(0)
@@ -85,9 +92,14 @@ class TestGRUCell(unittest.TestCase):
 
     def setUp(self):
         paddle.disable_static(self.place)
-        rnn1 = GRUCell(16, 32, bias=self.bias)
+        rnn1 = GRUCell(16, 32, weight=self.weight, bias=self.bias)
         rnn2 = paddle.nn.GRUCell(
-            16, 32, bias_ih_attr=self.bias, bias_hh_attr=self.bias
+            16,
+            32,
+            weight_ih_attr=self.weight,
+            weight_hh_attr=self.weight,
+            bias_ih_attr=self.bias,
+            bias_hh_attr=self.bias,
         )
         convert_params_for_cell(rnn1, rnn2)
 
@@ -128,17 +140,23 @@ class TestGRUCell(unittest.TestCase):
 
 
 class TestLSTMCell(unittest.TestCase):
-    def __init__(self, bias=True, place="cpu"):
+    def __init__(self, weight=True, bias=True, place="cpu"):
         super().__init__(methodName="runTest")
+        self.weight = weight
         self.bias = bias
         self.place = (
             paddle.CPUPlace() if place == "cpu" else paddle.CUDAPlace(0)
         )
 
     def setUp(self):
-        rnn1 = LSTMCell(16, 32, bias=self.bias)
+        rnn1 = LSTMCell(16, 32, weight=self.weight, bias=self.bias)
         rnn2 = paddle.nn.LSTMCell(
-            16, 32, bias_ih_attr=self.bias, bias_hh_attr=self.bias
+            16,
+            32,
+            weight_ih_attr=self.weight,
+            weight_hh_attr=self.weight,
+            bias_ih_attr=self.bias,
+            bias_hh_attr=self.bias,
         )
         convert_params_for_cell(rnn1, rnn2)
 
@@ -187,8 +205,13 @@ class TestLSTMCell(unittest.TestCase):
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()
     devices = ["cpu", "gpu"] if paddle.base.is_compiled_with_cuda() else ["cpu"]
-    for bias in [True, False]:
-        for device in devices:
-            for test_class in [TestSimpleRNNCell, TestGRUCell, TestLSTMCell]:
-                suite.addTest(test_class(bias, device))
+    for weight in [True, False]:
+        for bias in [True, False]:
+            for device in devices:
+                for test_class in [
+                    TestSimpleRNNCell,
+                    TestGRUCell,
+                    TestLSTMCell,
+                ]:
+                    suite.addTest(test_class(weight, bias, device))
     return suite


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
### PR changes
APIs 
### Description
Pcard-73263
diag_embed是一种使用频率较高的创建方法，需要支持Tensor.diag_embed的调用形式。简单的解决办法是在tensor_match_methods.py文件中import该函数将其作为Tensor类方法，但是此时会遇到import循环依赖的问题（解决成本较高，也无必要）。目前paddle将diag_embed API被放置在nn.funtional目录下。与其属于同类的的diag、diagflat、diagonal API却被放置在paddle/tensor/creation.py中。现在将diag_embed函数的实现迁移到同类API所在的creation.py文件中，而在原实现位置，调用creation.py，并做废弃警告处理。

