### PR TITLE
[TEST] Simplify the symbol in mock shape dialect

### DIFF
--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -136,7 +136,7 @@ bool ShapeConstraintIRAnalysis::IsProductEqual(Value lhs,
   return mgr_.IsSymbolicDimProductEqual(lhs_prod, rhs_prod);
 }
 
-const std::vector<shape::SymbolicDimOp>&
+std::vector<shape::SymbolicDimOp>&
 ShapeConstraintIRAnalysis::GetOrCreateSymbolicDimsForRankedValue(
     const Value& value) {
   if (value_to_sym_dims_.find(value) == value_to_sym_dims_.end()) {

--- a/paddle/pir/dialect/shape/utils/shape_utils.h
+++ b/paddle/pir/dialect/shape/utils/shape_utils.h
@@ -60,8 +60,8 @@ class IR_API ShapeConstraintIRAnalysis : public ShapeAnalysis {
   SymbolicDimMgr& symbolicDimMgr() { return mgr_; }
   const SymbolicDimMgr& symbolicDimMgr() const { return mgr_; }
 
-  const std::vector<shape::SymbolicDimOp>&
-  GetOrCreateSymbolicDimsForRankedValue(const Value& value);
+  std::vector<shape::SymbolicDimOp>& GetOrCreateSymbolicDimsForRankedValue(
+      const Value& value);
 
   // Returns true if the two value have the same symbolic shape.
   bool IsShapeEqual(Value lhs, Value rhs) override;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
用于在符号化维度推导时，将约束关系为相等的符号维度化简为相同的符号表示。
本PR中的处理方式仅适用于最小验证集下网络结构的符号表示优化，目的是为了便于编译器后端开展相关的机制开发工作。更完备的符号化简功能需要在`shape dialect`增加专门的归一处理。