### PR TITLE
【PIR API adaptor No.53、111、112、116、208、229、230】Migrate some ops into pir

### DIFF
--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -289,7 +289,9 @@ def monkey_patch_opresult():
                 python_api == paddle.divide
             ) and self.dtype in _supported_int_dtype_:
                 self = paddle.cast(self, DataType.FLOAT32)
-                other_var = paddle.cast(other_var_opresult, DataType.FLOAT32)
+                other_var_opresult = paddle.cast(
+                    other_var_opresult, DataType.FLOAT32
+                )
 
             out = python_api(self, other_var_opresult)
             return out

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -309,20 +309,20 @@ def linspace(start, stop, num, dtype=None, name=None):
     tensor_num = num
     tensor_start = start
     tensor_stop = stop
-    if not isinstance(num, Variable):
+    if not isinstance(num, (Variable, paddle.pir.OpResult)):
         check_type(num, 'num', (int), 'linspace')
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
-    if not isinstance(start, Variable):
+    if not isinstance(start, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_start = fill_constant([1], dtype, start, force_cpu=True)
-    if not isinstance(stop, Variable):
+    if not isinstance(stop, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_stop = fill_constant([1], dtype, stop, force_cpu=True)
-    if not isinstance(num, Variable):
+    if not isinstance(num, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_num = fill_constant([1], 'int32', num, force_cpu=True)
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.linspace(
             tensor_start,
             tensor_stop,
@@ -2006,7 +2006,7 @@ def diag(x, offset=0, padding_value=0, name=None):
             Tensor(shape=[1], dtype=int64, place=Place(cpu), stop_gradient=True,
             [4])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.diag(x, offset, padding_value)
     else:
         check_type(x, 'x', (Variable), 'diag_v2')

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3215,7 +3215,7 @@ def triangular_solve(
              [-2.],
              [-5.]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.triangular_solve(x, y, upper, transpose, unitriangular)
     else:
         inputs = {"X": [x], "Y": [y]}

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1964,7 +1964,7 @@ def slogdet(x, name=None):
              [ 0.25681755, -0.25061053, -0.10809582]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.slogdet(x)
     else:
         check_dtype(x.dtype, 'Input', ['float32', 'float64'], 'slogdet')

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1905,7 +1905,7 @@ def det(x, name=None):
 
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.det(x)
     else:
         check_dtype(x.dtype, 'Input', ['float16', 'float32', 'float64'], 'det')

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1415,7 +1415,7 @@ def t_(input, name=None):
             "length of Input(input) is %s. Perhaps you can use paddle."
             "tensor.transpose() instead." % len(input.shape)
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if len(input.shape) <= 1:
             return input
         # 2-D tensor

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -920,7 +920,7 @@ def cond(x, p=None, name=None):
         NOTE:
             Calculate the frobenius norm of a square matrix or batches of square matrices.
         """
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             pow_out = _C_ops.pow(input, porder)
             sum_out_1 = _C_ops.sum(pow_out, axis, None, False)
             sum_out_2 = _C_ops.sum(sum_out_1, axis, None, False)
@@ -983,7 +983,7 @@ def cond(x, p=None, name=None):
         """
         u, s, vh = svd(input, full_matrices=False)
 
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             if porder == "nuc":
                 return _C_ops.sum(s, axis, None, False)
             max_out = _C_ops.max(s, axis, False)
@@ -1054,7 +1054,7 @@ def cond(x, p=None, name=None):
                 return out
 
     def empty_tensor(input, shape):
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             return input.reshape(shape)
         raise ValueError(
             "only support x is nonempty tensor in static graph mode"

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -857,7 +857,7 @@ def cond(x, p=None, name=None):
             Calculate the matrix norm of a square matrix or batches of square matrices,
             when porder is in (1, -1, inf, -inf)
         """
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             abs_out = _C_ops.abs(input)
             sum_out = _C_ops.sum(abs_out, axis, None, False)
 
@@ -3143,7 +3143,7 @@ def solve(x, y, name=None):
             Tensor(shape=[2], dtype=float64, place=Place(cpu), stop_gradient=True,
             [2., 3.])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.solve(x, y)
     else:
         inputs = {"X": [x], "Y": [y]}

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1415,7 +1415,7 @@ def t_(input, name=None):
             "length of Input(input) is %s. Perhaps you can use paddle."
             "tensor.transpose() instead." % len(input.shape)
         )
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         if len(input.shape) <= 1:
             return input
         # 2-D tensor

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3523,7 +3523,7 @@ def broadcast_to(x, shape, name=None):
         if isinstance(shape, (list, tuple)):
             shape = paddle.utils.convert_shape_to_list(shape)
         return _C_ops.expand(x, shape)
-    if in_dynamic_or_pir_mode():
+    elif in_pir_mode():
         place = _current_expected_place()
         if isinstance(shape, (list, tuple)):
             if paddle.utils._contain_var(shape):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3520,8 +3520,6 @@ def broadcast_to(x, shape, name=None):
     """
 
     if in_dynamic_mode():
-        if isinstance(shape, (list, tuple)):
-            shape = paddle.utils.convert_shape_to_list(shape)
         return _C_ops.expand(x, shape)
     elif in_pir_mode():
         place = _current_expected_place()

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5093,7 +5093,7 @@ def index_add(x, index, axis, value, name=None):
              [1., 1., 1.],
              [2., 2., 2.]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.index_add(x, index, value, axis)
 
     helper = LayerHelper("index_add", **locals())
@@ -5229,7 +5229,7 @@ def index_put(x, indices, value, accumulate=False, name=None):
              [0., 0., 1.],
              [0., 1., 0.]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.index_put(x, indices, value, accumulate)
 
     helper = LayerHelper("index_put", **locals())

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2671,7 +2671,7 @@ def inverse(x, name=None):
              [0.        , 0.50000000]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.inverse(x)
     else:
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -221,7 +221,7 @@ def std(x, axis=None, unbiased=True, keepdim=False, name=None):
             [1.       2.081666]
 
     """
-    if not in_dynamic_mode():
+    if not in_dynamic_or_pir_mode():
         check_variable_and_dtype(
             x, 'x', ['float16', 'float32', 'float64'], 'std'
         )

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -159,8 +159,8 @@ def var(x, axis=None, unbiased=True, keepdim=False, name=None):
     out = paddle.sum(paddle.pow((x - u), 2), axis, keepdim=keepdim, name=name)
 
     dtype = x.dtype
-    n = paddle.cast(paddle.numel(x), paddle.int64) / paddle.cast(
-        paddle.numel(out), paddle.int64
+    n = paddle.cast(paddle.numel(x), "int64") / paddle.cast(
+        paddle.numel(out), "int64"
     )
     n = n.astype(dtype)
     if unbiased:

--- a/test/legacy_test/test_broadcast_to_op.py
+++ b/test/legacy_test/test_broadcast_to_op.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -40,6 +41,9 @@ class TestBroadcastToError(unittest.TestCase):
 
 # Test python API
 class TestBroadcastToAPI(unittest.TestCase):
+    # TODO: add test_with_pir_api
+    # base.backward.calc_gradient maybe not support pir
+    # AttributeError: 'paddle.base.libpaddle.pir.Program' object has no attribute '_appending_grad_times'
     def test_api(self):
         input = np.random.random([12, 14]).astype("float32")
         x = paddle.static.data(name='x', shape=[12, 14], dtype="float32")
@@ -70,6 +74,7 @@ class TestBroadcastToAPI(unittest.TestCase):
         np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
         np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
 
+    @test_with_pir_api
     def test_api_fp16_gpu(self):
         if paddle.base.core.is_compiled_with_cuda():
             place = paddle.CUDAPlace(0)

--- a/test/legacy_test/test_determinant_op.py
+++ b/test/legacy_test/test_determinant_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -30,10 +31,10 @@ class TestDeterminantOp(OpTest):
         self.outputs = {'Out': self.target}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['Input'], ['Out'])
+        self.check_grad(['Input'], ['Out'], check_pir=True)
 
     def init_data(self):
         np.random.seed(0)
@@ -85,6 +86,7 @@ class TestDeterminantAPI(unittest.TestCase):
         self.x = np.random.random(self.shape).astype(np.float32)
         self.place = paddle.CPUPlace()
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -114,11 +116,13 @@ class TestSlogDeterminantOp(OpTest):
         self.outputs = {'Out': self.target}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         # the slog det's grad value is always huge
-        self.check_grad(['Input'], ['Out'], max_relative_error=0.1)
+        self.check_grad(
+            ['Input'], ['Out'], max_relative_error=0.1, check_pir=True
+        )
 
     def init_data(self):
         np.random.seed(0)
@@ -142,6 +146,7 @@ class TestSlogDeterminantAPI(unittest.TestCase):
         self.x = np.random.random(self.shape).astype(np.float32)
         self.place = paddle.CPUPlace()
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_diag_v2.py
+++ b/test/legacy_test/test_diag_v2.py
@@ -51,11 +51,11 @@ class TestDiagV2Op(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestDiagV2OpCase1(TestDiagV2Op):
@@ -335,12 +335,12 @@ class TestDiagV2BF16OP(OpTest):
     def test_check_output(self):
         paddle.enable_static()
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X'], 'Out')
+        self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -18,7 +18,8 @@ import numpy as np
 from op_test import OpTest, convert_float_to_uint16
 
 import paddle
-from paddle.base import Program, core
+from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def compute_index_add_ref(
@@ -93,10 +94,10 @@ class TestIndexAddOp(OpTest):
         self.add_value_shape = (3, 3)
 
     def test_check_output(self):
-        self.check_output(atol=1e-2)
+        self.check_output(atol=1e-2, check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'AddValue'], 'Out')
+        self.check_grad(['X', 'AddValue'], 'Out', check_pir=True)
 
 
 class TestIndexAddFP16Op(TestIndexAddOp):
@@ -156,10 +157,12 @@ class TestIndexAddBF16Op(OpTest):
         self.dtype = np.uint16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad_with_place(self.place, ['X', 'AddValue'], 'Out')
+        self.check_grad_with_place(
+            self.place, ['X', 'AddValue'], 'Out', check_pir=True
+        )
 
 
 class TestIndexAddAPI(unittest.TestCase):
@@ -290,15 +293,16 @@ class TestIndexAddAPI(unittest.TestCase):
                 "Index": self.index_np,
                 "AddValue": self.add_value_np,
             },
-            fetch_list=[out.name],
+            fetch_list=[out],
             return_numpy=False,
         )
         return res
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         for device in self.place:
-            with paddle.static.program_guard(Program()):
+            with paddle.static.program_guard(paddle.static.Program()):
                 out = self.run_static(device)
             ref_out = compute_index_add_ref(
                 self.axis,

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.pir_utils import test_with_pir_api
 
 
 def compute_index_put_ref(x_np, indices_np, value_np, accumulate=False):
@@ -144,7 +143,7 @@ class TestIndexPutAPIBase(unittest.TestCase):
             )
             np.testing.assert_allclose(ref_res, pd_res.numpy(), atol=1e-7)
 
-    @test_with_pir_api
+    # @test_with_pir_api
     def test_static_forward(self):
         paddle.enable_static()
         for place in self.place:
@@ -195,14 +194,13 @@ class TestIndexPutAPIBase(unittest.TestCase):
                     feed_list.update({"indice" + str(i): self.indices_np[i]})
                 feed_list.update({"value": self.value_np})
                 pd_res = exe.run(
-                    paddle.static.default_main_program(),
                     feed=feed_list,
                     fetch_list=[out],
-                )[0]
+                )
                 ref_res = compute_index_put_ref(
                     self.x_np, self.indices_np, self.value_np, self.accumulate
                 )
-                np.testing.assert_allclose(ref_res, pd_res, atol=1e-7)
+                np.testing.assert_allclose(ref_res, pd_res[0], atol=1e-7)
 
 
 class TestIndexPutAPI0(TestIndexPutAPIBase):
@@ -249,7 +247,7 @@ class TestIndexPutAPI3(TestIndexPutAPIBase):
         self.indices_shapes = [(110, 94)]
         self.value_shape = (5170,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = False
 
 
@@ -261,7 +259,7 @@ class TestIndexPutAPI4(TestIndexPutAPIBase):
         self.indices_shapes = [(110, 94)]
         self.value_shape = (5170,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = True
 
 
@@ -297,7 +295,7 @@ class TestIndexPutAPI7(TestIndexPutAPIBase):
         self.indices_shapes = [(110,)]
         self.value_shape = (55, 94)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = False
 
 
@@ -309,7 +307,7 @@ class TestIndexPutAPI8(TestIndexPutAPIBase):
         self.indices_shapes = [(110,)]
         self.value_shape = (55, 94)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = True
 
 
@@ -369,7 +367,7 @@ class TestIndexPutAPI13(TestIndexPutAPIBase):
         self.indices_shapes = [(44,)]
         self.value_shape = (94,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = False
 
 
@@ -381,7 +379,7 @@ class TestIndexPutAPI14(TestIndexPutAPIBase):
         self.indices_shapes = [(44,)]
         self.value_shape = (94,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = True
 
 
@@ -393,7 +391,7 @@ class TestIndexPutAPI15(TestIndexPutAPIBase):
         self.indices_shapes = [(44,)]
         self.value_shape = (1,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = False
 
 
@@ -405,7 +403,7 @@ class TestIndexPutAPI16(TestIndexPutAPIBase):
         self.indices_shapes = [(44,)]
         self.value_shape = (1,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.bool
+        self.index_type_pd = "bool"
         self.accumulate = True
 
 
@@ -417,7 +415,7 @@ class TestIndexPutAPI17(TestIndexPutAPIBase):
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -429,7 +427,7 @@ class TestIndexPutAPI18(TestIndexPutAPIBase):
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -440,8 +438,8 @@ class TestIndexPutAPI19(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float32
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "float32"
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -452,8 +450,8 @@ class TestIndexPutAPI20(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float32
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "float32"
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -464,8 +462,8 @@ class TestIndexPutAPI21(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float16
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "float16"
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -476,8 +474,8 @@ class TestIndexPutAPI22(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float16
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "float16"
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -488,8 +486,8 @@ class TestIndexPutAPI23(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.int32
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "int32"
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -500,8 +498,8 @@ class TestIndexPutAPI24(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.int32
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "int32"
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -513,7 +511,7 @@ class TestIndexPutAPI25(TestIndexPutAPIBase):
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
         self.dtype_pd = "int64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -525,7 +523,7 @@ class TestIndexPutAPI26(TestIndexPutAPIBase):
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
         self.dtype_pd = "int64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -536,8 +534,8 @@ class TestIndexPutAPI27(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.bool
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "bool"
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -548,8 +546,8 @@ class TestIndexPutAPI28(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.bool
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "bool"
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -561,7 +559,7 @@ class TestIndexPutAPI29(TestIndexPutAPIBase):
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (16, 16, 56)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = False
 
 
@@ -573,7 +571,7 @@ class TestIndexPutAPI30(TestIndexPutAPIBase):
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (16, 16, 56)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = True
 
 
@@ -584,8 +582,8 @@ class TestIndexPutAPI31(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.bool
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "bool"
+        self.index_type_pd = "int32"
         self.accumulate = False
         self.is_all_false = True
 
@@ -597,8 +595,8 @@ class TestIndexPutAPI32(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.bool
-        self.index_type_pd = paddle.int32
+        self.dtype_pd = "bool"
+        self.index_type_pd = "int32"
         self.accumulate = True
         self.is_all_false = True
 
@@ -898,7 +896,7 @@ class TestIndexPutAPIBackward(unittest.TestCase):
             paddle.device.set_device(place)
             value = paddle.ones(shape=[2, 1], dtype="float64")
             x = paddle.ones(shape=[16, 21], dtype="float64")
-            ix = paddle.zeros(shape=[16, 21], dtype=paddle.bool)
+            ix = paddle.zeros(shape=[16, 21], dtype="bool")
 
             value.stop_gradient = False
             x.stop_gradient = False
@@ -936,7 +934,7 @@ class TestIndexPutAPIBackward(unittest.TestCase):
                 atol=1e-7,
             )
 
-    @test_with_pir_api
+    # @test_with_pir_api
     def test_backward_in_static(self):
         paddle.enable_static()
         exe = paddle.static.Executor()
@@ -954,8 +952,16 @@ class TestIndexPutAPIBackward(unittest.TestCase):
 
             z = paddle.index_put(y, (index,), value)
             l = z.sum()
-            paddle.static.append_backward(l)
-            res = exe.run(fetch_list=[z, x.grad_name, value.grad_name])
+            if paddle.framework.in_pir_mode():
+                grads = paddle.autograd.ir_backward.grad(l, [x, value])
+                x_grad = grads[0]
+                value_grad = grads[1]
+            else:
+                paddle.static.append_backward(l)
+                x_grad = x.grad_name
+                value_grad = value.grad_name
+
+            res = exe.run(fetch_list=[z, x_grad, value_grad])
 
             expected_z = np.ones((4, 2, 5))
             expected_z[[0, 1, 3]] = np.ones((5,))
@@ -979,13 +985,13 @@ class TestIndexPutAPIMixedIndices(TestIndexPutAPIBase):
         self.indices_shapes = ((16, 16), (16, 16))
         self.value_shape = (16, 16, 56)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = False
 
         self.mixed_indices = True
         self.index_type_np1 = np.bool_
         self.indices_shapes1 = [(32,)]
-        self.index_type_pd1 = paddle.bool
+        self.index_type_pd1 = "bool"
 
 
 class TestIndexPutAPIMixedIndices1(TestIndexPutAPIBase):
@@ -996,13 +1002,13 @@ class TestIndexPutAPIMixedIndices1(TestIndexPutAPIBase):
         self.indices_shapes = ((16, 16), (16, 16))
         self.value_shape = (16, 16, 56)
         self.dtype_pd = "float64"
-        self.index_type_pd = paddle.int32
+        self.index_type_pd = "int32"
         self.accumulate = True
 
         self.mixed_indices = True
         self.index_type_np1 = np.bool_
         self.indices_shapes1 = [(32,)]
-        self.index_type_pd1 = paddle.bool
+        self.index_type_pd1 = "bool"
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.base import Program
+from paddle.pir_utils import test_with_pir_api
 
 
 def compute_index_put_ref(x_np, indices_np, value_np, accumulate=False):
@@ -115,8 +115,8 @@ class TestIndexPutAPIBase(unittest.TestCase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = False
 
     def setPlace(self):
@@ -144,10 +144,11 @@ class TestIndexPutAPIBase(unittest.TestCase):
             )
             np.testing.assert_allclose(ref_res, pd_res.numpy(), atol=1e-7)
 
+    @test_with_pir_api
     def test_static_forward(self):
         paddle.enable_static()
         for place in self.place:
-            with paddle.static.program_guard(Program()):
+            with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data(
                     name="x", shape=self.x_shape, dtype=self.dtype_pd
                 )
@@ -211,8 +212,8 @@ class TestIndexPutAPI0(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = True
 
 
@@ -223,8 +224,8 @@ class TestIndexPutAPI1(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16), (1, 16))
         self.value_shape = (16, 16)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = False
 
 
@@ -235,8 +236,8 @@ class TestIndexPutAPI2(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16), (1, 16))
         self.value_shape = (16, 16)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = True
 
 
@@ -247,7 +248,7 @@ class TestIndexPutAPI3(TestIndexPutAPIBase):
         self.x_shape = (110, 94)
         self.indices_shapes = [(110, 94)]
         self.value_shape = (5170,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = False
 
@@ -259,7 +260,7 @@ class TestIndexPutAPI4(TestIndexPutAPIBase):
         self.x_shape = (110, 94)
         self.indices_shapes = [(110, 94)]
         self.value_shape = (5170,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = True
 
@@ -271,8 +272,8 @@ class TestIndexPutAPI5(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (16, 16, 56)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = False
 
 
@@ -283,8 +284,8 @@ class TestIndexPutAPI6(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (16, 16, 56)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = True
 
 
@@ -295,7 +296,7 @@ class TestIndexPutAPI7(TestIndexPutAPIBase):
         self.x_shape = (110, 94)
         self.indices_shapes = [(110,)]
         self.value_shape = (55, 94)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = False
 
@@ -307,7 +308,7 @@ class TestIndexPutAPI8(TestIndexPutAPIBase):
         self.x_shape = (110, 94)
         self.indices_shapes = [(110,)]
         self.value_shape = (55, 94)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = True
 
@@ -319,8 +320,8 @@ class TestIndexPutAPI9(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (56,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = False
 
 
@@ -331,8 +332,8 @@ class TestIndexPutAPI10(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (56,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = True
 
 
@@ -343,8 +344,8 @@ class TestIndexPutAPI11(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (1,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = False
 
 
@@ -355,8 +356,8 @@ class TestIndexPutAPI12(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (1,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = True
 
 
@@ -367,7 +368,7 @@ class TestIndexPutAPI13(TestIndexPutAPIBase):
         self.x_shape = (44, 94)
         self.indices_shapes = [(44,)]
         self.value_shape = (94,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = False
 
@@ -379,7 +380,7 @@ class TestIndexPutAPI14(TestIndexPutAPIBase):
         self.x_shape = (44, 94)
         self.indices_shapes = [(44,)]
         self.value_shape = (94,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = True
 
@@ -391,7 +392,7 @@ class TestIndexPutAPI15(TestIndexPutAPIBase):
         self.x_shape = (44, 94)
         self.indices_shapes = [(44,)]
         self.value_shape = (1,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = False
 
@@ -403,7 +404,7 @@ class TestIndexPutAPI16(TestIndexPutAPIBase):
         self.x_shape = (44, 94)
         self.indices_shapes = [(44,)]
         self.value_shape = (1,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.bool
         self.accumulate = True
 
@@ -415,7 +416,7 @@ class TestIndexPutAPI17(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.int32
         self.accumulate = False
 
@@ -427,7 +428,7 @@ class TestIndexPutAPI18(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.int32
         self.accumulate = True
 
@@ -511,7 +512,7 @@ class TestIndexPutAPI25(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.int64
+        self.dtype_pd = "int64"
         self.index_type_pd = paddle.int32
         self.accumulate = False
 
@@ -523,7 +524,7 @@ class TestIndexPutAPI26(TestIndexPutAPIBase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.int64
+        self.dtype_pd = "int64"
         self.index_type_pd = paddle.int32
         self.accumulate = True
 
@@ -559,7 +560,7 @@ class TestIndexPutAPI29(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (16, 16, 56)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.int32
         self.accumulate = False
 
@@ -571,7 +572,7 @@ class TestIndexPutAPI30(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 56, 56)
         self.indices_shapes = ((16, 16), (16, 16), (1, 16))
         self.value_shape = (16, 16, 56)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.int32
         self.accumulate = True
 
@@ -618,8 +619,8 @@ class TestIndexPutInplaceAPI(unittest.TestCase):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = False
 
     def setPlace(self):
@@ -656,8 +657,8 @@ class TestIndexPutInplaceAPI1(TestIndexPutInplaceAPI):
         self.x_shape = (100, 110)
         self.indices_shapes = [(21,), (21,)]
         self.value_shape = (21,)
-        self.dtype_pd = paddle.float64
-        self.index_type_pd = paddle.int64
+        self.dtype_pd = "float64"
+        self.index_type_pd = "int64"
         self.accumulate = True
 
 
@@ -674,10 +675,10 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         paddle.disable_static()
         for place in self.place:
             paddle.device.set_device(place)
-            value = paddle.ones(shape=[4], dtype=paddle.float64)
-            x = paddle.ones(shape=[16, 21], dtype=paddle.float64)
-            ix1 = paddle.to_tensor([0, 1, 2, 3], dtype=paddle.int64)
-            ix2 = paddle.to_tensor([0, 1, 2, 3], dtype=paddle.int64)
+            value = paddle.ones(shape=[4], dtype="float64")
+            x = paddle.ones(shape=[16, 21], dtype="float64")
+            ix1 = paddle.to_tensor([0, 1, 2, 3], dtype="int64")
+            ix2 = paddle.to_tensor([0, 1, 2, 3], dtype="int64")
             value.stop_gradient = False
             x.stop_gradient = False
             out = paddle.index_put(x, (ix1, ix2), value, False)
@@ -719,10 +720,10 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         paddle.disable_static()
         for place in self.place:
             paddle.device.set_device(place)
-            value = paddle.ones(shape=[1], dtype=paddle.float64)
-            x = paddle.ones(shape=[16, 21], dtype=paddle.float64)
-            ix1 = paddle.to_tensor([0, 1, 2, 3], dtype=paddle.int64)
-            ix2 = paddle.to_tensor([0, 1, 2, 3], dtype=paddle.int64)
+            value = paddle.ones(shape=[1], dtype="float64")
+            x = paddle.ones(shape=[16, 21], dtype="float64")
+            ix1 = paddle.to_tensor([0, 1, 2, 3], dtype="int64")
+            ix2 = paddle.to_tensor([0, 1, 2, 3], dtype="int64")
             value.stop_gradient = False
             x.stop_gradient = False
             out = paddle.index_put(x, (ix1, ix2), value, False)
@@ -760,10 +761,10 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         paddle.disable_static()
         for place in self.place:
             paddle.device.set_device(place)
-            value = paddle.ones(shape=[2], dtype=paddle.float64)
-            x = paddle.ones(shape=[16, 21], dtype=paddle.float64)
-            ix1 = paddle.to_tensor([[0, 1], [2, 3]], dtype=paddle.int64)
-            ix2 = paddle.to_tensor([[0, 1], [2, 3]], dtype=paddle.int64)
+            value = paddle.ones(shape=[2], dtype="float64")
+            x = paddle.ones(shape=[16, 21], dtype="float64")
+            ix1 = paddle.to_tensor([[0, 1], [2, 3]], dtype="int64")
+            ix2 = paddle.to_tensor([[0, 1], [2, 3]], dtype="int64")
             value.stop_gradient = False
             x.stop_gradient = False
             out = paddle.index_put(x, (ix1, ix2), value, False)
@@ -805,10 +806,10 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         paddle.disable_static()
         for place in self.place:
             paddle.device.set_device(place)
-            value = paddle.ones(shape=[1, 2], dtype=paddle.float64)
-            x = paddle.ones(shape=[16, 21], dtype=paddle.float64)
-            ix1 = paddle.to_tensor([[0, 1], [2, 3]], dtype=paddle.int64)
-            ix2 = paddle.to_tensor([[0, 1], [2, 3]], dtype=paddle.int64)
+            value = paddle.ones(shape=[1, 2], dtype="float64")
+            x = paddle.ones(shape=[16, 21], dtype="float64")
+            ix1 = paddle.to_tensor([[0, 1], [2, 3]], dtype="int64")
+            ix2 = paddle.to_tensor([[0, 1], [2, 3]], dtype="int64")
             value.stop_gradient = False
             x.stop_gradient = False
             out = paddle.index_put(x, (ix1, ix2), value, False)
@@ -850,10 +851,10 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         paddle.disable_static()
         for place in self.place:
             paddle.device.set_device(place)
-            value = paddle.ones(shape=[2, 1], dtype=paddle.float64)
-            x = paddle.ones(shape=[16, 21], dtype=paddle.float64)
-            ix1 = paddle.to_tensor([[0, 1], [2, 3]], dtype=paddle.int64)
-            ix2 = paddle.to_tensor([[0, 1], [2, 3]], dtype=paddle.int64)
+            value = paddle.ones(shape=[2, 1], dtype="float64")
+            x = paddle.ones(shape=[16, 21], dtype="float64")
+            ix1 = paddle.to_tensor([[0, 1], [2, 3]], dtype="int64")
+            ix2 = paddle.to_tensor([[0, 1], [2, 3]], dtype="int64")
             value.stop_gradient = False
             x.stop_gradient = False
             out = paddle.index_put(x, (ix1, ix2), value, False)
@@ -895,8 +896,8 @@ class TestIndexPutAPIBackward(unittest.TestCase):
         paddle.disable_static()
         for place in self.place:
             paddle.device.set_device(place)
-            value = paddle.ones(shape=[2, 1], dtype=paddle.float64)
-            x = paddle.ones(shape=[16, 21], dtype=paddle.float64)
+            value = paddle.ones(shape=[2, 1], dtype="float64")
+            x = paddle.ones(shape=[16, 21], dtype="float64")
             ix = paddle.zeros(shape=[16, 21], dtype=paddle.bool)
 
             value.stop_gradient = False
@@ -935,6 +936,7 @@ class TestIndexPutAPIBackward(unittest.TestCase):
                 atol=1e-7,
             )
 
+    @test_with_pir_api
     def test_backward_in_static(self):
         paddle.enable_static()
         exe = paddle.static.Executor()
@@ -976,7 +978,7 @@ class TestIndexPutAPIMixedIndices(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 32, 56)
         self.indices_shapes = ((16, 16), (16, 16))
         self.value_shape = (16, 16, 56)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.int32
         self.accumulate = False
 
@@ -993,7 +995,7 @@ class TestIndexPutAPIMixedIndices1(TestIndexPutAPIBase):
         self.x_shape = (110, 42, 32, 56)
         self.indices_shapes = ((16, 16), (16, 16))
         self.value_shape = (16, 16, 56)
-        self.dtype_pd = paddle.float64
+        self.dtype_pd = "float64"
         self.index_type_pd = paddle.int32
         self.accumulate = True
 

--- a/test/legacy_test/test_inverse_op.py
+++ b/test/legacy_test/test_inverse_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestInverseOp(OpTest):
@@ -40,10 +41,10 @@ class TestInverseOp(OpTest):
         self.outputs = {'Output': inverse}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_grad(self):
-        self.check_grad(['Input'], 'Output')
+        self.check_grad(['Input'], 'Output', check_pir=True)
 
 
 class TestInverseOpBatched(TestInverseOp):
@@ -60,7 +61,9 @@ class TestInverseOpLarge(TestInverseOp):
         self.python_api = paddle.tensor.math.inverse
 
     def test_grad(self):
-        self.check_grad(['Input'], 'Output', max_relative_error=1e-6)
+        self.check_grad(
+            ['Input'], 'Output', max_relative_error=1e-6, check_pir=True
+        )
 
 
 class TestInverseOpFP32(TestInverseOp):
@@ -70,7 +73,9 @@ class TestInverseOpFP32(TestInverseOp):
         self.python_api = paddle.tensor.math.inverse
 
     def test_grad(self):
-        self.check_grad(['Input'], 'Output', max_relative_error=1e-2)
+        self.check_grad(
+            ['Input'], 'Output', max_relative_error=1e-2, check_pir=True
+        )
 
 
 class TestInverseOpBatchedFP32(TestInverseOpFP32):
@@ -113,6 +118,7 @@ class TestInverseAPI(unittest.TestCase):
                 fetches[0], np.linalg.inv(input_np), rtol=1e-05
             )
 
+    @test_with_pir_api
     def test_static(self):
         for place in self.places:
             self.check_static_result(place=place)
@@ -181,6 +187,7 @@ class TestInverseSingularAPI(unittest.TestCase):
             except ValueError as ex:
                 print("The mat is singular")
 
+    @test_with_pir_api
     def test_static(self):
         for place in self.places:
             self.check_static_result(place=place)

--- a/test/legacy_test/test_inverse_op.py
+++ b/test/legacy_test/test_inverse_op.py
@@ -100,7 +100,9 @@ class TestInverseAPI(unittest.TestCase):
             self.places.append(base.CUDAPlace(0))
 
     def check_static_result(self, place):
-        with base.program_guard(base.Program(), base.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             input = paddle.static.data(
                 name="input", shape=[4, 4], dtype="float64"
             )
@@ -110,7 +112,7 @@ class TestInverseAPI(unittest.TestCase):
 
             exe = base.Executor(place)
             fetches = exe.run(
-                base.default_main_program(),
+                paddle.static.default_main_program(),
                 feed={"input": input_np},
                 fetch_list=[result],
             )
@@ -167,7 +169,9 @@ class TestInverseSingularAPI(unittest.TestCase):
             self.places.append(base.CUDAPlace(0))
 
     def check_static_result(self, place):
-        with base.program_guard(base.Program(), base.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             input = paddle.static.data(
                 name="input", shape=[4, 4], dtype="float64"
             )
@@ -178,7 +182,7 @@ class TestInverseSingularAPI(unittest.TestCase):
             exe = base.Executor(place)
             try:
                 fetches = exe.run(
-                    base.default_main_program(),
+                    paddle.static.default_main_program(),
                     feed={"input": input_np},
                     fetch_list=[result],
                 )

--- a/test/legacy_test/test_linspace.py
+++ b/test/legacy_test/test_linspace.py
@@ -43,7 +43,7 @@ class TestLinspaceOpCommonCase(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestLinspaceOpReverseCase(TestLinspaceOpCommonCase):
@@ -56,7 +56,7 @@ class TestLinspaceOpReverseCase(TestLinspaceOpCommonCase):
         self.outputs = {'Out': np.arange(10, -1, -1).astype(self.dtype)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestLinspaceOpNumOneCase(TestLinspaceOpCommonCase):
@@ -69,7 +69,7 @@ class TestLinspaceOpNumOneCase(TestLinspaceOpCommonCase):
         self.outputs = {'Out': np.array([10], dtype=self.dtype)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestLinspaceOpCommonCaseFP16(TestLinspaceOpCommonCase):
@@ -111,7 +111,7 @@ class TestLinspaceOpCommonCaseBF16(TestLinspaceOpCommonCaseFP16):
         }
 
     def test_check_output(self):
-        return self.check_output_with_place(core.CUDAPlace(0))
+        return self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
 
 
 class TestLinspaceOpReverseCaseBF16(TestLinspaceOpCommonCaseBF16):

--- a/test/legacy_test/test_solve_op.py
+++ b/test/legacy_test/test_solve_op.py
@@ -50,10 +50,10 @@ class TestSolveOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 # x broadcast + 3D batch case
@@ -71,10 +71,12 @@ class TestSolveOpBatched_case0(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=1e-1)
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=1e-1, check_pir=True
+        )
 
 
 # 3D batch + y vector case
@@ -92,10 +94,12 @@ class TestSolveOpBatched_case1(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.04)
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=0.04, check_pir=True
+        )
 
 
 # 3D batch + y broadcast case
@@ -113,10 +117,12 @@ class TestSolveOpBatched_case2(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.02)
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=0.02, check_pir=True
+        )
 
 
 # x broadcast + 3D batch case
@@ -134,10 +140,12 @@ class TestSolveOpBatched_case3(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.02)
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=0.02, check_pir=True
+        )
 
 
 # 3D normal batch case
@@ -155,10 +163,10 @@ class TestSolveOpBatched_case4(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 # 4D normal batch case
@@ -176,10 +184,10 @@ class TestSolveOpBatched_case5(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 # 4D batch + y broadcast case
@@ -197,10 +205,10 @@ class TestSolveOpBatched_case6(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 # 5D normal batch case
@@ -218,10 +226,12 @@ class TestSolveOpBatched_case7(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.04)
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=0.04, check_pir=True
+        )
 
 
 # 5D batch + y broadcast case
@@ -239,10 +249,12 @@ class TestSolveOpBatched_case8(OpTest):
         self.outputs = {'Out': result}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.04)
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=0.04, check_pir=True
+        )
 
 
 class TestSolveOpError(unittest.TestCase):

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -47,7 +47,6 @@ class TestStdAPI(unittest.TestCase):
     def set_attrs(self):
         pass
 
-    @test_with_pir_api
     def static(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.shape, self.dtype)
@@ -63,6 +62,7 @@ class TestStdAPI(unittest.TestCase):
         paddle.enable_static()
         return out.numpy()
 
+    @test_with_pir_api
     def test_api(self):
         out_ref = ref_std(self.x, self.axis, self.unbiased, self.keepdim)
         out_dygraph = self.dygraph()

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def ref_std(x, axis=None, unbiased=True, keepdim=False):
@@ -46,6 +47,7 @@ class TestStdAPI(unittest.TestCase):
     def set_attrs(self):
         pass
 
+    @test_with_pir_api
     def static(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.shape, self.dtype)
@@ -120,6 +122,7 @@ class TestStdError(unittest.TestCase):
 
 
 class Testfp16Std(unittest.TestCase):
+    @test_with_pir_api
     def test_fp16_with_gpu(self):
         paddle.enable_static()
         if paddle.base.core.is_compiled_with_cuda():

--- a/test/legacy_test/test_triangular_solve_op.py
+++ b/test/legacy_test/test_triangular_solve_op.py
@@ -64,10 +64,10 @@ class TestTriangularSolveOp(OpTest):
         self.outputs = {'Out': self.output}
 
     def test_check_output(self):
-        self.check_output(check_cinn=True)
+        self.check_output(check_cinn=True, check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', check_cinn=True)
+        self.check_grad(['X', 'Y'], 'Out', check_cinn=True, check_pir=True)
 
 
 # 2D(broadcast) + 3D, test 'transpose'


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将如下算子迁移升级至 pir，并更新单测

- `expand`/`broadcast_to`(1/2): base.backward.calc_gradient好像不支持 pir报错 AttributeError: 'paddle.base.libpaddle.pir.Program' object has no attribute '_appending_grad_times'
- `solve`(20/20)
- `diag`(4/4)
- `linspace`(4/4)
- `std`(2/2)
- `cond`：依赖于 #58446 
- `slogdet`/`det`(6/6)
- `index_add`(5/5)
- `index_put`(0/34)：添加 PIR 测试遇到问题
- `inverse`(7/7)：


#### 遇到问题
<del>
std 测试
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.10/3.10.13/lib/python3.10/site-packages/paddle/tensor/manipulation.py", line 187, in cast
    return _C_ops.cast(x, dtype)
ValueError: (InvalidArgument) cast: argument (position 2) must be one of paddle::DataType, but got paddle.base.libpaddle.VarType (at /workspace/Paddle/paddle/fluid/pybind/eager_utils.cc:697)
</del>

index_put 测试

按照 https://github.com/PaddlePaddle/Paddle/pull/58496/files#diff-1ccaa1eaa0f1a4a582a62b7813e9d6d9c561d0579aea019074a39eba769be687R649
等参考内容修改后，依然会有如下报错
ValueError: (InvalidArgument) The Variable type must be N3phi11DenseTensorE, but the type it holds is N6paddle9framework9PhiVectorIPKNS0_8VariableEEE.
  [Hint: Expected holder_->Type() == VarTypeTrait<T>::kId, but received holder_->Type():64 != VarTypeTrait<T>::kId:7.] (at /workspace/Paddle/paddle/fluid/framework/variable.h:52)