### PR TITLE
add profiler_range

### DIFF
--- a/python/paddle/profiler/utils.py
+++ b/python/paddle/profiler/utils.py
@@ -234,13 +234,13 @@ def _nvprof_range(iter_id, start, end, exit_after_prof=True):
 
 
 @contextmanager
-def profiler_range(iter_id, start, end, exit_after_prof=True):
+def job_schedule_profiler_range(iter_id, start, end, exit_after_prof=True):
     if start >= end:
         yield False
         return
 
     try:
-        if (iter_id == start) or (iter_id >= start):
+        if iter_id >= start and iter_id < end:
             yield True
         else:
             yield False

--- a/python/paddle/profiler/utils.py
+++ b/python/paddle/profiler/utils.py
@@ -231,3 +231,20 @@ def _nvprof_range(iter_id, start, end, exit_after_prof=True):
             core.nvprof_stop()
             if exit_after_prof:
                 sys.exit()
+
+
+@contextmanager
+def profiler_range(iter_id, start, end, exit_after_prof=True):
+    if start >= end:
+        yield False
+        return
+
+    try:
+        if (iter_id == start) or (iter_id >= start):
+            yield True
+        else:
+            yield False
+    finally:
+        if iter_id == end - 1:
+            if exit_after_prof:
+                sys.exit()

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -244,4 +244,4 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
 endif()
 
 py_test_modules(test_job_schedule_profiler_range MODULES
-                  test_job_schedule_profiler_range)
+                test_job_schedule_profiler_range)

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -242,3 +242,6 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()
+
+py_test_modules(test_job_schedule_profiler_range MODULES
+                  test_job_schedule_profiler_range)

--- a/test/auto_parallel/test_job_schedule_profiler_range.py
+++ b/test/auto_parallel/test_job_schedule_profiler_range.py
@@ -18,21 +18,41 @@ from paddle.profiler.utils import job_schedule_profiler_range
 
 
 class TestJobScheDuleProfilerRange(unittest.TestCase):
-    def test_exit_after_prof_1(self):
-        status_list = [False, False, False, True, True]
+    def test_not_exit_after_prof_1(self):
+        status_list = [
+            False,
+            False,
+            False,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ]
         for i in range(10):
-            with job_schedule_profiler_range(i, 3, 5) as status:
+            with job_schedule_profiler_range(i, 3, 6, False) as status:
                 self.assertEqual(status, status_list[i])
-            assert i < 5
 
-    def test_exit_after_prof_2(self):
-        status_list = [True, True, True, True, True]
+    def test_not_exit_after_prof_2(self):
+        status_list = [
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
         for i in range(10):
-            with job_schedule_profiler_range(i, 0, 5) as status:
+            with job_schedule_profiler_range(i, 0, 5, False) as status:
                 self.assertEqual(status, status_list[i])
-            assert i < 5
 
-    def test_not_exit_after_prof(self):
+    def test_not_exit_after_prof_3(self):
         status_list = [
             False,
             False,

--- a/test/auto_parallel/test_job_schedule_profiler_range.py
+++ b/test/auto_parallel/test_job_schedule_profiler_range.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.profiler.utils import job_schedule_profiler_range
+
+
+class TestJobScheDuleProfilerRange(unittest.TestCase):
+    def test_exit_after_prof_1(self):
+        status_list = [False, False, False, True, True]
+        for i in range(10):
+            with job_schedule_profiler_range(i, 3, 5) as status:
+                self.assertEqual(status, status_list[i])
+            assert i < 5
+
+    def test_exit_after_prof_2(self):
+        status_list = [True, True, True, True, True]
+        for i in range(10):
+            with job_schedule_profiler_range(i, 0, 5) as status:
+                self.assertEqual(status, status_list[i])
+            assert i < 5
+
+    def test_not_exit_after_prof(self):
+        status_list = [
+            False,
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
+        for i in range(10):
+            with job_schedule_profiler_range(i, 3, 5, False) as status:
+                self.assertEqual(status, status_list[i])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/test_job_schedule_profiler_range.py
+++ b/test/auto_parallel/test_job_schedule_profiler_range.py
@@ -69,6 +69,23 @@ class TestJobScheDuleProfilerRange(unittest.TestCase):
             with job_schedule_profiler_range(i, 3, 5, False) as status:
                 self.assertEqual(status, status_list[i])
 
+    def test_end_less_than_start(self):
+        status_list = [
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
+        for i in range(10):
+            with job_schedule_profiler_range(i, 5, 3, False) as status:
+                self.assertEqual(status, status_list[i])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
添加 profiler_range 工具，方便 便捷地启用 profile 工具：

```python
with profiler_range(step, job_schedule_profiler_start, job_schedule_profiler_end) as enable_profiler:
    engine.enable_job_schedule_profiler = enable_profiler
```

相关pr：

- https://github.com/PaddlePaddle/PaddleNLP/pull/7343
