### PR TITLE
[AutoConfig] add blacklist mechanism and scheduling in specified order

### DIFF
--- a/python/paddle/distributed/auto_tuner/recorder.py
+++ b/python/paddle/distributed/auto_tuner/recorder.py
@@ -58,7 +58,7 @@ class HistoryRecorder:
                 or best_cfg["time"] == -1
             ):
                 return (best_cfg, True)
-            first_few = 1
+            first_few = 0
             for cfg in self.history:
                 if (
                     not isinstance(cfg["max_mem_usage"], str)

--- a/python/paddle/distributed/auto_tuner/recorder.py
+++ b/python/paddle/distributed/auto_tuner/recorder.py
@@ -51,7 +51,7 @@ class HistoryRecorder:
         self.sort_metric(direction=direction, metric_name=metric)
         if len(self.history) == 0:
             return (self.history[0], True)
-        if mode == "SFT" or mode == "LoRA":
+        if mode == "SFT" or mode == "LoRA" or mode == "Pretrain":
             best_cfg = self.history[0]
             if (
                 isinstance(best_cfg["max_mem_usage"], str)
@@ -67,7 +67,7 @@ class HistoryRecorder:
                 ):
                     best_cfg = cfg
                 first_few += 1
-                if first_few >= 5:
+                if first_few >= 3:
                     break
             return (best_cfg, False)
         if isinstance(self.history[0]["max_mem_usage"], str) or (

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -49,10 +49,33 @@ class GridSearch(SearchAlgo):
         super().__init__(tuner_cfg)
         self.idx = 0
         self.all_tasks = search_all(tuner_cfg)
+        need_baseline = self.tuner_cfg.get("need_baseline", False)
+        self.baseline = None
+        if need_baseline:
+            from .utils import memory_sort
+
+            self.all_tasks.sort(key=memory_sort)
+        self.previous_cfg = None
 
     def search_once(self, history_cfgs):
         new_cfg = None
         stop = False
+        if self.previous_cfg:
+            if self.previous_cfg.get("time", -1) > 0:
+                if self.baseline is None:
+                    from .utils import performance_sort
+
+                    self.baseline = self.previous_cfg
+                    self.all_tasks[self.idx :] = sorted(
+                        self.all_tasks[self.idx : len(self.all_tasks)],
+                        key=performance_sort,
+                    )
+                    if self.tuner_cfg.get("schedule_prior", False):
+                        from .utils import sort_by_sepecial
+
+                        self.all_tasks[self.idx :] = sort_by_sepecial(
+                            self.all_tasks[self.idx :], self.tuner_cfg
+                        )
         while not stop:
             if self.idx < len(self.all_tasks):
                 new_cfg = self.all_tasks[self.idx]
@@ -60,6 +83,8 @@ class GridSearch(SearchAlgo):
                 stop = not self.prune(self.tuner_cfg, new_cfg, history_cfgs)
             else:
                 return None
+        if self.previous_cfg is None:
+            self.previous_cfg = new_cfg
         return new_cfg
 
 

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -60,12 +60,12 @@ class GridSearch(SearchAlgo):
     def search_once(self, history_cfgs):
         new_cfg = None
         stop = False
-        if self.previous_cfg:
-            if self.previous_cfg.get("time", -1) > 0:
+        if history_cfgs:
+            if history_cfgs[-1].get("time", -1) > 0:
                 if self.baseline is None:
                     from .utils import performance_sort
 
-                    self.baseline = self.previous_cfg
+                    self.baseline = history_cfgs[-1]
                     self.all_tasks[self.idx :] = sorted(
                         self.all_tasks[self.idx : len(self.all_tasks)],
                         key=performance_sort,
@@ -83,8 +83,7 @@ class GridSearch(SearchAlgo):
                 stop = not self.prune(self.tuner_cfg, new_cfg, history_cfgs)
             else:
                 return None
-        if self.previous_cfg is None:
-            self.previous_cfg = new_cfg
+
         return new_cfg
 
 

--- a/python/paddle/distributed/auto_tuner/utils.py
+++ b/python/paddle/distributed/auto_tuner/utils.py
@@ -414,7 +414,130 @@ def search_all(tuner_cfg):
     logger.info(
         f"{search_space_size_before_prune - search_space_size_after_prune} tasks are pruned before launching."
     )
+    if tuner_cfg.get("schedule_prior", False):
+        pruned_all_cfgs = sort_by_sepecial(pruned_all_cfgs, tuner_cfg)
     return pruned_all_cfgs
+
+
+def sort_by_sepecial(cfgs, tuner_cfg):
+    assert tuner_cfg.get("schedule_prior", False)
+    prior_strategy = tuner_cfg["schedule_prior"]
+    prior_strategy.sort(reverse=True)
+    for strategy in prior_strategy:
+        idx = 0
+        matched_count = 0
+        while idx < len(cfgs):
+            cfg = cfgs[idx]
+            if _matched(cfg, strategy):
+                cfgs.pop(idx)
+                cfgs.insert(0, cfg)
+                matched_count += 1
+            idx += 1
+        tmp = cfgs[:matched_count]
+        tmp.reverse()
+        cfgs[:matched_count] = tmp
+    return cfgs
+
+
+def memory_sort(cfg):
+    # ascending order in default
+    return (
+        -cfg['mp_degree'],
+        -cfg['pp_degree'],
+        -cfg['vpp_degree'],
+        -cfg["sharding_degree"],
+        -cfg["sharding_stage"],
+        cfg["micro_batch_size"],
+        -cfg["use_recompute"],
+    )
+
+
+def performance_sort(cfg):
+    return -cfg["micro_batch_size"]
+
+
+def _matched(cur_cfg, strategy):
+    mapping = {
+        "dp_degree": "dp",
+        "mp_degree": "mp",
+        "pp_degree": "pp",
+        "vpp_degree": "vpp",
+        "micro_batch_size": "mbs",
+        "sharding_degree": "sharding",
+        "sharding_stage": "stage",
+        "use_recompute": "recompute",
+        "recompute_granularity": "granularity",
+    }
+    granularity_mapping = {0: "full", 1: "full_attn", 2: "core_attn"}
+    reversed_mapping = {}
+    for key in mapping:
+        reversed_mapping[mapping[key]] = key
+
+    assert isinstance(strategy, str)
+    dims = strategy.split("_")
+    has_matched = 0
+    for dim in dims:
+        matched = None
+        for key in reversed_mapping:
+            if dim.startswith(key):
+                matched = key
+                break
+        if matched:
+            value = dim[len(matched)]
+            # * means this strategy turned on
+            if matched in ["dp", "mp", "pp", "vpp", "sharding"]:
+                if value == "*":
+                    if cur_cfg[reversed_mapping[matched]] > 1:
+                        has_matched += 1
+                        continue
+                else:
+                    value = int(value)
+                    if cur_cfg[reversed_mapping[matched]] == value:
+                        has_matched += 1
+                        continue
+            elif matched == "recompute":
+                if value == "*":
+                    if cur_cfg[reversed_mapping[matched]]:
+                        has_matched += 1
+                        continue
+                else:
+                    value = bool(int(value))
+                    if cur_cfg[reversed_mapping[matched]] == value:
+                        has_matched += 1
+                        continue
+            elif matched == "stage":
+                if value == "*":
+                    if cur_cfg[reversed_mapping["sharding"]] > 1:
+                        has_matched += 1
+                        continue
+                else:
+                    value = int(value)
+                    if cur_cfg[reversed_mapping[matched]] == value:
+                        has_matched += 1
+                        continue
+            elif matched == "mbs":
+                if value == "*":
+                    has_matched += 1
+                    continue
+                else:
+                    value = int(value)
+                    if cur_cfg[reversed_mapping[matched]] == value:
+                        has_matched += 1
+                        continue
+            elif matched == "granularity":
+                if value == "*":
+                    if cur_cfg[reversed_mapping["use_recompute"]]:
+                        has_matched += 1
+                        continue
+                else:
+                    value = int(value)
+                    granularity = granularity_mapping[value]
+                    if cur_cfg[reversed_mapping[matched]] == granularity:
+                        has_matched += 1
+                        continue
+    if has_matched == len(dims):
+        return True
+    return False
 
 
 def _param2range(param_from_json_file, max_value, param_key):

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -1016,6 +1016,7 @@ def launch():
             cur_best_cfgs, err = recorder.get_best(
                 metric=tuner_cfg['metric_cfg']['name'],
                 direction=tuner_cfg['metric_cfg']['OptimizationDirection'],
+                mode=mode,
             )
             if not err:
                 ctx.logger.info(f"Current best config: {cur_best_cfgs}")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PCard-80244
This PR adds two import features for autotuner, namely blacklist and schedule prior oeder mechanism.

- invalid_strategy: for example, the blacklist is [stage3_mp*], it means not support hybrid parallelism of model parallelism and sharding stage3.
- schedule_prior：for example, the schedule_prior is [mp4], it means mp4 related strategies will be prioritized for running.