### PR TITLE
[Dy2St] Refine dy2st unittest decorators name

### DIFF
--- a/test/dygraph_to_static/test_assert.py
+++ b/test/dygraph_to_static/test_assert.py
@@ -17,8 +17,8 @@ import unittest
 import numpy
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 
 import paddle
@@ -37,7 +37,6 @@ def dyfunc_assert_non_variable(x=True):
     assert x
 
 
-# @dy2static_unittest
 class TestAssertVariable(Dy2StTestBase):
     def _run(self, func, x, with_exception, to_static):
         paddle.jit.enable_to_static(to_static)
@@ -53,8 +52,8 @@ class TestAssertVariable(Dy2StTestBase):
         self._run(func, x, with_exception, True)
         self._run(func, x, with_exception, False)
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_non_variable(self):
         self._run_dy_static(
             dyfunc_assert_non_variable, x=False, with_exception=True
@@ -63,8 +62,8 @@ class TestAssertVariable(Dy2StTestBase):
             dyfunc_assert_non_variable, x=True, with_exception=False
         )
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_bool_variable(self):
         self._run_dy_static(
             dyfunc_assert_variable, x=numpy.array([False]), with_exception=True
@@ -73,8 +72,8 @@ class TestAssertVariable(Dy2StTestBase):
             dyfunc_assert_variable, x=numpy.array([True]), with_exception=False
         )
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_int_variable(self):
         self._run_dy_static(
             dyfunc_assert_variable, x=numpy.array([0]), with_exception=True

--- a/test/dygraph_to_static/test_ast_util.py
+++ b/test/dygraph_to_static/test_ast_util.py
@@ -19,8 +19,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 from ifelse_simple_func import (
     dyfunc_with_if_else,
@@ -35,7 +35,6 @@ from paddle.jit.dy2static.utils import ast_to_func
 from paddle.utils import gast
 
 
-# @dy2static_unittest
 class TestAST2Func(Dy2StTestBase):
     """
     TestCase for the transformation from ast.AST into python callable function.
@@ -48,7 +47,7 @@ class TestAST2Func(Dy2StTestBase):
         transformed_func, _ = ast_to_func(ast_root, func)
         return transformed_func
 
-    @ast_only_test
+    @test_ast_only
     def test_ast2func(self):
         def func(x, y):
             return x + y
@@ -56,7 +55,7 @@ class TestAST2Func(Dy2StTestBase):
         x, y = 10, 20
         self.assertEqual(func(x, y), self._ast2func(func)(x, y))
 
-    @ast_only_test
+    @test_ast_only
     def test_ast2func_dygraph(self):
         paddle.disable_static()
         funcs = [dyfunc_with_if_else, dyfunc_with_if_else2, nested_if_else]
@@ -68,8 +67,8 @@ class TestAST2Func(Dy2StTestBase):
                 test_ret = self._ast2func(func)(x_v).numpy()
                 self.assertTrue((true_ret == test_ret).all())
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_ast2func_static(self):
         paddle.enable_static()
 
@@ -88,7 +87,7 @@ class TestAST2Func(Dy2StTestBase):
             ret = exe.run(main_program, fetch_list=[true_ret, test_ret])
             self.assertTrue((ret[0] == ret[1]).all())
 
-    @ast_only_test
+    @test_ast_only
     def test_ast2func_error(self):
         with self.assertRaises(Exception) as e:
             self.assertRaises(TypeError, ast_to_func("x = a + b", 'foo'))

--- a/test/dygraph_to_static/test_backward_without_params.py
+++ b/test/dygraph_to_static/test_backward_without_params.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import (
-    Dy2StTestBase,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 
@@ -32,9 +29,8 @@ class Net(paddle.nn.Layer):
         return out
 
 
-# @dy2static_unittest
 class TestBackwardWithoutParams(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_run(self):
         net = paddle.jit.to_static(Net())
 
@@ -57,9 +53,8 @@ class ZeroSizeNet(paddle.nn.Layer):
         return y, out
 
 
-# @dy2static_unittest
 class TestZeroSizeNet(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_run(self):
         net = paddle.jit.to_static(ZeroSizeNet())
         x = paddle.ones([2, 2])

--- a/test/dygraph_to_static/test_cast.py
+++ b/test/dygraph_to_static/test_cast.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 
 from paddle import base
@@ -60,7 +60,6 @@ def test_mix_cast(x):
     return x
 
 
-# @dy2static_unittest
 class TestCastBase(Dy2StTestBase):
     def setUp(self):
         self.place = (
@@ -89,9 +88,8 @@ class TestCastBase(Dy2StTestBase):
             res = self.func(self.input)
             return res
 
-    @ast_only_test  # TODO: add new symbolic only test.
-    @test_and_compare_with_new_ir(False)
-    # @set_to_static_mode(ToStaticMode.LEGACY_AST)
+    @test_ast_only  # TODO: add new sot only test.
+    @test_legacy_and_pir
     def test_cast_result(self):
         res = self.do_test().numpy()
         self.assertTrue(
@@ -156,8 +154,8 @@ class TestMixCast(TestCastBase):
     def set_func(self):
         self.func = to_static(full_graph=True)(test_mix_cast)
 
-    @ast_only_test  # TODO: add new symbolic only test.
-    @test_and_compare_with_new_ir(False)
+    @test_ast_only  # TODO: add new symbolic only test.
+    @test_legacy_and_pir
     def test_cast_result(self):
         res = self.do_test().numpy()
         self.assertTrue(
@@ -188,8 +186,8 @@ class TestNotVarCast(TestCastBase):
     def set_func(self):
         self.func = to_static(full_graph=True)(test_not_var_cast)
 
-    @ast_only_test
-    @test_and_compare_with_new_ir(False)
+    @test_ast_only
+    @test_legacy_and_pir
     def test_cast_result(self):
         # breakpoint()
         # print("run once!!!")

--- a/test/dygraph_to_static/test_closure_analysis.py
+++ b/test/dygraph_to_static/test_closure_analysis.py
@@ -15,10 +15,7 @@
 import inspect
 import unittest
 
-from dygraph_to_static_utils_new import (
-    Dy2StTestBase,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 from numpy import append
 
 import paddle
@@ -263,7 +260,7 @@ class TestClosureAnalysis_PushPop(TestClosureAnalysis):
 
 
 class TestPushPopTrans(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test(self):
         def vlist_of_dict(x):
             ma = {'a': []}
@@ -274,7 +271,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test2(self):
         import numpy as np
 
@@ -287,7 +284,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test3(self):
         import numpy as np
 
@@ -300,7 +297,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test4(self):
         import numpy as np
 
@@ -313,7 +310,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test5(self):
         import numpy as np
 

--- a/test/dygraph_to_static/test_declarative.py
+++ b/test/dygraph_to_static/test_declarative.py
@@ -19,8 +19,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 from test_basic_api_transformation import dyfunc_to_variable
 
@@ -124,8 +124,8 @@ class TestInputSpec(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_with_input_spec(self):
         with base.dygraph.guard(base.CPUPlace()):
             x = to_variable(np.ones([4, 10]).astype('float32'))
@@ -186,7 +186,7 @@ class TestInputSpec(Dy2StTestBase):
                 )
                 net.add_func(x, y)
 
-    @ast_only_test
+    @test_ast_only
     def test_concrete_program(self):
         with base.dygraph.guard(base.CPUPlace()):
             x = to_variable(np.ones([4, 10]).astype('float32'))
@@ -226,8 +226,8 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
     def setUp(self):
         paddle.jit.enable_to_static(True)
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_with_different_input(self):
         with base.dygraph.guard(base.CPUPlace()):
             x_data = np.ones([16, 10]).astype('float32')
@@ -273,7 +273,7 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
             recent_program = foo.program_cache.last()
             self.assertTrue(first_program == recent_program)
 
-    @ast_only_test
+    @test_ast_only
     def test_get_concrete_program(self):
         foo = to_static(foo_func)
 
@@ -314,8 +314,8 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
                 InputSpec([10]), InputSpec([10]), e=4
             )
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_concrete_program(self):
         with base.dygraph.guard(base.CPUPlace()):
             # usage 1
@@ -364,7 +364,7 @@ class TestInputDefaultName(Dy2StTestBase):
 
 
 class TestDeclarativeAPI(Dy2StTestBase):
-    @ast_only_test
+    @test_ast_only
     def test_error(self):
         func = to_static(dyfunc_to_variable)
 
@@ -388,15 +388,15 @@ class TestDecorateModelDirectly(Dy2StTestBase):
         paddle.jit.enable_to_static(True)
         self.x = to_variable(np.ones([4, 10]).astype('float32'))
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_fake_input(self):
         net = SimpleNet()
         net = to_static(net)
         y = net(self.x)
         self.assertTrue(len(net.forward.program_cache) == 1)
 
-    @ast_only_test
+    @test_ast_only
     def test_input_spec(self):
         net = SimpleNet()
         net = to_static(net, input_spec=[InputSpec([None, 8, 10])])
@@ -454,7 +454,7 @@ class CallNonForwardFuncSubNet(paddle.nn.Layer):
 
 
 class TestCallNonForwardFunc(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_call_non_forward(self):
         paddle.disable_static()
         net = CallNonForwardFuncNet()
@@ -494,7 +494,7 @@ class TestSetBuffers(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_set_buffers1(self):
         paddle.disable_static()
         net = SetBuffersNet1()
@@ -503,7 +503,7 @@ class TestSetBuffers(Dy2StTestBase):
         paddle.jit.save(net, self.model_path)
         paddle.enable_static()
 
-    @ast_only_test
+    @test_ast_only
     def test_set_buffers2(self):
         paddle.disable_static()
         net = SetBuffersNet2()

--- a/test/dygraph_to_static/test_decorator_transform.py
+++ b/test/dygraph_to_static/test_decorator_transform.py
@@ -21,8 +21,8 @@ import decos
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 
 import paddle
@@ -186,7 +186,7 @@ def deco_with_paddle_api():
 
 
 class TestDecoratorTransform(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_deco_transform(self):
         outs = paddle.jit.to_static(forward)()
         np.testing.assert_allclose(outs[0], np.array(3), rtol=1e-05)
@@ -198,7 +198,7 @@ class TestDecoratorTransform(Dy2StTestBase):
         np.testing.assert_allclose(outs[6], np.array(9), rtol=1e-05)
         np.testing.assert_allclose(outs[7], np.array(10), rtol=1e-05)
 
-    @ast_only_test
+    @test_ast_only
     def test_contextmanager_warning(self):
         paddle.disable_static()
         with warnings.catch_warnings(record=True) as w:
@@ -215,7 +215,7 @@ class TestDecoratorTransform(Dy2StTestBase):
                     break
             self.assertTrue(flag)
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_deco_with_paddle_api(self):
         self.assertTrue(deco_with_paddle_api())
 

--- a/test/dygraph_to_static/test_deepcopy.py
+++ b/test/dygraph_to_static/test_deepcopy.py
@@ -16,19 +16,15 @@ import unittest
 from copy import deepcopy
 
 import numpy as np
-from dygraph_to_static_utils_new import (
-    Dy2StTestBase,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 from test_rollback import Net, foo
 
 import paddle
 from paddle.jit.dy2static.program_translator import StaticFunction
 
 
-# @dy2static_unittest
 class TestDeepCopy(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_net(self):
         net = Net()
         net = paddle.jit.to_static(net)
@@ -44,7 +40,7 @@ class TestDeepCopy(Dy2StTestBase):
         self.assertTrue(id(copy_net), id(copy_net.forward.__self__))
         np.testing.assert_array_equal(src_out.numpy(), copy_out.numpy())
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_func(self):
         st_foo = paddle.jit.to_static(foo)
         x = paddle.randn([3, 4])

--- a/test/dygraph_to_static/test_grid_generator.py
+++ b/test/dygraph_to_static/test_grid_generator.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import (
-    Dy2StTestBase,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, compare_legacy_with_pir
 
 import paddle
 from paddle import ParamAttr, nn
@@ -133,7 +130,7 @@ class TestGridGenerator(Dy2StTestBase):
     def setUp(self):
         self.x = paddle.uniform(shape=[1, 20, 2], dtype='float32')
 
-    @test_and_compare_with_new_ir(True)
+    @compare_legacy_with_pir
     def _run(self, to_static):
         paddle.jit.enable_to_static(to_static)
 

--- a/test/dygraph_to_static/test_load_transformer.py
+++ b/test/dygraph_to_static/test_load_transformer.py
@@ -16,10 +16,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import (
-    Dy2StTestBase,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 
@@ -48,7 +45,7 @@ class TestFallback(Dy2StTestBase):
     def setUp(self):
         self.x = paddle.to_tensor(1.0).astype('int')
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_name_load(self):
         net_dy = Net()
         net_st = Net()
@@ -58,7 +55,7 @@ class TestFallback(Dy2StTestBase):
 
 
 class TestLoad2(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_name_load_nograd(self):
         @paddle.no_grad()
         def func(x):

--- a/test/dygraph_to_static/test_partial_program.py
+++ b/test/dygraph_to_static/test_partial_program.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 from test_fetch_feed import Linear
 
@@ -89,7 +89,7 @@ class TestWithNestedInput(Dy2StTestBase):
 
         return out.numpy()
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_nest(self):
         dygraph_res = self._run(to_static=False)
         static_res = self._run(to_static=True)
@@ -116,7 +116,7 @@ class TestWithNestedOutput(Dy2StTestBase):
 
         return out
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_nest(self):
         dygraph_res = self._run(to_static=False)
         dygraph_res = paddle.utils.flatten(dygraph_res)
@@ -136,8 +136,8 @@ class TestWithNestedOutput(Dy2StTestBase):
 
 
 class TestWithTrainAndEval(Dy2StTestBase):
-    @ast_only_test
-    @test_and_compare_with_new_ir(False)
+    @test_ast_only
+    @test_legacy_and_pir
     def test_switch_eval_and_train(self):
         with base.dygraph.guard():
             linear_net = Linear()
@@ -169,8 +169,8 @@ class TestWithTrainAndEval(Dy2StTestBase):
 
 
 class TestWithNoGrad(Dy2StTestBase):
-    @ast_only_test
-    @test_and_compare_with_new_ir(False)
+    @test_ast_only
+    @test_legacy_and_pir
     def test_with_no_grad(self):
         with base.dygraph.guard():
             linear_net = Linear()
@@ -205,7 +205,7 @@ class GPT2LMHeadModel(paddle.nn.Layer):
 
 
 class TestPruneUnusedParamInProgram(Dy2StTestBase):
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_prune(self):
         input_ids = np.array([[15, 11, 6, 3, 18, 13]]).astype("float32")
 

--- a/test/dygraph_to_static/test_partial_program_hook.py
+++ b/test/dygraph_to_static/test_partial_program_hook.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 from dygraph_to_static_util import dy2static_unittest
 
 import paddle
 from paddle.base import core
+from paddle.jit.api import ENV_ENABLE_SOT
 from paddle.jit.dy2static import partial_program, program_translator
 
 
 @dy2static_unittest
 class TestPartiaProgramLayerHook(unittest.TestCase):
     def setUp(self):
-        os.environ["ENABLE_FALL_BACK"] = "False"
+        ENV_ENABLE_SOT.set(False)
         self._hook = partial_program.PartialProgramLayerHook()
 
     def test_before_append_backward(self):
@@ -41,7 +41,7 @@ class TestPartiaProgramLayerHook(unittest.TestCase):
 @dy2static_unittest
 class TestPrimHook(unittest.TestCase):
     def setUp(self):
-        os.environ["ENABLE_FALL_BACK"] = "False"
+        ENV_ENABLE_SOT.set(False)
         core._set_prim_all_enabled(False)
 
         def f():

--- a/test/dygraph_to_static/test_set_dynamic_shape.py
+++ b/test/dygraph_to_static/test_set_dynamic_shape.py
@@ -14,13 +14,13 @@
 
 import unittest
 
-from dygraph_to_static_utils_new import Dy2StTestBase, ast_only_test
+from dygraph_to_static_utils_new import Dy2StTestBase, test_ast_only
 
 import paddle
 
 
 class TestSetDynamicShape(Dy2StTestBase):
-    @ast_only_test
+    @test_ast_only
     def test_start(self):
         def dygraph_func(loop_number):
             mask = paddle.randn([2, 2])

--- a/test/dygraph_to_static/test_spec_names.py
+++ b/test/dygraph_to_static/test_spec_names.py
@@ -16,8 +16,8 @@ import unittest
 
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    test_ast_only,
+    test_legacy_and_pir,
 )
 
 import paddle
@@ -48,8 +48,8 @@ class TestArgsSpecName(Dy2StTestBase):
         self.m = paddle.randn([4, 2, 8])
         self.n = paddle.randn([4, 2, 8])
 
-    @test_and_compare_with_new_ir(False)
-    @ast_only_test
+    @test_legacy_and_pir
+    @test_ast_only
     def test_spec_name_hash(self):
         net = Net()
         net = paddle.jit.to_static(net)

--- a/test/dygraph_to_static/test_tensor_shape.py
+++ b/test/dygraph_to_static/test_tensor_shape.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    ast_only_test,
-    test_and_compare_with_new_ir,
+    compare_legacy_with_pir,
+    test_ast_only,
 )
 
 import paddle
@@ -266,7 +266,7 @@ class TestTensorShapeBasic(Dy2StTestBase):
     def get_dygraph_output(self):
         return self._run(to_static=False)
 
-    @test_and_compare_with_new_ir(True)
+    @compare_legacy_with_pir
     def get_static_output(self):
         return self._run(to_static=True)
 
@@ -293,7 +293,7 @@ class TestTensorShapeBasic(Dy2StTestBase):
                 [op for op in block.ops if op.type == "slice"]
             )
 
-    @ast_only_test
+    @test_ast_only
     def test_op_num(self):
         static_layer = paddle.jit.to_static(self.dygraph_func, self.input_spec)
         program = static_layer.main_program
@@ -526,7 +526,7 @@ class TestOpNumBasicWithTensorShape(Dy2StTestBase):
                 [op for op in block.ops if op.type == "slice"]
             )
 
-    @ast_only_test
+    @test_ast_only
     def test_op_num(self):
         static_layer = paddle.jit.to_static(self.dygraph_func, self.input_spec)
         program = static_layer.main_program
@@ -617,7 +617,7 @@ def dyfunc_with_static_convert_var_shape(x):
 
 
 class TestFindStatiConvertVarShapeSuffixVar(Dy2StTestBase):
-    @ast_only_test
+    @test_ast_only
     def test(self):
         x_spec = paddle.static.InputSpec(shape=[None, 10])
         func = paddle.jit.to_static(dyfunc_with_if_2, input_spec=[x_spec])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

- 调整 #57824 新增的装饰器的名字，将会在近期对相关装饰器进行推全
    - `ast_only_test` -> `test_ast_only`
    - `sot_only_test` -> `test_sot_only`
    - `test_with_new_ir` -> `test_pir_only`
    - `test_and_compare_with_new_ir(False)` -> `test_legacy_and_pir`
    - `test_and_compare_with_new_ir(True)` -> `compare_legacy_with_pir`（注意该装饰器和其他装饰器是完全不一样的）
    - `enable_fallback_guard` -> `paddle.jit.api.sot_mode_guard`
- 将 #58301 遗留的 `ENABLE_FALL_BACK` 也用新的环境变量管理机制，避免在各种地方写各种环境变量

PCard-66972