### PR TITLE
add_n supports mixed dtype

### DIFF
--- a/paddle/phi/kernels/gpu/add_n_kernel.cu
+++ b/paddle/phi/kernels/gpu/add_n_kernel.cu
@@ -38,6 +38,28 @@ __global__ void SumArrayCUDAKernel(
   }
 }
 
+template <class T, class HALF>
+__global__ void SumArrayMixedTypeCUDAKernel(const T *in_0,
+                                            void **in_others,
+                                            T *out,
+                                            int64_t N,
+                                            size_t in_others_size,
+                                            bool read_dst) {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  CUDA_KERNEL_LOOP_TYPE(idx, N, int64_t) {
+    MPType total(read_dst ? static_cast<MPType>(out[idx])
+                          : static_cast<MPType>(0));
+    total += static_cast<MPType>(in_0[idx]);
+    for (int i = 0; i < in_others_size; ++i) {
+      const HALF *tmp = static_cast<HALF *>(in_others[i]);
+      if (tmp) {
+        total += static_cast<MPType>(tmp[idx]);
+      }
+    }
+    out[idx] = static_cast<T>(total);
+  }
+}
+
 template <class T>
 __global__ void SumSelectedRowsCUDAKernel(T **sr_in_out,
                                           int64_t N,
@@ -129,6 +151,73 @@ void AddNKernel(const Context &dev_ctx,
   if (!in_place) {
     phi::funcs::SetConstant<phi::GPUContext, T> constant_functor;
     constant_functor(dev_ctx, out, static_cast<T>(0));
+  }
+
+  // Support mixed inputs for master grad accumulation
+  // conditions:
+  // 1. all inputs are DensorTensor and number >= 2
+  // 2. the first tensor is fp32 type and the others are fp16/bf16 type
+  if (in_num >= 2 && DenseTensor::classof(x[0]) &&
+      x[0]->dtype() == phi::DataType::FLOAT32 &&
+      x[1]->dtype() != phi::DataType::FLOAT32) {
+    auto in_other_dtype = x[1]->dtype();
+    int64_t numel = static_cast<const DenseTensor *>(x[0])->numel();
+    bool all_dense_tensor = true;
+    std::vector<const void *> in_data;
+    const T *in_0 = static_cast<const DenseTensor *>(x[0])->data<T>();
+    for (int i = 1; i < in_num; ++i) {
+      PADDLE_ENFORCE_EQ(
+          in_other_dtype,
+          x[i]->dtype(),
+          errors::InvalidArgument("The dtype of inputs should be the same, "
+                                  "but received the dtype of input 1 is %s, "
+                                  "input %d is %s",
+                                  i,
+                                  x[i]->dtype()));
+      if (DenseTensor::classof(x[i])) {
+        auto &in_i = *(static_cast<const DenseTensor *>(x[i]));
+        if (in_i.IsInitialized()) {
+          in_data.emplace_back(in_i.data());
+        }
+      } else {
+        all_dense_tensor = false;
+        break;
+      }
+    }
+
+    if (all_dense_tensor && (in_other_dtype == phi::DataType::BFLOAT16 ||
+                             in_other_dtype == phi::DataType::FLOAT16)) {
+      auto tmp_in_array = phi::memory_utils::Alloc(
+          dev_ctx.GetPlace(), in_data.size() * sizeof(void *));
+      memory_utils::Copy(dev_ctx.GetPlace(),
+                         tmp_in_array->ptr(),
+                         phi::CPUPlace(),
+                         reinterpret_cast<void *>(in_data.data()),
+                         in_data.size() * sizeof(void *),
+                         dev_ctx.stream());
+
+      void **in_array_data = reinterpret_cast<void **>(tmp_in_array->ptr());
+      ComputeKernelParameter(numel);
+      VLOG(4) << "Call SumArrayMixedTypeCUDAKernel";
+      if (in_other_dtype == phi::DataType::FLOAT16) {
+        SumArrayMixedTypeCUDAKernel<T, phi::float16>
+            <<<grids, blocks, 0, stream>>>(in_0,
+                                           in_array_data,
+                                           out->data<T>(),
+                                           numel,
+                                           in_data.size(),
+                                           in_place);
+      } else if (in_other_dtype == phi::DataType::BFLOAT16) {
+        SumArrayMixedTypeCUDAKernel<T, phi::bfloat16>
+            <<<grids, blocks, 0, stream>>>(in_0,
+                                           in_array_data,
+                                           out->data<T>(),
+                                           numel,
+                                           in_data.size(),
+                                           in_place);
+      }
+      return;
+    }
   }
 
   std::vector<const T *> in_data;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Inorder to support master grad in static graph, make add_n supports mixed dtype inputs, i.e., `add_n(fp32, fp16, fp16, ...)` or `add_n(fp32, bf16, bf16, ...)`, align with `elementwise_add`

Pcard-76459