### PR TITLE
[xdoctest] reformat example code with google style in No.386-389

### DIFF
--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -351,16 +351,13 @@ def flash_attn_unpadded(
     Examples:
         .. code-block:: python
 
-            >>> # doctest: +SKIP("`is_sm8x || is_sm75` check failed at /paddle/third_party/flashattn/csrc/flash_attn/flash_attn.cpp:293")
             >>> import paddle
-
             >>> paddle.seed(2023)
             >>> q = paddle.rand((2, 128, 8, 16), dtype='float16')
             >>> cu = paddle.arange(0, 384, 128, dtype='int32')
             >>> qq = paddle.reshape(q, [256, 8, 16])
             >>> output = paddle.nn.functional.flash_attention.flash_attn_unpadded(qq, qq, qq, cu, cu, 128, 128, 0.25, 0.0, False, False)
-            >>> print(output)
-            >>> # doctest: -SKIP
+
     """
     if in_dynamic_mode():
         (
@@ -477,7 +474,7 @@ def scaled_dot_product_attention(
     Examples:
         .. code-block:: python
 
-            >>> # doctest: +SKIP((InvalidArgument) flash_attn(): argument (position 5) must be double, but got NoneType (at ../paddle/fluid/pybind/op_function_common.cc:241))
+            >>> # doctest: +SKIP('bfloat need V100 compile')
             >>> import paddle
             >>> q = paddle.rand((1, 128, 2, 16), dtype=paddle.bfloat16)
             >>> output = paddle.nn.functional.scaled_dot_product_attention(q, q, q, None, 0.9, False)

--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -183,10 +183,22 @@ def flash_attention(
 
             >>> import paddle
 
-            >>> paddle.seed(1)
+            >>> paddle.seed(2023)
             >>> q = paddle.rand((1, 128, 2, 16))
 
             >>> output = paddle.nn.functional.flash_attention.flash_attention(q, q, q, 0.9, False, False)
+            >>> print(output)
+            (Tensor(shape=[1, 128, 2, 16], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[[[0.34992966, 0.34456208, 0.45826620, ..., 0.39883569,
+                0.42132431, 0.39157745],
+               [0.76687670, 0.65837246, 0.69117945, ..., 0.82817286,
+                0.76690865, 0.71485823]],
+              ...,
+              [[0.71662450, 0.57275224, 0.57053083, ..., 0.48108247,
+                0.53336465, 0.54540104],
+               [0.59137970, 0.51350880, 0.50449550, ..., 0.38860250,
+                0.40526697, 0.60541755]]]]), None)
+
     """
     head_dim = query.shape[3]
     sdp_func_name = _select_sdp(head_dim)
@@ -339,12 +351,16 @@ def flash_attn_unpadded(
     Examples:
         .. code-block:: python
 
+            >>> # doctest: +SKIP("`is_sm8x || is_sm75` check failed at /paddle/third_party/flashattn/csrc/flash_attn/flash_attn.cpp:293")
             >>> import paddle
-            >>> paddle.seed(1)
-            >>> q = paddle.rand((1, 128, 2, 16))
 
-            >>> output = paddle.nn.functional.flash_attention.flash_attn_unpadded(q, q, q, 0.9, False, False)
+            >>> paddle.seed(2023)
+            >>> q = paddle.rand((2, 128, 8, 16), dtype='float16')
+            >>> cu = paddle.arange(0, 384, 128, dtype='int32')
+            >>> qq = paddle.reshape(q, [256, 8, 16])
+            >>> output = paddle.nn.functional.flash_attention.flash_attn_unpadded(qq, qq, qq, cu, cu, 128, 128, 0.25, 0.0, False, False)
             >>> print(output)
+            >>> # doctest: -SKIP
     """
     if in_dynamic_mode():
         (
@@ -461,7 +477,7 @@ def scaled_dot_product_attention(
     Examples:
         .. code-block:: python
 
-            >>> # doctest: +SKIP()
+            >>> # doctest: +SKIP((InvalidArgument) flash_attn(): argument (position 5) must be double, but got NoneType (at ../paddle/fluid/pybind/op_function_common.cc:241))
             >>> import paddle
             >>> q = paddle.rand((1, 128, 2, 16), dtype=paddle.bfloat16)
             >>> output = paddle.nn.functional.scaled_dot_product_attention(q, q, q, None, 0.9, False)

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -127,12 +127,10 @@ class QuantConfig:
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> q_config.add_layer_config([model.fc], activation=quanter, weight=quanter)
-                >>> # doctest: +SKIP
-                >>> print(q_config)
-                Global config:
-                None
-                Layer prefix config:
-                {'linear_0': <paddle.quantization.config.SingleLayerConfig object at 0x7fe41a680ee0>}
+                >>> print(q_config.default_qat_layer_mapping)
+                {<class 'paddle.nn.quant.stub.Stub'>: <class 'paddle.nn.quant.stub.QuanterStub'>,
+                <class 'paddle.nn.layer.common.Linear'>: <class 'paddle.nn.quant.qat.linear.QuantedLinear'>,
+                <class 'paddle.nn.layer.conv.Conv2D'>: <class 'paddle.nn.quant.qat.conv.QuantedConv2D'>}
 
         """
         if isinstance(layer, list):
@@ -176,12 +174,10 @@ class QuantConfig:
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> q_config.add_name_config([model.fc.full_name()], activation=quanter, weight=quanter)
-                >>> # doctest: +SKIP
-                >>> print(q_config)
-                Global config:
-                None
-                Layer prefix config:
-                {'linear_0': <paddle.quantization.config.SingleLayerConfig object at 0x7fe41a680fd0>}
+                >>> print(q_config.default_qat_layer_mapping)
+                {<class 'paddle.nn.quant.stub.Stub'>: <class 'paddle.nn.quant.stub.QuanterStub'>,
+                <class 'paddle.nn.layer.common.Linear'>: <class 'paddle.nn.quant.qat.linear.QuantedLinear'>,
+                <class 'paddle.nn.layer.conv.Conv2D'>: <class 'paddle.nn.quant.qat.conv.QuantedConv2D'>}
 
         """
         if isinstance(layer_name, str):
@@ -226,12 +222,10 @@ class QuantConfig:
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> q_config.add_type_config([Linear], activation=quanter, weight=quanter)
-                >>> # doctest: +SKIP
-                >>> print(q_config)
-                Global config:
-                None
-                Layer type config:
-                {<class 'paddle.nn.layer.common.Linear'>: <paddle.quantization.config.SingleLayerConfig object at 0x7fe41a680a60>}
+                >>> print(q_config.default_qat_layer_mapping)
+                {<class 'paddle.nn.quant.stub.Stub'>: <class 'paddle.nn.quant.stub.QuanterStub'>,
+                <class 'paddle.nn.layer.common.Linear'>: <class 'paddle.nn.quant.qat.linear.QuantedLinear'>,
+                <class 'paddle.nn.layer.conv.Conv2D'>: <class 'paddle.nn.quant.qat.conv.QuantedConv2D'>}
 
         """
         if isinstance(layer_type, type) and issubclass(

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -127,10 +127,12 @@ class QuantConfig:
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> q_config.add_layer_config([model.fc], activation=quanter, weight=quanter)
-                >>> print(q_config.default_qat_layer_mapping)
-                {<class 'paddle.nn.quant.stub.Stub'>: <class 'paddle.nn.quant.stub.QuanterStub'>,
-                <class 'paddle.nn.layer.common.Linear'>: <class 'paddle.nn.quant.qat.linear.QuantedLinear'>,
-                <class 'paddle.nn.layer.conv.Conv2D'>: <class 'paddle.nn.quant.qat.conv.QuantedConv2D'>}
+                >>> # doctest: +SKIP('random memory address')
+                >>> print(q_config)
+                Global config:
+                None
+                Layer prefix config:
+                {'linear_0': <paddle.quantization.config.SingleLayerConfig object at 0x7fe41a680ee0>}
 
         """
         if isinstance(layer, list):
@@ -174,10 +176,12 @@ class QuantConfig:
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> q_config.add_name_config([model.fc.full_name()], activation=quanter, weight=quanter)
-                >>> print(q_config.default_qat_layer_mapping)
-                {<class 'paddle.nn.quant.stub.Stub'>: <class 'paddle.nn.quant.stub.QuanterStub'>,
-                <class 'paddle.nn.layer.common.Linear'>: <class 'paddle.nn.quant.qat.linear.QuantedLinear'>,
-                <class 'paddle.nn.layer.conv.Conv2D'>: <class 'paddle.nn.quant.qat.conv.QuantedConv2D'>}
+                >>> # doctest: +SKIP('random memory address')
+                >>> print(q_config)
+                Global config:
+                None
+                Layer prefix config:
+                {'linear_0': <paddle.quantization.config.SingleLayerConfig object at 0x7fe41a680fd0>}
 
         """
         if isinstance(layer_name, str):
@@ -222,10 +226,12 @@ class QuantConfig:
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
                 >>> q_config.add_type_config([Linear], activation=quanter, weight=quanter)
-                >>> print(q_config.default_qat_layer_mapping)
-                {<class 'paddle.nn.quant.stub.Stub'>: <class 'paddle.nn.quant.stub.QuanterStub'>,
-                <class 'paddle.nn.layer.common.Linear'>: <class 'paddle.nn.quant.qat.linear.QuantedLinear'>,
-                <class 'paddle.nn.layer.conv.Conv2D'>: <class 'paddle.nn.quant.qat.conv.QuantedConv2D'>}
+                >>> # doctest: +SKIP('random memory address')
+                >>> print(q_config)
+                Global config:
+                None
+                Layer type config:
+                {<class 'paddle.nn.layer.common.Linear'>: <paddle.quantization.config.SingleLayerConfig object at 0x7fe41a680a60>}
 
         """
         if isinstance(layer_type, type) and issubclass(

--- a/python/paddle/quantization/factory.py
+++ b/python/paddle/quantization/factory.py
@@ -83,8 +83,7 @@ def quanter(class_name):
     Examples:
         .. code-block:: python
 
-            >>> # doctest: +SKIP
-            >>> # Given codes in ./customized_quanter.py
+            >>> from paddle.quantization import QuantConfig
             >>> from paddle.quantization import quanter
             >>> from paddle.quantization import BaseQuanter
             >>> @quanter("CustomizedQuanter")
@@ -92,13 +91,14 @@ def quanter(class_name):
             ...     def __init__(self, arg1, kwarg1=None):
             ...         pass
 
-            >>> # Used in ./test.py
-            >>> # from .customized_quanter import CustomizedQuanter
-            >>> from paddle.quantization import QuantConfig
             >>> arg1_value = "test"
             >>> kwarg1_value = 20
             >>> quanter = CustomizedQuanter(arg1_value, kwarg1=kwarg1_value)
             >>> q_config = QuantConfig(activation=quanter, weight=quanter)
+            >>> print(q_config)
+            Global config:
+            activation: CustomizedQuanter(test,kwarg1=20)
+            weight: CustomizedQuanter(test,kwarg1=20)
 
     """
 

--- a/python/paddle/quantization/factory.py
+++ b/python/paddle/quantization/factory.py
@@ -83,7 +83,8 @@ def quanter(class_name):
     Examples:
         .. code-block:: python
 
-            >>> from paddle.quantization import QuantConfig
+            >>> # doctest: +SKIP('need 2 file to run example')
+            >>> # Given codes in ./customized_quanter.py
             >>> from paddle.quantization import quanter
             >>> from paddle.quantization import BaseQuanter
             >>> @quanter("CustomizedQuanter")
@@ -91,14 +92,13 @@ def quanter(class_name):
             ...     def __init__(self, arg1, kwarg1=None):
             ...         pass
 
+            >>> # Used in ./test.py
+            >>> # from .customized_quanter import CustomizedQuanter
+            >>> from paddle.quantization import QuantConfig
             >>> arg1_value = "test"
             >>> kwarg1_value = 20
             >>> quanter = CustomizedQuanter(arg1_value, kwarg1=kwarg1_value)
             >>> q_config = QuantConfig(activation=quanter, weight=quanter)
-            >>> print(q_config)
-            Global config:
-            activation: CustomizedQuanter(test,kwarg1=20)
-            weight: CustomizedQuanter(test,kwarg1=20)
 
     """
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2799,10 +2799,12 @@ def eigh(x, UPLO='L', name=None):
             property.  For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
+        2-element tuple containing
+
         - out_value(Tensor):  A Tensor with shape [*, N] and data type of float32 and float64.
-            The eigenvalues of eigh op.
+          The eigenvalues of eigh op.
         - out_vector(Tensor): A Tensor with shape [*, N, N] and data type of float32,float64,
-            complex64 and complex128. The eigenvectors of eigh op.
+          complex64 and complex128. The eigenvectors of eigh op.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2801,9 +2801,9 @@ def eigh(x, UPLO='L', name=None):
     Returns:
         2-element tuple containing
 
-        - out_value(Tensor):  A Tensor with shape [*, N] and data type of float32 and float64.
+        - out_value(Tensor): A Tensor with shape :math:`[*, N]` and data type of float32 and float64.
           The eigenvalues of eigh op.
-        - out_vector(Tensor): A Tensor with shape [*, N, N] and data type of float32,float64,
+        - out_vector(Tensor): A Tensor with shape :math:`[*, N, N]` and data type of float32, float64,
           complex64 and complex128. The eigenvectors of eigh op.
 
     Examples:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1958,14 +1958,12 @@ def slogdet(x, name=None):
 
             >>> import paddle
             >>> paddle.seed(2023)
-            >>> x =  paddle.randn([3,3,3])
+            >>> x =  paddle.randn([3, 3, 3])
             >>> A = paddle.linalg.slogdet(x)
             >>> print(A)
-            >>> # doctest: +SKIP
             Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[-1.        ,  1.        ,  1.        ],
              [ 0.25681755, -0.25061053, -0.10809582]])
-            >>> # doctest: -SKIP
 
     """
     if in_dynamic_mode():

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1958,7 +1958,7 @@ def slogdet(x, name=None):
 
             >>> import paddle
             >>> paddle.seed(2023)
-            >>> x =  paddle.randn([3, 3, 3])
+            >>> x = paddle.randn([3, 3, 3])
             >>> A = paddle.linalg.slogdet(x)
             >>> print(A)
             Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/55629
386-389
flash_attention 里面2个函数
1、flash_attn_unpadded error: "`is_sm8x || is_sm75` check failed at /paddle/third_party/flashattn/csrc/flash_attn/flash_attn.cpp:293"
2、scaled_dot_product_attention error: (InvalidArgument) flash_attn(): argument (position 5) must be double, but got NoneType (at ../paddle/fluid/pybind/op_function_common.cc:241)
在cpu和gpu下还是报错