### PR TITLE
[PIR]Fix call InterpolateInferMeta in PIR

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -24,6 +24,7 @@ _INFERMETA_NEED_META_CONFIG = {
     'StackInferMeta',
     'Conv2dTransposeInferMeta',
     'Conv2dFusionInferMeta',
+    'InterpolateInferMeta',
 }
 
 _PREPARE_DATA_WITH_VECTOR_INT64_MTTABLE_ATTRIBUTE = {'FrobeniusNormOp'}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Fix call InterpolateInferMeta in PIR
修复 https://github.com/PaddlePaddle/Paddle/pull/59378 中的test_yolov3组网时调用interpolate函数后输出shape错误的问题
Pcard-67164