### PR TITLE
[AutoParallel] Optimize Reshard [part2: optimize _reshard_input]

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/reshard.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard.py
@@ -342,7 +342,9 @@ class Inserter:
             lod_level=tensor.lod_level,
         )
 
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
         cast_op = insert_operation(
             idx,
             type='cast',
@@ -361,7 +363,9 @@ class Inserter:
     def insert_send_op(block, idx, tensor, src, dst, op_role, sync=True):
         """Insert send op into block at the given index."""
         op_type = 'send_v2'
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
         # use pair comm group
         process_group = new_process_group([src, dst], group_type='p2p')
         send_op = insert_operation(
@@ -382,7 +386,9 @@ class Inserter:
     def insert_recv_op(block, idx, tensor, src, dst, op_role, sync=True):
         """Insert recv op into block at the given index."""
         op_type = 'recv_v2'
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
         # use pair group
         process_group = new_process_group([src, dst], group_type='p2p')
         recv_op = insert_operation(
@@ -409,7 +415,9 @@ class Inserter:
         new_var_name = paddle.utils.unique_name.generate_with_ignorable_key(
             ".".join(["reset_lod@RESHARD", 'tmp'])
         )
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
 
         reset_lod_out = block.create_var(
             name=new_var_name,
@@ -437,7 +445,9 @@ class Inserter:
         attrs['axis'] = axis
         attrs['op_role'] = op_role
 
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
         # to avoid name conflict with framework
         helper = LayerHelper('concat@RESHARD', **locals())
         with paddle.static.program_guard(block.program):
@@ -477,7 +487,9 @@ class Inserter:
         for index, item in enumerate(slice_shape):
             if item != global_shape[index]:
                 diff_dims.append(index)
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
 
         # use assign
         if len(diff_dims) == 0:
@@ -574,7 +586,9 @@ class Inserter:
         input_shape = tensor.shape
         inputs = {'X': tensor}
         attrs = {'num': num_or_sections, 'axis': axis, 'op_role': op_role}
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
 
         new_shape = []
         for index, item in enumerate(tensor.shape):
@@ -630,7 +644,9 @@ class Inserter:
             inputs=inputs, attrs=attrs, shape=shape, op_type='fill_constant'
         )
 
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
         fillconstant_op = insert_operation(
             idx,
             type='fill_constant',
@@ -655,7 +671,9 @@ class Inserter:
         op_type = 'c_allgather'
         # to avoid name conflict with framework
         helper = LayerHelper(op_type + "@RESHARD", **locals())
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
 
         with paddle.static.program_guard(block.program):
             allgather_out = block.create_var(
@@ -705,7 +723,9 @@ class Inserter:
         """Insert c_concat op into block at the given index."""
         group = new_process_group(ranks)
         idx_offset = 0
-        insert_operation = block._insert_op if sync else block._insert_op_without_sync
+        insert_operation = (
+            block._insert_op if sync else block._insert_op_without_sync
+        )
 
         # insert c_concat op
         op_type = 'c_concat'


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->


静态图模式下分析得，_reshard_input 中的 parse_op_desc 里面调用了很多 sync_with_cpp 消耗了较多的时间，耗时图如下所示：

<img width="1642" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/55493212/13f758f0-c52e-4151-a41b-8b683634909b">

经过分析可得，parse_op_desc 中 Insert 类的操作 如insert_c_concat_op、insert_slice_op、insert_concat_op等操作，每次插入op之前都会和cpp端进行同步，这是没有必要的，我们只需要在op插入完成之后做一次同步即可。经模型验证，该优化不会影响模型精度，模型精度可与优化前对齐。

本地测试优化后模型实际Run之前的耗时，优化幅度达 0.208 倍 （23.889 -> 18.928）。

测试环境：本地四卡 1080Ti机器，PaddleNLP Llama2 7b模型, 静态图模式（hack config: config.num_hidden_layers = 12）

优化前后 cprofiler 结果如下, `<-- !!!` 指向的是被优化的项：

```
优化前：
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   23.889   23.889 run_pretrain_auto.py:414(main) <-- !!!
        1    0.000    0.000   15.531   15.531 engine.py:1465(prepare)
        1    0.000    0.000   15.531   15.531 engine.py:562(_prepare_program)
        1    0.000    0.000    9.015    9.015 engine.py:762(_parallel)
        1    0.000    0.000    9.015    9.015 parallelizer_v2.py:65(parallel)
7795/6419    0.019    0.000    4.790    0.001 decorator.py:229(fun)
7795/6419    0.010    0.000    4.610    0.001 wrapped_decorator.py:23(__impl__)
        1    0.000    0.000    4.311    4.311 reshard.py:2797(reshard)
        1    0.033    0.033    4.184    4.184 reshard.py:2416(_reshard_input) <-- !!!
      261    0.388    0.001    3.974    0.015 reshard.py:1784(parse_op_desc)
        1    0.000    0.000    3.306    3.306 engine.py:575(_build)
        1    0.000    0.000    3.198    3.198 helper.py:222(build_program)
        3    0.000    0.000    3.125    1.042 program_translator.py:912(concrete_program)
        3    0.000    0.000    3.125    1.042 program_translator.py:942(concrete_program_specify_input_spec)
        3    0.000    0.000    3.125    1.042 program_translator.py:825(get_concrete_program)
        3    0.000    0.000    3.125    1.042 program_translator.py:1637(__getitem__)
        1    0.000    0.000    3.125    3.125 program_translator.py:1558(_build_once)
  264/151    0.001    0.000    3.032    0.020 base.py:66(__impl__)
        1    0.000    0.000    3.015    3.015 program_translator.py:1276(from_func_spec)
        1    0.000    0.000    3.013    3.013 parallel.py:943(init_parallel_env)
        6    3.012    0.502    3.012    0.502 {built-in method paddle.base.libpaddle.create_or_get_global_tcp_store}
      355    2.242    0.006    2.787    0.008 framework.py:4568(_sync_with_cpp) <-- !!!

优化后：
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   18.928   18.928 run_pretrain_auto.py:414(main) <-- !!!
        1    0.000    0.000   13.129   13.129 engine.py:1465(prepare)
        1    0.000    0.000   13.129   13.129 engine.py:562(_prepare_program)
        1    0.000    0.000    6.603    6.603 engine.py:762(_parallel)
        1    0.000    0.000    6.602    6.602 parallelizer_v2.py:65(parallel)
7795/6419    0.018    0.000    4.683    0.001 decorator.py:229(fun)
7795/6419    0.009    0.000    4.518    0.001 wrapped_decorator.py:23(__impl__)
        1    0.000    0.000    3.294    3.294 engine.py:575(_build)
        1    0.000    0.000    3.169    3.169 helper.py:222(build_program)
        3    0.000    0.000    3.101    1.034 program_translator.py:912(concrete_program)
        3    0.000    0.000    3.101    1.034 program_translator.py:942(concrete_program_specify_input_spec)
        3    0.000    0.000    3.101    1.034 program_translator.py:825(get_concrete_program)
        3    0.000    0.000    3.101    1.034 program_translator.py:1637(__getitem__)
        1    0.000    0.000    3.101    3.101 program_translator.py:1558(_build_once)
  264/151    0.001    0.000    2.984    0.020 base.py:66(__impl__)
        1    0.000    0.000    2.967    2.967 program_translator.py:1276(from_func_spec)
        2    0.000    0.000    2.826    1.413 executor.py:1565(run)
        2    0.000    0.000    2.826    1.413 executor.py:1744(_run_impl)
        2    0.000    0.000    2.814    1.407 executor.py:920(get_program_and_executor)
        1    0.000    0.000    2.733    2.733 ProxyLayer__trainoav3wtu6.py:9(_train)
        1    0.000    0.000    2.719    2.719 engine.py:1521(run)
        2    0.000    0.000    2.712    1.356 executor.py:942(_get_program_and_executor)
        5    0.000    0.000    2.412    0.482 pass_base.py:91(apply)
        5    0.000    0.000    2.411    0.482 pass_base.py:111(_apply_impl)
        1    0.036    0.036    1.891    1.891 reshard.py:2450(_reshard_input) <-- !!!
       25    0.001    0.000    1.664    0.067 creation.py:1298(arange)
       24    1.649    0.069    1.649    0.069 {built-in method paddle.base.libpaddle.pir.ops.arange}
      261    0.382    0.001    1.649    0.006 reshard.py:1804(parse_op_desc)
      ...
      132    0.294    0.002    0.520    0.004 framework.py:4567(_sync_with_cpp) <-- !!!
```



优化后的耗时可视化如下：

<img width="1339" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/55493212/706b90df-e853-412c-9c6c-2628ec702ac3">

脚本启动命令：

```bash
python -u -m paddle.distributed.launch \
    --gpus "0,1,2,3" \
    --log_dir "output/$task_name""_log" \
    auto_parallel/run_pretrain_auto.py \
    --model_type "llama" \
    --model_name_or_path "facebook/llama-7b" \
    --tokenizer_name_or_path "facebook/llama-7b" \
    --input_dir "./data" \
    --output_dir "output/$task_name" \
    --split 949,50,1 \
    --max_seq_length 2048 \
    --per_device_train_batch_size 1 \
    --per_device_eval_batch_size 4 \
    --gradient_accumulation_steps 16 \
    --fp16 1 \
    --fp16_opt_level "O2"  \
    --scale_loss 1024 \
    --pipeline_parallel_degree 2 \
    --tensor_parallel_degree 2 \
    --sharding_parallel_degree 1 \
    --sharding "stage1" \
    --learning_rate 0.0001 \
    --min_learning_rate 0.00001 \
    --max_steps 30 \
    --save_steps 5000 \
    --weight_decay 0.01 \
    --warmup_ratio 0.01 \
    --max_grad_norm 1.0 \
    --logging_steps 1\
    --dataloader_num_workers 1 \
    --sharding "" \
    --eval_steps 1000 \
    --report_to "visualdl" \
    --disable_tqdm true \
    --continue_training 0\
    --recompute 1 \
    --do_train 1 \
    --do_eval 0 \
    --device "gpu" \
    --data_impl "mmap" \
    --parallel_mode "auto" \
    --fuse_attention_qkv 1 \
    --fuse_attention_ffn 1 \
    --use_fused_rope 1 \
    --use_flash_attention 1
```
