### PR TITLE
disable_trt_uts

### DIFF
--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -293,6 +293,10 @@ disable_wingpu_cuda12_test="^test_cholesky_op$|\
 ^test_trt_convert_transpose$|\
 ^test_trt_convert_unsqueeze2$|\
 ^test_simplify_with_basic_ops_pass_autoscan$|\
+^test_trt_convert_nearest_interp$|\
+^test_trt_pool_op$|\ 
+^test_trt_convert_clip$|\ 
+^test_trt_convert_grid_sampler$|\
 ^disable_wingpu_cuda12_test$"
 
 # /*=================Fixed Disabled Windows TRT MKL unittests=======================*/

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -297,6 +297,7 @@ disable_wingpu_cuda12_test="^test_cholesky_op$|\
 ^test_trt_pool_op$|\ 
 ^test_trt_convert_clip$|\ 
 ^test_trt_convert_grid_sampler$|\
+^test_trt_convert_p_norm$|\
 ^disable_wingpu_cuda12_test$"
 
 # /*=================Fixed Disabled Windows TRT MKL unittests=======================*/


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others 

### Description
Pcard-73263
追加禁用在windows_cuda12环境下耗时较长或失败的trt单测
