### PR TITLE
[AutoParallel] Remove p2r in forward api

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -109,6 +109,7 @@ phi::DenseTensor ReshardXToReplicated(
     phi::distributed::TensorDistAttr dist_attr(dist_tensor->dist_attr());
     std::vector<int64_t> dims_mapping(dist_tensor->dims().size(), -1);
     dist_attr.set_dims_mapping(dims_mapping);
+    dist_attr.clean_partial_status();
 
     // reshard to replicate dist tensor
     auto* func =

--- a/paddle/phi/api/yaml/generator/dist_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_api_gen.py
@@ -55,9 +55,8 @@ MAIN_DIST_BRANCH_TEMPLATE = """
       // 7. Infer Local DenseTensor Meta{}
       // 8. DenseTensor Kernel Call{}
     }}\n
-    // 9. Reshard Partial Output to Replicated (Temporary){}\n
-    // 10. Set Output Dist Attr For Default Impl{}\n
-    // 11. Return
+    // 9. Set Output Dist Attr For Default Impl{}\n
+    // 10. Return
     {}
   }}
 """
@@ -361,17 +360,7 @@ VECTOR_SET_DIST_OUT_DIMS = """
 PREFIX_VECTOR_TENSOR_NAME = "dense_input_"
 SUFFIX_VECTOR_TENSOR_NAME = "_vec"
 
-# 9. Reshard Partial Output to Replicated
-RESHARD_P2R_SINGLE_OUTPUT_TEMPLATE = """
-    dev_ctx = phi::distributed::GetDistTensorDeviceContext(dist_out);
-    ReshardOutputPartialAxisToReplicated(dev_ctx, dist_out);"""
-RESHARD_P2R_MULTI_SINGLE_OUTPUT_TEMPLATE = """
-    dev_ctx = phi::distributed::GetDistTensorDeviceContext(dist_out_{idx});
-    ReshardOutputPartialAxisToReplicated(dev_ctx, dist_out_{idx});"""
-UNSUPPORTED_RESHARD_OUTPUT_COMMENT_TEMPLATE = """
-      // API `{}` does not need to support ReshardOutput now."""
-
-# 10. Set Output DistAttr for Default impl
+# 9. Set Output DistAttr for Default impl
 # Dist Branch will not generated in the API that doesn't have input tensor.
 CURRENT_PROCESS_MESH_TEMPLATE = """
     auto current_process_mesh = paddle::holds_alternative<phi::distributed::TensorDistAttr>(spmd_info.first[0]) ?
@@ -1363,36 +1352,6 @@ class DistForwardAPI(ForwardAPI):
                     result += MULTI_SINGLE_SET_DIST_OUT_DIMS.format(i, i)
         return result
 
-    def generate_reshard_partial_out_to_replicated_code(self) -> str:
-        reshard_p2r_code = ""
-        if self.infer_meta['spmd_rule'] is not None:
-            output_num = len(self.outputs['types'])
-            if output_num == 1:
-                if self.outputs['types'][0] == 'Tensor':
-                    reshard_p2r_code += RESHARD_P2R_SINGLE_OUTPUT_TEMPLATE
-                else:
-                    self.vector_output_size_assertion_check()
-            elif output_num > 1:
-                for i, out_type in enumerate(self.outputs['types']):
-                    if out_type == 'Tensor':
-                        reshard_p2r_code += (
-                            RESHARD_P2R_MULTI_SINGLE_OUTPUT_TEMPLATE.format(
-                                idx=i
-                            )
-                        )
-                    else:
-                        self.vector_output_size_assertion_check()
-            else:
-                raise ValueError(
-                    f"{self.api} : Output error: the output should not be empty."
-                )
-        else:
-            reshard_p2r_code = (
-                UNSUPPORTED_RESHARD_OUTPUT_COMMENT_TEMPLATE.format(self.api)
-            )
-
-        return reshard_p2r_code
-
     def generate_output_dist_attr_setting(self) -> str:
         set_out_dist_attr_code = ""
         if self.generate_general_infer_spmd is True:
@@ -1432,7 +1391,6 @@ class DistForwardAPI(ForwardAPI):
             self.generate_prepare_data_code(),
             self.generate_infer_meta_code(),
             self.generate_kernel_call_code(),
-            self.generate_reshard_partial_out_to_replicated_code(),
             self.generate_output_dist_attr_setting(),
             self.generate_return_code(),
         )

--- a/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
@@ -36,7 +36,7 @@ MAIN_DIST_BRANCH_TEMPLATE = """
       // 8. Infer Local DenseTensor Meta{}
       // 9. DenseTensor Kernel Call{}
     }}
-    // 10. Reshard Partial Output to Replicated (Temporary){}\n
+    // 10. Reshard Kernel Output to API output{}\n
     // 11. Return
     {}
   }}

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -49,7 +49,6 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
   VLOG(3) << "Call RToPReshardFunction Eval";
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   int64_t local_rank = GetCurRankCoordInMesh(out_process_mesh)[0];
-  IntArray shape(in.dims().Get(), in.dims().size());
   const auto& in_reduce_type = out_dist_attr.partial_status().at(0);
 
   if (local_rank != 0) {
@@ -59,6 +58,7 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
           dev_ctx, Assign, in.value(), GetMutableTensor(out));
     } else {
       // reset the physical tensor to zero
+      IntArray shape(in.local_dims().Get(), in.local_dims().size());
       RESHARD_FUNCTOR(
           dev_ctx, Full, in.dtype(), shape, 0, GetMutableTensor(out));
     }

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h
@@ -75,14 +75,14 @@ CommContext* CreateOrGetCommContext(const DeviceContext& dev_ctx,
 #define RESHARD_FUNCTOR_IMPL(dev_ctx, fn_name, dtype, ...)            \
   do {                                                                \
     if (phi::CPUContext::classof(dev_ctx)) {                          \
-      VLOG(4) << "Call `" << #fn_name << "` in Resharding on GPU.";   \
+      VLOG(4) << "Call `" << #fn_name << "` in Resharding on CPU.";   \
       PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(                  \
           dtype, #fn_name, ([&] {                                     \
             fn_name<data_t>(static_cast<const CPUContext&>(*dev_ctx), \
                             __VA_ARGS__);                             \
           }));                                                        \
     } else if (phi::GPUContext::classof(dev_ctx)) {                   \
-      VLOG(4) << "Call `" << #fn_name << "` in Resharding on CPU.";   \
+      VLOG(4) << "Call `" << #fn_name << "` in Resharding on GPU.";   \
       PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES(                  \
           dtype, #fn_name, ([&] {                                     \
             fn_name<data_t>(static_cast<const GPUContext&>(*dev_ctx), \

--- a/paddle/phi/infermeta/spmd_rules/elementwise.cc
+++ b/paddle/phi/infermeta/spmd_rules/elementwise.cc
@@ -224,8 +224,8 @@ SpmdInfo ElementwiseBinaryInferSpmd(const DistMetaTensor& x,
   out_dist_attr.set_dims_mapping(out_dims_mapping);
 
   // Step2.3: Update inputs' dims mapping with merged one.
-  TensorDistAttr x_dist_attr_dst(x_dist_attr_src);
-  TensorDistAttr y_dist_attr_dst(y_dist_attr_src);
+  TensorDistAttr x_dist_attr_dst = CopyTensorDistAttrForOutput(x_dist_attr_src);
+  TensorDistAttr y_dist_attr_dst = CopyTensorDistAttrForOutput(y_dist_attr_src);
   x_dist_attr_dst.set_dims_mapping(
       GetDimsMappingForAxes(x_axes, axis_to_dim_map));
   y_dist_attr_dst.set_dims_mapping(

--- a/paddle/phi/infermeta/spmd_rules/reduction.cc
+++ b/paddle/phi/infermeta/spmd_rules/reduction.cc
@@ -210,8 +210,10 @@ SpmdInfo ReductionGradInferSpmd(const DistMetaTensor& x,
                                 const IntArray& axis,
                                 bool keep_dim,
                                 bool reduce_all) {
-  TensorDistAttr x_dist_attr = out_grad.dist_attr();
-  TensorDistAttr x_grad_dist_attr = out_grad.dist_attr();
+  TensorDistAttr out_grad_dist_attr = out_grad.dist_attr();
+  out_grad_dist_attr.clean_partial_status();
+  TensorDistAttr x_dist_attr = out_grad_dist_attr;
+  TensorDistAttr x_grad_dist_attr = out_grad_dist_attr;
 
   std::vector<int64_t> x_dim = phi::vectorize(x.dims());
   std::vector<int64_t> out_grad_dim = phi::vectorize(out_grad.dims());
@@ -241,7 +243,7 @@ SpmdInfo ReductionGradInferSpmd(const DistMetaTensor& x,
     x_grad_dist_attr.set_dims_mapping(dims_mapping);
   }
 
-  return {{x_dist_attr, out_grad.dist_attr()}, {x_grad_dist_attr}};
+  return {{x_dist_attr, out_grad_dist_attr}, {x_grad_dist_attr}};
 }
 
 }  // namespace distributed

--- a/test/auto_parallel/semi_auto_parallel_for_matmul.py
+++ b/test/auto_parallel/semi_auto_parallel_for_matmul.py
@@ -110,7 +110,6 @@ class TestMatmulApiForSemiAutoParallel:
         np.testing.assert_equal(
             dist_out.dist_attr.dims_mapping, [-1, -1], verbose=True
         )
-        assert dist_out.dist_attr._is_partial() is False
         # verify x_grad local shape and dist attr
         np.testing.assert_equal(
             dist_x_grad._local_shape, [64, 16], verbose=True

--- a/test/auto_parallel/test_semi_auto_parallel_hybrid_strategy.py
+++ b/test/auto_parallel/test_semi_auto_parallel_hybrid_strategy.py
@@ -19,7 +19,11 @@ import collective.test_communication_api_base as test_base
 
 class TestSemiAutoParallelHybridStrategy(test_base.CommunicationTestDistBase):
     def setUp(self):
-        super().setUp(num_of_devices=2, timeout=120, nnode=2)
+        super().setUp(
+            num_of_devices=2,
+            timeout=120,
+            nnode=2,
+        )
         self._default_envs = {
             "dtype": "float32",
             "seed": "2023",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-73145

[AutpParallel] Remove p2r in forward api

去掉前向API输出强制Partial转Replicate的逻辑，支持后续Sharding实现
- 支持reduce mean下，Replicated到partial的转换
- 修复Replicated到partial状态下，用全局shape构造全零张量，导致hang的问题
- 新增matmul反向推导修改Input dist_attr的逻辑
- 修复elementwise前向推导partial状态没清除的问题

八卡mp+dp+pp混合策略本地已跑通

<img width="1910" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/63526175/c7a1aa3b-df85-4991-8cb7-f82f8ac45343">
