### PR TITLE
【PIR API adaptor No.213、214】 Migrate CosineSimilarity/stanh into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -340,7 +340,7 @@ def stanh(x, scale_a=0.67, scale_b=1.7159, name=None):
 
     """
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.stanh(x, scale_a, scale_b)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3967,7 +3967,6 @@ class TestSTanhAPI(unittest.TestCase):
             out_ref = ref_stanh(self.x_np, self.scale_a, self.scale_b)
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
-    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -3886,7 +3886,10 @@ class TestSTanh(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
+
+    def test_check_output(self):
+        self.check_output(check_pir=True)
 
 
 class TestSTanhScaleA(TestSTanh):
@@ -3933,6 +3936,7 @@ class TestSTanhAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
@@ -3952,6 +3956,7 @@ class TestSTanhAPI(unittest.TestCase):
             for r in [out]:
                 np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
 
+    @test_with_pir_api
     def test_base_api(self):
         with static_guard():
             with base.program_guard(base.Program()):
@@ -3962,6 +3967,7 @@ class TestSTanhAPI(unittest.TestCase):
             out_ref = ref_stanh(self.x_np, self.scale_a, self.scale_b)
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
 
+    @test_with_pir_api
     def test_errors(self):
         with static_guard():
             with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_cosine_similarity_api.py
+++ b/test/legacy_test/test_cosine_similarity_api.py
@@ -18,8 +18,8 @@ import numpy as np
 
 import paddle
 import paddle.nn.functional as F
-from paddle import nn
-from paddle.base import Executor, Program, core, program_guard
+from paddle import nn, static
+from paddle.base import Executor, core
 from paddle.pir_utils import test_with_pir_api
 
 
@@ -41,7 +41,11 @@ class TestCosineSimilarityAPI(unittest.TestCase):
     def check_static_result(self, place):
         paddle.enable_static()
 
-        with program_guard(Program(), Program()):
+        main_program = static.Program()
+        startup_program = static.Program()
+        with static.program_guard(
+            main_program=main_program, startup_program=startup_program
+        ):
             shape = [10, 15]
             axis = 1
             eps = 1e-8

--- a/test/legacy_test/test_cosine_similarity_api.py
+++ b/test/legacy_test/test_cosine_similarity_api.py
@@ -19,13 +19,8 @@ import numpy as np
 import paddle
 import paddle.nn.functional as F
 from paddle import nn
-from paddle.base import (
-    Executor,
-    Program,
-    core,
-    default_main_program,
-    program_guard,
-)
+from paddle.base import Executor, Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestCosineSimilarityAPI(unittest.TestCase):
@@ -42,6 +37,7 @@ class TestCosineSimilarityAPI(unittest.TestCase):
         cos_sim = w12 / n12
         return cos_sim
 
+    @test_with_pir_api
     def check_static_result(self, place):
         paddle.enable_static()
 
@@ -58,7 +54,6 @@ class TestCosineSimilarityAPI(unittest.TestCase):
             result = F.cosine_similarity(x1, x2, axis=axis, eps=eps)
             exe = Executor(place)
             fetches = exe.run(
-                default_main_program(),
                 feed={"x1": np_x1, "x2": np_x2},
                 fetch_list=[result],
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
No.213、214
PIR API `CosineSimilarity/stanh` 推全升级
- https://github.com/PaddlePaddle/Paddle/issues/58067

`CosineSimilarity` 全部通过
`stanh` 的 `test_errors` 未通过：
```
2023-11-05 16:33:38 ======================================================================
2023-11-05 16:33:38 ERROR: test_errors (test_activation_op.TestSTanhAPI)
2023-11-05 16:33:38 ERROR: test_errors (test_activation_op.TestSTanhAPIScaleA)
2023-11-05 16:33:38 ERROR: test_errors (test_activation_op.TestSTanhAPIScaleB)
2023-11-05 16:33:38 ----------------------------------------------------------------------
2023-11-05 16:33:38 Traceback (most recent call last):
2023-11-05 16:33:38   File "/workspace/Paddle/build/python/paddle/pir_utils.py", line 119, in impl
2023-11-05 16:33:38     func(*args, **kwargs)
2023-11-05 16:33:38   File "/workspace/Paddle/build/test/legacy_test/test_activation_op.py", line 3975, in test_errors
2023-11-05 16:33:38     self.assertRaises(TypeError, paddle.stanh, 1)
2023-11-05 16:33:38   File "/usr/lib/python3.10/unittest/case.py", line 738, in assertRaises
2023-11-05 16:33:38     return context.handle('assertRaises', args, kwargs)
2023-11-05 16:33:38   File "/usr/lib/python3.10/unittest/case.py", line 201, in handle
2023-11-05 16:33:38     callable_obj(*args, **kwargs)
2023-11-05 16:33:38   File "/workspace/Paddle/build/python/paddle/tensor/math.py", line 344, in stanh
2023-11-05 16:33:38     return _C_ops.stanh(x, scale_a, scale_b)
2023-11-05 16:33:38 ValueError: 
2023-11-05 16:33:38 
2023-11-05 16:33:38 --------------------------------------
2023-11-05 16:33:38 C++ Traceback (most recent call last):
2023-11-05 16:33:38 --------------------------------------
2023-11-05 16:33:38 0   paddle::pybind::static_api_stanh(_object*, _object*, _object*)
2023-11-05 16:33:38 1   phi::enforce::EnforceNotMet::EnforceNotMet(phi::ErrorSummary const&, char const*, int)
2023-11-05 16:33:38 2   phi::enforce::GetCurrentTraceBackString[abi:cxx11](bool)
2023-11-05 16:33:38 
2023-11-05 16:33:38 ----------------------
2023-11-05 16:33:38 Error Message Summary:
2023-11-05 16:33:38 ----------------------
2023-11-05 16:33:38 InvalidArgumentError: stanh(): argument (position 1) must be OpResult, but got int (at ../paddle/fluid/pybind/eager_utils.cc:1528)
```