### PR TITLE
【PIR API adaptor No.188】 Migrate paddle.regularizer.L2Decay into pir

### DIFF
--- a/test/legacy_test/test_regularizer_api.py
+++ b/test/legacy_test/test_regularizer_api.py
@@ -188,7 +188,7 @@ class TestRegularizer(unittest.TestCase):
             paddle.static.Program(), paddle.static.Program()
         ):
             x = paddle.uniform([2, 2, 3])
-            linear = paddle.nn.Linear(1, 5, weight_attr=fc_param_attr)
+            linear = paddle.nn.Linear(3, 5, weight_attr=fc_param_attr)
             out = linear(x)
             loss = paddle.sum(out)
             sgd = paddle.optimizer.SGD(learning_rate=0.1, weight_decay=l2)

--- a/test/legacy_test/test_regularizer_api.py
+++ b/test/legacy_test/test_regularizer_api.py
@@ -22,6 +22,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 def bow_net(
@@ -102,8 +103,8 @@ class TestRegularizer(unittest.TestCase):
     def check_l2decay_regularizer(self, place, model):
         paddle.seed(1)
         paddle.framework.random._manual_program_seed(1)
-        main_prog = base.framework.Program()
-        startup_prog = base.framework.Program()
+        main_prog = paddle.static.Program()
+        startup_prog = paddle.static.Program()
         with self.scope_prog_guard(
             main_prog=main_prog, startup_prog=startup_prog
         ):
@@ -175,6 +176,7 @@ class TestRegularizer(unittest.TestCase):
                     rtol=5e-5,
                 )
 
+    @test_with_pir_api
     def test_repeated_regularization(self):
         paddle.enable_static()
         l1 = paddle.regularizer.L1Decay(0.1)
@@ -182,9 +184,12 @@ class TestRegularizer(unittest.TestCase):
         fc_param_attr = paddle.ParamAttr(
             regularizer=paddle.regularizer.L1Decay()
         )
-        with base.program_guard(base.Program(), base.Program()):
+        with base.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.uniform([2, 2, 3])
-            out = paddle.static.nn.fc(x, 5, weight_attr=fc_param_attr)
+            linear = paddle.nn.Linear(1, 5, weight_attr=fc_param_attr)
+            out = linear(x)
             loss = paddle.sum(out)
             sgd = paddle.optimizer.SGD(learning_rate=0.1, weight_decay=l2)
             sgd.minimize(loss)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级

https://github.com/PaddlePaddle/Paddle/issues/58067
No.187 将 paddle.regularizer.L2Decay 迁移升级至 pir，并更新单测，单测覆盖率：1/2。

bow_net中paddle.static.nn.sequence_lod.sequence_pool没有对应的pir实现op：
```
1869: ERROR: test_l2 (test_regularizer_api.TestRegularizer)
1869: ----------------------------------------------------------------------
1869: Traceback (most recent call last):
1869:   File "/wuzp/Paddle/build/python/paddle/pir_utils.py", line 113, in impl
1869:     func(*args, **kwargs)
1869:   File "/wuzp/Paddle/build/test/legacy_test/test_regularizer_api.py", line 167, in test_l2
1869:     framework_l2 = self.check_l2decay_regularizer(place, model)
1869:   File "/wuzp/Paddle/build/python/paddle/pir_utils.py", line 115, in impl
1869:     func(*args, **kwargs)
1869:   File "/wuzp/Paddle/build/test/legacy_test/test_regularizer_api.py", line 120, in check_l2decay_regularizer
1869:     avg_cost = model(data, label, self.word_len)
1869:   File "/wuzp/Paddle/build/test/legacy_test/test_regularizer_api.py", line 47, in bow_net
1869:     bow = paddle.static.nn.sequence_lod.sequence_pool(
1869:   File "/wuzp/Paddle/build/python/paddle/static/nn/sequence_lod.py", line 348, in sequence_pool
1869:     pool_out = helper.create_variable_for_type_inference(dtype)
1869:   File "/wuzp/Paddle/build/python/paddle/base/layer_helper_base.py", line 468, in create_variable_for_type_inference
1869:     return self.main_program.current_block().create_var(
1869:   File "/wuzp/Paddle/build/python/paddle/base/framework.py", line 4207, in create_var
1869:     var = Variable(block=self, *args, **kwargs)
1869:   File "/wuzp/Paddle/build/python/paddle/base/framework.py", line 1455, in __init__
1869:     dtype = convert_np_dtype_to_dtype_(dtype)
1869:   File "/wuzp/Paddle/build/python/paddle/base/framework.py", line 1157, in convert_np_dtype_to_dtype_
1869:     return pir.core.convert_np_dtype_to_dtype_(np_dtype)
1869:   File "/wuzp/Paddle/build/python/paddle/pir/core.py", line 75, in convert_np_dtype_to_dtype_
1869:     dtype = np.dtype(np_dtype)
1869: TypeError: Cannot interpret '<DataType.FLOAT32: 10>' as a data type
1869: 
1869: ----------------------------------------------------------------------
```

