### PR TITLE
[PIR] fix pir translate error.

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -25,7 +25,9 @@
 #include "paddle/fluid/ir_adaptor/translator/utils.h"
 #include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/utils/data_type.h"
 #include "paddle/pir/core/attribute.h"
 #include "paddle/pir/core/block.h"
 #include "paddle/pir/core/builtin_attribute.h"
@@ -278,6 +280,11 @@ const TCValue& TranslationContext::at(const TCKey& key) const {
   return values.back();
 }
 
+bool TranslationContext::Has(const Key& key) const {
+  return container_.find(key) != container_.end() ||
+         (parent_ && parent_->Has(key));
+}
+
 size_t TranslationContext::count(const TCKey& key) const {
   auto it = container_.find(key);
   if (it == container_.end()) {
@@ -499,58 +506,46 @@ void ProgramTranslator::TranslateWhileOperation(
     pir::Block* dst_block) {
   VLOG(8) << "=============>Start to translate while op:" << op;
   auto& sub_block = legacy_program_->Block(op->GetBlockAttrId("sub_block"));
-  int index = static_cast<int>(sub_block.OpSize()) - 1;
-  std::vector<std::pair<std::string, std::string>> loop_vars_reverse;
-  while (index >= 0) {
-    auto sub_op = sub_block.Op(index);
-    if (sub_op->Type() == "assign" &&
-        translation_ctx->count(sub_op->Output("Out")[0]) > 0) {
-      loop_vars_reverse.emplace_back(sub_op->Output("Out")[0],
-                                     sub_op->Input("X")[0]);
-      --index;
-    } else {
-      break;
+  auto& inputs = op->Output("Out");
+  auto& cond_var = op->Input("Condition")[0];
+  std::vector<std::string> loop_vars;
+  for (auto& var : inputs) {
+    if (var != cond_var) {
+      loop_vars.emplace_back(var);
     }
   }
-  PADDLE_ENFORCE(!loop_vars_reverse.empty(),
-                 platform::errors::PreconditionNotMet(
-                     "While op must has condition value input"));
-  PADDLE_ENFORCE(loop_vars_reverse.front().first == op->Input("Condition")[0],
-                 platform::errors::PreconditionNotMet(
-                     "The last op in sub_block of While op must used to assign "
-                     "condition var"));
   auto op_info = ctx_->GetRegisteredOpInfo(paddle::dialect::WhileOp::name());
   std::vector<pir::Value> op_inputs{
-      translation_ctx->at(loop_vars_reverse[0].first).value};
+      GetValueOrCreateInTop(cond_var, translation_ctx).value};
   std::vector<pir::Type> op_outputs_type;
   auto body_block = new pir::Block();
   auto* body_block_context = translation_ctx->CreateInnerContext();
-  for (size_t idx = loop_vars_reverse.size() - 1u; idx > 0; --idx) {
-    auto& name = loop_vars_reverse[idx].first;
-    auto& tc_value = translation_ctx->at(name);
+
+  for (auto& loop_var : loop_vars) {
+    auto& tc_value = GetValueOrCreateInTop(loop_var, translation_ctx);
     auto val_type = tc_value.value.type();
     op_inputs.push_back(tc_value.value);
     op_outputs_type.push_back(val_type);
-    body_block_context->PushValue(name, body_block->AddArgument(val_type));
+    body_block_context->PushValue(loop_var, body_block->AddArgument(val_type));
   }
+
   pir::Operation* while_op =
       pir::Operation::Create(op_inputs, {}, op_outputs_type, op_info, 1);
   dst_block->push_back(while_op);
   while_op->region(0).push_back(body_block);
-  TranslateBlock(sub_block, 0, index + 1, body_block_context, body_block);
+
+  TranslateBlock(
+      sub_block, 0, sub_block.OpSize(), body_block_context, body_block);
 
   auto yeild_info = ctx_->GetRegisteredOpInfo(pir::YieldOp::name());
-  std::vector<pir::Value> yeild_inputs{
-      body_block_context->at(loop_vars_reverse[0].second).value};
-  for (size_t idx = loop_vars_reverse.size() - 1u; idx > 0; --idx) {
-    auto& name = loop_vars_reverse[idx].second;
-    yeild_inputs.push_back(body_block_context->at(name).value);
+  std::vector<pir::Value> yeild_inputs{body_block_context->at(cond_var).value};
+  for (auto& loop_var : loop_vars) {
+    yeild_inputs.push_back(body_block_context->at(loop_var).value);
   }
   body_block->push_back(
       pir::Operation::Create(yeild_inputs, {}, {}, yeild_info));
-  auto name_iter = loop_vars_reverse.rbegin();
-  for (size_t idx = 0; idx < while_op->num_results(); ++idx) {
-    translation_ctx->PushValue(name_iter++->first, while_op->result(idx));
+  for (size_t idx = 0; idx < loop_vars.size(); ++idx) {
+    translation_ctx->PushValue(loop_vars[idx], while_op->result(idx));
   }
 
   while_op->Verify();
@@ -754,7 +749,24 @@ void ProgramTranslator::SetStopGradientAttributeForAllValue(
     }
   }
 }
-
+const VariableDefiningInfo& ProgramTranslator::GetValueOrCreateInTop(
+    const std::string& var_name, TranslationContext* translation_ctx) {
+  if (translation_ctx->Has(var_name)) return translation_ctx->at(var_name);
+  return CreateUndefinedVariable(var_name);
+}
+const VariableDefiningInfo& ProgramTranslator::CreateUndefinedVariable(
+    const std::string& var_name) {
+  auto var_desc = legacy_program_->Block(0).FindVar(var_name);
+  pir::Builder builder(ctx_, program_->block(), program_->block()->begin());
+  auto shape = var_desc->GetShape();
+  auto dtype = ::phi::TransToPhiDataType(var_desc->GetDataType());
+  auto val =
+      builder
+          .Build<paddle::dialect::DataOp>(var_name, shape, dtype, phi::Place())
+          .out();
+  param_map_.PushValue(var_name, val);
+  return param_map_.at(var_name);
+}
 void ProgramTranslator::SetIsPersisableAttributeForAllValue(
     const BlockDesc& block) {
   // Currently we set is persisable for operation that generated a value

--- a/paddle/fluid/ir_adaptor/translator/program_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.h
@@ -88,6 +88,7 @@ class TranslationContext {
 
   const Value& operator[](const Key& key) const;
   const Value& at(const Key& key) const;
+  bool Has(const Key& key) const;
   size_t count(const Key& key)
       const;  // Caution: not exactly same as count in stl library
 
@@ -155,6 +156,12 @@ class ProgramTranslator {
   void SetParameterFromSingleBlock(const BlockDesc& block);
   void SetStopGradientAttributeForAllValue(const BlockDesc& block);
   void SetIsPersisableAttributeForAllValue(const BlockDesc& block);
+
+  const VariableDefiningInfo& GetValueOrCreateInTop(
+      const std::string& var_name, TranslationContext* translation_ctx);
+
+  const VariableDefiningInfo& CreateUndefinedVariable(
+      const std::string& var_name);
 
   /// Translate methods for control flow ops.
   pir::Operation* TranslateCondIfOperation(

--- a/test/cpp/pir/core/program_translator_test.cc
+++ b/test/cpp/pir/core/program_translator_test.cc
@@ -320,7 +320,10 @@ TEST(OperatorDialectTest, WhileOpProgram) {
             if (body_body_id == 2) {
               EXPECT_TRUE(op2->isa<paddle::dialect::LessThanOp>());
             }
-            if (body_body_id == 3) {
+            if (body_body_id == 3 || body_body_id == 4) {
+              EXPECT_TRUE(op2->isa<paddle::dialect::AssignOp>());
+            }
+            if (body_body_id == 5) {
               EXPECT_TRUE(op2->isa<pir::YieldOp>());
             }
             body_body_id++;
@@ -329,7 +332,10 @@ TEST(OperatorDialectTest, WhileOpProgram) {
         if (body_id == 4) {
           EXPECT_TRUE(op1->isa<paddle::dialect::LessThanOp>());
         }
-        if (body_id == 5) {
+        if (body_id == 5 || body_id == 6) {
+          EXPECT_TRUE(op1->isa<paddle::dialect::AssignOp>());
+        }
+        if (body_id == 7) {
           EXPECT_TRUE(op1->isa<pir::YieldOp>());
         }
         body_id++;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others 

### Description
<!-- Describe what you’ve done -->
以下样例在翻译为新IR模型时会报错。
```python
import paddle
from paddle.static import Program, program_guard
import numpy as np
paddle.enable_static()
def external_cond(i, j, init, sums):
    return paddle.less_than(i, loop_len1)

def external_body(i, j, init, sums):
    def internal_cond(j, init, sums):
        return paddle.less_than(j, loop_len2)

    def internal_body(j, init, sums):
        init = paddle.add(x=init, y=ones)
        sums = paddle.add(x=init, y=sums)
        j = paddle.increment(j)
        return [j, init, sums]

    result = paddle.static.nn.while_loop(
        internal_cond, internal_body, [j, init, sums]
    )
    j = result[0]
    init = result[1]
    sums = result[2]
    sums = paddle.add(x=init, y=sums)
    i = paddle.increment(i)
    return [i, j, init, sums]

main_program = Program()
startup_program = Program()
with program_guard(main_program, startup_program):
  i = paddle.zeros(shape=[1], dtype='int64')
  j = paddle.zeros(shape=[1], dtype='int64')
  init = paddle.static.data(
      name='init', shape=[3, 3], dtype='float32'
  )
  sums = paddle.static.data(
      name='sums', shape=[3, 3], dtype='float32'
  )
  loop_len1 = paddle.tensor.fill_constant(
      shape=[1], dtype='int64', value=2
  )
  loop_len2 = paddle.tensor.fill_constant(
      shape=[1], dtype='int64', value=3
  )
  ones = paddle.tensor.fill_constant(
      shape=[3, 3], dtype='float32', value=1
  )

  out = paddle.static.nn.while_loop(
      external_cond, external_body, [i, j, init, sums]
)

data = np.random.rand(3, 3).astype('float32')
data_sums = np.zeros([3, 3]).astype('float32')
```
本pr对此样例进行了修复，修复后翻译结果为：
```cxx
 (%0) = "pd_op.data" () {dtype:(pd_op.DataType)float32,is_persisable:[false],name:"init",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[3,3],stop_gradient:[true]} : () -> pd_op.tensor<3x3xf32>
 (%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,is_persisable:[false],name:"sums",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[3,3],stop_gradient:[true]} : () -> pd_op.tensor<3x3xf32>
 (%2) = "pd_op.full" () {dtype:(pd_op.DataType)int64,is_persisable:[false],place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)0} : () -> pd_op.tensor<1xi64>
 (%3) = "pd_op.full" () {dtype:(pd_op.DataType)int64,is_persisable:[false],place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)0} : () -> pd_op.tensor<1xi64>
 (%4) = "pd_op.full" () {dtype:(pd_op.DataType)int64,is_persisable:[false],place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<1xi64>
 (%5) = "pd_op.full" () {dtype:(pd_op.DataType)int64,is_persisable:[false],place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)3} : () -> pd_op.tensor<1xi64>
 (%6) = "pd_op.full" () {dtype:(pd_op.DataType)float32,is_persisable:[false],place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[3,3],stop_gradient:[true],value:(Float)1} : () -> pd_op.tensor<3x3xf32>
 (%7) = "pd_op.less_than" (%2, %4) {is_persisable:[false],stop_gradient:[true]} : (pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<1xb>
 (%8, %9, %10, %11) = "pd_op.while"(%7) [%2, %1, %3, %0] { 
  ^%arg0, %arg1, %arg2, %arg3
  (%12) = "pd_op.less_than" (%arg2, %5) {} : (pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<1xb>
  (%13, %14, %15) = "pd_op.while"(%12) [%arg1, %arg2, %arg3] { 
        ^%arg4, %arg5, %arg6
       (%16) = "pd_op.add" (%arg6, %6) {} : (pd_op.tensor<3x3xf32>, pd_op.tensor<3x3xf32>) -> pd_op.tensor<3x3xf32>
       (%17) = "pd_op.add" (%16, %arg4) {} : (pd_op.tensor<3x3xf32>, pd_op.tensor<3x3xf32>) -> pd_op.tensor<3x3xf32>
       (%18) = "pd_op.increment_" (%arg5) {value:(Float)1} : (pd_op.tensor<1xi64>) -> pd_op.tensor<1xi64>
       (%19) = "pd_op.less_than" (%18, %5) {} : (pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<1xb>
       (%20) = "pd_op.assign" (%16) {} : (pd_op.tensor<3x3xf32>) -> pd_op.tensor<3x3xf32>
       (%21) = "pd_op.assign" (%17) {} : (pd_op.tensor<3x3xf32>) -> pd_op.tensor<3x3xf32>
       (%22) = "pd_op.assign" (%19) {} : (pd_op.tensor<1xb>) -> pd_op.tensor<1xb>
       () = "cf.yield" (%22, %21, %18, %20) {} : (pd_op.tensor<1xb>, pd_op.tensor<3x3xf32>, pd_op.tensor<1xi64>, pd_op.tensor<3x3xf32>) -> 
   }
   (%23) = "pd_op.add" (%15, %13) {} : (pd_op.tensor<3x3xf32>, pd_op.tensor<3x3xf32>) -> pd_op.tensor<3x3xf32>
   (%24) = "pd_op.increment_" (%arg0) {value:(Float)1} : (pd_op.tensor<1xi64>) -> pd_op.tensor<1xi64>
   (%25) = "pd_op.less_than" (%24, %4) {} : (pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<1xb>
   (%26) = "pd_op.assign" (%23) {} : (pd_op.tensor<3x3xf32>) -> pd_op.tensor<3x3xf32>
   (%27) = "pd_op.assign" (%25) {} : (pd_op.tensor<1xb>) -> pd_op.tensor<1xb>
   () = "cf.yield" (%27, %24, %26, %14, %15) {} : (pd_op.tensor<1xb>, pd_op.tensor<1xi64>, pd_op.tensor<3x3xf32>, pd_op.tensor<1xi64>, pd_op.tensor<3x3xf32>) -> 
  }
```

### Other
Pcard-67164
