### PR TITLE
Fix dirichlet test

### DIFF
--- a/test/white_list/pir_op_test_no_check_list
+++ b/test/white_list/pir_op_test_no_check_list
@@ -1,3 +1,4 @@
+test_dirichlet_op
 test_exponential_op
 test_randint_op
 test_seed_op

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -59,6 +59,7 @@ test_diag_embed
 test_diag_v2
 test_diagonal_op
 test_digamma_op
+test_dirichlet_op
 test_dist_op
 test_dot_op
 test_dpsgd_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
test_dirichlet_op失败原因是因为该op输出具有随机性导致的，所以将其加入`test/white_list/pir_op_test_no_check_list`