### PR TITLE
[CustomDevice] Fix setting default device before loading custom device

### DIFF
--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -388,9 +388,10 @@ def _contain_var(list_or_tuple):
     return False
 
 
-def get_int_tensor_list(
-    ele_list, place=_current_expected_place(), default_dtype='int64'
-):
+def get_int_tensor_list(ele_list, place=None, default_dtype='int64'):
+    if place is None:
+        place = _current_expected_place()
+
     int_tensor_list = []
     for ele in ele_list:
         if isinstance(ele, paddle.pir.OpResult):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->

API的默认参数使用函数获取，会在import 该API时获取调用函数获取默认值，该函数首次调用会设置默认设备，此时自定义设备还未加载，导致有custom device插件时，默认设备始终为CPU



