### PR TITLE
[AutoParallel] Fix xshape dtype in reshape and the dist_attr of reshard

### DIFF
--- a/paddle/phi/api/lib/tensor_utils.cc
+++ b/paddle/phi/api/lib/tensor_utils.cc
@@ -138,8 +138,12 @@ PADDLE_API std::shared_ptr<phi::distributed::DistTensor> reshard(
                                                                  dist_attr);
       dist_out_ptr = func->Eval(dev_ctx, *dist_tensor, dist_attr);
     } else {
-      dist_out_ptr = std::static_pointer_cast<phi::distributed::DistTensor>(
-          input_tensor_impl);
+      phi::distributed::DistTensor* dist_tensor =
+          static_cast<phi::distributed::DistTensor*>(input_tensor_impl.get());
+      dist_out_ptr = std::make_shared<phi::distributed::DistTensor>(
+          dist_tensor->dims(), dist_attr);
+      phi::DenseTensor* dense_out = dist_out_ptr->unsafe_mutable_value();
+      *dense_out = dist_tensor->value();
     }
   }
   return dist_out_ptr;

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3464,6 +3464,7 @@ void ReshapeWithXShapeInferMeta(const MetaTensor& x,
   xshape->set_dims(common::make_ddim(xshape_dims));
   xshape->share_lod(x);
   xshape->set_strides(x.strides());
+  xshape->set_dtype(DataType::INT64);
   ReshapeInferMeta(x, shape, out, config);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复reshape的infermeta没有dtype和reshard非计算rank没有配置正确的dist_attr的问题。

Pcard-73145