### PR TITLE
[Dy2St] Refactor dy2st unittest decorators name - Part 2

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils_new.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils_new.py
@@ -164,7 +164,7 @@ class Dy2StTestMeta(type):
             # Disable inherited test cases
             for base in bases:
                 for attr in dir(base):
-                    if attr.startswith(fn_name):
+                    if attr.startswith(f"{fn_name}__"):
                         new_attrs[attr] = None
             fn_to_static_modes = getattr(
                 fn, "to_static_mode", DEFAULT_TO_STATIC_MODE

--- a/test/dygraph_to_static/test_fallback.py
+++ b/test/dygraph_to_static/test_fallback.py
@@ -16,7 +16,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import ast_only_test, dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase, test_ast_only
 
 import paddle
 
@@ -51,8 +51,7 @@ class UnsuppportNet(paddle.nn.Layer):
             return unsupport_func(x - 1)
 
 
-@dy2static_unittest
-class TestFallback(unittest.TestCase):
+class TestFallback(Dy2StTestBase):
     def setUp(self):
         self.x = paddle.to_tensor([2]).astype('int')
 
@@ -86,7 +85,7 @@ class TestFallback(unittest.TestCase):
             u_net(self.x).numpy(),
         )
 
-    @ast_only_test
+    @test_ast_only
     def test_case_net_error(self):
         s_net = SuppportNet()
         u_net = UnsuppportNet()

--- a/test/dygraph_to_static/test_fetch_feed.py
+++ b/test/dygraph_to_static/test_fetch_feed.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import (
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, compare_legacy_with_pir
 
 import paddle
 from paddle import base
@@ -65,8 +62,7 @@ class Linear(paddle.nn.Layer):
         return pre, loss
 
 
-@dy2static_unittest
-class TestPool2D(unittest.TestCase):
+class TestPool2D(Dy2StTestBase):
     def setUp(self):
         self.dygraph_class = Pool2D
         self.data = np.random.random((1, 2, 4, 4)).astype('float32')
@@ -83,7 +79,7 @@ class TestPool2D(unittest.TestCase):
 
             return prediction.numpy()
 
-    @test_and_compare_with_new_ir(True)
+    @compare_legacy_with_pir
     def train_static(self):
         return self.train(to_static=True)
 

--- a/test/dygraph_to_static/test_for_enumerate.py
+++ b/test/dygraph_to_static/test_for_enumerate.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 from paddle import base
@@ -354,8 +354,7 @@ def tensor_array_slice_in_enumerate():
     return feat_n2
 
 
-@dy2static_unittest
-class TestTransformBase(unittest.TestCase):
+class TestTransformBase(Dy2StTestBase):
     def setUp(self):
         self.place = (
             base.CUDAPlace(0)
@@ -558,8 +557,7 @@ class TestSliceTensorArrayInEnumerate(TestTransformForOriginalList):
         self.transformed_result_compare()
 
 
-@dy2static_unittest
-class TestForZip(unittest.TestCase):
+class TestForZip(Dy2StTestBase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
 

--- a/test/dygraph_to_static/test_full_name_usage.py
+++ b/test/dygraph_to_static/test_full_name_usage.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import ast_only_test, dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase, test_ast_only
 
 import paddle
 from paddle import base
@@ -58,9 +58,8 @@ class DoubleDecorated:
         return jit_decorated_func(x)
 
 
-@dy2static_unittest
-class TestFullNameDecorator(unittest.TestCase):
-    @ast_only_test
+class TestFullNameDecorator(Dy2StTestBase):
+    @test_ast_only
     def test_run_success(self):
         x = np.ones([1, 2]).astype("float32")
         answer = np.zeros([1, 2]).astype("float32")

--- a/test/dygraph_to_static/test_grad.py
+++ b/test/dygraph_to_static/test_grad.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 
@@ -65,8 +65,7 @@ class NoGradLinearLayer(paddle.nn.Layer):
         return out
 
 
-@dy2static_unittest
-class TestGrad(unittest.TestCase):
+class TestGrad(Dy2StTestBase):
     def setUp(self):
         self.func = paddle.jit.to_static(GradLayer())
         self.x = paddle.ones(shape=[10, 2, 5], dtype='float32')
@@ -84,7 +83,6 @@ class TestGrad(unittest.TestCase):
         np.testing.assert_allclose(static_res, dygraph_res, rtol=1e-05)
 
 
-@dy2static_unittest
 class TestGradLinear(TestGrad):
     def setUp(self):
         self.func = paddle.jit.to_static(GradLinearLayer())

--- a/test/dygraph_to_static/test_gradient_aggregation.py
+++ b/test/dygraph_to_static/test_gradient_aggregation.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import (
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 
@@ -40,9 +37,8 @@ class SimpleNet(paddle.nn.Layer):
         # return [out2, out1] # 梯度正常
 
 
-@dy2static_unittest
-class TestGradientAggregationInDy2Static(unittest.TestCase):
-    @test_and_compare_with_new_ir(False)
+class TestGradientAggregationInDy2Static(Dy2StTestBase):
+    @test_legacy_and_pir
     def test_to_static(self):
         def simplenet_grad(inp, to_static=False):
             net = SimpleNet()

--- a/test/dygraph_to_static/test_gradname_parse.py
+++ b/test/dygraph_to_static/test_gradname_parse.py
@@ -16,7 +16,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 from paddle.nn import BatchNorm, Linear
@@ -41,8 +41,7 @@ class SimpleNet(paddle.nn.Layer):
         return dx[0]
 
 
-@dy2static_unittest
-class TestGradNameParse(unittest.TestCase):
+class TestGradNameParse(Dy2StTestBase):
     def test_grad_name_parse(self):
         net = SimpleNet()
         opt = paddle.optimizer.Adam(
@@ -69,8 +68,7 @@ def tanh_high_order_grad(x):
     return paddle.grad(y, x, create_graph=True)[0]
 
 
-@dy2static_unittest
-class TestTanhHighOrderGrad(unittest.TestCase):
+class TestTanhHighOrderGrad(Dy2StTestBase):
     def setUp(self):
         self.func = tanh_high_order_grad
 
@@ -118,7 +116,6 @@ def matmul_high_order_grad(x, y):
     return g[0]
 
 
-@dy2static_unittest
 class TestMatMulHighOrderGrad1(TestTanhHighOrderGrad):
     def setUp(self):
         self.func = matmul_high_order_grad
@@ -138,7 +135,6 @@ class TestMatMulHighOrderGrad1(TestTanhHighOrderGrad):
         self.dy2st_grad_input = (x2,)
 
 
-@dy2static_unittest
 class TestMatMulHighOrderGrad2(TestTanhHighOrderGrad):
     def setUp(self):
         self.func = matmul_high_order_grad

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import (
-    ast_only_test,
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    compare_legacy_with_pir,
+    test_ast_only,
 )
 from ifelse_simple_func import (
     NetWithControlFlowIf,
@@ -59,15 +59,14 @@ else:
     place = base.CPUPlace()
 
 
-@dy2static_unittest
-class TestDy2staticException(unittest.TestCase):
+class TestDy2staticException(Dy2StTestBase):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')
         self.dyfunc = None
         self.error = "Your if/else have different number of return value."
 
-    @ast_only_test
-    @test_and_compare_with_new_ir()
+    @test_ast_only
+    @compare_legacy_with_pir
     def test_error(self):
         if self.dyfunc:
             with self.assertRaisesRegex(Dygraph2StaticException, self.error):
@@ -77,8 +76,7 @@ class TestDy2staticException(unittest.TestCase):
         paddle.jit.enable_to_static(False)
 
 
-@dy2static_unittest
-class TestDygraphIfElse(unittest.TestCase):
+class TestDygraphIfElse(Dy2StTestBase):
     """
     TestCase for the transformation from control flow `if/else`
     dependent on tensor in Dygraph into Static `base.layers.cond`.
@@ -100,7 +98,7 @@ class TestDygraphIfElse(unittest.TestCase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -129,8 +127,7 @@ class TestDygraphIfElseWithListGenerator(TestDygraphIfElse):
         self.dyfunc = dyfunc_with_if_else_with_list_generator
 
 
-@dy2static_unittest
-class TestDygraphNestedIfElse(unittest.TestCase):
+class TestDygraphNestedIfElse(Dy2StTestBase):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')
         self.dyfunc = nested_if_else
@@ -147,7 +144,7 @@ class TestDygraphNestedIfElse(unittest.TestCase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -256,8 +253,7 @@ class TestDygraphIfElseWithClassVar(TestDygraphIfElse):
         self.dyfunc = if_with_class_var
 
 
-@dy2static_unittest
-class TestDygraphIfTensor(unittest.TestCase):
+class TestDygraphIfTensor(Dy2StTestBase):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')
         self.dyfunc = if_tensor_case
@@ -274,13 +270,12 @@ class TestDygraphIfTensor(unittest.TestCase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
 
-@dy2static_unittest
-class TestDygraphIfElseNet(unittest.TestCase):
+class TestDygraphIfElseNet(Dy2StTestBase):
     """
     TestCase for the transformation from control flow `if/else`
     dependent on tensor in Dygraph into Static `base.layers.cond`.
@@ -305,7 +300,7 @@ class TestDygraphIfElseNet(unittest.TestCase):
             ret = net(x_v)
             return ret.numpy()
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -359,7 +354,7 @@ class TestNetWithExternalFunc(TestDygraphIfElseNet):
         self.x = np.random.random([10, 16]).astype('float32')
         self.Net = NetWithExternalFunc
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -397,8 +392,7 @@ class DiffModeNet2(paddle.nn.Layer):
             raise ValueError('Illegal mode')
 
 
-@dy2static_unittest
-class TestDiffModeNet(unittest.TestCase):
+class TestDiffModeNet(Dy2StTestBase):
     """
     TestCase for the net with different modes
     """
@@ -418,7 +412,7 @@ class TestDiffModeNet(unittest.TestCase):
         ret = net(self.x, self.y)
         return ret.numpy()
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_train_mode(self):
         self.assertTrue(
             (
@@ -427,7 +421,7 @@ class TestDiffModeNet(unittest.TestCase):
             ).all()
         )
 
-    @test_and_compare_with_new_ir()
+    @compare_legacy_with_pir
     def test_infer_mode(self):
         self.assertTrue(
             (
@@ -442,9 +436,8 @@ class TestDiffModeNet2(TestDiffModeNet):
         self.Net = DiffModeNet2
 
 
-@dy2static_unittest
-class TestNewVarCreateInOneBranch(unittest.TestCase):
-    @test_and_compare_with_new_ir()
+class TestNewVarCreateInOneBranch(Dy2StTestBase):
+    @compare_legacy_with_pir
     def test_var_used_in_another_for(self):
         def case_func(training):
             # targets and targets_list is dynamically defined by training
@@ -467,8 +460,7 @@ class TestNewVarCreateInOneBranch(unittest.TestCase):
         self.assertEqual(paddle.jit.to_static(case_func)(True), -2)
 
 
-@dy2static_unittest
-class TestDy2StIfElseRetInt1(unittest.TestCase):
+class TestDy2StIfElseRetInt1(Dy2StTestBase):
     def setUp(self):
         self.x = np.random.random([5]).astype('float32')
         self.dyfunc = paddle.jit.to_static(dyfunc_ifelse_ret_int1)
@@ -481,8 +473,8 @@ class TestDy2StIfElseRetInt1(unittest.TestCase):
         paddle.jit.enable_to_static(False)
         return out
 
-    @ast_only_test
-    @test_and_compare_with_new_ir()
+    @test_ast_only
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out[0], (paddle.Tensor, core.eager.Tensor))
@@ -496,28 +488,26 @@ class TestDy2StIfElseRetInt2(TestDy2staticException):
         self.dyfunc = dyfunc_ifelse_ret_int2
 
 
-@dy2static_unittest
 class TestDy2StIfElseRetInt3(TestDy2StIfElseRetInt1):
     def setUp(self):
         self.x = np.random.random([5]).astype('float32')
         self.dyfunc = paddle.jit.to_static(dyfunc_ifelse_ret_int3)
         self.out = self.get_dy2stat_out()
 
-    @ast_only_test
-    @test_and_compare_with_new_ir()
+    @test_ast_only
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out, (paddle.Tensor, core.eager.Tensor))
 
 
-@dy2static_unittest
 class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
     def setUp(self):
         self.x = np.random.random([5]).astype('float32')
         self.dyfunc = paddle.jit.to_static(dyfunc_ifelse_ret_int4)
 
-    @ast_only_test
-    @test_and_compare_with_new_ir()
+    @test_ast_only
+    @compare_legacy_with_pir
     def test_ast_to_func(self):
         paddle.jit.enable_to_static(True)
         with self.assertRaises(Dygraph2StaticException):
@@ -552,8 +542,7 @@ class IfElseNet(paddle.nn.Layer):
         return b
 
 
-@dy2static_unittest
-class TestDy2StIfElseBackward(unittest.TestCase):
+class TestDy2StIfElseBackward(Dy2StTestBase):
     # TODO(zhangbo): open pir test (IfOp grad execution not yet supported)
     def test_run_backward(self):
         a = paddle.randn((4, 3), dtype='float32')

--- a/test/dygraph_to_static/test_isinstance.py
+++ b/test/dygraph_to_static/test_isinstance.py
@@ -26,10 +26,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import (
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, compare_legacy_with_pir
 
 import paddle
 from paddle import nn
@@ -78,7 +75,7 @@ class SequentialLayer(nn.Layer):
         return res
 
 
-@test_and_compare_with_new_ir(True)
+@compare_legacy_with_pir
 def train(model, to_static):
     paddle.jit.enable_to_static(to_static)
 
@@ -88,8 +85,7 @@ def train(model, to_static):
     return out.numpy()
 
 
-@dy2static_unittest
-class TestIsinstance(unittest.TestCase):
+class TestIsinstance(Dy2StTestBase):
     def test_isinstance_simple_return_layer(self):
         model = IsInstanceLayer(SimpleReturnLayer())
         self._test_model(model)

--- a/test/dygraph_to_static/test_jit_property_save.py
+++ b/test/dygraph_to_static/test_jit_property_save.py
@@ -14,13 +14,12 @@
 
 import unittest
 
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 
 
-@dy2static_unittest
-class TestPropertySave(unittest.TestCase):
+class TestPropertySave(Dy2StTestBase):
     """test jit property save"""
 
     def setUp(self):

--- a/test/dygraph_to_static/test_jit_setitem.py
+++ b/test/dygraph_to_static/test_jit_setitem.py
@@ -16,14 +16,13 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 import paddle.nn.functional as F
 
 
-@dy2static_unittest
-class TestSetItemBase(unittest.TestCase):
+class TestSetItemBase(Dy2StTestBase):
     def setUp(self) -> None:
         pass
 

--- a/test/dygraph_to_static/test_lambda.py
+++ b/test/dygraph_to_static/test_lambda.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 import paddle.nn.functional as F
@@ -80,8 +80,7 @@ def call_lambda_with_ifExpr2(x):
     return out
 
 
-@dy2static_unittest
-class TestLambda(unittest.TestCase):
+class TestLambda(Dy2StTestBase):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')
         self.x = np.array([1, 3]).astype('float32')

--- a/test/dygraph_to_static/test_layer_hook.py
+++ b/test/dygraph_to_static/test_layer_hook.py
@@ -17,10 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import (
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, compare_legacy_with_pir
 
 import paddle
 
@@ -59,8 +56,7 @@ class SimpleNet(paddle.nn.Layer):
         return out
 
 
-@dy2static_unittest
-class TestNestLayerHook(unittest.TestCase):
+class TestNestLayerHook(Dy2StTestBase):
     def setUp(self):
         paddle.seed(2022)
         self.x = paddle.randn([4, 10])
@@ -70,7 +66,7 @@ class TestNestLayerHook(unittest.TestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_and_compare_with_new_ir(True)
+    @compare_legacy_with_pir
     def train_net(self, to_static=False):
         paddle.seed(2022)
         net = SimpleNet()

--- a/test/dygraph_to_static/test_len.py
+++ b/test/dygraph_to_static/test_len.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 from paddle import base
@@ -43,8 +43,7 @@ def len_with_lod_tensor_array(x):
     return arr_len
 
 
-@dy2static_unittest
-class TestLen(unittest.TestCase):
+class TestLen(Dy2StTestBase):
     def setUp(self):
         self.place = (
             base.CUDAPlace(0)
@@ -115,8 +114,7 @@ def len_with_selected_rows(place):
     return result
 
 
-@dy2static_unittest
-class TestLenWithSelectedRows(unittest.TestCase):
+class TestLenWithSelectedRows(Dy2StTestBase):
     def setUp(self):
         self.place = (
             base.CUDAPlace(0)

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -16,7 +16,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 from paddle import base
@@ -208,8 +208,7 @@ def test_list_pop_in_while_loop(x, iter_num):
     return a[0], b[2]
 
 
-@dy2static_unittest
-class TestListWithoutControlFlow(unittest.TestCase):
+class TestListWithoutControlFlow(Dy2StTestBase):
     def setUp(self):
         self.place = (
             base.CUDAPlace(0)
@@ -356,8 +355,7 @@ class ListWithCondNet(paddle.nn.Layer):
         return z
 
 
-@dy2static_unittest
-class TestListWithCondGradInferVarType(unittest.TestCase):
+class TestListWithCondGradInferVarType(Dy2StTestBase):
     def test_to_static(self):
         net = ListWithCondNet()
         x = paddle.to_tensor([2, 3, 4], dtype='float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

#### 替换为全新的动转静单测机制

清理`dygraph_to_static_util` 并替换为`dygraph_to_static_utils_new`

#### 修复问题

最小复现

```python
class TestBert(Dy2StTestBase):
  def test_train():
    pass

class TestCase2(TestBert):
  def test_train():
    pass

  def test_train_new_ir():
    pass
```

日志

```bash
...
[showing TestB]
test_train__legacy_ast_legacy_program: <function to_legacy_program_test.<locals>.impl at 0x11c872980>
test_train__sot_legacy_program: <function to_legacy_program_test.<locals>.impl at 0x11c872ac0>
test_train_new_ir__legacy_ast_pir: None
test_train_new_ir__sot_pir: None
```

此处`test_train_new`方法不应该被屏蔽，需要运行单测

相关链接：

* #58316
* #58356
* #58389
