### PR TITLE
[CodeStyle] Use PFCCLab forked cmake-lint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -151,8 +151,8 @@ repos:
             (?x)^(
                 paddle/fluid/operators/CMakeLists.txt
             )$
--   repo: https://github.com/cmake-lint/cmake-lint
-    rev: 1.4.2
+-   repo: https://github.com/PFCCLab/cmake-lint-paddle
+    rev: v1.5.0
     hooks:
     -   id: cmakelint
         args: [--config=./tools/codestyle/.cmakelintrc]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,7 +152,7 @@ repos:
                 paddle/fluid/operators/CMakeLists.txt
             )$
 -   repo: https://github.com/PFCCLab/cmake-lint-paddle
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
     -   id: cmakelint
         args: [--config=./tools/codestyle/.cmakelintrc]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

我们现在使用的 https://github.com/cmake-lint/cmake-lint 已经是一个 fork 后继续维护的项目了，但是新的维护者已经 9 个月没有任何更新且不响应任何 issue、PR，最近发布的 Python 3.12 已经无法运行 cmake-lint（ https://github.com/cmake-lint/cmake-lint/issues/25 ），提了个 PR 也无人响应

另外我们现在的 CodeStyle（Python 3.10，与上述的 3.12 问题无关）流水线经常在 build cmake-lint 时候挂（近一两个月出现的），最近频率越来越高了（今天一天看到了三个，其中有一个是我的 PR，这就忍不了了）

比如 https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/9540260/job/24455968

```
2023-11-16 18:34:30 [INFO] Installing environment for https://github.com/cmake-lint/cmake-lint.
2023-11-16 18:34:30 [INFO] Once installed this environment will be reused.
2023-11-16 18:34:30 [INFO] This may take a few minutes...
2023-11-16 18:34:32 An unexpected error has occurred: CalledProcessError: command: ('/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/bin/python', '-mpip', 'install', '.')
2023-11-16 18:34:32 return code: 1
2023-11-16 18:34:32 expected return code: 0
2023-11-16 18:34:32 stdout:
2023-11-16 18:34:32     Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
2023-11-16 18:34:32     Processing /root/.cache/pre-commit/repogksjhhik
2023-11-16 18:34:32       Preparing metadata (setup.py): started
2023-11-16 18:34:32       Preparing metadata (setup.py): finished with status 'error'
2023-11-16 18:34:32     
2023-11-16 18:34:32 stderr:
2023-11-16 18:34:32       error: subprocess-exited-with-error
2023-11-16 18:34:32       
2023-11-16 18:34:32       ?? python setup.py egg_info did not run successfully.
2023-11-16 18:34:32       ??? exit code: 1
2023-11-16 18:34:32       ??????> [65 lines of output]
2023-11-16 18:34:32           /root/.cache/pre-commit/repogksjhhik/setup.py:3: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
2023-11-16 18:34:32             import imp
2023-11-16 18:34:32           /root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/dist.py:498: SetuptoolsDeprecationWarning: Invalid dash-separated options
2023-11-16 18:34:32           !!
2023-11-16 18:34:32           
2023-11-16 18:34:32                   ********************************************************************************
2023-11-16 18:34:32                   Usage of dash-separated 'index-url' will not be supported in future
2023-11-16 18:34:32                   versions. Please use the underscore name 'index_url' instead.
2023-11-16 18:34:32           
2023-11-16 18:34:32                   This deprecation is overdue, please update your project and remove deprecated
2023-11-16 18:34:32                   calls to avoid build errors in the future.
2023-11-16 18:34:32           
2023-11-16 18:34:32                   See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
2023-11-16 18:34:32                   ********************************************************************************
2023-11-16 18:34:32           
2023-11-16 18:34:32           !!
2023-11-16 18:34:32             opt = self.warn_dash_deprecation(opt, section)
2023-11-16 18:34:32           /root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/__init__.py:80: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
2023-11-16 18:34:32           !!
2023-11-16 18:34:32           
2023-11-16 18:34:32                   ********************************************************************************
2023-11-16 18:34:32                   Requirements should be satisfied by a PEP 517 installer.
2023-11-16 18:34:32                   If you are using pip, you can try `pip install --use-pep517`.
2023-11-16 18:34:32                   ********************************************************************************
2023-11-16 18:34:32           
2023-11-16 18:34:32           !!
2023-11-16 18:34:32             dist.fetch_build_eggs(dist.setup_requires)
2023-11-16 18:34:32           WARNING: The repository located at mirrors.baidubce.com is not a trusted or secure host and is being ignored. If this repository is available via HTTPS we recommend you use HTTPS instead, otherwise you may silence this warning and allow it anyway with '--trusted-host mirrors.baidubce.com'.
2023-11-16 18:34:32           ERROR: Could not find a version that satisfies the requirement pytest-runner (from versions: none)
2023-11-16 18:34:32           ERROR: No matching distribution found for pytest-runner
2023-11-16 18:34:32           Traceback (most recent call last):
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/installer.py", line 101, in _fetch_build_egg_no_warn
2023-11-16 18:34:32               subprocess.check_call(cmd)
2023-11-16 18:34:32             File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
2023-11-16 18:34:32               raise CalledProcessError(retcode, cmd)
2023-11-16 18:34:32           subprocess.CalledProcessError: Command '['/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmptdvkcbht', '--quiet', '--index-url', 'http://mirrors.baidubce.com/pypi/simple/', 'pytest-runner']' returned non-zero exit status 1.
2023-11-16 18:34:32           
2023-11-16 18:34:32           The above exception was the direct cause of the following exception:
2023-11-16 18:34:32           
2023-11-16 18:34:32           Traceback (most recent call last):
2023-11-16 18:34:32             File "<string>", line 2, in <module>
2023-11-16 18:34:32             File "<pip-setuptools-caller>", line 34, in <module>
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/setup.py", line 30, in <module>
2023-11-16 18:34:32               setup(name='cmakelint',
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/__init__.py", line 102, in setup
2023-11-16 18:34:32               _install_setup_requires(attrs)
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/__init__.py", line 75, in _install_setup_requires
2023-11-16 18:34:32               _fetch_build_eggs(dist)
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/__init__.py", line 80, in _fetch_build_eggs
2023-11-16 18:34:32               dist.fetch_build_eggs(dist.setup_requires)
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/dist.py", line 662, in fetch_build_eggs
2023-11-16 18:34:32               return _fetch_build_eggs(self, requires)
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/installer.py", line 38, in _fetch_build_eggs
2023-11-16 18:34:32               resolved_dists = pkg_resources.working_set.resolve(
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/pkg_resources/__init__.py", line 829, in resolve
2023-11-16 18:34:32               dist = self._resolve_dist(
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/pkg_resources/__init__.py", line 865, in _resolve_dist
2023-11-16 18:34:32               dist = best[req.key] = env.best_match(
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1135, in best_match
2023-11-16 18:34:32               return self.obtain(req, installer)
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1147, in obtain
2023-11-16 18:34:32               return installer(requirement)
2023-11-16 18:34:32             File "/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/lib/python3.10/site-packages/setuptools/installer.py", line 103, in _fetch_build_egg_no_warn
2023-11-16 18:34:32               raise DistutilsError(str(e)) from e
2023-11-16 18:34:32           distutils.errors.DistutilsError: Command '['/root/.cache/pre-commit/repogksjhhik/py_env-python3.10/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmptdvkcbht', '--quiet', '--index-url', 'http://mirrors.baidubce.com/pypi/simple/', 'pytest-runner']' returned non-zero exit status 1.
2023-11-16 18:34:32           [end of output]
2023-11-16 18:34:32       
2023-11-16 18:34:32       note: This error originates from a subprocess, and is likely not a problem with pip.
2023-11-16 18:34:32     error: metadata-generation-failed
2023-11-16 18:34:32     
2023-11-16 18:34:32     ?? Encountered error while generating package metadata.
2023-11-16 18:34:32     ??????> See above for output.
2023-11-16 18:34:32     
2023-11-16 18:34:32     note: This is an issue with the package mentioned above, not pip.
2023-11-16 18:34:32     hint: See above for details.
2023-11-16 18:34:32     
2023-11-16 18:34:32 Check the log at /root/.cache/pre-commit/pre-commit.log
2023-11-16 18:34:32 
2023-11-16 18:34:32 ************************************************************************************
2023-11-16 18:34:32 Your PR code style check failed.
2023-11-16 18:34:32 Please install pre-commit locally and set up git hook scripts:
2023-11-16 18:34:32 
2023-11-16 18:34:32     pip install pre-commit==2.17.0
2023-11-16 18:34:32     pre-commit install
2023-11-16 18:34:32 
2023-11-16 18:34:32 Then, run pre-commit to check codestyle issues in your PR:
2023-11-16 18:34:32 
2023-11-16 18:34:32     pre-commit run --files paddle/fluid/framework/ir/xpu/conv2d_xpu_fuse_pass.cc paddle/fluid/framework/ir/xpu/fc_xpu_fuse_pass.cc paddle/fluid/framework/ir/xpu/pass_utils.cc paddle/fluid/framework/ir/xpu/quant_utils.cc paddle/fluid/inference/analysis/argument.h paddle/fluid/inference/analysis/ir_pass_manager.cc paddle/fluid/inference/api/analysis_config.cc paddle/fluid/inference/api/analysis_predictor.cc paddle/fluid/inference/api/paddle_analysis_config.h paddle/phi/kernels/fusion/xpu/fc_xpu_kernel.cc
2023-11-16 18:34:32 
2023-11-16 18:34:32 For more information, please refer to our codestyle check guide:
2023-11-16 18:34:32 https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/git_guides/codestyle_check_guide_cn.html
2023-11-16 18:34:32 ************************************************************************************
```

根据报错可以得知是直接 PEP 517 build 时候挂了，原来的 cmake-lint 离谱地在 `setup_requires` 里写了个 `"pytest-runner"`，setup 时候依赖这个也不知道是为啥……

https://github.com/cmake-lint/cmake-lint/blob/5f6c59c5b3d6224542327db4e55289117d32c636/setup.py#L40-L42

所以直接 fork 了个到 PFCCLab（ https://github.com/PFCCLab/cmake-lint-paddle ），重写安装相关的，现在 3.7-3.12 都是有 CI 监测的

当然，以后如果有更优秀的 fork 或者更优秀的 CMake 相关 Linter 可以考虑切换

PCard-66972