### PR TITLE
[PIR] Delete @fetch for fetch op output

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -333,10 +333,9 @@ void HandleForSpecialOp(pir::Operation* op,
 
   if (op_name == "pd_op.fetch") {
     // fetch is a very special op, with no output
-    auto fetch_src_name =
+    auto fetch_var_name =
         op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString();
 
-    auto fetch_var_name = fetch_src_name + "@fetch";
     auto* var = const_cast<Scope*>(value_exe_info->GetScope()->root())
                     ->Var(fetch_var_name);
     var->GetMutable<phi::DenseTensor>();

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -100,8 +100,7 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
                                         ->attributes()
                                         .at("name")
                                         .dyn_cast<pir::StrAttribute>()
-                                        .AsString() +
-                                    "@fetch";
+                                        .AsString();
         }
       }
       auto kernel_program =

--- a/paddle/fluid/pir/transforms/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/constant_folding_pass.cc
@@ -89,8 +89,7 @@ class ConstantFoldingPattern : public pir::RewritePattern {
                                      ->attributes()
                                      .at("name")
                                      .dyn_cast<pir::StrAttribute>()
-                                     .AsString() +
-                                 "@fetch";
+                                     .AsString();
       }
     }
 

--- a/test/cpp/pir/cinn/group_op_test.cc
+++ b/test/cpp/pir/cinn/group_op_test.cc
@@ -214,10 +214,10 @@ TEST(GroupOp, CINNLowering) {
   paddle::framework::Scope exe_scope;
 
   paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
+      place, {"out"}, kernel_program->block(), &exe_scope);
 
   std::set<std::string> out_names;
-  out_names.insert("out@fetch");
+  out_names.insert("out");
   auto local_names = exe_scope.LocalVarNames();
   for (size_t i = 0; i < local_names.size(); ++i) {
     out_names.insert(local_names[i]);
@@ -227,7 +227,7 @@ TEST(GroupOp, CINNLowering) {
   executor.Run({}, true);
 
   auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
+      executor.local_scope()->FindVar("out")->Get<phi::DenseTensor>();
 
   bool res0 = simple_cmp(out_tensor.data<float>()[0], 3.88455);
   bool res1 = simple_cmp(out_tensor.data<float>()[1], 3.88455);

--- a/test/cpp/pir/cinn/jit_instruction_test.cc
+++ b/test/cpp/pir/cinn/jit_instruction_test.cc
@@ -153,11 +153,10 @@ TEST(CinnJitInstruction, Run) {
 
   paddle::framework::interpreter::ExecutionConfig exe_conf;
   exe_conf.create_local_scope = false;
-  InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
+  InterpreterCore executor(place, {"out"}, kernel_program->block(), &exe_scope);
 
   std::set<std::string> out_names;
-  out_names.insert("out@fetch");
+  out_names.insert("out");
   auto local_names = exe_scope.LocalVarNames();
   for (size_t i = 0; i < local_names.size(); ++i) {
     out_names.insert(local_names[i]);
@@ -166,7 +165,7 @@ TEST(CinnJitInstruction, Run) {
   executor.SetSkipGcVars(out_names);
   executor.Run({}, true);
   auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
+      executor.local_scope()->FindVar("out")->Get<phi::DenseTensor>();
 
   bool res0 = simple_cmp(out_tensor.data<float>()[0], 1.35701);
   bool res1 = simple_cmp(out_tensor.data<float>()[1], 1.35701);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PIR 下，执行器会对输出的 fetch_var_names 添加 @fetch 后缀，本 pr 删除该后缀的添加
Pcard-67164
