### PR TITLE
【易用性提升.No33】修复paddle.cast_在cpu上连续使用导致结果错误的bug

### DIFF
--- a/paddle/phi/kernels/cpu/cast_impl.h
+++ b/paddle/phi/kernels/cpu/cast_impl.h
@@ -51,10 +51,11 @@ void CastInplaceKernelImpl(const CPUContext& dev_ctx,
                            const DenseTensor& x,
                            DataType out_dtype,
                            DenseTensor* out) {
-  auto x_origin = x;
-  auto* in_begin = x_origin.data<InT>();
-  auto numel = x_origin.numel();
+  auto numel = x.numel();
+  auto* in_begin = new InT[numel];
   auto* in_end = in_begin + numel;
+  auto* data_origin = x.data<InT>();
+  memcpy(in_begin, data_origin, sizeof(InT) * numel);
 
   auto* out_begin = dev_ctx.Alloc<OutT>(out);
   out->set_type(out_dtype);
@@ -65,6 +66,7 @@ void CastInplaceKernelImpl(const CPUContext& dev_ctx,
         in_end,
         out_begin,
         CastOpTransformFunctor<InT, OutT>());
+  delete[] in_begin;
 }
 
 }  // namespace phi

--- a/test/legacy_test/test_cast_op.py
+++ b/test/legacy_test/test_cast_op.py
@@ -284,6 +284,21 @@ class TestCastTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestCastInplaceContinuous(unittest.TestCase):
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0]])
+            target = x.cast("uint8")
+            x.cast_("uint8")
+            np.testing.assert_array_equal(target.numpy(), x.numpy())
+            target = x.cast("float32")
+            x.cast_("float32")
+            np.testing.assert_array_equal(target.numpy(), x.numpy())
+
+        run(paddle.CPUPlace())
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
比较in_begin和out_begin这两个指针的地址发现：in_begin和out_begin的地址相同，修改out_begin的同时也修改了in_begin导致结果错误
https://github.com/PaddlePaddle/Paddle/issues/55883
