### PR TITLE
[Dy2St][AMP] Support local enable the `auto_cast`

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import collections
 import copy
 import functools
@@ -26,6 +28,7 @@ import traceback
 import warnings
 from collections.abc import Iterable
 from types import FunctionType, MethodType
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -38,6 +41,9 @@ from .proto import data_feed_pb2  # noqa: F401
 from .proto import framework_pb2
 from .variable_index import _getitem_static, _setitem_impl_, _setitem_static
 from .wrapped_decorator import signature_safe_contextmanager, wrap_decorator
+
+if TYPE_CHECKING:
+    from paddle.static.amp.fp16_utils import AmpOptions
 
 __all__ = []
 
@@ -2935,8 +2941,11 @@ class Operator:
             # attr for static graph mode cuda graph
             self._cuda_graph_attr = _current_cuda_graph_mode
 
-            # attr for OP should cast in AMP mode
-            self._should_auto_cast: bool = True
+            # attr for OP AMP mode
+            # using dynamic import to avoid cyclic dependency
+            from paddle.static.amp.fp16_utils import DEFAULT_AMP_OPTIONS
+
+            self._amp_options: AmpOptions = DEFAULT_AMP_OPTIONS
 
             op_maker = core.op_proto_and_checker_maker
 
@@ -3695,24 +3704,24 @@ class Operator:
         """
         self.desc.dist_attr = dist_attr
 
-    def set_auto_cast(self, auto_cast):
+    def set_amp_options(self, amp_options):
         """
         Set auto cast attribute of this Operator.
 
         Args:
-            auto_cast(bool): True if this Operator should cast in AMP mode.
+            amp_options (AmpOptions): AmpOptions of this Operator.
         """
-        self._should_auto_cast = auto_cast
+        self._amp_options = amp_options
 
     @property
-    def should_auto_cast(self):
+    def amp_options(self):
         """
         Get auto cast attribute of this Operator.
 
         Returns:
-            bool: True if this Operator should cast in AMP mode.
+            bool: AmpOptions of this Operator.
         """
-        return self._should_auto_cast
+        return self._amp_options
 
 
 @signature_safe_contextmanager
@@ -6985,7 +6994,7 @@ class Program:
                 if other_var.stop_gradient:
                     var.stop_gradient = True
 
-    def _copy_operator_info_from(self, other: "Program"):
+    def _copy_operator_info_from(self, other: Program):
         """
         Copy the information of Operator information from other program.
 
@@ -7001,7 +7010,7 @@ class Program:
             )
         for dst_block, src_block in zip(self.blocks, other.blocks):
             for dst_op, src_op in zip(dst_block.ops, src_block.ops):
-                dst_op.set_auto_cast(src_op.should_auto_cast)
+                dst_op.set_amp_options(src_op.amp_options)
 
     def list_vars(self):
         """

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from contextlib import contextmanager
 
 import paddle
@@ -822,6 +823,11 @@ def convert_auto_cast(
     use_promote=True,
 ):
     from .program_translator import ProgramTranslator
+
+    warnings.warn(
+        "paddle.amp.auto_cast is an experimental features in auto parallel."
+        + "This will take no effect in normal dy2static."
+    )
 
     amp_records = ProgramTranslator.get_instance()._amp_records
     main_program = paddle.static.default_main_program()

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -823,9 +823,6 @@ def convert_auto_cast(
 ):
     from .program_translator import ProgramTranslator
 
-    if enable:
-        raise NotImplementedError("Does not support local switching on amp now")
-
     amp_records = ProgramTranslator.get_instance()._amp_records
     main_program = paddle.static.default_main_program()
     current_block_idx = main_program.current_block_idx

--- a/test/dygraph_to_static/test_decorator_transform.py
+++ b/test/dygraph_to_static/test_decorator_transform.py
@@ -23,6 +23,7 @@ from dygraph_to_static_utils_new import (
     Dy2StTestBase,
     test_ast_only,
     test_legacy_and_pir,
+    test_legacy_and_pir_exe_and_pir_api,
 )
 
 import paddle
@@ -180,13 +181,12 @@ def fun10():
     return True
 
 
-@paddle.jit.to_static
 def deco_with_paddle_api():
     return fun10()
 
 
 class TestDecoratorTransform(Dy2StTestBase):
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test_deco_transform(self):
         outs = paddle.jit.to_static(forward)()
         np.testing.assert_allclose(outs[0], np.array(3), rtol=1e-05)
@@ -217,7 +217,7 @@ class TestDecoratorTransform(Dy2StTestBase):
 
     @test_legacy_and_pir
     def test_deco_with_paddle_api(self):
-        self.assertTrue(deco_with_paddle_api())
+        self.assertTrue(paddle.jit.to_static(deco_with_paddle_api)())
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_decorator_transform.py
+++ b/test/dygraph_to_static/test_decorator_transform.py
@@ -23,7 +23,6 @@ from dygraph_to_static_utils_new import (
     Dy2StTestBase,
     test_ast_only,
     test_legacy_and_pir,
-    test_legacy_and_pir_exe_and_pir_api,
 )
 
 import paddle
@@ -181,12 +180,13 @@ def fun10():
     return True
 
 
+@paddle.jit.to_static
 def deco_with_paddle_api():
     return fun10()
 
 
 class TestDecoratorTransform(Dy2StTestBase):
-    @test_legacy_and_pir_exe_and_pir_api
+    @test_legacy_and_pir
     def test_deco_transform(self):
         outs = paddle.jit.to_static(forward)()
         np.testing.assert_allclose(outs[0], np.array(3), rtol=1e-05)
@@ -217,7 +217,7 @@ class TestDecoratorTransform(Dy2StTestBase):
 
     @test_legacy_and_pir
     def test_deco_with_paddle_api(self):
-        self.assertTrue(paddle.jit.to_static(deco_with_paddle_api)())
+        self.assertTrue(deco_with_paddle_api())
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_local_cast.py
+++ b/test/dygraph_to_static/test_local_cast.py
@@ -18,7 +18,21 @@ import unittest
 
 import paddle
 from paddle.jit.dy2static.program_translator import ProgramTranslator
-from paddle.static.amp.fp16_utils import prepare_op_should_auto_cast
+from paddle.static.amp.fp16_utils import (
+    DEFAULT_AMP_OPTIONS,
+    AmpOptions,
+    prepare_op_amp_options,
+)
+
+GLOBAL_ENABLE_AMP_OPTIONS = DEFAULT_AMP_OPTIONS
+GLOBAL_DISABLE_AMP_OPTIONS = AmpOptions(
+    enable=False,
+    custom_black_list=DEFAULT_AMP_OPTIONS.custom_black_list,
+    custom_white_list=DEFAULT_AMP_OPTIONS.custom_white_list,
+    level=DEFAULT_AMP_OPTIONS.level,
+    dtype=DEFAULT_AMP_OPTIONS.dtype,
+    use_promote=DEFAULT_AMP_OPTIONS.use_promote,
+)
 
 
 class LocalAutoCastLayer1(paddle.nn.Layer):
@@ -62,6 +76,26 @@ class LocalAutoCastLayer2(paddle.nn.Layer):
         return x + 1
 
 
+class LocalAutoCastLayer3(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self._fc = paddle.nn.Linear(10, 10)
+
+    @paddle.jit.to_static(full_graph=True)
+    def forward(self, x):
+        with paddle.amp.auto_cast(True):
+            x = x.astype("float32")
+            x = self._fc(x)
+            y = self._fc(x) * 2
+        if x[0][0] > 1:
+            x = x + y
+        else:
+            x = x - y
+            x = x * 2
+
+        return x + 1
+
+
 class TestLocalCast(unittest.TestCase):
     def get_auto_cast_ops_info_from_program(self, program):
         auto_cast_ops_info = []
@@ -69,17 +103,20 @@ class TestLocalCast(unittest.TestCase):
             current_block_should_auto_cast = []
             auto_cast_ops_info.append(current_block_should_auto_cast)
             for op in block.ops:
-                current_block_should_auto_cast.append(op.should_auto_cast)
+                current_block_should_auto_cast.append(op.amp_options.enable)
         return auto_cast_ops_info
 
-    def should_auto_cast_for_each_ops(self, layer, input):
+    def should_auto_cast_for_each_ops(self, layer, input, global_amp_options):
         concrete_program, _ = layer.forward.get_concrete_program(input)
         program = concrete_program.main_program
-        prepare_op_should_auto_cast(
-            program, ProgramTranslator.get_instance()._amp_records
+        prepare_op_amp_options(
+            program,
+            ProgramTranslator.get_instance()._amp_records,
+            global_amp_options,
         )
         auto_cast_ops_info = self.get_auto_cast_ops_info_from_program(program)
         paddle.enable_static()
+        # Ensure the cloned program has the same auto_cast ops info
         cloned_program = program.clone()
         paddle.disable_static()
         cloned_auto_cast_ops_info = self.get_auto_cast_ops_info_from_program(
@@ -103,7 +140,9 @@ class TestLocalCast(unittest.TestCase):
             # All else branch in auto_cast(False) block
             [False, False, False],
         ]  # fmt: skip
-        actual = self.should_auto_cast_for_each_ops(layer, input)
+        actual = self.should_auto_cast_for_each_ops(
+            layer, input, GLOBAL_ENABLE_AMP_OPTIONS
+        )
         self.assertEqual(expected, actual)
 
     def test_should_auto_cast_2(self):
@@ -120,7 +159,29 @@ class TestLocalCast(unittest.TestCase):
             # All else branch out of auto_cast(False) block
             [True, True, True],
         ]  # fmt: skip
-        actual = self.should_auto_cast_for_each_ops(layer, input)
+        actual = self.should_auto_cast_for_each_ops(
+            layer, input, GLOBAL_ENABLE_AMP_OPTIONS
+        )
+        self.assertEqual(expected, actual)
+
+    def test_should_auto_cast_3(self):
+        layer = LocalAutoCastLayer3()
+        input = paddle.randn([10, 10])
+        expected = [
+            # There are part of ops in auto_cast(True) block
+            [
+                True, True, True, True, True, True,
+                False, False, False, False, False, False, False, False, False, False,
+            ],
+            # All if branch out of auto_cast(True) block
+            [False, False],
+            # All else branch out of auto_cast(True) block
+            [False, False, False],
+        ]  # fmt: skip
+        actual = self.should_auto_cast_for_each_ops(
+            layer, input, GLOBAL_DISABLE_AMP_OPTIONS
+        )
+
         self.assertEqual(expected, actual)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

在 #58628 基础上进行修改，支持了「局部开」的 AMP 策略

将 Operator 上的 `should_auto_cast: bool` 修改为拥有更多信息的 `amp_options: AmpOptions`，原来的 `op.should_auto_cast` 可通过 `op.amp_options.enable` 来访问，同样，`prepare_op_should_auto_cast` 也 rename 为 `prepare_op_amp_options`

因为原来假定了全局一定是启用 AMP 的，但对于「局部开」来说，全局应该是关的，因此在 `prepare_op_amp_options` 时需要额外传入全局的状态，可参考新增单测 `test_should_auto_cast_3` 即为「全局关局部开」的示例

PCard-66972