### PR TITLE
[Dy2St] lower time 20 - 100 in dy2st unittests

### DIFF
--- a/test/dygraph_to_static/test_break_continue.py
+++ b/test/dygraph_to_static/test_break_continue.py
@@ -15,7 +15,12 @@
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase, test_ast_only
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_ast_only,
+    test_default_mode_only,
+    test_pt_only,
+)
 
 import paddle
 from paddle import base
@@ -33,6 +38,7 @@ class TestDy2staticException(Dy2StTestBase):
         self.error = "Your if/else have different number of return value."
 
     @test_ast_only
+    @test_pt_only
     def test_error(self):
         if self.dyfunc:
             with self.assertRaisesRegex(Dygraph2StaticException, self.error):
@@ -227,6 +233,7 @@ class TestContinueInFor(Dy2StTestBase):
             res = to_static(self.dygraph_func)(self.input)
             return res.numpy()
 
+    @test_default_mode_only
     def test_transformed_static_result(self):
         static_res = self.run_static_mode()
         dygraph_res = self.run_dygraph_mode()

--- a/test/dygraph_to_static/test_decorator_transform.py
+++ b/test/dygraph_to_static/test_decorator_transform.py
@@ -22,7 +22,7 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
-    test_legacy_and_pt_and_pir,
+    test_default_and_pir,
     test_pt_only,
 )
 
@@ -186,7 +186,7 @@ def deco_with_paddle_api():
 
 
 class TestDecoratorTransform(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_deco_transform(self):
         outs = paddle.jit.to_static(forward)()
         np.testing.assert_allclose(outs[0], np.array(3), rtol=1e-05)
@@ -216,7 +216,7 @@ class TestDecoratorTransform(Dy2StTestBase):
                     break
             self.assertTrue(flag)
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_deco_with_paddle_api(self):
         self.assertTrue(paddle.jit.to_static(deco_with_paddle_api)())
 

--- a/test/dygraph_to_static/test_dict.py
+++ b/test/dygraph_to_static/test_dict.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
+    test_default_and_pir,
 )
 
 import paddle
@@ -142,7 +142,7 @@ class TestNetWithDict(Dy2StTestBase):
             ret = net(self.x)
             return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -196,7 +196,7 @@ class TestDictPop(Dy2StTestBase):
 
         return result.numpy()
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_transformed_result(self):
         dygraph_res = self._run_dygraph()
         static_res = self._run_static()
@@ -239,7 +239,7 @@ class TestDictPop3(TestNetWithDict):
             ret = net(z=0, x=self.x, y=True)
             return ret.numpy()
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_ast_to_func(self):
         dygraph_result = self._run_dygraph()
         static_result = self._run_static()
@@ -251,7 +251,7 @@ class TestDictPop3(TestNetWithDict):
 
 
 class TestDictCmpInFor(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_with_for(self):
         def func():
             pos = [1, 3]
@@ -268,7 +268,7 @@ class TestDictCmpInFor(Dy2StTestBase):
 
         self.assertEqual(paddle.jit.to_static(func)()['minus'], 8)
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_with_for_enumerate(self):
         def func():
             pos = [1, 3]

--- a/test/dygraph_to_static/test_for_enumerate.py
+++ b/test/dygraph_to_static/test_for_enumerate.py
@@ -19,7 +19,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
+    test_default_and_pir,
+    test_default_mode_only,
 )
 
 import paddle
@@ -392,6 +393,7 @@ class TestForInRange(TestTransform):
     def set_test_func(self):
         self.dygraph_func = for_in_range
 
+    @test_default_mode_only
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -401,7 +403,7 @@ class TestForIterList(TestTransform):
     def set_test_func(self):
         self.dygraph_func = for_iter_list
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -424,7 +426,7 @@ class TestForIterVarNumpy(TestTransform):
     def set_test_func(self):
         self.dygraph_func = for_iter_var_numpy
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -480,6 +482,7 @@ class TestForEnumerateVarWithNestedRange(TestForIterVarNumpy):
         self.dygraph_func = for_enumerate_var_with_nested_range
 
     # Remove this if we support control flow
+    @test_default_mode_only
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -519,7 +522,7 @@ class TestForOriginalList(TestTransformForOriginalList):
     def set_test_func(self):
         self.dygraph_func = for_original_list
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_transformed_result_compare(self):
         self.set_test_func()
         self.transformed_result_compare()
@@ -542,7 +545,7 @@ class TestForZip(Dy2StTestBase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_for_zip_error(self):
         with self.assertRaises(RuntimeError):
             model_path = os.path.join(self.temp_dir.name, 'for_zip_error')
@@ -557,6 +560,7 @@ class TestForZip(Dy2StTestBase):
                 model_path,
             )
 
+    @test_default_mode_only
     def test_for_zip(self):
         model_path = os.path.join(self.temp_dir.name, 'for_zip')
         paddle.jit.save(

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -18,6 +18,8 @@ import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     test_ast_only,
+    test_default_mode_only,
+    test_pt_only,
 )
 from ifelse_simple_func import (
     NetWithControlFlowIf,
@@ -64,6 +66,7 @@ class TestDy2staticException(Dy2StTestBase):
         self.error = "Your if/else have different number of return value."
 
     @test_ast_only
+    @test_pt_only
     def test_error(self):
         if self.dyfunc:
             with self.assertRaisesRegex(Dygraph2StaticException, self.error):
@@ -95,6 +98,7 @@ class TestDygraphIfElse(Dy2StTestBase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
+    @test_default_mode_only
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -140,6 +144,7 @@ class TestDygraphNestedIfElse(Dy2StTestBase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
+    @test_default_mode_only
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -265,6 +270,7 @@ class TestDygraphIfTensor(Dy2StTestBase):
                 ret = self.dyfunc(x_v)
             return ret.numpy()
 
+    @test_default_mode_only
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -294,6 +300,7 @@ class TestDygraphIfElseNet(Dy2StTestBase):
             ret = net(x_v)
             return ret.numpy()
 
+    @test_default_mode_only
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -346,6 +353,7 @@ class TestNetWithExternalFunc(TestDygraphIfElseNet):
         self.x = np.random.random([10, 16]).astype('float32')
         self.Net = NetWithExternalFunc
 
+    @test_default_mode_only
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
 
@@ -401,6 +409,7 @@ class TestDiffModeNet(Dy2StTestBase):
         ret = net(self.x, self.y)
         return ret.numpy()
 
+    @test_default_mode_only
     def test_train_mode(self):
         self.assertTrue(
             (
@@ -409,6 +418,7 @@ class TestDiffModeNet(Dy2StTestBase):
             ).all()
         )
 
+    @test_default_mode_only
     def test_infer_mode(self):
         self.assertTrue(
             (
@@ -424,6 +434,7 @@ class TestDiffModeNet2(TestDiffModeNet):
 
 
 class TestNewVarCreateInOneBranch(Dy2StTestBase):
+    @test_default_mode_only
     def test_var_used_in_another_for(self):
         def case_func(training):
             # targets and targets_list is dynamically defined by training
@@ -460,6 +471,7 @@ class TestDy2StIfElseRetInt1(Dy2StTestBase):
         return out
 
     @test_ast_only
+    @test_pt_only
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out[0], paddle.Tensor)
@@ -480,6 +492,7 @@ class TestDy2StIfElseRetInt3(TestDy2StIfElseRetInt1):
         self.out = self.get_dy2stat_out()
 
     @test_ast_only
+    @test_pt_only
     def test_ast_to_func(self):
         self.setUp()
         self.assertIsInstance(self.out, paddle.Tensor)
@@ -491,6 +504,7 @@ class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
         self.dyfunc = paddle.jit.to_static(dyfunc_ifelse_ret_int4)
 
     @test_ast_only
+    @test_pt_only
     def test_ast_to_func(self):
         paddle.jit.enable_to_static(True)
         with self.assertRaises(Dygraph2StaticException):
@@ -526,6 +540,7 @@ class IfElseNet(paddle.nn.Layer):
 
 class TestDy2StIfElseBackward(Dy2StTestBase):
     # TODO(zhangbo): open pir test (IfOp grad execution not yet supported)
+    @test_default_mode_only
     def test_run_backward(self):
         a = paddle.randn((4, 3), dtype='float32')
         a.stop_gradient = False

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -19,8 +19,8 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
-    test_sot_only,
+    test_default_and_pir,
+    test_default_mode_only,
 )
 
 import paddle
@@ -253,7 +253,7 @@ class TestNameVisitor(Dy2StTestBase):
 
         self.nested_for_loop_func = nested_for_loop_dyfunc
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_loop_vars(self):
         for i in range(len(self.loop_funcs)):
             func = self.loop_funcs[i]
@@ -269,7 +269,7 @@ class TestNameVisitor(Dy2StTestBase):
                     self.assertEqual(loop_var_names, self.loop_var_names[i])
                     self.assertEqual(create_var_names, self.create_var_names[i])
 
-    @test_legacy_and_pt_and_pir
+    @test_default_and_pir
     def test_nested_loop_vars(self):
         func = self.nested_for_loop_func
         test_func = inspect.getsource(func)
@@ -338,7 +338,7 @@ class TestTransformWhileLoop(Dy2StTestBase):
         else:
             return ret
 
-    @test_sot_only
+    @test_default_mode_only
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
@@ -412,7 +412,7 @@ class TestTransformForLoop(Dy2StTestBase):
             ret = self.dyfunc(self.len)
         return ret.numpy()
 
-    @test_sot_only
+    @test_default_mode_only
     def test_ast_to_func(self):
         np.testing.assert_allclose(
             self._run_dygraph(), self._run_static(), rtol=1e-05
@@ -469,6 +469,7 @@ class Net(paddle.nn.Layer):
 
 
 class TestForLoopMeetDict(Dy2StTestBase):
+    @test_default_mode_only
     def test_start(self):
         net = Net()
         model = paddle.jit.to_static(

--- a/test/dygraph_to_static/test_mnist_amp.py
+++ b/test/dygraph_to_static/test_mnist_amp.py
@@ -16,6 +16,7 @@ import unittest
 from time import time
 
 import numpy as np
+from dygraph_to_static.utils import test_default_mode_only
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle
@@ -32,6 +33,7 @@ class TestAMP(TestMNIST):
     def train_dygraph(self):
         return self.train(to_static=False)
 
+    @test_default_mode_only
     def test_mnist_to_static(self):
         dygraph_loss = self.train_dygraph()
         static_loss = self.train_static()

--- a/test/dygraph_to_static/test_mnist_amp.py
+++ b/test/dygraph_to_static/test_mnist_amp.py
@@ -16,7 +16,6 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static_utils import test_default_mode_only
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle
@@ -33,7 +32,6 @@ class TestAMP(TestMNIST):
     def train_dygraph(self):
         return self.train(to_static=False)
 
-    @test_default_mode_only
     def test_mnist_to_static(self):
         dygraph_loss = self.train_dygraph()
         static_loss = self.train_static()

--- a/test/dygraph_to_static/test_mnist_amp.py
+++ b/test/dygraph_to_static/test_mnist_amp.py
@@ -16,7 +16,7 @@ import unittest
 from time import time
 
 import numpy as np
-from dygraph_to_static.utils import test_default_mode_only
+from dygraph_to_static_utils import test_default_mode_only
 from test_mnist import MNIST, SEED, TestMNIST
 
 import paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
| test in dygraph_to_static | 是否有单测 | 1x1(sec) | time2(sec) | 倍数    |
|---------------------------|-------|----------|------------|-------|
| test_loop                 | 有     | 29.66    | 67.01      | 2.26  |
| test_mnist_amp            | 有     | 12.98    | 42.34      | 3.26  |
| test_for_enumerate        | 有     | 14.56    | 30.75      | 2.11  |
| test_ifelse               | 有     | 11.88    | 26.11      | 2.2   |
| test_dict                 | 有     | 7.85     | 23.25      | 2.96  |
| test_break_continue       | 有     | 9.63     | 23         | 2.39  |
| test_decorator_transform  | 有     | 7.54     | 20.88      | 2.77  |
link #59339 
@SigureMo 