### PR TITLE
[SOT] Add `paddle.metric` to paddle API

### DIFF
--- a/python/paddle/jit/sot/utils/paddle_api_config.py
+++ b/python/paddle/jit/sot/utils/paddle_api_config.py
@@ -38,6 +38,7 @@ def get_paddle_api():
         paddle.signal,
         paddle.fft,
         paddle.vision.ops,
+        paddle.metric,
     ]
     special_paddle_apis = [paddle.tensor.fill_constant]
     non_operator_related_apis = [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

将 paddle.metric 加入到 paddle 组网 API module 列表中，避免模拟执行

PCard-66972