### PR TITLE
Fix building on GCC 13 and Linux 6.0+

### DIFF
--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -61,6 +61,18 @@ if(CMAKE_COMPILER_IS_GNUCC)
         ${SOURCE_DIR}/gloo/ < ${types_header})
   endif()
 endif()
+
+file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/linux.cc.patch
+     linux_cc_ethtool)
+if(GLOO_PATCH_COMMAND STREQUAL "")
+  set(GLOO_PATCH_COMMAND
+      git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd
+      ${SOURCE_DIR}/gloo/common/ < ${linux_cc_ethtool})
+else()
+  set(GLOO_PATCH_COMMAND ${GLOO_PATCH_COMMAND} && patch -Nd
+      ${SOURCE_DIR}/gloo/common/ < ${linux_cc_ethtool})
+endif()
+
 include_directories(${GLOO_INCLUDE_DIR})
 
 ExternalProject_Add(

--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -65,12 +65,11 @@ endif()
 file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/linux.cc.patch
      linux_cc_ethtool)
 if(GLOO_PATCH_COMMAND STREQUAL "")
-  set(GLOO_PATCH_COMMAND
-      git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd
-      ${SOURCE_DIR}/gloo/common/ < ${linux_cc_ethtool})
+  set(GLOO_PATCH_COMMAND git checkout -- . && git checkout ${GLOO_TAG} && patch
+                         -Nd ${SOURCE_DIR}/gloo/common/ < ${linux_cc_ethtool})
 else()
   set(GLOO_PATCH_COMMAND ${GLOO_PATCH_COMMAND} && patch -Nd
-      ${SOURCE_DIR}/gloo/common/ < ${linux_cc_ethtool})
+                         ${SOURCE_DIR}/gloo/common/ < ${linux_cc_ethtool})
 endif()
 
 include_directories(${GLOO_INCLUDE_DIR})

--- a/paddle/fluid/platform/profiler/chrometracing_logger.h
+++ b/paddle/fluid/platform/profiler/chrometracing_logger.h
@@ -13,11 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <unordered_map>
 #include <utility>
-#include <cstdint>
 
 #include "paddle/fluid/platform/device/gpu/gpu_info.h"
 #include "paddle/fluid/platform/profiler/output_logger.h"

--- a/paddle/fluid/platform/profiler/chrometracing_logger.h
+++ b/paddle/fluid/platform/profiler/chrometracing_logger.h
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <set>
 #include <unordered_map>
 #include <utility>
+#include <cstdint>
 
 #include "paddle/fluid/platform/device/gpu/gpu_info.h"
 #include "paddle/fluid/platform/profiler/output_logger.h"

--- a/paddle/phi/common/place.h
+++ b/paddle/phi/common/place.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 

--- a/paddle/phi/core/os_info.h
+++ b/paddle/phi/core/os_info.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #ifdef _POSIX_C_SOURCE

--- a/paddle/utils/string/string_helper.h
+++ b/paddle/utils/string/string_helper.h
@@ -18,8 +18,8 @@
 #include <ctype.h>
 #include <stdio.h>
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <string>
@@ -103,12 +103,12 @@ inline int str_to_float(const char* str, float* v) {
   return index;
 }
 
-inline float* str_to_float(std::string& str) {
-  return (float*)const_cast<char*>(str.c_str());
+inline float* str_to_float(const std::string& str) {
+  return reinterpret_cast<float*>(const_cast<char*>(str.c_str()));
 }
 
 inline float* str_to_float(const char* str) {
-  return (float*)const_cast<char*>(str);
+  return reinterpret_cast<float*>(const_cast<char*>(str));
 }
 
 // checks whether the test string is a suffix of the input string.
@@ -248,7 +248,7 @@ struct str_ptr_stream {
   char* ptr = NULL;
   char* end = NULL;
   str_ptr_stream() {}
-  str_ptr_stream(const str_ptr& p) { reset(p.ptr, p.len); }
+  explicit str_ptr_stream(const str_ptr& p) { reset(p.ptr, p.len); }
   void reset(const str_ptr& p) { reset(p.ptr, p.len); }
   void reset(const char* p, size_t len) {
     ptr = const_cast<char*>(p);
@@ -317,7 +317,7 @@ inline int split_string_ptr(const char* str,
       ++p;
       continue;
     }
-    values->emplace_back(last, (size_t)(p - last));
+    values->emplace_back(last, static_cast<size_t>(p - last));
     ++num;
     ++p;
     // skip continue delim
@@ -327,7 +327,7 @@ inline int split_string_ptr(const char* str,
     last = p;
   }
   if (p > last) {
-    values->emplace_back(last, (size_t)(p - last));
+    values->emplace_back(last, static_cast<size_t>(p - last));
     ++num;
   }
   return num;
@@ -351,7 +351,7 @@ inline int split_string_ptr(const char* str,
       ++p;
       continue;
     }
-    values->emplace_back(last, (size_t)(p - last));
+    values->emplace_back(last, static_cast<size_t>(p - last));
     ++num;
     ++p;
     if (num >= max_num) {
@@ -364,7 +364,7 @@ inline int split_string_ptr(const char* str,
     last = p;
   }
   if (p > last) {
-    values->emplace_back(last, (size_t)(p - last));
+    values->emplace_back(last, static_cast<size_t>(p - last));
     ++num;
   }
   return num;

--- a/paddle/utils/string/string_helper.h
+++ b/paddle/utils/string/string_helper.h
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <stdio.h>
 
+#include <cstdint>
 #include <algorithm>
 #include <cstring>
 #include <sstream>

--- a/patches/gloo/linux.cc.patch
+++ b/patches/gloo/linux.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/gloo/common/linux.cc b/gloo/common/linux.cc
+index a3726da..9a42a12 100644
+--- a/linux.cc
++++ b/linux.cc
+@@ -188,8 +188,8 @@ static int getInterfaceSpeedGLinkSettings(int sock, struct ifreq* ifr) {
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+   constexpr auto link_mode_data_nwords = 3 * 127;
+   struct {
+-    struct ethtool_link_settings req;
+     __u32 link_mode_data[link_mode_data_nwords];
++    struct ethtool_link_settings req;
+   } ecmd;
+   int rv;


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
1. GCC 13 [breaking changes](https://gcc.gnu.org/gcc-13/porting_to.html) require `<cstdint>` header explicitly included.
2. Third-party dependency gloo can't compile on Linux 6.0+, for header changes. This add an [upstream patch](https://github.com/facebookincubator/gloo/commit/10909297fedab0a680799211a299203e53515032).