### PR TITLE
【PIR API adaptor No.188】 Migrate paddle.regularizer.L2Decay into pir

### DIFF
--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -244,7 +244,7 @@ class Momentum(Optimizer):
         )
 
     def _append_optimize_op(self, block, param_and_grad):
-        assert isinstance(block, framework.Block)
+        assert isinstance(block, (framework.Block, paddle.pir.Block))
         if isinstance(param_and_grad, dict):
             param_and_grad = self._update_param_group(param_and_grad)
 

--- a/test/legacy_test/test_momentum_op.py
+++ b/test/legacy_test/test_momentum_op.py
@@ -759,7 +759,12 @@ class TestFusedMomentumWithDecayAPI(unittest.TestCase):
             optimizer.minimize(loss)
         return main_program
 
-    def test_param_has_l2decay(self):
+    def test_luq(self):
+        with paddle.pir_utils.IrGuard():
+            self._test_param_has_l2decay()
+
+    # @test_with_pir_api
+    def _test_param_has_l2decay(self):
         paddle.enable_static()
         weight_attr = paddle.ParamAttr(
             name="weight",
@@ -768,7 +773,8 @@ class TestFusedMomentumWithDecayAPI(unittest.TestCase):
         )
         program = self.get_program(weight_attr, bias_attr=False)
         ops = program.global_block().ops
-
+        print("========= program ============")
+        print(program)
         self.assertEqual(ops[-1].attr('regularization_method'), 'l2_decay')
         self.assertEqual(ops[-1].attr('regularization_coeff'), np.float32(0.1))
         for i in range(len(ops)):

--- a/test/legacy_test/test_regularizer_api.py
+++ b/test/legacy_test/test_regularizer_api.py
@@ -78,7 +78,7 @@ class TestRegularizer(unittest.TestCase):
         scope = base.core.Scope()
         with base.unique_name.guard():
             with base.scope_guard(scope):
-                with base.program_guard(main_prog, startup_prog):
+                with paddle.static.program_guard(main_prog, startup_prog):
                     yield
 
     def run_program(self, place, feed_list):


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
任务 issue: https://github.com/PaddlePaddle/Paddle/issues/58067

paddle.regularizer.L2Decay

遇到问题：
1. pir 模式下，parameter 没有 regularizer 属性，导致 coeff 错误。设计单测：test/legacy_test/test_momentum_op.py 的 test_param_has_l2decay

2. pir.Operation 没有 'op_device' 属性，导致 python/paddle/optimizer/optimizer.py 在 _create_optimization_pass 时调用_update_param_device_map 出错
