### PR TITLE
【PIR API adaptor No.242、228】 Migrate unique_consecutive/moveaxis into pir

### DIFF
--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2681,7 +2681,7 @@
   backward: uniform_inplace_grad
 
 - op : unique_consecutive
-  args : (Tensor x, bool return_inverse = false, bool return_counts = false, int[] axis = {}, int dtype = 5)
+  args : (Tensor x, bool return_inverse = false, bool return_counts = false, int[] axis = {}, DataType dtype = DataType::INT32)
   output : Tensor(out), Tensor(index), Tensor(counts)
   infer_meta :
       func : UniqueConsecutiveInferMeta

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2681,7 +2681,7 @@
   backward: uniform_inplace_grad
 
 - op : unique_consecutive
-  args : (Tensor x, bool return_inverse = false, bool return_counts = false, int[] axis = {}, DataType dtype = DataType::INT32)
+  args : (Tensor x, bool return_inverse = false, bool return_counts = false, int[] axis = {}, DataType dtype = DataType::FLOAT32)
   output : Tensor(out), Tensor(index), Tensor(counts)
   infer_meta :
       func : UniqueConsecutiveInferMeta

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4852,7 +4852,7 @@ void UniqueConsecutiveInferMeta(const MetaTensor& x,
                                 bool return_inverse,
                                 bool return_counts,
                                 const std::vector<int>& axis,
-                                int dtype,
+                                DataType dtype,
                                 MetaTensor* out,
                                 MetaTensor* index,
                                 MetaTensor* counts) {

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -716,7 +716,7 @@ void UniqueConsecutiveInferMeta(const MetaTensor& x,
                                 bool return_inverse,
                                 bool return_counts,
                                 const std::vector<int>& axis,
-                                int dtype,
+                                DataType dtype,
                                 MetaTensor* out,
                                 MetaTensor* index,
                                 MetaTensor* counts);

--- a/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
+++ b/paddle/phi/kernels/cpu/unique_consecutive_kernel.cc
@@ -30,12 +30,11 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
                              bool return_inverse,
                              bool return_counts,
                              const std::vector<int>& axis,
-                             int dtype,
+                             DataType dtype,
                              DenseTensor* out,
                              DenseTensor* index,
                              DenseTensor* counts) {
-  auto data_type = phi::TransToPhiDataType(dtype);
-  if (data_type == phi::DataType::INT32) {
+  if (dtype == phi::DataType::INT32) {
     PADDLE_ENFORCE_LE(
         x.numel(),
         INT_MAX,
@@ -48,14 +47,14 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
 
   if (axis.empty()) {
     phi::VisitDataTypeTiny(
-        data_type,
+        dtype,
         UniqueConsecutiveFlattenedTensorFunctor<Context, T>(
             dev_ctx, x, out, return_inverse, return_counts, index, counts));
   } else {
     int valid_axis = axis[0];
     if (valid_axis < 0) valid_axis += x.dims().size();
     phi::VisitDataTypeTiny(
-        data_type,
+        dtype,
         UniqueConsecutiveDimFunctor<Context, T>(dev_ctx,
                                                 x,
                                                 out,

--- a/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_consecutive_kernel.cu
@@ -29,12 +29,11 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
                              bool return_inverse,
                              bool return_counts,
                              const std::vector<int>& axis,
-                             int dtype,
+                             DataType dtype,
                              DenseTensor* out,
                              DenseTensor* index,
                              DenseTensor* counts) {
-  auto data_type = phi::TransToPhiDataType(dtype);
-  if (data_type == phi::DataType::INT32) {
+  if (dtype == phi::DataType::INT32) {
     PADDLE_ENFORCE_LE(
         x.numel() + 1,
         INT_MAX,
@@ -48,7 +47,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
   // if 'axis' is not required, flatten the Tensor.
   if (axis.empty()) {
     phi::VisitDataTypeTiny(
-        data_type,
+        dtype,
         UniqueConsecutiveFlattenedCUDAFunctor<Context, T>(
             dev_ctx, x, out, return_inverse, return_counts, index, counts));
   } else {
@@ -56,7 +55,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
     int valid_axis = axis[0];
     if (valid_axis < 0) valid_axis += x.dims().size();
     phi::VisitDataTypeTiny(
-        data_type,
+        dtype,
         UniqueConsecutiveDimsCUDAFunctor<Context, T>(dev_ctx,
                                                      x,
                                                      out,

--- a/paddle/phi/kernels/unique_consecutive_kernel.h
+++ b/paddle/phi/kernels/unique_consecutive_kernel.h
@@ -26,7 +26,7 @@ void UniqueConsecutiveKernel(const Context& dev_ctx,
                              bool return_inverse,
                              bool return_counts,
                              const std::vector<int>& axis,
-                             int dtype,
+                             DataType dtype,
                              DenseTensor* out,
                              DenseTensor* index,
                              DenseTensor* counts);

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2481,7 +2481,7 @@ def unique_consecutive(
     else:
         axis = [axis]
     attr_dtype = convert_np_dtype_to_dtype_(dtype)
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out, inverse, counts = _C_ops.unique_consecutive(
             x, return_inverse, return_counts, axis, attr_dtype
         )

--- a/test/legacy_test/test_transpose_op.py
+++ b/test/legacy_test/test_transpose_op.py
@@ -710,6 +710,7 @@ class TestMoveAxis(unittest.TestCase):
         self.assertEqual(out.shape, [2, 3])
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_error(self):
         x = paddle.randn([2, 3, 4, 5])
         # src must have the same number with dst

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def reference_unique_consecutive(
@@ -99,7 +100,7 @@ class TestUniqueConsecutiveOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestUniqueConsecutiveOp2(TestUniqueConsecutiveOp):
@@ -203,6 +204,7 @@ class TestUniqueConsecutiveAPI(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.places.append(base.CUDAPlace(0))
 
+    @test_with_pir_api
     def check_static_result(self, place):
         with base.program_guard(base.Program(), base.Program()):
             paddle.enable_static()
@@ -240,6 +242,7 @@ class TestUniqueConsecutiveCase2API(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.places.append(base.CUDAPlace(0))
 
+    @test_with_pir_api
     def check_static_result(self, place):
         with base.program_guard(base.Program(), base.Program()):
             paddle.enable_static()
@@ -281,6 +284,7 @@ class TestUniqueConsecutiveCase3API(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.places.append(base.CUDAPlace(0))
 
+    @test_with_pir_api
     def check_static_result(self, place):
         with base.program_guard(base.Program(), base.Program()):
             paddle.enable_static()
@@ -347,7 +351,7 @@ class TestUniqueConsecutiveEmptyInput(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -219,7 +219,6 @@ class TestUniqueConsecutiveAPI(unittest.TestCase):
             x_np = np.random.randint(20, size=100).astype("float32")
             exe = base.Executor(place)
             fetches = exe.run(
-                base.default_main_program(),
                 feed={"input_x": x_np},
                 fetch_list=[result],
             )
@@ -259,7 +258,6 @@ class TestUniqueConsecutiveCase2API(unittest.TestCase):
             x_np = np.random.randint(20, size=100).astype("float32")
             exe = base.Executor(place)
             fetches = exe.run(
-                base.default_main_program(),
                 feed={"input_x": x_np},
                 fetch_list=[result],
             )
@@ -301,7 +299,6 @@ class TestUniqueConsecutiveCase3API(unittest.TestCase):
             x_np = np.random.randint(20, size=100).astype("float32")
             exe = base.Executor(place)
             fetches = exe.run(
-                base.default_main_program(),
                 feed={"input_x": x_np},
                 fetch_list=[result],
             )

--- a/test/legacy_test/test_unique_consecutive_op.py
+++ b/test/legacy_test/test_unique_consecutive_op.py
@@ -100,7 +100,7 @@ class TestUniqueConsecutiveOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output()
 
 
 class TestUniqueConsecutiveOp2(TestUniqueConsecutiveOp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
No.242、228
PIR API 推全升级

- https://github.com/PaddlePaddle/Paddle/issues/58067




`moveaxis` 单测全部通过
`unique_consecutive` 单测通过率 8/11

以下三个 `test_unique_consecutive_op` 的 `test_check_output` 都 raise `AssertionError`
```
2023-11-05 11:04:29 FAIL: test_check_output (test_unique_consecutive_op.TestUniqueConsecutiveOp2)
2023-11-05 11:04:29 FAIL: test_check_output (test_unique_consecutive_op.TestUniqueConsecutiveOp3)
2023-11-05 11:04:29 FAIL: test_check_output (test_unique_consecutive_op.TestUniqueConsecutiveOp4)
```

```shell
2023-11-05 11:04:29 ----------------------------------------------------------------------
2023-11-05 11:04:29 Traceback (most recent call last):
2023-11-05 11:04:29   File "/workspace/Paddle/build/test/legacy_test/test_unique_consecutive_op.py", line 103, in test_check_output
2023-11-05 11:04:29     self.check_output(check_pir=True)
2023-11-05 11:04:29   File "/workspace/Paddle/build/python/op_test.py", line 2676, in check_output
2023-11-05 11:04:29     res = self.check_output_with_place(
2023-11-05 11:04:29   File "/workspace/Paddle/build/python/op_test.py", line 2550, in check_output_with_place
2023-11-05 11:04:29     new_ir_checker.check()
2023-11-05 11:04:29   File "/workspace/Paddle/build/python/op_test.py", line 2151, in check
2023-11-05 11:04:29     self.calculate_output()
2023-11-05 11:04:29   File "/workspace/Paddle/build/python/op_test.py", line 2337, in calculate_output
2023-11-05 11:04:29     new_ir_outs = self.op_test._calc_new_ir_output(place)
2023-11-05 11:04:29   File "/workspace/Paddle/build/python/op_test.py", line 1353, in _calc_new_ir_output
2023-11-05 11:04:29     assert len(ret_tuple) == len(outputs_sig)
2023-11-05 11:04:29 AssertionError
2023-11-05 11:04:29 
2023-11-05 11:04:29 ----------------------------------------------------------------------
2023-11-05 11:04:29 Ran 11 tests in 0.147s
2023-11-05 11:04:29 
2023-11-05 11:04:29 FAILED (failures=3)
```