### PR TITLE
[PIR] Add c++ call stack for ir enforce

### DIFF
--- a/paddle/common/enforce.h
+++ b/paddle/common/enforce.h
@@ -173,6 +173,17 @@ inline bool is_error(const T& stat) {
 
 namespace pir {
 
+#ifdef __GNUC__
+inline std::string demangle(std::string name) {
+  int status = -4;  // some arbitrary value to eliminate the compiler warning
+  std::unique_ptr<char, void (*)(void*)> res{
+      abi::__cxa_demangle(name.c_str(), NULL, NULL, &status), std::free};
+  return (status == 0) ? res.get() : name;
+}
+#else
+inline std::string demangle(std::string name) { return name; }
+#endif
+
 static std::string GetCurrentTraceBackString() {
   std::ostringstream sout;
   sout << "\n\n--------------------------------------\n";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Add c++ call stack for ir enforce:
![image](https://github.com/PaddlePaddle/Paddle/assets/82555433/1bf6e253-5056-4aa4-95c5-6f96c7be3856)

Pcard-67164