### PR TITLE
feat(custom_reducer): size_1_tensor_not_concat/split

### DIFF
--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -429,6 +429,9 @@ void EagerGroup::ConcatTensors(const platform::Place &place) {
 
 void EagerGroup::SplitTensors(const platform::DeviceContext &context) {
   auto place = context.GetPlace();
+  if (dense_tensors_.size() == 1) {
+    return;
+  }
   if (platform::is_gpu_place(place)) {
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
     auto &gpu_context = static_cast<const phi::GPUContext &>(context);
@@ -448,9 +451,6 @@ void EagerGroup::SplitTensors(const platform::DeviceContext &context) {
 #endif
   } else if (platform::is_custom_place(place)) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
-    if (dense_tensors_.size() == 1) {
-      return;
-    }
     SplitTensorsWithType(
         static_cast<const platform::CustomDeviceContext &>(context),
         &dense_contents_,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
OPs

### Description
场景：
模型中权重分配不均匀，有个别层，权重很大，导致当前bucket中只有这一个gradient_tensor需要梯度规约

实现：
对于当前group bucket中，只有一个大梯度tensor的情况，不进行concat或split操作，直接ShareDataWith即可

效果：
可大幅提升ppocr系列个别小模型并行效率
