### PR TITLE
【PIR API adaptor No.7】Migrate paddle.angle into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5943,7 +5943,7 @@ def angle(x, name=None):
              [-1.10714877, -0.78539819,  0.        ,  0.78539819]])
     """
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.angle(x)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_angle_op.py
+++ b/test/legacy_test/test_angle_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import static
 from paddle.base import core, dygraph
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -49,7 +50,7 @@ class TestAngleOpFloat(OpTest):
         self.outputs = {'Out': out_ref}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -58,6 +59,7 @@ class TestAngleOpFloat(OpTest):
             user_defined_grads=[
                 angle_grad(self.x, np.ones_like(self.x) / self.x.size)
             ],
+            check_pir=True,
         )
 
 
@@ -93,7 +95,7 @@ class TestAngleBF16Op(OpTest):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
     def test_check_grad(self):
         self.check_grad_with_place(
@@ -103,6 +105,7 @@ class TestAngleBF16Op(OpTest):
             user_defined_grads=[
                 angle_grad(self.x, np.ones_like(self.x) / self.x.size)
             ],
+            check_pir=True,
         )
 
 
@@ -119,7 +122,7 @@ class TestAngleOpComplex(OpTest):
         self.outputs = {'Out': out_ref}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -128,6 +131,7 @@ class TestAngleOpComplex(OpTest):
             user_defined_grads=[
                 angle_grad(self.x, np.ones_like(self.x) / self.x.size)
             ],
+            check_pir=True,
         )
 
 
@@ -142,6 +146,7 @@ class TestAngleAPI(unittest.TestCase):
             out_np = paddle.angle(x).numpy()
         np.testing.assert_allclose(self.out, out_np, rtol=1e-05)
 
+    @test_with_pir_api
     def test_static(self):
         mp, sp = static.Program(), static.Program()
         with static.program_guard(mp, sp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Migrate paddle.angle into pir
- #58067
- `paddle.angle` unit test coverage 5/5
