### PR TITLE
[PIR]Perfect unittest for pad/ where / unsqueeze / slice / numel

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -21,6 +21,7 @@ _INFERMETA_NEED_META_CONFIG = {
     'ReduceIntArrayAxisInferMeta',
     'ReshapeWithXShapeInferMeta',
     'SliceRawInferMeta',
+    'StackInferMeta',
 }
 
 _PREPARE_DATA_WITH_VECTOR_INT64_MTTABLE_ATTRIBUTE = {'FrobeniusNormOp'}

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1583,8 +1583,6 @@ std::vector<pir::Value> CastPyArg2VectorOfValue(PyObject* obj,
                 ->tp_name));  // NOLINT
       }
     }
-  } else if (PyObject_TypeCheck(obj, g_ir_opresult_pytype)) {
-    return {::pybind11::handle(obj).cast<pir::OpResult>()};
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "%s(): argument (position %d) must be "

--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -1051,7 +1051,7 @@ def get_tensor_with_basic_indexing(
         )
         attrs['infer_flags'] = infer_flags
 
-        from . import in_dynamic_or_pir_mode
+        from . import in_dynamic_or_pir_mode, in_pir_mode
 
         if in_dynamic_or_pir_mode():
             if "StartsTensorList" in inputs.keys():
@@ -1071,6 +1071,13 @@ def get_tensor_with_basic_indexing(
                 if len(decrease_axes) > 0:
                     out = paddle._C_ops.squeeze(out, decrease_axes)
             else:
+                if in_pir_mode():
+                    if isinstance(st, (list, tuple)):
+                        if paddle.utils._contain_var(st):
+                            st = paddle.utils.get_int_tensor_list(st)
+                    if isinstance(end, (list, tuple)):
+                        if paddle.utils._contain_var(end):
+                            end = paddle.utils.get_int_tensor_list(end)
                 out = paddle._C_ops.slice(
                     x,
                     axes,

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -899,7 +899,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None, name=None):
         else:
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):
-                    shape = paddle.utils.get_pir_shape_tensor(shape, place)
+                    shape = paddle.utils.get_int_tensor_list(shape, place)
             elif isinstance(shape, paddle.pir.OpResult):
                 pass
             else:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1955,7 +1955,7 @@ def add_n(inputs, name=None):
              [14., 16., 18.]])
     """
     if in_dynamic_or_pir_mode():
-        if isinstance(inputs, Variable):
+        if isinstance(inputs, (Variable, paddle.pir.OpResult)):
             inputs = [inputs]
         return _C_ops.add_n(inputs)
     else:

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -797,7 +797,7 @@ def uniform(shape, dtype=None, min=-1.0, max=1.0, seed=0, name=None):
     if in_dynamic_or_pir_mode():
         shape = paddle.utils.convert_shape_to_list(shape)
         if in_pir_mode() and paddle.utils._contain_var(shape):
-            shape = paddle.utils.get_pir_shape_tensor(
+            shape = paddle.utils.get_int_tensor_list(
                 shape, _current_expected_place()
             )
         return _C_ops.uniform(

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -37,7 +37,7 @@ from .layers_utils import copy_mutable_vars  # noqa: F401
 from .layers_utils import padding_to_same_structure  # noqa: F401
 from .layers_utils import assert_same_structure  # noqa: F401
 from .layers_utils import get_shape_tensor_inputs  # noqa: F401
-from .layers_utils import get_pir_shape_tensor  # noqa: F401
+from .layers_utils import get_int_tensor_list  # noqa: F401
 from .layers_utils import convert_shape_to_list  # noqa: F401
 from .layers_utils import check_shape  # noqa: F401
 from .layers_utils import try_set_static_shape_tensor  # noqa: F401

--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -19,7 +19,6 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -132,7 +131,6 @@ class TestZeroSizeArangeOp(TestArangeOp):
 
 
 class TestArangeOpError(unittest.TestCase):
-    @test_with_pir_api
     def test_static_errors(self):
         with program_guard(Program(), Program()):
             paddle.enable_static()
@@ -140,7 +138,6 @@ class TestArangeOpError(unittest.TestCase):
 
 
 class TestArangeAPI(unittest.TestCase):
-    @test_with_pir_api
     def test_out(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -131,6 +132,7 @@ class TestZeroSizeArangeOp(TestArangeOp):
 
 
 class TestArangeOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_static_errors(self):
         with program_guard(Program(), Program()):
             paddle.enable_static()
@@ -138,6 +140,7 @@ class TestArangeOpError(unittest.TestCase):
 
 
 class TestArangeAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_assign_op.py
+++ b/test/legacy_test/test_assign_op.py
@@ -279,7 +279,9 @@ class TestAssignOpErrorApi(unittest.TestCase):
     @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             # The type of input must be Variable or numpy.ndarray.
             x1 = base.create_lod_tensor(
                 np.array([[-1]]), [[1]], base.CPUPlace()
@@ -293,7 +295,9 @@ class TestAssignOpErrorApi(unittest.TestCase):
     @test_with_pir_api
     def test_type_error(self):
         paddle.enable_static()
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = [paddle.randn([3, 3]), paddle.randn([3, 3])]
             # not support to assign list(var)
             self.assertRaises(TypeError, paddle.assign, x)

--- a/test/legacy_test/test_assign_value_op.py
+++ b/test/legacy_test/test_assign_value_op.py
@@ -108,7 +108,7 @@ class TestAssignApi(unittest.TestCase):
     def test_pir_assign(self):
         with paddle.pir_utils.IrGuard():
             main_program = paddle.pir.Program()
-            with paddle.pir.core.program_guard(main_program):
+            with paddle.static.program_guard(main_program):
                 x = paddle.zeros(shape=[1], dtype=self.dtype)
                 paddle.assign(self.value, output=x)
 

--- a/test/legacy_test/test_numel_op.py
+++ b/test/legacy_test/test_numel_op.py
@@ -18,8 +18,8 @@ import numpy as np
 from op_test import OpTest, convert_float_to_uint16
 
 import paddle
-from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestNumelOp(OpTest):
@@ -148,10 +148,11 @@ class TestNumelOp1BF16(TestNumelOpBF16):
 
 
 class TestNumelAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_numel_static(self):
-        main_program = base.Program()
-        startup_program = base.Program()
-        with base.program_guard(main_program, startup_program):
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
             shape1 = [2, 1, 4, 5]
             shape2 = [1, 4, 5]
             x_1 = paddle.static.data(shape=shape1, dtype='int32', name='x_1')
@@ -188,9 +189,9 @@ class TestNumelAPI(unittest.TestCase):
         paddle.enable_static()
 
     def test_error(self):
-        main_program = base.Program()
-        startup_program = base.Program()
-        with base.program_guard(main_program, startup_program):
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
 
             def test_x_type():
                 shape = [1, 4, 5]
@@ -198,6 +199,16 @@ class TestNumelAPI(unittest.TestCase):
                 out_1 = paddle.numel(input_1)
 
             self.assertRaises(TypeError, test_x_type)
+
+    def test_pir_error(self):
+        with paddle.pir_utils.IrGuard():
+
+            def test_x_type():
+                shape = [1, 4, 5]
+                input_1 = np.random.random(shape).astype("int32")
+                out_1 = paddle.numel(input_1)
+
+            self.assertRaises(ValueError, test_x_type)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -657,7 +657,7 @@ class TestSliceAPI(unittest.TestCase):
 
             exe = base.Executor(place=base.CPUPlace())
             res_1, res_2, res_3, res_4, res_5, res_6, res_7 = exe.run(
-                base.default_main_program(),
+                paddle.static.default_main_program(),
                 feed={
                     "x": input,
                     'starts': np.array([-3, 0, 2]).astype("int32"),
@@ -673,6 +673,67 @@ class TestSliceAPI(unittest.TestCase):
             np.testing.assert_array_equal(res_5, input[-3:3, 0:100, 2:-1, :])
             np.testing.assert_array_equal(res_6, input[-3:3, 0:100, :, 2:-1])
             np.testing.assert_array_equal(res_7, input[-1, 0:100, :, 2:-1])
+
+    def test_pir(self):
+        with paddle.pir_utils.IrGuard(), paddle.static.program_guard(
+            paddle.static.Program()
+        ):
+            input = np.random.random([3, 4, 5, 6]).astype("float64")
+            minus_1 = paddle.tensor.fill_constant([], "int32", -1)
+            minus_3 = paddle.tensor.fill_constant([], "int64", -3)
+            starts = paddle.static.data(
+                name='starts', shape=[1, 3], dtype="int32"
+            )
+            ends = paddle.static.data(name='ends', shape=[3], dtype="int32")
+            x = paddle.static.data(
+                name="x",
+                shape=[3, 4, 5, 6],
+                dtype="float64",
+            )
+
+            # value_int64 is greater than 2147483647 which is the max of int32
+            value_int64 = paddle.tensor.fill_constant([1], "int64", 2147483648)
+
+            out_1 = paddle.slice(
+                x,
+                axes=[0, 1, 2],
+                starts=[-3, 0, 2],
+                ends=[value_int64, 100, -1],
+            )
+            out_2 = paddle.slice(
+                x, axes=[0, 1, 3], starts=[minus_3, 0, 2], ends=[3, 100, -1]
+            )
+            out_3 = paddle.slice(
+                x,
+                axes=[0, 1, 3],
+                starts=[minus_3, 0, 2],
+                ends=[3, 100, minus_1],
+            )
+            out_4 = paddle.slice(x, axes=[0, 1, 2], starts=starts, ends=ends)
+
+            out_5 = x[-3:3, 0:100, 2:-1]
+            out_6 = x[minus_3:3, 0:100, :, 2:-1]
+            # open it after supporting control flow
+            # out_7 = x[minus_1, 0:100, :, 2:minus_1]
+
+            exe = base.Executor(place=base.CPUPlace())
+            res_1, res_2, res_3, res_4, res_5, res_6 = exe.run(
+                paddle.static.default_main_program(),
+                feed={
+                    "x": input,
+                    'starts': np.array([-3, 0, 2]).astype("int32"),
+                    'ends': np.array([3, 100, -1]).astype("int32"),
+                },
+                fetch_list=[out_1, out_2, out_3, out_4, out_5, out_6],
+            )
+
+            np.testing.assert_array_equal(res_1, input[-3:3, 0:100, 2:-1, :])
+            np.testing.assert_array_equal(res_2, input[-3:3, 0:100, :, 2:-1])
+            np.testing.assert_array_equal(res_3, input[-3:3, 0:100, :, 2:-1])
+            np.testing.assert_array_equal(res_4, input[-3:3, 0:100, 2:-1, :])
+            np.testing.assert_array_equal(res_5, input[-3:3, 0:100, 2:-1, :])
+            np.testing.assert_array_equal(res_6, input[-3:3, 0:100, :, 2:-1])
+            # np.testing.assert_array_equal(res_7, input[-1, 0:100, :, 2:-1])
 
 
 class TestSliceApiWithTensor(unittest.TestCase):
@@ -754,7 +815,7 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
 
     def set_program_and_run(self, main_program, case_num):
         with paddle_static_guard():
-            with base.program_guard(main_program):
+            with paddle.static.program_guard(main_program):
                 x = [
                     paddle.static.data(
                         name='x0', shape=self.shape, dtype="float32"
@@ -810,7 +871,7 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
                 )
 
     def test_case_1(self):
-        main_program = base.Program()
+        main_program = paddle.static.Program()
         self.set_program_and_run(main_program, 1)
 
         self.assertTrue(self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR)
@@ -822,7 +883,7 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
 
     def test_case_2(self):
         with paddle_static_guard():
-            main_program = base.Program()
+            main_program = paddle.static.Program()
             self.set_program_and_run(main_program, 2)
 
             self.assertTrue(
@@ -838,7 +899,7 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
 
     def test_case_3(self):
         with paddle_static_guard():
-            main_program = base.Program()
+            main_program = paddle.static.Program()
             self.set_program_and_run(main_program, 3)
 
             self.assertTrue(
@@ -892,6 +953,13 @@ class TestInferShape(unittest.TestCase):
 
             out0 = paddle.slice(x, axes=[1], starts=[0], ends=[3])
             self.assertEqual(out0.shape, (3, -1, 5))
+
+    def test_pir(self):
+        with paddle.pir_utils.IrGuard():
+            x = paddle.static.data('x', shape=[3, -1, 5])
+
+            out0 = paddle.slice(x, axes=[1], starts=[0], ends=[3])
+            self.assertEqual(out0.shape, [3, -1, 5])
 
     def test_axis_less_than_zero(self):
         # Using paddle.disable_static will make other unittests fail.

--- a/test/legacy_test/test_slice_op.py
+++ b/test/legacy_test/test_slice_op.py
@@ -681,9 +681,7 @@ class TestSliceAPI(unittest.TestCase):
             input = np.random.random([3, 4, 5, 6]).astype("float64")
             minus_1 = paddle.tensor.fill_constant([], "int32", -1)
             minus_3 = paddle.tensor.fill_constant([], "int64", -3)
-            starts = paddle.static.data(
-                name='starts', shape=[1, 3], dtype="int32"
-            )
+            starts = paddle.static.data(name='starts', shape=[3], dtype="int32")
             ends = paddle.static.data(name='ends', shape=[3], dtype="int32")
             x = paddle.static.data(
                 name="x",

--- a/test/legacy_test/test_squeeze2_op.py
+++ b/test/legacy_test/test_squeeze2_op.py
@@ -291,6 +291,16 @@ class TestSqueezeAPI(unittest.TestCase):
 
         self.assertRaises(TypeError, test_axes_type)
 
+    def test_pir_error(self):
+        def test_axes_type():
+            with paddle.pir_utils.IrGuard():
+                x2 = paddle.static.data(
+                    name="x2", shape=[2, 1, 25], dtype="int32"
+                )
+                self.squeeze(x2, axis=2.1)
+
+        self.assertRaises(ValueError, test_axes_type)
+
 
 class TestSqueezeInplaceAPI(TestSqueezeAPI):
     def executed_api(self):

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -19,8 +19,10 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle import base
+from paddle.autograd.ir_backward import grad
 from paddle.base import Program, core, program_guard
 from paddle.base.backward import append_backward
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestWhereOp(OpTest):
@@ -132,7 +134,9 @@ class TestWhereAPI(unittest.TestCase):
     def test_api(self, use_cuda=False):
         for x_stop_gradient in [False, True]:
             for y_stop_gradient in [False, True]:
-                with base.program_guard(Program(), Program()):
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
                     cond = paddle.static.data(
                         name='cond', shape=[-1] + self.shape, dtype='bool'
                     )
@@ -165,7 +169,7 @@ class TestWhereAPI(unittest.TestCase):
                         if y_stop_gradient is False:
                             fetch_list.append(y.grad_name)
                         out = exe.run(
-                            base.default_main_program(),
+                            paddle.static.default_main_program(),
                             feed={'cond': self.cond, 'x': self.x, 'y': self.y},
                             fetch_list=fetch_list,
                         )
@@ -183,13 +187,66 @@ class TestWhereAPI(unittest.TestCase):
                                 out[2], self.ref_y_backward(out[1])
                             )
 
+    def test_pir_api(self, use_cuda=False):
+        for x_stop_gradient in [False, True]:
+            for y_stop_gradient in [False, True]:
+                with paddle.pir_utils.IrGuard(), paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    cond = paddle.static.data(
+                        name='cond', shape=self.shape, dtype='bool'
+                    )
+                    x = paddle.static.data(
+                        name='x', shape=self.shape, dtype='float32'
+                    )
+                    y = paddle.static.data(
+                        name='y', shape=self.shape, dtype='float32'
+                    )
+                    x.stop_gradient = x_stop_gradient
+                    y.stop_gradient = y_stop_gradient
+                    result = paddle.where(cond, x, y)
+                    result.stop_gradient = False
+                    loss = paddle.mean(result)
+                    [x_grad, y_grad] = grad(loss, (x, y))
+                    default_main_program = paddle.static.default_main_program()
+                    fetch_list = [result]
+                    if x_stop_gradient is False:
+                        fetch_list.append(x_grad)
+                    if y_stop_gradient is False:
+                        fetch_list.append(y_grad)
+                    for use_cuda in [False, True]:
+                        if use_cuda and (not base.core.is_compiled_with_cuda()):
+                            break
+                        place = (
+                            base.CUDAPlace(0) if use_cuda else base.CPUPlace()
+                        )
+                        exe = base.Executor(place)
+
+                        out = exe.run(
+                            default_main_program,
+                            feed={'cond': self.cond, 'x': self.x, 'y': self.y},
+                            fetch_list=fetch_list,
+                        )
+                        np.testing.assert_array_equal(out[0], self.out)
+                        if x_stop_gradient is False:
+                            np.testing.assert_array_equal(
+                                out[1], self.ref_x_backward(out[1])
+                            )
+                            if y.stop_gradient is False:
+                                np.testing.assert_array_equal(
+                                    out[2], self.ref_y_backward(out[2])
+                                )
+                        elif y.stop_gradient is False:
+                            np.testing.assert_array_equal(
+                                out[1], self.ref_y_backward(out[1])
+                            )
+
+    @test_with_pir_api
     def test_api_broadcast(self, use_cuda=False):
-        main_program = Program()
-        with base.program_guard(main_program):
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program):
             x = paddle.static.data(name='x', shape=[-1, 4, 1], dtype='float32')
-            x.desc.set_need_check_feed(False)
             y = paddle.static.data(name='y', shape=[-1, 4, 2], dtype='float32')
-            y.desc.set_need_check_feed(False)
             x_i = np.array([[0.9383, 0.1983, 3.2, 1.2]]).astype('float32')
             y_i = np.array([[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]).astype(
                 'float32'
@@ -201,7 +258,7 @@ class TestWhereAPI(unittest.TestCase):
                 place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
                 exe = base.Executor(place)
                 out = exe.run(
-                    base.default_main_program(),
+                    paddle.static.default_main_program(),
                     feed={'x': x_i, 'y': y_i},
                     fetch_list=[result],
                 )
@@ -209,15 +266,14 @@ class TestWhereAPI(unittest.TestCase):
                     out[0], np.where((x_i > 1), x_i, y_i)
                 )
 
+    @test_with_pir_api
     def test_scalar(self):
-        paddle.enable_static()
-        main_program = Program()
-        with base.program_guard(main_program):
-            cond_shape = [2, 4]
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program):
+            cond_shape = [4]
             cond = paddle.static.data(
-                name='cond', shape=[-1] + cond_shape, dtype='bool'
+                name='cond', shape=cond_shape, dtype='bool'
             )
-            cond.desc.set_need_check_feed(False)
             x_data = 1.0
             y_data = 2.0
             cond_data = np.array([False, False, True, True]).astype('bool')
@@ -228,7 +284,7 @@ class TestWhereAPI(unittest.TestCase):
                 place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
                 exe = base.Executor(place)
                 out = exe.run(
-                    base.default_main_program(),
+                    paddle.static.default_main_program(),
                     feed={'cond': cond_data},
                     fetch_list=[result],
                 )
@@ -237,20 +293,13 @@ class TestWhereAPI(unittest.TestCase):
 
     def __test_where_with_broadcast_static(self, cond_shape, x_shape, y_shape):
         paddle.enable_static()
-        main_program = Program()
-        with base.program_guard(main_program):
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program):
             cond = paddle.static.data(
-                name='cond', shape=[-1] + cond_shape, dtype='bool'
+                name='cond', shape=cond_shape, dtype='bool'
             )
-            x = paddle.static.data(
-                name='x', shape=[-1] + x_shape, dtype='float32'
-            )
-            y = paddle.static.data(
-                name='y', shape=[-1] + y_shape, dtype='float32'
-            )
-            x.desc.set_need_check_feed(False)
-            y.desc.set_need_check_feed(False)
-            cond.desc.set_need_check_feed(False)
+            x = paddle.static.data(name='x', shape=x_shape, dtype='float32')
+            y = paddle.static.data(name='y', shape=y_shape, dtype='float32')
             cond_data_tmp = np.random.random(size=cond_shape).astype('float32')
             cond_data = cond_data_tmp < 0.3
             x_data = np.random.random(size=x_shape).astype('float32')
@@ -262,55 +311,63 @@ class TestWhereAPI(unittest.TestCase):
                 place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
                 exe = base.Executor(place)
                 out = exe.run(
-                    base.default_main_program(),
+                    paddle.static.default_main_program(),
                     feed={'cond': cond_data, 'x': x_data, 'y': y_data},
                     fetch_list=[result],
                 )
                 expect = np.where(cond_data, x_data, y_data)
                 np.testing.assert_array_equal(out[0], expect)
 
+    @test_with_pir_api
     def test_static_api_broadcast_1(self):
         cond_shape = [2, 4]
         a_shape = [2, 2, 4]
         b_shape = [2, 2, 4]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_2(self):
         cond_shape = [2, 1]
         a_shape = [2, 2, 4]
         b_shape = [2, 2, 4]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_3(self):
         cond_shape = [2, 2, 1]
         a_shape = [2, 2, 4]
         b_shape = [2, 2, 4]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_4(self):
         cond_shape = [2, 1, 4]
         a_shape = [2, 2, 4]
         b_shape = [2, 2, 4]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_5(self):
         cond_shape = [3, 2, 2, 4]
         a_shape = [2, 2, 4]
         b_shape = [2, 2, 4]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_6(self):
         cond_shape = [2, 2, 4]
         a_shape = [2, 2, 1]
         b_shape = [2, 2, 1]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_7(self):
         cond_shape = [2, 2, 4]
         a_shape = [2, 1, 4]
         b_shape = [2, 1, 4]
         self.__test_where_with_broadcast_static(cond_shape, a_shape, b_shape)
 
+    @test_with_pir_api
     def test_static_api_broadcast_8(self):
         cond_shape = [3, 2, 2, 4]
         a_shape = [2, 2, 1]
@@ -433,7 +490,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
 
 class TestWhereOpError(unittest.TestCase):
     def test_errors(self):
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x_i = np.array([0.9383, 0.1983, 3.2, 1.2]).astype('float64')
             y_i = np.array([1.0, 1.0, 1.0, 1.0]).astype('float64')
             cond_i = np.array([False, False, True, True]).astype('bool')
@@ -442,6 +501,12 @@ class TestWhereOpError(unittest.TestCase):
                 paddle.where(cond_i, x_i, y_i)
 
             self.assertRaises(TypeError, test_Variable)
+
+            def test_OpResult():
+                with paddle.pir_utils.IrGuard():
+                    paddle.where(cond_i, x_i, y_i)
+
+            self.assertRaises(ValueError, test_OpResult)
 
             def test_type():
                 x = paddle.static.data(name='x', shape=[-1, 4], dtype='bool')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
补全如下算子的新IR单测，并解决单测验证中出现的问题：
pad / where / unsqueeze / slice / numel
主要解决如下机制与单测问题：
1，修复pad api不支持传入可变attribute的问题
2，完善optimizer机制，支持默认使用Program全部Parameter进行优化
3，完善OpResult方法，支持cast类型转换功能
4，解决stack api在pir模式下编译期infermeta维度检查报错的问题
5，解决slice api输入0维 axis无法stack的问题

TODO：
1，机制完善后，stack，slice打开Lod_tensor_array相关单测
2，python端支持控制流后，打开slice切片单测