### PR TITLE
[PIR]Support generate op that is used for pir only

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/CMakeLists.txt
+++ b/paddle/cinn/hlir/dialect/operator/ir/CMakeLists.txt
@@ -17,12 +17,16 @@ if(NOT CINN_ONLY)
   set(cinn_op_yaml_file
       ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/operator/ir/ops.yaml)
 
+  set(cinn_update_op_yaml_file
+      ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/operator/ir/update_ops.yaml)
+
   set(parsed_op_dir ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/generated)
 
-  set(cinn_op_parsed_yaml_file ${parsed_op_dir}/ops.parsed.yaml
-                               ${parsed_op_dir}/update_ops.parsed.yaml)
+  set(cinn_op_parsed_yaml_file ${parsed_op_dir}/ops.parsed.yaml)
+  set(cinn_update_op_parsed_yaml_file ${parsed_op_dir}/update_ops.parsed.yaml)
 
-  set(cinn_op_parsed_yaml_files ${cinn_op_parsed_yaml_file})
+  set(cinn_op_parsed_yaml_files ${cinn_op_parsed_yaml_file}
+                                ${cinn_update_op_parsed_yaml_file})
 
   set(cinn_op_namespace cinn,dialect)
   set(cinn_op_dialect_name cinn_op)
@@ -32,11 +36,16 @@ if(NOT CINN_ONLY)
   set(cinn_op_source_file_tmp ${cinn_op_source_file}.tmp)
 
   add_custom_command(
-    OUTPUT ${cinn_op_parsed_yaml_file}
+    OUTPUT ${cinn_op_parsed_yaml_file} ${cinn_update_op_parsed_yaml_file}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${parsed_op_dir}
     COMMAND ${PYTHON_EXECUTABLE} ${cinn_op_gen_parsed_yaml_file} --op_yaml_path
             ${cinn_op_yaml_file} --output_path ${cinn_op_parsed_yaml_file}
+    COMMAND
+      ${PYTHON_EXECUTABLE} ${cinn_op_gen_parsed_yaml_file} --op_yaml_path
+      ${cinn_update_op_yaml_file} --output_path
+      ${cinn_update_op_parsed_yaml_file}
     DEPENDS ${cinn_op_gen_parsed_yaml_file} ${cinn_op_yaml_file}
+            ${cinn_update_op_yaml_file}
     VERBATIM)
 
   add_custom_command(
@@ -52,7 +61,7 @@ if(NOT CINN_ONLY)
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${cinn_op_source_file_tmp}
             ${cinn_op_source_file}
     DEPENDS ${cinn_op_gen_file} ${cinn_op_parsed_yaml_file}
-            ${cinn_op_compat_yaml_file}
+            ${cinn_update_op_parsed_yaml_file} ${cinn_op_compat_yaml_file}
     VERBATIM)
 
   cinn_cc_library(

--- a/paddle/cinn/hlir/dialect/operator/ir/CMakeLists.txt
+++ b/paddle/cinn/hlir/dialect/operator/ir/CMakeLists.txt
@@ -19,7 +19,8 @@ if(NOT CINN_ONLY)
 
   set(parsed_op_dir ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/generated)
 
-  set(cinn_op_parsed_yaml_file ${parsed_op_dir}/ops.parsed.yaml)
+  set(cinn_op_parsed_yaml_file ${parsed_op_dir}/ops.parsed.yaml
+                               ${parsed_op_dir}/update_ops.parsed.yaml)
 
   set(cinn_op_parsed_yaml_files ${cinn_op_parsed_yaml_file})
 

--- a/paddle/cinn/hlir/dialect/operator/ir/CMakeLists.txt
+++ b/paddle/cinn/hlir/dialect/operator/ir/CMakeLists.txt
@@ -17,16 +17,11 @@ if(NOT CINN_ONLY)
   set(cinn_op_yaml_file
       ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/operator/ir/ops.yaml)
 
-  set(cinn_update_op_yaml_file
-      ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/operator/ir/update_ops.yaml)
-
   set(parsed_op_dir ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/generated)
 
   set(cinn_op_parsed_yaml_file ${parsed_op_dir}/ops.parsed.yaml)
-  set(cinn_update_op_parsed_yaml_file ${parsed_op_dir}/update_ops.parsed.yaml)
 
-  set(cinn_op_parsed_yaml_files ${cinn_op_parsed_yaml_file}
-                                ${cinn_update_op_parsed_yaml_file})
+  set(cinn_op_parsed_yaml_files ${cinn_op_parsed_yaml_file})
 
   set(cinn_op_namespace cinn,dialect)
   set(cinn_op_dialect_name cinn_op)
@@ -36,16 +31,11 @@ if(NOT CINN_ONLY)
   set(cinn_op_source_file_tmp ${cinn_op_source_file}.tmp)
 
   add_custom_command(
-    OUTPUT ${cinn_op_parsed_yaml_file} ${cinn_update_op_parsed_yaml_file}
+    OUTPUT ${cinn_op_parsed_yaml_file}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${parsed_op_dir}
     COMMAND ${PYTHON_EXECUTABLE} ${cinn_op_gen_parsed_yaml_file} --op_yaml_path
             ${cinn_op_yaml_file} --output_path ${cinn_op_parsed_yaml_file}
-    COMMAND
-      ${PYTHON_EXECUTABLE} ${cinn_op_gen_parsed_yaml_file} --op_yaml_path
-      ${cinn_update_op_yaml_file} --output_path
-      ${cinn_update_op_parsed_yaml_file}
     DEPENDS ${cinn_op_gen_parsed_yaml_file} ${cinn_op_yaml_file}
-            ${cinn_update_op_yaml_file}
     VERBATIM)
 
   add_custom_command(
@@ -61,7 +51,7 @@ if(NOT CINN_ONLY)
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${cinn_op_source_file_tmp}
             ${cinn_op_source_file}
     DEPENDS ${cinn_op_gen_file} ${cinn_op_parsed_yaml_file}
-            ${cinn_update_op_parsed_yaml_file} ${cinn_op_compat_yaml_file}
+            ${cinn_op_compat_yaml_file}
     VERBATIM)
 
   cinn_cc_library(

--- a/paddle/fluid/operators/generator/parse_utils.py
+++ b/paddle/fluid/operators/generator/parse_utils.py
@@ -365,6 +365,7 @@ def check_op_config(op_entry, op_name):
         'data_transform',
         'composite',
         'support_dygraph_mode',
+        'support_tensor',
     )
     infer_meta_key_set = ('func', 'param', 'spmd_rule')
     kernel_key_set = (
@@ -508,6 +509,11 @@ def parse_op_entry(op_entry: Dict[str, Any], name_field="op"):
     else:
         data_trans = None
 
+    if "support_tensor" in op_entry.keys():
+        support_tensor = op_entry["support_tensor"]
+    else:
+        support_tensor = []
+
     op = {
         "name": op_name,
         "inputs": inputs,
@@ -515,6 +521,7 @@ def parse_op_entry(op_entry: Dict[str, Any], name_field="op"):
         "outputs": outputs,
         "no_need_buffer": no_buffer_args,
         "data_transform": data_trans,
+        "support_tensor": support_tensor,
     }
 
     # op should be is_base_op or is_invoke_op or is_only_composite_op

--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -152,14 +152,40 @@ class CodeGen:
     def __init__(self) -> None:
         pass
 
+    def _check_need_update_ops(self, op_yaml_files):
+        need_update_ops = False
+        for yaml_file in op_yaml_files:
+            if yaml_file.find("update_ops.parsed.yaml") != -1:
+                need_update_ops = True
+                update_yaml_file = yaml_file
+                break
+        return need_update_ops, update_yaml_file
+
+    def _update_ops(self, op_yaml_items, update_yaml_file):
+        with open(update_yaml_file, "r") as f:
+            update_ops = yaml.safe_load(f)
+        for i in range(len(op_yaml_items)):
+            for update_op in update_ops:
+                if op_yaml_items[i]['name'] == update_op['name']:
+                    op_yaml_items[i] = update_op
+                    break
+
     def _parse_yaml(self, op_yaml_files, op_compat_yaml_file):
         op_compat_parser = OpCompatParser(op_compat_yaml_file)
+        need_update_ops, update_yaml_file = self._check_need_update_ops(
+            op_yaml_files
+        )
 
         op_yaml_items = []
         for yaml_file in op_yaml_files:
+            if update_yaml_file == yaml_file:
+                continue
             with open(yaml_file, "r") as f:
                 ops = yaml.safe_load(f)
                 op_yaml_items = op_yaml_items + ops
+        # replace old ir ops with pir ops
+        if need_update_ops:
+            self._update_ops(op_yaml_items, update_yaml_file)
         op_info_items = []
         for op in op_yaml_items:
             op_compat_item = op_compat_parser.get_compat(op['name'])
@@ -178,6 +204,13 @@ class CodeGen:
                 and 'scalar' in op_compat_item
             ):
                 op_compat_item = op_compat_item.pop('scalar')
+            if op['support_tensor'] != []:
+                (
+                    scalar_item,
+                    int_array_item,
+                ) = op_compat_parser.parse_support_tensor(op)
+                op_compat_item['scalar'] = scalar_item
+                op_compat_item['int_array'] = int_array_item
 
             op_info_items.append(OpInfoParser(op, op_compat_item))
         return op_info_items

--- a/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
@@ -75,14 +75,41 @@ class OpCreatorCodeGen:
         self.op_info_items = self.parse_yaml(op_yaml_files, op_compat_yaml_file)
         self.dialect_name = dialect_name
 
+    def _check_need_update_ops(self, op_yaml_files):
+        need_update_ops = False
+        for yaml_file in op_yaml_files:
+            if yaml_file.find("update_ops.parsed.yaml") != -1:
+                need_update_ops = True
+                update_yaml_file = yaml_file
+                break
+        return need_update_ops, update_yaml_file
+
+    def _update_ops(self, op_yaml_items, update_yaml_file):
+        with open(update_yaml_file, "r") as f:
+            update_ops = yaml.safe_load(f)
+        for i in range(len(op_yaml_items)):
+            for update_op in update_ops:
+                if op_yaml_items[i]['name'] == update_op['name']:
+                    op_yaml_items[i] = update_op
+                    break
+
     def parse_yaml(self, op_yaml_files, op_compat_yaml_file):
         op_compat_parser = OpCompatParser(op_compat_yaml_file)
+        need_update_ops, update_yaml_file = self._check_need_update_ops(
+            op_yaml_files
+        )
 
         op_yaml_items = []
         for yaml_file in op_yaml_files:
+            if update_yaml_file == yaml_file:
+                continue
             with open(yaml_file, "r") as f:
                 ops = yaml.safe_load(f)
                 op_yaml_items = op_yaml_items + ops
+        # replace old ir ops with pir ops
+        if need_update_ops:
+            self._update_ops(op_yaml_items, update_yaml_file)
+
         op_info_items = []
         for op in op_yaml_items:
             op_compat_item = op_compat_parser.get_compat(op['name'])

--- a/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
@@ -77,6 +77,7 @@ class OpCreatorCodeGen:
 
     def _check_need_update_ops(self, op_yaml_files):
         need_update_ops = False
+        update_yaml_file = None
         for yaml_file in op_yaml_files:
             if yaml_file.find("update_ops.parsed.yaml") != -1:
                 need_update_ops = True

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -251,6 +251,23 @@ class OpCompatParser:
                         return compat
         return None
 
+    def parse_support_tensor(self, op):
+        scalar_item = {}
+        int_array_item = {}
+        for support_tensor_attr in op['support_tensor']:
+            for attr in op['attrs']:
+                if (
+                    attr['typename'] == 'Scalar'
+                    and attr['name'] == support_tensor_attr
+                ):
+                    scalar_item[support_tensor_attr] = {"support_tensor": True}
+                if (
+                    attr['typename'] == 'IntArray'
+                    and attr['name'] == support_tensor_attr
+                ):
+                    scalar_item[support_tensor_attr] = {"support_tensor": True}
+        return scalar_item, int_array_item
+
 
 # =====================================
 # Parse Op Information From Yaml
@@ -930,6 +947,26 @@ def get_mutable_attribute_grad_semantic(op_info, op_info_items):
     return mutable_attribute_grad_semantics
 
 
+def check_need_update_ops(op_yaml_files):
+    need_update_ops = False
+    for yaml_file in op_yaml_files:
+        if yaml_file.find("update_ops.parsed.yaml") != -1:
+            need_update_ops = True
+            update_yaml_file = yaml_file
+            break
+    return need_update_ops, update_yaml_file
+
+
+def update_ops(op_yaml_items, update_yaml_file):
+    with open(update_yaml_file, "r") as f:
+        update_ops = yaml.safe_load(f)
+    for i in range(len(op_yaml_items)):
+        for update_op in update_ops:
+            if op_yaml_items[i]['name'] == update_op['name']:
+                op_yaml_items[i] = update_op
+                break
+
+
 def OpGenerator(
     op_yaml_files,
     op_compat_yaml_file,
@@ -947,12 +984,19 @@ def OpGenerator(
 
     # (2) Prepare: Get all op item in all op_yaml_files
     op_compat_parser = OpCompatParser(op_compat_yaml_file)
+    need_update_ops, update_yaml_file = check_need_update_ops(op_yaml_files)
 
     op_yaml_items = []
     for yaml_file in op_yaml_files:
+        if update_yaml_file == yaml_file:
+            continue
         with open(yaml_file, "r") as f:
             ops = yaml.safe_load(f)
             op_yaml_items = op_yaml_items + ops
+    # replace old ir ops with pir ops
+    if need_update_ops:
+        update_ops(op_yaml_items, update_yaml_file)
+
     op_info_items = {}
     for op in op_yaml_items:
         op_compat_item = op_compat_parser.get_compat(op['name'])
@@ -969,6 +1013,13 @@ def OpGenerator(
             and 'scalar' in op_compat_item
         ):
             op_compat_item = op_compat_item.pop('scalar')
+
+        if op['support_tensor'] != []:
+            scalar_item, int_array_item = op_compat_parser.parse_support_tensor(
+                op
+            )
+            op_compat_item['scalar'] = scalar_item
+            op_compat_item['int_array'] = int_array_item
 
         op_info_items[op['name']] = OpInfoParser(op, op_compat_item)
     # (3) CodeGen: Traverse op_info_items and generate

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -949,6 +949,7 @@ def get_mutable_attribute_grad_semantic(op_info, op_info_items):
 
 def check_need_update_ops(op_yaml_files):
     need_update_ops = False
+    update_yaml_file = None
     for yaml_file in op_yaml_files:
         if yaml_file.find("update_ops.parsed.yaml") != -1:
             need_update_ops = True

--- a/paddle/fluid/pir/dialect/operator/ir/CMakeLists.txt
+++ b/paddle/fluid/pir/dialect/operator/ir/CMakeLists.txt
@@ -27,8 +27,11 @@ set(fused_op_backward_yaml_file
     ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/generator/parsed_ops/fused_backward.parsed.yaml
 )
 
-set(pd_op_forward_yaml_file
+set(pd_op_forward_yaml_file1
     ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/ops.yaml)
+
+set(pd_op_forward_yaml_file2
+    ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml)
 
 set(pd_op_backward_yaml_file
     ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml)
@@ -38,9 +41,10 @@ set(parsed_op_dir
 
 set(op_yaml_file3 ${parsed_op_dir}/ops.parsed.yaml)
 set(op_yaml_file4 ${parsed_op_dir}/ops_backward.parsed.yaml)
+set(op_yaml_file5 ${parsed_op_dir}/update_ops.parsed.yaml)
 
 set(op_yaml_files
-    ${op_forward_yaml_file1},${op_forward_yaml_file2},${op_backward_yaml_file1},${op_backward_yaml_file2},${fused_op_forward_yaml_file},${fused_op_backward_yaml_file},${op_yaml_file3},${op_yaml_file4}
+    ${op_forward_yaml_file1},${op_forward_yaml_file2},${op_backward_yaml_file1},${op_backward_yaml_file2},${fused_op_forward_yaml_file},${fused_op_backward_yaml_file},${op_yaml_file3},${op_yaml_file4},${op_yaml_file5}
 )
 set(op_namespace paddle,dialect)
 set(dialect_name pd_op)
@@ -55,7 +59,9 @@ set(op_vjp_source_file_tmp ${op_vjp_source_file}.tmp)
 execute_process(
   COMMAND ${CMAKE_COMMAND} -E make_directory ${parsed_op_dir}
   COMMAND ${PYTHON_EXECUTABLE} ${op_gen_parsed_yaml_file} --op_yaml_path
-          ${pd_op_forward_yaml_file} --output_path ${op_yaml_file3}
+          ${pd_op_forward_yaml_file1} --output_path ${op_yaml_file3}
+  COMMAND ${PYTHON_EXECUTABLE} ${op_gen_parsed_yaml_file} --op_yaml_path
+          ${pd_op_forward_yaml_file2} --output_path ${op_yaml_file5}
   COMMAND ${PYTHON_EXECUTABLE} ${op_gen_parsed_yaml_file} --op_yaml_path
           ${pd_op_backward_yaml_file} --output_path ${op_yaml_file4} --backward)
 
@@ -83,10 +89,11 @@ add_custom_command(
           ${op_compat_yaml_file}
           ${op_yaml_file3}
           ${op_yaml_file4}
+          ${op_yaml_file5}
   VERBATIM)
 
 set(api_gen_yaml_files
-    ${op_forward_yaml_file1},${op_forward_yaml_file2},${op_backward_yaml_file1},${op_backward_yaml_file2},${op_yaml_file3},${op_yaml_file4}
+    ${op_forward_yaml_file1},${op_forward_yaml_file2},${op_backward_yaml_file1},${op_backward_yaml_file2},${op_yaml_file3},${op_yaml_file4},${op_yaml_file5}
 )
 set(api_gen_file
     ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/op_generator/api_gen.py)
@@ -115,6 +122,7 @@ add_custom_command(
           ${op_compat_yaml_file}
           ${op_yaml_file3}
           ${op_yaml_file4}
+          ${op_yaml_file5}
   VERBATIM)
 
 set(python_c_gen_file
@@ -146,6 +154,7 @@ add_custom_command(
           ${op_compat_yaml_file}
           ${op_yaml_file3}
           ${op_yaml_file4}
+          ${op_yaml_file5}
   VERBATIM)
 
 add_custom_target(static_op_function_gen ALL DEPENDS ${python_c_header_file}

--- a/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml
@@ -1,7 +1,7 @@
 # Ops in this file is only used for pir currently and will replace ops of legacy_ops.yaml/ops.yaml of PHI in future.
 
 - op : arange
-  args : (Scalar start, Scalar end, Scalar step, DataType dtype, Place place={})
+  args : (Scalar start, Scalar end, Scalar step, DataType dtype=DataType::FLOAT64, Place place=CPUPlace())
   output : Tensor(out)
   infer_meta :
     func : ArangeInferMeta

--- a/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml
@@ -1,0 +1,14 @@
+# Ops in this file is only used for pir currently and will replace ops of legacy_ops.yaml/ops.yaml of PHI in future.
+
+- op : arange
+  args : (Scalar start, Scalar end, Scalar step, DataType dtype, Place place={})
+  output : Tensor(out)
+  infer_meta :
+    func : ArangeInferMeta
+    param : [start, end, step, dtype]
+  kernel :
+    func : arange
+    param : [start, end, step]
+    data_type : dtype
+    backend : place
+  support_tensor : [start, end, step]

--- a/paddle/fluid/pir/drr/CMakeLists.txt
+++ b/paddle/fluid/pir/drr/CMakeLists.txt
@@ -7,8 +7,12 @@ set(op_compat_yaml_file ${PADDLE_SOURCE_DIR}/paddle/phi/api/yaml/op_compat.yaml)
 set(op_forward_yaml_file1
     ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/generator/parsed_ops/ops.parsed.yaml
 )
+
 set(op_forward_yaml_file2
     ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/generator/parsed_ops/legacy_ops.parsed.yaml
+)
+set(op_forward_yaml_file3
+    ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/generator/parsed_ops/update_ops.parsed.yaml
 )
 set(op_backward_yaml_file1
     ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/generator/parsed_ops/backward_ops.parsed.yaml
@@ -34,9 +38,10 @@ set(parsed_op_dir
 
 set(op_yaml_file3 ${parsed_op_dir}/ops.parsed.yaml)
 set(op_yaml_file4 ${parsed_op_dir}/ops_backward.parsed.yaml)
+set(op_yaml_file5 ${parsed_op_dir}/update_ops.parsed.yaml)
 
 set(op_yaml_files
-    ${op_forward_yaml_file1},${op_forward_yaml_file2},${op_backward_yaml_file1},${op_backward_yaml_file2},${fused_op_forward_yaml_file},${fused_op_backward_yaml_file},${op_yaml_file3},${op_yaml_file4}
+    ${op_forward_yaml_file1},${op_forward_yaml_file2},${op_backward_yaml_file1},${op_backward_yaml_file2},${fused_op_forward_yaml_file},${fused_op_backward_yaml_file},${op_yaml_file3},${op_yaml_file4},${op_yaml_file5}
 )
 
 set(op_creator_file

--- a/paddle/fluid/primitive/codegen/CMakeLists.txt
+++ b/paddle/fluid/primitive/codegen/CMakeLists.txt
@@ -7,6 +7,9 @@ set(rev_legacy_path ${parsed_yaml_path}/legacy_backward_ops.parsed.yaml)
 set(fwd_pd_op_path
     ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/generated/ops.parsed.yaml
 )
+set(update_fwd_pd_op_path
+    ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/generated/update_ops.parsed.yaml
+)
 set(rev_pd_op_path
     ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/generated/ops_backward.parsed.yaml
 )
@@ -23,7 +26,8 @@ execute_process(
   COMMAND
     ${PYTHON_EXECUTABLE} ${scripts} --fwd_path ${fwd_path} --fwd_legacy_path
     ${fwd_legacy_path} --rev_path ${rev_path} --rev_legacy_path
-    ${rev_legacy_path} --fwd_pd_op_path ${fwd_pd_op_path} --rev_pd_op_path
+    ${rev_legacy_path} --fwd_pd_op_path ${fwd_pd_op_path}
+    --update_fwd_pd_op_path ${update_fwd_pd_op_path} --rev_pd_op_path
     ${rev_pd_op_path} --prim_path ${prim_path} --templates_dir ${templates_dir}
     --compat_path ${compat_path} --destination_dir ${destination_dir}
   RESULT_VARIABLE _result)

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -67,10 +67,10 @@
   args : (Tensor start, Tensor end, Tensor step, DataType dtype, Place place={})
   output : Tensor(out)
   infer_meta :
-    func : ArangeInferMeta
+    func : ArangeTensorInferMeta
     param : [start, end, step]
   kernel :
-    func : arange
+    func : arange_tensor
     param : [start, end, step]
     data_type : dtype
     backend : place

--- a/paddle/phi/api/yaml/static_ops.yaml
+++ b/paddle/phi/api/yaml/static_ops.yaml
@@ -72,9 +72,9 @@
   args : (Tensor start, Tensor end, Tensor step)
   output : Tensor(out)
   infer_meta :
-    func : ArangeInferMeta
+    func : ArangeTensorInferMeta
   kernel :
-    func : arange
+    func : arange_tensor
   data_transform :
     skip_transform : start, end, step
 

--- a/paddle/phi/infermeta/nullary.cc
+++ b/paddle/phi/infermeta/nullary.cc
@@ -16,6 +16,24 @@ limitations under the License. */
 
 namespace phi {
 
+void ArangeInferMeta(const Scalar& start,
+                     const Scalar& end,
+                     const Scalar& step,
+                     DataType dtype,
+                     MetaTensor* out) {
+  if (!start.FromTensor() && !end.FromTensor() && !step.FromTensor()) {
+    double start_value = start.to<double>();
+    double end_value = end.to<double>();
+    double step_value = step.to<double>();
+    int numel =
+        static_cast<int>(std::ceil((end_value - start_value) / step_value));
+    out->set_dims(phi::make_ddim(std::vector<int64_t>(1, numel)));
+  } else {
+    out->set_dims({-1});
+  }
+  out->set_dtype(dtype);
+}
+
 void AssignValueInferMeta(const std::vector<int>& shape,
                           DataType dtype,
                           MetaTensor* out) {

--- a/paddle/phi/infermeta/nullary.h
+++ b/paddle/phi/infermeta/nullary.h
@@ -31,6 +31,12 @@ namespace phi {
 //
 // The InferMeta Functions in this file are arranged in alphabetic order.
 
+void ArangeInferMeta(const Scalar& start,
+                     const Scalar& end,
+                     const Scalar& step,
+                     DataType dtype,
+                     MetaTensor* out);
+
 void AssignValueInferMeta(const std::vector<int>& shape,
                           DataType dtype,
                           MetaTensor* out);

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -295,10 +295,10 @@ void FlashAttnInferMeta(const MetaTensor& q,
   out->set_layout(q.layout());
 }
 
-void ArangeInferMeta(const MetaTensor& start,
-                     const MetaTensor& end,
-                     const MetaTensor& step,
-                     MetaTensor* out) {
+void ArangeTensorInferMeta(const MetaTensor& start,
+                           const MetaTensor& end,
+                           const MetaTensor& step,
+                           MetaTensor* out) {
   PADDLE_ENFORCE_EQ(phi::product(start.dims()),
                     1,
                     phi::errors::InvalidArgument(

--- a/paddle/phi/infermeta/ternary.h
+++ b/paddle/phi/infermeta/ternary.h
@@ -48,10 +48,10 @@ void AddmmInferMeta(const MetaTensor& input,
                     float alpha,
                     MetaTensor* out);
 
-void ArangeInferMeta(const MetaTensor& start,
-                     const MetaTensor& end,
-                     const MetaTensor& step,
-                     MetaTensor* out);
+void ArangeTensorInferMeta(const MetaTensor& start,
+                           const MetaTensor& end,
+                           const MetaTensor& step,
+                           MetaTensor* out);
 
 void BoxCoderInferMeta(const MetaTensor& prior_box,
                        const MetaTensor& prior_box_var,

--- a/paddle/phi/kernels/arange_kernel.h
+++ b/paddle/phi/kernels/arange_kernel.h
@@ -14,15 +14,23 @@
 
 #pragma once
 
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
 
 namespace phi {
 
 template <typename T, typename Context>
+void ArangeTensorKernel(const Context& dev_ctx,
+                        const DenseTensor& start,
+                        const DenseTensor& end,
+                        const DenseTensor& step,
+                        DenseTensor* out);
+
+template <typename T, typename Context>
 void ArangeKernel(const Context& dev_ctx,
-                  const DenseTensor& start,
-                  const DenseTensor& end,
-                  const DenseTensor& step,
+                  const Scalar& start,
+                  const Scalar& end,
+                  const Scalar& step,
                   DenseTensor* out);
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -21,14 +21,11 @@ limitations under the License. */
 namespace phi {
 
 template <typename T, typename Context>
-void ArangeKernel(const Context& dev_ctx,
-                  const DenseTensor& start,
-                  const DenseTensor& end,
-                  const DenseTensor& step,
-                  DenseTensor* out) {
-  T start_value = start.data<T>()[0];
-  T end_value = end.data<T>()[0];
-  T step_value = step.data<T>()[0];
+void ArangeFunc(const Context& dev_ctx,
+                const T& start_value,
+                const T& end_value,
+                const T& step_value,
+                DenseTensor* out) {
   int64_t size = 0;
   phi::funcs::GetSize(start_value, end_value, step_value, &size);
   out->Resize(phi::make_ddim({size}));
@@ -40,7 +37,39 @@ void ArangeKernel(const Context& dev_ctx,
   }
 }
 
+template <typename T, typename Context>
+void ArangeTensorKernel(const Context& dev_ctx,
+                        const DenseTensor& start,
+                        const DenseTensor& end,
+                        const DenseTensor& step,
+                        DenseTensor* out) {
+  T start_value = start.data<T>()[0];
+  T end_value = end.data<T>()[0];
+  T step_value = step.data<T>()[0];
+  ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+}
+
+template <typename T, typename Context>
+void ArangeKernel(const Context& dev_ctx,
+                  const Scalar& start,
+                  const Scalar& end,
+                  const Scalar& step,
+                  DenseTensor* out) {
+  T start_value = start.to<T>();
+  T end_value = end.to<T>();
+  T step_value = step.to<T>();
+  ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+}
+
 }  // namespace phi
 
+PD_REGISTER_KERNEL(arange_tensor,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::ArangeTensorKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t) {}
 PD_REGISTER_KERNEL(
     arange, CPU, ALL_LAYOUT, phi::ArangeKernel, float, double, int, int64_t) {}

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -20,11 +20,11 @@ limitations under the License. */
 namespace phi {
 
 template <typename T, typename Context>
-void ArangeKernel(const Context& dev_ctx,
-                  const DenseTensor& start,
-                  const DenseTensor& end,
-                  const DenseTensor& step,
-                  DenseTensor* out) {
+void ArangeTensorKernel(const Context& dev_ctx,
+                        const DenseTensor& start,
+                        const DenseTensor& end,
+                        const DenseTensor& step,
+                        DenseTensor* out) {
   T start_value = GetValue<T, Context>(dev_ctx, start);
   T end_value = GetValue<T, Context>(dev_ctx, end);
   T step_value = GetValue<T, Context>(dev_ctx, step);
@@ -49,8 +49,14 @@ void ArangeKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    arange, XPU, ALL_LAYOUT, phi::ArangeKernel, float, double, int, int64_t) {
+PD_REGISTER_KERNEL(arange_tensor,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::ArangeTensorKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);

--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -138,9 +139,12 @@ class TestArangeOpError(unittest.TestCase):
 
 
 class TestArangeAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         paddle.enable_static()
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x1 = paddle.arange(0, 5, 1, 'float32')
 
             place = (
@@ -151,9 +155,9 @@ class TestArangeAPI(unittest.TestCase):
             exe = paddle.static.Executor(place)
             out = exe.run(fetch_list=[x1])
 
-        expected_data = np.arange(0, 5, 1).astype(np.float32)
-        self.assertEqual((out == expected_data).all(), True)
-        self.assertListEqual(list(x1.shape), [5])
+            expected_data = np.arange(0, 5, 1).astype(np.float32)
+            self.assertEqual((out == expected_data).all(), True)
+            self.assertListEqual(list(x1.shape), [5])
         paddle.disable_static(place)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
完善自动代码生成机制，支持生成单独在新IR场景使用的最终态op：

- 可以通过配置update_ops.yaml文件，生成与现有体系重名的算子，该文件中的算子当前只在pir中使用，且后续会通过该yaml文件对phi下ops.yaml及legacy_ops.yaml中的算子进行不兼容升级改造
- 在update_ops.yaml中创建更规范的arange算子，支持在C++端进行infermeta功能，适配arange api，支持在pir模式下执行