### PR TITLE
【PIR API adaptor No.106】 Migrate paddle.i0e into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6708,7 +6708,7 @@ def i0e(x, name=None):
             Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.99999994, 0.46575963, 0.30850831, 0.24300036, 0.20700191])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.i0e(x)
     else:
         check_variable_and_dtype(x, "x", ["float32", "float64"], "i0e")

--- a/test/legacy_test/test_i0_op.py
+++ b/test/legacy_test/test_i0_op.py
@@ -20,7 +20,6 @@ from scipy import special
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(100)
 paddle.seed(100)
@@ -45,7 +44,6 @@ class TestI0API(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
 
-    @test_with_pir_api
     def test_api_static(self):
         def run(place):
             paddle.enable_static()
@@ -132,14 +130,13 @@ class TestI0Op(OpTest):
         self.target = output_i0(self.inputs['x'])
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output()
 
     def test_check_grad(self):
         self.check_grad(
             ['x'],
             'out',
             user_defined_grads=[ref_i0_grad(self.case, 1 / self.case.size)],
-            check_pir=True,
         )
 
 

--- a/test/legacy_test/test_i0_op.py
+++ b/test/legacy_test/test_i0_op.py
@@ -20,6 +20,7 @@ from scipy import special
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(100)
 paddle.seed(100)
@@ -44,6 +45,7 @@ class TestI0API(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
 
+    @test_with_pir_api
     def test_api_static(self):
         def run(place):
             paddle.enable_static()
@@ -130,13 +132,14 @@ class TestI0Op(OpTest):
         self.target = output_i0(self.inputs['x'])
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
             ['x'],
             'out',
             user_defined_grads=[ref_i0_grad(self.case, 1 / self.case.size)],
+            check_pir=True,
         )
 
 

--- a/test/legacy_test/test_i0e_op.py
+++ b/test/legacy_test/test_i0e_op.py
@@ -20,6 +20,7 @@ from scipy import special
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(100)
 paddle.seed(100)
@@ -44,10 +45,12 @@ class TestI0eAPI(unittest.TestCase):
 
     def setUp(self):
         self.x = np.array(self.DATA).astype(self.DTYPE)
+        self.out_ref = output_i0e(self.x)
         self.place = [paddle.CPUPlace()]
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
 
+    @test_with_pir_api
     def test_api_static(self):
         def run(place):
             paddle.enable_static()
@@ -62,8 +65,7 @@ class TestI0eAPI(unittest.TestCase):
                     feed={"x": self.x},
                     fetch_list=[y],
                 )
-                out_ref = output_i0e(self.x)
-                np.testing.assert_allclose(out_ref, res[0], rtol=1e-5)
+                np.testing.assert_allclose(self.out_ref, res[0], rtol=1e-5)
             paddle.disable_static()
 
         for place in self.place:
@@ -134,13 +136,14 @@ class TestI0eOp(OpTest):
         self.target = output_i0e(self.inputs['x'])
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
             ['x'],
             'out',
             user_defined_grads=[ref_i0e_grad(self.case, 1 / self.case.size)],
+            check_pir=True,
         )
 
 


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Description

PIR API 推全升级
将 `paddle.i0e` 迁移升级至 pir，并更新单测

单测覆盖率：8/8

问题：
~~对于 `i0e_` 缺少对应的 inplace 算子，是否需要添加？~~

https://github.com/PaddlePaddle/Paddle/issues/58067