### PR TITLE
[AutoParalle] Sequence Parallel Optimization Pass

### DIFF
--- a/python/paddle/distributed/auto_parallel/constants.py
+++ b/python/paddle/distributed/auto_parallel/constants.py
@@ -167,3 +167,9 @@ MP_OPTIMIZATION = "mp_optimization"
 set_field_default_config(
     MP_OPTIMIZATION, "allreduce_matmul_grad_overlapping", False
 )
+
+#########################################
+# sequence parallel configuration
+#########################################
+SP_OPTIMIZATION = "sp_optimization"
+set_field_default_config(SP_OPTIMIZATION, "enable", False)

--- a/python/paddle/distributed/auto_parallel/static/operators/common.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/common.py
@@ -55,7 +55,7 @@ class ParallelMode:
     """
 
     DataParallel = "auto_parallel/data_parallel"
-    ModelParallel = "auto_parallel/model_parallel"
+    TensorParallel = "auto_parallel/tensor_parallel"
     PipelineParalel = "auto_parallel/pipeline_paralel"
     MoEParallel = "auto_parallel/moe_parallel"
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_embedding.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_embedding.py
@@ -46,6 +46,7 @@ from ..utils import (
 from .common import (
     DistributedOperatorImpl,
     DistributedOperatorImplContainer,
+    ParallelMode,
     get_default_distributed_operator_impl,
     gradient_synchronization,
     infer_shape,
@@ -544,6 +545,9 @@ class DistributedEmbeddingImpl(DistributedOperatorImpl):
                 'use_model_parallel': True,
                 OP_ROLE_KEY: src_op.attr('op_role'),
             },
+        )
+        c_allreduce_sum_op._set_attr(
+            'op_namescope', '/' + ParallelMode.TensorParallel
         )
         if Out_var.shape != ref_shape:
             Out_var.desc.set_shape(ref_shape)

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
@@ -53,6 +53,7 @@ from ..utils import (
 from .common import (
     DistributedOperatorImpl,
     DistributedOperatorImplContainer,
+    ParallelMode,
     copy_op_without_infer_shape,
     gradient_synchronization,
     is_parameter_related,
@@ -456,6 +457,9 @@ def _right_operand_parameter_matmul_backward(ctx, *args, **kwargs):
                         'use_model_parallel': True,
                         OP_ROLE_KEY: OpRole.Backward,
                     },
+                )
+                c_allreduce_sum_op._set_attr(
+                    'op_namescope', '/' + ParallelMode.TensorParallel
                 )
                 set_comm_op_dist_attr_for_program(
                     c_allreduce_sum_op,
@@ -1165,6 +1169,9 @@ class DistributedMatmulImpl1(DistributedOperatorImpl):
                 'use_model_parallel': True,
                 OP_ROLE_KEY: src_op.attr('op_role'),
             },
+        )
+        c_allreduce_sum_op._set_attr(
+            'op_namescope', '/' + ParallelMode.TensorParallel
         )
 
         # set dist op's dist_attr with serial op's dist_attr
@@ -1922,6 +1929,9 @@ class DistributedMatmulV2Impl1(DistributedOperatorImpl):
                 OP_ROLE_KEY: src_op.attr('op_role'),
             },
         )
+        c_allreduce_sum_op._set_attr(
+            'op_namescope', '/' + ParallelMode.TensorParallel
+        )
 
         # set dist op's dist_attr with serial op's dist_attr
         matmulv2_op_dist_attr = OperatorDistAttr()
@@ -2654,6 +2664,9 @@ class DistributedMulImpl1(DistributedOperatorImpl):
                 'use_model_parallel': True,
                 OP_ROLE_KEY: src_op.attr('op_role'),
             },
+        )
+        c_allreduce_sum_op._set_attr(
+            'op_namescope', '/' + ParallelMode.TensorParallel
         )
 
         # set dist op's dist_attr with serial op's dist_attr

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -331,6 +331,16 @@ class Parallelizer:
         if self._strategy is None:
             return
 
+        # sequence parallel optimization
+        if self._strategy.sp_optimization.enable:
+            config = copy.deepcopy(self._strategy.sp_optimization.to_dict())
+            config["dist_context"] = self._dist_context
+            config["global_rank"] = rank
+            sp_pass = new_pass(
+                "auto_parallel_sequence_parallel_optimization", config
+            )
+            sp_pass.apply([main_program], [startup_program], self._pass_context)
+
         # data parallel optimization
         if self._strategy.dp_optimization.enable:
             config = copy.deepcopy(self._strategy.dp_optimization.to_dict())

--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -1316,11 +1316,11 @@ def naive_set_dist_op_attr_for_program_by_mesh(
     new_op_dist_attr = OperatorDistAttr()
 
     for input_varname in new_op.desc.input_arg_names():
-        var = ctx.serial_main_program.global_block().var(input_varname)
+        var = new_op.block.var(input_varname)
         mapping = ctx.get_tensor_dist_attr_for_program(var).dims_mapping
         new_op_dist_attr.set_input_dims_mapping(input_varname, mapping)
     for output_varname in new_op.desc.output_arg_names():
-        var = ctx.serial_main_program.global_block().var(output_varname)
+        var = new_op.block.var(output_varname)
         mapping = ctx.get_tensor_dist_attr_for_program(var).dims_mapping
         new_op_dist_attr.set_output_dims_mapping(output_varname, mapping)
 

--- a/python/paddle/distributed/auto_parallel/strategy.py
+++ b/python/paddle/distributed/auto_parallel/strategy.py
@@ -142,6 +142,12 @@ class MPOptimizationConfig(BaseConfig):
         super().__init__(category, config_dict)
 
 
+class SPOptimizationConfig(BaseConfig):
+    def __init__(self, config_dict=None):
+        category = constants.SP_OPTIMIZATION
+        super().__init__(category, config_dict)
+
+
 class Strategy(BaseConfig):
     """
     The `Strategy` object is used to configure the parallelization and optimization behaviors.
@@ -223,3 +229,6 @@ class Strategy(BaseConfig):
 
         config_dict = self._config_dict.get(constants.MP_OPTIMIZATION, None)
         self.mp_optimization = MPOptimizationConfig(config_dict)
+
+        config_dict = self._config_dict.get(constants.SP_OPTIMIZATION, None)
+        self.sp_optimization = SPOptimizationConfig(config_dict)

--- a/python/paddle/distributed/passes/__init__.py
+++ b/python/paddle/distributed/passes/__init__.py
@@ -24,6 +24,7 @@ from .auto_parallel_data_parallel_optimization import *  # noqa: F403
 from .auto_parallel_grad_clip import *  # noqa: F403
 from .auto_parallel_supplement_explicit_dependencies import *  # noqa: F403
 from .auto_parallel_pipeline import *  # noqa: F403
+from .auto_parallel_sequence_parallel_optimization import *  # noqa: F403
 from .allreduce_matmul_grad_overlapping import *  # noqa: F403
 from .cpp_pass import *  # noqa: F403
 from .fuse_all_reduce import *  # noqa: F403

--- a/python/paddle/distributed/passes/auto_parallel_sequence_parallel_optimization.py
+++ b/python/paddle/distributed/passes/auto_parallel_sequence_parallel_optimization.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import paddle
+from paddle.distributed.auto_parallel.static.utils import (
+    naive_set_dist_op_attr_for_program_by_mesh,
+)
+from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY
+from paddle.static import default_main_program
+
+from .auto_parallel_sharding import _is_reshard_op
+from .pass_base import PassBase, PassType, register_pass
+
+
+# NOTE we add the "auto_parallel" prefix to the pass in order to
+# indicate that this pass should obey some constrains by auto_parallel
+# for example all ops and vars should has dist attr before and after pass
+# should use dist op instead of custom comm op
+@register_pass("auto_parallel_sequence_parallel_optimization")
+class SequenceParallelOptimizationPass(PassBase):
+    """
+    This pass is used to optimize the sequence parallel.
+        1. Fuse the allreduce + split into reducescatter.
+        2. Trade off communication for memory in the row_parallel_linear output.
+        3. Overlap communication with computation in backward computation.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.set_attr("dist_context", None)
+
+    def _check_self(self):
+        if self.get_attr("dist_context") is None:
+            return False
+        if (not isinstance(self.get_attr("global_rank"), int)) or self.get_attr(
+            "global_rank"
+        ) < 0:
+            return False
+        if not self.get_attr("dist_context").strategy.sp_optimization.enable:
+            return False
+        return True
+
+    def _check_conflict(self, other_pass):
+        return True
+
+    def _type(self):
+        return PassType.COMM_OPT
+
+    def _apply_single_impl(self, main_program, startup_program, context):
+        self.dist_context = self.get_attr("dist_context")
+        self.global_rank = int(self.get_attr("global_rank"))
+
+        with paddle.static.program_guard(main_program, startup_program):
+            # TODO remove this pass when we use local reshard for all communication
+            self._fuse_allreduce_split()
+            self._memory_opimization()
+            self._overlap()
+
+    def _fuse_allreduce_split(self):
+        # allreduce is added by dist op and split is added by reshard, so we need this pass to fuse them as reducescatter.
+        # reducescatter should be infered by local reshard in future.
+
+        block = default_main_program().global_block()
+
+        # record valid split ops
+        valid_split_op_indices = []
+
+        def is_valid_split_op(idx, block):
+            op = block.ops[idx]
+            if not op.type == "split":
+                return False
+            pre_op = block.ops[idx - 1]
+            if not pre_op.type == "c_allreduce_sum":
+                return False
+            pre_output_name = pre_op.output_arg_names[0]
+            cur_input_name = op.input_arg_names[0]
+            if (
+                pre_output_name == cur_input_name
+                and _is_reshard_op(op)
+                and op.attr("axis") == 0
+            ):
+                return True
+            return False
+
+        for i in range(len(block.ops)):
+            if is_valid_split_op(i, block):
+                valid_split_op_indices.append(i)
+
+        # modify program
+        remove_varnames = []
+        for i in sorted(valid_split_op_indices, reverse=True):
+            allreduce_op = block.ops[i - 1]
+            split_op = block.ops[i]
+            consumer_op = block.ops[i + 1]
+
+            allreduce_input_name = allreduce_op.input("X")[0]
+            ring_id = int(allreduce_op.attr("ring_id"))
+            split_output_names = split_op.output("Out")
+            nranks = len(split_output_names)
+            consumer_input_names = consumer_op.input_arg_names
+            intersection = set(split_output_names).intersection(
+                set(consumer_input_names)
+            )
+            assert (
+                len(intersection) == 1
+            ), f"Sequence Parallel ReduceScatter Output more than 1: {intersection}."
+            keep_output_name = intersection.pop()
+            split_output_names.remove(keep_output_name)
+            remove_varnames.extend(split_output_names)
+
+            # replace ops
+            new_op = block._insert_op_without_sync(
+                index=i + 1,
+                type="c_reducescatter",
+                inputs={'X': [allreduce_input_name]},
+                outputs={'Out': [keep_output_name]},
+                attrs={
+                    'ring_id': ring_id,
+                    'nranks': nranks,
+                    'use_calc_stream': True,
+                    'op_namescope': allreduce_op.attr("op_namescope"),
+                    OP_ROLE_KEY: consumer_op.attr(OP_ROLE_KEY),
+                },
+            )
+            block._remove_op(i, False)
+            block._remove_op(i - 1, False)
+
+            # set dist attr
+            allreduce_input_dist_attr = (
+                self.dist_context.get_tensor_dist_attr_for_program(
+                    block.vars[allreduce_input_name]
+                )
+            )
+            ref_process_mesh = allreduce_input_dist_attr.process_mesh
+            naive_set_dist_op_attr_for_program_by_mesh(
+                new_op, ref_process_mesh, self.dist_context
+            )
+
+        # remove vars
+        for varname in remove_varnames:
+            block._remove_var(varname, sync=False)
+
+        block._sync_with_cpp()
+
+    def _memory_opimization(self):
+        pass
+
+    def _overlap(self):
+        pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization 

### PR changes
Others

### Description

Pcard-76459

This pass is used to optimize the sequence parallel.
    1. Fuse the allreduce + split into reducescatter.
    2. Trade off communication for memory in the row_parallel_linear output. （TBD）
    3. Overlap communication with computation in backward computation.（TBD）

