### PR TITLE
【Hackathon 5th No.30】 为 Paddle 新增 vdot API

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -153,6 +153,7 @@ from .tensor.linalg import (  # noqa: F401
     bincount,
     mv,
     eigvalsh,
+    vdot,
 )
 
 from .tensor.logic import (  # noqa: F401

--- a/python/paddle/linalg.py
+++ b/python/paddle/linalg.py
@@ -36,7 +36,7 @@ from .tensor.linalg import slogdet  # noqa: F401
 from .tensor.linalg import solve  # noqa: F401
 from .tensor.linalg import svd  # noqa: F401
 from .tensor.linalg import triangular_solve  # noqa: F401
-from .tensor.linalg import lstsq
+from .tensor.linalg import lstsq, vdot
 
 __all__ = [
     'cholesky',  # noqa
@@ -64,4 +64,5 @@ __all__ = [
     'cholesky_solve',
     'triangular_solve',
     'lstsq',
+    'vdot',
 ]

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3730,3 +3730,72 @@ def cdist(
     return paddle.linalg.norm(
         x[..., None, :] - y[..., None, :, :], p=p, axis=-1
     )
+
+
+def vdot(x, y, name=None):
+    r"""
+    Compute the dot product of two 1-D vectors along a dimension.
+    If the first argument is complex, the complex conjugate of the first argument is used for the calculation of the dot product.
+    .. math::
+        out = \sum_{i=0}^{N} \overline{x_{i}}y_{i}
+
+    Where:
+    - :math:`\overline{x_{i}}`: the conjugate for the :math:`i`-th complex tensor
+    - :math:`N`: the size of 1-D Tensor
+
+    Args:
+        x (Tensor): the input 1-D tensor, its data type should be float32, float64, complex64, complex128.
+        y (Tensor): the input 1-D tensor, its data type should be float32, float64, complex64, complex128.
+        name (str, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        Tensor: the calculated result Tensor.
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            import numpy as np
+
+            np_x = np.array([1+2j, 3-1j])
+            np_y = np.array([2+1j, 4-0j])
+            x = paddle.to_tensor(np_x)
+            y = paddle.to_tensor(np_y)
+
+            z = paddle.vdot(x, y)
+            np_z = z.numpy()
+            # [16.+1.j]
+
+            z = paddle.vdot(y, x)
+            np_z = z.numpy()
+            # [16.-1.j]
+    """
+    check_variable_and_dtype(
+        x, 'x', ('float32', 'float64', 'complex64', 'complex128'), 'vdot'
+    )
+    check_variable_and_dtype(
+        y, 'y', ('float32', 'float64', 'complex64', 'complex128'), 'vdot'
+    )
+
+    if len(x.shape) != 1:
+        raise ValueError(
+            "Input(x) only support 1-D tensor in vdot, but received "
+            "length of Input(input) is %s." % len(x.shape)
+        )
+
+    if len(y.shape) != 1:
+        raise ValueError(
+            "Input(y) only support 1-D tesnor in vdot, but received "
+            "length of Input(input) is %s." % len(y.shape)
+        )
+
+    assert x.shape[0] == y.shape[0], (
+        "The x and y must have same dimension, "
+        f"But received Input x's dimension is {x.shape[0]}, "
+        f"Input y's dimension is {y.shape[0]}.\n"
+    )
+
+    if paddle.is_complex(x):
+        return paddle.dot(paddle.conj(x), y)
+    else:
+        return paddle.dot(x, y)

--- a/test/legacy_test/test_vdot_op.py
+++ b/test/legacy_test/test_vdot_op.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.base import core
+from paddle.static import Program, program_guard
+
+DYNAMIC = 1
+STATIC = 2
+
+
+def _run_vdot(mode, x, y, device="cpu"):
+    # dynamic mode
+    if mode == DYNAMIC:
+        paddle.disable_static()
+        paddle.set_device(device)
+        x_ = paddle.to_tensor(x)
+        y_ = paddle.to_tensor(y)
+        res = paddle.vdot(x_, y_)
+        return res.numpy()
+    # static graph mode
+    elif mode == STATIC:
+        paddle.enable_static()
+        with program_guard(Program(), Program()):
+            x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
+            y_ = paddle.static.data(name="y", shape=y.shape, dtype=y.dtype)
+            res = paddle.vdot(x_, y_)
+            place = (
+                paddle.CPUPlace() if device == 'cpu' else paddle.CUDAPlace(0)
+            )
+            exe = paddle.static.Executor(place)
+            outs = exe.run(feed={"x": x, "y": y}, fetch_list=[res])
+            return outs[0]
+
+
+class TestVdotAPI(unittest.TestCase):
+    """TestVdotAPI."""
+
+    def setUp(self):
+        self.places = ["cpu"]
+        if core.is_compiled_with_cuda():
+            self.places.append("gpu")
+
+    def test_vdot(self):
+        """test_vdot."""
+        np.random.seed(8)
+        dim = np.random.randint(200, 300)
+
+        for place in self.places:
+            # test 1-d float32 * float32
+            x = np.random.rand(dim).astype(np.float32)
+            y = np.random.rand(dim).astype(np.float32)
+            res = _run_vdot(DYNAMIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+            res = _run_vdot(STATIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+
+            # test 1-d float64 * float64
+            x = np.random.rand(dim).astype(np.float64)
+            y = np.random.rand(dim).astype(np.float64)
+            res = _run_vdot(DYNAMIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+            res = _run_vdot(STATIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+
+            # test 1-d complex64 * complex64
+            x = np.random.rand(dim).astype(np.float32) + 1.0j * np.random.rand(
+                dim
+            ).astype(np.float32)
+            y = np.random.rand(dim).astype(np.float32) + 1.0j * np.random.rand(
+                dim
+            ).astype(np.float32)
+            res = _run_vdot(DYNAMIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+            res = _run_vdot(STATIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+
+            # test 1-d complex128 * complex128
+            x = np.random.rand(dim).astype(np.float64) + 1.0j * np.random.rand(
+                dim
+            ).astype(np.float64)
+            y = np.random.rand(dim).astype(np.float64) + 1.0j * np.random.rand(
+                dim
+            ).astype(np.float64)
+            res = _run_vdot(DYNAMIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+            res = _run_vdot(STATIC, x, y, place)
+            np.testing.assert_allclose(res, np.vdot(x, y), rtol=1e-05)
+
+
+class TestVdotError(unittest.TestCase):
+    """TestVdotError."""
+
+    def test_errors(self):
+        """test_errors."""
+        np.random.seed(8)
+        dim = np.random.randint(2, 10)
+
+        # test input data type
+        x = np.random.randint(10, size=dim)
+        y = np.random.rand(dim).astype(np.float32)
+        self.assertRaises(Exception, _run_vdot, DYNAMIC, x, y)
+        self.assertRaises(Exception, _run_vdot, STATIC, x, y)
+
+        x = np.random.rand(dim).astype(np.float32)
+        y = np.random.randint(10, size=dim)
+        self.assertRaises(Exception, _run_vdot, DYNAMIC, x, y)
+        self.assertRaises(Exception, _run_vdot, STATIC, x, y)
+
+        # test input data dimension
+        x = np.random.rand(dim, dim).astype(np.float32)
+        y = np.random.rand(dim).astype(np.float32)
+        self.assertRaises(Exception, _run_vdot, DYNAMIC, x, y)
+        self.assertRaises(Exception, _run_vdot, STATIC, x, y)
+
+        x = np.random.rand(dim).astype(np.float32)
+        y = np.random.rand(dim, dim).astype(np.float32)
+        self.assertRaises(Exception, _run_vdot, DYNAMIC, x, y)
+        self.assertRaises(Exception, _run_vdot, STATIC, x, y)
+
+        x = np.random.rand(dim).astype(np.float32)
+        y = np.random.rand(dim + 1).astype(np.float32)
+        self.assertRaises(Exception, _run_vdot, DYNAMIC, x, y)
+        self.assertRaises(Exception, _run_vdot, STATIC, x, y)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
 为 Paddle 新增 vdot API

### PR changes
python/paddle/__init__.py
python/paddle/linalg.py
python/paddle/tensor/linalg.py
test/legacy_test/test_vdot_op.py

### Description
 为 Paddle 新增 vdot API
