### PR TITLE
[xdoctest] reformat example code with google style in remaining files

### DIFF
--- a/python/paddle/distributed/fleet/dataset/dataset.py
+++ b/python/paddle/distributed/fleet/dataset/dataset.py
@@ -1240,10 +1240,10 @@ class InMemoryDataset(DatasetBase):
         Examples:
             .. code-block:: python
 
-            import paddle
-            paddle.enable_static()
-            dataset = paddle.distributed.InMemoryDataset()
-            dataset._set_fea_eval(1000000, True)
+                >>> import paddle
+                >>> paddle.enable_static()
+                >>> dataset = paddle.distributed.InMemoryDataset()
+                >>> dataset._set_fea_eval(1000000, True)
 
         """
         if fea_eval:
@@ -1299,11 +1299,10 @@ class QueueDataset(DatasetBase):
     QueueDataset, it will process data streamly.
 
     Examples:
+        .. code-block:: python
 
-    .. code-block:: python
-
-    import paddle
-    dataset = paddle.distributed.QueueDataset()
+            >>> import paddle
+            >>> dataset = paddle.distributed.QueueDataset()
 
     """
 
@@ -1510,6 +1509,7 @@ class BoxPSDataset(InMemoryDataset):
         """
         End Pass
         Notify BoxPS that current pass ended
+
         Examples:
             .. code-block:: python
 
@@ -1523,6 +1523,7 @@ class BoxPSDataset(InMemoryDataset):
         """
         Wait async preload done
         Wait Until Feed Pass Done
+
         Examples:
             .. code-block:: python
 
@@ -1539,6 +1540,7 @@ class BoxPSDataset(InMemoryDataset):
     def load_into_memory(self):
         """
         Load next pass into memory and notify boxps to fetch its emb from SSD
+
         Examples:
             .. code-block:: python
 
@@ -1555,6 +1557,7 @@ class BoxPSDataset(InMemoryDataset):
     def preload_into_memory(self):
         """
         Begin async preload next pass while current pass may be training
+
         Examples:
             .. code-block:: python
 
@@ -1588,11 +1591,13 @@ class BoxPSDataset(InMemoryDataset):
             slots(list[string]): the set of slots(string) to do slots shuffle.
 
         Examples:
-            import paddle
-            dataset = paddle.distributed.fleet.BoxPSDataset()
-            dataset.set_merge_by_lineid()
-            #suppose there is a slot 0
-            dataset.slots_shuffle(['0'])
+            .. code-block:: python
+
+                >>> import paddle
+                >>> dataset = paddle.distributed.fleet.BoxPSDataset()
+                >>> dataset._set_merge_by_lineid()
+                >>> #suppose there is a slot 0
+                >>> dataset.slots_shuffle(['0'])
         """
         slots_set = set(slots)
         self.boxps.slots_shuffle(slots_set)

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -857,13 +857,13 @@ class ParallelEnv:
         Its value is equal to the value of the environment variable ``PADDLE_PG_TIMEOUT`` . The default value is 30 minutes.
 
         Examples:
-          .. code-block:: python
+            .. code-block:: python
 
-            # execute this command in terminal: export PADDLE_PG_TIMEOUT=1800000
-            import paddle.distributed as dist
+                >>> # execute this command in terminal: export PADDLE_PG_TIMEOUT=1800000
+                >>> import paddle.distributed as dist
 
-            env = dist.ParallelEnv()
-            # the pg_timeout of process group 1800000
+                >>> env = dist.ParallelEnv()
+                >>> # the pg_timeout of process group 1800000
         """
         return self._pg_timeout
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

commit d144f5c605 扫了一下，这两个文件里面有几个地方当时应该是没注意到～

还有那个 pir.py 以及 365～370 了～

修改如下文件的示例代码，使其通过 `xdoctest` 检查：

- `python/paddle/distributed/fleet/dataset/dataset.py`
- `python/paddle/distributed/parallel.py`

### Related links
 
- #55629
- #55295

@sunzhongkai588 @SigureMo @megemini 
