### PR TITLE
[SOT][3.12] remove distutils import to avoid import error

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -19,7 +19,6 @@ import contextlib
 import copy
 import copyreg
 import dataclasses
-import distutils
 import enum
 import functools
 import importlib
@@ -94,7 +93,6 @@ NEED_SKIP_THIRD_PARTIY_MODULES = {
     codecs,
     uuid,
     setuptools,
-    distutils,
     warnings,
 }
 
@@ -104,6 +102,11 @@ if sys.version_info < (3, 11):
 
     NEED_SKIP_THIRD_PARTIY_MODULES.add(sre_compile)
     NEED_SKIP_THIRD_PARTIY_MODULES.add(sre_parse)
+
+if sys.version_info < (3, 12):
+    import distutils
+
+    NEED_SKIP_THIRD_PARTIY_MODULES.add(distutils)
 
 
 def _strip_init_py(s):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Python 3.12 已经移除 distutils 了，因此本 PR 将 SOT 中 import distutils 改为仅非 3.12 import

PCard-66972