### PR TITLE
【PIR API adaptor No.54-56】Migrate some ops into pir

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1746,7 +1746,7 @@ def diag_embed(input, offset=0, dim1=-2, dim2=-1):
     if not isinstance(input, Variable):
         input = assign(input)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.diag_embed(input, offset, dim1, dim2)
 
     inputs = {'Input': [input]}
@@ -1883,7 +1883,7 @@ def diagflat(x, offset=0, name=None):
              [0, 0, 3, 0, 0],
              [0, 0, 0, 4, 0]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if len(x.shape) <= 1:
             return _C_ops.diag(x, offset, 0)
         else:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3757,7 +3757,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1, name=None):
              [0.97020894, 0.97786582]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.diagonal(x, offset, axis1, axis2)
     else:
 

--- a/test/legacy_test/test_diag_embed.py
+++ b/test/legacy_test/test_diag_embed.py
@@ -21,6 +21,7 @@ from op_test import OpTest, paddle_static_guard
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestDiagEmbedOp(OpTest):
@@ -31,7 +32,7 @@ class TestDiagEmbedOp(OpTest):
         self.outputs = {'Out': self.target}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def init_config(self):
         self.case = np.random.randn(2, 3).astype('float32')
@@ -51,6 +52,7 @@ class TestDiagEmbedOpCase1(TestDiagEmbedOp):
 
 
 class TestDiagEmbedAPICase(unittest.TestCase):
+    @test_with_pir_api
     def test_case1(self):
         with paddle_static_guard():
             diag_embed = np.random.randn(2, 3, 4).astype('float32')

--- a/test/legacy_test/test_diag_embed.py
+++ b/test/legacy_test/test_diag_embed.py
@@ -69,7 +69,6 @@ class TestDiagEmbedAPICase(unittest.TestCase):
             exe = base.Executor(place)
             results = exe.run(
                 main,
-                base.default_main_program(),
                 feed={"data1": diag_embed},
                 fetch_list=[out1, out2],
                 return_numpy=True,

--- a/test/legacy_test/test_diag_embed.py
+++ b/test/legacy_test/test_diag_embed.py
@@ -16,7 +16,7 @@ import inspect
 import unittest
 
 import numpy as np
-from op_test import OpTest, paddle_static_guard
+from op_test import OpTest
 
 import paddle
 from paddle import base
@@ -54,7 +54,10 @@ class TestDiagEmbedOpCase1(TestDiagEmbedOp):
 class TestDiagEmbedAPICase(unittest.TestCase):
     @test_with_pir_api
     def test_case1(self):
-        with paddle_static_guard():
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
             diag_embed = np.random.randn(2, 3, 4).astype('float32')
             data1 = paddle.static.data(
                 name='data1', shape=[2, 3, 4], dtype='float32'
@@ -65,6 +68,7 @@ class TestDiagEmbedAPICase(unittest.TestCase):
             place = core.CPUPlace()
             exe = base.Executor(place)
             results = exe.run(
+                main,
                 base.default_main_program(),
                 feed={"data1": diag_embed},
                 fetch_list=[out1, out2],

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -68,6 +69,7 @@ class TestDiagFlatAPI(unittest.TestCase):
         y = paddle.diagflat(x, offset=-1)
         np.testing.assert_allclose(y.numpy(), self.expected5, rtol=1e-05)
 
+    @test_with_pir_api
     def run_static(self, use_gpu=False):
         x = paddle.static.data(name='input', shape=[10, 10], dtype='float64')
         x2 = paddle.static.data(name='input2', shape=[20], dtype='float64')

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -71,17 +71,19 @@ class TestDiagFlatAPI(unittest.TestCase):
 
     @test_with_pir_api
     def run_static(self, use_gpu=False):
-        x = paddle.static.data(name='input', shape=[10, 10], dtype='float64')
-        x2 = paddle.static.data(name='input2', shape=[20], dtype='float64')
-        result0 = paddle.diagflat(x)
-        result3 = paddle.diagflat(x2)
-
-        place = paddle.CUDAPlace(0) if use_gpu else paddle.CPUPlace()
         main = paddle.static.Program()
         startup = paddle.static.Program()
         with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(
+                name='input', shape=[10, 10], dtype='float64'
+            )
+            x2 = paddle.static.data(name='input2', shape=[20], dtype='float64')
+            result0 = paddle.diagflat(x)
+            result3 = paddle.diagflat(x2)
+
+            place = paddle.CUDAPlace(0) if use_gpu else paddle.CPUPlace()
             exe = paddle.static.Executor(place)
-            exe.run(startup) 
+            exe.run(startup)
             res0, res3 = exe.run(
                 main,
                 feed={"input": self.input_np, 'input2': self.input_np2},

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -112,6 +112,7 @@ class TestDiagFlatAPI(unittest.TestCase):
         with paddle.static.program_guard(Program()):
             self.run_static(use_gpu=True)
 
+    @test_with_pir_api
     def test_fp16_with_gpu(self, use_gpu=False):
         if paddle.base.core.is_compiled_with_cuda():
             place = paddle.CUDAPlace(0)

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -81,7 +81,6 @@ class TestDiagFlatAPI(unittest.TestCase):
         startup = paddle.static.Program()
         with paddle.static.program_guard(main, startup):
             exe = paddle.static.Executor(place)
-            exe.run(paddle.static.default_startup_program())
             res0, res3 = exe.run(
                 main,
                 feed={"input": self.input_np, 'input2': self.input_np2},

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -81,6 +81,7 @@ class TestDiagFlatAPI(unittest.TestCase):
         startup = paddle.static.Program()
         with paddle.static.program_guard(main, startup):
             exe = paddle.static.Executor(place)
+            exe.run(startup) 
             res0, res3 = exe.run(
                 main,
                 feed={"input": self.input_np, 'input2': self.input_np2},

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -77,15 +77,19 @@ class TestDiagFlatAPI(unittest.TestCase):
         result3 = paddle.diagflat(x2)
 
         place = paddle.CUDAPlace(0) if use_gpu else paddle.CPUPlace()
-        exe = paddle.static.Executor(place)
-        exe.run(paddle.static.default_startup_program())
-        res0, res3 = exe.run(
-            feed={"input": self.input_np, 'input2': self.input_np2},
-            fetch_list=[result0, result3],
-        )
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            exe = paddle.static.Executor(place)
+            exe.run(paddle.static.default_startup_program())
+            res0, res3 = exe.run(
+                main,
+                feed={"input": self.input_np, 'input2': self.input_np2},
+                fetch_list=[result0, result3],
+            )
 
-        np.testing.assert_allclose(res0, self.expected0, rtol=1e-05)
-        np.testing.assert_allclose(res3, self.expected3, rtol=1e-05)
+            np.testing.assert_allclose(res0, self.expected0, rtol=1e-05)
+            np.testing.assert_allclose(res3, self.expected3, rtol=1e-05)
 
     def test_cpu(self):
         paddle.disable_static(place=paddle.CPUPlace())

--- a/test/legacy_test/test_diagonal_op.py
+++ b/test/legacy_test/test_diagonal_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -32,10 +33,10 @@ class TestDiagonalOp(OpTest):
         self.outputs = {'Out': self.target}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['Input'], 'Out')
+        self.check_grad(['Input'], 'Out', check_pir=True)
 
     def init_dtype(self):
         self.dtype = 'float64'
@@ -85,6 +86,7 @@ class TestDiagonalOpCase2(TestDiagonalOp):
             'Out',
             user_defined_grads=[self.grad_x],
             user_defined_grad_outputs=[self.grad_out],
+            check_pir=True,
         )
 
 
@@ -139,6 +141,7 @@ class TestDiagonalAPI(unittest.TestCase):
         self.x = np.random.random((10, 3, 4)).astype(np.float32)
         self.place = paddle.CPUPlace()
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -197,11 +200,11 @@ class TestDiagonalBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['Input'], 'Out')
+        self.check_grad_with_place(place, ['Input'], 'Out', check_pir=True)
 
     def init_config(self):
         self.case = np.random.randn(10, 5, 2).astype(np.float32)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description

PIR API 推全升级
将如下算子迁移升级至 pir，并更新单测
- diagflat（1/2）：总计 2 个单测，打开1个单测，1个单测用来测试error的
- diag_embed（3/3）
- diagonal（9/9）


- https://github.com/PaddlePaddle/Paddle/issues/58067

