### PR TITLE
【SOT】fix sot memory leakage when fallback

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import gc
 import traceback
 import types
 from typing import List, Tuple
@@ -228,3 +229,5 @@ def start_translate(frame: types.FrameType, **kwargs) -> GuardedFunction:
         raise InnerError(OpcodeExecutorBase.error_message_summary(e)) from e
     finally:
         simulator.cleanup()
+        del simulator
+        gc.collect()

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -26,7 +26,7 @@ from typing import Any, Callable
 
 from ...infer_meta import InferMetaCache, LayerInferMetaCache, MetaInfo
 from ...profiler import EventGuard, event_register
-from ...symbolic.statement_ir import Symbol
+from ...symbolic.statement_ir import Reference, Symbol
 from ...symbolic.symbolic_context import SymbolicTraceContext
 from ...utils import (
     ENV_SHOW_TRACKERS,
@@ -426,6 +426,7 @@ class FunctionGraph:
     def call_layer(
         self,
         layer: PaddleLayerVariable,
+        weak_ref: bool,
         *args: VariableBase,
         **kwargs: VariableBase,
     ):
@@ -442,7 +443,7 @@ class FunctionGraph:
 
         def compute_fn(layer, inputs, outputs, stacks):
             self.sir_ctx.call_LAYER(
-                layer.value,
+                Reference(layer.value, weak_ref),
                 inputs=inputs,
                 outputs=outputs,
                 stacks=stacks,

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1460,6 +1460,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
     def cleanup(self):
         self._graph.pycode_gen = None
         Dispatcher.graph = None
+        self.call_stack = []
 
     @event_register("OpcodeExecutor: _prepare_virtual_env", event_level=2)
     def _prepare_virtual_env(self):

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1460,7 +1460,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
     def cleanup(self):
         self._graph.pycode_gen = None
         Dispatcher.graph = None
-        self.call_stack = []
+        self.call_stack[:] = []
 
     @event_register("OpcodeExecutor: _prepare_virtual_env", event_level=2)
     def _prepare_virtual_env(self):

--- a/python/paddle/jit/sot/symbolic/statement_ir.py
+++ b/python/paddle/jit/sot/symbolic/statement_ir.py
@@ -22,10 +22,24 @@ from __future__ import annotations
 import weakref
 from typing import Any, Callable
 
-import paddle
 from paddle.utils import is_sequence, map_structure
 
 from ..utils import NameGenerator, OrderedSet, Singleton, flatten_extend
+
+
+class Reference:  # to unify weak_ref and strong_ref
+    def __init__(self, value, is_weak):
+        self.is_weak = is_weak
+        if is_weak is True:
+            self.ref = weakref.ref(value)
+        else:
+            self.ref = value
+
+    def __call__(self):
+        if self.is_weak is True:
+            return self.ref()
+        else:
+            return self.ref
 
 
 class Symbol:
@@ -139,7 +153,7 @@ class MethodStatement(Statement):
 class LayerStatement(Statement):
     def __init__(
         self,
-        layer: paddle.nn.Layer,
+        layer: Reference,  # Reference of paddle.nn.Layer
         inputs: list[Symbol],
         outputs: list[Symbol],
         stacks: list[str],
@@ -147,7 +161,7 @@ class LayerStatement(Statement):
         super().__init__(
             "layer", layer.__class__.__name__, inputs, outputs, stacks
         )
-        self.layer = weakref.ref(layer)
+        self.layer = layer
 
 
 class StatementIR:

--- a/test/sot/test_simulate_initialize.py
+++ b/test/sot/test_simulate_initialize.py
@@ -31,6 +31,18 @@ def foo(x, y):
     return out
 
 
+def foo2(x, y):
+    t = nn.Softmax()
+    out1 = t(paddle.to_tensor([x, y], dtype="float32"))
+    out2 = t(paddle.to_tensor([x, y], dtype="float32"))
+    return out1 + out2
+
+
+def error_foo(x):
+    t = nn.Linear(10, 10)
+    return t(x)
+
+
 def bar(x):
     a = A(x)
     t = paddle.to_tensor(x)
@@ -40,11 +52,19 @@ def bar(x):
 class TestInit(TestCaseBase):
     def test_init_paddle_layer(self):
         self.assert_results(foo, 1, 2)
+        self.assert_results(foo2, 1, 2)
 
     def test_init_python_object(self):
         sot_output = symbolic_translate(bar)([1.0, 2.0])
         dyn_output = bar([1.0, 2.0])
         self.assert_nest_match(sot_output, dyn_output)
+
+    def test_error(self):
+        def run():
+            inputs = paddle.randn((10, 10))
+            symbolic_translate(error_foo)(inputs)
+
+        self.assertRaises(paddle.jit.sot.utils.exceptions.InnerError, run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
fix sot memory leakage when fallback
1. 延迟释放问题
2. 解决了泄漏的 frame 问题，使用 sys.getrefcount 还是可以比较好的二分定位到代码的位置。

PCard-66972