### PR TITLE
[XPU] remove generate_proposals and sequence_conv from xpu3_op_list

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -484,7 +484,6 @@ XPUOpMap& get_kl3_ops() {
       {"gelu_grad",
        XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
       {"gelu", XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
-      {"generate_proposals_v2", XPUKernelSet({phi::DataType::FLOAT32})},
       {"generate_sequence_xpu",
        XPUKernelSet({
            phi::DataType::FLOAT32,
@@ -1152,8 +1151,6 @@ XPUOpMap& get_kl3_ops() {
        XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
 
       // AddMore
-      {"sequence_conv", XPUKernelSet({phi::DataType::FLOAT32})},
-      {"sequence_conv_grad", XPUKernelSet({phi::DataType::FLOAT32})},
       {"sequence_unpad", XPUKernelSet({phi::DataType::FLOAT32})},
       // Fused op
       {"resnet_basic_block_grad", XPUKernelSet({phi::DataType::FLOAT32})},


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
QA测试时候发现，`test_sequence_conv_op_xpu`和`test_generate_proposals_v2_op_xpu`这两个单测不通过。排查发现这两个算子中有些需要的API暂时没有KL3的实现，因此将其从`xpu3_op_list.cc`中移除。