### PR TITLE
【PIR API adaptor No.117、118、119】Migrate is_empty / isfinite / isinf  into pir

### DIFF
--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -363,7 +363,7 @@ def is_empty(x, name=None):
             False)
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.is_empty(x)
     else:
         check_variable_and_dtype(

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4350,7 +4350,7 @@ def isfinite(x, name=None):
             Tensor(shape=[7], dtype=bool, place=Place(cpu), stop_gradient=True,
             [False, True , True , False, True , False, False])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.isfinite(x)
     else:
         helper = LayerHelper("isfinite_v2", **locals())
@@ -4397,7 +4397,7 @@ def isinf(x, name=None):
             Tensor(shape=[7], dtype=bool, place=Place(cpu), stop_gradient=True,
             [True , False, False, True , False, False, False])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.isinf(x)
     else:
         helper = LayerHelper("isinf_v2", **locals())

--- a/test/legacy_test/test_is_empty_op.py
+++ b/test/legacy_test/test_is_empty_op.py
@@ -18,7 +18,6 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
-from paddle.pir_utils import test_with_pir_api
 
 
 class TestEmpty(OpTest):
@@ -41,7 +40,6 @@ class TestNotEmpty(TestEmpty):
 
 
 class TestIsEmptyOpError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with paddle.static.program_guard(

--- a/test/legacy_test/test_is_empty_op.py
+++ b/test/legacy_test/test_is_empty_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestEmpty(OpTest):
@@ -28,7 +29,7 @@ class TestEmpty(OpTest):
         self.outputs = {'Out': np.array(False)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestNotEmpty(TestEmpty):
@@ -40,6 +41,7 @@ class TestNotEmpty(TestEmpty):
 
 
 class TestIsEmptyOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with paddle.static.program_guard(

--- a/test/legacy_test/test_isfinite_v2_op.py
+++ b/test/legacy_test/test_isfinite_v2_op.py
@@ -21,22 +21,18 @@ from paddle import base, static
 from paddle.pir_utils import test_with_pir_api
 
 
-@test_with_pir_api
 def run_static(x_np, dtype, op_str, use_gpu=False):
     paddle.enable_static()
-    startup_program = static.Program()
-    main_program = static.Program()
+    startup_program = paddle.static.Program()
+    main_program = paddle.static.Program()
     place = paddle.CPUPlace()
     if use_gpu and base.core.is_compiled_with_cuda():
         place = paddle.CUDAPlace(0)
     exe = base.Executor(place)
     with static.program_guard(main_program, startup_program):
         x = paddle.static.data(name='x', shape=x_np.shape, dtype=dtype)
-        res = getattr(paddle.tensor, op_str)(x)
-        exe.run(startup_program)
-        static_result = exe.run(
-            main_program, feed={'x': x_np}, fetch_list=[res]
-        )
+        res = getattr(paddle, op_str)(x)
+        static_result = exe.run(feed={'x': x_np}, fetch_list=[res])
     return static_result
 
 
@@ -46,7 +42,7 @@ def run_dygraph(x_np, op_str, use_gpu=True):
         place = paddle.CUDAPlace(0)
     paddle.disable_static(place)
     x = paddle.to_tensor(x_np)
-    dygraph_result = getattr(paddle.tensor, op_str)(x)
+    dygraph_result = getattr(paddle, op_str)(x)
     return dygraph_result
 
 
@@ -57,7 +53,7 @@ def run_eager(x_np, op_str, use_gpu=True):
             place = paddle.CUDAPlace(0)
 
         x = paddle.to_tensor(x_np)
-        dygraph_result = getattr(paddle.tensor, op_str)(x)
+        dygraph_result = getattr(paddle, op_str)(x)
         return dygraph_result
 
 
@@ -121,12 +117,21 @@ def test(test_case, op_str, use_gpu=False):
         meta_data = dict(meta_data)
         meta_data['op_str'] = op_str
         x_np, result_np = np_data_generator(**meta_data)
-        static_result = run_static(x_np, meta_data['type'], op_str, use_gpu)
-        dygraph_result = run_dygraph(x_np, op_str, use_gpu)
-        eager_result = run_eager(x_np, op_str, use_gpu)
-        test_case.assertTrue((static_result == result_np).all())
-        test_case.assertTrue((dygraph_result.numpy() == result_np).all())
-        test_case.assertTrue((eager_result.numpy() == result_np).all())
+
+        dygraph_result = run_dygraph(x_np, op_str, use_gpu).numpy()
+        eager_result = run_eager(x_np, op_str, use_gpu).numpy()
+
+        test_case.assertTrue((dygraph_result == result_np).all())
+        test_case.assertTrue((eager_result == result_np).all())
+
+        @test_with_pir_api
+        def test_static_or_pir_mode():
+            (static_result,) = run_static(
+                x_np, meta_data['type'], op_str, use_gpu
+            )
+            test_case.assertTrue((static_result == result_np).all())
+
+        test_static_or_pir_mode()
 
 
 class TestCPUNormal(unittest.TestCase):
@@ -154,23 +159,23 @@ class TestCUDANormal(unittest.TestCase):
 class TestError(unittest.TestCase):
     def test_bad_input(self):
         paddle.enable_static()
-        with static.program_guard(static.Program()):
+        with paddle.static.program_guard(paddle.static.Program()):
 
             def test_isinf_bad_x():
                 x = [1, 2, 3]
-                result = paddle.tensor.isinf(x)
+                result = paddle.isinf(x)
 
             self.assertRaises(TypeError, test_isinf_bad_x)
 
             def test_isnan_bad_x():
                 x = [1, 2, 3]
-                result = paddle.tensor.isnan(x)
+                result = paddle.isnan(x)
 
             self.assertRaises(TypeError, test_isnan_bad_x)
 
             def test_isfinite_bad_x():
                 x = [1, 2, 3]
-                result = paddle.tensor.isfinite(x)
+                result = paddle.isfinite(x)
 
             self.assertRaises(TypeError, test_isfinite_bad_x)
 

--- a/test/legacy_test/test_isfinite_v2_op.py
+++ b/test/legacy_test/test_isfinite_v2_op.py
@@ -18,8 +18,10 @@ import numpy as np
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
+@test_with_pir_api
 def run_static(x_np, dtype, op_str, use_gpu=False):
     paddle.enable_static()
     startup_program = base.Program()
@@ -150,6 +152,7 @@ class TestCUDANormal(unittest.TestCase):
 
 
 class TestError(unittest.TestCase):
+    @test_with_pir_api
     def test_bad_input(self):
         paddle.enable_static()
         with base.program_guard(base.Program()):

--- a/test/legacy_test/test_isfinite_v2_op.py
+++ b/test/legacy_test/test_isfinite_v2_op.py
@@ -17,20 +17,20 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import base
+from paddle import base, static
 from paddle.pir_utils import test_with_pir_api
 
 
 @test_with_pir_api
 def run_static(x_np, dtype, op_str, use_gpu=False):
     paddle.enable_static()
-    startup_program = base.Program()
-    main_program = base.Program()
+    startup_program = static.Program()
+    main_program = static.Program()
     place = paddle.CPUPlace()
     if use_gpu and base.core.is_compiled_with_cuda():
         place = paddle.CUDAPlace(0)
     exe = base.Executor(place)
-    with base.program_guard(main_program, startup_program):
+    with static.program_guard(main_program, startup_program):
         x = paddle.static.data(name='x', shape=x_np.shape, dtype=dtype)
         res = getattr(paddle.tensor, op_str)(x)
         exe.run(startup_program)
@@ -152,10 +152,9 @@ class TestCUDANormal(unittest.TestCase):
 
 
 class TestError(unittest.TestCase):
-    @test_with_pir_api
     def test_bad_input(self):
         paddle.enable_static()
-        with base.program_guard(base.Program()):
+        with static.program_guard(static.Program()):
 
             def test_isinf_bad_x():
                 x = [1, 2, 3]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 is_empty / isfinite / isinf  迁移升级至 pir，并更新单测

- https://github.com/PaddlePaddle/Paddle/issues/58067

单测
is_empty 单测通过率 3/4 `test_errors` 未开启
isfinite / isinf 单测通过率 6/7 `TestError.test_bad_input` 未开启
