### PR TITLE
[PIR] Reconstruct the Verify system

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -44,7 +44,7 @@ std::vector<pir::Operation *> GroupOp::ops() {
                                        inner_block->end());
 }
 
-void GroupOp::Verify() {}
+void GroupOp::VerifySig() {}
 
 void GroupOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -36,7 +36,7 @@ class GroupOp : public pir::Op<GroupOp> {
   pir::Block *block();
   std::vector<pir::Operation *> ops();
 
-  void Verify();
+  void VerifySig();
   void Print(pir::IrPrinter &printer);  // NOLINT
 };
 

--- a/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.cc
+++ b/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.cc
@@ -22,7 +22,7 @@ namespace dialect {
 
 const char* JitKernelOp::attributes_name[attributes_num] = {kAttrName};
 
-void JitKernelOp::Verify() {
+void JitKernelOp::VerifySig() {
   VLOG(4) << "Verifying inputs, outputs and attributes for: JitKernelOp.";
 
   auto& attributes = this->attributes();

--- a/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.h
+++ b/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.h
@@ -51,7 +51,7 @@ class JitKernelOp : public ::pir::Op<JitKernelOp> {
 
   hlir::framework::Instruction* instruction();
 
-  void Verify();
+  void VerifySig();
 };
 
 }  // namespace dialect

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -326,6 +326,8 @@ pir::Operation* ProgramTranslator::TranslateCondIfOperation(
                    true);
   }
   VLOG(4) << "[general op][conditional_block] IfOp false block translate end.";
+
+  operation->Verify();
   VLOG(4) << "[general op][conditional_block] IfOp translate end.";
   return operation;
 }

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_op.cc
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_op.cc
@@ -25,7 +25,7 @@ const char* PhiKernelOp::attributes_name[attributes_num] = {  // NOLINT
     "kernel_name",
     "kernel_key"};
 
-void PhiKernelOp::Verify() {
+void PhiKernelOp::VerifySig() {
   VLOG(4) << "Verifying inputs, outputs and attributes for: PhiKernelOp.";
 
   auto& attributes = this->attributes();
@@ -64,7 +64,7 @@ const char* LegacyKernelOp::attributes_name[attributes_num] = {  // NOLINT
     "kernel_name",
     "kernel_key"};
 
-void LegacyKernelOp::Verify() {
+void LegacyKernelOp::VerifySig() {
   VLOG(4) << "Verifying inputs, outputs and attributes for: LegacyKernelOp.";
 
   auto& attributes = this->attributes();

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_op.h
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_op.h
@@ -29,7 +29,7 @@ class PhiKernelOp : public pir::Op<PhiKernelOp> {
   std::string op_name();
   std::string kernel_name();
   phi::KernelKey kernel_key();
-  void Verify();
+  void VerifySig();
 };
 
 class LegacyKernelOp : public pir::Op<LegacyKernelOp> {
@@ -41,7 +41,7 @@ class LegacyKernelOp : public pir::Op<LegacyKernelOp> {
   std::string op_name();
   std::string kernel_name();
   phi::KernelKey kernel_key();
-  void Verify();
+  void VerifySig();
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -99,7 +99,7 @@ class {op_name} : public pir::Op<{op_name}{interfaces}{traits}> {{
   {build_mutable_attr_is_input}
   {build_attr_num_over_1}
   {build_mutable_attr_is_input_attr_num_over_1}
-  void Verify();
+  void VerifySig();
 {get_inputs_and_outputs}
 {exclusive_interface}
 }};

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -14,7 +14,7 @@
 
 # verify
 OP_VERIFY_TEMPLATE = """
-void {op_name}::Verify() {{
+void {op_name}::VerifySig() {{
   VLOG(4) << "Start Verifying inputs, outputs and attributes for: {op_name}.";
   VLOG(4) << "Verifying inputs:";
   {{
@@ -36,7 +36,7 @@ void {op_name}::Verify() {{
 """
 
 GRAD_OP_VERIFY_TEMPLATE = """
-void {op_name}::Verify() {{}}
+void {op_name}::VerifySig() {{}}
 """
 
 INPUT_TYPE_CHECK_TEMPLATE = """

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -111,12 +111,14 @@ void IfOp::Print(pir::IrPrinter &printer) {
   os << "\n }";
 }
 void IfOp::VerifySig() {
+  VLOG(4) << "Start Verifying inputs, outputs and attributes for: IfOp.";
   auto input_size = num_operands();
   PADDLE_ENFORCE_EQ(
       input_size,
       1u,
       phi::errors::PreconditionNotMet(
           "The size %d of inputs must be equal to 1.", input_size));
+
   PADDLE_ENFORCE((*this)->operand_source(0).type().isa<pir::DenseTensorType>(),
                  phi::errors::PreconditionNotMet(
                      "Type validation failed for the 1th input, it should be a "
@@ -131,9 +133,16 @@ void IfOp::VerifySig() {
                  phi::errors::PreconditionNotMet(
                      "Type validation failed for the 1th input, it should be a "
                      "bool DenseTensorType."));
+
+  PADDLE_ENFORCE_EQ((*this)->num_regions(),
+                    2u,
+                    phi::errors::PreconditionNotMet(
+                        "The size %d of regions must be equal to 2.",
+                        (*this)->num_regions()));
 }
 
 void IfOp::VerifyRegion() {
+  VLOG(4) << "Start Verifying sub regions for: IfOp.";
   PADDLE_ENFORCE_EQ(
       (*this)->region(0).size(),
       1u,

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -117,13 +117,14 @@ void IfOp::Verify() {
            "verification: op->dyn_cast<padding::dialect:IfOp>().Verify()";
     return;
   }
+
   PADDLE_ENFORCE_EQ(
-      (*this)->region(0)->size(),
-      (*this)->region(1)->size(),
+      (*this)->region(0).size(),
+      (*this)->region(1).size(),
       phi::errors::PreconditionNotMet("The size %d of true_region must be "
                                       "equal to the size %d of false_region.",
-                                      (*this)->region(0)->size(),
-                                      (*this)->region(1)->size()));
+                                      (*this)->region(0).size(),
+                                      (*this)->region(1).size()));
   if ((*this)->num_results() != 0) {
     auto *true_last_op = (*this)->region(0).front()->back();
     auto *false_last_op = (*this)->region(1).front()->back();

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -145,7 +145,7 @@ void IfOp::Verify() {
                       (*this)->num_results(),
                       phi::errors::PreconditionNotMet(
                           "The size of last of true block op's input must be "
-                          "equal to IfOp's outputs num."))
+                          "equal to IfOp's outputs num."));
   }
 }
 

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -19,6 +19,7 @@ paddle::dialect::IfOp, paddle::dialect::WhileOp
 
 #include "paddle/phi/core/enforce.h"
 #include "paddle/pir/core/builder.h"
+#include "paddle/pir/core/builtin_type.h"
 #include "paddle/pir/core/ir_printer.h"
 #include "paddle/pir/core/operation_utils.h"
 #include "paddle/pir/dialect/control_flow/ir/cf_ops.h"

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -119,20 +119,18 @@ void IfOp::VerifySig() {
       phi::errors::PreconditionNotMet(
           "The size %d of inputs must be equal to 1.", input_size));
 
-  PADDLE_ENFORCE((*this)->operand_source(0).type().isa<pir::DenseTensorType>(),
-                 phi::errors::PreconditionNotMet(
-                     "Type validation failed for the 1th input, it should be a "
-                     "DenseTensorType."));
-
-  PADDLE_ENFORCE((*this)
-                     ->operand_source(0)
-                     .type()
-                     .dyn_cast<pir::DenseTensorType>()
-                     .dtype()
-                     .isa<pir::BoolType>(),
-                 phi::errors::PreconditionNotMet(
-                     "Type validation failed for the 1th input, it should be a "
-                     "bool DenseTensorType."));
+  if ((*this)->operand_source(0).type().isa<pir::DenseTensorType>()) {
+    PADDLE_ENFORCE(
+        (*this)
+            ->operand_source(0)
+            .type()
+            .dyn_cast<pir::DenseTensorType>()
+            .dtype()
+            .isa<pir::BoolType>(),
+        phi::errors::PreconditionNotMet(
+            "Type validation failed for the 1th input, it should be a "
+            "bool DenseTensorType."));
+  }
 
   PADDLE_ENFORCE_EQ((*this)->num_regions(),
                     2u,

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -140,11 +140,11 @@ void IfOp::Verify() {
     PADDLE_ENFORCE_EQ(false_last_op->isa<pir::YieldOp>(),
                       true,
                       phi::errors::PreconditionNotMet(
-                          "The last of true block must be YieldOp"));
+                          "The last of false block must be YieldOp"));
     PADDLE_ENFORCE_EQ(false_last_op->num_operands(),
                       (*this)->num_results(),
                       phi::errors::PreconditionNotMet(
-                          "The size of last of true block op's input must be "
+                          "The size of last of false block op's input must be "
                           "equal to IfOp's outputs num."));
   }
 }

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -117,16 +117,15 @@ void IfOp::VerifySig() {
       1u,
       phi::errors::PreconditionNotMet(
           "The size %d of inputs must be equal to 1.", input_size));
-  PADDLE_ENFORCE(
-      (*this)->operand_source(0).type().isa<paddle::dialect::DenseTensorType>(),
-      phi::errors::PreconditionNotMet(
-          "Type validation failed for the 1th input, it should be a "
-          "DenseTensorType."));
+  PADDLE_ENFORCE((*this)->operand_source(0).type().isa<pir::DenseTensorType>(),
+                 phi::errors::PreconditionNotMet(
+                     "Type validation failed for the 1th input, it should be a "
+                     "DenseTensorType."));
 
   PADDLE_ENFORCE((*this)
                      ->operand_source(0)
                      .type()
-                     .dyn_cast<paddle::dialect::DenseTensorType>()
+                     .dyn_cast<pir::DenseTensorType>()
                      .dtype()
                      .isa<pir::BoolType>(),
                  phi::errors::PreconditionNotMet(

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
@@ -41,7 +41,8 @@ class IfOp : public pir::Op<IfOp> {
   pir::Block *true_block();
   pir::Block *false_block();
   void Print(pir::IrPrinter &printer);  // NOLINT
-  void Verify();
+  void VerifySig();
+  void VerifyRegion();
 };
 
 class WhileOp : public pir::Op<WhileOp> {
@@ -57,7 +58,8 @@ class WhileOp : public pir::Op<WhileOp> {
   pir::Block *cond_block();
   pir::Block *body_block();
   void Print(pir::IrPrinter &printer);  // NOLINT
-  void Verify() {}
+  void VerifySig() {}
+  void VerifyRegion() {}
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -50,7 +50,7 @@ OpInfoTuple AddNOp::GetOpInfo() {
   return std::make_tuple(inputs, attributes, outputs, run_time_info, "add_n");
 }
 
-void AddNOp::Verify() {
+void AddNOp::VerifySig() {
   VLOG(4) << "Start Verifying inputs, outputs and attributes for: AddNOp.";
   VLOG(4) << "Verifying inputs:";
   {
@@ -222,7 +222,7 @@ void AddN_Op::Build(pir::Builder &builder,
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
-void AddN_Op::Verify() {
+void AddN_Op::VerifySig() {
   VLOG(4) << "Start Verifying inputs, outputs and attributes for: AddN_Op.";
   VLOG(4) << "Verifying inputs:";
   {
@@ -345,7 +345,7 @@ void AddNWithKernelOp::Build(pir::Builder &builder,
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
-void AddNWithKernelOp::Verify() {
+void AddNWithKernelOp::VerifySig() {
   VLOG(4) << "Start Verifying inputs, outputs and attributes for: "
              "AddNWithKernelOp.";
   VLOG(4) << "Verifying inputs:";
@@ -561,7 +561,7 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
-void FusedGemmEpilogueOp::Verify() {
+void FusedGemmEpilogueOp::VerifySig() {
   VLOG(4) << "Start Verifying inputs, outputs and attributes for: "
              "FusedGemmEpilogueOp.";
   VLOG(4) << "Verifying inputs:";
@@ -833,7 +833,7 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
-void FusedGemmEpilogueGradOp::Verify() {}
+void FusedGemmEpilogueGradOp::VerifySig() {}
 
 void FusedGemmEpilogueGradOp::InferMeta(phi::InferMetaContext *infer_meta) {
   auto fn = PD_INFER_META(phi::FusedGemmEpilogueGradInferMeta);
@@ -983,7 +983,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
-void SplitGradOp::Verify() {
+void SplitGradOp::VerifySig() {
   VLOG(4) << "Start Verifying inputs, outputs and attributes for: SplitGradOp.";
   VLOG(4) << "Verifying inputs:";
   {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -45,7 +45,7 @@ class AddNOp : public pir::Op<AddNOp,
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value inputs);
 
-  void Verify();
+  void VerifySig();
   pir::Value inputs() { return operand_source(0); }
   pir::OpResult out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
@@ -69,7 +69,7 @@ class AddN_Op : public pir::Op<AddN_Op,
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value inputs_);
 
-  void Verify();
+  void VerifySig();
   pir::Value inputs() { return operand_source(0); }
   pir::OpResult out() { return result(0); }
 
@@ -89,7 +89,7 @@ class AddNWithKernelOp : public pir::Op<AddNWithKernelOp,
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value inputs_);
 
-  void Verify();
+  void VerifySig();
   pir::Value inputs() { return operand_source(0); }
   pir::OpResult out() { return result(0); }
 
@@ -113,7 +113,7 @@ class FusedGemmEpilogueOp
                     pir::Value y_,
                     pir::Value bias_,
                     pir::AttributeMap attributes);
-  void Verify();
+  void VerifySig();
   pir::Value x() { return operand_source(0); }
   pir::Value y() { return operand_source(1); }
   pir::Value bias() { return operand_source(2); }
@@ -141,7 +141,7 @@ class FusedGemmEpilogueGradOp
                     pir::Value reserve_space_,
                     pir::Value out_grad_,
                     pir::AttributeMap attributes);
-  void Verify();
+  void VerifySig();
   pir::Value x() { return operand_source(0); }
   pir::Value y() { return operand_source(1); }
   pir::Value reserve_space() { return operand_source(2); }
@@ -169,7 +169,7 @@ class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
                     pir::Value out_grad_,
                     pir::Value axis_);
 
-  void Verify();
+  void VerifySig();
   pir::Value out_grad() { return operand_source(0); }
   pir::Value axis() { return operand_source(1); }
   pir::OpResult x_grad() { return result(0); }

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -82,7 +82,7 @@ void ModuleOp::Destroy() {
   }
 }
 
-void ModuleOp::Verify() const {
+void ModuleOp::VerifySig() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: ModuleOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
@@ -118,7 +118,7 @@ void GetParameterOp::PassStopGradients(OperationArgument &argument) {
       pir::ArrayAttribute::get(pir::IrContext::Instance(), outs_stop_gradient));
 }
 
-void GetParameterOp::Verify() const {
+void GetParameterOp::VerifySig() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: GetParameterOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
@@ -144,7 +144,7 @@ void SetParameterOp::Build(Builder &builder,             // NOLINT
   argument.AddAttribute(attributes_name[0],
                         pir::StrAttribute::get(builder.ir_context(), name));
 }
-void SetParameterOp::Verify() const {
+void SetParameterOp::VerifySig() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: SetParameterOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 1, "The size of outputs must be equal to 1.");
@@ -170,7 +170,7 @@ void ShadowOutputOp::Build(Builder &builder,             // NOLINT
   argument.AddAttribute(attributes_name[0],
                         pir::StrAttribute::get(builder.ir_context(), name));
 }
-void ShadowOutputOp::Verify() const {
+void ShadowOutputOp::VerifySig() const {
   VLOG(4) << "Verifying inputs, outputs and attributes for: ShadowOutputOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 1, "The size of outputs must be equal to 1.");
@@ -198,7 +198,7 @@ void CombineOp::Build(Builder &builder,
   PassStopGradientsDefaultly(argument);
 }
 
-void CombineOp::Verify() const {
+void CombineOp::VerifySig() const {
   // outputs.size() == 1
   IR_ENFORCE(num_results() == 1u, "The size of outputs must be equal to 1.");
 
@@ -260,7 +260,7 @@ void SliceOp::PassStopGradients(OperationArgument &argument, int index) {
       pir::ArrayAttribute::get(pir::IrContext::Instance(), outs_stop_gradient));
 }
 
-void SliceOp::Verify() const {
+void SliceOp::VerifySig() const {
   // inputs.size() == 1
   auto input_size = num_operands();
   IR_ENFORCE(
@@ -364,7 +364,7 @@ void SplitOp::PassStopGradients(OperationArgument &argument) {
       pir::ArrayAttribute::get(pir::IrContext::Instance(), outs_stop_gradient));
 }
 
-void SplitOp::Verify() const {
+void SplitOp::VerifySig() const {
   // inputs.size() == 1
   IR_ENFORCE(num_operands() == 1u, "The size of inputs must be equal to 1.");
 
@@ -393,7 +393,7 @@ void ConstantOp::Build(Builder &builder,
   argument.output_types.push_back(output_type);
 }
 
-void ConstantOp::Verify() const {
+void ConstantOp::VerifySig() const {
   IR_ENFORCE(num_operands() == 0, "The size of inputs must be equal to 0.");
   IR_ENFORCE(num_results() == 1, "The size of outputs must be equal to 1.");
   IR_ENFORCE(attributes().count("value") > 0, "must has value attribute");

--- a/paddle/pir/core/builtin_op.h
+++ b/paddle/pir/core/builtin_op.h
@@ -31,7 +31,7 @@ class IR_API ModuleOp : public pir::Op<ModuleOp> {
   static const char *name() { return "builtin.module"; }
   static constexpr uint32_t attributes_num = 1;
   static const char *attributes_name[attributes_num];
-  void Verify() const;
+  void VerifySig() const;
   Program *program();
   Block *block();
 
@@ -56,7 +56,7 @@ class IR_API GetParameterOp : public pir::Op<GetParameterOp> {
                     OperationArgument &argument,  // NOLINT
                     const std::string &name,
                     Type type);
-  void Verify() const;
+  void VerifySig() const;
 
  private:
   static void PassStopGradients(OperationArgument &argument);  // NOLINT
@@ -76,7 +76,7 @@ class IR_API SetParameterOp : public pir::Op<SetParameterOp> {
                     OperationArgument &argument,  // NOLINT
                     Value parameter,
                     const std::string &name);
-  void Verify() const;
+  void VerifySig() const;
 };
 
 ///
@@ -93,7 +93,7 @@ class IR_API ShadowOutputOp : public pir::Op<ShadowOutputOp> {
                     OperationArgument &argument,  // NOLINT
                     Value parameter,
                     const std::string &name);
-  void Verify() const;
+  void VerifySig() const;
 };
 
 ///
@@ -113,7 +113,7 @@ class IR_API CombineOp : public pir::Op<CombineOp> {
                     OperationArgument &argument,  // NOLINT
                     const std::vector<Value> &inputs);
 
-  void Verify() const;
+  void VerifySig() const;
   std::vector<pir::Value> inputs() {
     std::vector<pir::Value> inputs;
     for (uint32_t idx = 0; idx < num_operands(); idx++) {
@@ -142,7 +142,7 @@ class IR_API SliceOp : public pir::Op<SliceOp> {
                     Value input,
                     int index);
 
-  void Verify() const;
+  void VerifySig() const;
   pir::Value input() { return operand_source(0); }
 
  private:
@@ -167,7 +167,7 @@ class IR_API SplitOp : public pir::Op<SplitOp> {
                     OperationArgument &argument,  // NOLINT
                     Value input);
 
-  void Verify() const;
+  void VerifySig() const;
   pir::Value input() { return operand_source(0); }
   std::vector<OpResult> outputs() {
     std::vector<OpResult> res;
@@ -203,7 +203,7 @@ class IR_API ConstantOp : public Op<ConstantOp, ConstantLikeTrait> {
                     Attribute value,
                     Type output_type);
 
-  void Verify() const;
+  void VerifySig() const;
 
   Attribute value() const;
 };

--- a/paddle/pir/core/dialect.h
+++ b/paddle/pir/core/dialect.h
@@ -100,7 +100,8 @@ class IR_API Dialect {
                                  ConcreteOp::GetTraitSet(),
                                  ConcreteOp::attributes_num,
                                  ConcreteOp::attributes_name,
-                                 ConcreteOp::VerifyInvariants);
+                                 ConcreteOp::VerifySigInvariants,
+                                 ConcreteOp::VerifyRegionInvariants);
   }
 
   void RegisterOp(const std::string &name, OpInfoImpl *op_info);

--- a/paddle/pir/core/ir_context.cc
+++ b/paddle/pir/core/ir_context.cc
@@ -291,7 +291,8 @@ void IrContext::RegisterOpInfo(Dialect *dialect,
                                const std::vector<TypeId> &trait_set,
                                size_t attributes_num,
                                const char **attributes_name,
-                               VerifyPtr verify) {
+                               VerifyPtr verify_sig,
+                               VerifyPtr verify_region) {
   if (impl().IsOpInfoRegistered(name)) {
     LOG(WARNING) << name << " op already registered.";
   } else {
@@ -302,7 +303,8 @@ void IrContext::RegisterOpInfo(Dialect *dialect,
                                      trait_set,
                                      attributes_num,
                                      attributes_name,
-                                     verify);
+                                     verify_sig,
+                                     verify_region);
     impl().RegisterOpInfo(name, info);
   }
 }

--- a/paddle/pir/core/ir_context.h
+++ b/paddle/pir/core/ir_context.h
@@ -113,7 +113,8 @@ class IR_API IrContext {
                       const std::vector<TypeId> &trait_set,
                       size_t attributes_num,
                       const char **attributes_name,
-                      void (*verify)(Operation *));
+                      void (*verify_sig)(Operation *),
+                      void (*verify_region)(Operation *));
 
   ///
   /// \brief Get registered operaiton infomation.

--- a/paddle/pir/core/op_base.h
+++ b/paddle/pir/core/op_base.h
@@ -63,6 +63,10 @@ class IR_API OpBase {
     return operation()->attribute<T>(name);
   }
 
+  void VerifySig() {}
+
+  void VerifyRegion() {}
+
  private:
   Operation *operation_;  // Not owned
 };
@@ -162,13 +166,20 @@ class Op : public OpBase {
     class EmptyOp : public Op<EmptyOp, TraitOrInterface...> {};
     return sizeof(ConcreteOp) == sizeof(EmptyOp);
   }
-  // Implementation of `VerifyInvariantsFn` OperationName hook.
-  static void VerifyInvariants(Operation *op) {
+
+  // Implementation of `VerifySigInvariantsFn` OperationName hook.
+  static void VerifySigInvariants(Operation *op) {
     static_assert(HasNoDataMembers(),
                   "Op class shouldn't define new data members");
-    op->dyn_cast<ConcreteOp>().Verify();
+    op->dyn_cast<ConcreteOp>().VerifySig();
     (void)std::initializer_list<int>{
         0, (VerifyTraitOrInterface<TraitOrInterface>::call(op), 0)...};
+  }
+
+  static void VerifyRegionInvariants(Operation *op) {
+    static_assert(HasNoDataMembers(),
+                  "Op class shouldn't define new data members");
+    op->dyn_cast<ConcreteOp>().VerifyRegion();
   }
 };
 

--- a/paddle/pir/core/op_info.cc
+++ b/paddle/pir/core/op_info.cc
@@ -35,7 +35,18 @@ const char *OpInfo::name() const { return impl_ ? impl_->name() : nullptr; }
 
 TypeId OpInfo::id() const { return impl_ ? impl_->id() : TypeId(); }
 
-void OpInfo::Verify(Operation *operation) const { impl_->verify()(operation); }
+void OpInfo::Verify(Operation *operation) const {
+  VerifySig(operation);
+  VerifyRegion(operation);
+}
+
+void OpInfo::VerifySig(Operation *operation) const {
+  impl_->VerifySig()(operation);
+}
+
+void OpInfo::VerifyRegion(Operation *operation) const {
+  impl_->VerifyRegion()(operation);
+}
 
 void *OpInfo::GetInterfaceImpl(TypeId interface_id) const {
   return impl_ ? impl_->GetInterfaceImpl(interface_id) : nullptr;

--- a/paddle/pir/core/op_info.h
+++ b/paddle/pir/core/op_info.h
@@ -54,6 +54,10 @@ class IR_API OpInfo {
 
   void Verify(Operation *) const;
 
+  void VerifySig(Operation *) const;
+
+  void VerifyRegion(Operation *) const;
+
   template <typename Trait>
   bool HasTrait() const {
     return HasTrait(TypeId::get<Trait>());

--- a/paddle/pir/core/op_info_impl.cc
+++ b/paddle/pir/core/op_info_impl.cc
@@ -24,7 +24,8 @@ OpInfo OpInfoImpl::Create(Dialect *dialect,
                           const std::vector<TypeId> &trait_set,
                           size_t attributes_num,
                           const char *attributes_name[],  // NOLINT
-                          VerifyPtr verify) {
+                          VerifyPtr verify_sig,
+                          VerifyPtr verify_region) {
   // (1) Malloc memory for interfaces, traits, opinfo_impl.
   size_t interfaces_num = interface_map.size();
   size_t traits_num = trait_set.size();
@@ -59,7 +60,8 @@ OpInfo OpInfoImpl::Create(Dialect *dialect,
                                                     traits_num,
                                                     attributes_num,
                                                     attributes_name,
-                                                    verify));
+                                                    verify_sig,
+                                                    verify_region));
   return op_info;
 }
 void OpInfoImpl::Destroy(OpInfo info) {

--- a/paddle/pir/core/op_info_impl.h
+++ b/paddle/pir/core/op_info_impl.h
@@ -42,14 +42,17 @@ class OpInfoImpl {
                        const std::vector<TypeId> &trait_set,
                        size_t attributes_num,
                        const char *attributes_name[],
-                       VerifyPtr verify);
+                       VerifyPtr verify_sig,
+                       VerifyPtr verify_region);
   static void Destroy(OpInfo info);
 
   TypeId id() const { return op_id_; }
 
   Dialect *dialect() const { return dialect_; }
 
-  VerifyPtr verify() const { return verify_; }
+  VerifyPtr VerifySig() const { return verify_sig_; }
+
+  VerifyPtr VerifyRegion() const { return verify_region_; }
 
   IrContext *ir_context() const;
 
@@ -76,7 +79,8 @@ class OpInfoImpl {
              uint32_t num_traits,
              uint32_t num_attributes,
              const char **p_attributes,
-             VerifyPtr verify)
+             VerifyPtr verify_sig,
+             VerifyPtr verify_region)
       : dialect_(dialect),
         op_id_(op_id),
         op_name_(op_name),
@@ -84,7 +88,8 @@ class OpInfoImpl {
         num_traits_(num_traits),
         num_attributes_(num_attributes),
         p_attributes_(p_attributes),
-        verify_(verify) {}
+        verify_sig_(verify_sig),
+        verify_region_(verify_region) {}
   void Destroy();
 
   /// The dialect of this Op belong to.
@@ -108,7 +113,9 @@ class OpInfoImpl {
   /// Attributes array address.
   const char **p_attributes_{nullptr};
 
-  VerifyPtr verify_{nullptr};
+  VerifyPtr verify_sig_{nullptr};
+
+  VerifyPtr verify_region_{nullptr};
 };
 
 }  // namespace pir

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -123,7 +123,7 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
 
   // 0. Verify
   if (op_info) {
-    op_info.Verify(op);
+    op_info.VerifySig(op);
   }
   return op;
 }

--- a/paddle/pir/dialect/control_flow/ir/cf_ops.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_ops.h
@@ -28,7 +28,7 @@ class IR_API YieldOp : public Op<YieldOp> {
   static void Build(Builder &builder,             // NOLINT
                     OperationArgument &argument,  // NOLINT
                     const std::vector<Value> &Value);
-  void Verify() {}
+  void VerifySig() {}
 };
 }  // namespace pir
 

--- a/paddle/pir/dialect/shape/ir/shape_op.h
+++ b/paddle/pir/dialect/shape/ir/shape_op.h
@@ -71,7 +71,7 @@ class IR_API SymbolicDim : public Op<SymbolicDim> {
     return "kSymbolicDimAttr";
   }
 
-  void Verify() {}
+  void VerifySig() {}
 };
 
 class IR_API DimOp : public Op<DimOp> {
@@ -89,7 +89,7 @@ class IR_API DimOp : public Op<DimOp> {
   const std::string getName();
   void setName(std::string attrValue);
   OpResult out() { return result(0); }
-  void Verify() {}
+  void VerifySig() {}
 };
 
 class IR_API TieProductEqualOp : public Op<TieProductEqualOp> {
@@ -111,7 +111,7 @@ class IR_API TieProductEqualOp : public Op<TieProductEqualOp> {
                     const std::vector<Value> &rhs);
   std::vector<Value> lhs();
   std::vector<Value> rhs();
-  void Verify() {}
+  void VerifySig() {}
 };
 
 class IR_API TieShapeOp : public Op<TieShapeOp> {
@@ -132,7 +132,7 @@ class IR_API TieShapeOp : public Op<TieShapeOp> {
                     const std::vector<Value> &dims);
   Value value();
   std::vector<Value> dims();
-  void Verify() {}
+  void VerifySig() {}
 };
 
 class IR_API FuncOp : public Op<FuncOp> {
@@ -147,7 +147,7 @@ class IR_API FuncOp : public Op<FuncOp> {
                     OperationArgument &argument);  // NOLINT
   void Print(IrPrinter &printer);                  // NOLINT
   Block *block();
-  void Verify() {}
+  void VerifySig() {}
 };
 
 class IR_API TensorDimOp : public Op<TensorDimOp> {
@@ -169,7 +169,7 @@ class IR_API TensorDimOp : public Op<TensorDimOp> {
   Value index();
   Value source();
   OpResult out() { return result(0); }
-  void Verify() {}
+  void VerifySig() {}
 };
 
 }  // namespace pir::dialect

--- a/test/cpp/pir/core/ir_infershape_test.cc
+++ b/test/cpp/pir/core/ir_infershape_test.cc
@@ -45,7 +45,7 @@ class OperationTest
   static const char *name() { return "test.operation2"; }
   static constexpr uint32_t attributes_num = 2;
   static const char *attributes_name[attributes_num];  // NOLINT
-  static void Verify() {}
+  static void VerifySig() {}
   static void InferMeta(phi::InferMetaContext *infer_meta) {
     auto fn = PD_INFER_META(phi::CreateInferMeta);
     fn(infer_meta);

--- a/test/cpp/pir/core/ir_program_test.cc
+++ b/test/cpp/pir/core/ir_program_test.cc
@@ -41,14 +41,14 @@ class AddOp : public pir::Op<AddOp> {
   static const char *name() { return "test.add"; }
   static constexpr const char **attributes_name = nullptr;
   static constexpr uint32_t attributes_num = 0;
-  void Verify();
+  void VerifySig();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value l_operand,
                     pir::Value r_operand,
                     pir::Type sum_type);
 };
-void AddOp::Verify() {
+void AddOp::VerifySig() {
   if (num_operands() != 2) {
     throw("The size of inputs must be equal to 2.");
   }

--- a/test/cpp/pir/pass/pass_manager_test.cc
+++ b/test/cpp/pir/pass/pass_manager_test.cc
@@ -69,14 +69,14 @@ class AddOp : public pir::Op<AddOp> {
   static const char *name() { return "test.add"; }
   static constexpr const char **attributes_name = nullptr;
   static constexpr uint32_t attributes_num = 0;
-  void Verify();
+  void VerifySig();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
                     pir::OpResult l_operand,
                     pir::OpResult r_operand,
                     pir::Type sum_type);
 };
-void AddOp::Verify() {
+void AddOp::VerifySig() {
   if (num_operands() != 2) {
     throw("The size of inputs must be equal to 2.");
   }

--- a/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
@@ -79,11 +79,11 @@ class Operation1 : public pir::Op<Operation1> {
   static const char *name() { return "test.Operation1"; }
   static constexpr uint32_t attributes_num = 2;
   static const char *attributes_name[attributes_num];  // NOLINT
-  void Verify();
+  void VerifySig();
   static void InferShape() { VLOG(2) << "This is op2's InferShape interface."; }
 };
 
-void Operation1::Verify() {
+void Operation1::VerifySig() {
   auto &attributes = this->attributes();
   if (attributes.count("op2_attr1") == 0 ||
       (!attributes.at("op2_attr1").isa<pir::StrAttribute>())) {
@@ -390,7 +390,7 @@ class Conv2dFusionOpTest : public pir::Op<Conv2dFusionOpTest,
                     pir::OpResult bias_,
                     pir::OpResult residual_,
                     pir::AttributeMap attributes);
-  void Verify();
+  void VerifySig();
   pir::Value input() { return operand_source(0); }
   pir::Value filter() { return operand_source(1); }
   pir::Value bias() { return operand_source(2); }
@@ -767,7 +767,7 @@ void Conv2dFusionOpTest::Build(pir::Builder &builder,
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
-void Conv2dFusionOpTest::Verify() {
+void Conv2dFusionOpTest::VerifySig() {
   VLOG(4)
       << "Start Verifying inputs, outputs and attributes for: Conv2dFusionOp.";
   VLOG(4) << "Verifying inputs:";

--- a/test/cpp/pir/tools/test_op.cc
+++ b/test/cpp/pir/tools/test_op.cc
@@ -29,7 +29,7 @@ void BranchOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddSuccessor(target);
 }
 
-void BranchOp::Verify() const {
+void BranchOp::VerifySig() const {
   IR_ENFORCE((*this)->num_successors() == 1u,
              "successors number must equal to 1.");
   IR_ENFORCE((*this)->successor(0), "successor[0] can't be nullptr");
@@ -45,7 +45,7 @@ void Operation1::Build(pir::Builder &builder,               // NOLINT
   argument.AddOutput(builder.float32_type());
   argument.AddAttributes(attributes);
 }
-void Operation1::Verify() const {
+void Operation1::VerifySig() const {
   auto &attributes = this->attributes();
   if (attributes.count("op1_attr1") == 0 ||
       !attributes.at("op1_attr1").isa<pir::StrAttribute>()) {

--- a/test/cpp/pir/tools/test_op.h
+++ b/test/cpp/pir/tools/test_op.h
@@ -34,7 +34,7 @@ class RegionOp : public pir::Op<RegionOp, OneRegionTrait> {
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,              // NOLINT
                     pir::OperationArgument &argument);  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 ///
@@ -50,7 +50,7 @@ class BranchOp : public pir::Op<BranchOp> {
                     pir::OperationArgument &argument,  // NOLINT
                     const std::vector<pir::OpResult> &target_operands,
                     pir::Block *target);
-  void Verify() const;
+  void VerifySig() const;
 };
 
 // Define case op1.
@@ -62,7 +62,7 @@ class Operation1 : public pir::Op<Operation1> {
   static const char *attributes_name[attributes_num];
   static void Build(pir::Builder &builder,              // NOLINT
                     pir::OperationArgument &argument);  // NOLINT
-  void Verify() const;
+  void VerifySig() const;
 };
 
 // Define op2.
@@ -75,7 +75,7 @@ class Operation2
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,                // NOLINT
                     pir::OperationArgument &argument) {}  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
   static void InferShape() { VLOG(2) << "This is op2's InferShape interface."; }
 };
 
@@ -98,7 +98,7 @@ class TraitExampleOp
                     pir::Value l_operand,
                     pir::Value r_operand,
                     pir::Type out_type);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsShapeTraitOp1.
@@ -111,7 +111,7 @@ class SameOperandsShapeTraitOp1
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,                // NOLINT
                     pir::OperationArgument &argument) {}  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsShapeTraitOp2.
@@ -127,7 +127,7 @@ class SameOperandsShapeTraitOp2
                     pir::Value l_operand,
                     pir::Value r_operand,
                     pir::Type out_type);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultShapeTraitOp1.
@@ -143,7 +143,7 @@ class SameOperandsAndResultShapeTraitOp1
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,                // NOLINT
                     pir::OperationArgument &argument) {}  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultShapeTraitOp2.
@@ -161,7 +161,7 @@ class SameOperandsAndResultShapeTraitOp2
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value l_operand,
                     pir::Value r_operand);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultShapeTraitOp3.
@@ -180,7 +180,7 @@ class SameOperandsAndResultShapeTraitOp3
                     pir::Value l_operand,
                     pir::Value r_operand,
                     pir::Type out_type);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsElementTypeTraitOp1.
@@ -194,7 +194,7 @@ class SameOperandsElementTypeTraitOp1
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,                // NOLINT
                     pir::OperationArgument &argument) {}  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsElementTypeTraitOp2.
@@ -211,7 +211,7 @@ class SameOperandsElementTypeTraitOp2
                     pir::Value l_operand,
                     pir::Value r_operand,
                     pir::Type out_type);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultElementTypeTraitOp1.
@@ -227,7 +227,7 @@ class SameOperandsAndResultElementTypeTraitOp1
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,                // NOLINT
                     pir::OperationArgument &argument) {}  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultElementTypeTraitOp2.
@@ -245,7 +245,7 @@ class SameOperandsAndResultElementTypeTraitOp2
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value l_operand,
                     pir::Value r_operand);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultElementTypeTraitOp3.
@@ -265,7 +265,7 @@ class SameOperandsAndResultElementTypeTraitOp3
                     pir::Value r_operand,
                     pir::Type out_type1,
                     pir::Type out_type2);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultTypeTraitOp1.
@@ -279,7 +279,7 @@ class SameOperandsAndResultTypeTraitOp1
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,                // NOLINT
                     pir::OperationArgument &argument) {}  // NOLINT
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultTypeTraitOp2.
@@ -295,7 +295,7 @@ class SameOperandsAndResultTypeTraitOp2
                     pir::OperationArgument &argument,  // NOLINT
                     pir::Value l_operand,
                     pir::Value r_operand);
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 // Define SameOperandsAndResultTypeTraitOp3.
@@ -315,7 +315,7 @@ class SameOperandsAndResultTypeTraitOp3
                     pir::Type out_type1,
                     pir::Type out_type2);
 
-  void Verify() const {}
+  void VerifySig() const {}
 };
 
 }  // namespace test


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
针对多 region 场景，重构 PIR 的 Verify 体系，重构背景如下：
- 在设计控制流算子的时候，我们发现原本的Verify 体系只是检验算子的输入、输出、属性（算子签名），如果该算子存在子 region，Verify 并不会递归的去校验，例如 IfOp 就存在两个子 region。
- 除上面这个问题，另外一个问题就是对于存在子 region 的算子，其子 region 的构造通常是在 IfOp 的 Operation::Create 之后，再去初始化的，但是目前的 Verify 是在 Operation::Create 函数的末尾自动构造的，这会导致原本的 Verify 体系是不支持校验这种子 region 的。

重构前后 Verify 体系的变化：
![image](https://github.com/PaddlePaddle/Paddle/assets/82555433/8c81e2ff-5833-4380-8ee6-aa0e2f0ed747)

重构后，算子的校验将分为两个维度：Verify = VerifySig + VerifyRegion
- VerifySig 仅用于校验是否符合算子签名，即仅对输入、输出、属性进行校验；
- VerifyRegion 用于对子 Region 进行校验，（默认的校验为空，若没有子 region，用户无需手动注册该函数）；

应用方法：
- 对于含有子 reigon 的算子，用户在完成算子的构造后（包括子 Region 的构造），使用 class Operation 提供的 Verify 函数进行校验：该函数会通过 OpInfo 体系自动调用到底层算子定义的 VerifySig + VerifyRegion；
- 对于不含子 region 的算子，构造后无需手动调用 Verify 函数：由于 Operation::Create 函数仅用于构造算子自身，并不会递归的对子 Region 进行构造，因此本函数会默认调用 VerifySig 进行检查。

Pcard-67164
