### PR TITLE
[PIR]Migrate Conv3D into pir

### DIFF
--- a/test/legacy_test/test_conv3d_op.py
+++ b/test/legacy_test/test_conv3d_op.py
@@ -208,7 +208,7 @@ def create_test_cudnn_bf16_class(parent):
         def test_check_output(self):
             place = core.CUDAPlace(0)
             self.check_output_with_place(
-                place, check_dygraph=(not self.use_mkldnn)
+                place, check_dygraph=(not self.use_mkldnn), check_pir=True
             )
 
         def test_check_grad_no_filter(self):
@@ -222,6 +222,7 @@ def create_test_cudnn_bf16_class(parent):
                 no_grad_set={'Filter'},
                 check_dygraph=(not self.use_mkldnn),
                 user_defined_grads=[numeric_grads],
+                check_pir=True,
             )
 
         def test_check_grad_no_input(self):
@@ -235,6 +236,7 @@ def create_test_cudnn_bf16_class(parent):
                 no_grad_set={'Input'},
                 check_dygraph=(not self.use_mkldnn),
                 user_defined_grads=[numeric_grads],
+                check_pir=True,
             )
 
         def test_check_grad(self):
@@ -248,6 +250,7 @@ def create_test_cudnn_bf16_class(parent):
                 'Output',
                 user_defined_grads=[numeric_input_grads, numeric_fliter_grads],
                 check_dygraph=(not self.use_mkldnn),
+                check_pir=True,
             )
 
     cls_name = "{}_{}".format(parent.__name__, "CUDNNBF16OP")
@@ -448,7 +451,10 @@ class TestConv3DOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_output_with_place(
-            place, atol=1e-5, check_dygraph=(not self.use_mkldnn)
+            place,
+            atol=1e-5,
+            check_dygraph=(not self.use_mkldnn),
+            check_pir=True,
         )
 
     def test_check_grad(self):
@@ -460,6 +466,7 @@ class TestConv3DOp(OpTest):
             'Output',
             max_relative_error=0.03,
             check_dygraph=(not self.use_mkldnn),
+            check_pir=True,
         )
 
     def test_check_grad_no_filter(self):
@@ -472,6 +479,7 @@ class TestConv3DOp(OpTest):
             max_relative_error=0.03,
             no_grad_set={'Filter'},
             check_dygraph=(not self.use_mkldnn),
+            check_pir=True,
         )
 
     def test_check_grad_no_input(self):
@@ -484,6 +492,7 @@ class TestConv3DOp(OpTest):
             max_relative_error=0.03,
             no_grad_set={'Input'},
             check_dygraph=(not self.use_mkldnn),
+            check_pir=True,
         )
 
     def init_test_case(self):
@@ -599,7 +608,7 @@ class TestFP16CUDNN(TestConv3DOp):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=2e-2)
+                self.check_output_with_place(place, atol=2e-2, check_pir=True)
 
 
 @unittest.skipIf(
@@ -623,7 +632,7 @@ class TestFP16WithGroup1CUDNN(TestWithGroup1):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=2e-2)
+                self.check_output_with_place(place, atol=2e-2, check_pir=True)
 
 
 @unittest.skipIf(
@@ -647,7 +656,7 @@ class TestFP16WithGroup2CUDNN(TestWithGroup2):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=2e-2)
+                self.check_output_with_place(place, atol=2e-2, check_pir=True)
 
 
 @unittest.skipIf(
@@ -671,7 +680,7 @@ class TestFP16With1x1CUDNN(TestWith1x1):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=2e-2)
+                self.check_output_with_place(place, atol=2e-2, check_pir=True)
 
 
 @unittest.skipIf(
@@ -695,7 +704,7 @@ class TestFP16WithInput1x1Filter1x1CUDNN(TestWithInput1x1Filter1x1):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=2e-2)
+                self.check_output_with_place(place, atol=2e-2, check_pir=True)
 
 
 class TestCUDNNExhaustiveSearch(TestCUDNN):
@@ -771,14 +780,18 @@ class TestConv3DOp_2(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
-        self.check_output_with_place(place, atol=1e-5)
+        self.check_output_with_place(place, atol=1e-5, check_pir=True)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.03
+            place,
+            {'Input', 'Filter'},
+            'Output',
+            max_relative_error=0.03,
+            check_pir=True,
         )
 
     def test_check_grad_no_filter(self):
@@ -791,6 +804,7 @@ class TestConv3DOp_2(OpTest):
             'Output',
             max_relative_error=0.03,
             no_grad_set={'Filter'},
+            check_pir=True,
         )
 
     def test_check_grad_no_input(self):
@@ -803,6 +817,7 @@ class TestConv3DOp_2(OpTest):
             'Output',
             max_relative_error=0.03,
             no_grad_set={'Input'},
+            check_pir=True,
         )
 
     def init_test_case(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Migrate Conv3D into pir
涉及两个单测文件：
- test_conv3d_op.py: 继承自TestCase的单测内因为使用了paddle.static.nn.conv3d，静态图专用的api没有适配，所以这类单测没有打开，其他继承自OpTest的单测都已经打开了
- test_conv3d_layer.py: 新增了一个pir的测试case，原有测试case没有打开

Pcard-67164