### PR TITLE
Enable FP16 IO in TRT convert tests

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/generic_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/generic_plugin.cu
@@ -530,10 +530,8 @@ int GenericPlugin::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
     const std::map<nvinfer1::DataType, std::pair<phi::DataType, int>> _map{
         {nvinfer1::DataType::kFLOAT, {phi::DataType::FLOAT32, sizeof(float)}},
         {nvinfer1::DataType::kHALF, {phi::DataType::FLOAT16, sizeof(half)}},
-        {nvinfer1::DataType::kINT8, {phi::DataType::INT8, sizeof(int8_t)}},
         {nvinfer1::DataType::kINT32, {phi::DataType::INT32, sizeof(int32_t)}},
         {nvinfer1::DataType::kBOOL, {phi::DataType::BOOL, sizeof(bool)}},
-        {nvinfer1::DataType::kUINT8, {phi::DataType::UINT8, sizeof(uint8_t)}},
     };
     CHECK(_map.count(nv_dtype))
         << "dtype [" << static_cast<int>(nv_dtype) << "] is not supported.";

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -748,9 +748,6 @@ class TrtLayerAutoScanTest(AutoScanTest):
             if not skip_baseline:
                 # baseline: gpu run, we only test float32
                 gpu_config = self.create_inference_config(use_trt=False)
-                prog_config = prog_config.set_input_type(
-                    np.float16
-                ).set_input_type(np.float32)
                 baseline_result = self.run_test_config(
                     model,
                     params,

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -681,9 +681,15 @@ class TrtLayerAutoScanTest(AutoScanTest):
             np.testing.assert_allclose(arr, baseline[key], rtol=rtol, atol=atol)
 
     def assert_op_size(self, trt_engine_num, paddle_op_num):
+        fp32_last_pass = "transpose_flatten_concat_fuse_pass"
+        fp16_last_pass = "tensorrt_subgraph_pass"
         last_passed_program = os.path.join(
-            self.cache_dir, "transpose_flatten_concat_fuse_pass.pdmodel"
+            self.cache_dir, f"{fp32_last_pass}.pdmodel"
         )
+        if not os.path.exists(last_passed_program):
+            last_passed_program = os.path.join(
+                self.cache_dir, f"{fp16_last_pass}.pdmodel"
+            )
         model_bytes = paddle.static.load_from_file(last_passed_program)
         pg = paddle.static.deserialize_program(model_bytes)
         main_block = pg.desc.block(0)
@@ -739,13 +745,6 @@ class TrtLayerAutoScanTest(AutoScanTest):
             if quant:
                 model, params = create_quant_model(model, params)
 
-            feed_data = {}
-            for name, tensor_config in prog_config.inputs.items():
-                feed_data[name] = {
-                    "data": tensor_config.data,
-                    "lod": tensor_config.lod,
-                }
-
             if not skip_baseline:
                 # baseline: gpu run, we only test float32
                 gpu_config = self.create_inference_config(use_trt=False)
@@ -757,7 +756,7 @@ class TrtLayerAutoScanTest(AutoScanTest):
                     params,
                     prog_config,
                     gpu_config,
-                    feed_data,
+                    prog_config.get_feed_data(),
                 )
                 self.success_log(f"basline program_config: {prog_config}")
 
@@ -813,6 +812,10 @@ class TrtLayerAutoScanTest(AutoScanTest):
                     continue
 
                 try:
+                    model, params = create_fake_model(prog_config)
+                    if quant:
+                        model, params = create_quant_model(model, params)
+                    feed_data = prog_config.get_feed_data()
                     pred_config_deserialize = paddle_infer.Config(pred_config)
                     trt_result = self.run_test_config(
                         model, params, prog_config, pred_config, feed_data

--- a/test/ir/inference/program_config.py
+++ b/test/ir/inference/program_config.py
@@ -288,6 +288,7 @@ class ProgramConfig:
         assert _type in [
             np.float32,
             np.float16,
+            None,
         ], "PaddleTRT only supports FP32 / FP16 IO"
         self.input_type = _type
 

--- a/test/ir/inference/program_config.py
+++ b/test/ir/inference/program_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import enum
 from typing import Any, Callable, Dict, List, Optional
 
@@ -236,7 +237,11 @@ class BlockConfig:
 
 
 class ProgramConfig:
-    '''A config builder for generating a Program.'''
+    '''A config builder for generating a Program.
+    input_type : (np.dtype, default=None), the inputs will be casted to input_type before
+                fed into TRT engine. If set to None, no casting will be performed.
+    no_cast_list : (List[str], default=None), specify the tensors that will skip the casting
+    '''
 
     def __init__(
         self,
@@ -244,6 +249,8 @@ class ProgramConfig:
         weights: Dict[str, TensorConfig],
         inputs: Dict[str, TensorConfig],
         outputs: List[str],
+        input_type: Optional[np.dtype] = None,
+        no_cast_list: Optional[List[str]] = None,
     ):
         self.ops = ops
         # if no weight need to save, we create a place_holder to help seriazlie params.
@@ -259,6 +266,8 @@ class ProgramConfig:
             self.weights = weights
         self.inputs = inputs
         self.outputs = outputs
+        self.input_type = input_type
+        self.no_cast_list = [] if no_cast_list is None else no_cast_list
 
     def __repr__(self):
         log_str = ''
@@ -272,22 +281,56 @@ class ProgramConfig:
             log_str += '[' + t + ': ' + str(v) + ']'
         for t, v in self.weights.items():
             log_str += '[' + t + ': ' + str(v) + ']'
-
+        log_str += f"['input_type': {self.input_type}]"
         return log_str
 
-    def set_input_type(self, type: np.dtype):
-        for inp in self.inputs.values():
-            inp.convert_type_inplace(type)
-        for weight in self.weights.values():
-            weight.convert_type_inplace(type)
-        return self
+    def set_input_type(self, _type: np.dtype) -> None:
+        assert _type in [
+            np.float32,
+            np.float16,
+        ], "PaddleTRT only supports FP32 / FP16 IO"
+        self.input_type = _type
 
-    def get_input_type(self) -> np.dtype:
-        return next(iter(self.inputs.values())).dtype
+    def get_feed_data(self) -> Dict[str, Dict[str, Any]]:
+        feed_data = {}
+        for name, tensor_config in self.inputs.items():
+            do_casting = (
+                self.input_type is not None and name not in self.no_cast_list
+            )
+            # Cast to target input_type
+            data = (
+                tensor_config.data.astype(self.input_type)
+                if do_casting
+                else tensor_config.data
+            )
+            # Truncate FP32 tensors to FP16 precision for FP16 test stability
+            if data.dtype == np.float32 and name not in self.no_cast_list:
+                data = data.astype(np.float16).astype(np.float32)
+
+            feed_data[name] = {
+                'data': data,
+                'lod': tensor_config.lod,
+            }
+        return feed_data
+
+    def _cast(self) -> None:
+        if self.input_type is None:
+            return
+        for name, inp in self.inputs.items():
+            if name in self.no_cast_list:
+                continue
+            inp.convert_type_inplace(self.input_type)
+        for name, weight in self.weights.items():
+            if name in self.no_cast_list:
+                continue
+            weight.convert_type_inplace(self.input_type)
+        return self
 
 
 def create_fake_model(program_config):
     '''Create a Paddle model(in memory) according to the given config.'''
+    program_config = copy.deepcopy(program_config)
+    program_config._cast()
     paddle.enable_static()
     main_program_desc = core.ProgramDesc()
     util_program = base.Program()

--- a/test/ir/inference/test_trt_convert_affine_channel.py
+++ b/test/ir/inference/test_trt_convert_affine_channel.py
@@ -133,12 +133,10 @@ class TrtConvertAffineChannelTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), (1e-3, 1e-3)
@@ -146,12 +144,10 @@ class TrtConvertAffineChannelTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_anchor_generator.py
+++ b/test/ir/inference/test_trt_convert_anchor_generator.py
@@ -112,7 +112,9 @@ class TrtConvertAnchorGeneratorTest(TrtLayerAutoScanTest):
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
+        # NOTE(tizheng): This config will fall back to paddle native OP,
+        # which only supports FP32 input.
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-3

--- a/test/ir/inference/test_trt_convert_batch_norm.py
+++ b/test/ir/inference/test_trt_convert_batch_norm.py
@@ -168,6 +168,9 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
                                         )
                                     },
                                     outputs=["batch_norm_out"],
+                                    no_cast_list=list(
+                                        dics_intputs[num_input].keys()
+                                    ),
                                 )
 
                                 yield program_config

--- a/test/ir/inference/test_trt_convert_bitwise_not.py
+++ b/test/ir/inference/test_trt_convert_bitwise_not.py
@@ -67,7 +67,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
                     },
                     outputs=["output_data"],
                 )
-                program_config.input_type = program_config.inputs[
+                program_config._input_type = program_config.inputs[
                     'input_data'
                 ].dtype
                 yield program_config
@@ -114,9 +114,9 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             if not dynamic_shape:
                 if self.dims == 1 or self.dims == 0:
                     return 0, 3
-            if program_config.input_type in ['int8', 'uint8']:
+            if program_config._input_type in ['int8', 'uint8']:
                 return 0, 3
-            elif program_config.input_type == 'bool':
+            elif program_config._input_type == 'bool':
                 if trt_version <= 8600 and self.dims == 0:
                     return 0, 3
                 elif trt_version <= 8400:
@@ -133,12 +133,10 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
@@ -146,12 +144,10 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5

--- a/test/ir/inference/test_trt_convert_bmm.py
+++ b/test/ir/inference/test_trt_convert_bmm.py
@@ -106,11 +106,11 @@ class TrtConvertBmmTest_dynamic(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
-        ), 1e-3
+        ), (1e-2, 1e-2)
 
         # The output has little diff between gpu and trt in CI-Windows-Inference
         tol_fp32 = 1e-4
-        tol_half = 1e-4
+        tol_half = 1e-2
         if os.name == 'nt':
             tol_fp32 = 1e-2
             tol_half = 1e-2
@@ -125,7 +125,7 @@ class TrtConvertBmmTest_dynamic(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
-        ), tol_half
+        ), (tol_half, tol_half)
 
     def add_skip_trt_case(self):
         pass

--- a/test/ir/inference/test_trt_convert_cast.py
+++ b/test/ir/inference/test_trt_convert_cast.py
@@ -164,12 +164,10 @@ class TrtConvertCastTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2
@@ -177,12 +175,10 @@ class TrtConvertCastTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2

--- a/test/ir/inference/test_trt_convert_clip.py
+++ b/test/ir/inference/test_trt_convert_clip.py
@@ -151,7 +151,7 @@ class TrtConvertClipTest(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
-        ), 1e-3
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -164,7 +164,7 @@ class TrtConvertClipTest(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
-        ), 1e-3
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/test/ir/inference/test_trt_convert_compare_and_logical.py
+++ b/test/ir/inference/test_trt_convert_compare_and_logical.py
@@ -766,12 +766,10 @@ class TrtConvertCompareSkipTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), (1e-3, 1e-3)
@@ -779,12 +777,10 @@ class TrtConvertCompareSkipTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_conv2d.py
+++ b/test/ir/inference/test_trt_convert_conv2d.py
@@ -181,7 +181,7 @@ class TrtConvertConv2dTest(TrtLayerAutoScanTest):
             attrs, False
         ), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), (1e-2, 1e-2)
@@ -199,7 +199,7 @@ class TrtConvertConv2dTest(TrtLayerAutoScanTest):
             attrs, True
         ), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-2, 1e-2)

--- a/test/ir/inference/test_trt_convert_conv2d_fusion.py
+++ b/test/ir/inference/test_trt_convert_conv2d_fusion.py
@@ -187,9 +187,9 @@ class TrtConvertConv2dFusionTest(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
-        ), (1e-3, 1e-3)
+        ), (1e-2, 1e-2)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), (1e-3, 1e-3)
@@ -205,9 +205,9 @@ class TrtConvertConv2dFusionTest(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
-        ), (1e-3, 1e-3)
+        ), (1e-2, 1e-2)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_cross_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_cross_multihead_matmul.py
@@ -270,21 +270,17 @@ class TrtConvertCrossMultiHeadMatmulTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 4), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 4), (1e-2, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 3), (1e-5, 1e-4)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 3), (1e-2, 1e-2)
 
     def add_skip_trt_case(self):

--- a/test/ir/inference/test_trt_convert_depthwise_conv2d.py
+++ b/test/ir/inference/test_trt_convert_depthwise_conv2d.py
@@ -156,11 +156,11 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(), (
-            1e-3,
+            5e-3,
             1e-3,
         )
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(), (
             1e-3,
             1e-3,
@@ -174,14 +174,14 @@ class TrtConvertDepthwiseConv2dTest(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(), (
-            1e-3,
+            5e-3,
             1e-3,
         )
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(), (
-            1e-3,
-            1e-3,
+            5e-3,
+            5e-3,
         )
 
     def add_skip_trt_case(self):

--- a/test/ir/inference/test_trt_convert_fill_any_like.py
+++ b/test/ir/inference/test_trt_convert_fill_any_like.py
@@ -167,12 +167,10 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
 
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
@@ -180,12 +178,10 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5

--- a/test/ir/inference/test_trt_convert_fill_constant.py
+++ b/test/ir/inference/test_trt_convert_fill_constant.py
@@ -142,12 +142,10 @@ class TrtConvertFillConstantTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-3

--- a/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
@@ -267,22 +267,18 @@ class TrtConvertFlashMultiHeadMatmulTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 2), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), (1, 2), (1e-3, 1e-3)
+        yield self.create_inference_config(), (1, 2), (2e-2, 5e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 2), (1e-5, 1e-4)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), (1, 2), (1e-2, 1e-3)
+        yield self.create_inference_config(), (1, 2), (2e-2, 5e-3)
 
     def add_skip_trt_case(self):
         def teller1(program_config, predictor_config):

--- a/test/ir/inference/test_trt_convert_gather_nd.py
+++ b/test/ir/inference/test_trt_convert_gather_nd.py
@@ -60,6 +60,7 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
                     ),
                 },
                 outputs=["output_data"],
+                no_cast_list=["index_data"],
             )
 
             yield program_config
@@ -154,6 +155,7 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
             outputs=["output_data"],
+            no_cast_list=["index_data"],
         )
 
         yield program_config
@@ -248,6 +250,7 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
             outputs=["output_data"],
+            no_cast_list=["index_data"],
         )
 
         yield program_config
@@ -342,6 +345,7 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
             outputs=["output_data"],
+            no_cast_list=["index_data"],
         )
 
         yield program_config
@@ -436,6 +440,7 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
             outputs=["output_data"],
+            no_cast_list=["index_data"],
         )
 
         yield program_config
@@ -532,6 +537,7 @@ class TrtConvertGatherNdTest_dim_3_3(TrtLayerAutoScanTest):
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
             outputs=["output_data"],
+            no_cast_list=["index_data"],
         )
 
         yield program_config

--- a/test/ir/inference/test_trt_convert_grid_sampler.py
+++ b/test/ir/inference/test_trt_convert_grid_sampler.py
@@ -138,10 +138,8 @@ class TrtConvertGridSampler(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 3), 1e-3
 
     def test(self):

--- a/test/ir/inference/test_trt_convert_index_select.py
+++ b/test/ir/inference/test_trt_convert_index_select.py
@@ -89,6 +89,7 @@ class TrtConvertIndexSelectTest(TrtLayerAutoScanTest):
                                         ),
                                     },
                                     outputs=["output_data"],
+                                    no_cast_list=["index_data"],
                                 )
 
                                 yield program_config

--- a/test/ir/inference/test_trt_convert_inverse.py
+++ b/test/ir/inference/test_trt_convert_inverse.py
@@ -82,19 +82,15 @@ class TrtConvertInverse(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (0, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (0, 3), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):

--- a/test/ir/inference/test_trt_convert_leaky_relu.py
+++ b/test/ir/inference/test_trt_convert_leaky_relu.py
@@ -113,7 +113,7 @@ class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
             attrs, False
         ), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), (1e-3, 1e-3)
@@ -131,7 +131,7 @@ class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
             attrs, True
         ), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_lookup_table_v2.py
+++ b/test/ir/inference/test_trt_convert_lookup_table_v2.py
@@ -70,6 +70,7 @@ class TrtConvertLookupTableV2Test(TrtLayerAutoScanTest):
                     )
                 },
                 outputs=["out_data"],
+                no_cast_list=["indices"],
             )
 
             yield program_config

--- a/test/ir/inference/test_trt_convert_matmul_v2.py
+++ b/test/ir/inference/test_trt_convert_matmul_v2.py
@@ -96,10 +96,8 @@ class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 3), (tol_fp32, tol_fp32)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 3), (tol_half, tol_half)
 
     def add_skip_trt_case(self):
@@ -177,17 +175,15 @@ class TrtConvertMatmulTest_dynamic2(TrtLayerAutoScanTest):
         ]
         # The output has little diff between gpu and trt in CI-Windows-Inference
         tol_fp32 = 1e-5
-        tol_half = 1e-5
+        tol_half = 1e-3
         if os.name == 'nt':
             tol_fp32 = 1e-3
             tol_half = 1e-3
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 3), (tol_fp32, tol_fp32)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 3), (tol_half, tol_half)
 
     def add_skip_trt_case(self):
@@ -315,11 +311,9 @@ class TrtConvertMatmulTest_dynamic3(TrtLayerAutoScanTest):
 
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
-        yield self.create_inference_config(), (1, 3), 1e-3
+        yield self.create_inference_config(), (1, 3), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
         def teller1(program_config, predictor_config):

--- a/test/ir/inference/test_trt_convert_multiclass_nms.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms.py
@@ -65,15 +65,13 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
 
     def sample_program_configs(self):
         def generate_boxes(batch, num_boxes):
-            return (
-                np.arange(batch * num_boxes * 4, dtype=np.float32)
-                .reshape([batch, num_boxes, 4])
-                .astype(np.float32)
+            return np.arange(batch * num_boxes * 4, dtype=np.float32).reshape(
+                [batch, num_boxes, 4]
             )
 
         def generate_scores(batch, num_boxes, num_classes):
             max_value = batch * num_classes * num_boxes
-            out = (1 / max_value) * np.arange(
+            return (1 / max_value) * np.arange(
                 max_value, dtype=np.float32
             ).reshape([batch, num_classes, num_boxes])
 

--- a/test/ir/inference/test_trt_convert_multiclass_nms.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms.py
@@ -65,13 +65,15 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
 
     def sample_program_configs(self):
         def generate_boxes(batch, num_boxes):
-            return np.arange(batch * num_boxes * 4, dtype=np.float32).reshape(
-                [batch, num_boxes, 4]
+            return (
+                np.arange(batch * num_boxes * 4, dtype=np.float32)
+                .reshape([batch, num_boxes, 4])
+                .astype(np.float32)
             )
 
         def generate_scores(batch, num_boxes, num_classes):
             max_value = batch * num_classes * num_boxes
-            return (1 / max_value) * np.arange(
+            out = (1 / max_value) * np.arange(
                 max_value, dtype=np.float32
             ).reshape([batch, num_classes, num_boxes])
 
@@ -160,12 +162,10 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2
@@ -173,7 +173,6 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5

--- a/test/ir/inference/test_trt_convert_multiclass_nms3.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms3.py
@@ -65,17 +65,14 @@ class TrtConvertMulticlassNMS3Test(TrtLayerAutoScanTest):
 
     def sample_program_configs(self):
         def generate_boxes(batch, num_boxes):
-            return (
-                np.arange(batch * num_boxes * 4, dtype=np.float32)
-                .reshape([batch, num_boxes, 4])
-                .astype(np.float32)
+            return np.arange(batch * num_boxes * 4, dtype=np.float32).reshape(
+                [batch, num_boxes, 4]
             )
 
         def generate_scores(batch, num_boxes, num_classes):
-            out = np.arange(
+            return np.arange(
                 batch * num_classes * num_boxes, dtype=np.float32
             ).reshape([batch, num_classes, num_boxes])
-            return out.astype(np.float32)
             # return np.random.rand(batch, num_classes, num_boxes).astype(np.float32)
 
         for batch in [1, 2]:

--- a/test/ir/inference/test_trt_convert_multiclass_nms3.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms3.py
@@ -65,14 +65,17 @@ class TrtConvertMulticlassNMS3Test(TrtLayerAutoScanTest):
 
     def sample_program_configs(self):
         def generate_boxes(batch, num_boxes):
-            return np.arange(batch * num_boxes * 4, dtype=np.float32).reshape(
-                [batch, num_boxes, 4]
+            return (
+                np.arange(batch * num_boxes * 4, dtype=np.float32)
+                .reshape([batch, num_boxes, 4])
+                .astype(np.float32)
             )
 
         def generate_scores(batch, num_boxes, num_classes):
-            return np.arange(
+            out = np.arange(
                 batch * num_classes * num_boxes, dtype=np.float32
             ).reshape([batch, num_classes, num_boxes])
+            return out.astype(np.float32)
             # return np.random.rand(batch, num_classes, num_boxes).astype(np.float32)
 
         for batch in [1, 2]:
@@ -167,12 +170,10 @@ class TrtConvertMulticlassNMS3Test(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2
@@ -180,7 +181,6 @@ class TrtConvertMulticlassNMS3Test(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5

--- a/test/ir/inference/test_trt_convert_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_multihead_matmul.py
@@ -985,7 +985,7 @@ class TrtConvertVitToMultiHeadMatmulTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.workspace_size = 2013265920
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        program_config.set_input_type(np.int8)
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(), (
             1e-3,
             1e-3,

--- a/test/ir/inference/test_trt_convert_multihead_matmul_roformer.py
+++ b/test/ir/inference/test_trt_convert_multihead_matmul_roformer.py
@@ -540,11 +540,9 @@ class TrtConvertMultiHeadMatmulRoformerTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 5), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 5), (1e-3, 1e-3)
 
     def test(self):

--- a/test/ir/inference/test_trt_convert_nearest_interp_v2.py
+++ b/test/ir/inference/test_trt_convert_nearest_interp_v2.py
@@ -83,12 +83,10 @@ class TrtConvertNearestInterpV2Test(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2
@@ -96,12 +94,10 @@ class TrtConvertNearestInterpV2Test(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2
@@ -178,12 +174,10 @@ class TrtConvertNearestInterpV2ShapeTensorTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2
@@ -191,12 +185,10 @@ class TrtConvertNearestInterpV2ShapeTensorTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2

--- a/test/ir/inference/test_trt_convert_one_hot.py
+++ b/test/ir/inference/test_trt_convert_one_hot.py
@@ -141,12 +141,10 @@ class TrtConvertOneHotTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
@@ -154,12 +152,10 @@ class TrtConvertOneHotTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5

--- a/test/ir/inference/test_trt_convert_p_norm.py
+++ b/test/ir/inference/test_trt_convert_p_norm.py
@@ -118,10 +118,12 @@ class TrtConvertPNormTest(TrtLayerAutoScanTest):
         # for dynamic_shape mode
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_p_norm.py
+++ b/test/ir/inference/test_trt_convert_p_norm.py
@@ -118,12 +118,10 @@ class TrtConvertPNormTest(TrtLayerAutoScanTest):
         # for dynamic_shape mode
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_pad3d.py
+++ b/test/ir/inference/test_trt_convert_pad3d.py
@@ -87,6 +87,7 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
                         },
                         inputs=inputs,
                         outputs=["output_data"],
+                        no_cast_list=["input_paddings"],
                     )
                     yield program_config
 
@@ -120,10 +121,12 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
 
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-3
@@ -131,10 +134,12 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-3
@@ -230,24 +235,28 @@ class TrtConvertPad3dListPadding(TrtLayerAutoScanTest):
 
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
-        ), 1e-3
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
-        ), 1e-3
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/test/ir/inference/test_trt_convert_pad3d.py
+++ b/test/ir/inference/test_trt_convert_pad3d.py
@@ -120,12 +120,10 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
 
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-3
@@ -133,12 +131,10 @@ class TrtConvertPad3dTensorPadding(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-3
@@ -234,12 +230,10 @@ class TrtConvertPad3dListPadding(TrtLayerAutoScanTest):
 
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-3
@@ -247,12 +241,10 @@ class TrtConvertPad3dListPadding(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-3

--- a/test/ir/inference/test_trt_convert_pool2d.py
+++ b/test/ir/inference/test_trt_convert_pool2d.py
@@ -153,12 +153,10 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), (1e-3, 1e-3)
@@ -166,12 +164,10 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (1e-3, 1e-3)

--- a/test/ir/inference/test_trt_convert_preln_residual_bias.py
+++ b/test/ir/inference/test_trt_convert_preln_residual_bias.py
@@ -169,12 +169,10 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
         # for static_shape, fall back to base fused op
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2  # atol=1e-2 while rtol is 1e-8
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2  # atol=1e-2 while rtol is 1e-8
@@ -182,12 +180,10 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
         # just support dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2  # atol=1e-2 while rtol is 1e-8
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2  # atol=1e-2 while rtol is 1e-8

--- a/test/ir/inference/test_trt_convert_preln_residual_no_bias.py
+++ b/test/ir/inference/test_trt_convert_preln_residual_no_bias.py
@@ -158,12 +158,10 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
         # for static_shape, fall back to base fused op
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2  # atol=1e-2 while rtol is 1e-8
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2  # atol=1e-2 while rtol is 1e-8
@@ -171,12 +169,10 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
         # just support dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2  # atol=1e-2 while rtol is 1e-8
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2  # atol=1e-2 while rtol is 1e-8

--- a/test/ir/inference/test_trt_convert_qk_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_qk_multihead_matmul.py
@@ -329,21 +329,17 @@ class TrtConvertQkAttentionTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 3), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 3), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 3), (1e-5, 1e-4)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 3), (1e-2, 1e-3)
 
     def add_skip_trt_case(self):

--- a/test/ir/inference/test_trt_convert_range.py
+++ b/test/ir/inference/test_trt_convert_range.py
@@ -130,12 +130,10 @@ class TrtConvertRangeDynamicTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-2
@@ -216,12 +214,10 @@ class TrtConvertRangeStaticTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-2

--- a/test/ir/inference/test_trt_convert_rnn.py
+++ b/test/ir/inference/test_trt_convert_rnn.py
@@ -264,12 +264,10 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), tol_fp32
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), tol_half

--- a/test/ir/inference/test_trt_convert_roi_align.py
+++ b/test/ir/inference/test_trt_convert_roi_align.py
@@ -129,6 +129,7 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
                                         weights={},
                                         inputs=program_input[num_input],
                                         outputs=["roi_align_out"],
+                                        no_cast_list=["RoisNum"],
                                     )
 
                                     yield program_config
@@ -190,12 +191,10 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-3
@@ -203,12 +202,10 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-3

--- a/test/ir/inference/test_trt_convert_scale.py
+++ b/test/ir/inference/test_trt_convert_scale.py
@@ -113,6 +113,9 @@ class TrtConvertScaleTest(TrtLayerAutoScanTest):
                                             )
                                         },
                                         outputs=["scale_out"],
+                                        no_cast_list=["scale_input"]
+                                        if is_int
+                                        else [],
                                     )
 
                                     yield program_config

--- a/test/ir/inference/test_trt_convert_scatter_nd_add.py
+++ b/test/ir/inference/test_trt_convert_scatter_nd_add.py
@@ -66,6 +66,7 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
                     ),
                 },
                 outputs=["output_data"],
+                no_cast_list=["index_data"],
             )
 
             yield program_config
@@ -102,16 +103,20 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (0, 5), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 5), 1e-3
+        program_config.set_input_type(np.float16)
+        yield self.create_inference_config(), (0, 5), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 4), 1e-3
+        program_config.set_input_type(np.float16)
+        yield self.create_inference_config(), (1, 4), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/test/ir/inference/test_trt_convert_scatter_nd_add.py
+++ b/test/ir/inference/test_trt_convert_scatter_nd_add.py
@@ -102,19 +102,15 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (0, 5), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (0, 5), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 4), 1e-3
 
     def test(self):

--- a/test/ir/inference/test_trt_convert_set_value.py
+++ b/test/ir/inference/test_trt_convert_set_value.py
@@ -163,7 +163,7 @@ class TrtConvertSetValue(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
-        ), (1e-3, 1e-3)
+        ), (1e-2, 1e-2)
 
     def test(self):
         self.run_test()

--- a/test/ir/inference/test_trt_convert_take_along_axis.py
+++ b/test/ir/inference/test_trt_convert_take_along_axis.py
@@ -77,6 +77,7 @@ class TrtConvertTakeAlongAxisTest(TrtLayerAutoScanTest):
                             ),
                         },
                         outputs=["output_data"],
+                        no_cast_list=["index_data"],
                     )
 
                     yield program_config
@@ -168,7 +169,7 @@ class TrtConvertTakeAlongAxisTest(TrtLayerAutoScanTest):
         program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             False
-        ), 1e-5
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)

--- a/test/ir/inference/test_trt_convert_trans_layernorm.py
+++ b/test/ir/inference/test_trt_convert_trans_layernorm.py
@@ -226,12 +226,10 @@ class TrtConvertTransLayernormTest(TrtLayerAutoScanTest):
         # just support dynamic_shape
         generate_dynamic_shape(attrs, inputs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), (

--- a/test/ir/inference/test_trt_convert_unfold.py
+++ b/test/ir/inference/test_trt_convert_unfold.py
@@ -87,15 +87,19 @@ class TrtConvertUnfold(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (0, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (0, 3), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
+        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):

--- a/test/ir/inference/test_trt_convert_unfold.py
+++ b/test/ir/inference/test_trt_convert_unfold.py
@@ -87,19 +87,15 @@ class TrtConvertUnfold(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (0, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (0, 3), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):

--- a/test/ir/inference/test_trt_convert_yolo_box.py
+++ b/test/ir/inference/test_trt_convert_yolo_box.py
@@ -153,12 +153,10 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
         ), 1e-3
@@ -166,12 +164,10 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        program_config.set_input_type(np.float32)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True
         ), 1e-3

--- a/test/ir/inference/test_trt_ops_fp32_mix_precision.py
+++ b/test/ir/inference/test_trt_ops_fp32_mix_precision.py
@@ -162,7 +162,6 @@ class TestTrtFp32MixPrecision(TrtLayerAutoScanTest):
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        program_config.set_input_type(np.float16)
         config = self.create_inference_config()
         InternalUtils.disable_tensorrt_half_ops(
             config,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
In most TRT convert tests, both Float and Half precisions will be tested. However, the input and output tensors are float tensors for both tests. This causes two problems for Half precision tests:
1. When input tensor is float, TRT engine needs to do casting before / after op. When TRT engine finetuning, it may find that,  "_float input -> cast to fp16 -> fp16 op -> cast back to float -> float output_" is slower than "float input -> float op -> float output". Therefore, even if precision is Half, FP16 kernel is not tested. This harms test coverage.
2. If the two routes mentioned above have similar running time, then the test could be non-deterministic, causing random numerical failures.

This PR enables FP16 inputs for Half precision tests. There was an attempt to achieve this in #55823 , but due to a bug, it did not actually take effect. This PR fixes the problem.

After change the input to FP16, some tests fail. Detailed explanation to changes per test:
[TRT convert tests.xlsx](https://github.com/PaddlePaddle/Paddle/files/13224937/TRT.convert.tests.xlsx)
