### PR TITLE
[PIR] Rename get_parameter op to parameter op

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -199,7 +199,7 @@ static auto GetNameFromValue(const ::pir::Block *block,
                  .dyn_cast<pir::StrAttribute>()
                  .AsString();
       value2name[op.operand(0).source()] = name;
-    } else if (is_input && op.name() == "builtin.get_parameter") {
+    } else if (is_input && op.name() == "builtin.parameter") {
       name = op.attributes()
                  .at("parameter_name")
                  .dyn_cast<pir::StrAttribute>()

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -1179,7 +1179,7 @@ std::unordered_set<std::string> GetSpecialOpNames() {
       "builtin.slice",
       "pd_op.feed",
       "builtin.set_parameter",
-      "builtin.get_parameter",
+      "builtin.parameter",
       "pd_op.data",
       "builtin.shadow_output",
   };

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -216,7 +216,7 @@ const std::unordered_set<std::string> SpecialOps = {"pd_op.feed",
                                                     "pd_op.fetch",
                                                     "builtin.combine",
                                                     "builtin.set_parameter",
-                                                    "builtin.get_parameter",
+                                                    "builtin.parameter",
                                                     "builtin.slice",
                                                     "builtin.split",
                                                     "pd_op.data",
@@ -230,7 +230,7 @@ Variable* CreateVar(pir::Value value,
                     ValueExecutionInfo* value_exe_info) {
   pir::Operation* def_op = value.dyn_cast<pir::OpResult>().owner();
   bool is_persisable = false;
-  if (def_op->isa<::pir::GetParameterOp>()) {
+  if (def_op->isa<::pir::ParameterOp>()) {
     is_persisable = true;
   } else if (def_op->HasAttribute(kAttrIsPersisable)) {
     is_persisable = def_op->attribute(kAttrIsPersisable)
@@ -429,8 +429,8 @@ void HandleForSpecialOp(pir::Operation* op,
     VLOG(8) << "var " << orig_name << " has been renamed to " << var_name;
 
     value_exe_info->Rename(value, var_name, orig_name);
-  } else if (op_name == "builtin.get_parameter") {
-    VLOG(6) << "Handle for builtin.get_parameter:";
+  } else if (op_name == "builtin.parameter") {
+    VLOG(6) << "Handle for builtin.parameter:";
     auto param_name = op->attributes()
                           .at("parameter_name")
                           .dyn_cast<pir::StrAttribute>()

--- a/paddle/fluid/framework/new_executor/pir_interpreter.h
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.h
@@ -229,7 +229,7 @@ class PirInterpreter : public InterpreterBaseImpl {
 
   std::vector<std::string> fetch_var_names_;
 
-  // Note(zhangbo): set_parameter_op's input and get_parameter_op's output
+  // Note(zhangbo): set_parameter_op's input and parameter_op's output
   // belongs to a parameter and cannot GC.
   std::unordered_set<std::string> parameter_var_names_;
 };

--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -570,8 +570,8 @@ void ProgramTranslator::TranslateGeneralOperation(
 inline pir::Operation* InsertGetParamaterOp(pir::IrContext* ctx,
                                             const VarDesc* var) {
   auto& type_translator = TypeTranslator::instance();
-  std::string get_parameter_op_name(pir::GetParameterOp::name());
-  pir::OpInfo op_info = ctx->GetRegisteredOpInfo(get_parameter_op_name);
+  std::string parameter_op_name(pir::ParameterOp::name());
+  pir::OpInfo op_info = ctx->GetRegisteredOpInfo(parameter_op_name);
   std::unordered_map<std::string, pir::Attribute> op_attribute_map = {
       {"parameter_name", pir::StrAttribute::get(ctx, var->Name())},
   };
@@ -626,8 +626,8 @@ void ProgramTranslator::GetParameterForSingleBlock(const BlockDesc& block) {
           var_desc = block.FindVarRecursive(var_name);
         }
 
-        bool need_get_parameter_op = is_parameter && is_unseen_variable;
-        if (need_get_parameter_op) {
+        bool need_parameter_op = is_parameter && is_unseen_variable;
+        if (need_parameter_op) {
           PADDLE_ENFORCE_NOT_NULL(
               var_desc,
               phi::errors::PreconditionNotMet(

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -46,12 +46,12 @@ pir::OpResult zeros_like(const pir::Value& x,
   return paddle::dialect::full_like(x, 0, dtype, place);
 }
 
-pir::OpResult get_parameter(const std::string& name) {
+pir::OpResult parameter(const std::string& name) {
   pir::Parameter* param = ApiBuilder::Instance().GetParameter(name);
-  pir::GetParameterOp get_parameter_op =
-      ApiBuilder::Instance().GetBuilder()->Build<pir::GetParameterOp>(
+  pir::ParameterOp parameter_op =
+      ApiBuilder::Instance().GetBuilder()->Build<pir::ParameterOp>(
           name, param->type());
-  return get_parameter_op.result(0);
+  return parameter_op.result(0);
 }
 
 void set_parameter(const pir::Value& parameter, const std::string& name) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -32,7 +32,7 @@ pir::OpResult zeros_like(const pir::Value& x,
                          phi::DataType dtype = phi::DataType::UNDEFINED,
                          const Place& place = {});
 
-pir::OpResult get_parameter(const std::string& name);
+pir::OpResult parameter(const std::string& name);
 
 void set_parameter(const pir::Value& parameter, const std::string& name);
 

--- a/paddle/fluid/pir/transforms/dead_code_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/dead_code_elimination_pass.cc
@@ -47,13 +47,12 @@ class DeadCodeEliminationPattern : public pir::RewritePattern {
 
   void Rewrite(pir::Operation* op,
                pir::PatternRewriter& rewriter) const override {  // NOLINT
-    if (op->isa<pir::GetParameterOp>()) {
+    if (op->isa<pir::ParameterOp>()) {
       // Delete parameter from program.
-      pir::GetParameterOp get_parameter_op =
-          op->dyn_cast<pir::GetParameterOp>();
-      get_parameter_op->GetParentProgram()->parameters().erase(
-          get_parameter_op->attributes()
-              .at(get_parameter_op.attributes_name[0])
+      pir::ParameterOp parameter_op = op->dyn_cast<pir::ParameterOp>();
+      parameter_op->GetParentProgram()->parameters().erase(
+          parameter_op->attributes()
+              .at(parameter_op.attributes_name[0])
               .dyn_cast<pir::StrAttribute>()
               .AsString());
     }

--- a/paddle/fluid/pir/transforms/params_sync_among_devices_pass.cc
+++ b/paddle/fluid/pir/transforms/params_sync_among_devices_pass.cc
@@ -47,7 +47,7 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
             "params_sync_among_devices_pass should run on module op."));
     auto* block = module_op.block();
     for (auto& inner_op : *block) {
-      if (inner_op.isa<pir::GetParameterOp>()) {
+      if (inner_op.isa<pir::ParameterOp>()) {
         std::string param_name = inner_op.attributes()
                                      .at("parameter_name")
                                      .dyn_cast<pir::StrAttribute>()

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -64,7 +64,7 @@ const std::unordered_set<std::string> UnchangeOutputOps = {
     pir::SliceOp::name(),
     pir::SplitOp::name(),
     pir::SetParameterOp::name(),
-    pir::GetParameterOp::name(),
+    pir::ParameterOp::name(),
     pir::ShadowOutputOp::name(),
     FeedOp::name(),
     DataOp::name(),
@@ -74,7 +74,7 @@ const std::unordered_set<std::string> UnchangeOutputOps = {
 const std::unordered_set<std::string> SpecialLowerOps = {
     pir::CombineOp::name(),
     pir::SetParameterOp::name(),
-    pir::GetParameterOp::name(),
+    pir::ParameterOp::name(),
     pir::ShadowOutputOp::name(),
     pir::SliceOp::name(),
     pir::SplitOp::name(),
@@ -1003,7 +1003,7 @@ void HandleForSpecialOp(
     op_output_types.push_back(t1);
   }
 
-  if (op_item->isa<::pir::GetParameterOp>()) {
+  if (op_item->isa<::pir::ParameterOp>()) {
     op_output_types.push_back(
         BuildOutputType(op_item->result(0).type(), place, ctx));
   }

--- a/paddle/fluid/pir/transforms/transform_general_functions.cc
+++ b/paddle/fluid/pir/transforms/transform_general_functions.cc
@@ -24,8 +24,8 @@
 namespace pir {
 
 std::string GetParameterNameFromValue(pir::Value value) {
-  pir::GetParameterOp op =
-      value.dyn_cast<OpResult>().owner()->dyn_cast<pir::GetParameterOp>();
+  pir::ParameterOp op =
+      value.dyn_cast<OpResult>().owner()->dyn_cast<pir::ParameterOp>();
   PADDLE_ENFORCE_NOT_NULL(
       op,
       phi::errors::InvalidArgument(

--- a/paddle/fluid/pir/transforms/transform_general_functions.h
+++ b/paddle/fluid/pir/transforms/transform_general_functions.h
@@ -27,7 +27,7 @@ namespace pir {
 /**
  * @brief Get the name of pararmeter from a value.
  *
- * @note The value must be a output of a GetParameterOp.
+ * @note The value must be a output of a ParameterOp.
  *
  * @param pir::Value
  *

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -25,18 +25,18 @@
 namespace paddle {
 
 namespace pybind {
-static PyObject *static_api_get_parameter(PyObject *self,
-                                          PyObject *args,
-                                          PyObject *kwargs) {
+static PyObject *static_api_parameter(PyObject *self,
+                                      PyObject *args,
+                                      PyObject *kwargs) {
   try {
-    VLOG(6) << "Add get_parameter op into program";
+    VLOG(6) << "Add parameter op into program";
     VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
 
     // Parse Attributes
     PyObject *name_obj = PyTuple_GET_ITEM(args, 0);
     std::string name = CastPyArg2String(name_obj, "name", 0);
     // Call ir static api
-    auto static_api_out = paddle::dialect::get_parameter(name);
+    auto static_api_out = paddle::dialect::parameter(name);
 
     return ToPyObject(static_api_out);
   } catch (...) {
@@ -240,10 +240,10 @@ static PyMethodDef ManualOpsAPI[] = {
      (PyCFunction)(void (*)(void))static_api_set_parameter,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for set_parameter."},
-    {"get_parameter",
-     (PyCFunction)(void (*)(void))static_api_get_parameter,
+    {"parameter",
+     (PyCFunction)(void (*)(void))static_api_parameter,
      METH_VARARGS | METH_KEYWORDS,
-     "C++ interface function for get_parameter."},
+     "C++ interface function for parameter."},
     {"create_array",
      (PyCFunction)(void (*)(void))static_api_create_array,
      METH_VARARGS | METH_KEYWORDS,

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -246,7 +246,7 @@ void BindProgram(py::module *m) {
 }
 
 void RefreshOpStopgradients(Operation *op) {
-  if (op->num_operands() == 0 || op->isa<pir::GetParameterOp>() ||
+  if (op->num_operands() == 0 || op->isa<pir::ParameterOp>() ||
       op->isa<paddle::dialect::UniformOp>()) {
     return;
   } else if (op->isa<pir::SliceOp>()) {
@@ -733,7 +733,7 @@ void BindOpResult(py::module *m) {
       .def_property_readonly(
           "name",
           [](OpResult &self) {
-            if (self.owner()->isa<::pir::GetParameterOp>()) {
+            if (self.owner()->isa<::pir::ParameterOp>()) {
               auto param_name =
                   self.owner()
                       ->attribute<pir::StrAttribute>("parameter_name")

--- a/paddle/pir/core/builtin_dialect.cc
+++ b/paddle/pir/core/builtin_dialect.cc
@@ -52,7 +52,7 @@ void BuiltinDialect::initialize() {
                      TypeAttribute>();
 
   RegisterOps<ModuleOp,
-              GetParameterOp,
+              ParameterOp,
               SetParameterOp,
               ShadowOutputOp,
               CombineOp,

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -123,20 +123,20 @@ void ModuleOp::VerifySig() const {
   IR_ENFORCE(num_results() == 0u, "The size of inputs must be equal to 0.");
 }
 
-const char *GetParameterOp::attributes_name[attributes_num] = {  // NOLINT
+const char *ParameterOp::attributes_name[attributes_num] = {  // NOLINT
     "parameter_name"};
 
-void GetParameterOp::Build(Builder &builder,
-                           OperationArgument &argument,
-                           const std::string &name,
-                           Type type) {
+void ParameterOp::Build(Builder &builder,
+                        OperationArgument &argument,
+                        const std::string &name,
+                        Type type) {
   argument.attributes[attributes_name[0]] =
       pir::StrAttribute::get(builder.ir_context(), name);
   argument.output_types.emplace_back(type);
   PassStopGradients(argument);
 }
 
-void GetParameterOp::PassStopGradients(OperationArgument &argument) {
+void ParameterOp::PassStopGradients(OperationArgument &argument) {
   std::vector<pir::Attribute> outs_stop_gradient(
       1, pir::BoolAttribute::get(pir::IrContext::Instance(), false));
   argument.AddAttribute(
@@ -144,8 +144,8 @@ void GetParameterOp::PassStopGradients(OperationArgument &argument) {
       pir::ArrayAttribute::get(pir::IrContext::Instance(), outs_stop_gradient));
 }
 
-void GetParameterOp::VerifySig() const {
-  VLOG(4) << "Verifying inputs, outputs and attributes for: GetParameterOp.";
+void ParameterOp::VerifySig() const {
+  VLOG(4) << "Verifying inputs, outputs and attributes for: ParameterOp.";
   // Verify inputs:
   IR_ENFORCE(num_operands() == 0u, "The size of inputs must be equal to 0.");
 
@@ -498,7 +498,7 @@ Attribute ConstantOp::value() const { return attributes().at("value"); }
 }  // namespace pir
 
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::ModuleOp)
-IR_DEFINE_EXPLICIT_TYPE_ID(pir::GetParameterOp)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::ParameterOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::SetParameterOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::ShadowOutputOp)
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::CombineOp)

--- a/paddle/pir/core/builtin_op.h
+++ b/paddle/pir/core/builtin_op.h
@@ -44,13 +44,13 @@ class IR_API ModuleOp : public pir::Op<ModuleOp> {
 };
 
 ///
-/// \brief GetParameterOp: OpResult = GetParameterOp({StrAttribute,
+/// \brief ParameterOp: OpResult = ParameterOp({StrAttribute,
 /// StrAttribute})
 ///
-class IR_API GetParameterOp : public pir::Op<GetParameterOp> {
+class IR_API ParameterOp : public pir::Op<ParameterOp> {
  public:
   using Op::Op;
-  static const char *name() { return "builtin.get_parameter"; }
+  static const char *name() { return "builtin.parameter"; }
   static constexpr uint32_t attributes_num = 1;
   static const char *attributes_name[attributes_num];
   static void Build(Builder &builder,             // NOLINT
@@ -216,7 +216,7 @@ void RefreshStopGradientsDefaultly(Operation *Op);
 }  // namespace pir
 
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::ModuleOp)
-IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::GetParameterOp)
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::ParameterOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::SetParameterOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::ShadowOutputOp)
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::CombineOp)

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -362,7 +362,7 @@ def append_backward_ops(
     if op don't has grad_op:
         if it don't has input and it's output has more than
         one output_grad, add sumop for grad aggregation.
-        (eg: full op and get_parameter op etc.)
+        (eg: full op and parameter op etc.)
 
         else continue to next op.
     '''

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -128,7 +128,7 @@ class RunableProgram:
                 ret[op.result(0)] = op.attrs()["name"]
             if op.name() == "builtin.set_parameter":
                 ret[op.operand(0).source()] = op.attrs()["parameter_name"]
-            if op.name() == "builtin.get_parameter":
+            if op.name() == "builtin.parameter":
                 ret[op.result(0)] = op.attrs()["parameter_name"]
         return ret
 
@@ -328,7 +328,7 @@ class PirPassContext:
     """
 
     INPUT_OP_NAME = "pd_op.data"
-    PARM_OP_NAME = "builtin.get_parameter"
+    PARM_OP_NAME = "builtin.parameter"
     OUTPUT_OP_NAME = "builtin.set_parameter"
 
     @classmethod

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.autograd as imperative_base
 from paddle import _C_ops
-from paddle._pir_ops import get_parameter, set_parameter
+from paddle._pir_ops import parameter, set_parameter
 from paddle.base import core
 from paddle.base.framework import (
     Variable,
@@ -478,7 +478,7 @@ class Optimizer:
                     if not isinstance(lr_var, paddle.pir.OpResult):
                         self._learning_rate._var_name = lr_name
                         with paddle.static.program_guard(main_program):
-                            param = get_parameter(lr_name, _lr_dtype, [])
+                            param = parameter(lr_name, _lr_dtype, [])
                         param.stop_gradient = True
                         param.persistable = True
                         main_program.lr_scheduler = self._learning_rate

--- a/python/paddle/pir/core.py
+++ b/python/paddle/pir/core.py
@@ -19,7 +19,7 @@ from paddle.base.core import VarDesc
 from paddle.base.libpaddle import DataType
 from paddle.base.libpaddle.pir import Program, set_global_program
 
-from .._pir_ops import get_parameter, set_parameter
+from .._pir_ops import parameter, set_parameter
 from ..base import unique_name
 from ..base.wrapped_decorator import signature_safe_contextmanager
 
@@ -287,7 +287,7 @@ def create_parameter(
 
     main_program.move_parameters_from(startup_program)
     with program_guard(default_main_program()):
-        param = get_parameter(op_result_name, dtype, shape)
+        param = parameter(op_result_name, dtype, shape)
         trainable = kwargs.get('trainable', True)
         param.stop_gradient = not trainable
         param.persistable = True

--- a/test/cpp/pir/core/TestParserText.txt
+++ b/test/cpp/pir/core/TestParserText.txt
@@ -32,7 +32,7 @@ pd_op.tensor<256xf32>
 
 //CHECK program
 {
- (%0) = "builtin.get_parameter" () {parameter_name:"conv2d_0.w_0"} : () -> pd_op.tensor<64x3x7x7xf32>
+ (%0) = "builtin.parameter" () {parameter_name:"conv2d_0.w_0"} : () -> pd_op.tensor<64x3x7x7xf32>
  (%1) = "pd_op.feed" () {col:(Int32)0,is_persisable:[false],name:"data",stop_gradient:[true]} : () -> pd_op.tensor<-1x3x224x224xf32>
  (%2) = "pd_op.conv2d" (%1, %0) {data_format:"NCHW",dilations:[(Int32)1,(Int32)1],groups:(Int32)1,is_persisable:[false],padding_algorithm:"EXPLICIT",paddings:[(Int32)3,(Int32)3],stop_gradient:[false],strides:[(Int32)2,(Int32)2]} : (pd_op.tensor<-1x3x224x224xf32>, pd_op.tensor<64x3x7x7xf32>) -> pd_op.tensor<-1x64x112x112xf32>
 }

--- a/test/cpp/pir/core/add_dialect_parser_test.cc
+++ b/test/cpp/pir/core/add_dialect_parser_test.cc
@@ -99,7 +99,7 @@ TEST(IrParserTest, AddAttribute) {
   ctx->GetOrRegisterDialect<TestParserDialect>();
 
   std::string op_str =
-      " (%0) = \"builtin.get_parameter\" () "
+      " (%0) = \"builtin.parameter\" () "
       "{parameter_name:\"conv2d_0.w_0\",test:(tp.char)a} : () -> "
       "pd_op.tensor<64x3x7x7xf32>";
   std::stringstream ss;

--- a/test/cpp/pir/core/ir_program_test.cc
+++ b/test/cpp/pir/core/ir_program_test.cc
@@ -105,9 +105,9 @@ TEST(program_test, program) {
   program.SetParameter("b", std::move(parameter_b));
   EXPECT_EQ(program.parameters_num() == 2, true);
 
-  // (4) Def a = GetParameterOp("a"), and create DenseTensor for a.
+  // (4) Def a = ParameterOp("a"), and create DenseTensor for a.
   pir::Builder builder(ctx, program.block());
-  auto op1 = builder.Build<pir::GetParameterOp>("a", dense_tensor_dtype);
+  auto op1 = builder.Build<pir::ParameterOp>("a", dense_tensor_dtype);
 
   EXPECT_EQ(&program, op1->GetParentProgram());
   EXPECT_EQ(op1->result_type(0).dialect().id(), paddle_dialect->id());
@@ -127,8 +127,8 @@ TEST(program_test, program) {
     EXPECT_EQ(*(a_tensor.data<float>() + i), data_a[i]);
   }
 
-  // (5) Def b = GetParameterOp("b"), and create DenseTensor for b.
-  auto op2 = builder.Build<pir::GetParameterOp>("b", dense_tensor_dtype);
+  // (5) Def b = ParameterOp("b"), and create DenseTensor for b.
+  auto op2 = builder.Build<pir::ParameterOp>("b", dense_tensor_dtype);
 
   EXPECT_EQ(op2->result_type(0).dialect().id(), paddle_dialect->id());
   Interface *b_interface =
@@ -217,8 +217,8 @@ TEST(program_test, slice_combine_test) {
   // (3) Create a float32 DenseTensor Parameter and save into Program
   pir::Type fp32_dtype = pir::Float32Type::get(ctx);
 
-  // (4) Def a = GetParameterOp("a")
-  std::string op1_name = pir::GetParameterOp::name();
+  // (4) Def a = ParameterOp("a")
+  std::string op1_name = pir::ParameterOp::name();
   pir::OpInfo op1_info = ctx->GetRegisteredOpInfo(op1_name);
   std::unordered_map<std::string, pir::Attribute> op1_attribute{
       {"parameter_name", pir::StrAttribute::get(ctx, "a")}};

--- a/test/cpp/pir/core/program_translator_test.cc
+++ b/test/cpp/pir/core/program_translator_test.cc
@@ -69,7 +69,7 @@ TEST(OperatorDialectTest, MainProgram) {
   std::stringstream ss;
   program->Print(ss);
 
-  // ops.size() = op size in BlockDesc + get_parameter_op + combine op + int
+  // ops.size() = op size in BlockDesc + parameter_op + combine op + int
   // array op + full op (Note: p already has a full)
   EXPECT_EQ(program->block()->size(),
             p.Block(0).OpSize() + program->parameters_num() + 20 + 5 + 8);
@@ -205,7 +205,7 @@ TEST(OperatorDialectTest, StartupProgram) {
   auto program = paddle::TranslateLegacyProgramToProgram(p);
 
   size_t op_size = program->block()->size();
-  // ops.size() = op size in BlockDesc + get_parameter_op +
+  // ops.size() = op size in BlockDesc + parameter_op +
   // consant_op_for_uniform
   // + consant_op for guassian
   EXPECT_EQ(op_size, p.Block(0).OpSize() + program->parameters_num() + 3 + 53);

--- a/test/ir/pir/test_ir_pybind.py
+++ b/test/ir/pir/test_ir_pybind.py
@@ -54,7 +54,7 @@ class TestPybind(unittest.TestCase):
         ops = block.ops
         self.assertEqual(
             len(ops), 6
-        )  # pir program add "builtin.get_parameter" by default, so size is 4
+        )  # pir program add "builtin.parameter" by default, so size is 4
         block.remove_op(ops[5])
         self.assertEqual(len(block.ops), 5)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
根据新 IR 的命名规范，将 GetParameterOp 更名为 ParameterOp
Pcard-67164
