### PR TITLE
[PIR]Add pir check dtype ut

### DIFF
--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -212,6 +212,18 @@ class TestPowerError(unittest.TestCase):
         y = int(np.random.rand() * 10)
         self.assertRaises(TypeError, paddle.pow, x, str(y))
 
+    def test_pir_error(self):
+        with paddle.pir_utils.IrGuard():
+
+            def x_dtype_error():
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    x = paddle.static.data('x', [2, 2], dtype='int8')
+                    out = paddle.pow(x, 2)
+
+            self.assertRaises(ValueError, x_dtype_error)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Add pir check dtype ut

pir下报错信息如下：
```
======================================================================
ERROR: test_pir_error (__main__.TestPowerError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_pow.py", line 223, in test_pir_error
    self.assertRaises(TypeError, x_dtype_error)
  File "/root/miniconda3/envs/py38/lib/python3.8/unittest/case.py", line 816, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/root/miniconda3/envs/py38/lib/python3.8/unittest/case.py", line 202, in handle
    callable_obj(*args, **kwargs)
  File "/workspace/Paddle/test/legacy_test/test_pow.py", line 222, in x_dtype_error
    out = paddle.pow(x, 2)
  File "/root/miniconda3/envs/py38/lib/python3.8/site-packages/paddle/tensor/math.py", line 509, in pow
    return _C_ops.pow(x, y)
ValueError: (InvalidArgument) Check data type error for op: pow, input: x, x.dtype is int8, and expected_dtype is bfloat16,float16,float32,float64,int32,int64, (at /workspace/Paddle/paddle/fluid/pir/dialect/operator/utils/utils.cc:279)


----------------------------------------------------------------------
Ran 1 test in 0.005s

FAILED (errors=1)
```

pir下C++端raise的是InvalidArgument抛到python后是ValueError类型。在老静态图下python端进行check_dtype时抛出的是TypeError，但是目前C++端没有对应TypeError类型的错误，这里需要在C++端新增错误类型吗？


Pcard-67164