### PR TITLE
[CodeStyle][ruff] fix `E226`, `NPY201`

### DIFF
--- a/python/paddle/distributed/launch/controllers/collective.py
+++ b/python/paddle/distributed/launch/controllers/collective.py
@@ -92,7 +92,9 @@ class CollectiveController(Controller):
         ips = self.ctx.args.ips.split(',')
 
         job_endpoints = [
-            f"{h}:{p+start_port}" for h in ips for p in range(self.pod.replicas)
+            f"{h}:{p + start_port}"
+            for h in ips
+            for p in range(self.pod.replicas)
         ]
 
         self.ctx.logger.debug(f"job endpoints: {job_endpoints}")

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -576,10 +576,10 @@ def launch():
 
             end_time = time.time()
             ctx.logger.info(
-                f"AtuoTuner for GBS search ends in {end_time-start_time}s."
+                f"AtuoTuner for GBS search ends in {end_time - start_time}s."
             )
             logger.info(
-                f"AtuoTuner for GBS search ends in {end_time-start_time}s."
+                f"AtuoTuner for GBS search ends in {end_time - start_time}s."
             )
 
         # build AutoTuner to get new config
@@ -1098,8 +1098,8 @@ def launch():
         assert best_cfg and best_cfg["time"] != -1
 
         end_time = time.time()
-        ctx.logger.info(f"AutoTuner ended in {end_time-start_time}s.")
-        logger.info(f"AutoTuner ended in {end_time-start_time}s.")
+        ctx.logger.info(f"AutoTuner ended in {end_time - start_time}s.")
+        logger.info(f"AutoTuner ended in {end_time - start_time}s.")
         # launch best cfg
         # estimation search need not run best cfg
         if not tuner_cfg.get("run_best", True) or tuner_cfg["search_algo"].get(

--- a/python/paddle/hapi/callbacks.py
+++ b/python/paddle/hapi/callbacks.py
@@ -1279,10 +1279,10 @@ class ReduceLROnPlateau(Callback):
             self.mode == 'auto' and 'acc' not in self.monitor
         ):
             self.monitor_op = lambda a, b: np.less(a, b - self.min_delta)
-            self.best = np.Inf
+            self.best = np.inf
         else:
             self.monitor_op = lambda a, b: np.greater(a, b + self.min_delta)
-            self.best = -np.Inf
+            self.best = -np.inf
         self.cooldown_counter = 0
         self.wait = 0
 

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -497,7 +497,7 @@ class OpcodeExecutorBase:
             )
             if current_line != -1:
                 message_lines.append(
-                    f"{indent}  {lines[current_line-start].rstrip()}"
+                    f"{indent}  {lines[current_line - start].rstrip()}"
                 )
         error_message = traceback.format_exception_only(
             type(original_error), original_error

--- a/python/paddle/static/quantization/quant2_int8_mkldnn_pass.py
+++ b/python/paddle/static/quantization/quant2_int8_mkldnn_pass.py
@@ -203,7 +203,7 @@ class Quant2Int8MkldnnPass:
                 scale = np.array(
                     1.0 / self._load_param(self._scope, scale_name)[0]
                 ).astype(np.float64)
-                scale[scale == np.Inf] = 0.0
+                scale[scale == np.inf] = 0.0
                 lod_tensor = self._convert_scale2tensor(scale)
                 use_unsigned_int = False
                 self._add_scale_for_vars(
@@ -238,7 +238,7 @@ class Quant2Int8MkldnnPass:
                 if attr_scale == 0.0:
                     continue
                 scale = np.array(1.0 / attr_scale).astype(np.float64)
-                scale[scale == np.Inf] = 0.0
+                scale[scale == np.inf] = 0.0
                 scale_lod_tensor = self._convert_scale2tensor(scale)
                 use_unsigned_int = False
                 for output_name in op.op().outputs():
@@ -561,7 +561,7 @@ class Quant2Int8MkldnnPass:
                         ),
                         axis=axis,
                     )
-                    scales[scales == np.Inf] = 0.0
+                    scales[scales == np.inf] = 0.0
 
                     lod_tensor = self._convert_scale2tensor(scales)
                     use_unsigned_int = False

--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -672,7 +672,7 @@ def plan_einsum(operands, g_view, g_shape, g_supports, g_count, n_bcast):
     if any(ax != dim for ax, dim in enumerate(view[:nout])):
         perm = [dim for dim in view if dim >= 0]
         if sorted(perm) != perm:
-            varname = f'op{nop-1}'
+            varname = f'op{nop - 1}'
             step = transpose, [varname], varname, perm
             plan.add_step(step)
         dim = 0
@@ -684,14 +684,14 @@ def plan_einsum(operands, g_view, g_shape, g_supports, g_count, n_bcast):
             if d == -1:
                 unsqueeze_dims.append(ax)
         if unsqueeze_dims:
-            varname = f'op{nop-1}'
+            varname = f'op{nop - 1}'
             step = unsqueeze, [varname], varname, unsqueeze_dims
             plan.add_step(step)
 
     squeeze_dims = [dim for dim in view[nout:] if dim != -1]
     if squeeze_dims:
         # plan_reduce(plan, nop-1, reduce_dims, keepdim=False)
-        varname = f'op{nop-1}'
+        varname = f'op{nop - 1}'
         step = squeeze, [varname], varname, squeeze_dims
         plan.add_step(step)
 

--- a/test/custom_runtime/test_custom_cpu_to_static.py
+++ b/test/custom_runtime/test_custom_cpu_to_static.py
@@ -42,7 +42,7 @@ def train_func_base(epoch_id, train_loader, model, cost, optimizer):
         )
     epoch_end = time.time()
     print(
-        f"Epoch ID: {epoch_id+1}, FP32 train epoch time: {(epoch_end - epoch_start) * 1000} ms"
+        f"Epoch ID: {epoch_id + 1}, FP32 train epoch time: {(epoch_end - epoch_start) * 1000} ms"
     )
 
 
@@ -75,7 +75,7 @@ def train_func_ampo1(epoch_id, train_loader, model, cost, optimizer, scaler):
         )
     epoch_end = time.time()
     print(
-        f"Epoch ID: {epoch_id+1}, AMPO1 train epoch time: {(epoch_end - epoch_start) * 1000} ms"
+        f"Epoch ID: {epoch_id + 1}, AMPO1 train epoch time: {(epoch_end - epoch_start) * 1000} ms"
     )
 
 
@@ -96,7 +96,7 @@ def test_func(epoch_id, test_loader, model, cost):
         avg_acc[1].append(acc_top5.numpy())
     model.train()
     print(
-        f"Epoch ID: {epoch_id+1}, Top1 accurary: {np.array(avg_acc[0]).mean()}, Top5 accurary: {np.array(avg_acc[1]).mean()}"
+        f"Epoch ID: {epoch_id + 1}, Top1 accurary: {np.array(avg_acc[0]).mean()}, Top5 accurary: {np.array(avg_acc[1]).mean()}"
     )
 
 

--- a/test/legacy_test/test_fill_constant_op.py
+++ b/test/legacy_test/test_fill_constant_op.py
@@ -413,9 +413,9 @@ class TestFillConstantImperative(unittest.TestCase):
 
     def test_ninf(self):
         with base.dygraph.guard():
-            res = paddle.tensor.fill_constant([1], 'float32', np.NINF)
+            res = paddle.tensor.fill_constant([1], 'float32', -np.inf)
             self.assertTrue(np.isinf(res.numpy().item(0)))
-            self.assertEqual(np.NINF, res.numpy().item(0))
+            self.assertEqual(-np.inf, res.numpy().item(0))
 
 
 class TestFillConstantOpError(unittest.TestCase):

--- a/test/legacy_test/test_seed_op.py
+++ b/test/legacy_test/test_seed_op.py
@@ -69,7 +69,9 @@ class TestDropoutWithRandomSeedGenerator(unittest.TestCase):
                 (out1,) = exe.run(
                     static.default_main_program(), fetch_list=res_list
                 )
-                self.assertEqual(out1, np.cast['int32'](self.rng1.random()))
+                self.assertEqual(
+                    out1, np.asarray(self.rng1.random(), dtype=np.int32)
+                )
 
     def test_static(self):
         for place in self.places:

--- a/test/legacy_test/test_seed_op.py
+++ b/test/legacy_test/test_seed_op.py
@@ -70,7 +70,8 @@ class TestDropoutWithRandomSeedGenerator(unittest.TestCase):
                     static.default_main_program(), fetch_list=res_list
                 )
                 self.assertEqual(
-                    out1, np.asarray(self.rng1.random(), dtype=np.int32)
+                    out1,
+                    np.asarray(self.rng1.random()).astype(np.int32),
                 )
 
     def test_static(self):

--- a/test/xpu/test_increment_op_xpu.py
+++ b/test/xpu/test_increment_op_xpu.py
@@ -41,7 +41,7 @@ class XPUTestIncrementOP(XPUOpTestWrapper):
             self.initTestCase()
 
             x = np.random.uniform(-100, 100, [1]).astype(self.dtype)
-            output = x + np.asarray(self.step, dtype=self.dtype)
+            output = x + np.asarray(self.step).astype(self.dtype)
             output = output.astype(self.dtype)
 
             self.inputs = {'X': x}

--- a/test/xpu/test_increment_op_xpu.py
+++ b/test/xpu/test_increment_op_xpu.py
@@ -41,7 +41,7 @@ class XPUTestIncrementOP(XPUOpTestWrapper):
             self.initTestCase()
 
             x = np.random.uniform(-100, 100, [1]).astype(self.dtype)
-            output = x + np.cast[self.dtype](self.step)
+            output = x + np.asarray(self.step, dtype=self.dtype)
             output = output.astype(self.dtype)
 
             self.inputs = {'X': x}

--- a/tools/gen_ut_cmakelists.py
+++ b/tools/gen_ut_cmakelists.py
@@ -275,7 +275,7 @@ class DistUTPortManager:
                 assert re.compile("^test_[0-9a-zA-Z_]+").search(
                     name
                 ), f'''we found a test for initial the latest dist_port but the test name '{name}' seems to be wrong
-                    at line {k-1}, in file {cmake_file_name}
+                    at line {k - 1}, in file {cmake_file_name}
                     '''
                 self.gset_port(name, port)
 
@@ -559,7 +559,7 @@ class CMakeGenerator:
                     print("===============PARSE LINE ERRORS OCCUR==========")
                     print(e)
                     print(f"[ERROR FILE]: {current_work_dir}/testslist.csv")
-                    print(f"[ERROR LINE {i+1}]: {line.strip()}")
+                    print(f"[ERROR LINE {i + 1}]: {line.strip()}")
                     sys.exit(1)
 
         for sub in sub_dirs:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

修复`E226`, `NPY201`存量，注意这些为 preview 功能

Numpy 2.0 适配情况:
- [x] `np.cast` -> `np. asarray`
- [ ] `np.trapz` -> `scipy.interpolate.trapezoid`
- [ ] `np.in1d` -> `np.isin`
- [ ] `np.row_stack` -> `np.vstack`
- [ ] `np.cross` -> ❓
- [ ] `numpy.testing.assert_array_equal` 参数位置改变 (但是我看好像只是换了个名字 [1.26](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_equal.html)、[dev](https://numpy.org/devdocs/reference/generated/numpy.testing.assert_array_equal.html#numpy.testing.assert_array_equal))
- [ ] `numpy.testing.assert_array_almost_equal` 参数位置改变 (同上 [1.26](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_almost_equal.html)、[dev](https://numpy.org/devdocs/reference/generated/numpy.testing.assert_array_almost_equal.html#numpy.testing.assert_array_almost_equal))



相关链接：
* [NPY201](https://docs.astral.sh/ruff/rules/numpy2-deprecation/)文档
* [E226](https://docs.astral.sh/ruff/rules/missing-whitespace-around-arithmetic-operator/)说明（主要是运算符前后加一个空格）
* [Numpy 2.0](https://numpy.org/devdocs/release/2.0.0-notes.html)更新说明
