### PR TITLE
【PIR API adaptor No.145】masked_select

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3724,4 +3724,3 @@ def cdist(
     return paddle.linalg.norm(
         x[..., None, :] - y[..., None, :, :], p=p, axis=-1
     )
- 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3724,3 +3724,4 @@ def cdist(
     return paddle.linalg.norm(
         x[..., None, :] - y[..., None, :, :], p=p, axis=-1
     )
+ 

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -913,21 +913,19 @@ def masked_select(x, mask, name=None):
             >>> print(out.numpy())
             [1. 5. 6. 9.]
     """
-
-    if in_dynamic_mode():
+    check_variable_and_dtype(
+        x,
+        'x',
+        ['float16', 'float32', 'float64', 'int32', 'int64', 'uint16'],
+        'paddle.tensor.search.mask_select',
+    )
+    check_variable_and_dtype(
+        mask, 'mask', ['bool'], 'paddle.tensor.search.masked_select'
+    )
+    if in_dynamic_or_pir_mode():
         return _C_ops.masked_select(x, mask)
-
     else:
         helper = LayerHelper("masked_select", **locals())
-        check_variable_and_dtype(
-            x,
-            'x',
-            ['float16', 'float32', 'float64', 'int32', 'int64', 'uint16'],
-            'paddle.tensor.search.mask_select',
-        )
-        check_variable_and_dtype(
-            mask, 'mask', ['bool'], 'paddle.tensor.search.masked_select'
-        )
         out = helper.create_variable_for_type_inference(dtype=x.dtype)
         helper.append_op(
             type='masked_select',

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -913,18 +913,18 @@ def masked_select(x, mask, name=None):
             >>> print(out.numpy())
             [1. 5. 6. 9.]
     """
-    check_variable_and_dtype(
-        x,
-        'x',
-        ['float16', 'float32', 'float64', 'int32', 'int64', 'uint16'],
-        'paddle.tensor.search.mask_select',
-    )
-    check_variable_and_dtype(
-        mask, 'mask', ['bool'], 'paddle.tensor.search.masked_select'
-    )
     if in_dynamic_or_pir_mode():
         return _C_ops.masked_select(x, mask)
     else:
+        check_variable_and_dtype(
+            x,
+            'x',
+            ['float16', 'float32', 'float64', 'int32', 'int64', 'uint16'],
+            'paddle.tensor.search.mask_select',
+        )
+        check_variable_and_dtype(
+            mask, 'mask', ['bool'], 'paddle.tensor.search.masked_select'
+        )
         helper = LayerHelper("masked_select", **locals())
         out = helper.create_variable_for_type_inference(dtype=x.dtype)
         helper.append_op(

--- a/test/legacy_test/test_masked_select_op.py
+++ b/test/legacy_test/test_masked_select_op.py
@@ -16,10 +16,10 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
-from paddle.pir_utils import test_with_pir_api
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def np_masked_select(x, mask):
@@ -118,7 +118,9 @@ class TestMaskedSelectBF16Op(OpTest):
         self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad_with_place(core.CUDAPlace(0), ['X'], 'Y', check_pir=True)
+        self.check_grad_with_place(
+            core.CUDAPlace(0), ['X'], 'Y', check_pir=True
+        )
 
     def init(self):
         self.shape = (50, 3)

--- a/test/legacy_test/test_masked_select_op.py
+++ b/test/legacy_test/test_masked_select_op.py
@@ -16,10 +16,10 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
-from paddle.pir_utils import test_with_pir_api
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def np_masked_select(x, mask):
@@ -118,7 +118,9 @@ class TestMaskedSelectBF16Op(OpTest):
         self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad_with_place(core.CUDAPlace(0), ['X'], 'Y', check_pir=True)
+        self.check_grad_with_place(
+            core.CUDAPlace(0), ['X'], 'Y', check_pir=True
+        )
 
     def init(self):
         self.shape = (50, 3)
@@ -172,7 +174,6 @@ class TestMaskedSelectError(unittest.TestCase):
     def setUp(self):
         paddle.enable_static()
 
-    @test_with_pir_api
     def test_error(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()

--- a/test/legacy_test/test_masked_select_op.py
+++ b/test/legacy_test/test_masked_select_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16
+from paddle.pir_utils import test_with_pir_api
 
 import paddle
 from paddle.base import core
@@ -42,10 +43,10 @@ class TestMaskedSelectOp(OpTest):
         self.outputs = {'Y': out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Y')
+        self.check_grad(['X'], 'Y', check_pir=True)
 
     def init(self):
         self.shape = (50, 3)
@@ -77,10 +78,10 @@ class TestMaskedSelectFP16Op(OpTest):
         self.outputs = {'Y': out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Y')
+        self.check_grad(['X'], 'Y', check_pir=True)
 
     def init(self):
         self.shape = (50, 3)
@@ -114,10 +115,10 @@ class TestMaskedSelectBF16Op(OpTest):
         self.outputs = {'Y': convert_float_to_uint16(out)}
 
     def test_check_output(self):
-        self.check_output_with_place(core.CUDAPlace(0))
+        self.check_output_with_place(core.CUDAPlace(0), check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad_with_place(core.CUDAPlace(0), ['X'], 'Y')
+        self.check_grad_with_place(core.CUDAPlace(0), ['X'], 'Y', check_pir=True)
 
     def init(self):
         self.shape = (50, 3)
@@ -146,6 +147,7 @@ class TestMaskedSelectAPI(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), np_out, rtol=1e-05)
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_static_mode(self):
         shape = [8, 9, 6]
         x = paddle.static.data(shape=shape, dtype='float32', name='x')
@@ -170,6 +172,7 @@ class TestMaskedSelectError(unittest.TestCase):
     def setUp(self):
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_error(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description
<!-- Describe what you’ve done -->
[used AI Studio]

+ https://github.com/PaddlePaddle/Paddle/issues/58067

No.145 将 paddle.Tensor.masked_select 迁移升级至 pir，并更新单测 单测覆盖率：14/16
当前1个 test_error 单测已跳过，1个 Broadcast 单测中均为动态图
