### PR TITLE
【PIR API adaptor No.233、234】 Migrate paddle.trunc/frac into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2026,7 +2026,7 @@ def trunc(input, name=None):
             [[ 0.,  1.],
              [-0., -2.]])
     '''
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.trunc(input)
     else:
         inputs = {"X": input}
@@ -6065,7 +6065,7 @@ def frac(x, name=None):
         raise TypeError(
             f"The data type of input must be one of ['int32', 'int64', 'float32', 'float64'], but got {x.dtype}"
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         y = _C_ops.trunc(x)
         return _C_ops.subtract(x, y)
     else:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops, _legacy_C_ops
+from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
@@ -6061,6 +6062,10 @@ def frac(x, name=None):
         paddle.int64,
         paddle.float32,
         paddle.float64,
+        DataType.INT32,
+        DataType.INT64,
+        DataType.FLOAT32,
+        DataType.FLOAT64,
     ]:
         raise TypeError(
             f"The data type of input must be one of ['int32', 'int64', 'float32', 'float64'], but got {x.dtype}"

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -18,8 +18,9 @@ import numpy as np
 
 import paddle
 from paddle import base
-from paddle.base import Program, core, program_guard
+from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
+
 
 def ref_frac(x):
     return x - np.trunc(x)
@@ -43,13 +44,10 @@ class TestFracAPI(unittest.TestCase):
     @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
-        with program_guard(Program()):
+        with paddle.static.program_guard(paddle.static.Program()):
             input = paddle.static.data('X', self.x_np.shape, self.x_np.dtype)
             out = paddle.frac(input)
-            place = base.CPUPlace()
-            if base.core.is_compiled_with_cuda():
-                place = base.CUDAPlace(0)
-            exe = base.Executor(place)
+            exe = base.Executor(self.place)
             (res,) = exe.run(feed={'X': self.x_np}, fetch_list=[out])
         out_ref = ref_frac(self.x_np)
         np.testing.assert_allclose(out_ref, res, rtol=1e-05)

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -19,7 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
-
+from paddle.pir_utils import test_with_pir_api
 
 def ref_frac(x):
     return x - np.trunc(x)
@@ -40,6 +40,7 @@ class TestFracAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with program_guard(Program()):
@@ -101,6 +102,7 @@ class TestFracError(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_error(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_trunc_op.py
+++ b/test/legacy_test/test_trunc_op.py
@@ -37,10 +37,10 @@ class TestTruncOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output(check_pir = True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', numeric_grad_delta=1e-5, check_pir = True)
+        self.check_grad(['X'], 'Out', numeric_grad_delta=1e-5, check_pir=True)
 
 
 class TestFloatTruncOp(TestTruncOp):
@@ -87,7 +87,6 @@ class TestTruncAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-08)
         paddle.enable_static()
 
-    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', [20, 20], 'bool')
@@ -117,11 +116,13 @@ class TestTruncBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, check_pir = True)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X'], 'Out', numeric_grad_delta=1e-5, check_pir = True)
+        self.check_grad_with_place(
+            place, ['X'], 'Out', numeric_grad_delta=1e-5, check_pir=True
+        )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_trunc_op.py
+++ b/test/legacy_test/test_trunc_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -36,10 +37,10 @@ class TestTruncOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir = True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', numeric_grad_delta=1e-5)
+        self.check_grad(['X'], 'Out', numeric_grad_delta=1e-5, check_pir = True)
 
 
 class TestFloatTruncOp(TestTruncOp):
@@ -66,6 +67,7 @@ class TestTruncAPI(unittest.TestCase):
         self.x = np.random.random((20, 20)).astype(np.float32)
         self.place = paddle.CPUPlace()
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -85,6 +87,7 @@ class TestTruncAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-08)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', [20, 20], 'bool')
@@ -114,11 +117,11 @@ class TestTruncBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir = True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X'], 'Out', numeric_grad_delta=1e-5)
+        self.check_grad_with_place(place, ['X'], 'Out', numeric_grad_delta=1e-5, check_pir = True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 paddle.trunc/frac 迁移升级至 pir，并更新单测
- https://github.com/PaddlePaddle/Paddle/issues/58067

- frac 单测全部开启
- trunc 单测 `TestTruncAPI.test_errors` 没有开启
