### PR TITLE
[Dy2St] pir dy2st unittest verification - Part 7

### DIFF
--- a/test/dygraph_to_static/test_closure_analysis.py
+++ b/test/dygraph_to_static/test_closure_analysis.py
@@ -15,7 +15,10 @@
 import inspect
 import unittest
 
-from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    test_legacy_and_pir_exe_and_pir_api,
+)
 from numpy import append
 
 import paddle
@@ -194,6 +197,7 @@ class TestClosureAnalysis(Dy2StTestBase):
             {'func': set('i'), 'test_normal_argument': set('x')},
         ]
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_main(self):
         if self.judge_type == 'push_pop_vars':
             for push_pop_vars, func in zip(
@@ -260,7 +264,7 @@ class TestClosureAnalysis_PushPop(TestClosureAnalysis):
 
 
 class TestPushPopTrans(Dy2StTestBase):
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test(self):
         def vlist_of_dict(x):
             ma = {'a': []}
@@ -271,7 +275,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test2(self):
         import numpy as np
 
@@ -284,7 +288,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test3(self):
         import numpy as np
 
@@ -297,7 +301,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test4(self):
         import numpy as np
 
@@ -310,7 +314,7 @@ class TestPushPopTrans(Dy2StTestBase):
         x = paddle.to_tensor([3])
         print(paddle.jit.to_static(vlist_of_dict)(x))
 
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test5(self):
         import numpy as np
 

--- a/test/dygraph_to_static/test_gradient_aggregation.py
+++ b/test/dygraph_to_static/test_gradient_aggregation.py
@@ -15,7 +15,10 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils_new import Dy2StTestBase, test_legacy_and_pir
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    test_legacy_and_pir_exe_and_pir_api,
+)
 
 import paddle
 
@@ -38,7 +41,7 @@ class SimpleNet(paddle.nn.Layer):
 
 
 class TestGradientAggregationInDy2Static(Dy2StTestBase):
-    @test_legacy_and_pir
+    @test_legacy_and_pir_exe_and_pir_api
     def test_to_static(self):
         def simplenet_grad(inp, to_static=False):
             net = SimpleNet()

--- a/test/dygraph_to_static/test_jit_property_save.py
+++ b/test/dygraph_to_static/test_jit_property_save.py
@@ -14,7 +14,10 @@
 
 import unittest
 
-from dygraph_to_static_utils_new import Dy2StTestBase
+from dygraph_to_static_utils_new import (
+    Dy2StTestBase,
+    test_legacy_and_pir_exe_and_pir_api,
+)
 
 import paddle
 
@@ -33,18 +36,22 @@ class TestPropertySave(Dy2StTestBase):
         self.a = a
         self.b = b
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_property_save(self):
         self.assertEqual(self.a.get_float('a'), self.b.get_float('a'))
         self.assertEqual(self.a.get_float(0), 1.0)
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_size(self):
         self.assertEqual(self.b.size(), 2)
         self.assertEqual(self.a.size(), 2)
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_load_float(self):
         with self.assertRaises(ValueError):
             self.a.get_float(1)
 
+    @test_legacy_and_pir_exe_and_pir_api
     def test_set(self):
         """test property set."""
         try:

--- a/test/dygraph_to_static/test_se_resnet.py
+++ b/test/dygraph_to_static/test_se_resnet.py
@@ -43,13 +43,15 @@ EPOCH_NUM = 1
 PRINT_STEP = 2
 STEP_NUM = 10
 
-place = base.CUDAPlace(0) if base.is_compiled_with_cuda() else base.CPUPlace()
+place = (
+    paddle.CUDAPlace(0) if paddle.is_compiled_with_cuda() else paddle.CPUPlace()
+)
 
 # Note: Set True to eliminate randomness.
 #     1. For one operation, cuDNN has several algorithms,
 #        some algorithm results are non-deterministic, like convolution algorithms.
-if base.is_compiled_with_cuda():
-    base.set_flags({'FLAGS_cudnn_deterministic': True})
+if paddle.is_compiled_with_cuda():
+    paddle.set_flags({'FLAGS_cudnn_deterministic': True})
 
 train_parameters = {
     "learning_strategy": {

--- a/test/dygraph_to_static/test_warning.py
+++ b/test/dygraph_to_static/test_warning.py
@@ -21,7 +21,6 @@ import paddle
 from paddle.static.nn import cond
 
 
-@paddle.jit.to_static
 def fun1():
     a = paddle.to_tensor(1)
     b = paddle.to_tensor(2)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

| 状态 | 单测 | 错误类别 | 备注 | 报错信息 |
|:----:|:---:|:----:|:----:|:------------------------:|
| ✅ | `test_closure_analysis` |  |  |  |
| ❌ | `test_warning` | 控制流 | 暂不支持控制流 | `TypeError: The type of 'input' in ConditionalBlock must be <class 'paddle.base.framework.Variable'>, but received <class 'paddle.base.libpaddle.pir.OpResult'>.` |
| ❌ | `test_op_attr`: `test_set_op_attrs_with_sub_block` | 控制流  | `paddle.static.nn.control_flow.ConditionalBlock` 需要适配  | `TypeError: The type of 'input' in ConditionalBlock must be (<class 'paddle.base.framework.Variable'>, <class 'paddle.Tensor'>), but received <class 'paddle.base.libpaddle.pir.OpResult'>` |
| ❌ | `test_op_attr`: `test_set_op_attrs` | API  | `paddle.base.framework.Program`下没有`blocks` api 需要适配  | `AttributeError: 'paddle.base.libpaddle.pir.Program' object has no attribute 'blocks'` |
| ❌ | `test_typing` | API  | 需要适配`jit.api.save`方法  | `AttributeError: 'list' object has no attribute 'type'` |
| ❌ | `test_gradname_parse` | 动转静执行 | 段错误  | `segmentation fault` |
| ❌ | `test_resnet_pure_fp16` | AMP | 动转静 AMP 尚未支持 | `NotImplementedError: not implement error.` |
| ❌ | `test_cinn_prim_layer_norm` | 待明确 | 需要带 CINN 编译，应该也跑不通 | `NotImplementedError: (Unimplemented) Currently we only support CINN Pass for Pir under @to_static, please compile PaddlePaddle with CINN` |
| ❌ | `test_se_resnet` | API  | `paddle.tensor.math._multiply_with_axis`需要适配  | `TypeError: Cannot interpret '<DataType.FLOAT32: 10>' as a data type` |
| ❌ | `test_se_resnet` | 动转静执行 | 对 `_multiply_with_axis` 直接添加 `in_dynamic_or_pir_mode` 适配后在执行时报错  | `Destoryed a op_result that is still in use.  The owner op type is:pd_op.full_like` |
| ✅ | `test_gradient_aggregation` |   |   |  |
| ❌ | `test_return` | 控制流 | 暂不支持控制流 | `TypeError: The type of 'input' in ConditionalBlock must be <class 'paddle.base.framework.Variable'>, but received <class 'paddle.base.libpaddle.pir.OpResult'>.` |
| ✅ | `test_jit_property_save` |   |   |  |

相关链接:

* #58633 
* #58630
* #58686
* #58890
* #58936
* #59007
