### PR TITLE
【PIR API adaptor No.303】 Migrate paddle.nn.SpectralNorm into pir

### DIFF
--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -1950,7 +1950,7 @@ class SpectralNorm(Layer):
 
     def forward(self, x):
         weight = x
-        if in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             return _C_ops.spectral_norm(
                 weight,
                 self.weight_u,

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -26,6 +26,7 @@ from paddle.base.framework import (
     Variable,
     default_main_program,
     in_dygraph_mode,
+    in_dynamic_or_pir_mode,
     name_scope,
     program_guard,
     static_only,
@@ -3481,7 +3482,7 @@ def spectral_norm(weight, dim=0, power_iters=1, eps=1e-12, name=None):
     )
     v.stop_gradient = True
 
-    if in_dygraph_mode():
+    if in_dynamic_or_pir_mode():
         return paddle._C_ops.spectral_norm(weight, u, v, dim, power_iters, eps)
 
     inputs = {'Weight': weight}

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -986,6 +986,7 @@ class TestLayer(LayerTest):
 
         _test_errors()
 
+    @test_with_pir_api
     def test_spectral_norm(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)

--- a/test/legacy_test/test_spectral_norm_op.py
+++ b/test/legacy_test/test_spectral_norm_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest, skip_check_grad_ci
 import paddle
 from paddle import _C_ops
 from paddle.base.framework import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -84,7 +85,7 @@ class TestSpectralNormOpNoGrad(OpTest):
         self.outputs = {"Out": output}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
     def initTestCase(self):
         self.weight_shape = (10, 12)
@@ -116,6 +117,7 @@ class TestSpectralNormOp(TestSpectralNormOpNoGrad):
             ['Weight'],
             'Out',
             no_grad_set={"U", "V"},
+            check_pir=True,
         )
 
     def initTestCase(self):
@@ -138,6 +140,7 @@ class TestSpectralNormOp2(TestSpectralNormOp):
 
 
 class TestSpectralNormOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         with program_guard(Program(), Program()):
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
pcard-67164
PIR API 推全升级
将 paddle.nn.SpectralNorm 迁移升级至 pir，并更新单测

单测覆盖率：6/6
