### PR TITLE
[XPU] Open-Source quantize models support on XPU backend.

### DIFF
--- a/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
+++ b/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
@@ -128,10 +128,11 @@ void Conv2dTransFilterDilationsNxNTo1x1Pass::conv2d_dilation_trans(
     auto* new_weights =
         scope->Var(new_weights_name)->GetMutable<phi::DenseTensor>();
     new_weights->Resize({weights_shape[0], weights_shape[1], new_kh, new_kw});
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(
+        platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
     if (weights->dtype() == phi::DataType::FLOAT32) {
-      auto weights_data = weights->mutable_data<float>(platform::CPUPlace());
-      auto* new_weights_data =
-          new_weights->mutable_data<float>(platform::CPUPlace());
+      auto weights_data = weights->data<float>();
+      auto* new_weights_data = cpu_ctx->Alloc<float>(new_weights);
       memset(new_weights_data, 0, new_weights->numel() * sizeof(float));
       conv2d_dilation_trans_fn<float>(weights_data,
                                       new_weights_data,
@@ -144,10 +145,8 @@ void Conv2dTransFilterDilationsNxNTo1x1Pass::conv2d_dilation_trans(
                                       dilations[0],
                                       dilations[1]);
     } else if (weights->dtype() == phi::DataType::FLOAT16) {
-      auto weights_data =
-          weights->mutable_data<phi::dtype::float16>(platform::CPUPlace());
-      auto* new_weights_data =
-          new_weights->mutable_data<phi::dtype::float16>(platform::CPUPlace());
+      auto weights_data = weights->data<phi::dtype::float16>();
+      auto* new_weights_data = cpu_ctx->Alloc<phi::dtype::float16>(new_weights);
       memset(new_weights_data,
              0,
              new_weights->numel() * sizeof(phi::dtype::float16));
@@ -163,9 +162,8 @@ void Conv2dTransFilterDilationsNxNTo1x1Pass::conv2d_dilation_trans(
           dilations[0],
           dilations[1]);
     } else if (weights->dtype() == phi::DataType::INT8) {
-      auto weights_data = weights->mutable_data<int8_t>(platform::CPUPlace());
-      auto* new_weights_data =
-          new_weights->mutable_data<int8_t>(platform::CPUPlace());
+      auto weights_data = weights->data<int8_t>();
+      auto* new_weights_data = cpu_ctx->Alloc<int8_t>(new_weights);
       memset(new_weights_data, 0, new_weights->numel() * sizeof(int8_t));
       conv2d_dilation_trans_fn<int8_t>(weights_data,
                                        new_weights_data,

--- a/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
+++ b/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
@@ -120,6 +120,13 @@ void Conv2dTransFilterDilationsNxNTo1x1Pass::conv2d_dilation_trans(
     int new_kh = static_cast<int>(dilations[0] * (kh - 1) + 1);
     int new_kw = static_cast<int>(dilations[1] * (kw - 1) + 1);
     // New weights
+    if (!(weights->dtype() == phi::DataType::FLOAT32 ||
+          weights->dtype() == phi::DataType::FLOAT16)) {
+      VLOG(3)
+          << "Transfilter only support float32/float16 dtype of weights -- do "
+             "nothing and break.";
+      return;  // Only support fp32/fp16 dtype
+    }
     auto new_weights_name = weights_name + "_dilation_trans";
     auto* new_weights =
         scope->Var(new_weights_name)->GetMutable<phi::DenseTensor>();
@@ -158,11 +165,6 @@ void Conv2dTransFilterDilationsNxNTo1x1Pass::conv2d_dilation_trans(
           new_kw,
           dilations[0],
           dilations[1]);
-    } else {
-      VLOG(3)
-          << "Transfilter only support float32/float16 dtype of weights -- do "
-             "nothing and break.";
-      return;  // Only support fp32/fp16 dtype
     }
 
     VarDesc new_weights_desc(new_weights_name);

--- a/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
+++ b/paddle/fluid/framework/ir/conv2d_trans_filter_dilations_nxn_to_1x1_pass.cc
@@ -74,23 +74,23 @@ void Conv2dTransFilterDilationsNxNTo1x1Pass::ApplyImpl(ir::Graph* graph) const {
 template <class T>
 static void conv2d_dilation_trans_fn(const T* weights_data,
                                      T* new_weights_data,
-                                     uint kn,
-                                     uint kc,
-                                     uint kh,
-                                     uint kw,
-                                     uint new_kh,
-                                     uint new_kw,
-                                     uint dilation_h,
-                                     uint dilation_w) {
-  for (auto n = 0; n < kn; n++) {
-    for (auto c = 0; c < kc; c++) {
-      for (auto h = 0; h < kh; h++) {
-        auto h_offset = dilation_h * h;
-        for (auto w = 0; w < kw; w++) {
-          auto w_offset = dilation_w * w;
-          auto new_offset = n * kc * new_kh * new_kw + c * new_kh * new_kw +
-                            h_offset * new_kw + w_offset;
-          auto old_offset = n * kc * kh * kw + c * kh * kw + h * kw + w;
+                                     uint64_t kn,
+                                     uint64_t kc,
+                                     uint64_t kh,
+                                     uint64_t kw,
+                                     uint64_t new_kh,
+                                     uint64_t new_kw,
+                                     uint64_t dilation_h,
+                                     uint64_t dilation_w) {
+  for (uint64_t n = 0; n < kn; n++) {
+    for (uint64_t c = 0; c < kc; c++) {
+      for (uint64_t h = 0; h < kh; h++) {
+        uint64_t h_offset = dilation_h * h;
+        for (uint64_t w = 0; w < kw; w++) {
+          uint64_t w_offset = dilation_w * w;
+          uint64_t new_offset = n * kc * new_kh * new_kw + c * new_kh * new_kw +
+                                h_offset * new_kw + w_offset;
+          uint64_t old_offset = n * kc * kh * kw + c * kh * kw + h * kw + w;
           new_weights_data[new_offset] = weights_data[old_offset];
         }
       }

--- a/paddle/fluid/framework/ir/quantize_helper.h
+++ b/paddle/fluid/framework/ir/quantize_helper.h
@@ -32,11 +32,6 @@ void SaveQuantInfoInTheGraph(
 std::unordered_map<std::string, std::vector<float>> GetQuantInfoFromTheGraph(
     ir::Graph* graph, const std::string& flag, const std::string& key_suffix);
 
-std::unordered_map<std::string, std::vector<float>>
-GetQuantInfoFromTheGraphHelp(ir::Graph* graph,
-                             const std::string& flag,
-                             const std::string& key_suffix);
-
 bool AreScalesPresentForNodes(
     std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
     std::initializer_list<Node*> nodes);

--- a/paddle/fluid/framework/ir/quantize_helper.h
+++ b/paddle/fluid/framework/ir/quantize_helper.h
@@ -32,6 +32,11 @@ void SaveQuantInfoInTheGraph(
 std::unordered_map<std::string, std::vector<float>> GetQuantInfoFromTheGraph(
     ir::Graph* graph, const std::string& flag, const std::string& key_suffix);
 
+std::unordered_map<std::string, std::vector<float>>
+GetQuantInfoFromTheGraphHelp(ir::Graph* graph,
+                             const std::string& flag,
+                             const std::string& key_suffix);
+
 bool AreScalesPresentForNodes(
     std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
     std::initializer_list<Node*> nodes);
@@ -44,6 +49,20 @@ std::vector<float> GetScaleVecValueForNode(
     std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
     Node* node);
 
+template <typename T>
+inline std::string Vec2Str(const std::vector<T>& vec) {
+  std::ostringstream os;
+  if (vec.empty()) {
+    os << "()";
+    return os.str();
+  }
+  os << "(";
+  for (size_t i = 0; i < vec.size() - 1; ++i) {
+    os << vec[i] << ",";
+  }
+  os << vec[vec.size() - 1] << ")";
+  return os.str();
+}
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/ir/xpu/conv2d_transpose_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv2d_transpose_xpu_fuse_pass.cc
@@ -377,12 +377,14 @@ int Conv2dTransposeXPUFusePass::ApplyImpl(ir::Graph* graph,
     // filter max
     Node* filter_int16 = nullptr;
     Node* filter_max = nullptr;
+    Node* scale_max = nullptr;
     PrepareWeight<float, int16_t>(graph,
                                   scope,
                                   block,
                                   conv_filter,
                                   &filter_int16,
                                   &filter_max,
+                                  &scale_max,
                                   false,
                                   std::vector<float>({}));
     // output && output max

--- a/paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc
@@ -745,9 +745,6 @@ void Conv2dXPUFusePass::CreateFusionWeightsAndBias(
     auto* cpu_ctx = static_cast<phi::CPUContext*>(
         platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
     int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
-    if (weight_scale.size() != 1) {
-      max_ptr_size = weight_scale.size();
-    }
     ones_weight_max_tensor.set_type(phi::DataType::FLOAT32);
     ones_weight_max_tensor.Resize({max_ptr_size});
     std::vector<float> ones_weight(max_ptr_size, 1.0);

--- a/paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc
@@ -503,14 +503,13 @@ void Conv2dXPUFusePass::CreateTheReplicatedWeights(
     replicated_filter_desc.SetShape(vectorize(replicated_filter_tensor.dims()));
     replicated_filter_desc.SetDataType(
         framework::TransToProtoVarType(replicated_filter_tensor.dtype()));
+    graph->CreateVarNode(&replicated_filter_desc);
     auto* block_replicated_filter_desc = block->Var(replicated_filter_name);
     block_replicated_filter_desc->SetPersistable(
         replicated_filter_desc.Persistable());
     block_replicated_filter_desc->SetShape(replicated_filter_desc.GetShape());
     block_replicated_filter_desc->SetDataType(
         replicated_filter_desc.GetDataType());
-    auto* replicated_filter_node =
-        graph->CreateVarNode(&replicated_filter_desc);
     Assign(replicated_filter_tensor,
            scope->Var(replicated_filter_name)->GetMutable<phi::DenseTensor>());
   }

--- a/paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc
@@ -675,7 +675,6 @@ void Conv2dXPUFusePass::CreateFusionWeightsAndBias(
       }
     }
   }
-
   // deal with scale op
   if (with_scale) {
     auto* scale = GetNodeFromNodesMap(nodes_map, "scale", "scale");
@@ -745,9 +744,10 @@ void Conv2dXPUFusePass::CreateFusionWeightsAndBias(
     phi::DenseTensor ones_weight_max_tensor;
     auto* cpu_ctx = static_cast<phi::CPUContext*>(
         platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
-    int max_ptr_size = weight_scale.empty()
-                           ? phi::backends::xpu::get_xpu_max_ptr_size(-1)
-                           : weight_scale.size();
+    int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+    if (weight_scale.size() != 1) {
+      max_ptr_size = weight_scale.size();
+    }
     ones_weight_max_tensor.set_type(phi::DataType::FLOAT32);
     ones_weight_max_tensor.Resize({max_ptr_size});
     std::vector<float> ones_weight(max_ptr_size, 1.0);

--- a/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
@@ -527,8 +527,6 @@ void FcXPUFusePass::CreateFusionWeightsAndBias(
   Node* filter_intx = nullptr;
   Node* filter_max = nullptr;
   Node* scale_max = nullptr;
-  LOG(INFO) << "mul_w_replicated_node SHAPE:"
-            << Vec2Str(mul_w_replicated_node->Var()->GetShape());
   bool per_channel_quant =
       std::getenv("FLAGS_fc_gemm_use_per_channel") == nullptr ? false : true;
   if (op_weights_precision != "int8") {

--- a/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
@@ -514,9 +514,10 @@ void FcXPUFusePass::CreateFusionWeightsAndBias(
     phi::DenseTensor ones_weight_max_tensor;
     auto* cpu_ctx = static_cast<phi::CPUContext*>(
         platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
-    int max_ptr_size = weight_scale.empty()
-                           ? phi::backends::xpu::get_xpu_max_ptr_size(-1)
-                           : weight_scale.size();
+    int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+    if (weight_scale.size() != 1) {
+      max_ptr_size = weight_scale.size();
+    }
     ones_weight_max_tensor.set_type(phi::DataType::FLOAT32);
     ones_weight_max_tensor.Resize({max_ptr_size});
     std::vector<float> ones_weight(max_ptr_size, 1.0);

--- a/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
@@ -803,15 +803,14 @@ int FcXPUFusePass::ApplyImpl(ir::Graph* graph,
                                                   {"out_max_in", nullptr},
                                                   {"out", nullptr},
                                                   {"out_max", nullptr}};
+    auto mul_w_name = mul->Op()->Input("Y")[0];
+    Node* mul_w = FindNodeWithName(graph, mul_w_name);
+    if (!mul_w->Var()->Persistable() || mul_w->Var()->GetShape().size() != 2) {
+      return;
+    }
     auto filter_data_type = scope->FindVar(mul->Op()->Input("Y")[0])
                                 ->GetMutable<phi::DenseTensor>()
                                 ->dtype();
-    auto mul_w_name = mul->Op()->Input("Y")[0];
-    Node* mul_w = FindNodeWithName(graph, mul_w_name);
-    if (mul_w->Var()->GetShape().size() != 2) {
-      VLOG(4) << "FC fusion fuse pass only support weight shape size is 2!";
-      return;
-    }
     std::string op_weights_precision = "float32";
     if (filter_data_type == phi::DataType::INT8) {
       op_weights_precision = "int8";

--- a/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc
@@ -665,7 +665,7 @@ void FcXPUFusePass::CreateFusionInputs(
       true,
       platform::errors::InvalidArgument("mul_x node ptr can not be null"));
   // x max
-  std::string mul_x_max_name = mul_x->Name() + "_max";
+  std::string mul_x_max_name = mul_x->Name() + "_input_max";
   Node* mul_x_max = nullptr;
   if (op_weights_precision == "int8") {
     PADDLE_ENFORCE_EQ(AreScalesPresentForNodes(var_quant_scales, {mul_x}),

--- a/paddle/fluid/framework/ir/xpu/fused_multi_transformer_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/fused_multi_transformer_xpu_pass.cc
@@ -419,6 +419,7 @@ int FusedMultiTransformerXPUPass::FusedMultiTransformerXPUQuant(
         Node* w_node = FindNodeWithName(graph, w_name);
         Node* w_intx = nullptr;
         Node* w_max = nullptr;
+        Node* scale_max = nullptr;
         PADDLE_ENFORCE_NE(
             w_node,
             nullptr,
@@ -430,6 +431,7 @@ int FusedMultiTransformerXPUPass::FusedMultiTransformerXPUQuant(
                                        w_node,
                                        &w_intx,
                                        &w_max,
+                                       &scale_max,
                                        need_transpose,
                                        std::vector<float>({}));
         } else {
@@ -439,6 +441,7 @@ int FusedMultiTransformerXPUPass::FusedMultiTransformerXPUQuant(
                                         w_node,
                                         &w_intx,
                                         &w_max,
+                                        &scale_max,
                                         need_transpose,
                                         std::vector<float>({}));
         }

--- a/paddle/fluid/framework/ir/xpu/pass_utils.cc
+++ b/paddle/fluid/framework/ir/xpu/pass_utils.cc
@@ -135,15 +135,23 @@ void PrepareWeight(Graph* graph,
                    Node* weight,
                    Node** dst_weight,
                    Node** dst_weight_max,
+                   Node** dst_scale_max,
                    bool transpose,
-                   const std::vector<float>& weight_scales) {
+                   const std::vector<float>& weight_scales,
+                   bool per_channel_quant) {
   auto weight_name = weight->Name();
   auto* weight_tensor = scope->Var(weight_name)->GetMutable<phi::DenseTensor>();
   phi::DenseTensor dst_weight_tensor;
   Assign(*weight_tensor, &dst_weight_tensor);
   phi::DenseTensor dst_weight_max_tensor;
-  ConvertWeightWrapper<Tcpu, Txpu>(
-      &dst_weight_tensor, &dst_weight_max_tensor, transpose, weight_scales);
+  phi::DenseTensor dst_scale_max_tensor;
+  ConvertWeightWrapper<Tcpu, Txpu>(&dst_weight_tensor,
+                                   &dst_weight_max_tensor,
+                                   &dst_scale_max_tensor,
+                                   transpose,
+                                   weight_scales,
+                                   per_channel_quant);
+
   size_t dst_weight_hash = HashTensor<Txpu>(dst_weight_tensor);
   size_t dst_weight_max_hash = HashTensor<float>(dst_weight_max_tensor);
   std::string pre_name = GetPrefixWithoutHash(weight_name);
@@ -151,6 +159,7 @@ void PrepareWeight(Graph* graph,
       pre_name + "_#" + std::to_string(dst_weight_hash);
   std::string dst_weight_max_name =
       pre_name + "_max_#" + std::to_string(dst_weight_max_hash);
+
   *dst_weight = FindNodeWithName(graph, dst_weight_name);
   if (*dst_weight == nullptr) {
     // Create dst_weight node
@@ -207,6 +216,42 @@ void PrepareWeight(Graph* graph,
                                 dst_weight_name,
                                 weight_name));
   }
+
+  if (dst_scale_max_tensor.initialized()) {
+    size_t dst_scale_max_hash = HashTensor<float>(dst_scale_max_tensor);
+    std::string dst_scale_max_name =
+        pre_name + "_scale_max_#" + std::to_string(dst_scale_max_hash);
+    if (*dst_scale_max == nullptr) {
+      // Create dst_scale_max node
+      // Update dst_scale_max var_desc in block
+      VarDesc dst_scale_max_desc(dst_scale_max_name);
+      dst_scale_max_desc.SetPersistable(true);
+      dst_scale_max_desc.SetShape(vectorize(dst_weight_max_tensor.dims()));
+      dst_scale_max_desc.SetDataType(proto::VarType::Type::VarType_Type_FP32);
+      *dst_scale_max = graph->CreateVarNode(&dst_scale_max_desc);
+      auto* block_dst_scale_max_desc = block->Var(dst_scale_max_name);
+      block_dst_scale_max_desc->SetPersistable(
+          dst_scale_max_desc.Persistable());
+      block_dst_scale_max_desc->SetShape(dst_scale_max_desc.GetShape());
+      block_dst_scale_max_desc->SetDataType(dst_scale_max_desc.GetDataType());
+      // Find dst/dst_max variable in scope
+      auto* dst_scale_max_var = scope->FindVar(dst_scale_max_name);
+      if (dst_scale_max_var == nullptr) {
+        Assign(dst_scale_max_tensor,
+               scope->Var(dst_scale_max_name)->GetMutable<phi::DenseTensor>());
+      } else {
+        // Share the same variable
+        PADDLE_ENFORCE_NOT_NULL(
+            scope->FindVar(dst_scale_max_name),
+            platform::errors::Fatal("dst_scale_max(%s) variable should not be "
+                                    "nullptr if dst_weight(%s) "
+                                    "variable is exist. (weight_name is %s)",
+                                    dst_scale_max_name,
+                                    dst_weight_name,
+                                    weight_name));
+      }
+    }
+  }
 }
 
 template void PrepareWeight<float, int16_t>(
@@ -216,8 +261,10 @@ template void PrepareWeight<float, int16_t>(
     Node* weight,
     Node** dst_weight,
     Node** dst_weight_max,
+    Node** dst_scale_max,
     bool transpose,
-    const std::vector<float>& weight_scales);
+    const std::vector<float>& weight_scales,
+    bool per_channel_quant = false);
 
 template void PrepareWeight<float, int8_t>(
     Graph* graph,
@@ -226,8 +273,10 @@ template void PrepareWeight<float, int8_t>(
     Node* weight,
     Node** dst_weight,
     Node** dst_weight_max,
+    Node** dst_scale_max,
     bool transpose,
-    const std::vector<float>& weight_scales);
+    const std::vector<float>& weight_scales,
+    bool per_channel_quant = false);
 
 template void PrepareWeight<int8_t, int8_t>(
     Graph* graph,
@@ -236,8 +285,10 @@ template void PrepareWeight<int8_t, int8_t>(
     Node* weight,
     Node** dst_weight,
     Node** dst_weight_max,
+    Node** dst_scale_max,
     bool transpose,
-    const std::vector<float>& weight_scales);
+    const std::vector<float>& weight_scales,
+    bool per_channel_quant = false);
 
 void PrepareBias(
     Graph* graph, Scope* scope, BlockDesc* block, Node* src, Node** dst) {

--- a/paddle/fluid/framework/ir/xpu/pass_utils.h
+++ b/paddle/fluid/framework/ir/xpu/pass_utils.h
@@ -63,9 +63,12 @@ template <typename Tcpu,
               ptr = nullptr>
 void ConvertWeightWrapper(phi::DenseTensor* weight,
                           phi::DenseTensor* weight_max,
+                          phi::DenseTensor* scale_max,
                           bool transpose,
-                          const std::vector<float>& weight_scales) {
-  ConvertWithQuant<Tcpu, Txpu>(weight, weight_max, transpose, weight_scales);
+                          const std::vector<float>& weight_scales,
+                          bool per_channel_quant) {
+  ConvertWithQuant<Tcpu, Txpu>(
+      weight, weight_max, scale_max, transpose, per_channel_quant);
 }
 
 template <typename Tcpu,
@@ -74,9 +77,12 @@ template <typename Tcpu,
               ptr = nullptr>
 void ConvertWeightWrapper(phi::DenseTensor* weight,
                           phi::DenseTensor* weight_max,
+                          phi::DenseTensor* scale_max,
                           bool transpose,
-                          const std::vector<float>& weight_scales) {
-  ConvertWithoutQuant<Tcpu>(weight, weight_max, transpose, weight_scales);
+                          const std::vector<float>& weight_scales,
+                          bool per_channel_quant) {
+  ConvertWithoutQuant<Tcpu>(
+      weight, weight_max, scale_max, transpose, weight_scales);
 }
 
 // 1. Quant weight from fp32 to int16/int31/int8
@@ -89,8 +95,10 @@ void PrepareWeight(Graph* graph,
                    Node* weight,
                    Node** dst_weight,
                    Node** dst_weight_max,
+                   Node** dst_scale_max,
                    bool transpose,
-                   const std::vector<float>& weight_scales);
+                   const std::vector<float>& weight_scales,
+                   bool per_channel_quant = false);
 
 void PrepareBias(
     Graph* graph, Scope* scope, BlockDesc* block, Node* src, Node** dst);

--- a/paddle/fluid/framework/ir/xpu/quant_utils.cc
+++ b/paddle/fluid/framework/ir/xpu/quant_utils.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/fluid/framework/ir/xpu/quant_utils.h"
 #include <vector>
+#include "paddle/fluid/framework/ir/quantize_helper.h"
 #include "paddle/fluid/platform/device_context.h"
 #include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"
@@ -64,12 +65,15 @@ void Transpose2D(phi::DenseTensor* in, phi::DenseTensor* out) {
     case phi::DataType::FLOAT32:
       phi::TransposeKernel<float>(*cpu_ctx, *in, axis, out_ptr);
       break;
+    case phi::DataType::INT16:
+      phi::TransposeKernel<int16_t>(*cpu_ctx, *in, axis, out_ptr);
+      break;
     case phi::DataType::INT8:
       phi::TransposeKernel<int8_t>(*cpu_ctx, *in, axis, out_ptr);
       break;
     default:
       PADDLE_THROW(platform::errors::InvalidArgument(
-          "Only support fp16/fp32/int8, but received dtype is %s.",
+          "Only support fp16/fp32/int16/int8, but received dtype is %s.",
           phi::DataTypeToString(in->dtype())));
       break;
   }
@@ -267,8 +271,9 @@ template <
     typename std::enable_if<!std::is_same<Tcpu, float>::value, Tcpu>::type* ptr>
 void ConvertWithQuant(phi::DenseTensor* weight,
                       phi::DenseTensor* weight_max,
+                      phi::DenseTensor* scale_max,
                       bool transpose,
-                      const std::vector<float>& weight_scales) {
+                      bool per_channel_quant) {
   LOG(FATAL) << "Not support for Tcpu is "
              << phi::CppTypeToDataType<Tcpu>::Type();
 }
@@ -279,93 +284,143 @@ template <
     typename std::enable_if<std::is_same<Tcpu, float>::value, Tcpu>::type* ptr>
 void ConvertWithQuant(phi::DenseTensor* weight,
                       phi::DenseTensor* weight_max,
+                      phi::DenseTensor* scale_max,
                       bool transpose,
-                      const std::vector<float>& weight_scales) {
+                      bool per_channel_quant) {
   // Convert fp16 to fp32
   phi::DenseTensor weight_fp32;
   CastToFp32(weight, &weight_fp32);
 
-  if (transpose) {
+  if (transpose) {  // (k, n) -> (n, k)
     Transpose2D(&weight_fp32);
   }
 
-  // Find max
-  int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
-  int size = weight_fp32.numel();
-  auto* weight_data = weight_fp32.data<float>();
-  float max_val = FindMaxAbs(weight_data, size);
-  std::vector<float> max_vec(max_ptr_size, max_val);
-  weight_max->set_type(phi::DataType::FLOAT32);
-  weight_max->Resize({max_ptr_size});
   auto* cpu_ctx = static_cast<phi::CPUContext*>(
       platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
-  memcpy(cpu_ctx->Alloc<float>(weight_max),
-         max_vec.data(),
-         max_ptr_size * sizeof(float));
+  if (!per_channel_quant) {
+    // Find max
+    int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+    weight_max->set_type(phi::DataType::FLOAT32);
+    weight_max->Resize({max_ptr_size});
 
-  // Quant
-  weight->set_type(phi::CppTypeToDataType<Txpu>::Type());
-  weight->Resize(weight_fp32.dims());
-  QuantFP32ToIntX<Txpu>(
-      weight_data, cpu_ctx->Alloc<Txpu>(weight), max_val, size);
+    int size = weight_fp32.numel();
+    auto* weight_fp32_data = weight_fp32.data<float>();
+    float max_val = FindMaxAbs(weight_fp32_data, size);
+    std::vector<float> max_vec(max_ptr_size, max_val);
+    memcpy(cpu_ctx->Alloc<float>(weight_max),
+           max_vec.data(),
+           max_ptr_size * sizeof(float));
+    // Quant
+    weight->set_type(phi::CppTypeToDataType<Txpu>::Type());
+    weight->Resize(weight_fp32.dims());
+    QuantFP32ToIntX<Txpu>(
+        weight_fp32_data, cpu_ctx->Alloc<Txpu>(weight), max_val, size);
+  } else {
+    std::vector<float> quant_scales{};
+    auto GetQuantScales = [&](const float* weight_data,
+                              int n,
+                              int data_count) -> std::vector<float> {
+      std::vector<float> scales;
+      for (int i = 0; i < n; ++i) {
+        float max_val = FindMaxAbs(weight_data + i * data_count, data_count);
+        scales.push_back(max_val);
+      }
+      return scales;
+    };
+
+    int n = weight_fp32.dims()[0];
+    int data_count = weight_fp32.numel() / n;
+    auto* weight_fp32_data = weight_fp32.data<float>();
+    quant_scales = GetQuantScales(weight_fp32_data, n, data_count);
+    weight->set_type(phi::CppTypeToDataType<Txpu>::Type());
+    weight->Resize(weight_fp32.dims());
+    auto* weight_data = cpu_ctx->Alloc<Txpu>(weight);
+    for (int i = 0; i < n; ++i) {
+      QuantFP32ToIntX<Txpu>(weight_fp32_data + i * data_count,
+                            weight_data + i * data_count,
+                            quant_scales[i],
+                            data_count);
+    }
+    int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+    // 1. Create weight_max tensor(all data is 1.0f)
+    weight_max->set_type(phi::DataType::FLOAT32);
+    weight_max->Resize({max_ptr_size});
+    std::vector<float> ones_vec(max_ptr_size, 1.0);
+    memcpy(cpu_ctx->Alloc<float>(weight_max),
+           ones_vec.data(),
+           max_ptr_size * sizeof(float));
+    // 2. Create scale_max tensor
+    scale_max->set_type(phi::DataType::FLOAT32);
+    scale_max->Resize({static_cast<int64_t>(quant_scales.size())});
+    memcpy(cpu_ctx->Alloc<float>(scale_max),
+           quant_scales.data(),
+           quant_scales.size() * sizeof(float));
+  }
 }
 
 template <typename T>
 void ConvertWithoutQuant(phi::DenseTensor* weight,
                          phi::DenseTensor* weight_max,
+                         phi::DenseTensor* scale_max,
                          bool transpose,
                          const std::vector<float>& weight_scales) {
+  PADDLE_ENFORCE_EQ(
+      weight_scales.empty(),
+      false,
+      platform::errors::InvalidArgument(
+          "ConvertWithoutQuant is not allowed weight scales is empty!"));
   if (transpose) {
     Transpose2D(weight);
   }
+  bool per_tensor_quant = weight_scales.size() == 1;
   if (std::is_same<T, int8_t>::value || std::is_same<T, int16_t>::value) {
     auto* cpu_ctx = static_cast<phi::CPUContext*>(
         platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
-    int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
-    if (weight_scales.size() != 1) {
-      // Per-channel type
-      max_ptr_size = weight_scales.size();
-    }
-    weight_max->set_type(phi::DataType::FLOAT32);
-    weight_max->Resize({max_ptr_size});
-    if (!weight_scales.empty()) {
-      if (weight_scales.size() != 1) {
-        // Per-channel type
-        memcpy(cpu_ctx->Alloc<float>(weight_max),
-               weight_scales.data(),
-               max_ptr_size * sizeof(float));
-      } else {
-        // Per-tensor type
-        // This case for weight shape like [1, 17, 1, 1], the type of case is
-        // both  per-tensor type and a per-channel type.
-        std::vector<float> max_vec(max_ptr_size, weight_scales[0]);
-        memcpy(cpu_ctx->Alloc<float>(weight_max),
-               max_vec.data(),
-               max_ptr_size * sizeof(float));
-      }
+    if (per_tensor_quant) {
+      int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+      std::vector<float> max_vec(max_ptr_size, weight_scales[0]);
+      weight_max->set_type(phi::DataType::FLOAT32);
+      weight_max->Resize({max_ptr_size});
+      memcpy(cpu_ctx->Alloc<float>(weight_max),
+             max_vec.data(),
+             max_ptr_size * sizeof(float));
     } else {
-      LOG(FATAL) << "weight scales cannot be empty!";
+      int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+      // 1. Create weight_max tensor(all data is 1.0f)
+      weight_max->set_type(phi::DataType::FLOAT32);
+      weight_max->Resize({max_ptr_size});
+      std::vector<float> ones_vec(max_ptr_size, 1.0);
+      memcpy(cpu_ctx->Alloc<float>(weight_max),
+             ones_vec.data(),
+             max_ptr_size * sizeof(float));
+      // 2. Create scale_max tensor
+      scale_max->set_type(phi::DataType::FLOAT32);
+      scale_max->Resize({static_cast<int64_t>(weight_scales.size())});
+      memcpy(cpu_ctx->Alloc<float>(scale_max),
+             weight_scales.data(),
+             weight_scales.size() * sizeof(float));
     }
   } else {
     LOG(FATAL) << "Only support int8<->int8 and int16<->int16 convert.";
   }
 }
 
-template void ConvertWithQuant<float, int16_t>(
-    phi::DenseTensor* weight,
-    phi::DenseTensor* weight_max,
-    bool transpose,
-    const std::vector<float>& weight_scales);
+template void ConvertWithQuant<float, int16_t>(phi::DenseTensor* weight,
+                                               phi::DenseTensor* weight_max,
+                                               phi::DenseTensor* scale_max,
+                                               bool transpose,
+                                               bool per_channel_quant);
 
-template void ConvertWithQuant<float, int8_t>(
-    phi::DenseTensor* weight,
-    phi::DenseTensor* weight_max,
-    bool transpose,
-    const std::vector<float>& weight_scales);
+template void ConvertWithQuant<float, int8_t>(phi::DenseTensor* weight,
+                                              phi::DenseTensor* weight_max,
+                                              phi::DenseTensor* scale_max,
+                                              bool transpose,
+                                              bool per_channel_quant);
 
 template void ConvertWithoutQuant<int8_t>(
     phi::DenseTensor* weight,
     phi::DenseTensor* weight_max,
+    phi::DenseTensor* scale_max,
     bool transpose,
     const std::vector<float>& weight_scales);
 

--- a/paddle/fluid/framework/ir/xpu/quant_utils.h
+++ b/paddle/fluid/framework/ir/xpu/quant_utils.h
@@ -30,6 +30,7 @@ void CastToInt32(phi::DenseTensor* in, phi::DenseTensor* out = nullptr);
 template <typename T>
 void ConvertWithoutQuant(phi::DenseTensor* weight,
                          phi::DenseTensor* weight_max,
+                         phi::DenseTensor* scale_max,
                          bool transpose,
                          const std::vector<float>& weight_scales);
 
@@ -39,8 +40,9 @@ template <typename Tcpu,
               ptr = nullptr>
 void ConvertWithQuant(phi::DenseTensor* weight,
                       phi::DenseTensor* weight_max,
+                      phi::DenseTensor* scale_max,
                       bool transpose,
-                      const std::vector<float>& weight_scales);
+                      bool per_channel_quant = false);
 
 template <typename Tcpu,
           typename Txpu,
@@ -48,8 +50,10 @@ template <typename Tcpu,
                                   Tcpu>::type* ptr = nullptr>
 void ConvertWithQuant(phi::DenseTensor* weight,
                       phi::DenseTensor* weight_max,
+                      phi::DenseTensor* scale_max,
                       bool transpose,
-                      const std::vector<float>& weight_scales);
+                      const std::vector<float>& weight_scales,
+                      bool per_channel_quant = false);
 
 bool IsPerTensorQuant(const std::vector<float>& weight_max);
 

--- a/paddle/fluid/framework/ir/xpu/squeeze_excitation_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/squeeze_excitation_fuse_pass.cc
@@ -117,6 +117,10 @@ SqueezeExcitationFusePattern::SqueezeExcitationFusePattern(
   auto mul_w_teller = [](const Node* x) {
     auto* var_desc = x->Var();
     auto filter_dims = var_desc->GetShape();
+    auto filter_dtype = var_desc->GetDataType();
+    if (filter_dtype == proto::VarType::Type::VarType_Type_INT8) {
+      return false;
+    }
     auto in_c = filter_dims[0];
     auto out_c = filter_dims[1];
     auto bigger = std::max(in_c, out_c);

--- a/paddle/fluid/framework/ir/xpu/xpu_graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/xpu/xpu_graph_pattern_detector.h
@@ -90,6 +90,21 @@ struct MultipleQuantizeXPU : public PatternBase {
   PATTERN_DECL_NODE(prev_out);
 };
 
+// quantize_xpu(branch_input) + conv2d_xpu + dequantize_xpu
+struct QuantConv2dFusionDequantXPU : public PatternBase {
+  QuantConv2dFusionDequantXPU(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "quant_conv2d_fusion_dequant_xpu") {}
+  PDNode* operator()();
+
+  PATTERN_DECL_NODE(quant_in);
+  PATTERN_DECL_NODE(quant_op);
+  PATTERN_DECL_NODE(quant_out);
+  PATTERN_DECL_NODE(conv_op);
+  PATTERN_DECL_NODE(conv_out);
+  PATTERN_DECL_NODE(dequant_op);
+  PATTERN_DECL_NODE(dequant_out);
+};
+
 }  // namespace patterns
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_op_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_op_pass.cc
@@ -164,10 +164,12 @@ void XPUQuantizeOpPass::QuantizeConv(ir::Graph* graph) const {
           out_var_node = output_node;
         }
       }
-      if (!AreScalesPresentForNodes(&var_quant_scales_,
-                                    {x_var_node, w_var_node})) {
+      if (!AreScalesPresentForNodes(&var_quant_scales_, {x_var_node})) {
+        VLOG(4) << "Skip quantize op: " << n->Name()
+                << "x_var_node_name:" << x_var_node->Name()
+                << " w_var_node_name:" << w_var_node->Name();
         MarkAndLogCannotQuantizeOp(n, "No scale available for the operator");
-        return;
+        continue;
       }
 
       QuantizeInput(graph, n, x_var_node, "x");
@@ -240,7 +242,7 @@ void XPUQuantizeOpPass::QuantizeFC(ir::Graph* graph) const {
       if (!AreScalesPresentForNodes(&var_quant_scales_,
                                     {x_var_node, w_var_node})) {
         MarkAndLogCannotQuantizeOp(n, "No scale available for the operator");
-        return;
+        continue;
       }
 
       QuantizeInput(graph, n, x_var_node, "x");

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
@@ -331,10 +331,8 @@ void XPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   FindNodesToKeep(graph, &nodes_keep_counter);
   DequantQuantSquash(graph, &nodes_keep_counter);
   OpDequantSquash(graph);
-  QuantOpSquash(graph);  // If the quant op is fused into conv2d_xpu, the
-                         // performance will become worse.
+  QuantOpSquash(graph);
   QuantConv2dFusionDequantSquash(graph);
-
   MultipleQuantizeSquash(graph);
 }
 

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
@@ -268,7 +268,7 @@ void XPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   FindNodesToKeep(graph, &nodes_keep_counter);
   DequantQuantSquash(graph, &nodes_keep_counter);
   OpDequantSquash(graph);
-  // QuantOpSquash(graph); // If the quant op is fused into conv2d_xpu, the
+  QuantOpSquash(graph);  // If the quant op is fused into conv2d_xpu, the
   // performance will become worse.
   MultipleQuantizeSquash(graph);
 }

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.cc
@@ -136,6 +136,21 @@ void XPUQuantizeSquashPass::OpDequantSquash(Graph* graph) const {
           FindOutputNameByVarName(any_op->Op(), dequant_in->Name());
 
       if (output_name.empty()) return;
+      if (any_op->Op()->Type() == "conv2d_xpu") {
+        bool has_branch = any_op->Op()->HasInput("branch");
+        if (has_branch) {
+          std::string branch_name = any_op->Op()->Input("branch")[0];
+          auto* branch_node = FindNodeWithName(graph, branch_name);
+          // If branch datatype is not equal to dequant_out datatype, can not
+          // squash. Because phase1: dquantize + quantize squash maybe squash
+          // branch quantize, if so, We judge the datatype to decide whether to
+          // squash. If squash, the result will be wrong.
+          if (branch_node->Var()->GetDataType() !=
+              dequant_out->Var()->GetDataType()) {
+            return;
+          }
+        }
+      }
       any_op->Op()->SetAttr("out_dtype", dequant_out->Var()->GetDataType());
       any_op->Op()->SetOutput(output_name,
                               std::vector<std::string>({dequant_out->Name()}));
@@ -177,6 +192,9 @@ void XPUQuantizeSquashPass::QuantOpSquash(Graph* graph) const {
             next_op->Op()->Type() == "fc_xpu")) {
         return;
       }
+      if (next_op->Op()->Type() == "conv2d_xpu" && input_name == "branch") {
+        return;
+      }
       next_op->Op()->SetInput(input_name,
                               std::vector<std::string>({quant_in->Name()}));
       IR_NODE_LINK_TO(quant_in, next_op);
@@ -187,6 +205,51 @@ void XPUQuantizeSquashPass::QuantOpSquash(Graph* graph) const {
   gpd(graph, handler);
   AddStatis(found_quant_op_squash_count);
   PrettyLogDetail("---    squashed %d quantize with ops",
+                  found_quant_op_squash_count);
+}
+
+// conv2d_xpu
+void XPUQuantizeSquashPass::QuantConv2dFusionDequantSquash(Graph* graph) const {
+  GraphPatternDetector gpd;
+  patterns::QuantConv2dFusionDequantXPU quant_conv2d_fusion_dequant_pattern{
+      gpd.mutable_pattern(), "quant_conv2d_fusion_dequant_xpu"};
+  quant_conv2d_fusion_dequant_pattern();
+
+  int found_quant_op_squash_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    VLOG(4) << "squash conv2d_xpu op [branch quantize - out dequantize pair]";
+
+    GET_IR_NODE_FROM_SUBGRAPH(
+        quant_in, quant_in, quant_conv2d_fusion_dequant_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        quant_op, quant_op, quant_conv2d_fusion_dequant_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        quant_out, quant_out, quant_conv2d_fusion_dequant_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        conv_op, conv_op, quant_conv2d_fusion_dequant_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        conv_out, conv_out, quant_conv2d_fusion_dequant_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        dequant_op, dequant_op, quant_conv2d_fusion_dequant_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        dequant_out, dequant_out, quant_conv2d_fusion_dequant_pattern);
+
+    if (quant_out->outputs.size() == 1 && dequant_out->outputs.size() == 1) {
+      conv_op->Op()->SetInput("branch",
+                              std::vector<std::string>({quant_in->Name()}));
+      conv_op->Op()->SetOutput("out",
+                               std::vector<std::string>({dequant_out->Name()}));
+      conv_op->Op()->SetAttr("out_dtype", dequant_out->Var()->GetDataType());
+      IR_NODE_LINK_TO(quant_in, conv_op);
+      IR_NODE_LINK_TO(conv_op, dequant_out);
+      GraphSafeRemoveNodes(graph, {quant_op, quant_out, conv_out, dequant_op});
+      found_quant_op_squash_count++;
+    }
+  };
+  gpd(graph, handler);
+  AddStatis(found_quant_op_squash_count);
+  PrettyLogDetail("---    squashed %d branch quantize - out dequantize pairs",
                   found_quant_op_squash_count);
 }
 
@@ -269,7 +332,9 @@ void XPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   DequantQuantSquash(graph, &nodes_keep_counter);
   OpDequantSquash(graph);
   QuantOpSquash(graph);  // If the quant op is fused into conv2d_xpu, the
-  // performance will become worse.
+                         // performance will become worse.
+  QuantConv2dFusionDequantSquash(graph);
+
   MultipleQuantizeSquash(graph);
 }
 

--- a/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.h
+++ b/paddle/fluid/framework/ir/xpu/xpu_quantize_squash_pass.h
@@ -65,6 +65,11 @@ class XPUQuantizeSquashPass : public FusePassBase {
    */
   void QuantOpSquash(Graph* graph) const;
 
+  /*
+   * Squash quantize(branch) + dequantize(out) in conv2d_xpu
+   */
+  void QuantConv2dFusionDequantSquash(Graph* graph) const;
+
   const std::string name_scope_{"squash"};
 };
 

--- a/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
@@ -183,15 +183,18 @@ void IrParamsSyncAmongDevicesPass::CopyParamsToXpu(Argument *argument) {
   platform::CPUPlace cpu_place;
   platform::Place xpu_place = platform::XPUPlace(argument->xpu_device_id());
   auto *scope = argument->scope_ptr();
-  std::vector<std::string> all_vars = scope->LocalVarNames();
-  for (auto &var_name : all_vars) {
-    auto *var = scope->FindLocalVar(var_name);
-    PADDLE_ENFORCE_NOT_NULL(
-        var,
-        platform::errors::PreconditionNotMet("The var should not be nullptr"));
+  framework::ir::Graph &main_graph = argument->main_graph();
 
-    if (var->IsType<phi::DenseTensor>()) {
+  for (size_t i = 0; i < main_graph.SubGraphsSize(); i++) {
+    auto *graph = main_graph.GetSubGraph(i);
+    for (auto *node : graph->Nodes()) {
+      if (!node->IsVar() || !node->Var() || !node->Var()->Persistable())
+        continue;
+      auto *var = scope->FindVar(node->Name());
+      if (!var->IsType<phi::DenseTensor>()) continue;
       auto *tensor = var->GetMutable<phi::DenseTensor>();
+      if (tensor->place().GetType() == phi::AllocationType::XPU) continue;
+
       phi::DenseTensor temp_tensor;
       temp_tensor.Resize(tensor->dims());
       paddle::framework::TensorCopySync(*tensor, cpu_place, &temp_tensor);

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -560,11 +560,11 @@ XpuPassStrategy::XpuPassStrategy() : PassStrategy({}) {
       "yolo_box_xpu_fuse_pass",
       "fast_where_xpu_fuse_pass",
       "elementwise_mul_add_fuse_pass",
-      "link_xpu_op_max_pass",
       // "auto_mixed_precision_pass",
       "cast_mixed_precision_op_fuse_pass",
       "xpu_quantize_op_pass",
       "xpu_quantize_squash_pass",
+      "link_xpu_op_max_pass",
       "delete_isolated_node_pass",
       "inplace_op_var_pass",
   });


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
本 PR 主要解决 XPU 支持开源量化模型遇到的问题：
+ 修复 ppyoloe 量化模型中存在共享权重，导致推理失败的问题。 
  + conv2d 支持共享 weights。注意: 在写共享权重相关的 pass 时，要删除 pattern 匹配过程中权重节点的匹配 。
+ 修复 squeeze_excitation_fuse_pass 在跑量化模型时崩溃的问题。
+ 修复 fc_xpu_fuse_pass 在处理 int8场景时，x_max 和 out_max 重名的问题。
+ 修复 ir_params_sync_among_devices_pass 在进行多 block 程序中拷贝权重，程序崩溃的问题。
  + 控制流算子中，如果使用 graph 的 子block进行遍历，子 block 里面的 variable 在 while op 执行时才会进行初始化。在 while op 执行之前不能保证 node->Var() 是否为空, 因此不能直接使用 node->Var()->Persistable() 方法进行判断。
+ 修复 int8 在设置 max-ptr 时， per-tensor 情况长度不对的问题
+ 修复 xpu_quantize_squash_pass 中 conv2d_xpu 算子 branch + quantize 和 out + dequantize 融合错误，导致二者datatype 不一致的问题。
+ 修复 fc_xpu + bn 融合时，权重融合不正确的问题。
+ conv2d_trans_filter_dilations_nxn_to_1x1_pass （解决 deeplab-v3模型跑通问题）
  + 增加 int8 数据类型支持
  + 修复转换过程中 offset 使用 int 计算溢出（超出 int 数据类型表示范围）导致程序崩溃的问题。
  +  增加了 xdnn 相关条件限制（dilation < 8），否则 xdnn 执行时会引起  XDNN_NO_ENOUGH_WORKSPACE 的错误。
+ fc_xpu 支持权重共享
+ fc 、conv 支持 int16 per-channel 在线量化
