### PR TITLE
[SOT][3.11] fix pass `NULL` to resume function in jump breakgraph

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -245,11 +245,15 @@ class FunctionGraph:
         class VariableLoader:
             def __init__(self, index_for_load, pycode_gen):
                 self._index_for_load = index_for_load
-                self._pycode_gen = pycode_gen
+                self._pycode_gen: PyCodeGen = pycode_gen
 
-            def load(self, var):
+            def load(self, var, allow_push_null=True):
                 if isinstance(var, NullVariable):
-                    var.reconstruct(self._pycode_gen)
+                    if allow_push_null:
+                        var.reconstruct(self._pycode_gen)
+                    else:
+                        # Avoid passing NULL as a parameter to the resume function
+                        self._pycode_gen.gen_load_null_variable()
                     return
                 self._pycode_gen.gen_load_fast(self._index_for_load[var.id])
 

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -755,7 +755,7 @@ class PyCodeGen:
         """
         Generate the bytecode for loading a null variable.
         """
-        null_var = self.global_null_variable()
+        null_var = self.global_null_variable
         self.gen_load_object(null_var, "___null_var", push_null=False)
 
     def gen_load_fast(self, name):

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import random
 import sys
 import types
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import opcode
@@ -551,6 +552,12 @@ class PyCodeGen:
 
         return fn, inputs
 
+    @cached_property
+    def global_null_variable(self):
+        from .variables.basic import NullVariable
+
+        return NullVariable()
+
     def gen_disable_eval_frame(self):
         """
         Generates instructions to disable the evaluation frame.
@@ -743,6 +750,13 @@ class PyCodeGen:
         if obj_name not in self._f_globals:
             self._f_globals[obj_name] = obj
         self.gen_load_global(obj_name, push_null=push_null)
+
+    def gen_load_null_variable(self):
+        """
+        Generate the bytecode for loading a null variable.
+        """
+        null_var = self.global_null_variable()
+        self.gen_load_object(null_var, "___null_var", push_null=False)
 
     def gen_load_fast(self, name):
         """

--- a/test/sot/test_break_graph.py
+++ b/test/sot/test_break_graph.py
@@ -153,5 +153,16 @@ class TestBreakGraphRepeat(TestCaseBase):
         self.assert_results(test_break_graph_repeat, x)
 
 
+def break_graph_resume_pass_null(x, y):
+    return paddle.add(x, y[0:50] if y is not None else None)
+
+
+class TestBreakGraphResumePassNull(TestCaseBase):
+    def test_break_graph_resume_pass_null(self):
+        x = paddle.rand([50, 50], dtype=paddle.float32)
+        y = paddle.rand([100, 50], dtype=paddle.float32)
+        self.assert_results(break_graph_resume_pass_null, x, y)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

当发生子图打断的时候，是有可能将 NULL 恢复到栈上的（生成代码），一旦将 NULL 恢复到栈上并作为参数传递给后续的 resume function，就会触发段错误

之前我们对 call breakgraph 做了如果 resume 参数是 NULL 则改为 NullVariable 的处理，但在 3.11 中 jump breakgraph 有同样的问题，因此对 jump breakgraph 做同样的修复

PCard-66972