### PR TITLE
fix FindChannelAbsMaxFunctor cuda kernel bug

### DIFF
--- a/paddle/fluid/operators/fake_quantize_op.cu.h
+++ b/paddle/fluid/operators/fake_quantize_op.cu.h
@@ -201,7 +201,7 @@ struct FindChannelAbsMaxFunctor<phi::GPUContext, T> {
         FindChannelAbsMaxKernelQuantAxis1<T>
             <<<grid, block, block * sizeof(T), ctx.stream()>>>(
                 in_data, num, cin, cout, out_abs_max);
-        in_data += num / cin;
+        in_data += cout * max_threads;
       }
 
       int block = cin % max_threads;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-76510
- fix FindChannelAbsMaxFunctor cuda kernel bug when quant_axis=1. 