### PR TITLE
【PIR API adaptor No.37、38】 Migrate paddle.cholesky/cholesky_solve into pir

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1539,7 +1539,7 @@ def cholesky(x, upper=False, name=None):
              [1.06467664, 0.17859250, 0.        ],
              [1.30602181, 0.08326444, 0.22790681]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.cholesky(x, upper)
     else:
         check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'cholesky')
@@ -3283,7 +3283,7 @@ def cholesky_solve(x, y, upper=False, name=None):
              [-7.        ],
              [ 9.50000000]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.cholesky_solve(x, y, upper)
     else:
         helper = LayerHelper("cholesky_solve", **locals())

--- a/test/legacy_test/test_cholesky_op.py
+++ b/test/legacy_test/test_cholesky_op.py
@@ -22,6 +22,7 @@ from op_test import OpTest, skip_check_grad_ci
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 @skip_check_grad_ci(
@@ -58,7 +59,7 @@ class TestCholeskyOp(OpTest):
         self.outputs = {"Out": output_data}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         places = [base.CPUPlace()]
@@ -135,6 +136,7 @@ class TestCholeskySingularAPI(unittest.TestCase):
             except ValueError as ex:
                 print("The mat is singular")
 
+    @test_with_pir_api
     def test_static(self):
         for place in self.places:
             self.check_static_result(place=place)

--- a/test/legacy_test/test_cholesky_op.py
+++ b/test/legacy_test/test_cholesky_op.py
@@ -22,7 +22,6 @@ from op_test import OpTest, skip_check_grad_ci
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 
 @skip_check_grad_ci(
@@ -136,7 +135,6 @@ class TestCholeskySingularAPI(unittest.TestCase):
             except ValueError as ex:
                 print("The mat is singular")
 
-    @test_with_pir_api
     def test_static(self):
         for place in self.places:
             self.check_static_result(place=place)

--- a/test/legacy_test/test_cholesky_solve_op.py
+++ b/test/legacy_test/test_cholesky_solve_op.py
@@ -25,6 +25,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -139,7 +140,7 @@ class TestCholeskySolveOp(OpTest):
 
     # check Op forward result
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     # check Op grad
     def test_check_grad_normal(self):
@@ -193,6 +194,7 @@ class TestCholeskySolveAPI(unittest.TestCase):
             )
             np.testing.assert_allclose(fetches[0], z_np, rtol=1e-05)
 
+    @test_with_pir_api
     # test in static graph mode
     def test_static(self):
         for place in self.place:
@@ -239,6 +241,7 @@ class TestCholeskySolveAPI(unittest.TestCase):
 
 # test condition out of bounds
 class TestCholeskySolveOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_cholesky_solve_op.py
+++ b/test/legacy_test/test_cholesky_solve_op.py
@@ -25,7 +25,6 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
-from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -194,7 +193,6 @@ class TestCholeskySolveAPI(unittest.TestCase):
             )
             np.testing.assert_allclose(fetches[0], z_np, rtol=1e-05)
 
-    @test_with_pir_api
     # test in static graph mode
     def test_static(self):
         for place in self.place:
@@ -241,7 +239,6 @@ class TestCholeskySolveAPI(unittest.TestCase):
 
 # test condition out of bounds
 class TestCholeskySolveOpError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067
No.37 No.38
PIR API 推全升级
将 `paddle.cholesky` 迁移升级至 pir，并更新单测 单测覆盖率：5/6
将 `paddle.cholesky_solve ` 迁移升级至 pir，并更新单测 单测覆盖率：6/7


problem:
test_cholesky_solve_op.py: static_pir
TypeError: The type of 'main_program' in paddle.static.program_guard must be <class 'paddle.base.libpaddle.pir.Program'>, but received <class 'paddle.base.framework.Program'>. 

test_cholesky.py: static_pir
TypeError: The type of 'main_program' in paddle.static.program_guard must be <class 'paddle.base.libpaddle.pir.Program'>, but received <class 'paddle.base.framework.Program'>. 