### PR TITLE
【PIR API adaptor No.198-201】Migrate paddle.incubate.graph_send_recv, paddle.geometric.send_u_recv, paddle.geometric.send_ue_recv, paddle.geometric.send_uv into pir 

### DIFF
--- a/python/paddle/geometric/message_passing/send_recv.py
+++ b/python/paddle/geometric/message_passing/send_recv.py
@@ -128,7 +128,7 @@ def send_u_recv(
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
     if in_dynamic_or_pir_mode():
-        out_size = convert_out_size_to_list(out_size)
+        out_size = convert_out_size_to_list(out_size, 'graph_send_recv')
         return _C_ops.send_u_recv(
             x, src_index, dst_index, reduce_op.upper(), out_size
         )
@@ -313,7 +313,7 @@ def send_ue_recv(
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
     if in_dynamic_or_pir_mode():
-        out_size = convert_out_size_to_list(out_size)
+        out_size = convert_out_size_to_list(out_size, 'graph_send_ue_recv')
         return _C_ops.send_ue_recv(
             x,
             y,

--- a/python/paddle/geometric/message_passing/send_recv.py
+++ b/python/paddle/geometric/message_passing/send_recv.py
@@ -22,11 +22,7 @@ from paddle.base.data_feeder import (
 )
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
-from paddle.framework import (
-    in_dynamic_mode,
-    in_dynamic_or_pir_mode,
-    in_pir_mode,
-)
+from paddle.framework import in_dynamic_or_pir_mode
 
 from .utils import (
     convert_out_size_to_list,
@@ -131,12 +127,8 @@ def send_u_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out_size = convert_out_size_to_list(out_size)
-        return _C_ops.send_u_recv(
-            x, src_index, dst_index, reduce_op.upper(), out_size
-        )
-    elif in_pir_mode():
         return _C_ops.send_u_recv(
             x, src_index, dst_index, reduce_op.upper(), out_size
         )
@@ -320,18 +312,8 @@ def send_ue_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out_size = convert_out_size_to_list(out_size)
-        return _C_ops.send_ue_recv(
-            x,
-            y,
-            src_index,
-            dst_index,
-            message_op.upper(),
-            reduce_op.upper(),
-            out_size,
-        )
-    elif in_pir_mode():
         return _C_ops.send_ue_recv(
             x,
             y,

--- a/python/paddle/geometric/message_passing/send_recv.py
+++ b/python/paddle/geometric/message_passing/send_recv.py
@@ -137,7 +137,6 @@ def send_u_recv(
             x, src_index, dst_index, reduce_op.upper(), out_size
         )
     elif in_pir_mode():
-        out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_u_recv(
             x, src_index, dst_index, reduce_op.upper(), out_size
         )
@@ -333,7 +332,6 @@ def send_ue_recv(
             out_size,
         )
     elif in_pir_mode():
-        out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_ue_recv(
             x,
             y,

--- a/python/paddle/geometric/message_passing/send_recv.py
+++ b/python/paddle/geometric/message_passing/send_recv.py
@@ -22,7 +22,7 @@ from paddle.base.data_feeder import (
 )
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
-from paddle.framework import in_dynamic_mode
+from paddle.framework import in_dynamic_or_pir_mode
 
 from .utils import (
     convert_out_size_to_list,
@@ -127,7 +127,7 @@ def send_u_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_u_recv(
             x, src_index, dst_index, reduce_op.upper(), out_size
@@ -312,7 +312,7 @@ def send_ue_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_ue_recv(
             x,
@@ -472,7 +472,7 @@ def send_uv(x, y, src_index, dst_index, message_op="add", name=None):
         message_op = 'mul'
         y = 1.0 / (y + 1e-12)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.send_uv(x, y, src_index, dst_index, message_op.upper())
     else:
         helper = LayerHelper("graph_send_uv", **locals())

--- a/python/paddle/geometric/message_passing/send_recv.py
+++ b/python/paddle/geometric/message_passing/send_recv.py
@@ -22,7 +22,11 @@ from paddle.base.data_feeder import (
 )
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
-from paddle.framework import in_dynamic_or_pir_mode
+from paddle.framework import (
+    in_dynamic_mode,
+    in_dynamic_or_pir_mode,
+    in_pir_mode,
+)
 
 from .utils import (
     convert_out_size_to_list,
@@ -127,7 +131,12 @@ def send_u_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
+        out_size = convert_out_size_to_list(out_size)
+        return _C_ops.send_u_recv(
+            x, src_index, dst_index, reduce_op.upper(), out_size
+        )
+    elif in_pir_mode():
         out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_u_recv(
             x, src_index, dst_index, reduce_op.upper(), out_size
@@ -312,7 +321,18 @@ def send_ue_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
+        out_size = convert_out_size_to_list(out_size)
+        return _C_ops.send_ue_recv(
+            x,
+            y,
+            src_index,
+            dst_index,
+            message_op.upper(),
+            reduce_op.upper(),
+            out_size,
+        )
+    elif in_pir_mode():
         out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_ue_recv(
             x,

--- a/python/paddle/geometric/message_passing/utils.py
+++ b/python/paddle/geometric/message_passing/utils.py
@@ -19,7 +19,7 @@ from paddle.base.data_feeder import check_dtype, convert_dtype
 from paddle.base.framework import Variable
 
 
-def convert_out_size_to_list(out_size):
+def convert_out_size_to_list(out_size, op_type):
     """
     Convert out_size(int, np.int32, np.int64, Variable) to list
     in imperative mode.
@@ -30,6 +30,13 @@ def convert_out_size_to_list(out_size):
         out_size = [out_size]
     elif isinstance(out_size, (Variable, paddle.pir.OpResult)):
         out_size.stop_gradient = True
+        check_dtype(
+            out_size.dtype,
+            'out_size',
+            ['int32', 'int64'],
+            'op_type',
+            '(When type of out_size in' + op_type + ' is Variable.)',
+        )
         if convert_dtype(out_size.dtype) == 'int64':
             out_size = paddle.cast(out_size, 'int32')
     else:

--- a/python/paddle/geometric/message_passing/utils.py
+++ b/python/paddle/geometric/message_passing/utils.py
@@ -17,7 +17,6 @@ import numpy as np
 import paddle
 from paddle.base.data_feeder import check_dtype, convert_dtype
 from paddle.base.framework import Variable
-from paddle.framework import in_pir_mode
 
 
 def convert_out_size_to_list(out_size):
@@ -25,8 +24,6 @@ def convert_out_size_to_list(out_size):
     Convert out_size(int, np.int32, np.int64, Variable) to list
     in imperative mode.
     """
-    if in_pir_mode():
-        return convert_out_size_to_list(out_size)
     if out_size is None:
         out_size = [0]
     elif isinstance(out_size, (int, np.int32, np.int64)):

--- a/python/paddle/geometric/message_passing/utils.py
+++ b/python/paddle/geometric/message_passing/utils.py
@@ -28,8 +28,12 @@ def convert_out_size_to_list(out_size):
         out_size = [0]
     elif isinstance(out_size, (int, np.int32, np.int64)):
         out_size = [out_size]
+    elif isinstance(out_size, Variable):
+        out_size.stop_gradient = True
+        if convert_dtype(out_size.dtype) == 'int64':
+            out_size = paddle.cast(out_size, 'int32')
     else:
-        out_size = [int(out_size)]
+        raise TypeError("Out_size only supports Variable or int.")
     return out_size
 
 

--- a/python/paddle/geometric/message_passing/utils.py
+++ b/python/paddle/geometric/message_passing/utils.py
@@ -28,12 +28,12 @@ def convert_out_size_to_list(out_size):
         out_size = [0]
     elif isinstance(out_size, (int, np.int32, np.int64)):
         out_size = [out_size]
-    elif isinstance(out_size, Variable):
+    elif isinstance(out_size, (Variable, paddle.pir.OpResult)):
         out_size.stop_gradient = True
         if convert_dtype(out_size.dtype) == 'int64':
             out_size = paddle.cast(out_size, 'int32')
     else:
-        raise TypeError("Out_size only supports Variable or int.")
+        out_size = [int(out_size)]
     return out_size
 
 

--- a/python/paddle/geometric/message_passing/utils.py
+++ b/python/paddle/geometric/message_passing/utils.py
@@ -17,6 +17,7 @@ import numpy as np
 import paddle
 from paddle.base.data_feeder import check_dtype, convert_dtype
 from paddle.base.framework import Variable
+from paddle.framework import in_pir_mode
 
 
 def convert_out_size_to_list(out_size):
@@ -24,6 +25,8 @@ def convert_out_size_to_list(out_size):
     Convert out_size(int, np.int32, np.int64, Variable) to list
     in imperative mode.
     """
+    if in_pir_mode():
+        return convert_out_size_to_list(out_size)
     if out_size is None:
         out_size = [0]
     elif isinstance(out_size, (int, np.int32, np.int64)):

--- a/python/paddle/incubate/operators/graph_send_recv.py
+++ b/python/paddle/incubate/operators/graph_send_recv.py
@@ -137,7 +137,7 @@ def graph_send_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
     if in_dynamic_or_pir_mode():
-        out_size = convert_out_size_to_list(out_size)
+        out_size = convert_out_size_to_list(out_size, 'graph_send_recv')
         return _C_ops.send_u_recv(
             x, src_index, dst_index, pool_type.upper(), out_size
         )

--- a/python/paddle/incubate/operators/graph_send_recv.py
+++ b/python/paddle/incubate/operators/graph_send_recv.py
@@ -142,7 +142,6 @@ def graph_send_recv(
             x, src_index, dst_index, pool_type.upper(), out_size
         )
     elif in_pir_mode():
-        out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_u_recv(
             x, src_index, dst_index, pool_type.upper(), out_size
         )

--- a/python/paddle/incubate/operators/graph_send_recv.py
+++ b/python/paddle/incubate/operators/graph_send_recv.py
@@ -22,7 +22,7 @@ from paddle.base.data_feeder import (
 )
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
-from paddle.framework import in_dynamic_mode, in_pir_mode
+from paddle.framework import in_dynamic_or_pir_mode
 from paddle.geometric.message_passing.utils import (
     convert_out_size_to_list,
     get_out_size_tensor_inputs,
@@ -136,12 +136,8 @@ def graph_send_recv(
         )
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out_size = convert_out_size_to_list(out_size)
-        return _C_ops.send_u_recv(
-            x, src_index, dst_index, pool_type.upper(), out_size
-        )
-    elif in_pir_mode():
         return _C_ops.send_u_recv(
             x, src_index, dst_index, pool_type.upper(), out_size
         )

--- a/python/paddle/incubate/operators/graph_send_recv.py
+++ b/python/paddle/incubate/operators/graph_send_recv.py
@@ -24,7 +24,7 @@ from paddle.base.data_feeder import (
 )
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
-from paddle.framework import in_dynamic_mode
+from paddle.framework import in_dynamic_or_pir_mode
 from paddle.utils import deprecated
 
 
@@ -135,7 +135,7 @@ def graph_send_recv(
 
     # TODO(daisiming): Should we add judgement for out_size: max(dst_index) + 1.
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out_size = convert_out_size_to_list(out_size)
         return _C_ops.send_u_recv(
             x, src_index, dst_index, pool_type.upper(), out_size

--- a/python/paddle/incubate/operators/graph_send_recv.py
+++ b/python/paddle/incubate/operators/graph_send_recv.py
@@ -23,9 +23,11 @@ from paddle.base.data_feeder import (
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
 from paddle.framework import in_dynamic_mode, in_pir_mode
+from paddle.geometric.message_passing.utils import (
+    convert_out_size_to_list,
+    get_out_size_tensor_inputs,
+)
 from paddle.utils import deprecated
-
-from .utils import convert_out_size_to_list, get_out_size_tensor_inputs
 
 
 @deprecated(

--- a/test/legacy_test/test_graph_send_recv_op.py
+++ b/test/legacy_test/test_graph_send_recv_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def graph_send_recv_wrapper(
@@ -49,10 +50,12 @@ class TestGraphSendRecvMaxOp(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', user_defined_grads=[self.gradient])
+        self.check_grad(
+            ['X'], 'Out', user_defined_grads=[self.gradient], check_pir=True
+        )
 
 
 class TestGraphSendRecvMinOp(OpTest):
@@ -77,10 +80,12 @@ class TestGraphSendRecvMinOp(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', user_defined_grads=[self.gradient])
+        self.check_grad(
+            ['X'], 'Out', user_defined_grads=[self.gradient], check_pir=True
+        )
 
 
 class TestGraphSendRecvSumOp(OpTest):
@@ -103,10 +108,10 @@ class TestGraphSendRecvSumOp(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestGraphSendRecvMeanOp(OpTest):
@@ -131,10 +136,10 @@ class TestGraphSendRecvMeanOp(OpTest):
         self.outputs = {'Out': out, 'Dst_count': dst_count}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 def compute_graph_send_recv_for_sum_mean(inputs, attributes):
@@ -216,6 +221,7 @@ def compute_graph_send_recv_for_min_max(inputs, attributes):
 
 
 class API_GraphSendRecvOpTest(unittest.TestCase):
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -343,6 +349,7 @@ class API_GraphSendRecvOpTest(unittest.TestCase):
             np_res_set_outsize, res_set_outsize, rtol=1e-05, atol=1e-06
         )
 
+    @test_with_pir_api
     def test_out_size_tensor_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -378,6 +385,7 @@ class API_GraphSendRecvOpTest(unittest.TestCase):
 
 
 class API_GeometricSendURecvTest(unittest.TestCase):
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -489,6 +497,7 @@ class API_GeometricSendURecvTest(unittest.TestCase):
             np_res_set_outsize, res_set_outsize, rtol=1e-05, atol=1e-06
         )
 
+    @test_with_pir_api
     def test_out_size_tensor_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_graph_send_ue_recv_op.py
+++ b/test/legacy_test/test_graph_send_ue_recv_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def get_broadcast_shape(shp1, shp2):
@@ -314,10 +315,10 @@ class TestGraphSendUERecvSumOp(OpTest):
         self.message_op = 'ADD'
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 class TestSumCase1(TestGraphSendUERecvSumOp):
@@ -420,10 +421,10 @@ class TestGraphSendUERecvMeanOp(OpTest):
         self.message_op = 'ADD'
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 class TestMeanCase1(TestGraphSendUERecvMeanOp):
@@ -526,13 +527,14 @@ class TestGraphSendUERecvMaxOp(OpTest):
         self.message_op = 'ADD'
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
             ['X', 'Y'],
             'Out',
             user_defined_grads=self.gradients,
+            check_pir=True,
         )
 
 
@@ -636,13 +638,14 @@ class TestGraphSendUERecvMinOp(OpTest):
         self.message_op = 'ADD'
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
             ['X', 'Y'],
             'Out',
             user_defined_grads=self.gradients,
+            check_pir=True,
         )
 
 
@@ -1013,6 +1016,7 @@ class API_GeometricSendUERecvTest(unittest.TestCase):
             ),
         )
 
+    @test_with_pir_api
     def test_out_size_tensor_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_graph_send_uv_op.py
+++ b/test/legacy_test/test_graph_send_uv_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def compute_graph_send_uv(inputs, attributes):
@@ -63,10 +64,10 @@ class TestGraphSendUVOp(OpTest):
         self.outputs = {'out': out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['x', 'y'], 'out')
+        self.check_grad(['x', 'y'], 'out', check_pir=True)
 
     def set_config(self):
         self.x = np.random.random((10, 20)).astype("float64")
@@ -194,6 +195,7 @@ class API_GeometricSendUVTest(unittest.TestCase):
                 ),
             )
 
+    @test_with_pir_api
     def test_compute_all_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067

PIR API 推全升级
将 `paddle.incubate.graph_send_recv` 迁移升级至 pir，并更新单测 单测覆盖率：5/5
将 `paddle.geometric.send_u_recv` 迁移升级至 pir，并更新单测 单测覆盖率：1/1
将 `paddle.geometric.send_ue_recv` 迁移升级至 pir，并更新单测 单测覆盖率：33/33
将 `paddle.geometric.send_uv` 迁移升级至 pir，并更新单测 单测覆盖率：9/9

3个的static_test，在添加out_size参数后，都有同样的错误：
2023-11-02 18:38:26     out_size = convert_out_size_to_list(out_size)
2023-11-02 18:38:26   File "C:\home\workspace\Paddle\build\python\paddle\geometric\message_passing\utils.py", line 32, in convert_out_size_to_list
2023-11-02 18:38:26     out_size = [int(out_size)]
2023-11-02 18:38:26 TypeError: int() argument must be a string, a bytes-like object or a real number, not 'paddle.base.libpaddle.pir.OpResult'