### PR TITLE
change `.. code-block:: text` to `.. code-block:: python` in example code, in `python\paddle\distributed\fleet\fleet.py`

### DIFF
--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -957,7 +957,7 @@ class Fleet:
 
         Examples:
 
-            .. code-block:: text
+            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.enable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
change `.. code-block:: text` to `.. code-block:: python` in example code, in `python\paddle\distributed\fleet\fleet.py`
@SigureMo @sunzhongkai588 