### PR TITLE
【PIR API adaptor No.132】 Migrate paddle.Tensor.paddle.Tensor.logcumsumexp

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4190,7 +4190,7 @@ def logcumsumexp(x, axis=None, dtype=None, name=None):
     if dtype is not None and x.dtype != convert_np_dtype_to_dtype_(dtype):
         x = cast(x, dtype)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if axis is None:
             axis = -1
         return _C_ops.logcumsumexp(x, axis, flatten, False, False)

--- a/test/legacy_test/test_logcumsumexp_op.py
+++ b/test/legacy_test/test_logcumsumexp_op.py
@@ -22,6 +22,7 @@ from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def np_naive_logcumsumexp(x: np.ndarray, axis: Optional[int] = None):
@@ -145,7 +146,9 @@ class TestLogcumsumexp(unittest.TestCase):
         np.testing.assert_allclose(z, y.numpy(), rtol=1e-05)
 
     def run_static(self, use_gpu=False):
-        with base.program_guard(base.Program()):
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
             data_np = np.random.random((5, 4)).astype(np.float32)
             x = paddle.static.data('X', [5, 4])
             y = paddle.logcumsumexp(x)
@@ -156,15 +159,15 @@ class TestLogcumsumexp(unittest.TestCase):
 
             place = base.CUDAPlace(0) if use_gpu else base.CPUPlace()
             exe = base.Executor(place)
-            exe.run(base.default_startup_program())
             out = exe.run(
+                main,
                 feed={'X': data_np},
                 fetch_list=[
-                    y.name,
-                    y2.name,
-                    y3.name,
-                    y4.name,
-                    y5.name,
+                    y,
+                    y2,
+                    y3,
+                    y4,
+                    y5,
                 ],
             )
 
@@ -178,6 +181,7 @@ class TestLogcumsumexp(unittest.TestCase):
             z = np_logcumsumexp(data_np, axis=-2)
             np.testing.assert_allclose(z, out[4], rtol=1e-05)
 
+    @test_with_pir_api
     def test_cpu(self):
         paddle.disable_static(paddle.base.CPUPlace())
         self.run_imperative()
@@ -185,6 +189,7 @@ class TestLogcumsumexp(unittest.TestCase):
 
         self.run_static()
 
+    @test_with_pir_api
     def test_gpu(self):
         if not base.core.is_compiled_with_cuda():
             return
@@ -194,14 +199,18 @@ class TestLogcumsumexp(unittest.TestCase):
 
         self.run_static(use_gpu=True)
 
+    # @test_with_pir_api
     def test_name(self):
         with base.program_guard(base.Program()):
             x = paddle.static.data('x', [3, 4])
             y = paddle.logcumsumexp(x, name='out')
             self.assertTrue('out' in y.name)
 
+    @test_with_pir_api
     def test_type_error(self):
-        with base.program_guard(base.Program()):
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
             with self.assertRaises(TypeError):
                 data_np = np.random.random((100, 100), dtype=np.int32)
                 x = paddle.static.data('X', [100, 100], dtype='int32')
@@ -209,8 +218,7 @@ class TestLogcumsumexp(unittest.TestCase):
 
                 place = base.CUDAPlace(0)
                 exe = base.Executor(place)
-                exe.run(base.default_startup_program())
-                out = exe.run(feed={'X': data_np}, fetch_list=[y.name])
+                out = exe.run(main, feed={'X': data_np}, fetch_list=[y])
 
 
 def logcumsumexp_wrapper(
@@ -296,6 +304,7 @@ class TestLogcumsumexpFP16(unittest.TestCase):
         paddle.enable_static()
         return y_np, x_g_np
 
+    @test_with_pir_api
     def test_main(self):
         if not paddle.is_compiled_with_cuda():
             return

--- a/test/legacy_test/test_zero_dim_tensor.py
+++ b/test/legacy_test/test_zero_dim_tensor.py
@@ -25,6 +25,7 @@ from decorator_helper import prog_scope
 
 import paddle
 import paddle.nn.functional as F
+from paddle.pir_utils import test_with_pir_api
 
 unary_api_list = [
     paddle.nn.functional.elu,
@@ -2088,6 +2089,7 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out3.grad.shape, [])
         self.assertTrue(out3.grad.numpy() == 1)
 
+    @test_with_pir_api
     def test_logcumsumexp(self):
         x = paddle.rand([])
         x.stop_gradient = False
@@ -4342,6 +4344,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(out3.shape, ())
 
     @prog_scope()
+    @test_with_pir_api
     def test_logcumsumexp(self):
         x = paddle.rand([])
         x.stop_gradient = False

--- a/test/legacy_test/test_zero_dim_tensor.py
+++ b/test/legacy_test/test_zero_dim_tensor.py
@@ -25,7 +25,6 @@ from decorator_helper import prog_scope
 
 import paddle
 import paddle.nn.functional as F
-from paddle.pir_utils import test_with_pir_api
 
 unary_api_list = [
     paddle.nn.functional.elu,
@@ -2089,7 +2088,6 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out3.grad.shape, [])
         self.assertTrue(out3.grad.numpy() == 1)
 
-    @test_with_pir_api
     def test_logcumsumexp(self):
         x = paddle.rand([])
         x.stop_gradient = False
@@ -4344,7 +4342,6 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(out3.shape, ())
 
     @prog_scope()
-    @test_with_pir_api
     def test_logcumsumexp(self):
         x = paddle.rand([])
         x.stop_gradient = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 paddle.Tensor.log2 迁移升级至 pir，并更新单测

https://github.com/PaddlePaddle/Paddle/issues/58067

单测覆盖率：4/5

存在问题：
pir下test_name测例，不支持name属性的访问：
```
1256: test_logcumsumexp_op failed
1256:  ..E.ss.........
1256: ======================================================================
1256: ERROR: test_name (test_logcumsumexp_op.TestLogcumsumexp)
1256: ----------------------------------------------------------------------
1256: Traceback (most recent call last):
1256:   File "/wuzp/Paddle/build/python/paddle/pir_utils.py", line 119, in impl
1256:     func(*args, **kwargs)
1256:   File "/wuzp/Paddle/build/test/legacy_test/test_logcumsumexp_op.py", line 207, in test_name
1256:     self.assertTrue('out' in y.name)
1256: ValueError: (InvalidArgument) Currently, we can only get name of OpResult that is persistable (at /wuzp/Paddle/paddle/fluid/pybind/pir.cc:665)
1256: 
1256: 
1256: ----------------------------------------------------------------------
```
