### PR TITLE
[PIR] Migrate paddle.nn.MSELoss into pir

### DIFF
--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -62,8 +62,6 @@ class TestMseLoss(unittest.TestCase):
 class TestMseInvalidInput(unittest.TestCase):
     @test_with_pir_api
     def test_error(self):
-        paddle.enable_static()
-
         def test_invalid_input():
             input = [256, 3]
             label = paddle.static.data(
@@ -221,6 +219,7 @@ class TestNNMseLoss(unittest.TestCase):
 
 
 class TestNNFunctionalMseLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_NNFunctionalMseLoss_mean(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
             input_np = np.random.uniform(0.1, 0.5, dim).astype("float32")
@@ -263,6 +262,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
             self.assertEqual(dy_result.shape, ())
 
+    @test_with_pir_api
     def test_NNFunctionalMseLoss_sum(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
             input_np = np.random.uniform(0.1, 0.5, dim).astype("float32")
@@ -305,6 +305,7 @@ class TestNNFunctionalMseLoss(unittest.TestCase):
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
             self.assertEqual(dy_result.shape, ())
 
+    @test_with_pir_api
     def test_NNFunctionalMseLoss_none(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
             input_np = np.random.uniform(0.1, 0.5, dim).astype("float32")

--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -20,9 +20,11 @@ import paddle
 from paddle import base
 from paddle.base import core
 from paddle.base.executor import Executor
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestMseLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_mse_loss(self):
         input_val = np.random.uniform(0.1, 0.5, (2, 3)).astype("float32")
         label_val = np.random.uniform(0.1, 0.5, (2, 3)).astype("float32")
@@ -30,30 +32,38 @@ class TestMseLoss(unittest.TestCase):
         sub = input_val - label_val
         np_result = np.mean(sub * sub)
 
-        input_var = paddle.static.data(
-            name="input", shape=[-1, 3], dtype="float32"
-        )
-        label_var = paddle.static.data(
-            name="label", shape=[-1, 3], dtype="float32"
-        )
-
-        output = paddle.nn.functional.mse_loss(input=input_var, label=label_var)
-        for use_cuda in (
-            [False, True] if core.is_compiled_with_cuda() else [False]
-        ):
-            place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
-            exe = Executor(place)
-            (result,) = exe.run(
-                base.default_main_program(),
-                feed={"input": input_val, "label": label_val},
-                fetch_list=[output],
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            input_var = paddle.static.data(
+                name="input", shape=[-1, 3], dtype="float32"
+            )
+            label_var = paddle.static.data(
+                name="label", shape=[-1, 3], dtype="float32"
             )
 
-            np.testing.assert_allclose(np_result, result, rtol=1e-05)
+            output = paddle.nn.functional.mse_loss(
+                input=input_var, label=label_var
+            )
+            for use_cuda in (
+                [False, True] if core.is_compiled_with_cuda() else [False]
+            ):
+                place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
+                exe = Executor(place)
+                (result,) = exe.run(
+                    main,
+                    feed={"input": input_val, "label": label_val},
+                    fetch_list=[output],
+                )
+
+                np.testing.assert_allclose(np_result, result, rtol=1e-05)
 
 
 class TestMseInvalidInput(unittest.TestCase):
+    @test_with_pir_api
     def test_error(self):
+        paddle.enable_static()
+
         def test_invalid_input():
             input = [256, 3]
             label = paddle.static.data(
@@ -74,6 +84,7 @@ class TestMseInvalidInput(unittest.TestCase):
 
 
 class TestNNMseLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_NNMseLoss_mean(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
             input_np = np.random.uniform(0.1, 0.5, dim).astype("float32")
@@ -88,13 +99,11 @@ class TestNNMseLoss(unittest.TestCase):
             )
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
-                    name='input', shape=[-1] + dim, dtype='float32'
+                    name='input', shape=dim, dtype='float32'
                 )
-                input.desc.set_need_check_feed(False)
                 label = paddle.static.data(
-                    name='label', shape=[-1] + dim, dtype='float32'
+                    name='label', shape=dim, dtype='float32'
                 )
-                label.desc.set_need_check_feed(False)
                 mse_loss = paddle.nn.loss.MSELoss()
                 ret = mse_loss(input, label)
 
@@ -120,6 +129,7 @@ class TestNNMseLoss(unittest.TestCase):
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
             self.assertEqual(dy_result.shape, ())
 
+    @test_with_pir_api
     def test_NNMseLoss_sum(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
             input_np = np.random.uniform(0.1, 0.5, dim).astype("float32")
@@ -134,13 +144,11 @@ class TestNNMseLoss(unittest.TestCase):
             )
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
-                    name='input', shape=[-1] + dim, dtype='float32'
+                    name='input', shape=dim, dtype='float32'
                 )
-                input.desc.set_need_check_feed(False)
                 label = paddle.static.data(
-                    name='label', shape=[-1] + dim, dtype='float32'
+                    name='label', shape=dim, dtype='float32'
                 )
-                label.desc.set_need_check_feed(False)
                 mse_loss = paddle.nn.loss.MSELoss(reduction='sum')
                 ret = mse_loss(input, label)
 
@@ -166,6 +174,7 @@ class TestNNMseLoss(unittest.TestCase):
             np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
             self.assertEqual(dy_result.shape, ())
 
+    @test_with_pir_api
     def test_NNMseLoss_none(self):
         for dim in [[10, 10], [2, 10, 10], [3, 3, 10, 10]]:
             input_np = np.random.uniform(0.1, 0.5, dim).astype("float32")
@@ -180,13 +189,11 @@ class TestNNMseLoss(unittest.TestCase):
             )
             with base.program_guard(prog, startup_prog):
                 input = paddle.static.data(
-                    name='input', shape=[-1] + dim, dtype='float32'
+                    name='input', shape=dim, dtype='float32'
                 )
-                input.desc.set_need_check_feed(False)
                 label = paddle.static.data(
-                    name='label', shape=[-1] + dim, dtype='float32'
+                    name='label', shape=dim, dtype='float32'
                 )
-                label.desc.set_need_check_feed(False)
                 mse_loss = paddle.nn.loss.MSELoss(reduction='none')
                 ret = mse_loss(input, label)
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
PIR API 推全升级
将 paddle.nn.MSELoss 迁移升级至 pir，并更新单测. 
将 paddle.nn.functional.mse_loss 的单测迁移到 pir 体系下

单测覆盖率：4/4
