### PR TITLE
[PIR]Forbid hash and eq for OpResult in python

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -530,6 +530,8 @@ void BindValue(py::module *m) {
            [](Value &self, Value &op_value) {
              self.ReplaceAllUsesWith(op_value);
            })
+      .def("to_op_result",
+           [](Value &self) { return self.dyn_cast<pir::OpResult>(); })
       .def("__eq__", &Value::operator==)
       .def("__eq__",
            [](Value &self, OpResult &other) {
@@ -719,17 +721,11 @@ void BindOpResult(py::module *m) {
   OVERRIDE_COMPARE_OP_FOR_EACH(__gt__, greater_than);
   OVERRIDE_COMPARE_OP_FOR_EACH(__ge__, greater_equal);
 
-  op_result.def("__eq__", &OpResult::operator==)
-      .def("__eq__",
-           [](OpResult &self, Value &other) {
-             return self.Value::impl() == other.impl();
-           })
+  op_result
       .def("__neg__",
            [](OpResult &self) {
              return paddle::dialect::scale(self, -1.0, 0.0, true);
            })
-      .def("__hash__",
-           [](OpResult &self) { return std::hash<pir::Value>{}(self); })
       .def("__str__",
            [](OpResult &self) -> py::str {
              std::ostringstream print_stream;
@@ -824,6 +820,7 @@ void BindOpResult(py::module *m) {
            [](OpResult &self, OpResult &op_result) {
              self.ReplaceAllUsesWith(op_result);
            })
+      .def("to_value", [](OpResult &self) { return pir::Value(self.impl()); })
       .def_property(
           "stop_gradient",
           [](OpResult &self) {

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -372,6 +372,9 @@ def monkey_patch_opresult():
 
         array_write(x=var, i=array_length(self), array=self)
 
+    def op_result_hash(self):
+        raise NotImplementedError('In python OpResult can not hash!')
+
     import paddle
 
     opresult_methods = [
@@ -384,6 +387,7 @@ def monkey_patch_opresult():
         ('size', _size_),
         ('clone', clone),
         ('append', append),
+        ('__hash__', op_result_hash),
         (
             '__add__',
             _binary_creator_('__add__', paddle.tensor.add, False, _scalar_add_),

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -375,6 +375,9 @@ def monkey_patch_opresult():
     def op_result_hash(self):
         raise NotImplementedError('In python OpResult can not hash!')
 
+    def op_result_eq(self):
+        raise NotImplementedError('In python OpResult can not eq!')
+
     import paddle
 
     opresult_methods = [
@@ -388,6 +391,7 @@ def monkey_patch_opresult():
         ('clone', clone),
         ('append', append),
         ('__hash__', op_result_hash),
+        ('__eq__', op_result_eq),
         (
             '__add__',
             _binary_creator_('__add__', paddle.tensor.add, False, _scalar_add_),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Forbid hash for OpResult in python