### PR TITLE
Add FLOAT64 and FLOAT64S to CINN

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/transform_desc.cc
+++ b/paddle/fluid/framework/paddle2cinn/transform_desc.cc
@@ -218,6 +218,8 @@ void OpAttrsToCinn(framework::OpDesc *pb_desc, cpp::OpDesc *cpp_desc) {
       IMPL_ONE(BOOLEAN, bool);
       IMPL_ONE(LONG, int64_t);
       IMPL_ONE(LONGS, std::vector<int64_t>);
+      IMPL_ONE(FLOAT64, double);
+      IMPL_ONE(FLOAT64S, std::vector<double>);
       case AttrType::BLOCK: {
         auto i = pb_desc->GetAttrIfExists<int32_t>(name);
         cpp_desc->SetAttr<int32_t>(name, i);
@@ -254,6 +256,8 @@ void OpAttrsFromCinn(const cpp::OpDesc &cpp_desc, framework::OpDesc *pb_desc) {
       IMPL_ONE(BOOLEAN, bool);
       IMPL_ONE(LONG, int64_t);
       IMPL_ONE(LONGS, std::vector<int64_t>);
+      IMPL_ONE(FLOAT64, double);
+      IMPL_ONE(FLOAT64S, std::vector<double>);
       default:
         PADDLE_THROW(platform::errors::NotFound(
             "Unsupported attr type %d found ", static_cast<int>(type)));


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-77673
Add FLOAT64 and FLOAT64S to OpAttrsToCinn in transform_desc.cc.
This bug will cause an error when model with double or vector<double> as an argument in CINN. So we should add this two dtype to OpAttrsToCinn and OpAttrsFromCinn.