### PR TITLE
【PIR OpTest Fix No.7】 fix test_activation_op

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -124,6 +124,7 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'send_v2',
     'shadow_feed',
     'sparse_momentum',
+    'soft_relu',
     'uniform_random_batch_size_like',
 ]
 

--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -1133,6 +1133,16 @@
     func : slice
   backward : slice_grad
 
+- op : soft_relu
+  args : (Tensor x, float threshold = 20.0f)
+  output : Tensor(out)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [x]
+  kernel :
+    func : soft_relu
+  backward : soft_relu_grad
+
 - op : softmax
   args : (Tensor x, int axis)
   output : Tensor(out)

--- a/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
@@ -686,6 +686,16 @@
   backward : slice_double_grad
   no_need_buffer : input
 
+- backward_op : soft_relu_grad
+  forward : soft_relu (Tensor x, float threshold) -> Tensor(out)
+  args : (Tensor out, Tensor out_grad, float threshold)
+  output : Tensor(x_grad)
+  infer_meta :
+    func : UnchangedInferMeta
+    param : [out]
+  kernel :
+    func : soft_relu_grad
+
 - backward_op : softmax_grad
   forward : softmax (Tensor x, int axis) -> Tensor(out)
   args : (Tensor out, Tensor out_grad, int axis)

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -50,7 +50,9 @@ const std::unordered_set<std::string> LegacyOpList = {
     SeedOp::name(),
     ShareDataOp::name(),
     SparseMomentumOp::name(),
-    GetTensorFromSelectedRowsOp::name()};
+    GetTensorFromSelectedRowsOp::name(),
+    SoftReluOp::name(),
+    SoftReluGradOp::name()};
 
 enum class AttrType {
   UNDEFINED = 0,

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2820,6 +2820,13 @@
   outputs :
     out : Out
 
+- op : soft_relu
+  backward : soft_relu_grad
+  inputs :
+    x : X
+  outputs :
+    out : Out
+
 - op : softmax
   backward : softmax_grad
   inputs :

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -1,6 +1,7 @@
 test_accuracy_op
 test_activation_bf16_mkldnn_op
 test_activation_mkldnn_op
+test_activation_op
 test_adadelta_op
 test_adagrad_op
 test_adagrad_op_static_build


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PIR Op单测修复
修复单测 `test_activation_op`
修复后打开`FLAGS_enable_pir_in_executor`单测是否通过：否
报错信息：paddle::operators::DataOp::GetExpectedKernelType(paddle::framework::ExecutionContext const&) const
FatalError: `Segmentation fault` is detected by the operating system.