### PR TITLE
[PIR] delete Bias for onednn conv2d_grad

### DIFF
--- a/paddle/phi/kernels/onednn/conv_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_grad_kernel.cc
@@ -57,8 +57,6 @@ void ConvGradKernel(const Context& dev_ctx,
                         "Operator oneDNN ConvGrad must use CPUPlace"));
   const auto& onednn_engine = dev_ctx.GetEngine();
 
-  const auto* bias =
-      dev_ctx.HasDnnInput("Bias") ? dev_ctx.GetDnnInput("Bias") : nullptr;
   bool is_test = dev_ctx.HasDnnAttr("is_test")
                      ? PADDLE_GET_CONST(bool, dev_ctx.GetDnnAttr("is_test"))
                      : false;
@@ -75,7 +73,7 @@ void ConvGradKernel(const Context& dev_ctx,
                                                          dev_ctx.GetPlace(),
                                                          &input,
                                                          &filter,
-                                                         bias,
+                                                         nullptr,
                                                          &out_grad,
                                                          strides,
                                                          paddings,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
MKLDNN改造

MKLDNN conv2d_grad kernel删除对Bias的使用。https://github.com/PaddlePaddle/Paddle/pull/49121 已经将Bias迁移到fused kernel中了。剩余的代码为无效代码。
Pcard-67164