### PR TITLE
Improve send recv overlap

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -357,7 +357,7 @@ class Parallelizer:
 
         if self._strategy.mp_optimization.allreduce_matmul_grad_overlapping:
             if int(os.getenv("CUDA_DEVICE_MAX_CONNECTIONS", "0")) != 1:
-                self.logger.warning(
+                self._logger.warning(
                     "You set mp_optimization.allreduce_matmul_grad_overlapping=True, but you did not set environment "
                     "variable CUDA_DEVICE_MAX_CONNECTIONS=1, which may leads to performance "
                     "loss. Try to export CUDA_DEVICE_MAX_CONNECTIONS=1 for better performance."
@@ -443,7 +443,7 @@ class Parallelizer:
                 enable_send_recv_overlap
                 and int(os.getenv("CUDA_DEVICE_MAX_CONNECTIONS", "0")) != 1
             ):
-                self.logger.warning(
+                self._logger.warning(
                     "You set pipeline.enable_send_recv_overlap=True, but you did not set environment "
                     "variable CUDA_DEVICE_MAX_CONNECTIONS=1, which may leads to performance "
                     "loss. Try to export CUDA_DEVICE_MAX_CONNECTIONS=1 for better performance."

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -356,6 +356,13 @@ class Parallelizer:
             params_grads = self._pass_context.get_attr("params_grads")
 
         if self._strategy.mp_optimization.allreduce_matmul_grad_overlapping:
+            if int(os.getenv("CUDA_DEVICE_MAX_CONNECTIONS", "0")) != 1:
+                self.logger.warning(
+                    "You set mp_optimization.allreduce_matmul_grad_overlapping=True, but you did not set environment "
+                    "variable CUDA_DEVICE_MAX_CONNECTIONS=1, which may leads to performance "
+                    "loss. Try to export CUDA_DEVICE_MAX_CONNECTIONS=1 for better performance."
+                )
+
             allreduce_matmul_grad_overlapping_pass = new_pass(
                 "allreduce_matmul_grad_overlapping", {}
             )
@@ -436,10 +443,11 @@ class Parallelizer:
                 enable_send_recv_overlap
                 and int(os.getenv("CUDA_DEVICE_MAX_CONNECTIONS", "0")) != 1
             ):
-                self._logger.warning(
-                    "enable_send_recv_overlap requires environment variable CUDA_DEVICE_MAX_CONNECTIONS=1, but you did not set it. Paddle has been automatically set CUDA_DEVICE_MAX_CONNECTIONS to 1, try export CUDA_DEVICE_MAX_CONNECTIONS=1 to make this warning disappear."
+                self.logger.warning(
+                    "You set pipeline.enable_send_recv_overlap=True, but you did not set environment "
+                    "variable CUDA_DEVICE_MAX_CONNECTIONS=1, which may leads to performance "
+                    "loss. Try to export CUDA_DEVICE_MAX_CONNECTIONS=1 for better performance."
                 )
-                os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
 
             main_program._pipeline_opt = {}
             main_program._pipeline_opt["standalone_opt"] = {

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -35,6 +35,8 @@ __not_shape_var_type__ = [
     core.VarDesc.VarType.FETCH_LIST,
 ]
 
+logger = get_logger(logging.INFO)
+
 
 # NOTE: Here stream is just a presentation with different name,
 # it is up to executor to create the exact streams given the name.
@@ -264,7 +266,7 @@ def set_skip_gc_vars(num_micro_batches, type_to_program, jobs):
         required_vars = type_to_required_vars[job_type]
         micro_batch_id = job.micro_batch_id()
         skip_gc_vars = required_vars & suffixed_required_vars[micro_batch_id]
-        get_logger(logging.INFO).info(
+        logger.debug(
             f"Skip gc vars for {job_type}-({micro_batch_id}): {skip_gc_vars}"
         )
 

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass.py
@@ -379,10 +379,10 @@ class Pipeline1F1BPass(PipelinePassBase):
             )
 
         for i in range(len(types)):
-            logger.info(
+            logger.debug(
                 f"type = {types[i]}, sub_programs = {sub_programs[i]}\n"
             )
-        logger.info(f"jobs_in_stable_phase = {self.jobs_in_stable_phase}")
+        logger.debug(f"jobs_in_stable_phase = {self.jobs_in_stable_phase}")
 
         return types, sub_programs
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
PCard-71568

完善send-recv overlap：
1. 修复`auto_parallel.Strategy.pipeline.enable_send_recv_overlap`配置开关不生效问题
2. 增加配合环境变量`CUDA_DEVICE_MAX_CONNECTIONS`使用的用户提示。在设置`CUDA_DEVICE_MAX_CONNECTIONS=1`的情况下，`allreduce_matmul_grad_overlapping`和`enable_send_recv_overlap`策略可通过特定patten下的多流overlapping提升性能。但在未设置`CUDA_DEVICE_MAX_CONNECTIONS=1`时，因多流场景下device端通信和计算调度顺序不可控，可能出现计算kernel提前调度、占满资源阻塞通信拉起而导致端到端降速。
3. 将部分log信息输出级别从`INFO`更改为`DEBUG`，减少缺省状态下log数量。