### PR TITLE
[PIR] polish the backward tool op in control flow dialect.

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -79,7 +79,7 @@ const std::unordered_set<std::string> SpecialLowerOps = {
     WhileOp::name(),
     pir::StackCreateOp::name(),
     pir::TuplePushOp::name(),
-    pir::TuplePushOp::name(),
+    pir::TuplePopOp::name(),
     "cinn_runtime.jit_kernel"};
 
 static bool NeedFallBackCpu(const pir::Operation* op,
@@ -1046,7 +1046,7 @@ void HandleForSpecialOp(
     }
   }
 
-  if (op_item->isa<::pir::TuplePushOp>()) {
+  if (op_item->isa<::pir::TuplePopOp>()) {
     for (size_t i = 0; i < op_item->num_operands(); ++i) {
       auto cur_in = op_item->operand_source(i);
       auto new_in = GetNewInput(
@@ -1054,7 +1054,7 @@ void HandleForSpecialOp(
       vec_inputs.push_back(new_in);
     }
 
-    auto pop_back_op = op_item->dyn_cast<::pir::TuplePushOp>();
+    auto pop_back_op = op_item->dyn_cast<::pir::TuplePopOp>();
     for (size_t i = 0; i < op_item->num_results(); ++i) {
       auto cur_inlet_element = pop_back_op.inlet_element(i);
       PADDLE_ENFORCE_EQ(map_value_pair->count(cur_inlet_element),

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -77,9 +77,9 @@ const std::unordered_set<std::string> SpecialLowerOps = {
     pir::YieldOp::name(),
     IfOp::name(),
     WhileOp::name(),
-    pir::CreateStackOp::name(),
-    pir::PushBackOp::name(),
-    pir::PopBackOp::name(),
+    pir::StackCreateOp::name(),
+    pir::TuplePushOp::name(),
+    pir::TuplePushOp::name(),
     "cinn_runtime.jit_kernel"};
 
 static bool NeedFallBackCpu(const pir::Operation* op,
@@ -1029,8 +1029,8 @@ void HandleForSpecialOp(
     }
   }
 
-  if (op_item->isa<::pir::CreateStackOp>() ||
-      op_item->isa<::pir::PushBackOp>()) {
+  if (op_item->isa<::pir::StackCreateOp>() ||
+      op_item->isa<::pir::TuplePushOp>()) {
     for (size_t i = 0; i < op_item->num_operands(); ++i) {
       auto cur_in = op_item->operand_source(i);
       if (!cur_in) {
@@ -1046,7 +1046,7 @@ void HandleForSpecialOp(
     }
   }
 
-  if (op_item->isa<::pir::PopBackOp>()) {
+  if (op_item->isa<::pir::TuplePushOp>()) {
     for (size_t i = 0; i < op_item->num_operands(); ++i) {
       auto cur_in = op_item->operand_source(i);
       auto new_in = GetNewInput(
@@ -1054,7 +1054,7 @@ void HandleForSpecialOp(
       vec_inputs.push_back(new_in);
     }
 
-    auto pop_back_op = op_item->dyn_cast<::pir::PopBackOp>();
+    auto pop_back_op = op_item->dyn_cast<::pir::TuplePushOp>();
     for (size_t i = 0; i < op_item->num_results(); ++i) {
       auto cur_inlet_element = pop_back_op.inlet_element(i);
       PADDLE_ENFORCE_EQ(map_value_pair->count(cur_inlet_element),

--- a/paddle/pir/core/op_base.h
+++ b/paddle/pir/core/op_base.h
@@ -70,7 +70,7 @@ class IR_API OpBase {
 
   void VerifyRegion() {}
 
- private:
+ protected:
   Operation *operation_;  // Not owned
 };
 

--- a/paddle/pir/dialect/control_flow/ir/cf_dialect.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_dialect.cc
@@ -19,11 +19,7 @@
 namespace pir {
 void ControlFlowDialect::initialize() {
   RegisterTypes<StackType, InletType, OutletType>();
-  RegisterOps<YieldOp,
-              StackCreateOp,
-              TuplePushOp,
-              TuplePushOp,
-              HasElementsOp>();
+  RegisterOps<YieldOp, StackCreateOp, TuplePushOp, TuplePopOp, HasElementsOp>();
 }
 
 void ControlFlowDialect::PrintType(pir::Type type, std::ostream &os) const {

--- a/paddle/pir/dialect/control_flow/ir/cf_dialect.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_dialect.cc
@@ -19,7 +19,11 @@
 namespace pir {
 void ControlFlowDialect::initialize() {
   RegisterTypes<StackType, InletType, OutletType>();
-  RegisterOps<YieldOp, CreateStackOp, PushBackOp, PopBackOp, HasElementsOp>();
+  RegisterOps<YieldOp,
+              StackCreateOp,
+              TuplePushOp,
+              TuplePushOp,
+              HasElementsOp>();
 }
 
 void ControlFlowDialect::PrintType(pir::Type type, std::ostream &os) const {
@@ -38,7 +42,7 @@ void ControlFlowDialect::PrintType(pir::Type type, std::ostream &os) const {
 
 void ControlFlowDialect::PrintOperation(pir::Operation *op,
                                         pir::IrPrinter &printer) const {
-  if (auto create_op = op->dyn_cast<CreateStackOp>()) {
+  if (auto create_op = op->dyn_cast<StackCreateOp>()) {
     create_op.Print(printer);
   } else {
     printer.PrintGeneralOperation(op);

--- a/paddle/pir/dialect/control_flow/ir/cf_dialect.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_dialect.h
@@ -24,9 +24,9 @@ class ControlFlowDialect : public Dialect {
     initialize();
   }
   static const char *name() { return "cf"; }
-  void PrintType(pir::Type type, std::ostream &os) const override;
-  void PrintOperation(pir::Operation *op,
-                      pir::IrPrinter &printer) const override;  // NOLINT
+  void PrintType(Type type, std::ostream &os) const override;
+  void PrintOperation(Operation *op,
+                      IrPrinter &printer) const override;  // NOLINT
  private:
   void initialize();
 };

--- a/paddle/pir/dialect/control_flow/ir/cf_interface.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_interface.cc
@@ -12,13 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/pir/dialect/control_flow/ir/cf_type.h"
+#include "paddle/pir/dialect/control_flow/ir/cf_interface.h"
+#include "paddle/pir/dialect/control_flow/ir/cf_op.h"
 
 namespace pir {
-bool ContainerType::classof(Type type) { return StackType::classof(type); }
+TuplePushOp ContainerOpInterface::tuple_push_op() {
+  auto value = inlet();
+  IR_ENFORCE(value.HasOneUse(),
+             "The inlet value of container op can only be used once.");
+  return value.first_use().owner()->dyn_cast<TuplePushOp>();
+}
+TuplePopOp ContainerOpInterface::tuple_pop_op() {
+  auto value = outlet();
+  IR_ENFORCE(value.HasOneUse(),
+             "The outlet value of container op can only be used once.");
+  return value.first_use().owner()->dyn_cast<TuplePopOp>();
+}
 
 }  // namespace pir
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::ContainerType)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::StackType)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::InletType)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::OutletType)
+
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::ContainerOpInterface)

--- a/paddle/pir/dialect/control_flow/ir/cf_interface.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_interface.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/pir/core/op_base.h"
+
+namespace pir {
+
+class TuplePushOp;
+class TuplePopOp;
+///
+/// \brief This interface marks the op can create a container.
+///
+class ContainerOpInterface : public OpInterfaceBase<ContainerOpInterface> {
+ public:
+  struct Concept {
+    Value (*container_)(Operation* op);
+    Value (*inlet_)(Operation* op);
+    Value (*outlet_)(Operation* op);
+    size_t (*tuple_size_)(Operation* op);
+    Value (*inlet_element_)(Operation* op, size_t index);
+    Value (*outlet_element_)(Operation* op, size_t index);
+  };
+
+  template <class ConcreteOp>
+  struct Model : public Concept {
+    Model()
+        : Concept{container,
+                  inlet,
+                  outlet,
+                  tuple_size,
+                  inlet_element,
+                  inlet_element} {}
+    static Value container(Operation* op) {
+      return op->dyn_cast<ConcreteOp>().container();
+    }
+    static Value inlet(Operation* op) {
+      return op->dyn_cast<ConcreteOp>().inlet();
+    }
+    static Value outlet(Operation* op) {
+      return op->dyn_cast<ConcreteOp>().outlet();
+    }
+    static size_t tuple_size(Operation* op) {
+      return op->dyn_cast<ConcreteOp>().tuple_size();
+    }
+    static Value inlet_element(Operation* op, size_t index) {
+      return op->dyn_cast<ConcreteOp>().container();
+    }
+    static Value outlet_element(Operation* op, size_t index) {
+      return op->dyn_cast<ConcreteOp>().container();
+    }
+  };
+
+  Value container() { return impl_->container_(operation()); }
+  Value inlet() { return impl_->inlet_(operation()); }
+  Value outlet() { return impl_->outlet_(operation()); }
+  size_t tuple_size() { return impl_->tuple_size_(operation()); }
+  Value inlet_element(size_t index) {
+    return impl_->inlet_element_(operation(), index);
+  }
+  Value outlet_element(size_t index) {
+    return impl_->outlet_element_(operation(), index);
+  }
+
+  TuplePushOp tuple_push_op();
+  TuplePopOp tuple_pop_op();
+  /// Constructor
+  ContainerOpInterface(pir::Operation* op, Concept* impl)
+      : OpInterfaceBase<ContainerOpInterface>(op), impl_(impl) {}
+
+ private:
+  Concept* impl_;
+};
+}  // namespace pir
+
+IR_DECLARE_EXPLICIT_TYPE_ID(pir::ContainerOpInterface)

--- a/paddle/pir/dialect/control_flow/ir/cf_interface.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_interface.h
@@ -85,4 +85,4 @@ class ContainerOpInterface : public OpInterfaceBase<ContainerOpInterface> {
 };
 }  // namespace pir
 
-IR_DECLARE_EXPLICIT_TYPE_ID(pir::ContainerOpInterface)
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::ContainerOpInterface)

--- a/paddle/pir/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/dialect/control_flow/ir/cf_op.cc
@@ -25,147 +25,84 @@ void YieldOp::Build(Builder &builder,
   argument.AddInputs(inputs);
 }
 
-void CreateStackOp::Build(Builder &builder, OperationArgument &argument) {
-  auto stack_type = StackType::get(builder.ir_context());
-  auto inlet_type = InletType::get(builder.ir_context());
-  auto outlet_type = OutletType::get(builder.ir_context());
-  argument.AddOutputs({stack_type, inlet_type, outlet_type});
-}
-
-void CreateStackOp::VerifySig() {
-  VLOG(4) << "Verifying inputs, outputs and attributes for: CreateStackOp.";
-  // Verify inputs:
-  IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
-
-  // No attributes should be verify.
-
-  // Verify outputs:
-  IR_ENFORCE(num_results() == 3u, "The size of outputs must be equal to 3.");
-
-  IR_ENFORCE(result(0).type().isa<StackType>(),
-             "The first outputs of cf.create_stack must be stack_type.");
-  IR_ENFORCE(result(1).type().isa<InletType>(),
-             "The first outputs of cf.create_stack must be inlet_type.");
-  IR_ENFORCE(result(2).type().isa<OutletType>(),
-             "The first outputs of cf.create_stack must be outlet_type.");
-
-  VLOG(4) << "End Verifying for CreateStackOp.";
-}
-
-size_t CreateStackOp::stack_size() { return push_op().stack_size(); }
-
-Value CreateStackOp::inlet_element(size_t index) {
-  return push_op().inlet_element(index);
-}
-
-Value CreateStackOp::outlet_element(size_t index) {
-  return pop_op().outlet_element(index);
-}
-
-PushBackOp CreateStackOp::push_op() {
-  auto inlet_value = inlet();
-  IR_ENFORCE(inlet_value.HasOneUse(), "The inlet value must has one use.");
-  return inlet_value.first_use().owner()->dyn_cast<PushBackOp>();
-}
-
-PopBackOp CreateStackOp::pop_op() {
-  auto outlet_value = outlet();
-  IR_ENFORCE(outlet_value.HasOneUse(), "The outlet value must has one use.");
-  return outlet_value.first_use().owner()->dyn_cast<PopBackOp>();
-}
-
-void CreateStackOp::Print(IrPrinter &printer) {  // NOLINT
-  static std::unordered_map<IrPrinter *,
-                            std::unordered_map<Operation *, size_t>>
-      kConunters;
-  auto &counter = kConunters[&printer];
-  auto iter = counter.insert({*this, counter.size()});
-  auto index = iter.first->second;
-  if (iter.second) {
-    printer.AddValueAlias(stack(), "%stack_" + std::to_string(index));
-    printer.AddValueAlias(inlet(), "%inlet_" + std::to_string(index));
-    printer.AddValueAlias(outlet(), "%outlet_" + std::to_string(index));
-  }
-  printer.PrintGeneralOperation(*this);
-}
-
-void PushBackOp::Build(Builder &builder,             // NOLINT
-                       OperationArgument &argument,  // NOLINT
-                       Value inlet,
-                       const std::vector<Value> &elements) {
+void TuplePushOp::Build(Builder &builder,             // NOLINT
+                        OperationArgument &argument,  // NOLINT
+                        Value inlet,
+                        const std::vector<Value> &elements) {
   argument.AddInput(inlet);
   argument.AddInputs(elements);
 }
 
-void PushBackOp::Build(Builder &builder,             // NOLINT
-                       OperationArgument &argument,  // NOLINT
-                       Value inlet,
-                       std::initializer_list<Value> element_list) {
+void TuplePushOp::Build(Builder &builder,             // NOLINT
+                        OperationArgument &argument,  // NOLINT
+                        Value inlet,
+                        std::initializer_list<Value> element_list) {
   argument.AddInput(inlet);
   argument.AddInputs(element_list);
 }
 
-void PushBackOp::VerifySig() {
-  VLOG(4) << "Verifying inputs, outputs ,attributes for: PushBackOp.";
+void TuplePushOp::VerifySig() {
+  VLOG(4) << "Verifying inputs, outputs ,attributes for: TuplePushOp.";
   // Verify inputs:
-  IR_ENFORCE(num_operands() >= 2u, "The size of inputs must no less than 2.");
+  IR_ENFORCE(num_operands() >= 1u, "The size of inputs must no less than 1.");
   IR_ENFORCE(operand_source(0).type().isa<InletType>(),
-             "The first input of cf.push_back must be inlet_type.");
+             "The first input of cf.tuple_push must be inlet_type.");
   IR_ENFORCE(operand_source(0).HasOneUse(),
-             "The inlet value of cf.push_back can only be used once.");
+             "The inlet value of cf.tuple_push can only be used once.");
 
   // No attributes should be verify.
 
   // Verify outputs:
   IR_ENFORCE(num_results() == 0u, "The size of outputs must be equal to 0.");
-  VLOG(4) << "End Verifying for PushBackOp.";
+  VLOG(4) << "End Verifying for TuplePushOp.";
 }
 
-size_t PushBackOp::stack_size() {
+size_t TuplePushOp::tuple_size() {
   auto operands_size = num_operands();
-  IR_ENFORCE(operands_size >= 2u,
-             "The operands of push op must no less than 2.");
+  IR_ENFORCE(operands_size >= 1u,
+             "The operands of push op must no less than 1.");
   return operands_size - 1u;
 }
 
-PopBackOp PushBackOp::pop_op() { return create_op().pop_op(); }
+TuplePopOp TuplePushOp::tuple_pop_op() {
+  return container_interface().tuple_pop_op();
+}
 
-void PopBackOp::Build(Builder &builder,             // NOLINT
-                      OperationArgument &argument,  // NOLINT
-                      Value outlet) {
+void TuplePopOp::Build(Builder &builder,             // NOLINT
+                       OperationArgument &argument,  // NOLINT
+                       Value outlet) {
   argument.AddInput(outlet);
 
-  auto push_back_op = outlet.defining_op<CreateStackOp>().push_op();
+  auto push_op = outlet.defining_op<ContainerOpInterface>().tuple_push_op();
 
-  auto elements_size = push_back_op.stack_size();
+  auto elements_size = push_op.tuple_size();
 
   for (size_t index = 0; index < elements_size; ++index) {
-    argument.AddOutput(push_back_op.inlet_element(index).type());
+    argument.AddOutput(push_op.inlet_element(index).type());
   }
 }
 
-void PopBackOp::VerifySig() {
+void TuplePopOp::VerifySig() {
   VLOG(4) << "Verifying inputs, outputs ,attributes  and stack validity for: "
-             "PopBackOp.";
+             "TuplePopOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 1u, "The size of inputs must equal to 1.");
   IR_ENFORCE(operand_source(0).type().isa<OutletType>(),
-             "The first input of cf.pop_back must be outlet_type.");
+             "The first input of cf.tuple_pop must be outlet_type.");
   IR_ENFORCE(operand_source(0).HasOneUse(),
-             "The outlet value of cf.pop_back can only be used once.");
+             "The outlet value of cf.tuple_pop can only be used once.");
 
   // No attributes should be verify.
 
   // Verify outputs:
-  IR_ENFORCE(num_results() >= 1u,
-             "The size of outputs must no less than to 1.");
-  // Verify stack validity:
-  auto pop_back_op = create_op().pop_op();
-  IR_ENFORCE(*this == pop_back_op,
-             "The pop_op of stack_op must be this pop_op self.");
 
-  auto inlet_size = push_op().stack_size();
-  IR_ENFORCE(inlet_size == stack_size(),
+  // Verify stack validity:
+  auto pop_op = container_interface().tuple_pop_op();
+  IR_ENFORCE(*this == pop_op,
+             "The pop_op of tuple_pop_op must be this tuple_pop_op self.");
+
+  auto inlet_size = tuple_push_op().tuple_size();
+  IR_ENFORCE(inlet_size == tuple_size(),
              "The pop elements size must equal to push elements size.");
   for (size_t index = 0; index < inlet_size; ++index) {
     IR_ENFORCE(outlet_element(index).type() == inlet_element(index).type(),
@@ -174,7 +111,7 @@ void PopBackOp::VerifySig() {
                outlet_element(index).type(),
                inlet_element(index).type());
   }
-  VLOG(4) << "End Verifying for PopBackOp.";
+  VLOG(4) << "End Verifying for TuplePopOp.";
 }
 
 void HasElementsOp::Build(Builder &builder,             // NOLINT
@@ -198,10 +135,74 @@ void HasElementsOp::VerifySig() {
              "The type of cf.has_elements' output is not correct.");
 }
 
+void StackCreateOp::Build(Builder &builder, OperationArgument &argument) {
+  auto stack_type = StackType::get(builder.ir_context());
+  auto inlet_type = InletType::get(builder.ir_context());
+  auto outlet_type = OutletType::get(builder.ir_context());
+  argument.AddOutputs({stack_type, inlet_type, outlet_type});
+}
+
+void StackCreateOp::VerifySig() {
+  VLOG(4) << "Verifying inputs, outputs and attributes for: StackCreateOp.";
+  // Verify inputs:
+  IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
+
+  // No attributes should be verify.
+
+  // Verify outputs:
+  IR_ENFORCE(num_results() == 3u, "The size of outputs must be equal to 3.");
+
+  IR_ENFORCE(result(0).type().isa<StackType>(),
+             "The first outputs of cf.stack_create must be stack_type.");
+  IR_ENFORCE(result(1).type().isa<InletType>(),
+             "The first outputs of cf.stack_create must be inlet_type.");
+  IR_ENFORCE(result(2).type().isa<OutletType>(),
+             "The first outputs of cf.stack_create must be outlet_type.");
+
+  VLOG(4) << "End Verifying for StackCreateOp.";
+}
+
+size_t StackCreateOp::tuple_size() { return tuple_push_op().tuple_size(); }
+
+Value StackCreateOp::inlet_element(size_t index) {
+  return tuple_push_op().inlet_element(index);
+}
+
+Value StackCreateOp::outlet_element(size_t index) {
+  return tuple_pop_op().outlet_element(index);
+}
+
+TuplePushOp StackCreateOp::tuple_push_op() {
+  auto inlet_value = inlet();
+  IR_ENFORCE(inlet_value.HasOneUse(), "The inlet value must has one use.");
+  return inlet_value.first_use().owner()->dyn_cast<TuplePushOp>();
+}
+
+TuplePopOp StackCreateOp::tuple_pop_op() {
+  auto outlet_value = outlet();
+  IR_ENFORCE(outlet_value.HasOneUse(), "The outlet value must has one use.");
+  return outlet_value.first_use().owner()->dyn_cast<TuplePopOp>();
+}
+
+void StackCreateOp::Print(IrPrinter &printer) {  // NOLINT
+  static std::unordered_map<IrPrinter *,
+                            std::unordered_map<Operation *, size_t>>
+      kConunters;
+  auto &counter = kConunters[&printer];
+  auto iter = counter.insert({*this, counter.size()});
+  auto index = iter.first->second;
+  if (iter.second) {
+    printer.AddValueAlias(stack(), "%stack_" + std::to_string(index));
+    printer.AddValueAlias(inlet(), "%inlet_" + std::to_string(index));
+    printer.AddValueAlias(outlet(), "%outlet_" + std::to_string(index));
+  }
+  printer.PrintGeneralOperation(*this);
+}
+
 }  // namespace pir
 
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::YieldOp)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::CreateStackOp)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::PushBackOp)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::PopBackOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::StackCreateOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::TuplePushOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::TuplePopOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::HasElementsOp)

--- a/paddle/pir/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_op.h
@@ -17,6 +17,7 @@
 #include "paddle/pir/core/builder.h"
 #include "paddle/pir/core/op_base.h"
 #include "paddle/pir/core/op_trait.h"
+#include "paddle/pir/dialect/control_flow/ir/cf_interface.h"
 
 namespace pir {
 class IR_API YieldOp : public Op<YieldOp, SideEffectTrait> {
@@ -31,36 +32,14 @@ class IR_API YieldOp : public Op<YieldOp, SideEffectTrait> {
                     const std::vector<Value> &Value);
   void VerifySig() {}
 };
-class PushBackOp;
-class PopBackOp;
-class IR_API CreateStackOp : public Op<CreateStackOp> {
+
+///
+/// \brief Push a value tuple to a container.
+///
+class IR_API TuplePushOp : public Op<TuplePushOp, SideEffectTrait> {
  public:
   using Op::Op;
-  static const char *name() { return "cf.create_stack"; }
-  static constexpr uint32_t attributes_num = 0;
-  static constexpr const char **attributes_name = nullptr;
-  static void Build(Builder &builder,              // NOLINT
-                    OperationArgument &argument);  // NOLINT
-  void VerifySig();
-
-  Value stack() { return result(0); }
-  Value inlet() { return result(1); }
-  Value outlet() { return result(2); }
-  std::tuple<Value, Value, Value> out() { return {stack(), inlet(), outlet()}; }
-
-  size_t stack_size();
-  Value inlet_element(size_t index);
-  Value outlet_element(size_t index);
-  PushBackOp push_op();
-  PopBackOp pop_op();
-
-  void Print(pir::IrPrinter &printer);  // NOLINT
-};
-
-class IR_API PushBackOp : public Op<PushBackOp, SideEffectTrait> {
- public:
-  using Op::Op;
-  static const char *name() { return "cf.push_back"; }
+  static const char *name() { return "cf.tuple_push"; }
   static constexpr uint32_t attributes_num = 0;
   static constexpr const char **attributes_name = nullptr;
 
@@ -74,22 +53,24 @@ class IR_API PushBackOp : public Op<PushBackOp, SideEffectTrait> {
                     std::initializer_list<Value> element_list);
   void VerifySig();
 
-  Value stack() { return create_op().stack(); }
+  Value container() { return container_interface().container(); }
   Value inlet() { return operand_source(0); }
-  Value outlet() { return create_op().outlet(); }
-  size_t stack_size();
+  Value outlet() { return container_interface().outlet(); }
+  size_t tuple_size();
   Value inlet_element(size_t index) { return operand_source(index + 1u); }
   Value outlet_element(size_t index) {
-    return create_op().outlet_element(index);
+    return container_interface().outlet_element(index);
   }
-  CreateStackOp create_op() { return inlet().defining_op<CreateStackOp>(); }
-  PopBackOp pop_op();
+  ContainerOpInterface container_interface() {
+    return inlet().defining_op<ContainerOpInterface>();
+  }
+  TuplePopOp tuple_pop_op();
 };
 
-class IR_API PopBackOp : public Op<PopBackOp> {
+class IR_API TuplePopOp : public Op<TuplePopOp, SideEffectTrait> {
  public:
   using Op::Op;
-  static const char *name() { return "cf.pop_back"; }
+  static const char *name() { return "cf.tuple_pop"; }
   static constexpr uint32_t attributes_num = 0;
   static constexpr const char **attributes_name = nullptr;
 
@@ -98,15 +79,19 @@ class IR_API PopBackOp : public Op<PopBackOp> {
                     Value outlet);
   void VerifySig();
 
-  Value stack() { return create_op().stack(); }
-  Value inlet() { return create_op().inlet(); }
+  Value container() { return container_interface().container(); }
+  Value inlet() { return container_interface().inlet(); }
   Value outlet() { return operand_source(0); }
 
-  size_t stack_size() { return num_results(); }
-  Value inlet_element(size_t index) { return push_op().inlet_element(index); }
+  size_t tuple_size() { return num_results(); }
+  Value inlet_element(size_t index) {
+    return tuple_push_op().inlet_element(index);
+  }
   Value outlet_element(size_t index) { return result(index); }
-  CreateStackOp create_op() { return outlet().defining_op<CreateStackOp>(); }
-  PushBackOp push_op() { return create_op().push_op(); }
+  ContainerOpInterface container_interface() {
+    return outlet().defining_op<ContainerOpInterface>();
+  }
+  TuplePushOp tuple_push_op() { return container_interface().tuple_push_op(); }
 };
 
 class IR_API HasElementsOp : public Op<HasElementsOp> {
@@ -122,11 +107,34 @@ class IR_API HasElementsOp : public Op<HasElementsOp> {
   void VerifySig();
   Value out() { return result(0); }
 };
+class IR_API StackCreateOp : public Op<StackCreateOp, ContainerOpInterface> {
+ public:
+  using Op::Op;
+  static const char *name() { return "cf.stack_create"; }
+  static constexpr uint32_t attributes_num = 0;
+  static constexpr const char **attributes_name = nullptr;
+  static void Build(Builder &builder,              // NOLINT
+                    OperationArgument &argument);  // NOLINT
+  void VerifySig();
 
+  Value container() { return result(0); }
+  Value stack() { return result(0); }
+  Value inlet() { return result(1); }
+  Value outlet() { return result(2); }
+  std::tuple<Value, Value, Value> out() { return {stack(), inlet(), outlet()}; }
+
+  size_t tuple_size();
+  Value inlet_element(size_t index);
+  Value outlet_element(size_t index);
+  TuplePushOp tuple_push_op();
+  TuplePopOp tuple_pop_op();
+
+  void Print(pir::IrPrinter &printer);  // NOLINT
+};
 }  // namespace pir
 
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::YieldOp);
-IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::CreateStackOp);
-IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::PushBackOp);
-IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::PopBackOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::StackCreateOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::TuplePushOp);
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::TuplePopOp);
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::HasElementsOp);

--- a/paddle/pir/dialect/control_flow/ir/cf_type.h
+++ b/paddle/pir/dialect/control_flow/ir/cf_type.h
@@ -19,7 +19,14 @@
 #include "paddle/pir/core/type_base.h"
 
 namespace pir {
-class IR_API StackType : public Type::TypeBase<StackType, Type, TypeStorage> {
+
+class IR_API ContainerType : public Type {
+  using Type::Type;
+  static bool classof(Type);
+};
+
+class IR_API StackType
+    : public Type::TypeBase<StackType, ContainerType, TypeStorage> {
  public:
   using Base::Base;
 };
@@ -36,6 +43,7 @@ class IR_API OutletType : public Type::TypeBase<OutletType, Type, TypeStorage> {
 
 }  // namespace pir
 
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::ContainerType)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::StackType)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::InletType)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::OutletType)

--- a/test/cpp/pir/control_flow_dialect/if_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/if_op_test.cc
@@ -149,7 +149,7 @@ TEST(if_op_test, network_with_backward) {
   // construct the true block of if_grad
   builder.SetInsertionPointToStart(if_grad.true_block());
   auto pop_local1_z =
-      builder.Build<pir::TuplePushOp>(outlet_0).outlet_element(0);
+      builder.Build<pir::TuplePopOp>(outlet_0).outlet_element(0);
   auto local1_add_grad_op = builder.Build<AddGradOp>(pop_local1_z, y, out_grad);
   auto pop_local1_z_grad = local1_add_grad_op.x_grad(),
        local1_y_grad_0 = local1_add_grad_op.y_grad();
@@ -164,7 +164,7 @@ TEST(if_op_test, network_with_backward) {
   // construct the false block of if_grad
   builder.SetInsertionPointToStart(if_grad.false_block());
   auto pop_local2_z =
-      builder.Build<pir::TuplePushOp>(outlet_1).outlet_element(0);
+      builder.Build<pir::TuplePopOp>(outlet_1).outlet_element(0);
   auto local2_matmul_grad_op =
       builder.Build<MatmulGradOp>(pop_local2_z, y, out_grad);
   auto pop_local2_z_grad = local2_matmul_grad_op.x_grad(),

--- a/test/cpp/pir/control_flow_dialect/while_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/while_op_test.cc
@@ -146,7 +146,7 @@ TEST(while_op_test, network_with_backward) {
   auto local_x_out_grad_arg = bwd_body_block->AddArgument(x.type());
   auto local_y_grad_arg = bwd_body_block->AddArgument(y.type());
 
-  auto pop_op = builder.Build<pir::TuplePushOp>(outlet);
+  auto pop_op = builder.Build<pir::TuplePopOp>(outlet);
   auto bwd_body_x_argument = pop_op.outlet_element(0);
 
   auto add_grad_op =

--- a/test/cpp/pir/control_flow_dialect/while_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/while_op_test.cc
@@ -98,7 +98,7 @@ TEST(while_op_test, network_with_backward) {
   // }
   auto cond_value = builder.Build<LessThanOp>(i, ten).out();
 
-  auto [stack, inlet, outlet] = builder.Build<pir::CreateStackOp>().out();
+  auto [stack, inlet, outlet] = builder.Build<pir::StackCreateOp>().out();
   (void)(stack);
   auto while_op =
       builder.Build<WhileOp>(cond_value, std::vector<pir::Value>{i, x});
@@ -116,7 +116,7 @@ TEST(while_op_test, network_with_backward) {
   // comput new condition value: new_i < new_ten
   auto new_cond_value = builder.Build<LessThanOp>(new_i, ten).out();
 
-  builder.Build<pir::PushBackOp>(
+  builder.Build<pir::TuplePushOp>(
       inlet, std::initializer_list<pir::Value>{body_x_argument});
 
   builder.Build<pir::YieldOp>(
@@ -146,7 +146,7 @@ TEST(while_op_test, network_with_backward) {
   auto local_x_out_grad_arg = bwd_body_block->AddArgument(x.type());
   auto local_y_grad_arg = bwd_body_block->AddArgument(y.type());
 
-  auto pop_op = builder.Build<pir::PopBackOp>(outlet);
+  auto pop_op = builder.Build<pir::TuplePushOp>(outlet);
   auto bwd_body_x_argument = pop_op.outlet_element(0);
 
   auto add_grad_op =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

打磨控制流反向相关基础算子组件：

- 将CreateStackOp重命名为 StackCreateOp。表示一个由元祖组成的栈。类似于标准库的 std::stack<std::tuple\<pir::Value......>>

- 将PushBackOp重命名为TuplePushOp。表示将由一组变量组成的元组（tuple）压到容器里，如果变量个数为0， 表示将一个空的tuple压到了容器里。

- 将PopBackOp重命名为TuplePopOp。表示将容器末尾的元组（tuple）弹出，并拆分为相应的变量。如果输出个数为0， 表示弹出来的是一个空的tuple。

- HasElementsOp 的语意调整为判定该容器内是否还存在元组。

- 之所以做此修改，是为了考虑当while的反向算子不会用到前向算子的子局部变量时，仍然可以通过正常的容器进出操作来保证反向循环次数的正确性。


### Other

Pcard-67164
