### PR TITLE
fix bug of lbfgs test=develop

### DIFF
--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -222,10 +222,10 @@ def _strong_wolfe(
     low_pos, high_pos = (0, 1) if bracket_f[0] <= bracket_f[-1] else (1, 0)
     while not done and ls_iter < max_ls:
         # line-search bracket is so small
-        if (
-            paddle.abs(paddle.to_tensor(bracket[1] - bracket[0])) * d_norm
-            < tolerance_change
-        ):
+        bracket_ls = bracket[1] - bracket[0]
+        if not isinstance(bracket_ls, paddle.Tensor):
+            bracket_ls = paddle.to_tensor(bracket_ls, dtype=gtd_new.dtype)
+        if paddle.abs(bracket_ls) * d_norm < tolerance_change:
             break
 
         # compute new trial value

--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -155,12 +155,7 @@ def _strong_wolfe(
     gtd_new = paddle.dot(grad_new, d)
 
     # bracket an interval containing a point satisfying the Wolfe criteria
-    t_prev, f_prev, g_prev, gtd_prev = (
-        paddle.to_tensor(0, dtype=grad.dtype),
-        loss,
-        grad,
-        gtd,
-    )
+    t_prev, f_prev, g_prev, gtd_prev = (0, loss, grad, gtd)
     done = False
     ls_iter = 0
     while ls_iter < max_ls:
@@ -228,7 +223,7 @@ def _strong_wolfe(
     while not done and ls_iter < max_ls:
         # line-search bracket is so small
         if (
-            abs(float(bracket[1] - bracket[0])) * float(d_norm)
+            paddle.abs(paddle.to_tensor(bracket[1] - bracket[0])) * d_norm
             < tolerance_change
         ):
             break

--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -227,7 +227,10 @@ def _strong_wolfe(
     low_pos, high_pos = (0, 1) if bracket_f[0] <= bracket_f[-1] else (1, 0)
     while not done and ls_iter < max_ls:
         # line-search bracket is so small
-        if paddle.abs(bracket[1] - bracket[0]) * d_norm < tolerance_change:
+        if (
+            abs(float(bracket[1] - bracket[0])) * float(d_norm)
+            < tolerance_change
+        ):
             break
 
         # compute new trial value

--- a/test/legacy_test/test_lbfgs_class.py
+++ b/test/legacy_test/test_lbfgs_class.py
@@ -498,6 +498,16 @@ class TestLbfgs(unittest.TestCase):
             paddle.to_tensor([1.0]),
             max_ls=1,
         )
+        lbfgs._strong_wolfe(
+            func2,
+            paddle.to_tensor([1.0]),
+            -0.001,
+            paddle.to_tensor([1.0]),
+            paddle.to_tensor([1.0]),
+            paddle.to_tensor([1.0]),
+            paddle.to_tensor([1.0]),
+            max_ls=1,
+        )
 
         lbfgs._strong_wolfe(
             func3,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Pcard-66961
问题：
![image](https://github.com/PaddlePaddle/Paddle/assets/124568209/3cf0fd64-04f5-4ba3-b50e-80cb3d86bc5d)
出现原因：paddle.abs()不支持非tensor类型，因此需要保证每个paddle.abs的输入都是tensor
复现方法：运行如下代码即可复现
![image](https://github.com/PaddlePaddle/Paddle/assets/124568209/b9200dc2-b611-4aad-84d7-0eeb4c4f1e93)
修复方案：判断输入paddle.abs()的数据类型，若为非tensor类型则转换为tensor再输入