### PR TITLE
[CINN] Add cross thread reduction replacer

### DIFF
--- a/paddle/cinn/hlir/pe/reduction.cc
+++ b/paddle/cinn/hlir/pe/reduction.cc
@@ -1077,6 +1077,31 @@ std::vector<ir::Tensor> TwoStepBlockReduceAny(const ir::Tensor& A,
                                     Expr(false));
 }
 
+std::string CrossThreadReduceExternalFuncName(const ir::Expr& op,
+                                              const ir::Expr& tensor) {
+  CHECK_NOTNULL(tensor.as_tensor());
+  if (op.As<ir::Add>()) {
+    return "cinn_block_reduce_sum" +
+           Type2StrForReduce(tensor.as_tensor()->type()) + "_internal";
+  } else if (op.As<ir::Mul>()) {
+    return "cinn_block_reduce_prod" +
+           Type2StrForReduce(tensor.as_tensor()->type()) + "_internal";
+  } else if (op.As<ir::Max>()) {
+    return "cinn_block_reduce_max" +
+           Type2StrForReduce(tensor.as_tensor()->type()) + "_internal";
+  } else if (op.As<ir::Min>()) {
+    return "cinn_block_reduce_min" +
+           Type2StrForReduce(tensor.as_tensor()->type()) + "_internal";
+  } else if (op.As<ir::And>()) {
+    return "cinn_block_reduce_all_internal";
+  } else if (op.As<ir::Or>()) {
+    return "cinn_block_reduce_any_internal";
+  } else {
+    LOG(FATAL) << "Reduce type: " << op << " Not supported yet!";
+  }
+  return "";
+}
+
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/paddle/cinn/hlir/pe/reduction.h
+++ b/paddle/cinn/hlir/pe/reduction.h
@@ -467,6 +467,9 @@ std::vector<ir::Tensor> TwoStepBlockReduceAny(
     const std::vector<int>& axes,
     const bool keep_dim,
     const std::string& output_name = "T_Reduce_Any_out");
+
+std::string CrossThreadReduceExternalFuncName(const ir::Expr& op,
+                                              const ir::Expr& tensor);
 }  // namespace pe
 }  // namespace hlir
 }  // namespace cinn

--- a/paddle/cinn/optim/CMakeLists.txt
+++ b/paddle/cinn/optim/CMakeLists.txt
@@ -23,7 +23,8 @@ gather_srcs(
   lower_intrin.cc
   cast_bool_to_int8.cc
   var_mod_simplify.cc
-  remove_schedule_block.cc)
+  remove_schedule_block.cc
+  replace_cross_thread_reduction.cc)
 
 if(WITH_CUDA)
   gather_srcs(cinnapi_src SRCS transform_gpu_forloop.cc)
@@ -55,3 +56,5 @@ cinn_cc_test(test_cast_simplify SRCS cast_simplify_test.cc DEPS cinncore)
 cinn_cc_test(test_remove_schedule_block SRCS remove_schedule_block_test.cc DEPS
              cinncore)
 cinn_cc_test(test_unroll_loops SRCS unroll_loops_test.cc DEPS cinncore)
+cinn_cc_test(test_replace_cross_thread_reduction SRCS
+             replace_cross_thread_reduction_test.cc DEPS cinncore)

--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -29,6 +29,7 @@
 #include "paddle/cinn/optim/map_extern_call.h"
 #include "paddle/cinn/optim/remove_schedule_block.h"
 #include "paddle/cinn/optim/replace_const_param_to_integer.h"
+#include "paddle/cinn/optim/replace_cross_thread_reduction.h"
 #include "paddle/cinn/optim/transform_gpu_forloop.h"
 #include "paddle/cinn/optim/transform_polyfor_to_for.h"
 #include "paddle/cinn/optim/unroll_loops.h"
@@ -49,6 +50,7 @@ Expr Optimize(Expr e,
   ReplaceConstParamToInteger(&copied);
   // Simplify already contains CastSimplify
   Simplify(&copied);
+  ReplaceCrossThreadReduction(&copied);
   UnrollLoop(&copied);
   VLOG(4) << "After Optimize UnrollLoop:" << copied;
 
@@ -85,6 +87,7 @@ Expr Optimize(Expr e,
 
 ir::Module Optimize(const ir::Module& module, const Target& target) {
   auto copied = ir::ir_utils::IRCopy(Expr(module));
+  ReplaceCrossThreadReduction(&copied);
   UnrollLoop(&copied);
   VectorizeLoops(&copied, Target());
   VLOG(10) << "After VectorizeLoops:" << copied.as_module_ref();

--- a/paddle/cinn/optim/replace_cross_thread_reduction.cc
+++ b/paddle/cinn/optim/replace_cross_thread_reduction.cc
@@ -1,0 +1,154 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * This file implements the strategy to remove the unnecessary nested block.
+ */
+#pragma once
+#include "paddle/cinn/optim/replace_cross_thread_reduction.h"
+#include <vector>
+
+#include "paddle/cinn/common/common.h"
+#include "paddle/cinn/hlir/pe/reduction.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_mutator.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/schedule/ir_schedule_util.h"
+#include "paddle/cinn/lang/compute.h"
+
+namespace cinn {
+namespace optim {
+
+struct CrossThreadReductionReplacer : public ir::IRMutator<Expr*> {
+  void operator()(ir::Expr* expr) { Visit(expr); }
+
+ private:
+  bool CanReplace(const ir::ScheduleBlockRealize* block_realize) {
+    const ir::ScheduleBlock* schedule_block =
+        block_realize->schedule_block.As<ir::ScheduleBlock>();
+    CHECK_NOTNULL(schedule_block);
+
+    if (block_realize->schedule_block.As<ir::ScheduleBlock>()->name.substr(
+            0, 4) == "root") {
+      return false;
+    }
+
+    const std::vector<ir::Expr>& iter_values = block_realize->iter_values;
+    const std::vector<ir::Var>& iter_vars = schedule_block->iter_vars;
+    ir::Expr body = schedule_block->body;
+
+    std::unordered_set<std::string> reduce_var_names;
+    for (int i = 0; i < iter_values.size(); ++i) {
+      if (!iter_vars[i]->is_reduce_axis) {
+        continue;
+      }
+      ir::ir_utils::CollectIRNodesWithoutTensor(
+          iter_values[i], [&](const ir::Expr* x) {
+            if (x->as_var()) {
+              reduce_var_names.insert(x->as_var()->name);
+            }
+            return false;
+          });
+    }
+
+    std::vector<int> thread_binded_reduce_loop_indices;
+    for (int i = 0; i < cur_loops_.size(); ++i) {
+      if (reduce_var_names.count(cur_loops_[i].As<ir::For>()->loop_var->name) >
+          0) {
+        if (cur_loops_[i].As<ir::For>()->is_gpu_thread_binded()) {
+          if (ir::GetLoopExtent(cur_loops_[i]) > 1024) {
+            return false;
+          }
+          thread_binded_reduce_loop_indices.push_back(i);
+        }
+      }
+    }
+    if (thread_binded_reduce_loop_indices.size() == 0 ||
+        thread_binded_reduce_loop_indices.back() != cur_loops_.size() - 1) {
+      return false;
+    }
+    for (int i = 1; i < thread_binded_reduce_loop_indices.size(); ++i) {
+      if (thread_binded_reduce_loop_indices[i - 1] + 1 !=
+          thread_binded_reduce_loop_indices[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void Visit(ir::Expr* expr) { ir::IRMutator<>::Visit(expr, expr); }
+
+  void Visit(const ir::ScheduleBlockRealize* expr, ir::Expr* op) override {
+    if (!CanReplace(expr)) {
+      VLOG(6) << "Can't replace cross thread reduction: " << *op;
+      IRMutator::Visit(expr, op);
+      return;
+    }
+    VLOG(6) << "Can replace cross thread reduction: " << *op;
+
+    const ir::ScheduleBlock* schedule_block =
+        expr->schedule_block.As<ir::ScheduleBlock>();
+    CHECK_NOTNULL(schedule_block);
+    ir::Expr original_update_body = schedule_block->body;
+    ir::Expr original_update_stmt;
+    CHECK(original_update_body.As<ir::Block>() ||
+          original_update_body.As<ir::Store>());
+    if (original_update_body.As<ir::Block>()) {
+      CHECK_EQ(original_update_body.As<ir::Block>()->stmts.size(), 1);
+      original_update_stmt = original_update_body.As<ir::Block>()->stmts[0];
+    } else if (original_update_body.As<ir::Store>()) {
+      original_update_stmt = original_update_body;
+    }
+
+#define REPLACE_TO_EXTERNAL_CALL(Op)                                   \
+  if (original_update_stmt.As<ir::Store>()->value.As<Op>()) {          \
+    auto* node = original_update_stmt.As<ir::Store>()->value.As<Op>(); \
+    CHECK(node);                                                       \
+    auto& operand = node->b();                                         \
+    std::string reduce_func_name =                                     \
+        hlir::pe::CrossThreadReduceExternalFuncName(                   \
+            original_update_stmt.As<ir::Store>()->value,               \
+            operand.As<ir::Load>()->tensor);                           \
+    original_update_stmt.As<ir::Store>()->value =                      \
+        lang::CallExtern(reduce_func_name, {node->b()});               \
+  }
+
+    REPLACE_TO_EXTERNAL_CALL(ir::Add)
+    REPLACE_TO_EXTERNAL_CALL(ir::Mul)
+    REPLACE_TO_EXTERNAL_CALL(ir::Max)
+    REPLACE_TO_EXTERNAL_CALL(ir::Min)
+    REPLACE_TO_EXTERNAL_CALL(ir::And)
+    REPLACE_TO_EXTERNAL_CALL(ir::Or)
+#undef REPLACE_TO_EXTERNAL_CALL
+
+    VLOG(6) << "Replace cross thread reduction: " << *op;
+
+    IRMutator::Visit(expr, op);
+  }
+
+  void Visit(const ir::For* expr, ir::Expr* op) override {
+    cur_loops_.push_back(*op);
+    IRMutator::Visit(expr, op);
+    cur_loops_.pop_back();
+  }
+
+ private:
+  std::vector<ir::Expr> cur_loops_;
+};
+
+void ReplaceCrossThreadReduction(Expr* e) { CrossThreadReductionReplacer()(e); }
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/replace_cross_thread_reduction.h
+++ b/paddle/cinn/optim/replace_cross_thread_reduction.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * This file implements the strategy to remove the unnecessary nested block.
+ */
+#pragma once
+#include <vector>
+
+#include "paddle/cinn/common/common.h"
+#include "paddle/cinn/ir/ir.h"
+
+namespace cinn {
+namespace optim {
+
+/**
+ * Replace cross thread reduction to external call.
+ */
+void ReplaceCrossThreadReduction(Expr* e);
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/replace_cross_thread_reduction_test.cc
+++ b/paddle/cinn/optim/replace_cross_thread_reduction_test.cc
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/replace_cross_thread_reduction.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "paddle/cinn/cinn.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+#include "paddle/cinn/utils/string.h"
+
+namespace cinn {
+namespace optim {
+
+TEST(CrossThreadReductionReplacer, basic) {
+  Context::Global().ResetNameId();
+  Placeholder<float> A("A", {Expr(64), Expr(128)});
+  Target target = common::DefaultNVGPUTarget();
+  Module::Builder builder("reduce_sum", target);
+  Var reduce_j(128, "reduce_j");
+  ir::Tensor B = Compute(
+      {Expr(64)},
+      [&](Var i) { return lang::ReduceSum(A(i, reduce_j), {reduce_j}); },
+      "B");
+  ast_gen_ius::TensorGroup tensor_group({A, B});
+  auto func = lang::LowerToAst("reduce_sum", {A, B}, &tensor_group);
+  VLOG(6) << "original func\n" << func;
+
+  ir::ModuleExpr mod_expr({func->body});
+  ir::IRSchedule ir_sch(mod_expr);
+
+  ir_sch.Bind(ir_sch.GetLoops("B")[0], "blockIdx.x");
+  ir_sch.Bind(ir_sch.GetLoops("B")[1], "threadIdx.x");
+
+  ir::Expr new_func = ir_sch.GetModule().GetExprs()[0];
+  VLOG(6) << "After Bind: " << new_func;
+
+  ReplaceCrossThreadReduction(&new_func);
+  VLOG(6) << "After ReplaceCrossThreadReduction: " << new_func;
+
+  EXPECT_EQ(utils::GetStreamCnt(new_func), utils::Trim(R"ROC({
+  ScheduleBlock(root)
+  {
+    thread_bind[blockIdx.x] for (i, 0, 64)
+    {
+      ScheduleBlock(B__reduce_init)
+      {
+        i0 = axis.bind(i)
+        B__reduce_init[i0] = 0.00000000f
+      }
+      thread_bind[threadIdx.x] for (reduce_j, 0, 128)
+      {
+        ScheduleBlock(B)
+        {
+          i0_0, i1 = axis.bind(i, reduce_j)
+          B[i0_0] = cinn_block_reduce_sum_fp32_internal(A[i0_0, i1])
+        }
+      }
+    }
+  }
+}
+)ROC"));
+}
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/replace_cross_thread_reduction_test.cc
+++ b/paddle/cinn/optim/replace_cross_thread_reduction_test.cc
@@ -30,6 +30,7 @@ namespace cinn {
 namespace optim {
 
 TEST(CrossThreadReductionReplacer, basic) {
+#ifdef CINN_WITH_CUDA
   Context::Global().ResetNameId();
   Placeholder<float> A("A", {Expr(64), Expr(128)});
   Target target = common::DefaultNVGPUTarget();
@@ -77,6 +78,7 @@ TEST(CrossThreadReductionReplacer, basic) {
   }
 }
 )ROC"));
+#endif
 }
 
 }  // namespace optim

--- a/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
+++ b/paddle/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh
@@ -474,11 +474,11 @@ __device__ inline bool cinn_any(const bool left, const bool right) { return left
       tmp_val = __shfl_sync(mask, tmp_val, 0, 32);                                        \
       return tmp_val;                                                                     \
     } else {                                                                              \
-      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_down_sync(mask, tmp_val, 16, 32));     \
-      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_down_sync(mask, tmp_val, 8, 32));      \
-      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_down_sync(mask, tmp_val, 4, 32));      \
-      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_down_sync(mask, tmp_val, 2, 32));      \
-      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_down_sync(mask, tmp_val, 1, 32));      \
+      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_xor_sync(mask, tmp_val, 16, 32));     \
+      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_xor_sync(mask, tmp_val, 8, 32));      \
+      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_xor_sync(mask, tmp_val, 4, 32));      \
+      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_xor_sync(mask, tmp_val, 2, 32));      \
+      tmp_val = cinn_##REDUCE_TYPE(tmp_val, __shfl_xor_sync(mask, tmp_val, 1, 32));      \
       return tmp_val;                                                                     \
     }                                                                                     \
   }


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
Pcard-74042
Add cross thread reduction replacer, when we bind a reduce loop on ThreadIdx of CUDA, the pass will replace the reduce update stmt to a external call which do parallel tree-like reduction.
