### PR TITLE
support more dtype on paddle.set_default_dtype

### DIFF
--- a/python/paddle/framework/framework.py
+++ b/python/paddle/framework/framework.py
@@ -15,6 +15,9 @@
 
 import numpy as np
 
+import paddle
+from paddle.base.data_feeder import convert_dtype
+
 # TODO: define framework api
 from paddle.base.layer_helper_base import LayerHelperBase
 
@@ -26,7 +29,7 @@ def set_default_dtype(d):
     Set default dtype. The default dtype is initially float32.
 
     Args:
-        d(string|np.dtype): the dtype to make the default. It only
+        d(string|paddle.dtype|np.dtype): the dtype to make the default. It only
                             supports float16, bfloat16, float32 and float64.
 
     Returns:
@@ -49,6 +52,8 @@ def set_default_dtype(d):
                 ", but received %s" % d.__name__
             )
     else:
+        if isinstance(d, paddle.dtype):
+            d = convert_dtype(d)
         # This branch is for str
         if d in ['float16', 'float32', 'float64', 'bfloat16']:
             # NOTE(SigureMo): Since the np.dtype object is not an instance of

--- a/test/legacy_test/test_default_dtype.py
+++ b/test/legacy_test/test_default_dtype.py
@@ -48,6 +48,15 @@ class TestDefaultType(unittest.TestCase):
         set_default_dtype(np.float16)
         self.assertEqual("float16", get_default_dtype())
 
+        set_default_dtype(paddle.float64)
+        self.assertEqual("float64", get_default_dtype())
+
+        set_default_dtype(paddle.float32)
+        self.assertEqual("float32", get_default_dtype())
+
+        set_default_dtype(paddle.float16)
+        self.assertEqual("float16", get_default_dtype())
+
 
 class TestDefaultTypeInLayer(unittest.TestCase):
     def test_bfloat16(self):
@@ -60,8 +69,10 @@ class TestRaiseError(unittest.TestCase):
     def test_error(self):
         self.assertRaises(TypeError, set_default_dtype, "int32")
         self.assertRaises(TypeError, set_default_dtype, np.int32)
+        self.assertRaises(TypeError, set_default_dtype, paddle.int32)
         self.assertRaises(TypeError, set_default_dtype, "int64")
         self.assertRaises(TypeError, set_default_dtype, np.int64)
+        self.assertRaises(TypeError, set_default_dtype, paddle.int64)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
### PR changes
APIs 
### Description
Pcard-73263
现有的paddle.set_default_dtype不支持paddle原生数据类型输入，这是及其不合理的，对其进行修复。