### PR TITLE
【PIR API adaptor No.48、49】 Migrate cummax/min into pir

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -495,8 +495,8 @@
     data_type : out_grad
 
 - backward_op : cummax_grad
-  forward : cummax(Tensor x, int axis=-1, int dtype=3) -> Tensor(out), Tensor(indices)
-  args : (Tensor x, Tensor indices, Tensor out_grad, int axis, int dtype)
+  forward : cummax(Tensor x, int axis=-1, DataType dtype = DataType::INT64) -> Tensor(out), Tensor(indices)
+  args : (Tensor x, Tensor indices, Tensor out_grad, int axis, DataType dtype)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta
@@ -505,8 +505,8 @@
     func : cummax_grad
 
 - backward_op : cummin_grad
-  forward : cummin(Tensor x, int axis=-1, int dtype=3) -> Tensor(out), Tensor(indices)
-  args : (Tensor x, Tensor indices, Tensor out_grad, int axis, int dtype)
+  forward : cummin(Tensor x, int axis=-1, DataType dtype = DataType::INT64) -> Tensor(out), Tensor(indices)
+  args : (Tensor x, Tensor indices, Tensor out_grad, int axis, DataType dtype)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -503,6 +503,7 @@
     param: [x]
   kernel :
     func : cummax_grad
+    data_type : out_grad
 
 - backward_op : cummin_grad
   forward : cummin(Tensor x, int axis=-1, DataType dtype = DataType::INT64) -> Tensor(out), Tensor(indices)
@@ -513,6 +514,7 @@
     param: [x]
   kernel :
     func : cummin_grad
+    data_type : out_grad
 
 - backward_op : cumprod_grad
   forward : cumprod (Tensor x, int dim) -> Tensor(out)

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -602,7 +602,7 @@
   backward : cross_entropy_with_softmax_grad
 
 - op : cummax
-  args : (Tensor x, int axis=-1, int dtype=3)
+  args : (Tensor x, int axis=-1, DataType dtype = DataType::INT64)
   output : Tensor(out), Tensor(indices)
   infer_meta :
     func : CumWithIndicesInferMeta
@@ -611,7 +611,7 @@
   backward : cummax_grad
 
 - op : cummin
-  args : (Tensor x, int axis=-1, int dtype=3)
+  args : (Tensor x, int axis=-1, DataType dtype = DataType::INT64)
   output : Tensor(out), Tensor(indices)
   infer_meta :
     func : CumWithIndicesInferMeta

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -608,6 +608,7 @@
     func : CumWithIndicesInferMeta
   kernel :
     func : cummax
+    data_type : x
   backward : cummax_grad
 
 - op : cummin
@@ -617,6 +618,7 @@
     func : CumWithIndicesInferMeta
   kernel :
     func : cummin
+    data_type : x
   backward : cummin_grad
 
 - op : cumprod

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -549,17 +549,17 @@ void CumScalarAxisInferMeta(const MetaTensor& x,
 
 void CumWithIndicesInferMeta(const MetaTensor& x,
                              int axis,
-                             int dtype,
+                             DataType dtype,
                              MetaTensor* out,
                              MetaTensor* indices) {
   auto x_dims = x.dims();
-  auto indices_type = phi::TransToPhiDataType(dtype);
   PADDLE_ENFORCE_EQ(
-      (indices_type == DataType::INT32 || indices_type == DataType::INT64),
+      (dtype == DataType::INT32 || dtype == DataType::INT64),
       true,
-      phi::errors::InvalidArgument("dtype of indices must be int32 or int64"));
+      phi::errors::InvalidArgument(
+          "dtype of indices must be DataType::INT32 or DataType::INT64"));
 
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     int _axis = 0;
     if (axis < 0) {
       _axis = axis + x_dims.size();
@@ -606,7 +606,7 @@ void CumWithIndicesInferMeta(const MetaTensor& x,
   out->set_dtype(x.dtype());
   out->share_lod(x);
   indices->set_dims(x_dims);
-  indices->set_dtype(indices_type);
+  indices->set_dtype(dtype);
   indices->share_lod(x);
 }
 

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -137,7 +137,7 @@ void CumScalarAxisInferMeta(const MetaTensor& x,
 
 void CumWithIndicesInferMeta(const MetaTensor& x,
                              int axis,
-                             int dtype,
+                             DataType dtype,
                              MetaTensor* out,
                              MetaTensor* indices);
 

--- a/paddle/phi/kernels/cpu/cum_maxmin_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_maxmin_grad_kernel.cc
@@ -28,7 +28,7 @@ void CummaxGradKernel(const Context& dev_ctx,
                       const DenseTensor& indices,
                       const DenseTensor& out_grad,
                       int axis,
-                      int dtype,
+                      DataType dtype,
                       DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::SetConstant<Context, T> functor;
@@ -36,11 +36,10 @@ void CummaxGradKernel(const Context& dev_ctx,
   if (axis < 0) {
     axis = axis + x.dims().size();
   }
-  auto indices_type = phi::TransToPhiDataType(dtype);
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     phi::funcs::cpu_scatter_add_kernel<T, int32_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     phi::funcs::cpu_scatter_add_kernel<T, int64_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
   }
@@ -52,7 +51,7 @@ void CumminGradKernel(const Context& dev_ctx,
                       const DenseTensor& indices,
                       const DenseTensor& out_grad,
                       int axis,
-                      int dtype,
+                      DataType dtype,
                       DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::SetConstant<Context, T> functor;
@@ -60,11 +59,10 @@ void CumminGradKernel(const Context& dev_ctx,
   if (axis < 0) {
     axis = axis + x.dims().size();
   }
-  auto indices_type = phi::TransToPhiDataType(dtype);
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     phi::funcs::cpu_scatter_add_kernel<T, int32_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     phi::funcs::cpu_scatter_add_kernel<T, int64_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
   }

--- a/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
@@ -149,14 +149,13 @@ template <typename T, typename Context>
 void CummaxKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
-                  int dtype,
+                  DataType dtype,
                   DenseTensor* out,
                   DenseTensor* indices) {
-  auto indices_type = phi::TransToPhiDataType(dtype);
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     ScanWithIndicesKernel<T, int32_t, std::greater_equal<T>, Context>(
         dev_ctx, x, axis, out, indices);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     ScanWithIndicesKernel<T, int64_t, std::greater_equal<T>, Context>(
         dev_ctx, x, axis, out, indices);
   }
@@ -166,14 +165,13 @@ template <typename T, typename Context>
 void CumminKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
-                  int dtype,
+                  DataType dtype,
                   DenseTensor* out,
                   DenseTensor* indices) {
-  auto indices_type = phi::TransToPhiDataType(dtype);
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     ScanWithIndicesKernel<T, int32_t, std::less_equal<T>, Context>(
         dev_ctx, x, axis, out, indices);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     ScanWithIndicesKernel<T, int64_t, std::less_equal<T>, Context>(
         dev_ctx, x, axis, out, indices);
   }

--- a/paddle/phi/kernels/cum_maxmin_grad_kernel.h
+++ b/paddle/phi/kernels/cum_maxmin_grad_kernel.h
@@ -24,7 +24,7 @@ void CummaxGradKernel(const Context& dev_ctx,
                       const DenseTensor& indices,
                       const DenseTensor& out_grad,
                       int axis,
-                      int dtype,
+                      DataType dtype,
                       DenseTensor* x_grad);
 
 template <typename T, typename Context>
@@ -33,7 +33,7 @@ void CumminGradKernel(const Context& dev_ctx,
                       const DenseTensor& indices,
                       const DenseTensor& out_grad,
                       int axis,
-                      int dtype,
+                      DataType dtype,
                       DenseTensor* x_grad);
 
 }  // namespace phi

--- a/paddle/phi/kernels/cum_maxmin_kernel.h
+++ b/paddle/phi/kernels/cum_maxmin_kernel.h
@@ -22,7 +22,7 @@ template <typename T, typename Context>
 void CummaxKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
-                  int dtype,
+                  DataType dtype,
                   DenseTensor* out,
                   DenseTensor* indices);
 
@@ -30,7 +30,7 @@ template <typename T, typename Context>
 void CumminKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
-                  int dtype,
+                  DataType dtype,
                   DenseTensor* out,
                   DenseTensor* indices);
 

--- a/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
@@ -28,7 +28,7 @@ void CummaxGradKernel(const Context& dev_ctx,
                       const DenseTensor& indices,
                       const DenseTensor& out_grad,
                       int axis,
-                      int dtype,
+                      DataType dtype,
                       DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::SetConstant<Context, T> functor;
@@ -36,11 +36,11 @@ void CummaxGradKernel(const Context& dev_ctx,
   if (axis < 0) {
     axis = axis + x.dims().size();
   }
-  auto indices_type = phi::TransToPhiDataType(dtype);
-  if (indices_type == DataType::INT32) {
+
+  if (dtype == DataType::INT32) {
     phi::funcs::gpu_scatter_add_kernel<T, int32_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
   }
@@ -52,7 +52,7 @@ void CumminGradKernel(const Context& dev_ctx,
                       const DenseTensor& indices,
                       const DenseTensor& out_grad,
                       int axis,
-                      int dtype,
+                      DataType dtype,
                       DenseTensor* x_grad) {
   dev_ctx.template Alloc<T>(x_grad);
   phi::funcs::SetConstant<Context, T> functor;
@@ -60,11 +60,11 @@ void CumminGradKernel(const Context& dev_ctx,
   if (axis < 0) {
     axis = axis + x.dims().size();
   }
-  auto indices_type = phi::TransToPhiDataType(dtype);
-  if (indices_type == DataType::INT32) {
+
+  if (dtype == DataType::INT32) {
     phi::funcs::gpu_scatter_add_kernel<T, int32_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
         *x_grad, axis, indices, out_grad, dev_ctx);
   }

--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
@@ -312,17 +312,16 @@ template <typename T, typename Context>
 void CummaxKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
-                  int dtype,
+                  DataType dtype,
                   DenseTensor* out,
                   DenseTensor* indices) {
-  auto indices_type = phi::TransToPhiDataType(dtype);
   T init = std::is_floating_point<T>::value
                ? (-1 * std::numeric_limits<T>::infinity())
                : std::numeric_limits<T>::lowest();
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     ScanWithIndicesKernel<T, int32_t, std::greater_equal<T>, Context>(
         dev_ctx, x, axis, init, out, indices);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     ScanWithIndicesKernel<T, int64_t, std::greater_equal<T>, Context>(
         dev_ctx, x, axis, init, out, indices);
   }
@@ -332,16 +331,15 @@ template <typename T, typename Context>
 void CumminKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   int axis,
-                  int dtype,
+                  DataType dtype,
                   DenseTensor* out,
                   DenseTensor* indices) {
-  auto indices_type = phi::TransToPhiDataType(dtype);
   T init = std::is_floating_point<T>::value ? std::numeric_limits<T>::infinity()
                                             : std::numeric_limits<T>::max();
-  if (indices_type == DataType::INT32) {
+  if (dtype == DataType::INT32) {
     ScanWithIndicesKernel<T, int32_t, std::less_equal<T>, Context>(
         dev_ctx, x, axis, init, out, indices);
-  } else if (indices_type == DataType::INT64) {
+  } else if (dtype == DataType::INT64) {
     ScanWithIndicesKernel<T, int64_t, std::less_equal<T>, Context>(
         dev_ctx, x, axis, init, out, indices);
   }

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4034,7 +4034,7 @@ def cummax(x, axis=None, dtype='int64', name=None):
     check_dtype(dtype, 'dtype', ['int32', 'int64'], 'cummax')
     dtype = convert_np_dtype_to_dtype_(dtype)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.cummax(x, axis, dtype)
     else:
         check_variable_and_dtype(
@@ -4119,7 +4119,7 @@ def cummin(x, axis=None, dtype='int64', name=None):
     check_dtype(dtype, 'dtype', ['int32', 'int64'], 'cummin')
     dtype = convert_np_dtype_to_dtype_(dtype)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.cummin(x, axis, dtype)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_cummax_op.py
+++ b/test/legacy_test/test_cummax_op.py
@@ -165,20 +165,19 @@ class TestCummaxAPI(unittest.TestCase):
 
             place = base.CUDAPlace(0) if use_gpu else base.CPUPlace()
             exe = base.Executor(place)
-            exe.run(base.default_startup_program())
             out = exe.run(
                 feed={'x': data_np},
                 fetch_list=[
-                    y1.name,
-                    indices1.name,
-                    y2.name,
-                    indices2.name,
-                    y3.name,
-                    indices3.name,
-                    y4.name,
-                    indices4.name,
-                    y5.name,
-                    indices5.name,
+                    y1,
+                    indices1,
+                    y2,
+                    indices2,
+                    y3,
+                    indices3,
+                    y4,
+                    indices4,
+                    y5,
+                    indices5,
                 ],
             )
 

--- a/test/legacy_test/test_cummax_op.py
+++ b/test/legacy_test/test_cummax_op.py
@@ -92,11 +92,11 @@ class TestCummaxOp(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad(['x'], 'out')
+        self.check_grad(['x'], 'out', check_pir=True)
 
 
 class TestCummaxOpAxis1(TestCummaxOp):
@@ -152,6 +152,7 @@ class TestCummaxAPI(unittest.TestCase):
         np.testing.assert_array_equal(z, y.numpy())
         np.testing.assert_array_equal(ind, indices.numpy())
 
+    @test_with_pir_api
     def run_static(self, use_gpu=False):
         with base.program_guard(base.Program()):
             data_np = np.random.random((100, 100)).astype(np.float32)

--- a/test/legacy_test/test_cummax_op.py
+++ b/test/legacy_test/test_cummax_op.py
@@ -21,6 +21,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def cummax_dim2(arr, axis=None):
@@ -218,6 +219,7 @@ class TestCummaxAPI(unittest.TestCase):
         paddle.enable_static()
         with base.program_guard(base.Program()):
 
+            @test_with_pir_api
             def test_x_type():
                 data = [1, 2, 3]
                 y, indices = paddle.cummax(data, axis=0)

--- a/test/legacy_test/test_cummin_op.py
+++ b/test/legacy_test/test_cummin_op.py
@@ -165,20 +165,19 @@ class TestCumminAPI(unittest.TestCase):
 
             place = base.CUDAPlace(0) if use_gpu else base.CPUPlace()
             exe = base.Executor(place)
-            exe.run(base.default_startup_program())
             out = exe.run(
                 feed={'x': data_np},
                 fetch_list=[
-                    y1.name,
-                    indices1.name,
-                    y2.name,
-                    indices2.name,
-                    y3.name,
-                    indices3.name,
-                    y4.name,
-                    indices4.name,
-                    y5.name,
-                    indices5.name,
+                    y1,
+                    indices1,
+                    y2,
+                    indices2,
+                    y3,
+                    indices3,
+                    y4,
+                    indices4,
+                    y5,
+                    indices5,
                 ],
             )
 

--- a/test/legacy_test/test_cummin_op.py
+++ b/test/legacy_test/test_cummin_op.py
@@ -92,11 +92,11 @@ class TestCumminOp(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad(['x'], 'out')
+        self.check_grad(['x'], 'out', check_pir=True)
 
 
 class TestCuinOpAxis1(TestCumminOp):
@@ -152,6 +152,7 @@ class TestCumminAPI(unittest.TestCase):
         np.testing.assert_array_equal(z, y.numpy())
         np.testing.assert_array_equal(ind, indices.numpy())
 
+    @test_with_pir_api
     def run_static(self, use_gpu=False):
         with base.program_guard(base.Program()):
             data_np = np.random.random((100, 100)).astype(np.float32)

--- a/test/legacy_test/test_cummin_op.py
+++ b/test/legacy_test/test_cummin_op.py
@@ -21,6 +21,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def cummin_dim2(arr, axis=None):
@@ -218,6 +219,7 @@ class TestCumminAPI(unittest.TestCase):
         paddle.enable_static()
         with base.program_guard(base.Program()):
 
+            @test_with_pir_api
             def test_x_type():
                 data = [1, 2, 3]
                 y, indices = paddle.cummin(data, axis=0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
- https://github.com/PaddlePaddle/Paddle/issues/58067



cummin 单测覆盖率：11/11
cummax 单测覆盖率：11/11

<!--

```shell
ValueError: (InvalidArgument) cummin(): argument (position 3) must be int, 
but got paddle.base.libpaddle.DataType 
(at /home/aistudio/Paddle/paddle/fluid/pybind/op_function_common.cc:158)
```

以下三处加上 `check_pir = True` 或 `@test_with_pir_api` 会 raise 上边的问题
![image](https://github.com/PaddlePaddle/Paddle/assets/44900829/98cb73e3-2ca3-46ae-b3bc-59e6fc579702)
![image](https://github.com/PaddlePaddle/Paddle/assets/44900829/ef3b9f03-c7f2-4f9c-82a7-53a061dfe30c)
-->
