### PR TITLE
【PIR API adaptor No.148】outer

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2552,7 +2552,7 @@ def outer(x, y, name=None):
     nx = x.reshape((-1, 1))
     ny = y.reshape((1, -1))
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.matmul(nx, ny, False, False)
     else:
 

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -17,13 +17,14 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.static import Program, program_guard
 from paddle.pir_utils import test_with_pir_api
 
 
 class TestMultiplyApi(unittest.TestCase):
     def _run_static_graph_case(self, x_data, y_data):
-        with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             paddle.enable_static()
             x = paddle.static.data(
                 name='x', shape=x_data.shape, dtype=x_data.dtype
@@ -87,8 +88,7 @@ class TestMultiplyApi(unittest.TestCase):
         y_data = np.random.rand(50).astype(np.int64)
         res = self._run_static_graph_case(x_data, y_data)
         np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
-    
-    @test_with_pir_api
+
     def test_multiply_dynamic(self):
         # test dynamic computation graph: 3-d array
         x_data = np.random.rand(5, 10, 10).astype(np.float64)
@@ -142,13 +142,12 @@ class TestMultiplyApi(unittest.TestCase):
 
 
 class TestMultiplyError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors_static(self):
-        import pdb
-        pdb.set_trace()
         # test static computation graph: dtype can not be int8
         paddle.enable_static()
-        with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(name='x', shape=[100], dtype=np.int8)
             y = paddle.static.data(name='y', shape=[100], dtype=np.int8)
             self.assertRaises(TypeError, paddle.outer, x, y)

--- a/test/legacy_test/test_outer.py
+++ b/test/legacy_test/test_outer.py
@@ -18,11 +18,12 @@ import numpy as np
 
 import paddle
 from paddle.static import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestMultiplyApi(unittest.TestCase):
     def _run_static_graph_case(self, x_data, y_data):
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
             paddle.enable_static()
             x = paddle.static.data(
                 name='x', shape=x_data.shape, dtype=x_data.dtype
@@ -53,7 +54,8 @@ class TestMultiplyApi(unittest.TestCase):
         res = paddle.outer(x, y)
         return res.numpy()
 
-    def test_multiply(self):
+    @test_with_pir_api
+    def test_multiply_static(self):
         np.random.seed(7)
 
         # test static computation graph: 3-d array
@@ -85,7 +87,9 @@ class TestMultiplyApi(unittest.TestCase):
         y_data = np.random.rand(50).astype(np.int64)
         res = self._run_static_graph_case(x_data, y_data)
         np.testing.assert_allclose(res, np.outer(x_data, y_data), rtol=1e-05)
-
+    
+    @test_with_pir_api
+    def test_multiply_dynamic(self):
         # test dynamic computation graph: 3-d array
         x_data = np.random.rand(5, 10, 10).astype(np.float64)
         y_data = np.random.rand(2, 10).astype(np.float64)
@@ -138,14 +142,18 @@ class TestMultiplyApi(unittest.TestCase):
 
 
 class TestMultiplyError(unittest.TestCase):
-    def test_errors(self):
+    @test_with_pir_api
+    def test_errors_static(self):
+        import pdb
+        pdb.set_trace()
         # test static computation graph: dtype can not be int8
         paddle.enable_static()
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
             x = paddle.static.data(name='x', shape=[100], dtype=np.int8)
             y = paddle.static.data(name='y', shape=[100], dtype=np.int8)
             self.assertRaises(TypeError, paddle.outer, x, y)
 
+    def test_errors_dynamic(self):
         np.random.seed(7)
 
         # test dynamic computation graph: dtype must be Tensor type


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description
<!-- Describe what you’ve done -->
[used AI Studio]


+ https://github.com/PaddlePaddle/Paddle/issues/58067

No.148将 paddle.Tensor.outer 迁移升级至 pir，并更新单测 单测覆盖率：1/2
当前1个test_error单测已跳过