### PR TITLE
replace ProgramDesc* to std::shared_ptr<ProgramDesc>

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/plan.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/plan.cc
@@ -21,7 +21,8 @@ namespace framework {
 namespace interpreter {
 
 Plan::Plan(const std::vector<std::shared_ptr<Job>>& job_list,
-           const std::unordered_map<std::string, ProgramDesc*>& type_to_program)
+           const std::unordered_map<std::string, std::shared_ptr<ProgramDesc>>&
+               type_to_program)
     : job_list_(job_list),
       type_to_program_(type_to_program),
       micro_batch_num_(1) {
@@ -65,7 +66,8 @@ const std::vector<std::shared_ptr<Job>>& Plan::JobList() const {
   return job_list_;
 }
 
-const ProgramDesc* Plan::Program(const std::string& job_type) const {
+const std::shared_ptr<ProgramDesc> Plan::Program(
+    const std::string& job_type) const {
   return type_to_program_.at(job_type);
 }
 

--- a/paddle/fluid/framework/new_executor/interpreter/plan.h
+++ b/paddle/fluid/framework/new_executor/interpreter/plan.h
@@ -31,7 +31,8 @@ namespace interpreter {
 class Plan final {
  public:
   Plan(const std::vector<std::shared_ptr<Job>>& job_list,
-       const std::unordered_map<std::string, ProgramDesc*>& type_to_program);
+       const std::unordered_map<std::string, std::shared_ptr<ProgramDesc>>&
+           type_to_program);
   Plan(const std::vector<std::shared_ptr<Job>>& job_list,
        const std::unordered_map<std::string, std::shared_ptr<::pir::Program>>&
            type_to_ir_program);
@@ -40,7 +41,7 @@ class Plan final {
 
   const std::vector<std::shared_ptr<Job>>& JobList() const;
 
-  const ProgramDesc* Program(const std::string& job_type) const;
+  const std::shared_ptr<ProgramDesc> Program(const std::string& job_type) const;
   std::shared_ptr<::pir::Program> IrProgram(const std::string& job_type) const;
 
   void UpdateIrProgram(const std::string& job_type,
@@ -50,7 +51,8 @@ class Plan final {
 
  private:
   const std::vector<std::shared_ptr<Job>> job_list_;
-  const std::unordered_map<std::string, ProgramDesc*> type_to_program_;
+  const std::unordered_map<std::string, std::shared_ptr<ProgramDesc>>
+      type_to_program_;
   std::unordered_map<std::string, std::shared_ptr<::pir::Program>>
       type_to_ir_program_;
   int64_t micro_batch_num_;

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -94,7 +94,7 @@ static void DeserializeMessage(T *self, const std::string &str) {
 
 // Bind Methods
 void BindProgramDesc(pybind11::module *m) {
-  pybind11::class_<pd::ProgramDesc, std::shared_ptr<ProgramDesc>>(
+  pybind11::class_<pd::ProgramDesc, std::shared_ptr<pd::ProgramDesc>>(
       *m, "ProgramDesc", "")
       .def(pybind11::init<>())
       .def("__init__",

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -94,7 +94,8 @@ static void DeserializeMessage(T *self, const std::string &str) {
 
 // Bind Methods
 void BindProgramDesc(pybind11::module *m) {
-  pybind11::class_<pd::ProgramDesc>(*m, "ProgramDesc", "")
+  pybind11::class_<pd::ProgramDesc, std::shared_ptr<ProgramDesc>>(
+      *m, "ProgramDesc", "")
       .def(pybind11::init<>())
       .def("__init__",
            [](pd::ProgramDesc &self, const pd::ProgramDesc &other) {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2033,7 +2033,8 @@ All parameter, weight, gradient are variables in Paddle.
       .def(
           py::init<
               const std::vector<std::shared_ptr<framework::interpreter::Job>> &,
-              const std::unordered_map<std::string, framework::ProgramDesc *>
+              const std::unordered_map<std::string,
+                                       std::shared_ptr<framework::ProgramDesc>>
                   &>(),
           py::arg("job_list"),
           py::arg("type_to_program"))

--- a/test/cpp/new_executor/standalone_executor_test.cc
+++ b/test/cpp/new_executor/standalone_executor_test.cc
@@ -147,25 +147,28 @@ ProgramDesc GetLmMainProgram() {
 
 TEST(StandaloneExecutor, run) {
   auto place = platform::CUDAPlace(0);
-  ProgramDesc startup_prog = load_from_file("lm_startup_program");
-  ProgramDesc main_prog = GetLmMainProgram();
+  std::shared_ptr<ProgramDesc> p_startup_prog =
+      std::make_shared<ProgramDesc>(load_from_file("lm_startup_program"));
+  std::shared_ptr<ProgramDesc> p_main_prog =
+      std::make_shared<ProgramDesc>(GetLmMainProgram());
 
   Scope scope;
   std::shared_ptr<Job> startup_job = std::make_shared<Job>(Job("startup"));
   StandaloneExecutor startup_exec(
       place,
       Plan(std::vector<std::shared_ptr<Job>>({startup_job}),
-           std::unordered_map<std::string, ProgramDesc*>(
-               {{startup_job->Type(), &startup_prog}})),
+           std::unordered_map<std::string, std::shared_ptr<ProgramDesc>>(
+               {{startup_job->Type(), p_startup_prog}})),
       &scope);
   startup_exec.Run({});
 
   std::shared_ptr<Job> main_job = std::make_shared<Job>(Job("main"));
-  StandaloneExecutor exec(place,
-                          Plan(std::vector<std::shared_ptr<Job>>({main_job}),
-                               std::unordered_map<std::string, ProgramDesc*>(
-                                   {{main_job->Type(), &main_prog}})),
-                          &scope);
+  StandaloneExecutor exec(
+      place,
+      Plan(std::vector<std::shared_ptr<Job>>({main_job}),
+           std::unordered_map<std::string, std::shared_ptr<ProgramDesc>>(
+               {{main_job->Type(), p_main_prog}})),
+      &scope);
   exec.Run({});
   auto start = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Replace the usage of "ProgramDesc*" to a safer version "std::shared_ptr<ProgramDesc>".

PCard-76459