### PR TITLE
[PIR] No.43 Migrate paddle.unsqueeze into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2610,7 +2610,7 @@ def unsqueeze(x, axis, name=None):
     """
     input = x
     axes = axis
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if isinstance(axes, int):
             axes = [axes]
         elif isinstance(axes, Variable):

--- a/test/legacy_test/test_unsqueeze2_op.py
+++ b/test/legacy_test/test_unsqueeze2_op.py
@@ -43,7 +43,9 @@ class TestUnsqueezeOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output(no_check_set=["XShape"], check_prim=True, check_new_ir=True)
+        self.check_output(
+            no_check_set=["XShape"], check_prim=True, check_new_ir=True
+        )
 
     def test_check_grad(self):
         self.check_grad(["X"], "Out", check_prim=True, check_new_ir=True)

--- a/test/legacy_test/test_unsqueeze2_op.py
+++ b/test/legacy_test/test_unsqueeze2_op.py
@@ -43,10 +43,10 @@ class TestUnsqueezeOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output(no_check_set=["XShape"], check_prim=True)
+        self.check_output(no_check_set=["XShape"], check_prim=True, check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_prim=True)
+        self.check_grad(["X"], "Out", check_prim=True, check_new_ir=True)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -135,10 +135,10 @@ class TestUnsqueezeOp_AxesTensorList(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(no_check_set=["XShape"])
+        self.check_output(no_check_set=["XShape"], check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_new_ir=True)
 
     def init_test_case(self):
         self.ori_shape = (20, 5)
@@ -196,10 +196,10 @@ class TestUnsqueezeOp_AxesTensor(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(no_check_set=["XShape"])
+        self.check_output(no_check_set=["XShape"], check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_new_ir=True)
 
     def init_test_case(self):
         self.ori_shape = (20, 5)

--- a/test/legacy_test/test_unsqueeze_op.py
+++ b/test/legacy_test/test_unsqueeze_op.py
@@ -30,17 +30,16 @@ paddle.enable_static()
 class TestUnsqueezeOp(OpTest):
     def setUp(self):
         self.init_test_case()
-        self.python_api = paddle.unsqueeze
         self.op_type = "unsqueeze"
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
         self.init_attrs()
         self.outputs = {"Out": self.inputs["X"].reshape(self.new_shape)}
 
     def test_check_output(self):
-        self.check_output(check_new_ir=True)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_new_ir=False)
+        self.check_grad(["X"], "Out")
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -55,16 +54,15 @@ class TestUnsqueezeFP16Op(OpTest):
     def setUp(self):
         self.init_test_case()
         self.op_type = "unsqueeze"
-        self.python_api = paddle.unsqueeze
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float16")}
         self.init_attrs()
         self.outputs = {"Out": self.inputs["X"].reshape(self.new_shape)}
 
     def test_check_output(self):
-        self.check_output(check_new_ir=True)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_new_ir=False)
+        self.check_grad(["X"], "Out")
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -79,7 +77,6 @@ class TestUnsqueezeBF16Op(OpTest):
     def setUp(self):
         self.init_test_case()
         self.op_type = "unsqueeze"
-        self.python_api = paddle.unsqueeze
         self.dtype = np.uint16
         x = np.random.random(self.ori_shape).astype("float32")
         out = x.reshape(self.new_shape)
@@ -88,10 +85,10 @@ class TestUnsqueezeBF16Op(OpTest):
         self.outputs = {"Out": convert_float_to_uint16(out)}
 
     def test_check_output(self):
-        self.check_output(check_new_ir=True)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_new_ir=False)
+        self.check_grad(["X"], "Out")
 
     def init_test_case(self):
         self.ori_shape = (3, 40)

--- a/test/legacy_test/test_unsqueeze_op.py
+++ b/test/legacy_test/test_unsqueeze_op.py
@@ -30,6 +30,7 @@ paddle.enable_static()
 class TestUnsqueezeOp(OpTest):
     def setUp(self):
         self.init_test_case()
+        self.python_api = paddle.unsqueeze
         self.op_type = "unsqueeze"
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
         self.init_attrs()
@@ -39,7 +40,7 @@ class TestUnsqueezeOp(OpTest):
         self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_new_ir=True)
+        self.check_grad(["X"], "Out", check_new_ir=False)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -54,6 +55,7 @@ class TestUnsqueezeFP16Op(OpTest):
     def setUp(self):
         self.init_test_case()
         self.op_type = "unsqueeze"
+        self.python_api = paddle.unsqueeze
         self.inputs = {"X": np.random.random(self.ori_shape).astype("float16")}
         self.init_attrs()
         self.outputs = {"Out": self.inputs["X"].reshape(self.new_shape)}
@@ -62,7 +64,7 @@ class TestUnsqueezeFP16Op(OpTest):
         self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_new_ir=True)
+        self.check_grad(["X"], "Out", check_new_ir=False)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -77,6 +79,7 @@ class TestUnsqueezeBF16Op(OpTest):
     def setUp(self):
         self.init_test_case()
         self.op_type = "unsqueeze"
+        self.python_api = paddle.unsqueeze
         self.dtype = np.uint16
         x = np.random.random(self.ori_shape).astype("float32")
         out = x.reshape(self.new_shape)
@@ -88,7 +91,7 @@ class TestUnsqueezeBF16Op(OpTest):
         self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_new_ir=True)
+        self.check_grad(["X"], "Out", check_new_ir=False)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)

--- a/test/legacy_test/test_unsqueeze_op.py
+++ b/test/legacy_test/test_unsqueeze_op.py
@@ -36,10 +36,10 @@ class TestUnsqueezeOp(OpTest):
         self.outputs = {"Out": self.inputs["X"].reshape(self.new_shape)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_new_ir=True)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -59,10 +59,10 @@ class TestUnsqueezeFP16Op(OpTest):
         self.outputs = {"Out": self.inputs["X"].reshape(self.new_shape)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_new_ir=True)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -85,10 +85,10 @@ class TestUnsqueezeBF16Op(OpTest):
         self.outputs = {"Out": convert_float_to_uint16(out)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_new_ir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_new_ir=True)
 
     def init_test_case(self):
         self.ori_shape = (3, 40)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description
[PIR]Migrate unsqueeze into pir
总计 24 个单测，打开12个单测，12个单测继承自unittest.TestCase没有覆盖到

Pcard-67164

- https://github.com/PaddlePaddle/Paddle/issues/57097
