### PR TITLE
[Dy2static] add set_dynamic_shape for dy2static high-level users.

### DIFF
--- a/python/paddle/jit/dy2static/utils_helper.py
+++ b/python/paddle/jit/dy2static/utils_helper.py
@@ -183,3 +183,14 @@ class NodeVarType:
         # raise warning if not found
         warn("Currently we don't support annotation: %s" % annotation_str)
         return NodeVarType.UNKNOWN
+
+
+def set_dynamic_shape(variable, shape_list):
+    if paddle.base.dygraph.base.in_to_static_mode():
+        assert isinstance(
+            variable, paddle.base.framework.Variable
+        ), "In to_static mode, variable must be a Variable."
+        variable.desc.set_shape(shape_list)
+    else:
+        # in dygraph mode, dynamic shape is not needed, just do nothing.
+        return

--- a/test/dygraph_to_static/test_set_dynamic_shape.py
+++ b/test/dygraph_to_static/test_set_dynamic_shape.py
@@ -1,0 +1,39 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+class TestForLoopMeetDict(unittest.TestCase):
+    def test_start(self):
+        def dygraph_func(loop_number):
+            mask = paddle.randn([2, 2])
+            paddle.jit.dy2static.utils_helper.set_dynamic_shape(mask, [-1, 2])
+            n = paddle.randn([1, 2])
+            for i in range(loop_number):
+                mask = paddle.concat([mask, n], axis=0)
+                if mask.shape[0] == 5:
+                    break
+            return mask
+
+        loop_num = paddle.to_tensor(10)
+        expected_shape = dygraph_func(loop_num).shape
+        actual_shape = paddle.jit.to_static(dygraph_func)(loop_num).shape
+        self.assertEqual(expected_shape, actual_shape)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/dygraph_to_static/test_set_dynamic_shape.py
+++ b/test/dygraph_to_static/test_set_dynamic_shape.py
@@ -17,7 +17,7 @@ import unittest
 import paddle
 
 
-class TestForLoopMeetDict(unittest.TestCase):
+class TestSetDynamicShape(unittest.TestCase):
     def test_start(self):
         def dygraph_func(loop_number):
             mask = paddle.randn([2, 2])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
[Dy2static] add set_dynamic_shape for dy2static high-level users.
支持了控制流中动态修改shape的优化逻辑，不再需要使用reshape，可以直接使用这个函数：

```
        def dygraph_func(loop_number):
            mask = paddle.randn([2,2])
            paddle.jit.dy2static.utils_helper.set_dynamic_shape(mask, [-1, 2])
            n = paddle.randn([1,2])
            for i in range(loop_number):
                mask = paddle.concat([mask, n], axis=0)
                if mask.shape[0] == 5: 
                    break
            return mask
```
这里的 dygraph_func 中的mask是一个动态shape，可以被 set_dynamic_shape 来显示指定。
注意这里的shape一定要对应，可以将某些值变为 -1 ，不可以随便指定。否则会有未定义错误。后续会添加更多的断言。

PCard-66972