### PR TITLE
[CodeStyle] clean isort ignore

### DIFF
--- a/python/paddle/incubate/asp/__init__.py
+++ b/python/paddle/incubate/asp/__init__.py
@@ -13,8 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# isort: off
-# NOTE(gouzil): MaskAlgo can cause circular references, so sorting is disabled
+from .asp import (
+    ASPHelper,  # noqa: F401
+    decorate,
+    prune_model,
+    reset_excluded_layers,
+    set_excluded_layers,
+)
+from .supported_layer_list import add_supported_layer
 from .utils import (  # noqa: F401
     CheckMethod,
     MaskAlgo,
@@ -27,17 +33,6 @@ from .utils import (  # noqa: F401
     get_mask_2d_best,
     get_mask_2d_greedy,
 )
-
-# isort: on
-
-from .asp import ASPHelper  # noqa: F401
-from .asp import (
-    decorate,
-    prune_model,
-    reset_excluded_layers,
-    set_excluded_layers,
-)
-from .supported_layer_list import add_supported_layer
 
 __all__ = [
     'calculate_density',

--- a/python/paddle/incubate/asp/asp.py
+++ b/python/paddle/incubate/asp/asp.py
@@ -24,12 +24,12 @@ import numpy as np
 import paddle
 from paddle.base import core, global_scope, program_guard
 from paddle.base.framework import dygraph_only
-from paddle.incubate import asp
 
 from .supported_layer_list import (
     _default_pruning,
     supported_layers_and_prune_func_map,
 )
+from .utils import MaskAlgo
 
 OpRole = core.op_proto_and_checker_maker.OpRole
 OP_ROLE_KEY = core.op_proto_and_checker_maker.kOpRoleAttrName()
@@ -437,9 +437,9 @@ def prune_model(model, n=2, m=4, mask_algo='mask_1d', with_mask=True):
     place = paddle.set_device(device)
 
     MaskAlgo_mapping = {
-        'mask_1d': asp.MaskAlgo.MASK_1D,
-        'mask_2d_greedy': asp.MaskAlgo.MASK_2D_GREEDY,
-        'mask_2d_best': asp.MaskAlgo.MASK_2D_BEST,
+        'mask_1d': MaskAlgo.MASK_1D,
+        'mask_2d_greedy': MaskAlgo.MASK_2D_GREEDY,
+        'mask_2d_best': MaskAlgo.MASK_2D_BEST,
     }
     assert (
         mask_algo in MaskAlgo_mapping
@@ -568,7 +568,7 @@ class ASPHelper:
         main_program=None,
         n=2,
         m=4,
-        mask_algo=asp.MaskAlgo.MASK_1D,
+        mask_algo=MaskAlgo.MASK_1D,
         with_mask=True,
     ):
         r"""
@@ -620,7 +620,7 @@ class ASPHelper:
         layer,
         n=2,
         m=4,
-        mask_algo=asp.MaskAlgo.MASK_1D,
+        mask_algo=MaskAlgo.MASK_1D,
         with_mask=True,
     ):
         r"""

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Temporary disable isort to avoid circular import
-# This can be removed after the circular import is resolved
 from __future__ import annotations
 
 import inspect

--- a/python/paddle/jit/dy2static/__init__.py
+++ b/python/paddle/jit/dy2static/__init__.py
@@ -15,10 +15,6 @@
 from .assert_transformer import AssertTransformer  # noqa: F401
 from .ast_transformer import DygraphToStaticAst  # noqa: F401
 from .convert_call_func import convert_call as Call  # noqa: F401
-
-# isort: off
-# NOTE(gouzil): isort will delete the import
-# TODO(gouzil): Remove `isort: off` after adding the `combine-as-imports` configuration
 from .convert_operators import (  # noqa: F401
     convert_assert as Assert,
     convert_attr as Attr,
@@ -29,15 +25,13 @@ from .convert_operators import (  # noqa: F401
     convert_logical_not as Not,
     convert_logical_or as Or,
     convert_pop as Pop,
-    convert_shape_compare,
     convert_shape as Shape,
+    convert_shape_compare,
     convert_var_dtype as AsDtype,
     convert_while_loop as While,
     indexable as Indexable,
     unpack_by_structure as Unpack,
 )
-
-# isort: on
 from .program_translator import convert_to_static  # noqa: F401
 from .static_analysis import NodeVarType, StaticAnalysisVisitor  # noqa: F401
 from .utils import UndefinedVar, ast_to_source_code, saw  # noqa: F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

保留的`ignore`

* `python/paddle/base/core.py`: 保留注释信息，不做清理
* `python/paddle/framework/__init__.py`: 保留注释信息，不做清理
* `python/paddle/utils/cpp_extension/cpp_extension.py`: 有用`distutils`, 可以跟`distutils`一块清理

相关pr:
* #58967