### PR TITLE
[PIR]Fix affine grid cudnn kernel in pir

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -159,11 +159,14 @@ static bool NeedFallBackFromGPUDNN2GPU(pir::Operation* op,
   } else if ((op->isa<AffineGridOp>() || op->isa<AffineGridGradOp>()) &&
              kernel_key.backend() == phi::Backend::GPUDNN) {
     bool use_cudnn = true;
-    if (platform::DnnVersion() >= 6000 &&
-        op->attributes()
-                .at("align_corners")
-                .dyn_cast<pir::BoolAttribute>()
-                .data() == true) {
+    int version = -1;
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+    version = platform::DnnVersion();
+#endif
+    if (version >= 6000 && op->attributes()
+                                   .at("align_corners")
+                                   .dyn_cast<pir::BoolAttribute>()
+                                   .data() == true) {
       use_cudnn = true;
     } else {
       use_cudnn = false;
@@ -173,7 +176,7 @@ static bool NeedFallBackFromGPUDNN2GPU(pir::Operation* op,
     if (shape[1] == 3) {
       use_cudnn = false;
     }
-#ifdef PADDLE_WITH_HIP
+#if defined(PADDLE_WITH_HIP)
     use_cudnn = false;
 #endif
     return !use_cudnn;

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -65,6 +65,18 @@ pir::Type ConvertOpTypeToKernelType(pir::IrContext* ctx,
       "Not support op type %s in ConvertOpTypeToKernelType.", op_type));
 }
 
+std::vector<int64_t> GetValueShape(const pir::Value& value) {
+  if (value.type().isa<DenseTensorType>()) {
+    return phi::vectorize(value.type().dyn_cast<DenseTensorType>().dims());
+  } else if (value.type().isa<SelectedRowsType>()) {
+    return phi::vectorize(value.type().dyn_cast<SelectedRowsType>().dims());
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "Currently, we can only get shape for dense "
+        "tensor."));
+  }
+}
+
 std::unordered_map<std::string, phi::DataType> Str2PhiDataType = {
     {"DataType::FLOAT16", phi::DataType::FLOAT16},
     {"DataType::BFLOAT16", phi::DataType::BFLOAT16},
@@ -144,7 +156,29 @@ static bool NeedFallBackFromGPUDNN2GPU(pir::Operation* op,
              .data() == true)) {
       return true;
     }
+  } else if ((op->isa<AffineGridOp>() || op->isa<AffineGridGradOp>()) &&
+             kernel_key.backend() == phi::Backend::GPUDNN) {
+    bool use_cudnn = true;
+    if (platform::DnnVersion() >= 6000 &&
+        op->attributes()
+                .at("align_corners")
+                .dyn_cast<pir::BoolAttribute>()
+                .data() == true) {
+      use_cudnn = true;
+    } else {
+      use_cudnn = false;
+    }
+
+    auto shape = GetValueShape(op->operand_source(0));
+    if (shape[1] == 3) {
+      use_cudnn = false;
+    }
+#ifdef PADDLE_WITH_HIP
+    use_cudnn = false;
+#endif
+    return !use_cudnn;
   }
+
   return false;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PIR]Fix affine grid cudnn kernel in pir
Pcard-67164
在PIR下affine_grid对于gpudnn kernel的选择，在pd_op_to_kernel_pass.cc中对齐了python端的逻辑
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/8c8d69fa-f16c-4b38-a20c-ed9f1fd208f1)
