### PR TITLE
【CMake opt No.14】 Remove redundat deps of sub_graph

### DIFF
--- a/test/cpp/pir/sub_graph/CMakeLists.txt
+++ b/test/cpp/pir/sub_graph/CMakeLists.txt
@@ -1,15 +1,6 @@
 if(WITH_TESTING AND WITH_CINN)
-  paddle_test(
-    test_sub_graph_checker
-    SRCS
-    sub_graph_checker_test.cc
-    DEPS
-    op_with_group_merge_pass
-    pir_transforms
-    cinn_op_dialect
-    pd_to_cinn_pass
-    add_broadcast_to_elementwise_pass
-    sub_graph_checker)
+  paddle_test(test_sub_graph_checker SRCS sub_graph_checker_test.cc DEPS
+              sub_graph_checker)
 
   set_tests_properties(test_sub_graph_checker PROPERTIES LABELS "RUN_TYPE=CINN")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
删除paddle_test多余无用依赖

No.14 删除sub_graph多余依赖
