### PR TITLE
[Dygraph] Fix bugs for searching target path of unittests on Auto_Parallel_CI 

### DIFF
--- a/tools/auto_parallel/ci_auto_parallel.sh
+++ b/tools/auto_parallel/ci_auto_parallel.sh
@@ -38,10 +38,10 @@ for element in "${target_lists_for_semi_auto_ci[@]}";do
   fi
   count=$((count+1))
 done
-# get the location of "test/collective/fleet" in target_lists_for_dygraph_ci
+# get the location of "test/collective/hybrid_strategy" in target_lists_for_dygraph_ci
 count=0
 for element in "${target_lists_for_dygraph_ci[@]}";do
-  if [[ "$element" == "test/collective/fleet" ]]; then  
+  if [[ "$element" == "test/collective/hybrid_strategy" ]]; then  
     test_dygraph_num=$count
     break
   fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[Dygraph] Fix bugs for searching target path of unittests on Auto_Parallel_CI（card-5226）