### PR TITLE
Adapt test_collective_global_gather with Numpy >= 1.25.2

### DIFF
--- a/test/legacy_test/test_collective_api_base.py
+++ b/test/legacy_test/test_collective_api_base.py
@@ -609,16 +609,23 @@ class TestDistBase(unittest.TestCase):
                     send_ptr2 = send_ptr2 + global_expert_count2[idx]
             result1 = []
             result2 = []
+
+            def is_empyt_list(x):
+                if isinstance(x, list) and len(x) == 0:
+                    return True
+                return False
+
             for i in range(tot_expert):
                 for arr in output1[i]:
-                    if arr == []:
+                    if is_empyt_list(arr):
                         continue
                     result1.append(arr)
             for i in range(tot_expert):
                 for arr in output2[i]:
-                    if arr == []:
+                    if is_empyt_list(arr):
                         continue
                     result2.append(arr)
+
             if result1 == []:
                 output1 = np.array([])
             else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
It is not supported for elementwise comparison between np.array and python-builtin list when numpy >= 1.25.2, then casues failures on UT `test_collective_global_gather`. Proposed this PR to fix.

PS: In Numpy 1.22.0, there is a corresponding warning when running `test_collective_global_gather`.
 ```
DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
 ```
