### PR TITLE
[CodeStyle][task 29,31,32] enable ruff B019, C416 and F821 rule in `python/paddle/base`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,14 +104,6 @@ ignore = [
 # Ignore unnecessary lambda in dy2st unittest test_lambda
 "test/dygraph_to_static/test_lambda.py" = ["PLC3002"]
 
-# Temporarily ignored
-"python/paddle/base/**" = [
-    "UP030",
-    #"B019", # Confirmation required
-    #"C416",
-    #"F821",
-]
-
 # B017
 "test/auto_parallel/spmd_rules/test_reshape_rule.py" = ["B017"]
 "test/dygraph_to_static/test_assert.py" = ["B017"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,9 @@ ignore = [
 # Temporarily ignored
 "python/paddle/base/**" = [
     "UP030",
-    "B019", # Confirmation required
-    "C416",
-    "F821",
+    #"B019", # Confirmation required
+    #"C416",
+    #"F821",
 ]
 
 # B017

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -1027,6 +1027,13 @@ class _ExecutorCache:
         return program, new_exe
 
 
+@lru_cache()
+def _log_force_set_program_cache(self, use_program_cache):
+    logging.warning(
+        f"use_program_cache is force set to {use_program_cache} by FLAGS_FORCE_USE_PROGRAM_CACHE"
+    )
+
+
 class Executor:
     """
     :api_attr: Static Graph
@@ -1178,7 +1185,6 @@ class Executor:
         return self.micro_scope_cache.get(program_cache_key, None)
 
     # just for testing, will be removed later
-    @lru_cache()
     def _log_force_set_program_cache(self, use_program_cache):
         logging.warning(
             f"use_program_cache is force set to {use_program_cache} by FLAGS_FORCE_USE_PROGRAM_CACHE"
@@ -2722,7 +2728,7 @@ class Executor:
                         if return_numpy:
                             tensor = as_numpy(tensor)
                         else:
-                            tensor = [t for t in tensor]
+                            tensor = list(tensor)
 
                     if tensor:
                         scope_result_list.append(tensor)

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -744,6 +744,11 @@ def _can_use_interpreter_core(program, place):
     return True
 
 
+@lru_cache()
+def _warning_once(msg):
+    logging.warning(msg)
+
+
 class FetchHandler:
     def __init__(self, var_dict=None, period_secs=60):
         assert var_dict is not None
@@ -1027,13 +1032,6 @@ class _ExecutorCache:
         return program, new_exe
 
 
-@lru_cache()
-def _log_force_set_program_cache(self, use_program_cache):
-    logging.warning(
-        f"use_program_cache is force set to {use_program_cache} by FLAGS_FORCE_USE_PROGRAM_CACHE"
-    )
-
-
 class Executor:
     """
     :api_attr: Static Graph
@@ -1184,9 +1182,8 @@ class Executor:
     def _get_micro_scopes_cache(self, program_cache_key):
         return self.micro_scope_cache.get(program_cache_key, None)
 
-    # just for testing, will be removed later
     def _log_force_set_program_cache(self, use_program_cache):
-        logging.warning(
+        _warning_once(
             f"use_program_cache is force set to {use_program_cache} by FLAGS_FORCE_USE_PROGRAM_CACHE"
         )
 

--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -14,6 +14,7 @@
 
 import itertools
 import warnings
+from functools import reduce
 
 import numpy as np
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/57367
task 29\31\32  B019\C416\F821