### PR TITLE
Fix var_name conflict bug for auto parallel partitioner

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/partitioner.py
+++ b/python/paddle/distributed/auto_parallel/static/partitioner.py
@@ -123,6 +123,9 @@ class Partitioner:
             )
 
         partitioned_startup_prog = paddle.framework.Program()
+        partitioned_startup_prog._name_generator = (
+            serial_startup_program._name_generator.clone()
+        )
         ref_block = serial_main_program.global_block()
         target_block = partitioned_startup_prog.global_block()
         var2shape = {}
@@ -185,6 +188,9 @@ class Partitioner:
         """
 
         partitioned_main_prog = paddle.framework.Program()
+        partitioned_main_prog._name_generator = (
+            serial_main_program._name_generator.clone()
+        )
         dist_op_context = self._dist_context.dist_op_context
         dist_op_context.dst_main_program = partitioned_main_prog
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-76459
修复自动并行partitioner切图后，由于name_generator不同步而导致后续program改写出现var name冲突的问题。