### PR TITLE
[PIR] Fix feed variable not found in program when Executor.run

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -1333,7 +1333,7 @@ class Executor:
             if feed_name not in feed_target_names:
                 feed.pop(feed_name)
                 warnings.warn(
-                    "The variable %s is not found in program. It is not declared or is pruned."
+                    "The value %s is not found in program. It is not declared or is pruned."
                     % feed_name
                 )
 

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -1309,10 +1309,12 @@ class Executor:
 
     def _pir_feed_data(self, program, feed, scope):
         # feed var to framework
+        feed_target_names = set()
         global_block = program.global_block()
         for op in global_block.ops:
             if op.name() == 'pd_op.data':
                 feed_target_name = op.attrs()["name"]
+                feed_target_names.add(feed_target_name)
                 var_type = paddle_type_to_proto_type[op.attrs()["dtype"]]
                 var_shape = op.attrs()["shape"]
                 cur_feed = feed[feed_target_name]
@@ -1325,6 +1327,15 @@ class Executor:
                 core.set_feed_variable(scope, cur_feed, feed_target_name, 0)
             else:
                 break
+
+        # pop variable which is not found in program
+        for feed_name in list(feed.keys()):
+            if feed_name not in feed_target_names:
+                feed.pop(feed_name)
+                warnings.warn(
+                    "The variable %s is not found in program. It is not declared or is pruned."
+                    % feed_name
+                )
 
     def _fetch_data(self, fetch_list, fetch_var_name, scope):
         outs = [


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
It raised RuntimeError “(NotFound) Cannot find prepend in scope”, when running below code:
```python
input = np.array([1, 4, 5, 2]).astype('float32')
with paddle.pir_utils.IrGuard():
  with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
      x = paddle.static.data(
          name="input", shape=[1, 4, 5, 2], dtype=np.float32
      )
      prepend = None
      append = None
  
      exe = base.Executor(place)
      out = paddle.diff(
          x, n=self.n, axis=self.axis, prepend=prepend, append=append
      )
      fetches = exe.run(
          feed={
              "input": input,
              "prepend": prepend,
              "append": append,
          },
          fetch_list=[out],
      )
``` 
It’s because we did not pop feed name which was not found in Program. This PR add the logic that pops feed variable not found in program before Executor running.
