### PR TITLE
[CINN+PIR]Fix CombineOp Verify Failed after SliceOpPattern

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -337,6 +337,9 @@ class SliceOpPattern : public pir::OpRewritePattern<paddle::dialect::SliceOp> {
           end_vec,
           infer_flags,
           decrease_axis);
+      // NOTE(Aurelius84): In SliceRawInferMeta, it not always share_lod, so
+      // we need to update it maually.
+      cinn_slice.result(0).set_type(op.result(0).type());
       rewriter.ReplaceAllUsesWith(op.result(0), cinn_slice.result(0));
       rewriter.EraseOp(op);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164 

在CINN Dialect中，其Slice虽然也会调用SliceRawInferMeta函数逻辑，但不会触发share_lod 分支逻辑，导致在下游CombineOp 的Verify中会触发Type判断的错误。