### PR TITLE
【PIR API adaptor No.39、123】Migrate label_smooth & class_center_sample into pir

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2226,7 +2226,7 @@ def class_center_sample(label, num_classes, num_samples, group=None):
     if (seed is None or seed == 0) and default_main_program().random_seed != 0:
         seed = default_main_program().random_seed
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.class_center_sample(
             label,
             num_classes,

--- a/test/legacy_test/test_class_center_sample_op.py
+++ b/test/legacy_test/test_class_center_sample_op.py
@@ -19,7 +19,7 @@ import numpy as np
 from op_test import OpTest, paddle_static_guard
 
 import paddle
-from paddle.base import Program, core, program_guard
+from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
 
@@ -166,7 +166,9 @@ class TestClassCenterSampleV2(unittest.TestCase):
     @test_with_pir_api
     def check_static_result(self, place):
         with paddle_static_guard():
-            with program_guard(Program(), Program()):
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
                 label_np = np.random.randint(
                     0, self.num_classes, (self.batch_size,), dtype=self.dtype
                 )

--- a/test/legacy_test/test_class_center_sample_op.py
+++ b/test/legacy_test/test_class_center_sample_op.py
@@ -189,7 +189,6 @@ class TestClassCenterSampleV2(unittest.TestCase):
                 )
                 exe = paddle.base.Executor(place)
                 [remapped_label_res, sampled_class_index_res] = exe.run(
-                    paddle.base.default_main_program(),
                     feed={'label': label_np},
                     fetch_list=[remapped_label, sampled_class_index],
                 )

--- a/test/legacy_test/test_class_center_sample_op.py
+++ b/test/legacy_test/test_class_center_sample_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, paddle_static_guard
 
 import paddle
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 def class_center_sample_numpy(label, classes_list, num_samples):
@@ -118,7 +119,9 @@ class TestClassCenterSampleOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(no_check_set=['SampledLocalClassCenter'])
+        self.check_output(
+            no_check_set=['SampledLocalClassCenter'], check_pir=True
+        )
 
 
 class TestClassCenterSampleOpINT32(TestClassCenterSampleOp):
@@ -160,6 +163,7 @@ class TestClassCenterSampleV2(unittest.TestCase):
             for place in self.places:
                 self.check_static_result(place=place)
 
+    @test_with_pir_api
     def check_static_result(self, place):
         with paddle_static_guard():
             with program_guard(Program(), Program()):

--- a/test/legacy_test/test_label_smooth_functional.py
+++ b/test/legacy_test/test_label_smooth_functional.py
@@ -42,7 +42,6 @@ class LabelSmoothTestCase(unittest.TestCase):
     def setUp(self):
         self.label = np.random.randn(*(self.label_shape)).astype(self.dtype)
 
-    @test_with_pir_api
     def base_layer(self, place):
         paddle.enable_static()
         main = base.Program()
@@ -63,7 +62,6 @@ class LabelSmoothTestCase(unittest.TestCase):
         (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
         return y_np
 
-    @test_with_pir_api
     def functional(self, place):
         paddle.enable_static()
         main = base.Program()
@@ -93,11 +91,17 @@ class LabelSmoothTestCase(unittest.TestCase):
 
     def _test_equivalence(self, place):
         place = base.CPUPlace()
-        result1 = self.base_layer(place)
         result2 = self.functional(place)
         result3 = self.paddle_dygraph_layer()
-        np.testing.assert_array_almost_equal(result1, result2)
         np.testing.assert_array_almost_equal(result2, result3)
+
+        @test_with_pir_api
+        def dynamic_and_pir_mode_test():
+            result1 = self.base_layer(place)
+            result2 = self.functional(place)
+            np.testing.assert_array_almost_equal(result1, result2)
+
+        dynamic_and_pir_mode_test()
 
     def runTest(self):
         place = base.CPUPlace()

--- a/test/legacy_test/test_label_smooth_functional.py
+++ b/test/legacy_test/test_label_smooth_functional.py
@@ -20,6 +20,7 @@ import paddle
 import paddle.base.dygraph as dg
 import paddle.nn.functional as F
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class LabelSmoothTestCase(unittest.TestCase):
@@ -41,6 +42,7 @@ class LabelSmoothTestCase(unittest.TestCase):
     def setUp(self):
         self.label = np.random.randn(*(self.label_shape)).astype(self.dtype)
 
+    @test_with_pir_api
     def base_layer(self, place):
         paddle.enable_static()
         main = base.Program()
@@ -61,6 +63,7 @@ class LabelSmoothTestCase(unittest.TestCase):
         (y_np,) = exe.run(main, feed=feed_dict, fetch_list=[y_var])
         return y_np
 
+    @test_with_pir_api
     def functional(self, place):
         paddle.enable_static()
         main = base.Program()

--- a/test/legacy_test/test_label_smooth_functional.py
+++ b/test/legacy_test/test_label_smooth_functional.py
@@ -89,19 +89,14 @@ class LabelSmoothTestCase(unittest.TestCase):
         y_np = y_var.numpy()
         return y_np
 
+    @test_with_pir_api
     def _test_equivalence(self, place):
         place = base.CPUPlace()
+        result1 = self.base_layer(place)
         result2 = self.functional(place)
         result3 = self.paddle_dygraph_layer()
+        np.testing.assert_array_almost_equal(result1, result2)
         np.testing.assert_array_almost_equal(result2, result3)
-
-        @test_with_pir_api
-        def dynamic_and_pir_mode_test():
-            result1 = self.base_layer(place)
-            result2 = self.functional(place)
-            np.testing.assert_array_almost_equal(result1, result2)
-
-        dynamic_and_pir_mode_test()
 
     def runTest(self):
         place = base.CPUPlace()

--- a/test/legacy_test/test_label_smooth_op.py
+++ b/test/legacy_test/test_label_smooth_op.py
@@ -45,10 +45,10 @@ class TestLabelSmoothOp(OpTest):
         self.dtype = np.float64
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out")
+        self.check_grad(["X"], "Out", check_pir=True)
 
 
 @unittest.skipIf(
@@ -77,11 +77,11 @@ class TestLabelSmoothOpBF16(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ["X"], "Out")
+        self.check_grad_with_place(place, ["X"], "Out", check_pir=True)
 
 
 class TestLabelSmoothFP16OP(TestLabelSmoothOp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 label_smooth / class_center_sample 迁移升级至 pir，并更新单测

- https://github.com/PaddlePaddle/Paddle/issues/58067

`label_smooth` 单测全部通过
`class_center_sample` 单测全部通过