### PR TITLE
【AutoParallel】support bf16 of sync_op

### DIFF
--- a/paddle/fluid/operators/collective/c_sync_calc_stream_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_sync_calc_stream_op.cu.cc
@@ -24,4 +24,5 @@ PD_REGISTER_STRUCT_KERNEL(c_sync_calc_stream,
                           double,
                           int,
                           int64_t,
-                          plat::float16) {}
+                          plat::float16,
+                          plat::bfloat16) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-76459
Support `bfloat16` of `c_sync_calc_stream_op`.