### PR TITLE
[Distributed]Optimize memory in processgroup

### DIFF
--- a/paddle/fluid/distributed/collective/process_group.h
+++ b/paddle/fluid/distributed/collective/process_group.h
@@ -503,7 +503,13 @@ class ProcessGroupMapFromGid {
 
   void insert(int gid, ProcessGroup* pg) { map_[gid] = pg; }
 
-  ProcessGroup* get(int gid) { return map_.find(gid)->second; }
+  ProcessGroup* get(int gid) {
+    auto it = map_.find(gid);
+    if (it == map_.end()) {
+      return nullptr;
+    }
+    return it->second;
+  }
 
   static std::shared_ptr<ProcessGroupMapFromGid> getInstance() {
     static auto s_instance = std::make_shared<ProcessGroupMapFromGid>();

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -786,9 +786,10 @@ std::shared_ptr<ProcessGroupNCCL::NCCLTask> ProcessGroupNCCL::CreateTask(
     int rank,
     CommType comm_type,
     bool is_sync,
-    bool use_calc_stream) {
+    bool use_calc_stream,
+    int gid) {
   return std::make_shared<ProcessGroupNCCL::NCCLTask>(
-      place, rank, comm_type, is_sync, use_calc_stream);
+      place, rank, comm_type, is_sync, use_calc_stream, gid);
 }
 
 void ProcessGroupNCCL::BroadcastUniqueNCCLID(ncclUniqueId* nccl_id,

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -55,10 +55,12 @@ ProcessGroupNCCL::NCCLTask::NCCLTask(const Place& place,
                                      int rank,
                                      CommType comm_type,
                                      bool sync_op,
-                                     bool use_calc_stream)
+                                     bool use_calc_stream,
+                                     int gid)
     : TaskStream(rank, comm_type, sync_op, use_calc_stream),
       comm_event_(place, platform::GenerateDeviceEventFlag()),
-      task_place_(place) {}
+      task_place_(place),
+      gid_(gid) {}
 
 ProcessGroupNCCL::NCCLTask::~NCCLTask() {}
 
@@ -67,6 +69,15 @@ bool ProcessGroupNCCL::NCCLTask::IsCompleted() { return comm_event_.Query(); }
 void ProcessGroupNCCL::NCCLTask::UpdateWaitChain(
     const phi::DeviceContext& ctx) {
   comm_event_.Record(&ctx);
+}
+
+void ProcessGroupNCCL::NCCLTask::RemoveHolderStreamInGroup() {
+  auto map = distributed::ProcessGroupMapFromGid::getInstance();
+  distributed::ProcessGroup* pg = map->get(gid_);
+  if (!pg) return;
+  auto* pg_nccl = dynamic_cast<ProcessGroupNCCL*>(pg);
+  if (!pg_nccl) return;
+  pg_nccl->EraseTensorHolders();
 }
 
 // TODO(sheniang03): Add timeout for wait, now timeout unused
@@ -97,6 +108,7 @@ bool ProcessGroupNCCL::NCCLTask::Wait(std::chrono::milliseconds timeout) {
     PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceSynchronize());
 #endif
   }
+  RemoveHolderStreamInGroup();
   return true;
 }
 
@@ -884,7 +896,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
     SyncCalcStream(place, key);
   }
 
-  auto task = CreateTask(place, rank_, comm_type, sync_op, use_calc_stream);
+  auto task =
+      CreateTask(place, rank_, comm_type, sync_op, use_calc_stream, gid_);
 
   const auto* calc_ctx = place_to_calc_ctx_.at(key);
   const auto& comm_ctx = place_to_comm_ctx_.at(key);
@@ -921,6 +934,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
       memory::RecordStream(tensor.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);
+    allocation_stream_pairs.emplace_back(tensor.Holder(), nccl_stream);
   }
 
   if (FLAGS_enable_nccl_dynamic_check) {
@@ -974,7 +988,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
     SyncCalcStream(place, key);
   }
 
-  auto task = CreateTask(place, rank_, comm_type, sync_op, use_calc_stream);
+  auto task =
+      CreateTask(place, rank_, comm_type, sync_op, use_calc_stream, gid_);
   const auto* calc_ctx = place_to_calc_ctx_.at(key);
   const auto& comm_ctx = place_to_comm_ctx_.at(key);
 
@@ -1011,6 +1026,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
       memory::RecordStream(tensor.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);
+    allocation_stream_pairs.emplace_back(tensor.Holder(), nccl_stream);
   }
 
   if (FLAGS_enable_nccl_dynamic_check) {

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -217,6 +217,9 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
         memory::EraseStream(holder_ptr, allocation_stream.second);
       }
     }
+    VLOG(5) << "After task wait/synchronize, totoal "
+            << allocation_stream_pairs.size()
+            << " tensors allocation stream have been removed.";
     allocation_stream_pairs.clear();
   }
 

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -60,7 +60,7 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
              CommType CommType,
              const std::vector<phi::DenseTensor>& inputs);
 
-    void RemoveHolderStream();
+    void RemoveHolderStreamInGroup();
 
    private:
     bool block_cpu_in_wait_{false};
@@ -180,7 +180,8 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
                                                          int rank,
                                                          CommType op_type,
                                                          bool sync_op,
-                                                         bool use_calc_stream);
+                                                         bool use_calc_stream,
+                                                         int gid);
 
   void BroadcastUniqueNCCLID(ncclUniqueId* nccl_id,
                              bool is_p2p_op = false,

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -219,7 +219,7 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
     }
     VLOG(5) << "After task wait/synchronize, totoal "
             << allocation_stream_pairs.size()
-            << " tensors allocation stream have been removed.";
+            << " tensor(s) allocation stream have been removed.";
     allocation_stream_pairs.clear();
   }
 

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -427,6 +427,17 @@ class AllocatorFacadePrivate {
     }
   }
 
+  void EraseStream(std::shared_ptr<phi::Allocation> allocation,
+                   gpuStream_t stream) {
+    std::shared_ptr<StreamSafeCUDAAllocation> stream_safe_cuda_allocation =
+        std::dynamic_pointer_cast<StreamSafeCUDAAllocation>(allocation);
+    if (stream_safe_cuda_allocation != nullptr) {
+      stream_safe_cuda_allocation->EraseStream(stream);
+    } else {
+      VLOG(6) << "EraseStream for a non-StreamSafeCUDAAllocation";
+    }
+  }
+
   gpuStream_t GetStream(
       const std::shared_ptr<phi::Allocation>& allocation) const {
     const std::shared_ptr<StreamSafeCUDAAllocation>
@@ -1089,6 +1100,11 @@ uint64_t AllocatorFacade::Release(const platform::CUDAPlace& place,
 void AllocatorFacade::RecordStream(std::shared_ptr<phi::Allocation> allocation,
                                    gpuStream_t stream) {
   GetPrivate()->RecordStream(allocation, stream);
+}
+
+void AllocatorFacade::EraseStream(std::shared_ptr<phi::Allocation> allocation,
+                                  gpuStream_t stream) {
+  GetPrivate()->EraseStream(allocation, stream);
 }
 
 const std::shared_ptr<Allocator>& AllocatorFacade::GetAllocator(

--- a/paddle/fluid/memory/allocation/allocator_facade.h
+++ b/paddle/fluid/memory/allocation/allocator_facade.h
@@ -77,6 +77,8 @@ class AllocatorFacade {
   // TODO(zhiqiu): change gpuStream_t to phi::Stream if needed.
   uint64_t Release(const platform::CUDAPlace& place, gpuStream_t stream);
   void RecordStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream);
+  void EraseStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream);
+
   const std::shared_ptr<Allocator>& GetAllocator(const platform::Place& place,
                                                  gpuStream_t stream);
   gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation) const;

--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
@@ -59,6 +59,12 @@ void StreamSafeCUDAAllocation::RecordStream(gpuStream_t stream) {
   RecordGraphCapturingStreams();
 }
 
+void StreamSafeCUDAAllocation::EraseStream(gpuStream_t stream) {
+  VLOG(8) << "Try remove stream " << stream << " for address " << ptr();
+  std::lock_guard<SpinLock> lock_guard(outstanding_event_map_lock_);
+  outstanding_event_map_.erase(stream);
+}
+
 bool StreamSafeCUDAAllocation::CanBeFreed() {
 #ifdef PADDLE_WITH_CUDA
   if (UNLIKELY(phi::backends::gpu::CUDAGraph::IsThisThreadCapturing())) {

--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
@@ -41,6 +41,7 @@ class StreamSafeCUDAAllocation : public Allocation {
                            StreamSafeCUDAAllocator *allocator);
 
   void RecordStream(gpuStream_t stream);
+  void EraseStream(gpuStream_t stream);
   bool CanBeFreed();
   gpuStream_t GetOwningStream() const;
 

--- a/paddle/fluid/memory/malloc.cc
+++ b/paddle/fluid/memory/malloc.cc
@@ -67,6 +67,11 @@ void RecordStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream) {
                                                               stream);
 }
 
+void EraseStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream) {
+  return allocation::AllocatorFacade::Instance().EraseStream(allocation,
+                                                             stream);
+}
+
 gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation) {
   return allocation::AllocatorFacade::Instance().GetStream(allocation);
 }

--- a/paddle/fluid/memory/malloc.h
+++ b/paddle/fluid/memory/malloc.h
@@ -53,6 +53,8 @@ extern uint64_t Release(const platform::CUDAPlace& place, gpuStream_t stream);
 
 void RecordStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream);
 
+void EraseStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream);
+
 gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation);
 #endif
 }  // namespace memory


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
优化通信库process_group_nccl的显存释放。

1. 每次nccl通信，input调用``RecordStream``，保证通信时input不会提前释放。
2. 每次processgroupnccl 执行``task.Wait()``，擦除该group中的所有record的stream，保证显存复用。




