### PR TITLE
fix_unique_op

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -116,6 +116,8 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'set_value_with_tensor_',
     'shadow_feed',
     'sparse_momentum',
+    'unique_raw',
+    'unique_with_counts',
 ]
 
 

--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -180,6 +180,16 @@
     func: share_data
     param: [x]
 
+- op : unique_raw
+  args : (Tensor x, bool return_index, bool return_inverse, bool return_counts, int[] axis, DataType dtype=DataType::INT64, bool is_sorted=false)
+  output : Tensor(out), Tensor(indices), Tensor(inverse), Tensor(counts)
+  infer_meta :
+    func : UniqueRawInferMeta
+  kernel :
+    func : unique_raw
+    data_type : x
+  optional : indices, inverse, counts
+
 - op : write_to_array
   args : (Tensor i, Tensor x)
   output : Tensor[](out)
@@ -225,3 +235,12 @@
     func: sparse_momentum
     data_type: param
   optional: master_param, master_param_out
+
+- op: unique_with_counts
+  args: (Tensor x, int dtype)
+  output: Tensor(out), Tensor(index), Tensor(count)
+  infer_meta:
+    func: UniqueWithCountsInferMeta
+  kernel:
+    func: unique_with_counts
+    data_type: x

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -38,7 +38,8 @@ const std::unordered_set<std::string> LegacyOpList = {
     "pd_op.c_allgather",
     "pd_op.seed",
     "pd_op.share_data",
-    "pd_op.sparse_momentum"};
+    "pd_op.sparse_momentum",
+    "pd_op.unique_with_counts"};
 
 enum class AttrType {
   UNDEFINED = 0,

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -3141,6 +3141,14 @@
   outputs :
     {out : Out, index : Index, counts : Counts}
 
+- op : unique_raw
+  inputs :
+    {x : X}
+  outputs :
+    {out : Out, indices : Indices, inverse : Index, counts : Counts}
+  get_expected_kernel_type :
+    unique : GetUniqueExpectedKernelType
+
 - op : unpool
   inputs :
     {x : X, indices: Indices}
@@ -3428,6 +3436,12 @@
     x : X
   outputs :
     out : Out
+
+- op: unique_with_counts
+  inputs :
+    {x : X}
+  outputs :
+    {out : Out, index : Index, count : Count}
 
 - op: write_to_array
   inputs :

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5044,6 +5044,23 @@ void UnsqueezeInferMeta(const MetaTensor& x,
   }
 }
 
+void UniqueWithCountsInferMeta(const MetaTensor& x,
+                               int dtype,
+                               MetaTensor* out,
+                               MetaTensor* index,
+                               MetaTensor* count) {
+  auto in_dims = x.dims();
+  PADDLE_ENFORCE_EQ(
+      in_dims.size(),
+      1,
+      phi::errors::InvalidArgument("The Input(X) should be 1-D Tensor, "
+                                   "But now the dims of Input(X) is %d.",
+                                   in_dims.size()));
+  out->set_dims({-1});
+  index->set_dims(in_dims);
+  count->set_dims({-1});
+}
+
 void UnsqueezeWithXShapeInferMeta(const MetaTensor& x,
                                   const IntArray& axes,
                                   MetaTensor* out,

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -744,6 +744,12 @@ void UniqueRawInferMeta(const MetaTensor& x,
                         MetaTensor* index,
                         MetaTensor* counts);
 
+void UniqueWithCountsInferMeta(const MetaTensor& x,
+                               int dtype,
+                               MetaTensor* out,
+                               MetaTensor* index,
+                               MetaTensor* count);
+
 void UnsqueezeInferMeta(const MetaTensor& x,
                         const IntArray& axes,
                         MetaTensor* out,

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -205,6 +205,7 @@ test_trilinear_interp_v2_op
 test_triu_indices_op
 test_trunc_op
 test_unfold_op
+test_unique
 test_unique_consecutive_op
 test_unpool3d_op
 test_unpool_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
1. 在新Ir下补充算子`unique_with_counts`的定义
2. test_unique在新Ir下执行报错为`PreconditionNotMetError: Tensor holds no memory. Call Tensor::mutable_data firstly.`.这里的问题是由新Ir下默认将旧Ir下的`unique`只翻译成新Ir下的`unique`导致的。在旧Ir下`unique`会根据属性`is_sorted`的值选择`unique`或者`unique_raw`两个kernel执行。在新Ir下不存在这样的机制，所以需要根据`is_sorted`的值将旧Ir下的`unique`翻译为新Ir下的`unique`或者`unique_raw`两个OP.这里在新Ir下补充了`unique_raw`的定义。
3. 新IR下不适配`GetReduceGradExpectedKernelType`导致在GPU环境下Kernel选择 出现问题，暂时尚未处理