### PR TITLE
[PIR][Dynamic Shape] Add reshape test

### DIFF
--- a/test/ir/pir/cinn/symbolic/test_cinn_sub_graph_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_sub_graph_symbolic.py
@@ -42,8 +42,8 @@ def reshape(x):
     z = y - x
     i = paddle.shape(x)[0]
     j = paddle.shape(y)[0]
-    a = paddle.reshape(z, shape=[64, i, j])
-    out = paddle.reshape(z, shape=[128, 4, 2])
+    out = paddle.reshape(z, shape=[64, i, j])
+    # out = paddle.reshape(z, shape=[128, 4, 2])
     return out
 
 

--- a/test/ir/pir/cinn/symbolic/test_cinn_sub_graph_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_sub_graph_symbolic.py
@@ -98,10 +98,16 @@ class TestCinnSubGraphBase(unittest.TestCase):
 
 
 class TestCinnDyShapeBase(TestCinnSubGraphBase):
+    def prepare_data(self):
+        self.shape = [4, 256]
+        self.axis = -1
+        self.x = paddle.randn(self.shape, dtype="float32")
+        self.x.stop_gradient = False
+
     def eval_symbolic(self, use_cinn):
         paddle.seed(2022)
         net = CINNReshapeSubGraphNet()
-        input_spec = [InputSpec(shape=[None, 128], dtype='float32')]
+        input_spec = [InputSpec(shape=[None, 256], dtype='float32')]
         net = apply_to_static(net, use_cinn, input_spec)
         net.eval()
         out = net(self.x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Add a reshape test for dynamic shape of compiler

添加动态shape场景下reshape的test case，供各方统一调试使用，该case中包括了paddle.shape、slice等场景的使用，是reshape一个较复杂的典型使用场景，该case如能完整跑通，基本可以认为reshape场景得到解决。
运行命令（目前会在执行CINN时core dump，因此该PR无法合入，仅做各方统一调试case）：
FLAG_logbuflevel=-1 FLAGS_print_ir=1 FLAGS_call_stack_level=2 FLAGS_enable_pir_api=1 python test_cinn_sub_graph_symbolic.py TestCinnDyShapeBase > err.log 2>&1

reshape IR打印如下：

Splited Program (fwd | bwd): 
ForwardProgram is :
{
 (%0) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"x",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1,128],stop_gradient:[false]} : () -> pd_op.tensor<-1x128xf32>
 (%1) = "pd_op.exp" (%0) {stop_gradient:[false]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<-1x128xf32>
 (%2) = "pd_op.subtract" (%1, %0) {stop_gradient:[false]} : (pd_op.tensor<-1x128xf32>, pd_op.tensor<-1x128xf32>) -> pd_op.tensor<-1x128xf32>
 (%3) = "pd_op.shape" (%0) {stop_gradient:[true]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32>
 (%4) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)0]} : () -> pd_op.tensor<1xi64>
 (%5) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)1]} : () -> pd_op.tensor<1xi64>
 (%6) = "pd_op.slice" (%3, %4, %5) {axes:[(Int64)0],decrease_axis:[(Int64)0],infer_flags:[(Int64)1],stop_gradient:[true]} : (pd_op.tensor<2xi32>, pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<i32>
 (%7) = "pd_op.shape" (%1) {stop_gradient:[true]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32>
 (%8) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)0]} : () -> pd_op.tensor<1xi64>
 (%9) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)1]} : () -> pd_op.tensor<1xi64>
 (%10) = "pd_op.slice" (%7, %8, %9) {axes:[(Int64)0],decrease_axis:[(Int64)0],infer_flags:[(Int64)1],stop_gradient:[true]} : (pd_op.tensor<2xi32>, pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<i32>
 (%11) = "pd_op.full" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[],stop_gradient:[true],value:(Float)64} : () -> pd_op.tensor<i64>
 (%12) = "pd_op.cast" (%6) {dtype:(pd_op.DataType)int64,stop_gradient:[true]} : (pd_op.tensor<i32>) -> pd_op.tensor<i64>
 (%13) = "pd_op.cast" (%10) {dtype:(pd_op.DataType)int64,stop_gradient:[true]} : (pd_op.tensor<i32>) -> pd_op.tensor<i64>
 (%14) = "builtin.combine" (%11, %12, %13) {stop_gradient:[true]} : (pd_op.tensor<i64>, pd_op.tensor<i64>, pd_op.tensor<i64>) -> vec[pd_op.tensor<i64>,pd_op.tensor<i64>,pd_op.tensor<i64>]
 (%15) = "pd_op.stack" (%14) {axis:(Int32)0,stop_gradient:[true]} : (vec[pd_op.tensor<i64>,pd_op.tensor<i64>,pd_op.tensor<i64>]) -> pd_op.tensor<3xi64>
 (%16, %17) = "pd_op.reshape" (%2, %15) {stop_gradient:[false,false]} : (pd_op.tensor<-1x128xf32>, pd_op.tensor<3xi64>) -> pd_op.tensor<-1x-1x-1xf32>, pd_op.tensor<0x-1x128xi64>
 () = "builtin.set_parameter" (%16) {parameter_name:"output_0"} : (pd_op.tensor<-1x-1x-1xf32>) ->  
}
BackwardProgram is: 
{
}
