### PR TITLE
【PIR API adaptor No.23】Migrate paddle.Tensor.bincount into pir

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -16,6 +16,7 @@ import numpy as np
 
 import paddle
 from paddle import _C_ops
+from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
 
@@ -1785,7 +1786,12 @@ def bincount(x, weights=None, minlength=0, name=None):
             Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.        , 2.19999981, 0.40000001, 0.        , 0.50000000, 0.50000000])
     """
-    if x.dtype not in [paddle.int32, paddle.int64]:
+    if x.dtype not in [
+        paddle.int32,
+        paddle.int64,
+        DataType.INT32,
+        DataType.INT64,
+    ]:
         raise TypeError("Elements in Input(x) should all be integers")
 
     if in_dynamic_or_pir_mode():

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1788,7 +1788,7 @@ def bincount(x, weights=None, minlength=0, name=None):
     if x.dtype not in [paddle.int32, paddle.int64]:
         raise TypeError("Elements in Input(x) should all be integers")
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.bincount(x, weights, minlength)
     else:
         helper = LayerHelper('bincount', **locals())

--- a/test/legacy_test/test_bincount_op.py
+++ b/test/legacy_test/test_bincount_op.py
@@ -255,8 +255,6 @@ class TestTensorMinlength(unittest.TestCase):
         )
         np.testing.assert_allclose(np_out, pd_out.numpy())
 
-    # @test_with_pir_api
-    # pir mode not support paddle.static.save_inference_model
     def test_static_and_infer(self):
         paddle.enable_static()
         np_x = np.random.randn(100).astype('float32')

--- a/test/legacy_test/test_bincount_op.py
+++ b/test/legacy_test/test_bincount_op.py
@@ -255,7 +255,8 @@ class TestTensorMinlength(unittest.TestCase):
         )
         np.testing.assert_allclose(np_out, pd_out.numpy())
 
-    @test_with_pir_api
+    # @test_with_pir_api
+    # pir mode not support paddle.static.save_inference_model
     def test_static_and_infer(self):
         paddle.enable_static()
         np_x = np.random.randn(100).astype('float32')

--- a/test/legacy_test/test_bincount_op.py
+++ b/test/legacy_test/test_bincount_op.py
@@ -23,6 +23,7 @@ import paddle
 import paddle.inference as paddle_infer
 from paddle import base
 from paddle.base.framework import in_dygraph_mode
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -30,10 +31,11 @@ paddle.enable_static()
 class TestBincountOpAPI(unittest.TestCase):
     """Test bincount api."""
 
+    @test_with_pir_api
     def test_static_graph(self):
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(train_program, startup_program):
+        startup_program = paddle.static.Program()
+        train_program = paddle.static.Program()
+        with paddle.static.program_guard(train_program, startup_program):
             inputs = paddle.static.data(name='input', dtype='int64', shape=[7])
             weights = paddle.static.data(
                 name='weights', dtype='int64', shape=[7]
@@ -152,7 +154,7 @@ class TestBincountOp(OpTest):
         self.Out = np.bincount(self.np_input, minlength=self.minlength)
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestCase1(TestBincountOp):
@@ -253,6 +255,7 @@ class TestTensorMinlength(unittest.TestCase):
         )
         np.testing.assert_allclose(np_out, pd_out.numpy())
 
+    @test_with_pir_api
     def test_static_and_infer(self):
         paddle.enable_static()
         np_x = np.random.randn(100).astype('float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Migrate `paddle.Tensor.bincount` into pir

- #58067
- `paddle.Tensor.bincount` unit test coverage 10/10
test_errors 的单测和 paddle.static.save_inference_model 相关的单测不支持