### PR TITLE
[PIR] [dynamic shape] Add a vec to record kDynamic dims

### DIFF
--- a/paddle/pir/core/builtin_type_interfaces.cc
+++ b/paddle/pir/core/builtin_type_interfaces.cc
@@ -21,8 +21,8 @@ Type ShapedTypeInterface::GetElementType() const {
   return impl_->get_element_type(*this);
 }
 
-phi::DDim ShapedTypeInterface::GetShape() const {
-  return impl_->get_shape(*this);
+std::vector<int64_t> ShapedTypeInterface::GetDyShape() const {
+  return dy_shape_;
 }
 
 }  // namespace pir

--- a/paddle/pir/core/builtin_type_interfaces.cc
+++ b/paddle/pir/core/builtin_type_interfaces.cc
@@ -22,6 +22,14 @@ Type ShapedTypeInterface::GetElementType() const {
 }
 
 std::vector<int64_t> ShapedTypeInterface::GetDyShape() const {
+  if (dy_shape_.size() == 0) {
+    auto ddim_vec = vectorize(impl_->get_shape(*this));
+    dy_shape_ = ddim_vec;
+    std::replace(dy_shape_.begin(),
+                 dy_shape_.end(),
+                 (int64_t)-1,
+                 ShapedTypeInterface::kDynamic);
+  }
   return dy_shape_;
 }
 

--- a/paddle/pir/core/builtin_type_interfaces.h
+++ b/paddle/pir/core/builtin_type_interfaces.h
@@ -85,9 +85,7 @@ class ShapedTypeInterface : public TypeInterfaceBase<ShapedTypeInterface> {
   ///
   /// \brief Check whether the given dimension size is a dynamic dimension.
   ///
-  static constexpr bool IsDynamic(int64_t dValue) {
-    return dValue == kDynamic || dValue == -1;
-  }
+  static constexpr bool IsDynamic(int64_t dValue) { return dValue == kDynamic; }
 
   ///
   /// \brief Check whether the given shape has any size indicating a dynamic

--- a/paddle/pir/core/type_util.cc
+++ b/paddle/pir/core/type_util.cc
@@ -23,12 +23,12 @@ Type GetElementTypeOrSelf(Type type) {
   return type;
 }
 
-bool VerifyCompatibleShape(const phi::DDim &lhs_shape,
-                           const phi::DDim &rhs_shape) {
+bool VerifyCompatibleShape(const std::vector<int64_t> &lhs_shape,
+                           const std::vector<int64_t> &rhs_shape) {
   if (lhs_shape.size() != rhs_shape.size()) return false;
 
-  for (auto dim1 : phi::vectorize(lhs_shape)) {
-    for (auto dim2 : phi::vectorize(rhs_shape)) {
+  for (auto dim1 : lhs_shape) {
+    for (auto dim2 : rhs_shape) {
       if (!ShapedTypeInterface::IsDynamic(dim1) &&
           !ShapedTypeInterface::IsDynamic(dim2) && dim1 != dim2)
         return false;
@@ -47,8 +47,8 @@ bool VerifyCompatibleShape(Type lhs_type, Type rhs_type) {
 
   if (!lhs_shaped_type.HasRank() || !rhs_shaped_type.HasRank()) return true;
 
-  return VerifyCompatibleShape(lhs_shaped_type.GetShape(),
-                               rhs_shaped_type.GetShape());
+  return VerifyCompatibleShape(lhs_shaped_type.GetDyShape(),
+                               rhs_shaped_type.GetDyShape());
 }
 
 bool VerifyCompatibleDims(const std::vector<int64_t> &dims) {

--- a/paddle/pir/dialect/shape/transforms/shape_optimization.cc
+++ b/paddle/pir/dialect/shape/transforms/shape_optimization.cc
@@ -94,7 +94,7 @@ struct ExpandShapeOfOpPattern : public OpRewritePattern<shape::ShapeOfOp> {
 
     // std::vector<Value> dim_sizes;
     // for (int dim = 0, rank =
-    // type.dyn_cast<ShapedTypeInterface>().GetShape()[0];
+    // type.dyn_cast<ShapedTypeInterface>().GetDyShape()[0];
     //      dim < rank;
     //      ++dim) {
     //   dim_sizes.push_back(
@@ -183,7 +183,7 @@ bool IsCandidateShapeTensorType(Type type) {
   return (tensor_type && tensor_type && shaped_type.GetRank() == 1 &&
           shaped_type.HasStaticShape() &&
           shaped_type.GetElementType().IsIntOrIndex() &&
-          shaped_type.GetShape()[0] < 32);
+          shaped_type.GetDyShape()[0] < 32);
 }
 
 class ShapeComputationIRAnalysis {
@@ -309,7 +309,7 @@ bool ShapeComputationIRAnalysis::BuildShapeOnValue(Value value) {
   } else if (IsCandidateShapeTensorType(type)) {
     auto shaped_type = type.dyn_cast<ShapedTypeInterface>();
     std::vector<SymbolicDimOp> symbols;
-    for (size_t i = 0, d = shaped_type.GetShape()[0]; i < d; ++i)
+    for (size_t i = 0, d = shaped_type.GetDyShape()[0]; i < d; ++i)
       symbols.push_back(mgr_.NewSymbolicDim());
     shape_tensor_to_sym_dims_[value] = std::move(symbols);
   }

--- a/paddle/pir/dialect/shape/utils/shape_optimization_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_optimization_utils.cc
@@ -262,9 +262,10 @@ std::vector<SymbolicDimOp> SymbolicDimMgr::CreateSymbolicDimsForRankedValue(
   std::vector<SymbolicDimOp> symbols;
   auto dims = value.type().dyn_cast<pir::DenseTensorType>().dims();
   for (int idx = 0; idx < dims.size(); ++idx) {
-    symbols.push_back(dims[idx] == ShapedTypeInterface::kDynamic
-                          ? NewSymbolicDim()
-                          : NewConstantSymbolicDim(dims[idx]));
+    symbols.push_back(
+        (dims[idx] == ShapedTypeInterface::kDynamic || dims[idx] == -1)
+            ? NewSymbolicDim()
+            : NewConstantSymbolicDim(dims[idx]));
   }
   return symbols;
 }

--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -79,7 +79,7 @@ bool ShapeConstraintIRAnalysis::IsShapeEqual(Value lhs, Value rhs) {
     return false;
 
   if (lhs_type.HasStaticShape() && rhs_type.HasStaticShape()) {
-    return vectorize(lhs_type.GetShape()) == vectorize(rhs_type.GetShape());
+    return lhs_type.GetDyShape() == rhs_type.GetDyShape();
   }
 
   auto lhs_it = value_to_sym_dims_.find(lhs);
@@ -114,13 +114,13 @@ bool ShapeConstraintIRAnalysis::IsProductEqual(Value lhs,
         auto it = value_to_sym_dims_.find(value);
         if (!type || !type.HasRank()) return false;
         for (int idx : dim_idxs) {
-          if (type.GetShape()[idx] == ShapedTypeInterface::kDynamic) {
+          if (type.GetDyShape()[idx] == ShapedTypeInterface::kDynamic) {
             if (it == value_to_sym_dims_.end() ||
                 static_cast<int>(it->second.size()) <= idx)
               return false;
             prod.symbols.push_back(it->second[idx]);
           } else {
-            prod.factor *= type.GetShape()[idx];
+            prod.factor *= type.GetDyShape()[idx];
           }
         }
         return true;

--- a/test/cpp/pir/core/type_interface_test.cc
+++ b/test/cpp/pir/core/type_interface_test.cc
@@ -51,12 +51,12 @@ TEST(shapedtype_test, shapedtype_test) {
   EXPECT_EQ(
       dense_tensor_type_interface.GetElementType().isa<pir::Float32Type>(),
       true);
-  EXPECT_EQ(dense_tensor_type_interface.GetShape(), dims);
+  EXPECT_EQ(dense_tensor_type_interface.GetDyShape(), phi::vectorize(dims));
   EXPECT_EQ(dense_tensor_type_interface.kDynamic,
             std::numeric_limits<int64_t>::min());
   EXPECT_EQ(dense_tensor_type_interface.GetRank(), 2);
   EXPECT_EQ(dense_tensor_type_interface.IsDynamic(2), false);
-  EXPECT_EQ(dense_tensor_type_interface.IsDynamicShape(dims), false);
+  EXPECT_EQ(dense_tensor_type_interface.IsDynamicShape(), false);
   EXPECT_EQ(dense_tensor_type_interface.IsDynamicDim(1), false);
   EXPECT_EQ(dense_tensor_type_interface.GetNumDynamicDims(), 0);
   EXPECT_EQ(dense_tensor_type_interface.GetDimSize(0), 2);

--- a/test/cpp/pir/shape_dialect/constraint_pass_test.cc
+++ b/test/cpp/pir/shape_dialect/constraint_pass_test.cc
@@ -49,16 +49,10 @@ TEST(shape_constraint_pass, materialize_and_build_shape) {
   ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
 
-  pir::Operation *op0 =
-      test::CreateDenseTensorOp(ctx,
-                                {pir::ShapedTypeInterface::kDynamic, 2},
-                                {"op0_attr"},
-                                {"create_dense_tensor_op0"});
-  pir::Operation *op1 =
-      test::CreateDenseTensorOp(ctx,
-                                {pir::ShapedTypeInterface::kDynamic, 2, 2},
-                                {"op1_attr"},
-                                {"create_dense_tensor_op1"});
+  pir::Operation *op0 = test::CreateDenseTensorOp(
+      ctx, {-1, 2}, {"op0_attr"}, {"create_dense_tensor_op0"});
+  pir::Operation *op1 = test::CreateDenseTensorOp(
+      ctx, {-1, 2, 2}, {"op1_attr"}, {"create_dense_tensor_op1"});
   program.block()->push_back(op0);
   program.block()->push_back(op1);
 
@@ -99,8 +93,8 @@ TEST(shape_constraint_pass, shape_computation_run) {
       {"op0_name"},
       pir::Int64Type::get(pir::IrContext::Instance()));
   program.block()->push_back(op0);
-  pir::Operation *op1 = test::CreateDenseTensorOp(
-      ctx, {pir::ShapedTypeInterface::kDynamic, 2}, {"op1_attr"}, {"op1_name"});
+  pir::Operation *op1 =
+      test::CreateDenseTensorOp(ctx, {-1, 2}, {"op1_attr"}, {"op1_name"});
   program.block()->push_back(op1);
 
   pir::PassManager pm(ctx);

--- a/test/cpp/pir/shape_dialect/shape_op_test.cc
+++ b/test/cpp/pir/shape_dialect/shape_op_test.cc
@@ -124,8 +124,7 @@ TEST(shape_op, tie_shape_op) {
 
   pir::Builder builder = pir::Builder(ctx, program.block());
 
-  auto op = test::CreateDenseTensorOp(
-      ctx, {pir::ShapedTypeInterface::kDynamic, 2}, {"op_attr"}, {"op_name"});
+  auto op = test::CreateDenseTensorOp(ctx, {-1, 2}, {"op_attr"}, {"op_name"});
   pir::OpResult res = op->result(0);
 
   pir::shape::TieShapeOp tie_shape_op =
@@ -176,8 +175,8 @@ TEST(shape_op, tensor_dim_op) {
   ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
   pir::Builder builder = pir::Builder(ctx, program.block());
 
-  pir::Operation *op = test::CreateDenseTensorOp(
-      ctx, {pir::ShapedTypeInterface::kDynamic, 2}, {"op_attr"}, {"op_name"});
+  pir::Operation *op =
+      test::CreateDenseTensorOp(ctx, {-1, 2}, {"op_attr"}, {"op_name"});
   pir::OpResult res_dense_tensor_value = op->result(0);
 
   pir::shape::TensorDimOp tensor_dim_op0 =
@@ -210,8 +209,7 @@ TEST(shape_op, shape_of_op) {
   ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
   pir::Builder builder = pir::Builder(ctx, program.block());
 
-  auto op = test::CreateDenseTensorOp(
-      ctx, {pir::ShapedTypeInterface::kDynamic, 2}, {"op_attr"}, {"op_name"});
+  auto op = test::CreateDenseTensorOp(ctx, {-1, 2}, {"op_attr"}, {"op_name"});
   pir::OpResult res = op->result(0);
 
   pir::shape::ShapeOfOp shape_of_op = builder.Build<pir::shape::ShapeOfOp>(res);

--- a/test/cpp/pir/shape_dialect/shape_struct_test.cc
+++ b/test/cpp/pir/shape_dialect/shape_struct_test.cc
@@ -180,25 +180,10 @@ TEST(shape_struct_test, symbolic_dim_mgr_complex) {
       2,
       std::vector<pir::Value>{dim_op_s8, dim_op_s9, dim_op_s10, dim_op_s11});
 
-  auto op = test::CreateDenseTensorOp(ctx,
-                                      {pir::ShapedTypeInterface::kDynamic,
-                                       pir::ShapedTypeInterface::kDynamic,
-                                       pir::ShapedTypeInterface::kDynamic,
-                                       pir::ShapedTypeInterface::kDynamic,
-                                       pir::ShapedTypeInterface::kDynamic,
-                                       pir::ShapedTypeInterface::kDynamic},
-                                      {"op0_attr"},
-                                      {"op0_name"});
-  auto op_ = test::CreateDenseTensorOp(ctx,
-                                       {pir::ShapedTypeInterface::kDynamic,
-                                        pir::ShapedTypeInterface::kDynamic,
-                                        pir::ShapedTypeInterface::kDynamic,
-                                        pir::ShapedTypeInterface::kDynamic,
-                                        pir::ShapedTypeInterface::kDynamic,
-                                        10,
-                                        20},
-                                       {"op1_attr"},
-                                       {"op1_name"});
+  auto op = test::CreateDenseTensorOp(
+      ctx, {-1, -1, -1, -1, -1, -1}, {"op0_attr"}, {"op0_name"});
+  auto op_ = test::CreateDenseTensorOp(
+      ctx, {-1, -1, -1, -1, -1, 10, 20}, {"op1_attr"}, {"op1_name"});
   pir::OpResult res = op->result(0);
   pir::OpResult res_ = op_->result(0);
 
@@ -348,9 +333,9 @@ TEST(shape_struct_test, shape_analysis) {
   ::pir::Builder builder = ::pir::Builder(ctx, program.block());
   pir::shape::FuncOp func_op = builder.Build<pir::shape::FuncOp>();
 
-  phi::DDim dims_D_2 = {pir::ShapedTypeInterface::kDynamic, 2};
+  phi::DDim dims_D_2 = {-1, 2};
   phi::DDim dims_2_2 = {2, 2};
-  phi::DDim dims_D = {pir::ShapedTypeInterface::kDynamic};
+  phi::DDim dims_D = {-1};
 
   // same shape with dynamic: value1 == value2
   auto op1 =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
ShapedTypeInterface 中新增vec成员用于记录DDim中的信息，以及-1与kDynamic的转换，并修改相关接口及单测

