### PR TITLE
[Dy2St] pir dy2st unittest verification - Part 4

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils_new.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils_new.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import inspect
 import logging
 import os
 import unittest
 from enum import Flag, auto
 from functools import wraps
+from pathlib import Path
 
 import numpy as np
 
@@ -315,3 +317,26 @@ def show_all_test_cases(test_class):
         if attr.startswith("test"):
             fn = getattr(test_class, attr)
             logger.info(f"{attr}: {fn}")
+
+
+# Other utilities
+def import_module_from_path(module_name, module_path):
+    """A better way to import module from other directory than using sys.path.append"""
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def import_legacy_test_utils():
+    test_root = Path(__file__).parent.parent
+    legacy_test_utils_path = test_root / "legacy_test/utils.py"
+    legacy_test_utils = import_module_from_path(
+        "legacy_test_utils", legacy_test_utils_path
+    )
+    return legacy_test_utils
+
+
+legacy_test_utils = import_legacy_test_utils()
+dygraph_guard = legacy_test_utils.dygraph_guard
+static_guard = legacy_test_utils.static_guard

--- a/test/dygraph_to_static/dygraph_to_static_utils_new.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils_new.py
@@ -269,6 +269,11 @@ def test_pir_only(fn):
     return fn
 
 
+def test_pir_api_only(fn):
+    fn = set_ir_mode(IrMode.PIR_API)(fn)
+    return fn
+
+
 def test_legacy_and_pir(fn):
     fn = set_ir_mode(IrMode.LEGACY_IR | IrMode.PIR_EXE)(fn)
     return fn

--- a/test/dygraph_to_static/test_bmn.py
+++ b/test/dygraph_to_static/test_bmn.py
@@ -25,7 +25,6 @@ import paddle
 from paddle import base
 from paddle.base import ParamAttr
 from paddle.base.dygraph import to_variable
-from paddle.jit import to_static
 from paddle.jit.translated_layer import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 
 SEED = 2000
@@ -265,7 +264,6 @@ class BMN(paddle.nn.Layer):
             bias_attr=ParamAttr(name="PEM_2d4_b"),
         )
 
-    @to_static
     def forward(self, x):
         # Base Module
         x = paddle.nn.functional.relu(self.b_conv1(x))
@@ -656,104 +654,100 @@ class TestTrain(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    def train_bmn(self, args, place, to_static):
+    def train_bmn(self, args, to_static):
         paddle.jit.enable_to_static(to_static)
+        base.dygraph.disable_dygraph()
+        base.dygraph.enable_dygraph()
         loss_data = []
 
-        with base.dygraph.guard(place):
-            paddle.seed(SEED)
-            paddle.framework.random._manual_program_seed(SEED)
-            global local_random
-            local_random = np.random.RandomState(SEED)
+        paddle.seed(SEED)
+        paddle.framework.random._manual_program_seed(SEED)
+        global local_random
+        local_random = np.random.RandomState(SEED)
 
-            bmn = BMN(args)
-            bmn = paddle.jit.to_static(bmn)
-            adam = optimizer(args, parameter_list=bmn.parameters())
+        bmn = paddle.jit.to_static(BMN(args))
+        adam = optimizer(args, parameter_list=bmn.parameters())
 
-            train_reader = fake_data_reader(args, 'train')
+        train_reader = fake_data_reader(args, 'train')
 
-            for epoch in range(args.epoch):
-                for batch_id, data in enumerate(train_reader()):
-                    video_feat = np.array([item[0] for item in data]).astype(
-                        DATATYPE
-                    )
-                    gt_iou_map = np.array([item[1] for item in data]).astype(
-                        DATATYPE
-                    )
-                    gt_start = np.array([item[2] for item in data]).astype(
-                        DATATYPE
-                    )
-                    gt_end = np.array([item[3] for item in data]).astype(
-                        DATATYPE
-                    )
+        for epoch in range(args.epoch):
+            for batch_id, data in enumerate(train_reader()):
+                video_feat = np.array([item[0] for item in data]).astype(
+                    DATATYPE
+                )
+                gt_iou_map = np.array([item[1] for item in data]).astype(
+                    DATATYPE
+                )
+                gt_start = np.array([item[2] for item in data]).astype(DATATYPE)
+                gt_end = np.array([item[3] for item in data]).astype(DATATYPE)
 
-                    x_data = to_variable(video_feat)
-                    gt_iou_map = to_variable(gt_iou_map)
-                    gt_start = to_variable(gt_start)
-                    gt_end = to_variable(gt_end)
-                    gt_iou_map.stop_gradient = True
-                    gt_start.stop_gradient = True
-                    gt_end.stop_gradient = True
+                x_data = to_variable(video_feat)
+                gt_iou_map = to_variable(gt_iou_map)
+                gt_start = to_variable(gt_start)
+                gt_end = to_variable(gt_end)
+                gt_iou_map.stop_gradient = True
+                gt_start.stop_gradient = True
+                gt_end.stop_gradient = True
 
-                    pred_bm, pred_start, pred_end = bmn(x_data)
+                pred_bm, pred_start, pred_end = bmn(x_data)
 
-                    loss, tem_loss, pem_reg_loss, pem_cls_loss = bmn_loss_func(
-                        pred_bm,
-                        pred_start,
-                        pred_end,
-                        gt_iou_map,
-                        gt_start,
-                        gt_end,
-                        args,
-                    )
-                    avg_loss = paddle.mean(loss)
+                loss, tem_loss, pem_reg_loss, pem_cls_loss = bmn_loss_func(
+                    pred_bm,
+                    pred_start,
+                    pred_end,
+                    gt_iou_map,
+                    gt_start,
+                    gt_end,
+                    args,
+                )
+                avg_loss = paddle.mean(loss)
 
-                    avg_loss.backward()
-                    adam.minimize(avg_loss)
-                    bmn.clear_gradients()
-                    # log loss data to verify correctness
-                    loss_data += [
-                        float(avg_loss),
-                        float(tem_loss),
-                        float(pem_reg_loss),
-                        float(pem_cls_loss),
-                    ]
+                avg_loss.backward()
+                adam.minimize(avg_loss)
+                bmn.clear_gradients()
+                # log loss data to verify correctness
+                loss_data += [
+                    float(avg_loss),
+                    float(tem_loss),
+                    float(pem_reg_loss),
+                    float(pem_cls_loss),
+                ]
 
-                    if args.log_interval > 0 and (
-                        batch_id % args.log_interval == 0
-                    ):
-                        print(
-                            f'[TRAIN] Epoch {epoch}, iter {batch_id} '
-                            + '\tLoss = {}, \ttem_loss = {}, \tpem_reg_loss = {}, \tpem_cls_loss = {}'.format(
-                                '%f' % float(avg_loss),
-                                '%f' % float(tem_loss),
-                                '%f' % float(pem_reg_loss),
-                                '%f' % float(pem_cls_loss),
-                            )
+                if args.log_interval > 0 and (
+                    batch_id % args.log_interval == 0
+                ):
+                    print(
+                        f'[TRAIN] Epoch {epoch}, iter {batch_id} '
+                        + '\tLoss = {}, \ttem_loss = {}, \tpem_reg_loss = {}, \tpem_cls_loss = {}'.format(
+                            '%f' % float(avg_loss),
+                            '%f' % float(tem_loss),
+                            '%f' % float(pem_reg_loss),
+                            '%f' % float(pem_cls_loss),
                         )
+                    )
 
-                    # validation
-                    if batch_id % args.valid_interval == 0 and batch_id > 0:
-                        bmn.eval()
-                        val_loss_data = val_bmn(bmn, args)
-                        bmn.train()
-                        loss_data += val_loss_data
+                # validation
+                if batch_id % args.valid_interval == 0 and batch_id > 0:
+                    bmn.eval()
+                    val_loss_data = val_bmn(bmn, args)
+                    bmn.train()
+                    loss_data += val_loss_data
 
-                    if batch_id == args.train_batch_num:
-                        if to_static:
-                            paddle.jit.save(bmn, self.model_save_prefix)
-                        else:
-                            paddle.save(
-                                bmn.state_dict(),
-                                self.dy_param_path + '.pdparams',
-                            )
-                        break
-            return np.array(loss_data)
+                if batch_id == args.train_batch_num:
+                    if to_static:
+                        paddle.jit.save(bmn, self.model_save_prefix)
+                    else:
+                        paddle.save(
+                            bmn.state_dict(),
+                            self.dy_param_path + '.pdparams',
+                        )
+                    break
+        return np.array(loss_data)
 
     @test_pir_only
     def test_train_pir(self):
-        static_res = self.train_bmn(self.args, self.place, to_static=True)
-        dygraph_res = self.train_bmn(self.args, self.place, to_static=False)
+        static_res = self.train_bmn(self.args, to_static=True)
+        dygraph_res = self.train_bmn(self.args, to_static=False)
         np.testing.assert_allclose(
             dygraph_res,
             static_res,
@@ -766,8 +760,8 @@ class TestTrain(Dy2StTestBase):
         )
 
     def test_train(self):
-        static_res = self.train_bmn(self.args, self.place, to_static=True)
-        dygraph_res = self.train_bmn(self.args, self.place, to_static=False)
+        static_res = self.train_bmn(self.args, to_static=True)
+        dygraph_res = self.train_bmn(self.args, to_static=False)
         np.testing.assert_allclose(
             dygraph_res,
             static_res,
@@ -833,18 +827,17 @@ class TestTrain(Dy2StTestBase):
 
     def predict_dygraph(self, data):
         paddle.jit.enable_to_static(False)
-        with base.dygraph.guard(self.place):
-            bmn = BMN(self.args)
-            # load dygraph trained parameters
-            model_dict = paddle.load(self.dy_param_path + ".pdparams")
-            bmn.set_dict(model_dict)
-            bmn.eval()
+        bmn = paddle.jit.to_static(BMN(self.args))
+        # load dygraph trained parameters
+        model_dict = paddle.load(self.dy_param_path + ".pdparams")
+        bmn.set_dict(model_dict)
+        bmn.eval()
 
-            x = to_variable(data)
-            pred_res = bmn(x)
-            pred_res = [var.numpy() for var in pred_res]
+        x = to_variable(data)
+        pred_res = bmn(x)
+        pred_res = [var.numpy() for var in pred_res]
 
-            return pred_res
+        return pred_res
 
     def predict_static(self, data):
         paddle.enable_static()
@@ -866,18 +859,18 @@ class TestTrain(Dy2StTestBase):
             fetch_list=fetch_targets,
         )
 
+        paddle.disable_static()
         return pred_res
 
     def predict_dygraph_jit(self, data):
-        with base.dygraph.guard(self.place):
-            bmn = paddle.jit.load(self.model_save_prefix)
-            bmn.eval()
+        bmn = paddle.jit.load(self.model_save_prefix)
+        bmn.eval()
 
-            x = to_variable(data)
-            pred_res = bmn(x)
-            pred_res = [var.numpy() for var in pred_res]
+        x = to_variable(data)
+        pred_res = bmn(x)
+        pred_res = [var.numpy() for var in pred_res]
 
-            return pred_res
+        return pred_res
 
     def predict_analysis_inference(self, data):
         output = PredictorTools(

--- a/test/dygraph_to_static/test_bmn.py
+++ b/test/dygraph_to_static/test_bmn.py
@@ -656,8 +656,8 @@ class TestTrain(Dy2StTestBase):
 
     def train_bmn(self, args, to_static):
         paddle.jit.enable_to_static(to_static)
-        base.dygraph.disable_dygraph()
-        base.dygraph.enable_dygraph()
+        paddle.enable_static()
+        paddle.disable_static()
         loss_data = []
 
         paddle.seed(SEED)

--- a/test/dygraph_to_static/test_bmn.py
+++ b/test/dygraph_to_static/test_bmn.py
@@ -749,7 +749,7 @@ class TestTrain(Dy2StTestBase):
                                 self.dy_param_path + '.pdparams',
                             )
                         break
-        return np.array(loss_data)
+            return np.array(loss_data)
 
     @test_pir_only
     def test_train_pir(self):

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -16,7 +16,12 @@ import logging
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import Dy2StTestBase, test_ast_only
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    test_ast_only,
+    test_legacy_and_pir,
+    test_legacy_and_pir_exe_and_pir_api,
+)
 
 import paddle
 import paddle.jit.dy2static as _jst
@@ -31,7 +36,7 @@ np.random.seed(SEED)
 
 
 # Use a decorator to test exception
-@paddle.jit.to_static
+@paddle.jit.to_static(full_graph=True)
 def dyfunc_with_if(x_v):
     if paddle.mean(x_v).numpy() > 5:
         x_v = x_v - 1
@@ -40,7 +45,7 @@ def dyfunc_with_if(x_v):
     return x_v
 
 
-@paddle.jit.to_static
+@paddle.jit.to_static(full_graph=True)
 def nested_func(x_v):
     x_v = base.dygraph.to_variable(x_v)
 
@@ -51,7 +56,7 @@ def nested_func(x_v):
     return res
 
 
-@paddle.jit.to_static
+@paddle.jit.to_static(full_graph=True)
 def dyfunc_with_third_library_logging(x_v):
     logging.info('test dyfunc_with_third_library_logging')
     if paddle.mean(x_v).numpy() > 5:
@@ -71,7 +76,7 @@ class A:
         return paddle.to_tensor(a.numpy() + b.numpy())
 
 
-@paddle.jit.to_static
+@paddle.jit.to_static(full_graph=True)
 def dyfunc_with_staticmethod(x_v):
     a = A()
     return a.add(x_v, x_v)
@@ -85,24 +90,23 @@ class TestRecursiveCall1(Dy2StTestBase):
             if base.is_compiled_with_cuda()
             else base.CPUPlace()
         )
-        self.init_test_func()
 
     def init_test_func(self):
         self.dyfunc = nested_func
 
     def get_dygraph_output(self):
         paddle.jit.enable_to_static(False)
-        with base.dygraph.guard():
-            res = self.dyfunc(self.input).numpy()
-            return res
+        res = self.dyfunc(self.input).numpy()
+        return res
 
     def get_static_output(self):
         paddle.jit.enable_to_static(True)
-        with base.dygraph.guard():
-            res = self.dyfunc(self.input).numpy()
-            return res
+        res = self.dyfunc(self.input).numpy()
+        return res
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_transformed_static_result(self):
+        self.init_test_func()
         static_res = self.get_static_output()
         dygraph_res = self.get_dygraph_output()
         np.testing.assert_allclose(
@@ -131,14 +135,14 @@ class MyConvLayer(paddle.nn.Layer):
             ),
         )
 
-    @paddle.jit.to_static
+    @paddle.jit.to_static(full_graph=True)
     def forward(self, inputs):
         y = dyfunc_with_if(inputs)
         y = lambda_fun(y)
         y = self.dymethod(y)
         return y
 
-    @paddle.jit.to_static
+    @paddle.jit.to_static(full_graph=True)
     def dymethod(self, x_v):
         x_v = paddle.assign(x_v)
         return x_v
@@ -161,7 +165,7 @@ class MyLayer(paddle.nn.Layer):
         )
         self.act = paddle.nn.ReLU()
 
-    @paddle.jit.to_static
+    @paddle.jit.to_static(full_graph=True)
     def forward(self, inputs):
         h = self.conv(inputs)
         out = self.fc(h)
@@ -176,17 +180,15 @@ class TestRecursiveCall2(Dy2StTestBase):
             if base.is_compiled_with_cuda()
             else base.CPUPlace()
         )
-        self.set_func()
 
     def set_func(self):
         self.dygraph_func = MyLayer()
 
     def _run(self):
-        with base.dygraph.guard():
-            data = base.dygraph.to_variable(self.input)
-            res = self.dygraph_func(data)
+        data = base.dygraph.to_variable(self.input)
+        res = self.dygraph_func(data)
 
-            return res.numpy()
+        return res.numpy()
 
     def get_dygraph_output(self):
         paddle.jit.enable_to_static(False)
@@ -196,7 +198,9 @@ class TestRecursiveCall2(Dy2StTestBase):
         paddle.jit.enable_to_static(True)
         return self._run()
 
+    @test_legacy_and_pir
     def test_transformed_static_result(self):
+        self.set_func()
         dygraph_res = self.get_dygraph_output()
         static_res = self.get_static_output()
         np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-05)
@@ -239,12 +243,16 @@ class TestNotToConvert(TestRecursiveCall2):
         paddle.jit.not_to_static(self.net.sum)
         self.dygraph_func = paddle.jit.to_static(self.net.outer)
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_conversion_options(self):
+        self.set_func()
         options = getattr(self.net.sum, CONVERSION_OPTIONS, None)
         self.assertIsNotNone(options)
         self.assertTrue(options.not_convert)
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_code(self):
+        self.set_func()
         # check 'if statement' is not converted
         self.assertIn(
             "if x.shape[0] > 1", func_to_source_code(_jst.Call(self.net.sum))
@@ -258,13 +266,17 @@ class TestNotToConvert2(TestRecursiveCall2):
         paddle.jit.not_to_static(self.net.sum)
         self.dygraph_func = paddle.jit.to_static(self.net.sum)
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_conversion_options(self):
+        self.set_func()
         options = getattr(self.net.sum, CONVERSION_OPTIONS, None)
         self.assertIsNotNone(options)
         self.assertTrue(options.not_convert)
 
     @test_ast_only
+    @test_legacy_and_pir_exe_and_pir_api
     def test_code(self):
+        self.set_func()
         self.dygraph_func = paddle.jit.to_static(self.net.sum)
         # check 'if statement' is not converted
         self.assertIn("if x.shape[0] > 1", self.dygraph_func.code)
@@ -280,6 +292,7 @@ def forward(self, x):
 
 class TestConvertPaddleAPI(Dy2StTestBase):
     @test_ast_only
+    @test_legacy_and_pir_exe_and_pir_api
     def test_functional_api(self):
         func = paddle.nn.functional.relu
         func = paddle.jit.to_static(func)
@@ -287,6 +300,7 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         self.assertIn("if in_dynamic_or_pir_mode()", func.code)
 
     @test_ast_only
+    @test_legacy_and_pir_exe_and_pir_api
     def test_class_api(self):
         bn = paddle.nn.SyncBatchNorm(2)
         paddle.jit.to_static(bn)
@@ -294,6 +308,7 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         self.assertIn("if in_dynamic_mode()", bn.forward.code)
 
     @test_ast_only
+    @test_legacy_and_pir_exe_and_pir_api
     def test_class_patch_api(self):
         paddle.nn.SyncBatchNorm.forward = forward
         bn = paddle.nn.SyncBatchNorm(2)

--- a/test/dygraph_to_static/test_inplace_assign.py
+++ b/test/dygraph_to_static/test_inplace_assign.py
@@ -15,12 +15,17 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    test_legacy_and_pir,
+    test_legacy_and_pir_exe_and_pir_api,
+)
 
 import paddle
 
 
 class TestInplaceAssign(Dy2StTestBase):
+    @test_legacy_and_pir_exe_and_pir_api
     def test_case0(self):
         a = paddle.ones((1024, 2)) * 1
         b = paddle.ones((1024, 3)) * 2
@@ -30,6 +35,7 @@ class TestInplaceAssign(Dy2StTestBase):
         b._inplace_assign(c)
         np.testing.assert_array_equal(b.numpy(), c.numpy())
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_case1(self):
         def func(x):
             a = 1 * x
@@ -47,13 +53,12 @@ class TestInplaceAssign(Dy2StTestBase):
 
     @test_legacy_and_pir
     def test_case2(self):
-        @paddle.jit.to_static
         def func(a, x):
             x[:] = a * 2.0
             return x
 
         def forward(a, x):
-            output = func(a, x)
+            output = paddle.jit.to_static(func)(a, x)
             x._inplace_assign(output)
             return x
 

--- a/test/dygraph_to_static/test_inplace_assign.py
+++ b/test/dygraph_to_static/test_inplace_assign.py
@@ -17,15 +17,15 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils_new import (
     Dy2StTestBase,
+    test_ast_only,
     test_legacy_and_pir,
-    test_legacy_and_pir_exe_and_pir_api,
 )
 
 import paddle
 
 
 class TestInplaceAssign(Dy2StTestBase):
-    @test_legacy_and_pir_exe_and_pir_api
+    @test_ast_only
     def test_case0(self):
         a = paddle.ones((1024, 2)) * 1
         b = paddle.ones((1024, 3)) * 2
@@ -35,7 +35,7 @@ class TestInplaceAssign(Dy2StTestBase):
         b._inplace_assign(c)
         np.testing.assert_array_equal(b.numpy(), c.numpy())
 
-    @test_legacy_and_pir_exe_and_pir_api
+    @test_ast_only
     def test_case1(self):
         def func(x):
             a = 1 * x

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -15,7 +15,10 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import Dy2StTestBase, compare_legacy_with_pir
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    test_legacy_and_pir_exe_and_pir_api,
+)
 
 import paddle
 from paddle import base
@@ -46,7 +49,6 @@ class TestTypeHint(Dy2StTestBase):
     def _init_dyfunc(self):
         self.dyfunc = function
 
-    @compare_legacy_with_pir
     def _run_static(self):
         return self._run(to_static=True)
 
@@ -54,18 +56,18 @@ class TestTypeHint(Dy2StTestBase):
         return self._run(to_static=False)
 
     def _run(self, to_static):
-        with base.dygraph.guard(self.place):
-            # Set the input of dyfunc to Tensor
-            tensor_x = base.dygraph.to_variable(self.x, zero_copy=False)
-            if to_static:
-                ret = paddle.jit.to_static(self.dyfunc)(tensor_x)
-            else:
-                ret = self.dyfunc(tensor_x)
-            if hasattr(ret, "numpy"):
-                return ret.numpy()
-            else:
-                return ret
+        # Set the input of dyfunc to Tensor
+        tensor_x = base.dygraph.to_variable(self.x, zero_copy=False)
+        if to_static:
+            ret = paddle.jit.to_static(self.dyfunc)(tensor_x)
+        else:
+            ret = self.dyfunc(tensor_x)
+        if hasattr(ret, "numpy"):
+            return ret.numpy()
+        else:
+            return ret
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils_new import (
 )
 
 import paddle
-from paddle import base
 
 SEED = 2020
 np.random.seed(SEED)
@@ -39,9 +38,9 @@ def function(x: A) -> A:
 class TestTypeHint(Dy2StTestBase):
     def setUp(self):
         self.place = (
-            base.CUDAPlace(0)
-            if base.is_compiled_with_cuda()
-            else base.CPUPlace()
+            paddle.CUDAPlace(0)
+            if paddle.is_compiled_with_cuda()
+            else paddle.CPUPlace()
         )
         self.x = np.zeros(shape=(1), dtype=np.int32)
         self._init_dyfunc()
@@ -57,7 +56,7 @@ class TestTypeHint(Dy2StTestBase):
 
     def _run(self, to_static):
         # Set the input of dyfunc to Tensor
-        tensor_x = base.dygraph.to_variable(self.x, zero_copy=False)
+        tensor_x = paddle.to_tensor(self.x)
         if to_static:
             ret = paddle.jit.to_static(self.dyfunc)(tensor_x)
         else:

--- a/test/dygraph_to_static/test_word2vec.py
+++ b/test/dygraph_to_static/test_word2vec.py
@@ -21,7 +21,6 @@ from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
 
 import paddle
 from paddle import base
-from paddle.jit.api import to_static
 from paddle.nn import Embedding
 
 
@@ -247,7 +246,6 @@ class SkipGram(paddle.nn.Layer):
             ),
         )
 
-    @to_static
     def forward(self, center_words, target_words, label):
         center_words_emb = self.embedding(center_words)
         target_words_emb = self.embedding_out(target_words)
@@ -287,8 +285,8 @@ def train(to_static):
         base.default_startup_program().random_seed = 1000
         base.default_main_program().random_seed = 1000
 
-        skip_gram_model = SkipGram(
-            "skip_gram_model", vocab_size, embedding_size
+        skip_gram_model = paddle.jit.to_static(
+            SkipGram("skip_gram_model", vocab_size, embedding_size)
         )
         adam = paddle.optimizer.Adam(
             learning_rate=learning_rate,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->


| 状态 | 单测 | 备注|
|:----:|:----:|:----:|
| ❌ |`test_bmn` | `TestTrain.test_train_pir`未通过，需要适配`jit.api.save`, 均不能跑最终态 |
| ✅ |`test_typehint` | 全部可以跑最终态 |
| ❌ | `test_convert_call` | `TestRecursiveCall2`单测失败，需要适配`paddle.nn.Layer.__call__`或者`paddle.nn.Layer._dygraph_call_func`，且所有单测均为进入`run_program_op.__call__`，含 cond OP，控制流尚不支持 |
| 🚧 | `test_inplace_assign` | `TestInplaceAssign.test_case2`需要等待适配`OpResult.__setitem__`，剩余可以跑最终态 |
| ❌ | `test_word2vec` | `TestWord2Vec` `binary_cross_entropy_with_logits` API 未适配 |


添加一个新的装饰器`test_pir_api_only`，用于替换`test_pir_only`


相关链接:

* #58633 
* #58630
* #58686
* #58890