### PR TITLE
[XPU] fix gm allocaion on XPUContext::Impl::Init

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -151,7 +151,15 @@ struct XPUContext::Impl {
     LOG_FIRST_N(WARNING, 1)
         << "Please NOTE: xpu device: " << static_cast<int>(place_.device);
     context_ = xpu::create_context();
-    context_->set_option("XPUAPI_DEFAULT_SIZE", "1");
+    // Setup XPU GM Buffer
+    if (std::getenv("XPUAPI_DEFAULT_SIZE") != nullptr) {
+      context_->set_option("XPUAPI_DEFAULT_SIZE",
+                           std::getenv("XPUAPI_DEFAULT_SIZE"));
+    } else {
+      // Optimization described in
+      // https://github.com/PaddlePaddle/Paddle/pull/54674
+      context_->set_option("XPUAPI_DEFAULT_SIZE", "1");
+    }
     xpu_version_ = backends::xpu::get_xpu_version(place_.device);
     SetL3Cache();
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
This PR https://github.com/PaddlePaddle/Paddle/pull/54674 forces the option XPUAPI_DEFAULT_SIZE of xdnn::Context to 1 by default, regardless of whether we set the environment variable XPUAPI_DEFAULT_SIZE to a different value. It triggers a lot of `xpu_wait` calls.

This comment describes why `XPUAPI_DEFAULT_SIZE` is originally set to `1`: https://github.com/PaddlePaddle/Paddle/pull/54674#discussion_r1230455871