### PR TITLE
[AutoParalle] Make partial flow in backward

### DIFF
--- a/test/auto_parallel/semi_auto_parallel_for_matmul.py
+++ b/test/auto_parallel/semi_auto_parallel_for_matmul.py
@@ -96,7 +96,7 @@ class TestMatmulApiForSemiAutoParallel:
         np.testing.assert_equal(
             dist_y_grad.dist_attr.dims_mapping, [-1, -1], verbose=True
         )
-        assert dist_y_grad.dist_attr._is_partial() is False
+        assert dist_y_grad.dist_attr._is_partial() is True
 
     def test_matmul_x_column_shard(self):
         # case2: mk[-1, 0],kn[-1,-1] --> mk[-1, 0],kn[0, -1] = nm[-1, -1] partial[0]
@@ -159,7 +159,7 @@ class TestMatmulApiForSemiAutoParallel:
         np.testing.assert_equal(
             dist_y_grad.dist_attr.dims_mapping, [-1, -1], verbose=True
         )
-        assert dist_y_grad.dist_attr._is_partial() is False
+        assert dist_y_grad.dist_attr._is_partial() is True
 
     def test_matmul_x_column_shard_trans_x(self):
         # case1: mk[-1,0],kn[-1,-1] -> mk[0,-1],kn[-1,-1] = mn[0,-1] partial[], trans x
@@ -192,7 +192,7 @@ class TestMatmulApiForSemiAutoParallel:
         np.testing.assert_equal(
             dist_y_grad.dist_attr.dims_mapping, [-1, -1], verbose=True
         )
-        assert dist_y_grad.dist_attr._is_partial() is False
+        assert dist_y_grad.dist_attr._is_partial() is True
 
     def test_matmul_x_row_shard_trans_y(self):
         # case1: mk[0,-1],kn[-1,-1] -> mk[0,-1],kn[-1,-1] = mn[0,-1] partial[], trans y
@@ -225,7 +225,7 @@ class TestMatmulApiForSemiAutoParallel:
         np.testing.assert_equal(
             dist_y_grad.dist_attr.dims_mapping, [-1, -1], verbose=True
         )
-        assert dist_y_grad.dist_attr._is_partial() is False
+        assert dist_y_grad.dist_attr._is_partial() is True
 
     def test_matmul_with_complex_type(self):
         paddle.seed(self._seed)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-73145

在反向过程中，让梯度维持partial状态流动。取消生成的phi代码里，对partial到replicated的转换。