### PR TITLE
[fixbugs] cached property is not support in 3.7, replace with class

### DIFF
--- a/python/paddle/jit/dy2static/newir_partial_program.py
+++ b/python/paddle/jit/dy2static/newir_partial_program.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import itertools
-from functools import cached_property
 
 import numpy as np
 
@@ -34,6 +33,20 @@ from . import logging_utils
 from .utils import RETURN_NO_VALUE_MAGIC_NUM, backend_guard
 
 __all__ = []
+
+
+class cached_property:
+    """
+    Descriptor to implement lazy initialization of property.
+    """
+
+    def __init__(self, function):
+        self.function = function
+
+    def __get__(self, instance, cls):
+        val = self.function(instance)
+        setattr(instance, self.function.__name__, val)
+        return val
 
 
 class NestSequence:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
cached property is not support in 3.7, relace with class

PCard-66972