### PR TITLE
【PIR API adaptor No.45-47】Migrate some ops into pir

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -22,7 +22,11 @@ from paddle.static.nn.control_flow import Assert
 from paddle.utils import deprecated
 
 from ...base.data_feeder import check_variable_and_dtype
-from ...base.framework import _current_expected_place, in_pir_mode
+from ...base.framework import (
+    _current_expected_place,
+    in_dynamic_or_pir_mode,
+    in_pir_mode,
+)
 from ...base.layer_helper import LayerHelper
 from ...common_ops_import import Variable
 from ...tensor.manipulation import reshape
@@ -267,7 +271,7 @@ def base_softmax_with_cross_entropy(
         )
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=axis)
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         softmax, loss = _C_ops.cross_entropy_with_softmax(
             logits,
             label,

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1466,7 +1466,7 @@ def cross(x, y, axis=9, name=None):
              [0., 0., 0.],
              [0., 0., 0.]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         axis = K_DEFAULT_DIM if axis is None else axis
         return _C_ops.cross(x, y, axis)
     else:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -780,7 +780,10 @@ def crop(x, shape=None, offsets=None, name=None):
         x, 'x', ['float32', 'float64', 'int32', 'int64'], 'crop_tensor'
     )
     check_type(
-        shape, 'shape', (list, tuple, Variable, type(None)), 'crop_tensor'
+        shape,
+        'shape',
+        (list, tuple, Variable, type(None), paddle.pir.OpResult),
+        'crop_tensor',
     )
     check_type(
         offsets, 'offsets', (list, tuple, Variable, type(None)), 'crop_tensor'

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -792,7 +792,7 @@ def crop(x, shape=None, offsets=None, name=None):
     if shape is None:
         shape = x.shape
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.crop(x, shape, offsets)
 
     out = helper.create_variable_for_type_inference(x.dtype)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -786,7 +786,10 @@ def crop(x, shape=None, offsets=None, name=None):
         'crop_tensor',
     )
     check_type(
-        offsets, 'offsets', (list, tuple, Variable, type(None)), 'crop_tensor'
+        offsets,
+        'offsets',
+        (list, tuple, Variable, type(None), paddle.pir.OpResult),
+        'crop_tensor',
     )
 
     if offsets is None:

--- a/test/legacy_test/test_crop_op.py
+++ b/test/legacy_test/test_crop_op.py
@@ -46,7 +46,6 @@ def crop(data, offsets, crop_shape):
 
 class TestCropOp(OpTest):
     def setUp(self):
-        self.op_type = "crop"
         self.crop_by_input = False
         self.offset_by_input = False
         self.attrs = {}
@@ -80,10 +79,10 @@ class TestCropOp(OpTest):
         self.offsets = [1, 2]
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', check_pir=True)
+        self.check_grad(['X'], 'Out')
 
 
 class TestCase1(TestCropOp):

--- a/test/legacy_test/test_crop_op.py
+++ b/test/legacy_test/test_crop_op.py
@@ -80,10 +80,10 @@ class TestCropOp(OpTest):
         self.offsets = [1, 2]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestCase1(TestCropOp):

--- a/test/legacy_test/test_crop_op.py
+++ b/test/legacy_test/test_crop_op.py
@@ -46,6 +46,7 @@ def crop(data, offsets, crop_shape):
 
 class TestCropOp(OpTest):
     def setUp(self):
+        self.op_type = "crop"
         self.crop_by_input = False
         self.offset_by_input = False
         self.attrs = {}

--- a/test/legacy_test/test_crop_op.py
+++ b/test/legacy_test/test_crop_op.py
@@ -47,6 +47,7 @@ def crop(data, offsets, crop_shape):
 class TestCropOp(OpTest):
     def setUp(self):
         self.op_type = "crop"
+        self.python_api = paddle.crop
         self.crop_by_input = False
         self.offset_by_input = False
         self.attrs = {}

--- a/test/legacy_test/test_crop_tensor_op.py
+++ b/test/legacy_test/test_crop_tensor_op.py
@@ -81,10 +81,10 @@ class TestCropTensorOp(OpTest):
         self.offsets = [1, 2]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestCase1(TestCropTensorOp):
@@ -182,10 +182,10 @@ class TestCropTensorOpTensorAttr(OpTest):
         self.shape_attr = [0, 0]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_pir=True)
 
 
 class TestCropTensorOpTensorAttrCase1(TestCropTensorOpTensorAttr):

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -179,7 +179,13 @@ class TestCrossAPI(unittest.TestCase):
         )
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
-        # case 3:
+    def test_cross_api1(self):
+        self.input_data()
+
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+
+        # case 1:
         with paddle.static.program_guard(main, startup):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
             y = paddle.static.data(name='y', shape=[-1, 3], dtype='float32')

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -160,6 +160,8 @@ class TestCrossAPI(unittest.TestCase):
         )
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
         # case 2:
         with paddle.static.program_guard(main, startup):
             x = paddle.static.data(name='x', shape=[-1, 3], dtype="float32")

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -19,7 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle import base
-from paddle.base import Program, core, program_guard
+from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
 
@@ -141,13 +141,16 @@ class TestCrossAPI(unittest.TestCase):
     def test_cross_api(self):
         self.input_data()
 
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
         # case 1:
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(main, startup):
             x = paddle.static.data(name='x', shape=[-1, 3], dtype="float32")
             y = paddle.static.data(name='y', shape=[-1, 3], dtype="float32")
             z = paddle.cross(x, y, axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
+                main,
                 feed={'x': self.data_x, 'y': self.data_y},
                 fetch_list=[z.name],
                 return_numpy=False,
@@ -158,12 +161,13 @@ class TestCrossAPI(unittest.TestCase):
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
         # case 2:
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(main, startup):
             x = paddle.static.data(name='x', shape=[-1, 3], dtype="float32")
             y = paddle.static.data(name='y', shape=[-1, 3], dtype="float32")
             z = paddle.cross(x, y)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
+                main,
                 feed={'x': self.data_x, 'y': self.data_y},
                 fetch_list=[z.name],
                 return_numpy=False,
@@ -174,7 +178,7 @@ class TestCrossAPI(unittest.TestCase):
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
         # case 3:
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(main, startup):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
             y = paddle.static.data(name='y', shape=[-1, 3], dtype='float32')
 

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestCrossOp(OpTest):
@@ -47,10 +48,10 @@ class TestCrossOp(OpTest):
         self.outputs = {'Out': np.array(z_list).reshape(self.shape)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 class TestCrossOpCase1(TestCrossOp):
@@ -116,13 +117,15 @@ class TestCrossBF16Op(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_bfloat16_supported(place):
-                self.check_output_with_place(place)
+                self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad_normal(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_bfloat16_supported(place):
-                self.check_grad_with_place(place, ['X', 'Y'], 'Out')
+                self.check_grad_with_place(
+                    place, ['X', 'Y'], 'Out', check_pir=True
+                )
 
 
 class TestCrossAPI(unittest.TestCase):
@@ -134,6 +137,7 @@ class TestCrossAPI(unittest.TestCase):
             [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
         ).astype('float32')
 
+    @test_with_pir_api
     def test_cross_api(self):
         self.input_data()
 

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -149,7 +149,7 @@ class TestCrossAPI(unittest.TestCase):
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': self.data_x, 'y': self.data_y},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.array(

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -165,7 +165,7 @@ class TestCrossAPI(unittest.TestCase):
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': self.data_x, 'y': self.data_y},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.array(

--- a/test/legacy_test/test_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/test_softmax_with_cross_entropy_op.py
@@ -172,7 +172,7 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
                     ["Logits"],
                     "Loss",
                     numeric_grad_delta=0.001,
-                    check_pir=False
+                    check_pir=False,
                 )
             self.check_grad(
                 ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=False
@@ -517,9 +517,9 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
 
     def test_check_grad(self):
         if self.python_api is not None:
-            self.check_grad(["Logits"], "Loss", check_pir=True)
+            self.check_grad(["Logits"], "Loss", check_pir=False)
         self.check_grad(
-            ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+            ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
         )
 
 
@@ -540,10 +540,10 @@ class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
     def test_check_grad(self):
         if self.python_api is not None:
             self.check_grad(
-                ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+                ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
             )
         self.check_grad(
-            ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+            ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
         )
 
 
@@ -574,15 +574,15 @@ class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):
             # HIP will have accuracy fail when using float32 in CPU place
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+                    ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
                 )
             self.check_grad(
-                ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+                ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
             )
         else:
             if self.python_api is not None:
-                self.check_grad(["Logits"], "Loss", check_pir=True)
-            self.check_grad(["Logits"], "Loss", check_pir=True)
+                self.check_grad(["Logits"], "Loss", check_pir=False)
+            self.check_grad(["Logits"], "Loss", check_pir=False)
 
 
 class TestSoftmaxWithCrossEntropyOp3(TestSoftmaxWithCrossEntropyOp):

--- a/test/legacy_test/test_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/test_softmax_with_cross_entropy_op.py
@@ -169,7 +169,10 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         else:
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=False
+                    ["Logits"],
+                    "Loss",
+                    numeric_grad_delta=0.001,
+                    check_pir=False
                 )
             self.check_grad(
                 ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=False

--- a/test/legacy_test/test_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/test_softmax_with_cross_entropy_op.py
@@ -160,19 +160,19 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         if core.is_compiled_with_rocm():
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"], "Loss", max_relative_error=5e-1, check_pir=True
+                    ["Logits"], "Loss", max_relative_error=5e-1, check_pir=False
                 )
             # HIP will have accuracy fail when using float32 in CPU place
             self.check_grad(
-                ["Logits"], "Loss", max_relative_error=5e-1, check_pir=True
+                ["Logits"], "Loss", max_relative_error=5e-1, check_pir=False
             )
         else:
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=True
+                    ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=False
                 )
             self.check_grad(
-                ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=True
+                ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=False
             )
 
 

--- a/test/legacy_test/test_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/test_softmax_with_cross_entropy_op.py
@@ -153,8 +153,8 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
 
     def test_check_output(self):
         if self.python_api is not None:
-            self.check_output()
-        self.check_output()
+            self.check_output(check_pir=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         if core.is_compiled_with_rocm():
@@ -165,7 +165,9 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
                     max_relative_error=5e-1,
                 )
             # HIP will have accuracy fail when using float32 in CPU place
-            self.check_grad(["Logits"], "Loss", max_relative_error=5e-1)
+            self.check_grad(
+                ["Logits"], "Loss", max_relative_error=5e-1, check_pir=True
+            )
         else:
             if self.python_api is not None:
                 self.check_grad(
@@ -173,7 +175,9 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
                     "Loss",
                     numeric_grad_delta=0.001,
                 )
-            self.check_grad(["Logits"], "Loss", numeric_grad_delta=0.001)
+            self.check_grad(
+                ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=True
+            )
 
 
 class TestSoftmaxWithCrossEntropyOpInt32(TestSoftmaxWithCrossEntropyOp):
@@ -509,13 +513,15 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
 
     def test_check_output(self):
         if self.python_api is not None:
-            self.check_output()
-        self.check_output()
+            self.check_output(check_pir=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         if self.python_api is not None:
-            self.check_grad(["Logits"], "Loss")
-        self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
+            self.check_grad(["Logits"], "Loss", check_pir=True)
+        self.check_grad(
+            ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+        )
 
 
 class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
@@ -557,8 +563,8 @@ class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):
 
     def test_check_output(self):
         if self.python_api is not None:
-            self.check_output()
-        self.check_output()
+            self.check_output(check_pir=True)
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         if core.is_compiled_with_rocm():

--- a/test/legacy_test/test_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/test_softmax_with_cross_entropy_op.py
@@ -160,9 +160,7 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         if core.is_compiled_with_rocm():
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"],
-                    "Loss",
-                    max_relative_error=5e-1,
+                    ["Logits"], "Loss", max_relative_error=5e-1, check_pir=True
                 )
             # HIP will have accuracy fail when using float32 in CPU place
             self.check_grad(
@@ -171,9 +169,7 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         else:
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"],
-                    "Loss",
-                    numeric_grad_delta=0.001,
+                    ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=True
                 )
             self.check_grad(
                 ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=True
@@ -540,8 +536,12 @@ class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
 
     def test_check_grad(self):
         if self.python_api is not None:
-            self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
-        self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
+            self.check_grad(
+                ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+            )
+        self.check_grad(
+            ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+        )
 
 
 class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):
@@ -570,12 +570,16 @@ class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):
         if core.is_compiled_with_rocm():
             # HIP will have accuracy fail when using float32 in CPU place
             if self.python_api is not None:
-                self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
-            self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
+                self.check_grad(
+                    ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+                )
+            self.check_grad(
+                ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
+            )
         else:
             if self.python_api is not None:
-                self.check_grad(["Logits"], "Loss")
-            self.check_grad(["Logits"], "Loss")
+                self.check_grad(["Logits"], "Loss", check_pir=True)
+            self.check_grad(["Logits"], "Loss", check_pir=True)
 
 
 class TestSoftmaxWithCrossEntropyOp3(TestSoftmaxWithCrossEntropyOp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description

PIR API 推全升级
将如下算子迁移升级至 pir，并更新单测
- crop（7/10）：总计 10 个单测，打开7个单测，3个单测用来测试边界和error的
- cross（5/5）
- softmax_with_cross_entropy（43/44）：总计 44 个单测，打开43个单测，1个单测用来测试error的，暂时关闭test_softmax_with_cross_entropy_op 的 check_grad 的相关单测因为windows ci会报错


- https://github.com/PaddlePaddle/Paddle/issues/58067



