### PR TITLE
[CI]fix windows bug

### DIFF
--- a/paddle/common/CMakeLists.txt
+++ b/paddle/common/CMakeLists.txt
@@ -23,3 +23,6 @@ set(COMMON_BUILD_TYPE
     CACHE INTERNAL "" FORCE)
 
 cc_library(common ${COMMON_BUILD_TYPE} SRCS ${common_srcs})
+if(WIN32)
+  set_property(TARGET common PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()

--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -15,7 +15,7 @@
 			*paddle_infer::contrib::Status*;
 			*paddle_infer::services::PredictorPool*;
 			*paddle_infer::LayoutConvert*;
-
+			*paddle::common*;
 			*paddle::experimental*;
 			*paddle::Tensor*;
 			*paddle::internal*;

--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -15,7 +15,7 @@
 			*paddle_infer::contrib::Status*;
 			*paddle_infer::services::PredictorPool*;
 			*paddle_infer::LayoutConvert*;
-            *paddle::common*;
+			*paddle::common*;
 			*paddle::experimental*;
 			*paddle::Tensor*;
 			*paddle::internal*;

--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -15,7 +15,7 @@
 			*paddle_infer::contrib::Status*;
 			*paddle_infer::services::PredictorPool*;
 			*paddle_infer::LayoutConvert*;
-			*paddle::common*;
+            *paddle::common*;
 			*paddle::experimental*;
 			*paddle::Tensor*;
 			*paddle::internal*;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Description
<!-- Describe what you’ve done -->
修复在windows on_infer=on时，编译的时候没有动态库libcommon.dll的导入库libcommon.lib，导致编译无法打开libcommon.lib，需要在inference设置common的符号全部导出

Pcard-67010