### PR TITLE
rename_skip_quant

### DIFF
--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -277,7 +277,7 @@ class QuantizationTransformPass:
                 )
 
             if user_skipped:
-                op_node.op()._set_attr("skip_quant", True)
+                op_node.op()._set_attr("skip_quant_slim", True)
                 op_node.op()._set_attr("with_quant_attr", True)
 
         def _transform_forward(graph, op):
@@ -1056,8 +1056,8 @@ class QuantizationTransformPass:
         Analyse whether the op node skips quantization.
         """
         is_skip = False
-        if op_node.op().has_attr("skip_quant") and op_node.op().attr(
-            "skip_quant"
+        if op_node.op().has_attr("skip_quant_slim") and op_node.op().attr(
+            "skip_quant_slim"
         ):
             is_skip = True
         # if the inputs of mul and matmul are not all persistable, use
@@ -2524,7 +2524,7 @@ class QuantizationTransformPassV2(QuantizationTransformPass):
             )
 
         if user_skipped:
-            op_node.op()._set_attr("skip_quant", True)
+            op_node.op()._set_attr("skip_quant_slim", True)
             op_node.op()._set_attr("with_quant_attr", True)
 
     def _transform_forward(self, graph, op):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Description
<!-- Describe what you’ve done -->
将静态图属性“skip_quant”重新命名为“skip_quant_slim”，避免与inference执行pass时导致有该属性的计算节点无法进入trt子图。