### PR TITLE
【PIR API adaptor No.266、269】 Migrate ldexp, logaddexp into pir

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6987,9 +6987,9 @@ def ldexp(x, y, name=None):
             [4. , 8. , 12.])
 
     """
-    if not isinstance(x, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
+    if not isinstance(x, (paddle.Tensor, Variable, paddle.pir.OpResult)):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
+    if not isinstance(y, (paddle.Tensor, Variable, paddle.pir.OpResult)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64
@@ -7008,14 +7008,12 @@ def ldexp_(x, y, name=None):
     Inplace version of ``polygamma`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_polygamma`.
     """
-    if not isinstance(x, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
+    if not isinstance(x, (paddle.Tensor, Variable)):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
+    if not isinstance(y, (paddle.Tensor, paddle.pir.OpResult)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64
-    elif x.dtype == DataType.FLOAT64 or y.dtype == DataType.FLOAT64:
-        out_dtype = DataType.FLOAT64
     else:
         out_dtype = paddle.get_default_dtype()
     x = paddle.cast_(x, dtype=out_dtype)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6987,9 +6987,9 @@ def ldexp(x, y, name=None):
             [4. , 8. , 12.])
 
     """
-    if not isinstance(x, (paddle.Tensor, Variable)):
+    if not isinstance(x, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, (paddle.Tensor, Variable)):
+    if not isinstance(y, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64
@@ -7006,9 +7006,9 @@ def ldexp_(x, y, name=None):
     Inplace version of ``polygamma`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_polygamma`.
     """
-    if not isinstance(x, (paddle.Tensor, Variable)):
+    if not isinstance(x, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, (paddle.Tensor, Variable)):
+    if not isinstance(y, (paddle.Tensor, (Variable, paddle.pir.OpResult))):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6987,9 +6987,9 @@ def ldexp(x, y, name=None):
             [4. , 8. , 12.])
 
     """
-    if not isinstance(x, (paddle.Tensor, Variable, paddle.pir.OpResult)):
+    if not isinstance(x, (paddle.Tensor, Variable, paddle.pir.Value)):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, (paddle.Tensor, Variable, paddle.pir.OpResult)):
+    if not isinstance(y, (paddle.Tensor, Variable, paddle.pir.Value)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64
@@ -7008,9 +7008,9 @@ def ldexp_(x, y, name=None):
     Inplace version of ``polygamma`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_polygamma`.
     """
-    if not isinstance(x, (paddle.Tensor, Variable)):
+    if not isinstance(x, paddle.Tensor, Variable):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, (paddle.Tensor, paddle.pir.OpResult)):
+    if not isinstance(y, paddle.Tensor, Variable):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6993,6 +6993,8 @@ def ldexp(x, y, name=None):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64
+    elif x.dtype == DataType.FLOAT64 or y.dtype == DataType.FLOAT64:
+        out_dtype = DataType.FLOAT64
     else:
         out_dtype = paddle.get_default_dtype()
     x = paddle.cast(x, dtype=out_dtype)
@@ -7012,6 +7014,8 @@ def ldexp_(x, y, name=None):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64
+    elif x.dtype == DataType.FLOAT64 or y.dtype == DataType.FLOAT64:
+        out_dtype = DataType.FLOAT64
     else:
         out_dtype = paddle.get_default_dtype()
     x = paddle.cast_(x, dtype=out_dtype)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7008,9 +7008,9 @@ def ldexp_(x, y, name=None):
     Inplace version of ``polygamma`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_polygamma`.
     """
-    if not isinstance(x, paddle.Tensor, Variable):
+    if not isinstance(x, (paddle.Tensor, Variable)):
         raise TypeError(f"x must be tensor type, but got {type(x)}")
-    if not isinstance(y, paddle.Tensor, Variable):
+    if not isinstance(y, (paddle.Tensor, Variable)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
     if x.dtype == paddle.float64 or y.dtype == paddle.float64:
         out_dtype = paddle.float64

--- a/test/legacy_test/test_ldexp.py
+++ b/test/legacy_test/test_ldexp.py
@@ -19,7 +19,6 @@ import numpy as np
 import paddle
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
-from paddle.static import Program, program_guard
 
 
 def _run_ldexp_dynamic(x, y, device='cpu'):
@@ -43,7 +42,9 @@ def _run_ldexp_static(x, y, device='cpu'):
     paddle.enable_static()
     # y is scalar
     if isinstance(y, (int)):
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
             y_ = y
             res = paddle.ldexp(x_, y_)
@@ -51,11 +52,17 @@ def _run_ldexp_static(x, y, device='cpu'):
                 paddle.CPUPlace() if device == 'cpu' else paddle.CUDAPlace(0)
             )
             exe = paddle.static.Executor(place)
-            outs = exe.run(feed={'x': x, 'y': y}, fetch_list=[res])
+            outs = exe.run(
+                paddle.static.default_main_program(),
+                feed={'x': x, 'y': y},
+                fetch_list=[res],
+            )
             return outs[0]
     # y is tensor
     else:
-        with program_guard(Program(), Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
             y_ = paddle.static.data(name="y", shape=y.shape, dtype=y.dtype)
             res = paddle.ldexp(x_, y_)
@@ -63,7 +70,11 @@ def _run_ldexp_static(x, y, device='cpu'):
                 paddle.CPUPlace() if device == 'cpu' else paddle.CUDAPlace(0)
             )
             exe = paddle.static.Executor(place)
-            outs = exe.run(feed={'x': x, 'y': y}, fetch_list=[res])
+            outs = exe.run(
+                paddle.static.default_main_program(),
+                feed={'x': x, 'y': y},
+                fetch_list=[res],
+            )
             return outs[0]
 
 

--- a/test/legacy_test/test_ldexp.py
+++ b/test/legacy_test/test_ldexp.py
@@ -18,58 +18,53 @@ import numpy as np
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 from paddle.static import Program, program_guard
 
-DYNAMIC = 1
-STATIC = 2
 
-
-def _run_ldexp(mode, x, y, device='cpu'):
+def _run_ldexp_dynamic(x, y, device='cpu'):
     # dynamic mode
-    if mode == DYNAMIC:
-        paddle.disable_static()
-        # Set device
-        paddle.set_device(device)
-        x_ = paddle.to_tensor(x)
-        # y is scalar
-        if isinstance(y, (int)):
-            y_ = y
-        # y is tensor
-        else:
-            y_ = paddle.to_tensor(y)
-        res = paddle.ldexp(x_, y_)
-        return res.numpy()
+    paddle.disable_static()
+    # Set device
+    paddle.set_device(device)
+    x_ = paddle.to_tensor(x)
+    # y is scalar
+    if isinstance(y, (int)):
+        y_ = y
+    # y is tensor
+    else:
+        y_ = paddle.to_tensor(y)
+    res = paddle.ldexp(x_, y_)
+    return res.numpy()
+
+
+def _run_ldexp_static(x, y, device='cpu'):
     # static graph mode
-    elif mode == STATIC:
-        paddle.enable_static()
-        # y is scalar
-        if isinstance(y, (int)):
-            with program_guard(Program(), Program()):
-                x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
-                y_ = y
-                res = paddle.ldexp(x_, y_)
-                place = (
-                    paddle.CPUPlace()
-                    if device == 'cpu'
-                    else paddle.CUDAPlace(0)
-                )
-                exe = paddle.static.Executor(place)
-                outs = exe.run(feed={'x': x, 'y': y}, fetch_list=[res])
-                return outs[0]
-        # y is tensor
-        else:
-            with program_guard(Program(), Program()):
-                x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
-                y_ = paddle.static.data(name="y", shape=y.shape, dtype=y.dtype)
-                res = paddle.ldexp(x_, y_)
-                place = (
-                    paddle.CPUPlace()
-                    if device == 'cpu'
-                    else paddle.CUDAPlace(0)
-                )
-                exe = paddle.static.Executor(place)
-                outs = exe.run(feed={'x': x, 'y': y}, fetch_list=[res])
-                return outs[0]
+    paddle.enable_static()
+    # y is scalar
+    if isinstance(y, (int)):
+        with program_guard(Program(), Program()):
+            x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
+            y_ = y
+            res = paddle.ldexp(x_, y_)
+            place = (
+                paddle.CPUPlace() if device == 'cpu' else paddle.CUDAPlace(0)
+            )
+            exe = paddle.static.Executor(place)
+            outs = exe.run(feed={'x': x, 'y': y}, fetch_list=[res])
+            return outs[0]
+    # y is tensor
+    else:
+        with program_guard(Program(), Program()):
+            x_ = paddle.static.data(name="x", shape=x.shape, dtype=x.dtype)
+            y_ = paddle.static.data(name="y", shape=y.shape, dtype=y.dtype)
+            res = paddle.ldexp(x_, y_)
+            place = (
+                paddle.CPUPlace() if device == 'cpu' else paddle.CUDAPlace(0)
+            )
+            exe = paddle.static.Executor(place)
+            outs = exe.run(feed={'x': x, 'y': y}, fetch_list=[res])
+            return outs[0]
 
 
 def check_dtype(input, desired_dtype):
@@ -81,33 +76,27 @@ def check_dtype(input, desired_dtype):
         )
 
 
-class TestLdexpAPI(unittest.TestCase):
+class TestLdexpAPIWithDynamic(unittest.TestCase):
     def setUp(self):
         self.places = ['cpu']
         if core.is_compiled_with_cuda():
             self.places.append('gpu')
 
-    def test_ldexp(self):
+    def test_ldexp_dynamic(self):
         np.random.seed(7)
         for place in self.places:
             # test 1-d float tensor and 1-d int tensor
             dims = (np.random.randint(200, 300),)
             x = (np.random.rand(*dims) * 10).astype(np.float64)
             y = (np.random.randint(-10, 10, dims)).astype(np.int32)
-            res = _run_ldexp(DYNAMIC, x, y, place)
-            check_dtype(res, np.float64)
-            np.testing.assert_allclose(res, np.ldexp(x, y))
-            res = _run_ldexp(STATIC, x, y, place)
+            res = _run_ldexp_dynamic(x, y, place)
             check_dtype(res, np.float64)
             np.testing.assert_allclose(res, np.ldexp(x, y))
 
             dims = (np.random.randint(200, 300),)
             x = (np.random.rand(*dims) * 10).astype(np.float32)
             y = (np.random.randint(-10, 10, dims)).astype(np.int32)
-            res = _run_ldexp(DYNAMIC, x, y, place)
-            check_dtype(res, np.float32)
-            np.testing.assert_allclose(res, np.ldexp(x, y))
-            res = _run_ldexp(STATIC, x, y, place)
+            res = _run_ldexp_dynamic(x, y, place)
             check_dtype(res, np.float32)
             np.testing.assert_allclose(res, np.ldexp(x, y))
 
@@ -115,20 +104,14 @@ class TestLdexpAPI(unittest.TestCase):
             dims = (np.random.randint(200, 300),)
             x = (np.random.randint(-10, 10, dims)).astype(np.int64)
             y = (np.random.randint(-10, 10, dims)).astype(np.int32)
-            res = _run_ldexp(DYNAMIC, x, y, place)
-            check_dtype(res, np.float32)
-            np.testing.assert_allclose(res, np.ldexp(x, y))
-            res = _run_ldexp(STATIC, x, y, place)
+            res = _run_ldexp_dynamic(x, y, place)
             check_dtype(res, np.float32)
             np.testing.assert_allclose(res, np.ldexp(x, y))
 
             dims = (np.random.randint(200, 300),)
             x = (np.random.randint(-10, 10, dims)).astype(np.int32)
             y = (np.random.randint(-10, 10, dims)).astype(np.int32)
-            res = _run_ldexp(DYNAMIC, x, y, place)
-            check_dtype(res, np.float32)
-            np.testing.assert_allclose(res, np.ldexp(x, y))
-            res = _run_ldexp(STATIC, x, y, place)
+            res = _run_ldexp_dynamic(x, y, place)
             check_dtype(res, np.float32)
             np.testing.assert_allclose(res, np.ldexp(x, y))
 
@@ -140,10 +123,59 @@ class TestLdexpAPI(unittest.TestCase):
             )
             x = (np.random.rand(*dims) * 10).astype(np.float64)
             y = (np.random.randint(-10, 10, dims[-1])).astype(np.int32)
-            res = _run_ldexp(DYNAMIC, x, y)
+            res = _run_ldexp_dynamic(x, y)
             check_dtype(res, np.float64)
             np.testing.assert_allclose(res, np.ldexp(x, y))
-            res = _run_ldexp(STATIC, x, y)
+
+
+class TestLdexpAPIWithStatic(unittest.TestCase):
+    def setUp(self):
+        self.places = ['cpu']
+        if core.is_compiled_with_cuda():
+            self.places.append('gpu')
+
+    @test_with_pir_api
+    def test_ldexp_static(self):
+        np.random.seed(7)
+        for place in self.places:
+            dims = (np.random.randint(200, 300),)
+            x = (np.random.rand(*dims) * 10).astype(np.float64)
+            y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            res = _run_ldexp_static(x, y, place)
+            check_dtype(res, np.float64)
+            np.testing.assert_allclose(res, np.ldexp(x, y))
+
+            dims = (np.random.randint(200, 300),)
+            x = (np.random.rand(*dims) * 10).astype(np.float32)
+            y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            res = _run_ldexp_static(x, y, place)
+            check_dtype(res, np.float32)
+            np.testing.assert_allclose(res, np.ldexp(x, y))
+
+            # test 1-d int tensor and 1-d int tensor
+            dims = (np.random.randint(200, 300),)
+            x = (np.random.randint(-10, 10, dims)).astype(np.int64)
+            y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            res = _run_ldexp_static(x, y, place)
+            check_dtype(res, np.float32)
+            np.testing.assert_allclose(res, np.ldexp(x, y))
+
+            dims = (np.random.randint(200, 300),)
+            x = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            y = (np.random.randint(-10, 10, dims)).astype(np.int32)
+            res = _run_ldexp_static(x, y, place)
+            check_dtype(res, np.float32)
+            np.testing.assert_allclose(res, np.ldexp(x, y))
+
+            # test broadcast
+            dims = (
+                np.random.randint(1, 10),
+                np.random.randint(5, 10),
+                np.random.randint(5, 10),
+            )
+            x = (np.random.rand(*dims) * 10).astype(np.float64)
+            y = (np.random.randint(-10, 10, dims[-1])).astype(np.int32)
+            res = _run_ldexp_static(x, y)
             check_dtype(res, np.float64)
             np.testing.assert_allclose(res, np.ldexp(x, y))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
* https://github.com/PaddlePaddle/Paddle/issues/58067

No.266 paddle.Tensor.ldexp
No.269 paddle.Tensor.logaddexp

将 `paddle.Tensor.ldexp` 迁移升级至 pir，并更新单测 覆盖率1/1
将 `paddle.Tensor.logaddexp` 迁移升级至 pir，并更新单测 覆盖率0/0