### PR TITLE
[Paddle-Inference]support GQA in variable_length_memory_efficient_attention

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2931,10 +2931,19 @@ void VariableLengthMemoryEfficientAttentionInferMeta(
           "The batch size of Query, Key, Value should be equal."));
 
   PADDLE_ENFORCE_EQ(
-      ((query_num_head == key_num_head) && (key_num_head == value_num_head)),
+      (key_num_head == value_num_head),
       true,
       phi::errors::InvalidArgument(
           "The head number of Query, Key, Value should be equal."));
+
+  PADDLE_ENFORCE_EQ(
+      query_num_head % key_num_head,
+      0,
+      errors::InvalidArgument(
+          "The num_head of query must be divisible by the num_head of key, but "
+          "recived num_head of query is %d, and the num_head of key is %d",
+          query_num_head,
+          key_num_head));
 
   PADDLE_ENFORCE_EQ(query_head_size == key_head_size,
                     true,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2930,11 +2930,10 @@ void VariableLengthMemoryEfficientAttentionInferMeta(
       phi::errors::InvalidArgument(
           "The batch size of Query, Key, Value should be equal."));
 
-  PADDLE_ENFORCE_EQ(
-      (key_num_head == value_num_head),
-      true,
-      phi::errors::InvalidArgument(
-          "The head number of Query, Key, Value should be equal."));
+  PADDLE_ENFORCE_EQ((key_num_head == value_num_head),
+                    true,
+                    phi::errors::InvalidArgument(
+                        "The head number of Key, Value should be equal."));
 
   PADDLE_ENFORCE_EQ(
       query_num_head % key_num_head,

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/generate_variable_forward_kernels.py
@@ -179,6 +179,7 @@ void  {NAME}({CPP_CLASS} default_fmha, Params &params, const phi::GPUContext& ct
       problem_count,
       threadblock_count,
       params.num_heads,
+      params.kv_num_heads,
       const_cast<scalar_t*>(reinterpret_cast<const scalar_t*>(params.query_ptr)),
       const_cast<scalar_t*>(reinterpret_cast<const scalar_t*>(params.key_ptr)),
       params.mask_ptr
@@ -465,6 +466,7 @@ struct Params {{
   // Dimensions/strides
   int32_t num_batches;
   int32_t num_heads;
+  int32_t kv_num_heads;
   int32_t query_seq_len;
   int32_t key_value_seq_len;
   int32_t head_size;

--- a/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention.cu
+++ b/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention.cu
@@ -37,6 +37,7 @@ void MultiHeadAttentionVariableForwardKernel(
 
   params.num_batches = query.dims()[0];
   params.num_heads = query.dims()[1];
+  params.kv_num_heads = key.dims()[1];
   params.query_seq_len = query.dims()[2];
   params.head_size = query.dims()[3];
   params.key_value_seq_len = key.dims()[2];

--- a/test/legacy_test/test_variable_length_memory_efficient_attention.py
+++ b/test/legacy_test/test_variable_length_memory_efficient_attention.py
@@ -60,6 +60,20 @@ def create_attn_mask(
 
 
 def naive_attention_impl(query, key, value, mask, scale):
+    batch = query.shape[0]
+    heads = query.shape[1]
+    seq_len = query.shape[2]
+    head_dim = query.shape[3]
+    kv_head = key.shape[1]
+
+    key = key.reshape([batch, kv_head, 1, seq_len, head_dim])
+    key = paddle.tile(key, [1, 1, heads // kv_head, 1, 1])
+    key = key.reshape([batch, heads, seq_len, head_dim])
+
+    value = value.reshape([batch, kv_head, 1, seq_len, head_dim])
+    value = paddle.tile(value, [1, 1, heads // kv_head, 1, 1])
+    value = value.reshape([batch, heads, seq_len, head_dim])
+
     qk_res = paddle.matmul(query, key, transpose_y=True)
     attention = qk_res * scale
     attention = attention + mask
@@ -78,6 +92,7 @@ class TestMemEffAttentionVariableAPI(unittest.TestCase):
         self.place = paddle.CUDAPlace(0)
         self.batch_size = 1
         self.num_head = 8
+        self.kv_num_head = 2
         self.seq_len = 64
         self.dim_head = 16
         self.seq_lens = paddle.to_tensor(
@@ -90,6 +105,12 @@ class TestMemEffAttentionVariableAPI(unittest.TestCase):
         self.shape = (
             self.batch_size,
             self.num_head,
+            self.seq_len,
+            self.dim_head,
+        )
+        self.shape_kv = (
+            self.batch_size,
+            self.kv_num_head,
             self.seq_len,
             self.dim_head,
         )
@@ -111,11 +132,11 @@ class TestMemEffAttentionVariableAPI(unittest.TestCase):
         q = paddle.to_tensor(
             query, place=self.place, dtype=self.dtype, stop_gradient=False
         )
-        key = np.random.random(self.shape)
+        key = np.random.random(self.shape_kv)
         k = paddle.to_tensor(
             key, place=self.place, dtype=self.dtype, stop_gradient=False
         )
-        value = np.random.random(self.shape)
+        value = np.random.random(self.shape_kv)
         v = paddle.to_tensor(
             value, place=self.place, dtype=self.dtype, stop_gradient=False
         )
@@ -147,6 +168,7 @@ class TestMemEffAPIVariableDtypeFP16(TestMemEffAttentionVariableAPI):
         self.place = paddle.CUDAPlace(0)
         self.batch_size = 3
         self.num_head = 16
+        self.kv_num_head = 2
         self.seq_len = 64
         self.dim_head = 32
         self.seq_lens = paddle.to_tensor(
@@ -159,6 +181,12 @@ class TestMemEffAPIVariableDtypeFP16(TestMemEffAttentionVariableAPI):
         self.shape = (
             self.batch_size,
             self.num_head,
+            self.seq_len,
+            self.dim_head,
+        )
+        self.shape_kv = (
+            self.batch_size,
+            self.kv_num_head,
             self.seq_len,
             self.dim_head,
         )
@@ -180,6 +208,7 @@ class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
         self.place = paddle.CUDAPlace(0)
         self.batch_size = 2
         self.num_head = 8
+        self.kv_num_head = 2
         self.seq_len = 32
         self.dim_head = 128
         self.seq_lens = paddle.to_tensor(
@@ -192,6 +221,12 @@ class TestMemEffAPIVariableDtypeBF16(TestMemEffAttentionVariableAPI):
         self.shape = (
             self.batch_size,
             self.num_head,
+            self.seq_len,
+            self.dim_head,
+        )
+        self.shape_kv = (
+            self.batch_size,
+            self.kv_num_head,
             self.seq_len,
             self.dim_head,
         )
@@ -217,6 +252,7 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
         self.place = paddle.CUDAPlace(0)
         self.batch_size = 3
         self.num_head = 16
+        self.kv_num_head = 2
         self.seq_len = 64
         self.dim_head = 32
         self.seq_lens = paddle.to_tensor(
@@ -232,6 +268,12 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
             self.seq_len,
             self.dim_head,
         )
+        self.shape_kv = (
+            self.batch_size,
+            self.kv_num_head,
+            self.seq_len,
+            self.dim_head,
+        )
         self.dtype = 'float16'
         self.attention_mask = create_attn_mask(
             self.dtype,
@@ -242,8 +284,8 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
             * self.batch_size,
         ).numpy()
         self.q = np.random.random(self.shape).astype(self.dtype)
-        self.k = np.random.random(self.shape).astype(self.dtype)
-        self.v = np.random.random(self.shape).astype(self.dtype)
+        self.k = np.random.random(self.shape_kv).astype(self.dtype)
+        self.v = np.random.random(self.shape_kv).astype(self.dtype)
         self.scale = 1.0 / np.sqrt(self.shape[-1])
 
         self.ref_out = naive_attention_impl(
@@ -261,10 +303,10 @@ class TestMemEffAPIVariableDtypeFP16Static(unittest.TestCase):
                 name="query", shape=self.shape, dtype=self.dtype
             )
             k = paddle.static.data(
-                name="key", shape=self.shape, dtype=self.dtype
+                name="key", shape=self.shape_kv, dtype=self.dtype
             )
             v = paddle.static.data(
-                name="value", shape=self.shape, dtype=self.dtype
+                name="value", shape=self.shape_kv, dtype=self.dtype
             )
             mask = paddle.static.data(
                 name="mask",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Pcard-71500

- variable_length_memory_efficient_attention 支持GQA，不影响API层面
