### PR TITLE
[Fix] Fix DistributedBatchSampler for len(dataset) < num_replicas

### DIFF
--- a/python/paddle/io/dataloader/batch_sampler.py
+++ b/python/paddle/io/dataloader/batch_sampler.py
@@ -271,10 +271,13 @@ class DistributedBatchSampler(BatchSampler):
     def __iter__(self):
         num_samples = len(self.dataset)
         indices = np.arange(num_samples).tolist()
-        # Repeat indices until matching the total_size
-        while len(indices) < self.total_size:
-            indices += indices[
-                : min(num_samples, self.total_size - len(indices))
+        # add extra samples to make it evenly divisible
+        padding_size = self.total_size - len(indices)
+        if padding_size <= len(indices):
+            indices += indices[:padding_size]
+        else:
+            indices += (indices * math.ceil(padding_size / len(indices)))[
+                :padding_size
             ]
 
         assert len(indices) == self.total_size

--- a/python/paddle/io/dataloader/batch_sampler.py
+++ b/python/paddle/io/dataloader/batch_sampler.py
@@ -271,7 +271,12 @@ class DistributedBatchSampler(BatchSampler):
     def __iter__(self):
         num_samples = len(self.dataset)
         indices = np.arange(num_samples).tolist()
-        indices += indices[: (self.total_size - len(indices))]
+        # Repeat indices until matching the total_size
+        while len(indices) < self.total_size:
+            indices += indices[
+                : min(num_samples, self.total_size - len(indices))
+            ]
+
         assert len(indices) == self.total_size
         if self.shuffle:
             np.random.RandomState(self.epoch).shuffle(indices)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->

Pcard-66961

1. 假设样本数为 $N$，卡数为 $K$， $Res=N \\% K \in [0, K-1]$ ，当 $Res > 0$ 时，`DistributedBatchSampler` 现有逻辑仅仅**进行了一次** padding，而这在 $\lceil(Res \/ N)\rceil > 1$ 时，padding 一次是不一定刚好够的，因为 N 可能足够小，导致padding一次样本数仍然不够达到能被K整除的个数，然后就会触发 `assert len(indices) == self.total_size`，因此改为持续 padding 直到长度满足要求。
    例子：假设 $N=3$, $K=8$，则目标是 padding 样本使得刚好能被 K 整除，因此 padding 后 `indices` 的结果为：[0,1,2, **0,1,2, 0,1**]，末尾加粗的5个样本为padding数据，while 循环2次，padding策略为重复复制dataset从左侧开始的数据。