### PR TITLE
[PIR] remove unuseful AsOpaquePointer func.

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -1045,7 +1045,6 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
                  pir::Value cond,
                  std::vector<pir::Type> &&output_types) {
   VLOG(4) << "Start build IfOp";
-
   argument.AddRegions(2u);
   argument.AddInput(cond);
   argument.output_types.swap(output_types);
@@ -1086,11 +1085,9 @@ void WhileOp::Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
                     const std::vector<pir::Value> &inputs,
                     const std::vector<pir::Type> &output_types) {
-  // auto insert_point = builder.insert_point();
   argument.AddInputs(inputs);
   argument.AddOutputs(output_types);
-  argument.AddRegion(nullptr);
-  argument.AddRegion(nullptr);
+  argument.AddRegions(2u);
 }
 pir::Block *WhileOp::cond_block() {
   pir::Region &cond_region = (*this)->region(0);

--- a/paddle/pir/core/interface_support.h
+++ b/paddle/pir/core/interface_support.h
@@ -42,8 +42,7 @@ class ConstructInterfacesOrTraits {
   static void PlacementConstrctInterface(
       InterfaceValue *&p_interface) {  // NOLINT
     p_interface->swap(InterfaceValue::get<ConcreteT, T>());
-    VLOG(6) << "New a interface: id["
-            << (p_interface->type_id()).AsOpaquePointer() << "].";
+    VLOG(6) << "New a interface: id[" << p_interface->type_id() << "].";
     ++p_interface;
   }
 
@@ -51,7 +50,7 @@ class ConstructInterfacesOrTraits {
   template <typename T>
   static void PlacementConstrctTrait(pir::TypeId *&p_trait) {  // NOLINT
     *p_trait = TypeId::get<T>();
-    VLOG(6) << "New a trait: id[" << p_trait->AsOpaquePointer() << "].";
+    VLOG(6) << "New a trait: id[" << *p_trait << "].";
     ++p_trait;
   }
 };

--- a/paddle/pir/core/ir_context.cc
+++ b/paddle/pir/core/ir_context.cc
@@ -106,7 +106,7 @@ class IrContextImpl {
   void RegisterOpInfo(const std::string &name, OpInfo info) {
     std::lock_guard<pir::SpinLock> guard(registed_op_infos_lock_);
     VLOG(6) << "Register an operation of: [Name=" << name
-            << ", OpInfo ptr=" << info.AsOpaquePointer() << "].";
+            << ", OpInfo ptr=" << info << "].";
     registed_op_infos_.emplace(name, info);
   }
 
@@ -115,7 +115,7 @@ class IrContextImpl {
     auto iter = registed_op_infos_.find(name);
     if (iter != registed_op_infos_.end()) {
       VLOG(8) << "Found a cached OpInfo of: [name=" << name
-              << ", OpInfo: ptr=" << iter->second.AsOpaquePointer() << "].";
+              << ", OpInfo: ptr=" << iter->second << "].";
       return iter->second;
     }
     VLOG(8) << "No cache found operation of: [Name=" << name << "].";

--- a/paddle/pir/core/op_info.h
+++ b/paddle/pir/core/op_info.h
@@ -71,8 +71,7 @@ class IR_API OpInfo {
   template <typename InterfaceT>
   typename InterfaceT::Concept *GetInterfaceImpl() const;
 
-  operator const void *() const { return impl_; }
-  void *AsOpaquePointer() const { return impl_; }
+  operator void *() const { return impl_; }
   static OpInfo RecoverFromOpaquePointer(void *pointer) {
     return OpInfo(static_cast<OpInfoImpl *>(pointer));
   }
@@ -105,7 +104,7 @@ namespace std {
 template <>
 struct hash<pir::OpInfo> {
   std::size_t operator()(const pir::OpInfo &obj) const {
-    return std::hash<const void *>()(obj);
+    return std::hash<void *>()(obj);
   }
 };
 }  // namespace std

--- a/paddle/pir/core/type_id.h
+++ b/paddle/pir/core/type_id.h
@@ -53,8 +53,7 @@ class TypeId {
   ///
   /// \brief Support PointerLikeTypeTraits.
   ///
-  operator const void *() const { return storage_; }
-  void *AsOpaquePointer() const { return storage_; }
+  operator void *() const { return storage_; }
   static TypeId RecoverFromOpaquePointer(void *pointer) {
     return TypeId(static_cast<Storage *>(pointer));
   }
@@ -146,7 +145,7 @@ namespace std {
 template <>
 struct hash<pir::TypeId> {
   std::size_t operator()(const pir::TypeId &obj) const {
-    return std::hash<const void *>()(obj);
+    return std::hash<void *>()(obj);
   }
 };
 }  // namespace std

--- a/paddle/pir/core/value.cc
+++ b/paddle/pir/core/value.cc
@@ -46,10 +46,7 @@ bool Value::operator<(const Value &other) const {
 
 Value::operator bool() const { return impl_; }
 
-pir::Type Value::type() const {
-  CHECK_VALUE_NULL_IMPL(type);
-  return impl_->type();
-}
+pir::Type Value::type() const { return impl_ ? impl_->type() : nullptr; }
 
 void Value::set_type(pir::Type type) {
   CHECK_VALUE_NULL_IMPL(set_type);
@@ -66,8 +63,7 @@ Value::UseIterator Value::use_begin() const { return OpOperand(first_use()); }
 Value::UseIterator Value::use_end() const { return Value::UseIterator(); }
 
 OpOperand Value::first_use() const {
-  CHECK_VALUE_NULL_IMPL(first_use);
-  return impl_->first_use();
+  return impl_ ? impl_->first_use() : nullptr;
 }
 
 bool Value::use_empty() const { return !first_use(); }

--- a/paddle/pir/pattern_rewrite/pattern_match.cc
+++ b/paddle/pir/pattern_rewrite/pattern_match.cc
@@ -29,7 +29,7 @@ Pattern::Pattern(const std::string& root_name,
                  PatternBenefit benefit,
                  IrContext* context,
                  const std::vector<std::string>& generated_names)
-    : Pattern(context->GetRegisteredOpInfo(root_name).AsOpaquePointer(),
+    : Pattern(context->GetRegisteredOpInfo(root_name),
               RootKind::OperationInfo,
               generated_names,
               benefit,
@@ -46,7 +46,7 @@ Pattern::Pattern(MatchInterfaceOpTypeTag tag,
                  PatternBenefit benefit,
                  IrContext* context,
                  const std::vector<std::string>& generated_names)
-    : Pattern(interface_id.AsOpaquePointer(),
+    : Pattern(interface_id,
               RootKind::InterfaceId,
               generated_names,
               benefit,
@@ -57,11 +57,7 @@ Pattern::Pattern(MatchTraitOpTypeTag tag,
                  PatternBenefit benefit,
                  IrContext* context,
                  const std::vector<std::string>& generated_names)
-    : Pattern(trait_id.AsOpaquePointer(),
-              RootKind::TraitId,
-              generated_names,
-              benefit,
-              context) {}
+    : Pattern(trait_id, RootKind::TraitId, generated_names, benefit, context) {}
 
 Pattern::Pattern(void* root_val,
                  RootKind root_kind,

--- a/test/cpp/pir/core/op_info_test.cc
+++ b/test/cpp/pir/core/op_info_test.cc
@@ -39,7 +39,7 @@ TEST(ir_op_info_test, op_op_info_test) {
   auto& info_map = context->registered_op_info_map();
   EXPECT_FALSE(info_map.empty());
 
-  void* info_1 = op->info().AsOpaquePointer();
+  void* info_1 = op->info();
   auto info_2 = pir::OpInfo::RecoverFromOpaquePointer(info_1);
   EXPECT_EQ(op->info(), info_2);
   pir::Verify(program.module_op());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others 

### Description
<!-- Describe what you’ve done -->

pir::OpInfo和pir::TypeId都支持隐式转换为void*， AsOpaquePointer接口有点多余，予以移除。

### Other
Pcard-67164

