### PR TITLE
【CINN】Add SamplePerfectTile, SampleCategorical schedule primitive for dynamic shape

### DIFF
--- a/paddle/cinn/ir/schedule/impl/base.cc
+++ b/paddle/cinn/ir/schedule/impl/base.cc
@@ -270,7 +270,13 @@ Expr DyScheduleImpl::SampleCategorical(
     utils::LinearRandomEngine::StateType* rand_seed,
     const std::vector<int>& candidates,
     const std::vector<float>& probs) {
-  CINN_NOT_IMPLEMENTED;
+  // check two sizes
+  CHECK_EQ(candidates.size(), probs.size())
+      << "candidates and probs must have same size.";
+  int seed_idx = utils::SampleDiscreteFromDistribution(probs, rand_seed);
+  auto result = candidates[seed_idx];
+  Expr result_expr(result);
+  return result_expr;
 }
 
 std::vector<Expr> DyScheduleImpl::SamplePerfectTile(
@@ -278,7 +284,30 @@ std::vector<Expr> DyScheduleImpl::SamplePerfectTile(
     const Expr& loop,
     int n,
     int max_innermost_factor) {
-  CINN_NOT_IMPLEMENTED;
+  CHECK(loop.As<ir::For>())
+      << "Expr param of SamplePerfectTile should be a For loop";
+  CHECK_GE(n, 2) << "The number of tile factors should be at least 2";
+  CHECK_GE(max_innermost_factor, 1)
+      << "The max innermost factor should be at least 1";
+  CHECK(cinn::common::is_zero(loop.As<ir::For>()->min))
+      << "The For loop should start from 0";
+  int loop_extent = GetLoopExtent(loop);
+  std::vector<int> innermost_factors;
+  for (int i = max_innermost_factor; i >= 1; --i) {
+    if (loop_extent % i == 0) {
+      innermost_factors.push_back(i);
+    }
+  }
+  CHECK(!innermost_factors.empty()) << "No innermost factor found";
+  int innermost_factor = innermost_factors[utils::SampleUniformInt(
+      0, innermost_factors.size(), rand_seed)];
+  auto result = SampleTile(rand_seed, n - 1, loop_extent / innermost_factor);
+  std::vector<Expr> result_expr;
+  for (auto& factor : result) {
+    result_expr.push_back(Expr(factor));
+  }
+  result_expr.push_back(Expr(innermost_factor));
+  return result_expr;
 }
 
 Expr DyScheduleImpl::AddUnitLoop(const Expr& block) const {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR Add SamplePerfectTile, SampleCategorical schedule primitive for dynamic shape