### PR TITLE
fix pylayer memleak

### DIFF
--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -454,6 +454,10 @@ PyObject* pylayer_method_apply(PyObject* cls,
     }
   }
 
+  if (PyList_Check(outputs)) {
+    Py_XDECREF(outputs_tuple);
+  }
+
   Py_XDECREF(forward_args);
   Py_XDECREF(kwargs_value_list);
   Py_XDECREF(backward_function);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PyLayer的Apply对返回List的场景处理不恰当，导致PyObject*引用计数少减了1
Pcard-74613