### PR TITLE
PrintOP support more dtypes

### DIFF
--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1711,7 +1711,7 @@ def Print(
     check_variable_and_dtype(
         input,
         'input',
-        ['float32', 'float64', 'int32', 'int64', 'bool'],
+        ['uint16', 'float16', 'float32', 'float64', 'int32', 'int64', 'bool'],
         'paddle.static.Print',
     )
 

--- a/test/legacy_test/test_print_op.py
+++ b/test/legacy_test/test_print_op.py
@@ -97,8 +97,8 @@ class TestPrintOpError(unittest.TestCase):
                 np.array([[-1]]), [[1]], paddle.CPUPlace()
             )
             self.assertRaises(TypeError, paddle.static.Print, x1)
-            # The input dtype of Print_op must be float32, float64, int32_t, int64_t or bool.
-            x2 = paddle.static.data(name='x2', shape=[4], dtype="float16")
+            # The input dtype of Print_op must be uint16, float16, float32, float64, int32_t, int64_t or bool.
+            x2 = paddle.static.data(name='x2', shape=[4], dtype="int8")
             self.assertRaises(TypeError, paddle.static.Print, x2)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
pcard-75206
增加 Print OP 支持的数据类型，便于静态图在半精度下的调试
