### PR TITLE
contiguous tensor for process group

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -19,6 +19,7 @@
 #include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/platform/device/xpu/bkcl_helper.h"
 #include "paddle/fluid/platform/device/xpu/xpu_info.h"
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/api/lib/utils/allocator.h"
 #include "paddle/phi/core/device_context.h"
 #include "paddle/phi/core/distributed/check/static_check.h"
@@ -143,9 +144,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Send(
     int64_t numel,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensor);
   // numel > 0 indicates the tensor need to be sliced
   const phi::DenseTensor& tensor_maybe_partial =
-      numel > 0 ? GetPartialTensor(tensor, offset, numel) : tensor;
+      numel > 0 ? GetPartialTensor(tensor_tmp, offset, numel) : tensor_tmp;
 
   return Collective(
       nullptr,
@@ -248,7 +251,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Collective(
     CommType op_type,
     bool sync_op,
     bool use_calc_stream) {
-  const auto& place = in_tensor.place();
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
+  const auto& place = tensor_tmp.place();
   const auto& key = GetKeyFromPlace(place);
 
   if (!calc_event_ ||
@@ -266,7 +271,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Collective(
   const auto& comm_ctx = place_to_comm_ctx_[key];
   auto bkcl_stream = use_calc_stream ? calc_ctx->stream() : comm_ctx->stream();
   PADDLE_ENFORCE_XPU_SUCCESS(
-      fn(out_tensor, in_tensor, comm_ctx->bkcl_context(), bkcl_stream));
+      fn(out_tensor, tensor_tmp, comm_ctx->bkcl_context(), bkcl_stream));
 
   if (!use_calc_stream) {
     PADDLE_ENFORCE_NOT_NULL(
@@ -283,9 +288,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllReduce(
     const AllreduceOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       out_tensor,
-      in_tensor,
+      tensor_tmp,
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -320,9 +327,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Broadcast(
     const BroadcastOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       out_tensor,
-      in_tensor,
+      tensor_tmp,
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -372,8 +381,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
     int64_t numel,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   const phi::DenseTensor& in_tensor_maybe_partial =
-      numel > 0 ? GetPartialTensor(in_tensor, offset, numel) : in_tensor;
+      numel > 0 ? GetPartialTensor(tensor_tmp, offset, numel) : tensor_tmp;
   phi::distributed::CommStaticCheck::GatherLikeShape(*out_tensor,
                                                      in_tensor_maybe_partial,
                                                      /*dst_rank*/ rank_,
@@ -415,9 +426,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Reduce(
     const ReduceOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       out_tensor,
-      in_tensor,
+      tensor_tmp,
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -453,9 +466,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::ReduceScatter(
     const ReduceScatterOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       out_tensor,
-      in_tensor,
+      tensor_tmp,
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -532,8 +547,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllReduce(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const AllreduceOptions& opts) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      in_tensors.size(),
+      tensor_tmp.size(),
       1,
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
@@ -543,12 +560,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllReduce(
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInXPUPlace(in_tensors),
+      CheckTensorsInXPUPlace(tensor_tmp),
       true,
       platform::errors::InvalidArgument("All inputs should be in XPUPlace."));
   return Collective(
       &out_tensors[0],
-      in_tensors[0],
+      tensor_tmp[0],
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -581,8 +598,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllReduce(
     std::vector<phi::DenseTensor>& out_tensors,
     const AllreduceOptions& opts,
     bool sync_op) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      in_tensors.size(),
+      tensor_tmp.size(),
       1,
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
@@ -592,12 +611,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllReduce(
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInXPUPlace(in_tensors),
+      CheckTensorsInXPUPlace(tensor_tmp),
       true,
       platform::errors::InvalidArgument("All inputs should be in XPUPlace."));
   return Collective(
       &out_tensors[0],
-      in_tensors[0],
+      tensor_tmp[0],
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -629,8 +648,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Broadcast(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const BroadcastOptions& opts) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      in_tensors.size(),
+      tensor_tmp.size(),
       1,
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
@@ -640,19 +661,19 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Broadcast(
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInXPUPlace(in_tensors),
+      CheckTensorsInXPUPlace(tensor_tmp),
       true,
       platform::errors::InvalidArgument("All inputs should be in XPUPlace."));
 
   return Collective(
       &out_tensors[0],
-      in_tensors[0],
+      tensor_tmp[0],
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
           const XPUStream& stream) {
         const auto root =
-            opts.source_rank * in_tensors.size() + opts.source_root;
+            opts.source_rank * tensor_tmp.size() + opts.source_root;
         VLOG(3) << "calling bkcl_broadcast"
                 << ", rank_id: " << platform::GetBKCLRankID(comm)
                 << ", dev_id: " << platform::GetBKCLDevID(comm)
@@ -681,8 +702,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Broadcast(
     std::vector<phi::DenseTensor>& out_tensors,
     const BroadcastOptions& opts,
     bool sync_op) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      in_tensors.size(),
+      tensor_tmp.size(),
       1,
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
@@ -692,19 +715,19 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Broadcast(
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInXPUPlace(in_tensors),
+      CheckTensorsInXPUPlace(tensor_tmp),
       true,
       platform::errors::InvalidArgument("All inputs should be in XPUPlace."));
 
   return Collective(
       &out_tensors[0],
-      in_tensors[0],
+      tensor_tmp[0],
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
           const XPUStream& stream) {
         const auto root =
-            opts.source_rank * in_tensors.size() + opts.source_root;
+            opts.source_rank * tensor_tmp.size() + opts.source_root;
         VLOG(3) << "calling bkcl_broadcast"
                 << ", rank_id: " << platform::GetBKCLRankID(comm)
                 << ", dev_id: " << platform::GetBKCLDevID(comm)
@@ -731,8 +754,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::Broadcast(
 std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      in_tensors.size(),
+      tensor_tmp.size(),
       1,
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
@@ -742,7 +767,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInXPUPlace(in_tensors),
+      CheckTensorsInXPUPlace(tensor_tmp),
       true,
       platform::errors::InvalidArgument("All inputs should be in XPUPlace."));
   PADDLE_ENFORCE_EQ(
@@ -751,7 +776,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
       platform::errors::InvalidArgument("All outputs should be in XPUPlace."));
   return Collective(
       &out_tensors[0],
-      in_tensors[0],
+      tensor_tmp[0],
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,
@@ -781,8 +806,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     bool sync_op) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      in_tensors.size(),
+      tensor_tmp.size(),
       1,
       platform::errors::InvalidArgument(
           "BKCL only support single tensor collective communication."));
@@ -797,7 +824,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
       platform::errors::InvalidArgument("All outputs should be in XPUPlace."));
   return Collective(
       &out_tensors[0],
-      in_tensors[0],
+      tensor_tmp[0],
       [&](phi::DenseTensor* output,
           const phi::DenseTensor& input,
           BKCLContext_t comm,

--- a/paddle/fluid/distributed/collective/process_group_custom.cc
+++ b/paddle/fluid/distributed/collective/process_group_custom.cc
@@ -22,6 +22,7 @@
 #include "paddle/phi/core/flags.h"
 #include "paddle/phi/core/utils/data_type.h"
 
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/distributed/comm_context_manager.h"
 
 constexpr int64_t kWaitBlockTImeout = 10;
@@ -167,9 +168,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllGather(
     int64_t numel,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   // numel > 0 indicates the tensor need to be sliced
   const phi::DenseTensor& in_tensor_maybe_partial =
-      numel > 0 ? GetPartialTensor(in_tensor, offset, numel) : in_tensor;
+      numel > 0 ? GetPartialTensor(tensor_tmp, offset, numel) : tensor_tmp;
   return RunFnInXCCLEnv(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
@@ -187,16 +190,18 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllReduce(
     const AllreduceOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return RunFnInXCCLEnv(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
         comm_context->AllReduce(
             out_tensor,
-            in_tensor,
+            tensor_tmp,
             paddle::distributed::ToXCCLRedType(opts.reduce_op),
             stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::ALLREDUCE,
       sync_op,
       use_calc_stream);
@@ -209,8 +214,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
     const std::vector<int64_t>& in_size_each_rank,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   const phi::DDim& out_dim = out_tensor->dims();
-  const phi::DDim& in_dim = in_tensor.dims();
+  const phi::DDim& in_dim = tensor_tmp.dims();
   CheckSizeOnEachRank(out_dim, out_size_each_rank, size_);
   CheckSizeOnEachRank(in_dim, in_size_each_rank, size_);
 
@@ -222,7 +229,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
 
-        int64_t in_row_size = in_tensor.numel() / in_dim[0],
+        int64_t in_row_size = tensor_tmp.numel() / in_dim[0],
                 out_row_size = out_tensor->numel() / out_dim[0];
         int64_t in_offset = 0, in_numel = 0, out_offset = 0, out_numel = 0;
         phi::DenseTensor input_partial, output_partial;
@@ -232,7 +239,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
         std::vector<phi::ccl::CCLDataType> send_dtype, recv_dtype;
         for (auto i = 0; i < size_; i++) {
           in_numel = in_size_each_rank[i] * in_row_size;
-          input_partial = GetPartialTensor(in_tensor, in_offset, in_numel);
+          input_partial = GetPartialTensor(tensor_tmp, in_offset, in_numel);
           out_numel = out_size_each_rank[i] * out_row_size;
           output_partial = GetPartialTensor(*out_tensor, out_offset, out_numel);
           in_offset += in_numel;
@@ -258,7 +265,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
             comm_context->GetXcclComm(),
             stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::ALLTOALL,
       sync_op,
       use_calc_stream);
@@ -292,13 +299,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Broadcast(
     const BroadcastOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return RunFnInXCCLEnv(
       [&](const phi::stream::Stream& stream) {
         int root = opts.source_rank + opts.source_root;
         auto comm_context = this->GetCommContext();
-        comm_context->Broadcast(out_tensor, in_tensor, root, stream);
+        comm_context->Broadcast(out_tensor, tensor_tmp, root, stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::BROADCAST,
       sync_op,
       use_calc_stream);
@@ -310,16 +319,18 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Reduce(
     const ReduceOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return RunFnInXCCLEnv(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
         comm_context->Reduce(out_tensor,
-                             in_tensor,
+                             tensor_tmp,
                              paddle::distributed::ToXCCLRedType(opts.reduce_op),
                              opts.root_rank,
                              stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::REDUCE,
       sync_op,
       use_calc_stream);
@@ -331,16 +342,18 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::ReduceScatter(
     const ReduceScatterOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return RunFnInXCCLEnv(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
         comm_context->ReduceScatter(
             out_tensor,
-            in_tensor,
+            tensor_tmp,
             paddle::distributed::ToXCCLRedType(opts.reduce_op),
             stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::REDUCE_SCATTER,
       sync_op,
       use_calc_stream);
@@ -352,9 +365,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Scatter(
     const ScatterOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   phi::distributed::CommStaticCheck::ScatterLikeShape(
       *out_tensor,
-      in_tensor,
+      tensor_tmp,
       /*dst_rank*/ opts.root_rank,
       /*cur_rank*/ rank_,
       size_,
@@ -363,12 +378,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Scatter(
       [&](const phi::stream::Stream& stream) {
         auto comm_context = this->GetCommContext();
 
-        int64_t numel = in_tensor.numel() / size_;
+        int64_t numel = tensor_tmp.numel() / size_;
         if (rank_ == opts.root_rank) {
           int64_t offset = 0;
           phi::DenseTensor partial_tensor;
           for (auto i = 0; i < size_; i++) {
-            partial_tensor = GetPartialTensor(in_tensor, offset, numel);
+            partial_tensor = GetPartialTensor(tensor_tmp, offset, numel);
             if (i != rank_) {
               comm_context->Send(partial_tensor, numel, i, stream);
             } else {
@@ -384,7 +399,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Scatter(
           comm_context->Recv(out_tensor, numel, opts.root_rank, stream);
         }
       },
-      in_tensor,
+      tensor_tmp,
       CommType::SCATTER,
       sync_op,
       use_calc_stream);
@@ -396,6 +411,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Gather(
     const GatherOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   std::vector<phi::DenseTensor> partial_tensors;
   if (rank_ == opts.root_rank) {
     partial_tensors.reserve(size_);
@@ -406,7 +423,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Gather(
       offset += numel;
     }
   }
-  return Gather(&partial_tensors, in_tensor, opts, sync_op, use_calc_stream);
+  return Gather(&partial_tensors, tensor_tmp, opts, sync_op, use_calc_stream);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Gather(
@@ -415,6 +432,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Gather(
     const GatherOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   auto& gather_tensors = *gather_tensors_ptr;
   PADDLE_ENFORCE_GT(size_,
                     opts.root_rank,
@@ -480,9 +499,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Send(
     int64_t numel,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensor);
   // numel > 0 indicates the tensor need to be sliced
   const phi::DenseTensor& tensor_maybe_partial =
-      numel > 0 ? GetPartialTensor(tensor, offset, numel) : tensor;
+      numel > 0 ? GetPartialTensor(tensor_tmp, offset, numel) : tensor_tmp;
 
   return RunFnInXCCLEnv(
       [&](const phi::stream::Stream& stream) {
@@ -696,7 +717,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Collective(
     std::vector<phi::DenseTensor>& outputs,
     Fn fn,
     CommType op_type) {
-  const auto places = GetPlaceList(inputs);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(inputs);
+  const auto places = GetPlaceList(tensor_tmp);
   const auto key = GetKeyFromPlaces(places);
 
   {
@@ -709,15 +732,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Collective(
   SyncDefaultStream(
       places, *place_to_calc_event_.at(key), places_to_ctx_.at(key));
 
-  auto task = CreateTask(places, rank_, op_type, inputs);
+  auto task = CreateTask(places, rank_, op_type, tensor_tmp);
 
   // construct uninitialize guard for device
   {
     GroupStart(device_type_);
-    for (size_t i = 0; i < inputs.size(); ++i) {
+    for (size_t i = 0; i < tensor_tmp.size(); ++i) {
       phi::DeviceGuard guard(places[i]);
       const auto& xccl_stream = *places_to_ctx_.at(key)[i]->GetStream();
-      fn(inputs[i],
+      fn(tensor_tmp[i],
          outputs[i],
          places_to_ctx_.at(key)[i]->xccl_comm(),
          xccl_stream);
@@ -726,14 +749,14 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Collective(
   }
 
   if (FLAGS_use_stream_safe_cuda_allocator) {
-    for (size_t i = 0; i < inputs.size(); ++i) {
+    for (size_t i = 0; i < tensor_tmp.size(); ++i) {
       phi::DeviceGuard guard(places[i]);
-      memory::RecordStream(inputs[i].Holder(),
+      memory::RecordStream(tensor_tmp[i].Holder(),
                            places_to_ctx_.at(key)[i]->stream());
     }
   }
 
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (size_t i = 0; i < tensor_tmp.size(); ++i) {
     phi::DeviceGuard guard(places[i]);
     task->UpdateWaitChain(*places_to_ctx_.at(key)[i]);
   }
@@ -746,7 +769,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::PointToPoint(
     Fn fn,
     int dst_rank,
     CommType op_type) {
-  const auto places = GetPlaceList(tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensors);
+  const auto places = GetPlaceList(tensor_tmp);
   const auto key = GetKeyFromPlaces(places);
 
   {
@@ -759,17 +784,17 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::PointToPoint(
   SyncDefaultStream(
       places, *place_to_calc_event_.at(key), places_to_ctx_.at(key));
 
-  auto task = CreateTask(places, rank_, op_type, tensors);
+  auto task = CreateTask(places, rank_, op_type, tensor_tmp);
 
   // construct uninitialize guard for device
 
   {
     GroupStart(device_type_);
-    for (size_t i = 0; i < tensors.size(); ++i) {
+    for (size_t i = 0; i < tensor_tmp.size(); ++i) {
       phi::DeviceGuard guard(places[i]);
 
       const auto& xccl_stream = *places_to_ctx_.at(key)[i]->GetStream();
-      fn(tensors[i],
+      fn(tensor_tmp[i],
          places_to_ctx_.at(key)[i]->xccl_comm(),
          xccl_stream,
          dst_rank);
@@ -778,14 +803,14 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::PointToPoint(
   }
 
   if (FLAGS_use_stream_safe_cuda_allocator) {
-    for (size_t i = 0; i < tensors.size(); ++i) {
+    for (size_t i = 0; i < tensor_tmp.size(); ++i) {
       phi::DeviceGuard guard(places[i]);
-      memory::RecordStream(tensors[i].Holder(),
+      memory::RecordStream(tensor_tmp[i].Holder(),
                            places_to_ctx_.at(key)[i]->stream());
     }
   }
 
-  for (size_t i = 0; i < tensors.size(); ++i) {
+  for (size_t i = 0; i < tensor_tmp.size(); ++i) {
     phi::DeviceGuard guard(places[i]);
     task->UpdateWaitChain(*places_to_ctx_.at(key)[i]);
   }
@@ -796,12 +821,14 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllReduce(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const AllreduceOptions& opts) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInCustomPlace(in_tensors, device_type_),
+      CheckTensorsInCustomPlace(tensor_tmp, device_type_),
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
-      in_tensors,
+      tensor_tmp,
       out_tensors,
       [&](const phi::DenseTensor& input,
           phi::DenseTensor& output,
@@ -821,20 +848,22 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Broadcast(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const BroadcastOptions& opts) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInCustomPlace(in_tensors, device_type_),
+      CheckTensorsInCustomPlace(tensor_tmp, device_type_),
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
 
   return Collective(
-      in_tensors,
+      tensor_tmp,
       out_tensors,
       [&](phi::DenseTensor& input,
           phi::DenseTensor& output,
           const phi::ccl::CCLComm& comm,
           const phi::stream::Stream& stream) {
         const auto root =
-            opts.source_rank * in_tensors.size() + opts.source_root;
+            opts.source_rank * tensor_tmp.size() + opts.source_root;
         auto comm_context = this->GetCommContext();
         comm_context->Broadcast(&output, input, root, stream);
       },
@@ -854,8 +883,10 @@ inline void CheckTensorsInDifferentDevices(
                                    "number of available CustomDevices."));
 
   std::set<Place> used_devices;
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensors);
 
-  for (const auto& t : tensors) {
+  for (const auto& t : tensor_tmp) {
     PADDLE_ENFORCE_EQ(platform::is_custom_place(t.place()),
                       true,
                       phi::errors::InvalidArgument(
@@ -871,10 +902,12 @@ inline void CheckTensorsInDifferentDevices(
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Send(
     std::vector<phi::DenseTensor>& tensors, int dst_rank) {
-  CheckTensorsInDifferentDevices(tensors, static_cast<size_t>(GetSize()));
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensors);
+  CheckTensorsInDifferentDevices(tensor_tmp, static_cast<size_t>(GetSize()));
 
   auto task = PointToPoint(
-      tensors,
+      tensor_tmp,
       [&](phi::DenseTensor& input,
           const phi::ccl::CCLComm& comm,
           const phi::stream::Stream& stream,
@@ -889,10 +922,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Send(
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Recv(
     std::vector<phi::DenseTensor>& tensors, int src_rank) {
-  CheckTensorsInDifferentDevices(tensors, static_cast<size_t>(GetSize()));
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensors);
+  CheckTensorsInDifferentDevices(tensor_tmp, static_cast<size_t>(GetSize()));
 
   auto task = PointToPoint(
-      tensors,
+      tensor_tmp,
       [&](phi::DenseTensor& output,
           const phi::ccl::CCLComm& comm,
           const phi::stream::Stream& stream,
@@ -908,8 +943,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Recv(
 std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllGather(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInCustomPlace(in_tensors, device_type_),
+      CheckTensorsInCustomPlace(tensor_tmp, device_type_),
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   PADDLE_ENFORCE_EQ(
@@ -917,7 +954,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllGather(
       true,
       phi::errors::InvalidArgument("All outputs should be in CustomPlace."));
   return Collective(
-      in_tensors,
+      tensor_tmp,
       out_tensors,
       [&](const phi::DenseTensor& input,
           phi::DenseTensor& output,
@@ -932,8 +969,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllGather(
 std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInCustomPlace(in_tensors, device_type_),
+      CheckTensorsInCustomPlace(tensor_tmp, device_type_),
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   PADDLE_ENFORCE_EQ(
@@ -941,7 +980,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::AllToAll(
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
-      in_tensors,
+      tensor_tmp,
       out_tensors,
       [&](phi::DenseTensor& input,
           phi::DenseTensor& output,
@@ -983,12 +1022,14 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Reduce(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const ReduceOptions& opts) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInCustomPlace(in_tensors, device_type_),
+      CheckTensorsInCustomPlace(tensor_tmp, device_type_),
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
-      in_tensors,
+      tensor_tmp,
       out_tensors,
       [&](const phi::DenseTensor& input,
           phi::DenseTensor& output,
@@ -1008,8 +1049,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Scatter(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const ScatterOptions& opts) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   PADDLE_ENFORCE_EQ(
-      CheckTensorsInCustomPlace(in_tensors, device_type_),
+      CheckTensorsInCustomPlace(tensor_tmp, device_type_),
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   PADDLE_ENFORCE_EQ(
@@ -1017,7 +1060,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Scatter(
       true,
       phi::errors::InvalidArgument("All inputs should be in CustomPlace."));
   return Collective(
-      in_tensors,
+      tensor_tmp,
       out_tensors,
       [&](phi::DenseTensor& input,
           phi::DenseTensor& output,

--- a/paddle/fluid/distributed/collective/process_group_gloo.cc
+++ b/paddle/fluid/distributed/collective/process_group_gloo.cc
@@ -29,6 +29,7 @@
 #include "paddle/fluid/distributed/collective/common.h"
 #include "paddle/fluid/distributed/collective/process_group_gloo.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/distributed/comm_context_manager.h"
 
 namespace paddle {
@@ -217,12 +218,14 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Broadcast(
     std::vector<phi::DenseTensor>& outputs,
     const BroadcastOptions& opts,
     bool sync_op) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(inputs);
   auto root = opts.source_rank;
   std::unique_ptr<BroadcastGlooTask> task;
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
   task = std::make_unique<BroadcastGlooTask>(
-      comm_context, inputs, outputs, rank_, root, tag);
+      comm_context, tensor_tmp, outputs, rank_, root, tag);
   task->Run();
   return task;
 }
@@ -261,11 +264,13 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Send(
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Send(
     std::vector<phi::DenseTensor>& inputs, int dst_rank) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(inputs);
   std::unique_ptr<SendGlooTask> task;
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
   task = std::make_unique<SendGlooTask>(
-      comm_context, &inputs, rank_, dst_rank, tag);
+      comm_context, &tensor_tmp, rank_, dst_rank, tag);
   task->Run();
 
   return task;
@@ -368,11 +373,13 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::AllReduce(
     std::vector<phi::DenseTensor>& outputs,
     const AllreduceOptions& opts,
     bool sync_op) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(inputs);
   auto tag = next_tag();
   std::shared_ptr<GlooTask> task;
   auto comm_context = this->GetCommContext();
   task = std::make_shared<AllreduceGlooTask>(
-      rank_, comm_context, inputs, outputs, opts.reduce_op, tag);
+      rank_, comm_context, tensor_tmp, outputs, opts.reduce_op, tag);
   task->Run();
   return task;
 }
@@ -449,11 +456,13 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::AllGather(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     bool sync_op) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
   std::shared_ptr<AllgatherGlooTask> task;
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
   task = std::make_shared<AllgatherGlooTask>(
-      rank_, comm_context, in_tensors, out_tensors, tag);
+      rank_, comm_context, tensor_tmp, out_tensors, tag);
   task->Run();
   return task;
 }
@@ -499,10 +508,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Reduce(
     const ReduceOptions& opts,
     bool sync_op  // for compatibility, no use now
 ) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   std::shared_ptr<ReduceGlooTask> task;
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
-  std::vector<phi::DenseTensor> in_wrapper{in_tensor};
+  std::vector<phi::DenseTensor> in_wrapper{tensor_tmp};
   std::vector<phi::DenseTensor> out_wrapper{*out_tensor};
   task = std::make_shared<ReduceGlooTask>(rank_,
                                           comm_context,
@@ -562,9 +573,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Scatter(
     const ScatterOptions& opts,
     bool sync_op) {
   std::shared_ptr<ScatterGlooTask> task;
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
-  std::vector<phi::DenseTensor> in_wrapper{in_tensor};
+  std::vector<phi::DenseTensor> in_wrapper{tensor_tmp};
   std::vector<phi::DenseTensor> out_wrapper{*out_tensor};
   task = std::make_shared<ScatterGlooTask>(
       rank_, comm_context, in_wrapper, out_wrapper, opts.root_rank, size_, tag);
@@ -616,6 +629,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Gather(
     const GatherOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   PADDLE_ENFORCE_NE(
       use_calc_stream,
       true,
@@ -624,7 +639,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupGloo::Gather(
   auto tag = next_tag();
   auto comm_context = this->GetCommContext();
   task = std::make_shared<GatherGlooTask>(
-      rank_, comm_context, in_tensor, out_tensor, opts.root_rank, tag);
+      rank_, comm_context, tensor_tmp, out_tensor, opts.root_rank, tag);
   task->Run();
   return task;
 }

--- a/paddle/fluid/distributed/collective/process_group_mpi.cc
+++ b/paddle/fluid/distributed/collective/process_group_mpi.cc
@@ -15,6 +15,7 @@
 #include "paddle/fluid/distributed/collective/process_group_mpi.h"
 #include <chrono>
 #include "paddle/fluid/distributed/collective/common.h"
+#include "paddle/phi/api/lib/data_transform.h"
 
 constexpr int64_t kWaitBlockTImeout = 10;
 namespace paddle {
@@ -228,7 +229,9 @@ void ProcessGroupMPI::workLoop() {
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Enqueue(
     std::unique_ptr<TaskEntry> entry,
     const std::vector<phi::DenseTensor>& inputs) {
-  auto task = std::make_shared<MPITask>(entry->dst_, inputs);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(inputs);
+  auto task = std::make_shared<MPITask>(entry->dst_, tensor_tmp);
   std::unique_lock<std::mutex> lock(pg_mutex);
   queue_.push_back(std::make_tuple(std::move(entry), task));
   lock.unlock();
@@ -240,8 +243,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Broadcast(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const BroadcastOptions& opts) {
-  mpi::CheckValidInputs(in_tensors);
-  const auto places = GetPlaceList(in_tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
+  mpi::CheckValidInputs(tensor_tmp);
+  const auto places = GetPlaceList(tensor_tmp);
 
   std::function<void(std::unique_ptr<TaskEntry>&)> runFunc =
       [opts, this](std::unique_ptr<TaskEntry>& entry) {
@@ -255,15 +260,17 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Broadcast(
                             pg_comm));
       };
   auto entry = std::make_unique<TaskEntry>(
-      &in_tensors, &out_tensors, std::move(runFunc));
-  return Enqueue(std::move(entry), in_tensors);
+      &tensor_tmp, &out_tensors, std::move(runFunc));
+  return Enqueue(std::move(entry), tensor_tmp);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllReduce(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const AllreduceOptions& opts) {
-  mpi::CheckValidInputs(in_tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
+  mpi::CheckValidInputs(tensor_tmp);
 
   std::function<void(std::unique_ptr<TaskEntry>&)> runFunc =
       [opts, this](std::unique_ptr<TaskEntry>& entry) {
@@ -277,8 +284,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllReduce(
                                 pg_comm));
       };
   auto entry = std::make_unique<TaskEntry>(
-      &in_tensors, &out_tensors, std::move(runFunc));
-  return Enqueue(std::move(entry), in_tensors);
+      &tensor_tmp, &out_tensors, std::move(runFunc));
+  return Enqueue(std::move(entry), tensor_tmp);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Barrier(
@@ -296,9 +303,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Barrier(
 // NOTE: MPI_send tag set gid_
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Send(
     std::vector<phi::DenseTensor>& tensors, int dst_rank) {
-  mpi::CheckValidInputs(tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensors);
+  mpi::CheckValidInputs(tensor_tmp);
 
-  auto& tensor = tensors[0];
+  auto& tensor = tensor_tmp[0];
   MPI_Request request = MPI_REQUEST_NULL;
 
   {
@@ -312,7 +321,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Send(
                         &request));
   }
 
-  return std::make_shared<ProcessGroupMPI::MPIAsyncTask>(request, tensors);
+  return std::make_shared<ProcessGroupMPI::MPIAsyncTask>(request, tensor_tmp);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Recv(
@@ -339,7 +348,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Recv(
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllGather(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors) {
-  mpi::CheckValidInputs(in_tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
+  mpi::CheckValidInputs(tensor_tmp);
 
   PADDLE_ENFORCE_EQ(out_tensors.size() == 1,
                     true,
@@ -362,19 +373,21 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllGather(
       };
 
   auto entry = std::make_unique<TaskEntry>(
-      &in_tensors, &out_tensors, std::move(runFunc));
+      &tensor_tmp, &out_tensors, std::move(runFunc));
 
-  return Enqueue(std::move(entry), in_tensors);
+  return Enqueue(std::move(entry), tensor_tmp);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllToAll(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors) {
-  mpi::CheckValidInputs(in_tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
+  mpi::CheckValidInputs(tensor_tmp);
   mpi::CheckValidInputs(out_tensors);
 
-  PADDLE_ENFORCE_EQ(in_tensors[0].numel() == out_tensors[0].numel() &&
-                        in_tensors[0].dtype() == out_tensors[0].dtype(),
+  PADDLE_ENFORCE_EQ(tensor_tmp[0].numel() == out_tensors[0].numel() &&
+                        tensor_tmp[0].dtype() == out_tensors[0].dtype(),
                     true,
                     platform::errors::InvalidArgument(
                         "MPI AlltoAll: input and output are not equal in "
@@ -394,16 +407,18 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::AllToAll(
                                pg_comm));
       };
   auto entry = std::make_unique<TaskEntry>(
-      &in_tensors, &out_tensors, std::move(runFunc));
+      &tensor_tmp, &out_tensors, std::move(runFunc));
 
-  return Enqueue(std::move(entry), in_tensors);
+  return Enqueue(std::move(entry), tensor_tmp);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Reduce(
     std::vector<phi::DenseTensor>& tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const ReduceOptions& opts) {
-  mpi::CheckValidInputs(tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensors);
+  mpi::CheckValidInputs(tensor_tmp);
 
   std::function<void(std::unique_ptr<TaskEntry>&)> runFunc =
       [opts, this](std::unique_ptr<TaskEntry>& entry) {
@@ -422,15 +437,17 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Reduce(
                              pg_comm));
       };
   auto entry =
-      std::make_unique<TaskEntry>(&tensors, &tensors, std::move(runFunc));
-  return Enqueue(std::move(entry), tensors);
+      std::make_unique<TaskEntry>(&tensor_tmp, &tensor_tmp, std::move(runFunc));
+  return Enqueue(std::move(entry), tensor_tmp);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Scatter(
     std::vector<phi::DenseTensor>& in_tensors,
     std::vector<phi::DenseTensor>& out_tensors,
     const ScatterOptions& opts) {
-  mpi::CheckValidInputs(in_tensors);
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensors);
+  mpi::CheckValidInputs(tensor_tmp);
 
   std::function<void(std::unique_ptr<TaskEntry>&)> runFunc =
       [opts, this](std::unique_ptr<TaskEntry>& entry) {
@@ -455,12 +472,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupMPI::Scatter(
 
   if (rank_ == opts.root_rank) {
     auto entry = std::make_unique<TaskEntry>(
-        &in_tensors, &out_tensors, std::move(runFunc));
-    return Enqueue(std::move(entry), in_tensors);
+        &tensor_tmp, &out_tensors, std::move(runFunc));
+    return Enqueue(std::move(entry), tensor_tmp);
   } else {
     auto entry =
         std::make_unique<TaskEntry>(nullptr, &out_tensors, std::move(runFunc));
-    return Enqueue(std::move(entry), in_tensors);
+    return Enqueue(std::move(entry), tensor_tmp);
   }
 }
 

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -17,6 +17,7 @@
 #include "paddle/fluid/distributed/collective/common.h"
 #include "paddle/fluid/platform/cuda_device_guard.h"
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/api/lib/utils/allocator.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/core/distributed/check/nccl_dynamic_check.h"
@@ -180,9 +181,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllGather(
     int64_t numel,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   // numel > 0 indicates the tensor need to be sliced
   const phi::DenseTensor& in_tensor_maybe_partial =
-      numel > 0 ? GetPartialTensor(in_tensor, offset, numel) : in_tensor;
+      numel > 0 ? GetPartialTensor(tensor_tmp, offset, numel) : tensor_tmp;
   return Collective(
       [&](phi::distributed::NCCLCommContext* comm_context, gpuStream_t stream) {
         VLOG(3) << "[ncclAllGather] "
@@ -212,13 +215,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllReduce(
     const AllreduceOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       [&](phi::distributed::NCCLCommContext* comm_context, gpuStream_t stream) {
         VLOG(3) << "[ncclAllReduce] "
-                << "sendbuff: " << in_tensor.data()
+                << "sendbuff: " << tensor_tmp.data()
                 << ", recvbuff: " << out_tensor->data()
-                << ", count: " << in_tensor.numel() << ", datatype: "
-                << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+                << ", count: " << tensor_tmp.numel() << ", datatype: "
+                << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
                 << ", redop: "
                 << NCCLRedTypeToString(ToNCCLRedType(opts.reduce_op))
                 << ", ncclcomm: " << comm_context->GetNcclComm()
@@ -228,9 +233,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllReduce(
                 << GetGroupMessage();
 
         comm_context->AllReduce(
-            out_tensor, in_tensor, ToNCCLRedType(opts.reduce_op), stream);
+            out_tensor, tensor_tmp, ToNCCLRedType(opts.reduce_op), stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::ALLREDUCE,
       sync_op,
       use_calc_stream);
@@ -243,8 +248,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllToAll(
     const std::vector<int64_t>& in_size_each_rank,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   const phi::DDim& out_dim = out_tensor->dims();
-  const phi::DDim& in_dim = in_tensor.dims();
+  const phi::DDim& in_dim = tensor_tmp.dims();
   CheckSizeOnEachRank(out_dim, out_size_each_rank, size_);
   CheckSizeOnEachRank(in_dim, in_size_each_rank, size_);
 
@@ -253,7 +260,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllToAll(
   // shape check. Its shape check will be done by dynamic checks with
   // FLAGS_enable_nccl_dynamic_check.
   phi::distributed::CommStaticCheck::CheckShape(*out_tensor,
-                                                in_tensor,
+                                                tensor_tmp,
                                                 /*dst_rank*/ rank_,
                                                 /*cur_rank*/ rank_,
                                                 size_,
@@ -264,22 +271,22 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllToAll(
         if (FLAGS_enable_nccl_dynamic_check) {
           phi::distributed::NCCLDynamicCheck::CheckShape(
               *out_tensor,
-              in_tensor,
+              tensor_tmp,
               in_size_each_rank,
               rank_,
               size_,
               comm_context->GetNcclComm());
         }
-        int64_t in_row_size = in_tensor.numel() / in_dim[0],
+        int64_t in_row_size = tensor_tmp.numel() / in_dim[0],
                 out_row_size = out_tensor->numel() / out_dim[0];
         int64_t in_offset = 0, in_numel = 0, out_offset = 0, out_numel = 0;
         phi::DenseTensor input_partial, output_partial;
 
         VLOG(3) << "[AllToAll] "
-                << "sendbuff: " << in_tensor.data()
+                << "sendbuff: " << tensor_tmp.data()
                 << ", recvbuff: " << out_tensor->data()
-                << ", count: " << in_tensor.numel() << ", datatype: "
-                << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+                << ", count: " << tensor_tmp.numel() << ", datatype: "
+                << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
                 << ", ncclcomm: " << comm_context->GetNcclComm()
                 << ", stream: " << stream << ", rank_in_group: " << rank_
                 << ", nranks: " << size_ << ", out_size_each_rank: "
@@ -293,7 +300,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllToAll(
         GroupStart();
         for (auto i = 0; i < size_; i++) {
           in_numel = in_size_each_rank[i] * in_row_size;
-          input_partial = GetPartialTensor(in_tensor, in_offset, in_numel);
+          input_partial = GetPartialTensor(tensor_tmp, in_offset, in_numel);
           comm_context->Send(input_partial, in_numel, i, stream);
           in_offset += in_numel;
 
@@ -304,7 +311,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllToAll(
         }
         GroupEnd();
       },
-      in_tensor,
+      tensor_tmp,
       CommType::ALLTOALL,
       sync_op,
       use_calc_stream);
@@ -341,24 +348,26 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Broadcast(
     const BroadcastOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       [&](phi::distributed::NCCLCommContext* comm_context, gpuStream_t stream) {
         int root = opts.source_rank + opts.source_root;
 
         VLOG(3) << "[ncclBroadcast] "
-                << "sendbuff: " << in_tensor.data()
+                << "sendbuff: " << tensor_tmp.data()
                 << ", recvbuff: " << out_tensor->data()
-                << ", count: " << in_tensor.numel() << ", datatype: "
-                << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+                << ", count: " << tensor_tmp.numel() << ", datatype: "
+                << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
                 << ", root: " << root
                 << ", ncclcomm: " << comm_context->GetNcclComm()
                 << ", stream: " << stream << ", rank_in_group: " << rank_
                 << ", nranks: " << size_ << ", sync_op: " << sync_op
                 << ", use_calc_stream: " << use_calc_stream
                 << GetGroupMessage();
-        comm_context->Broadcast(out_tensor, in_tensor, root, stream);
+        comm_context->Broadcast(out_tensor, tensor_tmp, root, stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::BROADCAST,
       sync_op,
       use_calc_stream);
@@ -370,13 +379,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Reduce(
     const ReduceOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       [&](phi::distributed::NCCLCommContext* comm_context, gpuStream_t stream) {
         VLOG(3) << "[ncclReduce] "
-                << "sendbuff: " << in_tensor.data()
+                << "sendbuff: " << tensor_tmp.data()
                 << ", recvbuff: " << out_tensor->data()
-                << ", count: " << in_tensor.numel() << ", datatype: "
-                << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+                << ", count: " << tensor_tmp.numel() << ", datatype: "
+                << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
                 << ", redop: "
                 << NCCLRedTypeToString(ToNCCLRedType(opts.reduce_op))
                 << ", root: " << opts.root_rank
@@ -386,12 +397,12 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Reduce(
                 << ", use_calc_stream: " << use_calc_stream
                 << GetGroupMessage();
         comm_context->Reduce(out_tensor,
-                             in_tensor,
+                             tensor_tmp,
                              ToNCCLRedType(opts.reduce_op),
                              opts.root_rank,
                              stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::REDUCE,
       sync_op,
       use_calc_stream);
@@ -403,13 +414,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::ReduceScatter(
     const ReduceScatterOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   return Collective(
       [&](phi::distributed::NCCLCommContext* comm_context, gpuStream_t stream) {
         VLOG(3) << "[ncclReduceScatter] "
-                << "sendbuff: " << in_tensor.data()
+                << "sendbuff: " << tensor_tmp.data()
                 << ", recvbuff: " << out_tensor->data()
-                << ", count: " << in_tensor.numel() << ", datatype: "
-                << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+                << ", count: " << tensor_tmp.numel() << ", datatype: "
+                << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
                 << ", redop: "
                 << NCCLRedTypeToString(ToNCCLRedType(opts.reduce_op))
                 << ", ncclcomm: " << comm_context->GetNcclComm()
@@ -418,9 +431,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::ReduceScatter(
                 << ", use_calc_stream: " << use_calc_stream
                 << GetGroupMessage();
         comm_context->ReduceScatter(
-            out_tensor, in_tensor, ToNCCLRedType(opts.reduce_op), stream);
+            out_tensor, tensor_tmp, ToNCCLRedType(opts.reduce_op), stream);
       },
-      in_tensor,
+      tensor_tmp,
       CommType::REDUCE_SCATTER,
       sync_op,
       use_calc_stream);
@@ -432,9 +445,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Scatter(
     const ScatterOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   phi::distributed::CommStaticCheck::ScatterLikeShape(
       *out_tensor,
-      in_tensor,
+      tensor_tmp,
       /*dst_rank*/ opts.root_rank,
       /*cur_rank*/ rank_,
       size_);
@@ -449,10 +464,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Scatter(
         }
 
         VLOG(3) << "[Scatter] "
-                << "sendbuff: " << in_tensor.data()
+                << "sendbuff: " << tensor_tmp.data()
                 << ", recvbuff: " << out_tensor->data()
-                << ", count: " << in_tensor.numel() << ", datatype: "
-                << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+                << ", count: " << tensor_tmp.numel() << ", datatype: "
+                << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
                 << ", root: " << opts.root_rank
                 << ", ncclcomm: " << comm_context->GetNcclComm()
                 << ", stream: " << stream << ", rank_in_group: " << rank_
@@ -460,13 +475,13 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Scatter(
                 << ", use_calc_stream: " << use_calc_stream
                 << GetGroupMessage();
 
-        int64_t numel = in_tensor.numel() / size_;
+        int64_t numel = tensor_tmp.numel() / size_;
         if (rank_ == opts.root_rank) {
           int64_t offset = 0;
           phi::DenseTensor partial_tensor;
           GroupStart();
           for (auto i = 0; i < size_; i++) {
-            partial_tensor = GetPartialTensor(in_tensor, offset, numel);
+            partial_tensor = GetPartialTensor(tensor_tmp, offset, numel);
             comm_context->Send(partial_tensor, numel, i, stream);
             offset += numel;
           }
@@ -476,7 +491,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Scatter(
           comm_context->Recv(out_tensor, numel, opts.root_rank, stream);
         }
       },
-      in_tensor,
+      tensor_tmp,
       CommType::SCATTER,
       sync_op,
       use_calc_stream);
@@ -488,6 +503,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Gather(
     const GatherOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   std::vector<phi::DenseTensor> partial_tensors;
   if (rank_ == opts.root_rank) {
     partial_tensors.reserve(size_);
@@ -507,6 +524,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Gather(
     const GatherOptions& opts,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(in_tensor);
   auto& gather_tensors = *gather_tensors_ptr;
   PADDLE_ENFORCE_GT(size_,
                     opts.root_rank,
@@ -519,7 +538,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Gather(
     // shape check
     if (FLAGS_enable_nccl_dynamic_check) {
       phi::distributed::NCCLDynamicCheck::CheckGatherShape(
-          in_tensor,
+          tensor_tmp,
           gather_tensors,
           opts.root_rank,
           rank_,
@@ -528,9 +547,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Gather(
     }
 
     VLOG(3) << "[Gather] "
-            << "sendbuff: " << in_tensor.data()
-            << ", count: " << in_tensor.numel() << ", datatype: "
-            << NCCLDTypeToString(phi::ToNCCLDataType(in_tensor.dtype()))
+            << "sendbuff: " << tensor_tmp.data()
+            << ", count: " << tensor_tmp.numel() << ", datatype: "
+            << NCCLDTypeToString(phi::ToNCCLDataType(tensor_tmp.dtype()))
             << ", root: " << opts.root_rank
             << ", ncclcomm: " << comm_context->GetNcclComm()
             << ", stream: " << stream << ", rank_in_group: " << rank_
@@ -546,11 +565,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Gather(
       }
     }
     // send to root
-    comm_context->Send(in_tensor, in_tensor.numel(), opts.root_rank, stream);
+    comm_context->Send(tensor_tmp, tensor_tmp.numel(), opts.root_rank, stream);
     GroupEnd();
   };
   return Collective(
-      gather_func, in_tensor, CommType::GATHER, sync_op, use_calc_stream);
+      gather_func, tensor_tmp, CommType::GATHER, sync_op, use_calc_stream);
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Recv(
@@ -599,9 +618,11 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Send(
     int64_t numel,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensor);
   // numel > 0 indicates the tensor need to be sliced
   const phi::DenseTensor& tensor_maybe_partial =
-      numel > 0 ? GetPartialTensor(tensor, offset, numel) : tensor;
+      numel > 0 ? GetPartialTensor(tensor_tmp, offset, numel) : tensor_tmp;
 
   return Point2Point(
       [&](phi::distributed::NCCLCommContext* comm_context,
@@ -719,8 +740,10 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
     CommType comm_type,
     bool sync_op,
     bool use_calc_stream) {
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensor);
   comm_seq_++;
-  const auto& place = tensor.place();
+  const auto& place = tensor_tmp.place();
   const auto& key = GetKeyFromPlace(place);
 
   platform::CUDADeviceGuard cuda_guard(place);
@@ -754,7 +777,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
                                                          size_,
                                                          gid_,
                                                          comm_seq_,
-                                                         tensor.numel(),
+                                                         tensor_tmp.numel(),
                                                          sync_op,
                                                          use_calc_stream,
                                                          nccl_comm,
@@ -772,7 +795,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
 
   if (!use_calc_stream) {
     if (FLAGS_use_stream_safe_cuda_allocator) {
-      memory::RecordStream(tensor.Holder(), nccl_stream);
+      memory::RecordStream(tensor_tmp.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);
   }
@@ -805,7 +828,9 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
     CommType comm_type,
     bool sync_op,
     bool use_calc_stream) {
-  const auto& place = tensor.place();
+  auto tensor_tmp =
+      paddle::experimental::CheckAndTrans2NewContiguousTensor(tensor);
+  const auto& place = tensor_tmp.place();
 
   int p2p_rank = 0;
   int p2p_target_rank = 0;
@@ -850,7 +875,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
                                                        size_,
                                                        gid_,
                                                        comm_seq_,
-                                                       tensor.numel(),
+                                                       tensor_tmp.numel(),
                                                        sync_op,
                                                        use_calc_stream,
                                                        nccl_comm,
@@ -873,7 +898,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
 
   if (!use_calc_stream) {
     if (FLAGS_use_stream_safe_cuda_allocator) {
-      memory::RecordStream(tensor.Holder(), nccl_stream);
+      memory::RecordStream(tensor_tmp.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);
   }

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -269,6 +269,23 @@ void CheckAndTrans2Contiguous(phi::DenseTensor* tensor) {
   }
 }
 
+phi::DenseTensor CheckAndTrans2NewContiguousTensor(
+    const phi::DenseTensor& tensor) {
+  if (!tensor.meta().is_contiguous()) {
+    return Trans2Contiguous(tensor);
+  }
+  return tensor;
+}
+
+std::vector<phi::DenseTensor> CheckAndTrans2NewContiguousTensor(
+    const std::vector<phi::DenseTensor>& tensor) {
+  std::vector<phi::DenseTensor> out;
+  for (auto& t : tensor) {
+    out.emplace_back(std::move(CheckAndTrans2NewContiguousTensor(t)));
+  }
+  return out;
+}
+
 phi::DenseTensor TransformData(const phi::DenseTensor& tensor,
                                const phi::TensorArgDef& target_args_def,
                                const TransformFlag& transform_flag,

--- a/paddle/phi/api/lib/data_transform.h
+++ b/paddle/phi/api/lib/data_transform.h
@@ -157,6 +157,13 @@ void TransDataBackend(const phi::SelectedRows* tensor,
 phi::DenseTensor Trans2Contiguous(const phi::DenseTensor& tensor);
 
 void CheckAndTrans2Contiguous(phi::DenseTensor* tensor);
+
+phi::DenseTensor CheckAndTrans2NewContiguousTensor(
+    const phi::DenseTensor& tensor);
+
+std::vector<phi::DenseTensor> CheckAndTrans2NewContiguousTensor(
+    const std::vector<phi::DenseTensor>& tensor);
+
 inline bool NeedTransformPlace(const phi::Place& src_place,
                                const Backend& target,
                                const TransformFlag& transform_flag) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
框架支持stride之后，Tensor可能是非连续的。通信库算子不能支持非连续Tensor的读取。因此需要检查是否连续，不连续则转成连续的再使用。

Pcard-74613