### PR TITLE
[PIR]Migrate CrossEntropyLoss into pir

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2050,7 +2050,7 @@ def label_smooth(label, prior_dist=None, epsilon=0.1, name=None):
     if epsilon > 1.0 or epsilon < 0.0:
         raise ValueError("The value of epsilon must be between 0 and 1.")
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.label_smooth(label, prior_dist, float(epsilon))
 
     check_variable_and_dtype(

--- a/python/paddle/nn/functional/input.py
+++ b/python/paddle/nn/functional/input.py
@@ -17,7 +17,7 @@ from paddle import _C_ops
 from ...base.data_feeder import check_variable_and_dtype
 from ...base.layer_helper import LayerHelper
 from ...common_ops_import import Variable
-from ...framework import in_dynamic_mode, in_dynamic_or_pir_mode
+from ...framework import in_dynamic_or_pir_mode
 
 __all__ = []
 
@@ -89,7 +89,7 @@ def one_hot(x, num_classes, name=None):
 
     """
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.one_hot(x, num_classes)
     else:
         check_variable_and_dtype(x, 'input', ['int32', 'int64'], 'one_hot_v2')

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2899,21 +2899,23 @@ def cross_entropy(
                 if weight is None:
                     mask = paddle.cast(mask, dtype=out_sum.dtype)
                     count = _C_ops.sum(mask, [], None, False)
-                    ret = out_sum / (count + (count == 0.0))
+                    ret = out_sum / (count + paddle.equal(count, 0.0))
                 else:
                     mask = paddle.cast(mask, weight_gather_reshape.dtype)
                     weight_ignored = _C_ops.multiply(
                         mask, weight_gather_reshape
                     )
                     weight_sum = _C_ops.sum(weight_ignored, [], None, False)
-                    ret = out_sum / (weight_sum + (weight_sum == 0.0))
+                    ret = out_sum / (weight_sum + paddle.equal(weight_sum, 0.0))
                 return ret
             elif weight is not None:
                 out_sum = _C_ops.sum(out, [], None, False)
                 total_weight = _C_ops.sum(
                     weight_gather_reshape, [], None, False
                 )
-                return out_sum / (total_weight + (total_weight == 0.0))
+                return out_sum / (
+                    total_weight + paddle.equal(total_weight, 0.0)
+                )
             else:
                 return _C_ops.mean_all(out)
 

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -17,7 +17,7 @@ import math
 # TODO: define loss functions of neural network
 import paddle
 from paddle import _C_ops, base, in_dynamic_mode
-from paddle.framework import core
+from paddle.framework import core, in_dynamic_or_pir_mode
 from paddle.static.nn.control_flow import Assert
 from paddle.utils import deprecated
 
@@ -2806,7 +2806,7 @@ def cross_entropy(
         label = label.astype(input.dtype)
         label_dims = len(list(label.shape))
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if not soft_label:
             valid_label = (
                 paddle.cast(label != ignore_index, dtype=label.dtype) * label

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2889,7 +2889,7 @@ def cross_entropy(
             # 2. else
             #     numerator: loss's weighted sum
             #     denominator: cal the sum of weight where the sample's class_index!=ignore_index
-            is_ignore = label == ignore_index
+            is_ignore = paddle.equal(label, ignore_index)
             mask = ~is_ignore
             if paddle.count_nonzero(is_ignore) > 0:  # ignore label
                 out_sum = _C_ops.sum(out, [], None, False)

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -544,6 +544,7 @@ class CrossEntropyLoss(unittest.TestCase):
             self.assertIsNotNone(static_ret)
         paddle.disable_static()
 
+        breakpoint()
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -544,7 +544,6 @@ class CrossEntropyLoss(unittest.TestCase):
             self.assertIsNotNone(static_ret)
         paddle.disable_static()
 
-        breakpoint()
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -21,6 +21,7 @@ from test_softmax_with_cross_entropy_op import cross_entropy
 import paddle
 from paddle import base
 from paddle.base import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 def label_smooth(label, C, epsilon, is_onehot=True):
@@ -272,6 +273,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
     # soft_label test start
     # soft_label test 1
+    @test_with_pir_api
     def test_cross_entropy_loss_soft_1d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -360,6 +362,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # soft_label test 2
+    @test_with_pir_api
     def test_cross_entropy_loss_soft_1d_weight(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -460,6 +463,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # soft_label test 3
+    @test_with_pir_api
     def test_cross_entropy_loss_soft_1d_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -544,6 +548,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # soft_label test 4
+    @test_with_pir_api
     def test_cross_entropy_loss_soft_1d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -634,6 +639,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # soft_label test 5
+    @test_with_pir_api
     def test_cross_entropy_loss_soft_2d(self):
         def inner_cross_entropy_loss_soft_2d(soft_label):
             self.numeric_stable_mode = False
@@ -739,6 +745,7 @@ class CrossEntropyLoss(unittest.TestCase):
         inner_cross_entropy_loss_soft_2d(False)
 
     # soft_label test 6
+    @test_with_pir_api
     def test_cross_entropy_loss_soft_2d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -840,6 +847,7 @@ class CrossEntropyLoss(unittest.TestCase):
     # soft_label test end
 
     # label_smoothing test 1
+    @test_with_pir_api
     def test_cross_entropy_loss_onehot_label_smoothing_1d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -937,6 +945,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.enable_static()
 
     # label_smoothing test 2
+    @test_with_pir_api
     def test_cross_entropy_loss_onehot_label_smoothing_1d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1036,6 +1045,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test 3
+    @test_with_pir_api
     def test_cross_entropy_loss_onehot_label_smoothing_2d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1143,6 +1153,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test 4
+    @test_with_pir_api
     def test_cross_entropy_loss_onehot_label_smoothing_2d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1253,6 +1264,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test 5
+    @test_with_pir_api
     def test_cross_entropy_loss_integer_label_smoothing_1d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1350,6 +1362,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test 6
+    @test_with_pir_api
     def test_cross_entropy_loss_integer_label_smoothing_1d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1452,6 +1465,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test 7
+    @test_with_pir_api
     def test_cross_entropy_loss_integer_label_smoothing_2d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1557,6 +1571,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test 8
+    @test_with_pir_api
     def test_cross_entropy_loss_integer_label_smoothing_2d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -1667,7 +1682,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
     # label_smoothing test end
-
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_mean_ignore(self):
         input_np = np.random.random([2, 4]).astype(self.dtype)
         label_np = np.random.randint(0, 4, size=(2)).astype(np.int64)
@@ -1714,6 +1729,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_mean_ignore_negative(self):
         N = 100
         C = 200
@@ -1763,6 +1779,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_weight_mean_ignore(self):
         N = 100
         C = 200
@@ -1846,6 +1863,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_weight_mean(self):
         input_np = np.random.random([2, 4]).astype(self.dtype)
         label_np = np.random.randint(0, 4, size=(2)).astype(np.int64)
@@ -1901,6 +1919,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_weight_sum(self):
         input_np = np.random.random([100, 200]).astype(self.dtype)  # N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  # N,1
@@ -1954,6 +1973,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_weight_none(self):
         input_np = np.random.random([100, 200]).astype(self.dtype)  # N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  # N,1
@@ -2011,6 +2031,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret, expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_with_weight_none_func(self):
         input_np = np.random.random([100, 200]).astype(self.dtype)  # N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  # N
@@ -2064,6 +2085,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret, expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_mean(self):
         input_np = np.random.random([100, 200]).astype(self.dtype)  # N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  # N,1
@@ -2102,6 +2124,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_sum(self):
         input_np = np.random.random([100, 200]).astype(self.dtype)  # N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  # N,1
@@ -2144,6 +2167,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_1d_none(self):
         input_np = np.random.random([100, 200]).astype(self.dtype)  # N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  # N,1
@@ -2188,6 +2212,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret, expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_with_weight_none(self):
         input_np = np.random.random(size=(2, 2, 2, 3)).astype(
             self.dtype
@@ -2250,6 +2275,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret, expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_with_weight_axis_change_mean(self):
         input_np = np.random.random(size=(2, 3, 2, 2)).astype(
             self.dtype
@@ -2341,6 +2367,7 @@ class CrossEntropyLoss(unittest.TestCase):
         )[0]
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_with_weight_mean(self):
         input_np = np.random.random(size=(2, 2, 2, 3)).astype(
             self.dtype
@@ -2400,6 +2427,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_with_weight_sum(self):
         input_np = np.random.random(size=(2, 2, 2, 3)).astype(
             self.dtype
@@ -2460,6 +2488,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_none(self):
         input_np = np.random.random(size=(2, 2, 2, 3)).astype(
             self.dtype
@@ -2513,6 +2542,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret, expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_mean(self):
         input_np = np.random.random(size=(2, 2, 2, 3)).astype(
             self.dtype
@@ -2567,6 +2597,7 @@ class CrossEntropyLoss(unittest.TestCase):
         np.testing.assert_allclose(static_ret[0], expected, rtol=1e-05)
         np.testing.assert_allclose(dy_ret_value, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cross_entropy_loss_2d_sum(self):
         input_np = np.random.random(size=(2, 2, 2, 3)).astype(
             self.dtype


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Migrate CrossEntropyLoss into pir

- 动态图分支有类似 `if paddle.count_nonzero(is_ignore) > 0` 的的写法，这种代码无法在动态图下统一，所以在静态图分支进行了适配
- 除去error类的测试，其他测试case都已经打开了

Pcard-67164