### PR TITLE
rewrite master weight for amp training

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -276,6 +276,7 @@ class Optimizer:
         self._auxiliary_vars = {}
         self._already_create_accumulater = set()
 
+        self._master_weights = {}
         # create master gradients' states
         self._create_master_grad_states()
 

--- a/python/paddle/static/amp/decorator.py
+++ b/python/paddle/static/amp/decorator.py
@@ -301,7 +301,12 @@ class OptimizerWithMixedPrecision:
         self._to_fp16_var_names = None
 
     def amp_init(
-        self, place, scope=None, test_program=None, use_fp16_test=False
+        self,
+        place,
+        scope=None,
+        test_program=None,
+        use_fp16_test=False,
+        rewrite_master_weight=False,
     ):
         """
         Init the amp training, such as cast fp32 parameters to fp16 type.
@@ -369,6 +374,8 @@ class OptimizerWithMixedPrecision:
                 scope,
                 self._to_fp16_var_names,
                 self._amp_vartype,
+                rewrite_master_weight,
+                self._optimizer._master_weights,
             )
         if test_program is not None:
             if self._use_pure_fp16:

--- a/test/amp/test_amp_master_weight.py
+++ b/test/amp/test_amp_master_weight.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from amp_base_models import AmpTestBase
+
+import paddle
+from paddle.base import core
+
+
+class SimpleNet(paddle.nn.Layer):
+    def __init__(self, input_size, output_size):
+        super().__init__()
+        weight_attr = paddle.ParamAttr(
+            name="weight", initializer=paddle.nn.initializer.Constant(value=0.5)
+        )
+        bias_attr = paddle.ParamAttr(
+            name="bias", initializer=paddle.nn.initializer.Constant(value=1.0)
+        )
+        self.linear = paddle.nn.Linear(
+            input_size, output_size, weight_attr, bias_attr
+        )
+
+    def forward(self, x):
+        x = self.linear(x)
+        return x
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+class TestMasterWeight(AmpTestBase):
+    def run_dygraph(self, dtype, level, use_promote, max_iters, x_data):
+        losses = []
+        model = SimpleNet(100, 100)
+        optimizer = paddle.optimizer.AdamW(
+            learning_rate=0.01,
+            parameters=model.parameters(),
+        )
+        scaler = paddle.amp.GradScaler()
+        model, optimizer = paddle.amp.decorate(
+            models=model,
+            optimizers=optimizer,
+            level=level,
+            dtype=dtype,
+        )
+
+        for i in range(max_iters):
+            with paddle.amp.auto_cast(
+                enable=True,
+                dtype=dtype,
+                level=level,
+                use_promote=use_promote,
+            ):
+                x = paddle.to_tensor(x_data, dtype='float16')
+                out = model(x)
+                loss = paddle.mean(out)
+                losses.append(loss)
+            scaled = scaler.scale(loss)
+            scaled.backward()
+            scaler.minimize(optimizer, scaled)
+            optimizer.clear_grad()
+        return losses
+
+    def run_static(self, dtype, level, use_promote, max_iters, x_data):
+        paddle.enable_static()
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        losses = []
+        with paddle.utils.unique_name.guard():
+            with paddle.static.program_guard(main_program, startup_program):
+                model = SimpleNet(100, 100)
+                optimizer = paddle.optimizer.AdamW(learning_rate=0.01)
+                optimizer = paddle.static.amp.decorate(
+                    optimizer,
+                    level=level,
+                    dtype=dtype,
+                    use_promote=use_promote,
+                    master_weight=True,
+                )
+                x = paddle.static.data(
+                    name='input', shape=[100, 100], dtype='float16'
+                )
+                out = model(x)
+                loss = paddle.mean(out)
+                optimizer.minimize(loss)
+
+        place = paddle.CUDAPlace(0)
+        exe = paddle.static.Executor(place)
+        exe.run(startup_program)
+        optimizer.amp_init(
+            place,
+            scope=paddle.static.global_scope(),
+            rewrite_master_weight=True,
+        )
+        for iter_id in range(max_iters):
+            results = exe.run(
+                program=main_program,
+                feed={x.name: x_data},
+                fetch_list=[loss],
+            )
+            print(f"-- [AMP {dtype} {level}] iter={iter_id}, loss={results[0]}")
+            losses.append(results[0])
+
+        paddle.disable_static()
+        return losses
+
+    def test_master_weight(self):
+        dtype = 'float16'
+        level = 'O2'
+        use_promote = True
+        total_steps = 4
+        x_data = np.random.random(size=[100, 100]).astype("float16")
+
+        loss_dygraph = self.run_dygraph(
+            dtype, level, use_promote, total_steps, x_data
+        )
+        loss_static = self.run_static(
+            dtype, level, use_promote, total_steps, x_data
+        )
+
+        for i in range(total_steps):
+            self.assertEqual(loss_dygraph[i], loss_static[i])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Description
<!-- Describe what you’ve done --> rewrite master weight for amp training
Pcard-76459

为解决动静态图AMP训练时，master weight初始化不一致的问题，通过设置rewrite_master_weight=True实现一致性
原因：
- 动态图：在模型参数被转换为低精度后，在优化器调用阶段才对master weight进行初始化，即将低精度权重cast到fp32给master weight
- 静态图：master weight在run startup program时初始化，因此直接初始化为fp32类型。

调整后：在amp_init中，类似动态图将低精度权重cast到fp32重写了初始的master weight
