### PR TITLE
[PIR] support if_op build after subblock has been completed.

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/CMakeLists.txt
+++ b/paddle/fluid/pir/dialect/operator/ir/CMakeLists.txt
@@ -191,7 +191,7 @@ cc_library(
 cc_library(
   pd_op_dialect_op
   SRCS ${op_source_file} manual_op.cc control_flow_op.cc
-  DEPS pd_op_dialect_core)
+  DEPS pd_op_dialect_core pir_control_flow)
 cc_library(
   api_builder
   SRCS api_builder.cc

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
@@ -31,11 +31,11 @@ class IfOp : public pir::Op<IfOp> {
                     pir::Value cond,
                     std::vector<pir::Type> &&output_types);
 
-  // static void Build(pir::Builder &builder,             // NOLINT
-  //                   pir::OperationArgument &argument,  // NOLINT
-  //                   pir::Value cond,
-  //                   std::unique_ptr<pir::Block>&& true_block,
-  //                   std::unique_ptr<pir::Block>&& false_block);
+  static void Build(pir::Builder &builder,             // NOLINT
+                    pir::OperationArgument &argument,  // NOLINT
+                    pir::Value cond,
+                    std::unique_ptr<pir::Block> &&true_block,
+                    std::unique_ptr<pir::Block> &&false_block);
 
   pir::Value cond() { return operand_source(0); }
   pir::Block *true_block();

--- a/test/cpp/pir/control_flow_dialect/if_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/if_op_test.cc
@@ -59,3 +59,43 @@ TEST(if_op_test, base) {
 
   LOG(INFO) << ss.str();
 }
+
+TEST(if_op_test, build_by_block) {
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+  ctx->GetOrRegisterDialect<pir::ControlFlowDialect>();
+
+  pir::Program program(ctx);
+  pir::Block* block = program.block();
+  pir::Builder builder(ctx, block);
+  auto full_op = builder.Build<paddle::dialect::FullOp>(
+      std::vector<int64_t>{1}, true, phi::DataType::BOOL);
+
+  // construct true block
+  std::unique_ptr<pir::Block> true_block(new pir::Block());
+  builder.SetInsertionPointToStart(true_block.get());
+  auto full_op_1 = builder.Build<paddle::dialect::FullOp>(
+      std::vector<int64_t>{2}, true, phi::DataType::BOOL);
+  builder.Build<pir::YieldOp>(std::vector<pir::Value>{full_op_1.out()});
+
+  // construct false block
+  std::unique_ptr<pir::Block> false_block(new pir::Block());
+  builder.SetInsertionPointToStart(false_block.get());
+  auto full_op_2 = builder.Build<paddle::dialect::FullOp>(
+      std::vector<int64_t>{2}, true, phi::DataType::BOOL);
+  builder.Build<pir::YieldOp>(std::vector<pir::Value>{full_op_2.out()});
+
+  builder.SetInsertionPointToEnd(block);
+
+  builder.Build<paddle::dialect::IfOp>(
+      full_op.out(), std::move(true_block), std::move(false_block));
+
+  EXPECT_FALSE(true_block);
+  EXPECT_FALSE(false_block);
+  EXPECT_EQ(full_op_2->GetParentProgram(), &program);
+
+  std::stringstream ss;
+  program.Print(ss);
+
+  LOG(INFO) << ss.str();
+}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

 APIs

### Description
<!-- Describe what you’ve done -->

if_op支持先构造完成true_block和false_block, 然后通过构造得到的block去构造if_op。

### Other
Pcard-67164
