### PR TITLE
【PIR API adaptor No.154】Migrate paddle.Tensor.mode into pir

### DIFF
--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -607,7 +607,7 @@ def mode(x, axis=-1, keepdim=False, name=None):
              [2, 1]]))
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.mode(x, axis, keepdim)
     else:
         helper = LayerHelper("mode", **locals())

--- a/test/legacy_test/test_mode_op.py
+++ b/test/legacy_test/test_mode_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def _mode1D(a):
@@ -112,12 +113,12 @@ class TestModeOp(OpTest):
 
     def test_check_output(self):
         paddle.enable_static()
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
         paddle.enable_static()
         grad = self.init_numeric_grads()
-        self.check_grad({'X'}, 'Out', user_defined_grads=[grad])
+        self.check_grad({'X'}, 'Out', user_defined_grads=[grad], check_pir=True)
 
 
 @unittest.skipIf(
@@ -148,7 +149,7 @@ class TestModeBF16Op(TestModeOp):
         place = core.CUDAPlace(0)
         paddle.enable_static()
         if core.is_bfloat16_supported(place):
-            self.check_output_with_place(place)
+            self.check_output_with_place(place, check_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
@@ -157,7 +158,7 @@ class TestModeBF16Op(TestModeOp):
 
         if core.is_bfloat16_supported(place):
             self.check_grad_with_place(
-                place, {'X'}, 'Out', user_defined_grads=[grad]
+                place, {'X'}, 'Out', user_defined_grads=[grad], check_pir=True
             )
 
 
@@ -243,6 +244,7 @@ class TestModeOpInStatic(unittest.TestCase):
             np.random.random((2, 10, 10)) * 1000, dtype=np.float64
         )
 
+    @test_with_pir_api
     def test_run_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
- #58067 
No.154 将 `paddle.Tensor.mode`  迁移升级至 pir，并更新单测 单测覆盖率：7/10，其中单测 `TestModeZeroError.test_errors` 未覆盖到。
