### PR TITLE
[AutoConfig] Add DP Estimation

### DIFF
--- a/python/paddle/distributed/auto_tuner/cost_model.py
+++ b/python/paddle/distributed/auto_tuner/cost_model.py
@@ -86,7 +86,7 @@ def divisor(num, reverse=False):
 def get_not_oom_cfgs(cfgs, tuner_cfg):
     """Get not OOM parallel strategies."""
     total_cards, l, h, a, V, s, gbs, per_card_memory = (
-        tuner_cfg["estimated_num_gpus"],
+        tuner_cfg["search_algo"]["estimated_num_gpus"],
         tuner_cfg["model_cfg"]["num_layers"],
         tuner_cfg["model_cfg"]["hidden_size"],
         tuner_cfg["model_cfg"]["num_attention_heads"],

--- a/python/paddle/distributed/auto_tuner/recorder.py
+++ b/python/paddle/distributed/auto_tuner/recorder.py
@@ -88,6 +88,8 @@ class HistoryRecorder:
         # check if 'time' exists
         if 'time' in df.columns:
             df = df.drop(columns=['time'])
+        if 'has_error' in df.columns:
+            df = df.drop(columns=['has_error'])
         # write to csv
         df.to_csv(self.store_path, index=False)
 

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -59,15 +59,9 @@ class DpEstimationSearch(SearchAlgo):
         super().__init__(tuner_cfg)
         self.idx = 0
         self.all_tasks = search_by_dp_estimation(tuner_cfg)
-        assert len(self.all_tasks) > 0, "Unable to perform this search."
-        # change global_batch_size and dp_degree
-        tuner_cfg["model_cfg"]["global_batch_size"] = (
-            tuner_cfg["model_cfg"]["global_batch_size"]
-            // self.all_tasks[0]["dp_degree"]
-        )
-        for task in self.all_tasks:
-            task["estimated_dp_degree"] = task["dp_degree"]
-            task["dp_degree"] = 1
+        assert (
+            len(self.all_tasks) > 0
+        ), "Unable to perform single dp estimation search."
 
     def search_once(self, history_cfgs):
         new_cfg = None

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -15,7 +15,7 @@
 
 from abc import ABC, abstractmethod
 
-from .prune import _PRUNE_FUNC
+from .prune import _PRUNE_HISTORY_FUNC
 from .utils import gbs_search_all, search_all, search_by_dp_estimation
 
 
@@ -28,7 +28,7 @@ class SearchAlgo(ABC):
         pass
 
     def prune(self, tuner_cfg, cur_cfg, history_cfgs):
-        for func in _PRUNE_FUNC:
+        for func in _PRUNE_HISTORY_FUNC:
             result = func(tuner_cfg, cur_cfg, history_cfgs)
             if result:
                 return True

--- a/python/paddle/distributed/auto_tuner/utils.py
+++ b/python/paddle/distributed/auto_tuner/utils.py
@@ -487,7 +487,8 @@ def add_overlap_performance(cur_cfg, tuner_cfg, history_cfgs):
 
 def gen_sharding_overlap_args(res_args, cfg, tuner_cfg):
     """Generate args of sharding overlap."""
-    assert "sharding_overlap" in tuner_cfg["search_algo"]
+    if "sharding_overlap" not in tuner_cfg["search_algo"]:
+        return
     cmd = copy.deepcopy(tuner_cfg["search_algo"]["sharding_overlap"])
     if cfg.get("sharding_overlap", False):
         valid_hybrid_strategy = ["sharding_mp", "sharding_pp", "sharding_mp_pp"]

--- a/python/paddle/distributed/auto_tuner/utils.py
+++ b/python/paddle/distributed/auto_tuner/utils.py
@@ -19,6 +19,8 @@ import os
 import re
 from typing import Tuple
 
+from .prune import _PRUNE_FUNC
+
 
 def divisor(num, reverse=False):
     """Return the divisor of the given number."""
@@ -42,7 +44,10 @@ def dist_degree(mode, num_gpus, num_nodes, tuner_cfg=None):
     results = []
     prune_results = []
     if mode == "dp":
-        results = divisor(num_gpus, reverse=False)
+        if tuner_cfg.get("schedule_mode", "memory") != "performance":
+            results = divisor(num_gpus, reverse=False)
+        else:
+            results = divisor(num_gpus, reverse=True)
 
     elif mode == "pp":
         if num_nodes > 1 and tuner_cfg.get("enable_pp_prune", True):
@@ -64,9 +69,16 @@ def dist_degree(mode, num_gpus, num_nodes, tuner_cfg=None):
     elif mode == "mp":
         if tuner_cfg.get("enable_mp_prune", True):
             gpus_per_node = num_gpus // num_nodes
-            results = divisor(gpus_per_node, reverse=True)
+            if tuner_cfg.get("schedule_mode", "memory") != "performance":
+                results = divisor(gpus_per_node, reverse=True)
+            else:
+                results = divisor(gpus_per_node, reverse=False)
         else:
-            results = divisor(num_gpus, reverse=True)
+            if tuner_cfg.get("schedule_mode", "memory") != "performance":
+                results = divisor(num_gpus, reverse=True)
+            else:
+                results = divisor(num_gpus, reverse=False)
+
         for mp_degree in results:
             prune_flag = False
             hidden_size = tuner_cfg["model_cfg"].get("hidden_size", None)
@@ -101,10 +113,24 @@ def dist_degree(mode, num_gpus, num_nodes, tuner_cfg=None):
         results = divisor(num_gpus, reverse=True)
 
     elif mode == "mbs":
-        results = divisor(tuner_cfg["model_cfg"]["global_batch_size"])
+        if tuner_cfg.get("schedule_mode", "memory") != "performance":
+            results = divisor(
+                tuner_cfg["model_cfg"]["global_batch_size"], reverse=False
+            )
+        else:
+            results = divisor(
+                tuner_cfg["model_cfg"]["global_batch_size"], reverse=True
+            )
 
     elif mode == "vpp":
-        results = divisor(tuner_cfg["model_cfg"]["num_layers"], reverse=True)
+        if tuner_cfg.get("schedule_mode", "memory") != "performance":
+            results = divisor(
+                tuner_cfg["model_cfg"]["num_layers"], reverse=False
+            )
+        else:
+            results = divisor(
+                tuner_cfg["model_cfg"]["num_layers"], reverse=True
+            )
 
     return results
 
@@ -112,15 +138,21 @@ def dist_degree(mode, num_gpus, num_nodes, tuner_cfg=None):
 def default_candidates(tuner_cfg):
     """Return the default candidates of every hyper param which user defined auto"""
     candidates = {}
+    estimated_num_gpus = None
+    if (
+        "search_algo" in tuner_cfg
+        and "estimated_num_gpus" in tuner_cfg["search_algo"]
+    ):
+        estimated_num_gpus = tuner_cfg["search_algo"]["estimated_num_gpus"]
     num_gpus = (
         tuner_cfg["num_gpus"]
-        if "estimated_num_gpus" not in tuner_cfg
-        else tuner_cfg["estimated_num_gpus"]
+        if estimated_num_gpus is None
+        else estimated_num_gpus
     )
     num_nodes = (
         tuner_cfg["nodes"]
-        if "estimated_num_gpus" not in tuner_cfg
-        else tuner_cfg["estimated_num_gpus"] // 8
+        if estimated_num_gpus is None
+        else estimated_num_gpus // tuner_cfg["gpus_per_node"]
     )
     assert num_gpus > 0
 
@@ -170,21 +202,38 @@ def default_candidates(tuner_cfg):
         candidates["sharding_degree"] = [1]
 
     if tuner_cfg.get("sharding_stage", None) == "auto":
-        candidates["sharding_stage"] = [3, 2, 1]
+        if tuner_cfg.get("schedule_mode", "memory") != "performance":
+            candidates["sharding_stage"] = [3, 2, 1]
+        else:
+            candidates["sharding_stage"] = [1, 2, 3]
     elif tuner_cfg.get("sharding_stage", None):
         candidates["sharding_stage"] = tuner_cfg.get("sharding_stage")
     else:
         candidates["sharding_stage"] = [None]
 
     if tuner_cfg.get("use_recompute", None) == "auto":
-        candidates["use_recompute"] = [True, False]
+        if tuner_cfg.get("schedule_mode", "memory") != "performance":
+            candidates["use_recompute"] = [True, False]
+        else:
+            candidates["use_recompute"] = [False, True]
     elif tuner_cfg.get("use_recompute", None):
         candidates["use_recompute"] = tuner_cfg.get("use_recompute")
     else:
         candidates["use_recompute"] = [None]
 
     if tuner_cfg.get("recompute_granularity", None) == "auto":
-        candidates["recompute_granularity"] = ["full_attn", "full"]
+        if tuner_cfg.get("schedule_mode", "memory") != "performance":
+            candidates["recompute_granularity"] = [
+                "full",
+                "full_attn",
+                "core_attn",
+            ]
+        else:
+            candidates["recompute_granularity"] = [
+                "core_attn",
+                "full_attn",
+                "full",
+            ]
     elif tuner_cfg.get("recompute_granularity", None):
         candidates["recompute_granularity"] = tuner_cfg.get(
             "recompute_granularity"
@@ -220,8 +269,9 @@ def search_all(tuner_cfg):
 
     num_gpus = (
         tuner_cfg["num_gpus"]
-        if "estimated_num_gpus" not in tuner_cfg
-        else tuner_cfg["estimated_num_gpus"]
+        if "search_algo" not in tuner_cfg
+        or "estimated_num_gpus" not in tuner_cfg["search_algo"]
+        else tuner_cfg["search_algo"]["estimated_num_gpus"]
     )
     valid_degrees = []
 
@@ -303,23 +353,214 @@ def search_all(tuner_cfg):
         for idx, val in enumerate(cfg):
             new_cfg[mapping[idx]] = val
         new_all_cfgs.append(new_cfg)
-    return new_all_cfgs
+
+    pruned_all_cfgs = []
+    tuner_cfg["num_gpus"] = num_gpus
+    for cur_cfg in new_all_cfgs:
+        pruned = False
+        for func in _PRUNE_FUNC:
+            result = func(tuner_cfg, cur_cfg, [])
+            if result:
+                pruned = True
+                break
+        if not pruned:
+            pruned_all_cfgs.append(cur_cfg)
+    return pruned_all_cfgs
 
 
 def search_by_dp_estimation(tuner_cfg):
-    from .cost_model import get_not_oom_cfgs
-
     all_cfgs = search_all(tuner_cfg)
-    not_oom_cfgs = get_not_oom_cfgs(all_cfgs, tuner_cfg)
-    num_gpus_per_dp_degree = tuner_cfg["num_gpus"]
-    estimated_dp_degree = (
-        tuner_cfg["estimated_num_gpus"] // num_gpus_per_dp_degree
+    estimated_num_gpus = tuner_cfg["search_algo"].get(
+        "estimated_num_gpus", None
     )
-    result_cfgs = []
-    for cfg in not_oom_cfgs:
-        if cfg["dp_degree"] == estimated_dp_degree:
-            result_cfgs.append(cfg)
-    return result_cfgs
+    assert estimated_num_gpus is not None
+    # change global_batch_size, dp_degree, sharding_degree
+    new_all_cfgs = []
+    for task in all_cfgs:
+        task["estimated_dp_degree"] = int(
+            task["dp_degree"] * task["sharding_degree"]
+        )
+        task["dp_degree"] = 1
+        task["sharding_degree"] = 1
+        task["sharding_stage"] = 1
+        task["num_gpus"] = task["mp_degree"] * task["pp_degree"]
+        if task["num_gpus"] >= tuner_cfg["gpus_per_node"]:
+            task["nodes"] = task["num_gpus"] // tuner_cfg["gpus_per_node"]
+        else:
+            task["nodes"] = 1
+        task["global_batch_size"] = (
+            tuner_cfg["model_cfg"]["global_batch_size"]
+            // task["estimated_dp_degree"]
+        )
+        if task not in new_all_cfgs and task["nodes"] <= tuner_cfg["nodes"]:
+            new_all_cfgs.append(task)
+
+    # expanding sharding degree to run overlap and nonoverlap to calculate overlap benefits
+    if tuner_cfg["search_algo"].get("sharding_overlap", None):
+        sharding_all_cfgs = []
+        for task in new_all_cfgs:
+            new_task = copy.deepcopy(task)
+            given_num_gpus = tuner_cfg["nodes"] * tuner_cfg["gpus_per_node"]
+            sharding_degree = given_num_gpus // task["num_gpus"]
+            if sharding_degree > 1:
+                new_task["sharding_degree"] = sharding_degree
+                new_task["sharding_stage"] = 1
+                new_task["estimated_dp_degree"] = None
+                new_task["num_gpus"] = (
+                    new_task["mp_degree"]
+                    * new_task["pp_degree"]
+                    * new_task["sharding_degree"]
+                )
+                if new_task["num_gpus"] >= tuner_cfg["gpus_per_node"]:
+                    new_task["nodes"] = (
+                        new_task["num_gpus"] // tuner_cfg["gpus_per_node"]
+                    )
+                else:
+                    new_task["nodes"] = 1
+                new_task["global_batch_size"] = (
+                    task["global_batch_size"] * sharding_degree
+                )
+                new_task["sharding_overlap"] = False
+                sharding_all_cfgs.append(new_task)
+
+                overlap_new_task = copy.deepcopy(new_task)
+                overlap_new_task["sharding_overlap"] = True
+                sharding_all_cfgs.append(overlap_new_task)
+
+    new_all_cfgs.extend(sharding_all_cfgs)
+    return new_all_cfgs
+
+
+def add_overlap_performance(cur_cfg, tuner_cfg, history_cfgs):
+    """
+    In single dp search scenario,
+    the overlay acceleration ratio is obtained by automatically running overlap and non overlap tasks,
+    and the estimated performance of the multi dp after overlap is obtained.
+    """
+    if cur_cfg[tuner_cfg['metric_cfg']['name']]:
+        non_overlap_cfg = None
+        raw_cfg = None
+        for cfg in history_cfgs:
+            keys = [
+                "dp_degree",
+                "mp_degree",
+                "pp_degree",
+                "vpp_degree",
+                "micro_batch_size",
+                "use_recompute",
+                "recompute_granularity",
+                "sharding_stage",
+            ]
+            same = True
+            for key in keys:
+                if cfg[key] != cur_cfg[key]:
+                    same = False
+                    break
+            if same:
+                if "sharding_overlap" not in cfg:
+                    raw_cfg = cfg
+                elif not cfg["sharding_overlap"]:
+                    if cfg["sharding_degree"] == cur_cfg["sharding_degree"]:
+                        non_overlap_cfg = cfg
+        assert non_overlap_cfg is not None
+        assert raw_cfg is not None
+
+        before_overlap_performance = non_overlap_cfg[
+            tuner_cfg['metric_cfg']['name']
+        ]
+        overlap_performance = cur_cfg[tuner_cfg['metric_cfg']['name']]
+        raw_performance = raw_cfg[tuner_cfg['metric_cfg']['name']]
+        if (
+            raw_performance
+            and overlap_performance
+            and before_overlap_performance
+        ):
+            ratio = (
+                overlap_performance - before_overlap_performance
+            ) / before_overlap_performance
+            keys = copy.deepcopy(list(raw_cfg.keys()))
+            for key in keys:
+                if key.startswith("bw_") and raw_cfg[key]:
+                    mew_key = "overlap_" + key
+                    raw_cfg[mew_key] = round(raw_cfg[key] * (1 + ratio), 5)
+
+
+def gen_sharding_overlap_args(res_args, cfg, tuner_cfg):
+    """Generate args of sharding overlap."""
+    assert "sharding_overlap" in tuner_cfg["search_algo"]
+    cmd = copy.deepcopy(tuner_cfg["search_algo"]["sharding_overlap"])
+    if cfg.get("sharding_overlap", False):
+        valid_hybrid_strategy = ["sharding_mp", "sharding_pp", "sharding_mp_pp"]
+        for key in cmd:
+            if key not in valid_hybrid_strategy:
+                raise ValueError(
+                    f"Only support {valid_hybrid_strategy}, but got {key}."
+                )
+        sharding_degree = cfg["sharding_degree"]
+        assert sharding_degree > 1
+        mp_degree = cfg["mp_degree"]
+        pp_degree = cfg["pp_degree"]
+        arg = None
+        if mp_degree > 1 and pp_degree == 1:
+            arg = "sharding_mp"
+        elif mp_degree == 1 and pp_degree > 1:
+            arg = "sharding_pp"
+        elif mp_degree > 1 and pp_degree > 1:
+            arg = "sharding_mp_pp"
+        else:
+            return
+        assert arg is not None
+        if arg in cmd:
+            if "--" in cmd[arg][0]:
+                res_args.extend(cmd[arg])
+            elif "-o" in cmd[arg][0]:
+                res_args.extend(cmd[arg])
+            elif ".json" in cmd[arg][0]:
+                import json
+
+                file_path = cmd[arg][0]
+                try:
+                    with open(file_path, "r") as f:
+                        cmd_cfg = json.load(f)
+                except:
+                    raise ValueError(
+                        "Please check your auto tuner json whether valid."
+                    )
+                keys = cmd[arg][1].split(".")
+                value = None
+                for key in keys[: len(keys) - 1]:
+                    if value:
+                        value = value[key]
+                    else:
+                        value = cmd_cfg[key]
+                if value:
+                    value[keys[-1]] = cmd[arg][2]
+                else:
+                    cmd_cfg[keys[-1]] = cmd[arg][2]
+                json.dump(cmd_cfg, open(cmd[arg][0], "w"))
+            elif ".yaml" in cmd[arg][0]:
+                import yaml
+
+                file_path = cmd[arg][0]
+                try:
+                    with open(file_path, "r") as f:
+                        cmd_cfg = yaml.safe_load(f)
+                except:
+                    raise ValueError(
+                        "Please check your auto tuner json whether valid."
+                    )
+                keys = cmd[arg][1].split(".")
+                value = None
+                for key in keys[: len(keys) - 1]:
+                    if value:
+                        value = cmd_cfg[key]
+                    else:
+                        value = value[key]
+                if value:
+                    value[keys[-1]] = cmd[arg][2]
+                else:
+                    cmd_cfg[keys[-1]] = cmd[arg][2]
+                yaml.dump(cmd_cfg, open(cmd[arg][0], "w"))
 
 
 def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
@@ -394,10 +635,14 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                     )
                 yaml.dump(cmd_cfg, open(cmd[arg][0], "w"))
         elif arg == "local_batch_size" and arg in cmd:
+            global_batch_size = (
+                cfg["global_batch_size"]
+                if "global_batch_size"
+                in tuner_cfg["model_cfg"]["global_batch_size"]
+                else tuner_cfg["model_cfg"]["global_batch_size"]
+            )
             local_batch_size = (
-                tuner_cfg["model_cfg"]["global_batch_size"]
-                // cfg["sharding_degree"]
-                // cfg["dp_degree"]
+                global_batch_size // cfg["sharding_degree"] // cfg["dp_degree"]
             )
             if "--" in cmd["local_batch_size"][0]:
                 cmd["local_batch_size"][1] = cmd["local_batch_size"][1] + str(
@@ -480,8 +725,14 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
 
         elif arg == "gradient_accumulation_steps" and arg in cmd:
             try:
+                global_batch_size = (
+                    cfg["global_batch_size"]
+                    if "global_batch_size"
+                    in tuner_cfg["model_cfg"]["global_batch_size"]
+                    else tuner_cfg["model_cfg"]["global_batch_size"]
+                )
                 gradient_accumulation_steps = (
-                    tuner_cfg["model_cfg"]["global_batch_size"]
+                    global_batch_size
                     // cfg["sharding_degree"]
                     // cfg["dp_degree"]
                     // cfg["micro_batch_size"]
@@ -694,7 +945,39 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                     cmd_cfg[keys[-1]] = cmd[arg][2]
                 yaml.dump(cmd_cfg, open(cmd[arg][0], "w"))
 
+    # sharding overlap args
+    gen_sharding_overlap_args(res_args, cfg, tuner_cfg)
+
     return res_args
+
+
+def gen_new_ctx(ctx, cur_cfg, tuner_cfg):
+    """Generate new running context."""
+    new_ctx = copy.deepcopy(ctx)
+    if (
+        "search_algo" in tuner_cfg
+        and "estimated_num_gpus" in tuner_cfg["search_algo"]
+    ):
+        assert cur_cfg["dp_degree"] == 1
+        assert cur_cfg["sharding_stage"] == 1
+        actual_cards = (
+            cur_cfg["mp_degree"]
+            * cur_cfg["pp_degree"]
+            * cur_cfg["sharding_degree"]
+        )
+        if actual_cards <= tuner_cfg["gpus_per_node"]:
+            new_ctx.args.devices = ",".join(
+                [str(i) for i in range(actual_cards)]
+            )
+            if new_ctx.args.master:
+                new_ctx.args.nnodes = "1:1"
+        else:
+            new_ctx.args.devices = ",".join(
+                [str(i) for i in range(tuner_cfg["gpus_per_node"])]
+            )
+            nnodes = actual_cards // tuner_cfg["gpus_per_node"]
+            new_ctx.args.nnodes = f"{nnodes}:{nnodes}"
+    return new_ctx
 
 
 def read_metric_log(
@@ -756,6 +1039,46 @@ def read_metric_log(
         # round to 5 decimal places
         metric_ave = round(metric_ave, 5)
     res = metric_ave, err_code
+    return res
+
+
+def read_step_time_log(
+    path, file="workerlog.0", target_metric='interval_runtime'
+) -> Tuple[float, int]:
+    target_file = path + "/" + file
+    if not os.path.exists(target_file):
+        return None
+    with open(target_file, "r") as f:
+        # read file
+        re_metric_pattern = (
+            target_metric + r":* *(\d+(\.\d*)?)|(\d+(\.\d*)?) *" + target_metric
+        )
+        metric_list = []
+        lines = f.readlines()
+        for line in lines:
+            metric = re.findall(re_metric_pattern, line)
+            if metric:
+                value = None
+                for item in metric[0]:
+                    try:
+                        value = float(item)
+                        metric_list.append(value)
+                        break
+                    except:
+                        continue
+                assert value is not None
+        if not metric_list:
+            metric_ave = None
+            return None
+        elif len(metric_list) < 10:
+            metric_ave = metric_list[-1]
+        elif len(metric_list) < 20:
+            metric_ave = sum(metric_list[9:]) / (len(metric_list[9:]))
+        else:
+            metric_ave = sum(metric_list[-10:]) / 10
+        # round to 5 decimal places
+        metric_ave = round(metric_ave, 5)
+    res = metric_ave
     return res
 
 

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -302,7 +302,13 @@ def launch():
 
         from ..auto_tuner.recorder import HistoryRecorder
         from ..auto_tuner.tuner import AutoTuner
-        from ..auto_tuner.utils import gen_new_args, read_log
+        from ..auto_tuner.utils import (
+            add_overlap_performance,
+            gen_new_args,
+            gen_new_ctx,
+            read_log,
+            read_step_time_log,
+        )
         from . import controllers
 
         start_time = time.time()
@@ -348,13 +354,18 @@ def launch():
         else:
             nnodes = int(nnodes)
         tuner_cfg["nodes"] = nnodes
+        tuner_cfg["gpus_per_node"] = gpus_per_node
         tuner_cfg["num_gpus"] = gpus_per_node * tuner_cfg["nodes"]
+        if not tuner_cfg.get("search_algo", None):
+            tuner_cfg["search_algo"] = {"name": "grid"}
         mode = tuner_cfg.get("mode", None)
 
         history_file_path = os.path.join(
             os.path.dirname(ctx.args.auto_tuner_json),
             f'{os.path.basename(ctx.args.auto_tuner_json).split(".")[0]}_history.csv',
         )
+        sorted_ips = []
+        ip = None
         if nnodes > 1:
             from .utils.etcd_client import ETCDClient
 
@@ -364,8 +375,37 @@ def launch():
             client.delete("best_cfg")
             client.delete_prefix("auto_tuner")
 
+            import socket
+
+            try:
+                hostname = socket.gethostname()
+                ip = socket.gethostbyname(socket.getfqdn(hostname))
+            except:
+                ip = '127.0.0.1'
+            assert ip != '127.0.0.1'
+            if tuner_cfg["search_algo"].get("estimated_num_gpus", None):
+                # get all machine ips and sort them
+                # to avoid etcd deleting key and adding key at the same time
+                time.sleep(5)
+                path = f"auto_tuner/ip/{ip}"
+                while not client.put(path, f"{ip}".encode('latin-1')):
+                    time.sleep(1)
+
+                ips = list(client.get_prefix("auto_tuner/ip/"))
+                size = len(ips)
+                while size != nnodes:
+                    time.sleep(1)
+                    client.put(path, f"{ip}".encode('latin-1'))
+                    ips = list(client.get_prefix("auto_tuner/ip/"))
+                    size = len(ips)
+                sorted_ips = sorted([i[0].decode() for i in ips])
+                logger.info(
+                    f"The total count of nodes is {len(sorted_ips)} and sorted ips are {sorted_ips}."
+                )
+
         # get max time per task run
         max_time_per_task = tuner_cfg.get("max_time_per_task", 1800)
+        tuner_cfg["max_time_per_task"] = max_time_per_task
         ctx.max_time_per_task = max_time_per_task
 
         # warmup
@@ -400,7 +440,7 @@ def launch():
             best_gbs = None
             while gbs_cur_cfg:
                 ctx = copy.deepcopy(raw_ctx)
-                log_dir = "GBSSearch/GBS{}_DP{}_MP{}_PP{}_Sharding_degree_{}_stage_{}_MBS_{}_Recompute_{}_granularity_{}".format(
+                log_dir = "GBSSearch/GBS{}_DP{}_MP{}_PP{}_Sharding_degree_{}_stage_{}_MBS{}_Recompute_{}_granularity_{}".format(
                     gbs_cur_cfg["global_batch_size"],
                     gbs_cur_cfg["dp_degree"],
                     gbs_cur_cfg["mp_degree"],
@@ -540,26 +580,48 @@ def launch():
                 ctx.max_time_per_task = warmup_time
             is_first_task = False
             # auto tuner supports dp, mp, pp, micro batch size, sharding, recompute by default and every task has own log dir
+            global_batch_size = (
+                cur_cfg["global_batch_size"]
+                if "global_batch_size" in cur_cfg
+                else tuner_cfg["model_cfg"]["global_batch_size"]
+            )
             acc_steps = (
-                tuner_cfg["model_cfg"]["global_batch_size"]
+                global_batch_size
                 // cur_cfg["dp_degree"]
                 // cur_cfg["sharding_degree"]
                 // cur_cfg["micro_batch_size"]
             )
             cur_cfg["acc_steps"] = acc_steps
-            log_dir = "DP{}_MP{}_PP{}_VPP_{}_Sharding_degree_{}_stage_{}_MBS_{}_Recompute_{}_granularity_{}_AccStep_{}".format(
-                cur_cfg["dp_degree"],
-                cur_cfg["mp_degree"],
-                cur_cfg["pp_degree"],
-                cur_cfg["vpp_degree"],
-                cur_cfg["sharding_degree"],
-                cur_cfg["sharding_stage"],
-                cur_cfg["micro_batch_size"],
-                cur_cfg["use_recompute"],
-                cur_cfg["recompute_granularity"],
-                cur_cfg["acc_steps"],
-            )
-
+            cur_cfg["global_batch_size"] = global_batch_size
+            if "sharding_overlap" in cur_cfg:
+                log_dir = "GBS{}_DP{}_MP{}_PP{}_VPP{}_Sharding{}_Stage{}_MBS{}_Recompute_{}_Granularity_{}_AccStep{}_Overlap_{}".format(
+                    global_batch_size,
+                    cur_cfg["dp_degree"],
+                    cur_cfg["mp_degree"],
+                    cur_cfg["pp_degree"],
+                    cur_cfg["vpp_degree"],
+                    cur_cfg["sharding_degree"],
+                    cur_cfg["sharding_stage"],
+                    cur_cfg["micro_batch_size"],
+                    cur_cfg["use_recompute"],
+                    cur_cfg["recompute_granularity"],
+                    cur_cfg["acc_steps"],
+                    cur_cfg["sharding_overlap"],
+                )
+            else:
+                log_dir = "GBS{}_DP{}_MP{}_PP{}_VPP{}_Sharding{}_Stage{}_MBS{}_Recompute_{}_Granularity_{}_AccStep{}".format(
+                    global_batch_size,
+                    cur_cfg["dp_degree"],
+                    cur_cfg["mp_degree"],
+                    cur_cfg["pp_degree"],
+                    cur_cfg["vpp_degree"],
+                    cur_cfg["sharding_degree"],
+                    cur_cfg["sharding_stage"],
+                    cur_cfg["micro_batch_size"],
+                    cur_cfg["use_recompute"],
+                    cur_cfg["recompute_granularity"],
+                    cur_cfg["acc_steps"],
+                )
             ctx.args.log_dir = os.path.join(
                 os.path.dirname(ctx.args.auto_tuner_json), log_dir
             )
@@ -575,28 +637,80 @@ def launch():
 
             # launch task
             ctx.logger.info(
-                "Launch task from auto tuner: job_id {}, log_dir {}, config {}".format(
-                    task_job_id, log_dir, cur_cfg
-                )
+                f"Launch task: job_id {task_job_id}, log_dir {log_dir}"
             )
-            logger.info(
-                "Launch task from auto tuner: job_id {}, log_dir {}, config {}".format(
-                    task_job_id, log_dir, cur_cfg
-                )
-            )
+            logger.info(f"Launch task: job_id {task_job_id}, log_dir {log_dir}")
+
+            # in single dp estimation scene, just some nodes not all nodes run
+            ctx = gen_new_ctx(ctx, cur_cfg, tuner_cfg)
+            actual_nnodes = int(ctx.args.nnodes.split(":")[0])
+            if sorted_ips:
+                actual_exec_ips = sorted_ips[:actual_nnodes]
+                if ip not in actual_exec_ips:
+                    cur_cfg = client.get(f"auto_tuner/{log_dir}")[0]
+                    wait_start_time = time.time()
+                    while not cur_cfg:
+                        wait_end_time = time.time()
+                        if (
+                            wait_end_time - wait_start_time
+                            > tuner_cfg["max_time_per_task"] + 30
+                        ):
+                            raise ValueError(f"Wait {log_dir} failed")
+                        time.sleep(3)
+                        cur_cfg = client.get(f"auto_tuner/{log_dir}")[0]
+                    logger.info(
+                        f"Receive that task {log_dir} has ended by etcd."
+                    )
+                    ctx.logger.info(
+                        f"Receive that task {log_dir} has ended by etcd."
+                    )
+                    cur_cfg = json.loads(cur_cfg.decode())
+                    auto_tuner.history_cfgs.pop(-1)
+                    auto_tuner.add_cfg(cur_cfg)
+                    recorder.add_cfg(**cur_cfg)
+                    cur_best_cfgs, err = recorder.get_best(
+                        metric=tuner_cfg['metric_cfg']['name'],
+                        direction=tuner_cfg['metric_cfg'][
+                            'OptimizationDirection'
+                        ],
+                    )
+                    if not err:
+                        ctx.logger.info(f"Current best config: {cur_best_cfgs}")
+                        logger.info(f"Current best config: {cur_best_cfgs}")
+                    else:
+                        ctx.logger.info(
+                            "Get best config failed. Currently no config can be run."
+                        )
+                        logger.info(
+                            "Get best config failed. Currently no config can be run."
+                        )
+                    if (
+                        "sharding_overlap" in cur_cfg
+                        and cur_cfg["sharding_overlap"]
+                    ):
+                        add_overlap_performance(
+                            cur_cfg, tuner_cfg, recorder.history
+                        )
+                    recorder.store_history(history_file_path)
+                    # generate a new config
+                    new_cfg = auto_tuner.search_once()
+                    cur_cfg = copy.deepcopy(new_cfg)
+                    auto_tuner.add_cfg(cur_cfg)
+                    continue
+
             c = controllers.init(ctx)
             c.run()
 
             task_end_time = time.time()
             cur_cfg["exec_time"] = round(task_end_time - task_start_time, 2)
             ctx.logger.info(
-                "Task: job_id {}, log_dir {}, config {} ends in {}s".format(
-                    task_job_id, log_dir, cur_cfg, cur_cfg["exec_time"]
+                "Task: job_id {}, log_dir {} ended in {}s".format(
+                    task_job_id, log_dir, cur_cfg["exec_time"]
                 )
             )
             logger.info(
-                "Task: job_id {}, log_dir {}, config {} ends in {}s".format(
-                    task_job_id, log_dir, cur_cfg, cur_cfg["exec_time"]
+                "Task: job_id {}, log_dir {} ended in {}s".format(
+                    task_job_id, log_dir, cur_cfg["exec_time"]
                 )
             )
             # process generated result
@@ -610,38 +724,32 @@ def launch():
             # sync sigint
             timeout_flag = True
             OOM_flag = err & (1 << 1)
-
-            if nnodes > 1:
-                import socket
-
-                ip = None
-                try:
-                    hostname = socket.gethostname()
-                    ip = socket.gethostbyname(socket.getfqdn(hostname))
-                except:
-                    ip = '127.0.0.1'
-                assert ip != '127.0.0.1'
+            if actual_nnodes > 1:
                 path = f"auto_tuner/{job_id}/{ip}"
                 if OOM_flag:
-                    client.put(path, "OOM".encode('latin-1'))
+                    while not client.put(path, "OOM".encode('latin-1')):
+                        time.sleep(1)
                     ctx.logger.info(f"Put OOM to {path}")
                     logger.info(f"Put OOM to {path}")
                 elif hasattr(c, 'sigint') and c.sigint == 14:
-                    client.put(path, "OK".encode('latin-1'))
+                    while not client.put(path, "OK".encode('latin-1')):
+                        time.sleep(1)
                     ctx.logger.info(f"Put OK to {path}")
                     logger.info(f"Put OK to {path}")
                 elif not hasattr(c, 'sigint') and c.pod.exit_code == 0:
-                    client.put(path, "OK".encode('latin-1'))
+                    while not client.put(path, "OK".encode('latin-1')):
+                        time.sleep(1)
                     ctx.logger.info(f"Put OK to {path}")
                     logger.info(f"Put OK to {path}")
                 else:
-                    client.put(path, "Error".encode('latin-1'))
+                    while not client.put(path, "Error".encode('latin-1')):
+                        time.sleep(1)
                     ctx.logger.info(f"Put Error to {path}")
                     logger.info(f"Put Error to {path}")
 
                 result = list(client.get_prefix(f"auto_tuner/{job_id}/"))
                 size = len(result)
-                while size != nnodes:
+                while size != actual_nnodes:
                     time.sleep(1)
                     result = list(client.get_prefix(f"auto_tuner/{job_id}/"))
                     size = len(result)
@@ -658,10 +766,8 @@ def launch():
 
             has_error = False
             if err & (1 << 0):
-                ctx.logger.warning(
-                    f"Read metric failed for parameters: {log_dir}"
-                )
-                logger.warning(f"Read metric failed for parameters: {log_dir}")
+                ctx.logger.warning(f"Read metric of {log_dir} failed.")
+                logger.warning(f"Read metric of {log_dir} failed.")
                 # for pruner use
                 cur_cfg['time'] = -1
                 cur_cfg[tuner_cfg['metric_cfg']['name']] = None
@@ -669,8 +775,8 @@ def launch():
                 has_error = True
 
             if err & (1 << 1):
-                ctx.logger.warning(f"Out of memory for parameters: {log_dir}")
-                logger.warning(f"Out of memory for parameters: {log_dir}")
+                ctx.logger.warning(f"{log_dir} OOM.")
+                logger.warning(f"{log_dir} OOM.")
                 # for pruner use
                 cur_cfg['time'] = -1
                 cur_cfg[tuner_cfg['metric_cfg']['name']] = None
@@ -679,12 +785,8 @@ def launch():
 
             # not err & (1 << 1): do not record memory usage when out of memory
             if err & (1 << 2) and not err & (1 << 1):
-                ctx.logger.warning(
-                    f"Read memory usage failed for parameters: {log_dir}"
-                )
-                logger.warning(
-                    f"Read memory usage failed for parameters: {log_dir}"
-                )
+                ctx.logger.warning(f"Read memory usage of {log_dir} failed.")
+                logger.warning(f"Read memory usage of {log_dir} failed.")
                 cur_cfg["max_mem_usage"] = None if not OOM_flag else "OOM"
 
             if not has_error and timeout_flag:
@@ -698,12 +800,67 @@ def launch():
                 cur_cfg[tuner_cfg['metric_cfg']['name']] = None
                 cur_cfg["max_mem_usage"] = None if not OOM_flag else "OOM"
 
-            # record history
             if tuner_cfg['metric_cfg']['name'] not in cur_cfg:
                 cur_cfg[tuner_cfg['metric_cfg']['name']] = None
+
             cur_cfg['job_id'] = job_id
+
+            # multi dp conversion
+            if (
+                "conversion" in tuner_cfg["search_algo"]
+                and "step_time" in tuner_cfg["search_algo"]["conversion"]
+                and "sharding_overlap" not in cur_cfg
+            ):
+                single_dp_performance = cur_cfg[tuner_cfg['metric_cfg']['name']]
+                step_time_metric = tuner_cfg["search_algo"]["conversion"][
+                    "step_time"
+                ]
+                step_time = read_step_time_log(
+                    path=ctx.args.log_dir,
+                    file="workerlog.0",
+                    target_metric=step_time_metric,
+                )
+
+                # set default
+                comm_bw = tuner_cfg["search_algo"]["conversion"].get(
+                    "comm_bw", [100]
+                )
+                model_size_b = int(
+                    tuner_cfg["search_algo"]["conversion"].get(
+                        "model_size_b", 7
+                    )
+                )
+                amp = tuner_cfg["search_algo"]["conversion"].get("amp", False)
+                for bw in comm_bw:
+                    if amp:
+                        comm_time = model_size_b * (4 + 2) / bw
+                    else:
+                        comm_time = model_size_b * 4 / bw
+                    multi_dp_performace = (
+                        round(
+                            step_time
+                            / (step_time + comm_time)
+                            * single_dp_performance,
+                            5,
+                        )
+                        if single_dp_performance and step_time
+                        else None
+                    )
+                    cur_cfg[
+                        f"bw_{bw}_{tuner_cfg['metric_cfg']['name']}"
+                    ] = multi_dp_performace
+
+            # sync for single dp
+            if sorted_ips:
+                master_ip = sorted_ips[0]
+                if ip == master_ip:
+                    while not client.put(
+                        f"auto_tuner/{log_dir}",
+                        json.dumps(cur_cfg).encode('latin-1'),
+                    ):
+                        time.sleep(1)
+                    logger.info(f"{ip} put auto_tuner/{log_dir} successfully.")
             recorder.add_cfg(**cur_cfg)
-            recorder.store_history(history_file_path)
             cur_best_cfgs, err = recorder.get_best(
                 metric=tuner_cfg['metric_cfg']['name'],
                 direction=tuner_cfg['metric_cfg']['OptimizationDirection'],
@@ -712,12 +869,14 @@ def launch():
                 ctx.logger.info(f"Current best config: {cur_best_cfgs}")
                 logger.info(f"Current best config: {cur_best_cfgs}")
             else:
-                ctx.logger.info(
-                    "Get best config failed. Currently there are no appropriate configs."
-                )
-                logger.info(
-                    "Get best config failed. Currently there are no appropriate configs."
-                )
+                ctx.logger.info("Get best config failed, no config can be run.")
+                logger.info("Get best config failed, no config can be run.")
+
+            # record history
+            if "sharding_overlap" in cur_cfg and cur_cfg["sharding_overlap"]:
+                add_overlap_performance(cur_cfg, tuner_cfg, recorder.history)
+
+            recorder.store_history(history_file_path)
             c.finalize(exit=False)
 
             # generate a new config
@@ -746,15 +905,6 @@ def launch():
         best_cfg = None
         ctx = copy.deepcopy(raw_ctx)
         if nnodes > 1:
-            import socket
-
-            ip = None
-            try:
-                hostname = socket.gethostname()
-                ip = socket.gethostbyname(socket.getfqdn(hostname))
-            except:
-                ip = '127.0.0.1'
-
             collective_master_ip = os.environ.get("COLLECTIVE_MASTER_IP", None)
             assert collective_master_ip is not None
             if ip == collective_master_ip:
@@ -796,17 +946,20 @@ def launch():
         assert best_cfg and best_cfg["time"] != -1
 
         end_time = time.time()
-        ctx.logger.info(f"AutoTuner ends in {end_time-start_time}s.")
-        logger.info(f"AutoTuner ends in {end_time-start_time}s.")
+        ctx.logger.info(f"AutoTuner ended in {end_time-start_time}s.")
+        logger.info(f"AutoTuner ended in {end_time-start_time}s.")
         # launch best cfg
-        if not tuner_cfg.get("run_best", True):
+        # estimation search need not run best cfg
+        if not tuner_cfg.get("run_best", True) or tuner_cfg["search_algo"].get(
+            "estimated_num_gpus", None
+        ):
             sys.exit()
         new_args = gen_new_args(raw_args, best_cfg, tuner_cfg, run_best=True)
         ctx.run_best = True
         ctx.args.training_script_args = new_args
         ctx.args.job_id = "best_cfg"
-        ctx.logger.info(f"Launch best cfg from auto tuner: {best_cfg}")
-        logger.info(f"Launch best cfg from auto tuner: {best_cfg}")
+        ctx.logger.info(f"Launch best cfg: {best_cfg}")
+        logger.info(f"Launch best cfg: {best_cfg}")
         ctx.args.log_dir = ctx.args.log_dir = os.path.join(
             os.path.dirname(ctx.args.auto_tuner_json), "best_cfg"
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PCard-78429
This PR adds a new feature that estimates the optimal performance of multi Data Parallelism (DP) based on single DP, allowing for quickly identifying superior parallel strategies in large cluster environments.
The specific steps are：
1. Building a Single DP Search Space.

2. It can automatically profile the performance of a single-lane data parallel strategy based on the resources of a given small cluster. 

3. Then, it calculates the performance of multi-lane data parallel strategies in a larger cluster based on the communication bandwidth. 

Refer to the given example json to use this feature for PaddleNLP llama:
`{
    ...
    "search_algo":{
        "name": "dp_estimation",
        "estimated_num_gpus": 1024,
        "conversion":{
            "step_time": "interval_runtime",
            "comm_bw": [100, 200],
            "amp": true,
            "model_size_b": 7
        },
        "sharding_overlap": {
            "sharding_mp": ["--sharding_parallel_config", "enable_stage1_overlap"],
            "sharding_pp": ["--pipeline_parallel_config", "enable_sharding_comm_overlap"],
            "sharding_mp_pp": ["--pipeline_parallel_config", "enable_sharding_comm_overlap"]
        }
    }
    ...
}`
and the result is shown as follows:
![image](https://github.com/PaddlePaddle/Paddle/assets/48191911/c9e5d39f-314b-4abc-95c7-7bc03a437e7f)
