### PR TITLE
Support Fc And Conv Autotune Config, test=develop

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -531,6 +531,16 @@ void AnalysisPredictor::InitDeviceContexts() {
           auto &instance = memory::allocation::AllocatorFacade::Instance();
           auto *xpu_context =
               new InferXPUContext(place_, config_.xpu_config().context_gm_size);
+          xpu_context->SetConvAutotuneInfo(
+              config_.xpu_config_.conv_autotune_file,
+              config_.xpu_config_.conv_autotune_level,
+              config_.xpu_config_.conv_autotune_file_writeback,
+              place_);
+          xpu_context->SetFcAutotuneInfo(
+              config_.xpu_config_.fc_autotune_file,
+              config_.xpu_config_.fc_autotune_level,
+              config_.xpu_config_.fc_autotune_file_writeback,
+              place_);
           xpu_context->SetAllocator(instance.GetAllocator(place_).get());
           xpu_context->SetGenerator(
               phi::DefaultXPUGenerator(place_.GetDeviceId()).get());

--- a/paddle/fluid/inference/api/infer_context.cc
+++ b/paddle/fluid/inference/api/infer_context.cc
@@ -136,6 +136,93 @@ void InferXPUContext::SetL3Info(size_t l3_size,
   }
 }
 
+void InferXPUContext::SetConvAutotuneInfo(std::string conv_autotune_file,
+                                          int conv_autotune_level,
+                                          bool conv_autotune_file_writeback,
+                                          const phi::Place& place) {
+  phi::backends::xpu::XPUDeviceGuard guard(place.GetDeviceId());
+
+  VLOG(5) << "XPU conv autotune level:" << conv_autotune_level;
+  VLOG(5) << "XPU conv autotune file:" << conv_autotune_file;
+  VLOG(5) << "XPU conv autotune file writeback:"
+          << conv_autotune_file_writeback;
+
+  if (!conv_autotune_file.empty()) {
+    int ret;
+    ret = x_context()->set_option("XPU_CONV_AUTOTUNE_FILE",
+                                  conv_autotune_file.c_str());
+    PADDLE_ENFORCE_EQ(
+        ret,
+        0,
+        platform::errors::Unavailable(
+            "Failed to set XPU conv autotune file %s.", conv_autotune_file));
+  }
+  if (conv_autotune_level > 0) {
+    int ret;
+    ret = x_context()->set_option(
+        "XPU_CONV_AUTOTUNE", (std::to_string(conv_autotune_level)).c_str());
+    PADDLE_ENFORCE_EQ(
+        ret,
+        0,
+        platform::errors::Unavailable("Failed to set XPU conv autotune  %d.",
+                                      conv_autotune_level));
+  }
+  if (conv_autotune_file_writeback) {
+    int ret;
+    ret = x_context()->set_option(
+        "XPU_AUTOTUNE_WRITEBACK",
+        (std::to_string(conv_autotune_file_writeback)).c_str());
+    PADDLE_ENFORCE_EQ(ret,
+                      0,
+                      platform::errors::Unavailable(
+                          "Failed to set XPU conv autotune writeback %d.",
+                          conv_autotune_file_writeback));
+  }
+}
+
+void InferXPUContext::SetFcAutotuneInfo(std::string fc_autotune_file,
+                                        int fc_autotune_level,
+                                        bool fc_autotune_file_writeback,
+                                        const phi::Place& place) {
+  phi::backends::xpu::XPUDeviceGuard guard(place.GetDeviceId());
+
+  VLOG(5) << "XPU fc autotune level:" << fc_autotune_level;
+  VLOG(5) << "XPU fc autotune file:" << fc_autotune_file;
+  VLOG(5) << "XPU fc autotune file writeback:" << fc_autotune_file_writeback;
+
+  if (!fc_autotune_file.empty()) {
+    int ret;
+    ret = x_context()->set_option("XPU_FC_AUTOTUNE_FILE",
+                                  fc_autotune_file.c_str());
+    PADDLE_ENFORCE_EQ(
+        ret,
+        0,
+        platform::errors::Unavailable("Failed to set XPU fc autotune file %s.",
+                                      fc_autotune_file));
+  }
+  if (fc_autotune_level > 0) {
+    int ret;
+    ret = x_context()->set_option("XPU_FC_AUTOTUNE",
+                                  (std::to_string(fc_autotune_level)).c_str());
+    PADDLE_ENFORCE_EQ(
+        ret,
+        0,
+        platform::errors::Unavailable("Failed to set XPU fc autotune  %d.",
+                                      fc_autotune_level));
+  }
+  if (fc_autotune_file_writeback) {
+    int ret;
+    ret = x_context()->set_option(
+        "XPU_FC_AUTOTUNE_WRITEBACK",
+        (std::to_string(fc_autotune_file_writeback)).c_str());
+    PADDLE_ENFORCE_EQ(ret,
+                      0,
+                      platform::errors::Unavailable(
+                          "Failed to set XPU fc autotune writeback %d.",
+                          fc_autotune_file_writeback));
+  }
+}
+
 void InferXPUContext::L3CacheAutotune() {
   if (l3_autotune_size_ == 0) return;
   if (holder_map_.empty()) {

--- a/paddle/fluid/inference/api/infer_context.h
+++ b/paddle/fluid/inference/api/infer_context.h
@@ -69,6 +69,16 @@ class InferXPUContext : public phi::XPUContext {
 
   void L3CacheAutotune();
 
+  void SetConvAutotuneInfo(std::string conv_autotune_file,
+                           int conv_autotune_level,
+                           bool conv_autotune_file_writeback,
+                           const phi::Place& place);
+
+  void SetFcAutotuneInfo(std::string fc_autotune_file,
+                         int fc_autotune_level,
+                         bool fc_autotune_file_writeback,
+                         const phi::Place& place);
+
  private:
   size_t l3_size_{0};
   void* l3_ptr_{nullptr};


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New Feature
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Paddle-Inference xpu 后端增加支持conv autotune，fc autotune 配置的推理方法优化模型性能