### PR TITLE
【PIR API adaptor No.235、236】 Migrate paddle.unbind & unfold into pir

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4809,6 +4809,7 @@ void UnfoldInferMeta(const MetaTensor& x,
   }
   out_dims.push_back(output_col_length);
   out->set_dims(phi::make_ddim(out_dims));
+  out->set_dtype(x.dtype());
 }
 
 void UniformRandomInplaceInferMeta(const MetaTensor& x,

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -155,7 +155,7 @@ def unfold(x, kernel_sizes, strides=1, paddings=0, dilations=1, name=None):
             "of 2 or 4 integers"
         )
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.unfold(x, kernel_sizes, strides, paddings, dilations)
 
     out = helper.create_variable_for_type_inference(dtype=x.dtype)

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -109,7 +109,9 @@ def unfold(x, kernel_sizes, strides=1, paddings=0, dilations=1, name=None):
 
     helper = LayerHelper("unfold", **locals())
 
-    check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'unfold')
+    check_variable_and_dtype(
+        x, 'x', ['float16', 'float32', 'float64'], 'unfold'
+    )
 
     assert len(x.shape) == 4, "input should be the format of [N, C, H, W]"
 

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -110,7 +110,7 @@ def unfold(x, kernel_sizes, strides=1, paddings=0, dilations=1, name=None):
     helper = LayerHelper("unfold", **locals())
 
     check_variable_and_dtype(
-        x, 'x', ['float16', 'float32', 'float64'], 'unfold'
+        x, 'x', ['uint16', 'float16', 'float32', 'float64'], 'unfold'
     )
 
     assert len(x.shape) == 4, "input should be the format of [N, C, H, W]"

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2969,7 +2969,7 @@ def unbind(input, axis=0):
             f'The axis must in range({-input.ndim}, {input.ndim}).'
         )
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.unbind(input, axis)
     else:
         if isinstance(axis, np.generic):

--- a/test/legacy_test/test_unbind_op.py
+++ b/test/legacy_test/test_unbind_op.py
@@ -20,9 +20,11 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base, tensor
 from paddle.base import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestUnbind(unittest.TestCase):
+    @test_with_pir_api
     def test_unbind(self):
         paddle.enable_static()
 
@@ -41,6 +43,7 @@ class TestUnbind(unittest.TestCase):
         np.testing.assert_array_equal(res_1, input_1[0, 0:100])
         np.testing.assert_array_equal(res_2, input_1[1, 0:100])
 
+    @test_with_pir_api
     def test_unbind_static_fp16_gpu(self):
         if paddle.base.core.is_compiled_with_cuda():
             place = paddle.CUDAPlace(0)
@@ -81,6 +84,7 @@ class TestUnbind(unittest.TestCase):
 
 
 class TestLayersUnbind(unittest.TestCase):
+    @test_with_pir_api
     def test_layers_unbind(self):
         paddle.enable_static()
 
@@ -137,10 +141,10 @@ class TestUnbindOp(OpTest):
         self.op_type = "unbind"
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['out0', 'out1', 'out2'])
+        self.check_grad(['X'], ['out0', 'out1', 'out2'], check_pir=True)
 
 
 class TestUnbindOp1(TestUnbindOp):
@@ -149,7 +153,7 @@ class TestUnbindOp1(TestUnbindOp):
         self.num = 2
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['out0', 'out1'])
+        self.check_grad(['X'], ['out0', 'out1'], check_pir=True)
 
     def outReshape(self):
         self.out[0] = self.out[0].reshape((3, 2))
@@ -162,7 +166,7 @@ class TestUnbindOp2(TestUnbindOp):
         self.num = 2
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['out0', 'out1'])
+        self.check_grad(['X'], ['out0', 'out1'], check_pir=True)
 
     def outReshape(self):
         self.out[0] = self.out[0].reshape((3, 2))
@@ -178,7 +182,7 @@ class TestUnbindOp3(TestUnbindOp):
         self.attrs = {'axis': -1}
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['out0', 'out1'])
+        self.check_grad(['X'], ['out0', 'out1'], check_pir=True)
 
     def outReshape(self):
         self.out[0] = self.out[0].reshape((3, 2))
@@ -194,7 +198,7 @@ class TestUnbindOp4(TestUnbindOp):
         self.attrs = {'axis': -2}
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['out0', 'out1'])
+        self.check_grad(['X'], ['out0', 'out1'], check_pir=True)
 
     def outReshape(self):
         self.out[0] = self.out[0].reshape((3, 2))
@@ -228,7 +232,7 @@ class TestUnbindFP16Op(OpTest):
         return np.float16
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestUnbindBF16Op(OpTest):
@@ -264,13 +268,14 @@ class TestUnbindBF16Op(OpTest):
         self.op_type = "unbind"
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         pass
 
 
 class TestUnbindAxisError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         with program_guard(Program(), Program()):
             x = paddle.static.data(shape=[2, 3], dtype='float32', name='x')

--- a/test/legacy_test/test_unbind_op.py
+++ b/test/legacy_test/test_unbind_op.py
@@ -35,7 +35,6 @@ class TestUnbind(unittest.TestCase):
         exe = base.Executor(place=base.CPUPlace())
 
         [res_1, res_2] = exe.run(
-            base.default_main_program(),
             feed={"x_1": input_1, "axis": 0},
             fetch_list=[out_0, out_1],
         )
@@ -95,7 +94,6 @@ class TestLayersUnbind(unittest.TestCase):
         exe = base.Executor(place=base.CPUPlace())
 
         [res_1, res_2] = exe.run(
-            base.default_main_program(),
             feed={"x_1": input_1, "axis": 0},
             fetch_list=[out_0, out_1],
         )

--- a/test/legacy_test/test_unfold_op.py
+++ b/test/legacy_test/test_unfold_op.py
@@ -139,7 +139,7 @@ class TestUnfoldOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Y', check_pir=True)

--- a/test/legacy_test/test_unfold_op.py
+++ b/test/legacy_test/test_unfold_op.py
@@ -142,7 +142,7 @@ class TestUnfoldOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Y')
+        self.check_grad(['X'], 'Y', check_pir=True)
 
     def test_support_tuple(self):
         paddle.disable_static()
@@ -199,10 +199,10 @@ class TestUnfoldBF16Op(TestUnfoldOp):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], 'Y')
+        self.check_grad_with_place(self.place, ['X'], 'Y', check_pir=True)
 
 
 class TestUnfoldAPI(TestUnfoldOp):

--- a/test/legacy_test/test_unfold_op.py
+++ b/test/legacy_test/test_unfold_op.py
@@ -142,7 +142,7 @@ class TestUnfoldOp(OpTest):
         self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Y', check_pir=True)
+        self.check_grad(['X'], 'Y')
 
     def test_support_tuple(self):
         paddle.disable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 paddle.unbind /unfold 迁移升级至 pir，并更新单测

`unbind` 全部通过
`unfold` 的 `TestUnfoldOp.test_check_grad`  单测未开启，单测通过率 5/6，存在精度和shape对不上的问题

- https://github.com/PaddlePaddle/Paddle/issues/58067

