### PR TITLE
[Dy2St] Enable dy2st ut `test_assert` in PIR mode

### DIFF
--- a/test/dygraph_to_static/test_assert.py
+++ b/test/dygraph_to_static/test_assert.py
@@ -18,6 +18,7 @@ import numpy
 from dygraph_to_static_utils import (
     Dy2StTestBase,
     enable_to_static_guard,
+    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -48,6 +49,7 @@ class TestAssertVariable(Dy2StTestBase):
         self._run(func, x, with_exception, True)
         self._run(func, x, with_exception, False)
 
+    @test_legacy_and_pt_and_pir
     def test_non_variable(self):
         self._run_dy_static(
             paddle.jit.to_static(dyfunc_assert_non_variable),
@@ -60,6 +62,7 @@ class TestAssertVariable(Dy2StTestBase):
             with_exception=False,
         )
 
+    @test_legacy_and_pt_and_pir
     def test_bool_variable(self):
         self._run_dy_static(
             paddle.jit.to_static(dyfunc_assert_variable),
@@ -72,6 +75,7 @@ class TestAssertVariable(Dy2StTestBase):
             with_exception=False,
         )
 
+    @test_legacy_and_pt_and_pir
     def test_int_variable(self):
         self._run_dy_static(
             paddle.jit.to_static(dyfunc_assert_variable),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

启用 `test_assert` 单测理想态

PCard-66972

- #60131