### PR TITLE
【PIR API adaptor No.311、312、301、290、259】 Migrate some loss api into pir

### DIFF
--- a/test/legacy_test/test_hinge_embedding_loss.py
+++ b/test/legacy_test/test_hinge_embedding_loss.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.static import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(42)
 
@@ -45,7 +45,7 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
     def run_dynamic_check(self, place=paddle.CPUPlace()):
         paddle.disable_static(place=place)
         input = paddle.to_tensor(self.input_np)
-        label = paddle.to_tensor(self.label_np, dtype=paddle.float64)
+        label = paddle.to_tensor(self.label_np, dtype="float64")
 
         dy_result = paddle.nn.functional.hinge_embedding_loss(input, label)
         expected = calc_hinge_embedding_loss(self.input_np, self.label_np)
@@ -70,18 +70,21 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
         self.assertEqual(dy_result.shape, list(self.shape))
 
+    @test_with_pir_api
     def run_static_check(self, place=paddle.CPUPlace):
         paddle.enable_static()
         for reduction in ['none', 'mean', 'sum']:
             expected = calc_hinge_embedding_loss(
                 self.input_np, self.label_np, reduction=reduction
             )
-            with program_guard(Program(), Program()):
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
                 input = paddle.static.data(
-                    name="input", shape=self.shape, dtype=paddle.float64
+                    name="input", shape=self.shape, dtype="float64"
                 )
                 label = paddle.static.data(
-                    name="label", shape=self.shape, dtype=paddle.float64
+                    name="label", shape=self.shape, dtype="float64"
                 )
                 st_result = paddle.nn.functional.hinge_embedding_loss(
                     input, label, reduction=reduction
@@ -93,10 +96,12 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
                 )
                 np.testing.assert_allclose(result_numpy, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cpu(self):
         self.run_dynamic_check(place=paddle.CPUPlace())
         self.run_static_check(place=paddle.CPUPlace())
 
+    @test_with_pir_api
     def test_gpu(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -104,6 +109,7 @@ class TestFunctionalHingeEmbeddingLoss(unittest.TestCase):
         self.run_static_check(place=paddle.CUDAPlace(0))
 
     # test case the raise message
+    @test_with_pir_api
     def test_reduce_errors(self):
         def test_value_error():
             loss = paddle.nn.functional.hinge_embedding_loss(
@@ -124,7 +130,7 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
     def run_dynamic_check(self, place=paddle.CPUPlace()):
         paddle.disable_static(place=place)
         input = paddle.to_tensor(self.input_np)
-        label = paddle.to_tensor(self.label_np, dtype=paddle.float64)
+        label = paddle.to_tensor(self.label_np, dtype="float64")
         hinge_embedding_loss = paddle.nn.loss.HingeEmbeddingLoss()
         dy_result = hinge_embedding_loss(input, label)
         expected = calc_hinge_embedding_loss(self.input_np, self.label_np)
@@ -151,18 +157,21 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
         np.testing.assert_allclose(dy_result.numpy(), expected, rtol=1e-05)
         self.assertTrue(dy_result.shape, list(self.shape))
 
+    @test_with_pir_api
     def run_static_check(self, place=paddle.CPUPlace):
         paddle.enable_static()
         for reduction in ['none', 'mean', 'sum']:
             expected = calc_hinge_embedding_loss(
                 self.input_np, self.label_np, reduction=reduction
             )
-            with program_guard(Program(), Program()):
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
                 input = paddle.static.data(
-                    name="input", shape=self.shape, dtype=paddle.float64
+                    name="input", shape=self.shape, dtype="float64"
                 )
                 label = paddle.static.data(
-                    name="label", shape=self.shape, dtype=paddle.float64
+                    name="label", shape=self.shape, dtype="float64"
                 )
                 hinge_embedding_loss = paddle.nn.loss.HingeEmbeddingLoss(
                     reduction=reduction
@@ -175,10 +184,12 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
                 )
                 np.testing.assert_allclose(result_numpy, expected, rtol=1e-05)
 
+    @test_with_pir_api
     def test_cpu(self):
         self.run_dynamic_check(place=paddle.CPUPlace())
         self.run_static_check(place=paddle.CPUPlace())
 
+    @test_with_pir_api
     def test_gpu(self):
         if not paddle.is_compiled_with_cuda():
             return
@@ -186,6 +197,7 @@ class TestClassHingeEmbeddingLoss(unittest.TestCase):
         self.run_static_check(place=paddle.CUDAPlace(0))
 
     # test case the raise message
+    @test_with_pir_api
     def test_reduce_errors(self):
         def test_value_error():
             hinge_embedding_loss = paddle.nn.loss.HingeEmbeddingLoss(

--- a/test/legacy_test/test_poisson_nll_loss.py
+++ b/test/legacy_test/test_poisson_nll_loss.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 import paddle.nn.functional as F
 from paddle.base import core
+from paddle.pir_utils import test_with_pir_api
 
 np.random.seed(100)
 
@@ -75,6 +76,7 @@ class TestPoissonNLLLossBasicCase(unittest.TestCase):
             else paddle.CPUPlace()
         )
 
+    @test_with_pir_api
     def test_static_case(
         self,
         dtype="float32",
@@ -90,8 +92,6 @@ class TestPoissonNLLLossBasicCase(unittest.TestCase):
         with paddle.static.program_guard(prog, startup_prog):
             input = paddle.static.data('input', self.shape, dtype)
             label = paddle.static.data('label', self.shape, dtype)
-            input.desc.set_need_check_feed(False)
-            label.desc.set_need_check_feed(False)
             out1 = F.poisson_nll_loss(
                 input,
                 label,
@@ -203,6 +203,7 @@ class TestPoissonNLLLossErrCase(TestPoissonNLLLossBasicCase):
 
 
 class TestPoissonNLLLossFloat16Case(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         if core.is_compiled_with_cuda():
             self.test_static_case(dtype="float16")
@@ -210,6 +211,7 @@ class TestPoissonNLLLossFloat16Case(TestPoissonNLLLossBasicCase):
 
 
 class TestPoissonNLLLossBfloat16Case(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         if core.is_compiled_with_cuda():
             self.test_static_case(dtype="uint16")
@@ -217,30 +219,35 @@ class TestPoissonNLLLossBfloat16Case(TestPoissonNLLLossBasicCase):
 
 
 class TestPoissonNLLLossFloat32Case(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         self.test_static_case(dtype="float32")
         self.test_dynamic_case(dtype="float32")
 
 
 class TestPoissonNLLLossFloat64Case(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         self.test_static_case(dtype="float64")
         self.test_dynamic_case(dtype="float64")
 
 
 class TestPoissonNLLLossNoLoginputCase(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         self.test_static_case(log_input=False)
         self.test_dynamic_case(log_input=False)
 
 
 class TestPoissonNLLLossFulllossCase(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         self.test_static_case(full=True)
         self.test_dynamic_case(full=True)
 
 
 class TestPoissonNLLLossSumReductionCase(TestPoissonNLLLossBasicCase):
+    @test_with_pir_api
     def test_api(self):
         self.test_static_case(reduction="sum")
         self.test_dynamic_case(reduction="sum")

--- a/test/legacy_test/test_soft_margin_loss.py
+++ b/test/legacy_test/test_soft_margin_loss.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def test_static_layer(
@@ -122,6 +123,7 @@ def calc_softmarginloss(
 
 
 class TestSoftMarginLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_SoftMarginLoss(self):
         input_np = np.random.uniform(0.1, 0.8, size=(5, 5)).astype(np.float64)
         types = [np.int32, np.int64, np.float32, np.float64]

--- a/test/legacy_test/test_triplet_margin_loss.py
+++ b/test/legacy_test/test_triplet_margin_loss.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def call_TripletMarginLoss_layer(
@@ -193,6 +194,7 @@ def calc_triplet_margin_loss(
 
 
 class TestTripletMarginLoss(unittest.TestCase):
+    @test_with_pir_api
     def test_TripletMarginLoss(self):
         shape = (2, 2)
         input = np.random.uniform(0.1, 0.8, size=shape).astype(np.float64)
@@ -305,6 +307,7 @@ class TestTripletMarginLoss(unittest.TestCase):
         )
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_TripletMarginLoss_swap(self):
         reduction = 'mean'
         place = paddle.CPUPlace()
@@ -389,6 +392,7 @@ class TestTripletMarginLoss(unittest.TestCase):
         )
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_TripletMarginLoss_p(self):
         p = 3
         shape = (2, 2)

--- a/test/legacy_test/test_triplet_margin_with_distance_loss.py
+++ b/test/legacy_test/test_triplet_margin_with_distance_loss.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 
 def call_TripletMarginDistanceLoss_layer(
@@ -192,6 +193,7 @@ def calc_triplet_margin_distance_loss(
 
 
 class TestTripletMarginWithDistanceLossnew(unittest.TestCase):
+    @test_with_pir_api
     def test_TripletMarginDistanceLoss(self):
         shape = (5, 5)
         np.random.seed(1234)
@@ -286,6 +288,7 @@ class TestTripletMarginWithDistanceLossError(unittest.TestCase):
 
 
 class TestTripletMarginWithDistanceLossDF(unittest.TestCase):
+    @test_with_pir_api
     def test_TripletMarginDistanceLoss_distance_function(self):
         def distance_function_1(x1, x2):
             return 1.0 - paddle.nn.functional.cosine_similarity(x1, x2)
@@ -399,6 +402,7 @@ class TestTripletMarginWithDistanceLossDim(unittest.TestCase):
 
 
 class TestTripletMarginWithDistanceLossSwap(unittest.TestCase):
+    @test_with_pir_api
     def test_TripletMarginWithDistanceLoss_swap(self):
         reduction = 'mean'
         place = paddle.CPUPlace()


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
任务 issue: https://github.com/PaddlePaddle/Paddle/issues/58067

1. 将 paddle.nn.HingeEmbeddingLoss 迁移升级至 pir，并更新单测，单测覆盖率（2/2）

2. 将 paddle.nn.PoissonNLLLoss 迁移升级至 pir，并更新单测，单测覆盖率（8/8）

3. 将 paddle.nn.SoftMarginLoss 迁移升级至 pir，并更新单测，单测覆盖率（1/1）

4. 将 paddle.nn.TripletMarginLoss 迁移升级至 pir，并更新单测，单测覆盖率（3/3）

5. 将 paddle.nn.TripletMarginWithDistanceLoss 迁移升级至 pir，并更新单测，单测覆盖率（4/4）