### PR TITLE
【PIR API adaptor No.257、265】Migrate gcd，lcm into pir 

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5657,7 +5657,7 @@ def gcd(x, y, name=None):
         )
         return (paddle.where(x < y, y, x), paddle.where(x < y, x, y))
 
-    if in_dynamic_or_pir_mode():
+    if in_dynamic_mode():
         while _gcd_cond_fn(x, y):
             x, y = _gcd_body_fn(x, y)
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5657,7 +5657,7 @@ def gcd(x, y, name=None):
         )
         return (paddle.where(x < y, y, x), paddle.where(x < y, x, y))
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         while _gcd_cond_fn(x, y):
             x, y = _gcd_body_fn(x, y)
 

--- a/test/legacy_test/test_gcd.py
+++ b/test/legacy_test/test_gcd.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import base
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
@@ -33,6 +32,10 @@ class TestGcdAPI(unittest.TestCase):
 
     @test_with_pir_api
     def test_static_graph(self):
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+        else:
+            place = core.CPUPlace()
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()
         ):
@@ -44,11 +47,7 @@ class TestGcdAPI(unittest.TestCase):
             )
             out = paddle.gcd(x, y)
             out_ref = np.gcd(self.x_np, self.y_np)
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
+
             exe = paddle.static.Executor(place)
             res = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_gcd.py
+++ b/test/legacy_test/test_gcd.py
@@ -43,7 +43,7 @@ class TestGcdAPI(unittest.TestCase):
                 name='input2', dtype='int32', shape=self.y_shape
             )
             out = paddle.gcd(x, y)
-
+            out_ref = np.gcd(self.x_np, self.y_np)
             place = (
                 base.CUDAPlace(0)
                 if core.is_compiled_with_cuda()
@@ -55,9 +55,7 @@ class TestGcdAPI(unittest.TestCase):
                 feed={'input1': self.x_np, 'input2': self.y_np},
                 fetch_list=[out],
             )
-            self.assertTrue(
-                (np.array(res[0]) == np.gcd(self.x_np, self.y_np)).all()
-            )
+            self.assertTrue((res[0] == out_ref).all(), True)
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_gcd.py
+++ b/test/legacy_test/test_gcd.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -30,10 +31,11 @@ class TestGcdAPI(unittest.TestCase):
         self.x_shape = [1]
         self.y_shape = [1]
 
+    @test_with_pir_api
     def test_static_graph(self):
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(startup_program, train_program):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.static.data(
                 name='input1', dtype='int32', shape=self.x_shape
             )
@@ -47,9 +49,9 @@ class TestGcdAPI(unittest.TestCase):
                 if core.is_compiled_with_cuda()
                 else base.CPUPlace()
             )
-            exe = base.Executor(place)
+            exe = paddle.static.Executor(place)
             res = exe.run(
-                base.default_main_program(),
+                paddle.static.default_main_program(),
                 feed={'input1': self.x_np, 'input2': self.y_np},
                 fetch_list=[out],
             )

--- a/test/legacy_test/test_gcd.py
+++ b/test/legacy_test/test_gcd.py
@@ -52,7 +52,7 @@ class TestGcdAPI(unittest.TestCase):
                 feed={'input1': self.x_np, 'input2': self.y_np},
                 fetch_list=[out],
             )
-            self.assertTrue((res[0] == out_ref).all(), True)
+            self.assertTrue((res[0] == out_ref).all())
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_gcd.py
+++ b/test/legacy_test/test_gcd.py
@@ -20,8 +20,6 @@ import paddle
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
-paddle.enable_static()
-
 
 class TestGcdAPI(unittest.TestCase):
     def setUp(self):
@@ -98,3 +96,8 @@ class TestGcdAPI5(TestGcdAPI):
         self.y_np = -20
         self.x_shape = []
         self.y_shape = []
+
+
+if __name__ == "__main__":
+    paddle.enable_static()
+    unittest.main()

--- a/test/legacy_test/test_lcm.py
+++ b/test/legacy_test/test_lcm.py
@@ -51,7 +51,7 @@ class TestLcmAPI(unittest.TestCase):
                 feed={'input1': self.x_np, 'input2': self.y_np},
                 fetch_list=[out],
             )
-            self.assertTrue((res[0] == out_ref).all(), True)
+            self.assertTrue((res[0] == out_ref).all())
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_lcm.py
+++ b/test/legacy_test/test_lcm.py
@@ -43,7 +43,7 @@ class TestLcmAPI(unittest.TestCase):
                 name='input2', dtype='int32', shape=self.y_shape
             )
             out = paddle.lcm(x1, x2)
-
+            out_ref = np.lcm(self.x_np, self.y_np)
             place = (
                 base.CUDAPlace(0)
                 if core.is_compiled_with_cuda()
@@ -55,9 +55,7 @@ class TestLcmAPI(unittest.TestCase):
                 feed={'input1': self.x_np, 'input2': self.y_np},
                 fetch_list=[out],
             )
-            self.assertTrue(
-                (np.array(res[0]) == np.lcm(self.x_np, self.y_np)).all()
-            )
+            self.assertTrue((res[0] == out_ref).all(), True)
 
     def test_dygraph(self):
         paddle.disable_static()

--- a/test/legacy_test/test_lcm.py
+++ b/test/legacy_test/test_lcm.py
@@ -20,8 +20,6 @@ import paddle
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
-paddle.enable_static()
-
 
 class TestLcmAPI(unittest.TestCase):
     def setUp(self):
@@ -97,3 +95,8 @@ class TestLcmAPI5(TestLcmAPI):
         self.y_np = -20
         self.x_shape = []
         self.y_shape = []
+
+
+if __name__ == "__main__":
+    paddle.enable_static()
+    unittest.main()

--- a/test/legacy_test/test_lcm.py
+++ b/test/legacy_test/test_lcm.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import base
 from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
@@ -33,6 +32,10 @@ class TestLcmAPI(unittest.TestCase):
 
     @test_with_pir_api
     def test_static_graph(self):
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+        else:
+            place = core.CPUPlace()
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()
         ):
@@ -44,11 +47,6 @@ class TestLcmAPI(unittest.TestCase):
             )
             out = paddle.lcm(x1, x2)
             out_ref = np.lcm(self.x_np, self.y_np)
-            place = (
-                base.CUDAPlace(0)
-                if core.is_compiled_with_cuda()
-                else base.CPUPlace()
-            )
             exe = paddle.static.Executor(place)
             res = exe.run(
                 paddle.static.default_main_program(),

--- a/test/legacy_test/test_lcm.py
+++ b/test/legacy_test/test_lcm.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -30,10 +31,11 @@ class TestLcmAPI(unittest.TestCase):
         self.x_shape = []
         self.y_shape = []
 
+    @test_with_pir_api
     def test_static_graph(self):
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(startup_program, train_program):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x1 = paddle.static.data(
                 name='input1', dtype='int32', shape=self.x_shape
             )
@@ -47,9 +49,9 @@ class TestLcmAPI(unittest.TestCase):
                 if core.is_compiled_with_cuda()
                 else base.CPUPlace()
             )
-            exe = base.Executor(place)
+            exe = paddle.static.Executor(place)
             res = exe.run(
-                base.default_main_program(),
+                paddle.static.default_main_program(),
                 feed={'input1': self.x_np, 'input2': self.y_np},
                 fetch_list=[out],
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级 * https://github.com/PaddlePaddle/Paddle/issues/58067

No.257 `paddle.Tensor.gcd`
No.265 `paddle.Tensor.lcm`

因为lcm要使用gcd，故放一起。

将 `paddle.Tensor.gcd` 迁移升级至 pir，并更新单测 单测覆盖率：5/5
将 `paddle.Tensor.lcm` 迁移升级至 pir，并更新单测 单测覆盖率：5/5
