### PR TITLE
[PIR]Open pir test in test_elementwise_nn_grad.py

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4958,7 +4958,7 @@ def conj(x, name=None):
              [(4-4j), (5-5j), (6-6j)]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.conj(x)
     else:
         check_variable_and_dtype(
@@ -5863,7 +5863,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         dtype = x.dtype
         axes = [axis]
         infer_flags = [1 for i in range(len(axes))]
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             has_pend = False
             input_list = []
             if prepend is not None and append is not None:
@@ -5900,7 +5900,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
                 new_input, axes, starts_2, ends_2, infer_flags, []
             )
 
-            if x.dtype == paddle.bool:
+            if x.dtype == paddle.bool or x.dtype == core.DataType.BOOL:
                 return _C_ops.logical_xor(input_back, input_front)
             else:
                 return _C_ops.subtract(input_back, input_front)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1157,7 +1157,7 @@ def _add_with_axis(x, y, axis=-1, name=None):
 
 def _subtract_with_axis(x, y, axis=-1, name=None):
     # opt performance, only dynamic mode needs reshape
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _elementwise_op_with_axis(x, y, axis, name, "subtract")
     else:
         op_type = 'elementwise_sub'
@@ -1166,7 +1166,7 @@ def _subtract_with_axis(x, y, axis=-1, name=None):
 
 def _multiply_with_axis(x, y, axis=-1, name=None):
     # opt performance, only dynamic mode needs reshape
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _elementwise_op_with_axis(x, y, axis, name, "multiply")
     else:
         op_type = 'elementwise_mul'
@@ -1175,7 +1175,7 @@ def _multiply_with_axis(x, y, axis=-1, name=None):
 
 def _divide_with_axis(x, y, axis=-1, name=None):
     # opt performance, only dynamic mode needs reshape
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _elementwise_op_with_axis(x, y, axis, name, "divide")
     else:
         op_type = 'elementwise_div'
@@ -4958,7 +4958,7 @@ def conj(x, name=None):
              [(4-4j), (5-5j), (6-6j)]])
 
     """
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         return _C_ops.conj(x)
     else:
         check_variable_and_dtype(
@@ -5863,7 +5863,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         dtype = x.dtype
         axes = [axis]
         infer_flags = [1 for i in range(len(axes))]
-        if in_dynamic_or_pir_mode():
+        if in_dynamic_mode():
             has_pend = False
             input_list = []
             if prepend is not None and append is not None:
@@ -5900,7 +5900,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
                 new_input, axes, starts_2, ends_2, infer_flags, []
             )
 
-            if x.dtype == paddle.bool or x.dtype == core.DataType.BOOL:
+            if x.dtype == paddle.bool:
                 return _C_ops.logical_xor(input_back, input_front)
             else:
                 return _C_ops.subtract(input_back, input_front)

--- a/test/legacy_test/test_elementwise_nn_grad.py
+++ b/test/legacy_test/test_elementwise_nn_grad.py
@@ -21,9 +21,11 @@ from decorator_helper import prog_scope
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestElementwiseMulDoubleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -53,6 +55,7 @@ class TestElementwiseMulDoubleGradCheck(unittest.TestCase):
 
 
 class TestElementwiseMulBroadcastDoubleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -82,6 +85,7 @@ class TestElementwiseMulBroadcastDoubleGradCheck(unittest.TestCase):
 
 
 class TestElementwiseAddDoubleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -111,6 +115,7 @@ class TestElementwiseAddDoubleGradCheck(unittest.TestCase):
 
 
 class TestElementwiseAddBroadcastDoubleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -143,6 +148,7 @@ class TestElementwiseSubDoubleGradCheck(unittest.TestCase):
     def subtract_wrapper(self, x):
         return paddle.subtract(x[0], x[1])
 
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -179,6 +185,7 @@ class TestElementwiseSubDoubleGradCheck(unittest.TestCase):
 
 
 class TestElementwiseSubBroadcastDoubleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -211,6 +218,7 @@ class TestElementwiseDivDoubleGradCheck(unittest.TestCase):
     def divide_wrapper(self, x):
         return paddle.divide(x[0], x[1])
 
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -249,6 +257,7 @@ class TestElementwiseDivDoubleGradCheck(unittest.TestCase):
 
 
 class TestElementwiseDivBroadcastDoubleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -279,6 +288,7 @@ class TestElementwiseDivBroadcastDoubleGradCheck(unittest.TestCase):
 
 
 class TestElementwiseAddTripleGradCheck(unittest.TestCase):
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.
@@ -340,6 +350,7 @@ class TestElementwiseMulTripleGradCheck(unittest.TestCase):
     def multiply_wrapper(self, x):
         return paddle.multiply(x[0], x[1])
 
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         # the shape of input variable should be clearly specified, not inlcude -1.

--- a/test/legacy_test/test_nn_grad.py
+++ b/test/legacy_test/test_nn_grad.py
@@ -374,8 +374,7 @@ class TestConstantPadDoubleGradCheck(unittest.TestCase):
         )
 
     def test_grad(self):
-        # places = [base.CPUPlace()]
-        places = []
+        places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
pcard-67164
- test_elementwise_nn_grad.py passed
    - add, _add_with_axis, multiply, _multiply_with_axis, subtract, _subtract_with_axis, divide _divide_with_axis
    - _add_with_axis需要reshape，但reshape的三阶未支持，因此_add_with_axis和_multiply_with_axis三阶测试未开启
- fix comment bug in test_nn_grad.py