### PR TITLE
【PIR API adaptor No.17、33、72、101、121、125】Migrate paddle.atan2，paddle.deg2rad，paddle.floor_divide，paddle.heaviside，paddle.kron，paddle.lerp into pir 

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -19,7 +19,7 @@ math functions
 import numpy as np
 
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.utils.inplace_utils import inplace_apis_in_dygraph_only
@@ -3861,7 +3861,7 @@ def kron(x, y, name=None):
              [21, 24, 27, 28, 32, 36]])
     """
     if in_dynamic_or_pir_mode():
-        return _legacy_C_ops.kron(x, y)
+        return _C_ops.kron(x, y)
     else:
         helper = LayerHelper('kron', **locals())
         check_variable_and_dtype(

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3860,7 +3860,7 @@ def kron(x, y, name=None):
              [12, 15, 18, 16, 20, 24],
              [21, 24, 27, 28, 32, 36]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _legacy_C_ops.kron(x, y)
     else:
         helper = LayerHelper('kron', **locals())
@@ -5149,7 +5149,7 @@ def atan2(x, y, name=None):
 
     """
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.atan2(x, y)
     else:
         check_variable_and_dtype(
@@ -5279,7 +5279,7 @@ def lerp(x, y, weight, name=None):
     if isinstance(weight, float):
         weight = paddle.full(shape=[], fill_value=weight, dtype=x.dtype)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.lerp(x, y, weight)
     else:
         check_variable_and_dtype(
@@ -5478,7 +5478,7 @@ def deg2rad(x, name=None):
             3.14159274)
     """
     deg2rad_scale = np.pi / 180.0
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if convert_dtype(x.dtype) in ['int32', 'int64']:
             x = cast(x, dtype="float32")
         return _C_ops.scale(x, deg2rad_scale, 0.0, True)
@@ -6026,7 +6026,7 @@ def heaviside(x, y, name=None):
             [[0.        , 0.20000000, 1.        ],
              [0.        , 1.        , 0.30000001]])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.heaviside(x, y)
     else:
         op_type = 'elementwise_heaviside'

--- a/test/legacy_test/test_atan2_op.py
+++ b/test/legacy_test/test_atan2_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 np.random.seed(0)
@@ -45,10 +46,12 @@ class TestAtan2(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_grad(self):
-        self.check_grad(['X1', 'X2'], 'Out', check_cinn=self.check_cinn)
+        self.check_grad(
+            ['X1', 'X2'], 'Out', check_cinn=self.check_cinn, check_pir=True
+        )
 
     def test_check_output(self):
-        self.check_output(check_cinn=self.check_cinn)
+        self.check_output(check_cinn=self.check_cinn, check_pir=True)
 
     def init_dtype(self):
         self.dtype = np.float64
@@ -69,6 +72,7 @@ class TestAtan2_float(TestAtan2):
                     1 / self.inputs['X1'].size,
                 ),
                 check_cinn=self.check_cinn,
+                check_pir=True,
             )
 
 
@@ -100,6 +104,7 @@ class TestAtan2API(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
 
+    @test_with_pir_api
     def test_static_api(self):
         paddle.enable_static()
 
@@ -154,16 +159,23 @@ class TestAtan2BF16OP(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, check_cinn=self.check_cinn)
+        self.check_output_with_place(
+            place, check_cinn=self.check_cinn, check_pir=True
+        )
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
         self.check_grad_with_place(
-            place, ['X1', 'X2'], 'Out', check_cinn=self.check_cinn
+            place,
+            ['X1', 'X2'],
+            'Out',
+            check_cinn=self.check_cinn,
+            check_pir=True,
         )
 
 
 class TestAtan2Error(unittest.TestCase):
+    @test_with_pir_api
     def test_mismatch(self):
         paddle.enable_static()
 

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -33,26 +33,28 @@ class TestDeg2radAPI(unittest.TestCase):
         self.out_np = np.deg2rad(self.x_np)
 
     def test_static_graph(self):
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(startup_program, train_program):
+        place = (
+            base.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else base.CPUPlace()
+        )
+        paddle.enable_static()
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(
                 name='input', dtype=self.x_dtype, shape=self.x_shape
             )
-            out = paddle.deg2rad(x)
 
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
-            exe = base.Executor(place)
-            res = exe.run(
-                base.default_main_program(),
+            exe = paddle.static.Executor(place)
+            out = paddle.deg2rad(x)
+            (res,) = exe.run(
+                paddle.static.default_main_program(),
                 feed={'input': self.x_np},
                 fetch_list=[out],
             )
             self.assertTrue((np.array(out[0]) == self.out_np).all())
+        paddle.disable_static()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -19,7 +19,6 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -33,7 +32,6 @@ class TestDeg2radAPI(unittest.TestCase):
         self.x_shape = [6]
         self.out_np = np.deg2rad(self.x_np)
 
-    @test_with_pir_api
     def test_static_graph(self):
         place = (
             base.CUDAPlace(0)
@@ -55,7 +53,7 @@ class TestDeg2radAPI(unittest.TestCase):
                 feed={'input': self.x_np},
                 fetch_list=[out],
             )
-            self.assertTrue((res == self.out_np).all())
+            self.assertTrue((np.array(res[0]) == self.out_np).all())
         paddle.disable_static()
 
     def test_dygraph(self):

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -33,28 +33,26 @@ class TestDeg2radAPI(unittest.TestCase):
         self.out_np = np.deg2rad(self.x_np)
 
     def test_static_graph(self):
-        place = (
-            base.CUDAPlace(0)
-            if core.is_compiled_with_cuda()
-            else base.CPUPlace()
-        )
-        paddle.enable_static()
-        with paddle.static.program_guard(
-            paddle.static.Program(), paddle.static.Program()
-        ):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(startup_program, train_program):
             x = paddle.static.data(
                 name='input', dtype=self.x_dtype, shape=self.x_shape
             )
-
-            exe = paddle.static.Executor(place)
             out = paddle.deg2rad(x)
-            (res,) = exe.run(
-                paddle.static.default_main_program(),
+
+            place = (
+                base.CUDAPlace(0)
+                if core.is_compiled_with_cuda()
+                else base.CPUPlace()
+            )
+            exe = base.Executor(place)
+            res = exe.run(
+                base.default_main_program(),
                 feed={'input': self.x_np},
                 fetch_list=[out],
             )
-            self.assertTrue((np.array(res[0]) == self.out_np).all())
-        paddle.disable_static()
+            self.assertTrue((np.array(out[0]) == self.out_np).all())
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -32,6 +33,7 @@ class TestDeg2radAPI(unittest.TestCase):
         self.x_shape = [6]
         self.out_np = np.deg2rad(self.x_np)
 
+    @test_with_pir_api
     def test_static_graph(self):
         place = (
             base.CUDAPlace(0)

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -35,25 +35,28 @@ class TestDeg2radAPI(unittest.TestCase):
 
     @test_with_pir_api
     def test_static_graph(self):
+        place = (
+            base.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else base.CPUPlace()
+        )
+        paddle.enable_static()
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()
         ):
             x = paddle.static.data(
                 name='input', dtype=self.x_dtype, shape=self.x_shape
             )
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
-            exe = base.Executor(place)
+
+            exe = paddle.static.Executor(place)
             out = paddle.deg2rad(x)
-            res = exe.run(
+            (res,) = exe.run(
                 paddle.static.default_main_program(),
                 feed={'input': self.x_np},
                 fetch_list=[out],
             )
-            self.assertTrue((np.array(res[0]) == self.out_np).all())
+            self.assertTrue(res == self.out_np)
+        paddle.disable_static()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_deg2rad.py
+++ b/test/legacy_test/test_deg2rad.py
@@ -55,7 +55,7 @@ class TestDeg2radAPI(unittest.TestCase):
                 feed={'input': self.x_np},
                 fetch_list=[out],
             )
-            self.assertTrue(res == self.out_np)
+            self.assertTrue((res == self.out_np).all())
         paddle.disable_static()
 
     def test_dygraph(self):

--- a/test/legacy_test/test_elementwise_floordiv_op.py
+++ b/test/legacy_test/test_elementwise_floordiv_op.py
@@ -21,6 +21,7 @@ from op_test import OpTest, paddle_static_guard
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestElementwiseModOp(OpTest):
@@ -45,7 +46,7 @@ class TestElementwiseModOp(OpTest):
         self.outputs = {'Out': self.out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def init_input_output(self):
         self.x = np.random.uniform(0, 10000, [10, 10]).astype(self.dtype)
@@ -104,6 +105,7 @@ def device_guard(device=None):
 
 
 class TestFloorDivideOp(unittest.TestCase):
+    @test_with_pir_api
     def test_name(self):
         with paddle_static_guard():
             with base.program_guard(base.Program()):

--- a/test/legacy_test/test_elementwise_floordiv_op.py
+++ b/test/legacy_test/test_elementwise_floordiv_op.py
@@ -21,7 +21,6 @@ from op_test import OpTest, paddle_static_guard
 
 import paddle
 from paddle import base
-from paddle.pir_utils import test_with_pir_api
 
 
 class TestElementwiseModOp(OpTest):
@@ -105,8 +104,8 @@ def device_guard(device=None):
 
 
 class TestFloorDivideOp(unittest.TestCase):
-    @test_with_pir_api
     def test_name(self):
+        paddle.enable_static()
         with paddle_static_guard():
             with base.program_guard(base.Program()):
                 x = paddle.static.data(name="x", shape=[2, 3], dtype="int64")
@@ -114,6 +113,7 @@ class TestFloorDivideOp(unittest.TestCase):
 
                 y_1 = paddle.floor_divide(x, y, name='div_res')
                 self.assertEqual(('div_res' in y_1.name), True)
+            paddle.disable_static()
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_elementwise_heaviside_op.py
+++ b/test/legacy_test/test_elementwise_heaviside_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def Heaviside_grad(x, y, dout, astype="float16", is_bfloat16=False):
@@ -41,16 +42,16 @@ class TestElementwiseOp(OpTest):
         self.outputs = {'Out': np.heaviside(self.inputs['X'], self.inputs['Y'])}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
     def test_check_grad_ingore_x(self):
-        self.check_grad(['Y'], 'Out', no_grad_set=set("X"))
+        self.check_grad(['Y'], 'Out', no_grad_set=set("X"), check_pir=True)
 
     def test_check_grad_ingore_y(self):
-        self.check_grad(['X'], 'Out', no_grad_set=set('Y'))
+        self.check_grad(['X'], 'Out', no_grad_set=set('Y'), check_pir=True)
 
 
 class TestHeavisideBroadcast(unittest.TestCase):
@@ -98,6 +99,7 @@ class TestHeavisideAPI_float64(unittest.TestCase):
         self.out_np = np.heaviside(self.x_np, self.y_np)
         self.dtype = "float64"
 
+    @test_with_pir_api
     def test_static(self):
         for use_cuda in (
             [False, True] if paddle.device.is_compiled_with_cuda() else [False]
@@ -177,7 +179,7 @@ class TestHeavisideFP16Op(OpTest):
         self.outputs = {'Out': np.heaviside(self.inputs['X'], self.inputs['Y'])}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -186,6 +188,7 @@ class TestHeavisideFP16Op(OpTest):
             user_defined_grads=Heaviside_grad(
                 self.inputs['X'], self.inputs['Y'], 1 / self.inputs['X'].size
             ),
+            check_pir=True,
         )
 
 
@@ -212,7 +215,7 @@ class TestHeavisideBF16Op(OpTest):
         self.outputs['Out'] = convert_float_to_uint16(self.outputs['Out'])
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
     def test_check_grad(self):
         self.check_grad_with_place(
@@ -226,6 +229,7 @@ class TestHeavisideBF16Op(OpTest):
                 self.np_dtype,
                 True,
             ),
+            check_pir=True,
         )
 
 

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -138,6 +138,7 @@ class TestKronLayer(unittest.TestCase):
         place = base.CPUPlace()
         a = np.random.randn(10, 10).astype(np.float64)
         b = np.random.randn(10, 10).astype(np.float64)
+        out_np = np.kron(a, b)
         paddle.enable_static()
         prog = paddle.static.Program()
         with base.unique_name.guard():
@@ -147,7 +148,7 @@ class TestKronLayer(unittest.TestCase):
                 out_var = paddle.kron(a_var, b_var)
         exe = paddle.static.Executor(place=place)
         (res,) = exe.run(prog, feed={'a': a, 'b': b}, fetch_list=[out_var])
-        np.testing.assert_allclose(res, self.out_np)
+        np.testing.assert_allclose(res, out_np)
 
 
 class TestComplexKronOp(OpTest):

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -21,6 +21,7 @@ import paddle
 import paddle.base.dygraph as dg
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestKronOp(OpTest):
@@ -38,16 +39,16 @@ class TestKronOp(OpTest):
         return "float64"
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
     def test_check_grad_ignore_x(self):
-        self.check_grad(['Y'], 'Out', no_grad_set=set('X'))
+        self.check_grad(['Y'], 'Out', no_grad_set=set('X'), check_pir=True)
 
     def test_check_grad_ignore_y(self):
-        self.check_grad(['X'], 'Out', no_grad_set=set('Y'))
+        self.check_grad(['X'], 'Out', no_grad_set=set('Y'), check_pir=True)
 
 
 class TestKronOp2(TestKronOp):
@@ -102,51 +103,51 @@ class TestKronBF16Op(TestKronOp):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X', 'Y'], 'Out')
+        self.check_grad_with_place(
+            self.place, ['X', 'Y'], 'Out', check_pir=True
+        )
 
     def test_check_grad_ignore_x(self):
         self.check_grad_with_place(
-            self.place, ['Y'], 'Out', no_grad_set=set('X')
+            self.place, ['Y'], 'Out', no_grad_set=set('X'), check_pir=True
         )
 
     def test_check_grad_ignore_y(self):
         self.check_grad_with_place(
-            self.place, ['X'], 'Out', no_grad_set=set('Y')
+            self.place, ['X'], 'Out', no_grad_set=set('Y'), check_pir=True
         )
 
 
 class TestKronLayer(unittest.TestCase):
     def test_case(self):
-        a = np.random.randn(10, 10).astype(np.float64)
-        b = np.random.randn(10, 10).astype(np.float64)
-
+        self.a = np.random.randn(10, 10).astype(np.float64)
+        self.b = np.random.randn(10, 10).astype(np.float64)
+        self.out_np = np.kron(self.a, self.b)
         place = base.CPUPlace()
         with dg.guard(place):
-            a_var = dg.to_variable(a)
-            b_var = dg.to_variable(b)
+            a_var = dg.to_variable(self.a)
+            b_var = dg.to_variable(self.b)
             c_var = paddle.kron(a_var, b_var)
-            np.testing.assert_allclose(c_var.numpy(), np.kron(a, b))
+            np.testing.assert_allclose(c_var.numpy(), self.out_np)
 
+    @test_with_pir_api
     def test_case_with_output(self):
+        place = base.CPUPlace()
         a = np.random.randn(10, 10).astype(np.float64)
         b = np.random.randn(10, 10).astype(np.float64)
-
-        main = base.Program()
-        start = base.Program()
+        paddle.enable_static()
+        prog = paddle.static.Program()
         with base.unique_name.guard():
-            with base.program_guard(main, start):
+            with paddle.static.program_guard(prog, prog):
                 a_var = paddle.static.data("a", [-1, -1], dtype="float64")
                 b_var = paddle.static.data("b", [-1, -1], dtype="float64")
                 out_var = paddle.kron(a_var, b_var)
-
-        place = base.CPUPlace()
-        exe = base.Executor(place)
-        exe.run(start)
-        (c,) = exe.run(main, feed={'a': a, 'b': b}, fetch_list=[out_var])
-        np.testing.assert_allclose(c, np.kron(a, b))
+        exe = paddle.static.Executor(place=place)
+        (res,) = exe.run(prog, feed={'a': a, 'b': b}, fetch_list=[out_var])
+        np.testing.assert_allclose(res, self.out_np)
 
 
 class TestComplexKronOp(OpTest):
@@ -179,12 +180,13 @@ class TestComplexKronOp(OpTest):
         self.out = np.kron(self.x, self.y)
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
             ['X', 'Y'],
             'Out',
+            check_pir=True,
         )
 
     def test_check_grad_ingore_x(self):
@@ -192,6 +194,7 @@ class TestComplexKronOp(OpTest):
             ['Y'],
             'Out',
             no_grad_set=set("X"),
+            check_pir=True,
         )
 
     def test_check_grad_ingore_y(self):
@@ -199,6 +202,7 @@ class TestComplexKronOp(OpTest):
             ['X'],
             'Out',
             no_grad_set=set('Y'),
+            check_pir=True,
         )
 
 

--- a/test/legacy_test/test_kron_op.py
+++ b/test/legacy_test/test_kron_op.py
@@ -123,15 +123,14 @@ class TestKronBF16Op(TestKronOp):
 
 class TestKronLayer(unittest.TestCase):
     def test_case(self):
-        self.a = np.random.randn(10, 10).astype(np.float64)
-        self.b = np.random.randn(10, 10).astype(np.float64)
-        self.out_np = np.kron(self.a, self.b)
+        a = np.random.randn(10, 10).astype(np.float64)
+        b = np.random.randn(10, 10).astype(np.float64)
         place = base.CPUPlace()
         with dg.guard(place):
-            a_var = dg.to_variable(self.a)
-            b_var = dg.to_variable(self.b)
+            a_var = dg.to_variable(a)
+            b_var = dg.to_variable(b)
             c_var = paddle.kron(a_var, b_var)
-            np.testing.assert_allclose(c_var.numpy(), self.out_np)
+            np.testing.assert_allclose(c_var.numpy(), np.kron(a, b))
 
     @test_with_pir_api
     def test_case_with_output(self):

--- a/test/legacy_test/test_lerp_op.py
+++ b/test/legacy_test/test_lerp_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 np.random.seed(0)
@@ -52,10 +53,10 @@ class TestLerp(OpTest):
         self.wshape = [1]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 class TestLerpWithDim2(TestLerp):
@@ -139,6 +140,7 @@ class TestLerpAPI(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
 
+    @test_with_pir_api
     def test_static_api(self):
         paddle.enable_static()
 
@@ -268,7 +270,7 @@ class TestLerpBF16(TestLerp):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
@@ -277,6 +279,7 @@ class TestLerpBF16(TestLerp):
             ['X', 'Y'],
             'Out',
             user_defined_grads=[self.x_grad, self.y_grad],
+            check_pir=True,
         )
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067

PIR API 推全升级
No.17、33、72、101、121、125
将 `paddle.atan2` 迁移升级至 pir，并更新单测     7/7
将 `paddle.deg2rad` 迁移升级至 pir，并更新单测    0/1
将 `paddle.floor_divide` 迁移升级至 pir，并更新单测  6/7
将 `paddle.heaviside` 迁移升级至 pir，并更新单测 7/7
将 `paddle.kron` 迁移升级至 pir，并更新单测  7/7
将 `paddle.lerp` 迁移升级至 pir，并更新单测   13/13

floor_divide的static_test:
目前 test_name 相关的单测还不支持。所以这个单测应该没法切换到 pir 模式下。所以这个单测跳过

deg2rad中的static_test报错：
```shell
2023-11-07 17:00:50 ======================================================================
2023-11-07 17:00:50 FAIL: test_static_graph (test_deg2rad.TestDeg2radAPI)
2023-11-07 17:00:50 ----------------------------------------------------------------------
2023-11-07 17:00:50 Traceback (most recent call last):
2023-11-07 17:00:50   File "C:\home\workspace\Paddle\build\python\paddle\pir_utils.py", line 113, in impl
2023-11-07 17:00:50     func(*args, **kwargs)
2023-11-07 17:00:50   File "C:\home\workspace\Paddle\build\test\legacy_test\test_deg2rad.py", line 58, in test_static_graph
2023-11-07 17:00:50     self.assertTrue((res == self.out_np).all())
2023-11-07 17:00:50 AssertionError: False is not true
```