### PR TITLE
[Paddle Inference] modify a check statement in memory_optimize_pass.cc

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -92,7 +92,7 @@ void MemoryOptimizePass::CollectLifeCycle(
 
           auto in_shape = node->Var()->GetShape();
           for (auto i : in_shape) {
-            CHECK_GT(i, 0);
+            CHECK_GE(i, 0);
           }
           auto var_bytes = std::accumulate(in_shape.begin(),
                                            in_shape.end(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

P-card-71501

- 经过常量折叠之后，某些tensor的shape 中的元素可能为0，因为改正CHECK_GT为CHECK_GE
