### PR TITLE
[Custom]fix custom cuda GetStream conflict

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.h
+++ b/paddle/fluid/memory/allocation/allocator_facade.h
@@ -23,6 +23,7 @@
 #include "paddle/fluid/platform/device/xpu/xpu_info.h"
 #endif
 #include "paddle/fluid/platform/place.h"
+#include "paddle/phi/backends/stream.h"
 #include "paddle/phi/core/stream.h"
 
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
@@ -81,6 +82,9 @@ class AllocatorFacade {
 
   bool IsStreamSafeCUDAAllocatorUsed();
 
+  phi::stream::stream_t GetStream(
+      const std::shared_ptr<Allocation>& allocation) const;
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   // TODO(zhiqiu): change gpuStream_t to phi::Stream if needed.
   uint64_t Release(const platform::CUDAPlace& place, gpuStream_t stream);
@@ -89,7 +93,6 @@ class AllocatorFacade {
 
   const std::shared_ptr<Allocator>& GetAllocator(const platform::Place& place,
                                                  gpuStream_t stream);
-  gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation) const;
   void SetDefaultStream(const platform::CUDAPlace& place, gpuStream_t stream);
 #endif
 
@@ -105,8 +108,6 @@ class AllocatorFacade {
                     phi::stream::stream_t stream);
   const std::shared_ptr<Allocator>& GetAllocator(const platform::Place& place,
                                                  phi::stream::stream_t stream);
-  phi::stream::stream_t GetStream(
-      const std::shared_ptr<Allocation>& allocation) const;
   void SetDefaultStream(const platform::CustomPlace& place,
                         phi::stream::stream_t stream);
 #endif

--- a/paddle/fluid/memory/malloc.cc
+++ b/paddle/fluid/memory/malloc.cc
@@ -73,7 +73,8 @@ void EraseStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream) {
 }
 
 gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation) {
-  return allocation::AllocatorFacade::Instance().GetStream(allocation);
+  return (gpuStream_t)allocation::AllocatorFacade::Instance().GetStream(
+      allocation);
 }
 
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复https://github.com/PaddlePaddle/Paddle/issues/58444

对外的头文件接口 统一改成 phi::stream::stream_t GetStream(
      const std::shared_ptr<Allocation>& allocation) const;
内部private部分进行区分

phi::stream::stream_t和gpustream_t 都是一个指针，phi::stream::stream_t本质是一个void*, 统一用phi::stream::stream_t会更好

我个人认为这符合zhiqiu的想法。   // TODO(zhiqiu): change gpuStream_t to phi::Stream if needed.  

CustomDevice不应该和GPU冲突。
CustomDevice会存在和GPU一起工作的场景。
