### PR TITLE
【PIR API adaptor No.27、29、102 】 Migrate bmm/broadcast_tensors/histogram into pir

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1680,7 +1680,7 @@ def bmm(x, y, name=None):
               [60., 60.]]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.bmm(x, y)
     else:
         x_shape = x.shape

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1738,7 +1738,7 @@ def histogram(input, bins=100, min=0, max=0, name=None):
             Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 2, 1, 0])
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.histogram(input, bins, min, max)
     else:
         helper = LayerHelper('histogram', **locals())

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1286,7 +1286,7 @@ def broadcast_tensors(input, name=None):
     """
 
     num_inputs = len(input)
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.broadcast_tensors(input)
     else:
         check_type(input, 'input', (list, tuple), 'broadcast_tensors')

--- a/test/legacy_test/test_bmm_op.py
+++ b/test/legacy_test/test_bmm_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16, paddle_static_guard
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestBmmOp(OpTest):
@@ -33,10 +34,10 @@ class TestBmmOp(OpTest):
         self.outputs = {'Out': Out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_checkout_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 class TestBmmFP16Op(OpTest):
@@ -51,10 +52,10 @@ class TestBmmFP16Op(OpTest):
         self.outputs = {'Out': Out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_checkout_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_pir=True)
 
 
 @unittest.skipIf(
@@ -79,16 +80,21 @@ class TestBmmBF16Op(OpTest):
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_pir=True)
 
     def test_checkout_grad(self):
-        self.check_grad_with_place(self.place, ['X', 'Y'], 'Out')
+        self.check_grad_with_place(
+            self.place, ['X', 'Y'], 'Out', check_pir=True
+        )
 
 
 class API_TestBmm(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         with paddle_static_guard():
-            with base.program_guard(base.Program(), base.Program()):
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
                 data1 = paddle.static.data(
                     'data1', shape=[-1, 3, 4], dtype='float64'
                 )

--- a/test/legacy_test/test_broadcast_tensors_op.py
+++ b/test/legacy_test/test_broadcast_tensors_op.py
@@ -272,7 +272,6 @@ class TestBroadcastTensorsAPI(unittest.TestCase):
 
 
 class TestRaiseBroadcastTensorsError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         def test_type():
             inputs = [

--- a/test/legacy_test/test_broadcast_tensors_op.py
+++ b/test/legacy_test/test_broadcast_tensors_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 random.seed(2021)
 
@@ -135,7 +136,7 @@ class TestCPUBroadcastTensorsOp(OpTest):
     def test_check_output(self):
         self.run_dual_test(
             self.check_output_with_place,
-            {"place": self.place},
+            {"place": self.place, "check_pir": True},
         )
 
     def test_check_grad_normal(self):
@@ -145,6 +146,7 @@ class TestCPUBroadcastTensorsOp(OpTest):
                 "place": self.place,
                 "inputs_to_check": ['x0', 'x1'],
                 "output_names": ['out0', 'out1'],
+                "check_pir": True,
             },
         )
         self.run_triple_in_test(
@@ -153,6 +155,7 @@ class TestCPUBroadcastTensorsOp(OpTest):
                 "place": self.place,
                 "inputs_to_check": ['x0', 'x1', 'x2'],
                 "output_names": ['out0', 'out1', "out2"],
+                "check_pir": True,
             },
         )
 
@@ -209,7 +212,7 @@ class TestBroadcastTensorsBF16Op(OpTest):
     def test_check_output(self):
         self.run_dual_test(
             self.check_output_with_place,
-            {"place": self.place},
+            {"place": self.place, "check_pir": True},
         )
 
     def test_check_grad_normal(self):
@@ -220,6 +223,7 @@ class TestBroadcastTensorsBF16Op(OpTest):
                 "inputs_to_check": ['x0', 'x1'],
                 "output_names": ['out0', 'out1'],
                 "check_dygraph": False,
+                "check_pir": True,
             },
         )
         self.run_triple_in_test(
@@ -229,12 +233,14 @@ class TestBroadcastTensorsBF16Op(OpTest):
                 "inputs_to_check": ['x0', 'x1', 'x2'],
                 "output_names": ['out0', 'out1', 'out2'],
                 "check_dygraph": False,
+                "check_pir": True,
             },
         )
 
 
 class TestBroadcastTensorsAPI(unittest.TestCase):
     def test_api(self):
+        @test_with_pir_api
         def test_static():
             inputs = [
                 paddle.static.data(
@@ -266,6 +272,7 @@ class TestBroadcastTensorsAPI(unittest.TestCase):
 
 
 class TestRaiseBroadcastTensorsError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         def test_type():
             inputs = [

--- a/test/legacy_test/test_histogram_op.py
+++ b/test/legacy_test/test_histogram_op.py
@@ -19,16 +19,17 @@ from op_test import OpTest
 
 import paddle
 from paddle import base
-from paddle.base import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestHistogramOpAPI(unittest.TestCase):
     """Test histogram api."""
 
+    @test_with_pir_api
     def test_static_graph(self):
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(train_program, startup_program):
+        startup_program = paddle.static.Program()
+        train_program = paddle.static.Program()
+        with paddle.static.program_guard(train_program, startup_program):
             inputs = paddle.static.data(
                 name='input', dtype='int64', shape=[2, 3]
             )
@@ -37,11 +38,8 @@ class TestHistogramOpAPI(unittest.TestCase):
             if base.core.is_compiled_with_cuda():
                 place = base.CUDAPlace(0)
             exe = base.Executor(place)
-            exe.run(startup_program)
             img = np.array([[2, 4, 2], [2, 5, 4]]).astype(np.int64)
-            res = exe.run(
-                train_program, feed={'input': img}, fetch_list=[output]
-            )
+            res = exe.run(feed={'input': img}, fetch_list=[output])
             actual = np.array(res[0])
             expected = np.array([0, 3, 0, 2, 1]).astype(np.int64)
             self.assertTrue(
@@ -73,13 +71,14 @@ class TestHistogramOpError(unittest.TestCase):
     """Test histogram op error."""
 
     def run_network(self, net_func):
-        main_program = base.Program()
-        startup_program = base.Program()
-        with base.program_guard(main_program, startup_program):
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
             net_func()
             exe = base.Executor()
             exe.run(main_program)
 
+    @test_with_pir_api
     def test_bins_error(self):
         """Test bins should be greater than or equal to 1."""
 
@@ -92,6 +91,7 @@ class TestHistogramOpError(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.run_network(net_func)
 
+    @test_with_pir_api
     def test_min_max_error(self):
         """Test max must be larger or equal to min."""
 
@@ -104,6 +104,7 @@ class TestHistogramOpError(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.run_network(net_func)
 
+    @test_with_pir_api
     def test_min_max_range_error(self):
         """Test range of min, max is not finite"""
 
@@ -116,8 +117,9 @@ class TestHistogramOpError(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.run_network(net_func)
 
+    @test_with_pir_api
     def test_type_errors(self):
-        with program_guard(Program()):
+        with paddle.static.program_guard(paddle.static.Program()):
             # The input type must be Variable.
             self.assertRaises(
                 TypeError, paddle.histogram, 1, bins=5, min=1, max=5
@@ -154,7 +156,7 @@ class TestHistogramOp(OpTest):
         self.attrs = {"bins": self.bins, "min": self.min, "max": self.max}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class TestHistogramOp_ZeroDim(TestHistogramOp):

--- a/test/legacy_test/test_histogram_op.py
+++ b/test/legacy_test/test_histogram_op.py
@@ -104,7 +104,6 @@ class TestHistogramOpError(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.run_network(net_func)
 
-    @test_with_pir_api
     def test_min_max_range_error(self):
         """Test range of min, max is not finite"""
 
@@ -117,7 +116,6 @@ class TestHistogramOpError(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.run_network(net_func)
 
-    @test_with_pir_api
     def test_type_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             # The input type must be Variable.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/58067


- `broadcast_tensors` 单测 `TestRaiseBroadcastTensorsError.test_errors` 单测未开启，单测覆盖率 4/5
```
AssertionError: TypeError not raised by test_type
```
- `histogram` 单测 `TestHistogramOpError.test_min_max_range_error` 和 `TestHistogramOpError.test_type_errors` 未开启，单测覆盖率 6/8，二者单测中预期 `raise TypeError`, 但都抛出 `InvalidArgumentError`
- `bmm` 单测全部通过
