### PR TITLE
Fix dataloader error in static graph

### DIFF
--- a/python/paddle/incubate/multiprocessing/reductions.py
+++ b/python/paddle/incubate/multiprocessing/reductions.py
@@ -84,7 +84,7 @@ def _rebuild_tensor(cls, lodtensor, metadata):
         size, stop_gradient = metadata
         tensor = paddle.base.core.eager.Tensor()
         if lodtensor._is_initialized():
-            tensor.value().get_tensor()._share_data_with(lodtensor)
+            tensor.get_tensor()._share_data_with(lodtensor)
         else:
             tensor = paddle.to_tensor([], dtype=lodtensor._dtype())
         tensor.stop_gradient = stop_gradient
@@ -92,7 +92,7 @@ def _rebuild_tensor(cls, lodtensor, metadata):
 
 
 def _reduce_tensor(tensor):
-    lodtensor = tensor.value().get_tensor()
+    lodtensor = tensor.get_tensor()
 
     if not tensor.stop_gradient and not tensor.is_leaf:
         raise RuntimeError(

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -622,7 +622,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                                 if isinstance(
                                     slot, (paddle.Tensor, core.eager.Tensor)
                                 ):
-                                    slot = slot.value().get_tensor()
+                                    slot = slot.get_tensor()
                                 elif not isinstance(slot, core.LoDTensor):
                                     tmp = core.LoDTensor()
                                     tmp.set(slot, core.CPUPlace())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Method `value()` is only supported in dynamic mode and that leads to error in static mode.
Same as [PR#55541](https://github.com/PaddlePaddle/Paddle/pull/55541)
