### PR TITLE
fix custom operator utils while custom op contains optional inputs

### DIFF
--- a/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_utils.cc
@@ -466,7 +466,12 @@ std::tuple<bool, bool, phi::distributed::ProcessMesh> PrepareCtxForAutoParallel(
   const auto& inplace_map = paddle::OpMetaInfoHelper::GetInplaceMap(op_info);
 
   std::vector<Tensor>* all_inputs = ctx.AllMutableInput();
-  std::vector<Tensor> x = *all_inputs;
+  std::vector<Tensor> x;
+  for (auto& t : *all_inputs) {
+    if (t.impl().get()) {
+      x.emplace_back(t);
+    }
+  }
   const phi::distributed::ProcessMesh* mesh = nullptr;
   for (auto& input : x) {
     if (input.is_dist_tensor()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Solve the problem of failed execution of custom operators with optional inputs

Pcard-71502