### PR TITLE
[pir] get_input_names checks if OpYamlInfoInterface exists

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -399,6 +399,13 @@ void BindOperation(py::module *m) {
            })
       .def("get_input_names",
            [](Operation &self) -> py::list {
+             if (self.HasInterface<paddle::dialect::OpYamlInfoInterface>() ==
+                 false) {
+               PADDLE_THROW(phi::errors::InvalidArgument(
+                   "Currently, we can only get input names of Operation that "
+                   "has OpYamlInfoInterface"));
+             }
+
              py::list op_list;
              paddle::dialect::OpYamlInfoInterface yaml_interface =
                  self.dyn_cast<paddle::dialect::OpYamlInfoInterface>();

--- a/test/ir/pir/test_ir_pybind.py
+++ b/test/ir/pir/test_ir_pybind.py
@@ -213,6 +213,30 @@ class TestPybind(unittest.TestCase):
         self.assertIsInstance(a.id, str)
         self.assertIsInstance(result.id, str)
 
+    def test_operation_get_input_names_error(self):
+        """It will Raise error if operation `builtin.set_parameter` calls `get_input_names`. Because `builtin.set_parameter` does not have OpYamlInfoInterface"""
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                param1 = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[5, 10],
+                    name="param1",
+                    initializer=paddle.nn.initializer.Uniform(),
+                )
+
+                block = startup.global_block()
+                set_parameter_ops = [
+                    op
+                    for op in block.ops
+                    if op.name() == 'builtin.set_parameter'
+                ]
+                set_parameter_op = set_parameter_ops[0]
+                parameter_name = set_parameter_op.attrs()["parameter_name"]
+                with self.assertRaises(ValueError):
+                    input_names = set_parameter_op.get_input_names()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
一些 operation 不具有 `OpYamlInfoInterface` (比如 builtin.set_parameter )，其在使用 `get_input_names` 时会段错误。本 pr 为 get_input_names 添加检查
