### PR TITLE
[PIR][DynamicShape] Add Get&Set APIs for value2sym_expr map

### DIFF
--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -175,4 +175,16 @@ std::string GetValueId(Value* val) {
   return "op_" + std::to_string(op_id) + "_rst_" + std::to_string(val_idx);
 }
 
+const symbol::ShapeOrDataDimExprs&
+ShapeConstraintIRAnalysis::GetShapeOrDataForValue(Value* val) {
+  auto val_id = GetValueId(val);
+  return value_id_to_shapeordata[val_id];
+}
+
+void ShapeConstraintIRAnalysis::SetShapeOrDataForValue(
+    Value* val, const symbol::ShapeOrDataDimExprs& shape_or_data) {
+  auto val_id = GetValueId(val);
+  value_id_to_shapeordata[val_id] = shape_or_data;
+}
+
 }  // namespace pir

--- a/paddle/pir/dialect/shape/utils/shape_utils.h
+++ b/paddle/pir/dialect/shape/utils/shape_utils.h
@@ -85,6 +85,11 @@ class IR_API ShapeConstraintIRAnalysis : public ShapeAnalysis {
     return "S" + std::to_string(next_sym_idx_++);
   }
 
+  const symbol::ShapeOrDataDimExprs& GetShapeOrDataForValue(Value* val);
+
+  void SetShapeOrDataForValue(Value* val,
+                              const symbol::ShapeOrDataDimExprs& shape_or_data);
+
   // const symbol::ShapeOrData& GetShapeOrDataForValue() const;
 
   symbol::DimExprBuilder CreateDimExprBuilder() override;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164

att, add Get&Set APIs for value2sym_expr map