### PR TITLE
Support weights to be temporary variable in TRT NHWC IR pass

### DIFF
--- a/paddle/fluid/framework/ir/trt_support_nhwc_pass.cc
+++ b/paddle/fluid/framework/ir/trt_support_nhwc_pass.cc
@@ -127,10 +127,12 @@ bool ModelLayoutIsNHWC(const std::vector<ir::Node *> &op_nodes) {
 }
 
 // Do additional check if OP's weight is not persistable
-bool isOpWeight(
-    ir::Node *op_node,
-    ir::Node *var_node,
-    const std::unordered_map<std::string, std::string> &op_weight_pair) {
+typedef std::string OP_NAME;
+typedef std::string WEIGHT_NAME;
+typedef std::unordered_map<OP_NAME, WEIGHT_NAME> OP_WEIGHT_NAME;
+bool IsWeight(ir::Node *op_node,
+              ir::Node *var_node,
+              const OP_WEIGHT_NAME &op_weight_pair) {
   if (var_node->Var()->Persistable()) return true;
   auto *op_desc = op_node->Op();
   std::string op_type = op_desc->Type();
@@ -175,8 +177,7 @@ void TrtSupportNHWCPass::ApplyImpl(Graph *graph) const {
                                                     "nearest_interp_v2"};
   // Op's weight could be temporary variable, so we save the name of OP's weight
   // input
-  std::unordered_map<std::string, std::string> op_weight_pair{
-      {"conv2d", "Filter"}};
+  OP_WEIGHT_NAME op_weight_pair{{"conv2d", "Filter"}};
   // Ops must run under the original layout even though it has
   // data_format/data_layout attribute, otherwise it will be very troublesome!
   std::unordered_set<std::string> must_original_layout_ops{
@@ -215,7 +216,7 @@ void TrtSupportNHWCPass::ApplyImpl(Graph *graph) const {
     auto op_inputs = op_node->inputs;
     for (auto *in_var_node : op_inputs) {
       CHECK_EQ(in_var_node->IsVar(), true);
-      if (isOpWeight(op_node, in_var_node, op_weight_pair)) continue;
+      if (IsWeight(op_node, in_var_node, op_weight_pair)) continue;
 
       auto input_shape = in_var_node->Var()->GetShape();
       input_shape_4 &= (input_shape.size() == 4);
@@ -348,7 +349,7 @@ void TrtSupportNHWCPass::ApplyImpl(Graph *graph) const {
         for (auto *in_var_node : op_inputs) {
           CHECK_EQ(in_var_node->IsVar(), true);
 
-          if (isOpWeight(op_node, in_var_node, op_weight_pair)) continue;
+          if (IsWeight(op_node, in_var_node, op_weight_pair)) continue;
           if (vars_to_nchw.count(in_var_node)) continue;
 
           DoInsertTransposeOp(graph,

--- a/test/ir/inference/test_trt_support_nhwc_pass.py
+++ b/test/ir/inference/test_trt_support_nhwc_pass.py
@@ -93,6 +93,10 @@ class TRTNHWCConvertTest(unittest.TestCase):
             self.temp_dir.name, 'inference_pass', 'nhwc_converter', ''
         )
         self.model_prefix = self.path + 'infer_model'
+        self.set_args()
+
+    def set_args(self):
+        self.precision_mode = inference.PrecisionType.Float32
 
     def create_model(self):
         image = static.data(
@@ -115,7 +119,7 @@ class TRTNHWCConvertTest(unittest.TestCase):
             workspace_size=1 << 30,
             max_batch_size=1,
             min_subgraph_size=3,
-            precision_mode=inference.PrecisionType.Half,
+            precision_mode=self.precision_mode,
             use_static=False,
             use_calib_mode=False,
         )
@@ -148,6 +152,9 @@ class TRTNHWCConvertTest(unittest.TestCase):
 
 
 class TRTNHWCConvertAMPTest(TRTNHWCConvertTest):
+    def set_args(self):
+        self.precision_mode = inference.PrecisionType.Half
+
     def create_model(self):
         train_prog = paddle.static.Program()
         with paddle.static.program_guard(train_prog):

--- a/test/ir/inference/test_trt_support_nhwc_pass.py
+++ b/test/ir/inference/test_trt_support_nhwc_pass.py
@@ -115,7 +115,7 @@ class TRTNHWCConvertTest(unittest.TestCase):
             workspace_size=1 << 30,
             max_batch_size=1,
             min_subgraph_size=3,
-            precision_mode=inference.PrecisionType.Float32,
+            precision_mode=inference.PrecisionType.Half,
             use_static=False,
             use_calib_mode=False,
         )
@@ -145,6 +145,42 @@ class TRTNHWCConvertTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.path)
+
+
+class TRTNHWCConvertAMPTest(TRTNHWCConvertTest):
+    def create_model(self):
+        train_prog = paddle.static.Program()
+        with paddle.static.program_guard(train_prog):
+            with paddle.static.amp.fp16_guard():
+                image = paddle.static.data(
+                    name='image', shape=[None, 224, 224, 4], dtype='float32'
+                )
+                label = paddle.static.data(
+                    name='label', shape=[None, 1], dtype='int64'
+                )
+                predict = SimpleNet()(image)
+            cost = paddle.nn.functional.loss.cross_entropy(
+                input=predict, label=label
+            )
+            avg_cost = paddle.mean(x=cost)
+            optimizer = paddle.optimizer.Momentum(
+                momentum=0.9,
+                learning_rate=0.01,
+                weight_decay=paddle.regularizer.L2Decay(4e-5),
+            )
+            optimizer = paddle.static.amp.decorate(
+                optimizer,
+                use_dynamic_loss_scaling=False,
+                use_pure_fp16=False,
+            )
+            optimizer.minimize(avg_cost)
+        val_prog = train_prog.clone(for_test=True)
+
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
+        paddle.static.save_inference_model(
+            self.model_prefix, [image], [predict], exe, program=val_prog
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
The TRT NHWC IR pass determines an input is weight or not by checking its attribute `Persistable`.
However, after TRT 8.6, the weights of weighted OPs could be a temporary variable.
This PR adds a map of (op_type, weight_name) (ex. ("conv2d", "Filter")) and check the input is weight or not according to this map.