### PR TITLE
【PIR API adaptor No.192、308】 Migrate searchsorted, tensordot into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4723,7 +4723,9 @@ def tensordot(x, y, axes=2, name=None):
 
     check_variable_and_dtype(x, 'x', input_dtype, op_type)
     check_variable_and_dtype(y, 'y', input_dtype, op_type)
-    check_type(axes, 'axes', (int, tuple, list, Variable), op_type)
+    check_type(
+        axes, 'axes', (int, tuple, list, Variable, paddle.pir.Value), op_type
+    )
 
     def _var_to_list(var):
         if in_dynamic_mode():

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -1136,7 +1136,7 @@ def searchsorted(
              [1, 3, 4, 5]])
 
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.searchsorted(sorted_sequence, values, out_int32, right)
     else:
         check_variable_and_dtype(

--- a/test/legacy_test/test_searchsorted_op.py
+++ b/test/legacy_test/test_searchsorted_op.py
@@ -19,6 +19,7 @@ from op_test import OpTest
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -42,7 +43,7 @@ class TestSearchSorted(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def init_test_case(self):
         self.sorted_sequence = np.array([1, 3, 5, 7, 9]).astype("float32")
@@ -102,6 +103,7 @@ class TestSearchSortedAPI(unittest.TestCase):
         if core.is_compiled_with_cuda():
             self.place.append(paddle.CUDAPlace(0))
 
+    @test_with_pir_api
     def test_static_api(self):
         paddle.enable_static()
 
@@ -154,6 +156,7 @@ class TestSearchSortedAPI(unittest.TestCase):
 
 
 class TestSearchSortedError(unittest.TestCase):
+    @test_with_pir_api
     def test_error_api(self):
         paddle.enable_static()
 
@@ -201,6 +204,7 @@ class TestSearchSortedError(unittest.TestCase):
             RuntimeError, test_searchsorted_sortedsequence_size_error
         )
 
+    def test_check_type_error(self):
         def test_sortedsequence_values_type_error():
             with paddle.static.program_guard(paddle.static.Program()):
                 sorted_sequence = paddle.static.data(

--- a/test/legacy_test/test_tensordot.py
+++ b/test/legacy_test/test_tensordot.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(2021)
 
@@ -205,6 +206,7 @@ class TestTensordotAPI(unittest.TestCase):
                 np_res = tensordot_np(self.x, self.y, axes)
                 np.testing.assert_allclose(paddle_res, np_res, rtol=1e-6)
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         for axes in self.all_axes:
@@ -226,6 +228,7 @@ class TestTensordotAPI(unittest.TestCase):
                     np_res = tensordot_np(self.x, self.y, axes)
                     np.testing.assert_allclose(paddle_res[0], np_res, rtol=1e-6)
 
+    @test_with_pir_api
     def test_fp16_with_gpu(self):
         paddle.enable_static()
         if paddle.base.core.is_compiled_with_cuda():


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
任务 issue: https://github.com/PaddlePaddle/Paddle/issues/58067

**PIR API 推全升级**
1. 将 `paddle.searchsorted` 迁移升级至 pir，并更新单测，单测覆盖率（8/9）
test/legacy_test/test_searchsorted_op.py 文件下的 TestSearchSortedError.test_check_type_error 单测未适配，因为暂不支持，在 c++ 侧检查数据类型抛出的错误是 ValueError

2. 将 `paddle.tensor.tensordot` 迁移升级至 pir，并更新单测，单测覆盖率（9/10）
test/legacy_test/test_zero_dim_tensor.py 文件下的 TestSundryAPIStatic.test_tensordot 单测未适配，因为当前在 pir 模式下不支持 paddle.static.append_backward
