### PR TITLE
Revert "[Inference] jit.save() remove useless renaming process (#58492)"

### DIFF
--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -29,6 +29,7 @@ from paddle.base import (
     Variable,
     core,
     default_main_program,
+    program_guard,
     unique_name,
 )
 from paddle.base.executor import Executor, global_scope
@@ -256,13 +257,14 @@ def normalize_program(program, feed_vars, fetch_vars, **kwargs):
 
     # fix the bug that the activation op's output as target will be pruned.
     # will affect the inference performance.
-    # with program_guard(program):
-    #     uniq_fetch_vars = []
-    #     for i, var in enumerate(fetch_vars):
-    #         if var.dtype != paddle.bool:
-    #             var = paddle.scale(var, 1.0, name=f"save_infer_model/scale_{i}")
-    #         uniq_fetch_vars.append(var)
-    #     fetch_vars = uniq_fetch_vars
+    # TODO(Superjomn) add an IR pass to remove 1-scale op.
+    with program_guard(program):
+        uniq_fetch_vars = []
+        for i, var in enumerate(fetch_vars):
+            if var.dtype != paddle.bool:
+                var = paddle.scale(var, 1.0, name=f"save_infer_model/scale_{i}")
+            uniq_fetch_vars.append(var)
+        fetch_vars = uniq_fetch_vars
 
     # serialize program
     copy_program = program.clone()

--- a/test/legacy_test/test_static_save_load.py
+++ b/test/legacy_test/test_static_save_load.py
@@ -1899,7 +1899,7 @@ class TestSaveLoadInferenceModel(unittest.TestCase):
             self.assertEqual(feed_target_names, ['x'])
             self.assertEqual(fetch_targets[0].shape, (10, 10))
             ops = [op.type for op in inference_program.block(0).ops]
-            self.assertEqual(ops, ['feed', 'elementwise_add', 'fetch'])
+            self.assertEqual(ops, ['feed', 'elementwise_add', 'scale', 'fetch'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
This reverts commit e32c77aa0c4b030408747071875834b52d63b7d8.
Pcard-71500