### PR TITLE
add MergedAdamKernel and test for MergedAdamKernel and fix adam caculation process in test

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -577,6 +577,7 @@ XPUOpMap& get_kl2_ops() {
       {"mean_grad",
        XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
       {"mean", XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
+      {"merged_adam", XPUKernelSet({phi::DataType::FLOAT32})},
       {"merged_momentum",
        XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
       {"mish_grad", XPUKernelSet({phi::DataType::FLOAT32})},

--- a/paddle/phi/kernels/xpu/adam_kernel.cc
+++ b/paddle/phi/kernels/xpu/adam_kernel.cc
@@ -240,6 +240,229 @@ void AdamDenseKernel(const Context& dev_ctx,
   funcs::FreeData<float>(moment2, mom2_ptr);
   funcs::FreeData<float>(learning_rate, lr_ptr);
 }
+
+template <typename T, typename Context>
+void MergedAdamKernel(
+    const Context& dev_ctx,
+    const std::vector<const DenseTensor*>& param,
+    const std::vector<const DenseTensor*>& grad,
+    const std::vector<const DenseTensor*>& learning_rate,
+    const std::vector<const DenseTensor*>& moment1,
+    const std::vector<const DenseTensor*>& moment2,
+    const std::vector<const DenseTensor*>& beta1_pow,
+    const std::vector<const DenseTensor*>& beta2_pow,
+    const paddle::optional<std::vector<const DenseTensor*>>& master_param,
+    const Scalar& beta1,
+    const Scalar& beta2,
+    const Scalar& epsilon,
+    bool multi_precision,
+    bool use_global_beta_pow,
+    std::vector<DenseTensor*> param_out,
+    std::vector<DenseTensor*> moment1_out,
+    std::vector<DenseTensor*> moment2_out,
+    std::vector<DenseTensor*> beta1_pow_out,
+    std::vector<DenseTensor*> beta2_pow_out,
+    std::vector<DenseTensor*> master_param_out) {
+  VLOG(4) << "use_global_beta_pow:" << use_global_beta_pow;
+
+  auto beta1_ = beta1.to<float>();
+  auto beta2_ = beta2.to<float>();
+  auto epsilon_ = epsilon.to<float>();
+  int64_t step_ = 0;
+  int64_t mode_ = 2;
+  int64_t bias_correction_ = 1;
+  float weight_decay_ = 0.0;
+
+  DenseTensor lr_host;
+  lr_host.Resize(learning_rate[0]->dims());
+  dev_ctx.template HostAlloc<float>(&lr_host);
+  phi::Copy(dev_ctx, *learning_rate[0], CPUPlace(), false, &lr_host);
+  float lr_ = *(lr_host.template data<float>());
+
+  float beta1_pow_data;
+  if (beta1_pow[0]->place() == CPUPlace()) {
+    beta1_pow_data = *(beta1_pow[0]->data<float>());
+  } else {
+    DenseTensor beta1_pow_host;
+    beta1_pow_host.Resize(beta1_pow[0]->dims());
+    dev_ctx.template HostAlloc<float>(&beta1_pow_host);
+    phi::Copy(dev_ctx, *beta1_pow[0], CPUPlace(), false, &beta1_pow_host);
+    beta1_pow_data = *(beta1_pow_host.template data<float>());
+  }
+
+  float beta2_pow_data;
+  if (beta2_pow[0]->place() == CPUPlace()) {
+    beta2_pow_data = *(beta2_pow[0]->data<float>());
+  } else {
+    DenseTensor beta2_pow_host;
+    beta2_pow_host.Resize(beta2_pow[0]->dims());
+    dev_ctx.template HostAlloc<float>(&beta2_pow_host);
+    phi::Copy(dev_ctx, *beta2_pow[0], CPUPlace(), false, &beta2_pow_host);
+    beta2_pow_data = *(beta2_pow_host.template data<float>());
+  }
+
+  int param_num = param.size();
+  PADDLE_ENFORCE_EQ(param_num,
+                    param_out.size(),
+                    errors::InvalidArgument(
+                        "The size of Output(ParamOut) must be equal to "
+                        "Input(Param), but got the size of Output(ParamOut) "
+                        "is %d, the size of Input(Param) is %d.",
+                        param_out.size(),
+                        param_num));
+  PADDLE_ENFORCE_EQ(
+      param_num,
+      moment1_out.size(),
+      errors::InvalidArgument(
+          "The size of Input(Moment1) must be equal to Input(Param), but got "
+          "the size of Input(Moment1) is %d, the size of Input(Param) is %d.",
+          moment1.size(),
+          param_num));
+  PADDLE_ENFORCE_EQ(
+      param_num,
+      moment2_out.size(),
+      errors::InvalidArgument(
+          "The size of Input(Moment1) must be equal to Input(Param), but got "
+          "the size of Input(Moment1) is %d, the size of Input(Param) is %d.",
+          moment2.size(),
+          param_num));
+  PADDLE_ENFORCE_EQ(param_num,
+                    beta1_pow_out.size(),
+                    errors::InvalidArgument(
+                        "The size of Output(Beta1PowOut) must be equal to "
+                        "Input(Param), but got the size of Output(Beta1PowOut) "
+                        "is %d, the size of Input(Param) is %d.",
+                        beta1_pow_out.size(),
+                        param_num));
+  PADDLE_ENFORCE_EQ(param_num,
+                    beta2_pow_out.size(),
+                    errors::InvalidArgument(
+                        "The size of Output(Beta2PowOut) must be equal to "
+                        "Input(Param), but got the size of Output(Beta2PowOut) "
+                        "is %d, the size of Input(Param) is %d.",
+                        beta2_pow_out.size(),
+                        param_num));
+  PADDLE_ENFORCE_EQ(
+      param_num,
+      grad.size(),
+      errors::InvalidArgument(
+          "The size of Input(Grad) must be equal to Input(Param), but got "
+          "the size of Input(Grad) is %d, the size of Input(Param) is %d.",
+          grad.size(),
+          param_num));
+  PADDLE_ENFORCE_EQ(
+      param_num,
+      moment1.size(),
+      errors::InvalidArgument(
+          "The size of Input(Moment1) must be equal to Input(Param), but got "
+          "the size of Input(Moment1) is %d, the size of Input(Param) is %d.",
+          moment1.size(),
+          param_num));
+  PADDLE_ENFORCE_EQ(
+      param_num,
+      moment2.size(),
+      errors::InvalidArgument(
+          "The size of Input(Moment1) must be equal to Input(Param), but got "
+          "the size of Input(Moment1) is %d, the size of Input(Param) is %d.",
+          moment2.size(),
+          param_num));
+
+  std::vector<float*> param_list(param_num);
+  std::vector<float*> grad_list(param_num);
+  std::vector<float*> moment1_list(param_num);
+  std::vector<float*> moment2_list(param_num);
+  std::vector<int64_t> shape_list(param_num);
+
+  for (int j = 0; j < param_num; j++) {
+    param_list[j] = const_cast<float*>(param[j]->data<float>());
+    grad_list[j] = const_cast<float*>(grad[j]->data<float>());
+    moment1_list[j] = const_cast<float*>(moment1[j]->data<float>());
+    moment2_list[j] = const_cast<float*>(moment2[j]->data<float>());
+    shape_list[j] = param[j]->numel();
+
+    PADDLE_ENFORCE_EQ(
+        param[j],
+        param_out[j],
+        errors::InvalidArgument("The size of Input(Param) and Output(ParamOut) "
+                                "must be the same Tensors."));
+    PADDLE_ENFORCE_EQ(
+        moment1[j],
+        moment1_out[j],
+        errors::InvalidArgument("The size of Input(Param) and Output(ParamOut) "
+                                "must be the same Tensors."));
+    PADDLE_ENFORCE_EQ(
+        moment2[j],
+        moment2_out[j],
+        errors::InvalidArgument("The size of Input(Param) and Output(ParamOut) "
+                                "must be the same Tensors."));
+
+    dev_ctx.template Alloc<float>(param_out[j]);
+    dev_ctx.template Alloc<float>(moment1_out[j]);
+    dev_ctx.template Alloc<float>(moment2_out[j]);
+  }
+
+  int r = xpu::multi_tensor_adam(dev_ctx.x_context(),
+                                 grad_list,
+                                 param_list,
+                                 moment1_list,
+                                 moment2_list,
+                                 shape_list,
+                                 lr_,
+                                 beta1_,
+                                 beta2_,
+                                 epsilon_,
+                                 step_,
+                                 mode_,
+                                 bias_correction_,
+                                 weight_decay_,
+                                 beta1_pow_data,
+                                 beta2_pow_data);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "merged_adam");
+
+  // update param, moment1, moment2
+  for (int i = 0; i < param_num; i++) {
+    phi::Copy(dev_ctx, *param[i], dev_ctx.GetPlace(), false, param_out[i]);
+    phi::Copy(dev_ctx, *moment1[i], dev_ctx.GetPlace(), false, moment1_out[i]);
+    phi::Copy(dev_ctx, *moment2[i], dev_ctx.GetPlace(), false, moment2_out[i]);
+  }
+
+  if (!use_global_beta_pow) {
+    for (int i = 0; i < param_num; i++) {
+      if (beta1_pow[i]->place() == CPUPlace() &&
+          beta2_pow[i]->place() == CPUPlace()) {
+        funcs::SetBetaData<Context, float>(
+            *beta1_pow[i], beta1_pow_out[i], beta1_, dev_ctx);
+
+        funcs::SetBetaData<Context, float>(
+            *beta2_pow[i], beta2_pow_out[i], beta2_, dev_ctx);
+      } else {
+        float* beta1_pow_out_ptr = nullptr;
+        const float* beta1_pow_data = beta1_pow[i]->data<float>();
+        beta1_pow_out_ptr = dev_ctx.template Alloc<float>(beta1_pow_out[i]);
+        r = xpu::scale(dev_ctx.x_context(),
+                       beta1_pow_data,
+                       beta1_pow_out_ptr,
+                       beta1_pow[i]->numel(),
+                       false,
+                       beta1_,
+                       0.0f);
+        PADDLE_ENFORCE_XDNN_SUCCESS(r, "merged_adam");
+
+        float* beta2_pow_out_ptr = nullptr;
+        const float* beta2_pow_data = beta2_pow[i]->data<float>();
+        beta2_pow_out_ptr = dev_ctx.template Alloc<float>(beta2_pow_out[i]);
+        r = xpu::scale(dev_ctx.x_context(),
+                       beta2_pow_data,
+                       beta2_pow_out_ptr,
+                       beta2_pow[i]->numel(),
+                       false,
+                       beta2_,
+                       0.0f);
+        PADDLE_ENFORCE_XDNN_SUCCESS(r, "merged_adam");
+      }
+    }
+  }
+}
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
@@ -249,6 +472,14 @@ PD_REGISTER_KERNEL(
   kernel->InputAt(6).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(8).SetBackend(phi::Backend::ALL_BACKEND);
 
+  kernel->OutputAt(3).SetBackend(phi::Backend::UNDEFINED);
+  kernel->OutputAt(4).SetBackend(phi::Backend::UNDEFINED);
+}
+
+PD_REGISTER_KERNEL(merged_adam, XPU, ALL_LAYOUT, phi::MergedAdamKernel, float) {
+  // Skip beta1_pow, beta2_pow data transform
+  kernel->InputAt(5).SetBackend(phi::Backend::ALL_BACKEND);
+  kernel->InputAt(6).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->OutputAt(3).SetBackend(phi::Backend::UNDEFINED);
   kernel->OutputAt(4).SetBackend(phi::Backend::UNDEFINED);
 }

--- a/test/xpu/test_adam_op_xpu.py
+++ b/test/xpu/test_adam_op_xpu.py
@@ -271,7 +271,9 @@ def adam_step(inputs, attributes):
     moment1_out = beta1 * moment1 + (1 - beta1) * grad
     moment2_out = beta2 * moment2 + (1 - beta2) * np.square(grad)
     lr_t = lr * np.sqrt(1 - beta2_pow) / (1 - beta1_pow)
-    param_out = param - lr_t * (moment1_out / (np.sqrt(moment2_out) + epsilon))
+    param_out = param - lr_t * (
+        moment1_out / (np.sqrt(moment2_out) + epsilon * np.sqrt(1 - beta2_pow))
+    )
     return param_out, moment1_out, moment2_out
 
 

--- a/test/xpu/test_merged_adam_op_xpu.py
+++ b/test/xpu/test_merged_adam_op_xpu.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from get_test_cover_info import (
+    XPUOpTestWrapper,
+    create_test_class,
+    get_xpu_op_support_types,
+)
+
+import paddle
+
+# from op import Operator
+# from op_test_xpu import XPUOpTest
+from paddle import _C_ops, _legacy_C_ops
+from paddle.base.framework import in_dygraph_mode
+
+
+def run_adam_op(
+    params,
+    grads,
+    lrs,
+    moment1s,
+    moment2s,
+    beta1_pows,
+    beta2_pows,
+    master_params,
+    epsilon,
+    beta1,
+    beta2,
+    place,
+    multi_precision=False,
+    use_merged=False,
+):
+    assert len(params) == len(grads)
+    assert len(params) == len(lrs)
+    assert len(params) == len(moment1s)
+    assert len(params) == len(moment2s)
+    assert len(params) == len(beta1_pows)
+    assert len(params) == len(beta1_pows)
+    assert len(params) == len(master_params)
+    paddle.disable_static()
+    paddle.set_device(place)
+
+    param_vars = [paddle.base.dygraph.to_variable(p) for p in params]
+    grad_vars = [paddle.base.dygraph.to_variable(g) for g in grads]
+    lr_vars = [paddle.base.dygraph.to_variable(l) for l in lrs]
+    moment1_vars = [paddle.base.dygraph.to_variable(m) for m in moment1s]
+    moment2_vars = [paddle.base.dygraph.to_variable(m) for m in moment2s]
+    beta1_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta1_pows]
+    beta2_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta2_pows]
+    master_param_vars = [
+        paddle.base.dygraph.to_variable(m_p) for m_p in master_params
+    ]
+
+    if not use_merged:
+        for i in range(len(param_vars)):
+            _, _, _, _, _, _ = _legacy_C_ops.adam(
+                param_vars[i],
+                grad_vars[i],
+                lr_vars[i],
+                moment1_vars[i],
+                moment2_vars[i],
+                beta1_pow_vars[i],
+                beta2_pow_vars[i],
+                master_param_vars[i],
+                param_vars[i],
+                moment1_vars[i],
+                moment2_vars[i],
+                beta1_pow_vars[i],
+                beta2_pow_vars[i],
+                master_param_vars[i],
+                'epsilon',
+                epsilon,
+                'beta1',
+                beta1,
+                'beta2',
+                beta2,
+                'multi_precision',
+                False,
+            )
+    else:
+        if in_dygraph_mode():
+            _, _, _, _, _, _ = _C_ops.merged_adam_(
+                param_vars,
+                grad_vars,
+                lr_vars,
+                moment1_vars,
+                moment2_vars,
+                beta1_pow_vars,
+                beta2_pow_vars,
+                master_param_vars,
+                beta1,
+                beta2,
+                epsilon,
+                False,
+                False,
+            )
+        else:
+            _, _, _, _, _, _ = _legacy_C_ops.merged_adam(
+                param_vars,
+                grad_vars,
+                lr_vars,
+                moment1_vars,
+                moment2_vars,
+                beta1_pow_vars,
+                beta2_pow_vars,
+                master_param_vars,
+                param_vars,
+                moment1_vars,
+                moment2_vars,
+                beta1_pow_vars,
+                beta2_pow_vars,
+                master_param_vars,
+                'epsilon',
+                epsilon,
+                'beta1',
+                beta1,
+                'beta2',
+                beta2,
+                'multi_precision',
+                multi_precision,
+            )
+
+    outputs = {
+        'ParamOut': param_vars,
+        'Moment1Out': moment1_vars,
+        'Moment2Out': moment2_vars,
+        'Beta1PowOut': beta1_pow_vars,
+        'Beta2PowOut': beta2_pow_vars,
+        'MasterParamOut': master_param_vars,
+    }
+
+    return outputs
+
+
+class XPUTestMergedAdamWrapper(XPUOpTestWrapper):
+    def __init__(self):
+        self.op_name = 'merged_adam'
+        self.use_dynamic_create_class = False
+
+    class XPUTestMergedAdamBase(unittest.TestCase):
+        def setUp(self):
+            self.shapes = [[3, 4], [2, 7], [5, 6], [7, 8]]
+            self.seed = 10
+
+        def gen_rand_data(self, shapes, dtype):
+            return [np.random.random(s).astype(dtype) for s in shapes]
+
+        def prepare_data(self, shapes, seed):
+            np.random.seed(seed)
+            mp_dtype = np.float32
+            dtype = np.float32
+            params = self.gen_rand_data(shapes, dtype)
+            grads = self.gen_rand_data(shapes, dtype)
+            learning_rate = self.gen_rand_data([[1]], mp_dtype)
+            lrs = [learning_rate.copy() for _ in shapes]
+            moment1s = self.gen_rand_data(shapes, mp_dtype)
+            moment2s = self.gen_rand_data(shapes, mp_dtype)
+            beta1_pow = self.gen_rand_data([[1]], mp_dtype)
+            beta2_pow = self.gen_rand_data([[1]], mp_dtype)
+            beta1_pows = [beta1_pow.copy() for _ in shapes]
+            beta2_pows = [beta2_pow.copy() for _ in shapes]
+            master_params = [p.astype(mp_dtype) for p in params]
+            return (
+                params,
+                grads,
+                lrs,
+                moment1s,
+                moment2s,
+                beta1_pows,
+                beta2_pows,
+                master_params,
+            )
+
+        def check_with_place(self):
+            (
+                params,
+                grads,
+                lrs,
+                moment1s,
+                moment2s,
+                beta1_pows,
+                beta2_pows,
+                master_params,
+            ) = self.prepare_data(self.shapes, self.seed)
+
+            def run_op(use_merged, place):
+                return run_adam_op(
+                    params=params,
+                    grads=grads,
+                    lrs=lrs,
+                    moment1s=moment1s,
+                    moment2s=moment2s,
+                    beta1_pows=beta1_pows,
+                    beta2_pows=beta2_pows,
+                    master_params=master_params,
+                    epsilon=0.9,
+                    beta1=0.9,
+                    beta2=0.99,
+                    place=place,
+                    multi_precision=False,
+                    use_merged=use_merged,
+                )
+
+            outs1 = run_op(True, "xpu")
+            outs2 = run_op(True, "cpu")
+            outs3 = run_op(False, "xpu")
+            outs4 = run_op(False, "cpu")
+
+            self.assertEqual(len(outs1), len(outs2))
+            self.assertEqual(len(outs1), len(outs3))
+            self.assertEqual(len(outs1), len(outs4))
+
+            for key in outs1.keys():
+                value1 = outs1[key]
+                value2 = outs2[key]
+                value3 = outs3[key]
+                value4 = outs4[key]
+                for i in range(len(value1)):
+                    np.testing.assert_allclose(
+                        value1[i], value2[i], rtol=1e-05, atol=1e-07
+                    )
+                    np.testing.assert_allclose(
+                        value1[i], value3[i], rtol=1e-05, atol=1e-07
+                    )
+                    np.testing.assert_allclose(
+                        value1[i], value4[i], rtol=1e-05, atol=1e-07
+                    )
+
+    class TestMergedAdamOp(XPUTestMergedAdamBase):
+        def setUp(self):
+            super().setUp()
+            self.set_case()
+
+        def set_case(self):
+            self.shapes = [[3, 4], [2, 7], [5, 6], [7, 8]]
+            self.seed = 10
+
+        def testalltype(self):
+            self.check_with_place()
+
+    class TestMergedAdam1(TestMergedAdamOp):
+        def set_case(self):
+            self.shapes = [[3, 4]]
+
+    class TestMergedAdam2(TestMergedAdamOp):
+        def set_case(self):
+            self.shapes = [[3, 4], [2, 7]]
+
+    class TestMergedAdam3(TestMergedAdamOp):
+        def set_case(self):
+            self.shapes = [[3, 4], [2, 4], [3, 4]]
+
+    class TestMergedAdam4(TestMergedAdamOp):
+        def set_case(self):
+            self.shapes = [[3, 4], [2, 7], [5, 6], [9, 9]]
+
+
+support_types = get_xpu_op_support_types('merged_adam')
+for stype in support_types:
+    create_test_class(globals(), XPUTestMergedAdamWrapper, stype)
+
+if __name__ == "__main__":
+    paddle.enable_static()
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
1. 新增mergedAdamKernel，该Kernel的主要目的是将param打包为一个vector后整体进行运算。Kernel单测结果分别和CPU中adam、mergedAdam以及XPU adam的结果进行比对。
2. 修正XPU adam单测中模拟的计算结果。
![image](https://github.com/PaddlePaddle/Paddle/assets/48877749/a5b0c9ca-1b36-4291-8de6-6adcbad4ab8c)
 