### PR TITLE
[PIR] move opresult interface to value in python api.

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -243,12 +243,9 @@ Variable* CreateVar(pir::Value value,
   bool is_persisable = false;
   if (def_op->isa<::pir::ParameterOp>()) {
     is_persisable = true;
-  } else if (def_op->HasAttribute(kAttrIsPersisable)) {
-    is_persisable = def_op->attribute(kAttrIsPersisable)
-                        .dyn_cast<pir::ArrayAttribute>()
-                        .AsVector()[value.dyn_cast<pir::OpResult>().index()]
-                        .dyn_cast<pir::BoolAttribute>()
-                        .data();
+  } else if (auto attr =
+                 value.attribute<pir::BoolAttribute>(kAttrIsPersisable)) {
+    is_persisable = attr.data();
   }
 
   Variable* var = nullptr;

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -1714,21 +1714,9 @@ void PirInterpreter::SolvePersisableVarNames() {
   for (auto kv : value_exe_info_->GetValue2VarName()) {
     ::pir::Value value = kv.first;
     const std::string& var_name = kv.second;
-    ::pir::OpResult result = value.dyn_cast<::pir::OpResult>();
-    if (!result) {
-      continue;
-    }
-    auto* defining_op = result.owner();
-    if (defining_op->HasAttribute(kAttrIsPersisable)) {
-      auto is_persisables =
-          defining_op->attribute<::pir::ArrayAttribute>(kAttrIsPersisable)
-              .AsVector();
-      if (is_persisables[result.index()]
-              .dyn_cast<::pir::BoolAttribute>()
-              .data()) {
-        VLOG(6) << "parameter_var_names_ include: " << var_name;
-        parameter_var_names_.insert(var_name);
-      }
+    auto bool_attr = value.attribute<::pir::BoolAttribute>(kAttrIsPersisable);
+    if (bool_attr && bool_attr.data()) {
+      parameter_var_names_.insert(var_name);
     }
   }
 }

--- a/paddle/fluid/pir/transforms/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/inplace_pass.cc
@@ -57,16 +57,8 @@ static bool CanBeDeleted(pir::Value value) {
       !value.type().isa<paddle::dialect::AllocatedSelectedRowsType>()) {
     return false;
   }
-  if (auto op_result = value.dyn_cast<pir::OpResult>()) {
-    auto def_op = op_result.owner();
-    if (def_op->HasAttribute(kAttrIsPersisable)) {
-      return !(def_op->attribute<pir::ArrayAttribute>(kAttrIsPersisable)
-                   .AsVector()[op_result.index()]
-                   .dyn_cast<pir::BoolAttribute>()
-                   .data());
-    }
-  }
-  return true;
+  auto persist_attr = value.attribute<pir::BoolAttribute>(kAttrIsPersisable);
+  return !(persist_attr && persist_attr.data());
 }
 
 static bool CanDoInplace(const std::unordered_set<pir::Value>& eager_dels,

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1967,7 +1967,7 @@ paddle::Tensor CreateTensorFromOpResult(const pir::OpResult& op_result) {
   auto autograd_meta = egr::EagerUtils::autograd_meta(&tensor);
   autograd_meta->SetPersistable(false);
   autograd_meta->SetStopGradient(
-      GetOpResultBoolAttr(op_result, kAttrStopGradients));
+      GetValueBoolAttr(op_result, kAttrStopGradients));
 
   if (op_result.type().isa<paddle::dialect::DenseTensorType>()) {
     // TODO(jiabin): Maybe support LOD later

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -82,6 +82,7 @@ using paddle::dialect::SelectedRowsType;
 using pir::Attribute;
 using pir::Block;
 using pir::BlockArgument;
+using pir::BoolAttribute;
 using pir::IrParser;
 using pir::Operation;
 using pir::OpOperand;
@@ -600,7 +601,7 @@ void BindValue(py::module *m) {
 
   )DOC");
   g_ir_value_pytype = reinterpret_cast<PyTypeObject *>(value.ptr());
-  value
+  value.def(py::init<>())
       .def_property_readonly(
           "block",
           [](Value self) {
@@ -651,6 +652,37 @@ void BindValue(py::module *m) {
             PADDLE_THROW(phi::errors::InvalidArgument(
                 "can't set dtype when building static graph"));
           })
+      .def("initialized",
+           [](Value self) {
+             if (self.impl() == nullptr || self.type().storage() == nullptr) {
+               return false;
+             } else {
+               return true;
+             }
+           })
+      .def_property(
+          "stop_gradient",
+          [](Value self) {
+            auto stop_gradient =
+                self.attribute<BoolAttribute>(kAttrStopGradients);
+            return !stop_gradient || stop_gradient.data();
+          },
+          [](Value self, bool stop_gradient) {
+            self.set_attribute(
+                kAttrStopGradients,
+                BoolAttribute::get(pir::IrContext::Instance(), stop_gradient));
+          })
+      .def_property(
+          "persistable",
+          [](Value self) {
+            auto persistable = self.attribute<BoolAttribute>(kAttrIsPersisable);
+            return !persistable || persistable.data();
+          },
+          [](Value self, bool persistable) {
+            self.set_attribute(
+                kAttrIsPersisable,
+                BoolAttribute::get(pir::IrContext::Instance(), persistable));
+          })
       .def(
           "get_defining_op",
           [](Value self) -> pir::Operation * {
@@ -692,13 +724,27 @@ void BindValue(py::module *m) {
       .def("first_use", &Value::first_use, return_value_policy::reference)
       .def("has_one_use", &Value::HasOneUse)
       .def("use_empty", &Value::use_empty)
+      .def("__str__",
+           [](Value self) -> py::str {
+             std::ostringstream print_stream;
+             print_stream << "Value(";
+             print_stream << GetValueInfo(self);
+             auto stop_gradient =
+                 self.attribute<BoolAttribute>(kAttrStopGradients);
+             if (stop_gradient && !stop_gradient.data()) {
+               print_stream << ", stop_gradient=False";
+             } else {
+               print_stream << ", stop_gradient=True";
+             }
+             print_stream << ")";
+             return print_stream.str();
+           })
       .def("__neg__",
            [](Value self) {
              return paddle::dialect::scale(self, -1.0, 0.0, true);
            })
       .def("__eq__", &Value::operator==)
       .def("__hash__", [](Value self) { return std::hash<pir::Value>{}(self); })
-      .def("__str__", &Value2String)
       .def("__repr__", &Value2String);
   // For basaic operators
   OVERRIDE_OPERATOR_FOR_EACH(__add__, add, 1.0, other, true);
@@ -733,47 +779,9 @@ void BindOpOperand(py::module *m) {
       .def("owner", &OpOperand::owner, return_value_policy::reference);
 }
 
-bool GetOpResultBoolAttr(const OpResult &self, const std::string &attr_name) {
-  auto *defining_op = self.owner();
-  if (defining_op->HasAttribute(attr_name)) {
-    PADDLE_ENFORCE(
-        defining_op->attribute(attr_name).isa<pir::ArrayAttribute>(),
-        paddle::platform::errors::InvalidArgument(
-            "%s: Callstack attributes of %s is not ArrayAttribute type",
-            attr_name));
-    auto attrs = defining_op->attribute(attr_name)
-                     .dyn_cast<pir::ArrayAttribute>()
-                     .AsVector();
-    PADDLE_ENFORCE(attrs[self.index()].isa<pir::BoolAttribute>(),
-                   paddle::platform::errors::InvalidArgument(
-                       "The index %d in %s is not BoolAttribute type",
-                       self.index(),
-                       attr_name));
-    return attrs[self.index()].dyn_cast<pir::BoolAttribute>().data();
-  } else {
-    return true;
-  }
-}
-
-void SetOpResultBoolAttr(const OpResult &self,
-                         const std::string &attr_name,
-                         bool value,
-                         bool default_value) {
-  auto *defining_op = self.owner();
-  std::vector<pir::Attribute> attrs;
-  if (defining_op->HasAttribute(attr_name)) {
-    attrs = defining_op->attribute(attr_name)
-                .dyn_cast<pir::ArrayAttribute>()
-                .AsVector();
-  } else {
-    attrs = std::vector<pir::Attribute>(
-        defining_op->num_results(),
-        pir::BoolAttribute::get(pir::IrContext::Instance(), default_value));
-  }
-  attrs[self.index()] =
-      pir::BoolAttribute::get(pir::IrContext::Instance(), value);
-  defining_op->set_attribute(
-      attr_name, pir::ArrayAttribute::get(pir::IrContext::Instance(), attrs));
+bool GetValueBoolAttr(Value value, const std::string &attr_name) {
+  auto bool_attr = value.attribute<BoolAttribute>(attr_name);
+  return !bool_attr || bool_attr.data();
 }
 
 void BindOpResult(py::module *m) {
@@ -785,58 +793,10 @@ void BindOpResult(py::module *m) {
         when build network.
   )DOC");
   g_ir_opresult_pytype = reinterpret_cast<PyTypeObject *>(op_result.ptr());
-  op_result
-      .def(
-          "__init__",
-          [](OpResult &self) { new (&self) OpResult(); },
-          pybind11::return_value_policy::reference)
-      .def("__str__",
-           [](OpResult &self) -> py::str {
-             std::ostringstream print_stream;
-             print_stream << "OpResult(";
-             print_stream << GetValueInfo(self);
-             if (GetOpResultBoolAttr(self, kAttrStopGradients)) {
-               print_stream << ", stop_gradient=True";
-             } else {
-               print_stream << ", stop_gradient=False";
-             }
-             print_stream << ")";
-             return print_stream.str();
-           })
-      .def("initialized",
-           [](OpResult &self) {
-             if (self.impl() == nullptr || self.type().storage() == nullptr) {
-               return false;
-             } else {
-               return true;
-             }
-           })
-      .def_property(
-          "stop_gradient",
-          [](OpResult &self) {
-            return GetOpResultBoolAttr(self, kAttrStopGradients);
-          },
-          [](OpResult &self, bool stop_gradient) {
-            // NOTE(Aurelius84): For other OpResult, set theirs
-            // stop_gradient default value as true.
-            SetOpResultBoolAttr(self,
-                                kAttrStopGradients,
-                                stop_gradient,
-                                /*default_value=*/true);
-          })
-      .def_property(
-          "persistable",
-          [](OpResult &self) {
-            return GetOpResultBoolAttr(self, kAttrIsPersisable);
-          },
-          [](OpResult &self, bool persistable) {
-            // NOTE(Aurelius84): For other OpResult, set theirs
-            // persistable default value as false.
-            SetOpResultBoolAttr(self,
-                                kAttrIsPersisable,
-                                persistable,
-                                /*default_value=*/false);
-          });
+  op_result.def(
+      "__init__",
+      [](OpResult &self) { new (&self) OpResult(); },
+      pybind11::return_value_policy::reference);
 }
 
 void BindType(py::module *m) {

--- a/paddle/fluid/pybind/pir.h
+++ b/paddle/fluid/pybind/pir.h
@@ -21,9 +21,9 @@
 
 namespace paddle {
 namespace pybind {
-using pir::OpResult;
+using pir::Value;
 void BindPir(pybind11::module *m);
-const phi::DDim &GetValueDims(pir::Value value);
-bool GetOpResultBoolAttr(const OpResult &self, const std::string &attr_name);
+const phi::DDim &GetValueDims(Value value);
+bool GetValueBoolAttr(Value value, const std::string &attr_name);
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/pir/core/value.h
+++ b/paddle/pir/core/value.h
@@ -108,7 +108,7 @@ class IR_API Value {
   Attribute attribute(const std::string &key) const;
 
   template <typename T>
-  T attribute(const std::string &name) {
+  T attribute(const std::string &name) const {
     return attribute(name).dyn_cast<T>();
   }
 

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -24,7 +24,6 @@ import numpy as np
 from paddle import pir
 
 from ..pir import (
-    OpResult,
     Program as PirProgram,
     Value,
     translate_to_pir,
@@ -526,7 +525,7 @@ def _add_pir_fetch_ops(program, fetch_list, fetch_var_name):
         with paddle.static.program_guard(program):
             for i, fetch_input in enumerate(need_fetch_info):
                 assert isinstance(
-                    fetch_input, (OpResult, Value)
+                    fetch_input, Value
                 ), f"Wrong type for fetch_list[{i}]: {type(fetch_input)}"
                 out = paddle._pir_ops.fetch(
                     fetch_input, fetch_var_name + str(i), i
@@ -610,7 +609,7 @@ def _to_name_str(var):
             return str(var)
         elif isinstance(var, Operator):
             return str(id(var))
-        elif isinstance(var, OpResult):
+        elif isinstance(var, Value):
             return str(var)
         elif isinstance(var, Value):
             return str(var)
@@ -2071,9 +2070,7 @@ class Executor:
         return exe.run(feed)
 
     def _check_fetch_list(self, fetch_list):
-        is_fetch_var = lambda var: isinstance(
-            var, (Variable, str, OpResult, Value)
-        )
+        is_fetch_var = lambda var: isinstance(var, (Variable, str, Value))
         is_tuple_list = lambda var: isinstance(var, (tuple, list))
 
         if fetch_list is None:
@@ -2099,7 +2096,7 @@ class Executor:
                     res.append(var)
             else:
                 raise TypeError(
-                    "Require fetch_list[{}] 's type shall be one of (OpResult, str), but received {}.".format(
+                    "Require fetch_list[{}] 's type shall be one of (Value, str), but received {}.".format(
                         i, type(var).__name__
                     )
                 )

--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -39,7 +39,7 @@ def replace_ellipsis(var, item):
     item_remove_var = [
         ele
         for ele in item
-        if not isinstance(ele, (Variable, paddle.pir.OpResult, np.ndarray))
+        if not isinstance(ele, (Variable, paddle.pir.Value, np.ndarray))
         and ele is not None
     ]
     ell_count = item_remove_var.count(Ellipsis)
@@ -100,7 +100,7 @@ def is_integer_or_scalar_tensor(ele):
                 return True
         if len(ele.shape) == 0 and ele.dtype != paddle.bool:
             return True
-    elif isinstance(ele, paddle.pir.OpResult):
+    elif isinstance(ele, paddle.pir.Value):
         if len(ele.shape) == 0 and ele.dtype != paddle.base.libpaddle.BOOL:
             return True
     return False
@@ -112,7 +112,7 @@ def is_bool_tensor(ele):
     if isinstance(ele, Variable) and ele.dtype == paddle.bool:
         return True
     elif (
-        isinstance(ele, paddle.pir.OpResult)
+        isinstance(ele, paddle.pir.Value)
         and ele.dtype == paddle.base.libpaddle.BOOL
     ):
         return True
@@ -127,7 +127,7 @@ def deal_attrs(attrs, attr, attr_name, tensor_attr_name, inputs, infer_flags):
             attr, dtype="int64"
         )
         for i, dim in enumerate(attr):
-            if isinstance(dim, (Variable, paddle.pir.OpResult)):
+            if isinstance(dim, (Variable, paddle.pir.Value)):
                 attrs[attr_name].append(-1)
                 infer_flags[i] = -1
             else:
@@ -354,7 +354,7 @@ def parse_index(x, indices):
             has_advanced_index = True
             estimated_dim += 1
             dim += 1
-        elif isinstance(slice_item, paddle.pir.OpResult):
+        elif isinstance(slice_item, paddle.pir.Value):
             # In this case, the Variable is not 0-dim Tensor and will be treated as advanced-indexing.
             if slice_item.dtype == paddle.pir.core.DataType.BOOL:
                 if slice_item.ndim == 0:
@@ -385,9 +385,7 @@ def parse_index(x, indices):
             use_strided_slice = (
                 True
                 if (
-                    isinstance(
-                        step, (paddle.base.Variable, paddle.pir.OpResult)
-                    )
+                    isinstance(step, (paddle.base.Variable, paddle.pir.Value))
                     or step != 1
                 )
                 else use_strided_slice

--- a/python/paddle/decomposition/decomp.py
+++ b/python/paddle/decomposition/decomp.py
@@ -30,7 +30,7 @@ from . import register
 
 
 def _build_tensor_tuple(xs):
-    if isinstance(xs, pir.OpResult):
+    if isinstance(xs, pir.Value):
         return (xs,)
     elif isinstance(xs, typing.Sequence):
         return tuple(xs)
@@ -41,14 +41,14 @@ def _analyse_decomp_results(orig_outs, decomp_outs, op):
     assert len(orig_outs) == len(decomp_outs)
     res = []
     for idx, value in enumerate(decomp_outs):
-        if isinstance(orig_outs[idx], pir.OpResult):
+        if isinstance(orig_outs[idx], pir.Value):
             if (
                 op.name() in decomp_ops_contain_unused_output.keys()
                 and idx in decomp_ops_contain_unused_output[op.name()]
             ):
                 assert value[0] is None
             else:
-                assert len(value) == 1 and isinstance(value[0], pir.OpResult)
+                assert len(value) == 1 and isinstance(value[0], pir.Value)
             res.append(value[0])
         else:
             res.append(value)
@@ -76,7 +76,7 @@ def _prepare_python_api_arguments(op):
             inputs.append(input)
         else:
             # for optional input, such as scale for layer_norm op,
-            # if it is not set, there will be an empty OpResult which is not initialized in ops.operands
+            # if it is not set, there will be an empty Value which is not initialized in ops.operands
             # therefore append None for it.
             inputs.append(None)
 
@@ -191,7 +191,7 @@ def decompose(
 
     Args:
         program (Program): The program to be processed.
-        src_vars (list[OpResult]): In program, once some operator is decomposed, its vars will be replaced by new ones. This argument means some vars will be used later and corresponding vars will be returned for later usage.
+        src_vars (list[Value]): In program, once some operator is decomposed, its vars will be replaced by new ones. This argument means some vars will be used later and corresponding vars will be returned for later usage.
         blacklist (frozenset): The Operators that will be exclude when decomposed into primitives.
         whitelist (frozenset): Only the operators in whitelist will be decomposed into primitives.
 
@@ -230,7 +230,7 @@ def decompose(
     dst_vars = [None] * len(src_vars)
     dst_vars_dct = {}
     for idx, item in enumerate(src_vars):
-        if not isinstance(item, pir.OpResult):
+        if not isinstance(item, pir.Value):
             raise TypeError(
                 f"Each var in dst_vars should map corresponding var in src_vars, but got type {type(item)} in {src_vars}."
             )
@@ -243,7 +243,7 @@ def decompose(
             op_filter,
         )
     for idx, item in enumerate(dst_vars):
-        if not isinstance(item, pir.OpResult):
+        if not isinstance(item, pir.Value):
             if item is None:
                 dst_vars[idx] = src_vars[idx]
             else:

--- a/python/paddle/geometric/message_passing/utils.py
+++ b/python/paddle/geometric/message_passing/utils.py
@@ -28,7 +28,7 @@ def convert_out_size_to_list(out_size, op_type):
         out_size = [0]
     elif isinstance(out_size, (int, np.int32, np.int64)):
         out_size = [out_size]
-    elif isinstance(out_size, (Variable, paddle.pir.OpResult)):
+    elif isinstance(out_size, (Variable, paddle.pir.Value)):
         out_size.stop_gradient = True
         check_dtype(
             out_size.dtype,

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -36,7 +36,7 @@ from paddle.base.unique_name import (
 )
 from paddle.framework import in_dynamic_mode, use_pir_api
 from paddle.nn.layer import layers
-from paddle.pir import OpResult
+from paddle.pir import Value
 from paddle.utils import flatten, gast
 
 from . import error, logging_utils
@@ -1034,7 +1034,7 @@ class ASTStaticFunction(StaticFunction):
         inputs = [
             var
             for var in flatten(concrete_program.inputs)
-            if isinstance(var, (framework.Variable, OpResult))
+            if isinstance(var, (framework.Variable, Value))
         ]
         return inputs
 
@@ -1048,7 +1048,7 @@ class ASTStaticFunction(StaticFunction):
         outputs = [
             var
             for var in flatten(concrete_program.outputs)
-            if isinstance(var, (framework.Variable, OpResult))
+            if isinstance(var, (framework.Variable, Value))
         ]
 
         return outputs

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -42,8 +42,8 @@ class MetaInfo:
     @staticmethod
     def from_tensor(tensor):
         # We always use float32 in simulation if AMP is enabled.
-        if isinstance(tensor, paddle.pir.OpResult):
-            name = "OpResult@NoName"
+        if isinstance(tensor, paddle.pir.Value):
+            name = "Value@NoName"
             persistable = tensor.persistable
             dtype = framework.paddle_type_to_proto_type[tensor.dtype]
         else:
@@ -230,7 +230,7 @@ def convert_variable_to_meta_info(args):
     static_variable_type = (
         paddle.static.Variable
         if not paddle.base.framework.use_pir_api()
-        else paddle.pir.OpResult
+        else paddle.pir.Value
     )
     return map_if_extend(
         args,

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -412,7 +412,7 @@ def interpolate(
             'The x and size should satisfy rank(x) - 2 == len(size).'
         )
 
-    if isinstance(size, (Variable, paddle.pir.OpResult)):
+    if isinstance(size, (Variable, paddle.pir.Value)):
         size = size.cast("int32")  # static mode only support int32
         if size.ndim != 1:
             raise ValueError(
@@ -434,7 +434,7 @@ def interpolate(
         )
 
     if resample == 'AREA':
-        if isinstance(size, (list, tuple, Variable, paddle.pir.OpResult)):
+        if isinstance(size, (list, tuple, Variable, paddle.pir.Value)):
             if len(size) == 0:
                 raise ValueError("output size can not be empty")
         if size is None:
@@ -494,7 +494,7 @@ def interpolate(
         raise ValueError("Only one of size or scale_factor should be defined.")
     if out_shape is not None:
         if (
-            isinstance(out_shape, (Variable, paddle.pir.OpResult))
+            isinstance(out_shape, (Variable, paddle.pir.Value))
             and not in_dynamic_mode()
         ):
             out_shape.stop_gradient = True
@@ -514,7 +514,7 @@ def interpolate(
             # Validate the shape
             contain_var = False
             for dim_idx, dim_size in enumerate(out_shape):
-                if isinstance(dim_size, (Variable, paddle.pir.OpResult)):
+                if isinstance(dim_size, (Variable, paddle.pir.Value)):
                     contain_var = True
                     continue
                 assert (
@@ -525,7 +525,7 @@ def interpolate(
                 new_size_tensor = []
                 size_list = []
                 for dim in out_shape:
-                    if isinstance(dim, (Variable, paddle.pir.OpResult)):
+                    if isinstance(dim, (Variable, paddle.pir.Value)):
                         dim.stop_gradient = True
                         new_size_tensor.append(dim)
                         size_list.append(-1)
@@ -591,7 +591,7 @@ def interpolate(
                 scale = float(scale)
             else:
                 scale = list(scale.numpy())
-        if isinstance(scale, (Variable, paddle.pir.OpResult)):
+        if isinstance(scale, (Variable, paddle.pir.Value)):
             scale.stop_gradient = True
             inputs["Scale"] = scale
         elif isinstance(scale, (float, int, numpy.ndarray)):
@@ -1111,7 +1111,7 @@ def dropout(
             [[0., 0., 6.],
              [0., 0., 0.]])
     """
-    if not isinstance(p, (float, int, Variable, pir.OpResult)):
+    if not isinstance(p, (float, int, Variable, pir.Value)):
         raise TypeError("p argument should be a number or Variable")
 
     if isinstance(p, (int, float)):
@@ -1673,7 +1673,7 @@ def pad(x, pad, mode='constant', value=0.0, data_format="NCHW", name=None):
             return out
 
         if in_pir_mode():
-            if isinstance(pad_value, paddle.pir.OpResult):
+            if isinstance(pad_value, paddle.pir.Value):
                 return _C_ops.pad(x, paddings, pad_value)
             else:
                 return _C_ops.pad(x, paddings, float(pad_value))
@@ -1728,7 +1728,7 @@ def pad(x, pad, mode='constant', value=0.0, data_format="NCHW", name=None):
 
     unsqueezed_dim = []
 
-    if isinstance(pad, (Variable, pir.OpResult)):
+    if isinstance(pad, (Variable, pir.Value)):
         if data_format in ["NCL", "NCHW", "NCDHW"]:
             data_format = "NCDHW"
             if x_dim == 3:

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -1233,7 +1233,7 @@ def conv2d_transpose(
                 output_size = convert_to_list(output_size, 2, 'output_size')
         elif isinstance(output_size, int):
             output_size = convert_to_list(output_size, 2, 'output_size')
-        elif isinstance(output_size, (Variable, pir.OpResult)):
+        elif isinstance(output_size, (Variable, pir.Value)):
             check_dtype(
                 output_size.dtype,
                 'output_size',

--- a/python/paddle/nn/initializer/constant.py
+++ b/python/paddle/nn/initializer/constant.py
@@ -61,7 +61,7 @@ class ConstantInitializer(Initializer):
             (
                 framework.Variable,
                 framework.EagerParamBase,
-                paddle.pir.OpResult,
+                paddle.pir.Value,
                 paddle.pir.core.ParameterMeta,
             ),
         )

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -1678,7 +1678,7 @@ class Layer:
             _remove_if_exist(self.__dict__, self._buffers, self._sub_layers)
             params[name] = value
         elif (
-            isinstance(value, paddle.pir.OpResult)
+            isinstance(value, paddle.pir.Value)
             and value.get_defining_op().name() == 'builtin.parameter'
         ):
             if params is None:
@@ -1733,7 +1733,7 @@ class Layer:
                     # decorated function, such as `self.buffer = new_tensor`. So we update its
                     # value via `assign`.
                     if type(value) == framework.Variable or isinstance(
-                        value, paddle.pir.OpResult
+                        value, paddle.pir.Value
                     ):
                         from paddle import assign
 

--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 import paddle
 from paddle import _C_ops, pir
 from paddle.base.libpaddle import DataType
-from paddle.pir import OpResult
+from paddle.pir import Value
 
 from ..base import core, framework
 from ..base.dygraph import base as imperative_base
@@ -185,17 +185,17 @@ class Adam(Optimizer):
         assert beta1 is not None
         assert beta2 is not None
         assert epsilon is not None
-        if not isinstance(beta1, (Variable, OpResult)):
+        if not isinstance(beta1, (Variable, Value)):
             if not 0 <= beta1 < 1:
                 raise ValueError(
                     "Invaild value of beta1, expect beta1 in [0,1)."
                 )
-        if not isinstance(beta2, (Variable, OpResult)):
+        if not isinstance(beta2, (Variable, Value)):
             if not 0 <= beta2 < 1:
                 raise ValueError(
                     "Invaild value of beta2, expect beta2 in [0,1)."
                 )
-        if not isinstance(epsilon, (Variable, OpResult)):
+        if not isinstance(epsilon, (Variable, Value)):
             if not 0 <= epsilon:
                 raise ValueError(
                     "Invaild value of epsilon, expect epsilon >= 0."
@@ -245,7 +245,7 @@ class Adam(Optimizer):
             param=p,
             dtype=acc_dtype,
             fill_value=0.9
-            if isinstance(self._beta1, (Variable, OpResult))
+            if isinstance(self._beta1, (Variable, Value))
             else self._beta1,
             shape=[1],
             type=core.VarDesc.VarType.LOD_TENSOR,
@@ -256,7 +256,7 @@ class Adam(Optimizer):
             param=p,
             dtype=acc_dtype,
             fill_value=0.999
-            if isinstance(self._beta2, (Variable, OpResult))
+            if isinstance(self._beta2, (Variable, Value))
             else self._beta2,
             shape=[1],
             type=core.VarDesc.VarType.LOD_TENSOR,
@@ -709,12 +709,12 @@ class Adam(Optimizer):
                     found_inf = self._get_auxiliary_var('found_inf')
                     if found_inf:
                         if isinstance(
-                            found_inf, (core.eager.Tensor, pir.OpResult)
+                            found_inf, (core.eager.Tensor, pir.Value)
                         ):
                             self._set_auxiliary_var('found_inf', True)
                     else:
                         if isinstance(
-                            found_inf, (core.eager.Tensor, pir.OpResult)
+                            found_inf, (core.eager.Tensor, pir.Value)
                         ):
                             self._set_auxiliary_var('found_inf', False)
                         _, _, _, _, _, _ = _C_ops.merged_adam_(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
为了支持控制流算子，在python端逐步退场OpResult的使用，替换为Value。

### Other

Pcard-67164
