### PR TITLE
[PIR+CINN]Adjust GroupOps into natural Order in BuildCInnPass

### DIFF
--- a/paddle/fluid/pir/transforms/build_cinn_pass.cc
+++ b/paddle/fluid/pir/transforms/build_cinn_pass.cc
@@ -343,14 +343,14 @@ class CinnSubgraphDetector {
         continue;
       }
 
-      // sort group ops
+      // sort group ops by natural increasing index.
       std::vector<pir::Operation*> tmp_ops(subgraph->ops.begin(),
                                            subgraph->ops.end());
       auto& op2id = op2id_;
       std::sort(tmp_ops.begin(),
                 tmp_ops.end(),
                 [&op2id](pir::Operation* a, pir::Operation* b) {
-                  return op2id.at(a) > op2id.at(b);
+                  return op2id.at(a) < op2id.at(b);
                 });
 
       groups.push_back(tmp_ops);
@@ -600,13 +600,10 @@ class CinnSubgraphDetector {
 std::vector<pir::Value> AnalysisOutputs(GroupOpsVec& group_ops) {  // NOLINT
   // Get output by ud chain
   std::unordered_set<pir::Value> used_by_outside;
-  std::unordered_set<pir::Operation*> op_set;
+  std::unordered_set<pir::Operation*> op_set(group_ops.begin(),
+                                             group_ops.end());
 
-  for (auto* op : group_ops) {
-    op_set.insert(op);
-  }
-
-  std::vector<pir::Value> vec_res;
+  std::vector<pir::Value> outputs;
   for (auto* op : group_ops) {
     for (size_t i = 0; i < op->num_results(); ++i) {
       auto result = op->result(i);
@@ -614,20 +611,21 @@ std::vector<pir::Value> AnalysisOutputs(GroupOpsVec& group_ops) {  // NOLINT
       for (auto use_iter = result.use_begin(); use_iter != result.use_end();
            ++use_iter) {
         if (!op_set.count(use_iter->owner())) {
-          vec_res.push_back(result);
+          outputs.push_back(result);
           break;
         }
       }
     }
   }
-
-  if (vec_res.size() == 0) {
+  // NOTE: If all value are not used outside, we mark last op's results
+  // as outputs. But keep in mind that is risky.
+  if (outputs.size() == 0) {
     for (size_t i = 0; i < group_ops.back()->num_results(); ++i) {
-      vec_res.push_back(group_ops.back()->result(i));
+      outputs.push_back(group_ops.back()->result(i));
     }
   }
 
-  return vec_res;
+  return outputs;
 }
 
 void ReplaceWithGroupOp(pir::Block* block,
@@ -637,8 +635,8 @@ void ReplaceWithGroupOp(pir::Block* block,
   ctx->GetOrRegisterDialect<::pir::ControlFlowDialect>();
   ::pir::Builder builder = ::pir::Builder(ctx, block);
   // step 1: Ensure the insert point and create GroupOp here.
-  auto* laste_input_op = group_ops.front();
-  builder.SetInsertionPointAfter(laste_input_op);
+  auto* laste_op = group_ops.back();
+  builder.SetInsertionPointAfter(laste_op);
   std::vector<pir::Type> output_types;
   std::vector<pir::Value> outputs = AnalysisOutputs(group_ops);
 
@@ -650,7 +648,7 @@ void ReplaceWithGroupOp(pir::Block* block,
   pir::Block* group_block = new_group_op.block();
 
   for (auto op : group_ops) {
-    op->MoveTo(group_block, group_block->begin());
+    op->MoveTo(group_block, group_block->end());
   }
 
   // step 3: Replace outputs of inner ops


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164

对于一个Program 中的算子： A &rarr; B &rarr; C，经过`CinnSubgraphDetector` 之后得到的groups中算子是逆序的，即 C &rarr; B &rarr; A，存在如下问题：

+ 不符合直觉，下游逻辑都需要按照逆序来处理，不利于迭代维护
+ 可能有BUG，当所有的ops都属于一个group，此时解析outputs时却按照了自然序来解析的

故此PR将Group中的ops顺序调整为自然序，即 A &rarr; B &rarr; C，提高可维护性

修复前：
![FDB23AF00B15B223EB6FB54EA9CB6B2F](https://github.com/PaddlePaddle/Paddle/assets/9301846/a29eb8a5-fdd2-4246-a163-8a70b38a8742)
修复后：
<img width="1072" alt="8c7bb05951c827493a39533b225faf96" src="https://github.com/PaddlePaddle/Paddle/assets/9301846/f8f62aef-3a36-4f2c-972e-c192b4676d39">
