### PR TITLE
【PIR API adaptor No.261、273、283、285、286、313、315】 Migrate is_tensor/median/nanmean/nansum/neg/Unflatten/var into pir

### DIFF
--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -1108,7 +1108,7 @@ def is_tensor(x):
     """
     if in_dynamic_or_pir_mode():
         return isinstance(
-            x, (Tensor, paddle.base.core.eager.Tensor, paddle.pir.OpResult)
+            x, (Tensor, paddle.base.core.eager.Tensor, paddle.pir.Value)
         )
     else:
         return isinstance(x, Variable)

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -1106,8 +1106,10 @@ def is_tensor(x):
             False
 
     """
-    if in_dynamic_mode():
-        return isinstance(x, (Tensor, paddle.base.core.eager.Tensor))
+    if in_dynamic_or_pir_mode():
+        return isinstance(
+            x, (Tensor, paddle.base.core.eager.Tensor, paddle.pir.OpResult)
+        )
     else:
         return isinstance(x, Variable)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5596,7 +5596,7 @@ def unflatten(x, axis, shape, name=None):
         new_shape = (
             list(x.shape[:axis]) + list(shape) + list(x.shape[axis + 1 :])
         )
-    elif isinstance(shape, Variable):
+    elif isinstance(shape, (Variable, paddle.pir.OpResult)):
         # The data type returned by `paddle.shape` is only 'int32'.
         new_shape = paddle.concat(
             [

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5596,7 +5596,7 @@ def unflatten(x, axis, shape, name=None):
         new_shape = (
             list(x.shape[:axis]) + list(shape) + list(x.shape[axis + 1 :])
         )
-    elif isinstance(shape, (Variable, paddle.pir.OpResult)):
+    elif isinstance(shape, (Variable, paddle.pir.Value)):
         # The data type returned by `paddle.shape` is only 'int32'.
         new_shape = paddle.concat(
             [

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -16,6 +16,7 @@
 
 import paddle
 from paddle import _C_ops
+from paddle.base.libpaddle import DataType
 from paddle.framework import in_dynamic_mode, in_dynamic_or_pir_mode
 
 from ..base.data_feeder import check_type, check_variable_and_dtype
@@ -403,7 +404,7 @@ def median(x, axis=None, keepdim=False, name=None):
             [[4., 5., 6., 7.]])
 
     """
-    if not isinstance(x, Variable):
+    if not isinstance(x, (Variable, paddle.pir.OpResult)):
         raise TypeError("In median, the input x should be a Tensor.")
 
     if x.size == 0:
@@ -435,7 +436,11 @@ def median(x, axis=None, keepdim=False, name=None):
     sz = x.shape[axis]
     kth = sz >> 1
     tensor_topk, idx = paddle.topk(x, kth + 1, axis=axis, largest=False)
-    dtype = 'float64' if x.dtype == core.VarDesc.VarType.FP64 else 'float32'
+    dtype = (
+        'float64'
+        if x.dtype in [core.VarDesc.VarType.FP64, DataType.FLOAT64]
+        else 'float32'
+    )
     if sz & 1 == 0:
         out_tensor = paddle.slice(
             tensor_topk, axes=[axis], starts=[kth - 1], ends=[kth]

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -313,7 +313,7 @@ def nanmedian(x, axis=None, keepdim=False, name=None):
             >>> print(y4.numpy())
             2.0
     """
-    if not isinstance(x, Variable):
+    if not isinstance(x, (Variable, paddle.pir.OpResult)):
         raise TypeError("In median, the input x should be a Tensor.")
 
     if isinstance(axis, (list, tuple)) and len(axis) == 0:

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -314,7 +314,7 @@ def nanmedian(x, axis=None, keepdim=False, name=None):
             >>> print(y4.numpy())
             2.0
     """
-    if not isinstance(x, (Variable, paddle.pir.OpResult)):
+    if not isinstance(x, (Variable, paddle.pir.Value)):
         raise TypeError("In median, the input x should be a Tensor.")
 
     if isinstance(axis, (list, tuple)) and len(axis) == 0:
@@ -404,7 +404,7 @@ def median(x, axis=None, keepdim=False, name=None):
             [[4., 5., 6., 7.]])
 
     """
-    if not isinstance(x, (Variable, paddle.pir.OpResult)):
+    if not isinstance(x, (Variable, paddle.pir.Value)):
         raise TypeError("In median, the input x should be a Tensor.")
 
     if in_dynamic_mode() and x.size == 0:

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -407,7 +407,8 @@ def median(x, axis=None, keepdim=False, name=None):
     if not isinstance(x, (Variable, paddle.pir.OpResult)):
         raise TypeError("In median, the input x should be a Tensor.")
 
-    if x.size == 0:
+    if in_dynamic_mode() and x.size == 0:
+        # TODO: Currently, `__eq__` don't support arguments (`pir.Value` & `int`)
         raise ValueError("In median, the size of input x should not be 0.")
 
     is_flatten = False

--- a/test/legacy_test/test_bce_with_logits_loss.py
+++ b/test/legacy_test/test_bce_with_logits_loss.py
@@ -167,7 +167,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
                 np.testing.assert_allclose(dy_functional, expected, rtol=1e-05)
 
                 @test_with_pir_api
-                def test_dynamic_or_pir_mode():
+                def test_static_or_pir_mode():
                     static_result = test_static(
                         place, logit_np, label_np, reduction=reduction
                     )
@@ -192,7 +192,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
                         static_functional, dy_functional, rtol=1e-05
                     )
 
-                test_dynamic_or_pir_mode()
+                test_static_or_pir_mode()
 
     def test_BCEWithLogitsLoss_weight(self):
         logit_np = np.random.uniform(0.1, 0.8, size=(2, 3, 4, 10)).astype(
@@ -230,7 +230,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
             np.testing.assert_allclose(dy_functional, expected, rtol=1e-05)
 
             @test_with_pir_api
-            def test_dynamic_or_pir_mode():
+            def test_static_or_pir_mode():
                 static_result = test_static(
                     place,
                     logit_np,
@@ -257,7 +257,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
                     static_functional, dy_functional, rtol=1e-05
                 )
 
-            test_dynamic_or_pir_mode()
+            test_static_or_pir_mode()
 
     def test_BCEWithLogitsLoss_pos_weight(self):
         logit_np = np.random.uniform(0.1, 0.8, size=(2, 3, 4, 10)).astype(
@@ -294,7 +294,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_functional, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             static_result = test_static(
                 place, logit_np, label_np, weight_np, reduction, pos_weight_np
             )
@@ -315,7 +315,7 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
                 static_functional, dy_functional, rtol=1e-05
             )
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_BCEWithLogitsLoss_error(self):
         paddle.disable_static()

--- a/test/legacy_test/test_is_tensor.py
+++ b/test/legacy_test/test_is_tensor.py
@@ -15,6 +15,7 @@
 import unittest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 DELTA = 0.00001
 
@@ -49,10 +50,12 @@ class TestIsTensorStatic(unittest.TestCase):
     def tearDown(self):
         paddle.disable_static()
 
+    @test_with_pir_api
     def test_is_tensor(self):
         x = paddle.rand([3, 2, 4], dtype='float32')
         self.assertTrue(paddle.is_tensor(x))
 
+    @test_with_pir_api
     def test_is_tensor_array(self):
         x = paddle.tensor.create_array('float32')
         self.assertTrue(paddle.is_tensor(x))

--- a/test/legacy_test/test_median.py
+++ b/test/legacy_test/test_median.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.static import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 DELTA = 1e-6
 
@@ -32,10 +32,10 @@ class TestMedian(unittest.TestCase):
         paddle.enable_static()
         x, axis, keepdims = lis_test
         res_np = np.median(x, axis=axis, keepdims=keepdims)
-        main_program = Program()
-        startup_program = Program()
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
         exe = paddle.static.Executor()
-        with program_guard(main_program, startup_program):
+        with paddle.static.program_guard(main_program, startup_program):
             x_in = paddle.static.data(shape=x.shape, dtype=x.dtype, name='x')
             y = paddle.median(x_in, axis, keepdims)
             [res_pd] = exe.run(feed={'x': x}, fetch_list=[y])
@@ -48,6 +48,7 @@ class TestMedian(unittest.TestCase):
         res_pd = paddle.median(paddle.to_tensor(x), axis, keepdims)
         self.check_numpy_res(res_pd.numpy(False), res_np)
 
+    @test_with_pir_api
     def test_median_static(self):
         h = 3
         w = 4

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(10)
 
@@ -38,6 +39,7 @@ class TestNanmeanAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_api_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -87,6 +89,7 @@ class TestNanmeanAPI(unittest.TestCase):
         test_case(self.x, [0, 1, 2, 3])
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_nansum_api.py
+++ b/test/legacy_test/test_nansum_api.py
@@ -18,9 +18,11 @@ import numpy as np
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class API_Test_Nansum(unittest.TestCase):
+    @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
         startup_program = base.Program()
@@ -75,6 +77,7 @@ class API_Test_Nansum(unittest.TestCase):
             )
 
     # test nansum api with float16
+    @test_with_pir_api
     def test_static_graph_fp16(self):
         paddle.enable_static()
         startup_program = paddle.static.Program()

--- a/test/legacy_test/test_nansum_api.py
+++ b/test/legacy_test/test_nansum_api.py
@@ -25,9 +25,9 @@ class API_Test_Nansum(unittest.TestCase):
     @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(train_program, startup_program):
+        startup_program = paddle.static.Program()
+        train_program = paddle.static.Program()
+        with paddle.static.program_guard(train_program, startup_program):
             input = paddle.static.data(
                 name='input', dtype='float32', shape=[2, 4]
             )

--- a/test/legacy_test/test_neg_op.py
+++ b/test/legacy_test/test_neg_op.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestNegOp(unittest.TestCase):
@@ -35,6 +36,7 @@ class TestNegOp(unittest.TestCase):
             dy_result.numpy(), expected_result, rtol=1e-05
         )
 
+    @test_with_pir_api
     def run_static(self, use_gpu=False):
         input = paddle.static.data(
             name='input', shape=[32, 8], dtype=self.dtype

--- a/test/legacy_test/test_neg_op.py
+++ b/test/legacy_test/test_neg_op.py
@@ -38,25 +38,26 @@ class TestNegOp(unittest.TestCase):
 
     @test_with_pir_api
     def run_static(self, use_gpu=False):
-        input = paddle.static.data(
-            name='input', shape=[32, 8], dtype=self.dtype
-        )
-        result = paddle.neg(input)
+        with paddle.static.program_guard(paddle.static.Program()):
+            input = paddle.static.data(
+                name='input', shape=[32, 8], dtype=self.dtype
+            )
+            result = paddle.neg(input)
 
-        place = paddle.CUDAPlace(0) if use_gpu else paddle.CPUPlace()
-        exe = paddle.static.Executor(place)
-        exe.run(paddle.static.default_startup_program())
-        st_result = exe.run(feed={"input": self.input}, fetch_list=[result])
-        expected_result = np.negative(self.input)
-        np.testing.assert_allclose(st_result[0], expected_result, rtol=1e-05)
+            place = paddle.CUDAPlace(0) if use_gpu else paddle.CPUPlace()
+            exe = paddle.static.Executor(place)
+            exe.run(paddle.static.default_startup_program())
+            st_result = exe.run(feed={"input": self.input}, fetch_list=[result])
+            expected_result = np.negative(self.input)
+            np.testing.assert_allclose(
+                st_result[0], expected_result, rtol=1e-05
+            )
 
     def test_cpu(self):
         paddle.disable_static(place=paddle.CPUPlace())
         self.run_imperative()
         paddle.enable_static()
-
-        with paddle.static.program_guard(paddle.static.Program()):
-            self.run_static()
+        self.run_static()
 
     def test_gpu(self):
         if not paddle.base.core.is_compiled_with_cuda():
@@ -65,9 +66,7 @@ class TestNegOp(unittest.TestCase):
         paddle.disable_static(place=paddle.CUDAPlace(0))
         self.run_imperative()
         paddle.enable_static()
-
-        with paddle.static.program_guard(paddle.static.Program()):
-            self.run_static(use_gpu=True)
+        self.run_static(use_gpu=True)
 
 
 class TestNegOpFp32(TestNegOp):

--- a/test/legacy_test/test_nll_loss.py
+++ b/test/legacy_test/test_nll_loss.py
@@ -102,7 +102,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -125,7 +125,7 @@ class TestNLLLoss(unittest.TestCase):
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_1D_sum(self):
         np.random.seed(200)
@@ -141,7 +141,7 @@ class TestNLLLoss(unittest.TestCase):
         expected = nll_loss_1d(input_np, label_np, reduction='sum')[0]
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -179,7 +179,7 @@ class TestNLLLoss(unittest.TestCase):
             loss = eager_res.sum()
             loss.backward()
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
         np.testing.assert_allclose(eager_result, expected, rtol=1e-05)
@@ -200,7 +200,7 @@ class TestNLLLoss(unittest.TestCase):
         expected = nll_loss_1d(input_np, label_np, weight=weight_np)[0]
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -247,7 +247,7 @@ class TestNLLLoss(unittest.TestCase):
             loss.backward()
             eager_result = eager_res.numpy()
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
         np.testing.assert_allclose(eager_result, expected, rtol=1e-05)
@@ -281,7 +281,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -312,7 +312,7 @@ class TestNLLLoss(unittest.TestCase):
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_1D_with_weight_mean_cpu(self):
         np.random.seed(200)
@@ -336,7 +336,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -365,7 +365,7 @@ class TestNLLLoss(unittest.TestCase):
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_1D_with_weight_no_reduce_cpu(self):
         np.random.seed(200)
@@ -391,7 +391,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -422,7 +422,7 @@ class TestNLLLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_2D_mean(self):
         np.random.seed(200)
@@ -447,7 +447,7 @@ class TestNLLLoss(unittest.TestCase):
 
         # place = base.CPUPlace()
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -468,6 +468,8 @@ class TestNLLLoss(unittest.TestCase):
                 )
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
+
+        test_static_or_pir_mode()
 
     def test_NLLLoss_2D_sum(self):
         np.random.seed(200)
@@ -494,7 +496,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -515,6 +517,8 @@ class TestNLLLoss(unittest.TestCase):
                 )
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
+
+        test_static_or_pir_mode()
 
     def test_NLLLoss_2D_with_weight_mean(self):
         np.random.seed(200)
@@ -543,7 +547,7 @@ class TestNLLLoss(unittest.TestCase):
 
         # place = base.CPUPlace()
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -573,6 +577,8 @@ class TestNLLLoss(unittest.TestCase):
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
+        test_static_or_pir_mode()
+
     def test_NLLLoss_2D_with_weight_mean_cpu(self):
         np.random.seed(200)
         input_np = np.random.random(size=(5, 3, 5, 5)).astype(np.float64)
@@ -594,7 +600,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -624,6 +630,8 @@ class TestNLLLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
+        test_static_or_pir_mode()
+
     def test_NLLLoss_2D_with_weight_sum(self):
         np.random.seed(200)
         input_np = np.random.random(size=(5, 3, 5, 5)).astype(np.float64)
@@ -652,7 +660,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -684,6 +692,8 @@ class TestNLLLoss(unittest.TestCase):
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
+        test_static_or_pir_mode()
+
     def test_NLLLoss_in_dims_not_2or4_mean(self):
         np.random.seed(200)
         input_np = np.random.random(size=(5, 3, 5, 5, 5)).astype(np.float64)
@@ -713,7 +723,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -735,7 +745,7 @@ class TestNLLLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_in_dims_not_2or4_with_weight_mean(self):
         np.random.seed(200)
@@ -771,7 +781,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -800,6 +810,8 @@ class TestNLLLoss(unittest.TestCase):
 
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(dy_result, static_result, rtol=1e-05)
+
+        test_static_or_pir_mode()
 
     def test_NLLLoss_in_dims_not_2or4_with_weight_sum(self):
         np.random.seed(200)
@@ -839,7 +851,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -870,7 +882,7 @@ class TestNLLLoss(unittest.TestCase):
             np.testing.assert_allclose(static_result, expected, rtol=1e-05)
             np.testing.assert_allclose(dy_result, static_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_in_dims_not_2or4_with_weight_no_reduce(self):
         np.random.seed(200)
@@ -912,7 +924,7 @@ class TestNLLLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result, expected, rtol=1e-05)
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):
@@ -943,7 +955,7 @@ class TestNLLLoss(unittest.TestCase):
                 np.testing.assert_allclose(static_result, expected, rtol=1e-05)
                 np.testing.assert_allclose(static_result, dy_result, rtol=1e-05)
 
-        test_dynamic_or_pir_mode()
+        test_static_or_pir_mode()
 
     def test_NLLLoss_in_dims_not_2or4_with_weight_no_reduce_cpu(self):
         np.random.seed(200)
@@ -979,7 +991,7 @@ class TestNLLLoss(unittest.TestCase):
         place = base.CPUPlace()
 
         @test_with_pir_api
-        def test_dynamic_or_pir_mode():
+        def test_static_or_pir_mode():
             prog = paddle.static.Program()
             startup_prog = paddle.static.Program()
             with paddle.static.program_guard(prog, startup_prog):

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def ref_var(x, axis=None, unbiased=True, keepdim=False):
@@ -64,10 +65,17 @@ class TestVarAPI(unittest.TestCase):
     def test_api(self):
         out_ref = ref_var(self.x, self.axis, self.unbiased, self.keepdim)
         out_dygraph = self.dygraph()
-        out_static = self.static()
-        for out in [out_dygraph, out_static]:
-            np.testing.assert_allclose(out_ref, out, rtol=1e-05)
-            self.assertTrue(np.equal(out_ref.shape, out.shape).all())
+
+        np.testing.assert_allclose(out_ref, out_dygraph, rtol=1e-05)
+        self.assertTrue(np.equal(out_ref.shape, out_dygraph.shape).all())
+
+        @test_with_pir_api
+        def test_static_or_pir_mode():
+            out_static = self.static()
+            np.testing.assert_allclose(out_ref, out_static, rtol=1e-05)
+            self.assertTrue(np.equal(out_ref.shape, out_static.shape).all())
+
+        test_static_or_pir_mode()
 
 
 class TestVarAPI_dtype(TestVarAPI):
@@ -113,6 +121,7 @@ class TestVarAPI_alias(unittest.TestCase):
 
 
 class TestVarError(unittest.TestCase):
+    @test_with_pir_api
     def test_error(self):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', [2, 3, 4], 'int32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/58067



以下两个文件是修改之前的函数名字：
- test/legacy_test/test_bce_with_logits_loss.py
- test/legacy_test/test_nll_loss.py

- `test_is_tensor` 全部开启
- `test_median` 全部开启
- `test_nanmean_api` 全部开启
- `test_nansum_api` 全部开启
- `test_neg_op` 全部开启
- `test_unflatten` 全部开启
- `test_variance_layer` 全部开启