### PR TITLE
code-gen backward support vector of dtensor grad output

### DIFF
--- a/paddle/phi/api/lib/api_gen_utils.h
+++ b/paddle/phi/api/lib/api_gen_utils.h
@@ -161,8 +161,22 @@ std::vector<phi::distributed::DistTensor*> SetKernelDistOutput(
 std::shared_ptr<phi::distributed::DistTensor> CreateKernelDistOutput(
     Tensor* out,
     bool set_dist_output_as_tensor_impl,
+    const phi::distributed::TensorDistAttr& dist_attr);
+
+std::shared_ptr<phi::distributed::DistTensor> CreateKernelDistOutput(
+    Tensor* out,
+    bool set_dist_output_as_tensor_impl,
     const phi::distributed::ArgDistAttr& dist_attr =
         phi::distributed::TensorDistAttr());
+
+std::vector<std::shared_ptr<phi::distributed::DistTensor>>
+CreateKernelDistOutput(std::vector<Tensor*> out,
+                       bool set_dist_output_as_tensor_impl,
+                       const phi::distributed::ArgDistAttr& dist_attr);
+
+std::vector<std::shared_ptr<phi::distributed::DistTensor>>
+CreateKernelDistOutput(std::vector<Tensor*> out,
+                       bool set_dist_output_as_tensor_impl);
 
 std::shared_ptr<phi::distributed::DistTensor> CreateKernelDistOutput(
     Tensor* out, const phi::distributed::ArgDistAttr& dist_attr);

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -44,7 +44,8 @@ inline bool NeedTransformDataType(const DataType& input,
                                   const TransformFlag& transform_flag) {
   return input != target &&
          (transform_flag.need_trans_data_type() ||
-          target == DataType::COMPLEX64 || target == DataType::COMPLEX128);
+          ((target == DataType::COMPLEX64 || target == DataType::COMPLEX128) &&
+           (input != DataType::INT32 && input != DataType::INT64)));
 }
 
 inline bool NeedTransformLayout(const DataLayout& input,

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -44,8 +44,7 @@ inline bool NeedTransformDataType(const DataType& input,
                                   const TransformFlag& transform_flag) {
   return input != target &&
          (transform_flag.need_trans_data_type() ||
-          ((target == DataType::COMPLEX64 || target == DataType::COMPLEX128) &&
-           (input != DataType::INT32 && input != DataType::INT64)));
+          target == DataType::COMPLEX64 || target == DataType::COMPLEX128);
 }
 
 inline bool NeedTransformLayout(const DataLayout& input,
@@ -874,6 +873,24 @@ void ReshardKernelOutputToApiOutput(
   } else {
     VLOG(3) << "The output tensor is nullptr when call "
                "ReshardKernelOutputToApiOutput.";
+  }
+}
+
+void ReshardKernelOutputToApiOutput(
+    phi::DeviceContext* dev_ctx,
+    const std::vector<std::shared_ptr<phi::distributed::DistTensor>>&
+        src_tensors,
+    const std::vector<Tensor*>& dst_tensors) {
+  PADDLE_ENFORCE_EQ(
+      src_tensors.size(),
+      dst_tensors.size(),
+      phi::errors::PreconditionNotMet(
+          "src_tensors.size() [%d] and dst_tensors.size() [%d] not match",
+          src_tensors.size(),
+          dst_tensors.size()));
+  auto size = src_tensors.size();
+  for (size_t i = 0; i < size; i++) {
+    ReshardKernelOutputToApiOutput(dev_ctx, src_tensors[i], dst_tensors[i]);
   }
 }
 

--- a/paddle/phi/api/lib/data_transform.h
+++ b/paddle/phi/api/lib/data_transform.h
@@ -229,6 +229,12 @@ void ReshardKernelOutputToApiOutput(
     const std::shared_ptr<phi::distributed::DistTensor>& src_tensor,
     Tensor* dst_tensor);
 
+void ReshardKernelOutputToApiOutput(
+    phi::DeviceContext* dev_ctx,
+    const std::vector<std::shared_ptr<phi::distributed::DistTensor>>&
+        src_tensors,
+    const std::vector<Tensor*>& dst_tensors);
+
 std::shared_ptr<phi::distributed::DistTensor> PrepareDataForDistTensor(
     std::shared_ptr<phi::distributed::DistTensor> input,
     const phi::TensorArgDef& target_args_def,

--- a/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
@@ -71,7 +71,7 @@ SINGLE_OUT_CREATION_TEMPLATE = """
             phi::DenseTensorMeta());
     }}
 """
-VECTOR_OUT_CREATION_TEMPLATE = """
+VECTOR_OUT_CREATION_TEMPLATE_WITH_NO_SPMD = """
     auto dist_out = SetKernelDistOutput({name});
     std::vector<phi::DenseTensor*> dense_out(dist_out.size());
     for (size_t i=0; i<dist_out.size(); i++) {{
@@ -83,6 +83,43 @@ VECTOR_OUT_CREATION_TEMPLATE = """
       }}
     }}
 """
+
+VECTOR_OUT_CREATION_TEMPLATE_WITH_SPMD = """
+    auto shared_dist_out = CreateKernelDistOutput({name}, !rank_is_in_current_mesh, spmd_info.second[0]);
+    std::vector<phi::distributed::DistTensor*> dist_out;
+    for(auto& e: shared_dist_out){{
+      dist_out.push_back(e.get());
+    }}
+    std::vector<phi::DenseTensor*> dense_out(dist_out.size());
+    for (size_t i=0; i<dist_out.size(); i++) {{
+      dense_out[i] = dist_out[i]->unsafe_mutable_value();
+      if (dense_out[i] && !rank_is_in_current_mesh && !dist_out[i]->defined()) {{
+        *dense_out[i] = phi::DenseTensor(
+              std::make_shared<phi::Allocation>(nullptr, 0, phi::distributed::GetDefaultPlace()),
+              phi::DenseTensorMeta());
+      }}
+    }}
+"""
+
+
+VECTOR_OUT_CREATION_TEMPLATE = """
+    auto shared_dist_out = CreateKernelDistOutput({name}, !rank_is_in_current_mesh);
+    std::vector<phi::distributed::DistTensor*> dist_out;
+    for(auto& e: shared_dist_out){{
+      dist_out.push_back(e.get());
+    }}
+    std::vector<phi::DenseTensor*> dense_out(dist_out.size());
+    for (size_t i=0; i<dist_out.size(); i++) {{
+      dense_out[i] = dist_out[i]->unsafe_mutable_value();
+      if (dense_out[i] && !rank_is_in_current_mesh && !dist_out[i]->defined()) {{
+        *dense_out[i] = phi::DenseTensor(
+              std::make_shared<phi::Allocation>(nullptr, 0, phi::distributed::GetDefaultPlace()),
+              phi::DenseTensorMeta());
+      }}
+    }}
+"""
+
+
 INPLACE_OUT_CREATION_TEMPLATE = """
     *{} = {};
 """
@@ -133,8 +170,12 @@ MULTI_VECTOR_OUT_CREATION_TEMPLATE = """
 # 9. Reshard Output
 RESHARD_SINGLE_OUTPUT_TEMPLATE = """
       ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out, {});"""
+
 RESHARD_MULTI_SINGLE_OUTPUT_TEMPLATE = """
       ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out_{}, {});"""
+
+RESHARD_VECTOR_OUTPUT_TEMPLATE = """
+      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out, {});"""
 
 
 class DistBackwardAPI(DistForwardAPI, BackwardAPI):
@@ -169,9 +210,22 @@ class DistBackwardAPI(DistForwardAPI, BackwardAPI):
                         )
                     )
             elif self.outputs['types'][0] == 'std::vector<Tensor>':
-                output_creation_code += VECTOR_OUT_CREATION_TEMPLATE.format(
-                    name=self.outputs['names'][0]
-                )
+                if self.infer_meta['spmd_rule'] is not None:
+                    output_creation_code += (
+                        VECTOR_OUT_CREATION_TEMPLATE_WITH_SPMD.format(
+                            name=self.outputs['names'][0]
+                        )
+                    )
+                elif self.generate_general_infer_spmd is True:
+                    output_creation_code += VECTOR_OUT_CREATION_TEMPLATE.format(
+                        name=self.outputs['names'][0]
+                    )
+                else:
+                    output_creation_code += (
+                        VECTOR_OUT_CREATION_TEMPLATE_WITH_NO_SPMD.format(
+                            name=self.outputs['names'][0]
+                        )
+                    )
             else:
                 self.vector_output_size_assertion_check()
         elif output_num > 1:
@@ -264,6 +318,12 @@ class DistBackwardAPI(DistForwardAPI, BackwardAPI):
                 if self.outputs['types'][0] == 'Tensor':
                     reshard_output_code += (
                         RESHARD_SINGLE_OUTPUT_TEMPLATE.format(
+                            self.outputs['names'][0]
+                        )
+                    )
+                elif self.outputs['types'][0] == 'std::vector<Tensor>':
+                    reshard_output_code += (
+                        RESHARD_VECTOR_OUTPUT_TEMPLATE.format(
                             self.outputs['names'][0]
                         )
                     )

--- a/test/auto_parallel/semi_auto_parallel_for_concat.py
+++ b/test/auto_parallel/semi_auto_parallel_for_concat.py
@@ -38,7 +38,7 @@ class TestSplitAndConcatSemiAutoParallel(SemiAutoParallelTestBase):
             inputs_shape=shapes,
             inputs_specs=specs,
             op_func=paddle.concat,
-            with_backward=False,
+            with_backward=True,
             axis=0,
         )
         self.check_dim_mapping(outputs, [-1, -1, 0])
@@ -50,7 +50,7 @@ class TestSplitAndConcatSemiAutoParallel(SemiAutoParallelTestBase):
             inputs_shape=shapes,
             inputs_specs=specs,
             op_func=paddle.concat,
-            with_backward=False,
+            with_backward=True,
             axis=0,
         )
         self.check_dim_mapping(outputs, [-1, -1, 0])
@@ -62,7 +62,7 @@ class TestSplitAndConcatSemiAutoParallel(SemiAutoParallelTestBase):
             inputs_shape=shapes,
             inputs_specs=specs,
             op_func=paddle.stack,
-            with_backward=False,
+            with_backward=True,
             axis=0,
         )
         self.check_dim_mapping(outputs, [-1, -1, -1, 0])
@@ -74,7 +74,7 @@ class TestSplitAndConcatSemiAutoParallel(SemiAutoParallelTestBase):
             inputs_shape=shapes,
             inputs_specs=specs,
             op_func=paddle.stack,
-            with_backward=False,
+            with_backward=True,
             axis=0,
         )
         self.check_dim_mapping(outputs, [-1, 0, -1, -1])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
code gen dtensor 非兜底规则，支持 vector 梯度
card-77948 code-gen backward support vector of dtensor grad output