### PR TITLE
[AutoParallel] Support operators have mixed inputs.

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -72,6 +72,13 @@ PARSE_PYTHON_C_TENSORS_TEMPLATE = (
     "    auto {} = {}(\"{}\", \"{}\", args, {}, {});\n"
 )
 
+CONVERT_INPUT_TENSORS_TO_DIST_TENSOR_TEMPLATE = """
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    auto mesh_ptr = &mesh;
+    if (InputsContainDistTensor({inputs})) {{
+      ConvertAllInputsToDistTensor(*{inputs});
+    }}
+"""
 
 PARSE_PYTHON_C_ARGS_TEMPLATE = """    PyObject* {}_obj = PyTuple_GET_ITEM(args, {});
     {} {} = {}({}_obj, \"{}\", {});
@@ -325,7 +332,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         inplace_returns_pos_map = {}
         # Generate Python-C Tensors Parsing Logic
         get_eager_tensor_str = ""
+        input_names = "mesh_ptr, "
         for name, (ttype, pos) in forward_inputs_position_map.items():
+            input_names = input_names + name + ", "
             if forward_inplace_map and name in forward_inplace_map.keys():
                 inplace_args_pos_map[name] = pos
             is_optional = name in optional_inputs
@@ -375,6 +384,14 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                             "false",
                         )
                     )
+        # No inputs, skip convert to DistTensor
+        if len(input_names) > len("mesh_ptr, "):
+            input_names = input_names[:-2]
+            get_eager_tensor_str += (
+                CONVERT_INPUT_TENSORS_TO_DIST_TENSOR_TEMPLATE.format(
+                    inputs=input_names
+                )
+            )
 
         if forward_inplace_map:
             for name, (ttype, pos) in forward_outputs_position_map.items():

--- a/paddle/phi/api/lib/kernel_dispatch.h
+++ b/paddle/phi/api/lib/kernel_dispatch.h
@@ -171,20 +171,22 @@ struct KernelTypeParser : ArgsIterator<KernelTypeParser> {
 /* ------------------ for auto parallel ----------------------- */
 
 struct DistTensorTypeParser : ArgsIterator<DistTensorTypeParser> {
-  bool result = true;
+  bool result = false;
 
-  void operator()(const Tensor& x) { result &= x.is_dist_tensor(); }
+  bool short_circuit() { return result; }
+
+  void operator()(const Tensor& x) { result = x.is_dist_tensor(); }
 
   void operator()(const paddle::optional<Tensor>& x) {
     if (x) {
-      result &= x.get_ptr()->is_dist_tensor();
+      result = x.get_ptr()->is_dist_tensor();
     }
   }
 
   void operator()(const std::vector<Tensor>& x) {
     if (!x.empty()) {
       for (auto& t : x) {
-        result &= t.is_dist_tensor();
+        result = t.is_dist_tensor();
       }
     }
   }
@@ -193,7 +195,7 @@ struct DistTensorTypeParser : ArgsIterator<DistTensorTypeParser> {
     if (x) {
       if (!(x.get_ptr()->empty())) {
         for (auto& t : *(x.get_ptr())) {
-          result &= t.is_dist_tensor();
+          result = t.is_dist_tensor();
         }
       }
     }

--- a/test/auto_parallel/test_api_dist_branch.py
+++ b/test/auto_parallel/test_api_dist_branch.py
@@ -69,10 +69,10 @@ class TestDygraphAPIForDistTensorBranch(unittest.TestCase):
             local_t_2 = paddle.to_tensor(np_array, dtype='float16')
         elif np_array.dtype == np.int32:
             local_t_1 = paddle.to_tensor(np_array, dtype='int32')
-            # local_t_2 = paddle.to_tensor(np_array, dtype='float16')
+            local_t_2 = paddle.to_tensor(np_array, dtype='int32')
         elif np_array.dtype == np.bool_:
             local_t_1 = paddle.to_tensor(np_array, dtype='bool')
-            local_t_2 = paddle.to_tensor(np_array, dtype='float16')
+            local_t_2 = paddle.to_tensor(np_array, dtype='bool')
 
         local_t_1.stop_gradient = False
         local_t_2.stop_gradient = False
@@ -84,16 +84,16 @@ class TestDygraphAPIForDistTensorBranch(unittest.TestCase):
         x = np.random.random(size=[4, 4]).astype("float32")
         y = np.random.random(size=[4, 4]).astype("float32")
         local_x, dist_x = self.create_local_and_dist_tensor_pair(x)
-        local_y, dist_y = self.create_two_local_tensor_pair(y)
-        local_out = paddle.matmul(local_x, local_y)
-        dist_out = paddle.matmul(dist_x, dist_y)
+        local_y_1, local_y_2 = self.create_two_local_tensor_pair(y)
+        local_out = paddle.matmul(local_x, local_y_1)
+        dist_out = paddle.matmul(dist_x, local_y_2)
         self.check_tensor_eq(local_out, dist_out)
 
         # test backward
         local_out.backward()
         dist_out.backward()
         self.check_tensor_eq(local_x.grad, dist_x.grad)
-        self.check_tensor_eq(local_y.grad, local_y.grad)
+        self.check_tensor_eq(local_y_1.grad, local_y_2.grad)
 
     # input: std::vector<phi::Tensor>
     # output: phi::Tensor

--- a/test/auto_parallel/test_api_dist_branch.py
+++ b/test/auto_parallel/test_api_dist_branch.py
@@ -60,6 +60,41 @@ class TestDygraphAPIForDistTensorBranch(unittest.TestCase):
             dist_t_list.append(dist_t)
         return local_t_list, dist_t_list
 
+    def create_two_local_tensor_pair(self, np_array):
+        if np_array.dtype == np.float32:
+            local_t_1 = paddle.to_tensor(np_array, dtype='float32')
+            local_t_2 = paddle.to_tensor(np_array, dtype='float32')
+        elif np_array.dtype == np.float16:
+            local_t_1 = paddle.to_tensor(np_array, dtype='float16')
+            local_t_2 = paddle.to_tensor(np_array, dtype='float16')
+        elif np_array.dtype == np.int32:
+            local_t_1 = paddle.to_tensor(np_array, dtype='int32')
+            # local_t_2 = paddle.to_tensor(np_array, dtype='float16')
+        elif np_array.dtype == np.bool_:
+            local_t_1 = paddle.to_tensor(np_array, dtype='bool')
+            local_t_2 = paddle.to_tensor(np_array, dtype='float16')
+
+        local_t_1.stop_gradient = False
+        local_t_2.stop_gradient = False
+
+        return local_t_1, local_t_2
+
+    # mixed type of inputs: DenseTensor and DistTensor
+    def test_matmul_api_for_mixed_inputs_type(self):
+        x = np.random.random(size=[4, 4]).astype("float32")
+        y = np.random.random(size=[4, 4]).astype("float32")
+        local_x, dist_x = self.create_local_and_dist_tensor_pair(x)
+        local_y, dist_y = self.create_two_local_tensor_pair(y)
+        local_out = paddle.matmul(local_x, local_y)
+        dist_out = paddle.matmul(dist_x, dist_y)
+        self.check_tensor_eq(local_out, dist_out)
+
+        # test backward
+        local_out.backward()
+        dist_out.backward()
+        self.check_tensor_eq(local_x.grad, dist_x.grad)
+        self.check_tensor_eq(local_y.grad, local_y.grad)
+
     # input: std::vector<phi::Tensor>
     # output: phi::Tensor
     def test_concat_for_dist_tensor(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Pcard-73145

Support operators have mixed inputs like DenseTensor and DistTensor. DenseTensor will be sharded to replicate DistTensor automatically.

Former implementation is deployed in `phi` APIs: [PR 57684](https://github.com/PaddlePaddle/Paddle/pull/57684). However, inputs are all `const` reference, which means converting input `DenseTensor` to `DistTensor` is an unsafe operation. Meanwhile, there is modification of inputs in `AutoGrad` level like convert them to continuous Tensors. As a result, modification of `phi` input like `x_tmp` in `AutoGrad` level will not change the real input `x`, but backward node relies on the real input `x` information as Tensor metas. It's more properly to implement this sharding strategy in `Python-C` level.
