### PR TITLE
[PIR]Fix list of 0-D opresult

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -213,6 +213,7 @@ PD_MANUAL_OP_LIST = {
     'add_n_',
     'add_n_with_kernel',
     'split_grad',
+    'expand',
 }
 
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -18,6 +18,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/primitive/rule/vjp/vjp.h"
+#include "paddle/fluid/primitive/type/lazy_tensor.h"
 #include "paddle/phi/api/lib/utils/allocator.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
@@ -1046,6 +1047,315 @@ void SplitGradOp::InferMeta(phi::InferMetaContext *infer_meta) {
   fn(infer_meta);
 }
 
+OpInfoTuple ExpandOp::GetOpInfo() {
+  std::vector<paddle::dialect::OpInputInfo> inputs = {
+      paddle::dialect::OpInputInfo(
+          "x", "paddle::dialect::DenseTensorType", false, false, false, true),
+      paddle::dialect::OpInputInfo("shape",
+                                   "paddle::dialect::IntArrayAttribute",
+                                   false,
+                                   false,
+                                   true,
+                                   false)};
+  std::vector<paddle::dialect::OpAttributeInfo> attributes = {};
+  std::vector<paddle::dialect::OpOutputInfo> outputs = {
+      paddle::dialect::OpOutputInfo(
+          "out", "paddle::dialect::DenseTensorType", false, false)};
+  paddle::dialect::OpRunTimeInfo run_time_info =
+      paddle::dialect::OpRunTimeInfo("ExpandInferMeta",
+                                     {"x", "shape"},
+                                     "expand",
+                                     {"x", "shape"},
+                                     {"x"},
+                                     {},
+                                     {},
+                                     {});
+  return std::make_tuple(inputs, attributes, outputs, run_time_info, "expand");
+}
+
+void ExpandOp::Build(pir::Builder &builder,
+                     pir::OperationArgument &argument,
+                     pir::Value x_,
+                     const std::vector<int64_t> &shape) {
+  VLOG(4) << "Start build ExpandOp";
+
+  // Generate int_array mutable attribute: shape
+  paddle::dialect::FullIntArrayOp full_shape_op =
+      builder.Build<paddle::dialect::FullIntArrayOp>(
+          shape, phi::DataType::INT64, phi::CPUPlace());
+  pir::OpResult shape_ = full_shape_op->result(0);
+
+  VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x_, shape_};
+  argument.AddInputs(argument_inputs);
+
+  VLOG(4) << "Builder construction attributes";
+
+  VLOG(4) << "Builder construction outputs";
+  paddle::dialect::DenseTensorType x =
+      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
+  (void)x;
+
+  VLOG(4) << "Builder construction  dense_x";
+  paddle::dialect::IrMetaTensor ir_meta_tensor_x(
+      paddle::dialect::TransToPhiDataType(x.dtype()),
+      x.dims(),
+      x.data_layout(),
+      x.lod(),
+      x.offset());
+  VLOG(4) << "Builder construction  meta_x";
+  phi::MetaTensor meta_x(&ir_meta_tensor_x);
+  paddle::dialect::IrMetaTensor dense_out;
+  phi::MetaTensor meta_out(&dense_out);
+
+  phi::ExpandInferMeta(meta_x, shape, &meta_out);
+
+  std::vector<pir::Type> argument_outputs;
+  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
+      pir::IrContext::Instance(),
+      paddle::dialect::TransToIrDataType(dense_out.dtype()),
+      dense_out.dims(),
+      dense_out.layout(),
+      dense_out.lod(),
+      dense_out.offset());
+  argument_outputs.push_back(out_dense_tensor_type);
+  argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  ::pir::PassStopGradientsDefaultly(argument);
+}
+
+void ExpandOp::Build(pir::Builder &builder,
+                     pir::OperationArgument &argument,
+                     pir::Value x_,
+                     pir::AttributeMap attributes) {
+  VLOG(4) << "Start build ExpandOp";
+
+  IR_ENFORCE(attributes.find("shape") != attributes.end(),
+             "'shape' Attribute is expected for ExpandOp. ");
+  std::vector<int64_t> shape =
+      attributes.at("shape")
+          .dyn_cast<paddle::dialect::IntArrayAttribute>()
+          .data()
+          .GetData();
+
+  // Generate int_array mutable attribute: shape
+  paddle::dialect::FullIntArrayOp full_shape_op =
+      builder.Build<paddle::dialect::FullIntArrayOp>(
+          shape, phi::DataType::INT64, phi::CPUPlace());
+  pir::OpResult shape_ = full_shape_op->result(0);
+
+  VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x_, shape_};
+  argument.AddInputs(argument_inputs);
+
+  VLOG(4) << "Builder construction attributes";
+
+  VLOG(4) << "Builder construction outputs";
+  paddle::dialect::DenseTensorType x =
+      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
+  (void)x;
+
+  VLOG(4) << "Builder construction  dense_x";
+  paddle::dialect::IrMetaTensor ir_meta_tensor_x(
+      paddle::dialect::TransToPhiDataType(x.dtype()),
+      x.dims(),
+      x.data_layout(),
+      x.lod(),
+      x.offset());
+  VLOG(4) << "Builder construction  meta_x";
+  phi::MetaTensor meta_x(&ir_meta_tensor_x);
+  paddle::dialect::IrMetaTensor dense_out;
+  phi::MetaTensor meta_out(&dense_out);
+
+  phi::ExpandInferMeta(meta_x, shape, &meta_out);
+
+  std::vector<pir::Type> argument_outputs;
+  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
+      pir::IrContext::Instance(),
+      paddle::dialect::TransToIrDataType(dense_out.dtype()),
+      dense_out.dims(),
+      dense_out.layout(),
+      dense_out.lod(),
+      dense_out.offset());
+  argument_outputs.push_back(out_dense_tensor_type);
+  argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  ::pir::PassStopGradientsDefaultly(argument);
+}
+
+void ExpandOp::Build(pir::Builder &builder,
+                     pir::OperationArgument &argument,
+                     pir::Value x_,
+                     pir::Value shape_) {
+  VLOG(4) << "Start build ExpandOp";
+
+  VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x_, shape_};
+  argument.AddInputs(argument_inputs);
+
+  VLOG(4) << "Builder construction attributes";
+
+  VLOG(4) << "Builder construction outputs";
+  paddle::dialect::DenseTensorType x =
+      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
+  (void)x;
+  phi::IntArray shape;
+  if (shape_.dyn_cast<pir::OpResult>()
+          .owner()
+          ->isa<paddle::dialect::FullIntArrayOp>()) {
+    shape = std::move(phi::IntArray(paddle::dialect::GetInt64Vector(
+        shape_.dyn_cast<pir::OpResult>()
+            .owner()
+            ->dyn_cast<paddle::dialect::FullIntArrayOp>()
+            .attribute("value"))));
+  } else if (shape_.type().isa<pir::VectorType>()) {
+    size_t shape_size = shape_.type().dyn_cast<pir::VectorType>().size();
+    // In ExpandInferMeta use -2 to represent the element in expand_shape is a
+    // var.
+    shape = std::move(phi::IntArray(std::vector<int64_t>(shape_size, -2)));
+    shape.SetFromTensor(true);
+  } else if (shape_.type().isa<paddle::dialect::DenseTensorType>()) {
+    size_t shape_size = phi::product(
+        shape_.type().dyn_cast<paddle::dialect::DenseTensorType>().dims());
+    // In ExpandInferMeta use -2 to represent the element in expand_shape is a
+    // var.
+    shape = std::move(phi::IntArray(std::vector<int64_t>(shape_size, -2)));
+    shape.SetFromTensor(true);
+  } else {
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "Only support VectorType or DenseTensorType"));
+  }
+
+  VLOG(4) << "Builder construction  dense_x";
+  paddle::dialect::IrMetaTensor ir_meta_tensor_x(
+      paddle::dialect::TransToPhiDataType(x.dtype()),
+      x.dims(),
+      x.data_layout(),
+      x.lod(),
+      x.offset());
+  VLOG(4) << "Builder construction  meta_x";
+  phi::MetaTensor meta_x(&ir_meta_tensor_x);
+  paddle::dialect::IrMetaTensor dense_out;
+  phi::MetaTensor meta_out(&dense_out);
+
+  phi::ExpandInferMeta(meta_x, shape, &meta_out);
+
+  std::vector<pir::Type> argument_outputs;
+  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
+      pir::IrContext::Instance(),
+      paddle::dialect::TransToIrDataType(dense_out.dtype()),
+      dense_out.dims(),
+      dense_out.layout(),
+      dense_out.lod(),
+      dense_out.offset());
+  argument_outputs.push_back(out_dense_tensor_type);
+  argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  ::pir::PassStopGradientsDefaultly(argument);
+}
+
+void ExpandOp::VerifySig() {
+  VLOG(4) << "Start Verifying inputs, outputs and attributes for: ExpandOp.";
+  VLOG(4) << "Verifying inputs:";
+  {
+    auto input_size = num_operands();
+    IR_ENFORCE(input_size == 2u,
+               "The size %d of inputs must be equal to 2.",
+               input_size);
+    IR_ENFORCE((*this)
+                   ->operand_source(0)
+                   .type()
+                   .isa<paddle::dialect::DenseTensorType>(),
+               "Type validation failed for the 0th input.");
+    if (auto vec_type =
+            (*this)->operand_source(1).type().dyn_cast<pir::VectorType>()) {
+      for (size_t i = 0; i < vec_type.size(); ++i) {
+        IR_ENFORCE(vec_type[i].isa<paddle::dialect::DenseTensorType>(),
+                   "Type validation failed for the 1th input.");
+      }
+    } else {
+      IR_ENFORCE((*this)
+                     ->operand_source(1)
+                     .type()
+                     .isa<paddle::dialect::DenseTensorType>(),
+                 "Type validation failed for the 1th input.");
+    }
+  }
+  VLOG(4) << "Verifying attributes:";
+  {
+    // Attributes num is 0, not need to check attributes type.
+  }
+  VLOG(4) << "Verifying outputs:";
+  {
+    auto output_size = num_results();
+    IR_ENFORCE(output_size == 1u,
+               "The size %d of outputs must be equal to 1.",
+               output_size);
+    IR_ENFORCE(
+        (*this)->result(0).type().isa<paddle::dialect::DenseTensorType>(),
+        "Type validation failed for the 0th output.");
+  }
+  VLOG(4) << "End Verifying for: ExpandOp.";
+}
+
+void ExpandOp::InferMeta(phi::InferMetaContext *infer_meta) {
+  auto fn = PD_INFER_META(phi::ExpandInferMeta);
+  fn(infer_meta);
+}
+
+phi::DataType ExpandOp::GetKernelTypeForVar(
+    const std::string &var_name,
+    const phi::DataType &tensor_dtype,
+    const phi::DataType &expected_kernel_dtype) {
+  VLOG(4) << "Get KernelType for Var of op: ExpandOp";
+  return expected_kernel_dtype;
+}
+
+std::vector<std::vector<pir::OpResult>> ExpandOp::Vjp(
+    pir::Operation *op,
+    const std::vector<std::vector<pir::Value>> &inputs_,
+    const std::vector<std::vector<pir::OpResult>> &outputs,
+    const std::vector<std::vector<pir::Value>> &out_grads,
+    const std::vector<std::vector<bool>> &stop_gradients) {
+  PADDLE_ENFORCE_EQ(inputs_.size(),
+                    2,
+                    platform::errors::InvalidArgument(
+                        "expand op's inputs size should be 2, but now is %d.",
+                        inputs_.size()));
+  PADDLE_ENFORCE_EQ(outputs.size(),
+                    1,
+                    platform::errors::InvalidArgument(
+                        "expand op's outputs size should be 1, but now is %d.",
+                        outputs.size()));
+
+  VLOG(6) << "Prepare inputs of expand_grad";
+
+  Tensor x(std::make_shared<primitive::LazyTensor>(inputs_[0][0]));
+  Tensor out_grad(std::make_shared<primitive::LazyTensor>(out_grads[0][0]));
+
+  VLOG(6) << "Vjp prepare Prepare attributes of expand_grad";
+
+  Tensor shape(std::make_shared<primitive::LazyTensor>(inputs_[1][0]));
+
+  VLOG(6) << "Vjp prepare call expand's vjp inteface";
+
+  std::vector<std::vector<Tensor>> tensor_res =
+      primitive::expand_vjp(x, out_grad, shape, stop_gradients);
+
+  VLOG(6) << "Vjp prepare stop gradient of expand_grad";
+
+  std::vector<std::vector<pir::OpResult>> res(tensor_res.size());
+  for (size_t i = 0; i < tensor_res.size(); ++i) {
+    res[i].resize(tensor_res[i].size());
+    for (size_t j = 0; j < tensor_res[i].size(); ++j) {
+      if (tensor_res[i][j].defined()) {
+        res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(
+                        tensor_res[i][j].impl())
+                        ->value()
+                        .dyn_cast<pir::OpResult>();
+      }
+    }
+  }
+  return res;
+}
+
 }  // namespace dialect
 }  // namespace paddle
 
@@ -1055,3 +1365,4 @@ IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::AddN_Op)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::AddNWithKernelOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::FusedGemmEpilogueOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::FusedGemmEpilogueGradOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::ExpandOp)

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -17,6 +17,7 @@
 
 #include "paddle/fluid/framework/infershape_utils.h"
 #include "paddle/fluid/pir/dialect/operator/interface/decomp.h"
+#include "paddle/fluid/pir/dialect/operator/interface/get_kernel_type_for_var.h"
 #include "paddle/fluid/pir/dialect/operator/interface/infermeta.h"
 #include "paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h"
 #include "paddle/fluid/pir/dialect/operator/interface/vjp.h"
@@ -181,6 +182,52 @@ class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
   static void InferMeta(phi::InferMetaContext *infer_meta);
 };
 
+class ExpandOp : public pir::Op<ExpandOp,
+                                paddle::dialect::OpYamlInfoInterface,
+                                paddle::dialect::InferMetaInterface,
+                                paddle::dialect::VjpInterface,
+                                paddle::dialect::GetKernelTypeForVarInterface> {
+ public:
+  using Op::Op;
+  static const char *name() { return "pd_op.expand"; }
+  static constexpr const char **attributes_name = nullptr;
+  static constexpr uint32_t attributes_num = 0;
+  static OpInfoTuple GetOpInfo();
+  static void Build(pir::Builder &builder,             // NOLINT
+                    pir::OperationArgument &argument,  // NOLINT
+                    pir::Value x_,                     // NOLINT
+                    const std::vector<int64_t> &shape = {});
+  static void Build(pir::Builder &builder,             // NOLINT
+                    pir::OperationArgument &argument,  // NOLINT
+                    pir::Value x_,                     // NOLINT
+                    pir::Value shape_                  // NOLINT
+  );
+  static void Build(pir::Builder &builder,             // NOLINT
+                    pir::OperationArgument &argument,  // NOLINT
+                    pir::Value x_,                     // NOLINT
+                    pir::AttributeMap attributes       // NOLINT
+  );
+
+  void VerifySig();
+
+  static phi::DataType GetKernelTypeForVar(
+      const std::string &var_name,
+      const phi::DataType &tensor_dtype,
+      const phi::DataType &expected_kernel_dtype);
+
+  pir::Value x() { return operand_source(0); }
+  pir::Value shape() { return operand_source(1); }
+  pir::OpResult out() { return result(0); }
+
+  static void InferMeta(phi::InferMetaContext *infer_meta);
+  static std::vector<std::vector<pir::OpResult>> Vjp(
+      pir::Operation *op,
+      const std::vector<std::vector<pir::Value>> &inputs_,
+      const std::vector<std::vector<pir::OpResult>> &outputs,
+      const std::vector<std::vector<pir::Value>> &out_grads,
+      const std::vector<std::vector<bool>> &stop_gradients);
+};
+
 }  // namespace dialect
 }  // namespace paddle
 
@@ -190,3 +237,4 @@ IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::AddN_Op)
 IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::AddNWithKernelOp)
 IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::FusedGemmEpilogueOp)
 IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::FusedGemmEpilogueGradOp)
+IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::ExpandOp)

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
@@ -79,5 +79,53 @@ std::vector<std::vector<pir::OpResult>> AddNOp::Vjp(
   return res;
 }
 
+std::vector<std::vector<pir::OpResult>> ExpandOp::Vjp(
+    pir::Operation* op,
+    const std::vector<std::vector<pir::Value>>& inputs_,
+    const std::vector<std::vector<pir::OpResult>>& outputs,
+    const std::vector<std::vector<pir::Value>>& out_grads,
+    const std::vector<std::vector<bool>>& stop_gradients) {
+  PADDLE_ENFORCE_EQ(inputs_.size(),
+                    2,
+                    platform::errors::InvalidArgument(
+                        "expand op's inputs size should be 2, but now is %d.",
+                        inputs_.size()));
+  PADDLE_ENFORCE_EQ(outputs.size(),
+                    1,
+                    platform::errors::InvalidArgument(
+                        "expand op's outputs size should be 1, but now is %d.",
+                        outputs.size()));
+
+  VLOG(6) << "Prepare inputs of expand_grad";
+
+  Tensor x(std::make_shared<primitive::LazyTensor>(inputs_[0][0]));
+  Tensor out_grad(std::make_shared<primitive::LazyTensor>(out_grads[0][0]));
+
+  VLOG(6) << "Vjp prepare Prepare attributes of expand_grad";
+
+  Tensor shape(std::make_shared<primitive::LazyTensor>(inputs_[1][0]));
+
+  VLOG(6) << "Vjp prepare call expand's vjp inteface";
+
+  std::vector<std::vector<Tensor>> tensor_res =
+      primitive::expand_vjp(x, out_grad, shape, stop_gradients);
+
+  VLOG(6) << "Vjp prepare stop gradient of expand_grad";
+
+  std::vector<std::vector<pir::OpResult>> res(tensor_res.size());
+  for (size_t i = 0; i < tensor_res.size(); ++i) {
+    res[i].resize(tensor_res[i].size());
+    for (size_t j = 0; j < tensor_res[i].size(); ++j) {
+      if (tensor_res[i][j].defined()) {
+        res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(
+                        tensor_res[i][j].impl())
+                        ->value()
+                        .dyn_cast<pir::OpResult>();
+      }
+    }
+  }
+  return res;
+}
+
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -60,7 +60,8 @@ void OperatorDialect::initialize() {
               paddle::dialect::AddNWithKernelOp,
               paddle::dialect::FusedGemmEpilogueOp,
               paddle::dialect::FusedGemmEpilogueGradOp,
-              paddle::dialect::SplitGradOp>();
+              paddle::dialect::SplitGradOp,
+              paddle::dialect::ExpandOp>();
 
   RegisterInterfaces<ParameterConvertInterface>();
 }

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3647,7 +3647,7 @@ def expand(x, shape, name=None):
             shape.stop_gradient = True
         elif isinstance(shape, (list, tuple)):
             if paddle.utils._contain_var(shape):
-                shape = paddle.utils._convert_to_tensor_list(shape)
+                shape = paddle.utils.get_int_tensor_list(shape)
         else:
             TypeError("Shape only supports OpReslut, or list, or tuple.")
         return _C_ops.expand(x, shape)

--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -398,12 +398,12 @@ def get_int_tensor_list(ele_list, place=None, default_dtype='int64'):
             ele.stop_gradient = True
             if convert_dtype(ele.dtype) != default_dtype:
                 ele = paddle.cast(x=ele, dtype=default_dtype)
-            if ele.shape == []:
-                ele = paddle.reshape(ele, [-1])
+            if ele.shape != []:
+                ele = paddle.reshape(ele, [])
             int_tensor_list.append(ele)
         else:
             temp_out = paddle.full(
-                [1],
+                [],
                 ele,
                 convert_np_dtype_to_dtype_(np.dtype(default_dtype)),
                 place,

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -539,6 +539,15 @@ class TestExpandV2CompOpInt64_t(OpTest):
         self.check_output(check_prim=True)
 
 
+class TestExpandPirOpResultListShape(unittest.TestCase):
+    def test_opresult_list_shape(self):
+        with paddle.pir_utils.IrGuard():
+            x = paddle.static.data('x', [1, 3])
+            shape = [2, paddle.full([], 4)]
+            out = paddle.expand(x, shape)
+            np.testing.assert_array_equal(tuple(out.shape), (-1, -1))
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Fix list of 0-D opresult

Expand的infershape比较特殊，如果shape参数是类似[var1, var2, var3]，那么会用-2表示shape参数对应位置是var。所以它的build函数会比较特殊，所以把它放到了手写的文件中，改动了shape处理的代码

Pcard-67164