### PR TITLE
【PIR API adaptor No.41、138、153】 Migrate paddle.complex, paddle.logspace, paddle.meshgrid into pir

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -457,7 +457,7 @@ def logspace(start, stop, num, base=10.0, dtype=None, name=None):
     if not isinstance(base, Variable):
         with device_guard("cpu"):
             tensor_base = fill_constant([1], dtype, base)
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.logspace(
             tensor_start,
             tensor_stop,
@@ -1643,7 +1643,7 @@ def meshgrid(*args, **kwargs):
 
     if len(args) == 1 and isinstance(args[0], (list, tuple)):
         args = args[0]
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.meshgrid(list(args))
     else:
         name = kwargs.get("name", None)
@@ -2603,7 +2603,7 @@ def complex(real, imag, name=None):
             [[0j    , 1j    , 2j    ],
              [(1+0j), (1+1j), (1+2j)]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.complex(real, imag)
     else:
         check_variable_and_dtype(

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -441,20 +441,20 @@ def logspace(start, stop, num, base=10.0, dtype=None, name=None):
     tensor_start = start
     tensor_stop = stop
     tensor_base = base
-    if not isinstance(num, Variable):
+    if not isinstance(num, (Variable, paddle.pir.OpResult)):
         check_type(num, 'num', (int), 'logspace')
-    if not isinstance(dtype, core.VarDesc.VarType):
+    if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
         dtype = convert_np_dtype_to_dtype_(dtype)
-    if not isinstance(start, Variable):
+    if not isinstance(start, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_start = fill_constant([1], dtype, start)
-    if not isinstance(stop, Variable):
+    if not isinstance(stop, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_stop = fill_constant([1], dtype, stop)
-    if not isinstance(num, Variable):
+    if not isinstance(num, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_num = fill_constant([1], 'int32', num)
-    if not isinstance(base, Variable):
+    if not isinstance(base, (Variable, paddle.pir.OpResult)):
         with device_guard("cpu"):
             tensor_base = fill_constant([1], dtype, base)
     if in_dynamic_or_pir_mode():

--- a/test/legacy_test/test_complex_op.py
+++ b/test/legacy_test/test_complex_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 import paddle
 from paddle import static
 from paddle.base import dygraph
+from paddle.pir_uitls import test_with_pir_api
 
 paddle.enable_static()
 
@@ -45,12 +46,13 @@ class TestComplexOp(OpTest):
         self.outputs = {'Out': out_ref}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
             ['X', 'Y'],
             'Out',
+            check_pir=True,
         )
 
     def test_check_grad_ignore_x(self):
@@ -58,6 +60,7 @@ class TestComplexOp(OpTest):
             ['Y'],
             'Out',
             no_grad_set=set('X'),
+            check_pir=True,
         )
 
     def test_check_grad_ignore_y(self):
@@ -65,6 +68,7 @@ class TestComplexOp(OpTest):
             ['X'],
             'Out',
             no_grad_set=set('Y'),
+            check_pir=True,
         )
 
 
@@ -102,6 +106,7 @@ class TestComplexAPI(unittest.TestCase):
             out_np = paddle.complex(x, y).numpy()
         np.testing.assert_allclose(self.out, out_np, rtol=1e-05)
 
+    @test_with_pir_api
     def test_static(self):
         mp, sp = static.Program(), static.Program()
         with static.program_guard(mp, sp):

--- a/test/legacy_test/test_complex_op.py
+++ b/test/legacy_test/test_complex_op.py
@@ -20,7 +20,7 @@ from op_test import OpTest
 import paddle
 from paddle import static
 from paddle.base import dygraph
-from paddle.pir_uitls import test_with_pir_api
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 

--- a/test/legacy_test/test_logspace.py
+++ b/test/legacy_test/test_logspace.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_uitls import test_with_pir_api
 
 
 class TestLogspaceOpCommonCase(OpTest):
@@ -39,7 +40,7 @@ class TestLogspaceOpCommonCase(OpTest):
         self.outputs = {'Out': np.power(2, np.arange(0, 11)).astype(dtype)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestLogspaceFP16Op(TestLogspaceOpCommonCase):
@@ -87,7 +88,7 @@ class TestLogspaceBF16Op(OpTest):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
 
 class TestLogspaceOpReverseCase(TestLogspaceOpCommonCase):
@@ -143,6 +144,7 @@ class TestLogspaceOpZeroBaseCase(TestLogspaceOpCommonCase):
 
 
 class TestLogspaceAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_variable_input1(self):
         paddle.enable_static()
         prog = paddle.static.Program()
@@ -170,6 +172,7 @@ class TestLogspaceAPI(unittest.TestCase):
         self.assertEqual((out.numpy() == np_res).all(), True)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_dtype(self):
         paddle.enable_static()
         prog = paddle.static.Program()

--- a/test/legacy_test/test_logspace.py
+++ b/test/legacy_test/test_logspace.py
@@ -19,7 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
-from paddle.pir_uitls import test_with_pir_api
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestLogspaceOpCommonCase(OpTest):

--- a/test/legacy_test/test_logspace.py
+++ b/test/legacy_test/test_logspace.py
@@ -19,7 +19,6 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 
 class TestLogspaceOpCommonCase(OpTest):
@@ -40,7 +39,7 @@ class TestLogspaceOpCommonCase(OpTest):
         self.outputs = {'Out': np.power(2, np.arange(0, 11)).astype(dtype)}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output()
 
 
 class TestLogspaceFP16Op(TestLogspaceOpCommonCase):
@@ -88,7 +87,7 @@ class TestLogspaceBF16Op(OpTest):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_pir=True)
+        self.check_output_with_place(self.place)
 
 
 class TestLogspaceOpReverseCase(TestLogspaceOpCommonCase):
@@ -144,7 +143,6 @@ class TestLogspaceOpZeroBaseCase(TestLogspaceOpCommonCase):
 
 
 class TestLogspaceAPI(unittest.TestCase):
-    @test_with_pir_api
     def test_variable_input1(self):
         paddle.enable_static()
         prog = paddle.static.Program()
@@ -172,7 +170,6 @@ class TestLogspaceAPI(unittest.TestCase):
         self.assertEqual((out.numpy() == np_res).all(), True)
         paddle.enable_static()
 
-    @test_with_pir_api
     def test_dtype(self):
         paddle.enable_static()
         prog = paddle.static.Program()

--- a/test/legacy_test/test_logspace.py
+++ b/test/legacy_test/test_logspace.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestLogspaceOpCommonCase(OpTest):
@@ -39,7 +40,7 @@ class TestLogspaceOpCommonCase(OpTest):
         self.outputs = {'Out': np.power(2, np.arange(0, 11)).astype(dtype)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestLogspaceFP16Op(TestLogspaceOpCommonCase):
@@ -87,7 +88,7 @@ class TestLogspaceBF16Op(OpTest):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
 
 class TestLogspaceOpReverseCase(TestLogspaceOpCommonCase):
@@ -143,6 +144,7 @@ class TestLogspaceOpZeroBaseCase(TestLogspaceOpCommonCase):
 
 
 class TestLogspaceAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_variable_input1(self):
         paddle.enable_static()
         prog = paddle.static.Program()
@@ -170,6 +172,7 @@ class TestLogspaceAPI(unittest.TestCase):
         self.assertEqual((out.numpy() == np_res).all(), True)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_dtype(self):
         paddle.enable_static()
         prog = paddle.static.Program()

--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_uitls import test_with_pir_api
 
 
 def meshgrid_wrapper(x):
@@ -41,10 +42,12 @@ class TestMeshgridOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output(check_prim=True)
+        self.check_output(check_prim=True, check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['x0'], ['out0', 'out1'], check_prim=True)
+        self.check_grad(
+            ['x0'], ['out0', 'out1'], check_prim=True, check_pir=True
+        )
 
     def init_inputs_and_outputs(self):
         self.shape = self.get_x_shape()
@@ -122,15 +125,20 @@ class TestMeshgridOpBFP16OP(TestMeshgridOp):
         self.enable_cinn = False
 
     def test_check_output(self):
-        self.check_output_with_place(place=paddle.CUDAPlace(0))
+        self.check_output_with_place(place=paddle.CUDAPlace(0), check_pir=True)
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            paddle.CUDAPlace(0), ['x0'], ['out0', 'out1'], check_prim=True
+            paddle.CUDAPlace(0),
+            ['x0'],
+            ['out0', 'out1'],
+            check_prim=True,
+            check_pir=True,
         )
 
 
 class TestMeshgridOp3(unittest.TestCase):
+    @test_with_pir_api
     def test_api(self):
         x = paddle.static.data(shape=[100], dtype='int32', name='x')
         y = paddle.static.data(shape=[200], dtype='int32', name='y')
@@ -167,6 +175,7 @@ class TestMeshgridOp3(unittest.TestCase):
 
 
 class TestMeshgridOp4(unittest.TestCase):
+    @test_with_pir_api
     def test_list_input(self):
         x = paddle.static.data(shape=[100], dtype='int32', name='x')
         y = paddle.static.data(shape=[200], dtype='int32', name='y')
@@ -204,6 +213,7 @@ class TestMeshgridOp4(unittest.TestCase):
 
 
 class TestMeshgridOp5(unittest.TestCase):
+    @test_with_pir_api
     def test_tuple_input(self):
         x = paddle.static.data(shape=[100], dtype='int32', name='x')
         y = paddle.static.data(shape=[200], dtype='int32', name='y')

--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -20,7 +20,6 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 
 def meshgrid_wrapper(x):
@@ -138,7 +137,6 @@ class TestMeshgridOpBFP16OP(TestMeshgridOp):
 
 
 class TestMeshgridOp3(unittest.TestCase):
-    @test_with_pir_api
     def test_api(self):
         x = paddle.static.data(shape=[100], dtype='int32', name='x')
         y = paddle.static.data(shape=[200], dtype='int32', name='y')
@@ -175,7 +173,6 @@ class TestMeshgridOp3(unittest.TestCase):
 
 
 class TestMeshgridOp4(unittest.TestCase):
-    @test_with_pir_api
     def test_list_input(self):
         x = paddle.static.data(shape=[100], dtype='int32', name='x')
         y = paddle.static.data(shape=[200], dtype='int32', name='y')
@@ -213,7 +210,6 @@ class TestMeshgridOp4(unittest.TestCase):
 
 
 class TestMeshgridOp5(unittest.TestCase):
-    @test_with_pir_api
     def test_tuple_input(self):
         x = paddle.static.data(shape=[100], dtype='int32', name='x')
         y = paddle.static.data(shape=[200], dtype='int32', name='y')

--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def meshgrid_wrapper(x):
@@ -137,10 +138,8 @@ class TestMeshgridOpBFP16OP(TestMeshgridOp):
 
 
 class TestMeshgridOp3(unittest.TestCase):
+    @test_with_pir_api
     def test_api(self):
-        x = paddle.static.data(shape=[100], dtype='int32', name='x')
-        y = paddle.static.data(shape=[200], dtype='int32', name='y')
-
         input_1 = np.random.randint(
             0,
             100,
@@ -161,22 +160,24 @@ class TestMeshgridOp3(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = base.Executor(place=base.CPUPlace())
-        grid_x, grid_y = paddle.tensor.meshgrid(x, y)
-        res_1, res_2 = exe.run(
-            base.default_main_program(),
-            feed={'x': input_1, 'y': input_2},
-            fetch_list=[grid_x, grid_y],
-        )
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data(shape=[100], dtype='int32', name='x')
+            y = paddle.static.data(shape=[200], dtype='int32', name='y')
+
+            exe = base.Executor(place=base.CPUPlace())
+            grid_x, grid_y = paddle.tensor.meshgrid(x, y)
+            res_1, res_2 = exe.run(
+                paddle.static.default_main_program(),
+                feed={'x': input_1, 'y': input_2},
+                fetch_list=[grid_x, grid_y],
+            )
         np.testing.assert_array_equal(res_1, out_1)
         np.testing.assert_array_equal(res_2, out_2)
 
 
 class TestMeshgridOp4(unittest.TestCase):
+    @test_with_pir_api
     def test_list_input(self):
-        x = paddle.static.data(shape=[100], dtype='int32', name='x')
-        y = paddle.static.data(shape=[200], dtype='int32', name='y')
-
         input_1 = np.random.randint(
             0,
             100,
@@ -197,23 +198,24 @@ class TestMeshgridOp4(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = base.Executor(place=base.CPUPlace())
-        grid_x, grid_y = paddle.tensor.meshgrid([x, y])
-        res_1, res_2 = exe.run(
-            base.default_main_program(),
-            feed={'x': input_1, 'y': input_2},
-            fetch_list=[grid_x, grid_y],
-        )
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data(shape=[100], dtype='int32', name='x')
+            y = paddle.static.data(shape=[200], dtype='int32', name='y')
 
+            exe = base.Executor(place=base.CPUPlace())
+            grid_x, grid_y = paddle.tensor.meshgrid([x, y])
+            res_1, res_2 = exe.run(
+                paddle.static.default_main_program(),
+                feed={'x': input_1, 'y': input_2},
+                fetch_list=[grid_x, grid_y],
+            )
         np.testing.assert_array_equal(res_1, out_1)
         np.testing.assert_array_equal(res_2, out_2)
 
 
 class TestMeshgridOp5(unittest.TestCase):
+    @test_with_pir_api
     def test_tuple_input(self):
-        x = paddle.static.data(shape=[100], dtype='int32', name='x')
-        y = paddle.static.data(shape=[200], dtype='int32', name='y')
-
         input_1 = np.random.randint(
             0,
             100,
@@ -234,14 +236,17 @@ class TestMeshgridOp5(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = base.Executor(place=base.CPUPlace())
-        grid_x, grid_y = paddle.tensor.meshgrid((x, y))
-        res_1, res_2 = exe.run(
-            base.default_main_program(),
-            feed={'x': input_1, 'y': input_2},
-            fetch_list=[grid_x, grid_y],
-        )
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data(shape=[100], dtype='int32', name='x')
+            y = paddle.static.data(shape=[200], dtype='int32', name='y')
 
+            exe = base.Executor(place=base.CPUPlace())
+            grid_x, grid_y = paddle.tensor.meshgrid((x, y))
+            res_1, res_2 = exe.run(
+                paddle.static.default_main_program(),
+                feed={'x': input_1, 'y': input_2},
+                fetch_list=[grid_x, grid_y],
+            )
         np.testing.assert_array_equal(res_1, out_1)
         np.testing.assert_array_equal(res_2, out_2)
 

--- a/test/legacy_test/test_meshgrid_op.py
+++ b/test/legacy_test/test_meshgrid_op.py
@@ -20,7 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.pir_uitls import test_with_pir_api
+from paddle.pir_utils import test_with_pir_api
 
 
 def meshgrid_wrapper(x):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级

* https://github.com/PaddlePaddle/Paddle/issues/58067

No.41 将 `paddle.complex` 迁移升级至 pir，并更新单测 单测覆盖率：5/5
No.138 将 `paddle.logspace ` 迁移升级至 pir，并更新单测 单测覆盖率：8/12
No.153 将 `paddle.meshgrid` 迁移升级至 pir，并更新单测 单测覆盖率：7/12




