### PR TITLE
 [Docathon] Fix api_base_io_shuffle API Label

### DIFF
--- a/python/paddle/reader/decorator.py
+++ b/python/paddle/reader/decorator.py
@@ -126,9 +126,6 @@ def map_readers(func, *readers):
 
 def shuffle(reader, buf_size):
     """
-    paddle.base.io.shuffle ( :ref:`api_paddle_io_shuffle` ) is recommended to use,
-    and paddle.reader.shuffle is an alias.
-
     This API creates a decorated reader that outputs the shuffled data.
 
     The output data from the origin reader will be saved into a buffer,

--- a/python/paddle/reader/decorator.py
+++ b/python/paddle/reader/decorator.py
@@ -126,7 +126,7 @@ def map_readers(func, *readers):
 
 def shuffle(reader, buf_size):
     """
-    paddle.base.io.shuffle ( :ref:`api_base_io_shuffle` ) is recommended to use,
+    paddle.base.io.shuffle ( :ref:`api_paddle_io_shuffle` ) is recommended to use,
     and paddle.reader.shuffle is an alias.
 
     This API creates a decorated reader that outputs the shuffled data.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Description
<!-- Describe what you’ve done -->
删掉了paddle.base.io.shuffle 到 is an alias，诶嘿
@ooooo-create @sunzhongkai588