### PR TITLE
[Fix] adaptive max pool2d in static

### DIFF
--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -2000,8 +2000,7 @@ def adaptive_max_pool2d(x, output_size, return_mask=False, name=None):
                 "adaptive": True,
             },
         )
-        # return (pool_out, mask) if return_mask else pool_out
-        return pool_out
+        return (pool_out, mask) if return_mask else pool_out
 
 
 def adaptive_max_pool3d(x, output_size, return_mask=False, name=None):

--- a/test/legacy_test/test_adaptive_max_pool2d.py
+++ b/test/legacy_test/test_adaptive_max_pool2d.py
@@ -159,6 +159,61 @@ class TestAdaptiveMaxPool2DAPI(unittest.TestCase):
 
             np.testing.assert_allclose(res_5, self.res_5_np)
 
+    def test_static_graph_return_mask(self):
+        for use_cuda in (
+            [False, True] if core.is_compiled_with_cuda() else [False]
+        ):
+            place = paddle.CUDAPlace(0) if use_cuda else paddle.CPUPlace()
+            paddle.enable_static()
+            x = paddle.static.data(
+                name="x", shape=[2, 3, 7, 7], dtype="float32"
+            )
+
+            out_1 = paddle.nn.functional.adaptive_max_pool2d(
+                x=x, output_size=[3, 3], return_mask=True
+            )
+
+            out_2 = paddle.nn.functional.adaptive_max_pool2d(
+                x=x, output_size=5, return_mask=True
+            )
+
+            out_3 = paddle.nn.functional.adaptive_max_pool2d(
+                x=x, output_size=[2, 5], return_mask=True
+            )
+
+            # out_4 = paddle.nn.functional.adaptive_max_pool2d(
+            #    x=x, output_size=[3, 3], data_format="NHWC"), return_mask=True
+
+            out_5 = paddle.nn.functional.adaptive_max_pool2d(
+                x=x, output_size=[None, 3], return_mask=True
+            )
+
+            exe = paddle.static.Executor(place=place)
+            [
+                res_1,
+                mask_1,
+                res_2,
+                mask_2,
+                res_3,
+                mask_3,
+                res_5,
+                mask_5,
+            ] = exe.run(
+                base.default_main_program(),
+                feed={"x": self.x_np},
+                fetch_list=[out_1, out_2, out_3, out_5],
+            )
+
+            self.assertEqual(res_1.shape, mask_1.shape)
+
+            self.assertEqual(res_2.shape, mask_2.shape)
+
+            self.assertEqual(res_3.shape, mask_3.shape)
+
+            # self.assertEqual(res_4.shape, mask_4.shape)
+
+            self.assertEqual(res_5.shape, mask_5.shape)
+
     def test_dynamic_graph(self):
         for use_cuda in (
             [False, True] if core.is_compiled_with_cuda() else [False]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->

分析 `python/paddle/nn/functional/pooling.py` 时，发现 `adaptive_max_pool2d` 中 `return_mask` 在静态图不起作用，之前在代码中注释掉了，特此修改 ～

涉及文件：

- `python/paddle/nn/functional/pooling.py` 修改错误
- `test/legacy_test/test_adaptive_max_pool2d.py` 增加单测

请评审 ～ 谢谢 ～