### PR TITLE
【PIR API adaptor No.270】Migrate LogMelSpectrogram to pir

### DIFF
--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -14,6 +14,7 @@
 
 import paddle
 from paddle import _C_ops
+from paddle.base.framework import in_dynamic_or_pir_mode
 from paddle.framework import in_dynamic_mode
 
 from .base.data_feeder import check_variable_and_dtype
@@ -114,7 +115,7 @@ def frame(x, frame_length, hop_length, axis=-1, name=None):
             f'Unexpected hop_length: {hop_length}. It should be an positive integer.'
         )
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         if frame_length > x.shape[axis]:
             raise ValueError(
                 f'Attribute frame_length should be less equal than sequence length, '


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PIR API 推全升级 * https://github.com/PaddlePaddle/Paddle/issues/58067

尝试迁移LogMelSpectrogram到PIR下，之前的单测中没有静态图相关单测，添加静态图单测后发现在老静态图下LogMelSpectrogram这个API就无法正常组网，所以这个API之前应该只会在动态图下用到

下面的case可以体现，该API无法在老静态图下正常组网，但是动态图下可以组网
```python
import paddle
import re
from paddle import base

paddle.enable_static()

sr = 16000
window_str = "hamming"
n_fft = 128
hop_length = 128
n_mels = 64
fmin = 0.0
layer = paddle.audio.features.LogMelSpectrogram(
    sr=sr,
    n_fft=n_fft,
    hop_length=hop_length,
    window=window_str,
    center=True,
    n_mels=n_mels,
    f_min=fmin,
    top_db=None,
    dtype='float32',
)

print(layer)
```

报错信息：
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/2608eed6-702d-4845-a2ad-49c5c24985c7)
