### PR TITLE
Fix eig backward failed occasionally

### DIFF
--- a/test/legacy_test/test_eig_op.py
+++ b/test/legacy_test/test_eig_op.py
@@ -320,6 +320,7 @@ class TestEigDyGraph(unittest.TestCase):
         test_type = 'float64'
         paddle.set_device("cpu")
 
+        np.random.seed(1024)
         input_np = np.random.random(test_shape).astype(test_type)
         real_w, real_v = np.linalg.eig(input_np)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR fix test_eig_op occasionally failed because of unfixed random seed
Related PR [#55897](https://github.com/PaddlePaddle/Paddle/pull/55897)