### PR TITLE
[OneDNN] Replace cpu.h header in default OneDNN to deploy

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -949,9 +949,10 @@ void AnalysisConfig::Update() {
   //  Case3: pass_builder_ has been created and belongs to
   // GpuPassStrategy(or IpuPassStrategy), neither enable mkldnn and
   // disable mkldnn will be executed
-  if (!use_gpu() && !use_xpu() && !use_ipu() && !use_custom_device() &&
-      !use_mkldnn_) {
-    // User manually disable mkldnn
+  if ((!use_gpu() && !use_xpu() && !use_ipu() && !use_mkldnn_) ||
+      (!phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2) &&
+       !use_mkldnn_)) {
+    // User manually disable mkldnn or disable when not support AVX2
     pass_builder()->DisableMKLDNN();
   }
 #endif

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -953,6 +953,7 @@ void AnalysisConfig::Update() {
       (!phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2) &&
        use_mkldnn_)) {
     // User manually disable mkldnn or disable when not support AVX2
+    use_mkldnn_ = false;
     pass_builder()->DisableMKLDNN();
   }
 #endif

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -950,8 +950,8 @@ void AnalysisConfig::Update() {
   // GpuPassStrategy(or IpuPassStrategy), neither enable mkldnn and
   // disable mkldnn will be executed
   if ((!use_gpu() && !use_xpu() && !use_ipu() && !use_mkldnn_) ||
-      (!phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2) &&
-       use_mkldnn_)) {
+      (use_mkldnn_ &&
+       !phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2))) {
     // User manually disable mkldnn or disable when not support AVX2
     use_mkldnn_ = false;
     pass_builder()->DisableMKLDNN();

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -951,7 +951,7 @@ void AnalysisConfig::Update() {
   // disable mkldnn will be executed
   if ((!use_gpu() && !use_xpu() && !use_ipu() && !use_mkldnn_) ||
       (!phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2) &&
-       !use_mkldnn_)) {
+       use_mkldnn_)) {
     // User manually disable mkldnn or disable when not support AVX2
     pass_builder()->DisableMKLDNN();
   }

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -58,7 +58,6 @@
 #include "paddle/fluid/platform/profiler.h"
 #include "paddle/phi/api/include/context_pool.h"
 #include "paddle/phi/api/include/tensor.h"
-#include "paddle/phi/backends/cpu/cpu_info.h"
 #include "paddle/phi/common/backend.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
@@ -359,10 +358,6 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
     if (FLAGS_enable_pir_in_executor) {
       config_.SwitchIrOptim(false);
     }
-  }
-  if (config_.ir_optim() &&
-      phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2)) {
-    config_.EnableMKLDNN();
   }
   int trt_identifier = config_.trt_engine_memory_sharing_identifier_;
   if (trt_identifier > 0) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -58,6 +58,7 @@
 #include "paddle/fluid/platform/profiler.h"
 #include "paddle/phi/api/include/context_pool.h"
 #include "paddle/phi/api/include/tensor.h"
+#include "paddle/phi/backends/cpu/cpu_info.h"
 #include "paddle/phi/common/backend.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
@@ -358,6 +359,10 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
     if (FLAGS_enable_pir_in_executor) {
       config_.SwitchIrOptim(false);
     }
+  }
+  if (config_.ir_optim() &&
+      phi::backends::cpu::MayIUse(phi::backends::cpu::cpu_isa_t::avx2)) {
+    config_.EnableMKLDNN();
   }
   int trt_identifier = config_.trt_engine_memory_sharing_identifier_;
   if (trt_identifier > 0) {

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1300,7 +1300,11 @@ struct PD_INFER_DECL AnalysisConfig {
 
   std::unordered_set<std::string> trt_ops_run_float_;
 
+#ifdef PADDLE_WITH_DNNL
+  bool use_mkldnn_{true};
+#else
   bool use_mkldnn_{false};
+#endif
   std::unordered_set<std::string> mkldnn_enabled_op_types_;
 
   bool model_from_memory_{false};

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1333,7 +1333,6 @@ struct PD_INFER_DECL AnalysisConfig {
     if (nIds >= 0x00000001) {
       // EAX = 1
       cpuid(reg.data(), 0x00000001);
-      // AVX: ECX Bit 28
     }
     if (nIds >= 0x00000007) {
       // EAX = 7

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -41,29 +41,6 @@
 #ifdef PADDLE_WITH_DNNL
 #include "paddle_mkldnn_quantizer_config.h"  // NOLINT
 #endif
-#ifdef PADDLE_WITH_XBYAK
-#include "xbyak/xbyak_util.h"
-#endif
-
-#ifdef _WIN32
-#if defined(__AVX2__)
-#include <immintrin.h>  // avx2
-#elif defined(__AVX__)
-#include <intrin.h>  // avx
-#endif               // AVX
-#else                // WIN32
-#ifdef __AVX__
-#include <immintrin.h>
-#endif
-#endif  // WIN32
-
-#if defined(_WIN32)
-#define ALIGN32_BEG __declspec(align(32))
-#define ALIGN32_END
-#else
-#define ALIGN32_BEG
-#define ALIGN32_END __attribute__((aligned(32)))
-#endif  // _WIN32
 
 namespace paddle {
 
@@ -1365,12 +1342,8 @@ struct PD_INFER_DECL AnalysisConfig {
 #endif
     return false;
   }
-#endif
-  bool use_mkldnn_{SupportAVX2() ? true : false};
-#else
-  bool use_mkldnn_{false};
-#endif
 
+  bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;
 
   bool model_from_memory_{false};

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1300,49 +1300,6 @@ struct PD_INFER_DECL AnalysisConfig {
 
   std::unordered_set<std::string> trt_ops_run_float_;
 
-#ifdef PADDLE_WITH_DNNL
-#ifdef PADDLE_WITH_XBYAK
-  bool SupportAVX2() {
-    using namespace Xbyak::util;  // NOLINT
-    Xbyak::util::Cpu cpu;
-    return cpu.has(Cpu::tAVX2);
-  }
-#else
-  bool SupportAVX2() {
-#ifdef _WIN32
-#define cpuid(reg, x) __cpuidex(reg, x, 0)
-#else
-#if !defined(WITH_NV_JETSON) && !defined(PADDLE_WITH_ARM) &&  \
-    !defined(PADDLE_WITH_SW) && !defined(PADDLE_WITH_MIPS) && \
-    !defined(PADDLE_WITH_LOONGARCH)
-#include <cpuid.h>
-    inline void cpuid(int reg[4], int x) {
-      __cpuid_count(x, 0, reg[0], reg[1], reg[2], reg[3]);
-    }
-#endif
-#endif
-
-#if !defined(WITH_NV_JETSON) && !defined(PADDLE_WITH_ARM) &&  \
-    !defined(PADDLE_WITH_SW) && !defined(PADDLE_WITH_MIPS) && \
-    !defined(PADDLE_WITH_LOONGARCH)
-    std::array<int, 4> reg;
-    cpuid(reg.data(), 0);
-    int nIds = reg[0];
-    if (nIds >= 0x00000001) {
-      // EAX = 1
-      cpuid(reg.data(), 0x00000001);
-    }
-    if (nIds >= 0x00000007) {
-      // EAX = 7
-      cpuid(reg.data(), 0x00000007);
-      // AVX2: EBX Bit 5
-      int avx2_mask = (1 << 5);
-      return (reg[1] & avx2_mask) != 0;
-    }
-#endif
-    return false;
-  }
-
   bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;
 

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -44,6 +44,27 @@
 #ifdef PADDLE_WITH_XBYAK
 #include "xbyak/xbyak_util.h"
 #endif
+
+#ifdef _WIN32
+#if defined(__AVX2__)
+#include <immintrin.h>  // avx2
+#elif defined(__AVX__)
+#include <intrin.h>  // avx
+#endif               // AVX
+#else                // WIN32
+#ifdef __AVX__
+#include <immintrin.h>
+#endif
+#endif  // WIN32
+
+#if defined(_WIN32)
+#define ALIGN32_BEG __declspec(align(32))
+#define ALIGN32_END
+#else
+#define ALIGN32_BEG
+#define ALIGN32_END __attribute__((aligned(32)))
+#endif  // _WIN32
+
 namespace paddle {
 
 class AnalysisPredictor;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
cpu.h header in default OneDNN will have error in deploy causing by this header files cannot be exposed to the outside world and packaged.
