### PR TITLE
[4/4] CUDNNv8 ResNet Fusion: Add fuse_resunit IR pass

### DIFF
--- a/paddle/fluid/framework/details/CMakeLists.txt
+++ b/paddle/fluid/framework/details/CMakeLists.txt
@@ -384,6 +384,7 @@ set(IR_PASS_DEPS
 
 if(WITH_CUDNN_FRONTEND)
   set(IR_PASS_DEPS ${IR_PASS_DEPS} fuse_dot_product_attention_pass)
+  set(IR_PASS_DEPS ${IR_PASS_DEPS} fuse_resunit_pass)
 endif()
 
 if(WITH_CINN)

--- a/paddle/fluid/framework/details/build_strategy.cc
+++ b/paddle/fluid/framework/details/build_strategy.cc
@@ -185,6 +185,7 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
     AppendPassWithCheck(strategy_.fuse_dot_product_attention_,
                         "fuse_dot_product_attention_pass");
+    AppendPassWithCheck(strategy_.fuse_resunit_, "fuse_resunit_pass");
 #endif
     AppendPassWithCheck(strategy_.fuse_relu_depthwise_conv_,
                         "fuse_relu_depthwise_conv_pass");
@@ -558,4 +559,5 @@ USE_PASS(fuse_gemm_epilogue_pass);
 #endif
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
 USE_PASS(fuse_dot_product_attention_pass);
+USE_PASS(fuse_resunit_pass);
 #endif

--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -138,6 +138,8 @@ struct BuildStrategy {
   bool sequential_run_{false};
   // Fuse dot product attention
   bool fuse_dot_product_attention_{false};
+  // Fuse ResUnit
+  bool fuse_resunit_{false};
   // mkldnn_enabled_op_types specify the operator type list to
   // use MKLDNN acceleration. It is null in default, means
   // that all the operators supported by MKLDNN will be

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -173,6 +173,7 @@ message BuildStrategy {
   optional bool fused_attention = 18 [ default = false];
   optional bool fused_feedforward = 19 [ default = false];
   optional bool fuse_dot_product_attention = 20 [ default = false ];
+  optional bool fuse_resunit = 21 [ default = false ];
 }
 
 message ExecutionStrategy {

--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -356,6 +356,10 @@ if(WITH_CUDNN_FRONTEND)
     fuse_dot_product_attention_pass
     SRCS fuse_dot_product_attention_pass.cc
     DEPS pass graph_pattern_detector)
+  cc_library(
+    fuse_resunit_pass
+    SRCS fuse_resunit_pass.cc
+    DEPS pass graph_pattern_detector)
 endif()
 
 set(GLOB_PASS_LIB

--- a/paddle/fluid/framework/ir/fuse_resunit_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_resunit_pass.cc
@@ -1,0 +1,875 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 NVIDIA Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/ir/fuse_resunit_pass.h"
+
+#include <string>
+#include "paddle/fluid/framework/details/multi_devices_helper.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/platform/enforce.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+#define GET_IR_NODE_FROM_SUBGRAPH_COND(var, arg, pat, cond) \
+  ir::Node *var = nullptr;                                  \
+  if (cond) {                                               \
+    GET_IR_NODE_FROM_SUBGRAPH(_##var, arg, pat);            \
+    var = _##var;                                           \
+  }
+
+#define GET_CONV_BN_NODES_COND(idx, pattern_name, cond)                    \
+  /* OPERATORS */                                                          \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      conv##idx##_op, conv##idx##_op, pattern_name, cond);                 \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_op, bn##idx##_op, pattern_name, cond);                     \
+  /* CONV inputs */                                                        \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      conv##idx##_w, conv##idx##_w, pattern_name, cond);                   \
+  /* CONV outputs */                                                       \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      conv##idx##_out, conv##idx##_out, pattern_name, cond);               \
+  /* BN inputs */                                                          \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_scale, bn##idx##_scale, pattern_name, cond);               \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_bias, bn##idx##_bias, pattern_name, cond);                 \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_mean, bn##idx##_mean, pattern_name, cond);                 \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_variance, bn##idx##_variance, pattern_name, cond);         \
+  /* BN outputs */                                                         \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_out, bn##idx##_out, pattern_name, cond); /* Out */         \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_mean_out, bn##idx##_mean_out, pattern_name, cond);         \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_variance_out, bn##idx##_variance_out, pattern_name, cond); \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_saved_mean, bn##idx##_saved_mean, pattern_name, cond);     \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                          \
+      bn##idx##_saved_variance, bn##idx##_saved_variance, pattern_name, cond)
+
+#define GET_CONV_GRAD_NODES(pattern_name)                          \
+  /* OPERATORS */                                                  \
+  GET_IR_NODE_FROM_SUBGRAPH(conv_grad, conv_grad, pattern_name);   \
+  /* dCONV inputs */                                               \
+  GET_IR_NODE_FROM_SUBGRAPH(conv_w, conv_w, pattern_name);         \
+  GET_IR_NODE_FROM_SUBGRAPH(d_conv_out, d_conv_out, pattern_name); \
+  /* dCONV outputs */                                              \
+  GET_IR_NODE_FROM_SUBGRAPH(d_conv_x, d_conv_x, pattern_name);     \
+  GET_IR_NODE_FROM_SUBGRAPH(d_conv_w, d_conv_w, pattern_name)
+
+#define GET_BN_GRAD_NODES_COND(idx, pattern_name, cond)                        \
+  /* OPERATORS */                                                              \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      batch_norm##idx##_grad, batch_norm##idx##_grad, pattern_name, cond);     \
+  /* BN inputs */                                                              \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      bn##idx##_x, bn##idx##_x, pattern_name, cond);                           \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      bn##idx##_scale, bn##idx##_scale, pattern_name, cond);                   \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      bn##idx##_bias, bn##idx##_bias, pattern_name, cond);                     \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      bn##idx##_saved_mean, bn##idx##_saved_mean, pattern_name, cond);         \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      bn##idx##_saved_variance, bn##idx##_saved_variance, pattern_name, cond); \
+  /* BN outputs */                                                             \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      d_bn##idx##_x, d_bn##idx##_x, pattern_name, cond);                       \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      d_bn##idx##_scale, d_bn##idx##_scale, pattern_name, cond);               \
+  GET_IR_NODE_FROM_SUBGRAPH_COND(                                              \
+      d_bn##idx##_bias, d_bn##idx##_bias, pattern_name, cond)
+
+#define PRINT_DEBUG_INFO(idx)                                                  \
+  VLOG(4) << "\n\t " << x##idx->Name() << " and " << conv##idx##_w->Name()     \
+          << " -> " << conv##idx##_op->Name() << " -> "                        \
+          << conv##idx##_out->Name() << "\n";                                  \
+  VLOG(4) << "\n\t " << conv##idx##_out->Name() << ", "                        \
+          << bn##idx##_scale->Name() << ", " << bn##idx##_bias->Name() << ", " \
+          << " -> " << bn##idx##_op->Name() << " -> "                          \
+          << bn##idx##_mean_out->Name() << ", "                                \
+          << bn##idx##_variance_out->Name() << ", "                            \
+          << bn##idx##_saved_variance->Name() << ", "                          \
+          << bn##idx##_saved_mean->Name() << ", " << bn##idx##_out->Name()     \
+          << "\n";
+
+#define IR_NODE_LINK_TO_DEBUG(x, y)                       \
+  VLOG(4) << "LINK " << x->Name() << " -> " << y->Name(); \
+  IR_NODE_LINK_TO(x, y)
+
+ir::Node *CreateVarNode(Graph *g,
+                        const std::string scope,
+                        const std::string name) {
+  VarDesc var_desc(patterns::PDNodeName(scope, name));
+  return g->CreateVarNode(&var_desc);
+}
+
+ir::Node *CreateConvBNstatsOpNode(Graph *g,
+                                  BlockDesc *block,
+                                  bool fuse_prologue,
+                                  ir::Node *conv_op,
+                                  ir::Node *bn_op,
+                                  ir::Node *input,
+                                  ir::Node *filter,
+                                  ir::Node *input_scale,
+                                  ir::Node *input_bias,
+                                  ir::Node *bn_scale,
+                                  ir::Node *bn_bias,
+                                  ir::Node *bn_mean,
+                                  ir::Node *bn_variance,
+                                  ir::Node *conv_out,
+                                  ir::Node *bn_mean_out,
+                                  ir::Node *bn_variance_out,
+                                  ir::Node *bn_saved_mean,
+                                  ir::Node *bn_saved_variance,
+                                  ir::Node *eq_scale,
+                                  ir::Node *eq_bias) {
+  OpDesc op_desc(block);
+  op_desc.SetType("fused_scale_bias_relu_conv_bn");
+  op_desc.SetInput("x", {input->Name()});
+  op_desc.SetInput("w", {filter->Name()});
+  if (fuse_prologue) {
+    op_desc.SetInput("scale", {input_scale->Name()});
+    op_desc.SetInput("bias", {input_bias->Name()});
+  }
+  op_desc.SetInput("bn_scale", {bn_scale->Name()});
+  op_desc.SetInput("bn_bias", {bn_bias->Name()});
+  op_desc.SetInput("input_running_mean", {bn_mean->Name()});
+  op_desc.SetInput("input_running_var", {bn_variance->Name()});
+  op_desc.SetOutput("out", {conv_out->Name()});
+  op_desc.SetOutput("out_running_mean", {bn_mean_out->Name()});
+  op_desc.SetOutput("out_running_var", {bn_variance_out->Name()});
+  op_desc.SetOutput("saved_mean", {bn_saved_mean->Name()});
+  op_desc.SetOutput("saved_var", {bn_saved_variance->Name()});
+  op_desc.SetOutput("eq_scale", {eq_scale->Name()});
+  op_desc.SetOutput("eq_bias", {eq_bias->Name()});
+
+  op_desc.SetAttr(
+      "paddings",
+      PADDLE_GET_CONST(std::vector<int>, conv_op->Op()->GetAttr("paddings")));
+  op_desc.SetAttr(
+      "dilations",
+      PADDLE_GET_CONST(std::vector<int>, conv_op->Op()->GetAttr("dilations")));
+  op_desc.SetAttr(
+      "strides",
+      PADDLE_GET_CONST(std::vector<int>, conv_op->Op()->GetAttr("strides")));
+  op_desc.SetAttr(
+      "padding_algorithm",
+      PADDLE_GET_CONST(std::string,
+                       conv_op->Op()->GetAttr("padding_algorithm")));
+  op_desc.SetAttr("groups",
+                  PADDLE_GET_CONST(int, conv_op->Op()->GetAttr("groups")));
+  op_desc.SetAttr(
+      "data_format",
+      PADDLE_GET_CONST(std::string, conv_op->Op()->GetAttr("data_format")));
+  op_desc.SetAttr("momentum",
+                  PADDLE_GET_CONST(float, bn_op->Op()->GetAttr("momentum")));
+  op_desc.SetAttr("epsilon",
+                  PADDLE_GET_CONST(float, bn_op->Op()->GetAttr("epsilon")));
+  op_desc.SetAttr("fuse_prologue", fuse_prologue);
+  op_desc.SetAttr(
+      "exhaustive_search",
+      PADDLE_GET_CONST(bool, conv_op->Op()->GetAttr("exhaustive_search")));
+  // TODO(tizheng): need to change this for sync_bn
+  op_desc.SetAttr("accumulation_count", 0);
+  op_desc.SetAttr("op_role", conv_op->Op()->GetAttr("op_role"));
+  auto op_node = g->CreateOpNode(&op_desc);
+  IR_NODE_LINK_TO(input, op_node);
+  IR_NODE_LINK_TO(filter, op_node);
+  if (fuse_prologue) {
+    IR_NODE_LINK_TO(input_scale, op_node);
+    IR_NODE_LINK_TO(input_bias, op_node);
+  }
+  IR_NODE_LINK_TO(bn_scale, op_node);
+  IR_NODE_LINK_TO(bn_bias, op_node);
+  IR_NODE_LINK_TO(bn_mean, op_node);
+  IR_NODE_LINK_TO(bn_variance, op_node);
+
+  IR_NODE_LINK_TO(op_node, conv_out);
+  IR_NODE_LINK_TO(op_node, bn_mean_out);
+  IR_NODE_LINK_TO(op_node, bn_variance_out);
+  IR_NODE_LINK_TO(op_node, bn_saved_mean);
+  IR_NODE_LINK_TO(op_node, bn_saved_variance);
+  IR_NODE_LINK_TO(op_node, eq_scale);
+  IR_NODE_LINK_TO(op_node, eq_bias);
+  return op_node;
+}
+
+ir::Node *CreateSBAROpNode(Graph *g,
+                           BlockDesc *block,
+                           bool fuse_dual,
+                           bool exhaustive_search,
+                           ir::Node *act_op,
+                           ir::Node *x1,
+                           ir::Node *scale1,
+                           ir::Node *bias1,
+                           ir::Node *x2,
+                           ir::Node *scale2,
+                           ir::Node *bias2,
+                           ir::Node *y_out) {
+  OpDesc op_desc(block);
+  op_desc.SetType("fused_scale_bias_add_relu");
+  op_desc.SetInput("x1", {x1->Name()});
+  op_desc.SetInput("scale1", {scale1->Name()});
+  op_desc.SetInput("bias1", {bias1->Name()});
+  op_desc.SetInput("x2", {x2->Name()});
+  if (fuse_dual) {
+    op_desc.SetInput("scale2", {scale2->Name()});
+    op_desc.SetInput("bias2", {bias2->Name()});
+  }
+  op_desc.SetOutput("out", {y_out->Name()});
+  op_desc.SetAttr("fuse_dual", fuse_dual);
+  op_desc.SetAttr("exhaustive_search", exhaustive_search);
+  op_desc.SetAttr("op_role", act_op->Op()->GetAttr("op_role"));
+  auto op_node = g->CreateOpNode(&op_desc);
+
+  IR_NODE_LINK_TO(x1, op_node);
+  IR_NODE_LINK_TO(scale1, op_node);
+  IR_NODE_LINK_TO(bias1, op_node);
+  IR_NODE_LINK_TO(x2, op_node);
+  if (fuse_dual) {
+    IR_NODE_LINK_TO(scale2, op_node);
+    IR_NODE_LINK_TO(bias2, op_node);
+  }
+  IR_NODE_LINK_TO(op_node, y_out);
+  return op_node;
+}
+
+ir::Node *CreateDconvDreluDBNOpNode(Graph *g,
+                                    BlockDesc *block,
+                                    bool fuse_add,
+                                    bool fuse_dual,
+                                    bool fuse_shortcut,
+                                    ir::Node *conv_grad,
+                                    ir::Node *bn_grad,
+                                    ir::Node *bn2_grad,
+                                    ir::Node *d_conv_out,
+                                    ir::Node *conv_w,
+                                    ir::Node *d_conv_w,
+                                    ir::Node *bn_saved_mean,
+                                    ir::Node *bn_saved_variance,
+                                    ir::Node *bn_scale,
+                                    ir::Node *bn_bias,
+                                    ir::Node *bn_x,
+                                    ir::Node *d_bn_x,
+                                    ir::Node *d_bn_scale,
+                                    ir::Node *d_bn_bias,
+                                    ir::Node *d_relu_out_extra,
+                                    ir::Node *elewise_add_input_extra,
+                                    ir::Node *d_elewise_add_input_extra,
+                                    ir::Node *bn2_saved_mean,
+                                    ir::Node *bn2_saved_variance,
+                                    ir::Node *bn2_scale,
+                                    ir::Node *bn2_bias,
+                                    ir::Node *bn2_x,
+                                    ir::Node *d_bn2_x,
+                                    ir::Node *d_bn2_scale,
+                                    ir::Node *d_bn2_bias,
+                                    ir::Node *conv_x,
+                                    ir::Node *bn_eqscale,
+                                    ir::Node *bn_eqbias) {
+  OpDesc op_desc(block);
+  op_desc.SetType("fused_dconv_drelu_dbn");
+  op_desc.SetInput("grad_output", {d_conv_out->Name()});
+  op_desc.SetInput("weight", {conv_w->Name()});
+  op_desc.SetInput("bn1_mean", {bn_saved_mean->Name()});
+  op_desc.SetInput("bn1_inv_std", {bn_saved_variance->Name()});
+  op_desc.SetInput("bn1_gamma", {bn_scale->Name()});
+  op_desc.SetInput("bn1_beta", {bn_bias->Name()});
+  op_desc.SetInput("bn1_input", {bn_x->Name()});
+  op_desc.SetOutput("grad_bn1_input", {d_bn_x->Name()});
+  op_desc.SetOutput("grad_bn1_gamma", {d_bn_scale->Name()});
+  op_desc.SetOutput("grad_bn1_beta", {d_bn_bias->Name()});
+  op_desc.SetOutput("grad_weight", {d_conv_w->Name()});
+  if (fuse_add) {
+    op_desc.SetInput("grad_output_add", {d_relu_out_extra->Name()});
+  }
+  if (fuse_shortcut) {
+    op_desc.SetInput("residual_input", {elewise_add_input_extra->Name()});
+    op_desc.SetOutput("grad_bn2_input", {d_elewise_add_input_extra->Name()});
+  }
+  if (fuse_dual) {
+    op_desc.SetInput("bn2_mean", {bn2_saved_mean->Name()});
+    op_desc.SetInput("bn2_inv_std", {bn2_saved_variance->Name()});
+    op_desc.SetInput("bn2_gamma", {bn2_scale->Name()});
+    op_desc.SetInput("bn2_beta", {bn2_bias->Name()});
+    op_desc.SetInput("bn2_input", {bn2_x->Name()});
+    op_desc.SetOutput("grad_bn2_input", {d_bn2_x->Name()});
+    op_desc.SetOutput("grad_bn2_gamma", {d_bn2_scale->Name()});
+    op_desc.SetOutput("grad_bn2_beta", {d_bn2_bias->Name()});
+  }
+  if (fuse_dual || fuse_shortcut) {
+    op_desc.SetInput("conv_input", {conv_x->Name()});
+  } else {
+    op_desc.SetInput("bn1_eqscale", {bn_eqscale->Name()});
+    op_desc.SetInput("bn1_eqbias", {bn_eqbias->Name()});
+  }
+
+  op_desc.SetAttr(
+      "paddings",
+      PADDLE_GET_CONST(std::vector<int>, conv_grad->Op()->GetAttr("paddings")));
+  op_desc.SetAttr("dilations",
+                  PADDLE_GET_CONST(std::vector<int>,
+                                   conv_grad->Op()->GetAttr("dilations")));
+  op_desc.SetAttr(
+      "strides",
+      PADDLE_GET_CONST(std::vector<int>, conv_grad->Op()->GetAttr("strides")));
+  op_desc.SetAttr(
+      "padding_algorithm",
+      PADDLE_GET_CONST(std::string,
+                       conv_grad->Op()->GetAttr("padding_algorithm")));
+  op_desc.SetAttr("groups",
+                  PADDLE_GET_CONST(int, conv_grad->Op()->GetAttr("groups")));
+  op_desc.SetAttr(
+      "data_format",
+      PADDLE_GET_CONST(std::string, conv_grad->Op()->GetAttr("data_format")));
+  op_desc.SetAttr("fuse_shortcut", fuse_shortcut);
+  op_desc.SetAttr("fuse_dual", fuse_dual);
+  op_desc.SetAttr("fuse_add", fuse_add);
+  op_desc.SetAttr(
+      "exhaustive_search",
+      PADDLE_GET_CONST(bool, conv_grad->Op()->GetAttr("exhaustive_search")));
+  op_desc.SetAttr("op_role", conv_grad->Op()->GetAttr("op_role"));
+  auto conv_grad_op_role_val =
+      details::GetOpRoleVarsOrEmpty(*(conv_grad->Op()));
+  auto bn_grad_op_role_val = details::GetOpRoleVarsOrEmpty(*(bn_grad->Op()));
+  std::vector<std::string> fused_op_role_var;
+  for (auto i : conv_grad_op_role_val) {
+    fused_op_role_var.push_back(i);
+  }
+  for (auto i : bn_grad_op_role_val) {
+    fused_op_role_var.push_back(i);
+  }
+  if (fuse_dual) {
+    auto bn2_grad_op_role_val =
+        details::GetOpRoleVarsOrEmpty(*(bn2_grad->Op()));
+    for (auto i : bn2_grad_op_role_val) {
+      fused_op_role_var.push_back(i);
+    }
+  }
+  op_desc.SetAttr("op_role_var", fused_op_role_var);
+
+  auto op_node = g->CreateOpNode(&op_desc);
+
+  IR_NODE_LINK_TO_DEBUG(d_conv_out, op_node);
+  IR_NODE_LINK_TO_DEBUG(conv_w, op_node);
+  IR_NODE_LINK_TO_DEBUG(bn_saved_mean, op_node);
+  IR_NODE_LINK_TO_DEBUG(bn_saved_variance, op_node);
+  IR_NODE_LINK_TO_DEBUG(bn_scale, op_node);
+  IR_NODE_LINK_TO_DEBUG(bn_bias, op_node);
+  IR_NODE_LINK_TO_DEBUG(bn_x, op_node);
+
+  IR_NODE_LINK_TO_DEBUG(op_node, d_bn_x);
+  IR_NODE_LINK_TO_DEBUG(op_node, d_bn_scale);
+  IR_NODE_LINK_TO_DEBUG(op_node, d_bn_bias);
+  IR_NODE_LINK_TO_DEBUG(op_node, d_conv_w);
+
+  if (fuse_add) {
+    IR_NODE_LINK_TO_DEBUG(d_relu_out_extra, op_node);
+  }
+  if (fuse_shortcut) {
+    IR_NODE_LINK_TO_DEBUG(elewise_add_input_extra, op_node);
+    IR_NODE_LINK_TO_DEBUG(op_node, d_elewise_add_input_extra);
+  }
+  if (fuse_dual) {
+    IR_NODE_LINK_TO_DEBUG(bn2_saved_mean, op_node);
+    IR_NODE_LINK_TO_DEBUG(bn2_saved_variance, op_node);
+    IR_NODE_LINK_TO_DEBUG(bn2_scale, op_node);
+    IR_NODE_LINK_TO_DEBUG(bn2_bias, op_node);
+    IR_NODE_LINK_TO_DEBUG(bn2_x, op_node);
+
+    IR_NODE_LINK_TO_DEBUG(op_node, d_bn2_x);
+    IR_NODE_LINK_TO_DEBUG(op_node, d_bn2_scale);
+    IR_NODE_LINK_TO_DEBUG(op_node, d_bn2_bias);
+  }
+  if (fuse_dual || fuse_shortcut) {
+    IR_NODE_LINK_TO_DEBUG(conv_x, op_node);
+  } else {
+    IR_NODE_LINK_TO_DEBUG(bn_eqscale, op_node);
+    IR_NODE_LINK_TO_DEBUG(bn_eqbias, op_node);
+  }
+  return op_node;
+}
+
+ir::Node *RetrieveForwardNode(ir::Graph *graph,
+                              std::string name,
+                              std::string op_type) {
+  auto pos = name.find("@GRAD");
+  PADDLE_ENFORCE_NE(pos,
+                    std::string::npos,
+                    platform::errors::InvalidArgument(
+                        "expect @GRAD in name, got (%s)", name));
+  std::string fwd_name = name.substr(0, pos);
+  for (auto *node : graph->Nodes()) {
+    if (node->Name() == fwd_name) {
+      for (auto *op : node->outputs) {
+        if (op && op->IsOp() && op->Op() && op->Op()->Type() == op_type) {
+          return node;
+        }
+      }
+    }
+  }
+  PADDLE_THROW(platform::errors::InvalidArgument(
+      "The node (%d) does not exist.", fwd_name));
+  return nullptr;
+}
+
+void FuseResUnitPass::ApplyImpl(ir::Graph *graph) const {
+  // Training
+  ResUnitPassCache cache;
+  graph = FuseConvBNAddActFwd(graph, {"relu"}, false, true);
+  graph = FuseConvBNAddActFwd(graph, {"relu"}, true, true);
+
+  int iteration = 0;
+  int found_pattern_count = 0;
+  do {
+    VLOG(4) << "FuseConvBNActConvBNstats Iteration: " << iteration;
+    graph = FuseConvBNActConvBNstats(
+        graph, {"relu"}, true, &found_pattern_count, &cache);
+    ++iteration;
+  } while (found_pattern_count);
+
+  graph = FuseBNAddActConvBwd(graph, {"relu_grad"}, false, true);
+  graph = FuseBNAddActConvBwd(graph, {"relu_grad"}, true, true);
+  graph = FuseBNAddActConvBwd(graph, {"relu_grad"}, false, false);
+  graph = FuseBNAddActConvBwd(graph, {"relu_grad"}, true, false);
+  graph = FuseBNActConvBwd(graph, {"relu_grad"}, &cache);
+
+  // Try to fuse evaluation program
+  graph = FuseConvBNAddActFwd(graph, {"relu"}, false, false);
+  graph = FuseConvBNAddActFwd(graph, {"relu"}, true, false);
+
+  iteration = 0;
+  found_pattern_count = 0;
+  do {
+    VLOG(4) << "FuseConvBNActConvBNstats Iteration: " << iteration;
+    graph = FuseConvBNActConvBNstats(
+        graph, {"relu"}, false, &found_pattern_count, nullptr);
+    ++iteration;
+  } while (found_pattern_count);
+}
+
+ir::Graph *FuseResUnitPass::FuseConvBNAddActFwd(
+    ir::Graph *graph,
+    const std::unordered_set<std::string> &act_types,
+    bool shortcut,
+    bool is_training) const {
+  PADDLE_ENFORCE_NOT_NULL(
+      graph, platform::errors::InvalidArgument("Graph cannot be nullptr."));
+  const std::string scope_name("conv_bn_add_act");
+  FusePassBase::Init(scope_name, graph);
+
+  GraphPatternDetector gpd;
+  patterns::ConvBNAddAct conv_bn_add_act_pattern(gpd.mutable_pattern(),
+                                                 scope_name);
+  conv_bn_add_act_pattern(act_types, shortcut, is_training);
+
+  int found_pattern_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t &subgraph,
+                     Graph *g) {
+    VLOG(4) << "handle ConvBNAddAct fuse";
+
+    GET_IR_NODE_FROM_SUBGRAPH(x1, x1, conv_bn_add_act_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(x2, x2, conv_bn_add_act_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        elewise_add_op, elewise_add_op, conv_bn_add_act_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(act_op, act_op, conv_bn_add_act_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(add_out, add_out, conv_bn_add_act_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(act_out, act_out, conv_bn_add_act_pattern);
+    GET_CONV_BN_NODES_COND(1, conv_bn_add_act_pattern, true);
+    GET_CONV_BN_NODES_COND(2, conv_bn_add_act_pattern, (!shortcut));
+
+    auto bn1_eqscale = CreateVarNode(g, scope_name, "bn1_eqscale");
+    auto bn1_eqbias = CreateVarNode(g, scope_name, "bn1_eqbias");
+    ir::Node *bn2_eqscale = nullptr;
+    ir::Node *bn2_eqbias = nullptr;
+    if (!shortcut) {
+      bn2_eqscale = CreateVarNode(g, scope_name, "bn2_eqscale");
+      bn2_eqbias = CreateVarNode(g, scope_name, "bn2_eqbias");
+    }
+
+    CreateConvBNstatsOpNode(g,
+                            conv1_op->Op()->Block(),
+                            false,
+                            conv1_op,
+                            bn1_op,
+                            x1,
+                            conv1_w,
+                            nullptr,
+                            nullptr,
+                            bn1_scale,
+                            bn1_bias,
+                            bn1_mean,
+                            bn1_variance,
+                            conv1_out,
+                            bn1_mean_out,
+                            bn1_variance_out,
+                            bn1_saved_mean,
+                            bn1_saved_variance,
+                            bn1_eqscale,
+                            bn1_eqbias);
+
+    if (!shortcut) {
+      CreateConvBNstatsOpNode(g,
+                              conv2_op->Op()->Block(),
+                              false,
+                              conv2_op,
+                              bn2_op,
+                              x2,
+                              conv2_w,
+                              nullptr,
+                              nullptr,
+                              bn2_scale,
+                              bn2_bias,
+                              bn2_mean,
+                              bn2_variance,
+                              conv2_out,
+                              bn2_mean_out,
+                              bn2_variance_out,
+                              bn2_saved_mean,
+                              bn2_saved_variance,
+                              bn2_eqscale,
+                              bn2_eqbias);
+    }
+    auto *sbar_input2 = shortcut ? x2 : conv2_out;
+    bool exhaustive_search =
+        PADDLE_GET_CONST(bool, conv1_op->Op()->GetAttr("exhaustive_search"));
+    CreateSBAROpNode(g,
+                     act_op->Op()->Block(),
+                     !shortcut,
+                     exhaustive_search,
+                     act_op,
+                     conv1_out,
+                     bn1_eqscale,
+                     bn1_eqbias,
+                     sbar_input2,
+                     bn2_eqscale,
+                     bn2_eqbias,
+                     act_out);
+
+    PRINT_DEBUG_INFO(1);
+    if (shortcut) {
+      VLOG(4) << "\n\t " << bn1_out->Name() << ", " << x2->Name() << " -> "
+              << elewise_add_op->Name() << " -> " << add_out->Name() << " -> "
+              << act_op->Name() << " -> " << act_out->Name();
+    } else {
+      PRINT_DEBUG_INFO(2);
+      VLOG(4) << "\n\t " << bn1_out->Name() << ", " << bn2_out->Name() << " -> "
+              << elewise_add_op->Name() << " -> " << add_out->Name() << " -> "
+              << act_op->Name() << " -> " << act_out->Name();
+    }
+    std::unordered_set<const Node *> nodes_to_delete = {
+        conv1_op, bn1_op, elewise_add_op, act_op, bn1_out, add_out};
+
+    if (!shortcut) {
+      nodes_to_delete.insert(std::move(conv2_op));
+      nodes_to_delete.insert(std::move(bn2_op));
+      nodes_to_delete.insert(std::move(bn2_out));
+    }
+
+    GraphSafeRemoveNodes(g, nodes_to_delete);
+    found_pattern_count++;
+  };
+
+  gpd(graph, handler);
+
+  AddStatis(found_pattern_count);
+  return graph;
+}
+
+ir::Graph *FuseResUnitPass::FuseConvBNActConvBNstats(
+    ir::Graph *graph,
+    const std::unordered_set<std::string> &act_types,
+    bool is_training,
+    int *found_pattern_count_output,
+    ResUnitPassCache *cache) const {
+  PADDLE_ENFORCE_NOT_NULL(
+      graph, platform::errors::InvalidArgument("Graph cannot be nullptr."));
+  const std::string scope_name("conv_bn_act_conv_bnstats");
+  FusePassBase::Init(scope_name, graph);
+
+  GraphPatternDetector gpd;
+  patterns::ConvBNActConvBNStats conv_bn_act_conv_bnstats_pattern(
+      gpd.mutable_pattern(), scope_name);
+  conv_bn_act_conv_bnstats_pattern(act_types, is_training);
+
+  int found_pattern_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t &subgraph,
+                     Graph *g) {
+    VLOG(4) << "handle ConvBNActConvBNStats fuse";
+
+    GET_IR_NODE_FROM_SUBGRAPH(conv_x, conv_x, conv_bn_act_conv_bnstats_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(act_op, act_op, conv_bn_act_conv_bnstats_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        act_out, act_out, conv_bn_act_conv_bnstats_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        conv_bnstats_op, conv_bnstats_op, conv_bn_act_conv_bnstats_pattern);
+    GET_CONV_BN_NODES_COND(, conv_bn_act_conv_bnstats_pattern, true);
+
+    auto bn_eqscale = CreateVarNode(g, scope_name, "bn_eqscale");
+    auto bn_eqbias = CreateVarNode(g, scope_name, "bn_eqbias");
+
+    CreateConvBNstatsOpNode(g,
+                            conv_op->Op()->Block(),
+                            false,
+                            conv_op,
+                            bn_op,
+                            conv_x,
+                            conv_w,
+                            nullptr,
+                            nullptr,
+                            bn_scale,
+                            bn_bias,
+                            bn_mean,
+                            bn_variance,
+                            conv_out,
+                            bn_mean_out,
+                            bn_variance_out,
+                            bn_saved_mean,
+                            bn_saved_variance,
+                            bn_eqscale,
+                            bn_eqbias);
+
+    // Modify the following conv_bnstats_op
+    conv_bnstats_op->Op()->SetInput("scale", {bn_eqscale->Name()});
+    conv_bnstats_op->Op()->SetInput("bias", {bn_eqbias->Name()});
+    conv_bnstats_op->Op()->SetInput("x", {conv_out->Name()});
+    conv_bnstats_op->Op()->SetAttr("fuse_prologue", true);
+
+    IR_NODE_LINK_TO(conv_out, conv_bnstats_op);
+    IR_NODE_LINK_TO(bn_eqscale, conv_bnstats_op);
+    IR_NODE_LINK_TO(bn_eqbias, conv_bnstats_op);
+
+    if (is_training) {
+      // link bn_eqscale -> bn_saved_variance
+      // bn_eqbias -> bn_saved_mean
+      cache->Insert(
+          GetCacheKey(bn_saved_variance->Var()->Name(), g->GetBlockId()),
+          bn_eqscale);
+      cache->Insert(GetCacheKey(bn_saved_mean->Var()->Name(), g->GetBlockId()),
+                    bn_eqbias);
+    }
+
+    auto *x = conv_x;
+    PRINT_DEBUG_INFO();
+    VLOG(4) << "\n\t " << bn_out->Name() << " -> " << act_op->Name() << " -> "
+            << act_out->Name() << " -> " << conv_bnstats_op->Name();
+
+    std::unordered_set<const Node *> nodes_to_delete = {
+        conv_op, bn_op, act_op, bn_out, act_out};
+
+    GraphSafeRemoveNodes(g, nodes_to_delete);
+    found_pattern_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_pattern_count);
+  *found_pattern_count_output = found_pattern_count;
+  return graph;
+}
+
+ir::Graph *FuseResUnitPass::FuseBNActConvBwd(
+    ir::Graph *graph,
+    const std::unordered_set<std::string> &act_grad_types,
+    ResUnitPassCache *cache) const {
+  PADDLE_ENFORCE_NOT_NULL(
+      graph, platform::errors::InvalidArgument("Graph cannot be nullptr."));
+  VLOG(4) << "Applying FuseBNActConvBwd";
+  const std::string scope_name("bn_act_conv_bwd");
+  FusePassBase::Init(scope_name, graph);
+
+  GraphPatternDetector gpd;
+  patterns::BNActConvGrad bn_act_conv_grad_pattern(gpd.mutable_pattern(),
+                                                   scope_name);
+  bn_act_conv_grad_pattern(act_grad_types);
+
+  int found_pattern_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t &subgraph,
+                     Graph *g) {
+    VLOG(4) << "handle BNActConvBwd fuse";
+
+    GET_CONV_GRAD_NODES(bn_act_conv_grad_pattern);
+    GET_BN_GRAD_NODES_COND(, bn_act_conv_grad_pattern, true);
+    GET_IR_NODE_FROM_SUBGRAPH(act_grad, act_grad, bn_act_conv_grad_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(d_act_x, d_act_x, bn_act_conv_grad_pattern);
+
+    auto *bn_eqscale = cache->Get(
+        GetCacheKey(bn_saved_variance->Var()->Name(), g->GetBlockId()));
+    auto *bn_eqbias =
+        cache->Get(GetCacheKey(bn_saved_mean->Var()->Name(), g->GetBlockId()));
+    if (bn_eqscale == nullptr || bn_eqbias == nullptr) {
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "The bn_eqscale and bn_eqbias do not exist in the cache. "
+          "The forward fusion pass may not be successful."));
+    }
+    CreateDconvDreluDBNOpNode(g,
+                              conv_grad->Op()->Block(),
+                              false,
+                              false,
+                              false,
+                              conv_grad,
+                              batch_norm_grad,
+                              nullptr,
+                              d_conv_out,
+                              conv_w,
+                              d_conv_w,
+                              bn_saved_mean,
+                              bn_saved_variance,
+                              bn_scale,
+                              bn_bias,
+                              bn_x,
+                              d_bn_x,
+                              d_bn_scale,
+                              d_bn_bias,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              nullptr,
+                              bn_eqscale,
+                              bn_eqbias);
+
+    std::unordered_set<const Node *> nodes_to_delete = {
+        conv_grad, act_grad, batch_norm_grad, d_act_x, d_conv_x};
+
+    GraphSafeRemoveNodes(g, nodes_to_delete);
+    found_pattern_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_pattern_count);
+  return graph;
+}
+
+ir::Graph *FuseResUnitPass::FuseBNAddActConvBwd(
+    ir::Graph *graph,
+    const std::unordered_set<std::string> &act_grad_types,
+    bool shortcut,
+    bool with_sum) const {
+  PADDLE_ENFORCE_NOT_NULL(
+      graph, platform::errors::InvalidArgument("Graph cannot be nullptr."));
+  VLOG(4) << "Applying FuseBNAddActConvBwd, shortcut=" << shortcut
+          << ", with_sum=" << with_sum;
+  const std::string scope_name("bn_add_act_conv_bwd");
+  FusePassBase::Init(scope_name, graph);
+
+  GraphPatternDetector gpd;
+  patterns::BNAddActConvGrad bn_add_act_conv_grad_pattern(gpd.mutable_pattern(),
+                                                          scope_name);
+  bn_add_act_conv_grad_pattern(act_grad_types, shortcut, with_sum);
+
+  int found_pattern_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t &subgraph,
+                     Graph *g) {
+    VLOG(4) << "handle BNAddActConvGrad fuse";
+    GET_IR_NODE_FROM_SUBGRAPH(conv_x, conv_x, bn_add_act_conv_grad_pattern);
+    GET_CONV_GRAD_NODES(bn_add_act_conv_grad_pattern);
+    GET_BN_GRAD_NODES_COND(1, bn_add_act_conv_grad_pattern, true);
+    GET_BN_GRAD_NODES_COND(2, bn_add_act_conv_grad_pattern, (!shortcut));
+
+    GET_IR_NODE_FROM_SUBGRAPH(act_grad, act_grad, bn_add_act_conv_grad_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        elewise_add_grad, elewise_add_grad, bn_add_act_conv_grad_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH_COND(
+        sum, sum, bn_add_act_conv_grad_pattern, with_sum);
+    GET_IR_NODE_FROM_SUBGRAPH_COND(
+        sum_in_extra, sum_in_extra, bn_add_act_conv_grad_pattern, with_sum);
+    GET_IR_NODE_FROM_SUBGRAPH_COND(
+        sum_out, sum_out, bn_add_act_conv_grad_pattern, with_sum);
+
+    GET_IR_NODE_FROM_SUBGRAPH(d_act_x, d_act_x, bn_add_act_conv_grad_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        d_elewise_add_x, d_elewise_add_x, bn_add_act_conv_grad_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        d_elewise_add_y, d_elewise_add_y, bn_add_act_conv_grad_pattern);
+
+    ir::Node *d_elewise_add_input_extra = shortcut ? d_elewise_add_y : nullptr;
+    ir::Node *elewise_add_input_extra = nullptr;
+    if (shortcut) {
+      elewise_add_input_extra = RetrieveForwardNode(
+          graph, d_elewise_add_y->Name(), "elementwise_add_grad");
+    }
+    CreateDconvDreluDBNOpNode(g,
+                              conv_grad->Op()->Block(),
+                              with_sum,
+                              !shortcut,
+                              shortcut,
+                              conv_grad,
+                              batch_norm1_grad,
+                              batch_norm2_grad,
+                              d_conv_out,
+                              conv_w,
+                              d_conv_w,
+                              bn1_saved_mean,
+                              bn1_saved_variance,
+                              bn1_scale,
+                              bn1_bias,
+                              bn1_x,
+                              d_bn1_x,
+                              d_bn1_scale,
+                              d_bn1_bias,
+                              sum_in_extra,
+                              elewise_add_input_extra,
+                              d_elewise_add_input_extra,
+                              bn2_saved_mean,
+                              bn2_saved_variance,
+                              bn2_scale,
+                              bn2_bias,
+                              bn2_x,
+                              d_bn2_x,
+                              d_bn2_scale,
+                              d_bn2_bias,
+                              conv_x,
+                              nullptr,
+                              nullptr);
+
+    std::unordered_set<const Node *> nodes_to_delete = {conv_grad,
+                                                        act_grad,
+                                                        elewise_add_grad,
+                                                        batch_norm1_grad,
+                                                        d_conv_x,
+                                                        d_act_x,
+                                                        d_elewise_add_x};
+    if (with_sum) {
+      nodes_to_delete.insert(std::move(sum));
+      nodes_to_delete.insert(std::move(sum_out));
+    }
+    if (!shortcut) {
+      nodes_to_delete.insert(std::move(d_elewise_add_y));
+      nodes_to_delete.insert(std::move(batch_norm2_grad));
+    }
+    GraphSafeRemoveNodes(g, nodes_to_delete);
+    found_pattern_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_pattern_count);
+  return graph;
+}
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
+
+REGISTER_PASS(fuse_resunit_pass, paddle::framework::ir::FuseResUnitPass);

--- a/paddle/fluid/framework/ir/fuse_resunit_pass.h
+++ b/paddle/fluid/framework/ir/fuse_resunit_pass.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2022 NVIDIA Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+#include "paddle/fluid/framework/ir/fuse_pass_base.h"
+#include "paddle/fluid/framework/ir/graph.h"
+#include "paddle/fluid/framework/ir/graph_pattern_detector.h"
+#include "paddle/fluid/framework/ir/pass.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+class Graph;
+class Node;
+
+class ResUnitPassCache {
+ public:
+  ResUnitPassCache() {}
+
+  ResUnitPassCache(const ResUnitPassCache &) = delete;
+  void operator=(const ResUnitPassCache &) = delete;
+
+  bool Exists(const std::string &key) const { return var_map_.count(key); }
+
+  ir::Node *Get(const std::string &key) {
+    if (Exists(key)) {
+      return var_map_.find(key)->second;
+    }
+    return nullptr;
+  }
+
+  void Insert(const std::string &key, ir::Node *const value) {
+    if (!Exists(key)) {
+      mtx.lock();
+      var_map_.insert({key, value});
+      mtx.unlock();
+    } else {
+      PADDLE_THROW(platform::errors::AlreadyExists(
+          "The key (%d) of ResUnitPassCache already exist.", key));
+    }
+  }
+
+ private:
+  std::unordered_map<std::string, ir::Node *> var_map_;
+  std::mutex mtx;
+};
+
+class FuseResUnitPass : public FusePassBase {
+ public:
+  virtual ~FuseResUnitPass() {}
+
+ protected:
+  void ApplyImpl(ir::Graph *graph) const override;
+
+  ir::Graph *FuseConvBNAddActFwd(
+      ir::Graph *graph,
+      const std::unordered_set<std::string> &act_types,
+      bool shortcut,
+      bool is_training) const;
+
+  ir::Graph *FuseConvBNActConvBNstats(
+      ir::Graph *graph,
+      const std::unordered_set<std::string> &act_types,
+      bool is_training,
+      int *found_pattern_count_output,
+      ResUnitPassCache *cache) const;
+
+  ir::Graph *FuseBNActConvBwd(
+      ir::Graph *graph,
+      const std::unordered_set<std::string> &act_grad_types,
+      ResUnitPassCache *cache) const;
+
+  ir::Graph *FuseBNAddActConvBwd(
+      ir::Graph *graph,
+      const std::unordered_set<std::string> &act_grad_types,
+      bool shortcut,
+      bool with_sum) const;
+
+ private:
+  const std::string GetCacheKey(const std::string var_name,
+                                int block_id) const {
+    return std::to_string(block_id) + var_name;
+  }
+};
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/ir/fuse_resunit_pass.h
+++ b/paddle/fluid/framework/ir/fuse_resunit_pass.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
-// Copyright (c) 2022 NVIDIA Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 NVIDIA Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -5165,18 +5165,17 @@ PDNode *patterns::ConvBNActConvBNStats::operator()(
   auto *act_op = pattern->NewNode(act_op_repr())->assert_is_ops(act_types);
   auto *act_out_var =
       pattern->NewNode(act_out_repr())->assert_is_ops_output(act_types, "Out");
-  act_out_var->assert_is_op_input("fused_scale_bias_relu_conv_bnstats", "x");
+  act_out_var->assert_is_op_input("fused_scale_bias_relu_conv_bn", "x");
   if (is_training) {
-    // has link to conv_grad, relu_grad and fused_scale_bias_relu_conv_bnstats
+    // has link to conv_grad, relu_grad and fused_scale_bias_relu_conv_bn
     act_out_var->assert_has_n_outputs(3);
   } else {
     act_out_var->AsIntermediate();
   }
   // ConvBNStats
-  auto *conv_bnstats_op =
-      pattern->NewNode(conv_bnstats_op_repr())
-          ->assert_is_op("fused_scale_bias_relu_conv_bnstats")
-          ->assert_op_attr<bool>("fuse_prologue", false);
+  auto *conv_bnstats_op = pattern->NewNode(conv_bnstats_op_repr())
+                              ->assert_is_op("fused_scale_bias_relu_conv_bn")
+                              ->assert_op_attr<bool>("fuse_prologue", false);
 
   // Links
   conv_op->LinksFrom({conv_x_var, conv_w_var}).LinksTo({conv_out_var});

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -4937,6 +4937,513 @@ void patterns::MulMatmulMatmulV2::operator()(
   ops->LinksTo({ops_out});
 }
 
+PDNode *patterns::ConvBNAddAct::operator()(
+    const std::unordered_set<std::string> &act_types,
+    bool shortcut,
+    bool is_training) {
+  // Conv1
+  auto *x1 = pattern->NewNode(x1_repr())
+                 ->assert_is_op_input("conv2d", "Input")
+                 ->assert_var_dtype(proto::VarType::FP16);
+  auto *conv1_w =
+      pattern->NewNode(conv1_w_repr())->assert_is_op_input("conv2d", "Filter");
+  auto *conv1_out = pattern->NewNode(conv1_out_repr())
+                        ->assert_is_op_output("conv2d", "Output")
+                        ->assert_is_op_input("batch_norm", "X");
+  auto conv1_op = pattern->NewNode(conv1_op_repr())
+                      ->assert_is_op("conv2d")
+                      ->assert_op_attr<std::string>("data_format", "NHWC");
+  // Conv2
+  PDNode *x2 = nullptr;
+  PDNode *conv2_w = nullptr;
+  PDNode *conv2_out = nullptr;
+  PDNode *conv2_op = nullptr;
+  if (shortcut) {
+    x2 = pattern->NewNode(x2_repr())
+             ->assert_is_op_input("elementwise_add", "Y")
+             ->assert_var_dtype(proto::VarType::FP16);
+  } else {
+    x2 = pattern->NewNode(x2_repr())->assert_is_op_input("conv2d", "Input");
+    conv2_w = pattern->NewNode(conv2_w_repr())
+                  ->assert_is_op_input("conv2d", "Filter");
+    conv2_out = pattern->NewNode(conv2_out_repr())
+                    ->assert_is_op_output("conv2d", "Output")
+                    ->assert_is_op_input("batch_norm", "X");
+    conv2_op = pattern->NewNode(conv2_op_repr())
+                   ->assert_is_op("conv2d")
+                   ->assert_op_attr<std::string>("data_format", "NHWC");
+  }
+  // BN1
+  auto *bn1_scale_var = pattern->NewNode(bn1_scale_repr())
+                            ->assert_is_op_input("batch_norm", "Scale");
+  auto *bn1_bias_var = pattern->NewNode(bn1_bias_repr())
+                           ->assert_is_op_input("batch_norm", "Bias");
+  auto *bn1_variance_var = pattern->NewNode(bn1_variance_repr())
+                               ->assert_is_op_input("batch_norm", "Variance");
+  auto *bn1_mean_var = pattern->NewNode(bn1_mean_repr())
+                           ->assert_is_op_input("batch_norm", "Mean");
+
+  auto *bn1_op = pattern->NewNode(bn1_op_repr())
+                     ->assert_is_op("batch_norm")
+                     ->assert_is_not_op_input("MomentumTensor")
+                     ->assert_op_attr<bool>("use_global_stats", false)
+                     ->assert_op_attr<std::string>("data_layout", "NHWC");
+
+  auto *bn1_mean_out_var = pattern->NewNode(bn1_mean_out_repr())
+                               ->assert_is_op_output("batch_norm", "MeanOut");
+  auto *bn1_variance_out_var =
+      pattern->NewNode(bn1_variance_out_repr())
+          ->assert_is_op_output("batch_norm", "VarianceOut");
+  auto *bn1_saved_variance_var =
+      pattern->NewNode(bn1_saved_variance_repr())
+          ->assert_is_op_output("batch_norm", "SavedVariance");
+  auto *bn1_saved_mean_var =
+      pattern->NewNode(bn1_saved_mean_repr())
+          ->assert_is_op_output("batch_norm", "SavedMean");
+  auto *bn1_out_var =
+      pattern->NewNode(bn1_out_repr())->assert_is_op_output("batch_norm", "Y");
+  bn1_out_var->assert_is_op_input("elementwise_add", "X");
+
+  // BN2
+  PDNode *bn2_scale_var = nullptr;
+  PDNode *bn2_bias_var = nullptr;
+  PDNode *bn2_variance_var = nullptr;
+  PDNode *bn2_mean_var = nullptr;
+  PDNode *bn2_op = nullptr;
+  PDNode *bn2_mean_out_var = nullptr;
+  PDNode *bn2_variance_out_var = nullptr;
+  PDNode *bn2_saved_variance_var = nullptr;
+  PDNode *bn2_saved_mean_var = nullptr;
+  PDNode *bn2_out_var = nullptr;
+
+  if (!shortcut) {
+    bn2_scale_var = pattern->NewNode(bn2_scale_repr())
+                        ->assert_is_op_input("batch_norm", "Scale");
+    bn2_bias_var = pattern->NewNode(bn2_bias_repr())
+                       ->assert_is_op_input("batch_norm", "Bias");
+    bn2_variance_var = pattern->NewNode(bn2_variance_repr())
+                           ->assert_is_op_input("batch_norm", "Variance");
+    bn2_mean_var = pattern->NewNode(bn2_mean_repr())
+                       ->assert_is_op_input("batch_norm", "Mean");
+
+    bn2_op = pattern->NewNode(bn2_op_repr())
+                 ->assert_is_op("batch_norm")
+                 ->assert_is_not_op_input("MomentumTensor")
+                 ->assert_op_attr<bool>("use_global_stats", false)
+                 ->assert_op_attr<std::string>("data_layout", "NHWC");
+
+    bn2_mean_out_var = pattern->NewNode(bn2_mean_out_repr())
+                           ->assert_is_op_output("batch_norm", "MeanOut");
+    bn2_variance_out_var =
+        pattern->NewNode(bn2_variance_out_repr())
+            ->assert_is_op_output("batch_norm", "VarianceOut");
+    bn2_saved_variance_var =
+        pattern->NewNode(bn2_saved_variance_repr())
+            ->assert_is_op_output("batch_norm", "SavedVariance");
+    bn2_saved_mean_var = pattern->NewNode(bn2_saved_mean_repr())
+                             ->assert_is_op_output("batch_norm", "SavedMean");
+    bn2_out_var = pattern->NewNode(bn2_out_repr())
+                      ->assert_is_op_output("batch_norm", "Y");
+    bn2_out_var->assert_is_op_input("elementwise_add", "Y");
+  }
+
+  // Add
+  auto *add_out = pattern->NewNode(add_out_repr())
+                      ->assert_is_only_output_of_op("elementwise_add");
+  auto *elewise_add_op =
+      pattern->NewNode(elewise_add_op_repr())->assert_is_op("elementwise_add");
+  // Act
+  auto *act_op = pattern->NewNode(act_op_repr())->assert_is_ops(act_types);
+  auto *act_out =
+      pattern->NewNode(act_out_repr())->assert_is_ops_output(act_types, "Out");
+
+  // Links
+  conv1_op->LinksFrom({x1, conv1_w}).LinksTo({conv1_out});
+  bn1_op
+      ->LinksFrom({conv1_out,
+                   bn1_scale_var,
+                   bn1_bias_var,
+                   bn1_mean_var,
+                   bn1_variance_var})
+      .LinksTo({bn1_out_var,
+                bn1_mean_out_var,
+                bn1_variance_out_var,
+                bn1_saved_mean_var,
+                bn1_saved_variance_var});
+  if (!shortcut) {
+    conv2_op->LinksFrom({x2, conv2_w}).LinksTo({conv2_out});
+    bn2_op
+        ->LinksFrom({conv2_out,
+                     bn2_scale_var,
+                     bn2_bias_var,
+                     bn2_mean_var,
+                     bn2_variance_var})
+        .LinksTo({bn2_out_var,
+                  bn2_mean_out_var,
+                  bn2_variance_out_var,
+                  bn2_saved_mean_var,
+                  bn2_saved_variance_var});
+  }
+  if (shortcut) {
+    elewise_add_op->LinksFrom({bn1_out_var, x2}).LinksTo({add_out});
+  } else {
+    elewise_add_op->LinksFrom({bn1_out_var, bn2_out_var}).LinksTo({add_out});
+  }
+  act_op->LinksFrom({add_out}).LinksTo({act_out});
+
+  // Note(tizheng): The backward fusion pattern is
+  // dConv + Add + dReLU + dBN. Considering that forward
+  // and backward fusion should be applied (or not applied)
+  // simultaneously, we only fuse ConvBNAddAct with a following Conv2D.
+  if (is_training) {
+    act_out->assert_is_op_input("conv2d", "Input");
+  } else {
+    // For inference, avoid selecting this pattern in training programs
+    conv1_out->AsIntermediate();
+    bn1_out_var->AsIntermediate();
+    if (!shortcut) {
+      conv2_out->AsIntermediate();
+      bn2_out_var->AsIntermediate();
+    }
+    add_out->AsIntermediate();
+  }
+  return act_out;
+}
+
+PDNode *patterns::ConvBNActConvBNStats::operator()(
+    const std::unordered_set<std::string> &act_types, bool is_training) {
+  // Conv
+  auto *conv_x_var = pattern->NewNode(conv_x_repr())
+                         ->assert_is_op_input("conv2d", "Input")
+                         ->assert_var_dtype(proto::VarType::FP16);
+  auto *conv_w_var =
+      pattern->NewNode(conv_w_repr())->assert_is_op_input("conv2d", "Filter");
+  auto *conv_out_var = pattern->NewNode(conv_out_repr())
+                           ->assert_is_op_output("conv2d", "Output")
+                           ->assert_is_op_input("batch_norm", "X");
+  if (is_training) {
+    // has link to bn_grad
+    conv_out_var->assert_has_n_outputs(2);
+  } else {
+    conv_out_var->AsIntermediate();
+  }
+  auto conv_op = pattern->NewNode(conv_op_repr())
+                     ->assert_is_op("conv2d")
+                     ->assert_op_attr<std::string>("data_format", "NHWC");
+  // BN
+  auto *bn_scale_var = pattern->NewNode(bn_scale_repr())
+                           ->assert_is_op_input("batch_norm", "Scale");
+  auto *bn_bias_var = pattern->NewNode(bn_bias_repr())
+                          ->assert_is_op_input("batch_norm", "Bias");
+  auto *bn_variance_var = pattern->NewNode(bn_variance_repr())
+                              ->assert_is_op_input("batch_norm", "Variance");
+  auto *bn_mean_var = pattern->NewNode(bn_mean_repr())
+                          ->assert_is_op_input("batch_norm", "Mean");
+
+  auto *bn_op = pattern->NewNode(bn_op_repr())
+                    ->assert_is_op("batch_norm")
+                    ->assert_is_not_op_input("MomentumTensor")
+                    ->assert_op_attr<bool>("use_global_stats", false)
+                    ->assert_op_attr<std::string>("data_layout", "NHWC");
+
+  auto *bn_mean_out_var = pattern->NewNode(bn_mean_out_repr())
+                              ->assert_is_op_output("batch_norm", "MeanOut");
+  auto *bn_variance_out_var =
+      pattern->NewNode(bn_variance_out_repr())
+          ->assert_is_op_output("batch_norm", "VarianceOut");
+  auto *bn_saved_variance_var =
+      pattern->NewNode(bn_saved_variance_repr())
+          ->assert_is_op_output("batch_norm", "SavedVariance");
+  auto *bn_saved_mean_var =
+      pattern->NewNode(bn_saved_mean_repr())
+          ->assert_is_op_output("batch_norm", "SavedMean");
+  auto *bn_out_var = pattern->NewNode(bn_out_repr())
+                         ->assert_is_op_output("batch_norm", "Y")
+                         ->AsIntermediate();
+  bn_out_var->assert_is_ops_input(act_types);
+  // Act
+  auto *act_op = pattern->NewNode(act_op_repr())->assert_is_ops(act_types);
+  auto *act_out_var =
+      pattern->NewNode(act_out_repr())->assert_is_ops_output(act_types, "Out");
+  act_out_var->assert_is_op_input("fused_scale_bias_relu_conv_bnstats", "x");
+  if (is_training) {
+    // has link to conv_grad, relu_grad and fused_scale_bias_relu_conv_bnstats
+    act_out_var->assert_has_n_outputs(3);
+  } else {
+    act_out_var->AsIntermediate();
+  }
+  // ConvBNStats
+  auto *conv_bnstats_op =
+      pattern->NewNode(conv_bnstats_op_repr())
+          ->assert_is_op("fused_scale_bias_relu_conv_bnstats")
+          ->assert_op_attr<bool>("fuse_prologue", false);
+
+  // Links
+  conv_op->LinksFrom({conv_x_var, conv_w_var}).LinksTo({conv_out_var});
+  bn_op
+      ->LinksFrom({conv_out_var,
+                   bn_scale_var,
+                   bn_bias_var,
+                   bn_mean_var,
+                   bn_variance_var})
+      .LinksTo({bn_out_var,
+                bn_mean_out_var,
+                bn_variance_out_var,
+                bn_saved_mean_var,
+                bn_saved_variance_var});
+  act_op->LinksFrom({bn_out_var}).LinksTo({act_out_var});
+  conv_bnstats_op->LinksFrom({act_out_var});
+  return act_out_var;
+}
+
+PDNode *patterns::BNActConvGrad::operator()(
+    const std::unordered_set<std::string> &act_grad_types) {
+  auto *d_conv_out_var =
+      pattern->NewNode(d_conv_out_repr())
+          ->assert_is_op_input("conv2d_grad", GradVarName("Output"));
+  auto *conv_w_var = pattern->NewNode(conv_w_repr())
+                         ->assert_is_op_input("conv2d_grad", "Filter");
+  auto *d_conv_w_var =
+      pattern->NewNode(d_conv_w_repr())
+          ->assert_is_op_output("conv2d_grad", GradVarName("Filter"));
+  auto *d_conv_x_var =
+      pattern->NewNode(d_conv_x_repr())
+          ->assert_is_op_output("conv2d_grad", GradVarName("Input"));
+  d_conv_x_var->assert_is_ops_input(act_grad_types, GradVarName("Out"));
+  // No conv_x because it is already deleted by forward pass
+  auto *conv_grad = pattern->NewNode(conv_grad_repr())
+                        ->assert_is_op("conv2d_grad")
+                        ->assert_op_attr<std::string>("data_format", "NHWC")
+                        ->assert_has_n_inputs(2);
+  auto *act_grad =
+      pattern->NewNode(act_grad_repr())->assert_is_ops(act_grad_types);
+  auto *bn_grad = pattern->NewNode(batch_norm_grad_repr())
+                      ->assert_is_op("batch_norm_grad")
+                      ->assert_op_attr<bool>("use_global_stats", false)
+                      ->assert_op_attr<std::string>("data_layout", "NHWC");
+  auto *d_act_x_var =
+      pattern->NewNode(d_act_x_repr())
+          ->assert_is_ops_output(act_grad_types, GradVarName("X"))
+          ->assert_has_n_outputs(1)
+          ->assert_var_dtype(proto::VarType::FP16);  // d_act_x
+
+  d_act_x_var->AsIntermediate()->assert_is_op_input("batch_norm_grad",
+                                                    GradVarName("Y"));
+
+  auto *bn_x_var = pattern->NewNode(bn_x_repr())
+                       ->assert_is_op_input("batch_norm_grad", "X")
+                       ->assert_var_dtype(proto::VarType::FP16);
+  auto *bn_scale_var = pattern->NewNode(bn_scale_repr())
+                           ->assert_is_op_input("batch_norm_grad", "Scale");
+  auto *bn_bias_var = pattern->NewNode(bn_bias_repr())
+                          ->assert_is_op_input("batch_norm_grad", "Bias");
+  auto *bn_saved_mean_var =
+      pattern->NewNode(bn_saved_mean_repr())
+          ->assert_is_op_input("batch_norm_grad", "SavedMean");
+  auto *bn_saved_variance_var =
+      pattern->NewNode(bn_saved_variance_repr())
+          ->assert_is_op_input("batch_norm_grad", "SavedVariance");
+  auto *d_bn_x_var =
+      pattern->NewNode(d_bn_x_repr())
+          ->assert_is_not_ctrl_var()
+          ->assert_is_op_output("batch_norm_grad", GradVarName("X"))
+          ->assert_var_dtype(proto::VarType::FP16);
+  auto *d_bn_scale_var =
+      pattern->NewNode(d_bn_scale_repr())
+          ->assert_is_not_ctrl_var()
+          ->assert_is_op_output("batch_norm_grad", GradVarName("Scale"));
+  auto *d_bn_bias_var =
+      pattern->NewNode(d_bn_bias_repr())
+          ->assert_is_not_ctrl_var()
+          ->assert_is_op_output("batch_norm_grad", GradVarName("Bias"));
+
+  conv_grad->LinksFrom({d_conv_out_var, conv_w_var})
+      .LinksTo({d_conv_w_var, d_conv_x_var});
+
+  act_grad->LinksFrom({d_conv_x_var}).LinksTo({d_act_x_var});
+
+  bn_grad
+      ->LinksFrom({bn_x_var,
+                   d_act_x_var,
+                   bn_scale_var,
+                   bn_bias_var,
+                   bn_saved_mean_var,
+                   bn_saved_variance_var})
+      .LinksTo({d_bn_x_var, d_bn_scale_var, d_bn_bias_var});
+
+  return bn_grad;
+}
+
+PDNode *patterns::BNAddActConvGrad::operator()(
+    const std::unordered_set<std::string> &act_grad_types,
+    bool shortcut,
+    bool with_sum) {
+  // dConv
+  auto *d_conv_out_var =
+      pattern->NewNode(d_conv_out_repr())
+          ->assert_is_op_input("conv2d_grad", GradVarName("Output"));
+  auto *conv_x_var = pattern->NewNode(conv_x_repr())
+                         ->assert_is_op_input("conv2d_grad", "Input");
+  conv_x_var->assert_is_ops_input(act_grad_types, "Out");
+  auto *conv_w_var = pattern->NewNode(conv_w_repr())
+                         ->assert_is_op_input("conv2d_grad", "Filter");
+  auto *d_conv_w_var =
+      pattern->NewNode(d_conv_w_repr())
+          ->assert_is_op_output("conv2d_grad", GradVarName("Filter"));
+  auto *d_conv_x_var =
+      pattern->NewNode(d_conv_x_repr())
+          ->assert_is_op_output("conv2d_grad", GradVarName("Input"));
+  auto *conv_grad = pattern->NewNode(conv_grad_repr())
+                        ->assert_is_op("conv2d_grad")
+                        ->assert_op_attr<std::string>("data_format", "NHWC");
+  // (optional) sum
+  PDNode *sum_in_extra_var = nullptr;
+  PDNode *sum_out_var = nullptr;
+  PDNode *sum_op = nullptr;
+  if (with_sum) {
+    sum_op = pattern->NewNode(sum_repr())->assert_is_op("sum");
+    d_conv_x_var->assert_is_op_input("sum");
+    sum_in_extra_var =
+        pattern->NewNode(sum_in_extra_repr())->assert_is_op_input("sum");
+    sum_out_var =
+        pattern->NewNode(sum_out_repr())->assert_is_only_output_of_op("sum");
+    sum_out_var->assert_is_ops_input(act_grad_types, GradVarName("Out"));
+  } else {
+    d_conv_x_var->assert_is_ops_input(act_grad_types, GradVarName("Out"));
+  }
+  // dAct
+  auto *act_grad =
+      pattern->NewNode(act_grad_repr())->assert_is_ops(act_grad_types);
+  auto *d_act_x_var =
+      pattern->NewNode(d_act_x_repr())
+          ->assert_is_ops_output(act_grad_types, GradVarName("X"))
+          ->assert_has_n_outputs(1)
+          ->assert_var_dtype(proto::VarType::FP16);  // d_act_x
+
+  d_act_x_var->AsIntermediate()->assert_is_op_input("elementwise_add_grad");
+
+  // elementwise_add_grad
+  auto *elewise_add_grad = pattern->NewNode(elewise_add_grad_repr())
+                               ->assert_is_op("elementwise_add_grad");
+  auto *d_elewise_add_x_var = pattern->NewNode(d_elewise_add_x_repr())
+                                  ->assert_is_op_output("elementwise_add_grad");
+  auto *d_elewise_add_y_var = pattern->NewNode(d_elewise_add_y_repr())
+                                  ->assert_is_op_output("elementwise_add_grad");
+  d_elewise_add_x_var->assert_is_op_input("batch_norm_grad", GradVarName("Y"));
+  if (shortcut) {
+    d_elewise_add_y_var->AsOutput();
+  } else {
+    d_elewise_add_y_var->assert_is_op_input("batch_norm_grad",
+                                            GradVarName("Y"));
+  }
+  // dBN1
+  auto *bn1_grad = pattern->NewNode(batch_norm1_grad_repr())
+                       ->assert_is_op("batch_norm_grad")
+                       ->assert_op_attr<bool>("use_global_stats", false)
+                       ->assert_op_attr<std::string>("data_layout", "NHWC");
+
+  auto *bn1_x_var = pattern->NewNode(bn1_x_repr())
+                        ->assert_is_op_input("batch_norm_grad", "X")
+                        ->assert_var_dtype(proto::VarType::FP16);
+  auto *bn1_scale_var = pattern->NewNode(bn1_scale_repr())
+                            ->assert_is_op_input("batch_norm_grad", "Scale");
+  auto *bn1_bias_var = pattern->NewNode(bn1_bias_repr())
+                           ->assert_is_op_input("batch_norm_grad", "Bias");
+  auto *bn1_saved_mean_var =
+      pattern->NewNode(bn1_saved_mean_repr())
+          ->assert_is_op_input("batch_norm_grad", "SavedMean");
+  auto *bn1_saved_variance_var =
+      pattern->NewNode(bn1_saved_variance_repr())
+          ->assert_is_op_input("batch_norm_grad", "SavedVariance");
+  auto *d_bn1_x_var =
+      pattern->NewNode(d_bn1_x_repr())
+          ->assert_is_not_ctrl_var()
+          ->assert_is_op_output("batch_norm_grad", GradVarName("X"))
+          ->assert_var_dtype(proto::VarType::FP16);
+  auto *d_bn1_scale_var =
+      pattern->NewNode(d_bn1_scale_repr())
+          ->assert_is_not_ctrl_var()
+          ->assert_is_op_output("batch_norm_grad", GradVarName("Scale"));
+  auto *d_bn1_bias_var =
+      pattern->NewNode(d_bn1_bias_repr())
+          ->assert_is_not_ctrl_var()
+          ->assert_is_op_output("batch_norm_grad", GradVarName("Bias"));
+  // dBN2
+  PDNode *bn2_grad = nullptr;
+  PDNode *bn2_x_var = nullptr;
+  PDNode *bn2_scale_var = nullptr;
+  PDNode *bn2_bias_var = nullptr;
+  PDNode *bn2_saved_mean_var = nullptr;
+  PDNode *bn2_saved_variance_var = nullptr;
+  PDNode *d_bn2_x_var = nullptr;
+  PDNode *d_bn2_scale_var = nullptr;
+  PDNode *d_bn2_bias_var = nullptr;
+  if (!shortcut) {
+    bn2_grad = pattern->NewNode(batch_norm2_grad_repr())
+                   ->assert_is_op("batch_norm_grad")
+                   ->assert_op_attr<bool>("use_global_stats", false)
+                   ->assert_op_attr<std::string>("data_layout", "NHWC");
+
+    bn2_x_var = pattern->NewNode(bn2_x_repr())
+                    ->assert_is_op_input("batch_norm_grad", "X")
+                    ->assert_var_dtype(proto::VarType::FP16);
+    bn2_scale_var = pattern->NewNode(bn2_scale_repr())
+                        ->assert_is_op_input("batch_norm_grad", "Scale");
+    bn2_bias_var = pattern->NewNode(bn2_bias_repr())
+                       ->assert_is_op_input("batch_norm_grad", "Bias");
+    bn2_saved_mean_var =
+        pattern->NewNode(bn2_saved_mean_repr())
+            ->assert_is_op_input("batch_norm_grad", "SavedMean");
+    bn2_saved_variance_var =
+        pattern->NewNode(bn2_saved_variance_repr())
+            ->assert_is_op_input("batch_norm_grad", "SavedVariance");
+    d_bn2_x_var = pattern->NewNode(d_bn2_x_repr())
+                      ->assert_is_not_ctrl_var()
+                      ->assert_is_op_output("batch_norm_grad", GradVarName("X"))
+                      ->assert_var_dtype(proto::VarType::FP16);
+    d_bn2_scale_var =
+        pattern->NewNode(d_bn2_scale_repr())
+            ->assert_is_not_ctrl_var()
+            ->assert_is_op_output("batch_norm_grad", GradVarName("Scale"));
+    d_bn2_bias_var =
+        pattern->NewNode(d_bn2_bias_repr())
+            ->assert_is_not_ctrl_var()
+            ->assert_is_op_output("batch_norm_grad", GradVarName("Bias"));
+  }
+
+  conv_grad->LinksFrom({d_conv_out_var, conv_x_var, conv_w_var})
+      .LinksTo({d_conv_w_var, d_conv_x_var});
+  if (with_sum) {
+    sum_op->LinksFrom({d_conv_x_var, sum_in_extra_var}).LinksTo({sum_out_var});
+    act_grad->LinksFrom({sum_out_var, conv_x_var}).LinksTo({d_act_x_var});
+  } else {
+    act_grad->LinksFrom({d_conv_x_var, conv_x_var}).LinksTo({d_act_x_var});
+  }
+
+  elewise_add_grad->LinksFrom({d_act_x_var})
+      .LinksTo({d_elewise_add_x_var, d_elewise_add_y_var});
+
+  bn1_grad
+      ->LinksFrom({d_elewise_add_x_var,
+                   bn1_x_var,
+                   bn1_scale_var,
+                   bn1_bias_var,
+                   bn1_saved_mean_var,
+                   bn1_saved_variance_var})
+      .LinksTo({d_bn1_x_var, d_bn1_scale_var, d_bn1_bias_var});
+  if (!shortcut) {
+    bn2_grad
+        ->LinksFrom({d_elewise_add_y_var,
+                     bn2_x_var,
+                     bn2_scale_var,
+                     bn2_bias_var,
+                     bn2_saved_mean_var,
+                     bn2_saved_variance_var})
+        .LinksTo({d_bn2_x_var, d_bn2_scale_var, d_bn2_bias_var});
+  }
+  return bn1_grad;
+}
+
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -2423,6 +2423,205 @@ struct FusedFeedForwardBwd : public PatternBase {
 #undef FEEDFORWARD_LINEAR_DROPOUT_GRAD_NODE
 #endif
 };
+// The following patterns are used to fuse Conv + BN + Add + Act
+// pattern:
+// (a) shortcut=true
+//
+//     |        |
+//  [Conv]      |
+//   [BN]       |
+//     \       /
+//       [Add]
+//       [Act]
+//          |
+//
+// (b) shortcut=false
+//    |         |
+// [Conv]     [Conv]
+//  [BN]       [BN]
+//     \       /
+//       [Add]
+//       [Act]
+//         |
+struct ConvBNAddAct : public PatternBase {
+  ConvBNAddAct(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "conv_bn_add_act") {}
+
+  PDNode* operator()(const std::unordered_set<std::string>& act_types,
+                     bool shortcut,
+                     bool is_training);
+
+  // declare operator node's name
+  PATTERN_DECL_NODE(conv1_op);
+  PATTERN_DECL_NODE(bn1_op);
+  PATTERN_DECL_NODE(conv2_op);
+  PATTERN_DECL_NODE(bn2_op);
+  PATTERN_DECL_NODE(elewise_add_op);
+  PATTERN_DECL_NODE(act_op);
+
+  // declare variable node's name
+  PATTERN_DECL_NODE(x1);
+  PATTERN_DECL_NODE(conv1_w);
+  PATTERN_DECL_NODE(conv1_out);
+  PATTERN_DECL_NODE(bn1_scale);
+  PATTERN_DECL_NODE(bn1_bias);
+  PATTERN_DECL_NODE(bn1_variance);
+  PATTERN_DECL_NODE(bn1_mean);
+  PATTERN_DECL_NODE(bn1_mean_out);
+  PATTERN_DECL_NODE(bn1_variance_out);
+  PATTERN_DECL_NODE(bn1_saved_variance);
+  PATTERN_DECL_NODE(bn1_saved_mean);
+  PATTERN_DECL_NODE(bn1_out);
+  PATTERN_DECL_NODE(x2);
+  PATTERN_DECL_NODE(conv2_w);
+  PATTERN_DECL_NODE(conv2_out);
+  PATTERN_DECL_NODE(bn2_scale);
+  PATTERN_DECL_NODE(bn2_bias);
+  PATTERN_DECL_NODE(bn2_variance);
+  PATTERN_DECL_NODE(bn2_mean);
+  PATTERN_DECL_NODE(bn2_mean_out);
+  PATTERN_DECL_NODE(bn2_variance_out);
+  PATTERN_DECL_NODE(bn2_saved_variance);
+  PATTERN_DECL_NODE(bn2_saved_mean);
+  PATTERN_DECL_NODE(bn2_out);
+  PATTERN_DECL_NODE(add_out);
+  PATTERN_DECL_NODE(act_out);
+};
+
+// The following patterns are used to fuse Conv + BN + Act + ConvBNStats
+// pattern:
+struct ConvBNActConvBNStats : public PatternBase {
+  ConvBNActConvBNStats(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "conv_bn_act_conv_bnstats") {}
+
+  PDNode* operator()(const std::unordered_set<std::string>& act_types,
+                     bool is_training);
+
+  // declare operator node's name
+  PATTERN_DECL_NODE(conv_op);
+  PATTERN_DECL_NODE(bn_op);
+  PATTERN_DECL_NODE(act_op);
+  PATTERN_DECL_NODE(conv_bnstats_op);
+
+  // declare variable node's name
+  PATTERN_DECL_NODE(conv_x);
+  PATTERN_DECL_NODE(conv_w);
+  PATTERN_DECL_NODE(conv_out);
+  PATTERN_DECL_NODE(bn_scale);
+  PATTERN_DECL_NODE(bn_bias);
+  PATTERN_DECL_NODE(bn_variance);
+  PATTERN_DECL_NODE(bn_mean);
+  PATTERN_DECL_NODE(bn_mean_out);
+  PATTERN_DECL_NODE(bn_variance_out);
+  PATTERN_DECL_NODE(bn_saved_variance);
+  PATTERN_DECL_NODE(bn_saved_mean);
+  PATTERN_DECL_NODE(bn_out);
+  PATTERN_DECL_NODE(act_out);
+};
+
+// The following patterns are used to fuse dConv + dAct + dBN
+// pattern:
+struct BNActConvGrad : public PatternBase {
+  BNActConvGrad(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "bn_act_conv_grad") {}
+
+  PDNode* operator()(const std::unordered_set<std::string>& act_grad_types);
+  // declare operator node's name
+  PATTERN_DECL_NODE(conv_grad);
+  PATTERN_DECL_NODE(act_grad);
+  PATTERN_DECL_NODE(batch_norm_grad);
+  // declare variable node's name
+  PATTERN_DECL_NODE(d_conv_out);
+  PATTERN_DECL_NODE(conv_w);
+  PATTERN_DECL_NODE(d_conv_x);
+  PATTERN_DECL_NODE(d_conv_w);
+  PATTERN_DECL_NODE(d_act_x);
+  PATTERN_DECL_NODE(bn_x);
+  PATTERN_DECL_NODE(bn_scale);
+  PATTERN_DECL_NODE(bn_bias);
+  PATTERN_DECL_NODE(bn_saved_mean);
+  PATTERN_DECL_NODE(bn_saved_variance);
+  PATTERN_DECL_NODE(d_bn_x);
+  PATTERN_DECL_NODE(d_bn_scale);
+  PATTERN_DECL_NODE(d_bn_bias);
+};
+
+// The following patterns are used to fuse BN + Add + Act + Conv backward
+// pattern, [sum] is optional, controlled by with_sum
+// (a) shortcut=true
+//     |      |
+//  [dBN]     /
+//     |     /
+//  [dAdd]---
+//     |
+//  [dReLU]
+//     |
+//  [sum (optional)]
+//     |       |
+//  [dConv]    |
+//     |       |
+//
+// (b) shortcut=false
+//     |      |
+//  [dBN]   [dBN]
+//     |     /
+//  [dAdd]---
+//     |
+//  [dReLU]
+//     |
+//  [sum (optional)]
+//     |       |
+//  [dConv]    |
+//     |       |
+struct BNAddActConvGrad : public PatternBase {
+  BNAddActConvGrad(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "bn_add_act_conv_grad") {}
+
+  PDNode* operator()(const std::unordered_set<std::string>& act_grad_types,
+                     bool shortcut,
+                     bool with_sum);
+  // declare operator node's name
+  PATTERN_DECL_NODE(conv_grad);
+  PATTERN_DECL_NODE(act_grad);
+  PATTERN_DECL_NODE(elewise_add_grad);
+  PATTERN_DECL_NODE(sum);
+  PATTERN_DECL_NODE(batch_norm1_grad);
+  PATTERN_DECL_NODE(batch_norm2_grad);
+  // declare variable node's name
+  // dConv
+  PATTERN_DECL_NODE(d_conv_out);
+  PATTERN_DECL_NODE(conv_x);
+  PATTERN_DECL_NODE(conv_w);
+  PATTERN_DECL_NODE(d_conv_x);
+  PATTERN_DECL_NODE(d_conv_w);
+  // (optional) sum
+  PATTERN_DECL_NODE(sum_in_extra);
+  PATTERN_DECL_NODE(sum_out);
+  // dAct
+  PATTERN_DECL_NODE(d_act_x);
+  // dAdd
+  PATTERN_DECL_NODE(d_elewise_add_x);
+  PATTERN_DECL_NODE(d_elewise_add_y);
+  // BN 1
+  PATTERN_DECL_NODE(bn1_x);
+  PATTERN_DECL_NODE(bn1_scale);
+  PATTERN_DECL_NODE(bn1_bias);
+  PATTERN_DECL_NODE(bn1_saved_mean);
+  PATTERN_DECL_NODE(bn1_saved_variance);
+  PATTERN_DECL_NODE(d_bn1_x);
+  PATTERN_DECL_NODE(d_bn1_scale);
+  PATTERN_DECL_NODE(d_bn1_bias);
+  // (optional) BN 2
+  PATTERN_DECL_NODE(bn2_x);
+  PATTERN_DECL_NODE(bn2_scale);
+  PATTERN_DECL_NODE(bn2_bias);
+  PATTERN_DECL_NODE(bn2_saved_mean);
+  PATTERN_DECL_NODE(bn2_saved_variance);
+  PATTERN_DECL_NODE(d_bn2_x);
+  PATTERN_DECL_NODE(d_bn2_scale);
+  PATTERN_DECL_NODE(d_bn2_bias);
+};
+
 }  // namespace patterns
 
 // Link two ir::Nodes from each other.

--- a/paddle/fluid/pybind/parallel_executor.cc
+++ b/paddle/fluid/pybind/parallel_executor.cc
@@ -716,6 +716,36 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
                         >>> build_strategy.sequential_run = True
           )DOC")
       .def_property(
+          "fuse_resunit",
+          [](const BuildStrategy &self) { return self.fuse_resunit_; },
+          [](BuildStrategy &self, bool b) {
+            PADDLE_ENFORCE_NE(self.IsFinalized(),
+                              true,
+                              platform::errors::PreconditionNotMet(
+                                  "BuildStrategy has been finalized, cannot be "
+                                  "configured again."));
+            self.fuse_resunit_ = b;
+#ifndef PADDLE_WITH_CUDNN_FRONTEND
+            if (self.fuse_resunit_) {
+              PADDLE_THROW(platform::errors::PreconditionNotMet(
+                  "Paddle is not built with CUDNN Frontend support."));
+            }
+#endif
+          },
+          R"DOC((bool, optional): fuse_resunit Default is False.
+
+                Examples:
+                    .. code-block:: python
+
+                        import paddle
+                        import paddle.static as static
+
+                        paddle.enable_static()
+
+                        build_strategy = static.BuildStrategy()
+                        build_strategy.fuse_resunit = True
+                     )DOC")
+      .def_property(
           "fuse_bn_act_ops",
           [](const BuildStrategy &self) { return self.fuse_bn_act_ops_; },
           [](BuildStrategy &self, bool b) {

--- a/python/paddle/distributed/passes/cpp_pass.py
+++ b/python/paddle/distributed/passes/cpp_pass.py
@@ -168,6 +168,19 @@ class InplaceAddtoOpPass(CPPPassWrapper):
         return PassType.CALC_OPT
 
 
+@register_pass("fuse_resunit")
+class FuseResUnitPass(CPPPassWrapper):
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def cpp_name(self):
+        return "fuse_resunit_pass"
+
+    def _type(self):
+        return PassType.FUSION_OPT
+
+
 def _set_cinn_op_flag(flag_name, extra_ops):
     values = core.globals()[flag_name]
     values = [v.strip() for v in values.split(";") if v.strip()]

--- a/python/paddle/distributed/passes/pass_base.py
+++ b/python/paddle/distributed/passes/pass_base.py
@@ -247,6 +247,7 @@ PassBase._AFTER_WHITE_LISTS_DICT = {
 
 # The index of pass in this list represent the order in which the pass is processed.
 PassBase._PASS_PROCESS_ORDER_LIST = [
+    "fuse_resunit",
     "fuse_relu_depthwise_conv",
     "fuse_bn_add_act",
     "fuse_bn_act",

--- a/python/paddle/framework/ir.py
+++ b/python/paddle/framework/ir.py
@@ -86,6 +86,9 @@ def apply_build_strategy(
     if build_strategy.fuse_relu_depthwise_conv and use_cuda:
         apply_pass("fuse_relu_depthwise_conv_pass")
         build_strategy.fuse_relu_depthwise_conv = False
+    if build_strategy.fuse_resunit:
+        apply_pass("fuse_resunit_pass")
+        build_strategy.fuse_resunit = False
     if build_strategy.fuse_bn_act_ops and use_cuda:
         apply_pass("fuse_bn_act_pass")
         build_strategy.fuse_bn_act_ops = False

--- a/test/distributed_passes/CMakeLists.txt
+++ b/test/distributed_passes/CMakeLists.txt
@@ -27,6 +27,10 @@ if(NOT ((WITH_GPU) AND (CUDA_VERSION GREATER_EQUAL 11.6)))
   list(REMOVE_ITEM TEST_OPS test_auto_parallel_fused_linear_promotion_pass)
 endif()
 
+if(NOT WITH_CUDNN_FRONTEND)
+  list(REMOVE_ITEM TEST_OPS "test_dist_fuse_resunit_pass")
+endif()
+
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS "NVIDIA_TF32_OVERRIDE=0")
   list(APPEND DIST_TEST_OPS ${TEST_OP})

--- a/test/distributed_passes/test_dist_fuse_resunit_pass.py
+++ b/test/distributed_passes/test_dist_fuse_resunit_pass.py
@@ -237,6 +237,15 @@ class TestFuseResUnitPass(DistPassTestBase):
             "init_loss_scaling": 128.0,
             "use_dynamic_loss_scaling": True,
         }
+        build_strategy = paddle.static.BuildStrategy()
+        settings = {
+            "fuse_bn_act_ops": False,
+            "fuse_bn_add_act_ops": False,
+            "enable_inplace": False,
+        }
+        for k, v in settings.items():
+            setattr(build_strategy, k, v)
+        dist_strategy.build_strategy = build_strategy
         fleet.init(is_collective=True, strategy=dist_strategy)
         optimizer = fleet.distributed_optimizer(optimizer)
         optimizer.minimize(loss)

--- a/test/distributed_passes/test_dist_fuse_resunit_pass.py
+++ b/test/distributed_passes/test_dist_fuse_resunit_pass.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import numpy as np
+from dist_pass_test_base import DistPassTestBase
+
+import paddle
+from paddle import ParamAttr, nn
+from paddle.distributed import fleet
+from paddle.distributed.passes import PassManager, new_pass
+from paddle.nn import BatchNorm, Conv2D
+from paddle.nn.initializer import Constant, KaimingNormal
+
+paddle.enable_static()
+np.random.seed(12345)
+paddle.seed(12345)
+
+
+def skip_unit_test():
+    return (
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8
+        or paddle.get_cudnn_version() < 8900
+    )
+
+
+skip_msg = (
+    "only support with cuda and CUDNN 8.9 or later,"
+    " and only Ampere or later devices are supported"
+)
+
+
+class ConvBNLayer(nn.Layer):
+    def __init__(
+        self,
+        num_channels,
+        num_filters,
+        filter_size,
+        stride=1,
+        groups=1,
+        act=None,
+        lr_mult=1.0,
+        data_format="NCHW",
+        bn_weight_decay=True,
+    ):
+        super().__init__()
+        self.act = act
+        self.conv = Conv2D(
+            in_channels=num_channels,
+            out_channels=num_filters,
+            kernel_size=filter_size,
+            stride=stride,
+            padding=(filter_size - 1) // 2,
+            groups=groups,
+            weight_attr=ParamAttr(
+                learning_rate=lr_mult, initializer=KaimingNormal()
+            ),
+            bias_attr=False,
+            data_format=data_format,
+        )
+        self.bn = BatchNorm(
+            num_filters,
+            param_attr=ParamAttr(
+                learning_rate=lr_mult,
+                regularizer=None
+                if bn_weight_decay
+                else paddle.regularizer.L2Decay(0.0),
+                initializer=Constant(1.0),
+            ),
+            bias_attr=ParamAttr(
+                learning_rate=lr_mult,
+                regularizer=None
+                if bn_weight_decay
+                else paddle.regularizer.L2Decay(0.0),
+                initializer=Constant(0.0),
+            ),
+            data_layout=data_format,
+        )
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        if self.act:
+            x = self.relu(x)
+        return x
+
+
+class BottleneckBlock(nn.Layer):
+    def __init__(
+        self,
+        num_channels,
+        num_filters,
+        stride,
+        shortcut=True,
+        lr_mult=1.0,
+        data_format="NCHW",
+        bn_weight_decay=True,
+    ):
+        super().__init__()
+
+        self.conv0 = ConvBNLayer(
+            num_channels=num_channels,
+            num_filters=num_filters,
+            filter_size=1,
+            act="relu",
+            lr_mult=lr_mult,
+            data_format=data_format,
+            bn_weight_decay=bn_weight_decay,
+        )
+        self.conv1 = ConvBNLayer(
+            num_channels=num_filters,
+            num_filters=num_filters,
+            filter_size=3,
+            stride=stride,
+            act="relu",
+            lr_mult=lr_mult,
+            data_format=data_format,
+            bn_weight_decay=bn_weight_decay,
+        )
+        self.conv2 = ConvBNLayer(
+            num_channels=num_filters,
+            num_filters=num_filters * 4,
+            filter_size=1,
+            act=None,
+            lr_mult=lr_mult,
+            data_format=data_format,
+            bn_weight_decay=bn_weight_decay,
+        )
+
+        if not shortcut:
+            self.short = ConvBNLayer(
+                num_channels=num_channels,
+                num_filters=num_filters * 4,
+                filter_size=1,
+                stride=stride,
+                lr_mult=lr_mult,
+                data_format=data_format,
+                bn_weight_decay=bn_weight_decay,
+            )
+        self.relu = nn.ReLU()
+        self.shortcut = shortcut
+
+    def forward(self, x):
+        identity = x
+        x = self.conv0(x)
+        x = self.conv1(x)
+        x = self.conv2(x)
+
+        if self.shortcut:
+            short = identity
+        else:
+            short = self.short(identity)
+        x = paddle.add(x=x, y=short)
+        x = self.relu(x)
+        return x
+
+
+class ResUnitNet(nn.Layer):
+    def __init__(self, shortcut):
+        super().__init__()
+        self.shortcut = shortcut
+        self.conv1 = ConvBNLayer(
+            num_channels=3,
+            num_filters=64,
+            filter_size=3,
+            act='relu',
+            data_format='NHWC',
+        )
+
+        self.block = BottleneckBlock(
+            num_channels=64,
+            num_filters=16,
+            stride=1,
+            shortcut=self.shortcut,
+            lr_mult=1.0,
+            data_format="NHWC",
+            bn_weight_decay=True,
+        )
+
+        self.conv2 = ConvBNLayer(
+            num_channels=64,
+            num_filters=64,
+            filter_size=3,
+            act='relu',
+            data_format='NHWC',
+        )
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.block(out)
+        out = self.conv2(out)
+        out = paddle.flatten(out, 1)
+        return out
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitPass(DistPassTestBase):
+    def init(self):
+        self.atol = 1e-2
+        self.rtol = 1e-2
+        paddle.set_flags({'FLAGS_conv_workspace_size_limit': 1000})
+        self.init_attr()
+
+    def init_attr(self):
+        self.shortcut = True
+
+    def get_model(self, place, batch_size=32, image_shape=[224, 224, 3]):
+        image = paddle.static.data(
+            shape=[batch_size] + image_shape, dtype='float32', name='image'
+        )
+
+        model = ResUnitNet(self.shortcut)
+        pred_out = model(image)
+        loss = paddle.mean(pred_out)
+        optimizer = paddle.optimizer.Adam(learning_rate=1e-3)
+
+        dist_strategy = fleet.DistributedStrategy()
+        dist_strategy.fuse_all_reduce_ops = False
+        dist_strategy.without_graph_optimization = True
+        dist_strategy.amp = True
+        dist_strategy.amp_configs = {
+            "init_loss_scaling": 128.0,
+            "use_dynamic_loss_scaling": True,
+        }
+        fleet.init(is_collective=True, strategy=dist_strategy)
+        optimizer = fleet.distributed_optimizer(optimizer)
+        optimizer.minimize(loss)
+
+        rank = paddle.distributed.get_rank()
+
+        def reader():
+            seed = int(os.environ.get("SEED", 0))
+            np.random.seed(seed + rank)
+            for _ in range(10):
+                image_np = np.random.random(size=image.shape).astype('float32')
+                yield image_np,
+
+        main_program = paddle.static.default_main_program()
+        startup_program = paddle.static.default_startup_program()
+        return main_program, startup_program, [image], [loss], reader
+
+    def apply_passes(self, main_prog, startup_prog):
+        pass_manager = PassManager([new_pass("fuse_resunit")])
+        pass_manager.apply([main_prog], [startup_prog])
+        print(pass_manager.names)
+
+        op_type = []
+        for op in main_prog.global_block().ops:
+            op_type.append(op.type)
+        self.assertTrue("fused_scale_bias_add_relu" in op_type)
+        self.assertTrue("fused_scale_bias_relu_conv_bnstats" in op_type)
+        self.assertTrue("fused_dconv_drelu_dbn" in op_type)
+
+    def test_fuse_resunit(self):
+        self.check_main()
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitPassDual(TestFuseResUnitPass):
+    def init_attr(self):
+        self.shortcut = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed_passes/test_dist_fuse_resunit_pass.py
+++ b/test/distributed_passes/test_dist_fuse_resunit_pass.py
@@ -263,7 +263,7 @@ class TestFuseResUnitPass(DistPassTestBase):
         for op in main_prog.global_block().ops:
             op_type.append(op.type)
         self.assertTrue("fused_scale_bias_add_relu" in op_type)
-        self.assertTrue("fused_scale_bias_relu_conv_bnstats" in op_type)
+        self.assertTrue("fused_scale_bias_relu_conv_bn" in op_type)
         self.assertTrue("fused_dconv_drelu_dbn" in op_type)
 
     def test_fuse_resunit(self):

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -510,6 +510,7 @@ if(NOT WITH_CUDNN_FRONTEND)
   list(REMOVE_ITEM TEST_OPS test_fused_scale_bias_relu_conv_bn_op)
   list(REMOVE_ITEM TEST_OPS test_fused_scale_bias_add_relu_op)
   list(REMOVE_ITEM TEST_OPS test_fused_dconv_drelu_dbn_op)
+  list(REMOVE_ITEM TEST_OPS test_fuse_resunit_pass)
 endif()
 
 # Some ops need to check results when gc is enabled

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -506,7 +506,6 @@ if(NOT WITH_GPU
   list(REMOVE_ITEM TEST_OPS test_build_strategy_fusion_group_pass)
 endif()
 
-set_tests_properties(test_fuse_resunit_pass PROPERTIES TIMEOUT 300)
 if(NOT WITH_CUDNN_FRONTEND)
   list(REMOVE_ITEM TEST_OPS test_fused_scale_bias_relu_conv_bn_op)
   list(REMOVE_ITEM TEST_OPS test_fused_scale_bias_add_relu_op)
@@ -1196,6 +1195,10 @@ if(WITH_GLOO)
                        PROPERTIES TIMEOUT 120)
   set_tests_properties(test_parallel_dygraph_sparse_embedding_over_height_gloo
                        PROPERTIES TIMEOUT 120)
+endif()
+
+if(WITH_CUDNN_FRONTEND)
+  set_tests_properties(test_fuse_resunit_pass PROPERTIES TIMEOUT 300)
 endif()
 
 set(TEST_CINN_OPS

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -506,6 +506,7 @@ if(NOT WITH_GPU
   list(REMOVE_ITEM TEST_OPS test_build_strategy_fusion_group_pass)
 endif()
 
+set_tests_properties(test_fuse_resunit_pass PROPERTIES TIMEOUT 300)
 if(NOT WITH_CUDNN_FRONTEND)
   list(REMOVE_ITEM TEST_OPS test_fused_scale_bias_relu_conv_bn_op)
   list(REMOVE_ITEM TEST_OPS test_fused_scale_bias_add_relu_op)

--- a/test/legacy_test/test_fuse_resunit_pass.py
+++ b/test/legacy_test/test_fuse_resunit_pass.py
@@ -214,10 +214,10 @@ class TestFuseResUnitBase(unittest.TestCase):
             self.assertTrue(
                 verify_node_count(
                     program._graph,
-                    "fused_scale_bias_relu_conv_bnstats",
+                    "fused_scale_bias_relu_conv_bn",
                     conv_bnstats_count,
                 ),
-                "[{}] The number of fused_scale_bias_relu_conv_bnstats is miss-matched in the computing graph.".format(
+                "[{}] The number of fused_scale_bias_relu_conv_bn is miss-matched in the computing graph.".format(
                     type(self).__name__
                 ),
             )

--- a/test/legacy_test/test_fuse_resunit_pass.py
+++ b/test/legacy_test/test_fuse_resunit_pass.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2023 NVIDIA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle import nn
+
+
+def skip_unit_test():
+    return (
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8
+        or paddle.get_cudnn_version() < 8900
+    )
+
+
+skip_msg = (
+    "only support with cuda and CUDNN 8.9 or later,"
+    " and only Ampere or later devices are supported"
+)
+
+
+def verify_node_count(graph, node_name, target_count):
+    count = 0
+    for node in graph.nodes():
+        if node.name() == node_name:
+            count += 1
+    return count == target_count
+
+
+class ConvBNActLayer(paddle.nn.Layer):
+    def __init__(self, num_channels, num_filters, filter_size):
+        super().__init__()
+        self.act = nn.ReLU()
+        self.conv = nn.Conv2D(
+            in_channels=num_channels,
+            out_channels=num_filters,
+            kernel_size=filter_size,
+            stride=1,
+            padding=(filter_size - 1) // 2,
+            groups=1,
+            bias_attr=False,
+            data_format="NHWC",
+        )
+        self.bn = nn.BatchNorm(num_filters, data_layout="NHWC")
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        return self.act(x)
+
+
+class ResUnit(paddle.nn.Layer):
+    def __init__(self, hidden, is_shortcut):
+        super().__init__()
+        self.is_shortcut = is_shortcut
+        filter_size = 3
+        num_channels = hidden
+        num_filters = hidden
+        self.conv_bn1 = ConvBNActLayer(hidden, hidden, filter_size)
+        self.conv_bn2 = ConvBNActLayer(hidden, hidden, filter_size)
+        self.act = nn.ReLU()
+        self.conv1 = nn.Conv2D(
+            in_channels=num_channels,
+            out_channels=num_filters,
+            kernel_size=filter_size,
+            stride=1,
+            padding=(filter_size - 1) // 2,
+            groups=1,
+            bias_attr=False,
+            data_format="NHWC",
+        )
+        self.bn1 = nn.BatchNorm(num_filters, data_layout="NHWC")
+        if not self.is_shortcut:
+            self.conv2 = nn.Conv2D(
+                in_channels=num_channels,
+                out_channels=num_filters,
+                kernel_size=filter_size,
+                stride=1,
+                padding=(filter_size - 1) // 2,
+                groups=1,
+                bias_attr=False,
+                data_format="NHWC",
+            )
+            self.bn2 = nn.BatchNorm(num_filters, data_layout="NHWC")
+
+    def forward(self, input):
+        x1 = self.conv_bn1(input)
+        x1 = self.conv_bn2(x1)
+        x1 = self.conv1(x1)
+        x1 = self.bn1(x1)
+        if not self.is_shortcut:
+            x2 = self.conv2(input)
+            x2 = self.bn2(x2)
+        else:
+            x2 = input
+        output = self.act(paddle.add(x1, x2))
+        return output
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitBase(unittest.TestCase):
+    def setUp(self):
+        self.batch = 8
+        self.hidden = 16
+        self.width = 64
+        self.height = 64
+        self.iter = 5
+        self.set_attr()
+
+        paddle.enable_static()
+        np.random.seed(10)
+        paddle.seed(10)
+        paddle.framework.random._manual_program_seed(10)
+
+        self.place = paddle.CUDAPlace(0)
+        self.exe = paddle.static.Executor(self.place)
+
+        self.feeds = [
+            {
+                "input": np.random.random(
+                    (self.batch, self.height, self.width, self.hidden)
+                ).astype("float16")
+                + i,
+            }
+            for i in range(self.iter)
+        ]
+
+    def build_program(
+        self, main_program, startup_program, is_shortcut=True, is_training=False
+    ):
+        with paddle.static.program_guard(main_program, startup_program):
+            with paddle.utils.unique_name.guard():
+                x1 = paddle.static.data(
+                    name="input",
+                    shape=[-1, self.height, self.width, self.hidden],
+                    dtype='float16',
+                )
+                layer1 = ConvBNActLayer(self.hidden, self.hidden, 3)
+                resunit_layer1 = ResUnit(self.hidden, is_shortcut)
+                resunit_layer2 = ResUnit(self.hidden, is_shortcut)
+                layer2 = ConvBNActLayer(self.hidden, self.hidden, 3)
+                optimizer = None
+                with paddle.static.amp.fp16_guard():
+                    out = layer1(x1)
+                    out = resunit_layer1(out)
+                    out = resunit_layer2(out)
+                    out = layer2(out)
+                    loss = paddle.mean(out)
+                    if is_training:
+                        optimizer = paddle.optimizer.SGD(learning_rate=0.001)
+                        optimizer = paddle.static.amp.decorate(
+                            optimizer=optimizer,
+                            init_loss_scaling=128.0,
+                            use_dynamic_loss_scaling=True,
+                            use_pure_fp16=True,
+                            use_fp16_guard=True,
+                        )
+                        optimizer.minimize(loss)
+        return loss.name, optimizer
+
+    def cal_output(self, enable_fusion):
+        main_prog = paddle.static.Program()
+        startup_prog = paddle.static.Program()
+        output_name, optimizer = self.build_program(
+            main_prog, startup_prog, self.is_shortcut, self.is_training
+        )
+        loss_list = []
+        scope = paddle.static.Scope()
+        with paddle.static.scope_guard(scope):
+            self.exe.run(startup_prog)
+            if self.is_training:
+                optimizer.amp_init(self.place, scope=scope)
+            else:
+                self._cast_model_to_fp16(main_prog)
+            build_strategy = paddle.static.BuildStrategy()
+            build_strategy.fuse_resunit = enable_fusion
+            program = paddle.static.CompiledProgram(
+                main_prog, build_strategy=build_strategy
+            )
+
+            for i in range(self.iter):
+                result = self.exe.run(
+                    program, feed=self.feeds[i], fetch_list=[output_name]
+                )
+                loss_list.append(result)
+
+        if enable_fusion:
+            self.assertTrue(
+                verify_node_count(
+                    program._graph, "fused_scale_bias_add_relu", 2
+                ),
+                "[{}] The number of fused_scale_bias_add_relu is miss-matched in the computing graph.".format(
+                    type(self).__name__
+                ),
+            )
+            conv_bnstats_count = 6 if self.is_shortcut else 8
+            self.assertTrue(
+                verify_node_count(
+                    program._graph,
+                    "fused_scale_bias_relu_conv_bnstats",
+                    conv_bnstats_count,
+                ),
+                "[{}] The number of fused_scale_bias_relu_conv_bnstats is miss-matched in the computing graph.".format(
+                    type(self).__name__
+                ),
+            )
+
+        return np.array(loss_list)
+
+    def _test_output(self):
+        results_ref = self.cal_output(enable_fusion=False)
+        results_actual = self.cal_output(enable_fusion=True)
+
+        np.testing.assert_allclose(
+            results_ref,
+            results_actual,
+            rtol=self.rtol,
+            atol=self.atol,
+            err_msg=f"[{type(self).__name__}] outputs are miss-matched.",
+        )
+
+    def set_attr(self):
+        self.atol = 1e-4
+        self.rtol = 1e-4
+
+        self.is_shortcut = True
+        self.is_training = False
+
+    def _cast_model_to_fp16(self, prog):
+        fp16_var_list = paddle.static.amp.cast_model_to_fp16(prog)
+        paddle.static.amp.cast_parameters_to_fp16(
+            self.place, prog, to_fp16_var_names=fp16_var_list
+        )
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitShortcutFwd(TestFuseResUnitBase):
+    def set_attr(self):
+        self.atol = 1e-3
+        self.rtol = 1e-2
+
+        self.is_shortcut = True
+        self.is_training = False
+
+    def test_output(self):
+        self._test_output()
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitDualFwd(TestFuseResUnitBase):
+    def set_attr(self):
+        self.atol = 1e-3
+        self.rtol = 1e-2
+
+        self.is_shortcut = False
+        self.is_training = False
+
+    def test_output(self):
+        self._test_output()
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitBwd(TestFuseResUnitBase):
+    def set_attr(self):
+        self.atol = 1e-3
+        self.rtol = 1e-2
+
+        self.is_shortcut = True
+        self.is_training = True
+
+    def test_output(self):
+        self._test_output()
+
+
+@unittest.skipIf(skip_unit_test(), skip_msg)
+class TestFuseResUnitDualBwd(TestFuseResUnitBase):
+    def set_attr(self):
+        self.atol = 1e-3
+        self.rtol = 1e-2
+
+        self.is_shortcut = False
+        self.is_training = True
+
+    def test_output(self):
+        self._test_output()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/gpups_test.sh
+++ b/tools/gpups_test.sh
@@ -62,8 +62,10 @@ parallel_list="^init_phi_test$|\
 ^test_custom_kernel$|\
 ^test_dist_fleet_ps11$|\
 ^test_dist_fleet_ps12$|\
+^test_dist_fuse_resunit_pass$|\
 ^test_executor_feed_non_tensor$|\
 ^test_flash_attention$|\
+^test_fuse_resunit_pass$|\
 ^test_fused_adam_op$|\
 ^test_fused_attention_no_dropout$|\
 ^test_fused_attention_op$|\


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
This PR adds a `fuse_resunit` IR pass, which is able to detect ResUnit patterns and replace them with CUDNNv8 fused kernels.