### PR TITLE
Delete gather_nd skip_transform field to enable CPU fallback

### DIFF
--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -1051,8 +1051,6 @@
     func : gather_nd
     data_type : x
   backward : gather_nd_grad
-  data_transform :
-    skip_transform : index
 
 - op : gather_tree
   args : (Tensor ids, Tensor parents)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Description
Delete gather_nd skip_transform field to enable CPU fallback
