### PR TITLE
【PIR API adaptor No.10、11】Migrate paddle.as_real/as_complex into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4461,7 +4461,7 @@ def as_complex(x, name=None):
             [[1j      , (2+3j)  , (4+5j)  ],
              [(6+7j)  , (8+9j)  , (10+11j)]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.as_complex(x)
     else:
         check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'as_complex')
@@ -4512,7 +4512,7 @@ def as_real(x, name=None):
              [8. , 9. ],
              [10., 11.]]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.as_real(x)
     else:
         check_variable_and_dtype(x, 'x', ['complex64', 'complex128'], 'as_real')

--- a/test/legacy_test/test_complex_view_op.py
+++ b/test/legacy_test/test_complex_view_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 import paddle
 from paddle import static
 from paddle.base import dygraph
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -43,7 +44,7 @@ class TestViewAsComplexOp(OpTest):
         self.outputs = {'Out': out_ref}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -64,7 +65,7 @@ class TestViewAsRealOp(OpTest):
         self.python_api = paddle.as_real
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -84,6 +85,7 @@ class TestViewAsComplexAPI(unittest.TestCase):
             out_np = paddle.as_complex(x).numpy()
         np.testing.assert_allclose(self.out, out_np, rtol=1e-05)
 
+    @test_with_pir_api
     def test_static(self):
         mp, sp = static.Program(), static.Program()
         with static.program_guard(mp, sp):
@@ -107,6 +109,7 @@ class TestViewAsRealAPI(unittest.TestCase):
             out_np = paddle.as_real(x).numpy()
         np.testing.assert_allclose(self.out, out_np, rtol=1e-05)
 
+    @test_with_pir_api
     def test_static(self):
         mp, sp = static.Program(), static.Program()
         with static.program_guard(mp, sp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067
No.10 as_complex
No.11 as_real
PIR API 推全升级
将 `paddle.as_complex` 迁移升级至 pir，并更新单测，单测覆盖率：2/2
将 `paddle.as_real` 迁移升级至 pir，并更新单测，单测覆盖率：2/2
