### PR TITLE
[PIR]Perfect unittest for exp / full_like / gather_nd / gather / rms_norm / softmax / transpose

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_rms_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_rms_norm.py
@@ -15,7 +15,7 @@
 
 import paddle
 from paddle import _C_ops
-from paddle.framework import LayerHelper, in_dynamic_or_pir_mode
+from paddle.framework import LayerHelper, in_dynamic_mode, in_pir_mode
 
 
 def fused_rms_norm(
@@ -64,7 +64,7 @@ def fused_rms_norm(
             >>> epsilon = 1e-6
             >>> paddle_rmsnorm = paddle.incubate.nn.functional.fused_rms_norm(paddle_x, paddle_weight, paddle_bias, epsilon, 1)
     """
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         return _C_ops.rms_norm(
             x,
             bias,
@@ -78,7 +78,21 @@ def fused_rms_norm(
             quant_max_bound,
             quant_min_bound,
         )
-
+    if in_pir_mode():
+        out, residual_out = _C_ops.rms_norm(
+            x,
+            bias,
+            residual,
+            norm_weight,
+            norm_bias,
+            epsilon,
+            begin_norm_axis,
+            quant_scale,
+            quant_round_type,
+            quant_max_bound,
+            quant_min_bound,
+        )
+        return (out, residual_out) if residual is not None else out
     helper = LayerHelper('rms_norm', **locals())
     out = None
     if quant_scale <= 0:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1375,7 +1375,7 @@ def t(input, name=None):
             "length of Input(input) is %s. Perhaps you can use paddle."
             "tensor.transpose() instead." % len(input.shape)
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if len(input.shape) <= 1:
             return input
         # 2-D tensor

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2866,7 +2866,7 @@ def gather(x, index, axis=None, name=None):
     if axis is None:
         axis = 0
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.gather(x, index, axis)
     else:
         check_variable_and_dtype(
@@ -4690,7 +4690,7 @@ def moveaxis(x, source, destination, name=None):
     for i in range(len(src_dims)):
         perm[dst_dims[i]] = src_dims[i]
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out = _C_ops.transpose(x, perm)
         return out
     else:

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -205,9 +205,10 @@ class TestExp_Complex128(TestExp_Complex64):
 
 
 class Test_Exp_Op_Fp16(unittest.TestCase):
+    @test_with_pir_api
     def test_api_fp16(self):
         with static_guard():
-            with static.program_guard(
+            with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
                 np_x = np.array([[2, 3, 4], [7, 8, 9]])
@@ -559,6 +560,7 @@ class TestSiluAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -781,6 +783,7 @@ class TestTanhAPI(unittest.TestCase):
     def executed_api(self):
         self.tanh = F.tanh
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_full_like_op.py
+++ b/test/legacy_test/test_full_like_op.py
@@ -22,6 +22,7 @@ import paddle.framework.dtype as dtypes
 from paddle.base import core
 from paddle.base.framework import convert_np_dtype_to_dtype_
 from paddle.framework import in_pir_mode
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -45,11 +46,12 @@ def fill_any_like_wrapper(x, value, out_dtype=None, name=None):
 class TestFullOp(unittest.TestCase):
     """Test fill_any_like op(whose API is full_like) for attr out."""
 
+    @test_with_pir_api
     def test_attr_tensor_API(self):
         paddle.enable_static()
-        startup_program = Program()
-        train_program = Program()
-        with program_guard(train_program, startup_program):
+        startup_program = paddle.static.Program()
+        train_program = paddle.static.Program()
+        with paddle.static.program_guard(train_program, startup_program):
             fill_value = 2.0
             input = paddle.static.data(
                 name='input', dtype='float32', shape=[2, 3]

--- a/test/legacy_test/test_gather_nd_op.py
+++ b/test/legacy_test/test_gather_nd_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestGatherNdOpWithEmptyIndex(OpTest):
@@ -561,6 +562,7 @@ class TestGatherNdOpWithHighRankDiffBF16(TestGatherNdOpWithHighRankDiff):
 
 # Test Python API
 class TestGatherNdOpAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_case1(self):
         x1 = paddle.static.data(
             name='x1', shape=[-1, 30, 40, 50, 60], dtype='float32'
@@ -570,6 +572,7 @@ class TestGatherNdOpAPI(unittest.TestCase):
         )
         output1 = paddle.gather_nd(x1, index1)
 
+    @test_with_pir_api
     def test_case2(self):
         x2 = paddle.static.data(
             name='x2', shape=[-1, 30, 40, 50], dtype='float32'
@@ -579,6 +582,7 @@ class TestGatherNdOpAPI(unittest.TestCase):
         )
         output2 = paddle.gather_nd(x2, index2)
 
+    @test_with_pir_api
     def test_case3(self):
         x3 = paddle.static.data(name='x3', shape=[-1, 3, 4, 5], dtype='float32')
         index3 = paddle.static.data(
@@ -589,6 +593,7 @@ class TestGatherNdOpAPI(unittest.TestCase):
 
 # Test Raise Index Error
 class TestGatherNdOpRaise(unittest.TestCase):
+    @test_with_pir_api
     def test_check_raise(self):
         def check_raise_is_test():
             try:
@@ -638,16 +643,15 @@ class TestGatherNdError(unittest.TestCase):
 
 
 class TestGatherNdAPI2(unittest.TestCase):
+    @test_with_pir_api
     def test_static(self):
         with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data('data1', shape=[-1, 2], dtype='float64')
-            data1.desc.set_need_check_feed(False)
             index = paddle.static.data('index', shape=[-1, 1], dtype='int32')
-            index.desc.set_need_check_feed(False)
             out = paddle.gather_nd(data1, index)
             place = base.CPUPlace()
             exe = base.Executor(place)
-            input = np.array([[1, 2], [3, 4], [5, 6]])
+            input = np.array([[1, 2], [3, 4], [5, 6]]).astype('float64')
             index_1 = np.array([[1]]).astype('int32')
             (result,) = exe.run(
                 feed={"data1": input, "index": index_1}, fetch_list=[out]
@@ -655,6 +659,7 @@ class TestGatherNdAPI2(unittest.TestCase):
             expected_output = np.array([[3, 4]])
         np.testing.assert_allclose(result, expected_output, rtol=1e-05)
 
+    @test_with_pir_api
     def test_static_fp16_with_gpu(self):
         if paddle.base.core.is_compiled_with_cuda():
             place = paddle.CUDAPlace(0)
@@ -671,11 +676,9 @@ class TestGatherNdAPI2(unittest.TestCase):
                 x = paddle.static.data(
                     name="x", shape=[2, 3, 2], dtype="float16"
                 )
-                x.desc.set_need_check_feed(False)
                 idx = paddle.static.data(
                     name="index", shape=[1, 2], dtype="int32"
                 )
-                idx.desc.set_need_check_feed(False)
 
                 y = paddle.gather_nd(x, idx)
 

--- a/test/legacy_test/test_rms_norm_op.py
+++ b/test/legacy_test/test_rms_norm_op.py
@@ -18,6 +18,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def quant_helper(
@@ -342,49 +343,6 @@ class TestRMSNormStaticOp(unittest.TestCase):
             )
         return out_s[0], paddle_naive_rmsnorm_out
 
-    def test_rmsnorm_pir(self):
-        paddle.disable_static()
-        x = paddle.to_tensor(self.x_np.astype("float32"))
-        gamma = paddle.to_tensor(self.norm_weight_np.astype("float32"))
-        beta = paddle.to_tensor(self.norm_bias_np.astype("float32"))
-
-        paddle_naive_rmsnorm_out = naive_rms_norm(x, gamma, beta, self.epsilon)
-        paddle.enable_static()
-
-        with paddle.pir_utils.IrGuard():
-            x_static = paddle.static.data(
-                name="x_static", shape=[self.batch, self.cols], dtype="float32"
-            )
-            gamma_static = paddle.static.data(
-                name="gamma_static", shape=[self.cols], dtype="float32"
-            )
-            beta_static = paddle.static.data(
-                name="beta_static", shape=[self.cols], dtype="float32"
-            )
-            out, _ = paddle.incubate.nn.functional.fused_rms_norm(
-                x_static,
-                gamma_static,
-                beta_static,
-                self.epsilon,
-                begin_norm_axis=1,
-            )
-            exe = base.Executor(self.place)
-            out_s = exe.run(
-                feed={
-                    "x_static": self.x_np.astype("float32"),
-                    "gamma_static": self.norm_weight_np.astype("float32"),
-                    "beta_static": self.norm_bias_np.astype("float32"),
-                },
-                fetch_list=[out],
-            )
-
-        np.testing.assert_allclose(
-            out_s[0],
-            paddle_naive_rmsnorm_out.numpy(),
-            rtol=1e-3,
-            atol=1e-3,
-        )
-
     def check_rmsnorm_int8(self, x_np, gamma_np, beta_np, dtype):
         paddle.disable_static()
         x = paddle.to_tensor(x_np.astype(dtype))
@@ -491,6 +449,7 @@ class TestRMSNormStaticOp(unittest.TestCase):
             )
         return out_s[0], paddle_naive_rmsnorm_out
 
+    @test_with_pir_api
     def test_rmsnorm_fp16(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -505,6 +464,7 @@ class TestRMSNormStaticOp(unittest.TestCase):
             atol=1e-3,
         )
 
+    @test_with_pir_api
     def test_residual_bias_add_rmsnorm_fp16(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -524,6 +484,7 @@ class TestRMSNormStaticOp(unittest.TestCase):
             atol=1e-3,
         )
 
+    @test_with_pir_api
     def test_rmsnorm_int8(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/legacy_test/test_softmax_op.py
+++ b/test/legacy_test/test_softmax_op.py
@@ -22,6 +22,7 @@ import paddle
 import paddle.nn.functional as F
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(10)
 
@@ -512,6 +513,7 @@ class TestSoftmaxAPI(unittest.TestCase):
     def executed_api(self):
         self.softmax = F.softmax
 
+    @test_with_pir_api
     def test_static_check(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -590,6 +592,7 @@ class TestSoftmaxAPI_ZeroDim(unittest.TestCase):
 
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_static(self):
         with static_guard():
             main_prog = base.Program()
@@ -597,18 +600,17 @@ class TestSoftmaxAPI_ZeroDim(unittest.TestCase):
                 x = paddle.rand([])
                 x.stop_gradient = False
                 out = paddle.nn.functional.softmax(x)
-                base.backward.append_backward(out)
 
                 # Test compile shape
-                self.assertEqual(x.shape, ())
-                self.assertEqual(out.shape, ())
+                self.assertEqual(tuple(x.shape), ())
+                self.assertEqual(tuple(out.shape), ())
 
                 exe = base.Executor()
                 result = exe.run(main_prog, fetch_list=[x, out])
 
                 # Test runtime shape
-                self.assertEqual(result[0].shape, ())
-                self.assertEqual(result[1].shape, ())
+                self.assertEqual(tuple(result[0].shape), ())
+                self.assertEqual(tuple(result[1].shape), ())
 
 
 class TestSoftmaxInplaceAPI(TestSoftmaxAPI):

--- a/test/legacy_test/test_transpose_op.py
+++ b/test/legacy_test/test_transpose_op.py
@@ -22,6 +22,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -541,6 +542,7 @@ class TestTransposeOpError(unittest.TestCase):
 
 
 class TestTransposeApi(unittest.TestCase):
+    @test_with_pir_api
     def test_static_out(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -578,7 +580,8 @@ class TestTransposeApi(unittest.TestCase):
 
 
 class TestTAPI(unittest.TestCase):
-    def test_out(self):
+    @test_with_pir_api
+    def test_static_out(self):
         with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[10], dtype="float64", name="data")
             data_t = paddle.t(data)
@@ -613,6 +616,7 @@ class TestTAPI(unittest.TestCase):
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
+    def test_dygraph_out(self):
         with base.dygraph.guard():
             np_x = np.random.random([10]).astype("float64")
             data = base.dygraph.to_variable(np_x)
@@ -637,6 +641,7 @@ class TestTAPI(unittest.TestCase):
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
+    @test_with_pir_api
     def test_errors(self):
         with base.program_guard(base.Program()):
             x = paddle.static.data(name='x', shape=[10, 5, 3], dtype='float64')
@@ -648,7 +653,8 @@ class TestTAPI(unittest.TestCase):
 
 
 class TestMoveAxis(unittest.TestCase):
-    def test_moveaxis1(self):
+    @test_with_pir_api
+    def test_static_moveaxis1(self):
         x_np = np.random.randn(2, 3, 4, 5, 7)
         expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.enable_static()
@@ -661,6 +667,9 @@ class TestMoveAxis(unittest.TestCase):
 
         np.testing.assert_array_equal(out_np, expected)
 
+    def test_dygraph_moveaxis1(self):
+        x_np = np.random.randn(2, 3, 4, 5, 7)
+        expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.disable_static()
         x = paddle.to_tensor(x_np)
         out = paddle.moveaxis(x, [0, 4, 3, 2], [1, 3, 2, 0])
@@ -668,7 +677,8 @@ class TestMoveAxis(unittest.TestCase):
         np.testing.assert_array_equal(out.numpy(), expected)
         paddle.enable_static()
 
-    def test_moveaxis2(self):
+    @test_with_pir_api
+    def test_static_moveaxis2(self):
         x_np = np.random.randn(2, 3, 5)
         expected = np.moveaxis(x_np, -2, -1)
         paddle.enable_static()
@@ -681,6 +691,9 @@ class TestMoveAxis(unittest.TestCase):
 
         np.testing.assert_array_equal(out_np, expected)
 
+    def test_dygraph_moveaxis2(self):
+        x_np = np.random.randn(2, 3, 5)
+        expected = np.moveaxis(x_np, -2, -1)
         paddle.disable_static()
         x = paddle.to_tensor(x_np)
         out = x.moveaxis(-2, -1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
补全如下算子的新IR单测，并解决单测验证中出现的问题：
exp / full_like / gather_nd / gather / rms_norm / softmax / transpose

解决fetch rms_norm输出结果报Tensor内存错误的问题
未适配单测：
Type验证类单测