### PR TITLE
fix call to_tensor failed with dtype=int16

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -706,6 +706,8 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
             target_dtype = paddle.get_default_dtype()
         target_dtype = convert_dtype(target_dtype)
 
+        if data.dtype == "int16":
+            data = data.astype("int32")
         output = assign(data)
 
         if convert_dtype(output.dtype) != target_dtype:

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -208,7 +208,6 @@ class TestInt16(unittest.TestCase):
 
         paddle.enable_static()
         data = np.array([1, 2], dtype="int16")
-        paddle.enable_static()
         x = paddle.to_tensor(data)
         self.assertTrue(x.dtype == paddle.framework.core.VarDesc.VarType.INT16)
 

--- a/test/dygraph_to_static/test_to_tensor.py
+++ b/test/dygraph_to_static/test_to_tensor.py
@@ -202,5 +202,19 @@ class TestStatic(unittest.TestCase):
             res = exe.run(fetch_list=[x, out])
 
 
+class TestInt16(unittest.TestCase):
+    def test_static(self):
+        import numpy as np
+
+        paddle.enable_static()
+        data = np.array([1, 2], dtype="int16")
+        paddle.enable_static()
+        x = paddle.to_tensor(data)
+        self.assertTrue(x.dtype == paddle.framework.core.VarDesc.VarType.INT16)
+
+        y = paddle.to_tensor([1, 2], dtype="int16")
+        self.assertTrue(y.dtype == paddle.framework.core.VarDesc.VarType.INT16)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
This error caused by assign op, which not support int16 as input
if add int16 branch in assign, error raised below
![Pasted Graphic 3](https://github.com/PaddlePaddle/Paddle/assets/79986504/e713ae06-6aa6-4305-99c8-ce031682580d)


PCard-66972
