### PR TITLE
fix_softmax_backward

### DIFF
--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -1264,8 +1264,7 @@ bool UseCudnnSoftmax(const GPUContext& ctx,
   }
   constexpr int max_dim = 512;
   if (!cudnn_available || !last_dim ||
-      (softmax_dim <= max_dim && sizeof(T) <= 4) ||
-      softmax_dim >= MATRIX_SOFTMAX_THREAHOLD) {
+      (softmax_dim <= max_dim && sizeof(T) <= 4)) {
     return false;
   } else {
     return true;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
fix softmax backward

Temporarily disable the large vocabulary optimization and fix the backpropagation accuracy.
