### PR TITLE
fix PIR  OpTest: not found test_xxx_op in legacy_test

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2549,7 +2549,7 @@
 - op : reshape (reshape2)
   backward : reshape_grad (reshape2_grad)
   inputs:
-    x : z
+    x : X
   outputs:
     out : Out
     xshape: XShape
@@ -3380,7 +3380,7 @@
 
 - op: dpsgd
   inputs:
-    {param: param,grad: grad,learning_rate: LearningRate}
+    {param: Param,grad: grad,learning_rate: LearningRate}
   outputs:
     param_out : ParamOut
 

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2549,7 +2549,7 @@
 - op : reshape (reshape2)
   backward : reshape_grad (reshape2_grad)
   inputs:
-    x : X
+    x : z
   outputs:
     out : Out
     xshape: XShape
@@ -3380,7 +3380,7 @@
 
 - op: dpsgd
   inputs:
-    {param: Param,grad: Grad,learning_rate: LearningRate}
+    {param: param,grad: grad,learning_rate: LearningRate}
   outputs:
     param_out : ParamOut
 

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -3380,7 +3380,7 @@
 
 - op: dpsgd
   inputs:
-    {param: Param,grad: grad,learning_rate: LearningRate}
+    {param: Param,grad: Grad,learning_rate: LearningRate}
   outputs:
     param_out : ParamOut
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,38 @@ function(bash_test_modules TARGET_NAME)
   endif()
 endfunction()
 
+function(set_pit_tests_properties)
+  file(STRINGS "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_white_list"
+       PIR_OP_TESTS)
+  foreach(IR_OP_TEST ${PIR_OP_TESTS})
+    if(TEST ${IR_OP_TEST})
+      set_tests_properties(
+        ${IR_OP_TEST} PROPERTIES ENVIRONMENT "FLAGS_PIR_OPTEST_WHITE_LIST=True")
+    endif()
+  endforeach()
+
+  file(STRINGS "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_no_check_list"
+       PIR_OP_NO_CHECK_TESTS)
+  foreach(IR_OP_TEST ${PIR_OP_NO_CHECK_TESTS})
+    if(TEST ${IR_OP_TEST})
+      set_tests_properties(${IR_OP_TEST} PROPERTIES ENVIRONMENT
+                                                    "FLAGS_PIR_NO_CHECK=True")
+    endif()
+  endforeach()
+
+  file(STRINGS
+       "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_precision_white_list"
+       PIR_OP_RELAXED_TESTS)
+  foreach(IR_OP_TEST ${PIR_OP_RELAXED_TESTS})
+    if(TEST ${IR_OP_TEST})
+      set_tests_properties(
+        ${IR_OP_TEST} PROPERTIES ENVIRONMENT
+                                 "FLAGS_PIR_OPTEST_RELAX_CHECK=True")
+    endif()
+  endforeach()
+
+endfunction()
+
 if(WITH_TESTING)
   if(WITH_CINN)
     add_subdirectory(cpp/cinn)
@@ -256,3 +288,5 @@ add_custom_target(build_tests)
 if(${len} GREATER_EQUAL 1)
   add_dependencies(build_tests ${test_names})
 endif()
+
+set_pit_tests_properties()

--- a/test/distribution/CMakeLists.txt
+++ b/test/distribution/CMakeLists.txt
@@ -7,3 +7,5 @@ string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
+
+set_pit_tests_properties()

--- a/test/fft/CMakeLists.txt
+++ b/test/fft/CMakeLists.txt
@@ -7,3 +7,5 @@ string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
+
+set_pit_tests_properties()

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1398,41 +1398,6 @@ set_tests_properties(test_sync_batch_norm_op_static_build
                      PROPERTIES LABELS "RUN_TYPE=DIST")
 set_tests_properties(test_sync_batch_norm_op_static_build PROPERTIES TIMEOUT
                                                                      250)
-
-file(STRINGS "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_white_list"
-     PIR_OP_TESTS)
-foreach(IR_OP_TEST ${PIR_OP_TESTS})
-  if(TEST ${IR_OP_TEST})
-    set_tests_properties(
-      ${IR_OP_TEST} PROPERTIES ENVIRONMENT "FLAGS_PIR_OPTEST_WHITE_LIST=True")
-  else()
-    message(STATUS "PIR OpTest: not found ${IR_OP_TEST} in legacy_test")
-  endif()
-endforeach()
-
-file(STRINGS "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_no_check_list"
-     PIR_OP_NO_CHECK_TESTS)
-foreach(IR_OP_TEST ${PIR_OP_NO_CHECK_TESTS})
-  if(TEST ${IR_OP_TEST})
-    set_tests_properties(${IR_OP_TEST} PROPERTIES ENVIRONMENT
-                                                  "FLAGS_PIR_NO_CHECK=True")
-  else()
-    message(STATUS "PIR OpTest: not found ${IR_OP_TEST} in legacy_test")
-  endif()
-endforeach()
-
-file(STRINGS
-     "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_precision_white_list"
-     PIR_OP_RELAXED_TESTS)
-foreach(IR_OP_TEST ${PIR_OP_RELAXED_TESTS})
-  if(TEST ${IR_OP_TEST})
-    set_tests_properties(
-      ${IR_OP_TEST} PROPERTIES ENVIRONMENT "FLAGS_PIR_OPTEST_RELAX_CHECK=True")
-  else()
-    message(STATUS "PIR Relaxed OpTest: not found ${IR_OP_TEST} in legacy_test")
-  endif()
-endforeach()
-
 py_test_modules(test_stride MODULES test_stride ENVS
                 FLAGS_use_stride_kernel=true)
 
@@ -1448,3 +1413,5 @@ if((WITH_ROCM OR WITH_GPU) AND NOT WIN32)
     test_fleet_executor_with_task_nodes
     PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
 endif()
+
+set_pit_tests_properties()

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -26,7 +26,6 @@ test_auc_single_pred_op
 test_bce_loss
 test_bernoulli_op               
 test_bicubic_interp_v2_op
-test_bilinear_interp_mkldnn_op
 test_bilinear_interp_v2_mkldnn_op
 test_bilinear_interp_v2_op
 test_bilinear_tensor_product_op
@@ -167,7 +166,6 @@ test_index_select_op
 test_instance_norm_op
 test_instance_norm_op_v2
 test_inverse_op
-test_ir_pybind
 test_is_empty_op
 test_isclose_op
 test_kldiv_loss_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
1.fix PIR  OpTest: not found test_xxx_op in legacy_test
  - 统计出现`fix PIR OpTest: not found test_xxx_op in legacy_test`情况的算子单测，分别出现在`test/legacy_test`,`test/fft`,`test/distribution`,`test/auto_parallel`文件中。
  - 修改CmakeLists.txt之后，为了测试单测是否成功执行。修改了在`test/legacy_test`下的单测对应的`dpsgd`算子的op_compat.yaml信息，导致`op_translator`失败，在coverage流水线执行对应单测报错。修改了`test/mkldnn`单测对应的`reshape2`算子op_compat.yaml信息，同样报错。说明修改有效。
2.删除test_bilinear_interp_mkldnn_op、test_ir_pybind两个无关单测