### PR TITLE
[WIP]【PIR API adaptor No.183】Migrate python/paddle/nn/layer/rnn.py into pir

### DIFF
--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -24,7 +24,7 @@ from paddle.base.data_feeder import check_type, check_variable_and_dtype
 from paddle.base.dygraph.base import NON_PERSISTABLE_VAR_NAME_SUFFIX
 from paddle.base.framework import (
     default_startup_program,
-    in_dygraph_mode,
+    in_dynamic_or_pir_mode,
     program_guard,
 )
 from paddle.common_ops_import import Variable
@@ -106,7 +106,7 @@ def rnn(
 
     """
 
-    if in_dygraph_mode():
+    if in_dynamic_or_pir_mode():
         return _rnn_dynamic_graph(
             cell,
             inputs,
@@ -1590,7 +1590,7 @@ class RNNBase(LayerList):
         if not self.time_major:
             inputs = paddle.tensor.transpose(inputs, [1, 0, 2])
 
-        if in_dygraph_mode():
+        if in_dynamic_or_pir_mode():
             out, _, state = _C_ops.rnn(
                 inputs,
                 initial_states,
@@ -1604,29 +1604,6 @@ class RNNBase(LayerList):
                 self.num_layers,
                 self.mode,
                 0,
-                not self.training,
-            )
-        elif in_dynamic_mode():
-            _, _, out, state = _legacy_C_ops.rnn(
-                inputs,
-                initial_states,
-                self._all_weights,
-                sequence_length,
-                self._dropout_state,
-                self.state_components,
-                'dropout_prob',
-                self.dropout,
-                'is_bidirec',
-                self.num_directions == 2,
-                'input_size',
-                self.input_size,
-                'hidden_size',
-                self.hidden_size,
-                'num_layers',
-                self.num_layers,
-                'mode',
-                self.mode,
-                'is_test',
                 not self.training,
             )
         else:

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -39,7 +39,12 @@ from op import Operator
 from prim_op_test import OpTestUtils, PrimForwardChecker, PrimGradChecker
 from testsuite import append_input_output, append_loss_ops, create_op, set_input
 
-sys.path.append("..")
+# Add test/legacy and test to sys.path
+legacy_test_dir = pathlib.Path(__file__).parent  # test/legacy_test
+test_dir = legacy_test_dir.parent  # test
+sys.path.append(str(legacy_test_dir.absolute()))
+sys.path.append(str(test_dir.absolute()))
+
 from utils import static_guard
 from white_list import (
     check_shape_white_list,
@@ -65,8 +70,6 @@ from paddle.base.framework import (
     set_flags,
 )
 from paddle.base.wrapped_decorator import signature_safe_contextmanager
-
-sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
 
 @signature_safe_contextmanager

--- a/test/legacy_test/test_rnn_op.py
+++ b/test/legacy_test/test_rnn_op.py
@@ -168,7 +168,9 @@ class TestRNNOp(OpTest):
         }
 
     def test_output(self):
-        self.check_output(no_check_set=['Reserve', 'DropoutState'])
+        self.check_output(
+            no_check_set=['Reserve', 'DropoutState'], check_pir=True
+        )
 
     def set_attrs(self):
         pass
@@ -179,7 +181,9 @@ class TestRNNOp(OpTest):
             grad_check_list = ['Input', 'init_h', 'init_c']
             grad_check_list.extend(var_name_list)
             self.check_grad(
-                set(grad_check_list), ['Out', 'last_hidden', 'last_cell']
+                set(grad_check_list),
+                ['Out', 'last_hidden', 'last_cell'],
+                check_pir=True,
             )
 
     def test_grad_only_input(self):
@@ -188,7 +192,9 @@ class TestRNNOp(OpTest):
             grad_check_list = ['Input']
             grad_check_list.extend(var_name_list)
             self.check_grad(
-                set(grad_check_list), ['Out', 'last_hidden', 'last_cell']
+                set(grad_check_list),
+                ['Out', 'last_hidden', 'last_cell'],
+                check_pir=True,
             )
 
     def test_grad_only_h(self):
@@ -197,7 +203,9 @@ class TestRNNOp(OpTest):
             grad_check_list = ['init_h']
             grad_check_list.extend(var_name_list)
             self.check_grad(
-                set(grad_check_list), ['Out', 'last_hidden', 'last_cell']
+                set(grad_check_list),
+                ['Out', 'last_hidden', 'last_cell'],
+                check_pir=True,
             )
 
     def test_grad_only_c(self):
@@ -206,7 +214,9 @@ class TestRNNOp(OpTest):
             grad_check_list = ['init_c']
             grad_check_list.extend(var_name_list)
             self.check_grad(
-                set(grad_check_list), ['Out', 'last_hidden', 'last_cell']
+                set(grad_check_list),
+                ['Out', 'last_hidden', 'last_cell'],
+                check_pir=True,
             )
 
 

--- a/test/legacy_test/test_rnn_op.py
+++ b/test/legacy_test/test_rnn_op.py
@@ -15,6 +15,7 @@
 import random
 import sys
 import unittest
+from pathlib import Path
 
 import numpy as np
 from op_test import OpTest
@@ -22,7 +23,10 @@ from op_test import OpTest
 import paddle
 from paddle.base import core
 
-sys.path.append("../../test/rnn")
+# Add test/rnn to sys.path
+legacy_test_dir = Path(__file__).parent
+sys.path.append(str(legacy_test_dir.parent / "rnn"))
+
 from convert import get_params_for_net
 from rnn_numpy import LSTM
 
@@ -183,7 +187,7 @@ class TestRNNOp(OpTest):
             self.check_grad(
                 set(grad_check_list),
                 ['Out', 'last_hidden', 'last_cell'],
-                check_pir=True,
+                # check_pir=True,
             )
 
     def test_grad_only_input(self):
@@ -194,7 +198,7 @@ class TestRNNOp(OpTest):
             self.check_grad(
                 set(grad_check_list),
                 ['Out', 'last_hidden', 'last_cell'],
-                check_pir=True,
+                # check_pir=True,
             )
 
     def test_grad_only_h(self):
@@ -205,7 +209,7 @@ class TestRNNOp(OpTest):
             self.check_grad(
                 set(grad_check_list),
                 ['Out', 'last_hidden', 'last_cell'],
-                check_pir=True,
+                # check_pir=True,
             )
 
     def test_grad_only_c(self):
@@ -216,7 +220,7 @@ class TestRNNOp(OpTest):
             self.check_grad(
                 set(grad_check_list),
                 ['Out', 'last_hidden', 'last_cell'],
-                check_pir=True,
+                # check_pir=True,
             )
 
 

--- a/test/legacy_test/test_rnn_op.py
+++ b/test/legacy_test/test_rnn_op.py
@@ -49,7 +49,7 @@ def rnn_wrapper(
     seed=0,
     is_test=False,
 ):
-    dropout_state_in = paddle.Tensor()
+    dropout_state_in = paddle.tensor.fill_constant([], "float32", 0.0)
     return paddle._C_ops.rnn(
         Input,
         PreState,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级
将 python/paddle/nn/layer/rnn.py 迁移升级至 pir，并更新单测

- paddle.nn.GRU
- paddle.nn.LSTM
- paddle.nn.SimpleRNN

出现
![5C319D07A6B8D61486B8E8136732D6DB](https://github.com/PaddlePaddle/Paddle/assets/106524776/c0b96219-7841-44fe-9028-decb7d89c6e3)

未解决