### PR TITLE
[PIR] fix blockargument destroy log error.

### DIFF
--- a/paddle/pir/core/block_argument.cc
+++ b/paddle/pir/core/block_argument.cc
@@ -73,9 +73,9 @@ BlockArgument BlockArgument::Create(Type type, Block *owner, uint32_t index) {
 /// Destroy the argument.
 void BlockArgument::Destroy() {
   if (impl_) {
-    LOG(WARNING) << "Destroying a null block argument.";
-  } else {
     delete IMPL_;
+  } else {
+    LOG(WARNING) << "Destroying a null block argument.";
   }
 }
 

--- a/paddle/pir/core/op_info.h
+++ b/paddle/pir/core/op_info.h
@@ -72,7 +72,7 @@ class IR_API OpInfo {
   typename InterfaceT::Concept *GetInterfaceImpl() const;
 
   operator void *() const { return impl_; }
-  static OpInfo RecoverFromOpaquePointer(void *pointer) {
+  static OpInfo RecoverFromVoidPointer(void *pointer) {
     return OpInfo(static_cast<OpInfoImpl *>(pointer));
   }
 

--- a/paddle/pir/core/type.h
+++ b/paddle/pir/core/type.h
@@ -47,8 +47,7 @@ class IR_API Type {
 
   Type() = default;
 
-  Type(const Storage *storage)  // NOLINT
-      : storage_(storage) {}
+  Type(const Storage *storage) : storage_(storage) {}  // NOLINT
 
   Type(const Type &other) = default;
 
@@ -74,8 +73,8 @@ class IR_API Type {
   /// \brief Support PointerLikeTypeTraits.
   ///
   operator const void *() const { return storage_; }
-  static Type RecoverFromOpaquePointer(const void *pointer) {
-    return Type(reinterpret_cast<Storage *>(const_cast<void *>(pointer)));
+  static Type RecoverFromVoidPointer(const void *pointer) {
+    return Type(reinterpret_cast<const Storage *>(pointer));
   }
 
   ///

--- a/paddle/pir/core/type_id.h
+++ b/paddle/pir/core/type_id.h
@@ -54,7 +54,7 @@ class TypeId {
   /// \brief Support PointerLikeTypeTraits.
   ///
   operator void *() const { return storage_; }
-  static TypeId RecoverFromOpaquePointer(void *pointer) {
+  static TypeId RecoverFromVoidPointer(void *pointer) {
     return TypeId(static_cast<Storage *>(pointer));
   }
 
@@ -92,7 +92,7 @@ class alignas(8) UniqueingId {
   UniqueingId &operator=(UniqueingId &&) = delete;
 
   operator TypeId() { return id(); }
-  TypeId id() { return TypeId::RecoverFromOpaquePointer(this); }
+  TypeId id() { return TypeId::RecoverFromVoidPointer(this); }
 };
 
 template <typename T>

--- a/paddle/pir/pattern_rewrite/pattern_match.h
+++ b/paddle/pir/pattern_rewrite/pattern_match.h
@@ -76,19 +76,19 @@ class IR_API Pattern {
 
   std::optional<OpInfo> root_kind() const {
     if (root_kind_ == RootKind::OperationInfo)
-      return OpInfo::RecoverFromOpaquePointer(root_val_);
+      return OpInfo::RecoverFromVoidPointer(root_val_);
     return std::nullopt;
   }
 
   std::optional<TypeId> GetRootInterfaceID() const {
     if (root_kind_ == RootKind::InterfaceId)
-      return TypeId::RecoverFromOpaquePointer(root_val_);
+      return TypeId::RecoverFromVoidPointer(root_val_);
     return std::nullopt;
   }
 
   std::optional<TypeId> GetRootTraitID() const {
     if (root_kind_ == RootKind::TraitId)
-      return TypeId::RecoverFromOpaquePointer(root_val_);
+      return TypeId::RecoverFromVoidPointer(root_val_);
     return std::nullopt;
   }
 

--- a/test/cpp/pir/core/op_info_test.cc
+++ b/test/cpp/pir/core/op_info_test.cc
@@ -40,7 +40,7 @@ TEST(ir_op_info_test, op_op_info_test) {
   EXPECT_FALSE(info_map.empty());
 
   void* info_1 = op->info();
-  auto info_2 = pir::OpInfo::RecoverFromOpaquePointer(info_1);
+  auto info_2 = pir::OpInfo::RecoverFromVoidPointer(info_1);
   EXPECT_EQ(op->info(), info_2);
   pir::Verify(program.module_op());
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- 修复block_argument被销毁时的错误信息日志。
- 将RecoverFormOpaquePointer修改为RecoverFormVoidPointer

### Other
Pcard-67164
