### PR TITLE
[Pir] Set add_broadcast_to_elementwise_test property to CINN

### DIFF
--- a/test/cpp/pir/cinn/CMakeLists.txt
+++ b/test/cpp/pir/cinn/CMakeLists.txt
@@ -30,7 +30,8 @@ if(WITH_TESTING AND WITH_CINN)
     cinn_op_dialect
     add_broadcast_to_elementwise_pass
     pir)
-  set_tests_properties(dialect_convert_test PROPERTIES LABELS "RUN_TYPE=CINN")
+  set_tests_properties(add_broadcast_to_elementwise_test
+                       PROPERTIES LABELS "RUN_TYPE=CINN")
 
   paddle_test(
     ir_op_fusion_test


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

Set the property of unit test `add_broadcast_to_elementwise_test` to CINN