### PR TITLE
temporarily fix advanced-setitem grad error

### DIFF
--- a/test/indexing/test_setitem.py
+++ b/test/indexing/test_setitem.py
@@ -123,6 +123,23 @@ class TestSetitemInDygraph(unittest.TestCase):
 
         np.testing.assert_allclose(x.numpy(), np_data)
 
+    def test_inplace_with_stride(self):
+        v = paddle.randn((3, 1))
+        v.stop_gradient = False
+        vv = v * 1
+
+        zero = paddle.randn((3, 3, 5))
+        zero.stop_gradient = False
+
+        zero1 = zero * 1
+        zero1[paddle.to_tensor([0, 1])] = vv
+
+        loss = zero1.sum()
+        loss.backward()
+
+        expected_v_grad = np.ones((3, 1)) * 10.0
+        np.testing.assert_equal(v.grad.numpy(), expected_v_grad)
+
 
 class TestSetitemInStatic(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985

在 https://github.com/PaddlePaddle/Paddle/pull/57023 中，由于动态图下stride机制的支持，针对高级索引赋值的场景，移除了一次多余的set_value OP操作。即流程由 `基础索引get -> index_put获取高级索引赋值结果 -> set_value回写` 变为 `基础索引get到原tensor的view -> index_put_在view上执行inplace赋值` 。

上述修改在目前的动态图反向机制上存在一定问题，反向只以**被赋值节点**作为出发点，这导致index_put_等操作只完成了前向过程中修改值的功能，但并未参与到反向，导致部分模型无法收敛。经讨论，这个问题需要在 https://github.com/PaddlePaddle/Paddle/pull/57628/ 中修复，但由于涉及整体反向机制，需要一些时间。

因此这个PR将高级索引赋值改回此前的流程，执行一次额外的set_value赋值，保证前序操作均在反向流程中。当上述机制问题修复后再移除