### PR TITLE
Fix rms norm when dy2static

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_rms_norm.py
+++ b/python/paddle/incubate/nn/functional/fused_rms_norm.py
@@ -106,7 +106,7 @@ def fused_rms_norm(
     outputs_dict['residual_out'] = residual_out
 
     inputs = {'x': x, 'norm_weight': norm_weight}
-    if norm_bias:
+    if norm_bias is not None:
         inputs['norm_bias'] = norm_bias
     if residual is not None:
         inputs['residual'] = residual


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Optinonal input should use template as follows to avoid failing in dy2static:
```
def xxx(x, y = None): # y is optional
    if y is not None:
            xxxx
```

Pcard-71502