### PR TITLE
Revert PR #56982

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
@@ -431,6 +431,7 @@ void analyse_event_info_for_two_instructions<Instruction>(
 
   if (has_data_dependency<Instruction, std::string>(
           instructions[cur_instr_id], instructions[next_instr_id]) ||
+      !run_type_info[next_instr_id][DownstreamRunType::kEventRun].empty() ||
       instructions[next_instr_id]->OpBase()->Type() == "depend") {
     waiter_instr_ids->insert(next_instr_id);
     return;
@@ -490,6 +491,7 @@ void analyse_event_info_for_two_instructions<
 
   if (has_data_dependency<paddle::framework::InstructionBase, pir::Value>(
           instructions[cur_instr_id], instructions[next_instr_id]) ||
+      !run_type_info[next_instr_id][DownstreamRunType::kEventRun].empty() ||
       instructions[next_instr_id]->Name() == "pd_op.depend") {
     waiter_instr_ids->insert(next_instr_id);
     return;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
PCard-71568

PR #56982 尝试去除stream_analyzer中的冗余同步操作，但由于剪枝操作的存在，某些图中需要用控制边表达隐式依赖并预期能对隐式依赖加入多流同步，如：
```
OP1 -> OP2 -> OP3
OP1 => OP3
```
其中OP1和OP2分配在计算流上，OP3分配在通信流上。OP1和OP2、OP2和OP3存在控制边，OP1和OP3之间存在数据边。
由于控制边的存在，在调度时数据边OP1=>OP3可能被裁剪，从而导致OP1和OP3之间无法正确插入流同步。
在有冗余同步操作的情况下，由于在OP3之后存在计算流OP，OP2和OP3虽然没有数据依赖，仍会插入一个多流同步，从而使多流得以正确运行。若去除冗余同步操作，在这种case下将触发错误。
此case在ResNet50单机8卡数据并行下发现，导致该模型性能下降和出nan。当前临时revert修改，后续需重新设计图依赖控制和多流同步操作，将图依赖和多流的分析优化相互解耦，从而避免依赖分析的剪枝优化对后续的多流同步分析产生影响。
