### PR TITLE
[cmake治理]fix mkldnn off bug

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/CMakeLists.txt
+++ b/paddle/fluid/framework/paddle2cinn/CMakeLists.txt
@@ -3,7 +3,6 @@ set(paddle2cinn_deps
     gtest
     absl
     isl
-    mkldnn
     xxhash
     pybind
     python
@@ -18,6 +17,9 @@ set(paddle2cinn_deps
     schedule_desc_proto
     auto_schedule_proto
     parallel_executor)
+if(WITH_MKLDNN)
+  set(paddle2cinn ${paddle2cinn} mkldnn)
+endif()
 
 cc_library(
   paddle2cinn


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复with_mkldnn=off时，编译找不到-lmkldnn的问题
![07f008ed58a1dbfb45be059603005ba5](https://github.com/PaddlePaddle/Paddle/assets/62429225/4c8dcee8-7076-437d-8dd5-02648d545c4e)

Pcard-67010