### PR TITLE
[PIR] if_op support the not-same shape between true&false block.

### DIFF
--- a/paddle/common/ddim.cc
+++ b/paddle/common/ddim.cc
@@ -265,6 +265,22 @@ DDim DDim::transpose(const std::vector<int>& axis) const {
   return out_dims;
 }
 
+DDim ComputeCompatibleDim(const DDim& dim1, const DDim& dim2) {
+  IR_ENFORCE(dim1.size() == dim2.size(),
+             "Does not support rank inconsistency: dim1=%d, dim2=%d",
+             dim1.size(),
+             dim2.size());
+  std::vector<int64_t> result;
+  for (int i = 0; i < dim1.size(); ++i) {
+    if (dim1[i] != dim2[i]) {
+      result.push_back(-1);
+    } else {
+      result.push_back(dim1[i]);
+    }
+  }
+  return make_ddim(result);
+}
+
 }  // namespace common
 
 namespace std {

--- a/paddle/common/ddim.h
+++ b/paddle/common/ddim.h
@@ -233,6 +233,9 @@ TEST_API DDim flatten_to_1d(const DDim& src);
 TEST_API DDim stride(const DDim& ddim);
 
 TEST_API DDim stride_numel(const DDim& ddim);
+
+TEST_API DDim ComputeCompatibleDim(const DDim& dim1, const DDim& dim2);
+
 }  // namespace common
 
 namespace pir {

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "paddle/common/ddim.h"
 #include "paddle/common/enforce.h"
 #include "paddle/fluid/distributed/auto_parallel/dist_attr.h"
 #include "paddle/fluid/framework/op_desc.h"
@@ -1892,23 +1893,6 @@ struct FillConstantTranscriber : public OpTranscriber {
   }
 };
 
-static std::vector<int64_t> ParseCompatibleShapes(
-    const std::vector<int64_t>& dim1, const std::vector<int64_t>& dim2) {
-  IR_ENFORCE(dim1.size() == dim2.size(),
-             "Does not support rank inconsistency: dim1=%d, dim2=%d",
-             dim1.size(),
-             dim2.size());
-  std::vector<int64_t> result;
-  for (size_t i = 0; i < dim1.size(); ++i) {
-    if (dim1[i] != dim2[i]) {
-      result.push_back(-1);
-    } else {
-      result.push_back(dim1[i]);
-    }
-  }
-  return result;
-}
-
 struct SelectInputOpTranscriber : public OpTranscriber {
   pir::Operation* operator()(pir::IrContext* ctx,
                              TranslationContext* param_map,
@@ -1970,12 +1954,11 @@ struct SelectInputOpTranscriber : public OpTranscriber {
       }
       auto dim1 = input1.dyn_cast<paddle::dialect::DenseTensorType>().dims();
       auto dim2 = input2.dyn_cast<paddle::dialect::DenseTensorType>().dims();
-      std::vector<int64_t> compat_shape = ParseCompatibleShapes(
-          common::vectorize(dim1), common::vectorize(dim2));
+      auto dim = common::ComputeCompatibleDim(dim1, dim2);
       op_output_types.push_back(
           paddle::dialect::DenseTensorType::get(ctx,
                                                 tensor1.dtype(),
-                                                common::make_ddim(compat_shape),
+                                                dim,
                                                 tensor1.data_layout(),
                                                 tensor1.lod(),
                                                 tensor1.offset()));

--- a/paddle/pir/core/op_base.h
+++ b/paddle/pir/core/op_base.h
@@ -68,6 +68,11 @@ class IR_API OpBase {
 
   OpResult result(uint32_t index) const { return operation()->result(index); }
 
+  template <typename T = Type>
+  T result_type(uint32_t index) const {
+    return operation()->result_type<T>(index);
+  }
+
   void VerifySig() {}
 
   void VerifyRegion() {}

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -89,7 +89,10 @@ class IR_API alignas(8) Operation final
   ///
   uint32_t num_results() const { return num_results_; }
   OpResult result(uint32_t index) const { return op_result_impl(index); }
-  Type result_type(uint32_t index) const { return result(index).type(); }
+  template <typename T = Type>
+  T result_type(uint32_t index) const {
+    return result(index).type().dyn_cast<T>();
+  }
   std::vector<OpResult> results();
 
   ///

--- a/paddle/pir/core/type.h
+++ b/paddle/pir/core/type.h
@@ -115,6 +115,8 @@ class IR_API Type {
     return pir::cast<U>(*this);
   }
 
+  static Type dyn_cast_impl(Type type) { return type; }
+
   ///
   /// \brief Return true if this is an integer (any signedness) or an index
   /// type.

--- a/test/cpp/pir/control_flow_dialect/if_op_test.cc
+++ b/test/cpp/pir/control_flow_dialect/if_op_test.cc
@@ -91,7 +91,7 @@ TEST(if_op_test, build_by_block) {
   std::unique_ptr<pir::Block> false_block(new pir::Block());
   builder.SetInsertionPointToStart(false_block.get());
   auto full_op_2 = builder.Build<paddle::dialect::FullOp>(
-      std::vector<int64_t>{2}, true, phi::DataType::BOOL);
+      std::vector<int64_t>{3}, true, phi::DataType::BOOL);
   builder.Build<pir::YieldOp>(std::vector<pir::Value>{full_op_2.out()});
 
   builder.SetInsertionPointToBlockEnd(block);
@@ -112,6 +112,10 @@ TEST(if_op_test, build_by_block) {
   EXPECT_EQ(vec.size(), 2u);
   EXPECT_EQ(vec[0], &if_op.true_block());
   EXPECT_EQ(vec[1], &if_op.false_block());
+  EXPECT_EQ(if_op.num_results(), 1u);
+  auto type = if_op.result_type(0).dyn_cast<DenseTensorType>();
+  EXPECT_TRUE(type);
+  EXPECT_EQ(type.dims(), common::DDim{-1});
 }
 
 TEST(if_op_test, network_with_backward) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
if算子在构建时，支持true_block和false_block返回值的shape不一致的情景。
### Other
Pcard-67164