### PR TITLE
[PIR] Migrate paddle.nn.LeakyReLU into pir

### DIFF
--- a/python/paddle/nn/functional/activation.py
+++ b/python/paddle/nn/functional/activation.py
@@ -484,7 +484,7 @@ def leaky_relu(x, negative_slope=0.01, name=None):
             [-0.02000000,  0.        ,  1.        ])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.leaky_relu(x, negative_slope)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -2508,6 +2508,7 @@ class TestLeakyReluAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -2466,12 +2466,12 @@ class TestLeakyRelu(TestActivation):
         pass
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_pir=True)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out', check_prim=True)
+        self.check_grad(['X'], 'Out', check_prim=True, check_pir=True)
 
 
 class TestLeakyReluAlpha1(TestLeakyRelu):
@@ -4751,7 +4751,9 @@ create_test_act_fp16_class(TestHardSigmoid)
 create_test_act_fp16_class(TestSwish)
 create_test_act_fp16_class(TestHardSwish, check_prim=True)
 create_test_act_fp16_class(TestMish)
-create_test_act_fp16_class(TestLeakyRelu, check_prim=True, enable_cinn=True)
+create_test_act_fp16_class(
+    TestLeakyRelu, check_prim=True, enable_cinn=True, check_pir=True
+)
 create_test_act_fp16_class(
     TestLeakyReluAlpha1, check_prim=True, enable_cinn=True
 )
@@ -4899,7 +4901,7 @@ create_test_act_bf16_class(TestHardSigmoid)
 create_test_act_bf16_class(TestSwish)
 create_test_act_bf16_class(TestHardSwish, check_prim=True)
 create_test_act_bf16_class(TestMish)
-create_test_act_bf16_class(TestLeakyRelu, check_prim=True)
+create_test_act_bf16_class(TestLeakyRelu, check_prim=True, check_pir=True)
 create_test_act_bf16_class(TestLeakyReluAlpha1, check_prim=True)
 create_test_act_bf16_class(TestLeakyReluAlpha2, check_prim=True)
 create_test_act_bf16_class(TestLeakyReluAlpha3, check_prim=True)

--- a/test/mkldnn/test_activation_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_activation_bf16_mkldnn_op.py
@@ -202,20 +202,6 @@ class TestMKLDNNLeakyReluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         self.alpha = 0.2
         self.attrs = {"use_mkldnn": True, "alpha": self.alpha}
 
-    def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace(), check_pir=True)
-
-    def test_check_grad(self):
-        self.calculate_grads()
-        self.check_grad_with_place(
-            core.CPUPlace(),
-            ["X"],
-            "Out",
-            user_defined_grads=[self.dx],
-            user_defined_grad_outputs=[convert_float_to_uint16(self.out)],
-            check_pir=True,
-        )
-
 
 class TestMKLDNNSwishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
     def config(self):

--- a/test/mkldnn/test_activation_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_activation_bf16_mkldnn_op.py
@@ -202,6 +202,20 @@ class TestMKLDNNLeakyReluBF16Op(MKLDNNBF16ActivationOp, TestActivation):
         self.alpha = 0.2
         self.attrs = {"use_mkldnn": True, "alpha": self.alpha}
 
+    def test_check_output(self):
+        self.check_output_with_place(core.CPUPlace(), check_pir=True)
+
+    def test_check_grad(self):
+        self.calculate_grads()
+        self.check_grad_with_place(
+            core.CPUPlace(),
+            ["X"],
+            "Out",
+            user_defined_grads=[self.dx],
+            user_defined_grad_outputs=[convert_float_to_uint16(self.out)],
+            check_pir=True,
+        )
+
 
 class TestMKLDNNSwishBF16Op(MKLDNNBF16ActivationOp, TestActivation):
     def config(self):


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
PIR API 推全升级
将 paddle.nn.LeakyReLU 迁移升级至 pir，并更新单测 本 pr 进行补充.
paddle.nn.LeakyReLU 中包含 paddle.nn.functional.leaky_relu 调用，故一起进行适配.

单测覆盖率：8/10

TODO：

1. 目前缺少适配 test/legacy_test/test_activation_nn_grad.py 内 `TestLeakyReluDoubleGradCheck`
2. `test/mkldnn/test_activation_bf16_mkldnn_op.py` 内的 `TestMKLDNNLeakyReluBF16Op` 未适配，因为目前 PIR 不支持算子带有 mkldnn 属性