### PR TITLE
[fix ]fix sample code in `paddle.utils.require_version`

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -467,13 +467,13 @@ def require_version(min_version, max_version=None):
     Examples:
         .. code-block:: python
 
-            >>> import paddle.base as base
+            >>> import paddle
 
             >>> # any version >= 0.1.0 is acceptable.
-            >>> base.require_version('0.1.0')
+            >>> paddle.utils.require_version('0.1.0')
 
             >>> # if 0.1.0 <= version <= 10.0.0, it is acceptable.
-            >>> base.require_version(min_version='0.1.0', max_version='10.0.0')
+            >>> paddle.utils.require_version(min_version='0.1.0', max_version='10.0.0')
     """
     if not isinstance(min_version, str):
         raise TypeError(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
link [https://github.com/PaddlePaddle/docs/pull/6220](https://github.com/PaddlePaddle/docs/pull/6220)
在中文api_label修复过程中，发现缺失 require_version的中文文档，英文paddle.util.require_version 的示例代码使用的是 base。
link #57501 中也是确认过这个函数是暴露的

![图片](https://github.com/PaddlePaddle/Paddle/assets/106524776/d44d2f5c-bddf-4934-8193-a6d8d617a21d)

@sunzhongkai588 @SigureMo 