### PR TITLE
【PIR API adaptor No.257】Migrate paddle.Tensor.gcd into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5657,7 +5657,7 @@ def gcd(x, y, name=None):
         )
         return (paddle.where(x < y, y, x), paddle.where(x < y, x, y))
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         while _gcd_cond_fn(x, y):
             x, y = _gcd_body_fn(x, y)
 
@@ -5707,7 +5707,7 @@ def gcd_(x, y, name=None):
             paddle.where_(x >= y, x, y),
         )
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         while _gcd_cond_fn(x, y):
             y, x = _gcd_body_fn(x, y)
 

--- a/test/legacy_test/test_gcd.py
+++ b/test/legacy_test/test_gcd.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -30,6 +31,7 @@ class TestGcdAPI(unittest.TestCase):
         self.x_shape = [1]
         self.y_shape = [1]
 
+    @test_with_pir_api
     def test_static_graph(self):
         startup_program = base.Program()
         train_program = base.Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/58067
PIR API 推全升级
将算子迁移升级至 pir，并更新单测
paddle.Tensor.gcd（0/5）：添加test_with_pir_api时单测卡住没有结果
