### PR TITLE
[PIR] [dynamic shape] fix bug in dynamic shape Print

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -77,7 +77,7 @@ void OperatorDialect::PrintType(pir::Type type, std::ostream &os) const {
   if (auto tensor_type = type.dyn_cast<DenseTensorType>()) {
     os << "tensor<";
     for (auto d : phi::vectorize(tensor_type.dims())) {
-      pir::ShapedTypeInterface::IsDynamic(d) ? os << "?" : os << d;
+      os << d;
       os << "x";
     }
     tensor_type.dtype().Print(os);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
对动态shape的维度打印“?”会引起PIR不识别，从而在parse的过程出core，本PR将动态维度打印修改回“-1”，打印日志及其他场景下仍以“-1”表示动态维度，与之前框架行为一致
