### PR TITLE
【PIR API adaptor No.302】 Migrate paddle.nn.Softmax2D into pir

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1580,7 +1580,7 @@ def rot90(x, k=1, axes=[0, 1], name=None):
     """
 
     helper = LayerHelper("rot90", **locals())
-    check_type(x, 'X', (Variable, paddle.pir.OpResult), 'rot90')
+    check_type(x, 'X', (Variable, paddle.pir.Value), 'rot90')
     dtype = helper.input_dtype('x')
     check_dtype(
         dtype,

--- a/test/legacy_test/test_softmax2d.py
+++ b/test/legacy_test/test_softmax2d.py
@@ -19,6 +19,7 @@ from test_softmax_op import ref_softmax
 
 import paddle
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestSoftmax2DAPI(unittest.TestCase):
@@ -32,6 +33,7 @@ class TestSoftmax2DAPI(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_api(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -108,6 +110,7 @@ class TestSoftmax2DError(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_error(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
pcard-67164
PIR API 推全升级
将 `paddle.nn.Softmax2D` 迁移升级至 pir，并更新单测

单测覆盖率：6/6