### PR TITLE
[PIR]Perfect unittest for exp / full_like / gather_nd / gather / rms_norm / softmax / transpose

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -50,6 +50,7 @@ extern PyTypeObject* p_string_tensor_type;
 
 extern PyTypeObject* g_framework_scope_pytype;
 extern PyTypeObject* g_ir_opresult_pytype;
+extern PyTypeObject* g_ir_value_pytype;
 extern PyTypeObject* g_vartype_pytype;
 extern PyTypeObject* g_data_type_pytype;
 extern PyTypeObject* g_place_pytype;
@@ -1521,6 +1522,8 @@ pir::Value CastPyArg2Value(PyObject* obj,
                            size_t arg_pos) {
   if (PyObject_TypeCheck(obj, g_ir_opresult_pytype)) {
     return ::pybind11::handle(obj).cast<pir::OpResult>();
+  } else if (PyObject_TypeCheck(obj, g_ir_value_pytype)) {
+    return ::pybind11::handle(obj).cast<pir::Value>();
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "%s(): argument (position %d) must be "

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -78,6 +78,7 @@ namespace paddle {
 namespace pybind {
 
 PyTypeObject *g_ir_opresult_pytype = nullptr;
+PyTypeObject *g_ir_value_pytype = nullptr;
 
 void BindOpsAPI(pybind11::module *module);
 
@@ -408,6 +409,7 @@ void BindValue(py::module *m) {
         when build network.
 
   )DOC");
+  g_ir_value_pytype = reinterpret_cast<PyTypeObject *>(value.ptr());
   value
       .def(
           "get_defining_op",

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 
 import numpy as np
 
-from ..pir import OpResult
+from ..pir import OpResult, Value
 from . import compiler, core, framework, get_flags, set_flags, unique_name
 from .data_feeder import convert_dtype
 from .framework import (
@@ -513,7 +513,7 @@ def _add_pir_fetch_ops(program, fetch_list, fetch_var_name):
         with paddle.static.program_guard(program):
             for i, fetch_input in enumerate(fetch_list):
                 assert isinstance(
-                    fetch_input, OpResult
+                    fetch_input, (OpResult, Value)
                 ), f"Wrong type for fetch_list[{i}]: {type(fetch_input)}"
                 paddle._pir_ops.fetch(fetch_input, fetch_var_name + str(i), i)
 
@@ -1945,7 +1945,9 @@ class Executor:
         return exe.run(feed)
 
     def _check_fetch_list(self, fetch_list):
-        is_fetch_var = lambda var: isinstance(var, (Variable, str, OpResult))
+        is_fetch_var = lambda var: isinstance(
+            var, (Variable, str, OpResult, Value)
+        )
         is_tuple_list = lambda var: isinstance(var, (tuple, list))
 
         if fetch_list is None:
@@ -1971,7 +1973,7 @@ class Executor:
                     res.append(var)
             else:
                 raise TypeError(
-                    "Require fetch_list[{}] 's type shall be one of (Variable, str), but received {}.".format(
+                    "Require fetch_list[{}] 's type shall be one of (OpResult, str), but received {}.".format(
                         i, type(var).__name__
                     )
                 )

--- a/python/paddle/incubate/nn/functional/fused_rms_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_rms_norm.py
@@ -15,7 +15,7 @@
 
 import paddle
 from paddle import _C_ops
-from paddle.framework import LayerHelper, in_dynamic_or_pir_mode
+from paddle.framework import LayerHelper, in_dynamic_mode, in_pir_mode
 
 
 def fused_rms_norm(
@@ -64,7 +64,7 @@ def fused_rms_norm(
             >>> epsilon = 1e-6
             >>> paddle_rmsnorm = paddle.incubate.nn.functional.fused_rms_norm(paddle_x, paddle_weight, paddle_bias, epsilon, 1)
     """
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         return _C_ops.rms_norm(
             x,
             bias,
@@ -78,7 +78,21 @@ def fused_rms_norm(
             quant_max_bound,
             quant_min_bound,
         )
-
+    if in_pir_mode():
+        out, residual_out = _C_ops.rms_norm(
+            x,
+            bias,
+            residual,
+            norm_weight,
+            norm_bias,
+            epsilon,
+            begin_norm_axis,
+            quant_scale,
+            quant_round_type,
+            quant_max_bound,
+            quant_min_bound,
+        )
+        return (out, residual_out) if residual is not None else out
     helper = LayerHelper('rms_norm', **locals())
     out = None
     if quant_scale <= 0:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1375,7 +1375,7 @@ def t(input, name=None):
             "length of Input(input) is %s. Perhaps you can use paddle."
             "tensor.transpose() instead." % len(input.shape)
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if len(input.shape) <= 1:
             return input
         # 2-D tensor

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2037,6 +2037,7 @@ def split(x, num_or_sections, axis=0, name=None):
             >>> print(out2.shape)
             [3, 3, 5]
     """
+
     input = x
     dim = axis
     if in_dynamic_mode():
@@ -2061,15 +2062,32 @@ def split(x, num_or_sections, axis=0, name=None):
         else:
             return _C_ops.split(input, num_or_sections, dim)
     elif in_pir_mode():
+        if isinstance(dim, paddle.pir.OpResult):
+            dim.stop_gradient = True
         if isinstance(dim, int):
             assert len(input.shape) + dim >= 0, "(rank(x) + axis) must >= 0"
             dim = (len(input.shape) + dim) if dim < 0 else dim
 
+        input_shape = input.shape
         if isinstance(num_or_sections, int):
-            dim = dim if dim >= 0 else dim + len(input.shape)
+            assert num_or_sections > 0, 'num_or_sections must be than 0.'
+            if isinstance(dim, int) and input_shape[dim] > 0:
+                assert input_shape[dim] % num_or_sections == 0, (
+                    "The input's size along the split dimension "
+                    "must be evenly divisible by Attr(num_or_sections). "
+                    "But %d is not evenly divisible by %d. "
+                    % (num_or_sections, input_shape[dim])
+                )
             return _C_ops.split_with_num(input, num_or_sections, dim)
         else:
-            dim = dim if dim >= 0 else dim + len(input.shape)
+            if isinstance(dim, int) and input_shape[dim] > 0:
+                assert (
+                    len(num_or_sections) <= input_shape[dim]
+                ), 'len(num_or_sections) must not be more than input.shape[dim].'
+            if paddle.utils._contain_var(num_or_sections):
+                num_or_sections = paddle.utils.get_int_tensor_list(
+                    num_or_sections
+                )
             return _C_ops.split(input, num_or_sections, dim)
 
     else:
@@ -3603,7 +3621,21 @@ def expand(x, shape, name=None):
             [[1, 2, 3],
              [1, 2, 3]])
     """
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
+        return _C_ops.expand(x, shape)
+    elif in_pir_mode():
+        if convert_dtype(x.dtype) == 'bool' and not x.stop_gradient:
+            raise ValueError(
+                "When the data type of input 'x' for expand is bool, "
+                "you must set its stop_gradient to be False by "
+                "some_var.stop_gradient = True, supporting "
+                "some_var as the input."
+            )
+        if isinstance(shape, paddle.pir.OpResult):
+            shape.stop_gradient = True
+        elif isinstance(shape, (list, tuple)):
+            if paddle.utils._contain_var(shape):
+                shape = paddle.utils._convert_to_tensor_list(shape)
         return _C_ops.expand(x, shape)
     else:
         if isinstance(shape, Variable):
@@ -3777,6 +3809,24 @@ def reshape(x, shape, name=None):
         return attrs_shape
 
     if in_dynamic_mode():
+        check_variable_and_dtype(
+            x,
+            'x',
+            [
+                'float16',
+                'float32',
+                'float64',
+                'int16',
+                'int32',
+                'int64',
+                'bool',
+                'uint16',
+            ],
+            'reshape',
+        )
+        check_type(
+            shape, 'shape', (list, tuple, paddle.pir.OpResult), 'reshape'
+        )
         if isinstance(shape, (list, tuple)):
             new_shape = []
             for ele in shape:
@@ -3798,6 +3848,26 @@ def reshape(x, shape, name=None):
             )
         return out
     elif in_pir_mode():
+        check_variable_and_dtype(
+            x,
+            'x',
+            [
+                'float16',
+                'float32',
+                'float64',
+                'int8',
+                'uint8',
+                'int16',
+                'int32',
+                'int64',
+                'bool',
+                'uint16',
+            ],
+            'reshape',
+        )
+        check_type(
+            shape, 'shape', (list, tuple, paddle.pir.OpResult), 'reshape'
+        )
         if isinstance(shape, (list, tuple)):
             if paddle.utils._contain_var(shape):
                 new_shape = paddle.utils._convert_to_tensor_list(shape)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2866,7 +2866,7 @@ def gather(x, index, axis=None, name=None):
     if axis is None:
         axis = 0
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.gather(x, index, axis)
     else:
         check_variable_and_dtype(
@@ -4690,7 +4690,7 @@ def moveaxis(x, source, destination, name=None):
     for i in range(len(src_dims)):
         perm[dst_dims[i]] = src_dims[i]
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out = _C_ops.transpose(x, perm)
         return out
     else:

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -794,9 +794,28 @@ def uniform(shape, dtype=None, min=-1.0, max=1.0, seed=0, name=None):
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         shape = paddle.utils.convert_shape_to_list(shape)
-        if in_pir_mode() and paddle.utils._contain_var(shape):
+        return _C_ops.uniform(
+            shape,
+            dtype,
+            float(min),
+            float(max),
+            seed,
+            _current_expected_place(),
+        )
+    elif in_pir_mode():
+        check_type(
+            shape, 'shape', (list, tuple, paddle.pir.OpResult), 'uniform/rand'
+        )
+        check_dtype(dtype, 'dtype', supported_dtypes, 'uniform/rand')
+        check_type(
+            min, 'min', (float, int, paddle.pir.OpResult), 'uniform/rand'
+        )
+        check_type(
+            max, 'max', (float, int, paddle.pir.OpResult), 'uniform/rand'
+        )
+        if paddle.utils._contain_var(shape):
             shape = paddle.utils.get_int_tensor_list(
                 shape, _current_expected_place()
             )

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -205,9 +205,10 @@ class TestExp_Complex128(TestExp_Complex64):
 
 
 class Test_Exp_Op_Fp16(unittest.TestCase):
+    @test_with_pir_api
     def test_api_fp16(self):
         with static_guard():
-            with static.program_guard(
+            with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
                 np_x = np.array([[2, 3, 4], [7, 8, 9]])
@@ -559,6 +560,7 @@ class TestSiluAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -781,6 +783,7 @@ class TestTanhAPI(unittest.TestCase):
     def executed_api(self):
         self.tanh = F.tanh
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_concat_op.py
+++ b/test/legacy_test/test_concat_op.py
@@ -22,6 +22,7 @@ from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestConcatOp(OpTest):
@@ -591,76 +592,88 @@ class TestConcatOpError(unittest.TestCase):
 
 
 class TestConcatAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_base_api(self):
         paddle.enable_static()
-        x_1 = paddle.static.data(
-            shape=[None, 1, 4, 5], dtype='int32', name='x_1'
-        )
-        paddle.concat([x_1, x_1], 0)
+        with paddle.static.program_guard(paddle.static.Program()):
+            x_1 = paddle.static.data(
+                shape=[None, 1, 4, 5], dtype='int32', name='x_1'
+            )
+            paddle.concat([x_1, x_1], 0)
 
-        input_2 = np.random.random([2, 1, 4, 5]).astype("int32")
-        input_3 = np.random.random([2, 2, 4, 5]).astype("int32")
-        x_2 = paddle.static.data(shape=[2, 1, 4, 5], dtype='int32', name='x_2')
-        x_3 = paddle.static.data(shape=[2, 2, 4, 5], dtype='int32', name='x_3')
-        positive_1_int32 = paddle.tensor.fill_constant([1], "int32", 1)
-        positive_1_int64 = paddle.tensor.fill_constant([1], "int64", 1)
-        out_1 = paddle.concat([x_2, x_3], axis=1)
-        out_2 = paddle.concat([x_2, x_3], axis=positive_1_int32)
-        out_3 = paddle.concat([x_2, x_3], axis=positive_1_int64)
+            input_2 = np.random.random([2, 1, 4, 5]).astype("int32")
+            input_3 = np.random.random([2, 2, 4, 5]).astype("int32")
+            x_2 = paddle.static.data(
+                shape=[2, 1, 4, 5], dtype='int32', name='x_2'
+            )
+            x_3 = paddle.static.data(
+                shape=[2, 2, 4, 5], dtype='int32', name='x_3'
+            )
+            positive_1_int32 = paddle.tensor.fill_constant([1], "int32", 1)
+            positive_1_int64 = paddle.tensor.fill_constant([1], "int64", 1)
+            out_1 = paddle.concat([x_2, x_3], axis=1)
+            out_2 = paddle.concat([x_2, x_3], axis=positive_1_int32)
+            out_3 = paddle.concat([x_2, x_3], axis=positive_1_int64)
 
-        exe = base.Executor(place=base.CPUPlace())
-        [res_1, res_2, res_3] = exe.run(
-            base.default_main_program(),
-            feed={"x_1": input_2, "x_2": input_2, "x_3": input_3},
-            fetch_list=[out_1, out_2, out_3],
-        )
-        np.testing.assert_array_equal(
-            res_1, np.concatenate((input_2, input_3), axis=1)
-        )
-        np.testing.assert_array_equal(
-            res_2, np.concatenate((input_2, input_3), axis=1)
-        )
-        np.testing.assert_array_equal(
-            res_3, np.concatenate((input_2, input_3), axis=1)
-        )
+            exe = base.Executor(place=base.CPUPlace())
+            [res_1, res_2, res_3] = exe.run(
+                paddle.static.default_main_program(),
+                feed={"x_1": input_2, "x_2": input_2, "x_3": input_3},
+                fetch_list=[out_1, out_2, out_3],
+            )
+            np.testing.assert_array_equal(
+                res_1, np.concatenate((input_2, input_3), axis=1)
+            )
+            np.testing.assert_array_equal(
+                res_2, np.concatenate((input_2, input_3), axis=1)
+            )
+            np.testing.assert_array_equal(
+                res_3, np.concatenate((input_2, input_3), axis=1)
+            )
 
+    @test_with_pir_api
     def test_api(self):
         paddle.enable_static()
-        x_1 = paddle.static.data(
-            shape=[None, 1, 4, 5], dtype='int32', name='x_1'
-        )
-        paddle.concat([x_1, x_1], 0)
+        with paddle.static.program_guard(paddle.static.Program()):
+            x_1 = paddle.static.data(
+                shape=[None, 1, 4, 5], dtype='int32', name='x_1'
+            )
+            paddle.concat([x_1, x_1], 0)
 
-        input_2 = np.random.random([2, 1, 4, 5]).astype("int32")
-        input_3 = np.random.random([2, 2, 4, 5]).astype("int32")
-        x_2 = paddle.static.data(shape=[2, 1, 4, 5], dtype='int32', name='x_2')
-        x_3 = paddle.static.data(shape=[2, 2, 4, 5], dtype='int32', name='x_3')
-        positive_1_int32 = paddle.tensor.fill_constant([1], "int32", 1)
-        positive_1_int64 = paddle.tensor.fill_constant([1], "int64", 1)
-        negative_int64 = paddle.tensor.fill_constant([1], "int64", -3)
-        out_1 = paddle.concat(x=[x_2, x_3], axis=1)
-        out_2 = paddle.concat(x=[x_2, x_3], axis=positive_1_int32)
-        out_3 = paddle.concat(x=[x_2, x_3], axis=positive_1_int64)
-        out_4 = paddle.concat(x=[x_2, x_3], axis=negative_int64)
+            input_2 = np.random.random([2, 1, 4, 5]).astype("int32")
+            input_3 = np.random.random([2, 2, 4, 5]).astype("int32")
+            x_2 = paddle.static.data(
+                shape=[2, 1, 4, 5], dtype='int32', name='x_2'
+            )
+            x_3 = paddle.static.data(
+                shape=[2, 2, 4, 5], dtype='int32', name='x_3'
+            )
+            positive_1_int32 = paddle.tensor.fill_constant([1], "int32", 1)
+            positive_1_int64 = paddle.tensor.fill_constant([1], "int64", 1)
+            negative_int64 = paddle.tensor.fill_constant([1], "int64", -3)
+            out_1 = paddle.concat(x=[x_2, x_3], axis=1)
+            out_2 = paddle.concat(x=[x_2, x_3], axis=positive_1_int32)
+            out_3 = paddle.concat(x=[x_2, x_3], axis=positive_1_int64)
+            out_4 = paddle.concat(x=[x_2, x_3], axis=negative_int64)
 
-        exe = paddle.static.Executor(place=paddle.CPUPlace())
-        [res_1, res_2, res_3, res_4] = exe.run(
-            paddle.static.default_main_program(),
-            feed={"x_1": input_2, "x_2": input_2, "x_3": input_3},
-            fetch_list=[out_1, out_2, out_3, out_4],
-        )
-        np.testing.assert_array_equal(
-            res_1, np.concatenate((input_2, input_3), axis=1)
-        )
-        np.testing.assert_array_equal(
-            res_2, np.concatenate((input_2, input_3), axis=1)
-        )
-        np.testing.assert_array_equal(
-            res_3, np.concatenate((input_2, input_3), axis=1)
-        )
-        np.testing.assert_array_equal(
-            res_4, np.concatenate((input_2, input_3), axis=1)
-        )
+            exe = paddle.static.Executor(place=paddle.CPUPlace())
+            [res_1, res_2, res_3, res_4] = exe.run(
+                paddle.static.default_main_program(),
+                feed={"x_1": input_2, "x_2": input_2, "x_3": input_3},
+                fetch_list=[out_1, out_2, out_3, out_4],
+            )
+            np.testing.assert_array_equal(
+                res_1, np.concatenate((input_2, input_3), axis=1)
+            )
+            np.testing.assert_array_equal(
+                res_2, np.concatenate((input_2, input_3), axis=1)
+            )
+            np.testing.assert_array_equal(
+                res_3, np.concatenate((input_2, input_3), axis=1)
+            )
+            np.testing.assert_array_equal(
+                res_4, np.concatenate((input_2, input_3), axis=1)
+            )
 
     def test_imperative(self):
         in1 = np.array([[1, 2, 3], [4, 5, 6]])
@@ -729,8 +742,8 @@ class TestConcatAPIWithLoDTensorArray(unittest.TestCase):
     def set_program(self, use_base_api):
         paddle.enable_static()
         if use_base_api:
-            self.program = base.Program()
-            with base.program_guard(self.program):
+            self.program = paddle.static.Program()
+            with paddle.static.program_guard(self.program):
                 input = paddle.assign(self.x)
                 tensor_array = paddle.tensor.create_array(dtype='float32')
                 zero = paddle.tensor.fill_constant(

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -22,6 +22,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 # Situation 1: shape is a list(without tensor)
@@ -313,35 +314,35 @@ class TestExpandV2Error(unittest.TestCase):
 
 # Test python API
 class TestExpandV2API(unittest.TestCase):
+    @test_with_pir_api
     def test_api(self):
-        input = np.random.random([12, 14]).astype("float32")
-        x = paddle.static.data(name='x', shape=[12, 14], dtype="float32")
+        with paddle.static.program_guard(paddle.static.Program()):
+            input = np.random.random([12, 14]).astype("float32")
+            x = paddle.static.data(name='x', shape=[12, 14], dtype="float32")
 
-        positive_2 = paddle.tensor.fill_constant([1], "int32", 12)
-        expand_shape = paddle.static.data(
-            name="expand_shape",
-            shape=[2],
-            dtype="int32",
-        )
+            positive_2 = paddle.tensor.fill_constant([1], "int32", 12)
+            expand_shape = paddle.static.data(
+                name="expand_shape",
+                shape=[2],
+                dtype="int32",
+            )
 
-        out_1 = paddle.expand(x, shape=[12, 14])
-        out_2 = paddle.expand(x, shape=[positive_2, 14])
-        out_3 = paddle.expand(x, shape=expand_shape)
+            out_1 = paddle.expand(x, shape=[12, 14])
+            out_2 = paddle.expand(x, shape=[positive_2, 14])
+            out_3 = paddle.expand(x, shape=expand_shape)
 
-        g0 = base.backward.calc_gradient(out_2, x)
-
-        exe = base.Executor(place=base.CPUPlace())
-        res_1, res_2, res_3 = exe.run(
-            base.default_main_program(),
-            feed={
-                "x": input,
-                "expand_shape": np.array([12, 14]).astype("int32"),
-            },
-            fetch_list=[out_1, out_2, out_3],
-        )
-        np.testing.assert_array_equal(res_1, np.tile(input, (1, 1)))
-        np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
-        np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
+            exe = base.Executor(place=base.CPUPlace())
+            res_1, res_2, res_3 = exe.run(
+                paddle.static.default_main_program(),
+                feed={
+                    "x": input,
+                    "expand_shape": np.array([12, 14]).astype("int32"),
+                },
+                fetch_list=[out_1, out_2, out_3],
+            )
+            np.testing.assert_array_equal(res_1, np.tile(input, (1, 1)))
+            np.testing.assert_array_equal(res_2, np.tile(input, (1, 1)))
+            np.testing.assert_array_equal(res_3, np.tile(input, (1, 1)))
 
 
 class TestExpandInferShape(unittest.TestCase):

--- a/test/legacy_test/test_full_like_op.py
+++ b/test/legacy_test/test_full_like_op.py
@@ -22,6 +22,7 @@ import paddle.framework.dtype as dtypes
 from paddle.base import core
 from paddle.base.framework import convert_np_dtype_to_dtype_
 from paddle.framework import in_pir_mode
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -45,11 +46,12 @@ def fill_any_like_wrapper(x, value, out_dtype=None, name=None):
 class TestFullOp(unittest.TestCase):
     """Test fill_any_like op(whose API is full_like) for attr out."""
 
+    @test_with_pir_api
     def test_attr_tensor_API(self):
         paddle.enable_static()
-        startup_program = Program()
-        train_program = Program()
-        with program_guard(train_program, startup_program):
+        startup_program = paddle.static.Program()
+        train_program = paddle.static.Program()
+        with paddle.static.program_guard(train_program, startup_program):
             fill_value = 2.0
             input = paddle.static.data(
                 name='input', dtype='float32', shape=[2, 3]

--- a/test/legacy_test/test_gather_nd_op.py
+++ b/test/legacy_test/test_gather_nd_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestGatherNdOpWithEmptyIndex(OpTest):
@@ -561,6 +562,7 @@ class TestGatherNdOpWithHighRankDiffBF16(TestGatherNdOpWithHighRankDiff):
 
 # Test Python API
 class TestGatherNdOpAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_case1(self):
         x1 = paddle.static.data(
             name='x1', shape=[-1, 30, 40, 50, 60], dtype='float32'
@@ -570,6 +572,7 @@ class TestGatherNdOpAPI(unittest.TestCase):
         )
         output1 = paddle.gather_nd(x1, index1)
 
+    @test_with_pir_api
     def test_case2(self):
         x2 = paddle.static.data(
             name='x2', shape=[-1, 30, 40, 50], dtype='float32'
@@ -579,6 +582,7 @@ class TestGatherNdOpAPI(unittest.TestCase):
         )
         output2 = paddle.gather_nd(x2, index2)
 
+    @test_with_pir_api
     def test_case3(self):
         x3 = paddle.static.data(name='x3', shape=[-1, 3, 4, 5], dtype='float32')
         index3 = paddle.static.data(
@@ -589,6 +593,7 @@ class TestGatherNdOpAPI(unittest.TestCase):
 
 # Test Raise Index Error
 class TestGatherNdOpRaise(unittest.TestCase):
+    @test_with_pir_api
     def test_check_raise(self):
         def check_raise_is_test():
             try:
@@ -638,16 +643,15 @@ class TestGatherNdError(unittest.TestCase):
 
 
 class TestGatherNdAPI2(unittest.TestCase):
+    @test_with_pir_api
     def test_static(self):
         with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data('data1', shape=[-1, 2], dtype='float64')
-            data1.desc.set_need_check_feed(False)
             index = paddle.static.data('index', shape=[-1, 1], dtype='int32')
-            index.desc.set_need_check_feed(False)
             out = paddle.gather_nd(data1, index)
             place = base.CPUPlace()
             exe = base.Executor(place)
-            input = np.array([[1, 2], [3, 4], [5, 6]])
+            input = np.array([[1, 2], [3, 4], [5, 6]]).astype('float64')
             index_1 = np.array([[1]]).astype('int32')
             (result,) = exe.run(
                 feed={"data1": input, "index": index_1}, fetch_list=[out]
@@ -655,6 +659,7 @@ class TestGatherNdAPI2(unittest.TestCase):
             expected_output = np.array([[3, 4]])
         np.testing.assert_allclose(result, expected_output, rtol=1e-05)
 
+    @test_with_pir_api
     def test_static_fp16_with_gpu(self):
         if paddle.base.core.is_compiled_with_cuda():
             place = paddle.CUDAPlace(0)
@@ -671,11 +676,9 @@ class TestGatherNdAPI2(unittest.TestCase):
                 x = paddle.static.data(
                     name="x", shape=[2, 3, 2], dtype="float16"
                 )
-                x.desc.set_need_check_feed(False)
                 idx = paddle.static.data(
                     name="index", shape=[1, 2], dtype="int32"
                 )
-                idx.desc.set_need_check_feed(False)
 
                 y = paddle.gather_nd(x, idx)
 

--- a/test/legacy_test/test_lookup_table_v2_bf16_op.py
+++ b/test/legacy_test/test_lookup_table_v2_bf16_op.py
@@ -27,6 +27,7 @@ from test_lookup_table_bf16_op import (
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestLookupTableV2BF16Op(TestLookupTableBF16Op):
@@ -125,10 +126,12 @@ class TestEmbeddingLayerBF16ConstantInitializer(unittest.TestCase):
             self.prog, feed={'x': self.ids}, fetch_list=['emb_weight', self.emb]
         )
 
+    @test_with_pir_api
     def test_embedding_weights(self):
         result = convert_uint16_to_float(self.result[0])
         np.testing.assert_array_equal(self.w_fp32, result)
 
+    @test_with_pir_api
     def test_lookup_results(self):
         lookup_result = convert_uint16_to_float(self.result[1])
         lookup_ref = _lookup(self.w_fp32, self.ids, self.flat_ids, self.op_type)

--- a/test/legacy_test/test_lookup_table_v2_op.py
+++ b/test/legacy_test/test_lookup_table_v2_op.py
@@ -21,9 +21,11 @@ from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestStaticGraphSupportMultipleInt(unittest.TestCase):
+    @test_with_pir_api
     def test_main(self):
         dtypes = ['uint8', 'int8', 'int16', 'int32', 'int64']
         if paddle.in_dynamic_mode():

--- a/test/legacy_test/test_matmul_v2_op.py
+++ b/test/legacy_test/test_matmul_v2_op.py
@@ -21,6 +21,7 @@ from testsuite import create_op
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def reference_matmul(X, Y, transpose_X=False, transpose_Y=False):
@@ -508,7 +509,9 @@ class TestMatMulV2API(unittest.TestCase):
 
     def check_static_result(self, place):
         paddle.enable_static()
-        with base.program_guard(base.Program(), base.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             input_x = paddle.static.data(
                 name="input_x", shape=[4, 3], dtype="float32"
             )
@@ -523,12 +526,13 @@ class TestMatMulV2API(unittest.TestCase):
 
             exe = base.Executor(place)
             fetches = exe.run(
-                base.default_main_program(),
+                paddle.static.default_main_program(),
                 feed={"input_x": x_np, "input_y": y_np},
                 fetch_list=[result],
             )
         paddle.disable_static()
 
+    @test_with_pir_api
     def test_static(self):
         for place in self.places:
             self.check_static_result(place=place)

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -416,12 +417,13 @@ class TestReshapeAPI(unittest.TestCase):
     def _executed_api(self):
         self.reshape = paddle.reshape
 
+    @test_with_pir_api
     def _test_api(self):
         paddle.enable_static()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
-        main_prog = Program()
-        with program_guard(main_prog, Program()):
+        main_prog = paddle.static.Program()
+        with paddle.static.program_guard(main_prog, paddle.static.Program()):
             positive_five = self.fill_constant([1], "int32", 5)
             x = self.data(name="x", shape=[2, 25], dtype="float32")
 
@@ -517,13 +519,6 @@ class TestReshapeOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_x_type)
 
-            # The x dtype of reshape_op must be float16, float32, float64, int32 or int64.
-            def test_x_dtype():
-                x2 = self.data(name="x2", shape=[2, 25], dtype="int8")
-                self.reshape(x2, shape=[2, 5, 5])
-
-            self.assertRaises(TypeError, test_x_dtype)
-
             def test_x_dtype_float16():
                 x_float16 = self.data(
                     name="x_float16", shape=[2, 25], dtype="float16"
@@ -559,6 +554,7 @@ class TestReshapeOpError(unittest.TestCase):
             self.assertRaises(AssertionError, test_shape_3)
         paddle.disable_static()
 
+    @test_with_pir_api
     def test_paddle_api_error(self):
         self._set_paddle_api()
         self._test_errors()
@@ -649,25 +645,30 @@ class TestReshapeAPI_ZeroDim(unittest.TestCase):
 
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_static(self):
         main_prog = base.Program()
         with base.program_guard(main_prog, base.Program()):
             x = paddle.rand([])
             x.stop_gradient = False
             out = paddle.reshape(x, [-1])
-            base.backward.append_backward(out)
+            if paddle.framework.in_pir_mode():
+                grads = paddle.autograd.ir_backward.grad(out, x)
+                x_grad = grads[0]
+                out_grad = x_grad.get_defining_op().operand_source(1)
+            else:
+                base.backward.append_backward(out)
+                prog = paddle.static.default_main_program()
+                block = prog.global_block()
 
-            prog = paddle.static.default_main_program()
-            block = prog.global_block()
-
-            x_grad = block.var(base.framework.grad_var_name(x.name))
-            out_grad = block.var(base.framework.grad_var_name(out.name))
+                x_grad = block.var(base.framework.grad_var_name(x.name))
+                out_grad = block.var(base.framework.grad_var_name(out.name))
 
             # Test compile shape
-            self.assertEqual(x.shape, ())
-            self.assertEqual(out.shape, (1,))
-            self.assertEqual(x_grad.shape, ())
-            self.assertEqual(out_grad.shape, (1,))
+            self.assertEqual(tuple(x.shape), ())
+            self.assertEqual(tuple(out.shape), (1,))
+            self.assertEqual(tuple(x_grad.shape), ())
+            self.assertEqual(tuple(out_grad.shape), (1,))
 
             exe = base.Executor()
             result = exe.run(main_prog, fetch_list=[x, out, x_grad, out_grad])

--- a/test/legacy_test/test_rms_norm_op.py
+++ b/test/legacy_test/test_rms_norm_op.py
@@ -18,6 +18,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def quant_helper(
@@ -342,49 +343,6 @@ class TestRMSNormStaticOp(unittest.TestCase):
             )
         return out_s[0], paddle_naive_rmsnorm_out
 
-    def test_rmsnorm_pir(self):
-        paddle.disable_static()
-        x = paddle.to_tensor(self.x_np.astype("float32"))
-        gamma = paddle.to_tensor(self.norm_weight_np.astype("float32"))
-        beta = paddle.to_tensor(self.norm_bias_np.astype("float32"))
-
-        paddle_naive_rmsnorm_out = naive_rms_norm(x, gamma, beta, self.epsilon)
-        paddle.enable_static()
-
-        with paddle.pir_utils.IrGuard():
-            x_static = paddle.static.data(
-                name="x_static", shape=[self.batch, self.cols], dtype="float32"
-            )
-            gamma_static = paddle.static.data(
-                name="gamma_static", shape=[self.cols], dtype="float32"
-            )
-            beta_static = paddle.static.data(
-                name="beta_static", shape=[self.cols], dtype="float32"
-            )
-            out, _ = paddle.incubate.nn.functional.fused_rms_norm(
-                x_static,
-                gamma_static,
-                beta_static,
-                self.epsilon,
-                begin_norm_axis=1,
-            )
-            exe = base.Executor(self.place)
-            out_s = exe.run(
-                feed={
-                    "x_static": self.x_np.astype("float32"),
-                    "gamma_static": self.norm_weight_np.astype("float32"),
-                    "beta_static": self.norm_bias_np.astype("float32"),
-                },
-                fetch_list=[out],
-            )
-
-        np.testing.assert_allclose(
-            out_s[0],
-            paddle_naive_rmsnorm_out.numpy(),
-            rtol=1e-3,
-            atol=1e-3,
-        )
-
     def check_rmsnorm_int8(self, x_np, gamma_np, beta_np, dtype):
         paddle.disable_static()
         x = paddle.to_tensor(x_np.astype(dtype))
@@ -491,6 +449,7 @@ class TestRMSNormStaticOp(unittest.TestCase):
             )
         return out_s[0], paddle_naive_rmsnorm_out
 
+    @test_with_pir_api
     def test_rmsnorm_fp16(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -505,6 +464,7 @@ class TestRMSNormStaticOp(unittest.TestCase):
             atol=1e-3,
         )
 
+    @test_with_pir_api
     def test_residual_bias_add_rmsnorm_fp16(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -524,6 +484,7 @@ class TestRMSNormStaticOp(unittest.TestCase):
             atol=1e-3,
         )
 
+    @test_with_pir_api
     def test_rmsnorm_int8(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/legacy_test/test_scale_op.py
+++ b/test/legacy_test/test_scale_op.py
@@ -23,7 +23,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.static import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestScaleOp(OpTest):
@@ -200,11 +200,12 @@ class TestScaleApiStatic(unittest.TestCase):
     def _executed_api(self, x, scale=1.0, bias=0.0):
         return paddle.scale(x, scale, bias)
 
+    @test_with_pir_api
     def test_api(self):
         paddle.enable_static()
         input = np.random.random([2, 25]).astype("float32")
-        main_prog = Program()
-        with program_guard(main_prog, Program()):
+        main_prog = paddle.static.Program()
+        with paddle.static.program_guard(main_prog, paddle.static.Program()):
             x = paddle.static.data(name="x", shape=[2, 25], dtype="float32")
             out = self._executed_api(x, scale=2.0, bias=3.0)
 
@@ -300,7 +301,6 @@ class TestScaleTripleGradCheck(unittest.TestCase):
 
 class TestScaleOpZeroNumelVariable(unittest.TestCase):
     def test_check_zero_numel_cpu(self):
-        paddle.enable_static()
         paddle.set_device('cpu')
         data = paddle.ones([0, 1])
         out = paddle.scale(data, 2)

--- a/test/legacy_test/test_softmax_op.py
+++ b/test/legacy_test/test_softmax_op.py
@@ -22,6 +22,7 @@ import paddle
 import paddle.nn.functional as F
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(10)
 
@@ -512,6 +513,7 @@ class TestSoftmaxAPI(unittest.TestCase):
     def executed_api(self):
         self.softmax = F.softmax
 
+    @test_with_pir_api
     def test_static_check(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -590,6 +592,7 @@ class TestSoftmaxAPI_ZeroDim(unittest.TestCase):
 
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_static(self):
         with static_guard():
             main_prog = base.Program()
@@ -597,18 +600,17 @@ class TestSoftmaxAPI_ZeroDim(unittest.TestCase):
                 x = paddle.rand([])
                 x.stop_gradient = False
                 out = paddle.nn.functional.softmax(x)
-                base.backward.append_backward(out)
 
                 # Test compile shape
-                self.assertEqual(x.shape, ())
-                self.assertEqual(out.shape, ())
+                self.assertEqual(tuple(x.shape), ())
+                self.assertEqual(tuple(out.shape), ())
 
                 exe = base.Executor()
                 result = exe.run(main_prog, fetch_list=[x, out])
 
                 # Test runtime shape
-                self.assertEqual(result[0].shape, ())
-                self.assertEqual(result[1].shape, ())
+                self.assertEqual(tuple(result[0].shape), ())
+                self.assertEqual(tuple(result[1].shape), ())
 
 
 class TestSoftmaxInplaceAPI(TestSoftmaxAPI):

--- a/test/legacy_test/test_split_op.py
+++ b/test/legacy_test/test_split_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestSplitOp(OpTest):
@@ -321,39 +322,43 @@ create_test_bf16(TestSplitWithNumOp)
 
 
 class TestSplitAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_api(self):
-        input_1 = np.random.random([4, 5, 6]).astype("int32")
-        positive_1_int32 = paddle.tensor.fill_constant([1], "int32", 1)
-        positive_1_int64 = paddle.tensor.fill_constant([1], "int64", 1)
-        positive_2_int64 = paddle.tensor.fill_constant([1], "int64", 2)
-        x_1 = paddle.static.data(shape=[4, 5, 6], dtype='int32', name='x_1')
-        x_2 = paddle.static.data(shape=[4, 5, None], dtype='int32', name='x_2')
+        with paddle.static.program_guard(paddle.static.Program()):
+            input_1 = np.random.random([4, 5, 6]).astype("int32")
+            positive_1_int32 = paddle.tensor.fill_constant([1], "int32", 1)
+            positive_1_int64 = paddle.tensor.fill_constant([1], "int64", 1)
+            positive_2_int64 = paddle.tensor.fill_constant([1], "int64", 2)
+            x_1 = paddle.static.data(shape=[4, 5, 6], dtype='int32', name='x_1')
+            x_2 = paddle.static.data(
+                shape=[4, 5, None], dtype='int32', name='x_2'
+            )
 
-        out_0, out_1, out_2 = paddle.split(
-            x=x_1,
-            num_or_sections=[positive_2_int64, positive_1_int32, -1],
-            axis=positive_1_int64,
-        )
+            out_0, out_1, out_2 = paddle.split(
+                x=x_1,
+                num_or_sections=[positive_2_int64, positive_1_int32, -1],
+                axis=positive_1_int64,
+            )
 
-        out_3, out_4, out_5 = paddle.split(
-            x=x_1, num_or_sections=[2, 1, 2], axis=positive_1_int32
-        )
-        paddle.split(x=x_2, num_or_sections=2, axis=2)
+            out_3, out_4, out_5 = paddle.split(
+                x=x_1, num_or_sections=[2, 1, 2], axis=positive_1_int32
+            )
+            paddle.split(x=x_2, num_or_sections=2, axis=2)
 
-        exe = base.Executor(place=base.CPUPlace())
-        [res_0, res_1, res_2, res_3, res_4, res_5] = exe.run(
-            base.default_main_program(),
-            feed={"x_1": input_1, "x_2": input_1},
-            fetch_list=[out_0, out_1, out_2, out_3, out_4, out_5],
-        )
+            exe = base.Executor(place=base.CPUPlace())
+            [res_0, res_1, res_2, res_3, res_4, res_5] = exe.run(
+                paddle.static.default_main_program(),
+                feed={"x_1": input_1, "x_2": input_1},
+                fetch_list=[out_0, out_1, out_2, out_3, out_4, out_5],
+            )
 
-        out = np.split(input_1, [2, 3], 1)
-        np.testing.assert_array_equal(res_0, out[0])
-        np.testing.assert_array_equal(res_1, out[1])
-        np.testing.assert_array_equal(res_2, out[2])
-        np.testing.assert_array_equal(res_3, out[0])
-        np.testing.assert_array_equal(res_4, out[1])
-        np.testing.assert_array_equal(res_5, out[2])
+            out = np.split(input_1, [2, 3], 1)
+            np.testing.assert_array_equal(res_0, out[0])
+            np.testing.assert_array_equal(res_1, out[1])
+            np.testing.assert_array_equal(res_2, out[2])
+            np.testing.assert_array_equal(res_3, out[0])
+            np.testing.assert_array_equal(res_4, out[1])
+            np.testing.assert_array_equal(res_5, out[2])
 
 
 class TestSplitOpError(unittest.TestCase):
@@ -417,14 +422,13 @@ class TestSplitOpError(unittest.TestCase):
 
 
 class API_TestSplit(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data(
-                'data1', shape=[-1, 4, 6, 6], dtype='float64'
+                'data1', shape=[4, 6, 6], dtype='float64'
             )
-            data1.desc.set_need_check_feed(False)
-            data2 = paddle.static.data('data2', shape=[-1, 1], dtype='int32')
-            data2.desc.set_need_check_feed(False)
+            data2 = paddle.static.data('data2', shape=[1], dtype='int32')
             x0, x1, x2 = paddle.split(data1, num_or_sections=3, axis=data2)
             place = base.CPUPlace()
             exe = base.Executor(place)
@@ -444,12 +448,12 @@ class API_TestSplit(unittest.TestCase):
 
 
 class API_TestSplit2(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data(
-                'data1', shape=[-1, 4, 6, 6], dtype='float64'
+                'data1', shape=[4, 6, 6], dtype='float64'
             )
-            data1.desc.set_need_check_feed(False)
             x0, x1, x2 = paddle.split(data1, num_or_sections=3, axis=2)
             place = base.CPUPlace()
             exe = base.Executor(place)
@@ -466,6 +470,7 @@ class API_TestSplit2(unittest.TestCase):
 
 
 class API_TestSplit3(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         with base.program_guard(base.Program(), base.Program()):
             data = paddle.static.data('data', shape=[-1, 10], dtype='float64')
@@ -480,6 +485,7 @@ class API_TestSplit3(unittest.TestCase):
 
 
 class API_TestSplit4(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         with base.program_guard(base.Program(), base.Program()):
             data = paddle.static.data('data', shape=[-1, 10], dtype='float64')
@@ -498,6 +504,7 @@ class API_TestSplit4(unittest.TestCase):
 
 
 class API_TestSplit5(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         for use_cuda in (
             [False, True] if core.is_compiled_with_cuda() else [False]
@@ -518,6 +525,7 @@ class API_TestSplit5(unittest.TestCase):
 
 
 class API_TestSplit6(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         with base.program_guard(base.Program(), base.Program()):
             data = paddle.static.data('data', shape=[-1, 10], dtype='float64')

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -28,6 +28,7 @@ import paddle.inference as paddle_infer
 from paddle import base, enable_static
 from paddle.base import core
 from paddle.base.layer_helper import LayerHelper
+from paddle.pir_utils import test_with_pir_api
 
 
 def sum_wrapper(X, use_mkldnn=False):
@@ -393,6 +394,7 @@ class TestSumBF16Op(OpTest):
 
 
 class API_Test_Add_n(unittest.TestCase):
+    @test_with_pir_api
     def test_api(self):
         with base.program_guard(base.Program(), base.Program()):
             input0 = paddle.tensor.fill_constant(

--- a/test/legacy_test/test_transpose_op.py
+++ b/test/legacy_test/test_transpose_op.py
@@ -22,6 +22,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -541,6 +542,7 @@ class TestTransposeOpError(unittest.TestCase):
 
 
 class TestTransposeApi(unittest.TestCase):
+    @test_with_pir_api
     def test_static_out(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -578,7 +580,8 @@ class TestTransposeApi(unittest.TestCase):
 
 
 class TestTAPI(unittest.TestCase):
-    def test_out(self):
+    @test_with_pir_api
+    def test_static_out(self):
         with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[10], dtype="float64", name="data")
             data_t = paddle.t(data)
@@ -613,6 +616,7 @@ class TestTAPI(unittest.TestCase):
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
+    def test_dygraph_out(self):
         with base.dygraph.guard():
             np_x = np.random.random([10]).astype("float64")
             data = base.dygraph.to_variable(np_x)
@@ -637,6 +641,7 @@ class TestTAPI(unittest.TestCase):
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
+    @test_with_pir_api
     def test_errors(self):
         with base.program_guard(base.Program()):
             x = paddle.static.data(name='x', shape=[10, 5, 3], dtype='float64')
@@ -648,7 +653,8 @@ class TestTAPI(unittest.TestCase):
 
 
 class TestMoveAxis(unittest.TestCase):
-    def test_moveaxis1(self):
+    @test_with_pir_api
+    def test_static_moveaxis1(self):
         x_np = np.random.randn(2, 3, 4, 5, 7)
         expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.enable_static()
@@ -661,6 +667,9 @@ class TestMoveAxis(unittest.TestCase):
 
         np.testing.assert_array_equal(out_np, expected)
 
+    def test_dygraph_moveaxis1(self):
+        x_np = np.random.randn(2, 3, 4, 5, 7)
+        expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.disable_static()
         x = paddle.to_tensor(x_np)
         out = paddle.moveaxis(x, [0, 4, 3, 2], [1, 3, 2, 0])
@@ -668,7 +677,8 @@ class TestMoveAxis(unittest.TestCase):
         np.testing.assert_array_equal(out.numpy(), expected)
         paddle.enable_static()
 
-    def test_moveaxis2(self):
+    @test_with_pir_api
+    def test_static_moveaxis2(self):
         x_np = np.random.randn(2, 3, 5)
         expected = np.moveaxis(x_np, -2, -1)
         paddle.enable_static()
@@ -681,6 +691,9 @@ class TestMoveAxis(unittest.TestCase):
 
         np.testing.assert_array_equal(out_np, expected)
 
+    def test_dygraph_moveaxis2(self):
+        x_np = np.random.randn(2, 3, 5)
+        expected = np.moveaxis(x_np, -2, -1)
         paddle.disable_static()
         x = paddle.to_tensor(x_np)
         out = x.moveaxis(-2, -1)

--- a/test/legacy_test/test_uniform_random_bf16_op.py
+++ b/test/legacy_test/test_uniform_random_bf16_op.py
@@ -22,6 +22,7 @@ from test_uniform_random_op import output_hist, output_hist_diag
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 from paddle.tensor import random
 
 
@@ -160,6 +161,7 @@ class TestUniformRandomOpBF16SelectedRowsWithDiagInit(
 
 
 class TestUniformRandomOpAPISeed(unittest.TestCase):
+    @test_with_pir_api
     def test_attr_tensor_API(self):
         _seed = 10
         gen = paddle.seed(_seed)

--- a/test/legacy_test/test_uniform_random_op.py
+++ b/test/legacy_test/test_uniform_random_op.py
@@ -24,6 +24,7 @@ import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
 from paddle.base.framework import convert_np_dtype_to_dtype_
+from paddle.pir_utils import test_with_pir_api
 from paddle.tensor import random
 
 
@@ -223,8 +224,13 @@ class TestUniformRandomOpError(unittest.TestCase):
             self.assertRaises(TypeError, test_Variable2)
 
             def test_out_dtype():
-                out = paddle.uniform(shape=[3, 4], dtype='float64')
-                self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
+                out = paddle.tensor.random.uniform(
+                    shape=[3, 4], dtype='float64'
+                )
+                if paddle.framework.in_pir_mode():
+                    self.assertEqual(out.dtype, base.core.DataType.FLOAT64)
+                else:
+                    self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
             test_out_dtype()
         paddle.disable_static()
@@ -331,6 +337,7 @@ class TestUniformRandomOpApi(unittest.TestCase):
 
 
 class TestUniformRandomOp_attr_tensor_API(unittest.TestCase):
+    @test_with_pir_api
     def test_attr_tensor_API(self):
         paddle.enable_static()
         startup_program = base.Program()
@@ -348,6 +355,7 @@ class TestUniformRandomOp_attr_tensor_API(unittest.TestCase):
             outs = exe.run(train_program, fetch_list=[ret])
         paddle.disable_static()
 
+    @test_with_pir_api
     def test_attr_tensorlist_int32_API(self):
         paddle.enable_static()
         startup_program = base.Program()
@@ -389,6 +397,7 @@ class TestUniformRandomOp_attr_tensor_API(unittest.TestCase):
 
 
 class TestUniformRandomOp_API_seed(unittest.TestCase):
+    @test_with_pir_api
     def test_attr_tensor_API(self):
         paddle.enable_static()
         _seed = 10
@@ -490,6 +499,7 @@ class TestUniformRandomDygraphMode(unittest.TestCase):
 
 
 class TestUniformRandomBatchSizeLikeOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         main_prog = Program()
@@ -523,6 +533,7 @@ class TestUniformRandomBatchSizeLikeOpError(unittest.TestCase):
 
 
 class TestUniformAlias(unittest.TestCase):
+    @test_with_pir_api
     def test_alias(self):
         paddle.uniform([2, 3], min=-5.0, max=5.0)
         paddle.tensor.uniform([2, 3], min=-5.0, max=5.0)
@@ -535,6 +546,7 @@ class TestUniformAlias(unittest.TestCase):
 
 
 class TestUniformOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         main_prog = Program()
@@ -567,7 +579,10 @@ class TestUniformOpError(unittest.TestCase):
                 out = paddle.tensor.random.uniform(
                     shape=[3, 4], dtype='float64'
                 )
-                self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
+                if paddle.framework.in_pir_mode():
+                    self.assertEqual(out.dtype, base.core.DataType.FLOAT64)
+                else:
+                    self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
             test_out_dtype()
         paddle.disable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
补全如下算子的新IR单测，并解决单测验证中出现的问题：
exp / full_like / gather_nd / gather / rms_norm / softmax / transpose

解决fetch rms_norm输出结果报Tensor内存错误的问题
未适配单测：
部分Type验证类单测