### PR TITLE
【PIR API adaptor No.298】 Migrate paddle.rot90 into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1580,7 +1580,7 @@ def rot90(x, k=1, axes=[0, 1], name=None):
     """
 
     helper = LayerHelper("rot90", **locals())
-    check_type(x, 'X', (Variable), 'rot90')
+    check_type(x, 'X', (Variable, paddle.pir.OpResult), 'rot90')
     dtype = helper.input_dtype('x')
     check_dtype(
         dtype,

--- a/test/legacy_test/test_rot90_op.py
+++ b/test/legacy_test/test_rot90_op.py
@@ -18,11 +18,13 @@ import numpy as np
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestRot90_API(unittest.TestCase):
     """Test rot90 api."""
 
+    @test_with_pir_api
     def test_static_graph(self):
         paddle.enable_static()
         startup_program = base.Program()
@@ -53,6 +55,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_k_0(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -82,6 +85,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_k_2(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -111,6 +115,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_k_3(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -140,6 +145,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_neg_k_1(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -169,6 +175,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_neg_k_2(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -198,6 +205,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_neg_k_3(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -227,6 +235,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_static_neg_k_4(self):
         paddle.enable_static()
         input = paddle.static.data(name='input', dtype='float32', shape=[2, 3])
@@ -256,6 +265,7 @@ class TestRot90_API(unittest.TestCase):
                 msg='rot90 output is wrong, out =' + str(out_np),
             )
 
+    @test_with_pir_api
     def test_error_api(self):
         paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
pcard-67164
PIR API 推全升级
将 `paddle.rot90` 迁移升级至 pir，并更新单测

单测覆盖率：1/1