### PR TITLE
[Hackathon 5th No.49][pir] add `OpResult.append()`

### DIFF
--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -365,7 +365,7 @@ def monkey_patch_opresult():
         if not self.is_dense_tensor_array_type():
             raise TypeError(
                 "Only OpResult with pd_op.tensor_array support `append` method, but received type: {}".format(
-                    self.type
+                    self.type()
                 )
             )
         from paddle.tensor.array import array_length, array_write

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -356,6 +356,22 @@ def monkey_patch_opresult():
         """
         return paddle.assign(self)
 
+    def append(self, var):
+        """
+        **Notes**:
+           **The type OpResult must be LoD Tensor Array.
+
+        """
+        if not self.is_dense_tensor_array_type():
+            raise TypeError(
+                "Only OpResult with pd_op.tensor_array support `append` method, but received type: {}".format(
+                    self.type
+                )
+            )
+        from paddle.tensor.array import array_length, array_write
+
+        array_write(x=var, i=array_length(self), array=self)
+
     import paddle
 
     opresult_methods = [
@@ -367,6 +383,7 @@ def monkey_patch_opresult():
         ('astype', astype),
         ('size', _size_),
         ('clone', clone),
+        ('append', append),
         (
             '__add__',
             _binary_creator_('__add__', paddle.tensor.add, False, _scalar_add_),

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -29,7 +29,7 @@ def new_program():
     # TODO(gouzil): Optimize program code
     main_program = paddle.static.Program()
     startup_program = paddle.static.Program()
-    place = base.CPUPlace()
+    place = paddle.CPUPlace()
     exe = base.Executor(place)
     return (
         main_program,
@@ -443,6 +443,23 @@ class TestMathOpPatchesPir(unittest.TestCase):
                 )
                 np.testing.assert_array_equal(x_np, a_np)
                 self.assertNotEqual(id(x), id(a))
+
+    def test_append(self):
+        with paddle.pir_utils.IrGuard():
+            _, _, program_guard = new_program()
+            with program_guard:
+                x = paddle.static.data(name='x', shape=[-1, 1], dtype="float32")
+                init_data = [
+                    np.random.random(shape).astype('float32')
+                    for shape in [[10, 4], [8, 12], [1]]
+                ]
+
+                array = paddle.tensor.create_array(
+                    'int64', [paddle.to_tensor(x) for x in init_data]
+                )
+                array.append(x)
+                with self.assertRaises(TypeError):
+                    x.append(array)
 
     def test_math_exists(self):
         with paddle.pir_utils.IrGuard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

支持`OpResult.append()`方法


相关链接：
* #58118
* #57857
* #58042
* #58219
* #58343
* #58739
* #58791
* #58987
* #59115
* [No.49：python端补齐OpResult的patch方法](https://github.com/PaddlePaddle/community/blob/master/hackathon/hackathon_5th/%E3%80%90PaddlePaddle%20Hackathon%205th%E3%80%91%E5%BC%80%E6%BA%90%E8%B4%A1%E7%8C%AE%E4%B8%AA%E4%BA%BA%E6%8C%91%E6%88%98%E8%B5%9B%E6%A1%86%E6%9E%B6%E5%BC%80%E5%8F%91%E4%BB%BB%E5%8A%A1%E5%90%88%E9%9B%86.md#no49python%E7%AB%AF%E8%A1%A5%E9%BD%90opresult%E7%9A%84patch%E6%96%B9%E6%B3%95)