### PR TITLE
[PIR]Support op that has different args between op definition and kernels in pir

### DIFF
--- a/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.cc
@@ -222,5 +222,17 @@ const std::string& OpYamlInfoParser::GetOriginOpName() const {
   return std::get<4>(op_info_tuple_);
 }
 
+int OpYamlInfoParser::GetTensorParamIndexByArgsName(
+    const std::string& args_name) const {
+  const auto& iter = std::find(kernel_fn_tensor_params_.begin(),
+                               kernel_fn_tensor_params_.end(),
+                               args_name);
+  if (iter != kernel_fn_tensor_params_.end()) {
+    return std::distance(kernel_fn_tensor_params_.begin(), iter);
+  } else {
+    return -1;
+  }
+}
+
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h
+++ b/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h
@@ -65,6 +65,8 @@ class OpYamlInfoParser {
 
   const std::string& GetOriginOpName() const;
 
+  int GetTensorParamIndexByArgsName(const std::string& args_name) const;
+
  private:
   void parse();
   inline const std::vector<OpInputInfo>& InputInfo() const {

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -944,18 +944,21 @@ std::vector<pir::Value> BuildOpInputList(
 
     auto new_in = map_value_pair->at(cur_in);
 
-    int tensor_param_index = op_info_parser->GetTensorParamIndexByArgsName(
-        op_info_parser->InputNames()[i]);
-    // the input of op args is not the kernel parameter
-    if (tensor_param_index == -1) {
-      vec_inputs.emplace_back(new_in);
-      continue;
-    }
-
     auto new_in_type = new_in.type();
 
     auto& kernel = phi::KernelFactory::Instance().SelectKernelWithGPUDNN(
         kernel_fn_str, kernel_key);
+
+    int tensor_param_index = i;
+    if (kernel.IsValid()) {
+      tensor_param_index = op_info_parser->GetTensorParamIndexByArgsName(
+          op_info_parser->InputNames()[i]);
+      // the input of op args is not the kernel parameter
+      if (tensor_param_index == -1) {
+        vec_inputs.emplace_back(new_in);
+        continue;
+      }
+    }
 
     bool check_place_transfer =
         (op_item->isa<::pir::SetParameterOp>()) ||

--- a/test/legacy_test/test_assign_value_op.py
+++ b/test/legacy_test/test_assign_value_op.py
@@ -54,7 +54,7 @@ class TestAssignValueOp(op_test.OpTest):
         self.attrs["fp32_values"] = [float(v) for v in self.value.flat]
 
     def test_forward(self):
-        self.check_output(check_cinn=True, check_new_ir=False)
+        self.check_output(check_cinn=True, check_new_ir=True)
 
 
 class TestAssignValueOp2(TestAssignValueOp):

--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -63,11 +63,11 @@ class TestStackOpBase(OpTest):
         self.attrs = {'axis': self.axis}
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=False)
+        self.check_output(check_prim=True, check_new_ir=True)
 
     def test_check_grad(self):
         self.check_grad(
-            self.get_x_names(), 'Y', check_prim=True, check_new_ir=False
+            self.get_x_names(), 'Y', check_prim=True, check_new_ir=True
         )
 
 
@@ -189,11 +189,11 @@ class TestStackBF16Op(OpTest):
         self.attrs = {'axis': self.axis}
 
     def test_check_output(self):
-        self.check_output(check_prim=True, check_new_ir=False)
+        self.check_output(check_prim=True, check_new_ir=True)
 
     def test_check_grad(self):
         self.check_grad(
-            self.get_x_names(), 'Y', check_prim=True, check_new_ir=False
+            self.get_x_names(), 'Y', check_prim=True, check_new_ir=True
         )
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
完善pir机制，支持算子定义和Kernel输入不一致的算子执行，并打开stack和assign_value的pir单测