### PR TITLE
Fix and refactor trt_skip_layernorm ut

### DIFF
--- a/test/ir/inference/test_trt_skip_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_trt_skip_layernorm_fuse_pass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,39 +25,46 @@ from paddle.base import core
 from paddle.base.core import AnalysisConfig, PassVersionChecker
 
 
-class SkipLayernormFusePassTest0(InferencePassTest):
+class SkipLayernormFusePassTest(InferencePassTest):
     def setUp(self):
+        self.set_args()
+        input_shape_with_batch = [self.batch_size] + self.input_shape
+        min_input_shape_with_batch = [1] + self.min_input_shape
         with base.program_guard(self.main_program, self.startup_program):
             data1 = paddle.static.data(
-                name="data1", shape=[-1, 3, 128, 128], dtype="float32"
+                name='data1', shape=[-1] + self.input_shape, dtype='float32'
             )
             data2 = paddle.static.data(
-                name="data2", shape=[-1, 3, 128, 128], dtype="float32"
+                name='data2', shape=[-1] + self.input_shape, dtype='float32'
             )
-            eltwise_out = self.append_eltwise(data1, data2)
-            out = paddle.nn.functional.layer_norm(
-                eltwise_out, eltwise_out.shape[1:]
-            )
+            eltwise_out = paddle.add(data1, data2)
+            out = paddle.nn.LayerNorm(eltwise_out.shape[-1:])(eltwise_out)
         self.feeds = {
-            "data1": np.random.random([1, 3, 128, 128]).astype("float32"),
-            "data2": np.random.random([1, 3, 128, 128]).astype("float32"),
+            'data1': np.random.random(input_shape_with_batch).astype('float32'),
+            'data2': np.random.random(input_shape_with_batch).astype('float32'),
         }
         self.enable_trt = True
-        self.trt_parameters = SkipLayernormFusePassTest0.TensorRTParam(
-            1 << 30, 32, 0, AnalysisConfig.Precision.Float32, True, False
+        self.trt_parameters = SkipLayernormFusePassTest.TensorRTParam(
+            1 << 30, 32, 0, self.trt_precision, True, False
         )
-        self.dynamic_shape_params = (
-            SkipLayernormFusePassTest0.DynamicShapeParam(
-                {'data1': [1, 1, 1, 128], 'data2': [1, 1, 1, 128]},
-                {'data1': [1, 3, 128, 128], 'data2': [1, 3, 128, 128]},
-                {'data1': [1, 3, 128, 128], 'data2': [1, 3, 128, 128]},
-                False,
-            )
+        self.dynamic_shape_params = SkipLayernormFusePassTest.DynamicShapeParam(
+            {
+                'data1': min_input_shape_with_batch,
+                'data2': min_input_shape_with_batch,
+            },
+            {'data1': input_shape_with_batch, 'data2': input_shape_with_batch},
+            {'data1': input_shape_with_batch, 'data2': input_shape_with_batch},
+            False,
         )
         self.fetch_list = [out]
 
-    def append_eltwise(self, data1, data2):
-        return paddle.add(data1, data2)
+    def set_args(self):
+        self.input_shape = [3, 128, 256]
+        self.batch_size = 1
+        self.trt_precision = AnalysisConfig.Precision.Float32
+        self.min_input_shape = [1, 1, 256]
+        self.atol = 1e-2
+        self.rtol = 1e-5
 
     def test_check_output(self):
         opt_path = os.path.join(self.path, '_opt_cache')
@@ -65,154 +72,42 @@ class SkipLayernormFusePassTest0(InferencePassTest):
             shutil.rmtree(opt_path)
         if core.is_compiled_with_cuda():
             use_gpu = True
-            self.check_output_with_option(use_gpu, atol=0.01, rtol=0.00001)
+            self.check_output_with_option(
+                use_gpu, atol=self.atol, rtol=self.rtol
+            )
             self.assertTrue(
                 PassVersionChecker.IsCompatible('tensorrt_subgraph_pass')
             )
 
 
-class SkipLayernormFusePassTest1(InferencePassTest):
-    def setUp(self):
-        with base.program_guard(self.main_program, self.startup_program):
-            data1 = paddle.static.data(
-                name="data1", shape=[-1, 256, 1536], dtype="float32"
-            )
-            data2 = paddle.static.data(
-                name="data2", shape=[-1, 256, 1536], dtype="float32"
-            )
-            eltwise_out = self.append_eltwise(data1, data2)
-
-            out = paddle.nn.functional.layer_norm(
-                eltwise_out, eltwise_out.shape[1:]
-            )
-
-        self.feeds = {
-            "data1": np.random.random([1, 256, 1536]).astype("float32"),
-            "data2": np.random.random([1, 256, 1536]).astype("float32"),
-        }
-        self.enable_trt = True
-        self.trt_parameters = SkipLayernormFusePassTest1.TensorRTParam(
-            1 << 30, 32, 0, AnalysisConfig.Precision.Float32, True, False
-        )
-        self.dynamic_shape_params = (
-            SkipLayernormFusePassTest1.DynamicShapeParam(
-                {'data1': [1, 1, 1], 'data2': [1, 1, 1]},
-                {'data1': [1, 384, 1536], 'data2': [1, 384, 1536]},
-                {'data1': [1, 384, 1536], 'data2': [1, 384, 1536]},
-                False,
-            )
-        )
-        self.fetch_list = [out]
-
-    def append_eltwise(self, data1, data2):
-        return paddle.add(data1, data2)
-
-    def test_check_output(self):
-        opt_path = os.path.join(self.path, '_opt_cache')
-        if os.path.exists(opt_path):
-            shutil.rmtree(opt_path)
-        if core.is_compiled_with_cuda():
-            use_gpu = True
-            self.check_output_with_option(use_gpu, atol=0.01, rtol=0.00001)
-            self.assertTrue(
-                PassVersionChecker.IsCompatible('tensorrt_subgraph_pass')
-            )
+class SkipLayernormFusePassTest1(SkipLayernormFusePassTest):
+    def set_args(self):
+        self.input_shape = [256, 1536]
+        self.batch_size = 1
+        self.trt_precision = AnalysisConfig.Precision.Float32
+        self.min_input_shape = [1, 1]
+        self.atol = 1e-2
+        self.rtol = 1e-5
 
 
-class SkipLayernormFusePassTest2(InferencePassTest):
-    def setUp(self):
-        with base.program_guard(self.main_program, self.startup_program):
-            data1 = paddle.static.data(
-                name="data1", shape=[-1, 128, 64, 768], dtype="float32"
-            )
-            data2 = paddle.static.data(
-                name="data2", shape=[-1, 128, 64, 768], dtype="float32"
-            )
-            eltwise_out = self.append_eltwise(data1, data2)
-
-            out = paddle.nn.functional.layer_norm(
-                eltwise_out, eltwise_out.shape[1:]
-            )
-
-        self.feeds = {
-            "data1": np.random.random([1, 128, 64, 768]).astype("float32"),
-            "data2": np.random.random([1, 128, 64, 768]).astype("float32"),
-        }
-        self.enable_trt = True
-        self.trt_parameters = SkipLayernormFusePassTest2.TensorRTParam(
-            1 << 30, 32, 0, AnalysisConfig.Precision.Half, True, False
-        )
-        self.dynamic_shape_params = (
-            SkipLayernormFusePassTest2.DynamicShapeParam(
-                {'data1': [1, 1, 1, 1], 'data2': [1, 1, 1, 1]},
-                {'data1': [1, 128, 64, 768], 'data2': [1, 128, 64, 768]},
-                {'data1': [1, 128, 64, 768], 'data2': [1, 128, 64, 768]},
-                False,
-            )
-        )
-        self.fetch_list = [out]
-
-    def append_eltwise(self, data1, data2):
-        return paddle.add(data1, data2)
-
-    def test_check_output(self):
-        opt_path = os.path.join(self.path, '_opt_cache')
-        if os.path.exists(opt_path):
-            shutil.rmtree(opt_path)
-        if core.is_compiled_with_cuda():
-            use_gpu = True
-            self.check_output_with_option(use_gpu, atol=0.1, rtol=0.00001)
-            self.assertTrue(
-                PassVersionChecker.IsCompatible('tensorrt_subgraph_pass')
-            )
+class SkipLayernormFusePassTest2(SkipLayernormFusePassTest):
+    def set_args(self):
+        self.input_shape = [128, 64, 768]
+        self.batch_size = 1
+        self.trt_precision = AnalysisConfig.Precision.Half
+        self.min_input_shape = [1, 1, 1]
+        self.atol = 1e-1
+        self.rtol = 1e-5
 
 
-class SkipLayernormFusePassTest3(InferencePassTest):
-    def setUp(self):
-        with base.program_guard(self.main_program, self.startup_program):
-            data1 = paddle.static.data(
-                name="data1", shape=[-1, 128, 128], dtype="float32"
-            )
-            data2 = paddle.static.data(
-                name="data2", shape=[-1, 128, 128], dtype="float32"
-            )
-            eltwise_out = self.append_eltwise(data1, data2)
-
-            out = paddle.nn.functional.layer_norm(
-                eltwise_out, eltwise_out.shape[1:]
-            )
-
-        self.feeds = {
-            "data1": np.random.random([1, 128, 128]).astype("float32"),
-            "data2": np.random.random([1, 128, 128]).astype("float32"),
-        }
-        self.enable_trt = True
-        self.trt_parameters = SkipLayernormFusePassTest3.TensorRTParam(
-            1 << 30, 32, 0, AnalysisConfig.Precision.Half, True, False
-        )
-        self.dynamic_shape_params = (
-            SkipLayernormFusePassTest3.DynamicShapeParam(
-                {'data1': [1, 1, 1], 'data2': [1, 1, 1]},
-                {'data1': [1, 128, 128], 'data2': [1, 128, 128]},
-                {'data1': [1, 128, 128], 'data2': [1, 128, 128]},
-                False,
-            )
-        )
-        self.fetch_list = [out]
-
-    def append_eltwise(self, data1, data2):
-        return paddle.add(data1, data2)
-
-    def test_check_output(self):
-        opt_path = os.path.join(self.path, '_opt_cache')
-        if os.path.exists(opt_path):
-            shutil.rmtree(opt_path)
-        if core.is_compiled_with_cuda():
-            use_gpu = True
-            self.check_output_with_option(use_gpu, atol=0.1, rtol=0.00001)
-            self.assertTrue(
-                PassVersionChecker.IsCompatible('tensorrt_subgraph_pass')
-            )
+class SkipLayernormFusePassTest3(SkipLayernormFusePassTest):
+    def set_args(self):
+        self.input_shape = [128, 256]
+        self.batch_size = 1
+        self.trt_precision = AnalysisConfig.Precision.Half
+        self.min_input_shape = [1, 1]
+        self.atol = 1e-1
+        self.rtol = 1e-5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
The relevant test cannot cover the functionality of IR pass `trt_skip_layernorm_fuse_pass`.
This MR fixed this issue and refactored the code of UT.