### PR TITLE
fix the bug in moving skip_layernorm op to phi

### DIFF
--- a/paddle/phi/api/yaml/fused_ops.yaml
+++ b/paddle/phi/api/yaml/fused_ops.yaml
@@ -381,7 +381,7 @@
   infer_meta :
     func : SkipLayerNormInferMeta
   kernel :
-    func : skip_layer
+    func : skip_layernorm
     data_type : x
 
 - op : squeeze_excitation_block


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
fix the bug in this pr https://github.com/PaddlePaddle/Paddle/pull/58396