### PR TITLE
【Hackathon 5th No.33】 reshape more dtype and test -part

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3734,7 +3734,7 @@ def reshape(x, shape, name=None):
         - 3. Given a 3-D tensor x with a shape [2, 4, 6], and the target shape is [-1, 0, 3, 2], the reshape operator will transform x into a 4-D tensor with shape [2, 4, 3, 2] and leaving x's data unchanged. In this case, besides -1, 0 means the actual dimension value is going to be copied from the corresponding dimension of x.
 
     Args:
-        x (Tensor): An N-D Tensor. The data type is ``float32``, ``float64``, ``int32``, ``int64`` or ``bool``
+        x (Tensor): An N-D Tensor. The data type is ``float16``, ``float32``, ``float64``, ``int16``, ``int32``, ``int64``, ``uint16``, ``int8``, ``uint8``, ``complex64``, ``complex128``, ``bfloat16`` or ``bool``.
         shape (list|tuple|Tensor): Define the target shape. At most one dimension of the target shape can be -1.
                         The data type is ``int32`` . If ``shape`` is a list or tuple, each element of it should be integer or Tensor with shape [].
                         If ``shape`` is an Tensor, it should be an 1-D Tensor .
@@ -3879,6 +3879,11 @@ def reshape(x, shape, name=None):
                 'int64',
                 'bool',
                 'uint16',
+                'int8',
+                'uint8',
+                'complex64',
+                'complex128',
+                'bfloat16',
             ],
             'reshape',
         )

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3878,11 +3878,11 @@ def reshape(x, shape, name=None):
                 'int32',
                 'int64',
                 'bool',
+                'uint16',
                 'int8',
                 'uint8',
                 'complex64',
                 'complex128',
-                'bfloat16',
             ],
             'reshape',
         )

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3734,7 +3734,7 @@ def reshape(x, shape, name=None):
         - 3. Given a 3-D tensor x with a shape [2, 4, 6], and the target shape is [-1, 0, 3, 2], the reshape operator will transform x into a 4-D tensor with shape [2, 4, 3, 2] and leaving x's data unchanged. In this case, besides -1, 0 means the actual dimension value is going to be copied from the corresponding dimension of x.
 
     Args:
-        x (Tensor): An N-D Tensor. The data type is ``float16``, ``float32``, ``float64``, ``int16``, ``int32``, ``int64``, ``uint16``, ``int8``, ``uint8``, ``complex64``, ``complex128``, ``bfloat16`` or ``bool``.
+        x (Tensor): An N-D Tensor. The data type is ``float16``, ``float32``, ``float64``, ``int16``, ``int32``, ``int64``, ``int8``, ``uint8``, ``complex64``, ``complex128``, ``bfloat16`` or ``bool``.
         shape (list|tuple|Tensor): Define the target shape. At most one dimension of the target shape can be -1.
                         The data type is ``int32`` . If ``shape`` is a list or tuple, each element of it should be integer or Tensor with shape [].
                         If ``shape`` is an Tensor, it should be an 1-D Tensor .
@@ -3878,7 +3878,6 @@ def reshape(x, shape, name=None):
                 'int32',
                 'int64',
                 'bool',
-                'uint16',
                 'int8',
                 'uint8',
                 'complex64',

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -465,7 +465,6 @@ class TestReshapeAPI(unittest.TestCase):
             'int16',
             'int32',
             'int64',
-            'uint16',
             'int8',
             'uint8',
             'complex64',

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -453,9 +453,62 @@ class TestReshapeAPI(unittest.TestCase):
         np.testing.assert_array_equal(res_3, input.reshape([5, 10]))
         np.testing.assert_array_equal(res_4, input.reshape(shape))
 
+    def _test_static_dtype(self):
+        places = [paddle.CPUPlace()] + (
+            [paddle.CUDAPlace(0)] if base.core.is_compiled_with_cuda() else []
+        )
+
+        dtypes = [
+            'float16',
+            'float32',
+            'float64',
+            'int16',
+            'int32',
+            'int64',
+            'uint16',
+            'int8',
+            'uint8',
+            'complex64',
+            'complex128',
+            'bfloat16',
+            'bool',
+        ]
+        for place in places:
+            for dtype in dtypes:
+                # core is not compiled with CUDA and not support the bfloat16
+                if (
+                    dtype == 'bfloat16'
+                    and not base.core.is_compiled_with_cuda()
+                ):
+                    continue
+
+                dtype_paddle = dtype
+                # numpy not support bfloat16, use uint16 instead
+                dtype_numpy = dtype if dtype != 'bfloat16' else 'uint16'
+
+                paddle.enable_static()
+                input = np.random.random([2, 25]).astype(dtype_numpy)
+                shape = [2, 5, 5]
+                main_prog = paddle.static.Program()
+                with paddle.static.program_guard(
+                    main_prog, paddle.static.Program()
+                ):
+                    x = self.data(name="x", shape=[2, 25], dtype=dtype_paddle)
+                    out_1 = self.reshape(x, shape)
+
+                exe = paddle.static.Executor(place=place)
+                res_1 = exe.run(
+                    main_prog,
+                    feed={"x": input},
+                    fetch_list=[out_1],
+                )[0]
+
+                np.testing.assert_array_equal(res_1, input.reshape(shape))
+
     def test_paddle_api(self):
         self._set_paddle_api()
         self._test_api()
+        self._test_static_dtype()
 
     def test_imperative(self):
         self._set_paddle_api()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->

修改 `reshape` 静态图中数据类型检查，增加支持：
- 'int8',
- 'uint8',
- 'complex64',
- 'complex128',
- 'bfloat16',

并增加相应单元测试。

涉及文件：
- `python/paddle/tensor/manipulation.py` 修改数据支持类型
- `test/legacy_test/test_reshape_op.py` 增加单测

关联 PR： https://github.com/PaddlePaddle/Paddle/pull/58323

