### PR TITLE
[PHI API] [PHI API] fix issue of op api with inplace input output after falling back to CPU

### DIFF
--- a/paddle/phi/api/yaml/generator/api_gen.py
+++ b/paddle/phi/api/yaml/generator/api_gen.py
@@ -271,11 +271,46 @@ class ForwardAPI(BaseAPI):
                                 "SetInplaceOptionalVectorKernelOutput"
                             )
                             get_out_code = f"std::get<{i}>(api_output)"
-                    output_create = (
-                        output_create
-                        + f"""
+                    if self.outputs['names'][i] in self.inplace_map:
+                        if (
+                            self.inplace_map[self.outputs['names'][i]]
+                            not in self.optional_vars
+                        ):
+                            output_create = (
+                                output_create
+                                + f"""
+{code_indent}  std::vector<phi::DenseTensor*> kernel_out_{i};
+{code_indent}  if (kernel_result.has_fallback_cpu) {{
+{code_indent}    kernel_out_{i}.resize({self.outputs['out_size_expr'][i]});
+{code_indent}    for (size_t i = 0; i < {PREFIX_TENSOR_NAME}{self.inplace_map[self.outputs['names'][i]]}.size(); ++i) {{
+{code_indent}      kernel_out_{i}[i] = const_cast<phi::DenseTensor*>({PREFIX_TENSOR_NAME}{self.inplace_map[self.outputs['names'][i]]}.at(i));
+{code_indent}    }}
+{code_indent}  }}
+{code_indent}  else {{
+{code_indent}    kernel_out_{i} = {set_out_func}({self.outputs['out_size_expr'][i]}, {get_out_code});
+{code_indent}  }}"""
+                            )
+                        else:
+                            output_create = (
+                                output_create
+                                + f"""
+{code_indent}  std::vector<phi::DenseTensor*> kernel_out_{i};
+{code_indent}  if (kernel_result.has_fallback_cpu && {PREFIX_TENSOR_NAME}{self.inplace_map[self.outputs['names'][i]]}) {{
+{code_indent}    kernel_out_{i}.resize({self.outputs['out_size_expr'][i]});
+{code_indent}    for (size_t i = 0; i < {PREFIX_TENSOR_NAME}{self.inplace_map[self.outputs['names'][i]]}->size(); ++i) {{
+{code_indent}      kernel_out_{i}[i] = const_cast<phi::DenseTensor*>({PREFIX_TENSOR_NAME}{self.inplace_map[self.outputs['names'][i]]}->at(i));
+{code_indent}    }}
+{code_indent}  }}
+{code_indent}  else {{
+{code_indent}    kernel_out_{i} = {set_out_func}({self.outputs['out_size_expr'][i]}, {get_out_code});
+{code_indent}  }}"""
+                            )
+                    else:
+                        output_create = (
+                            output_create
+                            + f"""
 {code_indent}  auto kernel_out_{i} = {set_out_func}({self.outputs['out_size_expr'][i]}, {get_out_code});"""
-                    )
+                        )
 
                 else:
                     output_create = (


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Description
对于输入输出是inplace的std::vector<Tensor>类型的算子（例如merged_adam），在XPU上跑模型时，把该算子fallback到CPU后，会由于inplace的输入输出没有正确地在CPU和XPU上搬运而导致segmentation fault。这个PR修复了相关的问题。

api.cc文件kernel_backend相关代码：
修复前：
```
VLOG(6) << "merged_adam_ API kernel key: [" << kernel_backend << ", " << kernel_layout << ", "<< kernel_data_type << "]";
auto kernel_result = phi::KernelFactory::Instance().SelectKernelOrThrowError(
    "merged_adam", {kernel_backend, kernel_layout, kernel_data_type}, true);
const auto& kernel = kernel_result.kernel;
if (FLAGS_low_precision_op_list) {
  phi::KernelFactory::Instance().AddToLowPrecisionKernelList("merged_adam_", kernel_data_type);
}
VLOG(6) << "merged_adam kernel: " << kernel;
auto* dev_ctx = GetDeviceContextByBackend(kernel_result.has_fallback_cpu ? Backend::CPU : kernel_backend);
```
修复后：
```
VLOG(6) << "merged_adam_ API kernel key: [" << kernel_backend << ", " << kernel_layout << ", "<< kernel_data_type << "]";
auto kernel_result = phi::KernelFactory::Instance().SelectKernelOrThrowError(
    "merged_adam", {kernel_backend, kernel_layout, kernel_data_type}, true);
const auto& kernel = kernel_result.kernel;
if (FLAGS_low_precision_op_list) {
  phi::KernelFactory::Instance().AddToLowPrecisionKernelList("merged_adam_", kernel_data_type);
}
VLOG(6) << "merged_adam kernel: " << kernel;
// add actual_kernel_backend to select actual kernel backend after a potential falling-back to CPU
Backend actual_kernel_backend = kernel_result.has_fallback_cpu ? Backend::CPU : kernel_backend;
auto* dev_ctx = GetDeviceContextByBackend(actual_kernel_backend);
```
api.cc文件input相关部分代码：
修复前：
```
std::vector<const phi::DenseTensor*> input_param = TensorToConstDenseTensorPtr(param);
auto input_grad_vec = PrepareData(grad, GetKernelInputArgDef(kernel.InputAt(1), kernel_backend), {}, kernel_result.is_stride_kernel);
std::vector<const phi::DenseTensor*> input_grad(input_grad_vec->size());
for (size_t i = 0; i < input_grad.size(); ++i) {
  input_grad[i] = &input_grad_vec->at(i);
}
auto input_learning_rate_vec = PrepareData(learning_rate, GetKernelInputArgDef(kernel.InputAt(2), kernel_backend), {}, kernel_result.is_stride_kernel);
std::vector<const phi::DenseTensor*> input_learning_rate(input_learning_rate_vec->size());
for (size_t i = 0; i < input_learning_rate.size(); ++i) {
  input_learning_rate[i] = &input_learning_rate_vec->at(i);
}
std::vector<const phi::DenseTensor*> input_moment1 = TensorToConstDenseTensorPtr(moment1);
std::vector<const phi::DenseTensor*> input_moment2 = TensorToConstDenseTensorPtr(moment2);
std::vector<const phi::DenseTensor*> input_beta1_pow = TensorToConstDenseTensorPtr(beta1_pow);
std::vector<const phi::DenseTensor*> input_beta2_pow = TensorToConstDenseTensorPtr(beta2_pow);
paddle::optional<std::vector<const phi::DenseTensor*>> input_master_param = TensorToConstDenseTensorPtr(master_param);
```
修复后：
```
// inplace vector of tensors should also be transferred to CPU when kernel has fallen back
std::vector<const phi::DenseTensor*> input_param;
std::unique_ptr<std::vector<phi::DenseTensor>> input_param_vec;
if (kernel_result.has_fallback_cpu) {
  input_param_vec = PrepareData(param, GetKernelInputArgDef(kernel.InputAt(0), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
  input_param.resize(input_param_vec->size());
  for (size_t i = 0; i < input_param.size(); ++i) {
    input_param[i] = &input_param_vec->at(i);
  }
}
else {
  input_param = TensorToConstDenseTensorPtr(param);
}
auto input_grad_vec = PrepareData(grad, GetKernelInputArgDef(kernel.InputAt(1), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
std::vector<const phi::DenseTensor*> input_grad(input_grad_vec->size());
for (size_t i = 0; i < input_grad.size(); ++i) {
  input_grad[i] = &input_grad_vec->at(i);
}
auto input_learning_rate_vec = PrepareData(learning_rate, GetKernelInputArgDef(kernel.InputAt(2), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
std::vector<const phi::DenseTensor*> input_learning_rate(input_learning_rate_vec->size());
for (size_t i = 0; i < input_learning_rate.size(); ++i) {
  input_learning_rate[i] = &input_learning_rate_vec->at(i);
}
// inplace vector of tensors should also be transferred to CPU when kernel has fallen back
std::vector<const phi::DenseTensor*> input_moment1;
std::unique_ptr<std::vector<phi::DenseTensor>> input_moment1_vec;
if (kernel_result.has_fallback_cpu) {
  input_moment1_vec = PrepareData(moment1, GetKernelInputArgDef(kernel.InputAt(3), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
  input_moment1.resize(input_moment1_vec->size());
  for (size_t i = 0; i < input_moment1.size(); ++i) {
    input_moment1[i] = &input_moment1_vec->at(i);
  }
}
else {
  input_moment1 = TensorToConstDenseTensorPtr(moment1);
}
// inplace vector of tensors should also be transferred to CPU when kernel has fallen back
std::vector<const phi::DenseTensor*> input_moment2;
std::unique_ptr<std::vector<phi::DenseTensor>> input_moment2_vec;
if (kernel_result.has_fallback_cpu) {
  input_moment2_vec = PrepareData(moment2, GetKernelInputArgDef(kernel.InputAt(4), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
  input_moment2.resize(input_moment2_vec->size());
  for (size_t i = 0; i < input_moment2.size(); ++i) {
    input_moment2[i] = &input_moment2_vec->at(i);
  }
}
else {
  input_moment2 = TensorToConstDenseTensorPtr(moment2);
}
// inplace vector of tensors should also be transferred to CPU when kernel has fallen back
std::vector<const phi::DenseTensor*> input_beta1_pow;
std::unique_ptr<std::vector<phi::DenseTensor>> input_beta1_pow_vec;
if (kernel_result.has_fallback_cpu) {
  input_beta1_pow_vec = PrepareData(beta1_pow, GetKernelInputArgDef(kernel.InputAt(5), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
  input_beta1_pow.resize(input_beta1_pow_vec->size());
  for (size_t i = 0; i < input_beta1_pow.size(); ++i) {
    input_beta1_pow[i] = &input_beta1_pow_vec->at(i);
  }
}
else {
  input_beta1_pow = TensorToConstDenseTensorPtr(beta1_pow);
}
// inplace vector of tensors should also be transferred to CPU when kernel has fallen back
std::vector<const phi::DenseTensor*> input_beta2_pow;
std::unique_ptr<std::vector<phi::DenseTensor>> input_beta2_pow_vec;
if (kernel_result.has_fallback_cpu) {
  input_beta2_pow_vec = PrepareData(beta2_pow, GetKernelInputArgDef(kernel.InputAt(6), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
  input_beta2_pow.resize(input_beta2_pow_vec->size());
  for (size_t i = 0; i < input_beta2_pow.size(); ++i) {
    input_beta2_pow[i] = &input_beta2_pow_vec->at(i);
  }
}
else {
  input_beta2_pow = TensorToConstDenseTensorPtr(beta2_pow);
}
// inplace vector of tensors should also be transferred to CPU when kernel has fallen back
paddle::optional<std::vector<const phi::DenseTensor*>> input_master_param;
paddle::optional<std::vector<phi::DenseTensor>> input_master_param_vec;
if (kernel_result.has_fallback_cpu) {
  input_master_param_vec = PrepareData(master_param, GetKernelInputArgDef(kernel.InputAt(7), actual_kernel_backend), {}, kernel_result.is_stride_kernel);
  if (input_master_param_vec){
    input_master_param = paddle::optional<std::vector<const phi::DenseTensor*>>(input_master_param_vec->size());
    for (size_t i = 0; i < input_master_param_vec->size(); ++i) {
      input_master_param->at(i) = &input_master_param_vec->at(i);
    }
  }
}
else {
  input_master_param = TensorToConstDenseTensorPtr(master_param);
}
```
api.cc文件output相关部分代码：
修复前：
```
std::tuple<std::vector<Tensor>&, std::vector<Tensor>&, std::vector<Tensor>&, std::vector<Tensor>&, std::vector<Tensor>&, paddle::optional<std::vector<Tensor>>&> api_output{param, moment1, moment2, beta1_pow, beta2_pow, master_param};
auto kernel_out_0 = SetInplaceVectorKernelOutput(param.size(), &std::get<0>(api_output));
auto kernel_out_1 = SetInplaceVectorKernelOutput(param.size(), &std::get<1>(api_output));
auto kernel_out_2 = SetInplaceVectorKernelOutput(param.size(), &std::get<2>(api_output));
auto kernel_out_3 = SetInplaceVectorKernelOutput(param.size(), &std::get<3>(api_output));
auto kernel_out_4 = SetInplaceVectorKernelOutput(param.size(), &std::get<4>(api_output));
auto kernel_out_5 = SetInplaceOptionalVectorKernelOutput(param.size(), std::get<5>(api_output));
auto backup0 = ProcessStrideBackup(&kernel_out_0);
auto backup1 = ProcessStrideBackup(&kernel_out_1);
auto backup2 = ProcessStrideBackup(&kernel_out_2);
auto backup3 = ProcessStrideBackup(&kernel_out_3);
auto backup4 = ProcessStrideBackup(&kernel_out_4);
auto backup5 = ProcessStrideBackup(&kernel_out_5);
```
修复后：
```
std::tuple<std::vector<Tensor>&, std::vector<Tensor>&, std::vector<Tensor>&, std::vector<Tensor>&, std::vector<Tensor>&, paddle::optional<std::vector<Tensor>>&> api_output{param, moment1, moment2, beta1_pow, beta2_pow, master_param};
auto kernel_out_0 = SetInplaceVectorKernelOutput(param.size(), &std::get<0>(api_output));
if (kernel_result.has_fallback_cpu) {
  TransDataBackend(kernel_out_0, actual_kernel_backend, kernel_out_0);
}
auto kernel_out_1 = SetInplaceVectorKernelOutput(param.size(), &std::get<1>(api_output));
if (kernel_result.has_fallback_cpu) {
  TransDataBackend(kernel_out_1, actual_kernel_backend, kernel_out_1);
}
auto kernel_out_2 = SetInplaceVectorKernelOutput(param.size(), &std::get<2>(api_output));
if (kernel_result.has_fallback_cpu) {
  TransDataBackend(kernel_out_2, actual_kernel_backend, kernel_out_2);
}
auto kernel_out_3 = SetInplaceVectorKernelOutput(param.size(), &std::get<3>(api_output));
if (kernel_result.has_fallback_cpu) {
  TransDataBackend(kernel_out_3, actual_kernel_backend, kernel_out_3);
}
auto kernel_out_4 = SetInplaceVectorKernelOutput(param.size(), &std::get<4>(api_output));
if (kernel_result.has_fallback_cpu) {
  TransDataBackend(kernel_out_4, actual_kernel_backend, kernel_out_4);
}
auto kernel_out_5 = SetInplaceOptionalVectorKernelOutput(param.size(), std::get<5>(api_output));
if (kernel_result.has_fallback_cpu) {
  TransDataBackend(kernel_out_5, actual_kernel_backend, kernel_out_5);
}
auto backup0 = ProcessStrideBackup(&kernel_out_0);
auto backup1 = ProcessStrideBackup(&kernel_out_1);
auto backup2 = ProcessStrideBackup(&kernel_out_2);
auto backup3 = ProcessStrideBackup(&kernel_out_3);
auto backup4 = ProcessStrideBackup(&kernel_out_4);
auto backup5 = ProcessStrideBackup(&kernel_out_5);
```