### PR TITLE
[AutoParallel] Fix pipeline parallel get none grad in non-computatio rank.

### DIFF
--- a/paddle/fluid/eager/accumulation/accumulation_node.cc
+++ b/paddle/fluid/eager/accumulation/accumulation_node.cc
@@ -178,7 +178,8 @@ GradNodeAccumulation::operator()(
 
   if (!weak_grad_.expired() && !is_new_grad) {
     auto grad = weak_grad_.lock();
-    if (grad_out.defined() && grad_out.initialized()) {
+    if (grad_out.defined() &&
+        (grad_out.is_dist_tensor() || grad_out.initialized())) {
       CopyOrAddTensor(grad.get(), grad_out, is_fake_empty_);
     }
     // else { do nothing since there is no valid value in grad out tensor }

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -617,6 +617,13 @@ void EagerUtils::FillZeroForEmptyGradInput(paddle::Tensor* in_grad,
         *(static_cast<phi::distributed::DistTensor*>(in_grad->impl().get())
               ->unsafe_mutable_value()) =
             *(static_cast<phi::DenseTensor*>(tensor_with_zero.impl().get()));
+      } else {
+        *(static_cast<phi::distributed::DistTensor*>(in_grad->impl().get())
+              ->unsafe_mutable_value()) =
+            phi::DenseTensor(
+                std::make_shared<phi::Allocation>(
+                    nullptr, 0, phi::distributed::GetDefaultPlace()),
+                phi::DenseTensorMeta());
       }
     } else {
       auto tensor_with_zero =

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -2876,6 +2876,10 @@ static PyObject* tensor__grad_ivar(TensorObject* self,
   if (meta && meta->Grad().initialized()) {
     return ToPyObject(meta->Grad());
   } else {
+    if (meta && !meta->Grad().initialized() && meta->Grad().impl() &&
+        meta->Grad().is_dist_tensor()) {
+      return ToPyObject(meta->Grad(), false);
+    }
     RETURN_PY_NONE
   }
   EAGER_CATCH_AND_THROW_RETURN_NULL

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -287,10 +287,13 @@ PyObject* tensor_properties_get_grad(TensorObject* self, void* closure) {
   EAGER_TRY
   VLOG(6) << "Get grad for tensor: " << self->tensor.name();
   auto meta = egr::EagerUtils::nullable_autograd_meta(self->tensor);
-  VLOG(6) << meta << " initialized: " << meta->Grad().initialized();
   if (meta && meta->Grad().initialized()) {
     return ToPyObject(meta->Grad());
   } else {
+    if (meta && !meta->Grad().initialized() && meta->Grad().impl() &&
+        meta->Grad().is_dist_tensor()) {
+      return ToPyObject(meta->Grad(), false);
+    }
     RETURN_PY_NONE
   }
   EAGER_CATCH_AND_THROW_RETURN_NULL

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2436,7 +2436,8 @@ paddle::Tensor PyTensorHook::operator()(const paddle::Tensor& var) {
 
   PyObject* res = nullptr;
   try {
-    PyObject* p_tmp_var = ToPyObject(var);
+    bool return_py_none_if_not_initialize = var.is_dist_tensor() ? false : true;
+    PyObject* p_tmp_var = ToPyObject(var, return_py_none_if_not_initialize);
     res = PyObject_CallFunctionObjArgs(py_func_, p_tmp_var, nullptr);
     Py_DECREF(p_tmp_var);
   } catch (platform::EnforceNotMet& e) {

--- a/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
@@ -126,7 +126,7 @@ INPLACE_OUT_CREATION_TEMPLATE = """
 MULTI_SINGLE_OUT_CREATION_TEMPLATE_NO_SPMD = """
     auto dist_out_{idx} = SetKernelDistOutput({name});
     auto dense_out_{idx} = dist_out_{idx} ? dist_out_{idx}->unsafe_mutable_value() : nullptr;
-    if (dense_out_{idx} && !rank_is_in_current_mesh && dist_out_{idx}->defined()) {{
+    if (dense_out_{idx} && !rank_is_in_current_mesh && !dist_out_{idx}->defined()) {{
       *dense_out_{idx} = phi::DenseTensor(
         std::make_shared<phi::Allocation>(nullptr, 0, phi::distributed::GetDefaultPlace()),
         phi::DenseTensorMeta());
@@ -137,7 +137,7 @@ MULTI_SINGLE_OUT_CREATION_TEMPLATE_WITH_SPMD = """
         CreateKernelDistOutput({name}, !rank_is_in_current_mesh, spmd_info.second[{idx}]);
     phi::distributed::DistTensor* dist_out_{idx} = shared_dist_out_{idx}.get();
     phi::DenseTensor* dense_out_{idx} = dist_out_{idx} ? dist_out_{idx}->unsafe_mutable_value() : nullptr;
-    if (dense_out_{idx} && !rank_is_in_current_mesh && dist_out_{idx}->defined()) {{
+    if (dense_out_{idx} && !rank_is_in_current_mesh && !dist_out_{idx}->defined()) {{
       *dense_out_{idx} = phi::DenseTensor(
           std::make_shared<phi::Allocation>(nullptr, 0, phi::distributed::GetDefaultPlace()),
           phi::DenseTensorMeta());

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4023,6 +4023,7 @@ void SequenceMaskScalarInferMeta(const MetaTensor& x,
 
 void SquaredL2NormInferMeta(const MetaTensor& x, MetaTensor* out) {
   out->set_dims({1});
+  out->set_dtype(x.dtype());
 }
 
 void SqueezeInferMeta(const MetaTensor& x,

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -18,6 +18,7 @@ from sqlite3 import NotSupportedError
 
 import paddle
 import paddle.autograd as imperative_base
+import paddle.distributed as dist
 from paddle import _C_ops
 from paddle.base import core, framework, unique_name
 from paddle.base.data_feeder import check_variable_and_dtype
@@ -661,8 +662,6 @@ class ClipGradByGlobalNorm(ClipGradBase):
         # are so many hard code depends on `add_n` in the legacy static
         # manual hybrid-parallel.
         self._async_add_n = None
-        # just for auto parallel.
-        self._pp_mesh = None
 
     def __str__(self):
         return "Gradient Clip By GlobalNorm, global_norm=%f" % (self.clip_norm)
@@ -673,6 +672,8 @@ class ClipGradByGlobalNorm(ClipGradBase):
         sum_square_list = []
         sum_square_list_fp16 = []
         sum_square_list_fp32 = []
+        src_mesh = params_grads[0][0].process_mesh
+
         for p, g in params_grads:
             if g is None:
                 continue
@@ -689,6 +690,14 @@ class ClipGradByGlobalNorm(ClipGradBase):
                 merge_grad = get_tensor_from_selected_rows(merge_grad)
 
             sum_square = _squared_l2_norm(merge_grad)
+
+            # if the gradient mesh is not equal to src mesh
+            # do reshard to get the result of squared_l2 from other pp stage mesh
+            if src_mesh is not None and g.process_mesh != src_mesh:
+                sum_square = dist.reshard(
+                    sum_square, src_mesh, sum_square.placements
+                )
+
             if (
                 sum_square.dtype == core.VarDesc.VarType.FP16
                 or sum_square.dtype == core.VarDesc.VarType.BF16
@@ -715,64 +724,21 @@ class ClipGradByGlobalNorm(ClipGradBase):
         global_norm_var = []
         if len(sum_square_list_fp16) > 0:
             global_norm_var_fp16 = async_add_n(sum_square_list_fp16)
-            if self._pp_mesh is not None:
-                # sync pp
-                global_norm_var_fp16 = (
-                    paddle.distributed.auto_parallel.api.dtensor_from_local(
-                        global_norm_var_fp16._local_value().reshape([-1]),
-                        self._pp_mesh,
-                        [paddle.distributed.Partial()],
-                    )
-                )
-                global_norm_var_fp16 = paddle.distributed.reshard(
-                    global_norm_var_fp16,
-                    self._pp_mesh,
-                    [paddle.distributed.Replicate()],
-                )
             global_norm_var.append(global_norm_var_fp16.astype(sum_dtype))
         if len(sum_square_list_fp32) > 0:
             global_norm_var_fp32 = async_add_n(sum_square_list_fp32)
-            if self._pp_mesh is not None:
-                # sync pp
-                global_norm_var_fp32 = (
-                    paddle.distributed.auto_parallel.api.dtensor_from_local(
-                        global_norm_var_fp32._local_value().reshape([-1]),
-                        self._pp_mesh,
-                        [paddle.distributed.Partial()],
-                    )
-                )
-                global_norm_var_fp32 = paddle.distributed.reshard(
-                    global_norm_var_fp32,
-                    self._pp_mesh,
-                    [paddle.distributed.Replicate()],
-                )
             if sum_dtype == 'float32':
                 global_norm_var.append(global_norm_var_fp32)
             else:
                 global_norm_var.append(global_norm_var_fp32.astype(sum_dtype))
         if len(sum_square_list) > 0:
             global_norm_var_fp64 = async_add_n(sum_square_list)
-            if self._pp_mesh is not None:
-                # sync pp
-                global_norm_var_fp64 = (
-                    paddle.distributed.auto_parallel.api.dtensor_from_local(
-                        global_norm_var_fp64._local_value().reshape([-1]),
-                        self._pp_mesh,
-                        [paddle.distributed.Partial()],
-                    )
-                )
-                global_norm_var_fp64 = paddle.distributed.reshard(
-                    global_norm_var_fp64,
-                    self._pp_mesh,
-                    [paddle.distributed.Replicate()],
-                )
             global_norm_var.append(global_norm_var_fp64)
-        if self._pp_mesh is not None:
-            global_norm_var = [t._local_value() for t in global_norm_var]
+
         global_norm_var = async_add_n(global_norm_var)
         global_norm_var = paddle.sqrt(global_norm_var)
         max_global_norm = paddle.full(
-            shape=[], dtype=global_norm_var.dtype, fill_value=self.clip_norm
+            shape=[], dtype=sum_dtype, fill_value=self.clip_norm
         )
 
         need_clip = False
@@ -800,6 +766,10 @@ class ClipGradByGlobalNorm(ClipGradBase):
                     if clip_var.dtype != g.dtype
                     else clip_var
                 )
+                if clip_input.process_mesh != g.process_mesh:
+                    clip_input = paddle.distributed.reshard(
+                        clip_input, g.process_mesh, clip_input.placements
+                    )
                 new_grad = paddle.multiply(g, clip_input)
                 params_and_grads.append((p, new_grad))
             else:

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -1198,7 +1198,7 @@ class Optimizer:
                             # need to filter again here.
                             if (
                                 param_and_grad[1] is None
-                                or not param_and_grad[0]._is_initialized()
+                                or not param_and_grad[1]._is_initialized()
                             ):
                                 continue
                             if param_and_grad[0].stop_gradient is False:
@@ -1209,7 +1209,7 @@ class Optimizer:
                         for param_and_grad in parameters_and_grads['params']:
                             if (
                                 param_and_grad[1] is None
-                                or not param_and_grad[0]._is_initialized()
+                                or not param_and_grad[1]._is_initialized()
                             ):
                                 continue
                             if param_and_grad[0].stop_gradient is False:

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -1193,7 +1193,13 @@ class Optimizer:
                         self._set_auxiliary_var('found_inf', False)
                     if isinstance(parameters_and_grads, list):
                         for param_and_grad in parameters_and_grads:
-                            if param_and_grad[1] is None:
+                            # Parameters can be uninitialized in pipeline parallel of semi-auto parallel.
+                            # Since gradient clip and parameters update mixed up in one interface, so we
+                            # need to filter again here.
+                            if (
+                                param_and_grad[1] is None
+                                or not param_and_grad[0]._is_initialized()
+                            ):
                                 continue
                             if param_and_grad[0].stop_gradient is False:
                                 self._append_optimize_op(
@@ -1201,7 +1207,10 @@ class Optimizer:
                                 )
                     else:
                         for param_and_grad in parameters_and_grads['params']:
-                            if param_and_grad[1] is None:
+                            if (
+                                param_and_grad[1] is None
+                                or not param_and_grad[0]._is_initialized()
+                            ):
                                 continue
                             if param_and_grad[0].stop_gradient is False:
                                 param_grad_dict = {}

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_simple_net_sp.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_simple_net_sp.py
@@ -209,7 +209,7 @@ class TestSimpleNetHybridStrategyForSemiAutoParallel(
         for param, param_base in zip(
             self.dp_mp_sp_parameters, self.base_parameters
         ):
-            if param.grad is not None:
+            if param.grad._is_initialized():
                 self.check_tensor_eq(param, param_base)
                 self.check_tensor_eq(param.grad, param_base.grad)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
PCard-73145

修复动半下，流水线并行的非计算节点对 uninitialized Tensor 会返回 Python `None`的问题。并修复hook打印uninitialized Tensor会报错的问题。

`nn.Linear`有一个已知问题：`bias`可以为None，相应的传给`_C_ops.linear`的C++ bias Tensor是unitialized的，相应的会跳过add bias计算。这与动半pp的unitialized Tensor语义冲突。考虑这种情况：动半使用有bias的Linear，但非计算节点的Linear.bias天然是unitialized的，它会跳过调用PHI API `elementwise_add`的操作，而计算节点仍旧有`elementwise_add`。目前这个问题没有造成影响，例如save_load如果要存储Linear.bias，仍旧可以通过`paddle.distributed.reshard`，从对应节点取得正确的bias。动转静也是根据python侧的`nn.Linear`改写的，跳过PHI API的add bias计算没有影响。
