### PR TITLE
[PIR] add UNMATCHED_TYPE

### DIFF
--- a/paddle/common/errors.cc
+++ b/paddle/common/errors.cc
@@ -58,6 +58,9 @@ std::string error_name(ErrorCode code) {
     case ErrorCode::EXTERNAL:
       return "ExternalError";
       break;
+    case ErrorCode::UNMATCHED_TYPE:
+      return "UnmatchedTypeError";
+      break;
     default:
       throw std::invalid_argument("The error type is undefined.");
       break;

--- a/paddle/common/errors.cc
+++ b/paddle/common/errors.cc
@@ -58,7 +58,7 @@ std::string error_name(ErrorCode code) {
     case ErrorCode::EXTERNAL:
       return "ExternalError";
       break;
-    case ErrorCode::UNMATCHED_TYPE:
+    case ErrorCode::INVALID_TYPE:
       return "InvalidTypeError";
       break;
     default:

--- a/paddle/common/errors.cc
+++ b/paddle/common/errors.cc
@@ -59,7 +59,7 @@ std::string error_name(ErrorCode code) {
       return "ExternalError";
       break;
     case ErrorCode::UNMATCHED_TYPE:
-      return "TypeError";
+      return "InvalidTypeError";
       break;
     default:
       throw std::invalid_argument("The error type is undefined.");

--- a/paddle/common/errors.cc
+++ b/paddle/common/errors.cc
@@ -59,7 +59,7 @@ std::string error_name(ErrorCode code) {
       return "ExternalError";
       break;
     case ErrorCode::UNMATCHED_TYPE:
-      return "UnmatchedTypeError";
+      return "TypeError";
       break;
     default:
       throw std::invalid_argument("The error type is undefined.");

--- a/paddle/common/errors.h
+++ b/paddle/common/errors.h
@@ -85,6 +85,10 @@ enum ErrorCode {
   // Third-party library error.
   // Error type string: "ExternalError"
   EXTERNAL = 12,
+
+  // Client specified an unmatched type.
+  // Error type string: "UnmatchedTypeError"
+  UNMATCHED_TYPE = 13,
 };
 
 class ErrorSummary {
@@ -140,6 +144,7 @@ REGISTER_ERROR(Unimplemented, ErrorCode::UNIMPLEMENTED)
 REGISTER_ERROR(Unavailable, ErrorCode::UNAVAILABLE)
 REGISTER_ERROR(Fatal, ErrorCode::FATAL)
 REGISTER_ERROR(External, ErrorCode::EXTERNAL)
+REGISTER_ERROR(UnmatchedTypeError, ErrorCode::UNMATCHED_TYPE)
 
 #undef REGISTER_ERROR
 

--- a/paddle/common/errors.h
+++ b/paddle/common/errors.h
@@ -144,7 +144,7 @@ REGISTER_ERROR(Unimplemented, ErrorCode::UNIMPLEMENTED)
 REGISTER_ERROR(Unavailable, ErrorCode::UNAVAILABLE)
 REGISTER_ERROR(Fatal, ErrorCode::FATAL)
 REGISTER_ERROR(External, ErrorCode::EXTERNAL)
-REGISTER_ERROR(UnmatchedTypeError, ErrorCode::UNMATCHED_TYPE)
+REGISTER_ERROR(InvalidType, ErrorCode:: INVALID_TYPE)
 
 #undef REGISTER_ERROR
 

--- a/paddle/common/errors.h
+++ b/paddle/common/errors.h
@@ -88,7 +88,7 @@ enum ErrorCode {
 
   // Client specified an unmatched type.
   // Error type string: "UnmatchedTypeError"
-  UNMATCHED_TYPE = 13,
+  INVALID_TYPE = 13,
 };
 
 class ErrorSummary {

--- a/paddle/common/errors.h
+++ b/paddle/common/errors.h
@@ -87,7 +87,7 @@ enum ErrorCode {
   EXTERNAL = 12,
 
   // Client specified an unmatched type.
-  // Error type string: "UnmatchedTypeError"
+  // Error type string: "INVALID_TYPE"
   INVALID_TYPE = 13,
 };
 
@@ -144,7 +144,7 @@ REGISTER_ERROR(Unimplemented, ErrorCode::UNIMPLEMENTED)
 REGISTER_ERROR(Unavailable, ErrorCode::UNAVAILABLE)
 REGISTER_ERROR(Fatal, ErrorCode::FATAL)
 REGISTER_ERROR(External, ErrorCode::EXTERNAL)
-REGISTER_ERROR(InvalidType, ErrorCode:: INVALID_TYPE)
+REGISTER_ERROR(InvalidType, ErrorCode::INVALID_TYPE)
 
 #undef REGISTER_ERROR
 

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -289,7 +289,7 @@ void DoValueCheck(const pir::Value& value,
       std::copy(expected_dtype.begin(),
                 expected_dtype.end(),
                 std::ostream_iterator<std::string>(joined, ","));
-      PADDLE_THROW(phi::errors::UnmatchedTypeError(
+      PADDLE_THROW(phi::errors::InvalidType(
           "Check data type error for op: %s, input: %s, %s.dtype is %s, and "
           "expected_dtype is %s",
           op_name,

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -273,8 +273,8 @@ std::string GetValueDataType(const pir::Value& value) {
         value.type().dyn_cast<paddle::dialect::SelectedRowsType>().dtype()));
   } else {
     PADDLE_THROW(
-        phi::errors::InvalidArgument("Currently, we can only get dtype for "
-                                     "DenseTensorType and SelectedRowsType."));
+        phi::errors::InvalidType("Currently, we can only get dtype for "
+                                 "DenseTensorType and SelectedRowsType."));
   }
 }
 
@@ -330,7 +330,7 @@ void CheckDataType(const phi::DataType& dtype,
     std::copy(expected_dtype.begin(),
               expected_dtype.end(),
               std::ostream_iterator<std::string>(joined, ", "));
-    PADDLE_THROW(phi::errors::InvalidArgument(
+    PADDLE_THROW(phi::errors::InvalidType(
         "Check data type error for op: %s, dtype: %s, and "
         "expected_dtype: %s",
         op_name,

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "paddle/common/errors.h"
 #include "paddle/fluid/framework/phi_utils.h"
 #include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
@@ -281,44 +282,20 @@ void DoValueCheck(const pir::Value& value,
                   const std::string& input_name,
                   const std::set<std::string>& expected_dtype,
                   const std::string& op_name) {
-  if (value.type().isa<pir::DenseTensorType>()) {
-    std::string value_type = phi::DataTypeToString(dialect::TransToPhiDataType(
-        value.type().dyn_cast<pir::DenseTensorType>().dtype()));
-    if (expected_dtype.find(value_type) == expected_dtype.end()) {
-      std::ostringstream joined;
-      std::copy(expected_dtype.begin(),
-                expected_dtype.end(),
-                std::ostream_iterator<std::string>(joined, ","));
-      PADDLE_THROW(phi::errors::InvalidType(
-          "Check data type error for op: %s, input: %s, %s.dtype is %s, and "
-          "expected_dtype is %s",
-          op_name,
-          input_name,
-          input_name,
-          value_type,
-          joined.str()));
-    }
-  } else if (value.type().isa<paddle::dialect::SelectedRowsType>()) {
-    std::string value_type = phi::DataTypeToString(dialect::TransToPhiDataType(
-        value.type().dyn_cast<paddle::dialect::SelectedRowsType>().dtype()));
-    if (expected_dtype.find(value_type) == expected_dtype.end()) {
-      std::ostringstream joined;
-      std::copy(expected_dtype.begin(),
-                expected_dtype.end(),
-                std::ostream_iterator<std::string>(joined, ","));
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "Check data type error for op: %s, input: %s, %s.dtype is %s, and "
-          "expected_dtype is %s",
-          op_name,
-          input_name,
-          input_name,
-          value_type,
-          joined.str()));
-    }
-  } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
-        "Currently, we can only get dtype for dense "
-        "tensor."));
+  std::string value_type = GetValueDataType(value);
+  if (expected_dtype.find(value_type) == expected_dtype.end()) {
+    std::ostringstream joined;
+    std::copy(expected_dtype.begin(),
+              expected_dtype.end(),
+              std::ostream_iterator<std::string>(joined, ", "));
+    PADDLE_THROW(phi::errors::InvalidType(
+        "Check data type error for op: %s, input: %s, %s.dtype: %s, and "
+        "expected_dtype: %s",
+        op_name,
+        input_name,
+        input_name,
+        value_type,
+        joined.str()));
   }
 }
 

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -281,20 +281,44 @@ void DoValueCheck(const pir::Value& value,
                   const std::string& input_name,
                   const std::set<std::string>& expected_dtype,
                   const std::string& op_name) {
-  std::string value_type = GetValueDataType(value);
-  if (expected_dtype.find(value_type) == expected_dtype.end()) {
-    std::ostringstream joined;
-    std::copy(expected_dtype.begin(),
-              expected_dtype.end(),
-              std::ostream_iterator<std::string>(joined, ", "));
+  if (value.type().isa<pir::DenseTensorType>()) {
+    std::string value_type = phi::DataTypeToString(dialect::TransToPhiDataType(
+        value.type().dyn_cast<pir::DenseTensorType>().dtype()));
+    if (expected_dtype.find(value_type) == expected_dtype.end()) {
+      std::ostringstream joined;
+      std::copy(expected_dtype.begin(),
+                expected_dtype.end(),
+                std::ostream_iterator<std::string>(joined, ","));
+      PADDLE_THROW(phi::errors::UnmatchedTypeError(
+          "Check data type error for op: %s, input: %s, %s.dtype is %s, and "
+          "expected_dtype is %s",
+          op_name,
+          input_name,
+          input_name,
+          value_type,
+          joined.str()));
+    }
+  } else if (value.type().isa<paddle::dialect::SelectedRowsType>()) {
+    std::string value_type = phi::DataTypeToString(dialect::TransToPhiDataType(
+        value.type().dyn_cast<paddle::dialect::SelectedRowsType>().dtype()));
+    if (expected_dtype.find(value_type) == expected_dtype.end()) {
+      std::ostringstream joined;
+      std::copy(expected_dtype.begin(),
+                expected_dtype.end(),
+                std::ostream_iterator<std::string>(joined, ","));
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "Check data type error for op: %s, input: %s, %s.dtype is %s, and "
+          "expected_dtype is %s",
+          op_name,
+          input_name,
+          input_name,
+          value_type,
+          joined.str()));
+    }
+  } else {
     PADDLE_THROW(phi::errors::InvalidArgument(
-        "Check data type error for op: %s, input: %s, %s.dtype: %s, and "
-        "expected_dtype: %s",
-        op_name,
-        input_name,
-        input_name,
-        value_type,
-        joined.str()));
+        "Currently, we can only get dtype for dense "
+        "tensor."));
   }
 }
 

--- a/paddle/fluid/pybind/exception.cc
+++ b/paddle/fluid/pybind/exception.cc
@@ -32,7 +32,7 @@ namespace pybind {
  *   - UnavailableError -> RuntimeError
  *   - FatalError -> SystemError
  *   - ExternalError -> OSError
- *   - UnmatchedTypeError -> PyExc_TypeError
+ *   - INVALID_TYPE -> PyExc_TypeError
  */
 
 void BindException(pybind11::module* m) {

--- a/paddle/fluid/pybind/exception.cc
+++ b/paddle/fluid/pybind/exception.cc
@@ -32,6 +32,7 @@ namespace pybind {
  *   - UnavailableError -> RuntimeError
  *   - FatalError -> SystemError
  *   - ExternalError -> OSError
+ *   - UnmatchedTypeError -> PyExc_TypeError
  */
 
 void BindException(pybind11::module* m) {
@@ -71,6 +72,9 @@ void BindException(pybind11::module* m) {
           break;
         case paddle::platform::error::EXTERNAL:
           PyErr_SetString(PyExc_OSError, e.what());
+          break;
+        case paddle::platform::error::UNMATCHED_TYPE:
+          PyErr_SetString(PyExc_TypeError, e.what());
           break;
         default:
           exc(e.what());
@@ -123,6 +127,9 @@ void ThrowExceptionToPython(std::exception_ptr p) {
         break;
       case paddle::platform::error::EXTERNAL:
         PyErr_SetString(PyExc_OSError, e.what());
+        break;
+      case paddle::platform::error::UNMATCHED_TYPE:
+        PyErr_SetString(PyExc_TypeError, e.what());
         break;
       default:
         PyErr_SetString(EnforceNotMetException, e.what());

--- a/paddle/fluid/pybind/exception.cc
+++ b/paddle/fluid/pybind/exception.cc
@@ -73,7 +73,7 @@ void BindException(pybind11::module* m) {
         case paddle::platform::error::EXTERNAL:
           PyErr_SetString(PyExc_OSError, e.what());
           break;
-        case paddle::platform::error::UNMATCHED_TYPE:
+        case paddle::platform::error::INVALID_TYPE:
           PyErr_SetString(PyExc_TypeError, e.what());
           break;
         default:
@@ -128,7 +128,7 @@ void ThrowExceptionToPython(std::exception_ptr p) {
       case paddle::platform::error::EXTERNAL:
         PyErr_SetString(PyExc_OSError, e.what());
         break;
-      case paddle::platform::error::UNMATCHED_TYPE:
+      case paddle::platform::error::INVALID_TYPE:
         PyErr_SetString(PyExc_TypeError, e.what());
         break;
       default:

--- a/test/legacy_test/test_eye_op.py
+++ b/test/legacy_test/test_eye_op.py
@@ -23,7 +23,7 @@ import paddle
 from paddle import base
 from paddle.base import core, framework
 from paddle.base.framework import Program, program_guard
-from paddle.pir_utils import IrGuard, test_with_pir_api
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestEyeOp(OpTest):
@@ -123,6 +123,7 @@ class API_TestTensorEye(unittest.TestCase):
         paddle.enable_static()
         self.assertEqual((out.numpy() == expected_result).all(), True)
 
+    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
 
@@ -140,25 +141,6 @@ class API_TestTensorEye(unittest.TestCase):
                 paddle.eye(10, num_columns=10, dtype="int8")
 
             self.assertRaises(TypeError, test_num_columns_type_check1)
-
-    def test_pir_errors(self):
-        with IrGuard():
-            with paddle.static.program_guard(paddle.static.Program()):
-
-                def test_num_rows_type_check():
-                    paddle.eye(-1, dtype="int64")
-
-                self.assertRaises(TypeError, test_num_rows_type_check)
-
-                def test_num_columns_type_check():
-                    paddle.eye(10, num_columns=5.2, dtype="int64")
-
-                self.assertRaises(TypeError, test_num_columns_type_check)
-
-                def test_num_columns_type_check1():
-                    paddle.eye(10, num_columns=10, dtype="int8")
-
-                self.assertRaises(ValueError, test_num_columns_type_check1)
 
 
 class TestEyeRowsCol(UnittestBase):

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -222,7 +222,7 @@ class TestPowerError(unittest.TestCase):
                     x = paddle.static.data('x', [2, 2], dtype='int8')
                     out = paddle.pow(x, 2)
 
-            self.assertRaises(ValueError, x_dtype_error)
+            self.assertRaises(TypeError, x_dtype_error)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_randint_op.py
+++ b/test/legacy_test/test_randint_op.py
@@ -69,7 +69,11 @@ class TestRandintOpError(unittest.TestCase):
 
     def test_pir_error(self):
         with paddle.pir_utils.IrGuard():
+            self.assertRaises(TypeError, paddle.randint, 5, shape=np.array([2]))
             self.assertRaises(TypeError, paddle.randint, 5, dtype='float32')
+            self.assertRaises(ValueError, paddle.randint, 5, 5)
+            self.assertRaises(ValueError, paddle.randint, -5)
+            self.assertRaises(ValueError, paddle.randint, 5, shape=['2'])
 
 
 class TestRandintOp_attr_tensorlist(OpTest):


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
[PIR] add UNMATCHED_TYPE

在 C++ 端添加 UNMATCHED_TYPE 错误类型，以便区分 value 错误和 type 错误
