### PR TITLE
[oneDNN] Add test case for optional scale/bias of BatchNorm

### DIFF
--- a/test/legacy_test/test_batch_norm_op.py
+++ b/test/legacy_test/test_batch_norm_op.py
@@ -432,22 +432,9 @@ class TestBatchNormOpInference(unittest.TestCase):
             fetch_list=[y_tensor],
         )[0]
 
-        # When op is called without Executor then
-        # MKL-DNN Tensor is returned. For NHWC data layout
-        # dims will be in NCHW order as it is MKL-DNN way
-        # of memory descripting. So we need to convert NCHW
-        # dims into NHWC.
-        if data_layout == "NHWC" and self.use_mkldnn:
-            # Create executor to have MKL-DNN cache
-            # cleared after NHWC unit test
-            place = core.CPUPlace()
-            exe = base.Executor(place)
-            dims = y_tensor.shape()
-            c = dims.pop(1)
-            dims.append(c)
-            y_tensor._set_dims(dims)
-
         # check inference result
+        # since op is called by Executor, there is
+        # no need to transform y_tensor when data layout is "NHWC"
         atol = 1e-3
         if dtype == np.uint16:
             y_tensor = convert_uint16_to_float(y_tensor)

--- a/test/mkldnn/test_batch_norm_mkldnn_op.py
+++ b/test/mkldnn/test_batch_norm_mkldnn_op.py
@@ -136,6 +136,8 @@ class TestMKLDNNBatchNormOpInference(TestBatchNormOpInference):
         place = core.CPUPlace()
         data_format = "NCHW"
         self.check_with_place(place, data_format, self.dtype, [2, 3, 4, 5])
+        self.check_with_place_without_scale_and_bias(
+                    place, data_format, self.dtype, [2, 3, 4, 5])
 
 
 class TestMKLDNNBatchNormOpInference_NHWC(TestMKLDNNBatchNormOpInference):
@@ -143,6 +145,8 @@ class TestMKLDNNBatchNormOpInference_NHWC(TestMKLDNNBatchNormOpInference):
         place = core.CPUPlace()
         data_format = "NHWC"
         self.check_with_place(place, data_format, self.dtype, [2, 4, 5, 3])
+        self.check_with_place_without_scale_and_bias(
+                    place, data_format, self.dtype, [2, 4, 5, 3])
 
 
 class TestMKLDNNBatchNormOpWithReluInference(TestBatchNormOpInference):

--- a/test/mkldnn/test_batch_norm_mkldnn_op.py
+++ b/test/mkldnn/test_batch_norm_mkldnn_op.py
@@ -137,7 +137,8 @@ class TestMKLDNNBatchNormOpInference(TestBatchNormOpInference):
         data_format = "NCHW"
         self.check_with_place(place, data_format, self.dtype, [2, 3, 4, 5])
         self.check_with_place_without_scale_and_bias(
-                    place, data_format, self.dtype, [2, 3, 4, 5])
+            place, data_format, self.dtype, [2, 3, 4, 5]
+        )
 
 
 class TestMKLDNNBatchNormOpInference_NHWC(TestMKLDNNBatchNormOpInference):
@@ -146,7 +147,8 @@ class TestMKLDNNBatchNormOpInference_NHWC(TestMKLDNNBatchNormOpInference):
         data_format = "NHWC"
         self.check_with_place(place, data_format, self.dtype, [2, 4, 5, 3])
         self.check_with_place_without_scale_and_bias(
-                    place, data_format, self.dtype, [2, 4, 5, 3])
+            place, data_format, self.dtype, [2, 4, 5, 3]
+        )
 
 
 class TestMKLDNNBatchNormOpWithReluInference(TestBatchNormOpInference):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Add test cases for validating optional scale/bias of BatchNorm from oneDNN side.
