### PR TITLE
【PIR API adaptor No.238、239、240、241】 Migrate nn.initializer.XavierInitializer, nn.initializer.MSRAInitializer into pir

### DIFF
--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -118,6 +118,12 @@ class MSRAInitializer(Initializer):
                 type=core.VarDesc.VarType.LOD_TENSOR,
                 persistable=False,
             )
+        elif (
+            var.dtype in (core.DataType.FLOAT16, core.DataType.BFLOAT16)
+            and not self._uniform
+        ):
+            out_dtype = core.DataType.FLOAT32
+            out_var = var
         else:
             out_dtype = var.dtype
             out_var = var
@@ -170,8 +176,9 @@ class MSRAInitializer(Initializer):
                     out_var.shape, 0.0, std, self._seed, out_dtype, place
                 )
 
-            if var.dtype == core.DataType.FLOAT16 or (
-                var.dtype == core.DataType.BFLOAT16 and not self._uniform
+            if (
+                var.dtype in (core.DataType.FLOAT16, core.DataType.BFLOAT16)
+                and not self._uniform
             ):
                 return _C_ops.cast(out_var, var.dtype)
 

--- a/python/paddle/nn/initializer/kaiming.py
+++ b/python/paddle/nn/initializer/kaiming.py
@@ -15,10 +15,15 @@
 # TODO: define the initializers of Kaiming functions in neural network
 import math
 
+import paddle
 from paddle import _C_ops
 
 from ...base import core, framework, unique_name
-from ...base.framework import _current_expected_place, in_dygraph_mode
+from ...base.framework import (
+    _current_expected_place,
+    in_dygraph_mode,
+    in_pir_mode,
+)
 from .initializer import Initializer, calculate_gain
 
 __all__ = []
@@ -87,9 +92,10 @@ class MSRAInitializer(Initializer):
             The initialization op.
         """
         block = self._check_block(block)
-
-        assert isinstance(var, framework.Variable)
-        assert isinstance(block, framework.Block)
+        assert isinstance(
+            var, (framework.Variable, paddle.pir.core.ParameterMeta)
+        )
+        assert isinstance(block, (framework.Block, paddle.pir.Block))
         f_in, f_out = self._compute_fans(var)
 
         # If fan_in is passed, use it
@@ -144,6 +150,32 @@ class MSRAInitializer(Initializer):
             else:
                 out_var._share_underline_tensor_to(var)
             return None
+        elif in_pir_mode():
+            if self._uniform:
+                gain = calculate_gain(self._nonlinearity, self._negative_slope)
+                limit = gain * math.sqrt(3.0 / float(fan_in))
+                out_var = _C_ops.uniform(
+                    var.shape,
+                    out_dtype,
+                    -limit,
+                    limit,
+                    self._seed,
+                    _current_expected_place(),
+                )
+            else:
+                gain = calculate_gain(self._nonlinearity, self._negative_slope)
+                std = gain / math.sqrt(float(fan_in))
+                place = _current_expected_place()
+                out_var = _C_ops.gaussian(
+                    out_var.shape, 0.0, std, self._seed, out_dtype, place
+                )
+
+            if var.dtype == core.DataType.FLOAT16 or (
+                var.dtype == core.DataType.BFLOAT16 and not self._uniform
+            ):
+                return _C_ops.cast(out_var, var.dtype)
+
+            return out_var
         else:
             if self._uniform:
                 gain = calculate_gain(self._nonlinearity, self._negative_slope)

--- a/python/paddle/nn/initializer/xavier.py
+++ b/python/paddle/nn/initializer/xavier.py
@@ -119,6 +119,12 @@ class XavierInitializer(Initializer):
                 type=core.VarDesc.VarType.LOD_TENSOR,
                 persistable=False,
             )
+        elif (
+            var.dtype in (core.DataType.FLOAT16, core.DataType.BFLOAT16)
+            and not self._uniform
+        ):
+            out_dtype = core.DataType.FLOAT32
+            out_var = var
         else:
             out_dtype = var.dtype
             out_var = var
@@ -172,8 +178,9 @@ class XavierInitializer(Initializer):
                     _current_expected_place(),
                 )
 
-            if var.dtype == core.DataType.FLOAT16 or (
-                var.dtype == core.DataType.BFLOAT16 and not self._uniform
+            if (
+                var.dtype in (core.DataType.FLOAT16, core.DataType.BFLOAT16)
+                and not self._uniform
             ):
                 return _C_ops.cast(out_var, var.dtype)
 

--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -768,6 +768,207 @@ class TestMSRAInitializer(unittest.TestCase):
         block = self.test_msra_initializer_supplied_arguments("uint16")
 
 
+class TestMSRAInitializerPir(unittest.TestCase):
+    def setUp(self):
+        self.init_uniform_op_name = 'pd_op.uniform'
+        self.init_normal_op_name = 'pd_op.gaussian'
+        self.set_parameter_op_name = 'builtin.set_parameter'
+
+    def get_operand_definition_op_attrs(self, cur_op, operand_name, attr_name):
+        input_names = cur_op.get_input_names()
+        self.assertIn(operand_name, input_names)
+        attr = (
+            cur_op.operand(input_names.index(operand_name))
+            .source()
+            .get_defining_op()
+            .attrs()[attr_name]
+        )
+        return attr
+
+    def get_init_ops_by_op_name(self, block, op_name):
+        checked_ops = []
+        for op in block.ops:
+            # get init op
+            if op_name == op.name():
+                checked_ops.append(op)
+        return checked_ops
+
+    def test_uniform_msra_initializer(self):
+        """Test MSRA initializer with uniform distribution on
+        for matrix multiply.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10],
+                    name="param",
+                    initializer=paddle.nn.initializer.KaimingUniform(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_uniform_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                limit = np.sqrt(6.0 / param.shape[0])
+                min = self.get_operand_definition_op_attrs(
+                    init_op, "min", "value"
+                )
+                max = self.get_operand_definition_op_attrs(
+                    init_op, "max", "value"
+                )
+                self.assertAlmostEqual(min, -limit, delta=DELTA)
+                self.assertAlmostEqual(max, limit, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_uniform_msra_initializer_conv(self):
+        """Test MSRA initializer with uniform distribution on
+        for convolutions.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10, 15, 20],
+                    name="param",
+                    initializer=paddle.nn.initializer.KaimingUniform(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_uniform_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                receptive_field_size = float(15 * 20)
+                limit = np.sqrt(6.0 / (param.shape[1] * receptive_field_size))
+                min = self.get_operand_definition_op_attrs(
+                    init_op, "min", "value"
+                )
+                max = self.get_operand_definition_op_attrs(
+                    init_op, "max", "value"
+                )
+                self.assertAlmostEqual(min, -limit, delta=DELTA)
+                self.assertAlmostEqual(max, limit, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_normal_msra_initializer(self):
+        """Test MSRA initializer with normal distribution on
+        for matrix multiply.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10],
+                    name="param",
+                    initializer=paddle.nn.initializer.KaimingNormal(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_normal_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                std = np.sqrt(2.0 / param.shape[0])
+                self.assertAlmostEqual(
+                    init_op.attrs()['mean'], 0.0, delta=DELTA
+                )
+                self.assertAlmostEqual(init_op.attrs()['std'], std, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_normal_msra_initializer_conv(self):
+        """Test MSRA initializer with normal distribution on
+        for convolutions.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10, 15, 20],
+                    name="param",
+                    initializer=paddle.nn.initializer.KaimingNormal(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_normal_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                receptive_field_size = float(15 * 20)
+                std = np.sqrt(2.0 / (param.shape[1] * receptive_field_size))
+                self.assertAlmostEqual(
+                    init_op.attrs()['mean'], 0.0, delta=DELTA
+                )
+                self.assertAlmostEqual(init_op.attrs()['std'], std, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_msra_initializer_supplied_arguments(self, dtype="float32"):
+        """Test the MSRA initializer with supplied arguments"""
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype=dtype,
+                    shape=[5, 10],
+                    name="param",
+                    initializer=paddle.nn.initializer.MSRAInitializer(
+                        fan_in=12, seed=134
+                    ),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_uniform_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                limit = np.sqrt(6.0 / 12)
+                min = self.get_operand_definition_op_attrs(
+                    init_op, "min", "value"
+                )
+                max = self.get_operand_definition_op_attrs(
+                    init_op, "max", "value"
+                )
+                self.assertAlmostEqual(min, -limit, delta=DELTA)
+                self.assertAlmostEqual(max, limit, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 134)
+
+        return main, startup
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    )
+    def test_msra_initializer_fp16(self):
+        """Test the MSRA initializer with float16"""
+        main, startup = self.test_msra_initializer_supplied_arguments("float16")
+        with paddle.pir_utils.IrGuard():
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe.run(startup)
+            exe.run(main)
+
+    @unittest.skipIf(
+        not paddle.base.core.is_compiled_with_cuda()
+        or not paddle.base.core.is_bfloat16_supported(paddle.CUDAPlace(0)),
+        "core is not compiled with CUDA and do not support bfloat16",
+    )
+    def test_msra_initializer_bf16(self):
+        """Test the MSRA initializer with bfloat16"""
+        main, startup = self.test_msra_initializer_supplied_arguments("uint16")
+        with paddle.pir_utils.IrGuard():
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe.run(startup)
+            exe.run(main)
+
+
 class TestBilinearInitializer(unittest.TestCase):
     def test_bilinear_initializer(self, dtype="float32"):
         """Test the bilinear initializer with supplied arguments"""

--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -415,6 +415,234 @@ class TestXavierInitializer(unittest.TestCase):
         )
 
 
+class TestXavierInitializerPir(unittest.TestCase):
+    def setUp(self):
+        self.init_uniform_op_name = 'pd_op.uniform'
+        self.init_normal_op_name = 'pd_op.gaussian'
+        self.set_parameter_op_name = 'builtin.set_parameter'
+
+    def get_operand_definition_op_attrs(self, cur_op, operand_name, attr_name):
+        input_names = cur_op.get_input_names()
+        self.assertIn(operand_name, input_names)
+        attr = (
+            cur_op.operand(input_names.index(operand_name))
+            .source()
+            .get_defining_op()
+            .attrs()[attr_name]
+        )
+        return attr
+
+    def get_init_ops_by_op_name(self, block, op_name):
+        checked_ops = []
+        for op in block.ops:
+            # get init op
+            if op_name == op.name():
+                checked_ops.append(op)
+        return checked_ops
+
+    def test_uniform_xavier_initializer(self):
+        """Test Xavier initializer with uniform distribution on
+        for matrix multiply.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10],
+                    name="param",
+                    initializer=paddle.nn.initializer.XavierUniform(),
+                )
+
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_uniform_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                limit = np.sqrt(6.0 / (param.shape[0] + param.shape[1]))
+                min = self.get_operand_definition_op_attrs(
+                    init_op, "min", "value"
+                )
+                max = self.get_operand_definition_op_attrs(
+                    init_op, "max", "value"
+                )
+                self.assertAlmostEqual(min, -limit, delta=DELTA)
+                self.assertAlmostEqual(max, limit, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_uniform_xavier_initializer_conv(self):
+        """Test Xavier initializer with uniform distribution on
+        for convolutions.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10, 15, 20],
+                    name="param",
+                    initializer=paddle.nn.initializer.XavierUniform(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_uniform_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                receptive_field_size = float(15 * 20)
+                limit = np.sqrt(
+                    6.0
+                    / ((param.shape[0] + param.shape[1]) * receptive_field_size)
+                )
+                min = self.get_operand_definition_op_attrs(
+                    init_op, "min", "value"
+                )
+                max = self.get_operand_definition_op_attrs(
+                    init_op, "max", "value"
+                )
+                self.assertAlmostEqual(min, -limit, delta=DELTA)
+                self.assertAlmostEqual(max, limit, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_normal_xavier_initializer(self):
+        """Test Xavier initializer with normal distribution on
+        for matrix multiply.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10],
+                    name="param",
+                    initializer=paddle.nn.initializer.XavierNormal(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_normal_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                std = np.sqrt(2.0 / (param.shape[0] + param.shape[1]))
+                mean = init_op.attrs()["mean"]
+                std = init_op.attrs()["std"]
+                self.assertAlmostEqual(mean, 0.0, delta=DELTA)
+                self.assertAlmostEqual(std, std, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_normal_xavier_initializer_conv(self):
+        """Test Xavier initializer with normal distribution on
+        for convolutions.
+        """
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10, 15, 20],
+                    name="param",
+                    initializer=paddle.nn.initializer.XavierNormal(),
+                )
+                block = startup.global_block()
+                checked_ops = self.get_init_ops_by_op_name(
+                    block, self.init_normal_op_name
+                )
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                receptive_field_size = float(15 * 20)
+                std = np.sqrt(
+                    2.0
+                    / ((param.shape[0] + param.shape[1]) * receptive_field_size)
+                )
+                self.assertAlmostEqual(
+                    init_op.attrs()['mean'], 0.0, delta=DELTA
+                )
+                self.assertAlmostEqual(init_op.attrs()['std'], std, delta=DELTA)
+                self.assertEqual(init_op.attrs()['seed'], 0)
+
+    def test_xavier_initializer_supplied_arguments(
+        self, dtype="float32", uniform=True
+    ):
+        """Test the Xavier initializer with supplied arguments"""
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param = paddle.pir.core.create_parameter(
+                    dtype=dtype,
+                    shape=[5, 10],
+                    name="param",
+                    initializer=paddle.nn.initializer.XavierInitializer(
+                        uniform=uniform, fan_in=12, fan_out=23, seed=134
+                    ),
+                )
+                block = startup.global_block()
+                init_op_name = (
+                    self.init_uniform_op_name
+                    if uniform
+                    else self.init_normal_op_name
+                )
+
+                checked_ops = self.get_init_ops_by_op_name(block, init_op_name)
+                self.assertEqual(len(checked_ops), 1)
+                init_op = checked_ops[0]
+                if uniform:
+                    limit = np.sqrt(6.0 / (12 + 23))
+                    min = self.get_operand_definition_op_attrs(
+                        init_op, "min", "value"
+                    )
+                    max = self.get_operand_definition_op_attrs(
+                        init_op, "max", "value"
+                    )
+                    self.assertAlmostEqual(min, -limit, delta=DELTA)
+                    self.assertAlmostEqual(max, limit, delta=DELTA)
+
+                self.assertEqual(init_op.attrs()['seed'], 134)
+
+        return main, startup
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(), "core is not compiled with CUDA"
+    )
+    def test_xavier_initializer_fp16(self):
+        """Test the Xavier initializer with float16"""
+        main, startup = self.test_xavier_initializer_supplied_arguments(
+            "float16"
+        )
+        with paddle.pir_utils.IrGuard():
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe.run(startup)
+            exe.run(main)
+
+    @unittest.skipIf(
+        not paddle.base.core.is_compiled_with_cuda()
+        or not paddle.base.core.is_bfloat16_supported(paddle.CUDAPlace(0)),
+        "core is not compiled with CUDA and do not support bfloat16",
+    )
+    def test_xavier_initializer_bf16(self):
+        """Test the Xavier initializer with bfloat16"""
+        main_1, startup_1 = self.test_xavier_initializer_supplied_arguments(
+            "uint16"
+        )
+        with paddle.pir_utils.IrGuard():
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe.run(startup_1)
+            exe.run(main_1)
+
+        main_2, startup_2 = self.test_xavier_initializer_supplied_arguments(
+            "uint16", False
+        )
+        with paddle.pir_utils.IrGuard():
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe.run(startup_2)
+            exe.run(main_2)
+
+
 class TestMSRAInitializer(unittest.TestCase):
     def test_uniform_msra_initializer(self):
         """Test MSRA initializer with uniform distribution on

--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -528,10 +528,10 @@ class TestXavierInitializerPir(unittest.TestCase):
                 self.assertEqual(len(checked_ops), 1)
                 init_op = checked_ops[0]
                 std = np.sqrt(2.0 / (param.shape[0] + param.shape[1]))
-                mean = init_op.attrs()["mean"]
-                std = init_op.attrs()["std"]
-                self.assertAlmostEqual(mean, 0.0, delta=DELTA)
-                self.assertAlmostEqual(std, std, delta=DELTA)
+                self.assertAlmostEqual(
+                    init_op.attrs()["mean"], 0.0, delta=DELTA
+                )
+                self.assertAlmostEqual(init_op.attrs()["std"], std, delta=DELTA)
                 self.assertEqual(init_op.attrs()['seed'], 0)
 
     def test_normal_xavier_initializer_conv(self):


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
任务 issue: https://github.com/PaddlePaddle/Paddle/issues/58067

1. 将 paddle.nn.initializer.KaimingNormal 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

2. 将 paddle.nn.initializer.KaimingUniform 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

3. 将 paddle.nn.initializer.XavierNormal 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

4. 将 paddle.nn.initializer.XavierUniform 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

NOTE:
1. test/legacy_test/test_initializer_nn.py 下的 TestXavierNormal 单测和 test/legacy_test/test_initializer.py 下的 
TestXavierInitializer 单测相同，故前者不做迁移
2. test/legacy_test/test_initializer_nn.py 下的 TestKaimingInitializer 和 TestKaimingInitializer 单测和 test/legacy_test/test_initializer.py 下的 TestMSRAInitializer 单测相同，故前者不做迁移
3. test/legacy_test/test_layers.py 下的 test_batch_fc 单测使用 paddle.nn.initializer.XavierNormal 为 paddle.incubate.layers.nn.batch_fc 初始化参数，而该 api 为静态图专用 api，未找到动态图下相应 api，故不作迁移
4. test/legacy_test/test_layers.py 下的 test_rank_attention 单测使用 paddle.nn.initializer.XavierNormal 为 paddle.incubate.layers.nn.rank_attention 初始化参数，而该 api 为静态图专用 api，未找到动态图下相应 api，故不作迁移
