### PR TITLE
[No merge][Prim][PIR] fix prim reshape grad bug

### DIFF
--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -579,14 +579,14 @@ class Reshape2CompositeGradOpMaker : public prim::CompositeGradOpMakerBase {
   void Apply() override {
     // We prefer to use x.shape instead of using xshape, this is different from
     // PHI definition.
-    paddle::Tensor x = this->GetSingleForwardInput("X");
+    paddle::Tensor xshape = this->GetSingleForwardOutput("XShape");
     paddle::Tensor out_grad = this->GetSingleOutputGrad("Out");
     paddle::Tensor dx = this->GetSingleInputGrad("X");
 
     auto *dx_ptr = this->GetOutputPtr(&dx);
     std::string dx_name = this->GetOutputName(dx);
     VLOG(6) << "Runing reshape2_grad composite func";
-    prim::reshape_grad<prim::DescTensor>(x, out_grad, dx_ptr);
+    prim::reshape_grad<prim::DescTensor>(xshape, out_grad, dx_ptr);
     this->RecoverOutputName(dx, dx_name);
   }
 };

--- a/paddle/fluid/prim/api/api.yaml
+++ b/paddle/fluid/prim/api/api.yaml
@@ -45,6 +45,5 @@
 - cos
 - where
 - split
-- reshape
 - erf
 - tanh

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -187,9 +187,14 @@ void tanh_grad(const Tensor& out, const Tensor& grad_out, Tensor* grad_x) {
 }
 
 template <typename T>
-void reshape_grad(const Tensor& x, const Tensor& grad_out, Tensor* grad_x) {
+void reshape_grad(const Tensor& xshape,
+                  const Tensor& grad_out,
+                  Tensor* grad_x) {
   if (grad_x) {
-    auto grad_x_tmp = reshape<T>(grad_out, phi::vectorize(x.dims()));
+    // xshape: [0] + x.shape
+    auto shape = phi::vectorize(xshape.dims());
+    shape.erase(shape.begin());
+    auto grad_x_tmp = reshape<T>(grad_out, shape);
     set_output<T>(grad_x_tmp, grad_x);
   }
 }

--- a/paddle/fluid/prim/api/manual_prim/eager_prim_api.cc
+++ b/paddle/fluid/prim/api/manual_prim/eager_prim_api.cc
@@ -44,5 +44,11 @@ Tensor slice<Tensor>(const Tensor& input,
   return ::slice_ad_func(input, axes, starts, ends, infer_flags, decrease_axis);
 }
 
+template <>
+Tensor reshape<Tensor>(const Tensor& x, const IntArray& shape) {
+  VLOG(4) << "Eager Prim API reshape_ad_func call";
+  return ::reshape_ad_func(x, shape);
+}
+
 }  // namespace prim
 }  // namespace paddle

--- a/paddle/fluid/prim/api/manual_prim/prim_manual_api.h
+++ b/paddle/fluid/prim/api/manual_prim/prim_manual_api.h
@@ -46,5 +46,8 @@ Tensor slice(const Tensor& input,
              const std::vector<int64_t>& infer_flags,
              const std::vector<int64_t>& decrease_axis);
 
+template <typename T>
+Tensor reshape(const Tensor& x, const IntArray& shape);
+
 }  // namespace prim
 }  // namespace paddle

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -200,9 +200,14 @@ void gelu_grad(const Tensor& x,
 }
 
 template <typename T>
-void reshape_grad(const Tensor& x, const Tensor& grad_out, Tensor* grad_x) {
+void reshape_grad(const Tensor& xshape,
+                  const Tensor& grad_out,
+                  Tensor* grad_x) {
   if (grad_x) {
-    auto grad_x_tmp = reshape<T>(grad_out, phi::vectorize(x.dims()));
+    // xshape: [0] + x.shape
+    auto shape = phi::vectorize(xshape.dims());
+    shape.erase(shape.begin());
+    auto grad_x_tmp = reshape<T>(grad_out, shape);
     set_output<T>(grad_x_tmp, grad_x);
   }
 }

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -579,6 +579,7 @@
     backend: out_grad
     layout: out_grad
   backward : reshape_double_grad
+  composite: reshape_grad(xshape, out_grad, x_grad)
   inplace : (out_grad -> x_grad)
 
 - backward_op : rnn_grad

--- a/python/paddle/decomposition/rules.py
+++ b/python/paddle/decomposition/rules.py
@@ -39,7 +39,7 @@ def mean(x, axis, keepdim):
 
 
 @register_decomp('pd_op.gelu')
-def gelu_composite(x, approximate):
+def gelu(x, approximate):
     """define composite rule of op gelu"""
     M_SQRT1_2 = (
         0.70710678118654752440  # /* 1/sqrt(2) */ copy from gelu-kernel.cc
@@ -66,7 +66,7 @@ def gelu_composite(x, approximate):
 
 
 @register_decomp('pd_op.rsqrt')
-def rsqrt_composite(x):
+def rsqrt(x):
     """define composite rule of op rsqrt."""
     # rsqrt(x) = x^(-0.5)
     is_amp = False
@@ -77,7 +77,7 @@ def rsqrt_composite(x):
         is_amp = True
         x = cast(x, "float32")
     y = full(x.shape if len(x.shape) == 0 else [1], -0.5, x.dtype)
-    res = pow(x, y)
+    res = pow_composite(x, y)
     return res if not is_amp else cast(res, dtype)
 
 
@@ -104,7 +104,7 @@ def pow_composite(x, y):
 
 
 @register_decomp('pd_op.layer_norm')
-def layernorm_composite(x, scale, bias, epsilon, begin_norm_axis):
+def layernorm(x, scale, bias, epsilon, begin_norm_axis):
     """
     define composite rule of op layer_norm
     out = (x - mean(x)) / sqrt(var + epsilon))
@@ -146,7 +146,7 @@ def layernorm_composite(x, scale, bias, epsilon, begin_norm_axis):
 
 
 @register_decomp('pd_op.dropout')
-def dropout_composite(x, seed_tensor, p, is_test, mode, seed, fix_seed):
+def dropout(x, seed_tensor, p, is_test, mode, seed, fix_seed):
     """define composite rule of op dropout.
     upscale_in_train:
         train: out = input * mask / ( 1.0 - p )
@@ -207,7 +207,7 @@ def bernoulli(shape, dtype, p, seed=0):
 
 
 @register_decomp('pd_op.add_n')
-def sum_composite(x):
+def add_n(x):
     ans = x[0]
     for xi in x[1:]:
         ans = xi + ans


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Fix prim reshape grad bug:
The composite rules of reshape_grad will use xshape( output of op reshape, its shape: [0] + x.shape). Thus xshape.shape should be removed extra 0 before used in prim op reshape.