### PR TITLE
[PIR]Add pir grad check for conv and conv_transpose

### DIFF
--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1052,7 +1052,7 @@ set_tests_properties(test_elementwise_nn_grad PROPERTIES TIMEOUT 120)
 set_tests_properties(
   test_buffer_shared_memory_reuse_pass_and_fuse_optimization_op_pass
   PROPERTIES TIMEOUT 120)
-set_tests_properties(test_conv_nn_grad PROPERTIES TIMEOUT 120)
+set_tests_properties(test_conv_nn_grad PROPERTIES TIMEOUT 200)
 set_tests_properties(test_program_prune_backward PROPERTIES TIMEOUT 120)
 set_tests_properties(test_group_norm_op PROPERTIES TIMEOUT 1000)
 set_tests_properties(test_imperative_optimizer PROPERTIES TIMEOUT 250)

--- a/test/legacy_test/test_conv_nn_grad.py
+++ b/test/legacy_test/test_conv_nn_grad.py
@@ -19,8 +19,10 @@ import numpy as np
 from decorator_helper import prog_scope
 
 import paddle
+import paddle.nn.functional as F
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestConvDoubleGradCheck(unittest.TestCase):
@@ -41,13 +43,31 @@ class TestConvDoubleGradCheck(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 4, 3, 3]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, groups=1)
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
-
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConvDoubleGradCheckTest0(unittest.TestCase):
@@ -68,12 +88,31 @@ class TestConvDoubleGradCheckTest0(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 4, 3, 3]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w)
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConvDoubleGradCheckTest1(unittest.TestCase):
@@ -94,12 +133,31 @@ class TestConvDoubleGradCheckTest1(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 3, 3, 3]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, padding=1)
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DDoubleGradCheck(unittest.TestCase):
@@ -120,13 +178,31 @@ class TestConv3DDoubleGradCheck(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 4, 3, 4, 2]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w)
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
-        # places = [base.CPUPlace()]
-        places = []
+        places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DDoubleGradCheckTest1(unittest.TestCase):
@@ -147,12 +223,31 @@ class TestConv3DDoubleGradCheckTest1(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 4, 5, 3, 2]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w, padding=1)
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv2DoubleGradCheck_AsyPadding(unittest.TestCase):
@@ -180,12 +275,31 @@ class TestConv2DoubleGradCheck_AsyPadding(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 2, 3, 3]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, padding=[1, 0, 0, 1])
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv2DoubleGradCheck_PaddingSAME(unittest.TestCase):
@@ -213,12 +327,31 @@ class TestConv2DoubleGradCheck_PaddingSAME(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 2, 3, 3]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, padding="SAME")
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv2DoubleGradCheck_PaddingVALID(unittest.TestCase):
@@ -246,12 +379,31 @@ class TestConv2DoubleGradCheck_PaddingVALID(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 2, 3, 3]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, padding="VALID")
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv2DoubleGradCheck_ChannelLast(unittest.TestCase):
@@ -281,12 +433,32 @@ class TestConv2DoubleGradCheck_ChannelLast(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        x_shape = [2, 2, 3, 3]
+        w_shape = [2, 3, 1, 1]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', x_shape, dtype)
+        w = paddle.static.data('w', w_shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, padding=[1, 1], groups=1, data_format="NHWC")
+        x_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, w_shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv2DoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
@@ -316,12 +488,32 @@ class TestConv2DoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        x_shape = [2, 2, 3, 3]
+        w_shape = [2, 3, 1, 1]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', x_shape, dtype)
+        w = paddle.static.data('w', w_shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv2d(x, w, padding=[1, 0, 1, 0], groups=1, data_format="NHWC")
+        x_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, w_shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DDoubleGradCheck_AsyPadding(unittest.TestCase):
@@ -349,12 +541,31 @@ class TestConv3DDoubleGradCheck_AsyPadding(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 2, 2, 2, 2]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w, padding=[1, 0, 0, 1, 1, 2])
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DoubleGradCheck_PaddingSAME(unittest.TestCase):
@@ -383,12 +594,31 @@ class TestConv3DoubleGradCheck_PaddingSAME(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 2, 2, 2, 2]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w, padding="SAME")
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DoubleGradCheck_PaddingVALID(unittest.TestCase):
@@ -416,12 +646,31 @@ class TestConv3DoubleGradCheck_PaddingVALID(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        shape = [2, 2, 3, 3, 2]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', shape, dtype)
+        w = paddle.static.data('w', shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w, padding="VALID")
+        x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DDoubleGradCheck_ChannelLast(unittest.TestCase):
@@ -451,12 +700,32 @@ class TestConv3DDoubleGradCheck_ChannelLast(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        x_shape = [2, 2, 2, 2, 3]
+        w_shape = [2, 3, 1, 1, 1]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', x_shape, dtype)
+        w = paddle.static.data('w', w_shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w, padding=[1, 1, 1], data_format="NDHWC")
+        x_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, w_shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestConv3DDoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
@@ -486,12 +755,32 @@ class TestConv3DDoubleGradCheck_ChannelLast_AsyPadding(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        x_shape = [2, 2, 2, 2, 3]
+        w_shape = [2, 3, 1, 1, 1]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', x_shape, dtype)
+        w = paddle.static.data('w', w_shape, dtype)
+        x.persistable = True
+        w.persistable = True
+        y = F.conv3d(x, w, padding=[1, 0, 1, 0, 1, 0], data_format="NDHWC")
+        x_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, w_shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = [base.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestDepthWiseConvDoubleGradCheck(unittest.TestCase):
@@ -519,18 +808,39 @@ class TestDepthWiseConvDoubleGradCheck(unittest.TestCase):
             [x] + w, y, x_init=[x_arr] + w_arr, place=place, eps=eps
         )
 
+    @test_with_pir_api
+    @prog_scope()
+    def func_pir(self, place):
+        x_shape = [2, 4, 3, 3]
+        w_shape = [4, 1, 1, 1]
+        eps = 0.005
+        dtype = np.float32 if base.core.is_compiled_with_rocm() else np.float64
+        x = paddle.static.data('x', x_shape, dtype)
+        w = paddle.static.data('w', w_shape, dtype)
+        # x.persistable = True
+        # w.persistable = True
+        y = F.conv2d(x, w, groups=4)
+        x_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
+        w_arr = np.random.uniform(-1, 1, w_shape).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, w], y, x_init=[x_arr, w_arr], place=place, eps=eps
+        )
+
     def test_grad(self):
         places = []
         if core.is_compiled_with_cuda():
             places.append(base.CUDAPlace(0))
         for p in places:
             self.func(p)
+            self.func_pir(p)
 
 
 class TestDepthWiseConvDoubleGradCheckCase1(unittest.TestCase):
     def depthwise_conv2d_wrapper(self, x):
         return paddle.nn.functional.conv2d(x[0], x[1], groups=4)
 
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         x_shape = [2, 4, 3, 3]
@@ -572,6 +882,7 @@ class TestConv3DDoubleGradCheck_NN(unittest.TestCase):
     def conv3d_wrapper(self, x):
         return paddle.nn.functional.conv3d(x[0], x[1])
 
+    @test_with_pir_api
     @prog_scope()
     def func(self, place):
         x_shape = [2, 3, 8, 8, 8]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add pir grad check for conv and conv_transpose
- 由于原本的conv相关单测大部分是调用`static.nn`下的静态图专用接口，不适用于pir测试，因此对每个单测类新增`func_pir`函数，使用pir下的python api组网构建测试。其中w的值通过打印原始测试中的值获取，保证新增测试效果与原始测试一致。
