### PR TITLE
[SOT] enable PIR + SOT dy2st unittest cases

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils_new.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils_new.py
@@ -284,9 +284,6 @@ def _test_and_compare_with_new_ir(fn):
         outs = fn(*args, **kwargs)
         if core._is_bwd_prim_enabled() or core._is_fwd_prim_enabled():
             return outs
-        # Disable SOT + PIR test temprorily
-        if in_sot_mode():
-            return outs
         ir_outs = to_pir_test(fn)(*args, **kwargs)
         np.testing.assert_equal(
             outs,

--- a/test/dygraph_to_static/test_backward_without_params.py
+++ b/test/dygraph_to_static/test_backward_without_params.py
@@ -17,9 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
     test_and_compare_with_new_ir,
 )
 
@@ -38,7 +35,6 @@ class Net(paddle.nn.Layer):
 # @dy2static_unittest
 class TestBackwardWithoutParams(Dy2StTestBase):
     @test_and_compare_with_new_ir(False)
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR))
     def test_run(self):
         net = paddle.jit.to_static(Net())
 
@@ -64,7 +60,6 @@ class ZeroSizeNet(paddle.nn.Layer):
 # @dy2static_unittest
 class TestZeroSizeNet(Dy2StTestBase):
     @test_and_compare_with_new_ir(False)
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR))
     def test_run(self):
         net = paddle.jit.to_static(ZeroSizeNet())
         x = paddle.ones([2, 2])

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -18,9 +18,6 @@ from copy import deepcopy
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
     test_and_compare_with_new_ir,
 )
 from test_rollback import Net, foo
@@ -32,7 +29,6 @@ from paddle.jit.dy2static.program_translator import StaticFunction
 # @dy2static_unittest
 class TestDeepCopy(Dy2StTestBase):
     @test_and_compare_with_new_ir(False)
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR))
     def test_net(self):
         net = Net()
         net = paddle.jit.to_static(net)

--- a/test/dygraph_to_static/test_load_transformer.py
+++ b/test/dygraph_to_static/test_load_transformer.py
@@ -18,9 +18,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
     test_and_compare_with_new_ir,
 )
 
@@ -52,7 +49,6 @@ class TestFallback(Dy2StTestBase):
         self.x = paddle.to_tensor(1.0).astype('int')
 
     @test_and_compare_with_new_ir(False)
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR))
     def test_name_load(self):
         net_dy = Net()
         net_st = Net()
@@ -63,7 +59,6 @@ class TestFallback(Dy2StTestBase):
 
 class TestLoad2(Dy2StTestBase):
     @test_and_compare_with_new_ir(False)
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR))
     def test_name_load_nograd(self):
         @paddle.no_grad()
         def func(x):

--- a/test/dygraph_to_static/test_partial_program.py
+++ b/test/dygraph_to_static/test_partial_program.py
@@ -17,10 +17,7 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
     ast_only_test,
-    disable_test_case,
     test_and_compare_with_new_ir,
 )
 from test_fetch_feed import Linear
@@ -91,7 +88,6 @@ class TestWithNestedInput(Dy2StTestBase):
         return out.numpy()
 
     @test_and_compare_with_new_ir(False)
-    @disable_test_case((ToStaticMode.SOT, IrMode.PIR))
     def test_nest(self):
         dygraph_res = self._run(to_static=False)
         static_res = self._run(to_static=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

#57824 暂时禁用掉 SOT + PIR 的 test case，相关问题 #58075 已经修复，因此本 PR 尝试开启相关 test case

PCard-66972