### PR TITLE
[OneDNN] Upgrade OneDNN to v3.2

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -247,6 +247,14 @@ if(NOT DEFINED WITH_MKLDNN)
   endif()
 endif()
 
+if(WIN32)
+  if(MSVC)
+    if(MSVC_VERSION EQUAL 1911)
+      set(WITH_MKLDNN OFF)
+    endif()
+  endif()
+endif()
+
 if(WIN32
    OR APPLE
    OR NOT WITH_GPU

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -249,7 +249,7 @@ endif()
 
 if(WIN32)
   if(MSVC)
-    if(MSVC_VERSION EQUAL 1911)
+    if(MSVC_VERSION EQUAL 1916)
       set(WITH_MKLDNN OFF)
     endif()
   endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -249,7 +249,7 @@ endif()
 
 if(WIN32)
   if(MSVC)
-    if(MSVC_VERSION EQUAL 1916)
+    if(MSVC_VERSION LESS 1920)
       set(WITH_MKLDNN OFF)
     endif()
   endif()

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -47,7 +47,7 @@ if(WIN32)
   list(REMOVE_ITEM TEST_TRT_CONVERTER
        "test_trt_convert_quantize_dequantize_linear")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization")
-  if(NOT WITH_MKLDNN)
+  if(WITH_MKLDNN)
     list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
     list(REMOVE_ITEM TEST_TRT_IR_PASSES
          "test_trt_explicit_quantization_mobilenet")

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -48,7 +48,7 @@ if(WIN32)
        "test_trt_convert_quantize_dequantize_linear")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization")
   # if(WITH_MKLDNN)
-  message(STATUS "TEST_TRT_IR_PASSES = ${TEST_TRT_IR_PASSES}.")
+  # message(STATUS "TEST_TRT_IR_PASSES = ${TEST_TRT_IR_PASSES}.")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES
        "test_trt_explicit_quantization_mobilenet")
@@ -184,10 +184,10 @@ if(WITH_GPU AND TENSORRT_FOUND)
   set_tests_properties(test_trt_inference_predictor PROPERTIES TIMEOUT 60)
   set_tests_properties(test_trt_inference_fp16_io PROPERTIES TIMEOUT 300)
   set_tests_properties(test_trt_optimization_level PROPERTIES TIMEOUT 300)
-  set_tests_properties(test_trt_explicit_quantization_resnet PROPERTIES TIMEOUT
-                                                                        300)
-  set_tests_properties(test_trt_explicit_quantization_mobilenet
-                       PROPERTIES TIMEOUT 300)
+  # set_tests_properties(test_trt_explicit_quantization_resnet PROPERTIES TIMEOUT
+  #                                                                       300)
+  # set_tests_properties(test_trt_explicit_quantization_mobilenet
+  #                      PROPERTIES TIMEOUT 300)
   if(WITH_MKLDNN)
     set_tests_properties(test_save_optimized_model_pass PROPERTIES TIMEOUT 300)
   endif()

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -47,9 +47,9 @@ if(WIN32)
   list(REMOVE_ITEM TEST_TRT_CONVERTER
        "test_trt_convert_quantize_dequantize_linear")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization")
-  list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
-  list(REMOVE_ITEM TEST_TRT_IR_PASSES
-       "test_trt_explicit_quantization_mobilenet")
+  # list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
+  # list(REMOVE_ITEM TEST_TRT_IR_PASSES
+  #      "test_trt_explicit_quantization_mobilenet")
 endif()
 
 # Only for cpu(mkl + openblas)

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -47,12 +47,9 @@ if(WIN32)
   list(REMOVE_ITEM TEST_TRT_CONVERTER
        "test_trt_convert_quantize_dequantize_linear")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization")
-  # if(WITH_MKLDNN)
-  # message(STATUS "TEST_TRT_IR_PASSES = ${TEST_TRT_IR_PASSES}.")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES
        "test_trt_explicit_quantization_mobilenet")
-  # endif()
 endif()
 
 # Only for cpu(mkl + openblas)
@@ -184,10 +181,12 @@ if(WITH_GPU AND TENSORRT_FOUND)
   set_tests_properties(test_trt_inference_predictor PROPERTIES TIMEOUT 60)
   set_tests_properties(test_trt_inference_fp16_io PROPERTIES TIMEOUT 300)
   set_tests_properties(test_trt_optimization_level PROPERTIES TIMEOUT 300)
-  # set_tests_properties(test_trt_explicit_quantization_resnet PROPERTIES TIMEOUT
-  #                                                                       300)
-  # set_tests_properties(test_trt_explicit_quantization_mobilenet
-  #                      PROPERTIES TIMEOUT 300)
+  if(NOT WIN32)
+    set_tests_properties(test_trt_explicit_quantization_resnet
+                         PROPERTIES TIMEOUT 300)
+    set_tests_properties(test_trt_explicit_quantization_mobilenet
+                         PROPERTIES TIMEOUT 300)
+  endif()
   if(WITH_MKLDNN)
     set_tests_properties(test_save_optimized_model_pass PROPERTIES TIMEOUT 300)
   endif()

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -47,11 +47,12 @@ if(WIN32)
   list(REMOVE_ITEM TEST_TRT_CONVERTER
        "test_trt_convert_quantize_dequantize_linear")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization")
-  if(WITH_MKLDNN)
-    list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
-    list(REMOVE_ITEM TEST_TRT_IR_PASSES
-         "test_trt_explicit_quantization_mobilenet")
-  endif()
+  # if(WITH_MKLDNN)
+  message(STATUS "TEST_TRT_IR_PASSES = ${TEST_TRT_IR_PASSES}.")
+  list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
+  list(REMOVE_ITEM TEST_TRT_IR_PASSES
+       "test_trt_explicit_quantization_mobilenet")
+  # endif()
 endif()
 
 # Only for cpu(mkl + openblas)

--- a/test/ir/inference/CMakeLists.txt
+++ b/test/ir/inference/CMakeLists.txt
@@ -47,9 +47,11 @@ if(WIN32)
   list(REMOVE_ITEM TEST_TRT_CONVERTER
        "test_trt_convert_quantize_dequantize_linear")
   list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization")
-  # list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
-  # list(REMOVE_ITEM TEST_TRT_IR_PASSES
-  #      "test_trt_explicit_quantization_mobilenet")
+  if(NOT WITH_MKLDNN)
+    list(REMOVE_ITEM TEST_TRT_IR_PASSES "test_trt_explicit_quantization_resnet")
+    list(REMOVE_ITEM TEST_TRT_IR_PASSES
+         "test_trt_explicit_quantization_mobilenet")
+  endif()
 endif()
 
 # Only for cpu(mkl + openblas)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Upgrade OneDNN V3.2 in Paddle, and fix CI bug cause by merge conflict. PS: OneDNN has deprecated support for VS2017 and claim the support for [VS2019 and VS2022](https://github.com/oneapi-src/oneDNN/tree/rls-v3.2#validated-configurations) since [Microsoft ended the main stream support on April 12th, 2022](https://learn.microsoft.com/zh-cn/lifecycle/products/visual-studio-2017). We'll try to skip build with mkldnn on MSVC15
