### PR TITLE
fix cond create undefined var in global block

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -178,6 +178,21 @@ def data_layer_not_check(name, shape, dtype='float32', lod_level=0):
     )
 
 
+def create_undefined_variable_local():
+    helper = LayerHelper('create_undefined_variable', **locals())
+    var = helper.create_variable(
+        name=unique_name.generate("undefined_var"),
+        shape=[1],
+        dtype="float64",
+        type=core.VarDesc.VarType.LOD_TENSOR,
+        stop_gradient=False,
+        is_data=True,
+        need_check_feed=False,
+    )
+    paddle.assign(RETURN_NO_VALUE_MAGIC_NUM, var)
+    return var
+
+
 def create_undefined_variable():
     var = data_layer_not_check(
         unique_name.generate("undefined_var"), [1], "float64"

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1224,6 +1224,9 @@ def cond(pred, true_fn=None, false_fn=None, name=None, return_names=None):
         with true_cond_block.block():
             origin_true_output = true_fn()
             if origin_true_output is not None:
+                origin_true_output = map_structure(
+                    create_undefined_var_in_subblock, origin_true_output
+                )
                 true_output = map_structure(
                     copy_to_parent_func, origin_true_output
                 )
@@ -1240,6 +1243,9 @@ def cond(pred, true_fn=None, false_fn=None, name=None, return_names=None):
         with false_cond_block.block():
             origin_false_output = false_fn()
             if origin_false_output is not None:
+                origin_false_output = map_structure(
+                    create_undefined_var_in_subblock, origin_false_output
+                )
                 false_output = map_structure(
                     copy_to_parent_func, origin_false_output
                 )
@@ -1354,6 +1360,18 @@ def cond(pred, true_fn=None, false_fn=None, name=None, return_names=None):
     )
     merged_output = pack_sequence_as(false_output, flatten(merged_output))
     return merged_output
+
+
+def create_undefined_var_in_subblock(var):
+    # to make sure the undefined var created in subblock.
+    from paddle.jit.dy2static.utils import (
+        UndefinedVar,
+        create_undefined_variable_local,
+    )
+
+    if isinstance(var, UndefinedVar):
+        var = create_undefined_variable_local()
+    return var
 
 
 def copy_var_to_parent_block(var, layer_helper):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
fix cond create undefined var in global block
NOTE：
对于None的场景适配要更复杂点，还没有完全适配。比如
```
def func(b):
    a = None
    if b : 
        a = paddle.to_tensor([1,2])
    return 
```
PCard-66972