### PR TITLE
[PIR] adjust the implementation of pd_op.while.

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/while_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/while_instruction.cc
@@ -63,7 +63,9 @@ WhileInstruction::WhileInstruction(size_t id,
 
   auto while_op = op->dyn_cast<paddle::dialect::WhileOp>();
 
-  for (size_t i = 0; i < while_op.num_operands(); ++i) {
+  cond_var_ = inner_scope->GetVar(
+      parent_exe_info->GetValue2VarName().at(while_op.operand_source(0)));
+  for (size_t i = 1; i < while_op.num_operands(); ++i) {
     while_op_inputs_.push_back(inner_scope->GetVar(
         parent_exe_info->GetValue2VarName().at(while_op.operand_source(i))));
   }
@@ -73,32 +75,8 @@ WhileInstruction::WhileInstruction(size_t id,
         parent_exe_info->GetValue2VarName().at(while_op.result(i))));
   }
 
-  cond_block_ = while_op.cond_block();
   body_block_ = while_op.body_block();
-
-  auto cond_yied_inputs = GetYiedOpInputs(cond_block_);
-  auto body_yied_inputs = GetYiedOpInputs(body_block_);
-
-  Scope* cond_scope = &(parent_exe_info->GetScope()->NewScope());
-  auto cond_exe_info = parent_exe_info->NewChild(cond_scope);
-  for (size_t i = 0; i < cond_block_->args_size(); ++i) {
-    auto var_name = "block_arg_" + std::to_string(i);
-    cond_scope->Var(var_name);
-    cond_exe_info->Add(cond_block_->argument(i), var_name);
-  }
-  cond_inter_ = std::unique_ptr<NewIRInterpreter>(new NewIRInterpreter(
-      place, {}, cond_block_, cond_scope, cond_exe_info, {}));
-
-  std::set<std::string> cond_skip_gc_names_set;
-  for (auto value : cond_yied_inputs) {
-    cond_skip_gc_names_.push_back(cond_inter_->GetNameByValue(value));
-    cond_skip_gc_names_set.insert(cond_inter_->GetNameByValue(value));
-  }
-  cond_inter_->SetSkipGcVars(cond_skip_gc_names_set);
-
-  auto cond_value = cond_yied_inputs[0];
-  auto var_name = cond_inter_->GetNameByValue(cond_value);
-  cond_var = cond_inter_->local_scope()->GetVar(var_name);
+  auto body_block_outputs = GetYiedOpInputs(body_block_);
 
   Scope* body_scope = &(parent_exe_info->GetScope()->NewScope());
   auto body_exe_info = parent_exe_info->NewChild(body_scope);
@@ -111,31 +89,15 @@ WhileInstruction::WhileInstruction(size_t id,
       place, {}, body_block_, body_scope, body_exe_info, {}));
 
   std::set<std::string> body_skip_gc_names_set;
-  for (auto value : body_yied_inputs) {
+  for (auto value : body_block_outputs) {
     body_skip_gc_names_.push_back(body_inter_->GetNameByValue(value));
     body_skip_gc_names_set.insert(body_inter_->GetNameByValue(value));
   }
   body_inter_->SetSkipGcVars(body_skip_gc_names_set);
 
-  // the cond block and body block input also be the while_op inputs
-
   std::unordered_map<pir::Value, std::vector<int>> inputs;
   GetInputIds(op, *parent_exe_info, &inputs);
 
-  // TODO(phlrain): process cond and body block
-  // GetOutsideOpInputs(cond_block_,
-  //                    inner_scope,
-  //                    parent_exe_info->GetValue2VarName(),
-  //                    parent_exe_info->GetVarName2Id(),
-  //                    parent_exe_info->GetVar2VarName(),
-  //                    &inputs);
-
-  // GetOutsideOpInputs(body_block_,
-  //                    inner_scope,
-  //                    parent_exe_info->GetValue2VarName(),
-  //                    parent_exe_info->GetVarName2Id(),
-  //                    parent_exe_info->GetVar2VarName(),
-  //                    &inputs);
   SetInputs(inputs);
 
   std::unordered_map<pir::Value, std::vector<int>> outputs;
@@ -146,9 +108,9 @@ WhileInstruction::WhileInstruction(size_t id,
           parent_exe_info->GetValue2VarName().find(value),
           parent_exe_info->GetValue2VarName().end(),
           phi::errors::PreconditionNotMet(
-              "input should in name map, [%d] 'th input of [%s] op",
+              "output should in name map, [%d] 'th output of [%s] op",
               i,
-              "if op"));
+              "while op"));
       std::vector<int> outputs_id = GetValueIds(value, *parent_exe_info);
       outputs.emplace(value, outputs_id);
     }
@@ -156,62 +118,42 @@ WhileInstruction::WhileInstruction(size_t id,
   SetOutputs(outputs);
 }
 
-void WhileInstruction::CopyStepOutput() {
-  for (size_t i = 0; i < body_skip_gc_names_.size(); ++i) {
-    auto* inner_var =
-        body_inter_->local_scope()->GetVar(body_skip_gc_names_[i]);
-
+void WhileInstruction::CopyInputsToOutputs() {
+  for (size_t i = 0; i < while_op_outputs_.size(); ++i) {
     while_op_outputs_[i]->GetMutable<phi::DenseTensor>()->ShareDataWith(
-        inner_var->Get<phi::DenseTensor>());
-  }
-}
-
-void WhileInstruction::CopyWhileInputToBlockArgs(const NewIRInterpreter* inter,
-                                                 ::pir::Block* block) {
-  for (size_t i = 0; i < block->args_size(); ++i) {
-    auto block_arg = block->argument(i);
-    auto var_name = inter->GetNameByValue(block_arg);
-    auto* inner_var = inter->local_scope()->GetVar(var_name);
-    inner_var->GetMutable<phi::DenseTensor>()->ShareDataWith(
         while_op_inputs_[i]->Get<phi::DenseTensor>());
   }
 }
 
-void WhileInstruction::CopyStepOutputToBlockArgs(const NewIRInterpreter* inter,
-                                                 ::pir::Block* block) {
-  for (size_t i = 0; i < block->args_size(); ++i) {
-    auto out_var_name = body_skip_gc_names_[i];
-    auto* out_var = body_inter_->local_scope()->GetVar(out_var_name);
-
-    auto block_arg = block->argument(i);
-    auto block_in_var_name = inter->GetNameByValue(block_arg);
-
-    auto* inner_var = inter->local_scope()->GetVar(block_in_var_name);
-
+void WhileInstruction::PassArgsToBodyBlock() {
+  for (size_t i = 0; i < body_block_->args_size(); ++i) {
+    auto block_arg = body_block_->argument(i);
+    auto var_name = body_inter_->GetNameByValue(block_arg);
+    auto* inner_var = body_inter_->local_scope()->GetVar(var_name);
     inner_var->GetMutable<phi::DenseTensor>()->ShareDataWith(
-        out_var->Get<phi::DenseTensor>());
+        while_op_outputs_[i]->Get<phi::DenseTensor>());
   }
 }
 
-void WhileInstruction::Run() {
-  CopyWhileInputToBlockArgs(cond_inter_.get(), cond_block_);
-  CopyWhileInputToBlockArgs(body_inter_.get(), body_block_);
-
-  while (true) {
-    cond_inter_->Run({}, false);
-
-    if (cond_var->Get<phi::DenseTensor>().data<bool>()[0]) {
-      body_inter_->Run({}, false);
-
-      CopyStepOutputToBlockArgs(cond_inter_.get(), cond_block_);
-      CopyStepOutputToBlockArgs(body_inter_.get(), body_block_);
-    } else {
-      break;
-    }
+void WhileInstruction::GetValueFromBodyBlock() {
+  cond_var_->GetMutable<phi::DenseTensor>()->ShareDataWith(
+      body_inter_->local_scope()
+          ->GetVar(body_skip_gc_names_[0])
+          ->Get<phi::DenseTensor>());
+  for (size_t i = 0; i < while_op_outputs_.size(); ++i) {
+    auto& out_var_name = body_skip_gc_names_[i + 1];
+    auto* out_var = body_inter_->local_scope()->GetVar(out_var_name);
+    while_op_outputs_[i]->GetMutable<phi::DenseTensor>()->ShareDataWith(
+        out_var->Get<phi::DenseTensor>());
   }
-
-  // copy  output
-  CopyStepOutput();
+}
+void WhileInstruction::Run() {
+  CopyInputsToOutputs();
+  while (cond_var_->Get<phi::DenseTensor>().data<bool>()[0]) {
+    PassArgsToBodyBlock();
+    body_inter_->Run({}, false);
+    GetValueFromBodyBlock();
+  }
 }
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/instruction/while_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/while_instruction.h
@@ -27,6 +27,12 @@ class Value;
 class NewIRInterpreter;
 class ValueExecutionInfo;
 
+/// The execute semantics of while op ['output' = while_op('cond', 'intput')]
+/// is:
+///   'output' = 'input';
+///   while('cond') {
+///      'cond', 'output' = body_block('output');
+///  }
 class WhileInstruction : public InstructionBase {
  public:
   WhileInstruction(size_t id,
@@ -43,28 +49,24 @@ class WhileInstruction : public InstructionBase {
   ::pir::Operation* Operation() const override { return op_; }
 
  private:
-  void CopyStepOutput();
+  // 'output' = 'input'
+  void CopyInputsToOutputs();
 
-  void CopyWhileInputToBlockArgs(const NewIRInterpreter* inter,
-                                 ::pir::Block* block);
+  // Pass argument to body_block for execution.
+  void PassArgsToBodyBlock();
 
-  void CopyStepOutputToBlockArgs(const NewIRInterpreter* inter,
-                                 ::pir::Block* block);
+  // Get return value from body_block after each execution.
+  void GetValueFromBodyBlock();
 
   std::string cond_name_{"while_instruction"};
 
-  Variable* cond_var;
-
+  Variable* cond_var_;
   std::vector<Variable*> while_op_inputs_;
   std::vector<Variable*> while_op_outputs_;
 
-  std::unique_ptr<NewIRInterpreter> cond_inter_;
   std::unique_ptr<NewIRInterpreter> body_inter_;
-
-  std::vector<std::string> cond_skip_gc_names_;
   std::vector<std::string> body_skip_gc_names_;
 
-  ::pir::Block* cond_block_;
   ::pir::Block* body_block_;
 
   ::pir::Operation* op_;

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
@@ -45,6 +45,16 @@ class IfOp : public pir::Op<IfOp> {
   void VerifyRegion();
 };
 
+///
+/// \brief The WhileOp is an operation that iterates over a loop body based on a
+/// condition. It takes two inputs: cond_value and loop_vars. The output of the
+/// WhileOp must have the same arity (length and structure) with loop_vars." The
+/// semantics of WhileOp[outputs = while_op(cond, inputs)] are as below:
+///   outputs = inputs
+///   while(cond){
+///      cond, outputs = body(outputs)
+///   }
+///
 class WhileOp : public pir::Op<WhileOp> {
  public:
   using Op::Op;
@@ -54,9 +64,10 @@ class WhileOp : public pir::Op<WhileOp> {
 
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
+                    pir::Value cond,
                     const std::vector<pir::Value> &inputs);
-  pir::Block *cond_block();
   pir::Block *body_block();
+  pir::Value cond();
   void Print(pir::IrPrinter &printer);  // NOLINT
   void VerifySig() {}
   void VerifyRegion() {}

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -776,6 +776,7 @@ void HandleForWhileOp(
     std::unordered_map<pir::Operation*, pir::Operation*>* map_op_pair,
     std::unordered_map<pir::Value, pir::Value>* map_value_pair) {
   std::vector<pir::Value> vec_in;
+  pir::Value cond_val;
   for (size_t i = 0; i < op_item->num_operands(); ++i) {
     auto cur_in = op_item->operand_source(i);
 
@@ -785,36 +786,16 @@ void HandleForWhileOp(
         phi::errors::PreconditionNotMet(
             "[%d]'s input of [%s] op MUST in map pair", 0, op_item->name()));
     auto new_in = map_value_pair->at(cur_in);
-
-    vec_in.push_back(new_in);
+    if (i == 0)
+      cond_val = new_in;
+    else
+      vec_in.push_back(new_in);
   }
 
   pir::Builder builder(ctx, block);
 
   auto base_while_op = op_item->dyn_cast<paddle::dialect::WhileOp>();
-  std::vector<pir::Type> op_output_types;
-  for (size_t i = 0; i < base_while_op.num_results(); ++i) {
-    op_output_types.push_back(paddle::dialect::AllocatedDenseTensorType::get(
-        ctx,
-        place,
-        base_while_op.result(i).type().dyn_cast<dialect::DenseTensorType>()));
-  }
-  auto new_while_op = builder.Build<paddle::dialect::WhileOp>(vec_in);
-
-  pir::Block* cond_block = new_while_op.cond_block();
-  for (size_t i = 0; i < vec_in.size(); ++i) {
-    auto block_arg = cond_block->AddArgument(vec_in[i].type());
-    (*map_value_pair)[base_while_op.cond_block()->argument(i)] = block_arg;
-  }
-
-  // process cond block
-  ProcessBlock(place,
-               base_while_op.cond_block(),
-               cond_block,
-               ctx,
-               map_op_pair,
-               map_value_pair);
-
+  auto new_while_op = builder.Build<paddle::dialect::WhileOp>(cond_val, vec_in);
   pir::Block* body_block = new_while_op.body_block();
   for (size_t i = 0; i < vec_in.size(); ++i) {
     auto block_arg = body_block->AddArgument(vec_in[i].type());

--- a/paddle/pir/core/block.h
+++ b/paddle/pir/core/block.h
@@ -84,6 +84,7 @@ class IR_API Block {
   ArgsIterator args_end() { return arguments_.end(); }
   bool args_empty() const { return arguments_.empty(); }
   uint32_t args_size() const { return arguments_.size(); }
+  const BlockArgListType &args() const { return arguments_; }
   BlockArgument argument(uint32_t index) { return arguments_[index]; }
   Type argument_type(uint32_t index) const { return arguments_[index].type(); }
   void ClearArguments();

--- a/paddle/pir/core/ir_printer.cc
+++ b/paddle/pir/core/ir_printer.cc
@@ -204,11 +204,17 @@ void IrPrinter::PrintValue(Value v) {
     os << ret->second;
     return;
   }
-
-  std::string new_name = "%" + std::to_string(cur_var_number_);
-  cur_var_number_++;
-  aliases_[key] = new_name;
-  os << new_name;
+  if (v.isa<OpResult>()) {
+    std::string new_name = "%" + std::to_string(cur_result_number_);
+    cur_result_number_++;
+    aliases_[key] = new_name;
+    os << new_name;
+  } else {
+    std::string new_name = "%arg" + std::to_string(cur_block_argument_number_);
+    cur_block_argument_number_++;
+    aliases_[key] = new_name;
+    os << new_name;
+  }
 }
 
 void IrPrinter::PrintOpResult(Operation* op) {

--- a/paddle/pir/core/ir_printer.h
+++ b/paddle/pir/core/ir_printer.h
@@ -71,7 +71,8 @@ class IR_API IrPrinter : public BasicIrPrinter {
   void PrintOpReturnType(Operation* op);
 
  private:
-  size_t cur_var_number_{0};
+  size_t cur_result_number_{0};
+  size_t cur_block_argument_number_{0};
   std::unordered_map<const void*, std::string> aliases_;
 };
 

--- a/test/cpp/pir/control_flow_dialect/while_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/while_op_test.cc
@@ -24,6 +24,9 @@
 #include "paddle/pir/dialect/control_flow/ir/cf_ops.h"
 
 using namespace paddle::dialect;  // NOLINT
+
+// example for while_op use
+// while(i < ten) { i = i + 1;}
 TEST(while_op_test, base) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<pir::ControlFlowDialect>();
@@ -36,21 +39,15 @@ TEST(while_op_test, base) {
   auto i =
       builder.Build<FullOp>(std::vector<int64_t>{1}, 1, phi::DataType::INT32)
           .out();
-
   auto ten =
       builder.Build<FullOp>(std::vector<int64_t>{1}, 10, phi::DataType::INT32)
           .out();
 
-  auto while_op = builder.Build<WhileOp>(std::vector<pir::Value>{i, ten});
+  // comput condition value: i < ten
+  auto cond_value = builder.Build<LessThanOp>(i, ten).out();
 
-  // while(i < ten)
-  pir::Block* cond_block = while_op.cond_block();
-  auto cond_i_argument = cond_block->AddArgument(i.type());
-  auto cond_ten_argument = cond_block->AddArgument(ten.type());
-  builder.SetInsertionPointToStart(cond_block);
-  auto cond_value =
-      builder.Build<LessThanOp>(cond_i_argument, cond_ten_argument).out();
-  builder.Build<pir::YieldOp>(std::vector<pir::Value>{cond_value});
+  auto while_op =
+      builder.Build<WhileOp>(cond_value, std::vector<pir::Value>{i, ten});
 
   // { i = i + 1}
   pir::Block* body_block = while_op.body_block();
@@ -61,12 +58,19 @@ TEST(while_op_test, base) {
       builder.Build<FullOp>(std::vector<int64_t>{1}, 1, phi::DataType::INT32)
           .out();
   auto new_i = builder.Build<AddOp>(body_i_argument, one).out();
+
+  // comput new condition value: new_i < new_ten
+  auto new_cond_value =
+      builder.Build<LessThanOp>(new_i, body_ten_argument).out();
+
   builder.Build<pir::YieldOp>(
-      std::vector<pir::Value>{new_i, body_ten_argument});
+      std::vector<pir::Value>{new_cond_value, new_i, body_ten_argument});
 
   builder.SetInsertionPointAfter(while_op);
   std::stringstream ss;
   program.Print(ss);
 
   LOG(INFO) << ss.str();
+
+  EXPECT_EQ(while_op.cond(), cond_value);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

- 调整了pd_op.while的实现。
    调整之前的pd_op.while包含两个block： cond_block和body_body_block。 它的语意为：
    ···cxx
    output = input;
    while(cond(output)) {
    output = body(output)}
    ···
    新的pd_op.while只包含一个body_block.包含两个输入： cond和inputs。它的语意为：
    ···cxx
    outputs = intpus;
    while(cond) {
    cond, outputs = body(outputs)}
    ···

- 支持block_argument的打印。
### Other
Pcard-67164