### PR TITLE
[xpu] bugfix in paddle dependency packing

### DIFF
--- a/tools/xpu/pack_paddle_depence.sh
+++ b/tools/xpu/pack_paddle_depence.sh
@@ -26,13 +26,13 @@ XDNN_DIR_NAME=$4
 XCCL_URL=$5
 XCCL_DIR_NAME=$6
 
-wget --no-check-certificate ${XRE_URL} -c -q -O xre.tar.gz
+wget --no-check-certificate ${XRE_URL} -q -O xre.tar.gz
 tar xvf xre.tar.gz
 
-wget --no-check-certificate ${XDNN_URL} -c -q -O xdnn.tar.gz
+wget --no-check-certificate ${XDNN_URL} -q -O xdnn.tar.gz
 tar xvf xdnn.tar.gz
 
-wget --no-check-certificate ${XCCL_URL} -c -q -O xccl.tar.gz
+wget --no-check-certificate ${XCCL_URL} -q -O xccl.tar.gz
 tar xvf xccl.tar.gz
 
 mkdir -p xpu/include/xpu


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
xccl/xdnn/xre do not re-download tar ball in re-building when date/version is changed in cmake. This is due to the extra '-c' option in wget command since the target tarball name always stays the same.