### PR TITLE
[PHI] delete dense_tensor mem_desc_

### DIFF
--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -59,10 +59,6 @@ DenseTensor::DenseTensor(const DenseTensor& other) {
   storage_properties_ =
       std::move(CopyStorageProperties(other.storage_properties_));
   inplace_version_counter_ = other.inplace_version_counter_;
-
-#ifdef PADDLE_WITH_DNNL
-  mem_desc_ = other.mem_desc_;
-#endif
 }
 
 DenseTensor& DenseTensor::operator=(const DenseTensor& other) {
@@ -74,9 +70,6 @@ DenseTensor& DenseTensor::operator=(const DenseTensor& other) {
   storage_properties_ =
       std::move(CopyStorageProperties(other.storage_properties_));
   inplace_version_counter_ = other.inplace_version_counter_;
-#ifdef PADDLE_WITH_DNNL
-  mem_desc_ = other.mem_desc_;
-#endif
   return *this;
 }
 
@@ -85,9 +78,6 @@ DenseTensor& DenseTensor::operator=(DenseTensor&& other) noexcept {
   std::swap(holder_, other.holder_);
   storage_properties_ = std::move(other.storage_properties_);
   std::swap(inplace_version_counter_, other.inplace_version_counter_);
-#ifdef PADDLE_WITH_DNNL
-  mem_desc_ = other.mem_desc_;
-#endif
   return *this;
 }
 

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -22,12 +22,6 @@ limitations under the License. */
 #include "paddle/phi/core/tensor_meta.h"
 #include "paddle/utils/test_macros.h"
 
-/* @jim19930609: Move to MKLDNN_Tensor in the future
- */
-#ifdef PADDLE_WITH_DNNL
-#include "dnnl.hpp"  // NOLINT
-#endif
-
 namespace phi {
 
 class DenseTensorUtils;
@@ -289,18 +283,6 @@ class TEST_API DenseTensor : public TensorBase,
  protected:
   std::shared_ptr<InplaceVersion> inplace_version_counter_ =
       std::make_shared<InplaceVersion>();
-
-/* @jim19930609: This is a hack
-In general, it is badly designed to fuse MKLDNN-specific objects into a
-generic Tensor.
-We temporarily leave them here to unblock Tensor Unification progress.
-In the final state, we should come up with a MKLDNN_Tensor and move the
-following codes there.
-*/
-#ifdef PADDLE_WITH_DNNL
-  /// \brief memory descriptor of tensor which have layout set as kMKLDNN
-  dnnl::memory::desc mem_desc_;
-#endif
 
 #ifndef PADDLE_WITH_CUSTOM_KERNEL
 #include "paddle/phi/core/dense_tensor.inl"

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -107,7 +107,7 @@ following codes there.
 #ifdef PADDLE_WITH_DNNL
 
 public:
-const dnnl::memory::desc& mem_desc();
+const dnnl::memory::desc& mem_desc() const;
 
 void set_mem_desc(const dnnl::memory::desc& mem_desc);
 

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -109,7 +109,7 @@ following codes there.
 public:
 const dnnl::memory::desc& mem_desc() const;
 
-inline void set_mem_desc(const dnnl::memory::desc& mem_desc);
+void set_mem_desc(const dnnl::memory::desc& mem_desc);
 
 #endif
 

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -107,7 +107,7 @@ following codes there.
 #ifdef PADDLE_WITH_DNNL
 
 public:
-const dnnl::memory::desc& mem_desc() const;
+const dnnl::memory::desc& mem_desc();
 
 void set_mem_desc(const dnnl::memory::desc& mem_desc);
 

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -109,10 +109,7 @@ following codes there.
 public:
 const dnnl::memory::desc& mem_desc() const;
 
-inline void set_mem_desc(const dnnl::memory::desc& mem_desc) {
-  mem_desc_ = mem_desc;
-  meta_.layout = DataLayout::ONEDNN;
-}
+inline void set_mem_desc(const dnnl::memory::desc& mem_desc);
 
 #endif
 

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -377,7 +377,14 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 }
 
 #ifdef PADDLE_WITH_DNNL
-const dnnl::memory::desc& DenseTensor::mem_desc() const { return mem_desc_; }
+const dnnl::memory::desc& DenseTensor::mem_desc() const {
+  return this->storage_properties().mem_desc;
+}
+
+inline void DenseTensor::set_mem_desc(const dnnl::memory::desc& mem_desc) {
+  this->storage_properties().mem_desc = mem_desc;
+  meta_.layout = DataLayout::ONEDNN;
+}
 #endif
 
 // NOTE: For historical reasons, this interface has a special behavior,
@@ -394,9 +401,6 @@ DenseTensor& DenseTensor::ShareDataWith(const DenseTensor& src) {
   meta_.strides = src.meta_.strides;
   storage_properties_ =
       std::move(CopyStorageProperties(src.storage_properties_));
-#ifdef PADDLE_WITH_DNNL
-  mem_desc_ = src.mem_desc_;
-#endif
   return *this;
 }
 

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -381,7 +381,7 @@ const dnnl::memory::desc& DenseTensor::mem_desc() const {
   return this->storage_properties<OneDNNStorageProperties>().mem_desc;
 }
 
-inline void DenseTensor::set_mem_desc(const dnnl::memory::desc& mem_desc) {
+void DenseTensor::set_mem_desc(const dnnl::memory::desc& mem_desc) {
   PADDLE_ENFORCE_NOT_NULL(
       storage_properties_,
       phi::errors::PreconditionNotMet(

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -379,7 +379,7 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 #ifdef PADDLE_WITH_DNNL
 const dnnl::memory::desc& DenseTensor::mem_desc() const {
   if (storage_properties_ == nullptr) {
-    storage_properties_.reset(new OneDNNStorageProperties());
+    storage_properties_ = std::make_unique<OneDNNStorageProperties>();
   }
 
   return this->storage_properties<OneDNNStorageProperties>().mem_desc;
@@ -387,7 +387,7 @@ const dnnl::memory::desc& DenseTensor::mem_desc() const {
 
 void DenseTensor::set_mem_desc(const dnnl::memory::desc& mem_desc) {
   if (storage_properties_ == nullptr) {
-    storage_properties_.reset(new OneDNNStorageProperties());
+    storage_properties_ = std::make_unique<OneDNNStorageProperties>();
   }
   if (OneDNNStorageProperties::classof(storage_properties_.get())) {
     dynamic_cast<OneDNNStorageProperties*>(storage_properties_.get())

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -377,7 +377,7 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 }
 
 #ifdef PADDLE_WITH_DNNL
-const dnnl::memory::desc& DenseTensor::mem_desc() const {
+const dnnl::memory::desc& DenseTensor::mem_desc() {
   if (storage_properties_ == nullptr) {
     storage_properties_ = std::make_unique<OneDNNStorageProperties>();
   }

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -378,14 +378,17 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 
 #ifdef PADDLE_WITH_DNNL
 const dnnl::memory::desc& DenseTensor::mem_desc() const {
+  if (storage_properties_ == nullptr) {
+    storage_properties_.reset(new OneDNNStorageProperties());
+  }
+
   return this->storage_properties<OneDNNStorageProperties>().mem_desc;
 }
 
 void DenseTensor::set_mem_desc(const dnnl::memory::desc& mem_desc) {
-  PADDLE_ENFORCE_NOT_NULL(
-      storage_properties_,
-      phi::errors::PreconditionNotMet(
-          "The storage_properties of current DenseTensor is nullptr."));
+  if (storage_properties_ == nullptr) {
+    storage_properties_.reset(new OneDNNStorageProperties());
+  }
   if (OneDNNStorageProperties::classof(storage_properties_.get())) {
     dynamic_cast<OneDNNStorageProperties*>(storage_properties_.get())
         ->mem_desc = mem_desc;

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -378,6 +378,11 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 
 #ifdef PADDLE_WITH_DNNL
 const dnnl::memory::desc& DenseTensor::mem_desc() const {
+  if (storage_properties_ == nullptr) {
+    std::unique_ptr<StorageProperties>* storage_properties_ptr =
+        const_cast<std::unique_ptr<StorageProperties>*>(&storage_properties_);
+    *storage_properties_ptr = std::make_unique<OneDNNStorageProperties>();
+  }
   return this->storage_properties<OneDNNStorageProperties>().mem_desc;
 }
 

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -377,11 +377,7 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 }
 
 #ifdef PADDLE_WITH_DNNL
-const dnnl::memory::desc& DenseTensor::mem_desc() {
-  if (storage_properties_ == nullptr) {
-    storage_properties_ = std::make_unique<OneDNNStorageProperties>();
-  }
-
+const dnnl::memory::desc& DenseTensor::mem_desc() const {
   return this->storage_properties<OneDNNStorageProperties>().mem_desc;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
MKLDNN改造
DenseTensor中删除mem_desc_成员变量，改用storage_properties_

Pcard-67164