### PR TITLE
support_string_dtype

### DIFF
--- a/python/paddle/base/data_feeder.py
+++ b/python/paddle/base/data_feeder.py
@@ -45,6 +45,21 @@ _PADDLE_DTYPE_2_NUMPY_DTYPE = {
     core.VarDesc.VarType.COMPLEX128: 'complex128',
 }
 
+_NUMPY_DTYPE_2_PADDLE_DTYPE = {
+    'bool': core.VarDesc.VarType.BOOL,
+    'float16': core.VarDesc.VarType.FP16,
+    'uint16': core.VarDesc.VarType.BF16,
+    'float32': core.VarDesc.VarType.FP32,
+    'float64': core.VarDesc.VarType.FP64,
+    'int8': core.VarDesc.VarType.INT8,
+    'int16': core.VarDesc.VarType.INT16,
+    'int32': core.VarDesc.VarType.INT32,
+    'int64': core.VarDesc.VarType.INT64,
+    'uint8': core.VarDesc.VarType.UINT8,
+    'complex64': core.VarDesc.VarType.COMPLEX64,
+    'complex128': core.VarDesc.VarType.COMPLEX128,
+}
+
 _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE = {
     core.DataType.BOOL: 'bool',
     core.DataType.FLOAT16: 'float16',

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -15,6 +15,7 @@
 from ..base.core import VarDesc
 from ..base.core import finfo as core_finfo
 from ..base.core import iinfo as core_iinfo
+from ..base.data_feeder import _NUMPY_DTYPE_2_PADDLE_DTYPE
 
 dtype = VarDesc.VarType
 dtype.__qualname__ = "dtype"
@@ -45,7 +46,7 @@ def iinfo(dtype):
     This is similar to `numpy.iinfo <https://numpy.org/doc/stable/reference/generated/numpy.iinfo.html#numpy-iinfo>`_.
 
     Args:
-        dtype(paddle.dtype):  One of paddle.uint8, paddle.int8, paddle.int16, paddle.int32, and paddle.int64.
+        dtype(paddle.dtype|string):  One of paddle.uint8, paddle.int8, paddle.int16, paddle.int32, and paddle.int64.
 
     Returns:
         An iinfo object, which has the following 4 attributes:
@@ -73,6 +74,8 @@ def iinfo(dtype):
             uint8
 
     """
+    if dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
+        dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]
     return core_iinfo(dtype)
 
 
@@ -84,7 +87,7 @@ def finfo(dtype):
     This is similar to `numpy.finfo <https://numpy.org/doc/stable/reference/generated/numpy.finfo.html#numpy-finfo>`_.
 
     Args:
-        dtype(paddle.dtype):  One of ``paddle.float16``, ``paddle.float32``, ``paddle.float64``, ``paddle.bfloat16``,
+        dtype(paddle.dtype|string):  One of ``paddle.float16``, ``paddle.float32``, ``paddle.float64``, ``paddle.bfloat16``,
             ``paddle.complex64``, and ``paddle.complex128``.
 
     Returns:
@@ -129,4 +132,6 @@ def finfo(dtype):
         dtype, paddle.pir.core.DataType
     ):
         dtype = paddle.base.framework.paddle_type_to_proto_type[dtype]
+    elif dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
+        dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]
     return core_finfo(dtype)

--- a/test/legacy_test/test_iinfo_and_finfo.py
+++ b/test/legacy_test/test_iinfo_and_finfo.py
@@ -30,6 +30,13 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
             paddle.complex64,
             paddle.complex128,
             paddle.bool,
+            'float16',
+            'float32',
+            'float64',
+            'uint16',
+            'complex64',
+            'complex128',
+            'bool',
         ]:
             with self.assertRaises(ValueError):
                 _ = paddle.iinfo(dtype)
@@ -41,6 +48,11 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
             (paddle.int16, np.int16),
             (paddle.int8, np.int8),
             (paddle.uint8, np.uint8),
+            ('int64', np.int64),
+            ('int32', np.int32),
+            ('int16', np.int16),
+            ('int8', np.int8),
+            ('uint8', np.uint8),
         ]:
             xinfo = paddle.iinfo(paddle_dtype)
             xninfo = np.iinfo(np_dtype)
@@ -53,6 +65,8 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
         for paddle_dtype, np_dtype in [
             (paddle.float32, np.float32),
             (paddle.float64, np.float64),
+            ('float32', np.float32),
+            ('float64', np.float64),
         ]:
             xinfo = paddle.finfo(paddle_dtype)
             xninfo = np.finfo(np_dtype)
@@ -71,6 +85,8 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
         for paddle_dtype, np_dtype in [
             (paddle.complex64, np.complex64),
             (paddle.complex128, np.complex128),
+            ('complex64', np.complex64),
+            ('complex128', np.complex128),
         ]:
             xinfo = paddle.finfo(paddle_dtype)
             xninfo = np.finfo(np_dtype)
@@ -87,6 +103,16 @@ class TestIInfoAndFInfoAPI(unittest.TestCase):
                 )
 
         xinfo = paddle.finfo(paddle.float16)
+        self.assertEqual(xinfo.dtype, "float16")
+        self.assertEqual(xinfo.bits, 16)
+        self.assertAlmostEqual(xinfo.max, 65504.0)
+        self.assertAlmostEqual(xinfo.min, -65504.0)
+        self.assertAlmostEqual(xinfo.eps, 0.0009765625)
+        self.assertAlmostEqual(xinfo.tiny, 6.103515625e-05)
+        self.assertAlmostEqual(xinfo.resolution, 0.001)
+        self.assertAlmostEqual(xinfo.smallest_normal, 6.103515625e-05)
+
+        xinfo = paddle.finfo('float16')
         self.assertEqual(xinfo.dtype, "float16")
         self.assertEqual(xinfo.bits, 16)
         self.assertAlmostEqual(xinfo.max, 65504.0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization 
### PR changes
APIs 
### Description
Pcard-73263
现有的iinfo,finfo只支持paddle.dtype类型输入，而以sting类型的数据类型输入在绝大多数API都得到支持，该PR进行补全
