### PR TITLE
【PIR API adaptor No.253、310】Migrate cumulative_trapezoid，trapezoid into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6438,7 +6438,7 @@ def _trapezoid(y, x=None, dx=None, axis=-1, mode='sum'):
         paddle.base.core.DataType.FLOAT64,
     ]:
         raise TypeError(
-            f"The data type of input must be Tensor, and dtype should be one of ['paddle.float16', 'paddle.float32', 'paddle.float64'], but got {y.dtype}"
+            f"The data type of input must be Tensor, and dtype should be one of ['paddle.float16', 'paddle.float32', 'paddle.float64', 'paddle.base.core.DataType.FLOAT16', 'paddle.base.core.DataType.FLOAT32', 'paddle.base.core.DataType.FLOAT64'], but got {y.dtype}"
         )
 
     y_shape = y.shape
@@ -6461,7 +6461,7 @@ def _trapezoid(y, x=None, dx=None, axis=-1, mode='sum'):
             paddle.base.core.DataType.FLOAT64,
         ]:
             raise TypeError(
-                f"The data type of input must be Tensor, and dtype should be one of ['paddle.float16', 'paddle.float32', 'paddle.float64'], but got {x.dtype}"
+                f"The data type of input must be Tensor, and dtype should be one of ['paddle.float16', 'paddle.float32', 'paddle.float64', 'paddle.base.core.DataType.FLOAT16', 'paddle.base.core.DataType.FLOAT32', 'paddle.base.core.DataType.FLOAT64'], but got {x.dtype}"
             )
         # Reshape to correct shape
         if x.dim() == 1:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6429,7 +6429,13 @@ def _trapezoid(y, x=None, dx=None, axis=-1, mode='sum'):
 
     if not (x is None or dx is None):
         raise ValueError("Not permitted to specify both x and dx input args.")
-    if y.dtype not in [paddle.float16, paddle.float32, paddle.float64]:
+    if y.dtype not in [
+        paddle.float16,
+        paddle.float32,
+        paddle.float64,
+        paddle.base.core.DataType.FLOAT32,
+        paddle.base.core.DataType.FLOAT64,
+    ]:
         raise TypeError(
             f"The data type of input must be Tensor, and dtype should be one of ['paddle.float16', 'paddle.float32', 'paddle.float64'], but got {y.dtype}"
         )
@@ -6445,7 +6451,13 @@ def _trapezoid(y, x=None, dx=None, axis=-1, mode='sum'):
         if dx.dim() > 1:
             raise ValueError(f'Expected dx to be a scalar, got dx={dx}')
     else:
-        if x.dtype not in [paddle.float16, paddle.float32, paddle.float64]:
+        if x.dtype not in [
+            paddle.float16,
+            paddle.float32,
+            paddle.float64,
+            paddle.base.core.DataType.FLOAT32,
+            paddle.base.core.DataType.FLOAT64,
+        ]:
             raise TypeError(
                 f"The data type of input must be Tensor, and dtype should be one of ['paddle.float16', 'paddle.float32', 'paddle.float64'], but got {x.dtype}"
             )

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6433,6 +6433,7 @@ def _trapezoid(y, x=None, dx=None, axis=-1, mode='sum'):
         paddle.float16,
         paddle.float32,
         paddle.float64,
+        paddle.base.core.DataType.FLOAT16,
         paddle.base.core.DataType.FLOAT32,
         paddle.base.core.DataType.FLOAT64,
     ]:
@@ -6455,6 +6456,7 @@ def _trapezoid(y, x=None, dx=None, axis=-1, mode='sum'):
             paddle.float16,
             paddle.float32,
             paddle.float64,
+            paddle.base.core.DataType.FLOAT16,
             paddle.base.core.DataType.FLOAT32,
             paddle.base.core.DataType.FLOAT64,
         ]:

--- a/test/legacy_test/test_trapezoid.py
+++ b/test/legacy_test/test_trapezoid.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestTrapezoidAPI(unittest.TestCase):
@@ -63,6 +64,7 @@ class TestTrapezoidAPI(unittest.TestCase):
         self.setUp()
         self.func_dygraph()
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         places = [paddle.CPUPlace()]
@@ -226,6 +228,7 @@ class Testfp16Trapezoid(TestTrapezoidAPI):
         self.paddle_api = paddle.trapezoid
         self.ref_api = np.trapz
 
+    @test_with_pir_api
     def test_fp16_with_gpu(self):
         paddle.enable_static()
         if paddle.base.core.is_compiled_with_cuda():

--- a/test/legacy_test/test_trapezoid.py
+++ b/test/legacy_test/test_trapezoid.py
@@ -164,6 +164,7 @@ class TestTrapezoidError(unittest.TestCase):
     def set_api(self):
         self.paddle_api = paddle.trapezoid
 
+    @test_with_pir_api
     def test_errors(self):
         self.set_api()
         with paddle.static.program_guard(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
* https://github.com/PaddlePaddle/Paddle/issues/58067
No.253 paddle.cumulative_trapezoid
No.310 paddle.Tensor.trapezoid
将 `paddle.cumulative_trapezoid` 迁移升级至 pir，并更新单测  单测覆盖率 9/9
将 `paddle.Tensor.trapezoid` 迁移升级至 pir，并更新单测 单测覆盖率 13/13

cumulative_trapezoid和trapezoid 都是调用的 _trapezoid
根据传入参数判断是使用sum还是cumsum。
trapezoid 用sum
cumulative_trapezoid 用 cumsum。
sum和cumsum前期都已完成迁移。