### PR TITLE
【PIR API adaptor No.122】Migrate paddle.Tensor.kthvalue into pir

### DIFF
--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -28,6 +28,7 @@ from ..framework import (
     core,
     in_dynamic_mode,
     in_dynamic_or_pir_mode,
+    in_pir_mode,
 )
 
 # from ..base.layers import has_inf  #DEFINE_ALIAS
@@ -1214,6 +1215,12 @@ def kthvalue(x, k, axis=None, keepdim=False, name=None):
         if axis is not None:
             return _C_ops.kthvalue(x, k, axis, keepdim)
         else:
+            return _C_ops.kthvalue(x, k, -1, keepdim)
+    elif in_pir_mode():
+        if isinstance(axis, int):
+            return _C_ops.kthvalue(x, k, axis, keepdim)
+        elif isinstance(axis, paddle.pir.OpResult):
+            axis.stop_gradient = True
             return _C_ops.kthvalue(x, k, -1, keepdim)
 
     helper = LayerHelper("kthvalue", **locals())

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -28,7 +28,6 @@ from ..framework import (
     core,
     in_dynamic_mode,
     in_dynamic_or_pir_mode,
-    in_pir_mode,
 )
 
 # from ..base.layers import has_inf  #DEFINE_ALIAS
@@ -1211,16 +1210,10 @@ def kthvalue(x, k, axis=None, keepdim=False, name=None):
              [1, 1]]))
             >>> # doctest: -SKIP
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if axis is not None:
             return _C_ops.kthvalue(x, k, axis, keepdim)
         else:
-            return _C_ops.kthvalue(x, k, -1, keepdim)
-    elif in_pir_mode():
-        if isinstance(axis, int):
-            return _C_ops.kthvalue(x, k, axis, keepdim)
-        elif isinstance(axis, paddle.pir.OpResult):
-            axis.stop_gradient = True
             return _C_ops.kthvalue(x, k, -1, keepdim)
 
     helper = LayerHelper("kthvalue", **locals())

--- a/test/legacy_test/test_kthvalue_op.py
+++ b/test/legacy_test/test_kthvalue_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def cal_kthvalue(x, k, axis, keepdim=False):
@@ -58,11 +59,11 @@ class TestKthvalueOp(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad({'X'}, 'Out')
+        self.check_grad({'X'}, 'Out', check_pir=True)
 
 
 class TestKthvalueOpFp16(TestKthvalueOp):
@@ -93,11 +94,11 @@ class TestKthvalueOpWithKeepdim(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad({'X'}, 'Out')
+        self.check_grad({'X'}, 'Out', check_pir=True)
 
 
 class TestKthvalueOpWithKeepdimFp16(TestKthvalueOpWithKeepdim):
@@ -207,6 +208,7 @@ class TestModeOpInStatic(unittest.TestCase):
         self.input_data = np.random.random((2, 20, 1, 2, 80)).astype(np.float64)
         self.k = 10
 
+    @test_with_pir_api
     def test_run_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(
@@ -245,11 +247,11 @@ class TestKthvalueFP16Op(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
-        self.check_grad({'X'}, 'Out')
+        self.check_grad({'X'}, 'Out', check_pir=True)
 
 
 class TestKthvalueWithKeepdimFP16Op(TestKthvalueFP16Op):
@@ -285,12 +287,12 @@ class TestKthvalueBF16Op(OpTest):
     def test_check_output(self):
         paddle.enable_static()
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, {'X'}, 'Out')
+        self.check_grad_with_place(place, {'X'}, 'Out', check_pir=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/58067

No.122
PIR API 推全升级
将 `paddle.Tensor.kthvalue` 迁移升级至 pir，并更新单测  单测覆盖率：7/7