### PR TITLE
[PIR] fix backend bitset 0 bug

### DIFF
--- a/paddle/phi/api/lib/kernel_dispatch.cc
+++ b/paddle/phi/api/lib/kernel_dispatch.cc
@@ -79,6 +79,9 @@ BackendSet GetTensorBackendSet(const phi::TensorBase& t) {
 
 std::size_t CountLeadingZeros(uint32_t val) {
 #if defined(__clang__) || defined(__GNUC__)
+  if (val == 0) {
+    return 32;
+  }
   return __builtin_clz(val);
 #elif defined(_MSC_VER)
   // windows don't have built-in clz/ctz function


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
__builtin_clz在传入参数为0时，行为是未定义行为。因此backend.bitset()为0时需要特殊处理。否则导致GetHighestPriorityKernelKey崩溃。
Pcard-67164