### PR TITLE
[Dy2St] pir dy2st unittest verification - Part 1

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils_new.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils_new.py
@@ -45,7 +45,7 @@ class MyTest2(MyTest):
 """
 
 logger = logging.getLogger("Dygraph to static utils")
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARNING)
 
 
 class ToStaticMode(Flag):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

#### 背景

从流程图的`dy2st`开始垂直向下为早期 `legacy IR` 形成的动转静模式。

在现阶段如果想要执行`PIR executor`需要经过一层`ProaramTranslator`转写。

我们的目标就是让他使用一套完整的`PIR dy2st`, 我们也称之为最终态(理想态), 也就是右侧`PIR dy2st`垂直向下的部分。


```mermaid
graph TB
    A[dy2st] --> B[legacy static APi branch] 
    B --> C[legacy IR]
    C --> D[legacy IR executor]

    E[PIR dy2st] --> F[PIR static API branch]
    F --> G[PIR]
    G --> H[PIR executor]

    C -->|ProaramTranslator| G
```

#### 目标

从背景可以看出我们目前需要支持的单测有三种 IR 工作模式, 以及两种 dy2st 模式。

这样组合之后我们就能得到新机制需要运行的单测组合: 2*3=6 (如下图)

```mermaid
graph TB
    A[SOT] --> B[legacy IR] 
    A --> C[PIR EXE]
    A --> D[PIR API]

    E[AST] --> B
    E[AST] --> C
    E[AST] --> D

```

#### 修改

1. 模式修改

原有机制会对`ToStaticMode.PIR_AST` 和 `IrMode.LEGACY_IR` 进行组合, 这明显不合理, 我们不可能在一个执行器中跑两套 IR 模式

所以首先对组合模式进行了修改，将`ToStaticMode.PIR_AST` 模式下沉至 `IrMode.PIR_EXE`, 这样我们就能对不同动转静模式和 IR 模式进行组合测试

`PIR_EXE`对应的就是走的`ProaramTranslator`达到运行`PIR executor`模式。
`PIR_API`对应的就是走的全 PIR 模式, 也就是我们的最终态。

2. 为新的组合模式添加装饰器

`test_legacy_and_pir_api`和`test_legacy_and_pir_api_and_pir_exe`装饰器

3. pir api 推全

任务列表: #58633 