### PR TITLE
[PIR] delete conv kernel get_kerneltype_forvar_fn_

### DIFF
--- a/paddle/phi/kernels/onednn/conv_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_kernel.cc
@@ -36,7 +36,7 @@ void ConvKernel(const Context& dev_ctx,
   auto desc = input.mem_desc();
   auto input_local = input;
   if (data_format == "NHWC" && desc.get_dims().size() == 4 &&
-      desc == dnnl::memory::desc(desc.get_dims(),
+      desc != dnnl::memory::desc(desc.get_dims(),
                                  desc.get_data_type(),
                                  dnnl::memory::format_tag::nhwc)) {
     std::vector<int64_t> dims = desc.get_dims();
@@ -45,7 +45,7 @@ void ConvKernel(const Context& dev_ctx,
         dims, desc.get_data_type(), dnnl::memory::format_tag::nhwc));
     phi::OneDNNContext::tls().set_cur_paddle_data_layout(DataLayout::kNHWC);
   } else if (data_format == "NDHWC" && desc.get_dims().size() == 5 &&
-             desc == dnnl::memory::desc(desc.get_dims(),
+             desc != dnnl::memory::desc(desc.get_dims(),
                                         desc.get_data_type(),
                                         dnnl::memory::format_tag::nhwc)) {
     std::vector<int64_t> dims = desc.get_dims();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
尝试删除MKLDNN kernel中的get_kerneltype_forvar_fn_。框架默认按NCHW转换成OneDNN。如果Tensor实际是NHWC则重新计算dims。

Pcard-67164