### PR TITLE
[SOT] fix sot call locals

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py
@@ -191,6 +191,7 @@ def start_translate(frame: types.FrameType, **kwargs) -> GuardedFunction:
     """
     simulator = OpcodeExecutor(frame, **kwargs)
     try:
+        simulator.check_code_simulatable()
         new_custom_code, guard_fn = simulator.transform()
         return new_custom_code, guard_fn
     # TODO(zrr1999): InnerError maybe place before (FallbackError, BreakGraphError)

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -364,8 +364,14 @@ class OpcodeExecutorBase:
             str, ...
         ] | None = None  # store kwnames for Python 3.11+
         self._prepare_virtual_env()
-
         self.stop_state = None
+
+    def check_code_simulatable(self):
+        for instr in self._instructions:
+            if instr.opname == "LOAD_GLOBAL" and instr.argval == "locals":
+                raise FallbackError(
+                    "Can not support call builtin function `locals`"
+                )
 
     def print_sir(self):
         """

--- a/test/sot/test_unsupport_function.py
+++ b/test/sot/test_unsupport_function.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from test_case_base import TestCaseBase
+
+import paddle
+from paddle.jit.sot.utils import strict_mode_guard
+
+
+def call_locals(x: int, y: paddle.Tensor):
+    tmp = locals()
+    return x + y + len(list(tmp.keys())), list(tmp.keys())
+
+
+class TestUnsupportFunction(TestCaseBase):
+    @strict_mode_guard(False)
+    def test_locals(self):
+        x = paddle.to_tensor([2])
+        y = paddle.to_tensor([3])
+        self.assert_results(call_locals, x, y)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
currently we will call locals by break graph, but this will lead to error in some cases, so we will fallback before simulate if locals is called

PCard-66972