### PR TITLE
[XPU][PHI Kernels] use ctx_guard to allocate temporary buffer

### DIFF
--- a/paddle/fluid/operators/affine_channel_op_xpu.cc
+++ b/paddle/fluid/operators/affine_channel_op_xpu.cc
@@ -144,11 +144,10 @@ class AffineChannelGradXPUKernel : public framework::OpKernel<T> {
                             "The reduce_sum XPU OP return wrong value[%d %s]",
                             r,
                             XPUAPIErrorMsg[r]));
-      T* tmp = nullptr;
-      r = xpu_malloc(reinterpret_cast<void**>(&tmp), dy->numel() * sizeof(T));
-      PADDLE_ENFORCE_EQ(r,
-                        xpu::Error_t::SUCCESS,
-                        platform::errors::External("no enough memory in xpu"));
+      xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+      T* tmp = RAII_GUARD.alloc_l3_or_gm<T>(dy->numel());
+      PADDLE_ENFORCE_NOT_NULL(
+          tmp, platform::errors::External("XPU has no enough memory"));
 
       r = xpu::mul<T>(
           dev_ctx.x_context(), dy_d, x->data<T>(), tmp, dy->numel());
@@ -166,10 +165,6 @@ class AffineChannelGradXPUKernel : public framework::OpKernel<T> {
                             "The reduce_sum XPU OP return wrong value[%d %s]",
                             r,
                             XPUAPIErrorMsg[r]));
-      if (dev_ctx.x_context()->xpu_stream) {
-        dev_ctx.Wait();
-      }
-      xpu_free(tmp);
     }
     if (dx_d) {
       r = xpu::broadcast_mul(

--- a/paddle/phi/kernels/xpu/deformable_conv_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/deformable_conv_grad_kernel.cc
@@ -36,6 +36,7 @@ void DeformableConvGradKernel(const Context& dev_ctx,
                               DenseTensor* offset_grad,
                               DenseTensor* filter_grad,
                               DenseTensor* mask_grad) {
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
   T* dx_data = nullptr;
   T* dw_data = nullptr;
   T* dmask_data = nullptr;
@@ -81,28 +82,24 @@ void DeformableConvGradKernel(const Context& dev_ctx,
   const float* offset_ptr = offset.data<float>();
   const float* mask_ptr = mask->data<float>();
   if (dx_data == nullptr) {
-    PADDLE_ENFORCE_EQ(
-        xpu_malloc(reinterpret_cast<void**>(&dx_data), x.numel() * sizeof(T)),
-        XPU_SUCCESS,
-        errors::ResourceExhausted("XPU has no enough memory"));
+    dx_data = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
+    PADDLE_ENFORCE_NOT_NULL(
+        dx_data, errors::ResourceExhausted("XPU has no enough memory"));
   }
   if (dw_data == nullptr) {
-    PADDLE_ENFORCE_EQ(xpu_malloc(reinterpret_cast<void**>(&dw_data),
-                                 filter.numel() * sizeof(T)),
-                      XPU_SUCCESS,
-                      errors::ResourceExhausted("XPU has no enough memory"));
+    dw_data = RAII_GUARD.alloc_l3_or_gm<T>(filter.numel());
+    PADDLE_ENFORCE_NOT_NULL(
+        dw_data, errors::ResourceExhausted("XPU has no enough memory"));
   }
   if (doffset_data == nullptr) {
-    PADDLE_ENFORCE_EQ(xpu_malloc(reinterpret_cast<void**>(&doffset_data),
-                                 offset.numel() * sizeof(T)),
-                      XPU_SUCCESS,
-                      errors::ResourceExhausted("XPU has no enough memory"));
+    doffset_data = RAII_GUARD.alloc_l3_or_gm<T>(offset.numel());
+    PADDLE_ENFORCE_NOT_NULL(
+        doffset_data, errors::ResourceExhausted("XPU has no enough memory"));
   }
   if (dmask_data == nullptr) {
-    PADDLE_ENFORCE_EQ(xpu_malloc(reinterpret_cast<void**>(&dmask_data),
-                                 mask->numel() * sizeof(T)),
-                      XPU_SUCCESS,
-                      errors::ResourceExhausted("XPU has no enough memory"));
+    dmask_data = RAII_GUARD.alloc_l3_or_gm<T>(mask->numel());
+    PADDLE_ENFORCE_NOT_NULL(
+        dmask_data, errors::ResourceExhausted("XPU has no enough memory"));
   }
 
   int input_dim = x.numel() / x.dims()[0];
@@ -118,11 +115,9 @@ void DeformableConvGradKernel(const Context& dev_ctx,
   int w = x.dims()[3];
   int f = filter.dims()[0];
 
-  T* filter_grad_tmp = nullptr;
-  PADDLE_ENFORCE_EQ(xpu_malloc(reinterpret_cast<void**>(&filter_grad_tmp),
-                               filter_grad->numel() * sizeof(T)),
-                    XPU_SUCCESS,
-                    errors::ResourceExhausted("XPU has no enough memory"));
+  T* filter_grad_tmp = RAII_GUARD.alloc_l3_or_gm<T>(filter_grad->numel());
+  PADDLE_ENFORCE_NOT_NULL(
+      filter_grad_tmp, errors::ResourceExhausted("XPU has no enough memory"));
 
   // set zeros for d_table_data
   const int zero = 0;
@@ -175,21 +170,6 @@ void DeformableConvGradKernel(const Context& dev_ctx,
     r = baidu::xpu::api::add<T>(
         dev_ctx.x_context(), filter_grad_tmp, dw_data, dw_data, filter.numel());
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "add");
-  }
-
-  dev_ctx.Wait();
-  xpu_free(filter_grad_tmp);
-  if (dx == nullptr) {
-    xpu_free(dx_data);
-  }
-  if (filter_grad == nullptr) {
-    xpu_free(dw_data);
-  }
-  if (offset_grad == nullptr) {
-    xpu_free(doffset_data);
-  }
-  if (mask_grad == nullptr) {
-    xpu_free(dmask_data);
   }
 }
 

--- a/paddle/phi/kernels/xpu/lamb_kernel.cc
+++ b/paddle/phi/kernels/xpu/lamb_kernel.cc
@@ -112,9 +112,8 @@ void LambKernel(const Context& dev_ctx,
   xpu::ctx_guard RAII_GUARD(xpu_ctx);
 
   if (beta1_pow.place().GetType() == phi::AllocationType::CPU) {
-    int r = xpu_malloc(reinterpret_cast<void**>(&beta1_pow_xpu_ptr),
-                       (beta1_pow.numel()) * sizeof(MT));
-    PADDLE_ENFORCE_XPU_SUCCESS(r);
+    beta1_pow_xpu_ptr = RAII_GUARD.alloc_l3_or_gm<MT>(beta1_pow.numel());
+    PADDLE_ENFORCE_XDNN_NOT_NULL(beta1_pow_out_ptr);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        beta1_pow_xpu_ptr,
                        beta1_pow.place(),
@@ -128,9 +127,8 @@ void LambKernel(const Context& dev_ctx,
     beta1_pow_out_ptr = dev_ctx.template Alloc<MT>(beta1_pow_out);
   }
   if (beta2_pow.place().GetType() == phi::AllocationType::CPU) {
-    int r = xpu_malloc(reinterpret_cast<void**>(&beta2_pow_xpu_ptr),
-                       (beta2_pow.numel()) * sizeof(MT));
-    PADDLE_ENFORCE_XPU_SUCCESS(r);
+    beta2_pow_xpu_ptr = RAII_GUARD.alloc_l3_or_gm<MT>(beta2_pow.numel());
+    PADDLE_ENFORCE_XDNN_NOT_NULL(beta2_pow_xpu_ptr);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        beta2_pow_xpu_ptr,
                        beta2_pow.place(),
@@ -204,9 +202,6 @@ void LambKernel(const Context& dev_ctx,
                        dev_ctx.GetPlace(),
                        beta1_pow_out_ptr,
                        sizeof(MT) * beta1_pow_out->numel());
-    if (beta1_pow_xpu_ptr) {
-      xpu_free(beta1_pow_xpu_ptr);
-    }
   }
   if (beta2_pow.place().GetType() == phi::AllocationType::CPU) {
     // copy beta2_pow_out from xpu to cpu
@@ -215,9 +210,6 @@ void LambKernel(const Context& dev_ctx,
                        dev_ctx.GetPlace(),
                        beta2_pow_out_ptr,
                        sizeof(MT) * beta2_pow_out->numel());
-    if (beta2_pow_xpu_ptr) {
-      xpu_free(beta2_pow_xpu_ptr);
-    }
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/reduce_max_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_max_grad_kernel.cc
@@ -63,18 +63,20 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
   T* brocast1 = nullptr;
   T* brocast2 = nullptr;
   bool* equal = nullptr;
-  PADDLE_ENFORCE_EQ(
-      xpu_malloc(reinterpret_cast<void**>(&brocast1), x.numel() * sizeof(T)),
-      XPU_SUCCESS,
-      errors::ResourceExhausted("XPU has no enough memory"));
-  PADDLE_ENFORCE_EQ(
-      xpu_malloc(reinterpret_cast<void**>(&equal), x.numel() * sizeof(bool)),
-      XPU_SUCCESS,
-      errors::ResourceExhausted("XPU has no enough memory"));
-  PADDLE_ENFORCE_EQ(
-      xpu_malloc(reinterpret_cast<void**>(&brocast2), x.numel() * sizeof(T)),
-      XPU_SUCCESS,
-      errors::ResourceExhausted("XPU has no enough memory"));
+
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+
+  brocast1 = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
+  PADDLE_ENFORCE_NOT_NULL(
+      brocast1, errors::ResourceExhausted("XPU has no enough memory"));
+
+  equal = RAII_GUARD.alloc_l3_or_gm<bool>(x.numel());
+  PADDLE_ENFORCE_NOT_NULL(
+      equal, errors::ResourceExhausted("XPU has no enough memory"));
+
+  brocast2 = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
+  PADDLE_ENFORCE_NOT_NULL(
+      brocast2, errors::ResourceExhausted("XPU has no enough memory"));
 
   // use [1] to replace [], because xpu not support []
   if (xdims.size() == 0) {
@@ -107,13 +109,6 @@ void ReduceMaxGradKernel(const Context& dev_ctx,
                      xdims,
                      xdims);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "select");
-
-  if (dev_ctx.x_context()->xpu_stream) {
-    dev_ctx.Wait();
-  }
-  xpu_free(brocast1);
-  xpu_free(brocast2);
-  xpu_free(equal);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/roi_align_kernel.cc
+++ b/paddle/phi/kernels/xpu/roi_align_kernel.cc
@@ -114,37 +114,33 @@ void RoiAlignKernel(const Context& dev_ctx,
     }
   }
 
-  int* roi_id_data = nullptr;
-  int r = xpu_malloc(reinterpret_cast<void**>(&roi_id_data),
-                     (rois_batch_size + 1) * sizeof(int));
-  PADDLE_ENFORCE_XPU_SUCCESS(r);
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+  int* roi_id_data = RAII_GUARD.alloc_l3_or_gm<int>(rois_batch_size + 1);
+  PADDLE_ENFORCE_NOT_NULL(
+      roi_id_data, errors::ResourceExhausted("XPU has no enough memory"));
   memory_utils::Copy(xplace,
                      roi_id_data,
                      cplace,
                      cpu_lod,
                      (rois_batch_size + 1) * sizeof(int));
   delete[] cpu_lod;
-  r = xpu::roi_align<T, int>(dev_ctx.x_context(),
-                             x.data<T>(),
-                             dev_ctx.template Alloc<T>(out),
-                             boxes.data<T>(),
-                             roi_id_data,
-                             batch_size,
-                             channels,
-                             height,
-                             width,
-                             out->dims()[0],
-                             pooled_height,
-                             pooled_width,
-                             spatial_scale,
-                             sampling_ratio,
-                             true,
-                             aligned);
+  int r = xpu::roi_align<T, int>(dev_ctx.x_context(),
+                                 x.data<T>(),
+                                 dev_ctx.template Alloc<T>(out),
+                                 boxes.data<T>(),
+                                 roi_id_data,
+                                 batch_size,
+                                 channels,
+                                 height,
+                                 width,
+                                 out->dims()[0],
+                                 pooled_height,
+                                 pooled_width,
+                                 spatial_scale,
+                                 sampling_ratio,
+                                 true,
+                                 aligned);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "roi_align");
-  if (dev_ctx.x_context()->xpu_stream) {
-    dev_ctx.Wait();
-  }
-  xpu_free(roi_id_data);
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
使用RAII的机制分配替换原有的xpu_malloc和xpu_free，避免内存泄露出现。