### PR TITLE
[PIR] [dynamic shape] fix bug in dynamic shape Print

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -77,7 +77,8 @@ void OperatorDialect::PrintType(pir::Type type, std::ostream &os) const {
   if (auto tensor_type = type.dyn_cast<DenseTensorType>()) {
     os << "tensor<";
     for (auto d : phi::vectorize(tensor_type.dims())) {
-      pir::ShapedTypeInterface::IsDynamic(d) ? os << "?" : os << d;
+      // in DDim, "-1" represents the dynamic dim
+      d == -1 ? os << "?" : os << d;
       os << "x";
     }
     tensor_type.dtype().Print(os);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
对DDim判断动态shape维度必须使用“-1”，不能使用pir::ShapedTypeInterface::IsDynamic()，否则无法正确识别，本PR修复该bug
