### PR TITLE
Restrict numpy versions to<2.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 httpx
-numpy>=1.13
+numpy>=1.13, <2.0
 protobuf>=3.20.2 ; platform_system != "Windows"
 protobuf>=3.1.0, <=3.20.2 ; platform_system == "Windows"
 Pillow


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Restrict numpy versions to<2.0
Pcard-67012