### PR TITLE
【PIR OpTest Fix No.4】 fix test_sgd_op_bf16

### DIFF
--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -268,6 +268,7 @@ test_segment_ops
 test_segment_ops_static_build
 test_selu_op
 test_sgd_op
+test_sgd_op_bf16
 test_shape_mkldnn_op
 test_shape_op
 test_shard_index_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PIR Op单测修复
修复单测 `test_sgd_op_bf16`
修复后打开`FLAGS_enable_pir_in_executor`单测是否通过：修复中
报错信息：.......
遇到的问题：
单测`test_sgd_op_bf16.TestSGDOpBF16`和`test_sgd_op_bf16.TestSGDOpBF16Case2`中
![image](https://github.com/PaddlePaddle/Paddle/assets/135400902/de1c914c-9740-4178-abc3-2609d0e46672)
新旧IR下执行sgd精度误差过大：
![4](https://github.com/PaddlePaddle/Paddle/assets/135400902/9ca0df15-273b-4556-9077-9ad96d6610b9)
原因分析：
造成精度误差过大的原因是因为新旧IR下Kernel选择不一致造成的
- 旧IR下选择的Kernel
![1](https://github.com/PaddlePaddle/Paddle/assets/135400902/c5364b9f-065c-4c28-bd87-9ddea18e34fd)
- 新IR下选择的Kernel
![2](https://github.com/PaddlePaddle/Paddle/assets/135400902/0be89bbd-e4cf-48ac-a01a-780aa84153bf)

由旧IR输出日志及下面的代码来看，旧IR下如果`PADDLE_WITH_DNNL`有效，会将数据排布格式由`NCHW`转化为`ONEDNN`类型，并且选择对应的Kernel
![3](https://github.com/PaddlePaddle/Paddle/assets/135400902/2b776ccd-4a8e-46d3-9631-65bac4c53eef)
