### PR TITLE
【PIR API adaptor No.5-6】Migrate paddle.amax/amin into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3079,7 +3079,7 @@ def amax(x, axis=None, keepdim=False, name=None):
              [[0.50000000, 0.33333333],
               [0.        , 0.        ]]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.amax(x, axis, keepdim)
 
     else:
@@ -3227,7 +3227,7 @@ def amin(x, axis=None, keepdim=False, name=None):
              [[0.50000000, 0.33333333],
               [0.        , 0.        ]]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.amin(x, axis, keepdim)
 
     else:

--- a/test/legacy_test/test_max_min_amax_amin_op.py
+++ b/test/legacy_test/test_max_min_amax_amin_op.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -90,6 +91,7 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
         return out
 
     # We check the output between paddle API and numpy in static graph.
+    @test_with_pir_api
     def test_static_graph(self):
         def _test_static_graph(func):
             startup_program = base.Program()
@@ -103,7 +105,6 @@ class TestMaxMinAmaxAminAPI(unittest.TestCase):
 
                 exe = base.Executor(self.place)
                 res = exe.run(
-                    base.default_main_program(),
                     feed={'input': self.x_np},
                     fetch_list=[out],
                 )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Migrate paddle.amax/amin into pir
- #58067
- `paddle.amax` unit test coverage 8/8
- `paddle.amin` unit test coverage 8/8