### PR TITLE
修复了clang-tidy.py 在Windows中检查clang-tidy 版本失败的问题

### DIFF
--- a/tools/codestyle/clang-tidy.py
+++ b/tools/codestyle/clang-tidy.py
@@ -471,7 +471,7 @@ def main():
 if __name__ == '__main__':
     target_version = "15.0.2"
     try:
-        out = subprocess.check_output(['clang-tidy --version'], shell=True)
+        out = subprocess.check_output(['clang-tidy', '--version'], shell=True)
         version = out.decode('utf-8')
         if version.find(target_version) == -1:
             print(


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
在clang-tidy.py文件中，检测命令的参数“--version”需要通过一个数组元素单独提供，否则会导致Windows下的检测失败。
将原有代码：
```python
out = subprocess.check_output(['clang-tidy --version'], shell=True)
```
修改为：
```python
out = subprocess.check_output(['clang-tidy', '--version'], shell=True)
```
后检测成功。

