### PR TITLE
[cmake治理]fix can't find libcommon.so bug

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -137,7 +137,7 @@ if(WIN32)
   target_link_libraries(paddle_inference_shared phi)
 endif()
 set_target_properties(paddle_inference_shared PROPERTIES LINK_FLAGS
-                                                         "-Wl,-rpath,$ORIGIN/")
+                                                         "-Wl,-rpath,'$ORIGIN'")
 set_target_properties(paddle_inference_shared PROPERTIES OUTPUT_NAME
                                                          paddle_inference)
 if(NOT APPLE


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67010
修复推理libpaddle_inference.so找不到libcommon.so的问题