### PR TITLE
[pir][test] add `OpResult.cpu()` and `OpResult.cuda()` test

### DIFF
--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -412,12 +412,7 @@ class TestMathOpPatchesPir(unittest.TestCase):
                 self.assertTrue(len(w) == 1)
                 self.assertTrue("place" in str(w[-1].message))
 
-    def test_cpu(self):
-        with paddle.pir_utils.IrGuard():
-            x = paddle.static.data(name='x', shape=[3, 2, 1])
-            x.cpu()
-
-    def test_cuda(self):
+    def test_cpu_and_cuda(self):
         if base.is_compiled_with_cuda():
             paddle.device.set_device("gpu")
             with warnings.catch_warnings(record=True) as w:
@@ -425,7 +420,9 @@ class TestMathOpPatchesPir(unittest.TestCase):
                 with paddle.pir_utils.IrGuard():
                     x = paddle.static.data(name='x', shape=[3, 2, 1])
                     x.cpu()
+                    self.assertTrue(x.place.is_cpu_place())
                     x.cuda(1, False)
+                    self.assertTrue(x.place.is_gpu_place())
                     self.assertTrue(len(w) == 2)
                     self.assertTrue(
                         "device_id is not supported" in str(w[-2].message)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

补充测试

相关链接:

* #59300