### PR TITLE
Add run time recording for dist_attr

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/fluid/distributed/auto_parallel/dist_attr.cc
@@ -76,6 +76,7 @@ OperatorDistAttr& OperatorDistAttr::operator=(
   std::swap(this->stream_priority_, tmp.stream_priority_);
   std::swap(this->scheduling_priority_, tmp.scheduling_priority_);
   std::swap(this->annotated_, tmp.annotated_);
+  std::swap(this->run_time_us_, tmp.run_time_us_);
   // Note: Make sure all tensor dist attr has the same process_mesh
   set_process_mesh(this->process_mesh_);
   return *this;
@@ -125,6 +126,7 @@ void OperatorDistAttr::copy_from(const OperatorDistAttr& dist_attr) {
   set_events_to_wait(dist_attr.events_to_wait());
   set_scheduling_priority(dist_attr.scheduling_priority());
   set_annotated(dist_attr.annotated());
+  set_run_time_us(dist_attr.run_time_us());
 }
 
 void OperatorDistAttr::set_input_dist_attrs(

--- a/paddle/fluid/distributed/auto_parallel/dist_attr.h
+++ b/paddle/fluid/distributed/auto_parallel/dist_attr.h
@@ -229,6 +229,9 @@ class OperatorDistAttr {
     return key + "_" + std::to_string(id_++);
   }
 
+  double run_time_us() const { return this->run_time_us_; }
+  void set_run_time_us(const double& us) { this->run_time_us_ = us; }
+
  private:
   static std::vector<std::string> fields_;
   std::map<std::string, TensorDistAttr> input_dist_attrs_;
@@ -245,6 +248,8 @@ class OperatorDistAttr {
   int stream_priority_ = 0;          // lower value, higher priority
   int64_t scheduling_priority_ = 0;  // lower value, higher priority
   std::map<std::string, bool> annotated_;
+  double run_time_us_ = -1.0;  // stores the actual run time (us) of relevant
+                               // op, negative value means invalid.
 };
 
 inline std::ostream& operator<<(std::ostream& os, const OperatorDistAttr& obj) {

--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -486,6 +486,9 @@ void BindAutoParallel(py::module *m) {
           static_cast<std::map<std::string, TensorDistAttr> &(
               OperatorDistAttr::*)()>(&OperatorDistAttr::output_dist_attrs),
           &OperatorDistAttr::set_output_dist_attrs)
+      .def_property("run_time_us",
+                    &OperatorDistAttr::run_time_us,
+                    &OperatorDistAttr::set_run_time_us)
       .def("get_input_dist_attr",
            static_cast<TensorDistAttr &(
                OperatorDistAttr::*)(const std::string &)>(

--- a/test/standalone_executor/test_standalone_dist_attr_run_time_set_get.py
+++ b/test/standalone_executor/test_standalone_dist_attr_run_time_set_get.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import paddle
+from paddle.static import Program, program_guard
+
+paddle.enable_static()
+
+
+class TestOpProfiling(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def _build_startup_program_and_train_program(self):
+        startup_program = Program()
+        train_program = Program()
+        with program_guard(train_program, startup_program):
+            data = paddle.static.data(
+                name='X', shape=[1024, 1], dtype='float32'
+            )
+            hidden = paddle.static.nn.fc(data, 10)
+            loss = paddle.mean(hidden)
+            paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
+        return startup_program, train_program, loss
+
+    def test_run_time_us_set_get_method(self):
+        '''
+        * test if the newly added "run_time_us_" actually works (set then get)
+        '''
+        (
+            startup_program,
+            train_program,
+            loss,
+        ) = self._build_startup_program_and_train_program()
+        global_block = startup_program.global_block()
+        global_block.ops[0].dist_attr.run_time_us = 1.0  # set
+        dt = global_block.ops[0].dist_attr.run_time_us  # get
+        if dt != 1.0:
+            raise RuntimeError("dist_attr set/get method failed!")
+        else:
+            sys.stdout.write("OK.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Add new member for OperatorDistAttr class, used for recording the operator run time.
为OperatorDistAttr类添加新数据成员，用于存储后续Op运行时间剖析结果

PCard-76459