### PR TITLE
[CustomDevice] remove stream_safe_allocator when the allocater strage is naive_best_fit

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.h
+++ b/paddle/fluid/memory/allocation/allocator_facade.h
@@ -97,11 +97,14 @@ class AllocatorFacade {
 #endif
 
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
+  uint64_t Release(const platform::CustomPlace& place,
+                   phi::stream::stream_t stream);
+  void RecordStream(std::shared_ptr<Allocation> allocation,
+                    phi::stream::stream_t stream);
   const std::shared_ptr<Allocator>& GetAllocator(const platform::Place& place,
                                                  phi::stream::stream_t stream);
-  void RecordStream(std::shared_ptr<phi::Allocation> allocation,
-                    phi::stream::stream_t stream);
-
+  phi::stream::stream_t GetStream(
+      const std::shared_ptr<Allocation>& allocation) const;
   void SetDefaultStream(const platform::CustomPlace& place,
                         phi::stream::stream_t stream);
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
remove stream_safe_allocator when the allocater strage is naive_best_fit
