### PR TITLE
[XPU][Phi Kernel] nonzero kernel support simulator XPUSIM_SKIP_RUN mode

### DIFF
--- a/paddle/phi/kernels/xpu/nonzero_kernel.cc
+++ b/paddle/phi/kernels/xpu/nonzero_kernel.cc
@@ -14,6 +14,8 @@
 
 #include "paddle/phi/kernels/nonzero_kernel.h"
 
+#include "glog/logging.h"
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -40,6 +42,13 @@ void NonZeroKernel(const Context& dev_ctx,
                      dev_ctx.GetPlace(),
                      static_cast<void*>(true_num),
                      sizeof(int32_t));
+  if (std::getenv("XPU_SIMULATOR_MODE") && std::getenv("XPUSIM_SKIP_RUN") &&
+      std::strcmp(std::getenv("XPUSIM_SKIP_RUN"), "1") == 0) {
+    VLOG(3) << "WARNING: In the simulator mode, the variable true_num_cpu "
+               "stores a uninitialized value. To avoid allocating a memory of "
+               "random size, we assign numel to it";
+    true_num_cpu = numel;
+  }
 
   out->Resize(common::make_ddim({static_cast<int64_t>(true_num_cpu), rank}));
   auto* out_data = dev_ctx.template Alloc<int64_t>(out);

--- a/paddle/phi/kernels/xpu/nonzero_kernel.cc
+++ b/paddle/phi/kernels/xpu/nonzero_kernel.cc
@@ -42,12 +42,13 @@ void NonZeroKernel(const Context& dev_ctx,
                      dev_ctx.GetPlace(),
                      static_cast<void*>(true_num),
                      sizeof(int32_t));
-  if (std::getenv("XPU_SIMULATOR_MODE") && std::getenv("XPUSIM_SKIP_RUN") &&
+  if (std::getenv("XPUSIM_SKIP_RUN") &&
       std::strcmp(std::getenv("XPUSIM_SKIP_RUN"), "1") == 0) {
     VLOG(3) << "WARNING: In the simulator mode, the variable true_num_cpu "
-               "stores a uninitialized value. To avoid allocating a memory of "
-               "random size, we assign numel to it";
-    true_num_cpu = numel;
+               "stores an uninitialized value. To avoid allocating a memory of "
+               "random size, we limit the value of true_num_cpu to the range 0 "
+               "<= true_num_cpu < numel";
+    true_num_cpu = std::min(std::max(true_num_cpu, 0), static_cast<int>(numel));
   }
 
   out->Resize(common::make_ddim({static_cast<int64_t>(true_num_cpu), rank}));

--- a/test/xpu/test_where_index_xpu.py
+++ b/test/xpu/test_where_index_xpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 import numpy as np
@@ -112,6 +113,39 @@ class TestWhereRaiseError(unittest.TestCase):
             paddle.nonzero([10])
 
         self.assertRaises(AttributeError, test_type)
+
+
+class TestWhereSimulatorMode(unittest.TestCase):
+    def test_skip_run_on(self):
+        os.environ['XPUSIM_SKIP_RUN'] = '1'
+        cond = paddle.static.data(name='cond', shape=[-1, 4], dtype='bool')
+        result = paddle.nonzero(cond)
+
+        exe = base.Executor(paddle.XPUPlace(0))
+        exe.run(base.default_startup_program())
+        cond_i = np.array([True, False, False, False]).astype("bool")
+        out = exe.run(base.default_main_program(), feed={'cond': cond_i})
+        del os.environ['XPUSIM_SKIP_RUN']
+
+    def test_skip_run_off1(self):
+        cond = paddle.static.data(name='cond', shape=[-1, 4], dtype='bool')
+        result = paddle.nonzero(cond)
+
+        exe = base.Executor(paddle.XPUPlace(0))
+        exe.run(base.default_startup_program())
+        cond_i = np.array([True, False, False, False]).astype("bool")
+        out = exe.run(base.default_main_program(), feed={'cond': cond_i})
+
+    def test_skip_run_off2(self):
+        os.environ['XPUSIM_SKIP_RUN'] = '0'
+        cond = paddle.static.data(name='cond', shape=[-1, 4], dtype='bool')
+        result = paddle.nonzero(cond)
+
+        exe = base.Executor(paddle.XPUPlace(0))
+        exe.run(base.default_startup_program())
+        cond_i = np.array([True, False, False, False]).astype("bool")
+        out = exe.run(base.default_main_program(), feed={'cond': cond_i})
+        del os.environ['XPUSIM_SKIP_RUN']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
nonzero kernel support simulator XPUSIM_SKIP_RUN mode. 

In the simulator mode, the variable `true_num_cpu` stores an uninitialized value. To avoid allocating a memory of random size, we assign `numel` to it.