### PR TITLE
[PIR] Fix verify bug

### DIFF
--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -1446,7 +1446,7 @@ bool ProgramInterpreter::HasLocalScope() const {
 // miss. When a model is all KQueueAsync type OPs, all OPs will be distributed
 // to the DeviceThread for execution, and the multithreading scheduling will not
 // have any benefits. Therefore, in the dynamic to static, when the number of
-// KQueueAsync Ops is 0, we choose Trace mode.
+// KQueueSync Ops is 0, we choose Trace mode.
 void ProgramInterpreter::TraceInstructionList(
     const std::vector<Instruction>& vec_instr) {
   unfinished_op_number_ = vec_instr.size();

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -695,41 +695,36 @@ def gen_build_func_str(
     )
 
     GET_ATTRIBUTES_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(
+  IR_ENFORCE(
       attributes.find("{attribute_name}") != attributes.end(),
-      phi::errors::NotFound(
-          "'{attribute_name}' Attribute is expected for {op_name}. "));
+          "'{attribute_name}' Attribute is expected for {op_name}. ");
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<{attr_ir_type}>().data();
 """
     GET_STR_ATTRIBUTES_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(
+  IR_ENFORCE(
       attributes.find("{attribute_name}") != attributes.end(),
-      phi::errors::NotFound(
-          "'{attribute_name}' Attribute is expected for {op_name}. "));
+          "'{attribute_name}' Attribute is expected for {op_name}. ");
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<pir::StrAttribute>().AsString();
 """
     GET_ARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(
+  IR_ENFORCE(
       attributes.find("{attribute_name}") != attributes.end(),
-      phi::errors::NotFound(
-          "'{attribute_name}' Attribute is expected for {op_name}. "));
+          "'{attribute_name}' Attribute is expected for {op_name}. ");
   {attr_type} {attribute_name};
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
     {attribute_name}.push_back(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).dyn_cast<{inner_type}>().{data_name}());
   }}
 """
     GET_INTARRAY_ATTRIBUTE_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(
+  IR_ENFORCE(
       attributes.find("{attribute_name}") != attributes.end(),
-      phi::errors::NotFound(
-          "'{attribute_name}' Attribute is expected for {op_name}. "));
+          "'{attribute_name}' Attribute is expected for {op_name}. ");
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
 """
     GET_SCALAR_ATTRIBUTE_FROM_MAP_TEMPLATE = """
-  PADDLE_ENFORCE(
+  IR_ENFORCE(
       attributes.find("{attribute_name}") != attributes.end(),
-      phi::errors::NotFound(
-          "'{attribute_name}' Attribute is expected for {op_name}. "));
+          "'{attribute_name}' Attribute is expected for {op_name}. ");
   {attr_type} {attribute_name} = attributes.at("{attribute_name}").dyn_cast<paddle::dialect::ScalarAttribute>().data().to<{attr_type}>();
 """
 

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -19,8 +19,8 @@ void {op_name}::VerifySig() {{
   VLOG(4) << "Verifying inputs:";
   {{
   auto input_size = num_operands();
-  PADDLE_ENFORCE_EQ(input_size, {inputs_size}u,
-                    phi::errors::PreconditionNotMet("The size %d of inputs must be equal to {inputs_size}.", input_size));{inputs_type_check}
+  IR_ENFORCE(input_size == {inputs_size}u,
+                    "The size %d of inputs must be equal to {inputs_size}.", input_size);{inputs_type_check}
   }}
   VLOG(4) << "Verifying attributes:";
   {{{attributes_check}
@@ -28,8 +28,8 @@ void {op_name}::VerifySig() {{
   VLOG(4) << "Verifying outputs:";
   {{
   auto output_size = num_results();
-  PADDLE_ENFORCE_EQ(output_size, {outputs_size}u,
-                    phi::errors::PreconditionNotMet("The size %d of outputs must be equal to {outputs_size}.", output_size));{outputs_type_check}
+  IR_ENFORCE(output_size == {outputs_size}u,
+                    "The size %d of outputs must be equal to {outputs_size}.", output_size);{outputs_type_check}
   }}
   VLOG(4) << "End Verifying for: {op_name}.";
 }}
@@ -40,83 +40,83 @@ void {op_name}::VerifySig() {{}}
 """
 
 INPUT_TYPE_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE((*this)->operand_source({index}).type().isa<{standard}>(),
-                  phi::errors::PreconditionNotMet("Type validation failed for the {index}th input."));"""
+  IR_ENFORCE((*this)->operand_source({index}).type().isa<{standard}>(),
+                  "Type validation failed for the {index}th input.");"""
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        PADDLE_ENFORCE(vec_type[i].isa<{standard}>(),
-                       phi::errors::PreconditionNotMet("Type validation failed for the {index}th input."));
+        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                       "Type validation failed for the {index}th input.");
       }}
   }}
   else {{
-    PADDLE_ENFORCE((*this)->operand_source({index}).type().isa<{standard}>(),
-                   phi::errors::PreconditionNotMet("Type validation failed for the {index}th input."));
+    IR_ENFORCE((*this)->operand_source({index}).type().isa<{standard}>(),
+                   "Type validation failed for the {index}th input.");
   }}"""
 INPUT_OPTIONAL_TYPE_CHECK_TEMPLATE = """
   if (auto val = (*this)->operand({index})) {{
-    PADDLE_ENFORCE(val.type().isa<{standard}>(),
-                   phi::errors::PreconditionNotMet("Type validation failed for the {index}th input."));
+    IR_ENFORCE(val.type().isa<{standard}>(),
+                   "Type validation failed for the {index}th input.");
   }}"""
 INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        PADDLE_ENFORCE(vec_type[i].isa<{standard}>(),
-                          phi::errors::PreconditionNotMet("Type validation failed for the {index}th input."));
+        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                          "Type validation failed for the {index}th input.");
       }}
     }}
     else {{
-      PADDLE_ENFORCE(val.type().isa<{standard}>(),
-                        phi::errors::PreconditionNotMet("Type validation failed for the {index}th input."));
+      IR_ENFORCE(val.type().isa<{standard}>(),
+                        "Type validation failed for the {index}th input.");
     }}
   }}"""
 ATTRIBUTE_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.count("{attribute_name}")>0,
-                 phi::errors::PreconditionNotMet("{attribute_name} does not exist."));
-  PADDLE_ENFORCE(attributes.at("{attribute_name}").isa<{standard}>(),
-                 phi::errors::PreconditionNotMet("Type of attribute: {attribute_name} is not {standard}."));
+  IR_ENFORCE(attributes.count("{attribute_name}")>0,
+                 "{attribute_name} does not exist.");
+  IR_ENFORCE(attributes.at("{attribute_name}").isa<{standard}>(),
+                 "Type of attribute: {attribute_name} is not {standard}.");
 """
 ATTRIBUTE_VECTOR_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE(attributes.count("{attribute_name}")>0,
-                 phi::errors::PreconditionNotMet("{attribute_name} does not exist."));
-  PADDLE_ENFORCE(attributes.at("{attribute_name}").isa<pir::ArrayAttribute>(),
-                 phi::errors::PreconditionNotMet("Type of attribute: {attribute_name} is not pir::ArrayAttribute."));
+  IR_ENFORCE(attributes.count("{attribute_name}")>0,
+                 "{attribute_name} does not exist.");
+  IR_ENFORCE(attributes.at("{attribute_name}").isa<pir::ArrayAttribute>(),
+                 "Type of attribute: {attribute_name} is not pir::ArrayAttribute.");
   for (size_t i = 0; i < attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().size(); i++) {{
-    PADDLE_ENFORCE(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).isa<{standard}>(),
-                   phi::errors::PreconditionNotMet("Type of attribute: {attribute_name} is not right."));
+    IR_ENFORCE(attributes.at("{attribute_name}").dyn_cast<pir::ArrayAttribute>().at(i).isa<{standard}>(),
+                   "Type of attribute: {attribute_name} is not right.");
   }}"""
 OUTPUT_TYPE_CHECK_TEMPLATE = """
-  PADDLE_ENFORCE((*this)->result({index}).type().isa<{standard}>(),
-                 phi::errors::PreconditionNotMet("Type validation failed for the {index}th output."));"""
+  IR_ENFORCE((*this)->result({index}).type().isa<{standard}>(),
+                 "Type validation failed for the {index}th output.");"""
 OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      PADDLE_ENFORCE(vec_type[i].isa<{standard}>(),
-                     phi::errors::PreconditionNotMet("Type validation failed for the {index}th output."));
+      IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                     "Type validation failed for the {index}th output.");
     }}
   }}
   else {{
-    PADDLE_ENFORCE(output_{index}_type.isa<{standard}>(),
-                   phi::errors::PreconditionNotMet("Type validation failed for the {index}th output."));
+    IR_ENFORCE(output_{index}_type.isa<{standard}>(),
+                   "Type validation failed for the {index}th output.");
   }}"""
 OUTPUT_OPTIONAL_TYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
-    PADDLE_ENFORCE(output_{index}_type.isa<{standard}>(),
-                   phi::errors::PreconditionNotMet("Type validation failed for the {index}th output."));
+    IR_ENFORCE(output_{index}_type.isa<{standard}>(),
+                   "Type validation failed for the {index}th output.");
   }}"""
 OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        PADDLE_ENFORCE(vec_type[i].isa<{standard}>(),
-                       phi::errors::PreconditionNotMet("Type validation failed for the {index}th output."));
+        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                       "Type validation failed for the {index}th output.");
       }}
     }}
     else {{
-      PADDLE_ENFORCE(output_{index}_type.isa<{standard}>(),
-                     phi::errors::PreconditionNotMet("Type validation failed for the {index}th output."));
+      IR_ENFORCE(output_{index}_type.isa<{standard}>(),
+                     "Type validation failed for the {index}th output.");
     }}
   }}"""
 

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -25,10 +25,6 @@
 #include "paddle/pir/core/region.h"
 #include "paddle/pir/core/utils.h"
 
-#include "paddle/fluid/platform/enforce.h"
-#include "paddle/fluid/platform/errors.h"
-#include "paddle/phi/api/all.h"
-
 namespace pir {
 using detail::OpInlineResultImpl;
 using detail::OpOperandImpl;

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -129,9 +129,9 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
   if (op_info) {
     try {
       op_info.VerifySig(op);
-    } catch (const std::exception &e) {
+    } catch (const pir::IrNotMetException &e) {
       op->Destroy();
-      throw e.what();
+      throw e;
     }
   }
   return op;

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -25,6 +25,10 @@
 #include "paddle/pir/core/region.h"
 #include "paddle/pir/core/utils.h"
 
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/errors.h"
+#include "paddle/phi/api/all.h"
+
 namespace pir {
 using detail::OpInlineResultImpl;
 using detail::OpOperandImpl;
@@ -123,7 +127,12 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
 
   // 0. Verify
   if (op_info) {
-    op_info.VerifySig(op);
+    try {
+      op_info.VerifySig(op);
+    } catch (const std::exception &e) {
+      op->Destroy();
+      throw e.what();
+    }
   }
   return op;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

PCard-67164

verify报错：PrintOp缺失某一attr后在verify错误时不报正常错误而是抛出段错误

定位发现错误不在调用时期，而在于verify抛出错误报错之后调用析构函数，错误析构了没有成功create的op。现在在尝试对verify进行try-catch，如果有异常直接调用op的析构函数并catch错误。为了在外部获取内部抛出的错误，用IR_ENFORCE替换PADDLE_ENFORCE来捕捉异常。