### PR TITLE
[OneDNN]Concat kernel fallback when input size too large and bs is small

### DIFF
--- a/paddle/fluid/operators/generator/get_expected_kernel_func.cc
+++ b/paddle/fluid/operators/generator/get_expected_kernel_func.cc
@@ -99,11 +99,10 @@ phi::KernelKey GetConcatExpectedKernelType(
       break;
     }
   }
+  int batch_size = !inputs[0]->lod().empty() ? inputs[0]->lod()[0].size() - 1
+                                             : inputs[0]->dims()[0];
   if (inputs.size() > 64) {
-    int cur_batch_size = !inputs[0]->lod().empty()
-                             ? inputs[0]->lod()[0].size() - 1
-                             : inputs[0]->dims()[0];
-    if (cur_batch_size < 1000) {
+    if (batch_size < 1000) {
       op_ptr->SetDnnFallback(true);
     }
   }

--- a/paddle/fluid/operators/generator/get_expected_kernel_func.cc
+++ b/paddle/fluid/operators/generator/get_expected_kernel_func.cc
@@ -99,6 +99,9 @@ phi::KernelKey GetConcatExpectedKernelType(
       break;
     }
   }
+  if (inputs.size() > 64) {
+    op_ptr->SetDnnFallback(true);
+  }
   if (flag == 0) {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "All Inputs of Concat OP are Empty!"));

--- a/paddle/fluid/operators/generator/get_expected_kernel_func.cc
+++ b/paddle/fluid/operators/generator/get_expected_kernel_func.cc
@@ -101,10 +101,8 @@ phi::KernelKey GetConcatExpectedKernelType(
   }
   int batch_size = !inputs[0]->lod().empty() ? inputs[0]->lod()[0].size() - 1
                                              : inputs[0]->dims()[0];
-  if (inputs.size() > 64) {
-    if (batch_size < 1000) {
-      op_ptr->SetDnnFallback(true);
-    }
+  if (inputs.size() > 64 && batch_size < 1000) {
+    op_ptr->SetDnnFallback(true);
   }
   if (flag == 0) {
     PADDLE_THROW(platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/generator/get_expected_kernel_func.cc
+++ b/paddle/fluid/operators/generator/get_expected_kernel_func.cc
@@ -100,7 +100,12 @@ phi::KernelKey GetConcatExpectedKernelType(
     }
   }
   if (inputs.size() > 64) {
-    op_ptr->SetDnnFallback(true);
+    int cur_batch_size = !inputs[0]->lod().empty()
+                             ? inputs[0]->lod()[0].size() - 1
+                             : inputs[0]->dims()[0];
+    if (cur_batch_size < 1000) {
+      op_ptr->SetDnnFallback(true);
+    }
   }
   if (flag == 0) {
     PADDLE_THROW(platform::errors::InvalidArgument(

--- a/test/mkldnn/test_concat_mkldnn_op.py
+++ b/test/mkldnn/test_concat_mkldnn_op.py
@@ -98,6 +98,44 @@ class TestConcatAxis3OneDNNOp(TestConcatAxis0OneDNNOp):
         self.x2_shape = [5, 3, 5, 7]
 
 
+class TestConcatLargeInputNum(OpTest):
+    def setUp(self):
+        self.op_type = "concat"
+        self.mkldnn_data_type = "float32"
+        self.init_axis()
+        self.init_shape()
+        self.init_test_data()
+        self.configure_datatype()
+        self.inputs = {'X': [('x{}'.format(i), self.x) for i in range(136)]}
+        self.attrs = {
+            'axis': self.axis,
+            'use_mkldnn': True,
+            'mkldnn_data_type': self.mkldnn_data_type,
+        }
+
+        self.output = np.concatenate(
+            [self.x for i in range(136)], axis=self.axis
+        ).astype(self.dtype)
+
+        self.outputs = {'Out': self.output}
+
+    def configure_datatype(self):
+        self.mkldnn_data_type = "float32"
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+
+    def init_test_data(self):
+        self.x = np.ones(self.shape).astype(np.float32)
+
+    def init_axis(self):
+        self.axis = 0
+
+    def init_shape(self):
+        self.shape = [150, 9]
+
+
 if __name__ == '__main__':
     enable_static()
     unittest.main()

--- a/test/mkldnn/test_concat_mkldnn_op.py
+++ b/test/mkldnn/test_concat_mkldnn_op.py
@@ -106,7 +106,7 @@ class TestConcatLargeInputNum(OpTest):
         self.init_shape()
         self.init_test_data()
         self.configure_datatype()
-        self.inputs = {'X': [('x{}'.format(i), self.x) for i in range(136)]}
+        self.inputs = {'X': [(f'x{i}', self.x) for i in range(136)]}
         self.attrs = {
             'axis': self.axis,
             'use_mkldnn': True,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
In some extreme cases, it has large input size(such as ctr model have 136 inputs to concat), oneDNN performs worse than native kernel on small batch size, since it need more time to malloc and create descriptor. 
 
