### PR TITLE
[DistTensor] set rank_is_in_current_mesh default value to false

### DIFF
--- a/paddle/phi/api/yaml/generator/dist_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_api_gen.py
@@ -71,7 +71,7 @@ GET_MESH_TEMPLATE = """
 # Auto Parallel condition
 AUTO_PARALLEL_COND_TEMPLATE = """
   bool run_auto_parallel = AllInputsAreDistTensor({input_args});
-  bool rank_is_in_current_mesh = true;
+  bool rank_is_in_current_mesh = false;
   if (run_auto_parallel) {{{mesh}
   }}
   if (rank_is_in_current_mesh) {{{kernel_code}

--- a/paddle/phi/api/yaml/generator/dist_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_api_gen.py
@@ -103,11 +103,11 @@ INPLACE_API_OUT_CREATION_TEMPLATE = """
 SINGLE_OUT_CREATION_TEMPLATE_NO_SPMD = """
     auto dist_out = SetKernelDistOutput(&api_output);
     auto dense_out = dist_out->unsafe_mutable_value();
-    if (!rank_is_in_current_mesh) {{
+    if (!rank_is_in_current_mesh) {
       *dense_out = phi::DenseTensor(
             std::make_shared<phi::Allocation>(nullptr, 0, phi::distributed::GetDefaultPlace()),
             phi::DenseTensorMeta());
-    }}
+    }
 """
 MULTI_SINGLE_OUT_CREATION_TEMPLATE_NO_SPMD = """
     auto dist_out_{idx} = SetKernelDistOutput({out});


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
修复一处小问题。rank_is_in_current_mesh 的默认值应该为false。否则在非Dist模式下，rank_is_in_current_mesh 的值为true，会有无效执行逻辑。