### PR TITLE
【PIR API adaptor No.89、226】Migrate paddle.nn.functional.gather_tree，paddle.nn.functional.temporal_shift into pir

### DIFF
--- a/python/paddle/nn/functional/extension.py
+++ b/python/paddle/nn/functional/extension.py
@@ -21,7 +21,11 @@ from paddle.utils import deprecated
 from ...base.data_feeder import check_type, check_variable_and_dtype
 from ...base.layer_helper import LayerHelper
 from ...common_ops_import import Variable
-from ...framework import convert_np_dtype_to_dtype_, core
+from ...framework import (
+    convert_np_dtype_to_dtype_,
+    core,
+    in_dynamic_or_pir_mode,
+)
 
 __all__ = []
 
@@ -206,7 +210,7 @@ def gather_tree(ids, parents):
     if ids.ndim != parents.ndim:
         raise ValueError("The ids's shape must be the same as parents' shape. ")
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.gather_tree(ids, parents)
     else:
         helper = LayerHelper('gather_tree', **locals())
@@ -292,7 +296,7 @@ def temporal_shift(x, seg_num, shift_ratio=0.25, name=None, data_format="NCHW"):
             "Attr(data_format) should be 'NCHW' or 'NHWC'. "
             f"Received Attr(data_format): {data_format}."
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.temporal_shift(x, seg_num, shift_ratio, data_format)
     else:
         helper = LayerHelper("temporal_shift", **locals())

--- a/test/legacy_test/test_gather_tree_op.py
+++ b/test/legacy_test/test_gather_tree_op.py
@@ -102,15 +102,6 @@ class TestGatherTreeOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_Variable_parents)
 
-            def test_type_ids():
-                # dtype must be int32 or int64
-                bad_ids = paddle.static.data(
-                    name='bad_ids', shape=[5, 2, 2], dtype='float32'
-                )
-                paddle.nn.functional.gather_tree(bad_ids, parents)
-
-            self.assertRaises(TypeError, test_type_ids)
-
             def test_type_parents():
                 # dtype must be int32 or int64
                 bad_parents = paddle.static.data(
@@ -136,6 +127,26 @@ class TestGatherTreeOpError(unittest.TestCase):
 
             self.assertRaises(ValueError, test_parents_ndim)
 
+        paddle.disable_static()
+
+
+class TestGatherTreeOpErrorWithIds(unittest.TestCase):
+    def test_errors(self):
+        paddle.enable_static()
+        with program_guard(Program(), Program()):
+            ids = paddle.static.data(name='ids', shape=[5, 2, 2], dtype='int64')
+            parents = paddle.static.data(
+                name='parents', shape=[5, 2, 2], dtype='int64'
+            )
+
+            def test_type_ids():
+                # dtype must be int32 or int64
+                bad_ids = paddle.static.data(
+                    name='bad_ids', shape=[5, 2, 2], dtype='float32'
+                )
+                paddle.nn.functional.gather_tree(bad_ids, parents)
+
+            self.assertRaises(TypeError, test_type_ids)
         paddle.disable_static()
 
 

--- a/test/legacy_test/test_gather_tree_op.py
+++ b/test/legacy_test/test_gather_tree_op.py
@@ -102,6 +102,27 @@ class TestGatherTreeOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_Variable_parents)
 
+        paddle.disable_static()
+
+
+class TestGatherTreeOpErrorForOthers(unittest.TestCase):
+    def test_errors(self):
+        paddle.enable_static()
+        with program_guard(Program(), Program()):
+            ids = paddle.static.data(name='ids', shape=[5, 2, 2], dtype='int64')
+            parents = paddle.static.data(
+                name='parents', shape=[5, 2, 2], dtype='int64'
+            )
+
+            def test_type_ids():
+                # dtype must be int32 or int64
+                bad_ids = paddle.static.data(
+                    name='bad_ids', shape=[5, 2, 2], dtype='float32'
+                )
+                paddle.nn.functional.gather_tree(bad_ids, parents)
+
+            self.assertRaises(TypeError, test_type_ids)
+
             def test_type_parents():
                 # dtype must be int32 or int64
                 bad_parents = paddle.static.data(
@@ -127,26 +148,6 @@ class TestGatherTreeOpError(unittest.TestCase):
 
             self.assertRaises(ValueError, test_parents_ndim)
 
-        paddle.disable_static()
-
-
-class TestGatherTreeOpErrorWithIds(unittest.TestCase):
-    def test_errors(self):
-        paddle.enable_static()
-        with program_guard(Program(), Program()):
-            ids = paddle.static.data(name='ids', shape=[5, 2, 2], dtype='int64')
-            parents = paddle.static.data(
-                name='parents', shape=[5, 2, 2], dtype='int64'
-            )
-
-            def test_type_ids():
-                # dtype must be int32 or int64
-                bad_ids = paddle.static.data(
-                    name='bad_ids', shape=[5, 2, 2], dtype='float32'
-                )
-                paddle.nn.functional.gather_tree(bad_ids, parents)
-
-            self.assertRaises(TypeError, test_type_ids)
         paddle.disable_static()
 
 

--- a/test/legacy_test/test_gather_tree_op.py
+++ b/test/legacy_test/test_gather_tree_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest
 
 import paddle
 from paddle.base.framework import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestGatherTreeOp(OpTest):
@@ -36,7 +37,7 @@ class TestGatherTreeOp(OpTest):
         self.outputs = {'Out': self.backtrace(ids, parents)}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     @staticmethod
     def backtrace(ids, parents):
@@ -55,6 +56,7 @@ class TestGatherTreeOp(OpTest):
 
 
 class TestGatherTreeOpAPI(unittest.TestCase):
+    @test_with_pir_api
     def test_case(self):
         paddle.enable_static()
         ids = paddle.static.data(name='ids', shape=[5, 2, 2], dtype='int64')
@@ -77,6 +79,7 @@ class TestGatherTreeOpAPI(unittest.TestCase):
 
 
 class TestGatherTreeOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_temporal_shift_op.py
+++ b/test/legacy_test/test_temporal_shift_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def temporal_shift(x, seg_num, shift_ratio, data_format):
@@ -73,10 +74,10 @@ class TestTemporalShift(OpTest):
         self.dtype = 'float64'
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_ignore_uv(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
     def initTestCase(self):
         self.x_shape = (6, 4, 4, 4)
@@ -123,12 +124,12 @@ class TestTemporalShiftFP16(TestTemporalShift):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place)
+            self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad_ignore_uv(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_grad_with_place(place, ['X'], 'Out')
+            self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
 
 
 class TestTemporalShiftAPI(unittest.TestCase):
@@ -146,6 +147,7 @@ class TestTemporalShiftAPI(unittest.TestCase):
                 x=input, seg_num=2, shift_ratio=0.2
             )
 
+    @test_with_pir_api
     def test_static_fp16_gpu(self):
         if paddle.base.core.is_compiled_with_cuda():
             place = paddle.CUDAPlace(0)
@@ -224,11 +226,11 @@ class TestTemporalShiftBF16(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad_ignore_uv(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X'], 'Out')
+        self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067
No89
No226
PIR API 推全升级
将 `paddle.nn.functional.gather_tree` 迁移升级至 pir，并更新单测  单测覆盖率：4/4
将 `paddle.nn.functional.temporal_shift ` 迁移升级至 pir，并更新单测  单测覆盖率：7/7