### PR TITLE
[PIR]Remove refresh_stopgradient in backward

### DIFF
--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -792,7 +792,6 @@ def remove_op(block, op, state):
 
 def calc_gradient_helper(outputs, inputs, grad_outputs, no_grad_set):
     block = outputs[0].get_defining_op().get_parent_block()
-    block.refresh_stopgradient()
     state = State(block)
 
     # check all inputs and outputs in the same block

--- a/test/ir/pir/test_ir_backward.py
+++ b/test/ir/pir/test_ir_backward.py
@@ -249,29 +249,5 @@ class TestBackward_3(unittest.TestCase):
             input_grad = grad(res, x)
 
 
-class TestBackward_refrash_stopgradients(unittest.TestCase):
-    def test_refreash_stopgradients(self):
-        import numpy as np
-
-        program = paddle.pir.core.default_main_program()
-        with paddle.pir_utils.IrGuard(), paddle.pir.core.program_guard(program):
-            data1 = paddle.static.data('data1', [3, 4, 5], np.float32)
-            data2 = paddle.static.data('data2', [3, 4, 5], np.float32)
-            out = paddle.add_n([data1, data2])
-            data1_arr = np.random.uniform(-1, 1, data1.shape).astype(np.float32)
-            data2_arr = np.random.uniform(-1, 1, data2.shape).astype(np.float32)
-            self.assertEqual(
-                program.global_block().ops[3].result(0).stop_gradient, True
-            )
-
-            data1.stop_gradient = False
-            data2.stop_gradient = False
-
-            dout = grad(out, [data1, data2])
-            self.assertEqual(
-                program.global_block().ops[3].result(0).stop_gradient, False
-            )
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_concat_op.py
+++ b/test/legacy_test/test_concat_op.py
@@ -799,8 +799,10 @@ class TestConcatDoubleGradCheck(unittest.TestCase):
 
         data1 = paddle.static.data('data1', [2, 3], dtype)
         data1.persistable = True
+        data1.stop_gradient = False
         data2 = paddle.static.data('data2', [2, 3], dtype)
         data2.persistable = True
+        data2.stop_gradient = False
         out = paddle.concat([data1, data2])
         data1_arr = np.random.uniform(-1, 1, data1.shape).astype(dtype)
         data2_arr = np.random.uniform(-1, 1, data2.shape).astype(dtype)
@@ -841,8 +843,10 @@ class TestConcatTripleGradCheck(unittest.TestCase):
 
         data1 = paddle.static.data('data1', [2, 3, 4], dtype)
         data1.persistable = True
+        data1.stop_gradient = False
         data2 = paddle.static.data('data2', [2, 3, 4], dtype)
         data2.persistable = True
+        data2.stop_gradient = False
         out = paddle.concat([data1, data2], 1)
         data1_arr = np.random.uniform(-1, 1, data1.shape).astype(dtype)
         data2_arr = np.random.uniform(-1, 1, data2.shape).astype(dtype)

--- a/test/legacy_test/test_elementwise_nn_grad.py
+++ b/test/legacy_test/test_elementwise_nn_grad.py
@@ -66,7 +66,9 @@ class TestElementwiseMulBroadcastDoubleGradCheck(unittest.TestCase):
         x = paddle.static.data('x', shape, dtype)
         y = paddle.static.data('y', shape[:-1], dtype)
         x.persistable = True
+        x.stop_gradient = False
         y.persistable = True
+        y.stop_gradient = False
         out = paddle.tensor.math._multiply_with_axis(x, y, axis=0)
         x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
         y_arr = np.random.uniform(-1, 1, shape[:-1]).astype(dtype)
@@ -268,7 +270,9 @@ class TestElementwiseDivBroadcastDoubleGradCheck(unittest.TestCase):
         x = paddle.static.data('x', shape, dtype)
         y = paddle.static.data('y', shape[1:-1], dtype)
         x.persistable = True
+        x.stop_gradient = False
         y.persistable = True
+        y.stop_gradient = False
         out = paddle.tensor.math._divide_with_axis(x, y, axis=1)
         x_arr = np.random.uniform(-1, 1, shape).astype(dtype)
         y_arr = np.random.uniform(-1, 1, shape[1:-1]).astype(dtype)

--- a/test/legacy_test/test_nn_grad.py
+++ b/test/legacy_test/test_nn_grad.py
@@ -411,7 +411,9 @@ class TestConcatDoubleGradCheck(unittest.TestCase):
         x1 = paddle.static.data('x', x_shape, dtype)
         x2 = paddle.static.data('x', x_shape, dtype)
         x1.persistable = True
+        x1.stop_gradient = False
         x2.persistable = True
+        x2.stop_gradient = False
         out = paddle.concat([x1, x2], axis=0)
         x2_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
         x1_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -661,8 +661,10 @@ class TestAddNDoubleGradCheck(unittest.TestCase):
 
         data1 = paddle.static.data('data1', [3, 4, 5], dtype)
         data1.persistable = True
+        data1.stop_gradient = False
         data2 = paddle.static.data('data2', [3, 4, 5], dtype)
         data2.persistable = True
+        data2.stop_gradient = False
         out = paddle.add_n([data1, data2])
         data1_arr = np.random.uniform(-1, 1, data1.shape).astype(dtype)
         data2_arr = np.random.uniform(-1, 1, data1.shape).astype(dtype)
@@ -703,8 +705,10 @@ class TestAddNTripleGradCheck(unittest.TestCase):
 
         data1 = paddle.static.data('data1', [3, 4, 5], dtype)
         data1.persistable = True
+        data1.stop_gradient = False
         data2 = paddle.static.data('data2', [3, 4, 5], dtype)
         data2.persistable = True
+        data2.stop_gradient = False
         out = paddle.add_n([data1, data2])
         data1_arr = np.random.uniform(-1, 1, data1.shape).astype(dtype)
         data2_arr = np.random.uniform(-1, 1, data1.shape).astype(dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-67164
Remove refresh_stopgradient in backward