### PR TITLE
[CINN CI]fix cinn ci run test bug

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3388,12 +3388,12 @@ function build_pr_and_develop() {
         git checkout -b develop_base_pr upstream/$BRANCH
         git submodule update --init
         run_setup ${PYTHON_ABI:-""} "rerun-cmake bdist_wheel" ${parallel_number}
-        if [ ! -d "${PADDLE_ROOT}/build/python/dist/" ]; then
-            mkdir ${PADDLE_ROOT}/build/python/dist/
-        fi
         #NOTE(risemeup1):remove build directory of develop branch to avoid conflict with pr branch,we only need whl package of develop branch
         rm -rf ${PADDLE_ROOT}/build
         tar  --use-compress-program="pigz -1" -xpf build.tar.gz 
+        if [ ! -d "${PADDLE_ROOT}/build/python/dist/" ]; then
+            mkdir ${PADDLE_ROOT}/build/python/dist/
+        fi
         mv ${PADDLE_ROOT}/dist/*.whl ${PADDLE_ROOT}/build/python/dist/
         mkdir ${PADDLE_ROOT}/build/dev_whl && cp ${PADDLE_ROOT}/build/python/dist/*.whl ${PADDLE_ROOT}/build/dev_whl
     fi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3390,7 +3390,13 @@ function build_pr_and_develop() {
         run_setup ${PYTHON_ABI:-""} "rerun-cmake bdist_wheel" ${parallel_number}
         #NOTE(risemeup1):remove build directory of develop branch to avoid conflict with pr branch,we only need whl package of develop branch
         rm -rf ${PADDLE_ROOT}/build
-        tar  --use-compress-program="pigz -1" -xpf build.tar.gz 
+        if [ -e "${PADDLE_ROOT}/build.tar.gz" ]; then
+            tar  --use-compress-program="pigz -1" -xpf build.tar.gz 
+        else
+            echo "build.tar.gz of pr branch not exist"
+            exit 123
+        fi
+        
         if [ ! -d "${PADDLE_ROOT}/build/python/dist/" ]; then
             mkdir ${PADDLE_ROOT}/build/python/dist/
         fi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3379,6 +3379,7 @@ function build_pr_and_develop() {
         mkdir ${PADDLE_ROOT}/build/dev_whl && wget -q -P ${PADDLE_ROOT}/build/dev_whl ${dev_url}
         cp ${PADDLE_ROOT}/build/dev_whl/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl ${PADDLE_ROOT}/build/python/dist
     else
+        tar --use-compress-program="pigz -1" -cpPf build.tar.gz ${PADDLE_ROOT}
         if [[ ${cmake_change} ]];then
             rm -rf ${PADDLE_ROOT}/build/Makefile ${PADDLE_ROOT}/build/CMakeCache.txt ${PADDLE_ROOT}/build/build.ninja
             rm -rf ${PADDLE_ROOT}/build/third_party

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3379,7 +3379,7 @@ function build_pr_and_develop() {
         mkdir ${PADDLE_ROOT}/build/dev_whl && wget -q -P ${PADDLE_ROOT}/build/dev_whl ${dev_url}
         cp ${PADDLE_ROOT}/build/dev_whl/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl ${PADDLE_ROOT}/build/python/dist
     else
-        tar --use-compress-program="pigz -1" -cpPf build.tar.gz ${PADDLE_ROOT}
+        tar --use-compress-program="pigz -1" -cpPf build.tar.gz ${PADDLE_ROOT}/build
         if [[ ${cmake_change} ]];then
             rm -rf ${PADDLE_ROOT}/build/Makefile ${PADDLE_ROOT}/build/CMakeCache.txt ${PADDLE_ROOT}/build/build.ninja
             rm -rf ${PADDLE_ROOT}/build/third_party
@@ -3391,6 +3391,9 @@ function build_pr_and_develop() {
         if [ ! -d "${PADDLE_ROOT}/build/python/dist/" ]; then
             mkdir ${PADDLE_ROOT}/build/python/dist/
         fi
+        #NOTE(risemeup1):remove build directory of develop branch to avoid conflict with pr branch,we only need whl package of develop branch
+        rm -rf ${PADDLE_ROOT}/build
+        tar  --use-compress-program="pigz -1" -xpf build.tar.gz 
         mv ${PADDLE_ROOT}/dist/*.whl ${PADDLE_ROOT}/build/python/dist/
         mkdir ${PADDLE_ROOT}/build/dev_whl && cp ${PADDLE_ROOT}/build/python/dist/*.whl ${PADDLE_ROOT}/build/dev_whl
     fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67010

build ci编译两次，一次是PR分支，一次是develop分支，而最后拷贝到cinn流水线的是develop分支的目录，故cinn流水线起不到监测PR分支的效果，监测的是develop分支的情况，此PR修复这个问题