### PR TITLE
[Dygraph API] Fix skip_transform of input tensors, e.g. index, to ena…

### DIFF
--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -699,7 +699,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
     def gene_trans_flag(self, input_name):
         trans_flag = "{}"
         if input_name in self.data_transform['skip_transform']:
-            trans_flag = "{true}"
+            trans_flag = "{false, false, true, false}"
         elif input_name in self.data_transform['support_trans_dtype']:
             trans_flag = "{false, true}"
         return trans_flag
@@ -721,7 +721,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         input_tensor_code = (
             input_tensor_code
             + f"""
-{code_indent}  auto {PREFIX_TENSOR_NAME}{input_name} = PrepareData({input_name}, GetKernelInputArgDef(kernel.InputAt({kernel_param.index(input_name)}), kernel_backend), {trans_flag}, kernel_result.is_stride_kernel);"""
+{code_indent}  auto {PREFIX_TENSOR_NAME}{input_name} = PrepareData({input_name}, GetKernelInputArgDef(kernel.InputAt({kernel_param.index(input_name)}), actual_kernel_backend), {trans_flag}, kernel_result.is_stride_kernel);"""
         )
         return input_tensor_code
 
@@ -742,7 +742,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         input_tensor_code = (
             input_tensor_code
             + f"""
-{code_indent}  auto {PREFIX_TENSOR_NAME}{input_name} = PrepareDataForSelectedRows({input_name}, GetKernelInputArgDef(kernel.InputAt({kernel_param.index(input_name)}), kernel_backend), {trans_flag});
+{code_indent}  auto {PREFIX_TENSOR_NAME}{input_name} = PrepareDataForSelectedRows({input_name}, GetKernelInputArgDef(kernel.InputAt({kernel_param.index(input_name)}), actual_kernel_backend), {trans_flag});
 """
         )
         return input_tensor_code


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Description
Fix skip_transform of input tensors, e.g. index, to enable them being transferred between backends, while preserving the prohibited transformation of datatype and layout.
