### PR TITLE
【CMake opt No.11】Remove all DEPS op_with_group_merge_pass with paddle_test

### DIFF
--- a/test/cpp/pir/cinn/CMakeLists.txt
+++ b/test/cpp/pir/cinn/CMakeLists.txt
@@ -42,8 +42,7 @@ if(WITH_TESTING AND WITH_CINN)
     pir_transforms
     pir)
 
-  paddle_test(test_ir_op_fusion SRCS ir_op_fusion_test.cc DEPS cinn_op_dialect
-              pir)
+  paddle_test(test_ir_op_fusion SRCS ir_op_fusion_test.cc)
 
   paddle_test(
     test_pir_all_path

--- a/test/cpp/pir/cinn/CMakeLists.txt
+++ b/test/cpp/pir/cinn/CMakeLists.txt
@@ -42,21 +42,14 @@ if(WITH_TESTING AND WITH_CINN)
     pir_transforms
     pir)
 
-  paddle_test(
-    test_ir_op_fusion
-    SRCS
-    ir_op_fusion_test.cc
-    DEPS
-    op_with_group_merge_pass
-    cinn_op_dialect
-    pir)
+  paddle_test(test_ir_op_fusion SRCS ir_op_fusion_test.cc DEPS cinn_op_dialect
+              pir)
 
   paddle_test(
     test_pir_all_path
     SRCS
     pir_all_path_test.cc
     DEPS
-    op_with_group_merge_pass
     pir_transforms
     cinn_op_dialect
     pd_to_cinn_pass
@@ -69,7 +62,6 @@ if(WITH_TESTING AND WITH_CINN)
     DEPS
     pd_to_cinn_pass
     add_broadcast_to_elementwise_pass
-    op_with_group_merge_pass
     cinn_op_dialect
     pir_transforms)
 

--- a/test/cpp/pir/cinn/adt/CMakeLists.txt
+++ b/test/cpp/pir/cinn/adt/CMakeLists.txt
@@ -4,7 +4,6 @@ if(WITH_TESTING AND WITH_CINN)
     SRCS
     map_expr_test.cc
     DEPS
-    op_with_group_merge_pass
     op_dialect_vjp
     cinn_op_dialect
     pir)

--- a/test/cpp/pir/cinn/adt/CMakeLists.txt
+++ b/test/cpp/pir/cinn/adt/CMakeLists.txt
@@ -1,12 +1,5 @@
 if(WITH_TESTING AND WITH_CINN)
-  paddle_test(
-    map_expr_test
-    SRCS
-    map_expr_test.cc
-    DEPS
-    op_dialect_vjp
-    cinn_op_dialect
-    pir)
+  paddle_test(map_expr_test SRCS map_expr_test.cc)
   set_tests_properties(map_expr_test PROPERTIES LABELS "RUN_TYPE=CINN")
 
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/issues/60013

Remove all `DEPS op_with_group_merge_pass` with paddle_test