### PR TITLE
[pass]trt_delete_weight_dequant_linear_op_pass, fix bug in shared weights

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -3283,16 +3283,13 @@ void patterns::DeleteWeightQuantDequantLinearOpPattern::operator()() {
 
   auto weight_dequantize_linear_op_out =
       pattern->NewNode(weight_dequantize_linear_op_out_repr())
-          ->AsIntermediate()
+          ->AsOutput()
           ->assert_is_op_output("dequantize_linear", "Y");
-
-  auto any_op2 = pattern->NewNode(any_op2_repr())->assert_is_op()->AsOutput();
 
   weight_dequantize_linear_op
       ->LinksFrom(
           {weight_dequantize_linear_op_x, weight_dequantize_linear_op_scale})
       .LinksTo({weight_dequantize_linear_op_out});
-  any_op2->LinksFrom({weight_dequantize_linear_op_out});
 }
 
 void patterns::DeleteWeightDequantLinearOpEncoderPattern::operator()() {

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -1821,7 +1821,6 @@ struct DeleteWeightQuantDequantLinearOpPattern : public PatternBase {
   PATTERN_DECL_NODE(weight_dequantize_linear_op_scale);
   PATTERN_DECL_NODE(weight_dequantize_linear_op);
   PATTERN_DECL_NODE(weight_dequantize_linear_op_out);
-  PATTERN_DECL_NODE(any_op2);
 };
 
 struct DeleteWeightDequantLinearOpEncoderPattern : public PatternBase {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501

修改了trt_delete_weight_dequant_linear_op_pass的匹配规则，修复共享权重的dequant_linear_op无法删除问题