### PR TITLE
【PIR API adaptor No.212、245】Migrate paddle.vsplit & unstack into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -585,7 +585,7 @@ def unstack(x, axis=0, num=None):
         raise ValueError(f'`axis` must be in the range [-{x.ndim}, {x.ndim})')
     if num is not None and (num < 0 or num > x.shape[axis]):
         raise ValueError(f'`num` must be in the range [0, {x.shape[axis]})')
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if num is None:
             num = x.shape[axis]
         if num == 0:

--- a/test/legacy_test/test_splits_api.py
+++ b/test/legacy_test/test_splits_api.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def func_ref(func, x, num_or_sections):
@@ -52,6 +53,7 @@ class TestSplitsAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         paddle.enable_static()
         for func, func_type in test_list:
@@ -166,6 +168,7 @@ class TestSplitsError(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_error(self):
         paddle.enable_static()
         for func, _ in test_list:

--- a/test/legacy_test/test_unstack_op.py
+++ b/test/legacy_test/test_unstack_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestUnStackOpBase(OpTest):
@@ -60,10 +61,10 @@ class TestUnStackOpBase(OpTest):
         self.attrs = {'axis': self.axis, 'num': self.input_dim[self.axis]}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], self.get_y_names())
+        self.check_grad(['X'], self.get_y_names(), check_pir=True)
 
 
 class TestUnStackFP16Op(TestUnStackOpBase):
@@ -164,7 +165,7 @@ class TestUnStackBF16Op(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         with base.dygraph.guard():
@@ -181,6 +182,7 @@ class TestUnStackBF16Op(OpTest):
 
 
 class TestUnstackZeroInputOp(unittest.TestCase):
+    @test_with_pir_api
     def unstack_zero_input_static(self):
         paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 paddle.vsplit /unstack 迁移升级至 pir，并更新单测

单测全部通过

- https://github.com/PaddlePaddle/Paddle/issues/58067
