### PR TITLE
[oneDNN] Realize optional input of scale/bias from oneDNN backend

### DIFF
--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -1381,24 +1381,6 @@ class BatchNormOneDNNHandler
                                              flags);
   }
 
-  std::tuple<std::shared_ptr<dnnl::memory>, std::shared_ptr<dnnl::memory>>
-  AcquireScaleShiftMemory(const DenseTensor* scale, const DenseTensor* shift) {
-    auto scale_tz = vectorize(scale->dims());
-    PADDLE_ENFORCE_EQ(
-        scale_tz.size(),
-        1,
-        errors::InvalidArgument(
-            "Dims of scale tensor must be 1, but received scale's size is %d",
-            scale_tz.size()));
-
-    auto scale_memory = this->AcquireMemoryFromPrimitive(
-        this->fwd_pd_->weights_desc(), to_void_cast<T>(scale->data<T>()));
-    auto shift_memory = this->AcquireMemoryFromPrimitive(
-        this->fwd_pd_->weights_desc(), to_void_cast<T>(shift->data<T>()));
-
-    return std::make_tuple(scale_memory, shift_memory);
-  }
-
   std::shared_ptr<dnnl::memory> AcquireScaleMemory(const DenseTensor* scale) {
     auto scale_tz = vectorize(scale->dims());
     PADDLE_ENFORCE_EQ(
@@ -1427,16 +1409,6 @@ class BatchNormOneDNNHandler
         this->fwd_pd_->weights_desc(), to_void_cast<T>(shift->data<T>()));
 
     return shift_memory;
-  }
-
-  std::tuple<std::shared_ptr<dnnl::memory>, std::shared_ptr<dnnl::memory>>
-  AcquireDiffScaleShiftMemory(T* diff_scale_data, T* diff_shift_data) {
-    auto diff_scale_memory = this->AcquireMemoryFromPrimitive(
-        this->bwd_pd_->diff_weights_desc(), diff_scale_data);
-    auto diff_shift_memory = this->AcquireMemoryFromPrimitive(
-        this->bwd_pd_->diff_weights_desc(), diff_shift_data);
-
-    return std::make_tuple(diff_scale_memory, diff_shift_memory);
   }
 
   std::shared_ptr<dnnl::memory> AcquireDiffScaleMemory(T* diff_scale_data) {

--- a/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
@@ -68,8 +68,8 @@ void BatchNormGradFunctor(const Context& dev_ctx,
   const bool use_scale = scale ? true : false;
   const bool use_bias = bias ? true : false;
 
-  std::vector<long int> scale_tz;
-  std::vector<long int> bias_tz;
+  std::vector<int64_t> scale_tz;
+  std::vector<int64_t> bias_tz;
   if (use_scale) {
     scale_tz = vectorize<int64_t>(Scale->dims());
     PADDLE_ENFORCE_EQ(

--- a/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
@@ -65,8 +65,37 @@ void BatchNormGradFunctor(const Context& dev_ctx,
                           DenseTensor* bias_grad) {
   auto Scale = scale.get_ptr();
   auto Bias = bias.get_ptr();
-  funcs::BatchNormOneDNNHandler<T> handler(
-      dev_ctx.GetEngine(), dev_ctx.GetPlace(), epsilon, &x, Scale, &y_grad);
+  const bool use_scale = scale ? true : false;
+  const bool use_bias = bias ? true : false;
+
+  std::vector<long int> scale_tz;
+  std::vector<long int> bias_tz;
+  if (use_scale) {
+    scale_tz = vectorize<int64_t>(Scale->dims());
+    PADDLE_ENFORCE_EQ(
+        scale_tz.size(),
+        1,
+        errors::InvalidArgument(
+            "Dims of scale tensor must be 1, but received scale's size is %d",
+            scale_tz.size()));
+  }
+  if (use_bias) {
+    bias_tz = vectorize<int64_t>(Bias->dims());
+    PADDLE_ENFORCE_EQ(
+        bias_tz.size(),
+        1,
+        errors::InvalidArgument(
+            "Dims of bias tensor must be 1, but received bias's size is %d",
+            bias_tz.size()));
+  }
+
+  funcs::BatchNormOneDNNHandler<T> handler(dev_ctx.GetEngine(),
+                                           dev_ctx.GetPlace(),
+                                           epsilon,
+                                           &x,
+                                           use_scale,
+                                           use_bias,
+                                           &y_grad);
 
   T* diff_scale_data = dev_ctx.template Alloc<T>(scale_grad);
   T* diff_shift_data = dev_ctx.template Alloc<T>(bias_grad);
@@ -75,24 +104,37 @@ void BatchNormGradFunctor(const Context& dev_ctx,
   auto mean_memory = handler.AcquireMeanMemory(&saved_mean);
   auto variance_memory = handler.AcquireVarianceMemory(&saved_variance);
   auto diff_dst_memory = handler.AcquireDiffDstMemory(&y_grad);
-  auto scaleshift_mems = handler.AcquireScaleShiftMemory(Scale, Bias);
   auto diff_src_memory = handler.AcquireDiffSrcMemory(x_grad);
-  auto diff_scaleshift_mems =
-      handler.AcquireDiffScaleShiftMemory(diff_scale_data, diff_shift_data);
 
   auto batch_norm_bwd_p = handler.AcquireBackwardPrimitive();
 
+  std::shared_ptr<dnnl::memory> scale_memory(nullptr);
+  std::shared_ptr<dnnl::memory> diff_scale_memory(nullptr);
+  std::shared_ptr<dnnl::memory> diff_shift_memory(nullptr);
+  if (scale && bias) {
+    auto scaleshift_mems = handler.AcquireScaleShiftMemory(Scale, Bias);
+    auto diff_scaleshift_mems =
+        handler.AcquireDiffScaleShiftMemory(diff_scale_data, diff_shift_data);
+    scale_memory = std::get<0>(scaleshift_mems);
+    diff_scale_memory = std::get<0>(diff_scaleshift_mems);
+    diff_shift_memory = std::get<1>(diff_scaleshift_mems);
+  } else if (scale) {
+    scale_memory = handler.AcquireScaleMemory(Scale);
+    diff_scale_memory = handler.AcquireDiffScaleMemory(diff_scale_data);
+  } else if (bias) {
+    diff_shift_memory = handler.AcquireDiffShiftMemory(diff_shift_data);
+  }
+
   auto& astream = OneDNNContext::tls().get_stream();
-  batch_norm_bwd_p->execute(
-      astream,
-      {{DNNL_ARG_SRC, *src_memory},
-       {DNNL_ARG_MEAN, *mean_memory},
-       {DNNL_ARG_VARIANCE, *variance_memory},
-       {DNNL_ARG_DIFF_DST, *diff_dst_memory},
-       {DNNL_ARG_SCALE, *(std::get<0>(scaleshift_mems))},
-       {DNNL_ARG_DIFF_SRC, *diff_src_memory},
-       {DNNL_ARG_DIFF_SCALE, *(std::get<0>(diff_scaleshift_mems))},
-       {DNNL_ARG_DIFF_SHIFT, *(std::get<1>(diff_scaleshift_mems))}});
+  batch_norm_bwd_p->execute(astream,
+                            {{DNNL_ARG_SRC, *src_memory},
+                             {DNNL_ARG_MEAN, *mean_memory},
+                             {DNNL_ARG_VARIANCE, *variance_memory},
+                             {DNNL_ARG_DIFF_DST, *diff_dst_memory},
+                             {DNNL_ARG_SCALE, *scale_memory},
+                             {DNNL_ARG_DIFF_SRC, *diff_src_memory},
+                             {DNNL_ARG_DIFF_SCALE, *diff_scale_memory},
+                             {DNNL_ARG_DIFF_SHIFT, *diff_shift_memory}});
   astream.wait();
 
   // set memory descriptor of out tensor

--- a/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
@@ -111,16 +111,11 @@ void BatchNormGradFunctor(const Context& dev_ctx,
   std::shared_ptr<dnnl::memory> scale_memory(nullptr);
   std::shared_ptr<dnnl::memory> diff_scale_memory(nullptr);
   std::shared_ptr<dnnl::memory> diff_shift_memory(nullptr);
-  if (scale && bias) {
+  if (scale) {
     scale_memory = handler.AcquireScaleMemory(Scale);
     diff_scale_memory = handler.AcquireDiffScaleMemory(diff_scale_data);
-    diff_shift_memory = handler.AcquireDiffShiftMemory(diff_shift_data);
-  } else if (scale) {
-    scale_memory = handler.AcquireScaleMemory(Scale);
-    diff_scale_memory = handler.AcquireDiffScaleMemory(diff_scale_data);
-  } else if (bias) {
-    diff_shift_memory = handler.AcquireDiffShiftMemory(diff_shift_data);
   }
+  if (bias) diff_shift_memory = handler.AcquireDiffShiftMemory(diff_shift_data);
 
   auto& astream = OneDNNContext::tls().get_stream();
   batch_norm_bwd_p->execute(astream,

--- a/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_grad_kernel.cc
@@ -112,12 +112,9 @@ void BatchNormGradFunctor(const Context& dev_ctx,
   std::shared_ptr<dnnl::memory> diff_scale_memory(nullptr);
   std::shared_ptr<dnnl::memory> diff_shift_memory(nullptr);
   if (scale && bias) {
-    auto scaleshift_mems = handler.AcquireScaleShiftMemory(Scale, Bias);
-    auto diff_scaleshift_mems =
-        handler.AcquireDiffScaleShiftMemory(diff_scale_data, diff_shift_data);
-    scale_memory = std::get<0>(scaleshift_mems);
-    diff_scale_memory = std::get<0>(diff_scaleshift_mems);
-    diff_shift_memory = std::get<1>(diff_scaleshift_mems);
+    scale_memory = handler.AcquireScaleMemory(Scale);
+    diff_scale_memory = handler.AcquireDiffScaleMemory(diff_scale_data);
+    diff_shift_memory = handler.AcquireDiffShiftMemory(diff_shift_data);
   } else if (scale) {
     scale_memory = handler.AcquireScaleMemory(Scale);
     diff_scale_memory = handler.AcquireDiffScaleMemory(diff_scale_data);

--- a/paddle/phi/kernels/onednn/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_kernel.cc
@@ -85,9 +85,8 @@ void BatchNormKernel(const Context &dev_ctx,
   auto Scale = scale.get_ptr();
   auto Bias = bias.get_ptr();
   if (scale && bias) {
-    auto scaleshift_mems = handler.AcquireScaleShiftMemory(Scale, Bias);
-    scale_memory = std::get<0>(scaleshift_mems);
-    shift_memory = std::get<1>(scaleshift_mems);
+    scale_memory = handler.AcquireScaleMemory(Scale);
+    shift_memory = handler.AcquireShiftMemory(Bias);
   } else if (scale) {
     scale_memory = handler.AcquireScaleMemory(Scale);
   } else if (bias) {

--- a/paddle/phi/kernels/onednn/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_kernel.cc
@@ -49,19 +49,20 @@ void BatchNormKernel(const Context &dev_ctx,
       dev_ctx.HasDnnAttr("fuse_with_relu")
           ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("fuse_with_relu"))
           : false;
+  const bool use_scale = scale ? true : false;
+  const bool use_bias = bias ? true : false;
 
-  auto Scale = scale.get_ptr();
-  auto Bias = bias.get_ptr();
   funcs::BatchNormOneDNNHandler<T> handler(dev_ctx.GetEngine(),
                                            dev_ctx.GetPlace(),
                                            &x,
                                            epsilon,
+                                           use_scale,
+                                           use_bias,
                                            fuse_with_relu,
                                            global_stats,
                                            test_mode);
 
   auto src_memory = handler.AcquireSrcMemory(&x);
-  auto scaleshift_mems = handler.AcquireScaleShiftMemory(Scale, Bias);
   auto dst_memory = handler.AcquireDstMemory(y);
   auto batch_norm_p = handler.AcquireForwardPrimitive();
 
@@ -79,18 +80,32 @@ void BatchNormKernel(const Context &dev_ctx,
 
   y->set_mem_desc(dst_memory->get_desc());
 
+  std::shared_ptr<dnnl::memory> scale_memory(nullptr);
+  std::shared_ptr<dnnl::memory> shift_memory(nullptr);
+  auto Scale = scale.get_ptr();
+  auto Bias = bias.get_ptr();
+  if (scale && bias) {
+    auto scaleshift_mems = handler.AcquireScaleShiftMemory(Scale, Bias);
+    scale_memory = std::get<0>(scaleshift_mems);
+    shift_memory = std::get<1>(scaleshift_mems);
+  } else if (scale) {
+    scale_memory = handler.AcquireScaleMemory(Scale);
+  } else if (bias) {
+    shift_memory = handler.AcquireShiftMemory(Bias);
+  }
+
   auto &astream = OneDNNContext::tls().get_stream();
   batch_norm_p->execute(astream,
                         {{DNNL_ARG_SRC, *src_memory},
-                         {DNNL_ARG_SCALE, *(std::get<0>(scaleshift_mems))},
-                         {DNNL_ARG_SHIFT, *(std::get<1>(scaleshift_mems))},
+                         {DNNL_ARG_SCALE, *scale_memory},
+                         {DNNL_ARG_SHIFT, *shift_memory},
                          {DNNL_ARG_MEAN, *mean_memory},
                          {DNNL_ARG_VARIANCE, *variance_memory},
                          {DNNL_ARG_DST, *dst_memory}});
   astream.wait();
 
   if (!global_stats) {
-    const unsigned int C = phi::vectorize(Scale->dims())[0];
+    const unsigned int C = phi::vectorize(mean.dims())[0];
 
     // mkldnn only compute stats for current batch
     // so we need compute momentum stats via Eigen lib

--- a/paddle/phi/kernels/onednn/batch_norm_kernel.cc
+++ b/paddle/phi/kernels/onednn/batch_norm_kernel.cc
@@ -84,14 +84,8 @@ void BatchNormKernel(const Context &dev_ctx,
   std::shared_ptr<dnnl::memory> shift_memory(nullptr);
   auto Scale = scale.get_ptr();
   auto Bias = bias.get_ptr();
-  if (scale && bias) {
-    scale_memory = handler.AcquireScaleMemory(Scale);
-    shift_memory = handler.AcquireShiftMemory(Bias);
-  } else if (scale) {
-    scale_memory = handler.AcquireScaleMemory(Scale);
-  } else if (bias) {
-    shift_memory = handler.AcquireShiftMemory(Bias);
-  }
+  if (scale) scale_memory = handler.AcquireScaleMemory(Scale);
+  if (bias) shift_memory = handler.AcquireShiftMemory(Bias);
 
   auto &astream = OneDNNContext::tls().get_stream();
   batch_norm_p->execute(astream,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Description
Targeting new request from [#58326](https://github.com/PaddlePaddle/Paddle/issues/58326), now support optional scale/bias for BatchNorm from oneDNN beackend.
