### PR TITLE
[PIR] Add dtype transfer for multiply op

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_kerneltype_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_kerneltype_gen.py
@@ -36,8 +36,10 @@ OP_SKIP_TRANSFORM_CHECK_TEMPLATE = """
 
 OP_SUPPORT_TRANSFORM_CHECK_TEMPLATE = """
   // deal support data transform
-  VLOG(8) << "SUPPORT_TRANSFORM: " << \"{support_dtype_name};";
-  return tensor_dtype;
+  VLOG(8) << "SUPPORT_TRANSFORM";
+  if ({support_transform_check}){{
+    return tensor_dtype;
+  }}
 """
 
 OP_COMPLEX_PROMOTE_CHECK_TEMPLATE = """
@@ -65,10 +67,15 @@ def get_data_transform_check_str(op_data_transform_map):
                 )
         if "support_trans_dtype" in op_data_transform_map:
             args = op_data_transform_map["support_trans_dtype"]
-            # TODO:(chenxi) comlete SUPPORT logic
+            # TODO:(chenxi67) comlete SUPPORT logic
+            if args is not None:
+                if_cond_args = []
+                for support_arg in args:
+                    if_cond_args.append("var_name == \"" + support_arg + "\"")
             if args is not None:
                 support_trans_str = OP_SUPPORT_TRANSFORM_CHECK_TEMPLATE.format(
-                    support_dtype_name=args
+                    support_transform_check=' || '.join(if_cond_args)
+                    # support_dtype_name=args.join(", ")
                 )
 
     return OP_DATA_TRANSFORM_CHECK_TEMPLATE.format(

--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -876,6 +876,8 @@
            multiply_sr {selected_rows, dense -> selected_rows}
   inplace : (x -> out)
   backward : multiply_grad
+  data_transform :
+    support_trans_dtype : x,y
 
 - op : norm
   args : (Tensor x, int axis, float epsilon, bool is_test)

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1295,18 +1295,18 @@ void ElementwiseRawInferMeta(const MetaTensor& x,
     auto out_dims = common::make_ddim(out_dims_array);
     out->set_dims(out_dims);
   } else {
-    out->set_dims(x.dims());
+    out->set_dims(y.dims());
   }
   // dtype need promote when meet input dtype with more precision
-  paddle::experimental::DataTypeSet dtype_set{x.dtype()};
-  dtype_set = dtype_set | paddle::experimental::DataTypeSet(y.dtype());
+  paddle::experimental::DataTypeSet dtype_set{y.dtype()};
+  dtype_set = dtype_set | paddle::experimental::DataTypeSet(x.dtype());
   DataType promote_result = PromoteTypes(dtype_set);
   if (promote_result == DataType::UNDEFINED) {
-    promote_result = x.dtype();
+    promote_result = y.dtype();
   }
   out->set_dtype(promote_result);
-  out->set_layout(x.layout());
-  out->share_lod(x);
+  out->set_layout(y.layout());
+  out->share_lod(y);
 }
 
 void EmbeddingInferMeta(const MetaTensor& x,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1101,14 +1101,13 @@ def multiply(x, y, name=None):
               [2, 4, 6]]])
 
     """
+    if x.dtype != y.dtype:
+        raise TypeError(
+            f'Input tensors must be same type, but received type of x: {x.dtype}, type of y: {y.dtype} '
+        )
     if in_dynamic_or_pir_mode():
         return _C_ops.multiply(x, y)
     else:
-        if x.dtype != y.dtype:
-            raise TypeError(
-                f'Input tensors must be same type, but received type of x: {x.dtype}, type of y: {y.dtype} '
-            )
-
         return _elementwise_op(LayerHelper('elementwise_mul', **locals()))
 
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1101,13 +1101,14 @@ def multiply(x, y, name=None):
               [2, 4, 6]]])
 
     """
-    if x.dtype != y.dtype:
-        raise TypeError(
-            f'Input tensors must be same type, but received type of x: {x.dtype}, type of y: {y.dtype} '
-        )
     if in_dynamic_or_pir_mode():
         return _C_ops.multiply(x, y)
     else:
+        if x.dtype != y.dtype:
+            raise TypeError(
+                f'Input tensors must be same type, but received type of x: {x.dtype}, type of y: {y.dtype} '
+            )
+
         return _elementwise_op(LayerHelper('elementwise_mul', **locals()))
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

对于multiply op，输入dtype不一致时根据输出的类型对var进行cast
PCard-67164