### PR TITLE
[BugFix]Close cub in CUDA12

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1103,6 +1103,14 @@ void ReduceKernel(const KPDevice& dev_ctx,
   }
 #endif
 
+  // NOTE(YuanRisheng): hot fix
+  // cuda 12.0 + cub got wrong result in some shapes when build phi with shared
+  // library. For example, paddle.sum(paddle.ones([1024,100],
+  // dtype=paddle.float32)) is expected to 102400, but got 0.
+#ifdef PHI_SHARED&& CUDA_VERSION >= 12000
+  use_cub_reduce = false;
+#endif
+
   auto reducer = ReduceOp<MPType>();
   // launch ReduceHigherDimKernel
   // when reduce_dim.size() == 1 and reduce_dim[0] != x_dim.size() - 1, this

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1100,8 +1100,10 @@ void ReduceKernel(const KPDevice& dev_ctx,
   // cuda 12.0 + cub got wrong result in some shapes when build phi with shared
   // library. For example, paddle.sum(paddle.ones([1024,100],
   // dtype=paddle.float32)) is expected to 102400, but got 0.
-#ifdef PHI_SHARED&& CUDA_VERSION >= 12000
+#ifdef PHI_SHARED
+#if CUDA_VERSION >= 12000
   use_cub_reduce = false;
+#endif
 #endif
 
 #ifndef PADDLE_WITH_XPU_KP


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
cub库的reduce方法在cuda12下会存在计算结果异常，这里在cuda12下关闭cub库的使用