### PR TITLE
[Inference] execution_config.used_for_inference set to true in while op and refine some code

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -638,6 +638,9 @@ void BuildOpFuncList(const platform::Place& place,
       if (op->Type() == "while") {
         op->SetInputHooks(input_hookfuncs);
         op->SetOutputHooks(output_hookfuncs);
+        auto runtime_attrs = op->RuntimeAttrs();
+        runtime_attrs.insert(std::make_pair("used_for_inference", true));
+        op->SetRuntimeAttributeMap(runtime_attrs);
       }
     }
 

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -918,6 +918,7 @@ void ProgramInterpreter::RunOperator(const Instruction& instr_node) {
     if (op->Type() == "while") {
       op->SetInputHooks(input_hookfuncs_);
       op->SetOutputHooks(output_hookfuncs_);
+      op->SetAttr("used_for_inference", true);
     }
   }
 

--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -918,7 +918,9 @@ void ProgramInterpreter::RunOperator(const Instruction& instr_node) {
     if (op->Type() == "while") {
       op->SetInputHooks(input_hookfuncs_);
       op->SetOutputHooks(output_hookfuncs_);
-      op->SetAttr("used_for_inference", true);
+      auto runtime_attrs = op->RuntimeAttrs();
+      runtime_attrs.insert(std::make_pair("used_for_inference", true));
+      op->SetRuntimeAttributeMap(runtime_attrs);
     }
   }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1931,6 +1931,9 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
         if (std::getenv("FLAGS_initial_cpu_memory_in_mb") == nullptr) {
           SetGflag("initial_cpu_memory_in_mb", "0");
         }
+        if (std::getenv("FLAGS_cache_inference_while_scope") == nullptr) {
+          SetGflag("cache_inference_while_scope", "1");
+        }
       });
 
       if (config.thread_local_stream_enabled() &&

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -173,6 +173,9 @@ class WhileOp : public framework::OperatorBase {
       framework::Scope placeholder;  // Don't care if it's valid, just for
                                      // initialize InterpreterCore
       framework::interpreter::ExecutionConfig execution_config;
+      if (HasAttr("used_for_inference") && Attr<bool>("used_for_inference")) {
+        execution_config.used_for_inference = true;
+      }
       execution_config.create_local_scope = false;
       execution_config.used_for_control_flow_op = true;
       execution_config.skip_gc_vars =

--- a/paddle/fluid/pir/drr/drr_rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/drr_rewrite_pattern.cc
@@ -273,8 +273,9 @@ bool DrrRewritePattern::MatchFromOutputToInput(
       }
       auto* ir_producer_op =
           ir_node->operand(i).source().dyn_cast<pir::OpResult>().owner();
-      if (drr_input_tensors[i]->consumers().size() !=
-          ir_node->operand(i).source().use_count()) {
+      if (ir_producer_op == nullptr ||
+          drr_input_tensors[i]->consumers().size() !=
+              ir_node->operand(i).source().use_count()) {
         matched = false;
         VLOG(8) << drr_node->name() << " Match failed: consumers of drr intput["
                 << i << "] { " << drr_node->outputs().size()
@@ -396,7 +397,10 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
       auto ir_val = res_match_ctx.GetIrValue(input->name());
       if (ir_val) {
         Operation* ir_input_op = ir_val.dyn_cast<pir::OpResult>().owner();
-        if (max_input_op_index < op_2_temp_program_index.at(ir_input_op)) {
+        if (op_2_temp_program_index.count(ir_input_op) == 0) {
+          max_input_op_index = 0UL;
+        } else if (max_input_op_index <
+                   op_2_temp_program_index.at(ir_input_op)) {
           max_input_op_index = op_2_temp_program_index.at(ir_input_op);
           max_index_op = ir_input_op;
         } else if (max_input_op_index ==

--- a/paddle/fluid/pir/transforms/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/constant_folding_pass.cc
@@ -83,8 +83,9 @@ class ConstantFoldingPattern : public pir::RewritePattern {
         continue;
       }
       // 2. inputs must come from parameter op or constant op
-      if (!(pir::GetDefiningOpForInput(op, i)->isa<pir::ParameterOp>() ||
-            pir::GetDefiningOpForInput(op, i)->isa<pir::ConstantTensorOp>())) {
+      auto* prev_op = pir::GetDefiningOpForInput(op, i);
+      if (!prev_op || !(prev_op->isa<pir::ParameterOp>() ||
+                        prev_op->isa<pir::ConstantTensorOp>())) {
         return false;
       }
       // 3. inputs must be a dense tensor type
@@ -334,11 +335,6 @@ class ConstantFoldingPass : public pir::Pass {
       paddle::memory::Release(place_);
     }
     paddle::memory::Release(phi::CPUPlace{});
-  }
-
-  bool CanApplyOn(pir::Operation* op) const override {
-    // TODO(liuyuanle): remove op->isa<::pir::ModuleOp>()
-    return op->isa<::pir::ModuleOp>() && op->num_regions() > 0;
   }
 
  private:

--- a/paddle/fluid/pir/transforms/dead_code_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/dead_code_elimination_pass.cc
@@ -15,63 +15,45 @@
 #include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
 
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/core/block.h"
 #include "paddle/pir/core/builtin_op.h"
 #include "paddle/pir/core/op_trait.h"
-#include "paddle/pir/core/program.h"
-#include "paddle/pir/dialect/control_flow/ir/cf_op.h"
 #include "paddle/pir/pass/pass.h"
 #include "paddle/pir/pass/pass_registry.h"
-#include "paddle/pir/pattern_rewrite/frozen_rewrite_pattern_set.h"
-#include "paddle/pir/pattern_rewrite/pattern_match.h"
-#include "paddle/pir/pattern_rewrite/pattern_rewrite_driver.h"
 
 namespace {
-
-class DeadCodeEliminationPattern : public pir::RewritePattern {
- public:
-  DeadCodeEliminationPattern(
-      pir::IrContext* context,
-      pir::PatternBenefit benefit = 1,
-      const std::vector<std::string>& generated_names = {})
-      : RewritePattern(MatchAnyOpTypeTag(), benefit, context, generated_names) {
-  }
-
-  bool Match(pir::Operation* op) const override {
-    if (op->HasTrait<pir::SideEffectTrait>()) return false;
-
-    if (op->isa<paddle::dialect::DataOp>()) {
-      return false;
-    }
-    return op->use_empty();
-  }
-
-  void Rewrite(pir::Operation* op,
-               pir::PatternRewriter& rewriter) const override {  // NOLINT
-    rewriter.EraseOp(op);
-  }
-};
 
 class DeadCodeEliminationPass : public pir::Pass {
  public:
   DeadCodeEliminationPass() : pir::Pass("dead_code_elimination_pass", 0) {}
 
-  bool Initialize(pir::IrContext* context) override {
-    pir::RewritePatternSet ps(context);
-    ps.Add<DeadCodeEliminationPattern>(context);
-    patterns_ = pir::FrozenRewritePatternSet(std::move(ps));
-    return true;
-  }
-
   void Run(pir::Operation* op) override {
-    pir::GreedyRewriteConfig cfg;
-    cfg.use_top_down_traversal = true;
-    cfg.max_iterations = 10;
-    auto [_, num_rewrites] = pir::ApplyPatternsGreedily(op, patterns_, cfg);
-    PrintStatistics(num_rewrites);
+    VLOG(6) << "apply dead_code_elimination_pass";
+    int64_t num_erasers{0};
+    EraseOp(*op->GetParentProgram()->block(), &num_erasers);
+    PrintStatistics(num_erasers);
   }
 
  private:
-  pir::FrozenRewritePatternSet patterns_;
+  void EraseOp(const pir::Block& block, int64_t* num_erasers) {
+    for (auto& op : block) {
+      if (op.HasTrait<pir::SideEffectTrait>() ||
+          op.isa<paddle::dialect::DataOp>()) {
+        continue;
+      }
+      if (op.use_empty()) {
+        op.Erase();
+        (*num_erasers)++;
+      } else {
+        for (size_t i = 0; i < op.num_regions(); ++i) {
+          auto& inner_region = op.region(i);
+          for (auto& inner_block : inner_region) {
+            EraseOp(inner_block, num_erasers);
+          }
+        }
+      }
+    }
+  }
 };
 
 }  // namespace

--- a/paddle/fluid/pir/transforms/params_sync_among_devices_pass.cc
+++ b/paddle/fluid/pir/transforms/params_sync_among_devices_pass.cc
@@ -46,7 +46,7 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
   }
 
   void Run(pir::Operation* op) override {
-    VLOG(6) << "apply ParamsSyncAmongDevicesPass";
+    VLOG(6) << "apply params_sync_among_devices_pass";
     auto module_op = op->dyn_cast<pir::ModuleOp>();
     PADDLE_ENFORCE_NOT_NULL(
         module_op,

--- a/paddle/pir/pass/pass.cc
+++ b/paddle/pir/pass/pass.cc
@@ -35,16 +35,24 @@ Pass::~Pass() = default;
 bool Pass::CanApplyOn(Operation* op) const { return op->num_regions() > 0; }
 
 void Pass::PrintStatistics(int64_t match_count) const {
-  LOG(INFO) << "--- detected [" << match_count << "] subgraphs!";
+  if (match_count > 0) {
+    LOG(INFO) << "--- detected [" << match_count << "] subgraphs!";
+  }
 }
 
 void Pass::PrintStatistics(int64_t match_count, int64_t all_count) const {
-  LOG(INFO) << "--- detected [" << match_count << "/" << all_count
-            << "] subgraphs!";
+  IR_ENFORCE(match_count < all_count,
+             "match_count should smaller than all_count");
+  if (match_count > 0) {
+    LOG(INFO) << "--- detected [" << match_count << "/" << all_count
+              << "] subgraphs!";
+  }
 }
 
 void Pass::PrintStatistics(const std::string& custom_log) const {
-  LOG(INFO) << custom_log;
+  if (!custom_log.empty()) {
+    LOG(INFO) << custom_log;
+  }
 }
 
 detail::PassExecutionState& Pass::pass_state() {

--- a/test/cpp/pir/pattern_rewrite/drr_fuse_linear_param_grad_add_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_fuse_linear_param_grad_add_test.cc
@@ -175,7 +175,7 @@ TEST(DrrTest, FusedLinearParamGradAdd0) {
 
   pir::PassManager pm(ctx);
   pm.AddPass(pir::CreateFusedLinearParamGradAddPass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);
@@ -194,7 +194,7 @@ TEST(DrrTest, FusedLinearParamGradAdd1) {
 
   pir::PassManager pm(ctx);
   pm.AddPass(pir::CreateFusedLinearParamGradAddPass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);
@@ -213,7 +213,7 @@ TEST(DrrTest, FusedLinearParamGradAdd2) {
 
   pir::PassManager pm(ctx);
   pm.AddPass(pir::CreateFusedLinearParamGradAddPass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);
@@ -232,7 +232,7 @@ TEST(DrrTest, FusedLinearParamGradAdd3) {
 
   pir::PassManager pm(ctx);
   pm.AddPass(pir::CreateFusedLinearParamGradAddPass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);

--- a/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
@@ -136,7 +136,7 @@ TEST(DrrTest, FusedLinear) {
 
   pir::PassManager pm(ctx);
   pm.AddPass(pir::CreateFusedGemmEpiloguePass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);

--- a/test/cpp/pir/pattern_rewrite/drr_same_type_binding_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_same_type_binding_test.cc
@@ -310,7 +310,7 @@ TEST(DrrTest, drr_demo) {
   pir::PassManager pm(ctx);
   pm.AddPass(std::make_unique<DrrPatternRewritePass>());
   pm.AddPass(pir::CreateDeadCodeEliminationPass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);

--- a/test/cpp/pir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_test.cc
@@ -215,7 +215,7 @@ TEST(DrrTest, drr_demo) {
   pir::PassManager pm(ctx);
   pm.AddPass(std::make_unique<DrrPatternRewritePass>());
   pm.AddPass(pir::CreateDeadCodeEliminationPass());
-  // pm.EnablePassTiming();
+  pm.EnablePassTiming();
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- For old ir, execution_config.used_for_inference set to true in while op
- For pir, constant_folding_pass support while op
- For pir, rewrite dead_code_elimination_pass
- fix a bug in drr with sub block

TODO:
- For pir, execution_config.used_for_inference set to true in while op
### Others
Pcard-71500