### PR TITLE
[Hackathon 5th No.49][pir] add `OpResult.clone()` - Part 8

### DIFF
--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -331,6 +331,31 @@ def monkey_patch_opresult():
         """
         return paddle.numel(self)
 
+    def clone(self):
+        """
+        Returns a new static OpResult, which is the clone of the original static
+        OpResult. It remains in the current graph, that is, the cloned OpResult
+        provides gradient propagation. Calling ``out = tensor.clone()`` is same
+        as ``out = assign(tensor)`` .
+
+        Returns:
+            OpResult, The cloned OpResult.
+
+        Examples:
+            .. code-block:: python
+
+                >>> import paddle
+
+                >>> paddle.enable_static()
+
+                >>> # create a static OpResult
+                >>> x = paddle.static.data(name='x', shape=[3, 2, 1])
+                >>> # create a cloned OpResult
+                >>> y = x.clone()
+
+        """
+        return paddle.assign(self)
+
     import paddle
 
     opresult_methods = [
@@ -341,6 +366,7 @@ def monkey_patch_opresult():
         ('ndim', _ndim),
         ('astype', astype),
         ('size', _size_),
+        ('clone', clone),
         (
             '__add__',
             _binary_creator_('__add__', paddle.tensor.add, False, _scalar_add_),

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -427,6 +427,23 @@ class TestMathOpPatchesPir(unittest.TestCase):
                 (output_x,) = exe.run(main_program, fetch_list=[x.size])
                 self.assertEqual(output_x, 24)
 
+    def test_clone(self):
+        x_np = np.random.random(size=[100, 10]).astype('float64')
+        with paddle.pir_utils.IrGuard():
+            main_program, exe, program_guard = new_program()
+            with program_guard:
+                x = paddle.static.data(
+                    name='x', shape=[100, 10], dtype="float64"
+                )
+                a = x.clone()
+                (a_np,) = exe.run(
+                    main_program,
+                    feed={"x": x_np},
+                    fetch_list=[a],
+                )
+                np.testing.assert_array_equal(x_np, a_np)
+                self.assertNotEqual(id(x), id(a))
+
     def test_math_exists(self):
         with paddle.pir_utils.IrGuard():
             a = paddle.static.data(name='a', shape=[1], dtype='float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

支持`OpResult.clone()`方法

相关链接：
* #58118
* #57857
* #58042
* #58219
* #58343
* #58739
* #58791
* #58987
* [No.49：python端补齐OpResult的patch方法](https://github.com/PaddlePaddle/community/blob/master/hackathon/hackathon_5th/%E3%80%90PaddlePaddle%20Hackathon%205th%E3%80%91%E5%BC%80%E6%BA%90%E8%B4%A1%E7%8C%AE%E4%B8%AA%E4%BA%BA%E6%8C%91%E6%88%98%E8%B5%9B%E6%A1%86%E6%9E%B6%E5%BC%80%E5%8F%91%E4%BB%BB%E5%8A%A1%E5%90%88%E9%9B%86.md#no49python%E7%AB%AF%E8%A1%A5%E9%BD%90opresult%E7%9A%84patch%E6%96%B9%E6%B3%95)