### PR TITLE
[Hackathon 5th No.49][pir] add `OpResult.size` - Part 7

### DIFF
--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -324,9 +324,9 @@ def monkey_patch_opresult():
             >>> with paddle.static.program_guard(startup_prog, main_prog):
             ...     x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
             ...     (output_x,) = exe.run(main_program, fetch_list=[x.size()])
-            ...     print(f"new value's size is: {output_x}")
+            ...     print(f"value's size is: {output_x}")
             ...
-            new value's size is: 24
+            value's size is: 24
         """
         return paddle.numel(self)
 

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -180,7 +180,7 @@ def monkey_patch_opresult():
                 >>> with paddle.static.program_guard(startup_prog, main_prog):
                 ...     original_value = paddle.static.data(name = "new_value", shape=[2,2], dtype='float32')
                 ...     new_value = original_value.astype('int64')
-                ...     print("new value's dtype is: {}".format(new_value.dtype))
+                ...     print(f"new value's dtype is: {new_value.dtype}")
                 ...
                 new OpResult's dtype is: paddle.int64
 
@@ -308,6 +308,26 @@ def monkey_patch_opresult():
         return __impl__
 
     def size(self):
+        """
+        Returns the number of elements for current OpResult, which is a int64 OpResult with shape [] .
+
+        Returns:
+            OpResult, the number of elements for current OpResult
+
+        Examples:
+            .. code-block:: python
+
+            >>> import paddle
+            >>> paddle.enable_static()
+            >>> startup_prog = paddle.static.Program()
+            >>> main_prog = paddle.static.Program()
+            >>> with paddle.static.program_guard(startup_prog, main_prog):
+            ...     x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
+            ...     (output_x,) = exe.run(main_program, fetch_list=[x.size()])
+            ...     print(f"new value's size is: {output_x}")
+            ...
+            new value's size is: 24
+        """
         return paddle.numel(self)
 
     import paddle

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -307,6 +307,9 @@ def monkey_patch_opresult():
         __impl__.__name__ = method_name
         return __impl__
 
+    def size(self):
+        return paddle.numel(self)
+
     import paddle
 
     opresult_methods = [
@@ -316,6 +319,7 @@ def monkey_patch_opresult():
         ('ndimension', ndimension),
         ('ndim', _ndim),
         ('astype', astype),
+        ('size', size),
         (
             '__add__',
             _binary_creator_('__add__', paddle.tensor.add, False, _scalar_add_),

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -307,7 +307,8 @@ def monkey_patch_opresult():
         __impl__.__name__ = method_name
         return __impl__
 
-    def size(self):
+    @property
+    def _size_(self):
         """
         Returns the number of elements for current OpResult, which is a int64 OpResult with shape [] .
 
@@ -323,7 +324,7 @@ def monkey_patch_opresult():
             >>> main_prog = paddle.static.Program()
             >>> with paddle.static.program_guard(startup_prog, main_prog):
             ...     x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
-            ...     (output_x,) = exe.run(main_program, fetch_list=[x.size()])
+            ...     (output_x,) = exe.run(main_program, fetch_list=[x.size])
             ...     print(f"value's size is: {output_x}")
             ...
             value's size is: 24
@@ -339,7 +340,7 @@ def monkey_patch_opresult():
         ('ndimension', ndimension),
         ('ndim', _ndim),
         ('astype', astype),
-        ('size', size),
+        ('size', _size_),
         (
             '__add__',
             _binary_creator_('__add__', paddle.tensor.add, False, _scalar_add_),

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -424,7 +424,7 @@ class TestMathOpPatchesPir(unittest.TestCase):
             main_program, exe, program_guard = new_program()
             with program_guard:
                 x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
-                (output_x,) = exe.run(main_program, fetch_list=[x.size()])
+                (output_x,) = exe.run(main_program, fetch_list=[x.size])
                 self.assertEqual(output_x, 24)
 
     def test_math_exists(self):

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -419,6 +419,14 @@ class TestMathOpPatchesPir(unittest.TestCase):
             self.assertEqual(x.ndimension(), 3)
             self.assertEqual(x.ndim, 3)
 
+    def test_size(self):
+        with paddle.pir_utils.IrGuard():
+            main_program, exe, program_guard = new_program()
+            with program_guard:
+                x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
+                (output_x,) = exe.run(main_program, fetch_list=[x.size()])
+                self.assertEqual(output_x, 24)
+
     def test_math_exists(self):
         with paddle.pir_utils.IrGuard():
             a = paddle.static.data(name='a', shape=[1], dtype='float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

本pr主要是适配`OpResult.size`
老静态图下Variable的size是一个方法，动态图下Tensor的size是一个属性，pir下OpResult的size和动态图保持了一致

相关链接：
* #58118
* #57857
* #58042
* #58219
* #58343
* #58739
* #58791
* [No.49：python端补齐OpResult的patch方法](https://github.com/PaddlePaddle/community/blob/master/hackathon/hackathon_5th/%E3%80%90PaddlePaddle%20Hackathon%205th%E3%80%91%E5%BC%80%E6%BA%90%E8%B4%A1%E7%8C%AE%E4%B8%AA%E4%BA%BA%E6%8C%91%E6%88%98%E8%B5%9B%E6%A1%86%E6%9E%B6%E5%BC%80%E5%8F%91%E4%BB%BB%E5%8A%A1%E5%90%88%E9%9B%86.md#no49python%E7%AB%AF%E8%A1%A5%E9%BD%90opresult%E7%9A%84patch%E6%96%B9%E6%B3%95)