### PR TITLE
[CodeStyle][task 26] Enable Ruff B004 rule in `python/paddle/base`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ ignore = [
     "C408",
     "UP030",
     "C405",
-    "B004",
     "B009",
     "B016",
     "B019", # Confirmation required

--- a/python/paddle/base/backward.py
+++ b/python/paddle/base/backward.py
@@ -1320,7 +1320,7 @@ def _append_backward_ops_(
     if callbacks is not None:
         assert isinstance(callbacks, (list, tuple))
         for cb in callbacks:
-            if not hasattr(cb, '__call__'):
+            if not callable(cb):
                 raise ValueError("'callback' must be a callable object.")
 
     # grad_op_descs holds created grad_op, and will be appended to target_block


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
This PR comes after the idea in https://github.com/PaddlePaddle/Paddle/issues/57367.

The purpose is to activate Ruff's B004 check.

Ruff version: 0.0.290

What I've done:

Uncomment "B004", line in pyproject.toml
Take advantage of Ruff to identify and automatically fix relevant violations.
Make sure no B004 violation is found after the fix.
Make sure all local pre-commit hooks pass/skip

@gouzil