### PR TITLE
修复了clang-tidy.py 在Windows中检查clang-tidy 版本失败的问题

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -913,7 +913,11 @@ with open("@PADDLE_BINARY_DIR@/python/paddle/README.md", "r", encoding='UTF-8') 
 
 # strip *.so to reduce package size
 if '${WITH_STRIP}' == 'ON':
-    command = 'find ${shlex.quote(PADDLE_BINARY_DIR)}/python/paddle -name "*.so" | xargs -i strip {}'
+    command = (
+        'find '
+        + shlex.quote('${PADDLE_BINARY_DIR}')
+        + '/python/paddle -name "*.so" | xargs -i strip {}'
+    )
     if os.system(command) != 0:
         raise Exception("strip *.so failed, command: %s" % command)
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -9,6 +9,7 @@ import fnmatch
 import errno
 import platform
 import glob
+import shlex
 
 from contextlib import contextmanager
 from setuptools import Command
@@ -912,7 +913,7 @@ with open("@PADDLE_BINARY_DIR@/python/paddle/README.md", "r", encoding='UTF-8') 
 
 # strip *.so to reduce package size
 if '${WITH_STRIP}' == 'ON':
-    command = 'find ${PADDLE_BINARY_DIR}/python/paddle -name "*.so" | xargs -i strip {}'
+    command = 'find ${shlex.quote(PADDLE_BINARY_DIR)}/python/paddle -name "*.so" | xargs -i strip {}'
     if os.system(command) != 0:
         raise Exception("strip *.so failed, command: %s" % command)
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import multiprocessing
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -1699,7 +1700,7 @@ def main():
     if env_dict.get("WITH_STRIP") == 'ON':
         command = (
             'find '
-            + paddle_binary_dir
+            + shlex.quote(paddle_binary_dir)
             + '/python/paddle -name "*.so" | xargs -i strip {}'
         )
         if os.system(command) != 0:

--- a/tools/codestyle/clang-tidy.py
+++ b/tools/codestyle/clang-tidy.py
@@ -471,7 +471,7 @@ def main():
 if __name__ == '__main__':
     target_version = "15.0.2"
     try:
-        out = subprocess.check_output(['clang-tidy --version'], shell=True)
+        out = subprocess.check_output(['clang-tidy', '--version'], shell=True)
         version = out.decode('utf-8')
         if version.find(target_version) == -1:
             print(


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
在clang-tidy.py文件中，检测命令的参数“--version”需要通过一个数组元素单独提供，否则会导致Windows下的检测失败。
将原有代码：
```python
out = subprocess.check_output(['clang-tidy --version'], shell=True)
```
修改为：
```python
out = subprocess.check_output(['clang-tidy', '--version'], shell=True)
```
后检测成功。
