### PR TITLE
[SOT][3.11] Do not restore `KW_NAMES` + `PRECALL` in 3.11

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -262,15 +262,15 @@ class FunctionGraph:
 
         origin_instrs = get_instructions(self.pycode_gen._origin_code)
 
-        restroe_instrs = origin_instrs[:instr_idx]
+        restore_instrs = origin_instrs[:instr_idx]
         restore_instr_names = [
-            instr.opname for instr in restroe_instrs[:instr_idx]
+            instr.opname for instr in restore_instrs[:instr_idx]
         ]
         # NOTE(SigureMo): Trailing KW_NAMES + PRECALL is no need to restore in Python 3.11+
         if restore_instr_names[-2:] == ["KW_NAMES", "PRECALL"]:
-            restroe_instrs = restroe_instrs[:-2]
+            restore_instrs = restore_instrs[:-2]
 
-        for instr in restroe_instrs:
+        for instr in restore_instrs:
             if (
                 instr.opname == 'LOAD_FAST'
                 and instr.argval in self.pycode_gen._frame.f_locals.keys()

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -260,9 +260,17 @@ class FunctionGraph:
                 # only restored vars in stack, so used gen_load to process global var
                 self._pycode_gen.gen_load(self._store_var_info[var])
 
-        origin_instr = get_instructions(self.pycode_gen._origin_code)
+        origin_instrs = get_instructions(self.pycode_gen._origin_code)
 
-        for instr in origin_instr[0:instr_idx]:
+        restroe_instrs = origin_instrs[:instr_idx]
+        restore_instr_names = [
+            instr.opname for instr in restroe_instrs[:instr_idx]
+        ]
+        # NOTE(SigureMo): Trailing KW_NAMES + PRECALL is no need to restore in Python 3.11+
+        if restore_instr_names[-2:] == ["KW_NAMES", "PRECALL"]:
+            restroe_instrs = restroe_instrs[:-2]
+
+        for instr in restroe_instrs:
             if (
                 instr.opname == 'LOAD_FAST'
                 and instr.argval in self.pycode_gen._frame.f_locals.keys()
@@ -288,13 +296,13 @@ class FunctionGraph:
 
         nop = self.pycode_gen._add_instr("NOP")
 
-        for instr in origin_instr:
-            if instr.jump_to == origin_instr[instr_idx]:
+        for instr in origin_instrs:
+            if instr.jump_to == origin_instrs[instr_idx]:
                 instr.jump_to = nop
 
         self.pycode_gen.hooks.append(
             lambda: self.pycode_gen.extend_instrs(
-                iter(origin_instr[instr_idx + 1 :])
+                iter(origin_instrs[instr_idx + 1 :])
             )
         )
 

--- a/test/sot/test_min_graph_size.py
+++ b/test/sot/test_min_graph_size.py
@@ -46,6 +46,16 @@ def case_call(x):
     return x
 
 
+def call_with_kwargs_inner(x):
+    return paddle.to_tensor(x.numpy())
+
+
+def call_with_kwargs(x):
+    y = call_with_kwargs_inner(x=x)
+    x += y
+    return x
+
+
 def case_all(x, vars):
     x = x + 1
     for y in vars:
@@ -81,6 +91,11 @@ class TestMinGraphSize(TestCaseBase):
         x = paddle.to_tensor(1)
         layer = CustomLayer()
         self.assert_results(layer.forward, x)
+
+    @min_graph_size_guard(10)
+    def test_call_with_kwargs(self):
+        x = paddle.to_tensor(1)
+        self.assert_results(call_with_kwargs, x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

在发生 call breakgraph 时，不应该恢复已经执行过的序列中最后的 KW_NAMES + PRECALL，因为 KW_NAMES 是一个有副作用的字节码，会在后面需要的时候恢复，如果在开始就直接恢复会导致影响后面的 CALL，而 PRECALL 直接不用恢复，因为 PRECALL 的作用在模拟执行的时候就生效了，不需要生成字节码来实现

因此按照 trailing KW_NAMES + PRECALL pattern 来匹配，若匹配则删掉它们

PCard-66972