### PR TITLE
[PIR]Open pir grad_check for instance_norm

### DIFF
--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -441,7 +441,7 @@ def instance_norm(
                [ 0.74275863, -0.11246002,  1.73788261]]]])
 
     """
-    if in_dygraph_mode():
+    if in_dynamic_or_pir_mode():
         out = _C_ops.instance_norm(x, weight, bias, eps)
         return out
     else:

--- a/test/legacy_test/gradient_checker.py
+++ b/test/legacy_test/gradient_checker.py
@@ -763,6 +763,8 @@ def get_pir_static_double_grad(
     """
     if program is None:
         program = paddle.static.default_main_program()
+    exe = paddle.static.Executor(place)
+    exe.run(paddle.static.default_startup_program())
     if dy_init is None:
         y_grads = []
         y_grads_init = []
@@ -852,7 +854,7 @@ def get_pir_static_double_grad(
 
     # append second order backward
     ddx = base.gradients(y, x, dys)
-    exe = paddle.static.Executor()
+
     # filter None in dx for DX/DY may be None in kernel
     # only fetch not None dx in exe.run
     filted = [(i, dxi) for i, dxi in enumerate(ddx) if dxi is not None]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-67164
Open pir grad_check for instance_norm
- InstanceNorm系列算子内部使用了create_parameter，此算子需要run startup_program将scope中的数据拿到program中。
- 运行中出现cpu kernel中segmentation fault，是由于之前的exe创建时未指定place，导致一些算子默认选择gpu，所以在gpu下未报错，而cpu出现错误。