### PR TITLE
Fix compilation option settings in paddle_build.sh

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3554,6 +3554,7 @@ EOF
     export WITH_ONNXRUNTIME=${WITH_ONNXRUNTIME:-OFF}
     export WITH_CUDNN_FRONTEND=${WITH_CUDNN_FRONTEND:-OFF}
     export WITH_SHARED_PHI=${WITH_SHARED_PHI:-OFF}
+    export WITH_NVCC_LAZY=${WITH_NVCC_LAZY:-ON}
     
     if [ "$SYSTEM" == "Linux" ];then
       if [ `nproc` -gt 16 ];then


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复编译脚本中未设置WITH_NVCC_LAZY=ON导致的模型任务报错，Pcard-75939