### PR TITLE
[PIR]Fix cross_entropy_with_softmax vjp bug && check_grad passed

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -149,7 +149,7 @@ def gen_op_vjp_str(
             index_0 = fwd_outputs_list.index(bw_input_name)
         else:
             vjp_param_name = 'out_grads'
-            grad_idx += 1
+            grad_idx = fwd_outputs_list.index(bw_input_name[:-5])
             index_0 = grad_idx
         if op_grad_info.input_optional_list[idx] == 'true':
             if input_type == 'Tensor':

--- a/test/legacy_test/test_softmax_with_cross_entropy_op.py
+++ b/test/legacy_test/test_softmax_with_cross_entropy_op.py
@@ -160,11 +160,11 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         if core.is_compiled_with_rocm():
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"], "Loss", max_relative_error=5e-1, check_pir=False
+                    ["Logits"], "Loss", max_relative_error=5e-1, check_pir=True
                 )
             # HIP will have accuracy fail when using float32 in CPU place
             self.check_grad(
-                ["Logits"], "Loss", max_relative_error=5e-1, check_pir=False
+                ["Logits"], "Loss", max_relative_error=5e-1, check_pir=True
             )
         else:
             if self.python_api is not None:
@@ -172,10 +172,10 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
                     ["Logits"],
                     "Loss",
                     numeric_grad_delta=0.001,
-                    check_pir=False,
+                    check_pir=True,
                 )
             self.check_grad(
-                ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=False
+                ["Logits"], "Loss", numeric_grad_delta=0.001, check_pir=True
             )
 
 
@@ -517,9 +517,9 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
 
     def test_check_grad(self):
         if self.python_api is not None:
-            self.check_grad(["Logits"], "Loss", check_pir=False)
+            self.check_grad(["Logits"], "Loss", check_pir=True)
         self.check_grad(
-            ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
+            ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
         )
 
 
@@ -540,10 +540,10 @@ class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
     def test_check_grad(self):
         if self.python_api is not None:
             self.check_grad(
-                ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
+                ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
             )
         self.check_grad(
-            ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
+            ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
         )
 
 
@@ -574,15 +574,15 @@ class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):
             # HIP will have accuracy fail when using float32 in CPU place
             if self.python_api is not None:
                 self.check_grad(
-                    ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
+                    ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
                 )
             self.check_grad(
-                ["Logits"], "Loss", max_relative_error=0.1, check_pir=False
+                ["Logits"], "Loss", max_relative_error=0.1, check_pir=True
             )
         else:
             if self.python_api is not None:
-                self.check_grad(["Logits"], "Loss", check_pir=False)
-            self.check_grad(["Logits"], "Loss", check_pir=False)
+                self.check_grad(["Logits"], "Loss", check_pir=True)
+            self.check_grad(["Logits"], "Loss", check_pir=True)
 
 
 class TestSoftmaxWithCrossEntropyOp3(TestSoftmaxWithCrossEntropyOp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix cross_entropy_with_softmax vjp bug && check_grad passed
- cross_entropy_with_softmax 反向out_grads只需要第二个输出的梯度，原本的vjp生成逻辑是默认全部的梯度都被使用，因此获取out_grads的index是从0开始递增，在这种情况下会获取到不被使用的梯度，导致后面被使用的梯度被剪掉。修改生成逻辑变为根据out_grad变量名字去掉'_grad'找到对应out变量在output_list中的index，然后从grad列表中获取对应out_grad。
- 修复[#58682 ](https://github.com/PaddlePaddle/Paddle/pull/58682) 的反向报错问题，开启pir反向单测。