### PR TITLE
【PIR API adaptor No.181】Migrate repeat_interleave op into pir and enable cond test in pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4931,7 +4931,7 @@ def repeat_interleave(x, repeats, axis=None, name=None):
         x = paddle.flatten(x)
         axis = 0
     if in_dynamic_or_pir_mode():
-        if isinstance(repeats, (Variable, paddle.pir.OpResult)):
+        if isinstance(repeats, (Variable, paddle.pir.Value)):
             return _C_ops.repeat_interleave_with_tensor_index(x, repeats, axis)
         return _C_ops.repeat_interleave(x, repeats, axis)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4923,7 +4923,7 @@ def repeat_interleave(x, repeats, axis=None, name=None):
             [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6])
     """
     if (
-        isinstance(repeats, (Variable, paddle.pir.OpResult))
+        isinstance(repeats, (Variable, paddle.pir.Value))
         and not repeats.shape
     ):
         repeats = paddle.reshape(repeats, [1])

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4922,14 +4922,16 @@ def repeat_interleave(x, repeats, axis=None, name=None):
             Tensor(shape=[12], dtype=int64, place=Place(cpu), stop_gradient=True,
             [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6])
     """
-
-    if isinstance(repeats, Variable) and not repeats.shape:
+    if (
+        isinstance(repeats, (Variable, paddle.pir.OpResult))
+        and not repeats.shape
+    ):
         repeats = paddle.reshape(repeats, [1])
     if axis is None:
         x = paddle.flatten(x)
         axis = 0
-    if in_dynamic_mode():
-        if isinstance(repeats, Variable):
+    if in_dynamic_or_pir_mode():
+        if isinstance(repeats, (Variable, paddle.pir.OpResult)):
             return _C_ops.repeat_interleave_with_tensor_index(x, repeats, axis)
         return _C_ops.repeat_interleave(x, repeats, axis)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4922,10 +4922,7 @@ def repeat_interleave(x, repeats, axis=None, name=None):
             Tensor(shape=[12], dtype=int64, place=Place(cpu), stop_gradient=True,
             [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6])
     """
-    if (
-        isinstance(repeats, (Variable, paddle.pir.Value))
-        and not repeats.shape
-    ):
+    if isinstance(repeats, (Variable, paddle.pir.Value)) and not repeats.shape:
         repeats = paddle.reshape(repeats, [1])
     if axis is None:
         x = paddle.flatten(x)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ from setuptools.dist import Distribution
 # check python
 python_version = platform.python_version()
 version_detail = sys.version_info
-version = str(version_detail[0]) + '.' + str(version_detail[1]) 
+version = str(version_detail[0]) + '.' + str(version_detail[1])
 env_version = str(os.getenv("PY_VERSION"))
 
 if version_detail < (3, 7):
@@ -57,14 +57,12 @@ elif env_version != version:
         f"we will attempt to use the python version you set to execute."
     )
     cmd = 'which python' + env_version
-    res = subprocess.run(cmd, shell = True, stdout=subprocess.PIPE)
+    res = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
     if res.returncode == 0:
         os.environ["PYTHON_EXECUTABLE"] = res
     else:
-        raise RuntimeError(
-            "We can't find the version you set in your machine"
-        )
-        
+        raise RuntimeError("We can't find the version you set in your machine")
+
 
 # check cmake
 CMAKE = shutil.which('cmake3') or shutil.which('cmake')

--- a/test/legacy_test/test_linalg_cond.py
+++ b/test/legacy_test/test_linalg_cond.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 from paddle import static
+from paddle.pir_utils import test_with_pir_api
 
 p_list_n_n = ("fro", "nuc", 1, -1, np.inf, -np.inf)
 p_list_m_n = (None, 2, -2)
@@ -82,6 +83,7 @@ def gen_empty_input():
 
 
 class API_TestStaticCond(unittest.TestCase):
+    @test_with_pir_api
     def test_out(self):
         paddle.enable_static()
         # test calling results of 'cond' in static graph mode
@@ -115,6 +117,7 @@ class TestCondAPIError(unittest.TestCase):
                 x_tensor = paddle.to_tensor(x)
                 self.assertRaises(ValueError, paddle.linalg.cond, x_tensor, p)
 
+    @test_with_pir_api
     def test_static_api_error(self):
         paddle.enable_static()
         # test raising errors when 'cond' is called in static graph mode

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -19,7 +19,7 @@ from op_test import OpTest
 
 import paddle
 from paddle import base
-from paddle.base import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestRepeatInterleaveOp(OpTest):
@@ -115,25 +115,31 @@ class TestIndexSelectAPI(unittest.TestCase):
         self.data_zero_dim_index = np.array(2)
         self.data_index = np.array([0, 1, 2, 1]).astype('int32')
 
+    @test_with_pir_api
     def test_repeat_interleave_api(self):
         paddle.enable_static()
         self.input_data()
 
         # case 1:
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
-            x.desc.set_need_check_feed(False)
             index = paddle.static.data(
                 name='repeats_',
                 shape=[4],
                 dtype='int32',
             )
-            index.desc.set_need_check_feed(False)
+            if not paddle.framework.in_pir_mode():
+                x.desc.set_need_check_feed(False)
+                index.desc.set_need_check_feed(False)
+            x.stop_gradient = False
+            index.stop_gradient = False
             z = paddle.repeat_interleave(x, index, axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': self.data_x, 'repeats_': self.data_index},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.repeat(self.data_x, self.data_index, axis=1)
@@ -141,15 +147,18 @@ class TestIndexSelectAPI(unittest.TestCase):
 
         # case 2:
         repeats = np.array([1, 2, 1]).astype('int32')
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(name='x', shape=[-1, 4], dtype="float32")
-            x.desc.set_need_check_feed(False)
             index = paddle.static.data(
                 name='repeats_',
                 shape=[3],
                 dtype='int32',
             )
-            index.desc.set_need_check_feed(False)
+            if not paddle.framework.in_pir_mode():
+                x.desc.set_need_check_feed(False)
+                index.desc.set_need_check_feed(False)
             z = paddle.repeat_interleave(x, index, axis=0)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
@@ -157,53 +166,64 @@ class TestIndexSelectAPI(unittest.TestCase):
                     'x': self.data_x,
                     'repeats_': repeats,
                 },
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.repeat(self.data_x, repeats, axis=0)
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
         repeats = 2
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
-            x.desc.set_need_check_feed(False)
             z = paddle.repeat_interleave(x, repeats, axis=0)
+            if not paddle.framework.in_pir_mode():
+                x.desc.set_need_check_feed(False)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
-                feed={'x': self.data_x}, fetch_list=[z.name], return_numpy=False
+                feed={'x': self.data_x}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.repeat(self.data_x, repeats, axis=0)
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
         # case 3 zero_dim:
-        with program_guard(Program(), Program()):
-            x = paddle.static.data(name='x', shape=[-1], dtype="float32")
-            x.desc.set_need_check_feed(False)
-            z = paddle.repeat_interleave(x, repeats)
-            exe = base.Executor(base.CPUPlace())
-            (res,) = exe.run(
-                feed={'x': self.data_zero_dim_x},
-                fetch_list=[z.name],
-                return_numpy=False,
-            )
-        expect_out = np.repeat(self.data_zero_dim_x, repeats)
-        np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
+        if not paddle.framework.in_pir_mode():
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
+                x = paddle.static.data(name='x', shape=[-1], dtype="float32")
+                if not paddle.framework.in_pir_mode():
+                    x.desc.set_need_check_feed(False)
+                z = paddle.repeat_interleave(x, repeats)
+                exe = base.Executor(base.CPUPlace())
+                (res,) = exe.run(
+                    feed={'x': self.data_zero_dim_x},
+                    fetch_list=[z],
+                    return_numpy=False,
+                )
+            expect_out = np.repeat(self.data_zero_dim_x, repeats)
+            np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
         # case 4 negative axis:
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
-            x.desc.set_need_check_feed(False)
             index = paddle.static.data(
                 name='repeats_',
                 shape=[4],
                 dtype='int32',
             )
-            index.desc.set_need_check_feed(False)
+
+            if not paddle.framework.in_pir_mode():
+                x.desc.set_need_check_feed(False)
+                index.desc.set_need_check_feed(False)
             z = paddle.repeat_interleave(x, index, axis=-1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': self.data_x, 'repeats_': self.data_index},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.repeat(self.data_x, self.data_index, axis=-1)

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -58,10 +58,10 @@ class TestRepeatInterleaveOp(OpTest):
         self.index_size = self.x_shape[self.dim]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestRepeatInterleaveOp2(OpTest):
@@ -96,10 +96,10 @@ class TestRepeatInterleaveOp2(OpTest):
         self.index_size = self.x_shape[self.dim]
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_pir=True)
 
 
 class TestIndexSelectAPI(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将如下算子迁移升级至 pir，并更新单测

- `cond`：2/2
- `repeat_interleave`: 5/5