### PR TITLE
[Paddle-TRT] Enforce use new executor for trt engine memory sharing

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -370,6 +370,13 @@ AnalysisPredictor::AnalysisPredictor(const AnalysisConfig &config)
            "is enabled in Paddle-TRT, we set the id of these predictors to "
            "negative sharing_identifier you specified : "
         << predictor_id_;
+    PADDLE_ENFORCE_EQ(
+        config_.new_executor_enabled(),
+        true,
+        platform::errors::InvalidArgument(
+            "Please call the config.enable_new_executor() in python or "
+            "config.EnableNewExecutor() in c++ when you want share the engine "
+            "context memory of multiple predictors."));
   } else {
     predictor_id_ = inference::GetUniqueId();
   }

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -842,6 +842,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
       params.enable_low_precision_io = Attr<bool>("enable_low_precision_io");
       params.use_inspector = Attr<bool>("use_inspector");
       params.engine_info_path = Attr<std::string>("engine_info_path");
+      params.optimization_level = Attr<int>("optimization_level");
 
       if (!shape_range_info_path_.empty()) {
         inference::DeserializeShapeRangeInfo(shape_range_info_path_,

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -835,15 +835,30 @@ class TensorRTEngineOp : public framework::OperatorBase {
       params.calibrator = calibrator_.get();
       params.device_id = dev_place.device;
       params.with_dynamic_shape = with_dynamic_shape_;
-      params.context_memory_sharing = Attr<bool>("context_memory_sharing");
-      params.use_dla = Attr<bool>("use_dla");
-      params.dla_core = Attr<int>("dla_core");
-      params.disable_trt_plugin_fp16 = Attr<bool>("disable_trt_plugin_fp16");
-      params.enable_low_precision_io = Attr<bool>("enable_low_precision_io");
-      params.use_inspector = Attr<bool>("use_inspector");
-      params.engine_info_path = Attr<std::string>("engine_info_path");
-      params.optimization_level = Attr<int>("optimization_level");
-
+      if (HasAttr("context_memory_sharing")) {
+        params.context_memory_sharing = Attr<bool>("context_memory_sharing");
+      }
+      if (HasAttr("use_dla")) {
+        params.use_dla = Attr<bool>("use_dla");
+      }
+      if (HasAttr("dla_core")) {
+        params.dla_core = Attr<int>("dla_core");
+      }
+      if (HasAttr("disable_trt_plugin_fp16")) {
+        params.disable_trt_plugin_fp16 = Attr<bool>("disable_trt_plugin_fp16");
+      }
+      if (HasAttr("enable_low_precision_io")) {
+        params.enable_low_precision_io = Attr<bool>("enable_low_precision_io");
+      }
+      if (HasAttr("use_inspector")) {
+        params.use_inspector = Attr<bool>("use_inspector");
+      }
+      if (HasAttr("engine_info_path")) {
+        params.engine_info_path = Attr<std::string>("engine_info_path");
+      }
+      if (HasAttr("optimization_level")) {
+        params.optimization_level = Attr<int>("optimization_level");
+      }
       if (!shape_range_info_path_.empty()) {
         inference::DeserializeShapeRangeInfo(shape_range_info_path_,
                                              &params.min_input_shape,

--- a/test/ir/inference/test_trt_inference_fp16_io.py
+++ b/test/ir/inference/test_trt_inference_fp16_io.py
@@ -106,8 +106,9 @@ class TestEnableLowPrecisionIOWithTRTAllGraph(
             use_static=False,
             use_calib_mode=False,
         )
+        config.enable_tensorrt_memory_optim(True, 1)
         config.enable_tuned_tensorrt_dynamic_shape()
-        config.enable_memory_optim()
+        config.enable_new_executor()
         config.enable_low_precision_io(low_precision_io)
         config.disable_glog_info()
         predictor = create_predictor(config)
@@ -131,8 +132,9 @@ class TestEnableLowPrecisionIOWithTRTSubGraph(
             use_static=False,
             use_calib_mode=False,
         )
+        config.enable_tensorrt_memory_optim(True, 1)
         config.enable_tuned_tensorrt_dynamic_shape()
-        config.enable_memory_optim()
+        config.enable_new_executor()
         config.enable_low_precision_io(low_precision_io)
         config.exp_disable_tensorrt_ops(["flatten_contiguous_range"])
         config.disable_glog_info()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- Enforce use new executor for trt engine memory sharing
- add ut for trt engine memory sharing
### Others
Pcard-71500