### PR TITLE
[AutoParallel] Fix cuda version compile error in reshard

### DIFF
--- a/paddle/phi/core/visit_type.h
+++ b/paddle/phi/core/visit_type.h
@@ -150,7 +150,8 @@ namespace phi {
 
 ///////// BOOL and Floating and Integral Dispatch Marco ///////////
 
-#if (NCCL_VERSION_CODE >= 21000) && !defined(PADDLE_WITH_RCCL)
+#if (NCCL_VERSION_CODE >= 21000) && !defined(PADDLE_WITH_RCCL) && \
+    (CUDA_VERSION >= 11000)
 #define PD_VISIT_BOOL_AND_FLOATING_AND_INTEGRAL_TYPES_GPU(TYPE, NAME, ...)    \
   [&] {                                                                       \
     const auto& __dtype__ = TYPE;                                             \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73145
修复reshard_function中，在低版本下没有限制cuda version导致的编译错误。