### PR TITLE
[AutoParallel] add dist_concat and dist_unsqueeze2

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/concat.cc
+++ b/paddle/phi/infermeta/spmd_rules/concat.cc
@@ -102,7 +102,7 @@ SpmdInfo ConcatInferSpmdReverse(const std::vector<DistMetaTensor>& x,
                                 const DistMetaTensor& output,
                                 int axis) {
   auto out_dist_attr = output.dist_attr();
-  out_dist_attr = UnShardTensorDim(out_dist_attr, axis);
+  out_dist_attr = UnShardTensorDims(out_dist_attr, {axis});
   auto n_inputs = x.size();
   TensorDistAttr input_attr = CopyTensorDistAttrForOutput(out_dist_attr);
   const auto& input_dim_mapping = out_dist_attr.dims_mapping();

--- a/paddle/phi/infermeta/spmd_rules/rules.h
+++ b/paddle/phi/infermeta/spmd_rules/rules.h
@@ -102,6 +102,10 @@ PD_REGISTER_SPMD_RULE(
     unsqueeze,
     PD_INFER_SPMD(phi::distributed::UnsqueezeInferSpmd),
     PD_INFER_SPMD(phi::distributed::UnsqueezeInferSpmdReverse));
+PD_REGISTER_SPMD_RULE(
+    unsqueeze2,
+    PD_INFER_SPMD(phi::distributed::UnsqueezeInferSpmd),
+    PD_INFER_SPMD(phi::distributed::UnsqueezeInferSpmdReverse));
 
 // elementwise unary rule
 PD_REGISTER_SPMD_RULE(

--- a/paddle/phi/infermeta/spmd_rules/unsqueeze.cc
+++ b/paddle/phi/infermeta/spmd_rules/unsqueeze.cc
@@ -224,7 +224,8 @@ SpmdInfo UnsqueezeInferSpmdReverse(const DistMetaTensor& x,
           << "dims_mapping_dst: [" << str_join(dims_mapping_vec[0]) << "]";
   VLOG(4) << "X dims_mapping: [" << str_join(dims_mapping_vec[1]) << "]\n\n";
 
-  return {{x_dist_attr}, {out_dist_attr_dst}};
+  return {{x_dist_attr},
+          {out_dist_attr_dst, CreateUnsqueezeXshape(x_dist_attr)}};
 }
 
 SpmdInfo UnsqueezeGradInferSpmd(const DistMetaTensor& xshape,

--- a/paddle/phi/infermeta/spmd_rules/utils.cc
+++ b/paddle/phi/infermeta/spmd_rules/utils.cc
@@ -178,6 +178,8 @@ TensorDistAttr ReplicateTensorDim(const TensorDistAttr& dist_attr, int dim) {
 TensorDistAttr UnShardTensorDim(const TensorDistAttr& dist_attr, int dim) {
   TensorDistAttr dst_dist_attr = CopyTensorDistAttrForOutput(dist_attr);
   std::vector<int64_t> dims_mapping = dist_attr.dims_mapping();
+  int64_t n_dim = dims_mapping.size();
+  dim = dim < 0 ? n_dim + dim : dim;
   dims_mapping[dim] = kReplicateDim;
   dst_dist_attr.set_dims_mapping(dims_mapping);
   return dst_dist_attr;

--- a/python/paddle/distributed/auto_parallel/static/completion.py
+++ b/python/paddle/distributed/auto_parallel/static/completion.py
@@ -173,6 +173,7 @@ def _can_apply_infer_spmd_rule(dist_op):
         "split",
         "unsqueeze2",
         "silu",
+        "concat",
     ]
     parallel_ce = os.getenv("PARALLEL_CROSS_ENTROPY")
     if parallel_ce == "true":

--- a/python/paddle/distributed/auto_parallel/static/operators/__init__.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/__init__.py
@@ -37,6 +37,8 @@ from . import (  # noqa: F401
     dist_split,
     dist_transpose,
     dist_update_loss_scaling,
+    dist_concat,
+    dist_unsqueeze2,
 )
 from .common import (  # noqa: F401
     DistributedOperatorImpl,

--- a/python/paddle/distributed/auto_parallel/static/operators/common.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/common.py
@@ -15,6 +15,7 @@
 import abc
 import logging
 
+import paddle
 from paddle.base.log_helper import get_logger
 from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY, OpRole
 
@@ -685,20 +686,30 @@ def is_in_backward_phase(dist_ctx):
 
 
 def merge_forward_backward_dims_mapping(fw_results, bw_results):
-    ninputs = len(fw_results[0])
-    noutputs = len(fw_results[1])
+    flatten_fw_inputs = paddle.utils.flatten(fw_results[0])
+    flatten_fw_outputs = paddle.utils.flatten(fw_results[1])
+    flatten_bw_inputs = paddle.utils.flatten(bw_results[0])
+    flatten_bw_outputs = paddle.utils.flatten(bw_results[1])
+    ninputs = len(flatten_fw_inputs)
+    noutputs = len(flatten_fw_outputs)
     infered_input_dims_mappings = []
     infered_output_dims_mappings = []
 
     for i in range(ninputs):
         compatible_dims_mapping = compute_compatible_dims_mapping(
-            [fw_results[0][i].dims_mapping, bw_results[0][i].dims_mapping]
+            [
+                flatten_fw_inputs[i].dims_mapping,
+                flatten_bw_inputs[i].dims_mapping,
+            ]
         )
         infered_input_dims_mappings.append(compatible_dims_mapping)
 
     for i in range(noutputs):
         compatible_dims_mapping = compute_compatible_dims_mapping(
-            [fw_results[1][i].dims_mapping, bw_results[1][i].dims_mapping]
+            [
+                flatten_fw_outputs[i].dims_mapping,
+                flatten_bw_outputs[i].dims_mapping,
+            ]
         )
         infered_output_dims_mappings.append(compatible_dims_mapping)
     return infered_input_dims_mappings, infered_output_dims_mappings

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_concat.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_concat.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from ..completion import get_phi_spmd_rule
+from ..utils import get_dist_tensor_spec
+from .common import (
+    DistributedOperatorImplContainer,
+    get_default_distributed_operator_impl,
+    register_distributed_operator_impl_container,
+    update_op_dims_mapping,
+)
+
+
+class DistributedConcat(DistributedOperatorImplContainer):
+    def __init__(self, op_type):
+        super().__init__(op_type)
+
+    @staticmethod
+    def update_dims_mapping(dist_op):
+        # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
+        op_desc = dist_op.serial_op.desc
+
+        axis_tensor = op_desc.input('AxisTensor')
+        assert (
+            len(axis_tensor) == 0
+        ), "Please use axis attr instead of AxisTensor"
+
+        input_arg_names = op_desc.input_arg_names()
+        output_arg_names = op_desc.output_arg_names()
+        axis = op_desc.attr('axis')
+
+        input_specs = []
+        for name in input_arg_names:
+            input_specs.append(get_dist_tensor_spec(dist_op, name))
+        output_sepc = get_dist_tensor_spec(dist_op, output_arg_names[0], False)
+
+        # step2: infer spmd
+        rule = get_phi_spmd_rule("concat")
+        # tensor order following order in PHI defition
+        fw_results = rule.infer_forward(input_specs, axis)
+        bw_results = rule.infer_backward(input_specs, output_sepc, axis)
+
+        # step3: update dist_attr
+        # tensor order following order in PHI defition
+        changed = update_op_dims_mapping(
+            dist_op,
+            input_arg_names,
+            output_arg_names,
+            fw_results,
+            bw_results,
+        )
+
+        return changed
+
+    @staticmethod
+    def mapping_to_dist_operator_impl(dist_op, original_op_dist_attr):
+        op_dist_attr = dist_op.dist_attr
+        default_impl = get_default_distributed_operator_impl()
+        op_dist_attr.impl_type = default_impl.type
+        op_dist_attr.impl_idx = default_impl.idx
+
+        return False
+
+
+register_distributed_operator_impl_container(DistributedConcat("concat"))

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_unsqueeze2.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_unsqueeze2.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from ..completion import get_phi_spmd_rule
+from ..utils import get_dist_tensor_spec
+from .common import (
+    DistributedOperatorImplContainer,
+    get_default_distributed_operator_impl,
+    register_distributed_operator_impl_container,
+    update_op_dims_mapping,
+)
+
+
+class DistributedUnSqueeze2(DistributedOperatorImplContainer):
+    def __init__(self, op_type):
+        super().__init__(op_type)
+
+    @staticmethod
+    def update_dims_mapping(dist_op):
+        # step1: prepare inputs need for rule (order args as PHI definition and filter out unnecessary args)
+        op_desc = dist_op.serial_op.desc
+
+        axes_tensor = op_desc.input('AxesTensor')
+        axes_tensor_list = op_desc.input('AxesTensorList')
+        assert len(axes_tensor) == 0 and len(axes_tensor_list) == 0
+
+        x_name = op_desc.input('X')[0]
+        out_name = op_desc.output('Out')[0]
+        xshape_name = op_desc.output('XShape')[0]
+        axes = op_desc.attr('axes')
+
+        input_spec = get_dist_tensor_spec(dist_op, x_name)
+        output_spec = get_dist_tensor_spec(dist_op, out_name, False)
+
+        # step2: infer spmd
+        rule = get_phi_spmd_rule("unsqueeze2")
+        # tensor order following order in PHI defition
+        fw_results = rule.infer_forward(input_spec, axes)
+        bw_results = rule.infer_backward(input_spec, output_spec, axes)
+
+        # step3: update dist_attr
+        # tensor order following order in PHI defition
+        changed = update_op_dims_mapping(
+            dist_op,
+            [x_name],
+            [out_name, xshape_name],
+            fw_results,
+            bw_results,
+        )
+
+        return changed
+
+    @staticmethod
+    def mapping_to_dist_operator_impl(dist_op, original_op_dist_attr):
+        op_dist_attr = dist_op.dist_attr
+        default_impl = get_default_distributed_operator_impl()
+        op_dist_attr.impl_type = default_impl.type
+        op_dist_attr.impl_idx = default_impl.idx
+
+        return False
+
+
+register_distributed_operator_impl_container(
+    DistributedUnSqueeze2("unsqueeze2")
+)

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -274,6 +274,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
   py_test_modules(test_auto_conditional_block MODULES
                   test_auto_conditional_block)
   py_test_modules(test_strategy_api MODULES test_strategy_api)
+  py_test_modules(test_dist_concat MODULES test_dist_concat)
   # End of unittests WITH single card WITHOUT timeout
 
 endif()

--- a/test/auto_parallel/spmd_rules/test_concat_rule.py
+++ b/test/auto_parallel/spmd_rules/test_concat_rule.py
@@ -41,10 +41,29 @@ class TestConcatSPMDRule(unittest.TestCase):
             inputs.append(DistTensorSpec(shape, tensor_dist_attr))
         return inputs
 
+    def build_outputs(self):
+        tensor_dist_attr = TensorDistAttr()
+        tensor_dist_attr.dims_mapping = [-1, 1, 0]
+        tensor_dist_attr.process_mesh = self.process_mesh
+        return DistTensorSpec([4, 16, 16], tensor_dist_attr)
+
     def test_infer_forward(self):
         inputs = self.build_inputs()
         rule = core.get_phi_spmd_rule("concat")
         infered_dist_attrs = rule.infer_forward(inputs, 0)
+        infered_input_dist_attrs = infered_dist_attrs[0]
+        self.assertEqual(len(infered_input_dist_attrs), 1)
+        infered_output_dist_attrs = infered_dist_attrs[1]
+        self.assertEqual(len(infered_output_dist_attrs), 1)
+        for input_dist_attr in infered_input_dist_attrs[0]:
+            self.assertEqual(input_dist_attr.dims_mapping, [-1, 1, 0])
+        self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
+
+    def test_infer_backward(self):
+        inputs = self.build_inputs()
+        output = self.build_outputs()
+        rule = core.get_phi_spmd_rule("concat")
+        infered_dist_attrs = rule.infer_backward(inputs, output, 0)
         infered_input_dist_attrs = infered_dist_attrs[0]
         self.assertEqual(len(infered_input_dist_attrs), 1)
         infered_output_dist_attrs = infered_dist_attrs[1]

--- a/test/auto_parallel/spmd_rules/test_unsqueeze_rule.py
+++ b/test/auto_parallel/spmd_rules/test_unsqueeze_rule.py
@@ -191,7 +191,7 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         infered_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(infered_output_dist_attrs), 2)
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, 1])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 0, 1])
 
@@ -261,7 +261,7 @@ class TestUnsqueezeSPMDRule(unittest.TestCase):
         infered_output_dist_attrs = result_dist_attrs[1]
 
         self.assertEqual(len(infered_input_dist_attrs), 1)
-        self.assertEqual(len(infered_output_dist_attrs), 1)
+        self.assertEqual(len(infered_output_dist_attrs), 2)
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [1, 0])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, 1, 0])
 

--- a/test/auto_parallel/test_dist_concat.py
+++ b/test/auto_parallel/test_dist_concat.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.distributed.fleet import auto
+
+paddle.enable_static()
+
+
+def make_program():
+    main_program = paddle.base.Program()
+    start_program = paddle.base.Program()
+    with paddle.static.program_guard(main_program, start_program):
+        x = paddle.static.data(name='x', shape=[4, 4, 8], dtype='float32')
+        y = paddle.static.data(name='y', shape=[4, 4, 8], dtype='float32')
+        x.stop_gradient = False
+        x.stop_gradient = False
+        auto.shard_tensor(
+            x, auto.ProcessMesh([0, 1], dim_names=["x"]), [None, "x", None]
+        )
+        auto.shard_tensor(
+            y, auto.ProcessMesh([0, 1], dim_names=["x"]), [None, "x", None]
+        )
+        res = paddle.concat([x, y], axis=-1)
+    return main_program, start_program
+
+
+def parallelizer(program_func, rank):
+    from paddle.distributed.auto_parallel.static.completion import Completer
+    from paddle.distributed.auto_parallel.static.dist_context import (
+        DistributedContext,
+    )
+    from paddle.distributed.auto_parallel.static.partitioner import Partitioner
+
+    main_program, start_program = program_func()
+
+    dist_context = DistributedContext()
+    completer = Completer(dist_context)
+    completer.complete_forward_annotation(main_program)
+    dist_context.block_state.parse_forward_blocks(main_program)
+
+    partitioner = Partitioner(dist_context, rank)
+    dist_main_prog, _, _ = partitioner.partition(
+        main_program, start_program, []
+    )
+
+    return dist_main_prog, dist_context
+
+
+class TestDistConcat(unittest.TestCase):
+    def test_dist_concat(self):
+        dist_main_prog, dist_context = parallelizer(make_program, 0)
+        ops = dist_main_prog.global_block().ops
+        concat_op = ops[0]
+        dist_op = dist_context.get_dist_op_for_program(concat_op)
+        assert dist_op.dist_attr.impl_type == "default"
+        assert dist_op.dist_attr.impl_idx == 0
+
+        out_name = concat_op.output_arg_names[0]
+        out_dims_mapping = dist_op.dist_attr.get_output_dims_mapping(out_name)
+        for in_name in concat_op.input_arg_names:
+            in_dims_mapping = dist_op.dist_attr.get_input_dims_mapping(in_name)
+            assert in_dims_mapping == out_dims_mapping
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- fix concat `ConcatInferSpmdReverse`
- fix unsqueeze `UnsqueezeInferSpmdReverse` 
- add dist_concat and dist_unsqueeze for static semi_auto
### Others
Pcard-76459