### PR TITLE
[Add] test atleast_xd pir backward 

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4082,8 +4082,14 @@ def atleast_1d(*inputs, name=None):
             [[1.23000002]])]
     """
     out = []
-    for tensor in inputs:
-        tensor = paddle.to_tensor(tensor)
+    for input in inputs:
+        if not isinstance(
+            input, (paddle.Tensor, paddle.base.framework.Variable)
+        ):
+            tensor = paddle.to_tensor(input)
+        else:
+            tensor = input
+
         if tensor.dim() == 0:
             result = tensor.reshape((1,))
         else:
@@ -4139,8 +4145,14 @@ def atleast_2d(*inputs, name=None):
             [[[1.23000002]]])]
     """
     out = []
-    for tensor in inputs:
-        tensor = paddle.to_tensor(tensor)
+    for input in inputs:
+        if not isinstance(
+            input, (paddle.Tensor, paddle.base.framework.Variable)
+        ):
+            tensor = paddle.to_tensor(input)
+        else:
+            tensor = input
+
         if tensor.dim() == 0:
             result = tensor.reshape((1, 1))
         elif tensor.dim() == 1:
@@ -4198,8 +4210,14 @@ def atleast_3d(*inputs, name=None):
             [[[[1.23000002]]]])]
     """
     out = []
-    for tensor in inputs:
-        tensor = paddle.to_tensor(tensor)
+    for input in inputs:
+        if not isinstance(
+            input, (paddle.Tensor, paddle.base.framework.Variable)
+        ):
+            tensor = paddle.to_tensor(input)
+        else:
+            tensor = input
+
         if tensor.dim() == 0:
             result = tensor.reshape((1, 1, 1))
         elif tensor.dim() == 1:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4084,7 +4084,12 @@ def atleast_1d(*inputs, name=None):
     out = []
     for input in inputs:
         if not isinstance(
-            input, (paddle.Tensor, paddle.base.framework.Variable)
+            input,
+            (
+                paddle.Tensor,
+                paddle.base.framework.Variable,
+                paddle.base.libpaddle.pir.OpResult,
+            ),
         ):
             tensor = paddle.to_tensor(input)
         else:
@@ -4147,7 +4152,12 @@ def atleast_2d(*inputs, name=None):
     out = []
     for input in inputs:
         if not isinstance(
-            input, (paddle.Tensor, paddle.base.framework.Variable)
+            input,
+            (
+                paddle.Tensor,
+                paddle.base.framework.Variable,
+                paddle.base.libpaddle.pir.OpResult,
+            ),
         ):
             tensor = paddle.to_tensor(input)
         else:
@@ -4212,7 +4222,12 @@ def atleast_3d(*inputs, name=None):
     out = []
     for input in inputs:
         if not isinstance(
-            input, (paddle.Tensor, paddle.base.framework.Variable)
+            input,
+            (
+                paddle.Tensor,
+                paddle.base.framework.Variable,
+                paddle.base.libpaddle.pir.OpResult,
+            ),
         ):
             tensor = paddle.to_tensor(input)
         else:

--- a/test/legacy_test/test_atleast_xd.py
+++ b/test/legacy_test/test_atleast_xd.py
@@ -173,13 +173,7 @@ class BaseTest(unittest.TestCase):
                         dtype = dtypes[i]
                         name = names[i]
 
-                        # TODO(megemini) reshape in pir need stop_gradient?
-                        _x = paddle.static.data(name, shape, dtype)
-                        _x.stop_gradient = False
-                        x.append(_x)
-
-                        # TODO(megemini) reshape not works in pir
-                        # x.append(paddle.static.data(name, shape, dtype))
+                        x.append(paddle.static.data(name, shape, dtype))
 
                         # the data feeded should NOT be a Tensor
                         feed[name] = (

--- a/test/legacy_test/test_atleast_xd.py
+++ b/test/legacy_test/test_atleast_xd.py
@@ -172,9 +172,15 @@ class BaseTest(unittest.TestCase):
                         shape = shapes[i]
                         dtype = dtypes[i]
                         name = names[i]
+
+                        # TODO(megemini) reshape in pir need stop_gradient?
                         _x = paddle.static.data(name, shape, dtype)
                         _x.stop_gradient = False
                         x.append(_x)
+
+                        # TODO(megemini) reshape not works in pir
+                        # x.append(paddle.static.data(name, shape, dtype))
+
                         # the data feeded should NOT be a Tensor
                         feed[name] = (
                             input.numpy()
@@ -210,7 +216,7 @@ class BaseTest(unittest.TestCase):
                     # convert grad value to bool if dtype is bool
                     grad_value = 123.0 if dtypes[0] != 'bool' else True
                     np.testing.assert_allclose(
-                        res_grad, np.ones_like(res_grad) * grad_value
+                        res_grad, np.ones_like(y) * grad_value
                     )
 
                 out_ref = func_ref(

--- a/test/legacy_test/test_atleast_xd.py
+++ b/test/legacy_test/test_atleast_xd.py
@@ -172,7 +172,9 @@ class BaseTest(unittest.TestCase):
                         shape = shapes[i]
                         dtype = dtypes[i]
                         name = names[i]
-                        x.append(paddle.static.data(name, shape, dtype))
+                        _x = paddle.static.data(name, shape, dtype)
+                        _x.stop_gradient = False
+                        x.append(_x)
                         # the data feeded should NOT be a Tensor
                         feed[name] = (
                             input.numpy()
@@ -181,12 +183,35 @@ class BaseTest(unittest.TestCase):
                         )
 
                     out = func(*x)
-                    exe = paddle.static.Executor(place)
-                    res = exe.run(feed=feed, fetch_list=[out])
 
-                    # unwrap inputs when lenght 1
                     if len(inputs) == 1:
-                        res = res[0]
+                        out.stop_gradient = False
+                        y = out
+                    else:
+                        for o in out:
+                            o.stop_gradient = False
+                        y = out[0]
+
+                    z = y * 123
+
+                    fetch_list = [out]
+                    if paddle.framework.in_pir_mode():
+                        grads = paddle.autograd.ir_backward.grad(z, y)
+                        out_grad = grads[0]
+                        fetch_list.append(out_grad)
+                    else:
+                        paddle.static.append_backward(z)
+                        out_grad = y.grad_name
+                        fetch_list.append(out_grad)
+
+                    exe = paddle.static.Executor(place)
+                    *res, res_grad = exe.run(feed=feed, fetch_list=fetch_list)
+
+                    # convert grad value to bool if dtype is bool
+                    grad_value = 123.0 if dtypes[0] != 'bool' else True
+                    np.testing.assert_allclose(
+                        res_grad, np.ones_like(res_grad) * grad_value
+                    )
 
                 out_ref = func_ref(
                     func_type,
@@ -197,6 +222,9 @@ class BaseTest(unittest.TestCase):
                         for input in inputs
                     ]
                 )
+
+                if len(inputs) == 1:
+                    out_ref = [out_ref]
 
                 for n, p in zip(out_ref, res):
                     np.testing.assert_allclose(n, p, rtol=RTOL, atol=ATOL)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

这个 PR 主要涉及两个部分：

- 对于 atleast_xd 中的输入为 tensor 的(Tensor, Variable, OpResult)，不使用 to_tensor 新建一个

  这样可以不改变 tensor 类型的输入，相应的 stop_gradient 等也就不需要重新设置。

  之前使用 to_tensor 是因为，如果是 numpy 类似的输入，必定要新建 tensor，因此这里就统一用了 to_tensor 进行新建。

  不过，参考 reshape 等方法，stop_gradient 等属性也继承下来了，因此，此处考虑对于 tensor 单独处理，而对于 numpy 等类型使用 to_tensor 进行新建。

  请帮忙看一下是否合适？

- 增加单元测试中静态图的梯度回传测试

  https://github.com/PaddlePaddle/Paddle/pull/59127 这个 PR 里面添加静态图梯度回传的时候，发现目前 pir 下好像还有问题，因此考虑把：

  - https://github.com/PaddlePaddle/Paddle/pull/59127
  - https://github.com/PaddlePaddle/Paddle/pull/58917
  - https://github.com/PaddlePaddle/Paddle/pull/58323

  涉及到的 api 都增加静态图梯度回传测试。 

目前发现 reshape、concat 好像都有点问题 ～

以下测试环境，aistudio：

``` python
Python 3.10.10 (main, Mar 21 2023, 18:45:11) [GCC 11.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import paddle
paddle.
In [2]: paddle.version.commit
Out[2]: '907e42525e00d7dc3257672399d36aabbdaf8114'
```

- reshape 的问题

测试示例：
``` python
import paddle
from paddle.pir_utils import test_with_pir_api

@test_with_pir_api
def test_static_api():
    paddle.enable_static()

    with paddle.static.program_guard(paddle.static.Program()):
        x = paddle.static.data('x', (), 'float64')
        # 这里不应该影响后面需要的梯度回传
        # 在 pir 下，这里必须设置为 False，否则出错
        # 在旧的静态图下没有问题
        # x.stop_gradient = False

        feed = {'x': 123.0}

        out = paddle.reshape(x, (1,))

        out.stop_gradient = False

        z = out * 123

        fetch_list = [out]
        if paddle.framework.in_pir_mode():
            grads = paddle.autograd.ir_backward.grad(z, out)
            out_grad = grads[0]
            fetch_list.append(out_grad)
        else:
            paddle.static.append_backward(z)
            out_grad = out.grad_name
            fetch_list.append(out_grad)

        exe = paddle.static.Executor()
        *res, res_grad = exe.run(feed=feed, fetch_list=fetch_list)

        print(res, res_grad)

if __name__ == '__main__':
    test_static_api()
```

执行出错：

``` shell
Traceback (most recent call last):
  File "/home/aistudio/test_atleast/test_refresh_stopgradient.py", line 39, in <module>
    test_static_api()
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/pir_utils.py", line 115, in impl
    func(*args, **kwargs)
  File "/home/aistudio/test_atleast/test_refresh_stopgradient.py", line 34, in test_static_api
    *res, res_grad = exe.run(feed=feed, fetch_list=fetch_list)
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py", line 1715, in run
    res = self._run_pir_impl(
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py", line 1993, in _run_pir_impl
    fetch_list = self._check_fetch_list(fetch_list)
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py", line 2096, in _check_fetch_list
    raise TypeError(
TypeError: Require fetch_list[1] 's type shall be one of (OpResult, str), but received NoneType.
```

初步定位是 paddle/autograd/ir_backward.py 中的 block.refresh_stopgradient() 问题：

``` shell
> /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/autograd/ir_backward.py(672)calc_gradient_helper()
-> block.refresh_stopgradient()
(Pdb) l
667  
668     def calc_gradient_helper(outputs, inputs, grad_outputs, no_grad_set):
669         block = outputs[0].get_defining_op().get_parent_block()
670  
671         pdb.set_trace()
672  ->     block.refresh_stopgradient()
673  
674         state = State(block.program)
675  
676         # check all inputs and outputs in the same block
677         check_all_puts(block, inputs, outputs)
(Pdb) p inputs
[<paddle.base.libpaddle.pir.OpResult object at 0x7f20ace72130>]
(Pdb) p inputs[0].stop_gradient
False
(Pdb) p outputs
[<paddle.base.libpaddle.pir.OpResult object at 0x7f20aced8930>]
(Pdb) p outputs[0].stop_gradient
False
(Pdb) a
outputs = [<paddle.base.libpaddle.pir.OpResult object at 0x7f20aced8930>]
inputs = [<paddle.base.libpaddle.pir.OpResult object at 0x7f20ace72130>]
grad_outputs = []
no_grad_set = set()
(Pdb) s
> /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/autograd/ir_backward.py(674)calc_gradient_helper()
-> state = State(block.program)
(Pdb) p inputs[0].stop_gradient
True
(Pdb) p outputs[0].stop_gradient
True
(Pdb) a
outputs = [<paddle.base.libpaddle.pir.OpResult object at 0x7f20aced8930>]
inputs = [<paddle.base.libpaddle.pir.OpResult object at 0x7f20ace72130>]
grad_outputs = []
no_grad_set = set()
(Pdb) 
```

可以看到，在执行完 block.refresh_stopgradient() 后，原来 stop_gradient 为 False 的变为了 True，从而导致后续无法获得梯度。

如果将上面示例代码中的 `# x.stop_gradient = False` 注释打开，这样可以正常运行 ～ 但是这与旧的静态图以及动态图的行为不符 ～

参考 https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/faq/train_cn.html#stop-gradient-true ，x 的梯度回传不应该影响到后面的执行 ～

- concat 的问题

测试示例：
``` python
import pdb
import numpy as np
import paddle
from paddle.pir_utils import test_with_pir_api

@test_with_pir_api
def test_static_api():
    paddle.enable_static()

    with paddle.static.program_guard(paddle.static.Program()):
        x = paddle.static.data('x', (1, 2), 'float64')
        y = paddle.static.data('y', (1, 2), 'float64')

        # 这里不应该影响后面需要的梯度回传
        # 在 pir 下，这里必须设置为 False，否则出错
        # 在旧的静态图下没有问题
        x.stop_gradient = False
        y.stop_gradient = False

        feed = {'x': np.random.rand(1, 2), 'y': np.random.rand(1, 2)}

        pdb.set_trace()
        out = paddle.concat((x, y), axis=0)

        out.stop_gradient = False

        y = out * 123

        fetch_list = [out]
        if paddle.framework.in_pir_mode():
            grads = paddle.autograd.ir_backward.grad(y, out)
            out_grad = grads[0]
            fetch_list.append(out_grad)
        else:
            paddle.static.append_backward(y)
            out_grad = out.grad_name
            fetch_list.append(out_grad)

        exe = paddle.static.Executor()

        pdb.set_trace()
        *res, res_grad = exe.run(feed=feed, fetch_list=fetch_list)

        print(res, res[0].shape, res_grad)

if __name__ == '__main__':
    test_static_api()

```

执行出错：

``` shell
Traceback (most recent call last):
  File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 47, in <module>
    test_static_api()
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/pir_utils.py", line 113, in impl
    func(*args, **kwargs)
  File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 42, in test_static_api
    *res, res_grad = exe.run(feed=feed, fetch_list=fetch_list)
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py", line 1725, in run
    res = self._run_impl(
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py", line 1932, in _run_impl
    ret = new_exe.run(
  File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py", line 825, in run
    tensors = self._new_exe.run(
ValueError: In user code:

    File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 47, in <module>
      test_static_api()
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/pir_utils.py", line 113, in impl
      func(*args, **kwargs)
    File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 23, in test_static_api
      out = paddle.concat((x, y), axis=0)
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/tensor/manipulation.py", line 1311, in concat
      helper.append_op(
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/layer_helper.py", line 44, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/framework.py", line 4451, in append_op
      op = Operator(
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/framework.py", line 2999, in __init__
      for frame in traceback.extract_stack():

    InvalidArgumentError: Source and destination tensor should have the same dimension size, but source tensor dimension size is 1, destination tensor size is 2.
      [Hint: Expected src_stride_numel.size() == dst_stride_numel.size(), but received src_stride_numel.size():1 != dst_stride_numel.size():2.] (at /paddle/paddle/phi/kernels/funcs/strided_memcpy.h:105)
      [operator < concat_grad > error]
```

初步定位是 paddle/base/executor.py 中的 self._new_exe.run 问题：

``` shell
> /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py(825)run()
-> tensors = self._new_exe.run(
(Pdb) l
820                     (the Tensor specified in the fetch list) to numpy.ndarray. if it is False,
821                     the type of the return value is a list of :code:`LoDTensor`. The default is True.
822             """
823             import pdb
824             pdb.set_trace()
825  ->         tensors = self._new_exe.run(
826                 feed_names, enable_job_schedule_profiler
827             )._move_to_list()
828             if return_numpy:
829                 tensors = as_numpy(tensors, copy=True)
830                 if not get_flags("FLAGS_enable_pir_in_executor")[
(Pdb) p feed_names
['x', 'y']
(Pdb) p enable_job_schedule_profiler
False
(Pdb) s
> /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py(826)run()
-> feed_names, enable_job_schedule_profiler
(Pdb) s
> /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py(825)run()
-> tensors = self._new_exe.run(
(Pdb) s
I1125 15:42:22.781333 17598 program_interpreter.cc:202] New Executor is Running.
I1125 15:42:22.782413 17598 interpreter_util.cc:612] Standalone Executor is Used.
ValueError: In user code:

    File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 82, in <module>
      test_static_api()
    File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 60, in test_static_api
      out = vstack((x, y))
    File "/home/aistudio/test_stack_extension/test_concat_pir.py", line 11, in vstack
      return paddle.concat(arrays, axis=0, name=name)
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/tensor/manipulation.py", line 1311, in concat
      helper.append_op(
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/layer_helper.py", line 44, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/framework.py", line 4451, in append_op
      op = Operator(
    File "/opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/framework.py", line 2999, in __init__
      for frame in traceback.extract_stack():

    InvalidArgumentError: Source and destination tensor should have the same dimension size, but source tensor dimension size is 1, destination tensor size is 2.
      [Hint: Expected src_stride_numel.size() == dst_stride_numel.size(), but received src_stride_numel.size():1 != dst_stride_numel.size():2.] (at /paddle/paddle/phi/kernels/funcs/strided_memcpy.h:105)
      [operator < concat_grad > error]
> /opt/conda/envs/python35-paddle120-env/lib/python3.10/site-packages/paddle/base/executor.py(825)run()
-> tensors = self._new_exe.run(
```

在这个测试示例中，x/y 的 stop_gradient 都设置为 False，否则就会出现之前 reshape 的问题（无法梯度回传），但是设置之后仍然出现上述问题。

上述示例旧的静态图也有问题，只有一种情况可以正常运行：

- `@test_with_pir_api` 注释掉这句，也就是只跑旧的静态图
- x/y 的 stop_gradient 必须为 True，否则也会报错。

--- 

综上，目前我这边的这三个 PR 涉及到的 api 所依赖的 reshape、concat 的静态图梯度回传都有问题（之前测试到 split 的好像也有问题，但似乎这两天被解决了？）

还请帮忙看一下 ～ 非常感谢 ～

@luotao1



 