### PR TITLE
[PIR] add blocks interface for pir::Operation.

### DIFF
--- a/paddle/fluid/pybind/control_flow_api.cc
+++ b/paddle/fluid/pybind/control_flow_api.cc
@@ -48,38 +48,8 @@ using pir::Value;
 using pir::YieldOp;
 using pybind11::return_value_policy;
 
+using paddle::pybind::PyIfOp;
 namespace {
-class PyIfOp : public IfOp {
- public:
-  explicit PyIfOp(IfOp if_op);
-  void UpdateOutput();
-};
-
-PyIfOp::PyIfOp(IfOp if_op) : IfOp(if_op) {
-  PADDLE_ENFORCE_NOT_NULL(
-      if_op,
-      paddle::platform::errors::InvalidArgument(
-          "The if_op used to construct PyIfOp can't be nullptr"));
-}
-
-void PyIfOp::UpdateOutput() {
-  PADDLE_ENFORCE_NOT_NULL(
-      *this,
-      paddle::platform::errors::InvalidArgument(
-          "The if_op in PyIfOp used to update output can't be nullptr"));
-  auto block = parent();
-  PADDLE_ENFORCE_NOT_NULL(block,
-                          paddle::platform::errors::InvalidArgument(
-                              "The parent block of if_op which used to update "
-                              "output can't be nullptr"));
-  Block::Iterator iter = **this;
-  Builder builder(ir_context(), false);
-  auto new_if_op = builder.Build<IfOp>(
-      cond(), true_region().TakeBack(), false_region().TakeBack());
-  block->Assign(iter, new_if_op);
-  IfOp::operator=(new_if_op);
-  VerifyRegion();
-}
 
 PyIfOp BuildPyIfOp(Value cond) {
   return PyIfOp(ApiBuilder::Instance().GetBuilder()->Build<IfOp>(
@@ -185,11 +155,35 @@ void BuildPipeForBlock(Block* block) {
 
 namespace paddle {
 namespace pybind {
+PyIfOp::PyIfOp(IfOp if_op) : IfOp(if_op) {
+  PADDLE_ENFORCE_NOT_NULL(
+      if_op,
+      paddle::platform::errors::InvalidArgument(
+          "The if_op used to construct PyIfOp can't be nullptr"));
+}
+
+void PyIfOp::UpdateOutput() {
+  PADDLE_ENFORCE_NOT_NULL(
+      *this,
+      paddle::platform::errors::InvalidArgument(
+          "The if_op in PyIfOp used to update output can't be nullptr"));
+  auto block = parent();
+  PADDLE_ENFORCE_NOT_NULL(block,
+                          paddle::platform::errors::InvalidArgument(
+                              "The parent block of if_op which used to update "
+                              "output can't be nullptr"));
+  Block::Iterator iter = **this;
+  Builder builder(ir_context(), false);
+  auto new_if_op = builder.Build<IfOp>(
+      cond(), true_region().TakeBack(), false_region().TakeBack());
+  block->Assign(iter, new_if_op);
+  IfOp::operator=(new_if_op);
+  VerifyRegion();
+}
+
 void BindControlFlowApi(py::module* m) {
   m->def("get_used_external_value", GetUsedExternalValue);
   m->def("build_pipe_for_block", BuildPipeForBlock);
-  m->def("cvt_as_if_op",
-         [](Operation& op) { return PyIfOp(op.dyn_cast<IfOp>()); });
   BindIfOp(m);
 }
 }  // namespace pybind

--- a/paddle/fluid/pybind/control_flow_api.h
+++ b/paddle/fluid/pybind/control_flow_api.h
@@ -15,9 +15,16 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 
 namespace paddle {
 namespace pybind {
+class PyIfOp : public dialect::IfOp {
+ public:
+  explicit PyIfOp(dialect::IfOp if_op);
+  void UpdateOutput();
+};
+
 void BindControlFlowApi(pybind11::module *m);
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include "paddle/pir/core/block.h"
 #include "paddle/pir/core/enforce.h"
+#include "paddle/pir/core/iterator.h"
 #include "paddle/pir/core/macros.h"
 #include "paddle/pir/core/op_info.h"
 #include "paddle/pir/core/operation_utils.h"
@@ -34,7 +35,8 @@ class OpResultImpl;
 class OpOperendImpl;
 }  // namespace detail
 
-class IR_API alignas(8) Operation final {
+class IR_API alignas(8) Operation final
+    : public DoubleLevelContainer<Operation> {
  public:
   ///
   /// \brief Malloc memory and construct objects in the following order:
@@ -109,6 +111,7 @@ class IR_API alignas(8) Operation final {
   ///
   /// \brief region related public interfaces
   ///
+  using Element = Region;
   using Iterator = Region *;
   using ConstIterator = const Region *;
   uint32_t num_regions() const { return num_regions_; }
@@ -118,6 +121,10 @@ class IR_API alignas(8) Operation final {
   ConstIterator end() const { return regions_ + num_regions_; }
   Iterator begin() { return regions_; }
   Iterator end() { return regions_ + num_regions_; }
+
+  /// \brief block related public interfaces
+  using BlockContainer = DoubleLevelContainer<Operation>;
+  BlockContainer &blocks() { return *this; }
 
   ///
   /// \brief parent related public interfaces

--- a/paddle/pir/core/region.h
+++ b/paddle/pir/core/region.h
@@ -30,6 +30,7 @@ class Program;
 
 class IR_API Region {
  public:
+  using Element = Block;
   using Iterator = PointerListIterator<Block>;
   using ConstIterator = PointerListConstIterator<Block>;
   using ReverseIterator = std::reverse_iterator<Iterator>;

--- a/test/cpp/pir/control_flow_dialect/if_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/if_op_test.cc
@@ -95,7 +95,7 @@ TEST(if_op_test, build_by_block) {
 
   builder.SetInsertionPointToEnd(block);
 
-  builder.Build<paddle::dialect::IfOp>(
+  auto if_op = builder.Build<paddle::dialect::IfOp>(
       full_op.out(), std::move(true_block), std::move(false_block));
 
   EXPECT_FALSE(true_block);
@@ -103,6 +103,14 @@ TEST(if_op_test, build_by_block) {
   EXPECT_EQ(full_op_2->GetParentProgram(), &program);
 
   LOG(INFO) << program;
+
+  std::vector<pir::Block*> vec;
+  for (auto& block : if_op->blocks()) {
+    vec.push_back(&block);
+  }
+  EXPECT_EQ(vec.size(), 2u);
+  EXPECT_EQ(vec[0], if_op.true_block());
+  EXPECT_EQ(vec[1], if_op.false_block());
 }
 
 TEST(if_op_test, network_with_backward) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
- 新增模版双层容器 DoubleLevelContainer工具对象，支持将双层容器平铺为一层，跳过外层，对内层元素直接进行遍历。
- pir::Operation派生自DoubleLevelContainer<Operation>类，通过blocks()可将自身转换为DoubleLevelContainer<Operation>，进而可通过范围for循环跳过region直接遍历子block。
- python端通过 Operation.blocks()接口直接遍历block。
- 完成[PR59231](#59231) 中的遗留comment任务, 将 cvt_as_if_op重命名为 as_if_op,并在python端将其绑定为pir::Operation的成员函数。
### Other

Pcard-67164
