### PR TITLE
fix gru error for make foramt any

### DIFF
--- a/paddle/phi/kernels/fusion/onednn/fusion_gru_kernel.cc
+++ b/paddle/phi/kernels/fusion/onednn/fusion_gru_kernel.cc
@@ -108,7 +108,7 @@ class GRUOneDNNHandler
 
       // Create memory descriptors
       auto input_md = OneDNNMemDesc(
-          {Ti, N, IC}, OneDNNGetDataType<T>(), OneDNNMemoryFormat::ntc);
+          {Ti, N, IC}, OneDNNGetDataType<T>(), OneDNNMemoryFormat::any);
       auto weight_x_md =
           OneDNNMemDesc({L, D, IC, G, OC}, weights_dt, OneDNNMemoryFormat::any);
       auto weight_h_md =
@@ -116,7 +116,7 @@ class GRUOneDNNHandler
       auto bias_md = OneDNNMemDesc(
           {L, D, G, OC}, OneDNNGetDataType<float>(), OneDNNMemoryFormat::ldgo);
       auto hidden_md = OneDNNMemDesc(
-          {Ti, N, OC}, OneDNNGetDataType<T_out>(), OneDNNMemoryFormat::ntc);
+          {Ti, N, OC}, OneDNNGetDataType<T_out>(), OneDNNMemoryFormat::any);
       auto h0_md = OneDNNMemDesc(
           {L, D, N, OC}, OneDNNGetDataType<T>(), OneDNNMemoryFormat::ldnc);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
This is a bug in previous implement. Src has NTC or TNC two option layout, thus set it to any and make OneDNN choose it automatically. The error will not appear in v3.3 but in v3.3.3 and v3.4 because of the restriction of new OneDNN version.


