### PR TITLE
[PIR] Migrate paddle.cos into pir

### DIFF
--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -564,7 +564,7 @@ def cos(x, name=None):
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.92106098, 0.98006660, 0.99500418, 0.95533651])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.cos(x)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -1865,6 +1865,9 @@ class TestCos(TestActivation):
     def init_shape(self):
         self.shape = [10, 12]
 
+    def test_check_output(self):
+        self.check_output(check_pir=True)
+
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
@@ -1872,10 +1875,14 @@ class TestCos(TestActivation):
         if self.dtype == np.complex64 or self.dtype == np.complex128:
             # Complex64 [GPU]: AssertionError: 0.0057843705 not less than or equal to 0.005
             self.check_grad(
-                ['X'], 'Out', check_prim=False, max_relative_error=0.006
+                ['X'],
+                'Out',
+                check_prim=False,
+                max_relative_error=0.006,
+                check_pir=True,
             )
         else:
-            self.check_grad(['X'], 'Out', check_prim=True)
+            self.check_grad(['X'], 'Out', check_prim=True, check_pir=True)
 
     def if_enable_cinn(self):
         pass
@@ -4660,7 +4667,7 @@ create_test_act_fp16_class(TestCeil, grad_check=False, check_pir=True)
 create_test_act_fp16_class(
     TestFloor, check_prim=True, grad_check=False, enable_cinn=True
 )
-create_test_act_fp16_class(TestCos)
+create_test_act_fp16_class(TestCos, check_pir=True)
 create_test_act_fp16_class(TestTan)
 create_test_act_fp16_class(TestCosh)
 create_test_act_fp16_class(TestAcos)
@@ -4810,7 +4817,7 @@ create_test_act_bf16_class(
 create_test_act_bf16_class(TestAbs, check_prim=True, check_pir=True)
 create_test_act_bf16_class(TestCeil, grad_check=False, check_pir=True)
 create_test_act_bf16_class(TestFloor, grad_check=False, check_prim=True)
-create_test_act_bf16_class(TestCos)
+create_test_act_bf16_class(TestCos, check_pir=True)
 create_test_act_bf16_class(TestTan)
 create_test_act_bf16_class(TestCosh)
 create_test_act_bf16_class(TestAcos)


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
新 IR API 推全升级
将 `paddle.cos` 迁移升级至 new ir，并更新单测

单测覆盖率：6/8

备注：目前缺少适配 `test/legacy_test/test_activation_nn_grad.py` 内 `TestCosDoubleGradCheck` 和 `TestCosTripleGradCheck` 的单测，原因是当前不支持 `gradient_checker.double_grad_check` 和 `gradient_checker.triple_grad_check` 在 pir 体系下运行，具体的适配问题包括但不限于：目前缺少从 python 端获取 OpResult.name 的支持 ...

后续做自动微分推全工作的时候，可以进行支持
 