### PR TITLE
[Dy2St][Docs] fix error message in `to_static` doc

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -240,24 +240,29 @@ def to_static(
     **kwargs,
 ):
     """
-    Converts imperative dygraph APIs into declarative function APIs. Decorator
+    Converts dynamic graph APIs into static graph function APIs. Decorator
     @to_static handles the Program and Executor of static graph mode and returns
-    the result as dygraph Tensor(s). Users could use the returned dygraph
-    Tensor(s) to do imperative training, inference, or other operations. If the
-    decorated function calls other imperative function, the called one will be
-    converted into declarative function as well.
+    the result as dynamic graph Tensor(s). Users could use the returned dynamic
+    graph Tensor(s) to do dynamic graph training, inference, or other operations.
+    If the decorated function calls other dynamic graph function, the called one
+    will be converted into static graph function as well.
+
     Args:
-        function (callable): callable imperative function.
-        input_spec(list[InputSpec]|tuple[InputSpec]): list/tuple of InputSpec to specific the shape/dtype/name
-            information of each input Tensor.
-        build_strategy(BuildStrategy|None): This argument is used to compile the
+        function (callable): Callable dynamic graph function. If it used as a
+            decorator, the decorated function will be parsed as this parameter.
+        input_spec (list[InputSpec]|tuple[InputSpec]): list/tuple of InputSpec to
+            specific the shape/dtype/name information of each input Tensor.
+        build_strategy (BuildStrategy|None): This argument is used to compile the
             converted program with the specified options, such as operators' fusion
             in the computational graph and memory optimization during the execution
             of the computational graph. For more information about build_strategy,
             please refer to :code:`paddle.static.BuildStrategy`. The default is None.
-        backend(str, Optional): Specifies compilation backend, which can be `CINN` or None. When backend is `CINN`, CINN compiler will be used to speed up training and inference.
-        kwargs: Support keys including `property`, set `property` to True if the fucntion is python property.
+        backend(str, Optional): Specifies compilation backend, which can be `CINN` or
+            None. When backend is `CINN`, CINN compiler will be used to speed up
+            training and inference.
+        kwargs: Support keys including `property`.
 
+            - property: It indicates whether the decorated function is a python property.
 
     Returns:
         Tensor(s): containing the numerical result.

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -260,9 +260,8 @@ def to_static(
         backend(str, Optional): Specifies compilation backend, which can be `CINN` or
             None. When backend is `CINN`, CINN compiler will be used to speed up
             training and inference.
-        kwargs: Support keys including `property`.
-
-            - property: It indicates whether the decorated function is a python property.
+        kwargs: Support keys including `property`, set `property` to True if the function
+            is python property.
 
     Returns:
         Tensor(s): containing the numerical result.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Docs

### Description
<!-- Describe what you’ve done -->

修复 `to_static` 文档中的 ERROR_MESSAGE，并确保对齐中文文档

### Related links

- #58237 刚好看见 `to_static` 文档有问题，然后发现了这个 issue

### Preview

- en: http://preview-paddle-pr-58257.paddle-docs-preview.paddlepaddle.org.cn/documentation/docs/en/api/paddle/jit/to_static_en.html
- cn: http://preview-paddle-pr-58257.paddle-docs-preview.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/jit/to_static_cn.html

PCard-66972