### PR TITLE
[XPU] fix timeout problem in process_group.barrier()

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -490,6 +490,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Barrier(
                     0,
                     platform::errors::PreconditionNotMet(
                         "The barrier device id must greater or equal than 0."));
+  platform::XPUDeviceGuard guard(opts.device_id);
   platform::XPUPlace place(opts.device_id);
   auto allocator = std::unique_ptr<phi::Allocator>(
       new paddle::experimental::DefaultAllocator(place));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
In some running env calling process_group.barrier() raises timeout problem with warning: stream does not meet with current context. Add a XPU guard to avoid this problem.