### PR TITLE
[CodeStyle][task 28] Enable Ruff B016 rule in `python/paddle/base`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ ignore = [
     "C405",
     "B004",
     "B009",
-    "B016",
     "B019", # Confirmation required
     "C411",
     "C416",

--- a/python/paddle/base/backward.py
+++ b/python/paddle/base/backward.py
@@ -2461,7 +2461,7 @@ def calc_gradient_helper(
 
     for input in inputs:
         if input.block.program != prog:
-            raise "input must be in the same program as targets"
+            raise ValueError("input must be in the same program as targets")
     block_no_grad_set = set(map(_strip_grad_suffix_, no_grad_dict[0]))
 
     op_path_dict = dict()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
This PR comes after the idea in https://github.com/PaddlePaddle/Paddle/issues/57367.

The purpose is to activate Ruff's `B016` check.

Ruff version: 0.0.290

What I've done:

1. Uncomment `"B016",` line in `pyproject.toml`
2. Take advantage of Ruff to identify and automatically fix relevant violations.
3. Make sure no `B016` violation is found after the fix.
4. Make sure all local pre-commit hooks pass/skip

@gouzil
