### PR TITLE
【PIR API adaptor No.251-252】 paddle.vision.ops.yolo_box and yolo_loss

### DIFF
--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -20,7 +20,7 @@ from paddle.utils import convert_to_list
 
 from ..base import core
 from ..base.data_feeder import check_type, check_variable_and_dtype
-from ..base.framework import Variable, in_dygraph_mode
+from ..base.framework import Variable, in_dygraph_mode, in_dynamic_or_pir_mode
 from ..base.layer_helper import LayerHelper
 from ..framework import _current_expected_place
 from ..nn import BatchNorm2D, Conv2D, Layer, ReLU, Sequential

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -188,7 +188,7 @@ def yolo_loss(
             ...                                    scale_x_y=1.)
     """
 
-    if in_dygraph_mode():
+    if in_dynamic_or_pir_mode():
         loss = _C_ops.yolo_loss(
             x,
             gt_box,

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -365,7 +365,7 @@ def yolo_box(
             ...                                             clip_bbox=True,
             ...                                             scale_x_y=1.)
     """
-    if in_dygraph_mode():
+    if in_dynamic_or_pir_mode():
         boxes, scores = _C_ops.yolo_box(
             x,
             img_size,

--- a/test/legacy_test/test_device_guard.py
+++ b/test/legacy_test/test_device_guard.py
@@ -92,7 +92,6 @@ class TestDeviceGuard(unittest.TestCase):
 
         execute(main_program, startup_program)
 
-    @test_with_pir_api
     def test_cpu_only_op(self):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()

--- a/test/legacy_test/test_device_guard.py
+++ b/test/legacy_test/test_device_guard.py
@@ -17,7 +17,6 @@ import warnings
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 

--- a/test/legacy_test/test_device_guard.py
+++ b/test/legacy_test/test_device_guard.py
@@ -17,6 +17,7 @@ import warnings
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -92,6 +93,7 @@ class TestDeviceGuard(unittest.TestCase):
 
         execute(main_program, startup_program)
 
+    @test_with_pir_api
     def test_cpu_only_op(self):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()

--- a/test/legacy_test/test_yolo_box_op.py
+++ b/test/legacy_test/test_yolo_box_op.py
@@ -141,7 +141,7 @@ class TestYoloBoxOp(OpTest):
         self.outputs = {'Boxes': boxes, 'Scores': scores}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def initTestCase(self):
         self.anchors = [10, 13, 16, 30, 33, 23]

--- a/test/legacy_test/test_yolo_box_op.py
+++ b/test/legacy_test/test_yolo_box_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def sigmoid(x):
@@ -262,6 +263,7 @@ class TestYoloBoxDygraph(unittest.TestCase):
 
 
 class TestYoloBoxStatic(unittest.TestCase):
+    @test_with_pir_api
     def test_static(self):
         x1 = paddle.static.data('x1', [2, 14, 8, 8], 'float32')
         img_size = paddle.static.data('img_size', [2, 2], 'int32')

--- a/test/legacy_test/test_yolov3_loss_op.py
+++ b/test/legacy_test/test_yolov3_loss_op.py
@@ -20,6 +20,7 @@ from scipy.special import expit, logit
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def l1loss(x, y):
@@ -438,6 +439,7 @@ class TestYolov3LossDygraph(unittest.TestCase):
 
 
 class TestYolov3LossStatic(unittest.TestCase):
+    @test_with_pir_api
     def test_static(self):
         x = paddle.static.data('x', [2, 14, 8, 8], 'float32')
         gt_box = paddle.static.data('gt_box', [2, 10, 4], 'float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/58067

yolo_box：单测全
yolo_loss：继承自OpTest的单测忘记打开了

关于yolo_loss当前找到了test_yolov3_loss_op.py、test_device_guard.py两个测试文件，麻烦帮忙确认一下IR测试应当加到哪个文件里。