### PR TITLE
【PIR API adaptor No.28】Migrate `paddle.vision.ops.box_coder` into pir

### DIFF
--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -675,7 +675,7 @@ def box_coder(
             ...     box_normalized=False)
             ...
     """
-    if in_dygraph_mode():
+    if in_dynamic_or_pir_mode():
         if isinstance(prior_box_var, (core.eager.Tensor, OpResult)):
             output_box = _C_ops.box_coder(
                 prior_box,

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -15,6 +15,7 @@
 import numpy as np
 
 from paddle import _C_ops, _legacy_C_ops
+from paddle.pir import OpResult
 from paddle.tensor.math import _add_with_axis
 from paddle.utils import convert_to_list
 
@@ -675,7 +676,7 @@ def box_coder(
             ...
     """
     if in_dygraph_mode():
-        if isinstance(prior_box_var, core.eager.Tensor):
+        if isinstance(prior_box_var, (core.eager.Tensor, OpResult)):
             output_box = _C_ops.box_coder(
                 prior_box,
                 prior_box_var,

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -14,8 +14,8 @@
 
 import numpy as np
 
+import paddle
 from paddle import _C_ops, _legacy_C_ops
-from paddle.pir import OpResult
 from paddle.tensor.math import _add_with_axis
 from paddle.utils import convert_to_list
 
@@ -676,7 +676,7 @@ def box_coder(
             ...
     """
     if in_dynamic_or_pir_mode():
-        if isinstance(prior_box_var, (core.eager.Tensor, OpResult)):
+        if isinstance(prior_box_var, (core.eager.Tensor, paddle.pir.Value)):
             output_box = _C_ops.box_coder(
                 prior_box,
                 prior_box_var,

--- a/test/legacy_test/test_box_coder_op.py
+++ b/test/legacy_test/test_box_coder_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def box_decoder(t_box, p_box, pb_v, output_box, norm, axis=0):
@@ -109,7 +110,7 @@ def batch_box_coder(p_box, pb_v, t_box, lod, code_type, norm, axis=0):
 
 class TestBoxCoderOp(OpTest):
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def setUp(self):
         self.op_type = "box_coder"
@@ -142,7 +143,7 @@ class TestBoxCoderOp(OpTest):
 
 class TestBoxCoderOpWithoutBoxVar(OpTest):
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def setUp(self):
         self.python_api = paddle.vision.ops.box_coder
@@ -176,7 +177,7 @@ class TestBoxCoderOpWithoutBoxVar(OpTest):
 
 class TestBoxCoderOpWithLoD(OpTest):
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def setUp(self):
         self.python_api = paddle.vision.ops.box_coder
@@ -207,7 +208,7 @@ class TestBoxCoderOpWithLoD(OpTest):
 
 class TestBoxCoderOpWithAxis(OpTest):
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def setUp(self):
         self.python_api = paddle.vision.ops.box_coder
@@ -286,7 +287,7 @@ def wrapper_box_coder(
 
 class TestBoxCoderOpWithVariance(OpTest):
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def setUp(self):
         self.op_type = "box_coder"
@@ -370,6 +371,7 @@ class TestBoxCoderAPI(unittest.TestCase):
         self.prior_box_var_np = np.random.random((80, 4)).astype('float32')
         self.target_box_np = np.random.random((20, 80, 4)).astype('float32')
 
+    @test_with_pir_api
     def test_dygraph_with_static(self):
         paddle.enable_static()
         exe = paddle.static.Executor()
@@ -428,6 +430,7 @@ class TestBoxCoderSupporttuple(unittest.TestCase):
         self.prior_box_np = np.random.random((80, 4)).astype('float32')
         self.target_box_np = np.random.random((20, 80, 4)).astype('float32')
 
+    @test_with_pir_api
     def test_support_tuple(self):
         paddle.enable_static()
         exe = paddle.static.Executor()

--- a/test/legacy_test/test_box_coder_op.py
+++ b/test/legacy_test/test_box_coder_op.py
@@ -177,7 +177,7 @@ class TestBoxCoderOpWithoutBoxVar(OpTest):
 
 class TestBoxCoderOpWithLoD(OpTest):
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output()
 
     def setUp(self):
         self.python_api = paddle.vision.ops.box_coder


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Description
<!-- Describe what you’ve done -->
link #58067
PIR API 推全升级
将 `paddle.vision.ops.box_coder` 迁移升级至 pir，并更新单测
单测覆盖率:  `6/7`
单测会报错 `TestBoxCoderOpWithLoD` , 因为目前 pir 不支持 lod
![image](https://github.com/PaddlePaddle/Paddle/assets/106524776/eaf603bc-f6a5-4632-8132-fc66f8192de2)
