### PR TITLE
[XPU] fix is_xpu_support_op: should call get_kl3_ops

### DIFF
--- a/paddle/phi/backends/xpu/xpu_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu_op_list.cc
@@ -85,8 +85,11 @@ bool is_xpu_support_op(const std::string& fluid_op_name,
                        const phi::DataType type) {
   if (is_in_xpu_black_list(fluid_op_name)) return false;
   auto v = get_xpu_version(-1);
-  auto& ops = (v == phi::backends::xpu::XPUVersion::XPU1) ? get_kl1_ops()
-                                                          : get_kl2_ops();
+  auto& ops =
+      (v == phi::backends::xpu::XPUVersion::XPU1)
+          ? get_kl1_ops()
+          : ((v == phi::backends::xpu::XPUVersion::XPU2) ? get_kl2_ops()
+                                                         : get_kl3_ops());
   if (ops.find(fluid_op_name) != ops.end() &&
       ops[fluid_op_name].find(type) != ops[fluid_op_name].end()) {
     return true;


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
修复`is_xpu_support_op`函数的bug：目前只检测了XPU1和XPU2两种设备，这样会导致XPU3的算子列表不生效，因此会有一些算子明明有注册，但是执行的时候会报找不到。
本PR修复了此问题，添加了对`get_kl3_ops`函数的调用。

TODO：更优雅的方法，检查一下如果既不是XPU1也不是XPU2也不是XPU3，就报个错误出来。不过现有代码库中可能还有一些类似的地方可以改进，本PR优先解决bug，后续有空再“优雅化”。