### PR TITLE
[PIR] Add op compat for c_reducescatter

### DIFF
--- a/paddle/fluid/operators/generator/parse_utils.py
+++ b/paddle/fluid/operators/generator/parse_utils.py
@@ -367,6 +367,7 @@ def check_op_config(op_entry, op_name):
         'support_dygraph_mode',
         'support_tensor',
         'traits',
+        'interfaces',
     )
     infer_meta_key_set = ('func', 'param', 'spmd_rule')
     kernel_key_set = (
@@ -520,6 +521,11 @@ def parse_op_entry(op_entry: Dict[str, Any], name_field="op"):
     else:
         trait_list = []
 
+    if "interfaces" in op_entry.keys():
+        interface_list = parse_plain_list(op_entry["interfaces"])
+    else:
+        interface_list = []
+
     op = {
         "name": op_name,
         "inputs": inputs,
@@ -529,6 +535,7 @@ def parse_op_entry(op_entry: Dict[str, Any], name_field="op"):
         "data_transform": data_trans,
         "support_tensor": support_tensor,
         "traits": trait_list,
+        "interfaces": interface_list,
     }
 
     # op should be is_base_op or is_invoke_op or is_only_composite_op

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -125,7 +125,7 @@ get_kernel_type_for_var_declare_template = """
 """
 
 parse_kernel_key_template = """
-  static std::tuple<phi::DataType, phi::Backend> ParseKernelKey();
+  static std::tuple<phi::DataType, phi::Backend> ParseKernelKey(pir::Operation *op);
 """
 
 # =====================================

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -426,9 +426,18 @@ class OpInfoParser:
         # parse traits list
         self.traits_list = self.parse_op_traits()
 
+        # parse interfaces list
+        self.interfaces_list = self.parse_op_interfaces()
+
     def parse_op_traits(self):
         if 'traits' in self.op_yaml_item:
             return self.op_yaml_item['traits']
+        else:
+            return []
+
+    def parse_op_interfaces(self):
+        if 'interfaces' in self.op_yaml_item:
+            return self.op_yaml_item['interfaces']
         else:
             return []
 
@@ -1121,8 +1130,9 @@ def OpGenerator(
         op_inplace_map = op_info.inplace_map
         op_view_map = op_info.view_map
         op_data_transform_map = op_info.data_transform_map
-        op_interfaces = ["paddle::dialect::OpYamlInfoInterface"]
         op_traits = op_info.traits_list
+        op_interfaces = op_info.interfaces_list
+        op_interfaces += ["paddle::dialect::OpYamlInfoInterface"]
 
         if op_info.infer_meta_func:
             op_interfaces += ["paddle::dialect::InferMetaInterface"]

--- a/paddle/fluid/pir/dialect/op_generator/parse_kernel_key_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/parse_kernel_key_gen.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 OP_GET_KERNEL_TYPE_FOR_VAR_TEMPLATE = """
-std::tuple<phi::DataType, phi::Backend> ParseKernelKey() {{
+std::tuple<phi::DataType, phi::Backend> {op_name}::ParseKernelKey() {{
   VLOG(4) << "Parse kernel key for op: {op_name}";
   return {op_name}ParseKernelKey(operation());
 }}

--- a/paddle/fluid/pir/dialect/op_generator/parse_kernel_key_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/parse_kernel_key_gen.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OP_GET_KERNEL_TYPE_FOR_VAR_TEMPLATE = """
+std::tuple<phi::DataType, phi::Backend> ParseKernelKey() {{
+  VLOG(4) << "Parse kernel key for op: {op_name}";
+  return {op_name}ParseKernelKey(operation());
+}}
+"""
+
+
+def gen_parse_kernel_key_str(op_class_name):
+    return OP_GET_KERNEL_TYPE_FOR_VAR_TEMPLATE.format(op_name=op_class_name)

--- a/paddle/fluid/pir/dialect/op_generator/parse_kernel_key_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/parse_kernel_key_gen.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 OP_GET_KERNEL_TYPE_FOR_VAR_TEMPLATE = """
-std::tuple<phi::DataType, phi::Backend> {op_name}::ParseKernelKey() {{
+std::tuple<phi::DataType, phi::Backend> {op_name}::ParseKernelKey(pir::Operation *op) {{
   VLOG(4) << "Parse kernel key for op: {op_name}";
-  return {op_name}ParseKernelKey(operation());
+  return {op_name}ParseKernelKey(op);
 }}
 """
 

--- a/paddle/fluid/pir/dialect/operator/interface/interface.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/interface.cc
@@ -37,6 +37,19 @@ std::vector<std::vector<pir::OpResult>> VjpInterface::Vjp(
   }
   return impl_->vjp_(op, inputs, outputs, out_grads_value, stop_gradients);
 }
+
+KernelKeyTuple UniqueOpParseKernelKey(pir::Operation* op) {
+  DenseTensorType x_type =
+      op->operand_source(0).type().dyn_cast<paddle::dialect::DenseTensorType>();
+  phi::DataType dtype = TransToPhiDataType(x_type.dtype());
+  pir::BoolAttribute is_sort = op->attribute<pir::BoolAttribute>("is_sorted");
+  phi::Backend backend = phi::Backend::UNDEFINED;
+  if (is_sort.data()) {
+    backend = phi::Backend::CPU;
+  }
+  return {dtype, backend};
+}
+
 }  // namespace dialect
 }  // namespace paddle
 

--- a/paddle/fluid/pir/dialect/operator/interface/interface.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/interface.cc
@@ -16,7 +16,9 @@
 #include "paddle/fluid/pir/dialect/operator/interface/get_kernel_type_for_var.h"
 #include "paddle/fluid/pir/dialect/operator/interface/infermeta.h"
 #include "paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h"
+#include "paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h"
 #include "paddle/fluid/pir/dialect/operator/interface/vjp.h"
+
 namespace paddle {
 namespace dialect {
 std::vector<std::vector<pir::OpResult>> VjpInterface::Vjp(
@@ -43,3 +45,4 @@ IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::OpYamlInfoInterface)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::VjpInterface)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::DecompInterface)
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::GetKernelTypeForVarInterface)
+IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::ParseKernelKeyInterface)

--- a/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
+++ b/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
@@ -55,17 +55,7 @@ class ParseKernelKeyInterface
 };
 
 // Register the ParseKernelKeyInterface for unique op.
-KernelKeyTuple UniqueOpParseKernelKey(pir::Operation *op) {
-  DenseTensorType x_type =
-      op->operand_source(0).type().dyn_cast<paddle::dialect::DenseTensorType>();
-  phi::DataType dtype = TransToPhiDataType(x_type.dtype());
-  pir::BoolAttribute is_sort = op->attribute<pir::BoolAttribute>("is_sorted");
-  phi::Backend backend = phi::Backend::UNDEFINED;
-  if (is_sort.data()) {
-    backend = phi::Backend::CPU;
-  }
-  return {dtype, backend};
-}
+KernelKeyTuple UniqueOpParseKernelKey(pir::Operation *op);
 
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
+++ b/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
@@ -55,7 +55,7 @@ class ParseKernelKeyInterface
 };
 
 // Register the ParseKernelKeyInterface for unique op.
-KernelKeyTuple UniqueOpParseKernelKey(pir::Operation *op) {
+KernelKeyTuple UniqueOpParseKernelKey(const pir::Operation *op) {
   DenseTensorType x_type =
       op->operand_source(0).type().dyn_cast<paddle::dialect::DenseTensorType>();
   phi::DataType dtype = TransToPhiDataType(x_type.dtype());

--- a/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
+++ b/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
@@ -28,15 +28,15 @@ class ParseKernelKeyInterface
     : public pir::OpInterfaceBase<ParseKernelKeyInterface> {
  public:
   struct Concept {
-    explicit Concept(KernelKeyTuple (*parse_kernel_key)(pir::Operation *op))
+    explicit Concept(KernelKeyTuple (*parse_kernel_key)())
         : parse_kernel_key_(parse_kernel_key) {}
-    KernelKeyTuple (*parse_kernel_key_)(pir::Operation *op);
+    KernelKeyTuple (*parse_kernel_key_)();
   };
 
   template <class ConcreteOp>
   struct Model : public Concept {
-    static KernelKeyTuple ParseKernelKey(pir::Operation *op) {
-      return ConcreteOp::ParseKernelKey(op);
+    static KernelKeyTuple ParseKernelKey() {
+      return ConcreteOp::ParseKernelKey();
     }
 
     Model() : Concept(ParseKernelKey) {}
@@ -46,9 +46,7 @@ class ParseKernelKeyInterface
   ParseKernelKeyInterface(pir::Operation *op, Concept *impl)
       : pir::OpInterfaceBase<ParseKernelKeyInterface>(op), impl_(impl) {}
 
-  KernelKeyTuple ParseKernelKey(pir::Operation *op) {
-    return impl_->parse_kernel_key_(op);
-  }
+  KernelKeyTuple ParseKernelKey() { return impl_->parse_kernel_key_(); }
 
  private:
   Concept *impl_;

--- a/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
+++ b/paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
+#include "paddle/fluid/pir/dialect/operator/utils/utils.h"
+#include "paddle/phi/common/backend.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/pir/core/op_base.h"
+
+using KernelKeyTuple = std::tuple<phi::DataType, phi::Backend>;
+
+namespace paddle {
+namespace dialect {
+class ParseKernelKeyInterface
+    : public pir::OpInterfaceBase<ParseKernelKeyInterface> {
+ public:
+  struct Concept {
+    explicit Concept(KernelKeyTuple (*parse_kernel_key)(pir::Operation *op))
+        : parse_kernel_key_(parse_kernel_key) {}
+    KernelKeyTuple (*parse_kernel_key_)(pir::Operation *op);
+  };
+
+  template <class ConcreteOp>
+  struct Model : public Concept {
+    static KernelKeyTuple ParseKernelKey(pir::Operation *op) {
+      return ConcreteOp::ParseKernelKey(op);
+    }
+
+    Model() : Concept(ParseKernelKey) {}
+  };
+
+  /// Constructor
+  ParseKernelKeyInterface(pir::Operation *op, Concept *impl)
+      : pir::OpInterfaceBase<ParseKernelKeyInterface>(op), impl_(impl) {}
+
+  KernelKeyTuple ParseKernelKey(pir::Operation *op) {
+    return impl_->parse_kernel_key_(op);
+  }
+
+ private:
+  Concept *impl_;
+};
+
+// Register the ParseKernelKeyInterface for unique op.
+KernelKeyTuple UniqueOpParseKernelKey(pir::Operation *op) {
+  DenseTensorType x_type =
+      op->operand_source(0).type().dyn_cast<paddle::dialect::DenseTensorType>();
+  phi::DataType dtype = TransToPhiDataType(x_type.dtype());
+  pir::BoolAttribute is_sort = op->attribute<pir::BoolAttribute>("is_sorted");
+  phi::Backend backend = phi::Backend::UNDEFINED;
+  if (is_sort.data()) {
+    backend = phi::Backend::CPU;
+  }
+  return {dtype, backend};
+}
+
+}  // namespace dialect
+}  // namespace paddle
+
+IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::ParseKernelKeyInterface)

--- a/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/update_ops.yaml
@@ -12,3 +12,14 @@
     data_type : dtype
     backend : place
   support_tensor : [start, end, step]
+
+- op : unique
+  args : (Tensor x, bool return_index=false, bool return_inverse=false, bool return_counts=false, int[] axis={}, DataType dtype=DataType::INT64, bool is_sorted=false)
+  output : Tensor(out), Tensor(indices), Tensor(inverse), Tensor(counts)
+  optional : indices, counts
+  infer_meta :
+    func : UniqueRawInferMeta
+  kernel :
+    func : unique
+    data_type : x
+  interfaces : paddle::dialect::ParseKernelKeyInterface

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -22,6 +22,7 @@
 #include "paddle/fluid/pir/dialect/kernel/ir/kernel_op.h"
 #include "paddle/fluid/pir/dialect/kernel/ir/kernel_type.h"
 #include "paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h"
+#include "paddle/fluid/pir/dialect/operator/interface/parse_kernel_key.h"
 #include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
@@ -638,6 +639,13 @@ phi::KernelKey GetKernelKey(
   }
 
   // TODO(zhangbo): Add ParseKernelInterface
+  ParseKernelKeyInterface parse_kernel_key_interface =
+      op->dyn_cast<ParseKernelKeyInterface>();
+  if (parse_kernel_key_interface) {
+    auto parsed_key = parse_kernel_key_interface.ParseKernelKey(op);
+    kernel_dtype = std::get<0>(parsed_key);
+    kernel_backend = std::get<1>(parsed_key);
+  }
 
   if ((kernel_backend == phi::Backend::UNDEFINED ||
        kernel_dtype == phi::DataType::UNDEFINED) &&

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -637,6 +637,8 @@ phi::KernelKey GetKernelKey(
     }
   }
 
+  // TODO(zhangbo): Add ParseKernelInterface
+
   if ((kernel_backend == phi::Backend::UNDEFINED ||
        kernel_dtype == phi::DataType::UNDEFINED) &&
       op->num_operands() > 0) {
@@ -666,8 +668,7 @@ phi::KernelKey GetKernelKey(
       // don't know how to select the kernel in the next of op that
       // uses data op outout as inputs. So, we need set kernel backend
       // manually.
-      auto op_res = op->operand_source(i).dyn_cast<pir::OpResult>();
-
+      auto op_res = input_tmp.dyn_cast<pir::OpResult>();
       if (!op_res) {
         continue;
       }

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -3297,6 +3297,12 @@
   outputs :
     out: Out
 
+- op: c_reducescatter
+  inputs :
+    x : X
+  outputs :
+    out: Out
+
 - op: c_sync_calc_stream
   inputs :
     x : X

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -66,7 +66,7 @@ class IR_API alignas(8) Operation final {
   }
   const AttributeMap &attributes() const { return attributes_; }
   template <typename T>
-  T attribute(const std::string &name) const {
+  T attribute(const std::string &name) {
     Attribute attr = attribute(name);
     IR_ENFORCE(attr.isa<T>(), "Attribute (%s) type is not right.", name);
     return attr.dyn_cast<T>();

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -66,7 +66,7 @@ class IR_API alignas(8) Operation final {
   }
   const AttributeMap &attributes() const { return attributes_; }
   template <typename T>
-  T attribute(const std::string &name) {
+  T attribute(const std::string &name) const {
     Attribute attr = attribute(name);
     IR_ENFORCE(attr.isa<T>(), "Attribute (%s) type is not right.", name);
     return attr.dyn_cast<T>();

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2664,9 +2664,31 @@ def unique(
     else:
         axis = [axis]
     attr_dtype = convert_np_dtype_to_dtype_(dtype)
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         out, indices, inverse, counts = _C_ops.unique(
             x, return_index, return_inverse, return_counts, axis, attr_dtype
+        )
+        outs = [out]
+        if return_index:
+            outs.append(indices)
+        if return_inverse:
+            outs.append(inverse)
+        if return_counts:
+            outs.append(counts)
+
+        if len(outs) == 1:
+            return outs[0]
+
+        return tuple(outs)
+    elif in_pir_mode():
+        out, indices, inverse, counts = _C_ops.unique(
+            x,
+            return_index,
+            return_inverse,
+            return_counts,
+            axis,
+            attr_dtype,
+            True,
         )
         outs = [out]
         if return_index:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
为 c_reducescatter 算子添加新旧IR 的输入输出名字映射
Pcard-67164
