### PR TITLE
Fix inconsistency between index_fill and index_fill_

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5885,15 +5885,13 @@ def _index_fill_impl(x, index, axis, value, inplace):
     perm = list(range(len(x.shape)))
     perm[0] = axis
     perm[axis] = 0
-
+    out = paddle.transpose(x, perm)
+    out = paddle.index_put(out, (index,), value)
+    out = paddle.transpose(out, perm)
     if inplace:
-        paddle.transpose(x, perm)
-        paddle.index_put_(x, (index,), value)
+        x[:] = out
         return x
     else:
-        out = paddle.transpose(x, perm)
-        out = paddle.index_put(out, (index,), value)
-        out = paddle.transpose(out, perm)
         return out
 
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5885,13 +5885,16 @@ def _index_fill_impl(x, index, axis, value, inplace):
     perm = list(range(len(x.shape)))
     perm[0] = axis
     perm[axis] = 0
-    out = paddle.transpose(x, perm)
-    out = paddle.index_put(out, (index,), value)
-    out = paddle.transpose(out, perm)
+
     if inplace:
-        x[:] = out
+        paddle.transpose_(x, perm)
+        paddle.index_put_(x, (index,), value)
+        paddle.transpose_(x, perm)
         return x
     else:
+        out = paddle.transpose(x, perm)
+        out = paddle.index_put(out, (index,), value)
+        out = paddle.transpose(out, perm)
         return out
 
 

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1621,7 +1621,7 @@ class TestDygraphInplaceIndexFill(TestDygraphInplace):
     def init_data(self):
         self.input_var_numpy = np.random.random((20, 40))
         self.dtype = "float32"
-        self.axis = 0
+        self.axis = 1
         self.index = paddle.to_tensor([0, 2])
         self.value = -1
 

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1631,6 +1631,23 @@ class TestDygraphInplaceIndexFill(TestDygraphInplace):
     def non_inplace_api_processing(self, var):
         return paddle.index_fill(var, self.index, self.axis, self.value)
 
+    def test_forward_version(self):
+        with paddle.base.dygraph.guard():
+            var = paddle.to_tensor(self.input_var_numpy).astype(self.dtype)
+            self.assertEqual(var.inplace_version, 0)
+
+            inplace_var = self.inplace_api_processing(var)
+            self.assertEqual(var.inplace_version, 3)
+
+            inplace_var[0] = 2
+            self.assertEqual(var.inplace_version, 4)
+
+            inplace_var = self.inplace_api_processing(inplace_var)
+            self.assertEqual(var.inplace_version, 7)
+
+    def test_backward_error(self):
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR types

Bug fixes

### PR changes

APIs

### Description

我之前错误的认为transpose是inplace的导致两个API最终结果不相等，这里将transpose去除，直接对x赋值

会增加一些的赋值成本，但是transpose没有inplace版本，目前paddle也没有可以替代实现交换轴的inplace API

### Link

相关PR：https://github.com/PaddlePaddle/Paddle/pull/57416