### PR TITLE
[PIR] Fix hsigmoid_loss_grad infermeta bug

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -448,7 +448,9 @@ void GeneralTernaryGradInferMeta(const MetaTensor& x,
     dy->share_meta(y);
   }
   if (dz) {
-    dz->share_meta(z);
+    if (z) {
+      dz->share_meta(z);
+    }
   }
 }
 void GeneralQuaternaryGradInferMeta(const MetaTensor& x,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-67164
Fix hsigmoid_loss_grad infermeta bug
- hsigmoid存在bias为空的测试，因此对GeneralTernaryGradInferMeta中的第三个输入判断是否为nullptr