### PR TITLE
[CodeStyle][ruff] Flake8 Deprecated - 1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-select = C,E,W
+select = E
 exclude =
     ./build,
     # Exclude third-party libraries
@@ -19,12 +19,10 @@ ignore =
     # Do not assign a lambda expression, use a def
     E731,
     # Do not use variables named ‘l’, ‘O’, or ‘I’
-    E741,
-    # Line break before binary operator, it is not compatible with black
-    W503
+    E741
 per-file-ignores =
     # These files need tabs for testing.
-    test/dygraph_to_static/test_legacy_error.py:E101,W191
+    test/dygraph_to_static/test_legacy_error.py:E101
 
     # Ignore compare with True in sot unittest
     test/sot/test_dup_top.py:E712

--- a/.flake8
+++ b/.flake8
@@ -28,3 +28,4 @@ per-file-ignores =
 
     # Ignore compare with True in sot unittest
     test/sot/test_dup_top.py:E712
+    # test file diff

--- a/.flake8
+++ b/.flake8
@@ -28,4 +28,3 @@ per-file-ignores =
 
     # Ignore compare with True in sot unittest
     test/sot/test_dup_top.py:E712
-    # test file diff

--- a/paddle/scripts/conda_build.py
+++ b/paddle/scripts/conda_build.py
@@ -193,7 +193,7 @@ package:
     )
     meta_build = var.build + build_name_str
     meta_str = package_str + meta_build + requirement
-    if not (cuda_str is None):
+    if cuda_str is not None:
         meta_str = meta_str + cuda_str
     meta_str = meta_str + var.test + var.about
 
@@ -236,7 +236,7 @@ package:
     meta_build = var.build + build_name_str
     meta_str = package_str + meta_build + requirement
 
-    if not (cuda_str is None):
+    if cuda_str is not None:
         meta_str = meta_str + cuda_str
 
     blt_str = var.blt_const + blt_var

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,12 @@ target-version = "py37"
 
 [tool.ruff.lint]
 select = [
-    # Pyflakes
-    "F",
+    # Pycodestyle
     "E",
     "W",
+
+    # Pyflakes
+    "F",
 
     # Isort
     "I",
@@ -77,14 +79,8 @@ unfixable = [
     "NPY001"
 ]
 ignore = [
-    # `name` may be undefined, or defined from star imports: `module`
-    "F405",
-    # Local variable name is assigned to but never used
-    "F841",
-    # It not met the "Explicit is better than implicit" rule
-    "UP015",
-    # It will cause the performance regression on python3.10
-    "UP038",
+    # Whitespace before ‘,’, ‘;’, or ‘:’, it is not compatible with black
+    "E203",
     # Module level import not at top of file
     "E402",
     # Line too long (82 > 79 characters)
@@ -95,8 +91,16 @@ ignore = [
     "E722",
     # Do not assign a lambda expression, use a def
     "E731",
+    # Do not use variables named ‘l’, ‘O’, or ‘I’
     "E741",
-    "C901",
+    # `name` may be undefined, or defined from star imports: `module`
+    "F405",
+    # Local variable name is assigned to but never used
+    "F841",
+    # It not met the "Explicit is better than implicit" rule
+    "UP015",
+    # It will cause the performance regression on python3.10
+    "UP038",
 ]
 
 [tool.ruff.lint.isort]
@@ -106,6 +110,10 @@ known-first-party = ["paddle"]
 [tool.ruff.lint.per-file-ignores]
 # Ignore unused imports in __init__.py
 "__init__.py" = ["F401", "I001"]
+# These files need tabs for testing.
+"test/dygraph_to_static/test_legacy_error.py" = ["E101", "W191"]
+# Ignore compare with True in sot unittest
+"test/sot/test_dup_top.py" = ["E712"]
 # Ignore undefined variables in CMake config and some dygraph_to_static tests
 ".cmake-format.py" = ["F821"]
 "test/dygraph_to_static/test_closure_analysis.py" = ["F821"]
@@ -116,5 +124,3 @@ known-first-party = ["paddle"]
 "test/dygraph_to_static/test_loop.py" = ["C416", "F821"]
 # Ignore unnecessary lambda in dy2st unittest test_lambda
 "test/dygraph_to_static/test_lambda.py" = ["PLC3002"]
-# Ignore compare with True in sot unittest
-"test/sot/test_dup_top.py" = ["E712"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ target-version = "py37"
 select = [
     # Pyflakes
     "F",
+    "E",
+    "W",
 
     # Isort
     "I",
@@ -83,6 +85,18 @@ ignore = [
     "UP015",
     # It will cause the performance regression on python3.10
     "UP038",
+    # Module level import not at top of file
+    "E402",
+    # Line too long (82 > 79 characters)
+    "E501",
+    # Do not compare types, use `isinstance()`
+    "E721",
+    # Do not use bare except, specify exception instead
+    "E722",
+    # Do not assign a lambda expression, use a def
+    "E731",
+    "E741",
+    "C901",
 ]
 
 [tool.ruff.lint.isort]
@@ -102,3 +116,5 @@ known-first-party = ["paddle"]
 "test/dygraph_to_static/test_loop.py" = ["C416", "F821"]
 # Ignore unnecessary lambda in dy2st unittest test_lambda
 "test/dygraph_to_static/test_lambda.py" = ["PLC3002"]
+# Ignore compare with True in sot unittest
+"test/sot/test_dup_top.py" = ["E712"]

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -330,13 +330,13 @@ def amp_guard(
 
     # check amp_level: O0-O2
     level = level.upper()
-    if not (level in ['O0', 'OD', 'O1', 'O2']):
+    if level not in ['O0', 'OD', 'O1', 'O2']:
         raise ValueError("level should be O0, OD, O1 or O2.")
 
     # check amp_dtype: float16 or bfloat16
     dtype = dtype.lower()
     if enable:
-        if not (dtype in ['float16', 'bfloat16']):
+        if dtype not in ['float16', 'bfloat16']:
             raise ValueError(
                 "If enable amp, dtype should be 'float16' or 'bfloat16'."
             )
@@ -576,11 +576,11 @@ def amp_decorate(
             ...     print(output.dtype)
             paddle.float16
     """
-    if not (level in ['O1', 'O2']):
+    if level not in ['O1', 'O2']:
         raise ValueError(
             "level should be O1 or O2, O1 represent AMP train mode, O2 represent Pure fp16 train mode."
         )
-    if not (dtype in ['float16', 'bfloat16']):
+    if dtype not in ['float16', 'bfloat16']:
         raise ValueError("dtype only support float16 or bfloat16.")
 
     if level == 'O1':
@@ -660,7 +660,7 @@ def amp_decorate(
                 "optimizers must be either a single optimizer or a list of optimizers."
             )
         # support master_weight
-        use_multi_precision = not (master_weight is False)
+        use_multi_precision = master_weight is not False
         for opt in optimizers:
             _set_multi_precision(opt, use_multi_precision)
 
@@ -673,7 +673,7 @@ def amp_decorate(
                 )
 
     if save_dtype is not None:
-        if not (save_dtype in ['float16', 'bfloat16', 'float32', 'float64']):
+        if save_dtype not in ['float16', 'bfloat16', 'float32', 'float64']:
             raise ValueError(
                 "save_dtype can only be float16 float32 or float64, but your input save_dtype is %s."
                 % save_dtype

--- a/python/paddle/distributed/auto_parallel/static/completion.py
+++ b/python/paddle/distributed/auto_parallel/static/completion.py
@@ -29,10 +29,10 @@ from ..process_mesh import ProcessMesh, compute_compatible_process_mesh
 from .dist_attribute import OperatorDistAttr, TensorDistAttr
 from .dist_context import _node_id
 from .operators.common import (
+    _gradient_sync_by_partial_ops,
     find_compatible_distributed_operator_impls,
     find_distributed_operator_impl_container,
 )
-from .operators.common import _gradient_sync_by_partial_ops
 from .process_group import get_world_process_group
 from .utils import (
     __no_shape_var_type__,

--- a/python/paddle/distributed/ps/utils/public.py
+++ b/python/paddle/distributed/ps/utils/public.py
@@ -1043,7 +1043,7 @@ def entrance_exit_check(
         )
 
         for var in backward_entrance:
-            if not ("@GRAD" in var) and not (var in forward_all):
+            if "@GRAD" not in var and var not in forward_all:
                 current_block_entrance.append(var)
 
         current_block_entrance.sort()

--- a/python/paddle/incubate/distributed/fleet/parameter_server/ir/trainer_pass.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/ir/trainer_pass.py
@@ -1658,7 +1658,7 @@ def entrance_exit_check(
         )
 
         for var in backward_entrance:
-            if not ("@GRAD" in var) and not (var in forward_all):
+            if "@GRAD" not in var and var not in forward_all:
                 current_block_entrance.append(var)
 
         current_block_entrance.sort()

--- a/python/paddle/incubate/optimizer/pipeline.py
+++ b/python/paddle/incubate/optimizer/pipeline.py
@@ -1013,7 +1013,7 @@ class PipelineOptimizer:
             # append "MERGED" to the names of parameter gradients,
             # and mofify the op_role_var attribute (by rename_arg func).
             for name in in_out_names:
-                if not core.grad_var_suffix() in name:
+                if core.grad_var_suffix() not in name:
                     continue
                 param_name = name.strip(core.grad_var_suffix())
                 new_grad_name = name + "@MERGED"

--- a/python/paddle/static/amp/decorator.py
+++ b/python/paddle/static/amp/decorator.py
@@ -916,7 +916,7 @@ def decorate(  # noqa: F811
     """
     # check amp_level: O0-O2
     level = level.upper()
-    if not (level in ['O0', 'OD', 'O1', 'O2']):
+    if level not in ['O0', 'OD', 'O1', 'O2']:
         raise ValueError("level should be O0, OD, O1 or O2.")
 
     amp_dtype = check_amp_dtype(dtype)
@@ -935,7 +935,7 @@ def decorate(  # noqa: F811
 
     if optimizer is not None:
         # support master_weight
-        multi_precision = not (master_weight is False)
+        multi_precision = master_weight is not False
         _set_multi_precision(optimizer, multi_precision)
 
     mp_optimizer = OptimizerWithMixedPrecision(

--- a/python/paddle/vision/transforms/functional_tensor.py
+++ b/python/paddle/vision/transforms/functional_tensor.py
@@ -30,7 +30,7 @@ def _assert_image_tensor(img, data_format):
         not isinstance(img, (paddle.Tensor, Variable))
         or img.ndim < 3
         or img.ndim > 4
-        or not data_format.lower() in ('chw', 'hwc')
+        or data_format.lower() not in ('chw', 'hwc')
     ):
         raise RuntimeError(
             'not support [type={}, ndim={}, data_format={}] paddle image'.format(

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3173,7 +3173,7 @@ class OpTest(unittest.TestCase):
             if tensor_ndim > 0 and tensor_size < 100:
                 self.__class__.input_shape_is_large = False
 
-        if not type(output_names) is list:
+        if type(output_names) is not list:
             output_names = [output_names]
 
         if numeric_place is None:

--- a/test/xpu/op_test_xpu.py
+++ b/test/xpu/op_test_xpu.py
@@ -306,7 +306,7 @@ class XPUOpTest(OpTest):
         for input_to_check in inputs_to_check:
             set_input(self.scope, self.op, self.inputs, place)
 
-        if not type(output_names) is list:
+        if type(output_names) is not list:
             output_names = [output_names]
 
         if self.dtype not in mean_grad_op_types_np:

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -224,9 +224,9 @@ for API_FILE in ${API_FILES[*]}; do
       elif [ "${API_FILE}" == "python/paddle/autograd/ir_backward.py" ] || [ "${API_FILE}" == "python/paddle/autograd/backward_utils.py" ]; then
             echo_line="You must be approved by Aurelius84(zhangliujie) or cxxly(chenxiaoxu) or xiaoguoguo626807(wangruting) or changeyoung98(chenzhiyang) for python/paddle/autograd/ir_backward.py or python/paddle/autograd/backward_utils.py changes.\n"
             check_approval 1 Aurelius84 cxxly xiaoguoguo626807 changeyoung98
-      elif [ "${API_FILE}" == "paddle/scripts/paddle_build.sh" ]; then 
-	      echo_line="You must have one RD (tianshuo78520a or risemeup1 or zhangbo9674 or XieYunshen) for ${API_FILE} changes, which manages the Paddle CI on Linux.\n " 
-            check_approval 1 tianshuo78520a risemeup1 zhangbo9674 XieYunshen 
+      elif [ "${API_FILE}" == "paddle/scripts/paddle_build.sh" ]; then
+	      echo_line="You must have one RD (tianshuo78520a or risemeup1 or zhangbo9674 or XieYunshen) for ${API_FILE} changes, which manages the Paddle CI on Linux.\n "
+            check_approval 1 tianshuo78520a risemeup1 zhangbo9674 XieYunshen
       else
           echo_line="You must have one RD (XiaoguangHu01,chenwhql,zhiqiu,Xreki,luotao1,qili93,Aurelius84) approval for ${API_FILE}, which manages the underlying code for fluid.\n"
           check_approval 1 XiaoguangHu01 chenwhql zhiqiu Xreki luotao1 qili93 Aurelius84
@@ -386,8 +386,8 @@ fi
 
 DEPRECATED_FLAKE8=`git diff --name-only upstream/$BRANCH | grep ".flake8" || true`
 if [ "${DEPRECATED_FLAKE8}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
-    echo_line="You must have one RD sigureMo approval and @gouzil for file changes in .flake8, we are about to abandon Flake8 and replace it with Ruff.\n"
-    check_approval 1 sigureMo
+    echo_line="You must have one SigureMo or gouzil approval for file changes in .flake8, we are planned to replace Flake8 with Ruff in the future.\n"
+    check_approval 1 SigureMo gouzil
 fi
 
 HAS_MODIFIED_PHI_FILES=`git diff --name-only upstream/$BRANCH | grep "paddle/phi/" || true`

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -384,6 +384,12 @@ if [ "${INVALID_UNITTEST_ASSERT_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; the
     check_approval 1 qili93 luotao1 Aurelius84
 fi
 
+DEPRECATED_FLAKE8=`git diff --name-only upstream/$BRANCH | grep ".flake8" || true`
+if [ "${DEPRECATED_FLAKE8}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
+    echo_line="You must have one RD sigureMo approval and @gouzil for file changes in .flake8, we are about to abandon Flake8 and replace it with Ruff.\n"
+    check_approval 1 sigureMo
+fi
+
 HAS_MODIFIED_PHI_FILES=`git diff --name-only upstream/$BRANCH | grep "paddle/phi/" || true`
 PHI_INCLUDE_FLUID_FILES=""
 for CHANGE_FILE in ${HAS_MODIFIED_PHI_FILES}; do


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

使用 ruff 监控所有的 Flake8 检查码

TODO:

* Flake8 完全弃用之后删除`check_file_diff_approvals.sh`

NOTE:

* 为什么不在现阶段直接弃用？

当前 ruff 对 Flake8 的 `E` 检查码还在建设中，而 `C` 和 `W` 已经基本完成

