### PR TITLE
[Dy2St] remove `compare_legacy_with_pt` in dygraph_to_static

### DIFF
--- a/test/dygraph_to_static/test_dict.py
+++ b/test/dygraph_to_static/test_dict.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, compare_legacy_with_pt
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 from paddle import base
@@ -126,7 +126,6 @@ class TestNetWithDict(Dy2StTestBase):
         self.x = np.random.random([10, 16]).astype('float32')
         self.batch_size = self.x.shape[0]
 
-    @compare_legacy_with_pt
     def _run_static(self):
         return self.train(to_static=True)
 
@@ -182,7 +181,6 @@ class TestDictPop(Dy2StTestBase):
     def _set_test_func(self):
         self.dygraph_func = test_dic_pop
 
-    @compare_legacy_with_pt
     def _run_static(self):
         return self._run(to_static=True)
 

--- a/test/dygraph_to_static/test_layer_hook.py
+++ b/test/dygraph_to_static/test_layer_hook.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, compare_legacy_with_pt
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 
@@ -66,7 +66,6 @@ class TestNestLayerHook(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @compare_legacy_with_pt
     def train_net(self, to_static=False):
         paddle.seed(2022)
         net = SimpleNet()

--- a/test/dygraph_to_static/test_pir_selectedrows.py
+++ b/test/dygraph_to_static/test_pir_selectedrows.py
@@ -15,7 +15,7 @@
 import random
 import unittest
 
-from dygraph_to_static_utils import Dy2StTestBase, compare_legacy_with_pt
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 from paddle.jit.api import to_static
@@ -77,7 +77,6 @@ def train_dygraph():
     return train(net, adam, x)
 
 
-@compare_legacy_with_pt
 def train_static():
     paddle.seed(100)
     net = IRSelectedRowsTestNet()

--- a/test/dygraph_to_static/test_ptb_lm.py
+++ b/test/dygraph_to_static/test_ptb_lm.py
@@ -17,7 +17,7 @@ import time
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, compare_legacy_with_pt
+from dygraph_to_static_utils import Dy2StTestBase
 
 import paddle
 from paddle import base
@@ -315,7 +315,6 @@ def train_dygraph(place):
     return train(place)
 
 
-@compare_legacy_with_pt
 def train_static(place):
     paddle.jit.enable_to_static(True)
     return train(place)

--- a/test/dygraph_to_static/test_tensor_shape.py
+++ b/test/dygraph_to_static/test_tensor_shape.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    compare_legacy_with_pt,
     test_ast_only,
 )
 
@@ -266,7 +265,6 @@ class TestTensorShapeBasic(Dy2StTestBase):
     def get_dygraph_output(self):
         return self._run(to_static=False)
 
-    @compare_legacy_with_pt
     def get_static_output(self):
         return self._run(to_static=True)
 

--- a/test/dygraph_to_static/test_transformer.py
+++ b/test/dygraph_to_static/test_transformer.py
@@ -20,7 +20,7 @@ import unittest
 
 import numpy as np
 import transformer_util as util
-from dygraph_to_static_utils import Dy2StTestBase, compare_legacy_with_pt
+from dygraph_to_static_utils import Dy2StTestBase
 from transformer_dygraph_model import (
     CrossEntropyCriterion,
     Transformer,
@@ -36,7 +36,6 @@ SEED = 10
 STEP_NUM = 10
 
 
-@compare_legacy_with_pt
 def train_static(args, batch_generator):
     paddle.enable_static()
     paddle.seed(SEED)
@@ -419,7 +418,6 @@ def predict_dygraph(args, batch_generator):
         return seq_ids, seq_scores
 
 
-@compare_legacy_with_pt
 def predict_static(args, batch_generator):
     test_prog = base.Program()
     with base.program_guard(test_prog):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
remove compare_legacy_with_pt in dygraph_to_static
在 link #59312 中开启动转静 2x2+1的默认模式
compare_legacy_with_pt 现在只会浪费 CI 时间，因为我们已经通过单测生成的方式生成老的和 PT 单测 case 了
@SigureMo 