### PR TITLE
[Shape]Remove LOG(Waring) in ShapeOptimPass

### DIFF
--- a/paddle/fluid/pir/transforms/shape_optimization_pass.cc
+++ b/paddle/fluid/pir/transforms/shape_optimization_pass.cc
@@ -111,8 +111,8 @@ class InferSymbolicShapePass : public pir::Pass {
     if (it != infer_sym_shape_map.end()) {
       it->second(op, shape_analysis_);
     } else {
-      LOG(WARNING) << "[" << op.name()
-                   << "] is not supported for infer_symbolic_shape pass.";
+      LOG(3) << "[" << op.name()
+             << "] is not supported for infer_symbolic_shape pass.";
     }
   }
 

--- a/paddle/fluid/pir/transforms/shape_optimization_pass.cc
+++ b/paddle/fluid/pir/transforms/shape_optimization_pass.cc
@@ -111,8 +111,8 @@ class InferSymbolicShapePass : public pir::Pass {
     if (it != infer_sym_shape_map.end()) {
       it->second(op, shape_analysis_);
     } else {
-      LOG(3) << "[" << op.name()
-             << "] is not supported for infer_symbolic_shape pass.";
+      VLOG(3) << "[" << op.name()
+              << "] is not supported for infer_symbolic_shape pass.";
     }
   }
 
@@ -206,7 +206,7 @@ struct ExpandShapeOfOpPattern : public OpRewritePattern<shape::ShapeOfOp> {
 
   bool MatchAndRewrite(shape::ShapeOfOp op,
                        PatternRewriter& rewriter) const override {
-    VLOG(3) << "Apply ExpandShapeOfOpPattern...";
+    VLOG(5) << "Apply ExpandShapeOfOpPattern...";
 
     auto type = op.out().type().dyn_cast<pir::DenseTensorType>();
 
@@ -762,7 +762,7 @@ class ShapeOptimizationPass : public pir::Pass {
   ShapeOptimizationPass() : pir::Pass("shape_optimization_pass", 0) {}
 
   void Run(pir::Operation* op) override {
-    VLOG(0) << "===================== ShapeOptimizationPass Run start... "
+    VLOG(5) << "===================== ShapeOptimizationPass Run start... "
                "=============================";
     auto module_op = op->dyn_cast<pir::ModuleOp>();
     IR_ENFORCE(module_op, "ShapeOptimizationPass should run on module op.");
@@ -777,7 +777,7 @@ class ShapeOptimizationPass : public pir::Pass {
     // if (!OptimizeShapeComputation(module_op, runner)) {
     //   return;
     // }
-    VLOG(0) << "===================== ShapeOptimizationPass Run End. "
+    VLOG(5) << "===================== ShapeOptimizationPass Run End. "
                "=============================";
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164

shape_optimization_pass 这里不建议使用LOG(Waring)，这个会默认输出出来，比较影响体验
<img width="1095" alt="06ce1d89fd1e8c825d4c17f4695901c4" src="https://github.com/PaddlePaddle/Paddle/assets/9301846/3c9dba71-d1fb-4321-94b4-24fb9c5bd2fb">
