### PR TITLE
【PIR API adaptor No.59, 61, 63】Migrate some ops into pir

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -717,7 +717,7 @@ def dist(x, y, p=2, name=None):
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             0.)
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.dist(x, y, p)
 
     check_variable_and_dtype(
@@ -2818,7 +2818,7 @@ def eigh(x, UPLO='L', name=None):
              [ 0.3826833963394165j    , -0.9238795042037964j    ]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.eigh(x, UPLO)
     else:
 
@@ -3324,7 +3324,7 @@ def eigvalsh(x, UPLO='L', name=None):
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.17157286, 5.82842731])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         values, _ = _C_ops.eigvalsh(x, UPLO, x.stop_gradient)
         return values
     else:

--- a/test/legacy_test/test_dist_op.py
+++ b/test/legacy_test/test_dist_op.py
@@ -246,8 +246,8 @@ class TestDistAPI(unittest.TestCase):
     @test_with_pir_api
     def test_api(self):
         self.init_data_type()
-        main_program = base.Program()
-        startup_program = base.Program()
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
         with base.program_guard(main_program, startup_program):
             x = paddle.static.data(
                 name='x', shape=[2, 3, 4, 5], dtype=self.data_type

--- a/test/legacy_test/test_dist_op.py
+++ b/test/legacy_test/test_dist_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -113,13 +114,11 @@ class TestDistOp(OpTest):
         return x_grad, y_grad
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
-            ["X", "Y"],
-            "Out",
-            user_defined_grads=self.gradient,
+            ["X", "Y"], "Out", user_defined_grads=self.gradient, check_pir=True
         )
 
 
@@ -244,6 +243,7 @@ class TestDistAPI(unittest.TestCase):
             'float32' if core.is_compiled_with_rocm() else 'float64'
         )
 
+    @test_with_pir_api
     def test_api(self):
         self.init_data_type()
         main_program = base.Program()

--- a/test/legacy_test/test_dist_op.py
+++ b/test/legacy_test/test_dist_op.py
@@ -266,7 +266,7 @@ class TestDistAPI(unittest.TestCase):
             )
             exe = base.Executor(place)
             out = exe.run(
-                base.default_main_program(),
+                main_program,
                 feed={'x': x_i, 'y': y_i},
                 fetch_list=[result],
             )

--- a/test/legacy_test/test_eigh_op.py
+++ b/test/legacy_test/test_eigh_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def valid_eigh_result(A, eigh_value, eigh_vector, uplo):
@@ -92,7 +93,7 @@ class TestEighOp(OpTest):
     #     self.check_output(no_check_set=['Eigenvectors'])
 
     def test_grad(self):
-        self.check_grad(["X"], ["Eigenvalues"])
+        self.check_grad(["X"], ["Eigenvalues"], check_pir=True)
 
 
 class TestEighUPLOCase(TestEighOp):
@@ -183,6 +184,7 @@ class TestEighAPI(unittest.TestCase):
             )
             valid_eigh_result(self.complex_symm, actual_w, actual_v, self.UPLO)
 
+    @test_with_pir_api
     def test_in_static_mode(self):
         paddle.enable_static()
         self.check_static_float_result()

--- a/test/legacy_test/test_eigvalsh_op.py
+++ b/test/legacy_test/test_eigvalsh_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def compare_result(actual, expected):
@@ -72,10 +73,10 @@ class TestEigvalshOp(OpTest):
 
     def test_check_output(self):
         # Vectors in posetive or negative is equivalent
-        self.check_output(no_check_set=['Eigenvectors'])
+        self.check_output(no_check_set=['Eigenvectors'], check_pir=True)
 
     def test_grad(self):
-        self.check_grad(["X"], ["Eigenvalues"])
+        self.check_grad(["X"], ["Eigenvalues"], check_pir=True)
 
 
 class TestEigvalshUPLOCase(TestEigvalshOp):
@@ -166,6 +167,7 @@ class TestEigvalshAPI(unittest.TestCase):
             expected_w = np.linalg.eigvalsh(self.complex_symm)
             compare_result(actual_w[0], expected_w)
 
+    @test_with_pir_api
     def test_in_static_mode(self):
         paddle.enable_static()
         self.check_static_float_result()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description

PIR API 推全升级
将如下算子迁移升级至 pir，并更新单测
- dist（19/19）
- eigh（5/6）：有一个单测是用来测试error的
- eigvalsh（4/6）：有一个单测是用来测试error的


- https://github.com/PaddlePaddle/Paddle/issues/58067



