### PR TITLE
[XPU] do not patch rpath for libxpuapi.so

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -734,15 +734,6 @@ if '${WITH_ONNXRUNTIME}' == 'ON':
         package_data['paddle.libs']+=['${PADDLE2ONNX_LIB_NAME}', '${ONNXRUNTIME_LIB_NAME}']
 
 if '${WITH_XPU}' == 'ON':
-    # only change rpath in Release mode,
-    if '${CMAKE_BUILD_TYPE}' == 'Release':
-        if os.name != 'nt':
-            if "@APPLE@" == "1":
-                command = "install_name_tool -id \"@loader_path/\" ${XPU_API_LIB}"
-            else:
-                command = "patchelf --set-rpath '$ORIGIN/' ${XPU_API_LIB}"
-            if os.system(command) != 0:
-                raise Exception("patch ${XPU_API_LIB} failed, command: %s" % command)
     shutil.copy('${XPU_API_LIB}', libs_path)
     package_data['paddle.libs']+=['${XPU_API_LIB_NAME}']
     xpu_rt_lib_list = glob.glob('${XPU_RT_LIB}*')

--- a/setup.py
+++ b/setup.py
@@ -1150,23 +1150,6 @@ def get_package_data_and_package_dir():
             ]
 
     if env_dict.get("WITH_XPU") == 'ON':
-        # only change rpath in Release mode,
-        if env_dict.get("CMAKE_BUILD_TYPE") == 'Release':
-            if os.name != 'nt':
-                if env_dict.get("APPLE") == "1":
-                    command = (
-                        "install_name_tool -id \"@loader_path/\" "
-                        + env_dict.get("XPU_API_LIB")
-                    )
-                else:
-                    command = "patchelf --set-rpath '$ORIGIN/' " + env_dict.get(
-                        "XPU_API_LIB"
-                    )
-                if os.system(command) != 0:
-                    raise Exception(
-                        'patch ' + env_dict.get("XPU_API_LIB") + 'failed ,',
-                        "command: %s" % command,
-                    )
         shutil.copy(env_dict.get("XPU_API_LIB"), libs_path)
         package_data['paddle.libs'] += [env_dict.get("XPU_API_LIB_NAME")]
         xpu_rt_lib_list = glob.glob(env_dict.get("XPU_RT_LIB") + '*')


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
删除与“修改`libxpuapi.so`的`rpath`”相关的脚本。

XPU的依赖库`libxpuapi.so`，自身的`rpath`信息为`$ORIGIN`，并且它所依赖的其它动态链接库，如`libxpurt.so`，和它本身在同一个目录中，因此不需要修改成`$ORIGIN/`。

此外，执行`patchelf`命令会导致该动态链接库本身的`md5sum`校验和发生变化，在某些情况下不便于排查这个二进制文件具体是什么版本。

因此本PR删除了相关的脚本。