### PR TITLE
[PIR]Optimize executor in Python when add fetch op

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -422,14 +422,18 @@ def has_fetch_operations(
     """
 
     fetch_count = 0
+    mismatch_count = 0
     for op in block.ops:
         if op.name() == fetch_op:
-            fetch_count += 1
             if op.operand_source(0) not in fetch_targets:
-                raise Exception(
-                    "There is a fetch op in Program which will fetch variable that is not belong to fetch_targets."
-                )
-
+                mismatch_count += 1
+                continue
+            fetch_count += 1
+    warnings.warn(
+        "There are {} fetch ops in Program which are not responsible for the fetch targets that you have passed in fetch_list".format(
+            mismatch_count
+        )
+    )
     if fetch_count > 0 and fetch_count != len(fetch_targets):
         raise Exception(
             "Fetch operations in program do not match 'fetch_targets'"

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -429,11 +429,12 @@ def has_fetch_operations(
                 mismatch_count += 1
                 continue
             fetch_count += 1
-    warnings.warn(
-        "There are {} fetch ops in Program which are not responsible for the fetch targets that you have passed in fetch_list".format(
-            mismatch_count
+    if mismatch_count > 0:
+        warnings.warn(
+            "There are {} fetch ops in Program which are not responsible for the fetch targets that you have passed in fetch_list".format(
+                mismatch_count
+            )
         )
-    )
     if fetch_count > 0 and fetch_count != len(fetch_targets):
         raise Exception(
             "Fetch operations in program do not match 'fetch_targets'"

--- a/test/ir/pir/test_build_model.py
+++ b/test/ir/pir/test_build_model.py
@@ -47,6 +47,28 @@ class TestBuildModule(unittest.TestCase):
             (sum_value,) = exe.run(feed={'x': x_feed}, fetch_list=[out])
             self.assertEqual(sum_value, 10)
 
+    def test_basic_network_without_guard(self):
+        x = paddle.static.data('x', [4, 4], dtype='float32')
+        y = paddle.static.data('y', [4, 4], dtype='float32')
+        divide_out = paddle.divide(x, y)
+        sum_out = paddle.sum(divide_out)
+        exe = paddle.static.Executor()
+        x_feed = np.ones([4, 4], dtype=np.float32) * 10
+        y_feed = np.ones([4, 4], dtype=np.float32) * 2
+        (sum_value,) = exe.run(
+            feed={'x': x_feed, 'y': y_feed},
+            fetch_list=[sum_out],
+        )
+        self.assertEqual(sum_value, 5 * 4 * 4)
+
+        out = paddle.mean(x)
+        exe = paddle.static.Executor()
+        x_feed = np.ones([4, 4], dtype=np.float32) * 10
+        (sum_value,) = exe.run(
+            feed={'x': x_feed, 'y': y_feed}, fetch_list=[out]
+        )
+        self.assertEqual(sum_value, 10)
+
     def test_train_network(self):
         x_data = np.array(
             [[1.0], [3.0], [5.0], [9.0], [10.0], [20.0]], dtype="float32"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
在新IR执行器中追加fetch op的过程中，会对其中的fetch op进行检查，其需要严格对齐输入的fetch target. 由于多余的fetch op对program执行并没有太大影响，该PR会放松对其检查，以warning的形式而非error的形式进行抛出，减少检查错误报出加速api推全，后续如果有必要再进一步缩紧