### PR TITLE
Fix test_trt_convert_swish

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.cu
@@ -31,10 +31,12 @@ void SwishPlugin::terminate() TRT_NOEXCEPT {}
 bool SwishPlugin::supportsFormat(
     nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   if (with_fp16_) {
-    return type == nvinfer1::DataType::kFLOAT ||
-           type == nvinfer1::DataType::kHALF;
+    return (type == nvinfer1::DataType::kFLOAT ||
+            type == nvinfer1::DataType::kHALF) &&
+           (format == nvinfer1::TensorFormat::kLINEAR);
   }
-  return type == nvinfer1::DataType::kFLOAT;
+  return (type == nvinfer1::DataType::kFLOAT) &&
+         (format == nvinfer1::TensorFormat::kLINEAR);
 }
 
 nvinfer1::Dims SwishPlugin::getOutputDimensions(int index,

--- a/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.cu
@@ -179,13 +179,11 @@ bool SwishPluginDynamic::supportsFormatCombination(
     if (with_fp16_) {
       bool res = (in.type == nvinfer1::DataType::kFLOAT ||
                   in.type == nvinfer1::DataType::kHALF);
-// encounter trt crash bug
-#if IS_TRT_VERSION_LT(8000)
       res = res && (in.format == nvinfer1::TensorFormat::kLINEAR);
-#endif
       return res;
     } else {
-      return in.type == nvinfer1::DataType::kFLOAT;
+      return (in.type == nvinfer1::DataType::kFLOAT) &&
+             (in.format == nvinfer1::TensorFormat::kLINEAR);
     }
   }
   const nvinfer1::PluginTensorDesc &prev = in_out[pos - 1];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
In the implementation of Swish TRT plugin, there are no constraints on tensor format. It allows the freedom for TRT engine to cast the input to some padded format like `kHWC8`. However, the kernel is not designed to deal with this kind of padded tensor format, which will cause incorrect results. 

Therefore, `test_trt_convert_swish` fails randomly (very rarely, but do fails sometimes), with the following message:
```
Tue Oct 31 16:04:51-ERROR: FAIL: program_config: swish{'beta': 2.0} -- [input_data: {'shape': (1, 3, 64, 64), 'lod': None, 'dtype': dtype('float32')}][place_holder_weight: {'shape': (1,), 'lod': None, 'dtype': dtype('float32')}]['input_type': <class 'numpy.float16'>]
Tue Oct 31 16:04:51-ERROR: FAIL: predictor_config: {'use_trt': True, 'trt_precision': <Precision.Half: 2>, 'use_dynamic_shape': False}
Tue Oct 31 16:04:51-ERROR: FAIL:  ERROR INFO: 
Not equal to tolerance rtol=0.001, atol=0.001
Mismatched elements: 2048 / 12288 (16.7%)
Max absolute difference: 0.880797
Max relative difference: 1.
 x: array([[[[0.8804, 0.8804, 0.8804, ..., 0.8804, 0.8804, 0.8804],
         [0.8804, 0.8804, 0.8804, ..., 0.8804, 0.8804, 0.8804],
         [0.8804, 0.8804, 0.8804, ..., 0.8804, 0.8804, 0.8804],...
 y: array([[[[0.880797, 0.880797, 0.880797, ..., 0.880797, 0.880797,
          0.880797],
         [0.880797, 0.880797, 0.880797, ..., 0.880797, 0.880797,...
```
If you print out the TRT engine info, you will find input is cast to `kHWC8` before swish op, and then cast back to `kLINEAR` after swish in such failure case. Some of the output values become zeros, as the indexing of swish kernel is linear.

The solution is to add format check and only allows kLINEAR input.