### PR TITLE
【PIR API adaptor No.222】Migrate paddle.nn.SyncBatchNorm into pir

### DIFF
--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -1623,7 +1623,7 @@ class SyncBatchNorm(_BatchNormBase):
 
         # train mode: use mini-batch stats, eval mode: use global stats
         # use_global_stats only support False in sync_batch_norm
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             sync_batch_norm_out, _, _, _, _, _ = _C_ops.sync_batch_norm_(
                 x,
                 self._mean,

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -28,6 +28,7 @@ import paddle.jit.dy2static as _jst
 from paddle import base
 from paddle.jit.dy2static.convert_call_func import CONVERSION_OPTIONS
 from paddle.jit.dy2static.utils import func_to_source_code
+from paddle.pir_utils import test_with_pir_api
 
 SEED = 2020
 np.random.seed(SEED)

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -28,7 +28,6 @@ import paddle.jit.dy2static as _jst
 from paddle import base
 from paddle.jit.dy2static.convert_call_func import CONVERSION_OPTIONS
 from paddle.jit.dy2static.utils import func_to_source_code
-from paddle.pir_utils import test_with_pir_api
 
 SEED = 2020
 np.random.seed(SEED)
@@ -294,7 +293,7 @@ class TestConvertPaddleAPI(Dy2StTestBase):
         bn = paddle.nn.SyncBatchNorm(2)
         paddle.jit.to_static(bn)
         self.assertNotIn("_jst.IfElse", bn.forward.code)
-        self.assertIn("if in_dynamic_mode()", bn.forward.code)
+        self.assertIn("if in_dynamic_or_pir_mode()", bn.forward.code)
 
     @test_ast_only
     @test_legacy_and_pir_api

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -34,6 +34,7 @@ from paddle.incubate.layers.nn import (
     rank_attention,
     shuffle_batch,
 )
+from paddle.pir_utils import test_with_pir_api
 from paddle.tensor import random
 
 
@@ -275,6 +276,7 @@ class TestLayer(LayerTest):
 
             self.assertRaises(TypeError, test_type)
 
+    @test_with_pir_api
     def test_SyncBatchNorm(self):
         if core.is_compiled_with_cuda():
             with self.static_graph():

--- a/test/legacy_test/test_sync_batch_norm_op.py
+++ b/test/legacy_test/test_sync_batch_norm_op.py
@@ -30,8 +30,9 @@ from op_test import OpTest, _set_use_system_allocator, convert_float_to_uint16
 
 import paddle
 from paddle import base, nn
-from paddle.base import Program, core, program_guard
+from paddle.base import core
 from paddle.base.framework import in_dygraph_mode
+from paddle.pir_utils import test_with_pir_api
 
 _set_use_system_allocator(True)
 
@@ -359,12 +360,15 @@ class TestBF16SyncBatchNormOpTraining(TestSyncBatchNormOpTraining):
 
 
 class TestDygraphSyncBatchNormAPIError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         if not core.is_compiled_with_cuda():
             return
 
         cleanup = enable_static()
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             my_sync_batch_norm = paddle.nn.SyncBatchNorm(10)
             x1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], base.CUDAPlace(0)
@@ -382,11 +386,14 @@ class TestDygraphSyncBatchNormAPIError(unittest.TestCase):
 
 
 class TestConvertSyncBatchNorm(unittest.TestCase):
+    @test_with_pir_api
     def test_convert(self):
         if not core.is_compiled_with_cuda():
             return
 
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             compare_model = paddle.nn.Sequential(
                 paddle.nn.Conv2D(3, 5, 3),
                 paddle.nn.BatchNorm2D(5),
@@ -410,6 +417,7 @@ class TestConvertSyncBatchNorm(unittest.TestCase):
 
 
 class TestConvertSyncBatchNormCast1(unittest.TestCase):
+    @test_with_pir_api
     def test_convert(self):
         if not core.is_compiled_with_cuda():
             return

--- a/test/legacy_test/test_sync_batch_norm_op.py
+++ b/test/legacy_test/test_sync_batch_norm_op.py
@@ -360,7 +360,6 @@ class TestBF16SyncBatchNormOpTraining(TestSyncBatchNormOpTraining):
 
 
 class TestDygraphSyncBatchNormAPIError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         if not core.is_compiled_with_cuda():
             return


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/58067
No.222 paddle.nn.SyncBatchNorm
PIR API 推全升级

将 paddle.nn.SyncBatchNorm 迁移升级至 pir，并更新单测 单测覆盖率：3/4
TestSyncBatchNormOpTraining测试比较复杂无法直接适配pir，暂时没有适配

存在问题：

```
2023-11-21 05:27:45 test_sync_batch_norm_op failed
2023-11-21 05:27:45  ss..E.....
2023-11-21 05:27:45 ======================================================================
2023-11-21 05:27:45 ERROR: test_errors (test_sync_batch_norm_op.TestDygraphSyncBatchNormAPIError)
2023-11-21 05:27:45 ----------------------------------------------------------------------
2023-11-21 05:27:45 Traceback (most recent call last):
2023-11-21 05:27:45   File "/paddle/build/python/paddle/pir_utils.py", line 115, in impl
2023-11-21 05:27:45     func(*args, **kwargs)
2023-11-21 05:27:45   File "/mnt/paddle/build/test/legacy_test/test_sync_batch_norm_op.py", line 376, in test_errors
2023-11-21 05:27:45     self.assertRaises(TypeError, my_sync_batch_norm, x1)
2023-11-21 05:27:45   File "/usr/local/lib/python3.8/unittest/case.py", line 816, in assertRaises
2023-11-21 05:27:45     return context.handle('assertRaises', args, kwargs)
2023-11-21 05:27:45   File "/usr/local/lib/python3.8/unittest/case.py", line 202, in handle
2023-11-21 05:27:45     callable_obj(*args, **kwargs)
2023-11-21 05:27:45   File "/paddle/build/python/paddle/nn/layer/layers.py", line 1426, in __call__
2023-11-21 05:27:45     return self._dygraph_call_func(*inputs, **kwargs)
2023-11-21 05:27:45   File "/paddle/build/python/paddle/nn/layer/layers.py", line 1405, in _dygraph_call_func
2023-11-21 05:27:45     outputs = self.forward(*inputs, **kwargs)
2023-11-21 05:27:45   File "/paddle/build/python/paddle/nn/layer/norm.py", line 1627, in forward
2023-11-21 05:27:45     sync_batch_norm_out, _, _, _, _, _ = _C_ops.sync_batch_norm_(
2023-11-21 05:27:45 ValueError: 
2023-11-21 05:27:45 
2023-11-21 05:27:45 --------------------------------------
2023-11-21 05:27:45 C++ Traceback (most recent call last):
2023-11-21 05:27:45 --------------------------------------
2023-11-21 05:27:45 0   paddle::pybind::static_api_sync_batch_norm_(_object*, _object*, _object*)
2023-11-21 05:27:45 1   paddle::pybind::CastPyArg2Value(_object*, std::string const&, unsigned long)
2023-11-21 05:27:45 2   phi::enforce::EnforceNotMet::EnforceNotMet(phi::ErrorSummary const&, char const*, int)
2023-11-21 05:27:45 3   phi::enforce::GetCurrentTraceBackString[abi:cxx11](bool)
2023-11-21 05:27:45 
2023-11-21 05:27:45 ----------------------
2023-11-21 05:27:45 Error Message Summary:
2023-11-21 05:27:45 ----------------------
2023-11-21 05:27:45 InvalidArgumentError: sync_batch_norm_(): argument (position 1) must be OpResult, but got paddle.base.libpaddle.Tensor (at /paddle/paddle/fluid/pybind/eager_utils.cc:1925)
```
