### PR TITLE
[SOT] Fix `LOAD_METHOD` stack layout when bound instance override the `__getattr__`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -777,8 +777,11 @@ class OpcodeExecutorBase:
             getattr, graph=self._graph, tracker=DanglingTracker()
         )(obj, method_name_var)
 
-        if isinstance(method, MethodVariable):
-            # bound method, push the unbound method and the self
+        if isinstance(method, MethodVariable) and "__getattr__" not in dir(
+            method.bound_instance.get_py_type()
+        ):
+            # bound method or the class override the __getattr__
+            # push the unbound method and the self
             self.stack.push(method.fn)
             self.stack.push(obj)
         else:

--- a/test/sot/test_min_graph_size.py
+++ b/test/sot/test_min_graph_size.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# GET_ITER (new)
-# FOR_ITER (new)
-
 from __future__ import annotations
 
 import unittest
@@ -62,6 +59,14 @@ def case_all(x, vars):
     return x
 
 
+class CustomLayer(paddle.nn.Layer):
+    def forward(self, x):
+        return self.forward_features(x)
+
+    def forward_features(self, x):
+        return x.numpy()
+
+
 class TestMinGraphSize(TestCaseBase):
     @min_graph_size_guard(10)
     def test_cases(self):
@@ -70,6 +75,12 @@ class TestMinGraphSize(TestCaseBase):
         self.assert_results(case_if, x)
         self.assert_results(case_call, x)
         self.assert_results(case_all, x, [4, 5, 6])
+
+    @min_graph_size_guard(10)
+    def test_layer(self):
+        x = paddle.to_tensor(1)
+        layer = CustomLayer()
+        self.assert_results(layer.forward, x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复在 `LOAD_METHOD` 模拟执行时与 Python 行为不一致的问题

当 `LOAD_METHOD` 的实例对象类上重载了 `__getattr__` 时，method 并不会按照 `func | self | arg1 | arg2 | ... | argN`（左侧为栈底）的「method」布局，而是按照 `NULL | method | arg1 | arg2 | ... | argN` 的「function」布局，因此模拟执行与真实执行会有一点 diff，在生成代码将栈上 Variable 恢复的时候可能出问题

Python 3.8 的处理代码见：

https://github.com/python/cpython/blob/c1c6bedfd3ee66ad208e0cd9cdd732374c95b83d/Objects/object.c#L1149-L1153

`Layer` 本身重载了 `__getattr__`，因此用户继承的自定义类上的方法都会有这个问题，比如

```python
class MyLayer(paddle.nn.Layer):
    def __init__(self):
        ...

    def forward_features(self, x):
        return x.numpy()

    def forward(self, x):
        return self.forward_features(x)
```

这里的 `self.forward_features(x)` 的 LOAD_METHOD 会因为 `Layer` 重载了 `__getattr__` 而变成 `NULL | self.forward_features` 而不是 `MyLayer.forward_features | self`，此时发生 Fallback 而生成的代码就有可能出问题（最新的 fallback 会生成代码），因为模拟执行并不知道有一个 NULL，因此恢复时候将该 NULL STORE_FAST 到一个 local var，之后 LOAD 时候就会报错

因此按照类似 Python 的处理方式，当用户重载了 `__getattr__` 时，同样认为它是「function」layout

PCard-66972