### PR TITLE
[Dy2St] Refactor dy2st unittest decorators name - Part 3

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils_new.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils_new.py
@@ -31,7 +31,7 @@ class MyTest(Dy2StTestBase):
     @set_to_static_mode(
         ToStaticMode.LEGACY_AST | ToStaticMode.SOT | ToStaticMode.PIR_AST
     )
-    @set_ir_mode(IrMode.LEGACY_PROGRAM | IrMode.PIR)
+    @set_ir_mode(IrMode.LEGACY_IR | IrMode.PIR)
     def test_case1(self):
         raise ValueError("MyTest 1")
 
@@ -58,7 +58,7 @@ class ToStaticMode(Flag):
 
 
 class IrMode(Flag):
-    LEGACY_PROGRAM = auto()
+    LEGACY_IR = auto()
     PIR = auto()
 
     def lower_case_name(self):
@@ -66,7 +66,7 @@ class IrMode(Flag):
 
 
 DEFAULT_TO_STATIC_MODE = ToStaticMode.LEGACY_AST | ToStaticMode.SOT
-DEFAULT_IR_MODE = IrMode.LEGACY_PROGRAM
+DEFAULT_IR_MODE = IrMode.LEGACY_IR
 
 
 def to_legacy_ast_test(fn):
@@ -101,9 +101,10 @@ def to_pir_ast_test(fn):
     raise TypeError("Don't enable PIR AST mode now!")
 
 
-def to_legacy_program_test(fn):
+def to_legacy_ir_test(fn):
     def impl(*args, **kwargs):
-        logger.info("[Program] running legacy program")
+        logger.info("[Program] running legacy ir")
+        # breakpoint()
         return fn(*args, **kwargs)
 
     return impl
@@ -140,7 +141,7 @@ class Dy2StTestMeta(type):
     }
 
     IR_HANDLER_MAP = {
-        IrMode.LEGACY_PROGRAM: to_legacy_program_test,
+        IrMode.LEGACY_IR: to_legacy_ir_test,
         IrMode.PIR: to_pir_test,
     }
 
@@ -192,9 +193,9 @@ class Dy2StTestMeta(type):
             for to_static_mode, ir_mode in to_static_with_ir_modes:
                 if (
                     to_static_mode == ToStaticMode.PIR_AST
-                    and ir_mode == IrMode.LEGACY_PROGRAM
+                    and ir_mode == IrMode.LEGACY_IR
                 ):
-                    # PIR with LEGACY_PROGRAM is not a valid combination
+                    # PIR with LEGACY_IR is not a valid combination
                     continue
                 new_attrs[
                     Dy2StTestMeta.test_case_name(
@@ -264,7 +265,7 @@ def test_pir_only(fn):
 
 
 def test_legacy_and_pir(fn):
-    fn = set_ir_mode(IrMode.LEGACY_PROGRAM | IrMode.PIR)(fn)
+    fn = set_ir_mode(IrMode.LEGACY_IR | IrMode.PIR)(fn)
     return fn
 
 

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
-    compare_legacy_with_pir,
     test_ast_only,
+    test_legacy_and_pir,
 )
 from ifelse_simple_func import (
     NetWithControlFlowIf,
@@ -66,7 +66,7 @@ class TestDy2staticException(Dy2StTestBase):
         self.error = "Your if/else have different number of return value."
 
     @test_ast_only
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_error(self):
         if self.dyfunc:
             with self.assertRaisesRegex(Dygraph2StaticException, self.error):
@@ -98,7 +98,7 @@ class TestDygraphIfElse(Dy2StTestBase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -144,7 +144,7 @@ class TestDygraphNestedIfElse(Dy2StTestBase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -270,7 +270,7 @@ class TestDygraphIfTensor(Dy2StTestBase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -300,7 +300,7 @@ class TestDygraphIfElseNet(Dy2StTestBase):
             ret = net(x_v)
             return ret.numpy()
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -354,7 +354,7 @@ class TestNetWithExternalFunc(TestDygraphIfElseNet):
         self.x = np.random.random([10, 16]).astype('float32')
         self.Net = NetWithExternalFunc
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -412,7 +412,7 @@ class TestDiffModeNet(Dy2StTestBase):
         ret = net(self.x, self.y)
         return ret.numpy()
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_train_mode(self):
         self.assertTrue(
             (
@@ -421,7 +421,7 @@ class TestDiffModeNet(Dy2StTestBase):
             ).all()
         )
 
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_infer_mode(self):
         self.assertTrue(
             (
@@ -437,7 +437,7 @@ class TestDiffModeNet2(TestDiffModeNet):
 
 
 class TestNewVarCreateInOneBranch(Dy2StTestBase):
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_var_used_in_another_for(self):
         def case_func(training):
             # targets and targets_list is dynamically defined by training
@@ -474,7 +474,7 @@ class TestDy2StIfElseRetInt1(Dy2StTestBase):
         return out
 
     @test_ast_only
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out[0], (paddle.Tensor, core.eager.Tensor))
@@ -495,7 +495,7 @@ class TestDy2StIfElseRetInt3(TestDy2StIfElseRetInt1):
         self.out = self.get_dy2stat_out()
 
     @test_ast_only
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out, (paddle.Tensor, core.eager.Tensor))
@@ -507,7 +507,7 @@ class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
         self.dyfunc = paddle.jit.to_static(dyfunc_ifelse_ret_int4)
 
     @test_ast_only
-    @compare_legacy_with_pir
+    @test_legacy_and_pir
     def test_ast_to_func(self):
         paddle.jit.enable_to_static(True)
         with self.assertRaises(Dygraph2StaticException):

--- a/test/dygraph_to_static/test_inplace_assign.py
+++ b/test/dygraph_to_static/test_inplace_assign.py
@@ -15,12 +15,12 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import test_and_compare_with_new_ir
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 
 
-class TestInplaceAssign(unittest.TestCase):
+class TestInplaceAssign(Dy2StTestBase):
     def test_case0(self):
         a = paddle.ones((1024, 2)) * 1
         b = paddle.ones((1024, 3)) * 2
@@ -45,7 +45,7 @@ class TestInplaceAssign(unittest.TestCase):
         y.mean().backward()
         np.testing.assert_array_equal(x.grad.numpy(), np.array([2.0]))
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_case2(self):
         @paddle.jit.to_static
         def func(a, x):

--- a/test/dygraph_to_static/test_logical.py
+++ b/test/dygraph_to_static/test_logical.py
@@ -18,7 +18,7 @@ or nested loop have been covered in file test_ifelse.py and test_loop.py"""
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 from paddle import base
@@ -168,8 +168,7 @@ def test_shape_not_equal(x):
         return paddle.ones([1, 2, 3])
 
 
-@dy2static_unittest
-class TestLogicalBase(unittest.TestCase):
+class TestLogicalBase(Dy2StTestBase):
     def setUp(self):
         self.input = np.array([3]).astype('int32')
         self.place = (
@@ -264,8 +263,7 @@ class TestShapeNotEqual(TestLogicalNot):
         self.dygraph_func = test_shape_not_equal
 
 
-@dy2static_unittest
-class TestCmpopNodeToStr(unittest.TestCase):
+class TestCmpopNodeToStr(Dy2StTestBase):
     def test_exception(self):
         with self.assertRaises(KeyError):
             cmpop_node_to_str(gast.Or())

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -16,7 +16,7 @@ import inspect
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 import paddle.nn.functional as F
@@ -230,8 +230,7 @@ def for_loop_dufunc_with_listcomp(array):
     return res
 
 
-@dy2static_unittest
-class TestNameVisitor(unittest.TestCase):
+class TestNameVisitor(Dy2StTestBase):
     def setUp(self):
         self.loop_funcs = [
             while_loop_dyfunc,
@@ -301,8 +300,7 @@ class TestNameVisitor(unittest.TestCase):
                 i += 1
 
 
-@dy2static_unittest
-class TestTransformWhileLoop(unittest.TestCase):
+class TestTransformWhileLoop(Dy2StTestBase):
     def setUp(self):
         self.place = (
             base.CUDAPlace(0)
@@ -381,8 +379,7 @@ class TestLoopVarContainsProperty(TestTransformWhileLoop):
         self.dyfunc = loop_var_contains_property
 
 
-@dy2static_unittest
-class TestTransformForLoop(unittest.TestCase):
+class TestTransformForLoop(Dy2StTestBase):
     def setUp(self):
         self.place = (
             base.CUDAPlace(0)
@@ -464,8 +461,7 @@ class Net(paddle.nn.Layer):
         return out
 
 
-@dy2static_unittest
-class TestForLoopMeetDict(unittest.TestCase):
+class TestForLoopMeetDict(Dy2StTestBase):
     def test_start(self):
         net = Net()
         model = paddle.jit.to_static(

--- a/test/dygraph_to_static/test_lstm.py
+++ b/test/dygraph_to_static/test_lstm.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import ast_only_test, dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase, test_ast_only
 
 import paddle
 from paddle import nn
@@ -45,8 +45,7 @@ class Net(nn.Layer):
         return x
 
 
-@dy2static_unittest
-class TestLstm(unittest.TestCase):
+class TestLstm(Dy2StTestBase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
 
@@ -71,8 +70,7 @@ class TestLstm(unittest.TestCase):
         static_out = self.run_lstm(to_static=True)
         np.testing.assert_allclose(dygraph_out, static_out, rtol=1e-05)
 
-    @ast_only_test
-    def test_save_in_eval(self, with_training=True):
+    def save_in_eval(self, with_training: bool):
         paddle.jit.enable_to_static(True)
         net = Net(12, 2)
         x = paddle.randn((2, 10, 12))
@@ -115,8 +113,13 @@ class TestLstm(unittest.TestCase):
             err_msg=f'dygraph_out is {dygraph_out}\n static_out is \n{train_out}',
         )
 
+    @test_ast_only
     def test_save_without_training(self):
-        self.test_save_in_eval(with_training=False)
+        self.save_in_eval(with_training=False)
+
+    @test_ast_only
+    def test_save_with_training(self):
+        self.save_in_eval(with_training=True)
 
 
 class LinearNet(nn.Layer):
@@ -132,8 +135,7 @@ class LinearNet(nn.Layer):
         return y
 
 
-@dy2static_unittest
-class TestSaveInEvalMode(unittest.TestCase):
+class TestSaveInEvalMode(Dy2StTestBase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
 
@@ -176,8 +178,7 @@ class TestSaveInEvalMode(unittest.TestCase):
         )
 
 
-@dy2static_unittest
-class TestEvalAfterSave(unittest.TestCase):
+class TestEvalAfterSave(Dy2StTestBase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
 

--- a/test/dygraph_to_static/test_mnist.py
+++ b/test/dygraph_to_static/test_mnist.py
@@ -18,10 +18,10 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static_util import (
-    ast_only_test,
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    compare_legacy_with_pir,
+    test_ast_only,
 )
 from predictor_utils import PredictorTools
 
@@ -130,8 +130,7 @@ class MNIST(paddle.nn.Layer):
         return x
 
 
-@dy2static_unittest
-class TestMNIST(unittest.TestCase):
+class TestMNIST(Dy2StTestBase):
     def setUp(self):
         self.epoch_num = 1
         self.batch_size = 64
@@ -158,14 +157,14 @@ class TestMNISTWithToStatic(TestMNIST):
     still works if model is trained in dygraph mode.
     """
 
-    @test_and_compare_with_new_ir(True)
+    @compare_legacy_with_pir
     def train_static(self):
         return self.train(to_static=True)
 
     def train_dygraph(self):
         return self.train(to_static=False)
 
-    @ast_only_test
+    @test_ast_only
     def test_mnist_to_static(self):
         dygraph_loss = self.train_dygraph()
         static_loss = self.train_static()

--- a/test/dygraph_to_static/test_mnist_amp.py
+++ b/test/dygraph_to_static/test_mnist_amp.py
@@ -16,7 +16,7 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static_util import test_and_compare_with_new_ir
+from dygraph_to_static_utils_new import test_legacy_and_pir
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle
@@ -33,7 +33,7 @@ class TestAMP(TestMNIST):
     def train_dygraph(self):
         return self.train(to_static=False)
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_mnist_to_static(self):
         dygraph_loss = self.train_dygraph()
         static_loss = self.train_static()

--- a/test/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/test/dygraph_to_static/test_mnist_pure_fp16.py
@@ -16,7 +16,7 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static_util import test_and_compare_with_new_ir
+from dygraph_to_static_utils_new import test_legacy_and_pir
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle
@@ -32,7 +32,7 @@ class TestPureFP16(TestMNIST):
     def train_dygraph(self):
         return self.train(to_static=False)
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_mnist_to_static(self):
         if paddle.base.is_compiled_with_cuda():
             dygraph_loss = self.train_dygraph()

--- a/test/dygraph_to_static/test_mobile_net.py
+++ b/test/dygraph_to_static/test_mobile_net.py
@@ -19,7 +19,7 @@ import time
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import dy2static_unittest, test_with_new_ir
+from dygraph_to_static_utils_new import Dy2StTestBase, test_pir_only
 from predictor_utils import PredictorTools
 
 import paddle
@@ -656,8 +656,7 @@ def predict_analysis_inference(args, data):
     return out
 
 
-@dy2static_unittest
-class TestMobileNet(unittest.TestCase):
+class TestMobileNet(Dy2StTestBase):
     def setUp(self):
         self.args = Args()
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -727,7 +726,7 @@ class TestMobileNet(unittest.TestCase):
             err_msg=f'inference_pred_res:\n {predictor_pre}\n, st_pre: \n{st_pre}.',
         )
 
-    @test_with_new_ir
+    @test_pir_only
     def test_mobile_net_new_ir(self):
         # MobileNet-V1
         self.assert_same_loss("MobileNetV1")

--- a/test/dygraph_to_static/test_multi_forward.py
+++ b/test/dygraph_to_static/test_multi_forward.py
@@ -14,10 +14,7 @@
 
 import unittest
 
-from dygraph_to_static_util import (
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 
@@ -36,9 +33,8 @@ class MyLayer(paddle.nn.Layer):
         return self.linear(x)
 
 
-@dy2static_unittest
-class TestBackward(unittest.TestCase):
-    @test_and_compare_with_new_ir(False)
+class TestBackward(Dy2StTestBase):
+    @test_legacy_and_pir
     def test_order_0(self):
         """
         loss = 1 * w * 1 + 2 * w * 2
@@ -53,7 +49,7 @@ class TestBackward(unittest.TestCase):
         loss.backward()
         self.assertEqual(model.linear.weight.grad, 5)
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_order_1(self):
         """
         loss = 2 * w * 2  + 1 * w * 1

--- a/test/dygraph_to_static/test_new_ir_selectedrows.py
+++ b/test/dygraph_to_static/test_new_ir_selectedrows.py
@@ -15,7 +15,7 @@
 import random
 import unittest
 
-from dygraph_to_static_util import test_and_compare_with_new_ir
+from dygraph_to_static_utils_new import Dy2StTestBase, compare_legacy_with_pir
 
 import paddle
 from paddle.jit.api import to_static
@@ -77,7 +77,7 @@ def train_dygraph():
     return train(net, adam, x)
 
 
-@test_and_compare_with_new_ir(True)
+@compare_legacy_with_pir
 def train_static():
     paddle.seed(100)
     net = IRSelectedRowsTestNet()
@@ -90,7 +90,7 @@ def train_static():
     return to_static(train, full_graph=True)(net, adam, x)
 
 
-class TestSimnet(unittest.TestCase):
+class TestSimnet(Dy2StTestBase):
     def test_dygraph_static_same_loss(self):
         dygraph_loss = train_dygraph()
         static_loss = train_static()

--- a/test/dygraph_to_static/test_op_attr.py
+++ b/test/dygraph_to_static/test_op_attr.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from dygraph_to_static_util import ast_only_test, dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase, test_ast_only
 
 import paddle
 from paddle.static import InputSpec
@@ -52,8 +52,7 @@ class NetWithOpAttr(paddle.nn.Layer):
         return out
 
 
-@dy2static_unittest
-class CheckOpAttr(unittest.TestCase):
+class CheckOpAttr(Dy2StTestBase):
     def setUp(self):
         self.in_num = 16
         self.out_num = 16
@@ -78,7 +77,7 @@ class CheckOpAttr(unittest.TestCase):
             'elementwise_sub': self.sub_attrs,
         }
 
-    @ast_only_test
+    @test_ast_only
     def test_set_op_attrs(self):
         net = NetWithOpAttr(self.in_num, self.out_num)
         # set attrs
@@ -120,7 +119,7 @@ class CheckOpAttr(unittest.TestCase):
                         else:
                             self.assertEqual(op_val, expect_val)
 
-    @ast_only_test
+    @test_ast_only
     def test_set_op_attrs_with_sub_block(self):
         net = NetWithOpAttr(self.in_num, self.out_num)
         # set attrs

--- a/test/dygraph_to_static/test_origin_info.py
+++ b/test/dygraph_to_static/test_origin_info.py
@@ -16,7 +16,7 @@ import inspect
 import sys
 import unittest
 
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 from paddle.jit.api import to_static
 from paddle.jit.dy2static import DygraphToStaticAst
@@ -56,8 +56,7 @@ def decorated_func2(x):
     return x
 
 
-@dy2static_unittest
-class TestOriginInfo(unittest.TestCase):
+class TestOriginInfo(Dy2StTestBase):
     def setUp(self):
         self.set_test_func()
         self.dygraph_func = unwrap(self.func)

--- a/test/dygraph_to_static/test_param_guard.py
+++ b/test/dygraph_to_static/test_param_guard.py
@@ -15,10 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_util import (
-    dy2static_unittest,
-    test_and_compare_with_new_ir,
-)
+from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 from paddle.jit import to_static
@@ -53,8 +50,7 @@ class NetWithParameterListIter(NetWithParameterList):
         return out
 
 
-@dy2static_unittest
-class TestParameterList(unittest.TestCase):
+class TestParameterList(Dy2StTestBase):
     def setUp(self):
         self.seed = 2021
         self.iter_num = 5
@@ -79,7 +75,7 @@ class TestParameterList(unittest.TestCase):
 
         return loss
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_parameter_list(self):
         static_loss = self.train(False, to_static=True)
         dygraph_loss = self.train(False, to_static=False)
@@ -106,8 +102,7 @@ class NetWithRawParamList(paddle.nn.Layer):
         return out
 
 
-@dy2static_unittest
-class TestRawParameterList(unittest.TestCase):
+class TestRawParameterList(Dy2StTestBase):
     def setUp(self):
         self.seed = 2021
         self.iter_num = 5
@@ -133,7 +128,7 @@ class TestRawParameterList(unittest.TestCase):
 
         return loss
 
-    @test_and_compare_with_new_ir(False)
+    @test_legacy_and_pir
     def test_parameter_list(self):
         static_loss = self.train(to_static=True)
         dygraph_loss = self.train(to_static=False)

--- a/test/dygraph_to_static/test_params_no_grad.py
+++ b/test/dygraph_to_static/test_params_no_grad.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from dygraph_to_static_util import dy2static_unittest
+from dygraph_to_static_utils_new import Dy2StTestBase
 
 import paddle
 import paddle.distributed as dist
@@ -54,8 +54,7 @@ def train():
         print(loss)
 
 
-@dy2static_unittest
-class TestParamsNoGrad(unittest.TestCase):
+class TestParamsNoGrad(Dy2StTestBase):
     def test_two_card(self):
         if (
             paddle.is_compiled_with_cuda()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

替换为全新的动转静单测机制

修复上个pr #58458 的问题

重命名`LEGACY_PROGRAM` -> `LEGACY_IR`, `to_legacy_program_test`-> `to_legacy_ir_test`


相关链接：

* #58316
* #58356
* #58389
* #58458
