### PR TITLE
[cmake] fix capi_exp build failed

### DIFF
--- a/paddle/fluid/inference/capi_exp/CMakeLists.txt
+++ b/paddle/fluid/inference/capi_exp/CMakeLists.txt
@@ -36,6 +36,7 @@ if(APPLE)
     cryptopp
     protobuf
     phi
+    pir
     cblas)
 endif()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

修复`libpaddle_inference_c.dylib`编译错误

```bash
FAILED: paddle/fluid/inference/capi_exp/libpaddle_inference_c.dylib
: && /opt/homebrew/bin/ccache /Library/Developer/CommandLineTools/usr/bin/c++ -DCRYPTOPP_ARM_CRC32_AVAILABLE=0 -std=c++17 -Wno-deprecated-register -Werror=format -Werror=inconsistent-missing-override -Werror=braced-scalar-init -Werror=uninitialized -Werror=tautological-constant-out-of-range-compare -Werror=literal-conversion -Werror=pragma-pack -Werror=c++17-extensions  -fPIC -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.0.sdk -mmacosx-version-min=14.1 -dynamiclib -Wl,-headerpad_max_install_names  -o paddle/fluid/inference/capi_exp/libpaddle_inference_c.dylib -install_name @rpath/libpaddle_inference_c.dylib paddle/fluid/inference/capi_exp/CMakeFiles/paddle_inference_c_shared.dir/pd_config.cc.o paddle/fluid/inference/capi_exp/CMakeFiles/paddle_inference_c_shared.dir/pd_predictor.cc.o paddle/fluid/inference/capi_exp/CMakeFiles/paddle_inference_c_shared.dir/pd_tensor.cc.o paddle/fluid/inference/capi_exp/CMakeFiles/paddle_inference_c_shared.dir/pd_utils.cc.o  third_party/install/glog/lib/libglog.a  paddle/fluid/inference/libpaddle_inference.a  third_party/install/xxhash/lib/libxxhash.a  third_party/install/utf8proc/lib/libutf8proc.a  third_party/install/cryptopp/lib/libcryptopp.a  third_party/install/protobuf/lib/libprotobuf.a  paddle/phi/libphi.a  libcblas.a  third_party/install/xxhash/lib/libxxhash.a  third_party/install/utf8proc/lib/libutf8proc.a  third_party/install/openblas/lib/libopenblas.a  paddle/phi/api/profiler/libphi_profiler_proto.a  paddle/phi/core/distributed/auto_parallel/libauto_parallel_proto.a  third_party/install/protobuf/lib/libprotobuf.a  paddle/utils/libpaddle_flags.a  third_party/install/glog/lib/libglog.a && :
ld: warning: ignoring duplicate libraries: 'third_party/install/glog/lib/libglog.a', 'third_party/install/protobuf/lib/libprotobuf.a', 'third_party/install/utf8proc/lib/libutf8proc.a', 'third_party/install/xxhash/lib/libxxhash.a'
ld: Undefined symbols:
  pir::Float16Type::get(pir::IrContext*), referenced from:
      paddle::dialect::TransToIrDataType(phi::DataType, pir::IrContext*) in libpaddle_inference.a[1589](manual_op.cc.o)
      paddle::dialect::ParameterConvertInterface::VariableToParameter(paddle::framework::Variable*) in libpaddle_inference.a[1593](param_to_variable.cc.o)
      paddle::dialect::TransToIrDataType(phi::DataType, pir::IrContext*) in libpaddle_inference.a[1596](pd_op.cc.o)
      paddle::dialect::TransToIrDataType(phi::DataType, pir::IrContext*) in libpaddle_inference.a[1611](pd_op_to_kernel_pass.cc.o)
      std::__1::__function::__func<paddle::translator::TypeTranslator::TypeTranslator()::$_6, std::__1::allocator<paddle::translator::TypeTranslator::TypeTranslator()::$_6>, pir::Type (pir::IrContext*, paddle::framework::VarDesc const&)>::operator()(pir::IrContext*&&, paddle::framework::VarDesc const&) in libpaddle_inference.a[1626](type_translator.cc.o)
  pir::Float32Type::get(pir::IrContext*), referenced from:
      paddle::dialect::TransToIrDataType(phi::DataType, pir::IrContext*) in libpaddle_inference.a[1589](manual_op.cc.o)
      paddle::dialect::ParameterConvertInterface::VariableToParameter(paddle::framework::Variable*) in libpaddle_inference.a[1593](param_to_variable.cc.o)
      paddle::dialect::TransToIrDataType(phi::DataType, pir::IrContext*) in libpaddle_inference.a[1596](pd_op.cc.o)
      paddle::dialect::BuildOutputs(pir::Operation*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, phi::KernelKey const&, pir::IrContext*) in libpaddle_inference.a[1611](pd_op_to_kernel_pass.cc.o)

...
```

