### PR TITLE
[PIR] Add kernel op log before running instruction node

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -1261,8 +1261,8 @@ void PrintValuesAndVariables(
     const std::unordered_map<pir::Value, std::string>& value_2_var_name,
     const std::unordered_map<const paddle::framework::Variable*, std::string>&
         variable_2_var_name) {
-  std::stringstream ss;
   for (const auto& op : block) {
+    std::stringstream ss;
     VLOG(6) << "-----------------------------";
     op->Print(ss);
     VLOG(6) << ss.str();

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -1256,6 +1256,32 @@ const paddle::framework::Variable* GetVariableByName(
   return nullptr;
 }
 
+std::vector<std::string> GetOriginInputNames(std::string op_name) {
+  std::vector<std::string> ret;
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_name);
+  if (op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>()) {
+    paddle::dialect::OpYamlInfoParser yaml_parser(
+        op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>()
+            ->get_op_info_());
+    ret = yaml_parser.InputNames();
+  }
+  return ret;
+}
+
+std::vector<std::string> GetOriginOutputNames(std::string op_name) {
+  std::vector<std::string> ret;
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  pir::OpInfo op_info = ctx->GetRegisteredOpInfo(op_name);
+  if (op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>()) {
+    paddle::dialect::OpYamlInfoParser yaml_parser(
+        op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>()
+            ->get_op_info_());
+    ret = yaml_parser.OutputNames();
+  }
+  return ret;
+}
+
 void PrintValuesAndVariables(
     const pir::Block& block,
     const std::unordered_map<pir::Value, std::string>& value_2_var_name,
@@ -1267,28 +1293,51 @@ void PrintValuesAndVariables(
     op->Print(ss);
     VLOG(6) << ss.str();
 
+    std::string op_name = op->name();
+    if (op->attributes().count("op_name")) {
+      op_name = op->attributes()
+                    .at("op_name")
+                    .dyn_cast<pir::StrAttribute>()
+                    .AsString();
+    }
+    std::vector<std::string> origin_input_names = GetOriginInputNames(op_name);
+    std::vector<std::string> origin_output_names =
+        GetOriginOutputNames(op_name);
+
     // 1. output string
     std::string ret_value_str = "Value   : (";
     std::string ret_variable_str = "Variable: (";
     if (!op->results().empty()) {
-      for (auto& out_value : op->results()) {
+      for (size_t i = 0; i < op->num_results(); ++i) {
+        pir::Value out_value = op->result(i);
         if (value_2_var_name.count(out_value)) {
+          // get Variable by Value
           auto& var_name = value_2_var_name.at(out_value);
           const paddle::framework::Variable* out_variable =
               GetVariableByName(var_name, variable_2_var_name);
+
+          // get origin name
+          std::string origin_name;
+          if (!origin_output_names.empty())
+            origin_name = origin_output_names[i];
+          else
+            origin_name = var_name;
+
+          // process info
           ss.str("");
           ss << out_value.impl();
           ret_value_str +=
-              (std::string(var_name.length(), ' ') + "[" + ss.str() + "]");
+              (std::string(origin_name.length(), ' ') + "[" + ss.str() + "]");
           ss.str("");
           if (out_variable) {
             ss << out_variable;
-            ret_variable_str += (var_name + "[" + ss.str() + "]");
+            ret_variable_str += (origin_name + "[" + ss.str() + "]");
           } else {
-            ret_variable_str += (var_name + "[NULL]");
+            ret_variable_str += (origin_name + "[NULL]");
           }
         } else {
           ret_value_str += "NULL";
+          ret_variable_str += "NULL";
         }
         ret_value_str += ", ";
         ret_variable_str += ", ";
@@ -1301,15 +1350,6 @@ void PrintValuesAndVariables(
     ret_variable_str += ") = ";
 
     // 2. op name
-    std::string op_name;
-    if (op->attributes().find("op_name") != op->attributes().end()) {
-      op_name = op->attributes()
-                    .at("op_name")
-                    .dyn_cast<::pir::StrAttribute>()
-                    .AsString();
-    } else {
-      op_name = op->name();
-    }
     ret_value_str += op_name;
     ret_variable_str += op_name;
 
@@ -1317,25 +1357,36 @@ void PrintValuesAndVariables(
     ret_value_str += "(";
     ret_variable_str += "(";
     if (!op->operands().empty()) {
-      for (auto& input : op->operands()) {
-        ::pir::Value in_value = input.source();
+      for (size_t i = 0; i < op->num_operands(); ++i) {
+        ::pir::Value in_value = op->operand(i).source();
         if (value_2_var_name.count(in_value)) {
+          // get Variable by Value
           auto& var_name = value_2_var_name.at(in_value);
           const paddle::framework::Variable* in_variable =
               GetVariableByName(var_name, variable_2_var_name);
+
+          // get origin name
+          std::string origin_name;
+          if (!origin_input_names.empty())
+            origin_name = origin_input_names[i];
+          else
+            origin_name = var_name;
+
+          // process info
           ss.str("");
           ss << in_value.impl();
           ret_value_str +=
-              (std::string(var_name.length(), ' ') + "[" + ss.str() + "]");
+              (std::string(origin_name.length(), ' ') + "[" + ss.str() + "]");
           ss.str("");
           if (in_variable) {
             ss << in_variable;
-            ret_variable_str += (var_name + "[" + ss.str() + "]");
+            ret_variable_str += (origin_name + "[" + ss.str() + "]");
           } else {
-            ret_variable_str += (var_name + "[NULL]");
+            ret_variable_str += (origin_name + "[NULL]");
           }
         } else {
           ret_value_str += "NULL";
+          ret_variable_str += "NULL";
         }
         ret_value_str += ", ";
         ret_variable_str += ", ";

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
@@ -134,6 +134,10 @@ const paddle::framework::Variable* GetVariableByName(
     const std::unordered_map<const paddle::framework::Variable*, std::string>&
         variable_2_var_name);
 
+std::vector<std::string> GetOriginInputNames(std::string op_name);
+
+std::vector<std::string> GetOriginOutputNames(std::string op_name);
+
 void PrintValuesAndVariables(
     const pir::Block& block,
     const std::unordered_map<pir::Value, std::string>& value_2_var_name,

--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -1392,6 +1392,14 @@ void NewIRInterpreter::RunInstructionBase(InstructionBase* instr_node) {
   try {
     instr_node->WaitEvent(place_);
     VLOG(4) << "begin to run op " << instr_node->Name();
+    VLOG(4) << "begin: " << __func__ << " OP id:" << instr_node->Id()
+            << " name:" << instr_node->Name() << " type:"
+            << (instr_node->KernelType() == OpFuncType::kCpuSync
+                    ? "kCpuSync"
+                    : (instr_node->KernelType() == OpFuncType::kGpuSync
+                           ? "kGpuSync"
+                           : "kGpuAsync"))
+            << " runs on " << platform::GetCurrentThreadName();
     VLOG(4) << place_ << " "
             << instr_node->DebugStringEx(scope_,
                                          value_exe_info_->GetValue2VarName());
@@ -1406,8 +1414,8 @@ void NewIRInterpreter::RunInstructionBase(InstructionBase* instr_node) {
                 << "): context wait and get last error";
 #endif
       }
-
-      VLOG(4) << __func__ << " OP id:" << instr_node->Id()
+      VLOG(4) << "done instruction node run";
+      VLOG(4) << "done: " << __func__ << " OP id:" << instr_node->Id()
               << " name:" << instr_node->Name() << " type:"
               << (instr_node->KernelType() == OpFuncType::kCpuSync
                       ? "kCpuSync"
@@ -1415,15 +1423,13 @@ void NewIRInterpreter::RunInstructionBase(InstructionBase* instr_node) {
                              ? "kGpuSync"
                              : "kGpuAsync"))
               << " runs on " << platform::GetCurrentThreadName();
-
-      VLOG(4) << "done instruction node run";
+      VLOG(4) << place_ << " "
+              << instr_node->DebugStringEx(scope_,
+                                           value_exe_info_->GetValue2VarName());
       CheckGC(instr_node);
       VLOG(4) << "done CheckGC";
       interpreter::LogDeviceMemoryStats(place_);
     }
-    VLOG(4) << place_ << " "
-            << instr_node->DebugStringEx(scope_,
-                                         value_exe_info_->GetValue2VarName());
     VLOG(5) << "after run kernel";
     instr_node->RecordEvent(place_);
   } catch (platform::EnforceNotMet& ex) {

--- a/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/new_ir_interpreter.cc
@@ -1392,6 +1392,9 @@ void NewIRInterpreter::RunInstructionBase(InstructionBase* instr_node) {
   try {
     instr_node->WaitEvent(place_);
     VLOG(4) << "begin to run op " << instr_node->Name();
+    VLOG(4) << place_ << " "
+            << instr_node->DebugStringEx(scope_,
+                                         value_exe_info_->GetValue2VarName());
     if (!instr_node->IsArtificial()) {
       instr_node->Run();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

PCard-67164

1、在 run instruction node之前插入日志
2、将value、variable打印字段中的变量名称替换为初始yaml中的名称，便于理解
