### PR TITLE
fix rnn op bug for DCU

### DIFF
--- a/paddle/phi/kernels/gpu/rnn_functor.h
+++ b/paddle/phi/kernels/gpu/rnn_functor.h
@@ -99,11 +99,12 @@ class RNNDescriptors {
     // ------------------- cudnn dropout descriptors ---------------------
     size_t state_size;
     bool is_initialized = dropout_state->initialized();
-    if (!is_initialized) {
 #ifdef PADDLE_WITH_HIP
+    if (!is_initialized) {
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::miopenDropoutGetStatesSize(handle, &state_size));
 #else
+    if (!is_test_ && !is_initialized) {
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::cudnnDropoutGetStatesSize(handle, &state_size));
 #endif
@@ -114,7 +115,11 @@ class RNNDescriptors {
                              dev_ctx.GetPlace(),
                              is_initialized,
                              dropout_prob_,
+#ifdef PADDLE_WITH_HIP
                              dropout_state,
+#else
+                             is_test_ ? nullptr : dropout_state,
+#endif
                              seed_,
                              state_size);
 

--- a/paddle/phi/kernels/gpu/rnn_functor.h
+++ b/paddle/phi/kernels/gpu/rnn_functor.h
@@ -99,7 +99,7 @@ class RNNDescriptors {
     // ------------------- cudnn dropout descriptors ---------------------
     size_t state_size;
     bool is_initialized = dropout_state->initialized();
-    if (!is_test_ && !is_initialized) {
+    if (!is_initialized) {
 #ifdef PADDLE_WITH_HIP
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::miopenDropoutGetStatesSize(handle, &state_size));
@@ -114,7 +114,7 @@ class RNNDescriptors {
                              dev_ctx.GetPlace(),
                              is_initialized,
                              dropout_prob_,
-                             is_test_ ? nullptr : dropout_state,
+                             dropout_state,
                              seed_,
                              state_size);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- Bug fixes  -->

### PR changes
<!-- OPs  -->

### Description
fix rnn op bug for DCU 由于miopen的dropout相关接口使用方法发生改变，因此is_test=True时miopen会抛出参数无效导致rnn op无法正常使用
