### PR TITLE
【PIR API adaptor No.131】 Migrate paddle.Tensor.log2 into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3348,7 +3348,7 @@ def log2(x, name=None):
             Tensor(shape=[1], dtype=float64, place=Place(cpu), stop_gradient=True,
             [1.])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.log2(x)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3449,8 +3449,9 @@ class TestLog2(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
+    @test_with_pir_api
     def test_api(self):
         with static_guard():
             with paddle.static.program_guard(
@@ -3488,6 +3489,7 @@ class TestLog2_ZeroDim(TestLog2):
 
 
 class TestLog2_Op_Int(unittest.TestCase):
+    @test_with_pir_api
     def test_api_int(self):
         paddle.disable_static()
         for dtype in ['int32', 'int64', 'float16']:
@@ -3498,6 +3500,7 @@ class TestLog2_Op_Int(unittest.TestCase):
             np.testing.assert_allclose(y.numpy(), x_expect, rtol=1e-3)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_api_bf16(self):
         with static_guard():
             with static.program_guard(

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3489,7 +3489,6 @@ class TestLog2_ZeroDim(TestLog2):
 
 
 class TestLog2_Op_Int(unittest.TestCase):
-    @test_with_pir_api
     def test_api_int(self):
         paddle.disable_static()
         for dtype in ['int32', 'int64', 'float16']:
@@ -4781,9 +4780,9 @@ create_test_act_fp16_class(TestCELU)
 create_test_act_fp16_class(TestReciprocal)
 create_test_act_fp16_class(TestLog, check_prim=True, check_pir=True)
 if core.is_compiled_with_rocm():
-    create_test_act_fp16_class(TestLog2)
+    create_test_act_fp16_class(TestLog2, check_pir=True)
 else:
-    create_test_act_fp16_class(TestLog2)
+    create_test_act_fp16_class(TestLog2, check_pir=True)
 create_test_act_fp16_class(TestLog10, check_pir=True)
 create_test_act_fp16_class(TestLog1p)
 create_test_act_fp16_class(TestSquare, check_pir=True)
@@ -4931,9 +4930,9 @@ create_test_act_bf16_class(TestCELU)
 create_test_act_bf16_class(TestReciprocal)
 create_test_act_bf16_class(TestLog, check_prim=True, check_pir=True)
 if core.is_compiled_with_rocm():
-    create_test_act_bf16_class(TestLog2)
+    create_test_act_bf16_class(TestLog2, check_pir=True)
 else:
-    create_test_act_bf16_class(TestLog2)
+    create_test_act_bf16_class(TestLog2, check_pir=True)
 create_test_act_bf16_class(TestLog10, check_pir=True)
 create_test_act_bf16_class(TestLog1p)
 create_test_act_bf16_class(TestSquare, check_pir=True)

--- a/test/legacy_test/test_op_name_conflict.py
+++ b/test/legacy_test/test_op_name_conflict.py
@@ -18,9 +18,11 @@ import numpy as np
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestOpNameConflict(unittest.TestCase):
+    @test_with_pir_api
     def test_conflict(self):
         paddle.enable_static()
         main = base.Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 paddle.Tensor.log2 迁移升级至 pir，并更新单测

单测覆盖率：6/6
https://github.com/PaddlePaddle/Paddle/issues/58067