### PR TITLE
optimize slice over limit case in static

### DIFF
--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -292,6 +292,8 @@ def parse_index(x, indices):
                 start = 0 if step > 0 else MAX_INTEGER
             if end is None:
                 end = MAX_INTEGER if step > 0 else -1
+            if x.shape[dim] != -1 and end >= x.shape[dim]:
+                end = MAX_INTEGER
 
         elif isinstance(slice_item, (list, tuple)):
             advanced_index[estimated_dim] = (
@@ -355,7 +357,10 @@ def parse_index(x, indices):
                     slice_item
                 )
             )
-        if not (start is None or end is None or step is None):
+        if not (
+            (start is None or end is None or step is None)
+            or (start == 0 and end == MAX_INTEGER and step == 1)
+        ):
             starts.append(start)
             ends.append(end)
             steps.append(step)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985

For basic getitem case if slice is set but it cover the all element in the axis. e.g.`x[:10] if x.shape=(4,3,2)`. The result is same to `x`. We can add a fast path for this case to speed up models.

Different with dynamic-mode, static mode cannot deal all of this case since there is potential uncertain shape. Here we only deal with the certain shape.