### PR TITLE
[PIR] fused_bn_add_activation use phi_instruction

### DIFF
--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -22,8 +22,6 @@ const std::unordered_set<std::string> LegacyOpList = {
     "pd_op.load_combine",
     "pd_op.c_concat",
     "pd_op.c_broadcast_",
-    "pd_op.fused_bn_add_activation_",
-    "pd_op.fused_bn_add_activation_grad",
     "pd_op.c_sync_calc_stream_",
     "pd_op.c_sync_comm_stream_",
     "pd_op.send_v2",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
fused_bn_add_activation迁移到了PHI。同时需要修改paddle/fluid/pir/dialect/operator/utils/utils.cc，删除清单中的fused_bn_add_activation。否则fused_bn_add_activation会使用LegacyKernelInstruction

Pcard-67164