### PR TITLE
Adapt 0-d RepeatsTensor in repeat_interleave

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4572,6 +4572,8 @@ def repeat_interleave(x, repeats, axis=None, name=None):
             [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6])
     """
 
+    if isinstance(repeats, Variable) and not repeats.shape:
+        repeats = paddle.reshape(repeats, [1])
     if axis is None:
         x = paddle.flatten(x)
         axis = 0

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -112,6 +112,7 @@ class TestIndexSelectAPI(unittest.TestCase):
                 [9.0, 10.0, 11.0, 12.0],
             ]
         )
+        self.data_zero_dim_index = np.array(2)
         self.data_index = np.array([0, 1, 2, 1]).astype('int32')
 
     def test_repeat_interleave_api(self):
@@ -265,6 +266,17 @@ class TestIndexSelectAPI(unittest.TestCase):
             z = paddle.repeat_interleave(x, index, None)
             np_z = z.numpy()
         expect_out = np.repeat(self.data_zero_dim_x, index, axis=None)
+        np.testing.assert_allclose(expect_out, np_z, rtol=1e-05)
+
+        # case 4 zero_dim_index
+        with base.dygraph.guard():
+            x = base.dygraph.to_variable(self.data_zero_dim_x)
+            index = base.dygraph.to_variable(self.data_zero_dim_index)
+            z = paddle.repeat_interleave(x, index, None)
+            np_z = z.numpy()
+        expect_out = np.repeat(
+            self.data_zero_dim_x, self.data_zero_dim_index, axis=None
+        )
         np.testing.assert_allclose(expect_out, np_z, rtol=1e-05)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Adapt 0-d RepeatsTensor in repeat_interleave
示例代码
<img width="346" alt="66862b2864f1a8ddf05f18c61edf723b" src="https://github.com/PaddlePaddle/Paddle/assets/137985359/2e267708-b1da-49d4-a1c6-4f61476b56d7">
适配前的输出
<img width="1214" alt="6a5ae04bdff7acc851485290a79762c2" src="https://github.com/PaddlePaddle/Paddle/assets/137985359/9080d0a0-be6a-4fc0-a867-ad9e42e1cb1e">
适配后的输出
<img width="507" alt="903304ef7db4c677559248d2c8919102" src="https://github.com/PaddlePaddle/Paddle/assets/137985359/384b6087-0b2a-4e0e-bb0e-7b718b7b5752">
PCard-70444