### PR TITLE
[PIR] Refine Ir op build

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -405,10 +405,10 @@ def GenBuildOutputs(
     {name}.SetFromTensor(true);
   }}\n"""
 
-    CREATE_OUTPUT_METATENSOR_TEMPLATE = """  phi::DenseTensor dense_{name};
+    CREATE_OUTPUT_METATENSOR_TEMPLATE = """  paddle::dialect::IrMetaTensor dense_{name};
   phi::MetaTensor meta_{name}(&dense_{name});
 """
-    CREATE_OUTPUT_VEC_METATENSOR_TEMPLATE = """  std::vector<phi::DenseTensor> vec_dense_{name}(({output_size}), phi::DenseTensor());
+    CREATE_OUTPUT_VEC_METATENSOR_TEMPLATE = """  std::vector<paddle::dialect::IrMetaTensor> vec_dense_{name}(({output_size}), paddle::dialect::IrMetaTensor());
   std::vector<phi::MetaTensor> vec_meta_{name};
   for (size_t i=0; i < static_cast<size_t>({output_size}); i++) {{
     vec_meta_{name}.push_back(phi::MetaTensor(&vec_dense_{name}[i]));

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/meta_tensor.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
@@ -111,21 +112,16 @@ void AddNOp::Build(pir::Builder &builder,             // NOLINT
 
   VLOG(4) << "Builder construction outputs";
   pir::VectorType x = inputs.type().dyn_cast<pir::VectorType>();
-  (void)x;
 
-  std::vector<phi::DenseTensor> vec_dense_x;
+  std::vector<paddle::dialect::IrMetaTensor> vec_dense_x;
   for (size_t i = 0; i < x.size(); i++) {
-    vec_dense_x.push_back(phi::DenseTensor(
-        std::make_unique<paddle::experimental::DefaultAllocator>(
-            paddle::platform::CPUPlace())
-            .get(),
-        phi::DenseTensorMeta(
-            TransToPhiDataType(
-                x[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-            x[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-            x[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
-            x[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-            x[i].dyn_cast<paddle::dialect::DenseTensorType>().offset())));
+    vec_dense_x.push_back(
+        TransToPhiDataType(
+            x[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
+        x[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
+        x[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
+        x[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
+        x[i].dyn_cast<paddle::dialect::DenseTensorType>().offset());
   }
   std::vector<phi::MetaTensor> vec_meta_x;
   for (size_t i = 0; i < vec_dense_x.size(); i++) {
@@ -136,7 +132,8 @@ void AddNOp::Build(pir::Builder &builder,             // NOLINT
   for (size_t i = 0; i < static_cast<size_t>(vec_meta_x.size()); i++) {
     meta_x.push_back(&vec_meta_x[i]);
   }
-  phi::DenseTensor dense_out;
+
+  paddle::dialect::IrMetaTensor dense_out;
   phi::MetaTensor meta_out(&dense_out);
 
   phi::AddNInferMeta(meta_x, &meta_out);
@@ -189,21 +186,15 @@ void AddN_Op::Build(pir::Builder &builder,
 
   VLOG(4) << "Builder construction outputs";
   pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
-  std::vector<phi::DenseTensor> vec_dense_inputs;
+  std::vector<paddle::dialect::IrMetaTensor> vec_dense_inputs;
   for (size_t i = 0; i < static_cast<size_t>(inputs.size()); i++) {
-    vec_dense_inputs.push_back(phi::DenseTensor(
-        std::make_unique<paddle::experimental::DefaultAllocator>(
-            paddle::platform::CPUPlace())
-            .get(),
-        phi::DenseTensorMeta(
-            paddle::dialect::TransToPhiDataType(
-                inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-            inputs[i]
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .data_layout(),
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset())));
+    vec_dense_inputs.push_back(
+        paddle::dialect::TransToPhiDataType(
+            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset());
   }
   std::vector<phi::MetaTensor> vec_meta_inputs;
   for (size_t i = 0; i < vec_dense_inputs.size(); i++) {
@@ -214,7 +205,7 @@ void AddN_Op::Build(pir::Builder &builder,
   for (size_t i = 0; i < static_cast<size_t>(vec_meta_inputs.size()); i++) {
     meta_inputs.push_back(&vec_meta_inputs[i]);
   }
-  phi::DenseTensor dense_out;
+  paddle::dialect::IrMetaTensor dense_out;
   phi::MetaTensor meta_out(&dense_out);
 
   phi::AddNInferMeta(meta_inputs, &meta_out);
@@ -318,21 +309,15 @@ void AddNWithKernelOp::Build(pir::Builder &builder,
 
   VLOG(4) << "Builder construction outputs";
   pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
-  std::vector<phi::DenseTensor> vec_dense_inputs;
+  std::vector<paddle::dialect::IrMetaTensor> vec_dense_inputs;
   for (size_t i = 0; i < static_cast<size_t>(inputs.size()); i++) {
-    vec_dense_inputs.push_back(phi::DenseTensor(
-        std::make_unique<paddle::experimental::DefaultAllocator>(
-            paddle::platform::CPUPlace())
-            .get(),
-        phi::DenseTensorMeta(
-            paddle::dialect::TransToPhiDataType(
-                inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-            inputs[i]
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .data_layout(),
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset())));
+    vec_dense_inputs.push_back(
+        paddle::dialect::TransToPhiDataType(
+            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset());
   }
   std::vector<phi::MetaTensor> vec_meta_inputs;
   for (size_t i = 0; i < vec_dense_inputs.size(); i++) {
@@ -343,7 +328,7 @@ void AddNWithKernelOp::Build(pir::Builder &builder,
   for (size_t i = 0; i < static_cast<size_t>(vec_meta_inputs.size()); i++) {
     meta_inputs.push_back(&vec_meta_inputs[i]);
   }
-  phi::DenseTensor dense_out;
+  paddle::dialect::IrMetaTensor dense_out;
   phi::MetaTensor meta_out(&dense_out);
 
   phi::AddNInferMeta(meta_inputs, &meta_out);
@@ -508,46 +493,37 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
   (void)bias;
 
   VLOG(4) << "Builder construction  dense_x";
-  phi::DenseTensor dense_x(
-      std::make_unique<paddle::experimental::DefaultAllocator>(
-          paddle::platform::CPUPlace())
-          .get(),
-      phi::DenseTensorMeta(paddle::dialect::TransToPhiDataType(x.dtype()),
-                           x.dims(),
-                           x.data_layout(),
-                           x.lod(),
-                           x.offset()));
+  paddle::dialect::IrMetaTensor dense_x(
+      paddle::dialect::TransToPhiDataType(x.dtype()),
+      x.dims(),
+      x.data_layout(),
+      x.lod(),
+      x.offset());
   VLOG(4) << "Builder construction  meta_x";
   phi::MetaTensor meta_x(&dense_x);
 
   VLOG(4) << "Builder construction  dense_y";
-  phi::DenseTensor dense_y(
-      std::make_unique<paddle::experimental::DefaultAllocator>(
-          paddle::platform::CPUPlace())
-          .get(),
-      phi::DenseTensorMeta(paddle::dialect::TransToPhiDataType(y.dtype()),
-                           y.dims(),
-                           y.data_layout(),
-                           y.lod(),
-                           y.offset()));
+  paddle::dialect::IrMetaTensor dense_y(
+      paddle::dialect::TransToPhiDataType(y.dtype()),
+      y.dims(),
+      y.data_layout(),
+      y.lod(),
+      y.offset());
   VLOG(4) << "Builder construction  meta_y";
   phi::MetaTensor meta_y(&dense_y);
 
   VLOG(4) << "Builder construction  dense_bias";
-  phi::DenseTensor dense_bias(
-      std::make_unique<paddle::experimental::DefaultAllocator>(
-          paddle::platform::CPUPlace())
-          .get(),
-      phi::DenseTensorMeta(paddle::dialect::TransToPhiDataType(bias.dtype()),
-                           bias.dims(),
-                           bias.data_layout(),
-                           bias.lod(),
-                           bias.offset()));
+  paddle::dialect::IrMetaTensor dense_bias(
+      paddle::dialect::TransToPhiDataType(bias.dtype()),
+      bias.dims(),
+      bias.data_layout(),
+      bias.lod(),
+      bias.offset());
   VLOG(4) << "Builder construction  meta_bias";
   phi::MetaTensor meta_bias(&dense_bias);
-  phi::DenseTensor dense_out;
+  paddle::dialect::IrMetaTensor dense_out;
   phi::MetaTensor meta_out(&dense_out);
-  phi::DenseTensor dense_reserve_space;
+  paddle::dialect::IrMetaTensor dense_reserve_space;
   phi::MetaTensor meta_reserve_space(&dense_reserve_space);
 
   phi::FusedGemmEpilogueInferMeta(
@@ -768,66 +744,52 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
   (void)out_grad;
 
   VLOG(4) << "Builder construction  dense_x";
-  phi::DenseTensor dense_x(
-      std::make_unique<paddle::experimental::DefaultAllocator>(
-          paddle::platform::CPUPlace())
-          .get(),
-      phi::DenseTensorMeta(paddle::dialect::TransToPhiDataType(x.dtype()),
-                           x.dims(),
-                           x.data_layout(),
-                           x.lod(),
-                           x.offset()));
+  paddle::dialect::IrMetaTensor dense_x(
+      paddle::dialect::TransToPhiDataType(x.dtype()),
+      x.dims(),
+      x.data_layout(),
+      x.lod(),
+      x.offset());
   VLOG(4) << "Builder construction  meta_x";
   phi::MetaTensor meta_x(&dense_x);
 
   VLOG(4) << "Builder construction  dense_y";
-  phi::DenseTensor dense_y(
-      std::make_unique<paddle::experimental::DefaultAllocator>(
-          paddle::platform::CPUPlace())
-          .get(),
-      phi::DenseTensorMeta(paddle::dialect::TransToPhiDataType(y.dtype()),
-                           y.dims(),
-                           y.data_layout(),
-                           y.lod(),
-                           y.offset()));
+  paddle::dialect::IrMetaTensor dense_y(
+      paddle::dialect::TransToPhiDataType(y.dtype()),
+      y.dims(),
+      y.data_layout(),
+      y.lod(),
+      y.offset());
   VLOG(4) << "Builder construction  meta_y";
   phi::MetaTensor meta_y(&dense_y);
 
   VLOG(4) << "Builder construction  dense_reserve_space";
-  std::unique_ptr<phi::DenseTensor> dense_reserve_space =
+  std::unique_ptr<paddle::dialect::IrMetaTensor> dense_reserve_space =
       reserve_space_
-          ? std::make_unique<phi::DenseTensor>(
-                std::make_unique<paddle::experimental::DefaultAllocator>(
-                    paddle::platform::CPUPlace())
-                    .get(),
-                phi::DenseTensorMeta(
-                    paddle::dialect::TransToPhiDataType(reserve_space.dtype()),
-                    reserve_space.dims(),
-                    reserve_space.data_layout(),
-                    reserve_space.lod(),
-                    reserve_space.offset()))
+          ? std::make_unique<paddle::dialect::IrMetaTensor>(
+                paddle::dialect::TransToPhiDataType(reserve_space.dtype()),
+                reserve_space.dims(),
+                reserve_space.data_layout(),
+                reserve_space.lod(),
+                reserve_space.offset())
           : nullptr;
   VLOG(4) << "Builder construction  meta_reserve_space";
   phi::MetaTensor meta_reserve_space(dense_reserve_space.get());
 
   VLOG(4) << "Builder construction  dense_out_grad";
-  phi::DenseTensor dense_out_grad(
-      std::make_unique<paddle::experimental::DefaultAllocator>(
-          paddle::platform::CPUPlace())
-          .get(),
-      phi::DenseTensorMeta(
-          paddle::dialect::TransToPhiDataType(out_grad.dtype()),
-          out_grad.dims(),
-          out_grad.data_layout(),
-          out_grad.lod(),
-          out_grad.offset()));
+  paddle::dialect::IrMetaTensor dense_out_grad(
+      paddle::dialect::TransToPhiDataType(out_grad.dtype()),
+      out_grad.dims(),
+      out_grad.data_layout(),
+      out_grad.lod(),
+      out_grad.offset());
   VLOG(4) << "Builder construction  meta_out_grad";
   phi::MetaTensor meta_out_grad(&dense_out_grad);
-  phi::DenseTensor dense_x_grad;
+  paddle::dialect::IrMetaTensor dense_x_grad;
   phi::MetaTensor meta_x_grad(&dense_x_grad);
-  phi::DenseTensor dense_y_grad;
+  paddle::dialect::IrMetaTensor dense_y_grad;
   phi::MetaTensor meta_y_grad(&dense_y_grad);
-  phi::DenseTensor dense_bias_grad;
+  paddle::dialect::IrMetaTensor dense_bias_grad;
   phi::MetaTensor meta_bias_grad(&dense_bias_grad);
 
   phi::FusedGemmEpilogueGradInferMeta(meta_x,
@@ -929,25 +891,15 @@ void SplitGradOp::Build(pir::Builder &builder,
 
   VLOG(4) << "Builder construction outputs";
   pir::VectorType out_grad = out_grad_.type().dyn_cast<pir::VectorType>();
-  std::vector<phi::DenseTensor> vec_dense_out_grad;
+  std::vector<paddle::dialect::IrMetaTensor> vec_dense_out_grad;
   for (size_t i = 0; i < static_cast<size_t>(out_grad.size()); i++) {
-    vec_dense_out_grad.push_back(phi::DenseTensor(
-        std::make_unique<paddle::experimental::DefaultAllocator>(
-            paddle::platform::CPUPlace())
-            .get(),
-        phi::DenseTensorMeta(
-            paddle::dialect::TransToPhiDataType(
-                out_grad[i]
-                    .dyn_cast<paddle::dialect::DenseTensorType>()
-                    .dtype()),
-            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-            out_grad[i]
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .data_layout(),
-            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-            out_grad[i]
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .offset())));
+    vec_dense_out_grad.push_back(paddle::dialect::IrMetaTensor(
+        paddle::dialect::TransToPhiDataType(
+            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
   }
   std::vector<phi::MetaTensor> vec_meta_out_grad;
   for (size_t i = 0; i < vec_dense_out_grad.size(); i++) {
@@ -958,7 +910,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   for (size_t i = 0; i < static_cast<size_t>(vec_meta_out_grad.size()); i++) {
     meta_out_grad.push_back(&vec_meta_out_grad[i]);
   }
-  phi::DenseTensor dense_x_grad;
+  paddle::dialect::IrMetaTensor dense_x_grad;
   phi::MetaTensor meta_x_grad(&dense_x_grad);
 
   phi::ConcatInferMeta(meta_out_grad, axis, &meta_x_grad);
@@ -995,24 +947,15 @@ void SplitGradOp::Build(pir::Builder &builder,
                  .data()
                  .to<int>();
 
-  std::vector<phi::DenseTensor> vec_dense_out_grad;
+  std::vector<paddle::dialect::IrMetaTensor> vec_dense_out_grad;
   for (size_t i = 0; i < static_cast<size_t>(out_grad.size()); i++) {
-    vec_dense_out_grad.push_back(phi::DenseTensor(
-        std::make_unique<paddle::experimental::DefaultAllocator>(
-            paddle::platform::CPUPlace())
-            .get(),
-        phi::DenseTensorMeta(
-            TransToPhiDataType(out_grad[i]
-                                   .dyn_cast<paddle::dialect::DenseTensorType>()
-                                   .dtype()),
-            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-            out_grad[i]
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .data_layout(),
-            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-            out_grad[i]
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .offset())));
+    vec_dense_out_grad.push_back(paddle::dialect::IrMetaTensor(
+        TransToPhiDataType(
+            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
+        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
   }
   std::vector<phi::MetaTensor> vec_meta_out_grad;
   for (size_t i = 0; i < vec_dense_out_grad.size(); i++) {
@@ -1023,7 +966,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   for (size_t i = 0; i < static_cast<size_t>(vec_meta_out_grad.size()); i++) {
     meta_out_grad.push_back(&vec_meta_out_grad[i]);
   }
-  phi::DenseTensor dense_x_grad;
+  paddle::dialect::IrMetaTensor dense_x_grad;
   phi::MetaTensor meta_x_grad(&dense_x_grad);
 
   phi::ConcatInferMeta(meta_out_grad, axis, &meta_x_grad);

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -115,13 +115,13 @@ void AddNOp::Build(pir::Builder &builder,             // NOLINT
 
   std::vector<paddle::dialect::IrMetaTensor> vec_dense_x;
   for (size_t i = 0; i < x.size(); i++) {
-    vec_dense_x.push_back(
+    vec_dense_x.push_back(paddle::dialect::IrMetaTensor(
         TransToPhiDataType(
             x[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
         x[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
         x[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
         x[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        x[i].dyn_cast<paddle::dialect::DenseTensorType>().offset());
+        x[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
   }
   std::vector<phi::MetaTensor> vec_meta_x;
   for (size_t i = 0; i < vec_dense_x.size(); i++) {
@@ -188,13 +188,13 @@ void AddN_Op::Build(pir::Builder &builder,
   pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
   std::vector<paddle::dialect::IrMetaTensor> vec_dense_inputs;
   for (size_t i = 0; i < static_cast<size_t>(inputs.size()); i++) {
-    vec_dense_inputs.push_back(
+    vec_dense_inputs.push_back(paddle::dialect::IrMetaTensor(
         paddle::dialect::TransToPhiDataType(
             inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
         inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
         inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
         inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset());
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
   }
   std::vector<phi::MetaTensor> vec_meta_inputs;
   for (size_t i = 0; i < vec_dense_inputs.size(); i++) {
@@ -311,13 +311,13 @@ void AddNWithKernelOp::Build(pir::Builder &builder,
   pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
   std::vector<paddle::dialect::IrMetaTensor> vec_dense_inputs;
   for (size_t i = 0; i < static_cast<size_t>(inputs.size()); i++) {
-    vec_dense_inputs.push_back(
+    vec_dense_inputs.push_back(paddle::dialect::IrMetaTensor(
         paddle::dialect::TransToPhiDataType(
             inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
         inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
         inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
         inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset());
+        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
   }
   std::vector<phi::MetaTensor> vec_meta_inputs;
   for (size_t i = 0; i < vec_dense_inputs.size(); i++) {

--- a/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
+++ b/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
@@ -73,7 +73,7 @@ class IrMetaTensor : public phi::TensorBase,
  private:
   phi::DDim dims_;
   phi::DataType dtype_{phi::DataType::UNDEFINED};
-  phi::DataLayout layout_{phi::DataLayout::NCHW};
+  phi::DataLayout layout_{phi::DataLayout::UNDEFINED};
   LoD lod_;
   size_t offset_{0};
 };

--- a/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
+++ b/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
@@ -81,7 +81,7 @@ class IrMetaTensor : public phi::TensorBase,
  private:
   phi::DDim dims_;
   phi::DataType dtype_{phi::DataType::FLOAT32};
-  phi::DataLayout layout_{phi::DataLayout::NCHW};
+  phi::DataLayout layout_{phi::DataLayout::ANY};
   LoD lod_;
   size_t offset_{0};
 };

--- a/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
+++ b/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
@@ -51,13 +51,21 @@ class IrMetaTensor : public phi::TensorBase,
 
   const phi::DDim& dims() const noexcept override { return dims_; }
 
+  void SetDims(const phi::DDim& dims) { dims_ = dims; }
+
   const phi::Place& place() const override;
 
   phi::DataType dtype() const noexcept override { return dtype_; }
 
+  void SetDtype(phi::DataType dtype) { dtype_ = dtype; }
+
   phi::DataLayout layout() const noexcept override { return layout_; }
 
+  void SetLayout(phi::DataLayout layout) { layout_ = layout; }
+
   const LoD& lod() const noexcept { return lod_; }
+
+  void SetLod(LoD lod) { lod_ = lod; }
 
   size_t offset() const noexcept { return offset_; }
 
@@ -73,7 +81,7 @@ class IrMetaTensor : public phi::TensorBase,
  private:
   phi::DDim dims_;
   phi::DataType dtype_{phi::DataType::UNDEFINED};
-  phi::DataLayout layout_{phi::DataLayout::UNDEFINED};
+  phi::DataLayout layout_{phi::DataLayout::NCHW};
   LoD lod_;
   size_t offset_{0};
 };

--- a/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
+++ b/paddle/fluid/pir/dialect/operator/ir/meta_tensor.h
@@ -80,7 +80,7 @@ class IrMetaTensor : public phi::TensorBase,
 
  private:
   phi::DDim dims_;
-  phi::DataType dtype_{phi::DataType::UNDEFINED};
+  phi::DataType dtype_{phi::DataType::FLOAT32};
   phi::DataLayout layout_{phi::DataLayout::NCHW};
   LoD lod_;
   size_t offset_{0};

--- a/paddle/phi/core/meta_tensor.cc
+++ b/paddle/phi/core/meta_tensor.cc
@@ -75,6 +75,8 @@ void MetaTensor::set_dims(const DDim& dims) {
     if (!strided_kernel_used_) {
       meta->strides = meta->calc_strides(dims);
     }
+  } else if (paddle::dialect::IrMetaTensor::classof(tensor_)) {
+    static_cast<paddle::dialect::IrMetaTensor*>(tensor_)->SetDims(dims);
   } else if (phi::StringTensor::classof(tensor_)) {
     StringTensorUtils::GetMutableMeta(static_cast<StringTensor*>(tensor_))
         ->dims = dims;
@@ -107,6 +109,8 @@ void MetaTensor::set_dtype(DataType dtype) {
   if (phi::DenseTensor::classof(tensor_)) {
     DenseTensorUtils::GetMutableMeta(static_cast<DenseTensor*>(tensor_))
         ->dtype = dtype;
+  } else if (paddle::dialect::IrMetaTensor::classof(tensor_)) {
+    static_cast<paddle::dialect::IrMetaTensor*>(tensor_)->SetDtype(dtype);
   } else if (phi::StringTensor::classof(tensor_)) {
     // No need to set dtype
   } else if (phi::SelectedRows::classof(tensor_)) {
@@ -136,6 +140,8 @@ void MetaTensor::set_layout(DataLayout layout) {
     if (!strided_kernel_used_) {
       meta->strides = meta->calc_strides(meta->dims);
     }
+  } else if (paddle::dialect::IrMetaTensor::classof(tensor_)) {
+    static_cast<paddle::dialect::IrMetaTensor*>(tensor_)->SetLayout(layout);
   } else if (phi::StringTensor::classof(tensor_)) {
     // No need to set layout
   } else if (phi::SelectedRows::classof(tensor_)) {
@@ -178,6 +184,9 @@ void MetaTensor::share_lod(const MetaTensor& meta_tensor) {
     DenseTensorUtils::GetMutableMeta(
         static_cast<SelectedRows*>(tensor_)->mutable_value())
         ->lod = meta_tensor.lod();
+  } else if (paddle::dialect::IrMetaTensor::classof(tensor_)) {
+    static_cast<paddle::dialect::IrMetaTensor*>(tensor_)->SetLod(
+        meta_tensor.lod());
   } else {
     PADDLE_THROW(
         phi::errors::Unimplemented("Unsupported sharing lod inplace for `%s`.",
@@ -188,6 +197,7 @@ void MetaTensor::share_lod(const MetaTensor& meta_tensor) {
 void MetaTensor::share_meta(const MetaTensor& meta_tensor) {
   ValidCheck(*this);
   if (phi::DenseTensor::classof(tensor_) ||
+      paddle::dialect::IrMetaTensor::classof(tensor_) ||
       phi::SelectedRows::classof(tensor_) ||
       phi::SparseCooTensor::classof(tensor_) ||
       phi::SparseCsrTensor::classof(tensor_) ||
@@ -224,8 +234,9 @@ void MetaTensor::share_dims(const MetaTensor& meta_tensor) {
   bool is_sparse_coo = phi::SparseCooTensor::classof(tensor_);
   bool is_sparse_csr = phi::SparseCsrTensor::classof(tensor_);
   bool is_dist_tensor = phi::distributed::DistTensor::classof(tensor_);
+  bool is_ir_meta_tensor = paddle::dialect::IrMetaTensor::classof(tensor_);
   if (is_dense_tensor || is_selected_rows || is_sparse_coo || is_sparse_csr ||
-      is_dist_tensor) {
+      is_dist_tensor || is_ir_meta_tensor) {
     if (is_selected_rows) {
       const auto in_tensor_base = meta_tensor.tensor();
       PADDLE_ENFORCE_EQ(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
将 IR op build 中 infer_meta 所使用的 tensor 类型从 dense_tensor 改为 IrMetaTensor，解决 Program 与 Pir 的 layout 默认行为不一致的问题（Program 的 var_desc 体系下默认为 any_layout，dense_tensor 默认为 nchw）
Pcard-67164