### PR TITLE
[Bug]Fix inference can't find shared lib in jetpack env

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -137,14 +137,14 @@ if(WIN32)
   target_link_libraries(paddle_inference_shared phi)
 endif()
 
-if(NOT APPLE)
+if(APPLE)
   # apple can't recognize disable-new-dtags
+  set_target_properties(paddle_inference_shared
+                        PROPERTIES LINK_FLAGS "-Wl,-rpath,'$ORIGIN'")
+else()
   set_target_properties(
     paddle_inference_shared
     PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,'$ORIGIN'")
-else()
-  set_target_properties(paddle_inference_shared
-                        PROPERTIES LINK_FLAGS "-Wl,-rpath,'$ORIGIN'")
 endif()
 set_target_properties(paddle_inference_shared PROPERTIES OUTPUT_NAME
                                                          paddle_inference)

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -136,9 +136,15 @@ if(WIN32)
                PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
   target_link_libraries(paddle_inference_shared phi)
 endif()
-set_target_properties(
-  paddle_inference_shared PROPERTIES LINK_FLAGS
-                                     "-Wl,--disable-new-dtags,-rpath,'$ORIGIN'")
+if(NOT APPLE)
+  # apple can't recognize disable-new-dtags
+  set_target_properties(
+    paddle_inference_shared
+    PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,'$ORIGIN'")
+else()
+  set_target_properties(paddle_inference_shared
+                        PROPERTIES LINK_FLAGS "-Wl,-rpath,'$ORIGIN'")
+endif()
 set_target_properties(paddle_inference_shared PROPERTIES OUTPUT_NAME
                                                          paddle_inference)
 if(NOT APPLE

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -136,8 +136,9 @@ if(WIN32)
                PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
   target_link_libraries(paddle_inference_shared phi)
 endif()
-set_target_properties(paddle_inference_shared PROPERTIES LINK_FLAGS
-                                                         "-Wl,-rpath,'$ORIGIN'")
+set_target_properties(
+  paddle_inference_shared PROPERTIES LINK_FLAGS
+                                     "-Wl,--disable-new-dtags,-rpath,'$ORIGIN'")
 set_target_properties(paddle_inference_shared PROPERTIES OUTPUT_NAME
                                                          paddle_inference)
 if(NOT APPLE

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -142,6 +142,7 @@ if(APPLE)
   set_target_properties(paddle_inference_shared
                         PROPERTIES LINK_FLAGS "-Wl,-rpath,'$ORIGIN'")
 else()
+  # disable-new-dtags is used for compatible with higher version linux
   set_target_properties(
     paddle_inference_shared
     PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,'$ORIGIN'")

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -136,6 +136,7 @@ if(WIN32)
                PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
   target_link_libraries(paddle_inference_shared phi)
 endif()
+
 if(NOT APPLE)
   # apple can't recognize disable-new-dtags
   set_target_properties(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复jetpack 5.0.2上推理inference.so无法找到依赖动态库的问题