### PR TITLE
【CMake opt No.15】Remove all `DEPS common` with paddle_test

### DIFF
--- a/test/cpp/auto_parallel/CMakeLists.txt
+++ b/test/cpp/auto_parallel/CMakeLists.txt
@@ -22,8 +22,7 @@ if(WITH_DISTRIBUTE)
     DEPS
     spmd_rule_test_util
     spmd_rules
-    phi
-    common)
+    phi)
   paddle_test(
     softmax_grad_spmd_rule_test
     SRCS

--- a/test/cpp/eager/performance_tests/CMakeLists.txt
+++ b/test/cpp/eager/performance_tests/CMakeLists.txt
@@ -16,15 +16,15 @@ if(NOT (NOT WITH_PYTHON AND ON_INFER))
     eager_prim_api)
 
   paddle_test(test_egr_performance_benchmark_eager_cpu SRCS
-              benchmark_eager_cpu.cc DEPS performance_benchmark_utils common)
+              benchmark_eager_cpu.cc DEPS performance_benchmark_utils)
   paddle_test(test_egr_performance_benchmark_fluid_cpu SRCS
-              benchmark_fluid_cpu.cc DEPS performance_benchmark_utils common)
+              benchmark_fluid_cpu.cc DEPS performance_benchmark_utils)
 
   if(WITH_GPU)
     paddle_test(test_egr_performance_benchmark_eager_cuda SRCS
-                benchmark_eager_cuda.cc DEPS performance_benchmark_utils common)
+                benchmark_eager_cuda.cc DEPS performance_benchmark_utils)
     paddle_test(test_egr_performance_benchmark_fluid_cuda SRCS
-                benchmark_fluid_cuda.cc DEPS performance_benchmark_utils common)
+                benchmark_fluid_cuda.cc DEPS performance_benchmark_utils)
   endif()
 
   if(WITH_ONNXRUNTIME AND WIN32)

--- a/test/cpp/fluid/CMakeLists.txt
+++ b/test/cpp/fluid/CMakeLists.txt
@@ -128,7 +128,6 @@ if(WITH_CINN)
     op_debug_string_test.cc
     DEPS
     executor
-    common
     fleet_executor
     recurrent_op_helper
     recurrent_op
@@ -136,7 +135,7 @@ if(WITH_CINN)
     ${COMMON_OP_DEPS}
     python)
 else()
-  paddle_test(op_debug_string_test SRCS op_debug_string_test.cc DEPS common)
+  paddle_test(op_debug_string_test SRCS op_debug_string_test.cc)
 endif()
 
 if(WITH_GPU)

--- a/test/cpp/fluid/cinn/CMakeLists.txt
+++ b/test/cpp/fluid/cinn/CMakeLists.txt
@@ -6,7 +6,6 @@ if(WITH_TESTING)
     DEPS
     fleet_executor
     phi
-    common
     lod_tensor
     scope
     proto_desc

--- a/test/cpp/fluid/framework/CMakeLists.txt
+++ b/test/cpp/fluid/framework/CMakeLists.txt
@@ -317,8 +317,7 @@ if(WITH_CINN)
     python)
   set_tests_properties(cinn_cache_key_test PROPERTIES LABELS "RUN_TYPE=CINN")
 
-  paddle_test(build_cinn_pass_test SRCS paddle2cinn/build_cinn_pass_test.cc
-              DEPS common)
+  paddle_test(build_cinn_pass_test SRCS paddle2cinn/build_cinn_pass_test.cc)
   set_tests_properties(build_cinn_pass_test PROPERTIES LABELS "RUN_TYPE=CINN")
   # target_link_libraries(build_cinn_pass_test ${PYTHON_LIBRARIES})
 

--- a/test/cpp/fluid/lite/CMakeLists.txt
+++ b/test/cpp/fluid/lite/CMakeLists.txt
@@ -1,4 +1,4 @@
-paddle_test(test_lite_engine_op SRCS lite_engine_op_test.cc DEPS common)
+paddle_test(test_lite_engine_op SRCS lite_engine_op_test.cc)
 
 if(WITH_ONNXRUNTIME AND WIN32)
   # Copy onnxruntime for some c++ test in Windows, since the test will

--- a/test/cpp/fluid/pscore/CMakeLists.txt
+++ b/test/cpp/fluid/pscore/CMakeLists.txt
@@ -51,25 +51,22 @@ endif()
 
 set_source_files_properties(
   heter_server_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-paddle_test(heter_server_test SRCS heter_server_test.cc DEPS common)
+paddle_test(heter_server_test SRCS heter_server_test.cc)
 
 set_source_files_properties(
   send_and_recv_op_cpu_test.cc PROPERTIES COMPILE_FLAGS
                                           ${DISTRIBUTE_COMPILE_FLAGS})
-paddle_test(send_and_recv_cpu_test SRCS send_and_recv_op_cpu_test.cc DEPS
-            common)
+paddle_test(send_and_recv_cpu_test SRCS send_and_recv_op_cpu_test.cc)
 
 set_source_files_properties(
   send_and_recv_op_gpu_test.cc PROPERTIES COMPILE_FLAGS
                                           ${DISTRIBUTE_COMPILE_FLAGS})
-paddle_test(send_and_recv_gpu_test SRCS send_and_recv_op_gpu_test.cc DEPS
-            common)
+paddle_test(send_and_recv_gpu_test SRCS send_and_recv_op_gpu_test.cc)
 
 set_source_files_properties(
   heter_listen_and_server_test.cc PROPERTIES COMPILE_FLAGS
                                              ${DISTRIBUTE_COMPILE_FLAGS})
-paddle_test(heter_listen_and_server_test SRCS heter_listen_and_server_test.cc
-            DEPS common)
+paddle_test(heter_listen_and_server_test SRCS heter_listen_and_server_test.cc)
 
 #set_source_files_properties(heter_cloud_comm_cpu_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
 #cc_test(heter_cloud_comm_cpu_test SRCS heter_cloud_comm_cpu_test.cc DEPS executor scope proto_desc generated_static_op heter_listen_and_serv_op ${RPC_DEPS} ${DISTRIBUTE_DEPS} phi common)

--- a/test/cpp/new_executor/CMakeLists.txt
+++ b/test/cpp/new_executor/CMakeLists.txt
@@ -1,8 +1,7 @@
 # skip win32 since wget is not installed by default on windows machine.
 
 if(NOT WIN32)
-  paddle_test(standalone_executor_pir_test SRCS standalone_executor_pir_test.cc
-              DEPS common)
+  paddle_test(standalone_executor_pir_test SRCS standalone_executor_pir_test.cc)
 endif()
 
 set(OPS

--- a/test/cpp/prim/CMakeLists.txt
+++ b/test/cpp/prim/CMakeLists.txt
@@ -16,7 +16,7 @@ set(prim_eager_deps
 set(prim_generated_deps final_dygraph_function final_dygraph_node
                         dygraph_function dygraph_node)
 
-paddle_test(test_comp_static SRCS test_static_prim.cc DEPS common)
+paddle_test(test_comp_static SRCS test_static_prim.cc)
 
 if(NOT (NOT WITH_PYTHON AND ON_INFER))
   if(WITH_CINN)
@@ -25,8 +25,7 @@ if(NOT (NOT WITH_PYTHON AND ON_INFER))
   cc_library(init_env_utils SRCS init_env_utils.cc)
   target_compile_definitions(init_env_utils PUBLIC PADDLE_DLL_EXPORT)
 
-  paddle_test(test_comp_eager SRCS test_eager_prim.cc DEPS init_env_utils
-              common)
+  paddle_test(test_comp_eager SRCS test_eager_prim.cc DEPS init_env_utils)
 endif()
 
 # skip win32 since wget is not installed by default on windows machine.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/60013

Remove all `DEPS common` with paddle_test

顺手把所有的common都删了，还有第一题的依赖没办法删除~