### PR TITLE
fix the bug where excluded_layers of paddle.amp.decorate is invalid

### DIFF
--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -198,9 +198,10 @@ def set_excluded_layers(models, excluded_layers):
             include_self=True
         ):
             layer._cast_to_low_precison = False
+    excluded_layers_types = tuple(excluded_layers_types)
     for idx in range(len(models)):
         for layer in models[idx].sublayers(include_self=True):
-            if type(layer) in excluded_layers_types:
+            if isinstance(layer, excluded_layers_types):
                 layer._cast_to_low_precison = False
 
 


### PR DESCRIPTION
### PR types

Bug fixes 

### PR changes

APIs

### Description

The parameter `excluded_layers` of API `paddle.amp.decorate` is invalid, we use python API `instance` instead of `type` to filter all  excluded layers.
