### PR TITLE
[pir] Add pybind property id of OpResult

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -16,6 +16,7 @@
 #include <Python.h>
 #include <algorithm>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -732,6 +733,19 @@ void BindOpResult(py::module *m) {
                   "Currently, we can only get name of OpResult that "
                   "is "
                   "persistable"));
+            }
+          })
+      .def_property_readonly(
+          "id",
+          [](OpResult &self) {
+            if (self.impl() == nullptr) {
+              PADDLE_THROW(phi::errors::InvalidArgument(
+                  "Currently, we can only get id of OpResult whose impl "
+                  "is not nullptr"));
+            } else {
+              std::stringstream ss;
+              ss << std::hex << self.impl();
+              return ss.str();
             }
           })
       .def("initialized",

--- a/test/ir/pir/test_ir_pybind.py
+++ b/test/ir/pir/test_ir_pybind.py
@@ -205,6 +205,16 @@ class TestPybind(unittest.TestCase):
         p.global_seed(10)
         self.assertEqual(p._seed, 10)
 
+    def test_opresult_id(self):
+        with paddle.pir_utils.IrGuard():
+            a = paddle.static.data(name='a', shape=[4, 4], dtype='float32')
+            result = paddle.tanh(a)
+
+        self.assertIsInstance(a.id, str)
+        self.assertTrue(a.id.startswith("0x"))
+        self.assertIsInstance(result.id, str)
+        self.assertTrue(result.id.startswith("0x"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/ir/pir/test_ir_pybind.py
+++ b/test/ir/pir/test_ir_pybind.py
@@ -211,9 +211,7 @@ class TestPybind(unittest.TestCase):
             result = paddle.tanh(a)
 
         self.assertIsInstance(a.id, str)
-        self.assertTrue(a.id.startswith("0x"))
         self.assertIsInstance(result.id, str)
-        self.assertTrue(result.id.startswith("0x"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
为 OpResult 增添 pybind 绑定的 id 属性，作用是返回一个字符串类型，其内容是以十六进制表示的 impl 指针变量的值，如 `0x55de497e7ab0`