### PR TITLE
skip flash attention  test if device or cuda version do not support it 

### DIFF
--- a/test/auto_parallel/semi_auto_parallel_for_flash_attention.py
+++ b/test/auto_parallel/semi_auto_parallel_for_flash_attention.py
@@ -70,8 +70,11 @@ class TestFlashAttentionSemiAutoParallel(SemiAutoParallelTestBase):
 
         # flash attention is not supported yet for cpu
         if self._backend == "gpu":
-            self.test_flash_att_forward()
-            self.test_flash_att_forward_reshard()
+            cuda_version_main = int(paddle.version.cuda().split(".")[0])
+            device_prop_main = paddle.device.cuda.get_device_capability()[0]
+            if cuda_version_main >= 11 and device_prop_main >= 8:
+                self.test_flash_att_forward()
+                self.test_flash_att_forward_reshard()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
card-77949 skip flash attention test if device or cuda version do not support it