### PR TITLE
[PIR] fix full_with_tensor choose kernel

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -514,6 +514,16 @@ phi::KernelKey GetKernelKey(
                 op->result(0).type().dyn_cast<DenseTensorType>().dtype())};
   }
 
+  if (op->isa<paddle::dialect::FullWithTensorOp>()) {
+    auto backend = paddle::experimental::ParseBackend(place);
+    auto dtype = op->attributes()
+                     .at("dtype")
+                     .dyn_cast<dialect::DataTypeAttribute>()
+                     .data();
+
+    return {backend, phi::DataLayout::ANY, dtype};
+  }
+
   phi::Backend kernel_backend = phi::Backend::UNDEFINED;
   phi::DataLayout kernel_layout = phi::DataLayout::UNDEFINED;
   phi::DataType kernel_data_type = phi::DataType::UNDEFINED;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-67164
full_with_tensor的choose kernel特殊处理。place使用执行器的默认place。dtype使用参数中的dtype。