### PR TITLE
runtime(cinn): update cinn jit instruction to support dynamic shape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/attribute_storage.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/attribute_storage.h
@@ -77,12 +77,12 @@ struct GroupInfoAttributeStorage : public pir::AttributeStorage {
   ParamKey data_;
 };
 
-struct JITInfoAttributeStorage : public pir::AttributeStorage {
-  using ParamKey = cinn::hlir::framework::pir::CUDAJITInfo;
-  explicit JITInfoAttributeStorage(const ParamKey& key) : data_(key) {}
+struct CINNKernelInfoAttributeStorage : public pir::AttributeStorage {
+  using ParamKey = cinn::hlir::framework::pir::CINNKernelInfo;
+  explicit CINNKernelInfoAttributeStorage(const ParamKey& key) : data_(key) {}
 
-  static JITInfoAttributeStorage* Construct(const ParamKey& key) {
-    return new JITInfoAttributeStorage(key);
+  static CINNKernelInfoAttributeStorage* Construct(const ParamKey& key) {
+    return new CINNKernelInfoAttributeStorage(key);
   }
 
   static std::size_t HashValue(const ParamKey& key) {

--- a/paddle/cinn/hlir/dialect/operator/ir/op_attribute.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_attribute.cc
@@ -20,12 +20,12 @@ const GroupInfo &GroupInfoAttribute::data() const {
   return storage()->GetAsKey();
 }
 
-const cinn::hlir::framework::pir::CUDAJITInfo &CUDAJITInfoAttribute::data()
-    const {
+const cinn::hlir::framework::pir::CINNKernelInfo &
+CINNKernelInfoAttribute::data() const {
   return storage()->GetAsKey();
 }
 }  // namespace dialect
 }  // namespace cinn
 
 IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::GroupInfoAttribute)
-IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::CUDAJITInfoAttribute)
+IR_DEFINE_EXPLICIT_TYPE_ID(cinn::dialect::CINNKernelInfoAttribute)

--- a/paddle/cinn/hlir/dialect/operator/ir/op_attribute.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_attribute.h
@@ -33,22 +33,22 @@ class GroupInfoAttribute : public pir::Attribute {
   const GroupInfo& data() const;
 };
 
-class CUDAJITInfoAttribute : public pir::Attribute {
+class CINNKernelInfoAttribute : public pir::Attribute {
  public:
   using Attribute::Attribute;
 
-  DECLARE_ATTRIBUTE_UTILITY_FUNCTOR(CUDAJITInfoAttribute,
-                                    JITInfoAttributeStorage);
+  DECLARE_ATTRIBUTE_UTILITY_FUNCTOR(CINNKernelInfoAttribute,
+                                    CINNKernelInfoAttributeStorage);
 
-  bool operator<(const CUDAJITInfoAttribute& right) const {
+  bool operator<(const CINNKernelInfoAttribute& right) const {
     return storage() < right.storage();
   }
 
-  const cinn::hlir::framework::pir::CUDAJITInfo& data() const;
+  const cinn::hlir::framework::pir::CINNKernelInfo& data() const;
 };
 
 }  // namespace dialect
 }  // namespace cinn
 
 IR_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::GroupInfoAttribute)
-IR_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::CUDAJITInfoAttribute)
+IR_DECLARE_EXPLICIT_TYPE_ID(cinn::dialect::CINNKernelInfoAttribute)

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -41,7 +41,7 @@ void OperatorDialect::initialize() {
   RegisterOp<ConcatOp>();
   RegisterOp<SplitOp>();
   RegisterAttribute<GroupInfoAttribute>();
-  RegisterAttribute<CUDAJITInfoAttribute>();
+  RegisterAttribute<CINNKernelInfoAttribute>();
 }
 
 void OperatorDialect::PrintType(pir::Type type, std::ostream &os) const {}
@@ -57,8 +57,8 @@ void OperatorDialect::PrintAttribute(pir::Attribute attr,
          << "[" << data.fn_name << "]";
     }
     { os << "<#AttrNotImplemented>"; }
-  } else if (attr.isa<CUDAJITInfoAttribute>()) {
-    auto cuda_jit_info = attr.dyn_cast<CUDAJITInfoAttribute>();
+  } else if (attr.isa<CINNKernelInfoAttribute>()) {
+    auto cuda_jit_info = attr.dyn_cast<CINNKernelInfoAttribute>();
 
     os << "(" << cuda_jit_info.data().fn_ptr;
     os << ')';

--- a/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/op_dialect.cc
@@ -58,13 +58,13 @@ void OperatorDialect::PrintAttribute(pir::Attribute attr,
     }
     { os << "<#AttrNotImplemented>"; }
   } else if (attr.isa<CINNKernelInfoAttribute>()) {
-    auto cuda_jit_info = attr.dyn_cast<CINNKernelInfoAttribute>();
+    auto cinn_kernel_info = attr.dyn_cast<CINNKernelInfoAttribute>();
 
-    os << "(" << cuda_jit_info.data().fn_ptr;
+    os << "(" << cinn_kernel_info.data().fn_ptr;
     os << ')';
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
-        "cinn dialect only support GrupInfo and CUDAJITInfo"));
+        "cinn dialect only support GroupInfo and CINNKernelInfo"));
   }
 }
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/cinn_group_lowering_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/cinn_group_lowering_pass.cc
@@ -177,7 +177,7 @@ class GroupOpPattern : public pir::OpRewritePattern<cinn::dialect::GroupOp> {
       auto fn_ptr_res = ir_compiler->BuildCUDAJITInfo({group});
       std::unordered_map<std::string, ::pir::Attribute> op_attrs{
           {cinn::dialect::JitKernelOp::kAttrName,
-           cinn::dialect::CUDAJITInfoAttribute::get(ctx, fn_ptr_res[0])},
+           cinn::dialect::CINNKernelInfoAttribute::get(ctx, fn_ptr_res[0])},
       };
 
       // Generate jit kernel op input and output

--- a/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.cc
+++ b/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.cc
@@ -46,16 +46,16 @@ void JitKernelOp::VerifySig() {
 
   auto& attributes = this->attributes();
 
-  IR_ENFORCE(
-      attributes.count(kAttrName) > 0 &&
-          attributes.at(kAttrName).isa<cinn::dialect::CUDAJITInfoAttribute>(),
-      "Type of attribute: instruction is not right.");
+  IR_ENFORCE(attributes.count(kAttrName) > 0 &&
+                 attributes.at(kAttrName)
+                     .isa<cinn::dialect::CINNKernelInfoAttribute>(),
+             "Type of attribute: instruction is not right.");
 }
 
-const hlir::framework::pir::CUDAJITInfo& JitKernelOp::cuda_jit_info() {
+const hlir::framework::pir::CINNKernelInfo& JitKernelOp::cinn_kernel_info() {
   return attributes()
       .at(kAttrName)
-      .dyn_cast<cinn::dialect::CUDAJITInfoAttribute>()
+      .dyn_cast<cinn::dialect::CINNKernelInfoAttribute>()
       .data();
 }
 

--- a/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.h
+++ b/paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.h
@@ -27,7 +27,7 @@ class JitKernelOp : public ::pir::Op<JitKernelOp> {
   static const char* name() { return "cinn_runtime.jit_kernel"; }
   // TODO(Aurelius84): Think deeply what should contains
   static constexpr uint32_t attributes_num = 1;
-  static constexpr char* kAttrName = "jit_info";
+  static constexpr char* kAttrName = "kernel_info";
   static const char* attributes_name[attributes_num];
 
   static void Build(::pir::Builder& builder,             // NOLINT
@@ -36,7 +36,7 @@ class JitKernelOp : public ::pir::Op<JitKernelOp> {
                     const ::pir::AttributeMap& attributes,
                     const std::vector<::pir::Type>& out_types);
 
-  const hlir::framework::pir::CUDAJITInfo& cuda_jit_info();
+  const hlir::framework::pir::CINNKernelInfo& cinn_kernel_info();
 
   void VerifySig();
 };

--- a/paddle/cinn/hlir/framework/pir/compilation_task.cc
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.cc
@@ -90,6 +90,17 @@ std::unique_ptr<Instruction> CompilationTask::BuildInstruction() {
   return instr;
 }
 
+pir::CINNKernelInfo CompilationTask::BuildPirCINNKernelInfo() {
+  std::string fn_name = context_->group_->FuncName();
+  VLOG(4) << "Lookup kernel name: " << fn_name;
+  auto* fn_ptr = context_->backend_compiler_->Lookup(fn_name);
+  CHECK(fn_ptr);
+  pir::CINNKernelInfo cinn_kernel_info;
+  cinn_kernel_info.fn_ptr = fn_ptr;
+  cinn_kernel_info.int_args_map = context_->group_->int_args_map;
+  return cinn_kernel_info;
+}
+
 }  // namespace framework
 }  // namespace hlir
 }  // namespace cinn

--- a/paddle/cinn/hlir/framework/pir/compilation_task.h
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.h
@@ -63,6 +63,7 @@ class CompilationTask {
   void Lowering();
   void CodegenAndJit();
   std::unique_ptr<Instruction> BuildInstruction();
+  pir::CINNKernelInfo BuildPirCINNKernelInfo();
 
  private:
   GroupCompilationContext* context_;

--- a/paddle/cinn/hlir/framework/pir/group.h
+++ b/paddle/cinn/hlir/framework/pir/group.h
@@ -81,6 +81,7 @@ struct Group {
   std::vector<std::string> output_names;
   std::vector<::pir::Value> output_values;
   std::string fn_name{""};
+  std::map<int, CINNKernelInfo::ArgDimIdx> int_args_map;
 
   struct SharedGroupHasher {
     size_t operator()(const std::shared_ptr<Group>& group) const noexcept {

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -500,9 +500,7 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
           continue;
         }
         group->output_values.push_back(opresult);
-        // output arg tensors
         group_func_arg_tensors->push_back(tensor);
-        // output args
         group->output_names.push_back(tensor->name);
         group_func_args.emplace_back(tensor->buffer, ir::Argument::IO::kOutput);
       }

--- a/paddle/cinn/hlir/framework/pir/utils.h
+++ b/paddle/cinn/hlir/framework/pir/utils.h
@@ -31,15 +31,22 @@ namespace pir {
 struct CINNKernelInfo {
   void* fn_ptr;
 
-  // ArgDImId indicates the dim_idx dimension of the shape of the arg_idx
-  // argument in the kernel func parameter
   struct ArgDimIdx {
     int arg_idx;
     int dim_idx;
   };
   // int_args_map records the int_args_map.key argument (dtype is Int) in the
   // kernel parameter taken from the dim_idx dimension of the shape of the
-  // ArgDimIdx.arg_idx argument
+  // ArgDimIdx.arg_idx argument.
+  // Examples:
+  //   a func like: foo(tensor A, tensor B, int S1, int S2)
+  //   S1 = A.shape[3]
+  //   S2 = B.shape[2]
+  //   int_args_map will be like
+  //   {
+  //     2: {0, 3},
+  //     3: {1, 2}
+  //   }
   std::map<int, ArgDimIdx> int_args_map;
 };
 

--- a/paddle/cinn/hlir/framework/pir/utils.h
+++ b/paddle/cinn/hlir/framework/pir/utils.h
@@ -28,11 +28,19 @@ namespace framework {
 
 namespace pir {
 
-struct CUDAJITInfo {
+struct CINNKernelInfo {
   void* fn_ptr;
-  std::vector<int> block_dims;
-  std::vector<int> grid_dims;
-  void* compiler;
+
+  // ArgDImId indicates the dim_idx dimension of the shape of the arg_idx
+  // argument in the kernel func parameter
+  struct ArgDimIdx {
+    int arg_idx;
+    int dim_idx;
+  };
+  // int_args_map records the int_args_map.key argument (dtype is Int) in the
+  // kernel parameter taken from the dim_idx dimension of the shape of the
+  // ArgDimIdx.arg_idx argument
+  std::map<int, ArgDimIdx> int_args_map;
 };
 
 struct CompatibleInfo {

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -42,44 +42,51 @@ std::unique_ptr<Program> PirCompiler::Build() {
   return std::move(Build(groups));
 }
 
-std::vector<pir::CUDAJITInfo> PirCompiler::BuildCUDAJITInfo(
+std::vector<pir::CINNKernelInfo> PirCompiler::BuildCUDAJITInfo(
     const std::vector<pir::GroupPtr>& groups) {
-  std::vector<pir::CUDAJITInfo> vec_res;
+  std::vector<pir::CINNKernelInfo> cinn_kernel_info_vecs(groups.size());
 
-  auto op_lowerer = CreateOpLowerer<pir::GroupPtr>(target_);
+  if (FLAGS_cinn_bucket_compile) {
+    for (int i = 0; i < groups.size(); ++i) {
+      group_compilation_contexts_.emplace_back(target_, groups[i], scope_);
+    }
+    auto worker_fn = [&](int index) {
+      CompilationTask task(&group_compilation_contexts_[index]);
+      task();
+      cinn_kernel_info_vecs[index] = task.BuildPirCINNKernelInfo();
+    };
+    utils::parallel_run(
+        worker_fn, utils::SequenceDispatcher(0, groups.size()), -1);
+  } else {
+    auto op_lowerer = CreateOpLowerer<pir::GroupPtr>(target_);
 
-  std::vector<std::vector<ir::LoweredFunc>> lowered_funcs;
-  for (int i = 0; i < groups.size(); ++i) {
-    lowered_funcs.emplace_back(op_lowerer.Lower(groups[i]));
+    std::vector<std::vector<ir::LoweredFunc>> lowered_funcs;
+    for (int i = 0; i < groups.size(); ++i) {
+      lowered_funcs.emplace_back(op_lowerer.Lower(groups[i]));
+    }
+
+    for (auto&& lowered_func : lowered_funcs) {
+      ProcessFunction(lowered_func);
+    }
+    compiler_ = backends::Compiler::Create(target_);
+    auto build_module = m_builder_.Build();
+    compiler_->Build(build_module, "");
+
+    auto instructions = BuildInstructions(groups);
+
+    auto fn_ptrs = compiler_->GetFnPtr();
+
+    for (int idx = 0; idx < groups.size(); ++idx) {
+      pir::CINNKernelInfo cinn_kernel_info;
+      auto fn_name = groups[idx]->FuncName();
+      auto fn_ptr = compiler_->Lookup(fn_name);
+      cinn_kernel_info.fn_ptr = fn_ptr;
+      cinn_kernel_info.int_args_map = groups[idx]->int_args_map;
+
+      cinn_kernel_info_vecs[idx] = cinn_kernel_info;
+    }
   }
-
-  for (auto&& lowered_func : lowered_funcs) {
-    ProcessFunction(lowered_func);
-  }
-
-  compiler_ = backends::Compiler::Create(target_);
-  auto build_module = m_builder_.Build();
-  compiler_->Build(build_module, "");
-
-  auto instructions = BuildInstructions(groups);
-
-  auto fn_ptrs = compiler_->GetFnPtr();
-
-  auto* compilter_ptr = compiler_.release();
-  for (int idx = 0; idx < groups.size(); ++idx) {
-    pir::CUDAJITInfo jit_info;
-    jit_info.fn_ptr = fn_ptrs[idx];
-    jit_info.compiler = reinterpret_cast<void*>(compilter_ptr);
-
-    lowered_funcs[idx][0]->cuda_axis_info.CopyBlockDimsTo(
-        &(jit_info.block_dims));
-
-    lowered_funcs[idx][0]->cuda_axis_info.CopyGridDimsTo(&(jit_info.grid_dims));
-
-    vec_res.push_back(jit_info);
-  }
-
-  return vec_res;
+  return cinn_kernel_info_vecs;
 }
 
 std::unique_ptr<Program> PirCompiler::Build(

--- a/paddle/cinn/hlir/framework/pir_compiler.cc
+++ b/paddle/cinn/hlir/framework/pir_compiler.cc
@@ -72,8 +72,6 @@ std::vector<pir::CINNKernelInfo> PirCompiler::BuildCUDAJITInfo(
     auto build_module = m_builder_.Build();
     compiler_->Build(build_module, "");
 
-    auto instructions = BuildInstructions(groups);
-
     auto fn_ptrs = compiler_->GetFnPtr();
 
     for (int idx = 0; idx < groups.size(); ++idx) {

--- a/paddle/cinn/hlir/framework/pir_compiler.h
+++ b/paddle/cinn/hlir/framework/pir_compiler.h
@@ -41,7 +41,7 @@ class PirCompiler final {
 
   std::unique_ptr<Program> Build();
 
-  std::vector<pir::CUDAJITInfo> BuildCUDAJITInfo(
+  std::vector<pir::CINNKernelInfo> BuildCUDAJITInfo(
       const std::vector<pir::GroupPtr>& groups);
 
   std::unique_ptr<Program> Build(const std::vector<pir::GroupPtr>& groups);

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -22,47 +22,45 @@
 #include "paddle/fluid/framework/paddle2cinn/transform_type.h"
 #include "paddle/phi/core/errors.h"
 #if defined(PADDLE_WITH_CUDA)
-#include "paddle/cinn/runtime/cuda/cuda_util.h"
+#include "paddle/cinn/runtime/cinn_runtime.h"
 #endif
 
 namespace paddle {
 namespace framework {
 
+typedef void (*lower_func_ptr_g)(void*, int32_t, void*);
+
 class CinnJitInstruction::FnPtrImpl {
-  using CUDAJITInfo = cinn::hlir::framework::pir::CUDAJITInfo;
+  using CINNKernelInfo = cinn::hlir::framework::pir::CINNKernelInfo;
 
  public:
-  explicit FnPtrImpl(const CUDAJITInfo& cuda_jit_info)
-      : cuda_jit_info_(cuda_jit_info) {}
+  explicit FnPtrImpl(const CINNKernelInfo& cuda_kernel_info)
+      : cuda_kernel_info_(cuda_kernel_info) {}
+
   void Run(const std::vector<phi::DenseTensor*>& kernel_args, void* stream) {
     func_args_.clear();
-    ptr_storage_.resize(kernel_args.size());
+
+    // 1. Convert the phi::DenseTensor type to cinn_pod_value_t
     for (size_t i = 0; i < kernel_args.size(); ++i) {
-      ptr_storage_[i] = kernel_args[i]->data();
-      func_args_.push_back(ptr_storage_.data() + i);
+      auto* buffer = new cinn_buffer_t();
+      buffer->memory = reinterpret_cast<uint8_t*>(kernel_args[i]->data());
+      func_args_.emplace_back(buffer);
+    }
+    // 2. Convert arg's data about shape of Tensor to cinn_pod_value_t
+    for (const auto& int_arg_mp : cuda_kernel_info_.int_args_map) {
+      func_args_.emplace_back(kernel_args[int_arg_mp.second.arg_idx]->dims().at(
+          int_arg_mp.second.dim_idx));
     }
 
-#if defined(PADDLE_WITH_CUDA)
-    CUDA_DRIVER_CALL(
-        cuLaunchKernel(static_cast<CUfunction>(cuda_jit_info_.fn_ptr),
-                       cuda_jit_info_.grid_dims[0],
-                       cuda_jit_info_.grid_dims[1],
-                       cuda_jit_info_.grid_dims[2],
-                       cuda_jit_info_.block_dims[0],
-                       cuda_jit_info_.block_dims[1],
-                       cuda_jit_info_.block_dims[2],
-                       0,  // share memory
-                       static_cast<CUstream>(stream),
-                       func_args_.data(),
-                       nullptr))
-#endif
+        // 3. Launch host kernel
+        ((lower_func_ptr_g)cuda_kernel_info_.fn_ptr)(
+            static_cast <void*>(func_args_.data()), func_args_.size(), stream);
   }
 
  private:
-  CUDAJITInfo cuda_jit_info_;
+  CINNKernelInfo cuda_kernel_info_;
 
-  std::vector<void*> ptr_storage_;
-  std::vector<void*> func_args_;
+  std::vector<cinn_pod_value_t> func_args_;
 };
 
 CinnJitInstruction::CinnJitInstruction(
@@ -72,7 +70,7 @@ CinnJitInstruction::CinnJitInstruction(
     const ValueExecutionInfo& value_exec_info)
     : InstructionBase(id, place) {
   auto jit_kernel_op = op->dyn_cast<cinn::dialect::JitKernelOp>();
-  fn_ptr_impl_ = std::make_shared<FnPtrImpl>(jit_kernel_op.cuda_jit_info());
+  fn_ptr_impl_ = std::make_shared<FnPtrImpl>(jit_kernel_op.cinn_kernel_info());
   op_ = op;
 
   place_ = place;
@@ -122,12 +120,11 @@ void CinnJitInstruction::Run() {
   }
 
   fn_ptr_impl_->Run(tensor_args_, static_cast<void*>(stream));
-#endif
-
-#ifndef PADDLE_WITH_CUDA
+#else
   VLOG(phi::FATAL) << "Not Supported: cinn jit instruction currently does not "
                       "support non-CUDakernel";
 #endif
+
 }
 
 const std::string& CinnJitInstruction::Name() const {

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -34,8 +34,8 @@ class CinnJitInstruction::FnPtrImpl {
   using CINNKernelInfo = cinn::hlir::framework::pir::CINNKernelInfo;
 
  public:
-  explicit FnPtrImpl(const CINNKernelInfo& cuda_kernel_info)
-      : cuda_kernel_info_(cuda_kernel_info) {}
+  explicit FnPtrImpl(const CINNKernelInfo& cinn_kernel_info)
+      : cinn_kernel_info_(cinn_kernel_info) {}
 
   void Run(const std::vector<phi::DenseTensor*>& kernel_args, void* stream) {
     func_args_.clear();
@@ -47,18 +47,18 @@ class CinnJitInstruction::FnPtrImpl {
       func_args_.emplace_back(buffer);
     }
     // 2. Convert arg's data about shape of Tensor to cinn_pod_value_t
-    for (const auto& int_arg_mp : cuda_kernel_info_.int_args_map) {
+    for (const auto& int_arg_mp : cinn_kernel_info_.int_args_map) {
       func_args_.emplace_back(kernel_args[int_arg_mp.second.arg_idx]->dims().at(
           int_arg_mp.second.dim_idx));
     }
 
-        // 3. Launch host kernel
-        ((lower_func_ptr_g)cuda_kernel_info_.fn_ptr)(
-            static_cast <void*>(func_args_.data()), func_args_.size(), stream);
+    // 3. Launch host kernel
+    ((lower_func_ptr_g)cinn_kernel_info_.fn_ptr)(
+        static_cast<void*>(func_args_.data()), func_args_.size(), stream);
   }
 
  private:
-  CINNKernelInfo cuda_kernel_info_;
+  CINNKernelInfo cinn_kernel_info_;
 
   std::vector<cinn_pod_value_t> func_args_;
 };
@@ -122,9 +122,8 @@ void CinnJitInstruction::Run() {
   fn_ptr_impl_->Run(tensor_args_, static_cast<void*>(stream));
 #else
   VLOG(phi::FATAL) << "Not Supported: cinn jit instruction currently does not "
-                      "support non-CUDakernel";
+                      "support non-CUDA kernel";
 #endif
-
 }
 
 const std::string& CinnJitInstruction::Name() const {

--- a/test/cpp/pir/cinn/jit_instruction_test.cc
+++ b/test/cpp/pir/cinn/jit_instruction_test.cc
@@ -170,6 +170,7 @@ TEST(CinnJitInstruction, Run) {
   bool res1 = simple_cmp(out_tensor.data<float>()[1], 1.35701);
   bool res2 = simple_cmp(out_tensor.data<float>()[2], 1.35701);
   bool res3 = simple_cmp(out_tensor.data<float>()[3], 1.35701);
+
   EXPECT_EQ(res0, true);
   EXPECT_EQ(res1, true);
   EXPECT_EQ(res2, true);

--- a/test/cpp/pir/cinn/jit_instruction_test.cc
+++ b/test/cpp/pir/cinn/jit_instruction_test.cc
@@ -107,7 +107,7 @@ TEST(CinnJitInstruction, Run) {
       auto fn_ptr_res = ir_compiler->BuildCUDAJITInfo({group});
       std::unordered_map<std::string, ::pir::Attribute> op_attrs{
           {cinn::dialect::JitKernelOp::kAttrName,
-           cinn::dialect::CUDAJITInfoAttribute::get(ctx, fn_ptr_res[0])},
+           cinn::dialect::CINNKernelInfoAttribute::get(ctx, fn_ptr_res[0])},
       };
 
       auto out_type = it->result(0).type();
@@ -170,7 +170,6 @@ TEST(CinnJitInstruction, Run) {
   bool res1 = simple_cmp(out_tensor.data<float>()[1], 1.35701);
   bool res2 = simple_cmp(out_tensor.data<float>()[2], 1.35701);
   bool res3 = simple_cmp(out_tensor.data<float>()[3], 1.35701);
-
   EXPECT_EQ(res0, true);
   EXPECT_EQ(res1, true);
   EXPECT_EQ(res2, true);

--- a/test/cpp/pir/cinn/pir_compiler_test.cc
+++ b/test/cpp/pir/cinn/pir_compiler_test.cc
@@ -174,7 +174,7 @@ TEST(PirCompier, CompileSoftmax) {
 
   std::unordered_map<std::string, ::pir::Attribute> op_attrs{
       {cinn::dialect::JitKernelOp::kAttrName,
-       cinn::dialect::CUDAJITInfoAttribute::get(ctx, fn_ptr_res[0])},
+       cinn::dialect::CINNKernelInfoAttribute::get(ctx, fn_ptr_res[0])},
   };
 
   std::vector<pir::Type> vec_types;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
cinn jit instruction 支持动态shape。

- [x] 1. cinn jit instruction 由调用 cuda kernel ptr 改为 host kernel ptr

- [x] 2. CINNKernelInfo额外包含非tensor arg信息。数据结构详见代码注释。

以调用cos算子为例子，
host kernel cinn ir 如下
```cpp
Module Pir_host {
     function fn_cos (kernel_args, kernel_args_num, kernel_stream)
     cinn_call_cuda_kernel(fn_cos_kernel, kernel_args, kernel_args_num, 1, 1, 1, 4, 1, 1, kernel_stream)
}
```

cuda kernel cinn ir 如下

```cuda
function fn_cos_kernel (_var_0, _var_3)
 { 
   if ((threadIdx.x < 4)) {
      var_3[(threadIdx.x / 2), (threadIdx.x % 2)] = cinn_nvgpu_cos_fp32(var_0[(threadIdx.x / 2), (threadIdx.x % 2)])
   }
}

```

Pcard-78120
