### PR TITLE
【PIR API adaptor No.284, 293】 Migrate paddle.Tensor.nanquantile and paddle.Tensor.quantile into pir

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -19,7 +19,6 @@ from paddle import _C_ops
 from paddle.framework import (
     in_dynamic_mode,
     in_dynamic_or_pir_mode,
-    in_pir_mode,
 )
 
 from ..base.data_feeder import check_type, check_variable_and_dtype
@@ -578,32 +577,15 @@ def _compute_quantile(x, q, axis=None, keepdim=False, ignore_nan=False):
 
     # TODO(chenjianye): replace the for-loop to directly take elements.
     for index in indices:
-        if in_pir_mode():
-            indices_below = paddle.floor(index).astype(
-                paddle.base.core.DataType.INT32
-            )
-            indices_upper = paddle.ceil(index).astype(
-                paddle.base.core.DataType.INT32
-            )
-            tensor_upper = paddle.take_along_axis(
-                sorted_tensor, indices_upper, axis=axis
-            )
-            tensor_below = paddle.take_along_axis(
-                sorted_tensor, indices_below, axis=axis
-            )
-            weights = index - indices_below.astype(
-                paddle.base.core.DataType.FLOAT64
-            )
-        else:
-            indices_below = paddle.floor(index).astype(paddle.int32)
-            indices_upper = paddle.ceil(index).astype(paddle.int32)
-            tensor_upper = paddle.take_along_axis(
-                sorted_tensor, indices_upper, axis=axis
-            )
-            tensor_below = paddle.take_along_axis(
-                sorted_tensor, indices_below, axis=axis
-            )
-            weights = index - indices_below.astype('float64')
+        indices_below = paddle.floor(index).astype('int32')
+        indices_upper = paddle.ceil(index).astype('int32')
+        tensor_upper = paddle.take_along_axis(
+            sorted_tensor, indices_upper, axis=axis
+        )
+        tensor_below = paddle.take_along_axis(
+            sorted_tensor, indices_below, axis=axis
+        )
+        weights = index - indices_below.astype('float64')
         out = paddle.lerp(
             tensor_below.astype('float64'),
             tensor_upper.astype('float64'),

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -442,7 +442,8 @@ def median(x, axis=None, keepdim=False, name=None):
     tensor_topk, idx = paddle.topk(x, kth + 1, axis=axis, largest=False)
     dtype = (
         'float64'
-        if x.dtype in [core.VarDesc.VarType.FP64, DataType.FLOAT64]
+        if x.dtype
+        in [core.VarDesc.VarType.FP64, paddle.base.core.DataType.FLOAT64]
         else 'float32'
     )
     if sz & 1 == 0:
@@ -498,7 +499,7 @@ def _compute_quantile(x, q, axis=None, keepdim=False, ignore_nan=False):
         In order to obtain higher precision, data type of results will be float64.
     """
     # Validate x
-    if not isinstance(x, (Variable, paddle.pir.OpResult)):
+    if not isinstance(x, (Variable, paddle.pir.Value)):
         raise TypeError("input x should be a Tensor.")
 
     # Validate q

--- a/test/legacy_test/test_quantile_and_nanquantile.py
+++ b/test/legacy_test/test_quantile_and_nanquantile.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 API_list = [
     (paddle.quantile, np.quantile),
@@ -239,17 +240,18 @@ class TestQuantileRuntime(unittest.TestCase):
                         paddle_res.numpy(), np_res, rtol=1e-05
                     )
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         for func, res_func in API_list:
             for device in self.devices:
                 x = paddle.static.data(
-                    name="x", shape=self.input_data.shape, dtype=paddle.float32
+                    name="x", shape=self.input_data.shape, dtype="float32"
                 )
                 x_fp64 = paddle.static.data(
                     name="x_fp64",
                     shape=self.input_data.shape,
-                    dtype=paddle.float64,
+                    dtype="float64",
                 )
 
                 results = func(x, q=0.5, axis=1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 

### Description
<!-- Describe what you’ve done -->
PIR API 推全升级

https://github.com/PaddlePaddle/Paddle/issues/58067

No.284 将 paddle.Tensor.nanquantile迁移升级至 pir，并更新单测，单测覆盖率：1/2。

nanquantile 在 test/legacy_test/test_zero_dim_tensor.py 里的 test_nanquantile 单测暂不支持。因为 paddle.static.append_backward 尚未支持 pir 模式

No.293 将 paddle.Tensor.quantile迁移升级至 pir，并更新单测，单测覆盖率：1/2。

quantile 在 test/legacy_test/test_zero_dim_tensor.py 里的 TestSundryAPIStatic.test_quantile 单测暂不支持。因为 paddle.static.append_backward 尚未支持 pir 模式
