### PR TITLE
[clang-tidy] NO.20 enable `modernize-use-nullptr` check (part2)

### DIFF
--- a/paddle/fluid/inference/api/resource_manager.cc
+++ b/paddle/fluid/inference/api/resource_manager.cc
@@ -89,14 +89,14 @@ class EigenGpuStreamDevice : public Eigen::StreamInterface {
   }
 
   void* scratchpad() const override {
-    if (scratch_ == NULL) {
+    if (scratch_ == nullptr) {
       scratch_ = allocate(Eigen::kGpuScratchSize + sizeof(unsigned int));
     }
     return scratch_;
   }
 
   unsigned int* semaphore() const override {
-    if (semaphore_ == NULL) {
+    if (semaphore_ == nullptr) {
       char* scratch = static_cast<char*>(scratchpad()) + Eigen::kGpuScratchSize;
       semaphore_ = reinterpret_cast<unsigned int*>(scratch);
 #ifdef PADDLE_WITH_HIP

--- a/paddle/fluid/memory/memcpy.cc
+++ b/paddle/fluid/memory/memcpy.cc
@@ -275,7 +275,7 @@ inline void SyncCUDAStream() {
 #else
 inline void SyncCUDAStream() {
 #if !defined(_WIN32)
-  cudaStreamSynchronize(0);
+  cudaStreamSynchronize(nullptr);
 #else
   cudaError_t e_sync = cudaSuccess;
   while (e_sync = cudaStreamQuery(0)) {

--- a/paddle/fluid/pybind/eval_frame_tools.cc
+++ b/paddle/fluid/pybind/eval_frame_tools.cc
@@ -39,7 +39,7 @@ class TreeNode {
 
 void TreeNode::clear() {
   for (int i = 0; i < 256; i++) {
-    if (children[i] != NULL) delete children[i];
+    if (children[i] != nullptr) delete children[i];
   }
 }
 
@@ -48,7 +48,7 @@ int TreeNode::add_prefix(const char* filepath) {
   if (filepath[0] == '\0') return 1;
 
   int ch = (int)filepath[0];  // NOLINT
-  if (children[ch] == NULL) {
+  if (children[ch] == nullptr) {
     TreeNode* node = new TreeNode();
     children[ch] = node;
   }
@@ -64,7 +64,7 @@ int TreeNode::check_filename(const char* filename) {
 
   while (filename[cur_idx] != '\0') {
     cur_node = cur_node->children[(int)filename[cur_idx]];  // NOLINT
-    if (cur_node == NULL) return 0;
+    if (cur_node == nullptr) return 0;
     if (cur_node->is_prefix) return 1;
     cur_idx += 1;
   }

--- a/paddle/phi/api/profiler/device_tracer.cc
+++ b/paddle/phi/api/profiler/device_tracer.cc
@@ -196,7 +196,7 @@ void CUPTIAPI bufferCompleted(CUcontext ctx,
       errors::PermissionDenied(
           "Only one thread is allowed to call bufferCompleted()."));
   CUptiResult status;
-  CUpti_Activity *record = NULL;
+  CUpti_Activity *record = nullptr;
   if (validSize > 0) {
     do {
       status = dynload::cuptiActivityGetNextRecord(buffer, validSize, &record);

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -106,14 +106,14 @@ class EigenGpuStreamDevice : public Eigen::StreamInterface {
   }
 
   void* scratchpad() const override {
-    if (scratch_ == NULL) {
+    if (scratch_ == nullptr) {
       scratch_ = allocate(Eigen::kGpuScratchSize + sizeof(unsigned int));
     }
     return scratch_;
   }
 
   unsigned int* semaphore() const override {
-    if (semaphore_ == NULL) {
+    if (semaphore_ == nullptr) {
       char* scratch = static_cast<char*>(scratchpad()) + Eigen::kGpuScratchSize;
       semaphore_ = reinterpret_cast<unsigned int*>(scratch);
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/fusion/cpu/fusion_seqexpand_concat_fc_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fusion_seqexpand_concat_fc_kernel.cc
@@ -124,7 +124,7 @@ void FusionSeqExpandConcatFCKernel(const Context& dev_ctx,
      ref_in_data,
      w_data,
      out_data,
-     fc_bias ? fc_bias->data<T>() : NULL);
+     fc_bias ? fc_bias->data<T>() : nullptr);
   w_data = w_data + M0 * D;
   // first write on
   blas.MatMul(N, D, M1, in1_data, w_data, fc_out_data);

--- a/test/cpp/inference/api/analyzer_capi_exp_pd_tensor_tester.cc
+++ b/test/cpp/inference/api/analyzer_capi_exp_pd_tensor_tester.cc
@@ -56,7 +56,7 @@ void PD_run() {
 
   PD_TwoDimArraySize lod;
   lod.size = 0;
-  lod.data = NULL;
+  lod.data = nullptr;
   PD_TensorSetLod(tensor, &lod);
 
   PD_PredictorRun(predictor);

--- a/test/cpp/inference/api/analyzer_capi_exp_pd_threads_tester.cc
+++ b/test/cpp/inference/api/analyzer_capi_exp_pd_threads_tester.cc
@@ -70,7 +70,7 @@ void* run(void* thread_param) {
   PD_TensorDestroy(tensor);
   PD_OneDimArrayCstrDestroy(input_names);
   LOG(INFO) << "Thread " << param->thread_index << " end run!";
-  return NULL;
+  return nullptr;
 }
 void threads_run(int thread_num) {
   auto model_dir = FLAGS_infer_model;
@@ -94,12 +94,12 @@ void threads_run(int thread_num) {
     params[i].shape_size = 4;
     params[i].input_data = input;
     params[i].out_size = 0;
-    params[i].out_data = NULL;
+    params[i].out_data = nullptr;
     params[i].thread_index = i;
-    pthread_create(&(threads[i]), NULL, run, (params + i));
+    pthread_create(&(threads[i]), nullptr, run, (params + i));
   }
   for (int i = 0; i < thread_num; ++i) {
-    pthread_join(threads[i], NULL);
+    pthread_join(threads[i], nullptr);
   }
   ASSERT_GT(params[0].out_size, 0);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
NO.12 enable `modernize-use-nullptr` check (part2)

- #55800
- #54073
