### PR TITLE
Use Python 3.8 features and cleanup 3.7 branches

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -594,8 +594,11 @@ class CodeGen:
             for name in op_info.input_name_list[::-1]:
                 type = mapping_input_name_to_type[name]
                 optional = mapping_input_name_to_optional[name]
-                function_name = mapping_type_to_function_name.get(type, None)
-                if function_name is None:
+                if (
+                    function_name := mapping_type_to_function_name.get(
+                        type, None
+                    )
+                ) is None:
                     continue
 
                 if optional == 'false':
@@ -635,8 +638,9 @@ class CodeGen:
             if name not in mapping_name_to_type:
                 return ""
             type = mapping_name_to_type[name]
-            function_name = mapping_type_to_function_name.get(type, None)
-            if function_name is None:
+            if (
+                function_name := mapping_type_to_function_name.get(type, None)
+            ) is None:
                 return ""
             return CHECK_DATA_TYPE_TEMPLATE.format(
                 function=function_name,

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -41,8 +41,7 @@ try:
         # Note: from python3.8, PATH will not take effect
         # https://github.com/python/cpython/pull/12302
         # Use add_dll_directory to specify dll resolution path
-        if sys.version_info[:2] >= (3, 8):
-            os.add_dll_directory(third_lib_path)
+        os.add_dll_directory(third_lib_path)
 
 except ImportError as e:
     if os.name == 'nt':

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -771,7 +771,7 @@ def _can_use_interpreter_core(program, place):
     return True
 
 
-@lru_cache()
+@lru_cache
 def _warning_once(msg):
     logging.warning(msg)
 

--- a/python/paddle/jit/dy2static/pir_partial_program.py
+++ b/python/paddle/jit/dy2static/pir_partial_program.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+from functools import cached_property
 
 import numpy as np
 
@@ -31,20 +32,6 @@ from paddle.pir import OpResult, fake_op_result, is_fake_op_result
 from .utils import RETURN_NO_VALUE_MAGIC_NUM, backend_guard
 
 __all__ = []
-
-
-class cached_property:
-    """
-    Descriptor to implement lazy initialization of property.
-    """
-
-    def __init__(self, function):
-        self.function = function
-
-    def __get__(self, instance, cls):
-        val = self.function(instance)
-        setattr(instance, self.function.__name__, val)
-        return val
 
 
 class NestSequence:

--- a/test/legacy_test/test_gast_with_compatibility.py
+++ b/test/legacy_test/test_gast_with_compatibility.py
@@ -153,7 +153,7 @@ class TestPythonCompatibility(unittest.TestCase):
     #
     # More information please refer to:
     # https://github.com/serge-sans-paille/gast/issues/49
-    if sys.version_info < (3, 8):
+    if sys.version_info > (3, 8):
 
         def test_with(self):
             """

--- a/test/legacy_test/test_gast_with_compatibility.py
+++ b/test/legacy_test/test_gast_with_compatibility.py
@@ -153,7 +153,7 @@ class TestPythonCompatibility(unittest.TestCase):
     #
     # More information please refer to:
     # https://github.com/serge-sans-paille/gast/issues/49
-    if sys.version_info > (3, 8):
+    if sys.version_info >= (3, 9):
 
         def test_with(self):
             """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->


使用 3.8 的新特性，详见 [Python 3.8 Release Notes](https://docs.python.org/3/whatsnew/3.8.html)

- #59733 revert 的 `:=`
- #58667 revert 的 `cached_property`
- 无参装饰器 `lru_cached` 的使用方法

并清理部分 3.7- 分支

需等待 #59680 合入

Pcard-67164