### PR TITLE
【PIR API adaptor No.65, 69】Migrate some ops into pir

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1199,7 +1199,7 @@ def eye(num_rows, num_columns=None, dtype=None, name=None):
     else:
         num_columns = num_rows
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out = _C_ops.eye(
             num_rows, num_columns, dtype, _current_expected_place()
         )
@@ -2177,7 +2177,7 @@ def empty_like(x, dtype=None, name=None):
         dtype = x.dtype
     dtype = convert_dtype(dtype)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         out = _C_ops.empty(
             x.shape,
             convert_np_dtype_to_dtype_(dtype),

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1183,7 +1183,9 @@ def eye(num_rows, num_columns=None, dtype=None, name=None):
     """
 
     def _check_attr(attr, message):
-        if isinstance(attr, ((Variable, core.eager.Tensor))):
+        if isinstance(
+            attr, ((Variable, core.eager.Tensor, paddle.pir.OpResult))
+        ):
             assert len(attr.shape) == 1 and attr.shape[0] in [1, -1]
         elif not isinstance(attr, int) or attr < 0:
             raise TypeError(f"{message} should be a non-negative int.")

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2179,9 +2179,18 @@ def empty_like(x, dtype=None, name=None):
         dtype = x.dtype
     dtype = convert_dtype(dtype)
 
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         out = _C_ops.empty(
             x.shape,
+            convert_np_dtype_to_dtype_(dtype),
+            _current_expected_place(),
+        )
+        out.stop_gradient = True
+        return out
+    elif in_pir_mode():
+        shape = paddle.shape(x)
+        out = _C_ops.empty(
+            shape,
             convert_np_dtype_to_dtype_(dtype),
             _current_expected_place(),
         )

--- a/test/legacy_test/test_empty_like_op.py
+++ b/test/legacy_test/test_empty_like_op.py
@@ -178,19 +178,19 @@ class TestEmptyLikeAPI_Static(TestEmptyLikeAPICommon):
 
             out = paddle.empty_like(data_x)
 
-        place = (
-            paddle.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
-        exe = paddle.static.Executor(place)
-        res = exe.run(train_program, feed={'x': x}, fetch_list=[out])
-
-        self.dst_dtype = self.dtype
-        self.dst_shape = x.shape
-        self.__check_out__(res[0])
-
-        paddle.disable_static()
+            place = (
+                paddle.CUDAPlace(0)
+                if core.is_compiled_with_cuda()
+                else paddle.CPUPlace()
+            )
+            exe = paddle.static.Executor(place)
+            res = exe.run(train_program, feed={'x': x}, fetch_list=[out])
+    
+            self.dst_dtype = self.dtype
+            self.dst_shape = x.shape
+            self.__check_out__(res[0])
+    
+            paddle.disable_static()
 
     def init_config(self):
         self.x_shape = (200, 3)

--- a/test/legacy_test/test_empty_like_op.py
+++ b/test/legacy_test/test_empty_like_op.py
@@ -20,6 +20,7 @@ from op_test import convert_uint16_to_float
 import paddle
 from paddle.base import core
 from paddle.base.data_feeder import convert_dtype
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
 
@@ -163,6 +164,7 @@ class TestEmptyLikeAPI_Static(TestEmptyLikeAPICommon):
     def setUp(self):
         self.init_config()
 
+    @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
         train_program = Program()
@@ -212,6 +214,7 @@ class TestEmptyLikeAPI_StaticForFP16Op(TestEmptyLikeAPICommon):
         self.data_x_shape = [200, 3]
         self.dtype = 'float16'
 
+    @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
         if paddle.base.core.is_compiled_with_cuda():
@@ -245,6 +248,7 @@ class TestEmptyLikeAPI_StaticForBF16Op(TestEmptyLikeAPICommon):
         self.data_x_shape = [200, 3]
         self.dtype = 'uint16'
 
+    @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
         if paddle.base.core.is_compiled_with_cuda():

--- a/test/legacy_test/test_empty_like_op.py
+++ b/test/legacy_test/test_empty_like_op.py
@@ -21,7 +21,6 @@ import paddle
 from paddle.base import core
 from paddle.base.data_feeder import convert_dtype
 from paddle.pir_utils import test_with_pir_api
-from paddle.static import Program, program_guard
 
 
 class TestEmptyLikeAPICommon(unittest.TestCase):
@@ -167,10 +166,10 @@ class TestEmptyLikeAPI_Static(TestEmptyLikeAPICommon):
     @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
-        train_program = Program()
-        startup_program = Program()
+        train_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
 
-        with program_guard(train_program, startup_program):
+        with paddle.static.program_guard(train_program, startup_program):
             x = np.random.random(self.x_shape).astype(self.dtype)
             data_x = paddle.static.data(
                 'x', shape=self.data_x_shape, dtype=self.dtype
@@ -185,11 +184,11 @@ class TestEmptyLikeAPI_Static(TestEmptyLikeAPICommon):
             )
             exe = paddle.static.Executor(place)
             res = exe.run(train_program, feed={'x': x}, fetch_list=[out])
-    
+
             self.dst_dtype = self.dtype
             self.dst_shape = x.shape
             self.__check_out__(res[0])
-    
+
             paddle.disable_static()
 
     def init_config(self):

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -23,6 +23,7 @@ import paddle
 from paddle import base
 from paddle.base import core, framework
 from paddle.base.framework import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestEyeOp(OpTest):
@@ -46,7 +47,7 @@ class TestEyeOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def init_dtype(self):
         self.dtype = np.int32
@@ -69,7 +70,7 @@ class TestEyeOp1(OpTest):
         self.outputs = {'Out': np.eye(50, dtype=float)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestEyeOp2(OpTest):
@@ -85,7 +86,7 @@ class TestEyeOp2(OpTest):
         self.outputs = {'Out': np.eye(99, 1, dtype=float)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class API_TestTensorEye(unittest.TestCase):
@@ -144,6 +145,7 @@ class TestEyeRowsCol(UnittestBase):
         self.shapes = [[2, 3, 4]]
         self.save_path = os.path.join(self.temp_dir.name, self.path_prefix())
 
+    @test_with_pir_api
     def test_static(self):
         main_prog = Program()
         starup_prog = Program()
@@ -215,7 +217,7 @@ class TestEyeBF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -117,8 +117,10 @@ class API_TestTensorEye(unittest.TestCase):
         self.assertEqual((result == expected_result).all(), True)
 
     def test_dynamic_out(self):
+        paddle.disable_static()
         out = paddle.eye(10, dtype="int64")
         expected_result = np.eye(10, dtype="int64")
+        paddle.enable_static()
         self.assertEqual((out.numpy() == expected_result).all(), True)
 
     def test_errors(self):

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -23,7 +23,6 @@ import paddle
 from paddle import base
 from paddle.base import core, framework
 from paddle.base.framework import Program, program_guard
-from paddle.pir_utils import test_with_pir_api
 
 
 class TestEyeOp(OpTest):
@@ -145,7 +144,6 @@ class TestEyeRowsCol(UnittestBase):
         self.shapes = [[2, 3, 4]]
         self.save_path = os.path.join(self.temp_dir.name, self.path_prefix())
 
-    @test_with_pir_api
     def test_static(self):
         main_prog = Program()
         starup_prog = Program()

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -23,6 +23,7 @@ import paddle
 from paddle import base
 from paddle.base import core, framework
 from paddle.base.framework import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestEyeOp(OpTest):
@@ -89,7 +90,8 @@ class TestEyeOp2(OpTest):
 
 
 class API_TestTensorEye(unittest.TestCase):
-    def test_out(self):
+    @test_with_pir_api
+    def test_static_out(self):
         with paddle.static.program_guard(paddle.static.Program()):
             data = paddle.eye(10)
             place = base.CPUPlace()
@@ -114,10 +116,9 @@ class API_TestTensorEye(unittest.TestCase):
             expected_result = np.eye(10, dtype="int64")
         self.assertEqual((result == expected_result).all(), True)
 
-        paddle.disable_static()
+    def test_dynamic_out(self):
         out = paddle.eye(10, dtype="int64")
         expected_result = np.eye(10, dtype="int64")
-        paddle.enable_static()
         self.assertEqual((out.numpy() == expected_result).all(), True)
 
     def test_errors(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description

PIR API 推全升级
将如下算子迁移升级至 pir，并更新单测
- empty_like（3/3）
这个文件下继承自 TestEmptyLikeAPICommon 的单测均为动态图单测，不在本次组网API PIR 迁移的单测覆盖目标内。目前在 empty_like 的单测中，除了 TestEmptyError 尚未支持，其他都已经适配了
- eye（5/7）:TestEyeRowsCol暂时不支持


- https://github.com/PaddlePaddle/Paddle/issues/58067



