### PR TITLE
[PIR]Fix pir grad api optional output

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -197,7 +197,9 @@ class CodeGen:
             return True
         return False
 
-    def _is_optinonal_output(self, op_info, output_name):
+    def _is_optional_output(self, op_info, op_name, output_name):
+        if op_name.endswith('_grad'):
+            return False
         inplace_map = op_info.inplace_map
         input_optional_list = op_info.input_optional_list
         input_name_list = op_info.input_name_list
@@ -271,7 +273,7 @@ class CodeGen:
         )
         return (inputs + ', ' + attrs).strip(', ')
 
-    def _gen_ret_type(self, op_info):
+    def _gen_ret_type(self, op_info, op_name):
         name_list = op_info.output_name_list
         type_list = op_info.output_type_list
         intermediate_list = op_info.output_intermediate_list
@@ -285,7 +287,7 @@ class CodeGen:
             ):
                 if intermediate == 'true':
                     continue
-                if self._is_optinonal_output(op_info, name):
+                if self._is_optional_output(op_info, op_name, name):
                     ret.append(OPTIONAL_OUTPUT_TYPE_MAP[type])
                 else:
                     ret.append(OUTPUT_TYPE_MAP[type])
@@ -293,7 +295,7 @@ class CodeGen:
         elif output_num == 1:
             index = intermediate_list.index('false')
             name = name_list[index]
-            if self._is_optinonal_output(op_info, name):
+            if self._is_optional_output(op_info, op_name, name):
                 return OPTIONAL_OUTPUT_TYPE_MAP[type_list[index]]
             else:
                 return OUTPUT_TYPE_MAP[type_list[index]]
@@ -304,7 +306,7 @@ class CodeGen:
         self, op_info, op_name, is_mutable_attr, is_vector_mutable_attr
     ):
         return API_DECLARE_TEMPLATE.format(
-            ret_type=self._gen_ret_type(op_info),
+            ret_type=self._gen_ret_type(op_info, op_name),
             api_name=op_name,
             args=self._gen_api_args(
                 op_info, True, is_mutable_attr, is_vector_mutable_attr
@@ -367,7 +369,7 @@ class CodeGen:
         ):
             if intermediate == 'true':
                 continue
-            if self._is_optinonal_output(op_info, name):
+            if self._is_optional_output(op_info, op_name, name):
                 if VECTOR_TYPE in type:
                     ret += OPTIONAL_VECTOR_OPRESULT_OUTPUT_TEMPLATE.format(
                         name=name,
@@ -461,7 +463,7 @@ class CodeGen:
             op_inst_name,
         )
 
-    def _gen_out_split_and_ret_list(self, op_info, op_inst_name):
+    def _gen_out_split_and_ret_list(self, op_info, op_name, op_inst_name):
         name_list = op_info.output_name_list
         type_list = op_info.output_type_list
         intermediate_list = op_info.output_intermediate_list
@@ -480,7 +482,7 @@ class CodeGen:
         ):
             if intermediate == 'true':
                 continue
-            if self._is_optinonal_output(op_info, name):
+            if self._is_optional_output(op_info, op_name, name):
                 ret_list.append(f'optional_{name}')
             elif VECTOR_TYPE in type:
                 split_op_name = f'{name}_split_op'
@@ -503,7 +505,7 @@ class CodeGen:
     def _gen_one_impl(
         self, op_info, op_name, is_mutable_attr, is_vector_mutable_attr
     ):
-        ret_type = self._gen_ret_type(op_info)
+        ret_type = self._gen_ret_type(op_info, op_name)
         in_combine, in_combine_op_list = self._gen_in_combine(
             op_info, is_mutable_attr, is_vector_mutable_attr
         )
@@ -514,7 +516,7 @@ class CodeGen:
             compute_op += f' (void){op_inst_name};'
 
         out_split, ret_list = self._gen_out_split_and_ret_list(
-            op_info, op_inst_name
+            op_info, op_name, op_inst_name
         )
 
         ret = API_IMPL_TEMPLATE.format(

--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -198,7 +198,7 @@ class CodeGen:
         return False
 
     def _is_optional_output(self, op_info, op_name, output_name):
-        if op_name.endswith('_grad'):
+        if op_name.endswith(('_grad', '_grad_')):
             return False
         inplace_map = op_info.inplace_map
         input_optional_list = op_info.input_optional_list


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
对于grad api，返回值不应该是optional的，这个pr修改了代码生成的逻辑。修复反向api生成 optional 输出的问题
Pcard-67164
