### PR TITLE
[PIR]Refine manipulation transpose

### DIFF
--- a/python/paddle/nn/quant/functional_layers.py
+++ b/python/paddle/nn/quant/functional_layers.py
@@ -68,7 +68,7 @@ class transpose(FloatFunctionalLayer):
         super().__init__()
 
     def forward(self, x, perm, name=None):
-        return linalg.transpose(x, perm, name)
+        return manipulation.transpose(x, perm, name)
 
 
 class concat(FloatFunctionalLayer):

--- a/python/paddle/nn/quant/functional_layers.py
+++ b/python/paddle/nn/quant/functional_layers.py
@@ -68,7 +68,7 @@ class transpose(FloatFunctionalLayer):
         super().__init__()
 
     def forward(self, x, perm, name=None):
-        return manipulation.transpose(x, perm, name)
+        return linalg.transpose(x, perm, name)
 
 
 class concat(FloatFunctionalLayer):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops
-from paddle.tensor import fill_constant, transpose
+from paddle.tensor import fill_constant
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from ..base.data_feeder import (
@@ -1378,10 +1378,10 @@ def rot90(x, k=1, axes=[0, 1], name=None):
         axes_list[axes[0]],
     )
     if k == 1:
-        return transpose(flip(x, axes[1]), axes_list)
+        return flip(x, axes[1]).transpose(axes_list)
     else:
         # k == 3
-        return flip(transpose(x, axes_list), axes[1])
+        return flip(x.transpose(axes_list), axes[1])
 
 
 def flatten(x, start_axis=0, stop_axis=-1, name=None):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops
-from paddle.tensor import fill_constant
+from paddle.tensor import fill_constant, transpose
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
 from ..base.data_feeder import (
@@ -422,105 +422,6 @@ def slice(input, axes, starts, ends):
             type='slice', inputs=inputs, attrs=attrs, outputs={'Out': out}
         )
 
-        return out
-
-
-def transpose(x, perm, name=None):
-    """
-    Permute the data dimensions of `input` according to `perm`.
-
-    The `i`-th dimension  of the returned tensor will correspond to the
-    perm[i]-th dimension of `input`.
-
-    Args:
-        x (Tensor): The input Tensor. It is a N-D Tensor of data types bool, float32, float64, int32.
-        perm (list|tuple): Permute the input according to the data of perm.
-        name (str): The name of this layer. It is optional.
-
-    Returns:
-        Tensor, A transposed n-D Tensor, with data type being bool, float32, float64, int32, int64.
-
-    For Example:
-
-        .. code-block:: text
-
-         x = [[[ 1  2  3  4] [ 5  6  7  8] [ 9 10 11 12]]
-             [[13 14 15 16] [17 18 19 20] [21 22 23 24]]]
-         shape(x) =  [2,3,4]
-
-         # Example 1
-         perm0 = [1,0,2]
-         y_perm0 = [[[ 1  2  3  4] [13 14 15 16]]
-                   [[ 5  6  7  8]  [17 18 19 20]]
-                   [[ 9 10 11 12]  [21 22 23 24]]]
-         shape(y_perm0) = [3,2,4]
-
-         # Example 2
-         perm1 = [2,1,0]
-         y_perm1 = [[[ 1 13] [ 5 17] [ 9 21]]
-                   [[ 2 14] [ 6 18] [10 22]]
-                   [[ 3 15]  [ 7 19]  [11 23]]
-                   [[ 4 16]  [ 8 20]  [12 24]]]
-         shape(y_perm1) = [4,3,2]
-
-    Examples:
-
-        .. code-block:: python
-
-            import paddle
-
-            x = paddle.randn([2, 3, 4])
-            x_transposed = paddle.transpose(x, perm=[1, 0, 2])
-            print(x_transposed.shape)
-            # [3L, 2L, 4L]
-
-    """
-    if in_dynamic_mode():
-        return _C_ops.transpose(x, perm)
-    else:
-        check_variable_and_dtype(
-            x,
-            'x',
-            [
-                'bool',
-                'float16',
-                'float32',
-                'float64',
-                'int32',
-                'int64',
-                'uint16',
-                'complex64',
-                'complex128',
-            ],
-            'transpose',
-        )
-        check_type(perm, 'perm', (list, tuple), 'transpose')
-        if isinstance(perm, tuple):
-            perm = list(perm)
-        if len(perm) != len(x.shape):
-            raise ValueError(
-                "Input(perm) is the permutation of dimensions of Input(x), "
-                "its length should be equal to dimensions of Input(x), "
-                f"but received dimension of Input(x) is {len(x.shape)}, "
-                f"the length of Input(perm) is {len(perm)}."
-            )
-        for idx, dim in enumerate(perm):
-            if dim >= len(x.shape):
-                raise ValueError(
-                    "Each element in Input(perm) should be less than Input(x)'s dimension, "
-                    "but %d-th element in Input(perm) is %d which exceeds Input(x)'s "
-                    "dimension %d." % (idx, perm[idx], len(x.shape))
-                )
-
-        helper = LayerHelper('transpose', **locals())
-        out = helper.create_variable_for_type_inference(x.dtype)
-        x_shape = helper.create_variable_for_type_inference(x.dtype)
-        helper.append_op(
-            type='transpose2',
-            inputs={'X': [x]},
-            outputs={'Out': [out], 'XShape': [x_shape]},
-            attrs={'axis': perm},
-        )
         return out
 
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -428,25 +428,33 @@ def slice(input, axes, starts, ends):
 def transpose(x, perm, name=None):
     """
     Permute the data dimensions of `input` according to `perm`.
+
     The `i`-th dimension  of the returned tensor will correspond to the
     perm[i]-th dimension of `input`.
+
     Args:
         x (Tensor): The input Tensor. It is a N-D Tensor of data types bool, float32, float64, int32.
         perm (list|tuple): Permute the input according to the data of perm.
         name (str): The name of this layer. It is optional.
+
     Returns:
         Tensor, A transposed n-D Tensor, with data type being bool, float32, float64, int32, int64.
+
     For Example:
+
         .. code-block:: text
+
          x = [[[ 1  2  3  4] [ 5  6  7  8] [ 9 10 11 12]]
              [[13 14 15 16] [17 18 19 20] [21 22 23 24]]]
          shape(x) =  [2,3,4]
+
          # Example 1
          perm0 = [1,0,2]
          y_perm0 = [[[ 1  2  3  4] [13 14 15 16]]
                    [[ 5  6  7  8]  [17 18 19 20]]
                    [[ 9 10 11 12]  [21 22 23 24]]]
          shape(y_perm0) = [3,2,4]
+
          # Example 2
          perm1 = [2,1,0]
          y_perm1 = [[[ 1 13] [ 5 17] [ 9 21]]
@@ -454,13 +462,18 @@ def transpose(x, perm, name=None):
                    [[ 3 15]  [ 7 19]  [11 23]]
                    [[ 4 16]  [ 8 20]  [12 24]]]
          shape(y_perm1) = [4,3,2]
+
     Examples:
+
         .. code-block:: python
+
             import paddle
+
             x = paddle.randn([2, 3, 4])
             x_transposed = paddle.transpose(x, perm=[1, 0, 2])
             print(x_transposed.shape)
             # [3L, 2L, 4L]
+
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.transpose(x, perm)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
[PIR]Remove manipulation transpose
manipulation下的transpose api似乎没有对应单测。现在manipulation和linalg下各有一个transpose接口，两个接口完全一致，框架中使用的基本都是linalg下的接口，但是manipulation下直接删除的话可能会有兼容问题，所以修改了manipulation下的接口，使其支持pir
Pcard-67164