### PR TITLE
Add Paddle-TRT IR pass to remove AMP strategy OP

### DIFF
--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -165,6 +165,7 @@ if(WITH_TENSORRT)
   pass_library(trt_embedding_eltwise_layernorm_fuse_pass inference)
   pass_library(preln_embedding_eltwise_layernorm_fuse_pass inference)
   pass_library(split_layernorm_to_math_ops_pass inference)
+  pass_library(trt_remove_amp_strategy_op_pass inference)
 endif()
 
 if(WITH_GPU OR WITH_ROCM)

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -33,8 +33,9 @@ void CastDataTypeInplace(phi::DenseTensor *tensor) {
   phi::DenseTensor tmp_tensor;
   tmp_tensor.set_type(phi::CppTypeToDataType<OutType>::Type());
   tmp_tensor.Resize(tensor->dims());
-  auto *tmp_data =
-      tmp_tensor.mutable_data<OutType>(paddle::platform::CPUPlace());
+  auto *cpu_ctx = static_cast<phi::CPUContext *>(
+      platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
+  auto *tmp_data = cpu_ctx->Alloc<OutType>(&tmp_tensor);
   auto *data = tensor->mutable_data<InType>(paddle::platform::CPUPlace());
   for (int i = 0; i < tensor->numel(); i++) {
     tmp_data[i] = static_cast<OutType>(data[i]);

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -1,0 +1,158 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "paddle/fluid/framework/ir/graph_helper.h"
+#include "paddle/fluid/framework/ir/node.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/core/errors.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+namespace {
+template <typename InType, typename OutType>
+void CastDataTypeInplace(phi::DenseTensor *tensor) {
+  phi::DenseTensor tmp_tensor;
+  tmp_tensor.set_type(phi::CppTypeToDataType<OutType>::Type());
+  tmp_tensor.Resize(tensor->dims());
+  auto *tmp_data =
+      tmp_tensor.mutable_data<OutType>(paddle::platform::CPUPlace());
+  auto *data = tensor->mutable_data<InType>(paddle::platform::CPUPlace());
+  for (int i = 0; i < tensor->numel(); i++) {
+    tmp_data[i] = static_cast<OutType>(data[i]);
+  }
+  tensor->clear();
+  paddle::framework::TensorCopySync(
+      tmp_tensor, paddle::platform::CPUPlace(), tensor);
+}
+}  // namespace
+
+// This pass removes cast OPs that inserted by AMP strategy.
+// Also, this pass sets the QAT (+ AMP) scale to be fp32.
+void TrtRemoveAMPStrategyOpPass::ApplyImpl(Graph *graph) const {
+  PADDLE_ENFORCE_NOT_NULL(
+      graph,
+      platform::errors::PreconditionNotMet(
+          "During the trt_remove_strategy_op_pass, the graph "
+          "should not be null."));
+  FusePassBase::Init("trt_remove_strategy_op_pass", graph);
+  auto *scope = param_scope();
+  auto op_nodes = TopologySortOperations(*graph);
+
+  // Find all fp16 op nodes and variables
+  std::unordered_set<ir::Node *> fp16_ops;
+  std::unordered_set<ir::Node *> fp16_vars;
+  std::unordered_set<ir::Node *> cast_ops;
+  for (auto *op_node : op_nodes) {
+    CHECK_EQ(op_node->IsOp(), true);
+    auto *op_desc = op_node->Op();
+    if (op_desc->Type() == "cast") {
+      auto input_dtype = op_node->inputs[0]->Var()->GetDataType();
+      auto output_dtype = op_node->outputs[0]->Var()->GetDataType();
+      if (input_dtype == proto::VarType::FP32 &&
+          output_dtype == proto::VarType::FP16) {
+        auto op_outputs = op_node->outputs;
+        for (auto *out_var_node : op_outputs) {
+          fp16_vars.insert(out_var_node);
+        }
+        cast_ops.insert(op_node);
+      } else if (input_dtype == proto::VarType::FP16 &&
+                 output_dtype == proto::VarType::FP32) {
+        cast_ops.insert(op_node);
+      }
+    } else {
+      auto op_inputs = op_node->inputs;
+      for (auto *in_var_node : op_inputs) {
+        if (fp16_vars.count(in_var_node)) {
+          fp16_ops.insert(op_node);
+          auto op_outputs = op_node->outputs;
+          for (auto *out_var_node : op_outputs) {
+            fp16_vars.insert(out_var_node);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  // Set fp16 variables to be fp32
+  for (auto *var : fp16_vars) {
+    if (var->Var()->GetDataType() == proto::VarType::FP16) {
+      var->Var()->SetDataType(proto::VarType::FP32);
+    }
+  }
+
+  // Convert QDQ scale to be fp32
+  for (auto *op : fp16_ops) {
+    if (op->Op()->Type() == "quantize_linear" ||
+        op->Op()->Type() == "dequantize_linear") {
+      auto *scale_tensor = scope->FindVar(op->Op()->Input("Scale").front())
+                               ->GetMutable<phi::DenseTensor>();
+      if (scale_tensor->dtype() == phi::DataType::FLOAT16) {
+        CastDataTypeInplace<float16, float>(scale_tensor);
+      }
+    }
+  }
+
+  // Remove cast OPs
+  std::unordered_set<const ir::Node *> marked_nodes;
+  for (auto *op_node : cast_ops) {
+    auto *op_desc = op_node->Op();
+    if (op_desc->Type() == "cast") {
+      auto *in_var = op_node->inputs[0];
+      auto *out_var = op_node->outputs[0];
+      auto post_op = out_var->outputs;
+      IR_NODE_UNLINK(in_var, op_node);
+      IR_NODE_UNLINK(op_node, out_var);
+      for (int i = 0; i < post_op.size(); ++i) {
+        IR_NODE_UNLINK(out_var, post_op[i]);
+        IR_NODE_LINK_TO(in_var, post_op[i]);
+        post_op[i]->Op()->RenameInput(out_var->Var()->Name(),
+                                      in_var->Var()->Name());
+      }
+      marked_nodes.insert(op_node);
+      marked_nodes.insert(out_var);
+    }
+  }
+  GraphSafeRemoveNodes(graph, marked_nodes);
+
+  // Valid all cast OP is removed by this IR pass
+  auto updated_op_nodes = TopologySortOperations(*graph);
+  for (auto *op_node : updated_op_nodes) {
+    if (op_node->Op()->Type() == "cast") {
+      auto input_dtype = op_node->inputs[0]->Var()->GetDataType();
+      auto output_dtype = op_node->outputs[0]->Var()->GetDataType();
+      if ((input_dtype == proto::VarType::FP32 &&
+           output_dtype == proto::VarType::FP16) ||
+          (input_dtype == proto::VarType::FP16 &&
+           output_dtype == proto::VarType::FP32)) {
+        PADDLE_THROW(platform::errors::Fatal(
+            "There are cast OPs remaining in the graph."));
+      }
+    }
+  }
+}
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
+
+REGISTER_PASS(trt_remove_amp_strategy_op_pass,
+              paddle::framework::ir::TrtRemoveAMPStrategyOpPass);

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -122,7 +122,7 @@ void TrtRemoveAMPStrategyOpPass::ApplyImpl(Graph *graph) const {
       auto post_op = out_var->outputs;
       IR_NODE_UNLINK(in_var, op_node);
       IR_NODE_UNLINK(op_node, out_var);
-      for (int i = 0; i < post_op.size(); ++i) {
+      for (size_t i = 0; i < post_op.size(); ++i) {
         IR_NODE_UNLINK(out_var, post_op[i]);
         IR_NODE_LINK_TO(in_var, post_op[i]);
         post_op[i]->Op()->RenameInput(out_var->Var()->Name(),

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -36,7 +36,7 @@ void CastDataTypeInplace(phi::DenseTensor *tensor) {
   auto *cpu_ctx = static_cast<phi::CPUContext *>(
       platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
   auto *tmp_data = cpu_ctx->Alloc<OutType>(&tmp_tensor);
-  auto *data = tensor->mutable_data<InType>(paddle::platform::CPUPlace());
+  auto *data = tensor->data<InType>();
   for (int i = 0; i < tensor->numel(); i++) {
     tmp_data[i] = static_cast<OutType>(data[i]);
   }

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -136,15 +136,16 @@ void TrtRemoveAMPStrategyOpPass::ApplyImpl(Graph *graph) const {
   GraphSafeRemoveNodes(graph, marked_nodes);
 
   // Valid all cast OP is removed by this IR pass
+  using DataType = proto::VarType;
   auto updated_op_nodes = TopologySortOperations(*graph);
   for (auto *op_node : updated_op_nodes) {
     if (op_node->Op()->Type() == "cast") {
       auto input_dtype = op_node->inputs[0]->Var()->GetDataType();
       auto output_dtype = op_node->outputs[0]->Var()->GetDataType();
-      if ((input_dtype == proto::VarType::FP32 &&
-           output_dtype == proto::VarType::FP16) ||
-          (input_dtype == proto::VarType::FP16 &&
-           output_dtype == proto::VarType::FP32)) {
+      if ((input_dtype == DataType::FP32 &&
+           output_dtype == DataType::FP16) ||
+          (input_dtype == DataType::FP16 &&
+           output_dtype == DataType::FP32)) {
         PADDLE_THROW(platform::errors::Fatal(
             "There are cast OPs remaining in the graph."));
       }

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.cc
@@ -142,10 +142,8 @@ void TrtRemoveAMPStrategyOpPass::ApplyImpl(Graph *graph) const {
     if (op_node->Op()->Type() == "cast") {
       auto input_dtype = op_node->inputs[0]->Var()->GetDataType();
       auto output_dtype = op_node->outputs[0]->Var()->GetDataType();
-      if ((input_dtype == DataType::FP32 &&
-           output_dtype == DataType::FP16) ||
-          (input_dtype == DataType::FP16 &&
-           output_dtype == DataType::FP32)) {
+      if ((input_dtype == DataType::FP32 && output_dtype == DataType::FP16) ||
+          (input_dtype == DataType::FP16 && output_dtype == DataType::FP32)) {
         PADDLE_THROW(platform::errors::Fatal(
             "There are cast OPs remaining in the graph."));
       }

--- a/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.h
+++ b/paddle/fluid/framework/ir/trt_remove_amp_strategy_op_pass.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/framework/ir/fuse_pass_base.h"
+#include "paddle/fluid/framework/ir/graph.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+class TrtRemoveAMPStrategyOpPass : public FusePassBase {
+ public:
+  TrtRemoveAMPStrategyOpPass() = default;
+  ~TrtRemoveAMPStrategyOpPass() = default;
+
+ protected:
+  void ApplyImpl(Graph* graph) const override;
+};
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -88,7 +88,7 @@ void PaddlePassBuilder::AppendAnalysisPass(const std::string &pass) {
 void PaddlePassBuilder::ClearPasses() { passes_.clear(); }
 
 const std::vector<std::string> kTRTSubgraphPasses({
-      "trt_remove_amp_strategy_op_pass",                          //
+  "trt_remove_amp_strategy_op_pass",                              //
       "trt_support_nhwc_pass",                                    //
       "adaptive_pool2d_convert_global_pass",                      //
       "trt_map_ops_to_matrix_multiply_pass",                      //

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -88,7 +88,8 @@ void PaddlePassBuilder::AppendAnalysisPass(const std::string &pass) {
 void PaddlePassBuilder::ClearPasses() { passes_.clear(); }
 
 const std::vector<std::string> kTRTSubgraphPasses({
-  "trt_support_nhwc_pass",
+      "trt_remove_amp_strategy_op_pass",                          //
+      "trt_support_nhwc_pass",                                    //
       "adaptive_pool2d_convert_global_pass",                      //
       "trt_map_ops_to_matrix_multiply_pass",                      //
       "shuffle_channel_detect_pass",                              //
@@ -211,6 +212,9 @@ const std::vector<std::string> kGpuLowerPrecisionPasses{
     "inplace_op_var_pass"};
 
 const std::vector<std::string> kTrtLowerPrecisionPasses{
+    "trt_remove_amp_strategy_op_pass",
+    "trt_support_nhwc_pass",
+    "trt_map_ops_to_matrix_multiply_pass",
     "simplify_with_basic_ops_pass",
     // "conv_bn_fuse_pass",
     // "conv_eltwiseadd_bn_fuse_pass",

--- a/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
+++ b/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
@@ -18,9 +18,9 @@ import numpy as np
 
 import paddle
 import paddle.nn.functional as F
-from paddle.fluid import core
-from paddle.fluid.executor import global_scope
-from paddle.fluid.framework import IrGraph
+from paddle.base import core
+from paddle.base.executor import global_scope
+from paddle.base.framework import IrGraph
 from paddle.inference import Config, PrecisionType, create_predictor
 from paddle.static.quantization import QuantizationTransformPassV2
 

--- a/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
+++ b/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
@@ -32,6 +32,14 @@ class TestRemoveStrategyOpBase:
         np.random.seed(1024)
         paddle.seed(1024)
 
+    def build_program(self):
+        # The following attribute should be set
+        self.serialized_program = None
+        self.serialized_params = None
+        self.input_data = None
+        self.precision_mode = None
+        self.dynamic_shape_info = None
+
     def infer_program(self, use_trt=False):
         config = Config()
 
@@ -87,6 +95,10 @@ class TestRemoveStrategyOpBase:
         )
 
 
+@unittest.skipIf(
+    paddle.inference.get_trt_compile_version() < (8, 5, 1),
+    "Quantization axis is consistent with Paddle after TRT 8.5.2.",
+)
 class TestRemoveStrategyOpAMP(TestRemoveStrategyOpBase, unittest.TestCase):
     def build_program(self):
         place = paddle.CUDAPlace(0)
@@ -164,6 +176,10 @@ class TestRemoveStrategyOpAMP(TestRemoveStrategyOpBase, unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    paddle.inference.get_trt_compile_version() < (8, 5, 1),
+    "Quantization axis is consistent with Paddle after TRT 8.5.2.",
+)
 class TestRemoveStrategyOpAMPQAT(TestRemoveStrategyOpBase, unittest.TestCase):
     def build_program(self):
         place = paddle.CUDAPlace(0)

--- a/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
+++ b/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.nn.functional as F
+from paddle.fluid import core
+from paddle.fluid.executor import global_scope
+from paddle.fluid.framework import IrGraph
+from paddle.inference import Config, PrecisionType, create_predictor
+from paddle.static.quantization import QuantizationTransformPassV2
+
+paddle.enable_static()
+
+
+class TestRemoveStrategyOpBase:
+    def setUp(self):
+        np.random.seed(1024)
+        paddle.seed(1024)
+
+    def infer_program(self, use_trt=False):
+        config = Config()
+
+        # Determine the predictor config
+        config.set_model_buffer(
+            self.serialized_program,
+            len(self.serialized_program),
+            self.serialized_params,
+            len(self.serialized_params),
+        )
+        config.enable_use_gpu(256, 0, PrecisionType.Half)
+        config.enable_memory_optim()
+        config.disable_glog_info()
+        if use_trt:
+            config.enable_tensorrt_engine(
+                workspace_size=1 << 30,
+                max_batch_size=128,
+                min_subgraph_size=0,
+                precision_mode=self.precision_mode,
+                use_static=False,
+                use_calib_mode=False,
+            )
+            config.set_trt_dynamic_shape_info(*self.dynamic_shape_info)
+        predictor = create_predictor(config)
+
+        # Set the input data
+        input_names = predictor.get_input_names()
+        input_tensor = predictor.get_input_handle(input_names[0])
+        input_tensor.reshape(self.input_data.shape())
+        input_tensor.share_external_data(self.input_data)
+
+        predictor.run()
+
+        # Return the output data
+        output_names = predictor.get_output_names()
+        output_tensor = predictor.get_output_handle(output_names[0])
+        output_data = output_tensor.copy_to_cpu()
+        return output_data
+
+    def test_program(self):
+        # 1. Build program and save the model and params as attributed serialized_program and serialized_params
+        # 2. Run the inference with Paddle Inference
+        # 3. Run the inference with Paddle-TRT
+        # 4. Compare their predict label
+        self.build_program()
+        baseline = self.infer_program()
+        actual = self.infer_program(use_trt=True)
+        same = (baseline == actual).sum() / len(baseline)
+        self.assertGreaterEqual(
+            same,
+            0.9,
+            "There are more then 10% output difference between Paddle-Inference and Paddle-TRT.",
+        )
+
+
+class TestRemoveStrategyOpAMP(TestRemoveStrategyOpBase, unittest.TestCase):
+    def build_program(self):
+        place = paddle.CUDAPlace(0)
+        train_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        exe = paddle.static.Executor(place)
+
+        # Build program
+        with paddle.static.program_guard(train_program, startup_program):
+            data = paddle.static.data(
+                name='X', shape=[None, 1, 28, 28], dtype='float32'
+            )
+            label = paddle.static.data(
+                name='label', shape=[None, 1], dtype='int64'
+            )
+            conv2d = paddle.static.nn.conv2d(
+                input=data, num_filters=6, filter_size=3
+            )
+            bn = paddle.static.nn.batch_norm(input=conv2d, act="relu")
+
+            pool = F.max_pool2d(bn, kernel_size=2, stride=2)
+            hidden = paddle.static.nn.fc(pool, size=10)
+            cost = paddle.nn.functional.loss.cross_entropy(
+                input=hidden, label=label
+            )
+            avg_cost = paddle.mean(x=cost)
+            predict = paddle.argmax(hidden, axis=-1, dtype='int32')
+            optimizer = paddle.optimizer.Momentum(learning_rate=0.01)
+            optimizer = paddle.static.amp.decorate(
+                optimizer,
+                use_dynamic_loss_scaling=False,
+                use_pure_fp16=False,
+            )
+            optimizer.minimize(avg_cost)
+        exe.run(startup_program)
+        eval_program = train_program.clone(for_test=True)
+
+        # Training
+        def transform(x):
+            return np.reshape(x, [1, 28, 28]) - 127.5 / 127.5
+
+        train_dataset = paddle.vision.datasets.MNIST(
+            mode='train', backend='cv2', transform=transform
+        )
+        train_loader = paddle.io.DataLoader(
+            train_dataset,
+            places=place,
+            feed_list=[data, label],
+            drop_last=True,
+            return_list=False,
+            batch_size=64,
+        )
+
+        def train(program, stop_iter=100):
+            for it, data in enumerate(train_loader):
+                loss = exe.run(program, feed=data, fetch_list=[avg_cost])
+                if it == stop_iter:
+                    self.input_data = data[0]['X']
+                    break
+
+        train(train_program)
+
+        # Save the inference configuration
+        self.dynamic_shape_info = [
+            {"X": (1, 1, 28, 28)},
+            {"X": (128, 1, 28, 28)},
+            {"X": (64, 1, 28, 28)},
+        ]
+        self.precision_mode = PrecisionType.Half
+        self.serialized_program = paddle.static.serialize_program(
+            [data], [predict], program=eval_program
+        )
+        self.serialized_params = paddle.static.serialize_persistables(
+            [data], [predict], executor=exe, program=eval_program
+        )
+
+
+class TestRemoveStrategyOpAMPQAT(TestRemoveStrategyOpBase, unittest.TestCase):
+    def build_program(self):
+        place = paddle.CUDAPlace(0)
+        train_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        exe = paddle.static.Executor(place)
+
+        # Build program
+        with paddle.static.program_guard(train_program, startup_program):
+            data = paddle.static.data(
+                name='X', shape=[None, 1, 28, 28], dtype='float32'
+            )
+            label = paddle.static.data(
+                name='label', shape=[None, 1], dtype='int64'
+            )
+            conv2d = paddle.static.nn.conv2d(
+                input=data, num_filters=6, filter_size=3
+            )
+            bn = paddle.static.nn.batch_norm(input=conv2d, act="relu")
+
+            pool = F.max_pool2d(bn, kernel_size=2, stride=2)
+            hidden = paddle.static.nn.fc(pool, size=10)
+            cost = paddle.nn.functional.loss.cross_entropy(
+                input=hidden, label=label
+            )
+            avg_cost = paddle.mean(x=cost)
+            predict = paddle.argmax(hidden, axis=-1, dtype='int32')
+            optimizer = paddle.optimizer.Momentum(learning_rate=0.01)
+            optimizer = paddle.static.amp.decorate(
+                optimizer,
+                use_dynamic_loss_scaling=False,
+                use_pure_fp16=False,
+            )
+            optimizer.minimize(avg_cost)
+        exe.run(startup_program)
+        eval_program = train_program.clone(for_test=True)
+
+        # Training
+        def transform(x):
+            return np.reshape(x, [1, 28, 28]) - 127.5 / 127.5
+
+        train_dataset = paddle.vision.datasets.MNIST(
+            mode='train', backend='cv2', transform=transform
+        )
+        train_loader = paddle.io.DataLoader(
+            train_dataset,
+            places=place,
+            feed_list=[data, label],
+            drop_last=True,
+            return_list=False,
+            batch_size=64,
+        )
+
+        def train(program, stop_iter=100):
+            for it, data in enumerate(train_loader):
+                loss = exe.run(program, feed=data, fetch_list=[avg_cost])
+                if it == stop_iter:
+                    self.input_data = data[0]['X']
+                    break
+
+        train(train_program)
+
+        # Quantization aware training
+        scope = global_scope()
+
+        def insert_qdq(program, scope, place, for_test=False):
+            graph = IrGraph(core.Graph(program.desc), for_test=for_test)
+            transform_pass = QuantizationTransformPassV2(
+                scope=scope,
+                place=place,
+                activation_quantize_type='moving_average_abs_max',
+                weight_quantize_type='channel_wise_abs_max',
+            )
+            transform_pass.apply(graph)
+            quant_program = graph.to_program()
+            return quant_program
+
+        quant_train_program = insert_qdq(
+            train_program, scope, place, for_test=False
+        )
+        quant_eval_program = insert_qdq(
+            eval_program, scope, place, for_test=True
+        )
+        train(quant_train_program)
+
+        # Save the inference configuration
+        self.dynamic_shape_info = [
+            {"X": (1, 1, 28, 28)},
+            {"X": (128, 1, 28, 28)},
+            {"X": (64, 1, 28, 28)},
+        ]
+        self.precision_mode = PrecisionType.Int8
+        self.serialized_program = paddle.static.serialize_program(
+            [data], [predict], program=quant_eval_program
+        )
+        self.serialized_params = paddle.static.serialize_persistables(
+            [data], [predict], executor=exe, program=quant_eval_program
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
To make Paddle-TRT support AMP and AMP + QAT (Weight -> Cast -> Q -> DQ -> WeightedOP) models, this PR removes the cast OP and converts the data type of QDQ scales from FP16 to FP32.

This is a temporary workaround. In the future, TensorRT will support this, so we don't have to use this IR pass further.

Modifications

- Add an IR pass `trt_remove_amp_strategy_op_pass` to remove cast OP and update input graph and convert scale of QDQ node to FP32 data type.
- Add the IR pass `trt_remove_amp_strategy_op_pass` into IR pass list `kTRTSubgraphPasses`.
- AMP + QAT program will go through IR pass list `kTrtLowerPrecisionPasses` (some persistable variables are in FP16 data type), so we have to add some IR passes into IR pass list `kTrtLowerPrecisionPasses` to make sure our model can work (currently RN50 was tested).