### PR TITLE
【PIR API adaptor No.140-142】 Migrate lstsq/lu/lu_unpack into pir

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -308,7 +308,7 @@ def get_device():
 
     """
     device = ''
-    place = framework._current_expected_place()
+    place = framework.current_expected_place()
     if isinstance(place, core.CPUPlace):
         device = 'cpu'
     elif isinstance(place, core.CUDAPlace):

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -308,7 +308,7 @@ def get_device():
 
     """
     device = ''
-    place = framework.current_expected_place()
+    place = framework._current_expected_place_()
     if isinstance(place, core.CPUPlace):
         device = 'cpu'
     elif isinstance(place, core.CUDAPlace):

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2445,7 +2445,7 @@ def lu(x, pivot=True, get_infos=False, name=None):
             >>> # one can verify : X = P @ L @ U ;
     """
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         lu, p, info = _C_ops.lu(x, pivot)
     else:
         check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'lu')
@@ -2548,7 +2548,7 @@ def lu_unpack(x, y, unpack_ludata=True, unpack_pivots=True, name=None):
         raise ValueError(
             f"The shape of Pivots should be (*, K), but received ndim is [{y.ndim} < 1]"
         )
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         P, L, U = _C_ops.lu_unpack(x, y, unpack_ludata, unpack_pivots)
         return P, L, U
     else:
@@ -3474,7 +3474,7 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         elif x.dtype == paddle.float64:
             rcond = 1e-15 * max(x.shape[-2], x.shape[-1])
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         solution, residuals, rank, singular_values = _C_ops.lstsq(
             x, y, rcond, driver
         )

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3448,7 +3448,16 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
     else:
         raise RuntimeError("Only support lstsq api for CPU or CUDA device.")
 
-    if not (x.dtype == y.dtype and x.dtype in (paddle.float32, paddle.float64)):
+    if not (
+        x.dtype == y.dtype
+        and x.dtype
+        in (
+            paddle.float32,
+            paddle.float64,
+            paddle.base.core.DataType.FLOAT32,
+            paddle.base.core.DataType.FLOAT64,
+        )
+    ):
         raise ValueError(
             "Only support x and y have the same dtype such as 'float32' and 'float64'."
         )
@@ -3469,9 +3478,15 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         )
 
     if rcond is None:
-        if x.dtype == paddle.float32:
+        if (
+            x.dtype == paddle.float32
+            or x.dtype == paddle.base.core.DataType.FLOAT32
+        ):
             rcond = 1e-7 * max(x.shape[-2], x.shape[-1])
-        elif x.dtype == paddle.float64:
+        elif (
+            x.dtype == paddle.float64
+            or x.dtype == paddle.base.core.DataType.FLOAT64
+        ):
             rcond = 1e-15 * max(x.shape[-2], x.shape[-1])
 
     if in_dynamic_or_pir_mode():
@@ -3479,7 +3494,13 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             x, y, rcond, driver
         )
         if driver == "gels":
-            rank = paddle.empty(shape=[0], dtype=paddle.int32)
+            if in_dynamic_mode():
+                rank = paddle.empty(shape=[0], dtype=paddle.int32)
+
+            else:
+                rank = paddle.empty(
+                    shape=[0], dtype=paddle.base.core.DataType.INT32
+                )
             singular_values = paddle.empty(shape=[0], dtype=x.dtype)
         elif driver == "gelsy":
             singular_values = paddle.empty(shape=[0], dtype=x.dtype)

--- a/test/legacy_test/test_linalg_lstsq_op.py
+++ b/test/legacy_test/test_linalg_lstsq_op.py
@@ -17,8 +17,9 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import base
+from paddle import base, static
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class LinalgLstsqTestCase(unittest.TestCase):
@@ -91,12 +92,13 @@ class LinalgLstsqTestCase(unittest.TestCase):
             self._result_sg_values = results[3].numpy()
             self.assert_np_close()
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         for dev in self.devices:
             paddle.set_device(dev)
             place = base.CPUPlace() if dev == "cpu" else base.CUDAPlace(0)
-            with base.program_guard(base.Program(), base.Program()):
+            with static.program_guard(static.Program(), static.Program()):
                 x = paddle.static.data(
                     name="x",
                     shape=self._input_shape_1,
@@ -112,7 +114,6 @@ class LinalgLstsqTestCase(unittest.TestCase):
                 )
                 exe = base.Executor(place)
                 fetches = exe.run(
-                    base.default_main_program(),
                     feed={"x": self._input_data_1, "y": self._input_data_2},
                     fetch_list=[results],
                 )
@@ -282,6 +283,7 @@ class TestLinalgLstsqAPIError(unittest.TestCase):
     def setUp(self):
         pass
 
+    @test_with_pir_api
     def test_api_errors(self):
         def test_x_bad_shape():
             x = paddle.to_tensor(np.random.random(size=(5)), dtype=np.float32)

--- a/test/legacy_test/test_linalg_lstsq_op.py
+++ b/test/legacy_test/test_linalg_lstsq_op.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import base, static
+from paddle import base
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
@@ -27,7 +27,7 @@ class LinalgLstsqTestCase(unittest.TestCase):
         self.devices = ["cpu"]
         self.init_config()
         if core.is_compiled_with_cuda() and self.driver == "gels":
-            self.devices.append("gpu:0")
+            self.devices.append("gpu")
         self.generate_input()
         self.generate_output()
         np.random.seed(2022)
@@ -98,7 +98,9 @@ class LinalgLstsqTestCase(unittest.TestCase):
         for dev in self.devices:
             paddle.set_device(dev)
             place = base.CPUPlace() if dev == "cpu" else base.CUDAPlace(0)
-            with static.program_guard(static.Program(), static.Program()):
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
                 x = paddle.static.data(
                     name="x",
                     shape=self._input_shape_1,

--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -259,7 +259,9 @@ class TestLUAPI(unittest.TestCase):
             if core.is_compiled_with_cuda():
                 places.append(base.CUDAPlace(0))
             for place in places:
-                with base.program_guard(base.Program(), base.Program()):
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
                     batch_size = a.size // (a.shape[-1] * a.shape[-2])
                     sP, sl, sU = scipy_lu(a, pivot)
                     sL = np.tril(sl, -1)

--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -288,7 +288,6 @@ class TestLUAPI(unittest.TestCase):
                     lu, p = paddle.linalg.lu(x, pivot=pivot)
                     exe = base.Executor(place)
                     fetches = exe.run(
-                        base.default_main_program(),
                         feed={"input": a},
                         fetch_list=[lu, p],
                     )

--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -24,6 +24,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def scipy_lu(A, pivot):
@@ -156,10 +157,10 @@ class TestLUOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['Out'])
+        self.check_grad(['X'], ['Out'], check_pir=True)
 
 
 # m = n 2D
@@ -238,6 +239,7 @@ class TestLUAPI(unittest.TestCase):
         for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
             run_lu_dygraph(tensor_shape, dtype)
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
 

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -24,6 +24,7 @@ from op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def scipy_lu_unpack(A):
@@ -168,10 +169,10 @@ class TestLU_UnpackOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['L', 'U'])
+        self.check_grad(['X'], ['L', 'U'], check_pir=True)
 
 
 # m = n
@@ -258,6 +259,7 @@ class TestLU_UnpackAPI(unittest.TestCase):
         for tensor_shape, dtype in itertools.product(tensor_shapes, dtypes):
             run_lu_unpack_dygraph(tensor_shape, dtype)
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
 

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -173,7 +173,7 @@ class TestLU_UnpackOp(OpTest):
         self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], ['L', 'U'], check_pir=True)
+        self.check_grad(['X'], ['L', 'U'])
 
 
 # m = n

--- a/test/legacy_test/test_lu_unpack_op.py
+++ b/test/legacy_test/test_lu_unpack_op.py
@@ -139,7 +139,9 @@ class TestLU_UnpackOp(OpTest):
             lu = lu.numpy()
             pivots = pivots.numpy()
         else:
-            with base.program_guard(base.Program(), base.Program()):
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
                 place = base.CPUPlace()
                 if core.is_compiled_with_cuda():
                     place = base.CUDAPlace(0)
@@ -149,7 +151,6 @@ class TestLU_UnpackOp(OpTest):
                 lu, p = paddle.linalg.lu(xv)
                 exe = base.Executor(place)
                 fetches = exe.run(
-                    base.default_main_program(),
                     feed={"input": x},
                     fetch_list=[lu, p],
                 )
@@ -277,7 +278,9 @@ class TestLU_UnpackAPI(unittest.TestCase):
             if core.is_compiled_with_cuda():
                 places.append(base.CUDAPlace(0))
             for place in places:
-                with base.program_guard(base.Program(), base.Program()):
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
                     sP, sL, sU = scipy_lu_unpack(a)
 
                     x = paddle.static.data(
@@ -287,7 +290,6 @@ class TestLU_UnpackAPI(unittest.TestCase):
                     pP, pL, pU = paddle.linalg.lu_unpack(lu, p)
                     exe = base.Executor(place)
                     fetches = exe.run(
-                        base.default_main_program(),
                         feed={"input": a},
                         fetch_list=[pP, pL, pU],
                     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
- https://github.com/PaddlePaddle/Paddle/issues/58067


lstsq/lu 全部通过
`lu_unpack` 存在以下问题，`check_grad` 没有通过

```
TestLU_UnpackOp
TestLU_UnpackOp2
TestLU_UnpackOp3
TestLU_UnpackOp4
```
以上四者都未开启 `check_grad`, 由于精度和shape对不上的问题


```
2023-11-15 16:17:10 ======================================================================
2023-11-15 16:17:10 ERROR: test_check_grad (test_lu_unpack_op.TestLU_UnpackOp4)
2023-11-15 16:17:10 ----------------------------------------------------------------------
2023-11-15 16:17:10 Traceback (most recent call last):
2023-11-15 16:17:10   File "/workspace/Paddle/build/test/legacy_test/test_lu_unpack_op.py", line 176, in test_check_grad
2023-11-15 16:17:10     self.check_grad(['X'], ['L', 'U'], check_pir=True)
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/op_test.py", line 2878, in check_grad
2023-11-15 16:17:10     self.check_grad_with_place(
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/op_test.py", line 3135, in check_grad_with_place
2023-11-15 16:17:10     pir_grad = self._get_ir_gradient(
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/op_test.py", line 3675, in _get_ir_gradient
2023-11-15 16:17:10     outs = executor.run(
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/paddle/base/executor.py", line 1707, in run
2023-11-15 16:17:10     res = self._run_pir_impl(
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/paddle/base/executor.py", line 2022, in _run_pir_impl
2023-11-15 16:17:10     ret = new_exe.run(list(feed.keys()), return_numpy)
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/paddle/base/executor.py", line 821, in run
2023-11-15 16:17:10     tensors = self._new_exe.run(feed_names)._move_to_list()
2023-11-15 16:17:10 ValueError: 
2023-11-15 16:17:10 
2023-11-15 16:17:10   Compile Traceback (most recent call last):
2023-11-15 16:17:10 
2023-11-15 16:17:10 --------------------------------------
2023-11-15 16:17:10 C++ Traceback (most recent call last):
2023-11-15 16:17:10 --------------------------------------
2023-11-15 16:17:10 0   paddle::framework::ThreadPoolTempl<paddle::framework::StlThreadEnvironment>::WorkerLoop(int)
2023-11-15 16:17:10 1   paddle::framework::PirInterpreter::RunInstructionBaseAsync(unsigned long)
2023-11-15 16:17:10 2   paddle::framework::PirInterpreter::RunInstructionBase(paddle::framework::InstructionBase*)
2023-11-15 16:17:10 3   paddle::framework::PhiKernelInstruction::Run()
2023-11-15 16:17:10 4   phi::KernelImpl<void (*)(phi::CPUContext const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, bool, bool, phi::DenseTensor*), &(void phi::LUUnpackGradKernel<double, phi::CPUContext>(phi::CPUContext const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, bool, bool, phi::DenseTensor*))>::Compute(phi::KernelContext*)
2023-11-15 16:17:10 5   void phi::LUUnpackGradKernel<double, phi::CPUContext>(phi::CPUContext const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, bool, bool, phi::DenseTensor*)
2023-11-15 16:17:10 6   phi::funcs::GetMidDims(phi::DDim const&, phi::DDim const&, int, int*, int*, int*, int*)
2023-11-15 16:17:10 7   phi::enforce::EnforceNotMet::EnforceNotMet(phi::ErrorSummary const&, char const*, int)
2023-11-15 16:17:10 8   phi::enforce::GetCurrentTraceBackString[abi:cxx11](bool)
2023-11-15 16:17:10 
2023-11-15 16:17:10 ----------------------
2023-11-15 16:17:10 Error Message Summary:
2023-11-15 16:17:10 ----------------------
2023-11-15 16:17:10 InvalidArgumentError: Broadcast dimension mismatch. Operands could not be broadcast together with the shape of X = [10, 12] and the shape of Y = [10, 10]. Received [12] in X is not equal to [10] in Y.
2023-11-15 16:17:10   [Hint: Expected y_dims[i] == 1 || x_dims[i + axis] == 1 == true, but received y_dims[i] == 1 || x_dims[i + axis] == 1:0 != true:1.] (at ../paddle/phi/kernels/funcs/elementwise_utils.h:55)
2023-11-15 16:17:10   [operator < pd_kernel.phi_kernel > error]
2023-11-15 16:17:10 

2023-11-15 16:17:10 ======================================================================
2023-11-15 16:17:10 FAIL: test_check_grad (test_lu_unpack_op.TestLU_UnpackOp2)
2023-11-15 16:17:10 ----------------------------------------------------------------------
2023-11-15 16:17:10 Traceback (most recent call last):
2023-11-15 16:17:10   File "/workspace/Paddle/build/test/legacy_test/test_lu_unpack_op.py", line 176, in test_check_grad
2023-11-15 16:17:10     self.check_grad(['X'], ['L', 'U'], check_pir=True)
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/op_test.py", line 2878, in check_grad
2023-11-15 16:17:10     self.check_grad_with_place(
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/op_test.py", line 3159, in check_grad_with_place
2023-11-15 16:17:10     self._assert_is_close(
2023-11-15 16:17:10   File "/workspace/Paddle/build/python/op_test.py", line 2836, in _assert_is_close
2023-11-15 16:17:10     self.assertLessEqual(max_diff, max_relative_error, err_msg())
2023-11-15 16:17:10 AssertionError: 1.0 not less than or equal to 1e-07 : Operator lu_unpack error, Gradient Check On Place(cpu) variable X (shape: (2, 10, 10), dtype: float64) max gradient diff 1.000000e+00 over limit 1.000000e-07, the first error element is 10, expected 2.500000e-03, but got 0.000000e+00.
2023-11-15 16:17:10 
2023-11-15 16:17:10 ----------------------------------------------------------------------
```