### PR TITLE
[WIP][SOT][3.11] DECREF for original frame to avoid memory leak

### DIFF
--- a/paddle/fluid/pybind/eval_frame.c
+++ b/paddle/fluid/pybind/eval_frame.c
@@ -441,7 +441,10 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   eval_frame_callback_set(Py_None);
 
 #if PY_VERSION_HEX >= 0x030b0000
+  // We only pass the proxy ownership to Python side, the frame will not be
+  // automatically released, so we need to call DECREF manually.
   PyObject *args = Py_BuildValue("(O)", PyInterpreterFrameProxy_New(frame));
+  Py_DECREF(frame);
 #else
   PyObject *args = Py_BuildValue("(O)", frame);
 #endif

--- a/paddle/fluid/pybind/eval_frame.c
+++ b/paddle/fluid/pybind/eval_frame.c
@@ -441,7 +441,7 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
   eval_frame_callback_set(Py_None);
 
 #if PY_VERSION_HEX >= 0x030b0000
-  // We only pass the proxy ownership to Python side, the frame will not be
+  // This only take the ownership of proxy to Python side, the frame will not be
   // automatically released, so we need to call DECREF manually.
   PyObject *args = Py_BuildValue("(O)", PyInterpreterFrameProxy_New(frame));
   Py_DECREF(frame);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 3.11 eval frame 少对 frame DECREF 导致的模型级别测试大量 OOM 的问题

> **Note**
>
> 当前实现还有问题