### PR TITLE
[PIR]Fix optional output error when input is none

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -85,6 +85,7 @@ API_INNER_CODE_TEMPLATE = """
     {in_combine}
     {compute_op}
     {handle_optional_outputs}
+    {set_null_type}
     {out_split}
     {return_result}"""
 
@@ -147,6 +148,12 @@ OPTIONAL_VECTOR_OPRESULT_OUTPUT_TEMPLATE = """
         auto optional_{name}_slice_op = ApiBuilder::Instance().GetBuilder()->Build<pir::SplitOp>({op_name}_op.result({index}));
         optional_{name} = paddle::make_optional<std::vector<pir::OpResult>>(optional_{name}_slice_op.outputs());
     }}"""
+
+SET_NULL_TYPE_TEMPLATE = """
+    if (!{input}) {{
+        {op_name}_op.result({index}).set_type(pir::Type());
+    }}"""
+
 
 COMBINE_OP_TEMPLATE = """
     auto {op_name} = ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>({in_name});"""
@@ -433,6 +440,21 @@ class CodeGen:
                         op_name=op_name,
                         index=i,
                     )
+        return ret
+
+    def _gen_set_null_type(self, op_info, op_name):
+        name_list = op_info.output_name_list
+        inplace_map = op_info.inplace_map
+        if inplace_map is None:
+            return ""
+
+        ret = ""
+        for i, out_name in enumerate(name_list):
+            if self._is_optional_output(op_info, out_name):
+                in_name = inplace_map[out_name]
+                ret += SET_NULL_TYPE_TEMPLATE.format(
+                    input=in_name, op_name=op_name, index=i
+                )
         return ret
 
     def _gen_in_combine(self, op_info, is_mutable_attr, is_vector_mutable_attr):
@@ -727,6 +749,7 @@ class CodeGen:
                     handle_optional_outputs=self._gen_handle_optional_outputs(
                         op_info, kernel_name
                     ),
+                    set_null_type=self._gen_set_null_type(op_info, kernel_name),
                     out_split=out_split,
                     return_result=self._gen_return_result(ret_list),
                 )
@@ -782,6 +805,7 @@ class CodeGen:
                 handle_optional_outputs=self._gen_handle_optional_outputs(
                     op_info, op_name
                 ),
+                set_null_type=self._gen_set_null_type(op_info, op_name),
                 out_split=out_split,
                 return_result=self._gen_return_result(ret_list),
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复optional 输出的bug，以masked_multihead_attention_为例
```yaml
- op : masked_multihead_attention_
  args : (Tensor x, Tensor cache_kv, Tensor bias, Tensor src_mask, Tensor cum_offsets, Tensor sequence_lengths, Tensor rotary_tensor, Tensor beam_cache_offset, Tensor qkv_out_scale, Tensor out_shift, Tensor out_smooth, int seq_len, int rotary_emb_dims, bool use_neox_rotary_style=false, str compute_dtype = "default", float out_scale=-1, int quant_round_type=1, float quant_max_bound=127.0, float quant_min_bound=-127.0)
  output : Tensor(out), Tensor(cache_kv_out), Tensor(beam_cache_offset_out)
  infer_meta :
    func : MaskedMultiheadAttentionInferMeta
  kernel :
    func : masked_multihead_attention
    data_type : x
  optional : bias, src_mask, cum_offsets, sequence_lengths, rotary_tensor, beam_cache_offset, qkv_out_scale, out_shift, out_smooth
  inplace : (cache_kv -> cache_kv_out), (beam_cache_offset -> beam_cache_offset_out)
```
第三个输出beam_cache_offset_out是optional的，它会和输入beam_cache_offset做inplace，输入beam_cache_offset是optional 的，当输入beam_cache_offset为None时，执行器会报错。在此PR中对这种情况做了处理，当beam_cache_offset为None时，将beam_cache_offset_out的type设置为null type。会在API内生成类似下面的代码
```c++
  if (!beam_cache_offset) {
    masked_multihead_attention__op.result(2).set_type(pir::Type());
  }
```


Pcard-67164