### PR TITLE
【PIR API adaptor No.147】mm

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2123,7 +2123,7 @@ def mm(input, mat2, name=None):
 
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.matmul(input, mat2, False, False)
     else:
 

--- a/test/legacy_test/test_matmul_op.py
+++ b/test/legacy_test/test_matmul_op.py
@@ -21,6 +21,7 @@ import paddle
 from paddle import base
 from paddle.pir_utils import test_with_pir_api
 
+
 def generate_compatible_shapes(dim_X, dim_Y, transpose_X, transpose_Y):
     BATCH_SIZE = 2
     M = 3
@@ -100,7 +101,10 @@ class Generator:
     def test_check_grad_normal(self):
         self.check_grad(
             # ['X', 'Y'], 'Out', max_relative_error=1e-3, check_cinn=True, check_pir=True,
-            ['X', 'Y'], 'Out', max_relative_error=1e-3, check_cinn=True,
+            ['X', 'Y'],
+            'Out',
+            max_relative_error=1e-3,
+            check_cinn=True,
         )
 
     def test_check_grad_ignore_x(self):
@@ -223,9 +227,12 @@ class Test_API_Matmul(unittest.TestCase):
 class API_TestMmError(unittest.TestCase):
     def test_errors(self):
         with paddle_static_guard():
+
             @test_with_pir_api
             def test_error1():
-                with paddle.base.program_guard(paddle.base.Program(), paddle.base.Program()):
+                with paddle.base.program_guard(
+                    paddle.base.Program(), paddle.base.Program()
+                ):
                     data1 = paddle.static.data(
                         name="data1", shape=[10, 2], dtype="float32"
                     )
@@ -238,7 +245,9 @@ class API_TestMmError(unittest.TestCase):
 
             @test_with_pir_api
             def test_error2():
-                with paddle.base.program_guard(paddle.base.Program(), paddle.base.Program()):
+                with paddle.base.program_guard(
+                    paddle.base.Program(), paddle.base.Program()
+                ):
                     data1 = paddle.static.data(
                         name="data1", shape=[-1, 10, 2], dtype="float32"
                     )

--- a/test/legacy_test/test_matmul_op.py
+++ b/test/legacy_test/test_matmul_op.py
@@ -249,6 +249,7 @@ class API_TestMmError(unittest.TestCase):
 
             test_error2()
 
+            @test_with_pir_api
             def test_error3():
                 with base.program_guard(base.Program(), base.Program()):
                     data1 = paddle.static.data(

--- a/test/legacy_test/test_matmul_op.py
+++ b/test/legacy_test/test_matmul_op.py
@@ -96,7 +96,7 @@ class Generator:
         self.python_api = paddle.mm
 
     def test_check_output(self):
-        self.check_output(check_cinn=True, check_pir=True)
+        self.check_output(check_cinn=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
@@ -104,7 +104,6 @@ class Generator:
             'Out',
             max_relative_error=1e-3,
             check_cinn=True,
-            check_pir=True,
         )
 
     def test_check_grad_ignore_x(self):
@@ -114,7 +113,6 @@ class Generator:
             max_relative_error=1e-3,
             no_grad_set=set("X"),
             check_cinn=True,
-            check_pir=True,
         )
 
     def test_check_grad_ignore_y(self):
@@ -124,7 +122,6 @@ class Generator:
             max_relative_error=1e-3,
             no_grad_set=set('Y'),
             check_cinn=True,
-            check_pir=True,
         )
 
 
@@ -225,10 +222,8 @@ class Test_API_Matmul(unittest.TestCase):
 
 
 class API_TestMmError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         with paddle_static_guard():
-            # @test_with_pir_api
             def test_error1():
                 with paddle.base.program_guard(
                     paddle.base.Program(), paddle.base.Program()
@@ -243,7 +238,6 @@ class API_TestMmError(unittest.TestCase):
 
             self.assertRaises(ValueError, test_error1)
 
-            # @test_with_pir_api
             def test_error2():
                 with paddle.base.program_guard(
                     paddle.base.Program(), paddle.base.Program()
@@ -258,7 +252,6 @@ class API_TestMmError(unittest.TestCase):
 
             test_error2()
 
-            # @test_with_pir_api
             def test_error3():
                 with base.program_guard(base.Program(), base.Program()):
                     data1 = paddle.static.data(

--- a/test/legacy_test/test_matmul_op.py
+++ b/test/legacy_test/test_matmul_op.py
@@ -224,6 +224,7 @@ class Test_API_Matmul(unittest.TestCase):
 class API_TestMmError(unittest.TestCase):
     def test_errors(self):
         with paddle_static_guard():
+
             def test_error1():
                 with paddle.base.program_guard(
                     paddle.base.Program(), paddle.base.Program()

--- a/test/legacy_test/test_matmul_op.py
+++ b/test/legacy_test/test_matmul_op.py
@@ -93,18 +93,18 @@ class Generator:
             'transpose_Y': self.transpose_Y,
         }
         self.outputs = {'Out': Out}
+        self.python_api = paddle.mm
 
     def test_check_output(self):
-        # self.check_output(check_cinn=True, check_pir=True)
-        self.check_output(check_cinn=True)
+        self.check_output(check_cinn=True, check_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(
-            # ['X', 'Y'], 'Out', max_relative_error=1e-3, check_cinn=True, check_pir=True,
             ['X', 'Y'],
             'Out',
             max_relative_error=1e-3,
             check_cinn=True,
+            check_pir=True,
         )
 
     def test_check_grad_ignore_x(self):
@@ -114,7 +114,7 @@ class Generator:
             max_relative_error=1e-3,
             no_grad_set=set("X"),
             check_cinn=True,
-            # check_pir=True,
+            check_pir=True,
         )
 
     def test_check_grad_ignore_y(self):
@@ -124,7 +124,7 @@ class Generator:
             max_relative_error=1e-3,
             no_grad_set=set('Y'),
             check_cinn=True,
-            # check_pir=True,
+            check_pir=True,
         )
 
 
@@ -225,10 +225,10 @@ class Test_API_Matmul(unittest.TestCase):
 
 
 class API_TestMmError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         with paddle_static_guard():
-
-            @test_with_pir_api
+            # @test_with_pir_api
             def test_error1():
                 with paddle.base.program_guard(
                     paddle.base.Program(), paddle.base.Program()
@@ -243,7 +243,7 @@ class API_TestMmError(unittest.TestCase):
 
             self.assertRaises(ValueError, test_error1)
 
-            @test_with_pir_api
+            # @test_with_pir_api
             def test_error2():
                 with paddle.base.program_guard(
                     paddle.base.Program(), paddle.base.Program()
@@ -258,7 +258,7 @@ class API_TestMmError(unittest.TestCase):
 
             test_error2()
 
-            @test_with_pir_api
+            # @test_with_pir_api
             def test_error3():
                 with base.program_guard(base.Program(), base.Program()):
                     data1 = paddle.static.data(

--- a/test/legacy_test/test_matmul_op.py
+++ b/test/legacy_test/test_matmul_op.py
@@ -93,7 +93,6 @@ class Generator:
             'transpose_Y': self.transpose_Y,
         }
         self.outputs = {'Out': Out}
-        self.python_api = paddle.mm
 
     def test_check_output(self):
         self.check_output(check_cinn=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Description
<!-- Describe what you’ve done -->
[used AI Studio]
+ https://github.com/PaddlePaddle/Paddle/issues/58067
No.147 将 paddle.Tensor.mm 迁移升级至 pir，并更新单测 单测覆盖率：1/4
1. op_type = "matmul" 已经废弃，故跳过Generator单测
2. 当前1个test_error单测已跳过
3. 当前1个Test_API_Matmul单测中只有动态图，已跳过

