### PR TITLE
【PIR API adaptor No.24-26】Migrate paddle.bitwise_not/bitwise_or/bitwise_xor into pir

### DIFF
--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -1234,7 +1234,7 @@ def bitwise_or_(x, y, name=None):
                 out_shape, x.shape
             )
         )
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         return _C_ops.bitwise_or_(x, y)
 
 
@@ -1292,7 +1292,7 @@ def bitwise_xor_(x, y, name=None):
                 out_shape, x.shape
             )
         )
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         return _C_ops.bitwise_xor_(x, y)
 
 
@@ -1342,7 +1342,7 @@ def bitwise_not_(x, name=None):
     Inplace version of ``bitwise_not`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_bitwise_not`.
     """
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         return _C_ops.bitwise_not_(x)
 
 

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -1213,7 +1213,7 @@ def bitwise_or(x, y, out=None, name=None):
             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [-1, -1, -3])
     """
-    if in_dynamic_mode() and out is None:
+    if in_dynamic_or_pir_mode() and out is None:
         return _C_ops.bitwise_or(x, y)
 
     return _bitwise_op(
@@ -1234,7 +1234,7 @@ def bitwise_or_(x, y, name=None):
                 out_shape, x.shape
             )
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.bitwise_or_(x, y)
 
 
@@ -1272,7 +1272,7 @@ def bitwise_xor(x, y, out=None, name=None):
             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [-1, -3, -4])
     """
-    if in_dynamic_mode() and out is None:
+    if in_dynamic_or_pir_mode() and out is None:
         return _C_ops.bitwise_xor(x, y)
     return _bitwise_op(
         op_name="bitwise_xor", x=x, y=y, name=name, out=out, binary_op=True
@@ -1292,7 +1292,7 @@ def bitwise_xor_(x, y, name=None):
                 out_shape, x.shape
             )
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.bitwise_xor_(x, y)
 
 
@@ -1328,7 +1328,7 @@ def bitwise_not(x, out=None, name=None):
             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [ 4,  0, -2])
     """
-    if in_dynamic_mode() and out is None:
+    if in_dynamic_or_pir_mode() and out is None:
         return _C_ops.bitwise_not(x)
 
     return _bitwise_op(
@@ -1342,7 +1342,7 @@ def bitwise_not_(x, name=None):
     Inplace version of ``bitwise_not`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_bitwise_not`.
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.bitwise_not_(x)
 
 

--- a/test/legacy_test/test_bitwise_op.py
+++ b/test/legacy_test/test_bitwise_op.py
@@ -150,7 +150,7 @@ class TestBitwiseOr(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output(check_cinn=True)
+        self.check_output(check_cinn=True, check_pir=True)
 
     def test_check_grad(self):
         pass
@@ -258,7 +258,7 @@ class TestBitwiseXor(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output(check_cinn=True)
+        self.check_output(check_cinn=True, check_pir=True)
 
     def test_check_grad(self):
         pass
@@ -363,7 +363,7 @@ class TestBitwiseNot(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output(check_cinn=True)
+        self.check_output(check_cinn=True, check_pir=True)
 
     def test_check_grad(self):
         pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067
No.24 No.25 No.26
PIR API 推全升级
将 `paddle.bitwise_not` 迁移升级至 pir，并更新单测，单测覆盖率：6/6
将 `paddle.bitwise_or` 迁移升级至 pir，并更新单测，单测覆盖率：8/8
将 `paddle.bitwise_xor` 迁移升级至 pir，并更新单测，单测覆盖率：8/8