### PR TITLE
【PIR API adaptor No.282】 Migrate paddle.Tensor.nan_to_num into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1634,8 +1634,16 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None, name=None):
     posinf_value = paddle.full_like(x, float("+inf"))
     neginf_value = paddle.full_like(x, float("-inf"))
     nan = paddle.full_like(x, nan)
-    assert x.dtype in [paddle.float32, paddle.float64]
-    is_float32 = x.dtype == paddle.float32
+    assert x.dtype in [
+        paddle.float32,
+        paddle.float64,
+        paddle.base.core.DataType.FLOAT32,
+        paddle.base.core.DataType.FLOAT64,
+    ]
+    is_float32 = (
+        x.dtype == paddle.float32
+        or x.dtype == paddle.base.core.DataType.FLOAT32
+    )
     if posinf is None:
         posinf = (
             np.finfo(np.float32).max if is_float32 else np.finfo(np.float64).max
@@ -1647,8 +1655,8 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None, name=None):
         )
     neginf = paddle.full_like(x, neginf)
     x = paddle.where(paddle.isnan(x), nan, x)
-    x = paddle.where(x == posinf_value, posinf, x)
-    x = paddle.where(x == neginf_value, neginf, x)
+    x = paddle.where(paddle.equal(x, posinf_value), posinf, x)
+    x = paddle.where(paddle.equal(x, neginf_value), neginf, x)
     return x
 
 

--- a/test/legacy_test/test_nan_to_num_op.py
+++ b/test/legacy_test/test_nan_to_num_op.py
@@ -19,6 +19,7 @@ import numpy as np
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 # from op_test import OpTest
 
@@ -61,6 +62,7 @@ class TestNanToNum(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static(self):
         x_np = np.array([[1, np.nan, -2], [np.inf, 0, -np.inf]]).astype(
             np.float32


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级

https://github.com/PaddlePaddle/Paddle/issues/58067

No.282 将 paddle.Tensor.nan_to_num 迁移升级至 pir，并更新单测，单测覆盖率：1/1。