### PR TITLE
[SOT] Increase ref timeout for unittest `test_sot_resnet50_backward`

### DIFF
--- a/test/sot/CMakeLists.txt
+++ b/test/sot/CMakeLists.txt
@@ -10,6 +10,6 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${SOT_ENVS})
 endforeach()
 
-if(WIN32 AND NOT WITH_GPU)
+if(WIN32)
   set_tests_properties(test_sot_resnet50_backward PROPERTIES TIMEOUT 420)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

给 `test_sot_resnet50_backward` WIN + GPU 也增加 TIMEOUT，避免随机挂

PCard-66972