### PR TITLE
[PIR]Migrate unique into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2485,7 +2485,7 @@ def unique(
     else:
         axis = [axis]
     attr_dtype = convert_np_dtype_to_dtype_(dtype)
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out, indices, inverse, counts = _C_ops.unique(
             x, return_index, return_inverse, return_counts, axis, attr_dtype
         )

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16, paddle_static_guard
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestUniqueOp(OpTest):
@@ -413,6 +414,7 @@ class TestUniqueAPI(unittest.TestCase):
         self.assertTrue((inverse.numpy() == np_inverse).all(), True)
         self.assertTrue((counts.numpy() == np_counts).all(), True)
 
+    @test_with_pir_api
     def test_static_graph(self):
         with paddle_static_guard():
             with paddle.static.program_guard(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Migrate unique into pir

- 继承自OpTest的单测，都设置了check_dygraph=False，如果设置check_pir=True 和 设置check_dygraph=True报的错误的一样的。所以这个PR中没有打开继承自OpTest的单测。
- 打开了TestUniqueAPI.test_static_graph这唯一的静态图单测

Pcard-67164