### PR TITLE
fix_seed_op

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -520,10 +520,7 @@ phi::KernelKey GetKernelKey(
   if (op->isa<paddle::dialect::SeedOp>()) {
     VLOG(6) << "SeedOp doesn't need a kernel";
     auto backend = paddle::experimental::ParseBackend(place);
-    return {backend,
-            phi::DataLayout::ANY,
-            TransToPhiDataType(
-                op->result(0).type().dyn_cast<DenseTensorType>().dtype())};
+    return {backend, phi::DataLayout::ANY, phi::DataType::INT32};
   }
 
   if (op->isa<paddle::dialect::FullWithTensorOp>()) {

--- a/test/white_list/new_ir_op_test_no_check_list
+++ b/test/white_list/new_ir_op_test_no_check_list
@@ -1,1 +1,2 @@
 test_exponential_op
+test_seed_op

--- a/test/white_list/new_ir_op_test_white_list
+++ b/test/white_list/new_ir_op_test_white_list
@@ -176,6 +176,7 @@ test_roi_pool_op
 test_rrelu_op
 test_scale_op
 test_searchsorted_op
+test_seed_op
 test_segment_ops
 test_segment_ops_static_build
 test_selu_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复seed_op
旧Ir下定义的`GetExpectedKernelType`为
```C++
  phi::KernelKey GetExpectedKernelType(
      const framework::ExecutionContext& ctx) const override {
    return phi::KernelKey(framework::proto::VarType::INT32, ctx.GetPlace());
  }
```
在新Ir下也改为INT32类型
因为seed op的Out具有随机性所以加入`test/white_list/new_ir_op_test_no_check_list`