### PR TITLE
[Change] reshape dtype in pir mode

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3857,8 +3857,8 @@ def reshape(x, shape, name=None):
                 'int64',
                 'bool',
                 'uint16',
-                # 'complex64',
-                # 'complex128',
+                'complex64',
+                'complex128',
             ],
             'reshape',
         )

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3857,6 +3857,8 @@ def reshape(x, shape, name=None):
                 'int64',
                 'bool',
                 'uint16',
+                'complex64',
+                'complex128',
             ],
             'reshape',
         )

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3857,8 +3857,8 @@ def reshape(x, shape, name=None):
                 'int64',
                 'bool',
                 'uint16',
-                'complex64',
-                'complex128',
+                # 'complex64',
+                # 'complex128',
             ],
             'reshape',
         )

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -453,6 +453,7 @@ class TestReshapeAPI(unittest.TestCase):
         np.testing.assert_array_equal(res_3, input.reshape([5, 10]))
         np.testing.assert_array_equal(res_4, input.reshape(shape))
 
+    @test_with_pir_api
     def _test_static_dtype(self):
         places = [paddle.CPUPlace()] + (
             [paddle.CUDAPlace(0)] if base.core.is_compiled_with_cuda() else []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->

修改 `reshape` 在 `pir` 下支持的数据类型。

涉及文件

- `python/paddle/tensor/manipulation.py` 将 reshape 在 pir 下支持的数据类型修改为与 https://github.com/PaddlePaddle/Paddle/pull/58764 中的一致
- `test/legacy_test/test_reshape_op.py` 将之前对于 static 数据类型的检查，添加 `@test_with_pir_api`
