### PR TITLE
【PIR API adaptor No.139】 Migrate logsumexp into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2626,7 +2626,7 @@ def logsumexp(x, axis=None, keepdim=False, name=None):
     """
     reduce_all, axis = _get_reduce_axis(axis, x)
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.logsumexp(x, axis, keepdim, reduce_all)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_logsumexp.py
+++ b/test/legacy_test/test_logsumexp.py
@@ -19,6 +19,7 @@ from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def ref_logsumexp(x, axis=None, keepdim=False, reduce_all=False):
@@ -87,7 +88,7 @@ class TestLogsumexp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -95,6 +96,7 @@ class TestLogsumexp(OpTest):
             ['Out'],
             user_defined_grads=self.user_defined_grads,
             user_defined_grad_outputs=self.user_defined_grad_outputs,
+            check_pir=True,
         )
 
     def calc_grad(self):
@@ -212,11 +214,11 @@ class TestLogsumexpBF16Op(TestLogsumexp):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place)
+        self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
-        self.check_grad_with_place(place, ['X'], 'Out')
+        self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
 
     def set_attrs(self):
         pass
@@ -258,6 +260,7 @@ class TestLogsumexpAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-05)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_api(self):
         self.api_case()
         self.api_case(2)


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
任务 issue: https://github.com/PaddlePaddle/Paddle/issues/58067

**PIR API 推全升级**
将 `paddle.Tensor.logsumexp` 迁移升级至 pir，并更新单测，单测覆盖率（11/12）

TODO: test_logsumexp.py 中的 TestLogsumexpError 的 test_errors 做 check_dtype 检查，当前先跳过
