### PR TITLE
[CINN] Use cinn_fusion prefix when register pass

### DIFF
--- a/paddle/cinn/common/macros.h
+++ b/paddle/cinn/common/macros.h
@@ -67,10 +67,10 @@
                              __test_global_namespace_##uniq_name##__>::value, \
                 msg)
 
-#define USE_FUSION_PASS(pass_name)                               \
-  STATIC_ASSERT_GLOBAL_NAMESPACE(                                \
-      __use_fusion_pass_##pass_name,                             \
-      "USE_OP_ITSELF must be called in global namespace");       \
-  extern int TouchFusionPassRegistrar_##pass_name();             \
-  [[maybe_unused]] static int __use_fusion_pass_##pass_name##_ = \
-      TouchFusionPassRegistrar_##pass_name()
+#define USE_FUSION_PASS(pass_name)                                    \
+  STATIC_ASSERT_GLOBAL_NAMESPACE(                                     \
+      __use_cinn_fusion_pass_##pass_name,                             \
+      "USE_FUSION_PASS must be called in global namespace");          \
+  extern int TouchCinnFusionPassRegistrar_##pass_name();              \
+  [[maybe_unused]] static int __use_cinn_fusion_pass_##pass_name##_ = \
+      TouchCinnFusionPassRegistrar_##pass_name()

--- a/paddle/cinn/hlir/pass/general_fusion_merge_pass/fusion_pass_registrar.h
+++ b/paddle/cinn/hlir/pass/general_fusion_merge_pass/fusion_pass_registrar.h
@@ -52,11 +52,11 @@ class FusionPassRegistrar final : public Registrar {
 
 #define CINN_REGISTER_FUSION_PASS(pass_name, pass_class)               \
   STATIC_ASSERT_GLOBAL_NAMESPACE(                                      \
-      __reg_pass__##pass_name,                                         \
+      __reg_cinn_fusion_pass__##pass_name,                             \
       "CINN_REGISTER_FUSION_PASS must be called in global namespace"); \
   static ::cinn::hlir::pass::FusionPassRegistrar<pass_class>           \
-      __pass_registrar_##pass_name##__(#pass_name);                    \
-  int TouchFusionPassRegistrar_##pass_name() {                         \
-    __pass_registrar_##pass_name##__.Touch();                          \
+      __cinn_fusion_pass_registrar_##pass_name##__(#pass_name);        \
+  int TouchCinnFusionPassRegistrar_##pass_name() {                     \
+    __cinn_fusion_pass_registrar_##pass_name##__.Touch();              \
     return 0;                                                          \
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

统一对 global namespace 的全局 static 变量命名加上 cinn_fusion 前缀，避免 libpaddle.so 与 cinnapi.so 中同名 pass 导致符号变量仅初始化一次，引起运行时另一个同名 Pass 未注册的错误

