### PR TITLE
[PIR] Optimize the execution order strategy of the pir interpreter

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -125,7 +125,7 @@ PirInterpreter::PirInterpreter(const platform::Place& place,
     SchedulingPriority rhs_scheduling_priority =
         vec_instruction_base_[rhs]->GetSchedulingPriority();
     if (lhs_scheduling_priority == rhs_scheduling_priority) {
-      return lhs < rhs;
+      return lhs > rhs;
     }
     return lhs_scheduling_priority > rhs_scheduling_priority;
   };
@@ -187,7 +187,7 @@ PirInterpreter::PirInterpreter(
     SchedulingPriority rhs_scheduling_priority =
         vec_instruction_base_[rhs]->GetSchedulingPriority();
     if (lhs_scheduling_priority == rhs_scheduling_priority) {
-      return lhs < rhs;
+      return lhs > rhs;
     }
     return lhs_scheduling_priority > rhs_scheduling_priority;
   };

--- a/paddle/fluid/pir/transforms/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/inplace_pass.cc
@@ -95,6 +95,11 @@ static bool CanDoInplace(const std::unordered_set<pir::Value>& eager_dels,
       int64_t in_numel = 1;
       int64_t out_numel = 1;
       for (int i = 0; i < in.dims().size(); i++) {
+        if (in.dims()[i] == -1 && in.dims().size() == 1) {
+          VLOG(9) << "     -- input's shape has -1 and dim size is 1, can't "
+                     "do inplace";
+          return false;
+        }
         if (in.dims()[i] == -1 && i != 0) {
           VLOG(9) << "     -- input's shape has -1 and not in first dim, can't "
                      "do inplace";
@@ -104,6 +109,11 @@ static bool CanDoInplace(const std::unordered_set<pir::Value>& eager_dels,
       }
 
       for (int i = 0; i < out.dims().size(); i++) {
+        if (out.dims()[i] == -1 && out.dims().size() == 1) {
+          VLOG(9) << "     -- output's shape has -1 and dim size is 1, can't "
+                     "do inplace";
+          return false;
+        }
         if (out.dims()[i] == -1 && i != 0) {
           VLOG(9)
               << "     -- output's shape has -1 and not in first dim, can't "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Optimize the execution order strategy of the pir interpreter, which defaults to executing in the order of user networking
Pcard-67164