### PR TITLE
Fix block_idx bug for auto parallel

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -4061,8 +4061,7 @@ class Block:
         ), "skip_op_callstack parameter's type is error, expect bool, received {}".format(
             type(skip_op_callstack)
         )
-        block_str = "{ // block "
-        block_str += f"{self.idx}\n"
+        block_str = f"{{ // block_idx:{self.idx}  parallel_idx:{self.parent_idx}  forward_idx:{self.forward_block_idx}  backward_idx:{self.backward_block_idx}\n"
         for var in list(self.vars.values()):
             block_str += f"    {var._to_readable_code()}\n"
         block_str += "\n"
@@ -6921,6 +6920,9 @@ class Program:
         self.current_block_idx = new_block_idx
         self.blocks.append(Block(self, self.current_block_idx))
         return self.current_block()
+
+    def _roll_to_global_block(self):
+        self.current_block_idx = 0
 
     def _rollback(self):
         """

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -4061,7 +4061,7 @@ class Block:
         ), "skip_op_callstack parameter's type is error, expect bool, received {}".format(
             type(skip_op_callstack)
         )
-        block_str = f"{{ // block_idx:{self.idx}  parallel_idx:{self.parent_idx}  forward_idx:{self.forward_block_idx}  backward_idx:{self.backward_block_idx}\n"
+        block_str = f"{{ // block_idx:{self.idx}  parent_idx:{self.parent_idx}  forward_idx:{self.forward_block_idx}  backward_idx:{self.backward_block_idx}\n"
         for var in list(self.vars.values()):
             block_str += f"    {var._to_readable_code()}\n"
         block_str += "\n"

--- a/python/paddle/distributed/auto_parallel/static/dist_context.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_context.py
@@ -1199,9 +1199,7 @@ class BlockState:
         self.backward_to_forward_index_map = {}
 
     def parse_forward_blocks(self, program):
-        while program.current_block_idx != 0:
-            program._rollback()
-
+        program._roll_to_global_block()
         assert program.current_block_idx == 0
 
         for idx, block in enumerate(program.blocks):

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -276,8 +276,6 @@ def _create_cond_block_and_update_optimizer(
         cur_block_idx = main_program.current_block_idx
         cur_block = main_program.current_block()
 
-        # cur_block's forward_block & backward_block is itself
-        cur_block._set_forward_block_idx(cur_block_idx)
         if avg:
             for _, new_grad in new_params_to_grads:
                 # grad /= k_steps
@@ -364,9 +362,6 @@ def parse_program(
     optimize_ops_block = _remove_and_get_optimizer_op(
         main_program, dist_context
     )
-
-    # back to block 0
-    main_program._rollback()
 
     # 2 append gradient merge backward op to main_program
     (

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -614,9 +614,9 @@ def _program_for_fthenb_and_1f1b(program, enable_send_recv_overlap=False):
     bwd_prog._sync_with_cpp()
     opt_prog._sync_with_cpp()
 
-    fwd_prog._rollback()
-    bwd_prog._rollback()
-    opt_prog._rollback()
+    fwd_prog._roll_to_global_block()
+    bwd_prog._roll_to_global_block()
+    opt_prog._roll_to_global_block()
 
     # It MUST return in this order
     return [fwd_prog, bwd_prog, opt_prog]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-76459
修复自动并行`gradient_merge`和`pipeline`切图策略在网络存在多个子block的情况下，block_idx索引错乱的bug。