### PR TITLE
Stage1 support bf16

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -105,6 +105,7 @@ message AMPConfig {
   optional bool use_fp16_guard = 11 [ default = true ];
   optional bool use_optimizer_fp16 = 12
       [ default = false ]; // auto parallel effective only
+  optional bool use_pure_bf16 = 13 [ default = false ];
 }
 
 message LocalSGDConfig {

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -930,6 +930,8 @@ class DistributedStrategy:
 
             use_pure_fp16(bool): Whether to use the pure fp16 training. Default False.
 
+            use_pure_bf16(bool): Whether to use the pure bf16 training. Default False.
+
             use_fp16_guard(bool): Whether to use `fp16_guard` when constructing the program.
                    Default True. Only takes effect when `use_pure_fp16` is turned on.
 

--- a/python/paddle/distributed/fleet/model.py
+++ b/python/paddle/distributed/fleet/model.py
@@ -85,19 +85,28 @@ def distributed_model(model):
     if paddle.distributed.get_world_size() <= 1:
         return model
 
-    amp_enable = False
     strategy = fleet_env._user_defined_strategy
     if strategy.amp:
-        amp_enable = True
-        amp_level = "O2" if strategy.amp_configs['use_pure_fp16'] else "O1"
-        if amp_level.upper() == "O2":
+        if strategy.amp_configs['use_pure_fp16']:
             model = paddle.amp.decorate(
                 models=model,
                 optimizers=None,
                 level="O2",
                 master_weight=None,
                 save_dtype=None,
+                dtype="float16",
             )
+
+        if strategy.amp_configs['use_pure_bf16']:
+            model = paddle.amp.decorate(
+                models=model,
+                optimizers=None,
+                level="O2",
+                master_weight=None,
+                save_dtype=None,
+                dtype="bfloat16",
+            )
+
         init_loss_scaling = strategy.amp_configs['init_loss_scaling']
         incr_ratio = strategy.amp_configs['incr_ratio']
         decr_ratio = strategy.amp_configs['decr_ratio']

--- a/python/paddle/distributed/fleet/model.py
+++ b/python/paddle/distributed/fleet/model.py
@@ -87,24 +87,23 @@ def distributed_model(model):
 
     strategy = fleet_env._user_defined_strategy
     if strategy.amp:
-        if strategy.amp_configs['use_pure_fp16']:
-            model = paddle.amp.decorate(
-                models=model,
-                optimizers=None,
-                level="O2",
-                master_weight=None,
-                save_dtype=None,
-                dtype="float16",
-            )
+        level = (
+            "O2"
+            if strategy.amp_configs['use_pure_fp16']
+            or strategy.amp_configs['use_pure_bf16']
+            else "O1"
+        )
 
-        if strategy.amp_configs['use_pure_bf16']:
+        if level == "O2":
             model = paddle.amp.decorate(
                 models=model,
                 optimizers=None,
                 level="O2",
                 master_weight=None,
                 save_dtype=None,
-                dtype="bfloat16",
+                dtype="float16"
+                if strategy.amp_configs['use_pure_fp16']
+                else "bfloat16",
             )
 
         init_loss_scaling = strategy.amp_configs['init_loss_scaling']

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -328,6 +328,21 @@ if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
 endif()
 if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
   bash_test_modules(
+    test_dygraph_sharding_stage1_bf16
+    START_BASH
+    ../../legacy_test/dist_test.sh
+    TIMEOUT
+    "200"
+    LABELS
+    "RUN_TYPE=DIST"
+    ENVS
+    "PADDLE_DIST_UT_PORT=22024;NVIDIA_TF32_OVERRIDE=0;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
+  )
+  set_tests_properties(test_dygraph_sharding_stage1_bf16 PROPERTIES TIMEOUT
+                                                                    "200")
+endif()
+if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
+  bash_test_modules(
     test_dygraph_sharding_stage1_fp16
     START_BASH
     ../../legacy_test/dist_test.sh

--- a/test/collective/fleet/dygraph_group_sharded_stage1_bf16.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage1_bf16.py
@@ -223,7 +223,7 @@ def test_stage1_bf16():
         o2_32_loss = paddle.cast(o2_losses[i], dtype='float32').detach()
         np.testing.assert_array_equal(o1_32_loss, o2_32_loss)
 
-    # stage1 scaler test
+    # stage1 scaler test with main_grad
     mlp3 = MLP()
     mlp3.set_state_dict(state_dict)
     train_mlp(
@@ -231,6 +231,17 @@ def test_stage1_bf16():
         sharding_stage=1,
         use_pure_bf16=True,
         use_main_grad=True,
+        test_scaler=True,
+    )
+
+    # stage1 scaler test without main_grad
+    mlp4 = MLP()
+    mlp4.set_state_dict(state_dict)
+    train_mlp(
+        mlp4,
+        sharding_stage=1,
+        use_pure_bf16=True,
+        use_main_grad=False,
         test_scaler=True,
     )
 

--- a/test/collective/fleet/dygraph_group_sharded_stage1_bf16.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage1_bf16.py
@@ -59,16 +59,16 @@ class RandomDataset(paddle.io.Dataset):
         return self.num_samples
 
 
-def optimizer_setting(model, use_pure_fp16, use_main_grad):
+def optimizer_setting(model, use_pure_bf16, use_main_grad):
     if use_main_grad:
-        assert use_pure_fp16
-        model = mix_precision_utils.MixPrecisionLayer(model, dtype="float16")
+        assert use_pure_bf16
+        model = mix_precision_utils.MixPrecisionLayer(model, dtype="bfloat16")
     optimizer = paddle.optimizer.AdamW(
         parameters=model.parameters(),
         learning_rate=0.00001,
         weight_decay=0.00001,
         grad_clip=paddle.nn.ClipGradByGlobalNorm(clip_norm=1.0),
-        multi_precision=use_pure_fp16,
+        multi_precision=use_pure_bf16,
     )
     if use_main_grad:
         optimizer = mix_precision_utils.MixPrecisionOptimizer(optimizer)
@@ -79,30 +79,40 @@ def optimizer_setting(model, use_pure_fp16, use_main_grad):
 def train_mlp(
     model,
     sharding_stage,
-    use_pure_fp16=False,
+    use_pure_bf16=False,
     accumulate_grad=False,
     use_main_grad=False,
     test_scaler=False,
 ):
+    # bf16 not support dynamic loss scaling
+    # disable dynamic_loss_scaling to coverage distributed_scaler
+    dynamic_loss_scaling = False
     scaler = None
     scale_loss = 1024
     if test_scaler:
         assert sharding_stage == 1
         assert not accumulate_grad
-        scaler = paddle.amp.GradScaler(init_loss_scaling=scale_loss)
+        scaler = paddle.amp.GradScaler(
+            init_loss_scaling=scale_loss,
+            use_dynamic_loss_scaling=dynamic_loss_scaling,
+        )
         scaler = fleet.distributed_scaler(scaler)
     optimizer = optimizer_setting(
-        model=model, use_pure_fp16=use_pure_fp16, use_main_grad=use_main_grad
+        model=model, use_pure_bf16=use_pure_bf16, use_main_grad=use_main_grad
     )
 
     strategy = fleet.DistributedStrategy()
-    if use_pure_fp16:
+    if use_pure_bf16:
         level = 'O2'
         custom_white_list = None
 
-        amp_configs = {"init_loss_scaling": scale_loss, "use_pure_fp16": True}
-        strategy.amp_configs = amp_configs
+        amp_configs = {
+            "init_loss_scaling": scale_loss,
+            "use_pure_bf16": True,
+            "use_dynamic_loss_scaling": dynamic_loss_scaling,
+        }
         strategy.amp = True
+        strategy.amp_configs = amp_configs
     else:
         level = 'O1'
         custom_white_list = [
@@ -140,10 +150,10 @@ def train_mlp(
     if sharding_stage == 1:
         model.to(device="gpu")
 
-    if not use_pure_fp16:
+    if not use_pure_bf16:
         for param in model.parameters():
             t = paddle.cast(
-                paddle.cast(param, dtype='float16'), dtype='float32'
+                paddle.cast(param, dtype='bfloat16'), dtype='float32'
             )
             param.set_value(t)
 
@@ -157,7 +167,7 @@ def train_mlp(
             with paddle.amp.auto_cast(
                 True,
                 level=level,
-                dtype="float16",
+                dtype="bfloat16",
                 custom_white_list=custom_white_list,
             ):
                 out = model(data)
@@ -184,15 +194,15 @@ def train_mlp(
     return losses
 
 
-def test_stage1_fp16():
-    if not paddle.amp.is_float16_supported():
+def test_stage1_bf16():
+    if not paddle.amp.is_bfloat16_supported():
         return
     paddle.distributed.init_parallel_env()
 
     mlp = MLP()
     state_dict = mlp.state_dict()
 
-    # stage1 fp16 O1 vs stage1 fp16 O2 main_grad
+    # stage1 bf16 O1 vs stage1 bf16 O2 main_grad
     mlp1 = MLP()
     mlp2 = MLP()
     mlp1.set_state_dict(state_dict)
@@ -200,12 +210,12 @@ def test_stage1_fp16():
     o1_losses = train_mlp(
         mlp1,
         sharding_stage=1,
-        use_pure_fp16=False,
+        use_pure_bf16=False,
     )
     o2_losses = train_mlp(
         mlp2,
         sharding_stage=1,
-        use_pure_fp16=True,
+        use_pure_bf16=True,
         use_main_grad=True,
     )
     for i in range(len(o1_losses)):
@@ -219,7 +229,7 @@ def test_stage1_fp16():
     train_mlp(
         mlp3,
         sharding_stage=1,
-        use_pure_fp16=True,
+        use_pure_bf16=True,
         use_main_grad=True,
         test_scaler=True,
     )
@@ -232,13 +242,13 @@ def test_stage1_fp16():
     o1_losses_grad_acc = train_mlp(
         mlp5,
         sharding_stage=1,
-        use_pure_fp16=False,
+        use_pure_bf16=False,
         accumulate_grad=True,
     )
     o2_losses_grad_acc = train_mlp(
         mlp6,
         sharding_stage=1,
-        use_pure_fp16=True,
+        use_pure_bf16=True,
         use_main_grad=True,
         accumulate_grad=True,
     )
@@ -255,4 +265,4 @@ def test_stage1_fp16():
 
 
 if __name__ == '__main__':
-    test_stage1_fp16()
+    test_stage1_bf16()

--- a/test/collective/fleet/test_dygraph_sharding_stage1_bf16.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage1_bf16.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+
+
+class TestDygraphShardingStage1(TestMultipleGpus):
+    # check sharding logic as well as the accuracy with single mode
+    def test_dygraph_sharding_stage1_bf16(self):
+        self.run_mnist_2gpu('dygraph_group_sharded_stage1_bf16.py')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/testslist.csv
+++ b/test/collective/fleet/testslist.csv
@@ -25,6 +25,7 @@ test_static_model_parallel,,,240,DIST,../../legacy_test/dist_test.sh,2,,http_pro
 test_parallel_dygraph_no_sync,,GPU,300,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,WITH_NCCL
 test_dygraph_sharding_stage2,,,200,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_dygraph_sharding_stage2_bf16,,,200,DIST,../../legacy_test/dist_test.sh,2,,NVIDIA_TF32_OVERRIDE=0;http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_dygraph_sharding_stage1_bf16,,,200,DIST,../../legacy_test/dist_test.sh,2,,NVIDIA_TF32_OVERRIDE=0;http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_dygraph_sharding_stage1_fp16,,,200,DIST,../../legacy_test/dist_test.sh,2,,NVIDIA_TF32_OVERRIDE=0;http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_parallel_dygraph_control_flow,,,350,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_fleet_lars_meta_optimizer,,GPU;XPU,,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,

--- a/tools/gpups_test.sh
+++ b/tools/gpups_test.sh
@@ -30,6 +30,7 @@ function collect_failed_tests() {
 serial_list="^test_conv2d_op$|\
 ^test_conv2d_transpose_op$|\
 ^test_dygraph_sharding_stage1_fp16$|\
+^test_dygraph_sharding_stage1_bf16$|\
 ^test_dygraph_sharding_stage2_bf16$|\
 ^test_dygraph_sharding_stage3_bf16$|\
 ^test_conv3d_op$"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
stage1 support bf16
refine `dygraph_group_sharded_stage1_fp16.py`

用户接口改动：
1. `DistributedStrategy`的`amp_configs`添加`use_pure_bf16`选项