### PR TITLE
[Prim][PIR] Sink forward prim rule of batch_norm

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -19,6 +19,7 @@
 # come into effect in generated file pd_op.h
 # manual decomp interface declare are located in manual_op.h
 decomp_interface_declare_gen_op_list = [
+    "batch_norm",
     "mean",
     "squeeze",
     "add_n",
@@ -30,6 +31,7 @@ decomp_interface_declare_gen_op_list = [
 # come into effect in generated file op_decomp.cc
 # manual decomp interface implementation are located in manual_op_decomp.cc
 decomp_interface_implementation_gen_op_list = [
+    "batch_norm",
     "mean",
     "squeeze",
     "add_n",

--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -31,7 +31,6 @@ decomp_interface_declare_gen_op_list = [
 # come into effect in generated file op_decomp.cc
 # manual decomp interface implementation are located in manual_op_decomp.cc
 decomp_interface_implementation_gen_op_list = [
-    "batch_norm",
     "mean",
     "squeeze",
     "add_n",

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
@@ -98,8 +98,6 @@ std::vector<std::vector<pir::OpResult>> BatchNormOp::Decomp(
                        std::get<2>(op_res).impl())
                        ->value()
                        .dyn_cast<pir::OpResult>());
-  //   bool use_run_stat = (is_test && (!trainable_statistics)) ||
-  //   use_global_stats; if (!use_run_stat) {
   res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<3>(op_res).impl())
                        ->value()
@@ -110,7 +108,6 @@ std::vector<std::vector<pir::OpResult>> BatchNormOp::Decomp(
                        .dyn_cast<pir::OpResult>());
   pir::OpResult reserve_space;
   res[5].push_back(reserve_space);
-  //   }
   return res;
 }
 

--- a/paddle/fluid/primitive/codegen/decomp_gen.py
+++ b/paddle/fluid/primitive/codegen/decomp_gen.py
@@ -197,7 +197,7 @@ def gen(
         for attr_item in item["attrs"]:
             if attr_item["typename"] not in attr_types_map.keys():
                 raise TypeError
-            attr_item["mapped_type"] = attr_types_map[attr_item["typename"]][0]
+            attr_item["mapped_type"] = attr_types_map[attr_item["typename"]]
         for out_item in item["outputs"]:
             if out_item["typename"] not in output_type_map.keys():
                 name = out_item["typename"]

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -106,7 +106,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
       paddle::dialect::GetInt64Vector({{item.name}}_define_op->attribute("value")));
 
       {% else %}
-        {% if {{item.mapped_type[0]}} == "pir::StrAttribute" %}
+        {% if item.mapped_type[0] == "pir::StrAttribute" %}
   {{item.mapped_type[1]}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type[0]}}>().AsString();
         {% else %}
   {{item.mapped_type[1]}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type[0]}}>().data();

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -25,6 +25,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   (void)op_obj;
 
   FLAGS_tensor_operants_mode = "static";
+  VLOG(4) << "Decomp call {{fwd_name}}'s decomp interface begin";
 
   VLOG(4) << "Decomp Prepare inputs of {{fwd_name}}";
 
@@ -120,8 +121,10 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   auto org_res = op->results();
   std::vector<std::vector<pir::OpResult>> res(org_res.size());
 
+  VLOG(4) << "Decomp call {{fwd_name}}'s forward composite rule begin";
   {% if outputs|length == 1 %}
   Tensor op_res = paddle::primitive::details::{{fwd_name}}_decomp<primitive::LazyTensor>({{common.args(input_names, attr_names)}});
+  VLOG(4) << "Decomp call {{fwd_name}}'s forward composite rule end";
   res[0].push_back(
     std::static_pointer_cast<primitive::LazyTensor>(op_res.impl())
         ->value()
@@ -133,6 +136,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
     {% endfor %}
   std::tuple<{{common.sequence('', '', ', ', output_types)}}> op_res = paddle::primitive::details::{{fwd_name}}_decomp<primitive::LazyTensor>(
           {{common.args(input_names, attr_names)}});
+  VLOG(4) << "Decomp call {{fwd_name}}'s forward composite rule end";
   {% for k in range(outputs|length) %}
     {% if outputs[k].intermediate and fwd_name in decomp_ops_list_contain_unused_output %}
   pir::OpResult {{outputs[k].name}};
@@ -143,6 +147,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   {% endfor %}
   {% endif %}
 
+  VLOG(4) << "Decomp call {{fwd_name}}'s decomp interface end";
   return res;
 }
 {% endmacro %}

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -106,7 +106,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
       paddle::dialect::GetInt64Vector({{item.name}}_define_op->attribute("value")));
 
       {% else %}
-        if ({{item.mapped_type[0]}} == "pir::StrAttribute")
+        {% if {{item.mapped_type[0]}} == "pir::StrAttribute" %}
   {{item.mapped_type[1]}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type[0]}}>().AsString();
         {% else %}
   {{item.mapped_type[1]}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type[0]}}>().data();

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -21,13 +21,14 @@ using IntArray = paddle::experimental::IntArray;
 {% set output_types=[] %}
 
 std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* op) {
+  VLOG(4) << "Decomp call {{fwd_name}}'s decomp interface begin";
+
   {{class_name}} op_obj = op->dyn_cast<{{class_name}}>();
   (void)op_obj;
 
   FLAGS_tensor_operants_mode = "static";
-  VLOG(4) << "Decomp call {{fwd_name}}'s decomp interface begin";
 
-  VLOG(4) << "Decomp Prepare inputs of {{fwd_name}}";
+  VLOG(6) << "Decomp Prepare inputs of {{fwd_name}}";
 
     {% for item in inputs -%}
       {% do input_names.append(item.name) %}
@@ -67,7 +68,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
       {% endif %}
     {% endfor %}
 
-  VLOG(4) << "Decomp prepare attributes of {{fwd_name}}";
+  VLOG(6) << "Decomp prepare attributes of {{fwd_name}}";
     {% if attrs %}
       {% for item in attrs %}
       {% do attr_names.append(item.name) %}
@@ -116,15 +117,16 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
       {% endfor %}
     {% endif %}
 
-  VLOG(4) << "Decomp prepare call {{fwd_name}}'s decomp interface";
+  VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule prepare";
 
   auto org_res = op->results();
   std::vector<std::vector<pir::OpResult>> res(org_res.size());
 
-  VLOG(4) << "Decomp call {{fwd_name}}'s forward composite rule begin";
+  VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule begin";
   {% if outputs|length == 1 %}
   Tensor op_res = paddle::primitive::details::{{fwd_name}}_decomp<primitive::LazyTensor>({{common.args(input_names, attr_names)}});
-  VLOG(4) << "Decomp call {{fwd_name}}'s forward composite rule end";
+  VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule end";
+
   res[0].push_back(
     std::static_pointer_cast<primitive::LazyTensor>(op_res.impl())
         ->value()
@@ -136,7 +138,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
     {% endfor %}
   std::tuple<{{common.sequence('', '', ', ', output_types)}}> op_res = paddle::primitive::details::{{fwd_name}}_decomp<primitive::LazyTensor>(
           {{common.args(input_names, attr_names)}});
-  VLOG(4) << "Decomp call {{fwd_name}}'s forward composite rule end";
+  VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule end";
   {% for k in range(outputs|length) %}
     {% if outputs[k].intermediate and fwd_name in decomp_ops_list_contain_unused_output %}
   pir::OpResult {{outputs[k].name}};

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -106,7 +106,11 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
       paddle::dialect::GetInt64Vector({{item.name}}_define_op->attribute("value")));
 
       {% else %}
-  {{item.typename}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type}}>().data();
+        if ({{item.mapped_type[0]}} == "pir::StrAttribute")
+  {{item.mapped_type[1]}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type[0]}}>().AsString();
+        {% else %}
+  {{item.mapped_type[1]}} {{item.name}} = op->attribute("{{item.name}}").dyn_cast<{{item.mapped_type[0]}}>().data();
+        {% endif %}
       {% endif %}
       {% endfor %}
     {% endif %}

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -128,8 +128,10 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
       x_hat = (x - reshape<T>(batch_mean, stats_shape)) *
               reshape<T>(inv_std, stats_shape);
     }
-    // run_mean = run_mean * momentum + batch_mean * (1 - momentum);
-    // run_var = run_var * momentum + batch_var * (1 - momentum);
+    run_mean = run_mean * momentum;
+    run_var = run_var * momentum;
+    // run_mean = run_mean * momentum + batch_mean * (1. - momentum);
+    // run_var = run_var * momentum + batch_var * (1. - momentum);
   } else {
     batch_mean = full<T>(phi::vectorize(run_mean.dims()), 0, run_mean.dtype());
     auto batch_var =

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -135,8 +135,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
               reshape<T>(inv_std, stats_shape);
     }
     run_mean_ = run_mean * momentum + batch_mean * (1. - momentum);
-    // run_var = run_var * momentum;
-    // run_mean = run_mean * momentum + batch_mean * (1. - momentum);
     run_var_ = run_var * momentum + batch_var * (1. - momentum);
   } else {
     batch_mean = full<T>(phi::vectorize(run_mean.dims()), 0, run_mean.dtype());
@@ -156,14 +154,12 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
   }
   VLOG(4) << "bn================================= 3";
   Tensor y;
-  auto scale_ptr = scale.get_ptr();
-  auto bias_ptr = bias.get_ptr();
   Tensor new_scale =
-      scale_ptr ? *scale_ptr
-                : full<T>(phi::vectorize(x_cast.dims()), 1, x_cast.dtype());
+      scale ? scale.get()
+            : full<T>(phi::vectorize(x_cast.dims()), 1, x_cast.dtype());
   Tensor new_bias =
-      bias_ptr ? *bias_ptr
-               : full<T>(phi::vectorize(x_cast.dims()), 0, x_cast.dtype());
+      bias ? bias.get()
+           : full<T>(phi::vectorize(x_cast.dims()), 0, x_cast.dtype());
   if (data_layout_ == DataLayout::kNHWC) {
     y = x_hat * new_scale + new_bias;
   } else {

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -75,8 +75,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     const std::string& data_layout,
     bool use_global_stats,
     bool trainable_statistics) {
-  VLOG(4) << "bn================================= begin";
-
   auto org_dtype = x.dtype();
   Tensor x_cast = x;
 
@@ -122,7 +120,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
   Tensor inv_std;
   Tensor run_mean_;
   Tensor run_var_;
-  VLOG(4) << "bn================================= 2";
   if (!use_run_stat) {
     batch_mean = mean_decomp<T>(x_cast, IntArray(reduce_axes), false);
     auto temp = mean_decomp<T>(x_cast * x_cast, IntArray(reduce_axes), false);
@@ -152,7 +149,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     run_mean_ = assign<T>(run_mean);
     run_var_ = assign<T>(run_var);
   }
-  VLOG(4) << "bn================================= 3";
   Tensor y;
   Tensor new_scale =
       scale ? scale.get()
@@ -173,7 +169,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
 
   auto batch_mean_ = assign<T>(batch_mean);
   auto inv_std_ = assign<T>(inv_std);
-  VLOG(4) << "bn================================= end";
   if (!use_run_stat) {
     return std::make_tuple(
         y, run_mean_, run_var_, batch_mean_, inv_std_, reserve_space);

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -83,7 +83,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     const std::string& data_layout,
     bool use_global_stats,
     bool trainable_statistics) {
-  VLOG(4) << "Decomp prepare call batch_norm's decomp interface";
+  VLOG(4) << "bn================================= begin";
 
   std::vector<int64_t> x_dim = phi::vectorize<int64_t>(x.dims());
   int rank = x_dim.size();
@@ -120,7 +120,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
   Tensor inv_std;
   Tensor run_mean_;
   Tensor run_var_;
-
+  VLOG(4) << "bn================================= 2";
   if (!use_run_stat) {
     batch_mean = mean_decomp<T>(x, IntArray(reduce_axes), false);
     auto temp = mean_decomp<T>(x * x, IntArray(reduce_axes), false);
@@ -151,6 +151,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
     run_mean_ = assign<T>(run_mean);
     run_var_ = assign<T>(run_var);
   }
+  VLOG(4) << "bn================================= 3";
   Tensor y;
   auto scale_ptr = scale.get_ptr();
   auto bias_ptr = bias.get_ptr();
@@ -168,6 +169,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> batch_norm_decomp(
 
   auto batch_mean_ = assign<T>(batch_mean);
   auto inv_std_ = assign<T>(inv_std);
+  VLOG(4) << "bn================================= end";
   if (!use_run_stat) {
     return std::make_tuple(
         y, run_mean_, run_var_, batch_mean_, inv_std_, reserve_space);

--- a/paddle/fluid/primitive/utils/utils.h
+++ b/paddle/fluid/primitive/utils/utils.h
@@ -139,5 +139,13 @@ std::vector<std::vector<Tensor>> ConstructVjpResultByStopGradients(
     const std::vector<std::vector<Tensor>>& outputs,
     const std::vector<std::vector<bool>>& stop_gradients);
 
+static bool find_value(const std::vector<int64_t>& vec, int64_t value) {
+  if (std::find(vec.begin(), vec.end(), value) != vec.end()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 }  // namespace primitive
 }  // namespace paddle

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -503,8 +503,14 @@ ops_contain_none = {
     "unsqueeze2": ["XShape"],
 }
 
+
 # some intermediate outputs like xshape will no longer used after decomp, but return none to keep output num the same as origin op
-decomp_ops_list_contain_unused_output = ["pd_op.squeeze", "pd_op.unsqueeze"]
+# key is the name of op, and value is the index of output in op.outputs
+decomp_ops_contain_unused_output = {
+    "pd_op.squeeze": [1],
+    "pd_op.unsqueeze": [1],
+    "pd_op.batch_norm": [5],
+}
 
 
 def _set_prim_forward_blacklist(*args):

--- a/test/legacy_test/test_batch_norm_op_prim_nchw.py
+++ b/test/legacy_test/test_batch_norm_op_prim_nchw.py
@@ -64,6 +64,7 @@ class TestBatchNormOp(OpTest):
         self.op_type = "batch_norm"
         self.prim_op_type = "comp"
         self.python_out_sig = ["Y"]
+        self.check_prim_pir = True
         self.initConfig()
         self.initTestCase()
 
@@ -74,7 +75,7 @@ class TestBatchNormOp(OpTest):
                 no_check_set=None,
                 check_prim=True,
                 only_check_prim=True,
-                check_prim_pir=True,
+                check_prim_pir=self.check_prim_pir,
             )
         if paddle.is_compiled_with_cuda():
             self.check_output_with_place(
@@ -82,7 +83,7 @@ class TestBatchNormOp(OpTest):
                 no_check_set=None,
                 check_prim=True,
                 only_check_prim=True,
-                check_prim_pir=True,
+                check_prim_pir=self.check_prim_pir,
             )
 
     def test_check_grad_x(self):
@@ -94,7 +95,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
-                check_prim_pir=True,
+                check_prim_pir=self.check_prim_pir,
             )
         if paddle.is_compiled_with_cuda():
             self.check_grad_with_place(
@@ -104,7 +105,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
-                check_prim_pir=True,
+                check_prim_pir=self.check_prim_pir,
             )
 
     def test_check_grad_scale_bias(self):
@@ -128,7 +129,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
-                check_prim_pir=True,
+                check_prim_pir=self.check_prim_pir,
             )
         if paddle.is_compiled_with_cuda():
             self.check_grad_with_place(
@@ -138,7 +139,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
-                check_prim_pir=True,
+                check_prim_pir=self.check_prim_pir,
             )
 
     def initConfig(self):
@@ -343,6 +344,8 @@ class TestBatchNormOpNCHWbf16(TestBatchNormOp):
         self.epsilon = 1e-05
         self.data_format = "NCHW"
         self.use_global_stats = None
+        # Todo(CZ): open this
+        self.check_prim_pir = False
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_batch_norm_op_prim_nchw.py
+++ b/test/legacy_test/test_batch_norm_op_prim_nchw.py
@@ -81,6 +81,7 @@ class TestBatchNormOp(OpTest):
                 no_check_set=None,
                 check_prim=True,
                 only_check_prim=True,
+                check_prim_pir=True,
             )
 
     def test_check_grad_x(self):

--- a/test/legacy_test/test_batch_norm_op_prim_nchw.py
+++ b/test/legacy_test/test_batch_norm_op_prim_nchw.py
@@ -74,6 +74,7 @@ class TestBatchNormOp(OpTest):
                 no_check_set=None,
                 check_prim=True,
                 only_check_prim=True,
+                check_prim_pir=True,
             )
         if paddle.is_compiled_with_cuda():
             self.check_output_with_place(
@@ -93,6 +94,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
+                check_prim_pir=True,
             )
         if paddle.is_compiled_with_cuda():
             self.check_grad_with_place(
@@ -102,6 +104,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
+                check_prim_pir=True,
             )
 
     def test_check_grad_scale_bias(self):
@@ -125,6 +128,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
+                check_prim_pir=True,
             )
         if paddle.is_compiled_with_cuda():
             self.check_grad_with_place(
@@ -134,6 +138,7 @@ class TestBatchNormOp(OpTest):
                 user_defined_grad_outputs=self.out_grad,
                 check_prim=True,
                 only_check_prim=True,
+                check_prim_pir=True,
             )
 
     def initConfig(self):

--- a/test/legacy_test/test_batch_norm_op_prim_nhwc.py
+++ b/test/legacy_test/test_batch_norm_op_prim_nhwc.py
@@ -109,6 +109,8 @@ class TestBatchNormOpNHWC(TestBatchNormOp):
         self.epsilon = 1e-05
         self.data_format = "NHWC"
         self.use_global_stats = None
+        # Todo(CZ): open this
+        self.check_prim_pir = False
 
 
 class TestBatchNormOpNHWCFp64(TestBatchNormOp):

--- a/test/legacy_test/test_batch_norm_op_prim_nhwc.py
+++ b/test/legacy_test/test_batch_norm_op_prim_nhwc.py
@@ -109,8 +109,6 @@ class TestBatchNormOpNHWC(TestBatchNormOp):
         self.epsilon = 1e-05
         self.data_format = "NHWC"
         self.use_global_stats = None
-        # Todo(CZ): open this
-        self.check_prim_pir = False
 
 
 class TestBatchNormOpNHWCFp64(TestBatchNormOp):
@@ -163,6 +161,8 @@ class TestBatchNormOpNHWCbf16(TestBatchNormOp):
         self.epsilon = 1e-05
         self.data_format = "NHWC"
         self.use_global_stats = None
+        # Todo(CZ): open this
+        self.check_prim_pir = False
 
 
 class TestBatchNormOpNHWCShape2(TestBatchNormOp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
Pcard-66975
1. Sink forward rule of batch_norm in PIR.
2. Fix attr type error in codegen:
before:
const str data_layout =
      op->attribute("data_layout").dyn_cast<pir::StrAttribute>().data();
after:
const std::string& data_layout =
      op->attribute("data_layout").dyn_cast<pir::StrAttribute>().AsString();
