### PR TITLE
[PIR] normalize the name of insertion point.

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -86,7 +86,7 @@ OPTIONAL_VECTOR_VALUE_INPUT_TEMPLATE = """
     if (!{name}) {{
         optional_{name} = paddle::make_optional<pir::Value>(pir::Value());
     }} else {{
-        auto optional_{name}_combine_op = APIBuilder::Instance().GetBuilder()->Build<pir::CombineOp>({name}.get());
+        auto optional_{name}_combine_op = ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>({name}.get());
         optional_{name} = paddle::make_optional<pir::Value>(optional_{name}_combine_op.out());
     }}"""
 
@@ -107,18 +107,18 @@ OPTIONAL_OPRESULT_OUTPUT_TEMPLATE = """
 OPTIONAL_VECTOR_OPRESULT_OUTPUT_TEMPLATE = """
     paddle::optional<std::vector<pir::OpResult>> optional_{name};
     if (!IsEmptyValue({op_name}_op.result({index}))) {{
-        auto optional_{name}_slice_op = APIBuilder::Instance().GetBuilder()->Build<pir::SplitOp>({op_name}_op.result({index}));
+        auto optional_{name}_slice_op = ApiBuilder::Instance().GetBuilder()->Build<pir::SplitOp>({op_name}_op.result({index}));
         optional_{name} = paddle::make_optional<std::vector<pir::OpResult>>(optional_{name}_slice_op.outputs());
     }}"""
 
 COMBINE_OP_TEMPLATE = """
-    auto {op_name} = APIBuilder::Instance().GetBuilder()->Build<pir::CombineOp>({in_name});"""
+    auto {op_name} = ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>({in_name});"""
 
 SPLIT_OP_TEMPLATE = """
-    auto {op_name} = APIBuilder::Instance().GetBuilder()->Build<pir::SplitOp>({in_name});"""
+    auto {op_name} = ApiBuilder::Instance().GetBuilder()->Build<pir::SplitOp>({in_name});"""
 
 COMPUTE_OP_TEMPLATE = """
-    paddle::dialect::{op_class_name} {op_inst_name} = APIBuilder::Instance().GetBuilder()->Build<paddle::dialect::{op_class_name}>({args});"""
+    paddle::dialect::{op_class_name} {op_inst_name} = ApiBuilder::Instance().GetBuilder()->Build<paddle::dialect::{op_class_name}>({args});"""
 
 OP_INPUT = 'pir::Value'
 VECTOR_TYPE = 'pir::VectorType'

--- a/paddle/fluid/pir/dialect/operator/ir/api_builder.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/api_builder.cc
@@ -19,41 +19,34 @@
 namespace paddle {
 namespace dialect {
 
-APIBuilder::APIBuilder() : builder_(nullptr) {
+ApiBuilder::ApiBuilder() : builder_(std::make_shared<pir::Builder>(ctx_);) {
   ctx_ = pir::IrContext::Instance();
+  IR_ENFORCE(builder_ != nullptr, "api builder construct error!");
 }
 
-void APIBuilder::SetProgram(pir::Program* program) {
-  builder_ = std::make_shared<pir::Builder>(ctx_, program->block());
+void ApiBuilder::SetProgram(pir::Program* program) {
+  IR_ENFORCE(program != nullptr, "argument of program is nullptr");
+  SetInsertionPointToBlockEnd(program->block());
 }
 
-void APIBuilder::SetInsertionPoint(pir::Operation* op) {
-  IR_ENFORCE(builder_ != nullptr,
-             "builder doesn't hold program, please call SetProgram for "
-             "initialization.");
-  builder_->SetInsertionPoint(op);
+void ApiBuilder::set_insertion_point(pir::Operation* op) {
+  builder_->set_insertion_point(op);
 }
 
-void APIBuilder::ResetInsertionPointToStart() {
-  IR_ENFORCE(builder_ != nullptr,
-             "builder doesn't hold program, please call SetProgram for "
-             "initialization.");
+void ApiBuilder::ResetInsertionPointToStart() {
   builder_->SetInsertionPointToStart(builder_->block());
 }
 
-void APIBuilder::ResetInsertionPointToEnd() {
-  IR_ENFORCE(builder_ != nullptr,
-             "builder doesn't hold program, please call SetProgram for "
-             "initialization.");
+void ApiBuilder::ResetInsertionPointToEnd() {
   builder_->SetInsertionPointToEnd(builder_->block());
 }
 
-pir::Parameter* APIBuilder::GetParameter(const std::string& name) const {
+pir::Parameter* ApiBuilder::GetParameter(const std::string& name) const {
   pir::Program* program = builder_->block()->GetParentOp()->GetParentProgram();
   return program->GetParameter(name);
 }
 
-void APIBuilder::SetParameter(const std::string& name,
+void ApiBuilder::SetParameter(const std::string& name,
                               std::unique_ptr<pir::Parameter>&& parameter) {
   pir::Program* program = builder_->block()->GetParentOp()->GetParentProgram();
   program->SetParameter(name, std::move(parameter));

--- a/paddle/fluid/pir/dialect/operator/ir/api_builder.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/api_builder.cc
@@ -19,14 +19,15 @@
 namespace paddle {
 namespace dialect {
 
-ApiBuilder::ApiBuilder() : builder_(std::make_shared<pir::Builder>(ctx_);) {
-  ctx_ = pir::IrContext::Instance();
+ApiBuilder::ApiBuilder()
+    : ctx_(pir::IrContext::Instance()),
+      builder_(std::make_shared<pir::Builder>(ctx_)) {
   IR_ENFORCE(builder_ != nullptr, "api builder construct error!");
 }
 
 void ApiBuilder::SetProgram(pir::Program* program) {
   IR_ENFORCE(program != nullptr, "argument of program is nullptr");
-  SetInsertionPointToBlockEnd(program->block());
+  builder_->SetInsertionPointToEnd(program->block());
 }
 
 void ApiBuilder::set_insertion_point(pir::Operation* op) {

--- a/paddle/fluid/pir/dialect/operator/ir/api_builder.h
+++ b/paddle/fluid/pir/dialect/operator/ir/api_builder.h
@@ -23,19 +23,19 @@
 namespace paddle {
 namespace dialect {
 ///
-/// \brief APIBuilder is used in IR API for building op
+/// \brief ApiBuilder is used in IR API for building op
 ///
-class APIBuilder {
+class ApiBuilder {
  public:
-  static APIBuilder& Instance() {
-    static APIBuilder api_builder;
+  static ApiBuilder& Instance() {
+    static ApiBuilder api_builder;
     return api_builder;
   }
   void SetProgram(pir::Program* program);
 
   /// Set the insertion point to the specified operation, which will cause
   /// subsequent insertions to go right before it.
-  void SetInsertionPoint(pir::Operation* op);
+  void set_insertion_point(pir::Operation* op);
 
   void ResetInsertionPointToStart();
 
@@ -48,10 +48,18 @@ class APIBuilder {
 
   std::shared_ptr<pir::Builder> GetBuilder() { return builder_; }
 
- private:
-  APIBuilder();
+  const pir::InsertionPoint& insertion_point() const {
+    return builder_->insertion_point();
+  }
 
-  DISABLE_COPY_AND_ASSIGN(APIBuilder);
+  void set_insertion_point(const pir::InsertionPoint& insertion_point) {
+    builder_->set_insertion_point(insertion_point);
+  }
+
+ private:
+  ApiBuilder();
+
+  DISABLE_COPY_AND_ASSIGN(ApiBuilder);
 
   pir::IrContext* ctx_;
   std::shared_ptr<pir::Builder> builder_;

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -24,7 +24,7 @@ namespace dialect {
 
 pir::OpResult builtin_combine(const std::vector<pir::Value>& x) {
   auto combine_op =
-      APIBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(x);
+      ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(x);
   return combine_op.out();
 }
 
@@ -33,7 +33,7 @@ std::vector<pir::OpResult> add_n_grad(const std::vector<pir::Value>& inputs,
   std::vector<pir::OpResult> inputs_grad;
   for (size_t i = 0; i < inputs.size(); i++) {
     paddle::dialect::ScaleOp scale_op =
-        APIBuilder::Instance().GetBuilder()->Build<paddle::dialect::ScaleOp>(
+        ApiBuilder::Instance().GetBuilder()->Build<paddle::dialect::ScaleOp>(
             out_grad, 1.0, 0.0, true);
     inputs_grad.push_back(scale_op.result(0));
   }
@@ -47,9 +47,9 @@ pir::OpResult zeros_like(const pir::Value& x,
 }
 
 pir::OpResult get_parameter(const std::string& name) {
-  pir::Parameter* param = APIBuilder::Instance().GetParameter(name);
+  pir::Parameter* param = ApiBuilder::Instance().GetParameter(name);
   pir::GetParameterOp get_parameter_op =
-      APIBuilder::Instance().GetBuilder()->Build<pir::GetParameterOp>(
+      ApiBuilder::Instance().GetBuilder()->Build<pir::GetParameterOp>(
           name, param->type());
   return get_parameter_op.result(0);
 }
@@ -57,8 +57,8 @@ pir::OpResult get_parameter(const std::string& name) {
 void set_parameter(const pir::Value& parameter, const std::string& name) {
   std::unique_ptr<pir::Parameter> param(
       new pir::Parameter(nullptr, 0, parameter.type()));
-  APIBuilder::Instance().SetParameter(name, std::move(param));
-  APIBuilder::Instance().GetBuilder()->Build<pir::SetParameterOp>(parameter,
+  ApiBuilder::Instance().SetParameter(name, std::move(param));
+  ApiBuilder::Instance().GetBuilder()->Build<pir::SetParameterOp>(parameter,
                                                                   name);
 }
 
@@ -84,9 +84,9 @@ pir::OpResult embedding_grad(const pir::Value& x,
 pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
                                   int axis) {
   auto out_grad_combine_op =
-      APIBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(out_grad);
+      ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(out_grad);
   paddle::dialect::SplitGradOp split_grad_op =
-      APIBuilder::Instance().GetBuilder()->Build<paddle::dialect::SplitGradOp>(
+      ApiBuilder::Instance().GetBuilder()->Build<paddle::dialect::SplitGradOp>(
           out_grad_combine_op.out(), axis);
   return split_grad_op.result(0);
 }
@@ -94,9 +94,9 @@ pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
 pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
                                   const pir::Value& axis) {
   auto out_grad_combine_op =
-      APIBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(out_grad);
+      ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(out_grad);
   paddle::dialect::SplitGradOp split_grad_op =
-      APIBuilder::Instance().GetBuilder()->Build<paddle::dialect::SplitGradOp>(
+      ApiBuilder::Instance().GetBuilder()->Build<paddle::dialect::SplitGradOp>(
           out_grad_combine_op.out(), axis);
   return split_grad_op.result(0);
 }

--- a/paddle/fluid/pir/drr/drr_rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/drr_rewrite_pattern.cc
@@ -413,7 +413,7 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
           src_match_ctx.Operation(source_pattern_graph.owned_op_call()[0].get())
               .get();
       max_input_op_index = op_2_temp_program_index[source_patter_first_op];
-      rewriter.SetInsertionPoint(source_patter_first_op);
+      rewriter.set_insertion_point(source_patter_first_op);
     } else {
       rewriter.SetInsertionPointAfter(max_index_op);
     }

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -65,7 +65,7 @@
 #endif
 
 namespace py = pybind11;
-using paddle::dialect::APIBuilder;
+using paddle::dialect::ApiBuilder;
 using paddle::dialect::DenseTensorType;
 using paddle::dialect::SelectedRowsType;
 using pir::Attribute;
@@ -1300,13 +1300,20 @@ void BindUtils(pybind11::module *m) {
   m->def("fake_op_result", FakeOpResult);
   m->def("is_fake_op_result", IsFakeOpResult);
   m->def("set_global_program",
-         [](Program *program) { APIBuilder::Instance().SetProgram(program); });
+         [](Program *program) { ApiBuilder::Instance().SetProgram(program); });
+  m->def(
+      "cur_insertion_point",
+      []() { return ApiBuilder::Instance().insertion_point(); },
+      return_value_policy::reference);
+  m->def("set_insertion_point", [](const pir::InsertionPoint &insertion_point) {
+    ApiBuilder::Instance().set_insertion_point(insertion_point);
+  });
   m->def("set_insertion_point",
-         [](Operation *op) { APIBuilder::Instance().SetInsertionPoint(op); });
+         [](Operation *op) { ApiBuilder::Instance().set_insertion_point(op); });
   m->def("reset_insertion_point_to_start",
-         []() { APIBuilder::Instance().ResetInsertionPointToStart(); });
+         []() { ApiBuilder::Instance().ResetInsertionPointToStart(); });
   m->def("reset_insertion_point_to_end",
-         []() { APIBuilder::Instance().ResetInsertionPointToEnd(); });
+         []() { ApiBuilder::Instance().ResetInsertionPointToEnd(); });
   m->def("register_paddle_dialect", []() {
     pir::IrContext::Instance()
         ->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();

--- a/paddle/pir/core/builder.cc
+++ b/paddle/pir/core/builder.cc
@@ -33,8 +33,8 @@ Operation *Builder::Build(const std::vector<Value> &inputs,
 }
 
 Operation *Builder::Insert(Operation *op) {
-  if (insert_point_.first) {
-    insert_point_.first->insert(insert_point_.second, op);
+  if (insertion_point_.first) {
+    insertion_point_.first->insert(insertion_point_.second, op);
   } else {
     LOG(WARNING) << "Builder's Block is nullptr, insert failed.";
   }

--- a/paddle/pir/core/builder.h
+++ b/paddle/pir/core/builder.h
@@ -44,7 +44,7 @@ class Int64Attribute;
 class ArrayAttribute;
 class PointerAttribute;
 
-using InsertPoint = std::pair<Block *, Block::Iterator>;
+using InsertionPoint = std::pair<Block *, Block::Iterator>;
 ///
 /// \brief Unified interface of the Attribute class. Derivation of all Attribute
 /// classes only derives interfaces, not members.
@@ -52,7 +52,7 @@ using InsertPoint = std::pair<Block *, Block::Iterator>;
 class Builder {
  public:
   Builder(IrContext *context, Block *block, Block::Iterator insert_point)
-      : context_(context), insert_point_(block, insert_point) {}
+      : context_(context), insertion_point_(block, insert_point) {}
 
   Builder(IrContext *context, Block *block)
       : Builder(context, block, block->end()) {}
@@ -60,46 +60,46 @@ class Builder {
   explicit Builder(IrContext *context)
       : Builder(context, nullptr, Block::Iterator{}) {}
 
-  Builder(IrContext *context, const InsertPoint &insert_point)
-      : context_(context), insert_point_(insert_point) {}
+  Builder(IrContext *context, const InsertionPoint &insert_point)
+      : context_(context), insertion_point_(insert_point) {}
 
-  void SetInsertionPoint(const InsertPoint &insert_point) {
-    insert_point_ = insert_point;
+  void set_insertion_point(const InsertionPoint &insert_point) {
+    insertion_point_ = insert_point;
   }
 
   /// Set the insert point to the start of the specified block.
   void SetInsertionPointToStart(Block *block) {
-    SetInsertionPoint(block, block->begin());
+    set_insertion_point(block, block->begin());
   }
 
   /// Set the insertion point to the specified location.
-  void SetInsertionPoint(Block *block, Block::Iterator insert_point) {
-    insert_point_.first = block;
-    insert_point_.second = insert_point;
+  void set_insertion_point(Block *block, Block::Iterator insert_point) {
+    insertion_point_.first = block;
+    insertion_point_.second = insert_point;
   }
 
   /// Set the insertion point to the specified operation, which will cause
   /// subsequent insertions to go right before it.
-  void SetInsertionPoint(Operation *op) {
-    SetInsertionPoint(op->GetParent(), Block::Iterator{*op});
+  void set_insertion_point(Operation *op) {
+    set_insertion_point(op->GetParent(), Block::Iterator{*op});
   }
 
   /// Set the insertion point to the node after the specified operation, which
   /// will cause subsequent insertions to go right after it.
   void SetInsertionPointAfter(Operation *op) {
-    SetInsertionPoint(op->GetParent(), std::next(Block::Iterator{*op}));
+    set_insertion_point(op->GetParent(), std::next(Block::Iterator{*op}));
   }
 
   /// Set the insertion point to the end of the specified block.
   void SetInsertionPointToEnd(Block *block) {
-    SetInsertionPoint(block, block->end());
+    set_insertion_point(block, block->end());
   }
 
   IrContext *ir_context() const { return context_; }
 
-  Block *block() const { return insert_point_.first; }
+  Block *block() const { return insertion_point_.first; }
 
-  const InsertPoint &insert_point() const { return insert_point_; }
+  const InsertionPoint &insertion_point() const { return insertion_point_; }
 
   /// Creates an operation given the fields represented as an OperationState.
   IR_API Operation *Build(OperationArgument &&argument);
@@ -142,7 +142,7 @@ class Builder {
 
   IrContext *context_;
 
-  InsertPoint insert_point_;
+  InsertionPoint insertion_point_;
 };
 
 template <typename OpTy, typename... Args>

--- a/paddle/pir/pattern_rewrite/pattern_applicator.cc
+++ b/paddle/pir/pattern_rewrite/pattern_applicator.cc
@@ -102,7 +102,7 @@ bool PatternApplicator::MatchAndRewrite(
 
     if (can_apply && !can_apply(*best_pattern)) continue;
 
-    rewriter.SetInsertionPoint(op);
+    rewriter.set_insertion_point(op);
 
     const auto* pattern = static_cast<const RewritePattern*>(best_pattern);
     result = pattern->MatchAndRewrite(op, rewriter);

--- a/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
@@ -221,7 +221,7 @@ class RedundantTransposeFusePattern
       IR_ENFORCE(axis_first.size() == axis_last.size(),
                  "tranpose op's perm rank should be same.");
       auto new_perm = GetPerm(axis_first, axis_last);
-      rewriter.SetInsertionPoint(op);
+      rewriter.set_insertion_point(op);
       auto new_transpose_op = rewriter.Build<paddle::dialect::TransposeOp>(
           pir::GetDefiningOpForInput(prev_trans_op, 0)->result(0), new_perm);
       rewriter.ReplaceOp(op, {new_transpose_op.out()});
@@ -291,7 +291,7 @@ class Conv2dBnFusePattern
     pir::Value bn_bias = op.bias();
 
     // --- deal with filter ---
-    rewriter.SetInsertionPoint(op);
+    rewriter.set_insertion_point(op);
     phi::DDim bn_variance_shape =
         bn_variance.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
     float epsilon = op.attribute<pir::FloatAttribute>("epsilon").data();

--- a/test/cpp/prim/test_vjp.cc
+++ b/test/cpp/prim/test_vjp.cc
@@ -56,10 +56,10 @@ TEST(VJP, TanhBackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
   paddle::dialect::TanhOp op2 =
@@ -111,10 +111,10 @@ TEST(VJP, Tanh_BackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1}, 1.0, phi::DataType::FLOAT32, phi::CPUPlace());
   paddle::dialect::Tanh_Op op2 =
@@ -167,10 +167,10 @@ TEST(VJP, MeanBackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{2, 2}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
   paddle::dialect::MeanOp op2 =
@@ -225,10 +225,10 @@ TEST(VJP, ConcatBackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1, 2}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
   std::vector<pir::Value> combine_input{{op1.out(), op1.out()}};
@@ -292,10 +292,10 @@ TEST(VJP, AddBackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
   paddle::dialect::FullOp op2 = builder->Build<paddle::dialect::FullOp>(
@@ -357,10 +357,10 @@ TEST(VJP, Add_BackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
   paddle::dialect::FullOp op2 = builder->Build<paddle::dialect::FullOp>(
@@ -423,10 +423,10 @@ TEST(VJP, SplitBackwardTest) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
   pir::Program program((ctx));
-  paddle::dialect::APIBuilder::Instance().SetProgram(&program);
+  paddle::dialect::ApiBuilder::Instance().SetProgram(&program);
 
   std::shared_ptr<pir::Builder> builder =
-      paddle::dialect::APIBuilder::Instance().GetBuilder();
+      paddle::dialect::ApiBuilder::Instance().GetBuilder();
   paddle::dialect::FullOp op1 = builder->Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{2, 2}, 2.0, phi::DataType::FLOAT32, phi::CPUPlace());
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

 Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others
### Description
<!-- Describe what you’ve done -->
1. 规范了pir中insertion_point的命名。
2. 微调了APIBuilder的实现,并将其归范围ApiBuilder。
3. 新增了**cur_insertion_point** 和 **set_insertion_point**这两个python api。

### Todo
支持if算子的python api组网。

### Other
Pcard-67164
