### PR TITLE
[PIR] add some backward api for controw flow op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -40,10 +40,10 @@ void GroupOp::Build(pir::Builder &builder,             // NOLINT
                     std::unique_ptr<pir::Block> &&block) {
   VLOG(4) << "Start build GroupOp";
   if (block && !block->empty()) {
-    IR_ENFORCE(block->back()->isa<pir::YieldOp>());
-    auto *op = block->back();
-    for (size_t i = 0; i < op->num_operands(); ++i) {
-      argument.AddOutput(op->operand(i).type());
+    IR_ENFORCE(block->back().isa<pir::YieldOp>());
+    auto &op = block->back();
+    for (size_t i = 0; i < op.num_operands(); ++i) {
+      argument.AddOutput(op.operand(i).type());
     }
   }
   argument.AddRegion()->push_back(block.release());

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -52,7 +52,7 @@ void GroupOp::Build(pir::Builder &builder,             // NOLINT
 pir::Block *GroupOp::block() {
   pir::Region &region = (*this)->region(0);
   if (region.empty()) region.emplace_back();
-  return region.front();
+  return &region.front();
 }
 
 std::vector<pir::Operation *> GroupOp::ops() {

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -196,10 +196,10 @@ OpFuncType AnalyseOpFuncType(pir::Operation* op, const platform::Place& place) {
 std::vector<pir::Value> GetYiedOpInputs(pir::Block* block) {
   std::vector<pir::Value> vec_res;
 
-  if (block && !block->empty() && block->back()->isa<pir::YieldOp>()) {
-    auto* op = block->back();
-    for (size_t i = 0; i < op->num_operands(); ++i) {
-      vec_res.emplace_back(op->operand_source(i));
+  if (block && !block->empty() && block->back().isa<pir::YieldOp>()) {
+    auto& op = block->back();
+    for (size_t i = 0; i < op.num_operands(); ++i) {
+      vec_res.emplace_back(op.operand_source(i));
     }
   }
   return vec_res;

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -471,7 +471,7 @@ pir::Operation* ProgramTranslator::TranslateCondIfOperation(
                    0,
                    true_sub_block.OpSize(),
                    true_block_context,
-                   true_region.front(),
+                   &true_region.front(),
                    true,
                    cond_ops.TrueBlockOutputVarNames(),
                    cond_ops.TrueBlockInitOps());
@@ -488,7 +488,7 @@ pir::Operation* ProgramTranslator::TranslateCondIfOperation(
                    0,
                    false_sub_block.OpSize(),
                    false_block_context,
-                   false_region.front(),
+                   &false_region.front(),
                    true,
                    cond_ops.FalseBlockOutputVarNames(),
                    cond_ops.FalseBlockInitOps());

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -45,25 +45,25 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
                  std::unique_ptr<pir::Block> &&false_block) {
   VLOG(4) << "Start build IfOp";
   if (true_block && !true_block->empty() &&
-      true_block->back()->isa<pir::YieldOp>()) {
-    auto *op = true_block->back();
-    for (size_t i = 0; i < op->num_operands(); ++i) {
-      argument.AddOutput(op->operand(i).type());
+      true_block->back().isa<pir::YieldOp>()) {
+    auto &op = true_block->back();
+    for (size_t i = 0; i < op.num_operands(); ++i) {
+      argument.AddOutput(op.operand(i).type());
     }
   }
   if (false_block && !false_block->empty() &&
-      false_block->back()->isa<pir::YieldOp>()) {
-    auto *op = false_block->back();
-    PADDLE_ENFORCE_EQ(op->num_operands(),
+      false_block->back().isa<pir::YieldOp>()) {
+    auto &op = false_block->back();
+    PADDLE_ENFORCE_EQ(op.num_operands(),
                       argument.output_types.size(),
                       phi::errors::PreconditionNotMet(
                           "The output size of true block and false block must "
                           "be equal. but they are %u and %u, respectively",
                           argument.output_types.size(),
-                          op->num_operands()));
-    for (size_t i = 0; i < op->num_operands(); ++i) {
+                          op.num_operands()));
+    for (size_t i = 0; i < op.num_operands(); ++i) {
       PADDLE_ENFORCE_EQ(
-          op->operand(i).type(),
+          op.operand(i).type(),
           argument.output_types[i],
           phi::errors::PreconditionNotMet("The output[%d] type of true block "
                                           "and false block must be equal.",
@@ -84,12 +84,12 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
 pir::Block *IfOp::true_block() {
   pir::Region &region = true_region();
   if (region.empty()) region.emplace_back();
-  return region.front();
+  return &region.front();
 }
 pir::Block *IfOp::false_block() {
   pir::Region &region = false_region();
   if (region.empty()) region.emplace_back();
-  return region.front();
+  return &region.front();
 }
 
 void IfOp::Print(pir::IrPrinter &printer) {
@@ -158,22 +158,22 @@ void IfOp::VerifyRegion() {
                                         (*this)->region(0).size(),
                                         (*this)->region(1).size()));
 
-    auto *true_last_op = (*this)->region(0).front()->back();
-    auto *false_last_op = (*this)->region(1).front()->back();
-    PADDLE_ENFORCE_EQ(true_last_op->isa<pir::YieldOp>(),
+    auto &true_last_op = (*this)->region(0).front().back();
+    auto &false_last_op = (*this)->region(1).front().back();
+    PADDLE_ENFORCE_EQ(true_last_op.isa<pir::YieldOp>(),
                       true,
                       phi::errors::PreconditionNotMet(
                           "The last of true block must be YieldOp"));
-    PADDLE_ENFORCE_EQ(true_last_op->num_operands(),
+    PADDLE_ENFORCE_EQ(true_last_op.num_operands(),
                       (*this)->num_results(),
                       phi::errors::PreconditionNotMet(
                           "The size of last of true block op's input must be "
                           "equal to IfOp's outputs num."));
-    PADDLE_ENFORCE_EQ(false_last_op->isa<pir::YieldOp>(),
+    PADDLE_ENFORCE_EQ(false_last_op.isa<pir::YieldOp>(),
                       true,
                       phi::errors::PreconditionNotMet(
                           "The last of false block must be YieldOp"));
-    PADDLE_ENFORCE_EQ(false_last_op->num_operands(),
+    PADDLE_ENFORCE_EQ(false_last_op.num_operands(),
                       (*this)->num_results(),
                       phi::errors::PreconditionNotMet(
                           "The size of last of false block op's input must be "
@@ -195,7 +195,7 @@ void WhileOp::Build(pir::Builder &builder,             // NOLINT
 pir::Block *WhileOp::body_block() {
   pir::Region &body_region = (*this)->region(0);
   if (body_region.empty()) body_region.emplace_back();
-  return body_region.front();
+  return &body_region.front();
 }
 pir::Value WhileOp::cond() { return (*this)->operand_source(0); }
 

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -54,14 +54,15 @@ void IfOp::Build(pir::Builder &builder,             // NOLINT
   if (false_block && !false_block->empty() &&
       false_block->back().isa<pir::YieldOp>()) {
     auto &op = false_block->back();
-    PADDLE_ENFORCE_EQ(op.num_operands(),
+    auto size = op.num_operands();
+    PADDLE_ENFORCE_EQ(size,
                       argument.output_types.size(),
                       phi::errors::PreconditionNotMet(
                           "The output size of true block and false block must "
                           "be equal. but they are %u and %u, respectively",
                           argument.output_types.size(),
-                          op.num_operands()));
-    for (size_t i = 0; i < op.num_operands(); ++i) {
+                          size));
+    for (size_t i = 0; i < size; ++i) {
       PADDLE_ENFORCE_EQ(
           op.operand(i).type(),
           argument.output_types[i],
@@ -160,8 +161,8 @@ void IfOp::VerifyRegion() {
 
     auto &true_last_op = (*this)->region(0).front().back();
     auto &false_last_op = (*this)->region(1).front().back();
-    PADDLE_ENFORCE_EQ(true_last_op.isa<pir::YieldOp>(),
-                      true,
+    PADDLE_ENFORCE_EQ(true,
+                      true_last_op.isa<pir::YieldOp>(),
                       phi::errors::PreconditionNotMet(
                           "The last of true block must be YieldOp"));
     PADDLE_ENFORCE_EQ(true_last_op.num_operands(),
@@ -169,8 +170,8 @@ void IfOp::VerifyRegion() {
                       phi::errors::PreconditionNotMet(
                           "The size of last of true block op's input must be "
                           "equal to IfOp's outputs num."));
-    PADDLE_ENFORCE_EQ(false_last_op.isa<pir::YieldOp>(),
-                      true,
+    PADDLE_ENFORCE_EQ(true,
+                      false_last_op.isa<pir::YieldOp>(),
                       phi::errors::PreconditionNotMet(
                           "The last of false block must be YieldOp"));
     PADDLE_ENFORCE_EQ(false_last_op.num_operands(),

--- a/paddle/fluid/pybind/control_flow_api.cc
+++ b/paddle/fluid/pybind/control_flow_api.cc
@@ -188,7 +188,7 @@ namespace pybind {
 void BindControlFlowApi(py::module* m) {
   m->def("get_used_external_value", GetUsedExternalValue);
   m->def("build_pipe_for_block", BuildPipeForBlock);
-  m->def("cvt_to_if_op",
+  m->def("cvt_as_if_op",
          [](Operation& op) { return PyIfOp(op.dyn_cast<IfOp>()); });
   BindIfOp(m);
 }

--- a/paddle/fluid/pybind/control_flow_api.cc
+++ b/paddle/fluid/pybind/control_flow_api.cc
@@ -147,7 +147,7 @@ std::vector<Value> GetUsedExternalValue(const Operation& op) {
   return used_values;
 }
 
-void ModifyFwdControlflowBlock(Block* block) {
+void BuildPipeForBlock(Block* block) {
   PADDLE_ENFORCE_NOT_NULL(
       block,
       paddle::platform::errors::InvalidArgument(
@@ -187,7 +187,7 @@ namespace paddle {
 namespace pybind {
 void BindControlFlowApi(py::module* m) {
   m->def("get_used_external_value", GetUsedExternalValue);
-  m->def("modify_fwd_control_flow_block", ModifyFwdControlflowBlock);
+  m->def("build_pipe_for_block", BuildPipeForBlock);
   m->def("cvt_to_if_op",
          [](Operation& op) { return PyIfOp(op.dyn_cast<IfOp>()); });
   BindIfOp(m);

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -266,7 +266,11 @@ void BindBlock(py::module *m) {
         The constructor of Block should not be invoked directly. You can
         use `Program.block()` to get a block.
   )DOC");
-  block.def("front", &Block::front, return_value_policy::reference)
+  block
+      .def(
+          "front",
+          [](Block &self) { return &self.front(); },
+          return_value_policy::reference)
       .def_property_readonly(
           "program",
           [](Block &self) { return self.GetParentOp()->GetParentProgram(); },
@@ -287,6 +291,7 @@ void BindBlock(py::module *m) {
            [](Block &self, py::object, py::object, py::object) {
              ApiBuilder::Instance().PopInsertionPoint();
            })
+      .def("__len__", [](Block &self) { return self.size(); })
       .def(
           "remove_op",
           [](Block &self, Operation *op) {

--- a/paddle/pir/core/block.h
+++ b/paddle/pir/core/block.h
@@ -25,6 +25,7 @@
 
 namespace pir {
 class Operation;
+class Program;
 
 class IR_API Block {
   using OpListType = std::list<Operation *>;
@@ -42,6 +43,12 @@ class IR_API Block {
   Region *GetParent() const { return parent_; }
   Operation *GetParentOp() const;
 
+  // return the program which contains this block.
+  // if block is not in a program, return nullptr.
+  Program *parent_program() const {
+    return parent_ ? parent_->parent_program() : nullptr;
+  }
+
   bool empty() const { return ops_.empty(); }
   size_t size() const { return ops_.size(); }
 
@@ -54,8 +61,11 @@ class IR_API Block {
   ReverseIterator rbegin() { return ops_.rbegin(); }
   ReverseIterator rend() { return ops_.rend(); }
 
-  Operation *back() const { return ops_.back(); }
-  Operation *front() const { return ops_.front(); }
+  Operation &back() { return *ops_.back(); }
+  Operation &front() { return *ops_.front(); }
+  const Operation &back() const { return *ops_.back(); }
+  const Operation &front() const { return *ops_.front(); }
+
   void push_back(Operation *op);
   void push_front(Operation *op);
   Iterator insert(ConstIterator iterator, Operation *op);

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -88,7 +88,7 @@ Block *ModuleOp::block() {
   assert(operation() != nullptr);
   assert(operation()->num_regions() == 1);
   assert(operation()->region(0).size() == 1);
-  return operation()->region(0).front();
+  return &operation()->region(0).front();
 }
 
 ModuleOp ModuleOp::Create(IrContext *context, Program *pointer) {

--- a/paddle/pir/core/parser/ir_parser.cc
+++ b/paddle/pir/core/parser/ir_parser.cc
@@ -190,7 +190,7 @@ std::unique_ptr<Program> IrParser::ParseProgram() {
 
 // Region := Block
 void IrParser::ParseRegion(Region& region) {  // NOLINT
-  ParseBlock(*region.front());
+  ParseBlock(region.front());
   IR_ENFORCE(PeekToken().val_ != "{",
              "Only one block in a region is supported");
 }

--- a/paddle/pir/core/region.cc
+++ b/paddle/pir/core/region.cc
@@ -69,9 +69,11 @@ void Region::clear() {
     blocks_.pop_back();
   }
 }
-
+Program *Region::parent_program() const {
+  return parent_ ? parent_->GetParentProgram() : nullptr;
+}
 IrContext *Region::ir_context() const {
-  IR_ENFORCE(parent_, "Region is not attached to a container.");
+  IR_ENFORCE(parent_, "Region is not attached to a operation.");
   return parent_->ir_context();
 }
 }  // namespace pir

--- a/paddle/pir/core/region.h
+++ b/paddle/pir/core/region.h
@@ -26,6 +26,7 @@ namespace pir {
 class Block;
 class Operation;
 class IrContext;
+class Program;
 
 class IR_API Region {
  public:
@@ -50,8 +51,12 @@ class IR_API Region {
   ConstReverseIterator rbegin() const { return blocks_.rbegin(); }
   ConstReverseIterator rend() const { return blocks_.rend(); }
 
-  Block *back() const { return blocks_.back(); }
-  Block *front() const { return blocks_.front(); }
+  Block &front() { return *blocks_.front(); }
+  Block &back() { return *blocks_.back(); }
+
+  const Block &front() const { return *blocks_.front(); }
+  const Block &back() const { return *blocks_.back(); }
+
   void push_back(Block *block);
   Block *emplace_back();
   void push_front(Block *block);
@@ -66,6 +71,9 @@ class IR_API Region {
 
   Operation *GetParent() const { return parent_; }
   void set_parent(Operation *parent) { parent_ = parent; }
+  // return the program which contains this region.
+  // if region is not in a program, return nullptr.
+  Program *parent_program() const;
 
   IrContext *ir_context() const;
 

--- a/paddle/pir/dialect/shape/ir/shape_op.cc
+++ b/paddle/pir/dialect/shape/ir/shape_op.cc
@@ -244,7 +244,7 @@ void FuncOp::Build(Builder &builder, OperationArgument &argument) {
 Block *FuncOp::block() {
   Region &region = (*this)->region(0);
   if (region.empty()) region.emplace_back();
-  return region.front();
+  return &region.front();
 }
 
 void FuncOp::Print(IrPrinter &printer) {

--- a/test/cpp/pir/cinn/build_cinn_pass_test.cc
+++ b/test/cpp/pir/cinn/build_cinn_pass_test.cc
@@ -162,9 +162,8 @@ TEST(BuildCinnPassTest, OneCinnSubgraph) {
   LOG(INFO) << "after pass: " << *origin_program;
 
   CHECK_EQ(origin_program->block()->size(), 4u);
-  pir::Operation* group_op = origin_program->block()->front();
-  pir::Block* group_block =
-      group_op->dyn_cast<cinn::dialect::GroupOp>().block();
+  pir::Operation& group_op = origin_program->block()->front();
+  pir::Block* group_block = group_op.dyn_cast<cinn::dialect::GroupOp>().block();
   CHECK_EQ(group_block->size(), 4u);
 
   std::vector<std::string> op_names = {

--- a/test/cpp/pir/cinn/build_cinn_pass_test.cc
+++ b/test/cpp/pir/cinn/build_cinn_pass_test.cc
@@ -60,9 +60,8 @@ TEST(BuildCinnPassTest, AllOpSupportCinn) {
   LOG(INFO) << "after pass: " << *origin_program;
 
   CHECK_EQ(origin_program->block()->size(), 1u);
-  pir::Operation* group_op = origin_program->block()->front();
-  pir::Block* group_block =
-      group_op->dyn_cast<cinn::dialect::GroupOp>().block();
+  pir::Operation& group_op = origin_program->block()->front();
+  pir::Block* group_block = group_op.dyn_cast<cinn::dialect::GroupOp>().block();
   CHECK_EQ(group_block->size(), 6u);
 
   std::vector<std::string> op_names = {
@@ -219,7 +218,7 @@ TEST(BuildCinnPassTest, MultiCinnSubgraph) {
   LOG(INFO) << "after pass: " << *origin_program;
 
   CHECK_EQ(origin_program->block()->size(), 6u);
-  pir::Operation* group_op = origin_program->block()->front();
+  pir::Operation* group_op = &origin_program->block()->front();
   pir::Block* group_block =
       group_op->dyn_cast<cinn::dialect::GroupOp>().block();
   CHECK_EQ(group_block->size(), 3u);
@@ -234,7 +233,7 @@ TEST(BuildCinnPassTest, MultiCinnSubgraph) {
     CHECK_EQ(op.name(), op_names_front[index++]);
   }
 
-  group_op = origin_program->block()->back();
+  group_op = &origin_program->block()->back();
   group_block = group_op->dyn_cast<cinn::dialect::GroupOp>().block();
   CHECK_EQ(group_block->size(), 2u);
 

--- a/test/cpp/pir/cinn/pir_compiler_test.cc
+++ b/test/cpp/pir/cinn/pir_compiler_test.cc
@@ -175,7 +175,7 @@ TEST(PirCompier, CompileSoftmax) {
 
   std::vector<pir::Type> vec_types;
 
-  vec_types.push_back(groups[0]->ops.back()->result(0).type());
+  vec_types.push_back(groups[0]->ops.back().result(0).type());
 
   std::string jit_op_name = cinn::dialect::JitKernelOp::name();
   ::pir::OpInfo op_info = ctx->GetRegisteredOpInfo(jit_op_name);

--- a/test/cpp/pir/cinn/pir_compiler_test.cc
+++ b/test/cpp/pir/cinn/pir_compiler_test.cc
@@ -175,7 +175,7 @@ TEST(PirCompier, CompileSoftmax) {
 
   std::vector<pir::Type> vec_types;
 
-  vec_types.push_back(groups[0]->ops.back().result(0).type());
+  vec_types.push_back(groups[0]->ops.back()->result(0).type());
 
   std::string jit_op_name = cinn::dialect::JitKernelOp::name();
   ::pir::OpInfo op_info = ctx->GetRegisteredOpInfo(jit_op_name);

--- a/test/cpp/pir/core/ir_op_test.cc
+++ b/test/cpp/pir/core/ir_op_test.cc
@@ -69,9 +69,9 @@ TEST(op_test, region_test) {
   region.push_back(new pir::Block());
   region.push_front(new pir::Block());
   region.insert(region.begin(), new pir::Block());
-  pir::Block *block = region.front();
-  block->push_front(op1);
-  block->insert(block->begin(), op_2);
+  auto &block = region.front();
+  block.push_front(op1);
+  block.insert(block.begin(), op_2);
   op3->Destroy();
 }
 

--- a/test/cpp/pir/core/ir_program_test.cc
+++ b/test/cpp/pir/core/ir_program_test.cc
@@ -271,7 +271,7 @@ TEST(program_test, builder) {
       std::vector<int64_t>{2, 2}, 1.5, phi::DataType::FLOAT32, phi::CPUPlace());
   pir::Type full_op_output = full_op->result_type(0);
   EXPECT_EQ(program.block()->size(), 1u);
-  EXPECT_EQ(program.block()->back(), full_op.operation());
+  EXPECT_EQ(program.block()->back(), *full_op.operation());
   EXPECT_EQ(full_op.num_operands(), 0u);
   EXPECT_EQ(full_op.num_results(), 1u);
   EXPECT_EQ(full_op.attributes().size(), 5u);

--- a/test/cpp/pir/core/ir_region_test.cc
+++ b/test/cpp/pir/core/ir_region_test.cc
@@ -45,7 +45,7 @@ TEST(region, erase_op_test) {
   // Test pir::Block::erase
   pir::Block* block = program.block();
   EXPECT_EQ(block->size(), 3u);
-  block->erase(*(block->back()));
+  block->erase(block->back());
   EXPECT_EQ(block->size(), 2u);
 
   // Test pir::Region::erase

--- a/test/cpp/pir/core/op_info_test.cc
+++ b/test/cpp/pir/core/op_info_test.cc
@@ -32,15 +32,15 @@ TEST(ir_op_info_test, op_op_info_test) {
   builder.Build<pir::ConstantOp>(pir::Int32Attribute::get(context, 5),
                                  pir::Int32Type::get(context));
 
-  pir::Operation* op = block->back();
+  auto& op = block->back();
 
-  EXPECT_EQ(block->end(), ++pir::Block::Iterator(*op));
+  EXPECT_EQ(block->end(), ++pir::Block::Iterator(op));
 
   auto& info_map = context->registered_op_info_map();
   EXPECT_FALSE(info_map.empty());
 
-  void* info_1 = op->info();
+  void* info_1 = op.info();
   auto info_2 = pir::OpInfo::RecoverFromVoidPointer(info_1);
-  EXPECT_EQ(op->info(), info_2);
+  EXPECT_EQ(op.info(), info_2);
   pir::Verify(program.module_op());
 }

--- a/test/cpp/pir/shape_dialect/shape_op_test.cc
+++ b/test/cpp/pir/shape_dialect/shape_op_test.cc
@@ -164,7 +164,7 @@ TEST(shape_op, func_op) {
   builder.SetInsertionPointToStart(func_block);
   builder.Build<pir::ConstantOp>(pir::Int32Attribute::get(ctx, 2),
                                  pir::Int32Type::get(ctx));
-  EXPECT_EQ(func_block, func_op->region(0).front());
+  EXPECT_EQ(func_block, &func_op->region(0).front());
   EXPECT_EQ(func_op->region(0).size(), static_cast<size_t>(1));
   EXPECT_EQ(func_block->size(), static_cast<size_t>(1));
 }

--- a/test/ir/pir/test_if_api.py
+++ b/test/ir/pir/test_if_api.py
@@ -17,7 +17,7 @@ import unittest
 import paddle
 from paddle.base.libpaddle.pir import (
     build_pipe_for_block,
-    cvt_to_if_op,
+    cvt_as_if_op,
     get_used_external_value,
 )
 
@@ -60,7 +60,7 @@ class TestBuildModuleWithIfOp(unittest.TestCase):
             out = paddle.static.nn.cond(pred, true_func, false_func)
         self.assertEqual(out[0].get_defining_op().name(), "pd_op.if")
         self.assertEqual(len(out), 2)
-        if_op = cvt_to_if_op(out[0].get_defining_op())
+        if_op = cvt_as_if_op(out[0].get_defining_op())
         true_block = if_op.true_block()
         self.assertEqual(len(true_block), 3)
         build_pipe_for_block(true_block)

--- a/test/ir/pir/test_if_api.py
+++ b/test/ir/pir/test_if_api.py
@@ -15,7 +15,11 @@
 import unittest
 
 import paddle
-from paddle.base.libpaddle.pir import get_used_external_value
+from paddle.base.libpaddle.pir import (
+    cvt_to_if_op,
+    get_used_external_value,
+    modify_fwd_control_flow_block,
+)
 
 paddle.enable_static()
 
@@ -56,6 +60,11 @@ class TestBuildModuleWithIfOp(unittest.TestCase):
             out = paddle.static.nn.cond(pred, true_func, false_func)
         self.assertEqual(out[0].get_defining_op().name(), "pd_op.if")
         self.assertEqual(len(out), 2)
+        if_op = cvt_to_if_op(out[0].get_defining_op())
+        true_block = if_op.true_block()
+        self.assertEqual(len(true_block), 3)
+        modify_fwd_control_flow_block(true_block)
+        self.assertEqual(len(true_block), 4)
 
 
 if __name__ == "__main__":

--- a/test/ir/pir/test_if_api.py
+++ b/test/ir/pir/test_if_api.py
@@ -16,9 +16,9 @@ import unittest
 
 import paddle
 from paddle.base.libpaddle.pir import (
+    build_pipe_for_block,
     cvt_to_if_op,
     get_used_external_value,
-    modify_fwd_control_flow_block,
 )
 
 paddle.enable_static()
@@ -63,7 +63,7 @@ class TestBuildModuleWithIfOp(unittest.TestCase):
         if_op = cvt_to_if_op(out[0].get_defining_op())
         true_block = if_op.true_block()
         self.assertEqual(len(true_block), 3)
-        modify_fwd_control_flow_block(true_block)
+        build_pipe_for_block(true_block)
         self.assertEqual(len(true_block), 4)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

- 增加python api:     
  - cvt_as_if_op, 用来将operation转换为if_op
  -  build_pipe_for_block, 在该block的尾端添加cf.tuple_push算子，将所有该block中定义的局部变量压栈。
  - get_used_external_value, 获得该op及其嵌套op中中用到的所有该op之外定义的变量。
- 修改region、block的front()和back()接口。 返回类型调整为 Block& 和Operation&， 跟\*begin()和\*rbegin()的结果保持一致。
   

### Other
Pcard-67164
