### PR TITLE
[PIR]Move Operation::operand_index() into Operand::index()

### DIFF
--- a/paddle/fluid/pir/transforms/transform_general_functions.cc
+++ b/paddle/fluid/pir/transforms/transform_general_functions.cc
@@ -84,8 +84,7 @@ std::vector<std::pair<Operation*, int32_t>> GetUseOpsForOutput(Operation* op,
   auto result = op->result(index);
   std::vector<std::pair<Operation*, int32_t>> use_ops;
   for (auto it = result.use_begin(); it != result.use_end(); ++it) {
-    use_ops.push_back(
-        std::make_pair(it->owner(), it->owner()->operand_index(*it)));
+    use_ops.push_back(std::make_pair(it->owner(), it->index()));
   }
   return use_ops;
 }

--- a/paddle/pir/core/op_operand.cc
+++ b/paddle/pir/core/op_operand.cc
@@ -53,6 +53,11 @@ Operation *OpOperand::owner() const {
   return impl_->owner();
 }
 
+int32_t OpOperand::index() const {
+  CHECK_OPOPEREND_NULL_IMPL(index);
+  return impl_->index();
+}
+
 void OpOperand::RemoveFromUdChain() {
   CHECK_OPOPEREND_NULL_IMPL(RemoveFromUdChain);
   return impl_->RemoveFromUdChain();

--- a/paddle/pir/core/op_operand.cc
+++ b/paddle/pir/core/op_operand.cc
@@ -53,7 +53,7 @@ Operation *OpOperand::owner() const {
   return impl_->owner();
 }
 
-int32_t OpOperand::index() const {
+uint32_t OpOperand::index() const {
   CHECK_OPOPEREND_NULL_IMPL(index);
   return impl_->index();
 }

--- a/paddle/pir/core/op_operand.h
+++ b/paddle/pir/core/op_operand.h
@@ -57,6 +57,8 @@ class IR_API OpOperand {
 
   Operation *owner() const;
 
+  int32_t index() const;
+
   void RemoveFromUdChain();
 
   friend Operation;

--- a/paddle/pir/core/op_operand.h
+++ b/paddle/pir/core/op_operand.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-
+#include <cstdint>
 #include "paddle/pir/core/dll_decl.h"
 
 namespace pir {
@@ -57,7 +57,7 @@ class IR_API OpOperand {
 
   Operation *owner() const;
 
-  int32_t index() const;
+  uint32_t index() const;
 
   void RemoveFromUdChain();
 

--- a/paddle/pir/core/op_operand_impl.cc
+++ b/paddle/pir/core/op_operand_impl.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/pir/core/op_operand_impl.h"
+#include "paddle/common/enforce.h"
 #include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/value_impl.h"
 
@@ -46,6 +47,7 @@ int32_t OpOperandImpl::index() const {
       reinterpret_cast<const char *>(owner_) + sizeof(Operation);
   const char *end = reinterpret_cast<const char *>(this);
   int32_t index = (end - start) / sizeof(OpOperandImpl);
+  IR_ENFORCE(index >= 0, "Required index >= 0, but received index = %d", index);
   return index;
 }
 

--- a/paddle/pir/core/op_operand_impl.cc
+++ b/paddle/pir/core/op_operand_impl.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/pir/core/op_operand_impl.h"
-#include "paddle/common/enforce.h"
 #include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/value_impl.h"
 
@@ -42,13 +41,11 @@ OpOperandImpl::OpOperandImpl(pir::Value source, pir::Operation *owner)
   InsertToUdChain();
 }
 
-int32_t OpOperandImpl::index() const {
+uint32_t OpOperandImpl::index() const {
   const char *start =
       reinterpret_cast<const char *>(owner_) + sizeof(Operation);
   const char *end = reinterpret_cast<const char *>(this);
-  int32_t index = (end - start) / sizeof(OpOperandImpl);
-  IR_ENFORCE(index >= 0, "Required index >= 0, but received index = %d", index);
-  return index;
+  return (end - start) / sizeof(OpOperandImpl);
 }
 
 void OpOperandImpl::InsertToUdChain() {

--- a/paddle/pir/core/op_operand_impl.cc
+++ b/paddle/pir/core/op_operand_impl.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/pir/core/op_operand_impl.h"
+#include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/value_impl.h"
 
 namespace pir {
@@ -38,6 +39,14 @@ OpOperandImpl::OpOperandImpl(pir::Value source, pir::Operation *owner)
     return;
   }
   InsertToUdChain();
+}
+
+int32_t OpOperandImpl::index() const {
+  const char *start =
+      reinterpret_cast<const char *>(owner_) + sizeof(Operation);
+  const char *end = reinterpret_cast<const char *>(this);
+  int32_t index = (start - end) / sizeof(OpOperandImpl);
+  return index;
 }
 
 void OpOperandImpl::InsertToUdChain() {

--- a/paddle/pir/core/op_operand_impl.cc
+++ b/paddle/pir/core/op_operand_impl.cc
@@ -45,7 +45,7 @@ int32_t OpOperandImpl::index() const {
   const char *start =
       reinterpret_cast<const char *>(owner_) + sizeof(Operation);
   const char *end = reinterpret_cast<const char *>(this);
-  int32_t index = (start - end) / sizeof(OpOperandImpl);
+  int32_t index = (end - start) / sizeof(OpOperandImpl);
   return index;
 }
 

--- a/paddle/pir/core/op_operand_impl.h
+++ b/paddle/pir/core/op_operand_impl.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <cstdint>
 #include "paddle/pir/core/value.h"
 
 namespace pir {
@@ -33,7 +34,7 @@ class OpOperandImpl {
 
   void set_source(Value value);
 
-  int32_t index() const;
+  uint32_t index() const;
 
   /// Remove this op_operand from the current use list.
   void RemoveFromUdChain();

--- a/paddle/pir/core/op_operand_impl.h
+++ b/paddle/pir/core/op_operand_impl.h
@@ -33,6 +33,8 @@ class OpOperandImpl {
 
   void set_source(Value value);
 
+  int32_t index() const;
+
   /// Remove this op_operand from the current use list.
   void RemoveFromUdChain();
 

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -245,17 +245,6 @@ std::vector<Value> Operation::operands_source() const {
   return res;
 }
 
-int32_t Operation::operand_index(const OpOperand &op_operand) const {
-  int32_t res = -1;
-  for (uint32_t i = 0; i < num_operands(); ++i) {
-    if (op_operand == operand(i)) {
-      res = i;
-      break;
-    }
-  }
-  return res;
-}
-
 ///
 /// \brief op successor related public interfaces
 ///

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -100,7 +100,6 @@ class IR_API alignas(8) Operation final
   std::vector<OpOperand> operands();
   Value operand_source(uint32_t index) const;
   std::vector<Value> operands_source() const;
-  int32_t operand_index(const OpOperand &op_operand) const;
 
   ///
   /// \brief op successor related public interfaces


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164


由于指针偏移方案依赖 sizeof(Operation)，故在operand_impl.cc 编译单元里include了 operation.h的头文件。