### PR TITLE
[oneDNN] Optimize fused elementwise kernel

### DIFF
--- a/paddle/phi/kernels/fusion/onednn/fused_elementwise_kernel.cc
+++ b/paddle/phi/kernels/fusion/onednn/fused_elementwise_kernel.cc
@@ -66,8 +66,18 @@ void FusedElementwiseKernel(const OneDNNContext& dev_ctx,
     std::swap(non_const_x, non_const_y);
   }
 
-  const auto src_x_memory = handler.AcquireSrcMemory(non_const_x);
-  const auto src_y_memory = handler.AcquireSecondSrcMemory(non_const_y);
+  const auto src_x_memory =
+      handler.swin_case ? (x.numel() == y.numel()
+                               ? handler.AcquireExtendSrcMemory(non_const_x, 0)
+                               : handler.AcquireSrcMemory(non_const_x))
+                        : handler.AcquireSrcMemory(non_const_x);
+
+  const auto src_y_memory =
+      handler.swin_case ? (x.numel() == y.numel()
+                               ? handler.AcquireSecondSrcMemory(non_const_y)
+                               : handler.AcquireExtendSrcMemory(non_const_y, 1))
+                        : handler.AcquireSecondSrcMemory(non_const_y);
+
   // For Inplace src and dst should be the same memory object.
   // So x should share buffer with z. But UT mechanics is testing inplace
   // execution for this op not checking that x can be bradcasted to match in


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
This PR aims for int8 case in https://github.com/PaddlePaddle/Paddle/issues/59252 when `config.enable_mkldnn_int8()` is activated. For float & int8, paddle will go through different passes and hence different kernels. So for int8 case, the refreshed kernel can not utilizes what former PR https://github.com/PaddlePaddle/Paddle/pull/59421 optimizes. 