### PR TITLE
【PIR API adaptor No.73, 74】 Migrate paddle.fmax/paddle.fmin into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1345,7 +1345,7 @@ def fmax(x, y, name=None):
             Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
             [5.  , 3.  , inf.])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.fmax(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_fmax', **locals()))
@@ -1409,7 +1409,7 @@ def fmin(x, y, name=None):
             Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
             [ 1.  , -inf.,  5.  ])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.fmin(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_fmin', **locals()))

--- a/test/legacy_test/test_fmax_op.py
+++ b/test/legacy_test/test_fmax_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class ApiFMaxTest(unittest.TestCase):
@@ -43,6 +44,7 @@ class ApiFMaxTest(unittest.TestCase):
         self.np_expected3 = np.fmax(self.input_a, self.input_c)
         self.np_expected4 = np.fmax(self.input_b, self.input_c)
 
+    @test_with_pir_api
     def test_static_api(self):
         """test_static_api"""
         paddle.enable_static()
@@ -145,11 +147,11 @@ class TestElementwiseFmaxOp(OpTest):
 
     def test_check_output(self):
         """test_check_output"""
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         """test_check_grad_normal"""
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
     def test_check_grad_ingore_x(self):
         """test_check_grad_ingore_x"""
@@ -158,6 +160,7 @@ class TestElementwiseFmaxOp(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set("X"),
+            check_pir=True,
         )
 
     def test_check_grad_ingore_y(self):
@@ -167,6 +170,7 @@ class TestElementwiseFmaxOp(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set('Y'),
+            check_pir=True,
         )
 
 
@@ -190,11 +194,11 @@ class TestElementwiseFmax2Op(OpTest):
 
     def test_check_output(self):
         """test_check_output"""
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         """test_check_grad_normal"""
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
     def test_check_grad_ingore_x(self):
         """test_check_grad_ingore_x"""
@@ -203,6 +207,7 @@ class TestElementwiseFmax2Op(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set("X"),
+            check_pir=True,
         )
 
     def test_check_grad_ingore_y(self):
@@ -212,6 +217,7 @@ class TestElementwiseFmax2Op(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set('Y'),
+            check_pir=True,
         )
 
 
@@ -234,11 +240,11 @@ class TestElementwiseFmax3Op(OpTest):
 
     def test_check_output(self):
         """test_check_output"""
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         """test_check_grad_normal"""
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 @unittest.skipIf(
@@ -263,11 +269,11 @@ class TestFmaxBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X', 'Y'], 'Out')
+        self.check_grad_with_place(place, ['X', 'Y'], 'Out', check_pir=True)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fmin_op.py
+++ b/test/legacy_test/test_fmin_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -45,6 +46,7 @@ class ApiFMinTest(unittest.TestCase):
         self.np_expected3 = np.fmin(self.input_a, self.input_c)
         self.np_expected4 = np.fmin(self.input_b, self.input_c)
 
+    @test_with_pir_api
     def test_static_api(self):
         """test_static_api"""
         paddle.enable_static()
@@ -147,11 +149,11 @@ class TestElementwiseFminOp(OpTest):
 
     def test_check_output(self):
         """test_check_output"""
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         """test_check_grad_normal"""
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
     def test_check_grad_ingore_x(self):
         """test_check_grad_ingore_x"""
@@ -160,6 +162,7 @@ class TestElementwiseFminOp(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set("X"),
+            check_pir=True,
         )
 
     def test_check_grad_ingore_y(self):
@@ -169,6 +172,7 @@ class TestElementwiseFminOp(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set('Y'),
+            check_pir=True,
         )
 
 
@@ -192,11 +196,11 @@ class TestElementwiseFmin2Op(OpTest):
 
     def test_check_output(self):
         """test_check_output"""
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         """test_check_grad_normal"""
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
     def test_check_grad_ingore_x(self):
         """test_check_grad_ingore_x"""
@@ -205,6 +209,7 @@ class TestElementwiseFmin2Op(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set("X"),
+            check_pir=True,
         )
 
     def test_check_grad_ingore_y(self):
@@ -214,6 +219,7 @@ class TestElementwiseFmin2Op(OpTest):
             'Out',
             max_relative_error=0.005,
             no_grad_set=set('Y'),
+            check_pir=True,
         )
 
 
@@ -236,11 +242,11 @@ class TestElementwiseFmin3Op(OpTest):
 
     def test_check_output(self):
         """test_check_output"""
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         """test_check_grad_normal"""
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 @unittest.skipIf(
@@ -265,11 +271,11 @@ class TestFminBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X', 'Y'], 'Out')
+        self.check_grad_with_place(place, ['X', 'Y'], 'Out', check_pir=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->

PIR API 推全升级
将 `paddle.fmax` 、`paddle.fmin`迁移升级至 pir，并更新单测

1. paddle.fmax单测覆盖率：5/5
2. paddle.fmin单测覆盖率：5/5

https://github.com/PaddlePaddle/Paddle/issues/58067

