### PR TITLE
fix brpc flag declare

### DIFF
--- a/paddle/fluid/distributed/ps/service/simple_rpc/baidu_rpc_server.cc
+++ b/paddle/fluid/distributed/ps/service/simple_rpc/baidu_rpc_server.cc
@@ -19,8 +19,8 @@
 #include "paddle/phi/core/enforce.h"
 
 namespace brpc {
-PD_DECLARE_uint64(max_body_size);
-PD_DECLARE_int64(socket_max_unwritten_bytes);
+DECLARE_uint64(max_body_size);
+DECLARE_int64(socket_max_unwritten_bytes);
 }  // namespace brpc
 
 namespace paddle {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-75937
fix brpc flag declare，which will cause gpugraph(PADDLE_WITH_GPU_GRAPH=ON) compile error