### PR TITLE
cinn(py-dsl): add printer of Python DSL

### DIFF
--- a/paddle/cinn/ir/buffer.h
+++ b/paddle/cinn/ir/buffer.h
@@ -109,12 +109,15 @@ class _Buffer_ : public ExprNode<_Buffer_> {
   static Buffer Make(const std::string& name,
                      const std::vector<Expr>& shape = {});
 
-  static Buffer Make(const std::string& name, Type type) {
+  static Buffer Make(const std::string& name,
+                     Type type,
+                     const std::vector<Expr>& shape = {}) {
     CHECK(!type.is_void());
     CHECK(!type.is_unk());
     auto n = make_shared<_Buffer_>();
     n->name = name;
     n->dtype = type;
+    n->shape = shape;
     return Buffer(n);
   }
 

--- a/paddle/cinn/ir/ir_printer.cc
+++ b/paddle/cinn/ir/ir_printer.cc
@@ -21,9 +21,12 @@
 #include "paddle/cinn/ir/lowered_func.h"
 #include "paddle/cinn/ir/module.h"
 #include "paddle/cinn/ir/tensor.h"
+#include "paddle/cinn/ir/utils/ir_python_printer.h"
 #include "paddle/cinn/optim/ir_simplify.h"
 #include "paddle/cinn/runtime/intrinsic.h"
 #include "paddle/cinn/utils/string.h"
+
+PD_DECLARE_bool(cinn_print_python_script);
 
 namespace cinn {
 namespace ir {
@@ -669,16 +672,26 @@ void IrPrinter::Visit(const intrinsics::BuiltinIntrin *x) {
 
 std::ostream &operator<<(std::ostream &os, Expr a) {
   std::stringstream ss;
-  IrPrinter printer(ss);
-  printer.Print(a);
+  if (FLAGS_cinn_print_python_script) {
+    IrPythonPrinter printer(ss);
+    printer.Print(a);
+  } else {
+    IrPrinter printer(ss);
+    printer.Print(a);
+  }
   os << ss.str();
   return os;
 }
 
 std::ostream &operator<<(std::ostream &os, const std::vector<Expr> &a) {
   std::stringstream ss;
-  IrPrinter printer(ss);
-  printer.Print(a);
+  if (FLAGS_cinn_print_python_script) {
+    IrPythonPrinter printer(ss);
+    printer.Print(a);
+  } else {
+    IrPrinter printer(ss);
+    printer.Print(a);
+  }
   os << ss.str();
   return os;
 }

--- a/paddle/cinn/ir/utils/CMakeLists.txt
+++ b/paddle/cinn/ir/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ core_gather_headers()
 gather_srcs(
   cinnapi_src
   SRCS
+  ir_python_printer.cc
   ir_verify.cc
   ir_compare.cc
   ir_nodes_collector.cc

--- a/paddle/cinn/ir/utils/ir_python_printer.cc
+++ b/paddle/cinn/ir/utils/ir_python_printer.cc
@@ -1,0 +1,620 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <algorithm>
+#include <iomanip>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "paddle/cinn/common/type.h"
+#include "paddle/cinn/ir/buffer.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/ir_visitor.h"
+#include "paddle/cinn/ir/lowered_func.h"
+#include "paddle/cinn/ir/module.h"
+#include "paddle/cinn/ir/tensor.h"
+#include "paddle/cinn/ir/utils/ir_python_printer.h"
+#include "paddle/cinn/optim/ir_simplify.h"
+#include "paddle/cinn/runtime/intrinsic.h"
+#include "paddle/cinn/utils/string.h"
+namespace cinn {
+namespace ir {
+using common::bfloat16;
+using common::float16;
+
+void IrPythonPrinter::Print(const Expr &e) {
+  IRVisitorRequireReImpl::Visit(&e);
+  os_ << str_;
+  str_ = "";
+}
+void IrPythonPrinter::Print(const std::vector<Expr> &exprs,
+                            const std::string &splitter) {
+  for (std::size_t i = 0; !exprs.empty() && i + 1 < exprs.size(); i++) {
+    Visit(exprs[i]);
+    str_ += splitter;
+  }
+  if (!exprs.empty()) Visit(exprs.back());
+  os_ << str_;
+  str_ = "";
+}
+void IrPythonPrinter::DoIndent() {
+  str_ += "\n";
+  str_ += std::string(indent_, ' ');
+}
+void IrPythonPrinter::IncIndent() { indent_ += indent_unit; }
+void IrPythonPrinter::DecIndent() { indent_ -= indent_unit; }
+
+// Type
+void IrPythonPrinter::Visit(const IntImm *x) {
+  str_ += std::to_string(x->value);
+}
+
+void IrPythonPrinter::Visit(const UIntImm *x) {
+  if (x->type().is_uint(1)) {
+    if (x->value) {
+      str_ += "True";
+    } else {
+      str_ += "False";
+    }
+  } else {
+    str_ += std::to_string(x->value);
+  }
+}
+void IrPythonPrinter::Visit(const FloatImm *x) {
+  std::ostringstream ss;
+  ss << x->value;
+  str_ += ss.str();
+}
+void IrPythonPrinter::Visit(const StringImm *x) {
+  str_ += "\"";
+  str_ += x->value;
+  str_ += "\"";
+}
+
+// Var
+void IrPythonPrinter::Visit(const _Var_ *x) { str_ += x->name; }
+
+// Buffer
+void IrPythonPrinter::Visit(const _Buffer_ *x) {
+  std::vector<std::string> dim_names;
+  std::transform(x->shape.begin(),
+                 x->shape.end(),
+                 std::back_inserter(dim_names),
+                 [&](const Expr &x) { return utils::GetStreamCnt(x); });
+
+  str_ += x->name;
+}
+
+// Expr
+void IrPythonPrinter::Visit(const Cast *x) {
+  str_ += x->type().to_string();
+  str_ += "(";
+  Visit(x->v());
+  str_ += ")";
+}
+
+// Expr BinOp
+void IrPythonPrinter::Visit(const Add *x) { PrintBinaryOp("+", x); }
+void IrPythonPrinter::Visit(const Sub *x) { PrintBinaryOp("-", x); }
+void IrPythonPrinter::Visit(const Mul *x) { PrintBinaryOp("*", x); }
+void IrPythonPrinter::Visit(const Div *x) { PrintBinaryOp("/", x); }
+void IrPythonPrinter::Visit(const Mod *x) { PrintBinaryOp("%", x); }
+void IrPythonPrinter::Visit(const Min *x) {
+  str_ += "cinn_min(";
+  Visit(x->a());
+  str_ += ", ";
+  Visit(x->b());
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const Max *x) {
+  str_ += "cinn_max(";
+  Visit(x->a());
+  str_ += ", ";
+  Visit(x->b());
+  str_ += ")";
+}
+
+void IrPythonPrinter::Visit(const EQ *x) { PrintBinaryOp("==", x); }
+void IrPythonPrinter::Visit(const NE *x) { PrintBinaryOp("!=", x); }
+void IrPythonPrinter::Visit(const LT *x) { PrintBinaryOp("<", x); }
+void IrPythonPrinter::Visit(const LE *x) { PrintBinaryOp("<=", x); }
+void IrPythonPrinter::Visit(const GT *x) { PrintBinaryOp(">", x); }
+void IrPythonPrinter::Visit(const GE *x) { PrintBinaryOp(">=", x); }
+void IrPythonPrinter::Visit(const And *x) { PrintBinaryOp("and", x); }
+void IrPythonPrinter::Visit(const Or *x) { PrintBinaryOp("or", x); }
+
+// Expr Unary Op
+void IrPythonPrinter::Visit(const Not *x) {
+  str_ += "not ";
+  Visit(x->v());
+}
+
+void IrPythonPrinter::Visit(const Minus *x) {
+  str_ += "-(";
+  Visit(x->v());
+  str_ += ")";
+}
+
+// Expr
+void IrPythonPrinter::Visit(const Select *x) {
+  str_ += "ir.Select.make(";
+  Visit(x->condition);
+  str_ += ", ";
+  Visit(x->true_value);
+  str_ += ", ";
+  Visit(x->false_value);
+  str_ += ")";
+}
+
+void IrPythonPrinter::Visit(const Load *x) {
+  if (x->is_addr_tensor()) {
+    auto *tensor = x->tensor.As<ir::_Tensor_>();
+    CHECK(tensor);
+    str_ += tensor->name;
+  } else if (x->is_addr_scalar()) {
+    Visit(x->tensor);
+  } else {
+    CINN_NOT_IMPLEMENTED
+  }
+
+  str_ += "[";
+  for (std::size_t i = 0; i + 1 < x->indices.size(); i++) {
+    Visit(x->indices[i]);
+    str_ += ", ";
+  }
+  if (!x->indices.empty()) Visit(x->indices.back());
+  str_ += "]";
+}
+void IrPythonPrinter::Visit(const Broadcast *x) {
+  str_ += "ir.Broadcast.make(";
+  Visit(x->value);
+  str_ += ", ";
+  str_ += std::to_string(x->lanes);
+  str_ += ")";
+}
+
+void IrPythonPrinter::Visit(const Ramp *x) {
+  str_ += "ir.Ramp(";
+  Visit(x->base);
+  str_ += ", ";
+  Visit(x->stride);
+  str_ += ", ";
+  str_ += std::to_string(x->lanes);
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const ir::Call *op) {
+  if (op->call_type == CallType::Extern) {
+    str_ += "lang.call_extern(";
+    str_ += "\"";
+    str_ += op->name;
+    str_ += "\", [";
+    if (!op->read_args.empty()) {
+      for (std::size_t i = 0; i + 1 < op->read_args.size(); i++) {
+        IrPythonPrinter::Visit(op->read_args[i]);
+        str_ += ", ";
+      }
+      IrPythonPrinter::Visit(op->read_args.back());
+    }
+
+    if (!op->write_args.empty()) {
+      if (!op->read_args.empty()) str_ += ", ";
+
+      for (std::size_t i = 0; i + 1 < op->write_args.size(); i++) {
+        IrPythonPrinter::Visit(op->write_args[i]);
+        str_ += ", ";
+      }
+      IrPythonPrinter::Visit(op->write_args.back());
+    }
+    str_ += "], {";
+
+    for (const auto &kv : op->attrs) {
+      str_ += kv.first;
+      absl::visit(
+          [this](auto &&arg) {
+            std::ostringstream ss;
+            ss << arg;
+            this->str_ += ss.str();
+          },
+          kv.second);
+    }
+    str_ += "}";
+    str_ += ")";
+  } else {
+    IrPythonPrinter::Visit(op);
+  }
+}
+void IrPythonPrinter::Visit(const Let *f) {
+  CHECK(f->type().valid());
+  str_ += f->type().to_string();
+  str_ += " ";
+  Visit(f->symbol);
+  if (f->body.defined()) {
+    str_ += " = ";
+    Visit(f->body);
+  }
+}
+// stmt
+void IrPythonPrinter::Visit(const For *x) {
+  // if (x->is_parallel()) {
+  //   // TODO(6clc):
+  // } else if (x->is_unrolled()) {
+  //   // TODO(6clc):
+  // } else if (x->is_vectorized()) {
+  //   // TODO(6clc):
+  // } else if (x->is_binded()) {
+  //   // TODO(6clc):
+  // }
+  DoIndent();
+  str_ += "for ";
+  IrPythonPrinter::Visit(x->loop_var);
+  str_ += " in range(";
+  IrPythonPrinter::Visit(x->min);
+  str_ += ", ";
+  IrPythonPrinter::Visit(x->extent);
+  str_ += "):";
+
+  IncIndent();
+  IrPythonPrinter::Visit(x->body);
+  DecIndent();
+}
+void IrPythonPrinter::Visit(const Store *x) {
+  if (x->is_addr_tensor()) {
+    auto *tensor_node = x->tensor.As<ir::_Tensor_>();
+    CHECK(tensor_node);
+    str_ += tensor_node->name;
+  } else if (x->is_addr_scalar()) {
+    Visit(x->tensor);
+  } else {
+    CINN_NOT_IMPLEMENTED
+  }
+
+  str_ += "[";
+  for (std::size_t i = 0; i + 1 < x->indices.size(); i++) {
+    Visit(x->indices[i]);
+    str_ += ", ";
+  }
+  if (!x->indices.empty()) Visit(x->indices.back());
+  str_ += "] = ";
+  Visit(x->value);
+}
+void IrPythonPrinter::Visit(const Alloc *x) {
+  auto *buffer = x->destination.As<ir::_Buffer_>();
+  CHECK(buffer);
+  str_ += "alloc(";
+  str_ += buffer->name;
+  str_ += ", ";
+  Visit(x->extents);
+  str_ += ")";
+}
+
+void IrPythonPrinter::Visit(const IfThenElse *x) {
+  DoIndent();
+  str_ += "if (";
+  IrPythonPrinter::Visit(x->condition);
+  str_ += "):";
+  IncIndent();
+  IrPythonPrinter::Visit(x->true_case);
+  DecIndent();
+
+  if (x->false_case.defined()) {
+    DoIndent();
+    str_ += "else:";
+    IncIndent();
+    IrPythonPrinter::Visit(x->false_case);
+    DecIndent();
+  }
+}
+
+void IrPythonPrinter::Visit(const Block *x) {
+  for (std::size_t i = 0; !x->stmts.empty() && i < x->stmts.size(); i++) {
+    // DoIndent();
+    IrPythonPrinter::Visit(x->stmts[i]);
+  }
+}
+
+void IrPythonPrinter::Visit(const ScheduleBlock *x) {}
+
+void IrPythonPrinter::Visit(const ScheduleBlockRealize *x) {
+  auto *schedule_block = x->schedule_block.As<ScheduleBlock>();
+  if (schedule_block->name == "root") {
+    IrPythonPrinter::Visit(schedule_block->body);
+    return;
+  }
+  DoIndent();
+  str_ += "with ir.ScheduleBlockContext(\"";
+  str_ += schedule_block->name;
+  str_ += "\") as ";
+  str_ += schedule_block->name;
+  str_ += "_block:";
+  IncIndent();
+  // print block vars and bindings
+  auto iter_vars = schedule_block->iter_vars;
+  auto iter_values = x->iter_values;
+  CHECK_EQ(iter_vars.size(), iter_values.size());
+  if (!iter_vars.empty()) {
+    DoIndent();
+  }
+  for (std::size_t i = 0; i < iter_vars.size(); i++) {
+    if (i) str_ += ", ";
+    str_ += iter_vars[i]->name;
+  }
+  if (!iter_vars.empty()) str_ += " = ir.AxisMap(\"";
+
+  for (const Var &iter_var : iter_vars) {
+    if (iter_var->is_reduce_axis)
+      str_ += "R";
+    else
+      str_ += "S";
+  }
+  str_ += "\", [";
+  for (std::size_t i = 0; i < iter_values.size(); i++) {
+    if (i) str_ += ", ";
+    IrPythonPrinter::Visit(iter_values[i]);
+  }
+  str_ += "]";
+  if (!iter_vars.empty()) str_ += ")";
+  DoIndent();
+  IrPythonPrinter::Visit(schedule_block->body);
+  DecIndent();
+}
+void IrPythonPrinter::Visit(const ir::_LoweredFunc_ *op) {
+  str_ += "# from cinn import ir, lang, to_cinn_llir\n";
+  str_ += "# from cinn.runtime.data_array import DataArray\n";
+  str_ += "# from cinn.schedule import IRSchedule as sch\n";
+  str_ += "def fn_";
+  str_ += op->name;
+  str_ += "(";
+
+  std::vector<std::string> arg_names;
+  auto &func_args = op->args;
+  for (int i = 0; i < func_args.size(); i++) {
+    if (i) {
+      str_ += ", ";
+    }
+    if (func_args[i].is_buffer()) {
+      str_ += func_args[i].name().substr(1);
+      str_ += ": DataArray((";
+      PrintShape(func_args[i].buffer_arg()->shape);
+      str_ += "))";
+    } else {
+      str_ += func_args[i].name();
+      str_ += ": ";
+      str_ += "";
+    }
+  }
+  str_ += "):";
+
+  IncIndent();
+  ir::IrPythonPrinter::Visit(op->body);
+  DecIndent();
+}
+void IrPythonPrinter::Visit(const _Tensor_ *x) {
+  str_ += x->name;
+  str_ += ", ";
+  str_ += "[";
+  if (!x->shape.empty()) {
+    for (std::size_t i = 0; i + 1 < x->shape.size(); i++) {
+      Visit(x->shape[i]);
+      str_ += ",";
+    }
+    Visit(x->shape.back());
+  }
+  str_ += "]";
+}
+void IrPythonPrinter::Visit(const PrimitiveNode *x) {
+  str_ += x->name;
+  str_ += "(";
+  std::vector<std::string> args_repr;
+  for (auto &args : x->arguments) {
+    std::vector<std::string> arg_repr;
+    for (auto &arg : args) {
+      arg_repr.push_back(utils::GetStreamCnt(arg));
+    }
+    args_repr.push_back(utils::Join(arg_repr, ","));
+  }
+
+  str_ += utils::Join(args_repr, ",");
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const IntrinsicOp *x) {
+  switch (x->getKind()) {
+#define __(op__)                                \
+  case IntrinsicKind::k##op__:                  \
+    Visit(llvm::dyn_cast<intrinsics::op__>(x)); \
+    break;
+
+    INTRINSIC_KIND_FOR_EACH(__)
+#undef __
+  }
+}
+void IrPythonPrinter::Visit(const Free *x) {
+  DoIndent();
+  auto *buffer = x->destination.As<ir::_Buffer_>();
+  CHECK(buffer);
+  str_ += "free(";
+  str_ += buffer->name;
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const PolyFor *x) {
+  DoIndent();
+  if (x->is_parallel()) {
+    str_ += "parallel poly_for (";
+  } else {
+    str_ += "poly_for (";
+  }
+  Visit(x->iterator);
+  str_ += ", ";
+  Visit(x->init);
+  str_ += ", ";
+  Visit(x->condition);
+  str_ += ", ";
+  Visit(x->inc);
+  DoIndent();
+  Visit(x->body);
+}
+void IrPythonPrinter::Visit(const _Module_ *x) {}
+void IrPythonPrinter::Visit(const _BufferRange_ *x) {
+  auto *buffer = x->buffer.As<ir::_Buffer_>();
+  CHECK(buffer);
+  str_ += buffer->name;
+  str_ += "[";
+  for (std::size_t i = 0; i < x->ranges.size(); i++) {
+    if (i) str_ += ", ";
+    auto &range = x->ranges[i];
+    str_ += range->name;
+    str_ += "(";
+    if (range->lower_bound.defined()) {
+      Visit(range->lower_bound);
+      str_ += ":";
+    } else {
+      str_ += "undefined:";
+    }
+
+    if (range->upper_bound.defined()) {
+      Visit(range->upper_bound);
+    } else {
+      str_ += "undefined";
+    }
+    str_ += ")";
+  }
+  str_ += "]";
+}
+void IrPythonPrinter::Visit(const Reduce *f) {
+  str_ += "Reduce(";
+  switch (f->reduce_type) {
+    case Reduce::ReduceType::kSum:
+      str_ += "sum";
+      break;
+    case Reduce::ReduceType::kSub:
+      str_ += "sub";
+      break;
+    case Reduce::ReduceType::kDiv:
+      str_ += "Div";
+      break;
+    case Reduce::ReduceType::kMul:
+      str_ += "Mul";
+      break;
+    case Reduce::ReduceType::kMax:
+      str_ += "Max";
+      break;
+    case Reduce::ReduceType::kMin:
+      str_ += "Min";
+      break;
+    case Reduce::ReduceType::kAll:
+      str_ += "&&";
+      break;
+    case Reduce::ReduceType::kAny:
+      str_ += "||";
+      break;
+  }
+  str_ += ", ";
+  Visit(f->body);
+  str_ += ",";
+  Visit(f->init);
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const Sum *x) {
+  str_ += "(";
+  for (std::size_t i = 0; i + 1 < x->operands().size(); i++) {
+    Visit(x->operand(i));
+    str_ += " + ";
+  }
+  if (!x->operands().empty()) Visit(x->operands().back());
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const FracOp *x) {
+  str_ += "(";
+  Visit(x->a());
+  str_ += " / ";
+  Visit(x->b());
+  str_ += ")";
+}
+
+void IrPythonPrinter::Visit(const Product *x) {
+  str_ += "(";
+  for (std::size_t i = 0; i + 1 < x->operands().size(); i++) {
+    Visit(x->operand(i));
+    str_ += " * ";
+  }
+  if (!x->operands().empty()) Visit(x->operands().back());
+  str_ += ")";
+}
+
+// intrinsics op
+void IrPythonPrinter::Visit(const intrinsics::BufferGetDataHandle *x) {
+  str_ += runtime::intrinsic::buffer_get_data_handle;
+  Visit(x->buffer);
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const intrinsics::BufferGetDataConstHandle *x) {
+  str_ += runtime::intrinsic::buffer_get_data_const_handle;
+  Visit(x->buffer);
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const intrinsics::PodValueToX *x) {
+  str_ += "pod_value_to_";
+  str_ += x->GetOutputType(0).to_string();
+  str_ += "(";
+  Visit(x->pod_value_ptr);
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const intrinsics::BufferCreate *x) {
+  str_ += runtime::intrinsic::buffer_create;
+  str_ += "()";
+}
+void IrPythonPrinter::Visit(const intrinsics::GetAddr *x) {
+  str_ += "get_addr(";
+  Visit(x->data);
+  str_ += ")";
+}
+void IrPythonPrinter::Visit(const intrinsics::ArgsConstruct *x) {
+  str_ += runtime::intrinsic::args_construct_repr;
+  str_ += "(";
+  Visit(std::vector<Expr>(x->args.begin(), x->args.end()));
+  str_ += ")";
+}
+
+void IrPythonPrinter::Visit(const intrinsics::BuiltinIntrin *x) {
+  str_ += runtime::intrinsic::builtin_intrin_repr;
+  str_ += "_";
+  str_ += x->name;
+  str_ += "(";
+  if (!x->args.empty()) {
+    for (std::size_t i = 0; i + 1 < x->args.size(); i++) {
+      Visit(x->args[i]);
+      str_ += ", ";
+    }
+    Visit(x->args.back());
+  }
+
+  str_ += ")";
+}
+void IrPythonPrinter::Print(const common::Type &type) {
+  str_ += "cinn.common.type_of(\"";
+  str_ += common::Type2Str(type);
+  str_ += "\")";
+  os_ << str_;
+  str_ = "";
+}
+void IrPythonPrinter::PrintShape(const std::vector<Expr> &shape) {
+  for (int i = 0; i < shape.size() - 1; i++) {
+    IrPythonPrinter::Visit(shape[i]);
+    str_ += ", ";
+  }
+  if (shape.size() > 1) IrPythonPrinter::Visit(shape.back());
+}
+}  // namespace ir
+
+}  // namespace cinn

--- a/paddle/cinn/ir/utils/ir_python_printer.h
+++ b/paddle/cinn/ir/utils/ir_python_printer.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "paddle/cinn/common/common.h"
+#include "paddle/cinn/ir/intrinsic_ops.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/lowered_func.h"
+#include "paddle/cinn/ir/module.h"
+#include "paddle/cinn/lang/packed_func.h"
+#include "paddle/cinn/runtime/cinn_runtime.h"
+#include "paddle/utils/flags.h"
+
+namespace cinn {
+
+namespace ir {
+class IrPythonPrinter : public IRVisitorRequireReImpl<void> {
+ public:
+  explicit IrPythonPrinter(std::ostream &os) : os_(os), str_("") {}
+  //! Emit an expression on the output stream.
+  void Print(const Expr &e);
+  //! Emit a expression list with , splitted.
+  void Print(const std::vector<Expr> &exprs,
+             const std::string &splitter = ", ");
+
+  //! Prefix the current line with `indent_` spaces.
+  void DoIndent();
+  //! Increase the indent size.
+  void IncIndent();
+  //! Decrease the indent size.
+  void DecIndent();
+  template <typename IRN>
+  void PrintBinaryOp(const std::string &op, const BinaryOpNode<IRN> *x);
+  void Visit(const Expr &x) { IRVisitorRequireReImpl::Visit(&x); }
+  void Visit(const std::vector<Expr> &exprs,
+             const std::string &splitter = ", ") {
+    for (std::size_t i = 0; !exprs.empty() && i + 1 < exprs.size(); i++) {
+      Visit(exprs[i]);
+      str_ += splitter;
+    }
+    if (!exprs.empty()) Visit(exprs.back());
+  }
+
+#define __DEFINE_VISIT(op__) void Visit(const ir::op__ *op) override;
+  NODETY_FORALL(__DEFINE_VISIT)
+#undef __DEFINE_VISIT
+
+#define __DEFINE_VISIT(op__) void Visit(const ir::intrinsics::op__ *op);
+  INTRINSIC_KIND_FOR_EACH(__DEFINE_VISIT)
+#undef __DEFINE_VISIT
+
+  void Print(const common::Type &);
+  void PrintShape(const std::vector<Expr> &shape);
+
+ private:
+  std::string str_;
+  std::ostream &os_;
+  uint16_t indent_{};
+  const int indent_unit{4};
+};
+template <typename IRN>
+void IrPythonPrinter::PrintBinaryOp(const std::string &op,
+                                    const BinaryOpNode<IRN> *x) {
+  str_ += "(";
+  Visit(x->a());
+  str_ += " ";
+  str_ += op;
+  str_ += " ";
+  Visit(x->b());
+  str_ += ")";
+}
+
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/pybind/bind_utils.h
+++ b/paddle/cinn/pybind/bind_utils.h
@@ -24,6 +24,7 @@
 #include "paddle/cinn/ir/ir_base.h"
 #include "paddle/cinn/ir/ir_visitor.h"
 #include "paddle/cinn/ir/tensor.h"
+#include "paddle/cinn/ir/utils/ir_python_printer.h"
 #include "paddle/cinn/pybind/bind.h"
 #include "paddle/cinn/runtime/cinn_runtime.h"
 
@@ -183,4 +184,8 @@ class IrNodeWrapper : ir::IrNode {
   using ir::IrNode::IrNode;
 };
 
+#define BIND_PYTHON_PRINTER(PrintType)                       \
+  .def("__str__", [](const PrintType &self) -> std::string { \
+    return utils::GetStreamCnt(self);                        \
+  })
 }  // namespace cinn::pybind

--- a/paddle/cinn/pybind/common.cc
+++ b/paddle/cinn/pybind/common.cc
@@ -18,11 +18,13 @@
 #include "paddle/cinn/common/target.h"
 #include "paddle/cinn/common/type.h"
 #include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/utils/ir_python_printer.h"
 #include "paddle/cinn/pybind/bind.h"
 #include "paddle/cinn/pybind/bind_utils.h"
 #include "paddle/cinn/runtime/flags.h"
 #include "paddle/cinn/utils/string.h"
 
+PD_DECLARE_bool(cinn_print_python_script);
 namespace py = pybind11;
 
 namespace cinn::pybind {
@@ -125,7 +127,17 @@ void BindType(py::module *m) {
   type.def("vector_of", &Type::VectorOf)
       .def("element_of", &Type::ElementOf)
       .def("pointer_of", &Type::PointerOf)
-      .def("__str__", [](const Type &self) { return GetStreamCnt(self); })
+      .def("__str__",
+           [](const Type &self) {
+             std::stringstream ss;
+             if (FLAGS_cinn_print_python_script) {
+               ir::IrPythonPrinter printer(ss);
+               printer.Print(self);
+               return ss.str();
+             } else {
+               return GetStreamCnt(self);
+             }
+           })
       .def("__repr__", [](const Type &self) {
         return StringFormat("<Type: %s>", GetStreamCnt(self).c_str());
       });

--- a/paddle/cinn/runtime/flags.cc
+++ b/paddle/cinn/runtime/flags.cc
@@ -199,6 +199,10 @@ PD_DEFINE_double(cinn_infer_model_version,
                  "Paddle has different model format in inference model. We use "
                  "a flag to load different versions.");
 
+PD_DEFINE_bool(cinn_print_python_script,
+               BoolFromEnv("FLAGS_cinn_print_python_script", false),
+               "Whether to replace the default printer to python script.");
+
 namespace cinn {
 namespace runtime {
 

--- a/python/cinn/compiler/compute_code_generator.py
+++ b/python/cinn/compiler/compute_code_generator.py
@@ -65,7 +65,7 @@ class ComputeCodeGenerator(ast.NodeVisitor):
                         ir.Expr(dim) for dim in self.inputs_signature[i].shape
                     ]
                     llir_value = ir._Buffer_.make(
-                        arg_name, self.inputs_signature[i].dtype
+                        arg_name, self.inputs_signature[i].dtype, tensor_shape
                     )
                     ir.Arg(arg_name, llir_value)
                     llir_value = ir._Tensor_.make(
@@ -219,7 +219,7 @@ class ComputeCodeGenerator(ast.NodeVisitor):
                 if node.orelse:
                     with ir.ElseContext():
                         with self.variables_table:
-                            self.visit_compound_statement(node.body)
+                            self.visit_compound_statement(node.orelse)
 
     def visit_With(self, node):
         with self.variables_table:

--- a/python/cinn/ir/__init__.py
+++ b/python/cinn/ir/__init__.py
@@ -140,6 +140,8 @@ from ..core_api.ir import (  # noqa: F401
     Sequential,
     TensorStore,
     AxisMap,
+    Ramp,
+    Broadcast,
 )
 
 

--- a/python/cinn/runtime/data_array.py
+++ b/python/cinn/runtime/data_array.py
@@ -63,7 +63,7 @@ class DataArray:
         elif self.dtype.is_bool():
             np_dtype = "bool"
         else:
-            raise TypeError(f"no support {self.dtype} in CINN")
+            raise TypeError(f"Unsupported {self.dtype} in CINN")
 
         np_arr = np.empty(self.shape, np_dtype)
         assert np_arr.flags["C_CONTIGUOUS"]
@@ -97,7 +97,7 @@ class DataArray:
         }
         dtype_np = str(np_array.dtype).split(".")[-1]
         assert str(dtype_np) in dtype_np_to_common, (
-            str(dtype_np) + " not support in CINN"
+            str(dtype_np) + "Unsupported in CINN"
         )
         assert dtype_np in dtype_np_to_common.keys()
 

--- a/test/cinn/CMakeLists.txt
+++ b/test/cinn/CMakeLists.txt
@@ -306,7 +306,8 @@ if(WITH_GPU)
       COMMAND
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
-        python3 ${CMAKE_CURRENT_SOURCE_DIR}/${ir_test_name}.py
+        FLAGS_cinn_print_python_script=True python3
+        ${CMAKE_CURRENT_SOURCE_DIR}/${ir_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endforeach()
 

--- a/test/cinn/ir/test_llir_printer.py
+++ b/test/cinn/ir/test_llir_printer.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import cinn
+from cinn import ir, lang, to_cinn_llir
+from cinn.runtime.data_array import DataArray
+
+
+def _assert_print(script, expected):
+    script_str = str(script).strip()
+    expected_str = str(expected).strip()
+    min_len = (
+        len(script_str)
+        if len(script_str) < len(expected_str)
+        else len(expected_str)
+    )
+    sufix_err_msg = ""
+    if len(script_str) > min_len:
+        sufix_err_msg = f"script has more code:\n{sufix_err_msg[min_len:-1]}"
+    elif len(expected_str) > min_len:
+        sufix_err_msg = f"script has more code:\n{expected_str[min_len:-1]}"
+    for i in range(min_len):
+        if script_str[i] != expected_str[i]:
+            raise Exception(
+                f"\n Different characters exist.\nscript:\n{script_str[0:i+1]}...\nexpected:\n{expected_str[0:i+1]}...\n"
+            )
+
+
+def test_cinn_type():
+    obj = cinn.common.Float(32)
+    expected = 'cinn.common.type_of("float32")'
+    _assert_print(obj, expected)
+
+
+def test_int_imm():
+    a = ir.Expr(42)
+    expected = '42'
+    _assert_print(a, expected)
+
+
+def test_uint_imm():
+    a = ir.Expr(True)
+    expected = "True"
+    _assert_print(a, expected)
+
+
+def test_float_imm():
+    a = ir.Expr(42.5)
+    expected = "42.5"
+    _assert_print(a, expected)
+
+
+def test_var():
+    a = ir.Var("a", cinn.common.Float(32))
+    expected = 'a'
+    _assert_print(a, expected)
+
+
+def test_buffer():
+    a = ir._Buffer_.make(
+        "A", cinn.common.Float(32), [ir.Expr(128), ir.Expr(128)]
+    )
+    expected = "A"
+    _assert_print(a, expected)
+
+
+def test_cast():
+    pass
+    # b = ir.Cast(cinn.common.Float(64), ir.Var("a", cinn.common.Float(32)))
+    # print(b)
+
+
+def test_binary_op():
+    a = ir.Expr(ir.Var("a", cinn.common.Int(32)))
+    b = ir.Expr(ir.Var("b", cinn.common.Int(32)))
+    for cinn_op, op_sign in [
+        (ir.Add.make, "+"),
+        (ir.Sub.make, "-"),
+        (ir.Mul.make, "*"),
+        (ir.Div.make, "/"),
+        (ir.Mod.make, "%"),
+        (ir.EQ.make, "=="),
+        (ir.NE.make, "!="),
+        (ir.LT.make, "<"),
+        (ir.LE.make, "<="),
+        (ir.GT.make, ">"),
+        (ir.GE.make, ">="),
+    ]:
+        expected = f"(a {op_sign} b)"
+        c = cinn_op(a, b)
+        _assert_print(c, expected)
+
+
+def test_logical():
+    a = ir.Expr(ir.Var("a", cinn.common.UInt(1)))
+    b = ir.Expr(ir.Var("b", cinn.common.UInt(1)))
+    c = ir.And.make(a, b)
+    expected = "(a and b)"
+    _assert_print(c, expected)
+    c = ir.Or.make(a, b)
+    expected = "(a or b)"
+    _assert_print(c, expected)
+    c = ir.Not.make(a)
+    expected = "not a"
+    _assert_print(c, expected)
+
+
+def test_select():
+    select = ir.Select.make(ir.Expr(True), ir.Expr(42), ir.Expr(-42))
+    expected = "ir.Select.make(True, 42, -42)"
+
+    _assert_print(select, expected)
+
+
+def test_tensor_load():
+    tensor_shape = [ir.Expr(224), ir.Expr(224), ir.Expr(3)]
+    tensor = ir._Tensor_.make(
+        "tensor", cinn.common.Float(32), tensor_shape, tensor_shape
+    ).Expr()
+    load_idx = [ir.Expr(1), ir.Expr(1), ir.Expr(2)]
+    load = ir.Load.make(tensor, load_idx)
+    expected = "tensor[1, 1, 2]"
+    _assert_print(load, expected)
+
+
+def test_ramp():
+    base = ir.Expr(ir.Var("a", cinn.common.Int(32)))
+    stride = ir.Expr(2)
+    lanes = 32
+    ramp = ir.Ramp.make(base, stride, lanes)
+    expected = "ir.Ramp(a, 2, 32)"
+    _assert_print(ramp, expected)
+
+
+def test_broadcast():
+    broadcast = ir.Broadcast.make(ir.Expr(4), 4)
+    expected = "ir.Broadcast.make(4, 4)"
+    _assert_print(broadcast, expected)
+
+
+def test_call():
+    call = lang.call_extern("sin", [ir.Expr(1.0)], {})
+    expected = 'lang.call_extern("sin", [1], {})'
+    _assert_print(call, expected)
+
+
+def test_call_extern():
+    @to_cinn_llir
+    def call_sinh(A: DataArray((1, 4, 256, 512)), B: DataArray((1, 4, 256))):
+        for i1 in range(1):
+            for j1 in range(4):
+                for k1 in range(256):
+                    with ir.ScheduleBlockContext("init") as init:
+                        vi, vj, vk = ir.AxisMap("SSS", [i1, j1, k1])
+                        B[vi, vj, vk] = lang.call_extern(
+                            "sinh", [A[vi, vi, vj, vk]], {}
+                        )
+
+    expected = """
+# from cinn import ir, lang, to_cinn_llir
+# from cinn.runtime.data_array import DataArray
+# from cinn.schedule import IRSchedule as sch
+def fn_call_sinh(A: DataArray((1, 4, 256, 512)), B: DataArray((1, 4, 256))):
+    for i1 in range(0, 1):
+        for j1 in range(0, 4):
+            for k1 in range(0, 256):
+                with ir.ScheduleBlockContext("init") as init_block:
+                    vi, vj, vk = ir.AxisMap("SSS", [i1, j1, k1])
+                    B[vi, vj, vk] = lang.call_extern("sinh", [A[vi, vi, vj, vk]], {})
+    """
+    _assert_print(call_sinh, expected)
+
+
+def test_stmts():
+    # include For, Store, IfThenElse, Block, ScheduleBlock, ScheduleBlockRealize, LowerFunction
+    @to_cinn_llir
+    def if_then_else(A: DataArray((1, 4, 256, 512)), B: DataArray((1, 4, 256))):
+        for i1 in range(1):
+            for j1 in range(4):
+                for k1 in range(256):
+                    if k1 < 128:
+                        with ir.ScheduleBlockContext("if") as if_block:
+                            vi, vj, vk = ir.AxisMap("SSS", [i1, j1, k1])
+                            B[vi, vj, vk] = lang.call_extern(
+                                "sinh", [A[vi, vi, vj, vk]], {}
+                            )
+                    else:
+                        with ir.ScheduleBlockContext("else") as else_block:
+                            vi, vj, vk = ir.AxisMap("SSS", [i1, j1, k1])
+                            B[vi, vj, vk] = 0.0
+
+    expected = """
+# from cinn import ir, lang, to_cinn_llir
+# from cinn.runtime.data_array import DataArray
+# from cinn.schedule import IRSchedule as sch
+def fn_if_then_else(A: DataArray((1, 4, 256, 512)), B: DataArray((1, 4, 256))):
+    for i1 in range(0, 1):
+        for j1 in range(0, 4):
+            for k1 in range(0, 256):
+                if ((k1 < 128)):
+                    with ir.ScheduleBlockContext("if") as if_block:
+                        vi, vj, vk = ir.AxisMap("SSS", [i1, j1, k1])
+                        B[vi, vj, vk] = lang.call_extern("sinh", [A[vi, vi, vj, vk]], {})
+                else:
+                    with ir.ScheduleBlockContext("else") as else_block:
+                        vi, vj, vk = ir.AxisMap("SSS", [i1, j1, k1])
+                        B[vi, vj, vk] = 0
+    """
+    _assert_print(if_then_else, expected)
+
+
+if __name__ == "__main__":
+    test_cinn_type()
+    test_var()
+    test_int_imm()
+    test_uint_imm()
+    test_float_imm()
+    test_buffer()
+    test_cast()
+    test_binary_op()
+    test_logical()
+    test_select()
+    test_tensor_load()
+    test_ramp()
+    test_broadcast()
+    test_call()
+    test_call_extern()
+    test_stmts()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-72423

添加Python DSL的printer，设置环境变量
```bash
export FLAGS_cinn_print_python_script=true
```
后，将打印python script格式的CINN IR。还未设置成默认的printer，因为CINN有大量单测依赖原始打印格式的字符串。

将CINN IR分为下面类别实现

- [x] type, var, buffer  https://github.com/PaddlePaddle/Paddle/pull/58160
- [x] expr
- [x] op
- [x] stmts 1
  - [x] BufferStore
  - [x] Store
- [x] stmts 2
  - [x] IfThenElse
  - [x] for
- [x] stmts 3
  - [x] function
  - [x] Block
  - [x] ScheduleBlock
  - [x] ScheduleBlockRealize
- [ ] intrinsic op

​                  
