### PR TITLE
[PIR] add control flow op backward components.

### DIFF
--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_type.cc
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_type.cc
@@ -29,7 +29,7 @@ const phi::DDim& AllocatedDenseTensorType::dims() const {
   return storage()->dense_tensor_type_.dims();
 }
 
-const phi::DataLayout& AllocatedDenseTensorType::data_layout() const {
+phi::DataLayout AllocatedDenseTensorType::data_layout() const {
   return storage()->dense_tensor_type_.data_layout();
 }
 
@@ -37,7 +37,7 @@ const phi::LoD& AllocatedDenseTensorType::lod() const {
   return storage()->dense_tensor_type_.lod();
 }
 
-const size_t& AllocatedDenseTensorType::offset() const {
+size_t AllocatedDenseTensorType::offset() const {
   return storage()->dense_tensor_type_.offset();
 }
 
@@ -45,7 +45,7 @@ const phi::Place& AllocatedSelectedRowsType::place() const {
   return storage()->place_;
 }
 
-const pir::Type& AllocatedSelectedRowsType::dtype() const {
+pir::Type AllocatedSelectedRowsType::dtype() const {
   return storage()->selected_rows_type_.dtype();
 }
 
@@ -53,7 +53,7 @@ const phi::DDim& AllocatedSelectedRowsType::dims() const {
   return storage()->selected_rows_type_.dims();
 }
 
-const phi::DataLayout& AllocatedSelectedRowsType::data_layout() const {
+phi::DataLayout AllocatedSelectedRowsType::data_layout() const {
   return storage()->selected_rows_type_.data_layout();
 }
 
@@ -61,7 +61,7 @@ const phi::LoD& AllocatedSelectedRowsType::lod() const {
   return storage()->selected_rows_type_.lod();
 }
 
-const size_t& AllocatedSelectedRowsType::offset() const {
+size_t AllocatedSelectedRowsType::offset() const {
   return storage()->selected_rows_type_.offset();
 }
 

--- a/paddle/fluid/pir/dialect/kernel/ir/kernel_type.h
+++ b/paddle/fluid/pir/dialect/kernel/ir/kernel_type.h
@@ -55,11 +55,11 @@ class AllocatedDenseTensorType
 
   const phi::DDim &dims() const;
 
-  const phi::DataLayout &data_layout() const;
+  phi::DataLayout data_layout() const;
 
   const phi::LoD &lod() const;
 
-  const size_t &offset() const;
+  size_t offset() const;
 };
 
 class AllocatedSelectedRowsType
@@ -92,15 +92,15 @@ class AllocatedSelectedRowsType
 
   const phi::Place &place() const;
 
-  const pir::Type &dtype() const;
+  pir::Type dtype() const;
 
   const phi::DDim &dims() const;
 
-  const phi::DataLayout &data_layout() const;
+  phi::DataLayout data_layout() const;
 
   const phi::LoD &lod() const;
 
-  const size_t &offset() const;
+  size_t offset() const;
 };
 
 }  // namespace dialect

--- a/paddle/pir/core/builtin_type.cc
+++ b/paddle/pir/core/builtin_type.cc
@@ -19,19 +19,19 @@ std::vector<Type> VectorType::data() const { return storage()->GetAsKey(); }
 
 pir::Type DenseTensorType::dtype() const { return storage()->dtype_; }
 
-const DenseTensorTypeStorage::Dim& DenseTensorType::dims() const {
+const DenseTensorType::Dim& DenseTensorType::dims() const {
   return storage()->dims_;
 }
 
-const DenseTensorTypeStorage::DataLayout& DenseTensorType::data_layout() const {
+DenseTensorType::DataLayout DenseTensorType::data_layout() const {
   return storage()->layout_;
 }
 
-const DenseTensorTypeStorage::LoD& DenseTensorType::lod() const {
+const DenseTensorType::LoD& DenseTensorType::lod() const {
   return storage()->lod_;
 }
 
-const size_t& DenseTensorType::offset() const { return storage()->offset_; }
+size_t DenseTensorType::offset() const { return storage()->offset_; }
 }  // namespace pir
 
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::UInt8Type)

--- a/paddle/pir/core/builtin_type.h
+++ b/paddle/pir/core/builtin_type.h
@@ -58,16 +58,23 @@ class DenseTensorType : public Type::TypeBase<DenseTensorType,
                                               ShapedTypeInterface> {
  public:
   using Base::Base;
+  using Dim = DenseTensorTypeStorage::Dim;
+  using DataLayout = DenseTensorTypeStorage::DataLayout;
+  using LoD = DenseTensorTypeStorage::LoD;
 
   Type dtype() const;
-
-  const DenseTensorTypeStorage::Dim &dims() const;
-
-  const DenseTensorTypeStorage::DataLayout &data_layout() const;
-
-  const DenseTensorTypeStorage::LoD &lod() const;
-
-  const size_t &offset() const;
+  const Dim &dims() const;
+  DataLayout data_layout() const;
+  const LoD &lod() const;
+  size_t offset() const;
+  static DenseTensorType get(IrContext *ctx,
+                             Type dtype,
+                             const Dim &dims,
+                             DataLayout layout = DataLayout::kNCHW,
+                             const LoD &lod = {},
+                             size_t offset = 0u) {
+    return Base::get(ctx, dtype, dims, layout, lod, offset);
+  }
 };
 
 #define DECLARE_BUILTIN_TYPE(__name)                                       \

--- a/paddle/pir/core/builtin_type_storage.h
+++ b/paddle/pir/core/builtin_type_storage.h
@@ -53,11 +53,11 @@ struct DenseTensorTypeStorage : public pir::TypeStorage {
   using DataLayout = phi::DataLayout;
   using Dim = phi::DDim;
   using LoD = std::vector<std::vector<size_t>>;
-  using ParamKey = std::tuple<pir::Type, Dim, DataLayout, LoD, size_t>;
+  using ParamKey = std::tuple<Type, Dim, DataLayout, LoD, size_t>;
 
-  DenseTensorTypeStorage(const pir::Type& dtype,
+  DenseTensorTypeStorage(Type dtype,
                          const Dim& dims,
-                         const DataLayout& layout,
+                         DataLayout layout,
                          const LoD& lod,
                          size_t offset)
       : dtype_(dtype),

--- a/paddle/pir/core/ir_printer.cc
+++ b/paddle/pir/core/ir_printer.cc
@@ -200,7 +200,7 @@ void IrPrinter::PrintValue(Value v) {
     os << "<<NULL VALUE>>";
     return;
   }
-  const void* key = static_cast<const void*>(v.impl());
+  const void* key = v.impl();
   auto ret = aliases_.find(key);
   if (ret != aliases_.end()) {
     os << ret->second;
@@ -310,6 +310,11 @@ void IrPrinter::PrintOpReturnType(Operation* op) {
       [this]() { this->os << ", "; });
 }
 
+void IrPrinter::AddValueAlias(Value v, const std::string& alias) {
+  const void* key = v.impl();
+  IR_ENFORCE(aliases_.find(key) == aliases_.end(), "Value already has alias");
+  aliases_[key] = alias;
+}
 void Dialect::PrintOperation(Operation* op, IrPrinter& printer) const {
   printer.PrintGeneralOperation(op);
 }

--- a/paddle/pir/core/ir_printer.h
+++ b/paddle/pir/core/ir_printer.h
@@ -70,6 +70,8 @@ class IR_API IrPrinter : public BasicIrPrinter {
 
   void PrintOpReturnType(Operation* op);
 
+  void AddValueAlias(Value value, const std::string& alias);
+
  private:
   size_t cur_result_number_{0};
   size_t cur_block_argument_number_{0};

--- a/paddle/pir/core/op_result.cc
+++ b/paddle/pir/core/op_result.cc
@@ -26,8 +26,7 @@ bool OpResult::classof(Value value) {
 }
 
 Operation *OpResult::owner() const {
-  CHECK_OPRESULT_NULL_IMPL(owner);
-  return IMPL_->owner();
+  return impl_ ? static_cast<detail::OpResultImpl *>(impl_)->owner() : nullptr;
 }
 
 uint32_t OpResult::index() const {

--- a/paddle/pir/core/operation_utils.h
+++ b/paddle/pir/core/operation_utils.h
@@ -75,6 +75,9 @@ struct OperationArgument {
   template <class InputIt>
   void AddOutputs(InputIt first, InputIt last);
 
+  void AddOutputs(std::initializer_list<Type> type_list) {
+    AddOutputs(std::begin(type_list), std::end(type_list));
+  }
   template <class TypeContainer>
   void AddOutputs(const TypeContainer& type_container) {
     AddOutputs(std::begin(type_container), std::end(type_container));

--- a/paddle/pir/core/value.cc
+++ b/paddle/pir/core/value.cc
@@ -46,6 +46,8 @@ Value::operator bool() const { return impl_; }
 
 pir::Type Value::type() const { return impl_ ? impl_->type() : nullptr; }
 
+Operation *Value::defining_op() const { return dyn_cast<OpResult>().owner(); }
+
 void Value::set_type(pir::Type type) {
   CHECK_VALUE_NULL_IMPL(set_type);
   impl_->set_type(type);

--- a/paddle/pir/core/value.h
+++ b/paddle/pir/core/value.h
@@ -59,6 +59,16 @@ class IR_API Value {
 
   Type type() const;
 
+  /// If this value is the result of an operation, return the operation that
+  /// defines it, else return nullptr;
+  Operation *defining_op() const;
+
+  template <typename OpTy>
+  OpTy defining_op() const {
+    /// It is safety even if defining_op() return nullptr.
+    return OpTy::dyn_cast(defining_op());
+  }
+
   void set_type(Type type);
 
   std::string PrintUdChain();

--- a/paddle/pir/dialect/control_flow/ir/cf_dialect.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_dialect.cc
@@ -12,9 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/pir/dialect/control_flow/ir/cf_dialect.h"
+#include "paddle/pir/core/ir_printer.h"
 #include "paddle/pir/dialect/control_flow/ir/cf_op.h"
+#include "paddle/pir/dialect/control_flow/ir/cf_type.h"
 
 namespace pir {
-void ControlFlowDialect::initialize() { RegisterOps<YieldOp>(); }
+void ControlFlowDialect::initialize() {
+  RegisterTypes<StackType, InletType, OutletType>();
+  RegisterOps<YieldOp, CreateStackOp, PushBackOp, PopBackOp, HasElementsOp>();
+}
+
+void ControlFlowDialect::PrintType(pir::Type type, std::ostream &os) const {
+  os << name();
+  os << '.';
+  if (type.isa<StackType>()) {
+    os << "stack";
+  } else if (type.isa<InletType>()) {
+    os << "inlet";
+  } else if (type.isa<OutletType>()) {
+    os << "outlet";
+  } else {
+    os << "unknown type";
+  }
+}
+
+void ControlFlowDialect::PrintOperation(pir::Operation *op,
+                                        pir::IrPrinter &printer) const {
+  if (auto create_op = op->dyn_cast<CreateStackOp>()) {
+    create_op.Print(printer);
+  } else {
+    printer.PrintGeneralOperation(op);
+  }
+}
 }  // namespace pir
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::ControlFlowDialect)

--- a/paddle/pir/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_op.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "paddle/pir/dialect/control_flow/ir/cf_op.h"
+#include "paddle/pir/core/builtin_type.h"
+#include "paddle/pir/core/ir_printer.h"
+#include "paddle/pir/dialect/control_flow/ir/cf_type.h"
 
 namespace pir {
 
@@ -21,6 +24,171 @@ void YieldOp::Build(Builder &builder,
                     const std::vector<Value> &inputs) {
   argument.AddInputs(inputs);
 }
+
+void CreateStackOp::Build(Builder &builder, OperationArgument &argument) {
+  auto stack_type = StackType::get(builder.ir_context());
+  auto inlet_type = InletType::get(builder.ir_context());
+  auto outlet_type = OutletType::get(builder.ir_context());
+  argument.AddOutputs({stack_type, inlet_type, outlet_type});
+}
+void CreateStackOp::VerifySig() {
+  VLOG(4) << "Verifying inputs, outputs and attributes for: CreateStackOp.";
+  // Verify inputs:
+  IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
+
+  // No attributes should be verify.
+
+  // Verify outputs:
+  IR_ENFORCE(num_results() == 3u, "The size of outputs must be equal to 3.");
+
+  IR_ENFORCE(result(0).type().isa<StackType>(),
+             "The first outputs of cf.create_stack must be stack_type.");
+  IR_ENFORCE(result(1).type().isa<InletType>(),
+             "The first outputs of cf.create_stack must be inlet_type.");
+  IR_ENFORCE(result(2).type().isa<OutletType>(),
+             "The first outputs of cf.create_stack must be outlet_type.");
+
+  VLOG(4) << "End Verifying for CreateStackOp.";
+}
+size_t CreateStackOp::stack_size() { return push_op().stack_size(); }
+Value CreateStackOp::inlet_element(size_t index) {
+  return push_op().inlet_element(index);
+}
+Value CreateStackOp::outlet_element(size_t index) {
+  return pop_op().outlet_element(index);
+}
+PushBackOp CreateStackOp::push_op() {
+  auto inlet_value = inlet();
+  IR_ENFORCE(inlet_value.HasOneUse(), "The inlet value must has one use.");
+  return inlet_value.first_use().owner()->dyn_cast<PushBackOp>();
+}
+PopBackOp CreateStackOp::pop_op() {
+  auto outlet_value = outlet();
+  IR_ENFORCE(outlet_value.HasOneUse(), "The outlet value must has one use.");
+  return outlet_value.first_use().owner()->dyn_cast<PopBackOp>();
+}
+
+void CreateStackOp::Print(IrPrinter &printer) {  // NOLINT
+  static std::unordered_map<IrPrinter *,
+                            std::unordered_map<Operation *, size_t>>
+      kConunters;
+  auto &counter = kConunters[&printer];
+  auto iter = counter.insert({*this, counter.size()});
+  auto index = iter.first->second;
+  if (iter.second) {
+    printer.AddValueAlias(stack(), "%stack_" + std::to_string(index));
+    printer.AddValueAlias(inlet(), "%inlet_" + std::to_string(index));
+    printer.AddValueAlias(outlet(), "%outlet_" + std::to_string(index));
+  }
+  printer.PrintGeneralOperation(*this);
+}
+
+void PushBackOp::Build(Builder &builder,             // NOLINT
+                       OperationArgument &argument,  // NOLINT
+                       Value inlet,
+                       const std::vector<Value> &elements) {
+  argument.AddInput(inlet);
+  argument.AddInputs(elements);
+}
+
+void PushBackOp::Build(Builder &builder,             // NOLINT
+                       OperationArgument &argument,  // NOLINT
+                       Value inlet,
+                       std::initializer_list<Value> element_list) {
+  argument.AddInput(inlet);
+  argument.AddInputs(element_list);
+}
+
+void PushBackOp::VerifySig() {
+  VLOG(4) << "Verifying inputs, outputs ,attributes for: PushBackOp.";
+  // Verify inputs:
+  IR_ENFORCE(num_operands() >= 2u, "The size of inputs must no less than 2.");
+  IR_ENFORCE(operand_source(0).type().isa<InletType>(),
+             "The first input of cf.push_back must be inlet_type.");
+
+  // No attributes should be verify.
+
+  // Verify outputs:
+  IR_ENFORCE(num_results() == 0u, "The size of outputs must be equal to 0.");
+  VLOG(4) << "End Verifying for PushBackOp.";
+}
+
+size_t PushBackOp::stack_size() {
+  auto operands_size = num_operands();
+  IR_ENFORCE(operands_size >= 2u,
+             "The operands of push op must no less than 2.");
+  return operands_size - 1u;
+}
+
+PopBackOp PushBackOp::pop_op() { return create_op().pop_op(); }
+void PopBackOp::Build(Builder &builder,             // NOLINT
+                      OperationArgument &argument,  // NOLINT
+                      Value outlet) {
+  argument.AddInput(outlet);
+
+  auto push_back_op = outlet.defining_op<CreateStackOp>().push_op();
+
+  auto elements_size = push_back_op.stack_size();
+
+  for (size_t index = 0; index < elements_size; ++index) {
+    argument.AddOutput(push_back_op.inlet_element(index).type());
+  }
+}
+
+void PopBackOp::VerifySig() {
+  VLOG(4) << "Verifying inputs, outputs ,attributes  and stack validity for: "
+             "PopBackOp.";
+  // Verify inputs:
+  IR_ENFORCE(num_operands() == 1u, "The size of inputs must equal to 1.");
+  IR_ENFORCE(operand_source(0).type().isa<OutletType>(),
+             "The first input of cf.pop_back must be outlet_type.");
+
+  // No attributes should be verify.
+
+  // Verify outputs:
+  IR_ENFORCE(num_results() >= 1u,
+             "The size of outputs must no less than to 1.");
+  // Verify stack validity:
+  auto pop_back_op = create_op().pop_op();
+  IR_ENFORCE(*this == pop_back_op,
+             "The pop_op of stack_op must be this pop_op self.");
+
+  auto inlet_size = push_op().stack_size();
+  IR_ENFORCE(inlet_size == stack_size(),
+             "The pop elements size must equal to push elements size.");
+  for (size_t index = 0; index < inlet_size; ++index) {
+    IR_ENFORCE(outlet_element(index).type() == inlet_element(index).type(),
+               "The %d element's push type isn't equal to pop type",
+               index);
+  }
+  VLOG(4) << "End Verifying for PopBackOp.";
+}
+
+void HasElementsOp::Build(Builder &builder,             // NOLINT
+                          OperationArgument &argument,  // NOLINT
+                          Value stack) {
+  argument.AddInput(stack);
+  argument.AddOutput(builder.bool_type());
+}
+void HasElementsOp::VerifySig() {
+  VLOG(4) << "Verifying inputs, outputs ,attributes for: HasElementsOp.";
+  // Verify inputs:
+  IR_ENFORCE(num_operands() == 1u, "The size of inputs must equal to 1.");
+  IR_ENFORCE(operand_source(0).type().isa<StackType>(),
+             "The first input of cf.has_elements must be stack_type.");
+
+  // No attributes should be verify.
+
+  // Verify outputs:
+  IR_ENFORCE(num_results() == 1u, "The size of outputs must be equal to 1.");
+  IR_ENFORCE((*this)->result_type(0) == BoolType::get(ir_context()),
+             "The type of cf.has_elements' output is not correct.");
+}
+
 }  // namespace pir
 
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::YieldOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::CreateStackOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::PushBackOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::PopBackOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::HasElementsOp)

--- a/paddle/pir/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_op.h
@@ -30,6 +30,102 @@ class IR_API YieldOp : public Op<YieldOp> {
                     const std::vector<Value> &Value);
   void VerifySig() {}
 };
+class PushBackOp;
+class PopBackOp;
+class IR_API CreateStackOp : public Op<CreateStackOp> {
+ public:
+  using Op::Op;
+  static const char *name() { return "cf.create_stack"; }
+  static constexpr uint32_t attributes_num = 0;
+  static constexpr const char **attributes_name = nullptr;
+  static void Build(Builder &builder,              // NOLINT
+                    OperationArgument &argument);  // NOLINT
+  void VerifySig();
+
+  Value stack() { return result(0); }
+  Value inlet() { return result(1); }
+  Value outlet() { return result(2); }
+  std::tuple<Value, Value, Value> out() { return {stack(), inlet(), outlet()}; }
+
+  size_t stack_size();
+  Value inlet_element(size_t index);
+  Value outlet_element(size_t index);
+  PushBackOp push_op();
+  PopBackOp pop_op();
+
+  void Print(pir::IrPrinter &printer);  // NOLINT
+};
+
+class IR_API PushBackOp : public Op<PushBackOp> {
+ public:
+  using Op::Op;
+  static const char *name() { return "cf.push_back"; }
+  static constexpr uint32_t attributes_num = 0;
+  static constexpr const char **attributes_name = nullptr;
+
+  static void Build(Builder &builder,             // NOLINT
+                    OperationArgument &argument,  // NOLINT
+                    Value inlet,
+                    const std::vector<Value> &elements);
+  static void Build(Builder &builder,             // NOLINT
+                    OperationArgument &argument,  // NOLINT
+                    Value inlet,
+                    std::initializer_list<Value> element_list);
+  void VerifySig();
+
+  Value stack() { return create_op().stack(); }
+  Value inlet() { return operand_source(0); }
+  Value outlet() { return create_op().outlet(); }
+  size_t stack_size();
+  Value inlet_element(size_t index) { return operand_source(index + 1u); }
+  Value outlet_element(size_t index) {
+    return create_op().outlet_element(index);
+  }
+  CreateStackOp create_op() { return inlet().defining_op<CreateStackOp>(); }
+  PopBackOp pop_op();
+};
+
+class IR_API PopBackOp : public Op<PopBackOp> {
+ public:
+  using Op::Op;
+  static const char *name() { return "cf.pop_back"; }
+  static constexpr uint32_t attributes_num = 0;
+  static constexpr const char **attributes_name = nullptr;
+
+  static void Build(Builder &builder,             // NOLINT
+                    OperationArgument &argument,  // NOLINT
+                    Value outlet);
+  void VerifySig();
+
+  Value stack() { return create_op().stack(); }
+  Value inlet() { return create_op().inlet(); }
+  Value outlet() { return operand_source(0); }
+
+  size_t stack_size() { return num_results(); }
+  Value inlet_element(size_t index) { return push_op().inlet_element(index); }
+  Value outlet_element(size_t index) { return result(index); }
+  CreateStackOp create_op() { return outlet().defining_op<CreateStackOp>(); }
+  PushBackOp push_op() { return create_op().push_op(); }
+};
+
+class IR_API HasElementsOp : public Op<HasElementsOp> {
+ public:
+  using Op::Op;
+  static const char *name() { return "cf.has_elements"; }
+  static constexpr uint32_t attributes_num = 0;
+  static constexpr const char **attributes_name = nullptr;
+
+  static void Build(Builder &builder,             // NOLINT
+                    OperationArgument &argument,  // NOLINT
+                    Value stack);
+  void VerifySig();
+  Value out() { return result(0); }
+};
+
 }  // namespace pir
 
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::YieldOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::CreateStackOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::PushBackOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::PopBackOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::HasElementsOp);

--- a/paddle/pir/dialect/control_flow/ir/cf_type.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_type.cc
@@ -12,24 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#include "paddle/pir/dialect/control_flow/ir/cf_type.h"
 
-#include "paddle/pir/core/dialect.h"
-
-namespace pir {
-class ControlFlowDialect : public Dialect {
- public:
-  explicit ControlFlowDialect(IrContext *context)
-      : Dialect(name(), context, TypeId::get<ControlFlowDialect>()) {
-    initialize();
-  }
-  static const char *name() { return "cf"; }
-  void PrintType(pir::Type type, std::ostream &os) const override;
-  void PrintOperation(pir::Operation *op,
-                      pir::IrPrinter &printer) const override;  // NOLINT
- private:
-  void initialize();
-};
-
-}  // namespace pir
-IR_DECLARE_EXPLICIT_TYPE_ID(pir::ControlFlowDialect)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::StackType)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::InletType)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::OutletType)

--- a/paddle/pir/dialect/control_flow/ir/cf_type.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_type.h
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,22 +15,27 @@
 
 #pragma once
 
-#include "paddle/pir/core/dialect.h"
+#include "paddle/pir/core/type.h"
+#include "paddle/pir/core/type_base.h"
 
 namespace pir {
-class ControlFlowDialect : public Dialect {
+class IR_API StackType : public Type::TypeBase<StackType, Type, TypeStorage> {
  public:
-  explicit ControlFlowDialect(IrContext *context)
-      : Dialect(name(), context, TypeId::get<ControlFlowDialect>()) {
-    initialize();
-  }
-  static const char *name() { return "cf"; }
-  void PrintType(pir::Type type, std::ostream &os) const override;
-  void PrintOperation(pir::Operation *op,
-                      pir::IrPrinter &printer) const override;  // NOLINT
- private:
-  void initialize();
+  using Base::Base;
+};
+
+class IR_API InletType : public Type::TypeBase<InletType, Type, TypeStorage> {
+ public:
+  using Base::Base;
+};
+
+class IR_API OutletType : public Type::TypeBase<OutletType, Type, TypeStorage> {
+ public:
+  using Base::Base;
 };
 
 }  // namespace pir
-IR_DECLARE_EXPLICIT_TYPE_ID(pir::ControlFlowDialect)
+
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::StackType)
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::InletType)
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::OutletType)

--- a/test/cpp/pir/control_flow_dialect/if_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/if_op_test.cc
@@ -23,6 +23,8 @@
 #include "paddle/pir/dialect/control_flow/ir/cf_dialect.h"
 #include "paddle/pir/dialect/control_flow/ir/cf_op.h"
 
+using namespace paddle::dialect;  // NOLINT
+
 TEST(if_op_test, base) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
@@ -93,6 +95,85 @@ TEST(if_op_test, build_by_block) {
   EXPECT_FALSE(true_block);
   EXPECT_FALSE(false_block);
   EXPECT_EQ(full_op_2->GetParentProgram(), &program);
+
+  std::stringstream ss;
+  program.Print(ss);
+
+  LOG(INFO) << ss.str();
+}
+
+TEST(if_op_test, network_with_backward) {
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<OperatorDialect>();
+  ctx->GetOrRegisterDialect<pir::ControlFlowDialect>();
+
+  pir::Program program(ctx);
+  pir::Block* block = program.block();
+  pir::Builder builder(ctx, block);
+  auto x = builder.Build<FullOp>(std::vector<int64_t>{2, 2}, 1.0f).out();
+  auto y = builder.Build<FullOp>(std::vector<int64_t>{2, 2}, 2.0f).out();
+  auto cond = builder.Build<LessThanOp>(x, y).out();
+  auto [stack_0, inlet_0, outlet_0] = builder.Build<pir::CreateStackOp>().out();
+  auto [stack_1, inlet_1, outlet_1] = builder.Build<pir::CreateStackOp>().out();
+  (void)(stack_0);
+  (void)(stack_1);
+
+  auto if_op = builder.Build<IfOp>(cond, std::vector<pir::Type>{x.type()});
+
+  builder.SetInsertionPointToStart(if_op.true_block());
+  auto local1_z = builder.Build<AddOp>(x, y).out();
+  auto local1_w = builder.Build<AddOp>(local1_z, y).out();
+  builder.Build<pir::PushBackOp>(inlet_0,
+                                 std::initializer_list<pir::Value>{local1_z});
+  builder.Build<pir::YieldOp>(std::vector<pir::Value>{local1_w});
+
+  builder.SetInsertionPointToStart(if_op.false_block());
+  auto local2_z = builder.Build<MatmulOp>(x, y).out();
+  auto local2_w = builder.Build<MatmulOp>(local2_z, y).out();
+  builder.Build<pir::PushBackOp>(inlet_1,
+                                 std::initializer_list<pir::Value>{local2_z});
+  builder.Build<pir::YieldOp>(std::vector<pir::Value>{local2_w});
+
+  builder.SetInsertionPointToEnd(block);
+
+  // build backward network
+  auto out_grad = builder.Build<FullOp>(std::vector<int64_t>{2, 2}, 1.0f).out();
+  // the output of if_grad op is {x_grad, y_grad}
+  auto if_grad =
+      builder.Build<IfOp>(cond, std::vector<pir::Type>{x.type(), y.type()});
+
+  // construct the true block of if_grad
+  builder.SetInsertionPointToStart(if_grad.true_block());
+  auto pop_local1_z = builder.Build<pir::PopBackOp>(outlet_0).outlet_element(0);
+  auto local1_add_grad_op = builder.Build<AddGradOp>(pop_local1_z, y, out_grad);
+  auto pop_local1_z_grad = local1_add_grad_op.x_grad(),
+       local1_y_grad_0 = local1_add_grad_op.y_grad();
+  auto local1_add_grad_op_1 = builder.Build<AddGradOp>(x, y, pop_local1_z_grad);
+  auto local1_x_grad = local1_add_grad_op_1.x_grad(),
+       local1_y_grad_1 = local1_add_grad_op_1.y_grad();
+  auto local1_y_grad =
+      builder.Build<AddOp>(local1_y_grad_0, local1_y_grad_1).out();
+  builder.Build<pir::YieldOp>(
+      std::vector<pir::Value>{local1_x_grad, local1_y_grad});
+
+  // construct the false block of if_grad
+  builder.SetInsertionPointToStart(if_grad.false_block());
+  auto pop_local2_z = builder.Build<pir::PopBackOp>(outlet_1).outlet_element(0);
+  auto local2_matmul_grad_op =
+      builder.Build<MatmulGradOp>(pop_local2_z, y, out_grad);
+  auto pop_local2_z_grad = local2_matmul_grad_op.x_grad(),
+       local2_y_grad_0 = local2_matmul_grad_op.y_grad();
+  auto local2_matmul_grad_op_1 =
+      builder.Build<MatmulGradOp>(x, y, pop_local2_z_grad);
+  auto local2_x_grad = local2_matmul_grad_op_1.x_grad(),
+       local2_y_grad_1 = local2_matmul_grad_op_1.y_grad();
+
+  auto local2_y_grad =
+      builder.Build<AddOp>(local2_y_grad_0, local2_y_grad_1).out();
+  builder.Build<pir::YieldOp>(
+      std::vector<pir::Value>{local2_x_grad, local2_y_grad});
+
+  builder.SetInsertionPointToEnd(block);
 
   std::stringstream ss;
   program.Print(ss);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
- 添加控制流反向所需的基础组件相关算子： CreateStackOp、PushBackOp、PopBackOp、HasElementsOp。

### Other
Pcard-67164
