### PR TITLE
[SOT][3.11] Combine PRECALL and CALL as a super instruction in simulation

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -291,15 +291,7 @@ class FunctionGraph:
             store_var_info[var.id] = name
             self.pycode_gen.gen_store_fast(store_var_info[var.id])
 
-        loader = VariableLoader(store_var_info, self.pycode_gen)
-
-        for var in stack_vars:
-            self.pycode_gen.gen_load_global("print", push_null=True)
-            loader.load(var)
-            self.pycode_gen.gen_call_function(1)
-            self.pycode_gen.gen_pop_top()
-
-        return loader
+        return VariableLoader(store_var_info, self.pycode_gen)
 
     def _build_compile_fn_with_name_store(self, ret_vars, to_store_vars):
         class VariableLoader:

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -286,9 +286,7 @@ class FunctionGraph:
         name_gen = NameGenerator("__start_compile_saved_orig_")
 
         for var in stack_vars[::-1]:
-            name = name_gen.next()
-            print("[VAR]", name, var)
-            store_var_info[var.id] = name
+            store_var_info[var.id] = name_gen.next()
             self.pycode_gen.gen_store_fast(store_var_info[var.id])
 
         return VariableLoader(store_var_info, self.pycode_gen)

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -257,16 +257,13 @@ class FunctionGraph:
         origin_instrs = get_instructions(self.pycode_gen._origin_code)
         is_precall = origin_instrs[instr_idx].opname == "PRECALL"
         current_idx = instr_idx
-        next_idx = instr_idx + (2 if is_precall else 1)
+        next_idx = instr_idx + 1 + int(is_precall)
 
         restore_instrs = origin_instrs[:current_idx]
         restore_instr_names = [
             instr.opname for instr in restore_instrs[:current_idx]
         ]
-        # NOTE(SigureMo): Trailing KW_NAMES or PRECALL is no need to restore in Python 3.11+
-        if restore_instr_names[-1:] == ["PRECALL"]:
-            restore_instrs = restore_instrs[:-1]
-            restore_instr_names = restore_instr_names[:-1]
+        # NOTE(SigureMo): Trailing KW_NAMES is no need to restore in Python 3.11+
         if restore_instr_names[-1:] == ["KW_NAMES"]:
             restore_instrs = restore_instrs[:-1]
             restore_instr_names = restore_instr_names[:-1]

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -257,6 +257,7 @@ class FunctionGraph:
         origin_instrs = get_instructions(self.pycode_gen._origin_code)
         is_precall = origin_instrs[instr_idx].opname == "PRECALL"
         current_idx = instr_idx
+        # skip CALL if current instr is PRECALL
         next_idx = instr_idx + 1 + int(is_precall)
 
         restore_instrs = origin_instrs[:current_idx]

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1698,10 +1698,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
         # gen call resume fn opcode
         # NOTE(SigureMo): In Python 3.11，we need generate KW_NAMES if the call shape is not None.
         self._graph.pycode_gen.gen_kw_names(self._call_shape)
-        # if instr.opname == "CALL":
-        #     self._graph.pycode_gen.gen_call_function(instr.arg)
-        # else:
-        #     self._graph.pycode_gen.extend_instrs([instr])
         self._graph.pycode_gen.extend_instrs(
             self._instructions[index:next_index]
         )

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1676,19 +1676,20 @@ class OpcodeExecutor(OpcodeExecutorBase):
         push_n = push_n(instr.arg) if callable(push_n) else push_n
         is_precall = instr.opname == "PRECALL"
         index = self.indexof(instr)
-        next_index = index + (2 if is_precall else 1)
+        call_instr = self._instructions[index + int(is_precall)]
+        next_index = index + 1 + int(is_precall)
         self.stack = origin_stack
 
         # gen call static fn opcode
 
-        resume_input_name = analysis_inputs(self._instructions, index + 1)
+        resume_input_name = analysis_inputs(self._instructions, next_index)
 
         var_loader = self.gen_compute_in_break_with_name_store(
-            resume_input_name, self.indexof(instr)
+            resume_input_name, index
         )
 
         # gen graph break call fn opcode
-        stack_effect = calc_stack_effect(instr)
+        stack_effect = calc_stack_effect(call_instr)
         pop_n = push_n - stack_effect
 
         for i, stack_arg in enumerate(self.stack):

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1676,7 +1676,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
         push_n = push_n(instr.arg) if callable(push_n) else push_n
         is_precall = instr.opname == "PRECALL"
         index = self.indexof(instr)
+        # Use CALL instead of PRECALL to calculate the real stack effect
         call_instr = self._instructions[index + int(is_precall)]
+        # skip CALL if current instr is PRECALL
         next_index = index + 1 + int(is_precall)
         self.stack = origin_stack
 

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -558,8 +558,10 @@ class OpcodeExecutorBase:
             print(log_message)
             breakpoint()  # breakpoint for debug
 
-        with EventGuard(f"{instr.opname}", event_level=1):
-            return getattr(self, instr.opname)(instr)  # run single step.
+        opname = instr.opname if instr.opname != "PRECALL" else "PRECALL__CALL"
+        assert opname != "CALL", "CALL should fused with PRECALL"
+        with EventGuard(f"{opname}", event_level=1):
+            return getattr(self, opname)(instr)  # run single step.
 
     def indexof(self, instr: Instruction):
         """
@@ -1027,6 +1029,19 @@ class OpcodeExecutorBase:
             )
         )
 
+    @call_break_graph_decorator(push_n=1)
+    def PRECALL__CALL(self, instr: Instruction):
+        """
+        presudo super-instruction for PRECALL + CALL
+        """
+        assert isinstance(instr.arg, int)
+        assert instr.opname == "PRECALL"
+        self.PRECALL(instr)
+        next_instr = self._instructions[self._lasti]
+        self._lasti += 1
+        assert next_instr.opname == "CALL"
+        self.CALL(next_instr)
+
     def PRECALL(self, instr: Instruction):
         assert isinstance(instr.arg, int)
         is_method_layout = not isinstance(
@@ -1045,7 +1060,6 @@ class OpcodeExecutorBase:
         assert isinstance(instr.arg, int)
         self._call_shape = self._co_consts[instr.arg].get_py_value()
 
-    @call_break_graph_decorator(push_n=1)
     def CALL(self, instr: Instruction):
         assert isinstance(instr.arg, int)
         assert instr.arg + 2 <= len(self.stack)
@@ -1660,7 +1674,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
         """
         push_n = push_n(instr.arg) if callable(push_n) else push_n
+        is_precall = instr.opname == "PRECALL"
         index = self.indexof(instr)
+        next_index = index + (2 if is_precall else 1)
         self.stack = origin_stack
 
         # gen call static fn opcode
@@ -1681,11 +1697,17 @@ class OpcodeExecutor(OpcodeExecutorBase):
         # gen call resume fn opcode
         # NOTE(SigureMo): In Python 3.11，we need generate KW_NAMES if the call shape is not None.
         self._graph.pycode_gen.gen_kw_names(self._call_shape)
-        self._graph.pycode_gen.extend_instrs([instr])
+        # if instr.opname == "CALL":
+        #     self._graph.pycode_gen.gen_call_function(instr.arg)
+        # else:
+        #     self._graph.pycode_gen.extend_instrs([instr])
+        self._graph.pycode_gen.extend_instrs(
+            self._instructions[index:next_index]
+        )
         self.stack.pop_n(pop_n)
         stack_size = len(self.stack) + push_n
 
-        resume_fn, _ = self._create_resume_fn(index + 1, stack_size)
+        resume_fn, _ = self._create_resume_fn(next_index, stack_size)
 
         if resume_fn:
             self._graph.pycode_gen.gen_load_object(

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
@@ -27,6 +27,7 @@ def apply_instr_pass(instrs, code_options):
         remove_duplicate_resume,
         check_precall_followed_by_call,
     )
+    supported_passes = ()
 
     for instr_pass in supported_passes:
         instr_pass(instrs, code_options)

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
@@ -27,7 +27,6 @@ def apply_instr_pass(instrs, code_options):
         remove_duplicate_resume,
         check_precall_followed_by_call,
     )
-    supported_passes = ()
 
     for instr_pass in supported_passes:
         instr_pass(instrs, code_options)

--- a/test/sot/test_break_graph.py
+++ b/test/sot/test_break_graph.py
@@ -164,5 +164,26 @@ class TestBreakGraphResumePassNull(TestCaseBase):
         self.assert_results(break_graph_resume_pass_null, x, y)
 
 
+class MyLayer(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.head = paddle.nn.Linear(3, 10)
+
+    def forward_features(self, x):
+        paddle.jit.sot.psdb.breakgraph()
+        return x
+
+    def forward(self, x):
+        x = self.forward_features(x)
+        return self.head(x)
+
+
+class TestBreakGraphInLayer(TestCaseBase):
+    def test_break_graph_in_layer(self):
+        x = paddle.rand([2, 3], dtype=paddle.float32)
+        net = MyLayer()
+        self.assert_results(net.forward, x)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Python 3.11 #59860 针对 PRECALL 的解决方案仍然有问题，当原始字节码如下时

```
AAA
PRECALL
CALL     <---- 发生 breakgraph
BBB
```

#59860 之前会生成如下字节码

```
AAA
PRECALL
---            以上为 copy 部分，以下为生成部分
CCC
CALL
DDD
```

#59860 的结论是 PRECALL 后面一定要跟随 CALL，因为如果后面不是 CALL 在 PRECALL builtin 特化时一定会报错

#59860 的解决方案是移除 copy 的 PRECALL，即

```
AAA
CCC
---            以上为 copy 部分，以下为生成部分
CALL
DDD
```

但这又有了另一个问题，就是模拟时其实 PRECALL 已经跑完了，但 copy 代码部分并没有 PRECALL，那么在用 VariableLoader load var 的时候模拟执行 Variable 和真实执行 PyObject 就对不上，其关键在于无法判断一个 Variable 对应的真实值是否为 NULL，这个问题类似 #58956

> [!NOTE]
>
> 值得注意的是，这里的关键并不是后面生成的 CALL 前面没有 PRECALL，没有 PRECALL 其实是没有任何问题的，也尝试过在 CALL 前面添加 PRECALL 是没有效果的，因为问题不在这里

其实这里关键是 PRECALL 和 CALL 分开导致 CALL 打断的时候模拟时候已经有了 PRECALL 的副作用，如果能够自动恢复这个副作用就没有任何问题了。而对于单个字节码来说，我们本身就有这样的机制来恢复，另一方面，从模拟的角度来说，PRECALL 和 CALL 永远是一起的，它们不应该独立分析。因此将它们整合成一个字节码来分析就可以保证两者的统一，PRECALL 和 CALL 发生 breakgraph 时会回退到 PRECALL 之前的状态，生成代码时也会将 PRECALL 和 CALL 一起生成

这里参考了 Python 3.11 中的超指令（super-instruction）的概念，在模拟执行时将 PRECALL+CALL 融合成 `PRECALL__CALL`（命名也是参考超指令的命名规范，比如 `LOAD_CONST__LOAD_FAST`）

PCard-66972