### PR TITLE
【PIR OpTest Fix No.9】 fix test_sequence_mask

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -122,6 +122,7 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'rnn_',
     'seed',
     'send_v2',
+    'sequence_mask',
     'shadow_feed',
     'sparse_momentum',
     'uniform_random_batch_size_like',

--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -1084,6 +1084,18 @@
     func : send_v2
     param : [x, ring_id, dynamic_shape, peer, use_calc_stream]
 
+- op : sequence_mask
+  args : (Tensor x, Tensor max_len_tensor, int out_dtype, int maxlen=-1)
+  output : Tensor(y)
+  infer_meta:
+     func : SequenceMaskInferMeta
+     param : [x, max_len_tensor, maxlen, out_dtype]
+  kernel :
+     func : sequence_mask
+     param : [x, max_len_tensor, maxlen, out_dtype]
+     data_type : x
+  optional : max_len_tensor
+
 - op : set_value
   args : (Tensor x, IntArray starts, IntArray ends, IntArray steps, int64_t[] axes, int64_t[] decrease_axes, int64_t[] none_axes, int64_t[] shape, Scalar[] values)
   output : Tensor(out)

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2709,6 +2709,12 @@
 - op : send_uv (graph_send_uv)
   backward : send_uv_grad (graph_send_uv_grad)
 
+- op : sequence_mask
+  inputs:
+    {x : X, max_len_tensor : MaxLenTensor}
+  outputs:
+    {y : Y}
+
 - op : sequence_softmax
   backward : sequence_softmax_grad
   extra :

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -265,6 +265,7 @@ test_seed_op
 test_segment_ops
 test_segment_ops_static_build
 test_selu_op
+test_sequence_mask
 test_sgd_op
 test_shape_mkldnn_op
 test_shape_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PIR Op单测修复
修复单测 `test_sequence_mask`
修复后打开`FLAGS_enable_pir_in_executor`单测是否通过：是
