### PR TITLE
【PIR API adaptor No.178、169、137、34、129】 Migrate ReLU6/PReLU/LogSigmoid/CELU/LogSoftmax into pir

### DIFF
--- a/python/paddle/nn/functional/activation.py
+++ b/python/paddle/nn/functional/activation.py
@@ -61,7 +61,7 @@ def celu(x, alpha=1.0, name=None):
     """
     if alpha == 0:
         raise ZeroDivisionError("alpha cannot be 0 for celu")
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.celu(x, alpha)
     else:
         check_variable_and_dtype(
@@ -594,7 +594,7 @@ def prelu(x, weight, data_format="NCHW", name=None):
             ), "The weight size should be equal to x input channel in prelu() when weight shape is not [1]."
         mode = 'channel'
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.prelu(x, weight, data_format, mode)
     else:
         check_variable_and_dtype(
@@ -813,7 +813,7 @@ def log_sigmoid(x, name=None):
             [-0.31326166, -0.12692805, -0.04858733, -0.01814996])
     """
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.logsigmoid(x)
     else:
         check_variable_and_dtype(
@@ -942,7 +942,7 @@ def relu6(x, name=None):
             [0.        , 0.30000001, 6.        ])
     """
     threshold = 6.0
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.relu6(x)
 
     check_variable_and_dtype(
@@ -1683,7 +1683,7 @@ def log_softmax(x, axis=-1, dtype=None, name=None):
     if (dtype is not None) and (not isinstance(dtype, core.VarDesc.VarType)):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if dtype is not None:
             x = _C_ops.cast(x, dtype)
         return _C_ops.log_softmax(x, axis)

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -409,7 +409,7 @@ class TestSigmoid_Complex64(TestSigmoid):
         self.dtype = np.complex64
 
     def test_check_output(self):
-        self.check_output(check_prim=False, check_pir=True)
+        self.check_output(check_prim=False)
 
     def test_check_grad(self):
         self.check_grad(
@@ -680,7 +680,6 @@ class TestLogSigmoidAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -2848,7 +2847,6 @@ class TestRelu6API(unittest.TestCase):
             out_ref = ref_relu6(self.x_np)
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
-    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -2867,7 +2865,6 @@ class TestRelu6API(unittest.TestCase):
 
 
 class TestRelu6APIWarnings(unittest.TestCase):
-    @test_with_pir_api
     def test_warnings(self):
         with static_guard():
             with warnings.catch_warnings(record=True) as context:
@@ -3275,7 +3272,6 @@ class TestCELUAPI(unittest.TestCase):
             for r in [out1, out2]:
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
-    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -626,7 +626,7 @@ class TestLogSigmoid(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out', max_relative_error=0.008)
+        self.check_grad(['X'], 'Out', max_relative_error=0.008, check_pir=True)
 
 
 class TestLogSigmoidComplex64(TestLogSigmoid):
@@ -655,6 +655,7 @@ class TestLogSigmoidAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -679,6 +680,7 @@ class TestLogSigmoidAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -2791,7 +2793,7 @@ class TestRelu6(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestRelu6_ZeroDim(TestRelu6):
@@ -2811,6 +2813,7 @@ class TestRelu6API(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -2834,6 +2837,7 @@ class TestRelu6API(unittest.TestCase):
             for r in [out1, out2]:
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
+    @test_with_pir_api
     def test_base_api(self):
         with static_guard():
             with base.program_guard(base.Program()):
@@ -2844,6 +2848,7 @@ class TestRelu6API(unittest.TestCase):
             out_ref = ref_relu6(self.x_np)
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
+    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -2862,6 +2867,7 @@ class TestRelu6API(unittest.TestCase):
 
 
 class TestRelu6APIWarnings(unittest.TestCase):
+    @test_with_pir_api
     def test_warnings(self):
         with static_guard():
             with warnings.catch_warnings(record=True) as context:
@@ -3213,7 +3219,7 @@ class TestCELU(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestCELU_ZeroDim(TestCELU):
@@ -3236,6 +3242,7 @@ class TestCELUAPI(unittest.TestCase):
     def executed_api(self):
         self.celu = F.celu
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -3268,6 +3275,7 @@ class TestCELUAPI(unittest.TestCase):
             for r in [out1, out2]:
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
+    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_log_softmax.py
+++ b/test/legacy_test/test_log_softmax.py
@@ -236,7 +236,6 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
             self.check_api(axis)
         self.check_api(-1, 'float64')
 
-    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data(name='X1', shape=[100], dtype='int32')

--- a/test/legacy_test/test_log_softmax.py
+++ b/test/legacy_test/test_log_softmax.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 import paddle.nn.functional as F
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(10)
 
@@ -63,10 +64,12 @@ class TestLogSoftmaxOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['Out'], user_defined_grads=[self.x_grad])
+        self.check_grad(
+            ['X'], ['Out'], user_defined_grads=[self.x_grad], check_pir=True
+        )
 
 
 class TestLogSoftmaxOp_ZeroDim(TestLogSoftmaxOp):
@@ -83,10 +86,10 @@ class TestLogSoftmaxOp_ZeroDim(TestLogSoftmaxOp):
         self.attrs = {'axis': -1}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['Out'])
+        self.check_grad(['X'], ['Out'], check_pir=True)
 
 
 class TestLogSoftmaxShape(TestLogSoftmaxOp):
@@ -104,10 +107,10 @@ class TestLogSoftmaxFP16OP(TestLogSoftmaxOp):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output(atol=1e-3)
+        self.check_output(atol=1e-3, check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['Out'], max_relative_error=1e-2)
+        self.check_grad(['X'], ['Out'], max_relative_error=1e-2, check_pir=True)
 
 
 class TestLogSoftmaxShapeFP16OP(TestLogSoftmaxFP16OP):
@@ -143,7 +146,7 @@ class TestLogSoftmaxBF16Op(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
@@ -152,6 +155,7 @@ class TestLogSoftmaxBF16Op(OpTest):
             ['X'],
             ['Out'],
             user_defined_grads=[self.x_grad],
+            check_pir=True,
         )
 
 
@@ -171,6 +175,7 @@ class TestNNLogSoftmaxAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def check_api(self, axis=-1):
         ref_out = np.apply_along_axis(ref_log_softmax, axis, self.x)
 
@@ -190,6 +195,7 @@ class TestNNLogSoftmaxAPI(unittest.TestCase):
         np.testing.assert_allclose(y.numpy(), ref_out, rtol=1e-05)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_check_api(self):
         for axis in [-1, 1]:
             self.check_api(axis)
@@ -205,6 +211,7 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def check_api(self, axis=-1, dtype=None):
         x = self.x.copy()
         if dtype is not None:
@@ -223,11 +230,13 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
         np.testing.assert_allclose(y.numpy(), ref_out, rtol=1e-05)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_check_api(self):
         for axis in [-1, 1]:
             self.check_api(axis)
         self.check_api(-1, 'float64')
 
+    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data(name='X1', shape=[100], dtype='int32')

--- a/test/legacy_test/test_prelu_op.py
+++ b/test/legacy_test/test_prelu_op.py
@@ -80,7 +80,6 @@ class TestFunctionalPReluAPI(unittest.TestCase):
         self.dygraph_check(self.weight_np_0)
         self.dygraph_check(self.weight_np_1)
 
-    @test_with_pir_api
     def test_error(self):
         with paddle.static.program_guard(paddle.static.Program()):
             weight_fp32 = paddle.static.data(
@@ -512,7 +511,6 @@ class TestModeError(unittest.TestCase):
         )
         self.x_np = np.ones([1, 2, 3, 4]).astype('float32')
 
-    @test_with_pir_api
     def test_mode_error(self):
         main_program = Program()
         with base.program_guard(main_program, Program()):
@@ -522,7 +520,6 @@ class TestModeError(unittest.TestCase):
             except Exception as e:
                 assert e.args[0].find('InvalidArgument') != -1
 
-    @test_with_pir_api
     def test_data_format_error1(self):
         main_program = Program()
         with base.program_guard(main_program, Program()):
@@ -532,7 +529,6 @@ class TestModeError(unittest.TestCase):
             except Exception as e:
                 assert e.args[0].find('InvalidArgument') != -1
 
-    @test_with_pir_api
     def test_data_format_error2(self):
         main_program = Program()
         with base.program_guard(main_program, Program()):

--- a/test/legacy_test/test_prelu_op.py
+++ b/test/legacy_test/test_prelu_op.py
@@ -21,6 +21,7 @@ import paddle
 import paddle.nn.functional as F
 from paddle import base
 from paddle.base import Program, core
+from paddle.pir_utils import test_with_pir_api
 
 
 def ref_prelu(x, weight):
@@ -48,6 +49,7 @@ class TestFunctionalPReluAPI(unittest.TestCase):
         self.weight_np_0 = np.random.randn(1).astype('float32')
         self.weight_np_1 = np.random.randn(self.x_np.shape[1]).astype('float32')
 
+    @test_with_pir_api
     def static_check(self, weight_np):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.x_np.shape, 'float32')
@@ -69,6 +71,7 @@ class TestFunctionalPReluAPI(unittest.TestCase):
         np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_static_api(self):
         self.static_check(self.weight_np_0)
         self.static_check(self.weight_np_1)
@@ -77,6 +80,7 @@ class TestFunctionalPReluAPI(unittest.TestCase):
         self.dygraph_check(self.weight_np_0)
         self.dygraph_check(self.weight_np_1)
 
+    @test_with_pir_api
     def test_error(self):
         with paddle.static.program_guard(paddle.static.Program()):
             weight_fp32 = paddle.static.data(
@@ -105,6 +109,7 @@ class TestNNPReluAPI(unittest.TestCase):
         )
         self.x_np = np.ones([1, 2, 3, 4]).astype('float32')
 
+    @test_with_pir_api
     def test_static_api(self):
         startup_program = paddle.static.Program()
         train_program = paddle.static.Program()
@@ -226,10 +231,10 @@ class PReluTest(OpTest):
         self.attrs = {'mode': "channel", "data_format": "NCHW"}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Alpha'], 'Out')
+        self.check_grad(['X', 'Alpha'], 'Out', check_pir=True)
 
 
 @skip_check_grad_ci(
@@ -392,13 +397,17 @@ def create_test_fp16_class(
             if core.is_compiled_with_cuda():
                 place = core.CUDAPlace(0)
                 if core.is_float16_supported(place):
-                    self.check_output_with_place(place, atol=atol)
+                    self.check_output_with_place(
+                        place, atol=atol, check_pir=True
+                    )
 
         def test_check_grad(self):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place) and check_grad:
                 # Use the default max_relative_error, not use max_relative_error
-                self.check_grad_with_place(place, ['X', 'Alpha'], 'Out')
+                self.check_grad_with_place(
+                    place, ['X', 'Alpha'], 'Out', check_pir=True
+                )
 
     cls_name = "{}_{}".format(parent.__name__, "Fp16Op")
     TestPReluFp16Case.__name__ = cls_name
@@ -426,13 +435,15 @@ def create_test_bf16_class(
 
         def test_check_output(self):
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=atol)
+            self.check_output_with_place(place, atol=atol, check_pir=True)
 
         def test_check_grad(self):
             place = core.CUDAPlace(0)
             if check_grad:
                 # Use the default max_relative_error, not use max_relative_error
-                self.check_grad_with_place(place, ['X', 'Alpha'], 'Out')
+                self.check_grad_with_place(
+                    place, ['X', 'Alpha'], 'Out', check_pir=True
+                )
 
     cls_name = "{}_{}".format(parent.__name__, "BF16Op")
     TestPReluBF16Op.__name__ = cls_name
@@ -501,6 +512,7 @@ class TestModeError(unittest.TestCase):
         )
         self.x_np = np.ones([1, 2, 3, 4]).astype('float32')
 
+    @test_with_pir_api
     def test_mode_error(self):
         main_program = Program()
         with base.program_guard(main_program, Program()):
@@ -510,6 +522,7 @@ class TestModeError(unittest.TestCase):
             except Exception as e:
                 assert e.args[0].find('InvalidArgument') != -1
 
+    @test_with_pir_api
     def test_data_format_error1(self):
         main_program = Program()
         with base.program_guard(main_program, Program()):
@@ -519,6 +532,7 @@ class TestModeError(unittest.TestCase):
             except Exception as e:
                 assert e.args[0].find('InvalidArgument') != -1
 
+    @test_with_pir_api
     def test_data_format_error2(self):
         main_program = Program()
         with base.program_guard(main_program, Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others


### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
No.178、169、137、34、129
PIR API 推全升级

- https://github.com/PaddlePaddle/Paddle/issues/58067

将 PReLU 迁移升级至 pir，并更新单测 单测覆盖率：38/42
将 LogSigmoid 迁移升级至 pir，并更新单测 单测覆盖率：4/7
将 CELU 迁移升级至 pir，并更新单测 单测覆盖率：4/5
将 LogSoftmax 迁移升级至 pir，并更新单测 单测覆盖率：18/19
将 ReLU6 迁移升级至 pir，并更新单测 单测覆盖率：4/6

存在问题:

**PReLU**
```shell
======================================================================
ERROR: test_error (__main__.TestFunctionalPReluAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_prelu_op.py", line 90, in test_error
    self.assertRaises(TypeError, F.prelu, x=1, weight=weight_fp32)
  File "/usr/lib/python3.8/unittest/case.py", line 816, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/lib/python3.8/unittest/case.py", line 202, in handle
    callable_obj(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/functional/activation.py", line 598, in prelu
    return _C_ops.prelu(x, weight, data_format, mode)
ValueError: (InvalidArgument) prelu(): argument (position 1) must be OpResult, but got int (at /home/aistudio/lbwnb/Paddle/paddle/fluid/pybind/eager_utils.cc:1530)


======================================================================
ERROR: test_data_format_error1 (__main__.TestModeError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_prelu_op.py", line 528, in test_data_format_error1
    with base.program_guard(main_program, Program()):
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir/core.py", line 234, in program_guard
    check_type(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/data_feeder.py", line 188, in check_type
    raise TypeError(
TypeError: The type of 'main_program' in paddle.static.program_guard must be <class 'paddle.base.libpaddle.pir.Program'>, but received <class 'paddle.base.framework.Program'>. 

======================================================================
ERROR: test_data_format_error2 (__main__.TestModeError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_prelu_op.py", line 538, in test_data_format_error2
    with base.program_guard(main_program, Program()):
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir/core.py", line 234, in program_guard
    check_type(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/data_feeder.py", line 188, in check_type
    raise TypeError(
TypeError: The type of 'main_program' in paddle.static.program_guard must be <class 'paddle.base.libpaddle.pir.Program'>, but received <class 'paddle.base.framework.Program'>. 

======================================================================
ERROR: test_mode_error (__main__.TestModeError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_prelu_op.py", line 518, in test_mode_error
    with base.program_guard(main_program, Program()):
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir/core.py", line 234, in program_guard
    check_type(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/data_feeder.py", line 188, in check_type
    raise TypeError(
TypeError: The type of 'main_program' in paddle.static.program_guard must be <class 'paddle.base.libpaddle.pir.Program'>, but received <class 'paddle.base.framework.Program'>. 

----------------------------------------------------------------------
```

**LogSoftmax** 
```
======================================================================
FAIL: test_errors (__main__.TestNNFunctionalLogSoftmaxAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_log_softmax.py", line 243, in test_errors
    self.assertRaises(TypeError, F.log_softmax, x)
AssertionError: TypeError not raised by log_softmax
```


**CELU**
```
ERROR: test_errors (__main__.TestCELUAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_activation_op.py", line 3283, in test_errors
    self.assertRaises(TypeError, self.celu, 1)
  File "/usr/lib/python3.8/unittest/case.py", line 816, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/lib/python3.8/unittest/case.py", line 202, in handle
    callable_obj(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/functional/activation.py", line 65, in celu
    return _C_ops.celu(x, alpha)
ValueError: (InvalidArgument) celu(): argument (position 1) must be OpResult, but got int (at /home/aistudio/lbwnb/Paddle/paddle/fluid/pybind/eager_utils.cc:1530)
```


**LogSigmoid**

```
ERROR: test_errors (__main__.TestLogSigmoidAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_activation_op.py", line 688, in test_errors
    self.assertRaises(TypeError, F.log_sigmoid, 1)
  File "/usr/lib/python3.8/unittest/case.py", line 816, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/lib/python3.8/unittest/case.py", line 202, in handle
    callable_obj(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/functional/activation.py", line 817, in log_sigmoid
    return _C_ops.logsigmoid(x)
ValueError: (InvalidArgument) logsigmoid(): argument (position 1) must be OpResult, but got int (at /home/aistudio/lbwnb/Paddle/paddle/fluid/pybind/eager_utils.cc:1530)
```

```
ERROR: test_check_output (__main__.TestSigmoid_Complex64)
ERROR: test_check_output (__main__.TestSigmoid_Complex128)

    InvalidArgumentError: The type of data we are trying to retrieve (float32) does not match the type of data (complex64) currently contained in the container.
      [Hint: Expected dtype() == phi::CppTypeToDataType<T>::Type(), but received dtype():12 != phi::CppTypeToDataType<T>::Type():10.] (at /home/aistudio/lbwnb/Paddle/paddle/phi/core/dense_tensor.cc:171)
      [operator < sigmoid_grad_grad > error]
```

**ReLU6 **

```
ERROR: test_errors (__main__.TestRelu6API)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_activation_op.py", line 2855, in test_errors
    self.assertRaises(TypeError, F.relu6, 1)
  File "/usr/lib/python3.8/unittest/case.py", line 816, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/lib/python3.8/unittest/case.py", line 202, in handle
    callable_obj(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/nn/functional/activation.py", line 946, in relu6
    return _C_ops.relu6(x)
ValueError: (InvalidArgument) relu6(): argument (position 1) must be OpResult, but got int (at /home/aistudio/lbwnb/Paddle/paddle/fluid/pybind/eager_utils.cc:1530)


======================================================================
ERROR: test_warnings (__main__.TestRelu6APIWarnings)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir_utils.py", line 119, in impl
    func(*args, **kwargs)
  File "test/legacy_test/test_activation_op.py", line 2879, in test_warnings
    out = helper.create_variable_for_type_inference(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/layer_helper_base.py", line 466, in create_variable_for_type_inference
    return self.main_program.current_block().create_var(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/framework.py", line 4176, in create_var
    var = Variable(block=self, *args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/framework.py", line 1449, in __init__
    dtype = convert_np_dtype_to_dtype_(dtype)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/framework.py", line 1151, in convert_np_dtype_to_dtype_
    return pir.core.convert_np_dtype_to_dtype_(np_dtype)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/pir/core.py", line 75, in convert_np_dtype_to_dtype_
    dtype = np.dtype(np_dtype)
TypeError: Cannot interpret '<DataType.FLOAT32: 10>' as a data type
```