### PR TITLE
Fix nccl trace

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -114,6 +114,11 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       pg_timeout_(timeout) {
   LOG(INFO) << "ProcessGroupNCCL pg_timeout_ " << pg_timeout_;
 }
+ProcessGroupNCCL::~ProcessGroupNCCL() {
+    LOG(INFO) << "ProcessGroupNCCL destruct ";
+    auto& comm_task_manager = phi::distributed::CommTaskManager::GetInstance();
+    comm_task_manager.Stop();
+}
 
 void ProcessGroupNCCL::GroupStart() {
   NCCL_CHECK(phi::dynload::ncclGroupStart());

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -115,9 +115,9 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   LOG(INFO) << "ProcessGroupNCCL pg_timeout_ " << pg_timeout_;
 }
 ProcessGroupNCCL::~ProcessGroupNCCL() {
-    LOG(INFO) << "ProcessGroupNCCL destruct ";
-    auto& comm_task_manager = phi::distributed::CommTaskManager::GetInstance();
-    comm_task_manager.Stop();
+  LOG(INFO) << "ProcessGroupNCCL destruct ";
+  auto& comm_task_manager = phi::distributed::CommTaskManager::GetInstance();
+  comm_task_manager.Stop();
 }
 
 void ProcessGroupNCCL::GroupStart() {

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -78,6 +78,7 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
                    int size,
                    int gid,
                    int64_t timeout = 20 * 1000);
+  ~ProcessGroupNCCL();
 
   std::string GetBackendName() const override { return "NCCL"; }
 

--- a/paddle/phi/core/distributed/comm_task_manager.cc
+++ b/paddle/phi/core/distributed/comm_task_manager.cc
@@ -112,9 +112,9 @@ void CommTaskManager::CommTaskLoop() {
         iter = comm_task_list_.erase(iter);
       } else {
         if (task->IsStarted() && task->IsCompleted()) {
-            iter = comm_task_list_.erase(iter);
+          iter = comm_task_list_.erase(iter);
         } else {
-            ++iter;
+          ++iter;
         }
       }
     }

--- a/paddle/phi/core/distributed/comm_task_manager.cc
+++ b/paddle/phi/core/distributed/comm_task_manager.cc
@@ -88,7 +88,6 @@ void CommTaskManager::Stop() {
 void CommTaskManager::CommTaskLoop() {
   bool done = false;
   while (!terminated_.load() || !done) {
-    LOG(INFO) << "CommTaskManager terminated_ " << terminated_.load() << ", done " << done;
     std::unique_lock<std::mutex> lock(comm_task_list_mutex_);
     comm_task_list_cv_.wait_for(
         lock,
@@ -144,9 +143,6 @@ void CommTaskManager::CommTaskLoop() {
       }
     }
 
-    LOG(INFO) << "debug comm_task size: " << comm_task_list_.size()
-              << ", init_comm_task size: " << init_comm_task_map_.size()
-              << ", start_comm_task size: " << start_comm_task_map_.size();
     if (comm_task_list_.empty() && init_comm_task_map_.empty() &&
         start_comm_task_map_.empty()) {
       done = true;

--- a/paddle/phi/core/distributed/comm_task_manager.h
+++ b/paddle/phi/core/distributed/comm_task_manager.h
@@ -47,6 +47,7 @@ class CommTaskManager {
   }
 
   void CommTaskEnqueue(std::shared_ptr<CommTask> comm_task);
+  void Stop();
 
  private:
   void CommTaskLoop();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Pcard-70448
1. comm trace function instance exits when training process finished
