### PR TITLE
【PIR API adaptor No.217、256、279、280】 Migrate nn.functional.square_error_cost, nn.GaussianNLLLoss/MultiLabelSoftMarginLoss/MultiMarginLoss  into pir

### DIFF
--- a/test/legacy_test/test_multi_label_soft_margin_loss.py
+++ b/test/legacy_test/test_multi_label_soft_margin_loss.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def call_MultiLabelSoftMarginLoss_layer(
@@ -139,6 +140,7 @@ def calc_multilabel_margin_loss(
 
 
 class TestMultiLabelMarginLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_MultiLabelSoftMarginLoss(self):
         input = np.random.uniform(0.1, 0.8, size=(5, 5)).astype(np.float64)
         label = np.random.randint(0, 2, size=(5, 5)).astype(np.float64)
@@ -209,6 +211,7 @@ class TestMultiLabelMarginLoss(unittest.TestCase):
         )
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_MultiLabelSoftMarginLoss_weights(self):
         input = np.random.uniform(0.1, 0.8, size=(5, 5)).astype(np.float64)
         label = np.random.randint(0, 2, size=(5, 5)).astype(np.float64)

--- a/test/legacy_test/test_multimarginloss.py
+++ b/test/legacy_test/test_multimarginloss.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def call_MultiMarginLoss_layer(
@@ -238,6 +239,7 @@ def calc_multi_margin_loss(
 
 
 class TestMultiMarginLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_MultiMarginLoss(self):
         batch_size = 5
         num_classes = 2
@@ -330,6 +332,7 @@ class TestMultiMarginLoss(unittest.TestCase):
         )
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_MultiMarginLoss_p(self):
         p = 2
         batch_size = 5
@@ -383,6 +386,7 @@ class TestMultiMarginLoss(unittest.TestCase):
         np.testing.assert_allclose(static_functional, dy_functional)
         np.testing.assert_allclose(dy_functional, expected)
 
+    @test_with_pir_api
     def test_MultiMarginLoss_weight(self):
         batch_size = 5
         num_classes = 2
@@ -436,6 +440,7 @@ class TestMultiMarginLoss(unittest.TestCase):
         np.testing.assert_allclose(static_functional, dy_functional)
         np.testing.assert_allclose(dy_functional, expected)
 
+    @test_with_pir_api
     def test_MultiMarginLoss_static_data_shape(self):
         batch_size = 5
         num_classes = 2

--- a/test/legacy_test/test_square_error_cost.py
+++ b/test/legacy_test/test_square_error_cost.py
@@ -20,34 +20,43 @@ import paddle
 from paddle import base
 from paddle.base import core
 from paddle.base.executor import Executor
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestSquareErrorCost(unittest.TestCase):
+    @test_with_pir_api
     def test_square_error_cost(self):
-        input_val = np.random.uniform(0.1, 0.5, (2, 3)).astype("float32")
-        label_val = np.random.uniform(0.1, 0.5, (2, 3)).astype("float32")
+        paddle.enable_static()
+        shape = [2, 3]
+        input_val = np.random.uniform(0.1, 0.5, shape).astype("float32")
+        label_val = np.random.uniform(0.1, 0.5, shape).astype("float32")
 
         sub = input_val - label_val
         np_result = sub * sub
 
-        input_var = paddle.tensor.create_tensor(dtype="float32", name="input")
-        label_var = paddle.tensor.create_tensor(dtype="float32", name="label")
-        output = paddle.nn.functional.square_error_cost(
-            input=input_var, label=label_var
-        )
-
         for use_cuda in (
             [False, True] if core.is_compiled_with_cuda() else [False]
         ):
-            place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
-            exe = Executor(place)
-            (result,) = exe.run(
-                base.default_main_program(),
-                feed={"input": input_val, "label": label_val},
-                fetch_list=[output],
-            )
+            with paddle.static.program_guard(paddle.static.Program()):
+                input_var = paddle.static.data(
+                    name="input", shape=shape, dtype="float32"
+                )
+                label_var = paddle.static.data(
+                    name="label", shape=shape, dtype="float32"
+                )
+                output = paddle.nn.functional.square_error_cost(
+                    input=input_var, label=label_var
+                )
 
-            np.testing.assert_allclose(np_result, result, rtol=1e-05)
+                place = base.CUDAPlace(0) if use_cuda else base.CPUPlace()
+                exe = Executor(place)
+                (result,) = exe.run(
+                    paddle.static.default_main_program(),
+                    feed={"input": input_val, "label": label_val},
+                    fetch_list=[output],
+                )
+
+                np.testing.assert_allclose(np_result, result, rtol=1e-05)
 
 
 class TestSquareErrorInvalidInput(unittest.TestCase):


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
任务 issue: https://github.com/PaddlePaddle/Paddle/issues/58067

**PIR API 推全升级**
1. 将 `paddle.nn.functional.square_error_cost` 迁移升级至 pir，并更新单测，单测覆盖率（1/2）

2. 将 `paddle.nn.GaussianNLLLoss` 迁移升级至 pir，并更新单测，单测覆盖率（0/2）

3. 将 `paddle.nn.MultiLabelSoftMarginLoss` 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

4. 将 `paddle.nn.MultiMarginLoss ` 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

NOTE:
1. test/legacy_test/test_square_error_cost.py 下的 TestSquareErrorInvalidInput.test_error 单测尚不支持 pir 模式
2. GaussianNLLLoss 和 gaussian_nll_loss 未迁移，因为涉及 paddle.static.nn.Assert API，该 API 为控制流 API，暂未迁移到 PIR 模式下
