### PR TITLE
[PIR]Polish AttributeMap Conversion Checker to avoid Segment Fault

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h
@@ -285,7 +285,12 @@ void BuildPhiContext(pir::Operation* op,
 
       continue;
     }
-
+    PADDLE_ENFORCE_NE(
+        attr_map.find(t),
+        attr_map.end(),
+        phi::errors::NotFound("Not found %s in attr_map, it maybe need mapping "
+                              "it in OpTranslator.",
+                              t));
     auto& attr_type_name = op_yaml_info.AttrTypeName(t);
     if (attr_type_name == "paddle::dialect::IntArrayAttribute") {
       ctx->EmplaceBackAttr(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164

在一些场景下，由于在AttributeMap的转换 if-else逻辑中使用的 `Map[t]` 接口，但前面并未对 t 是否在 Map 进行判断，导致会存在`Map[t]` 对 t 新建一个对象，引发后续取值时的 Segment Fault.

从规范性上来讲，所有Map的『单纯访问元素』的操作应该使用`Map.at(t)`接口，若要使用 `Map[t]` 则必须添加存在性判断，以减少非预期行为。