### PR TITLE
【PIR API adaptor No.177】Migrate paddle.geometric.reindex_graph into pir

### DIFF
--- a/python/paddle/geometric/reindex.py
+++ b/python/paddle/geometric/reindex.py
@@ -17,7 +17,7 @@ from paddle import _C_ops
 from paddle.base.data_feeder import check_variable_and_dtype
 from paddle.base.framework import Variable
 from paddle.base.layer_helper import LayerHelper
-from paddle.framework import in_dynamic_mode, in_dynamic_or_pir_mode
+from paddle.framework import in_dynamic_or_pir_mode
 
 __all__ = []
 
@@ -90,7 +90,7 @@ def reindex_graph(
         True if value_buffer is not None and index_buffer is not None else False
     )
 
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         reindex_src, reindex_dst, out_nodes = _C_ops.reindex_graph(
             x,
             neighbors,

--- a/test/legacy_test/test_graph_reindex.py
+++ b/test/legacy_test/test_graph_reindex.py
@@ -129,6 +129,7 @@ class TestGraphReindex(unittest.TestCase):
         np.testing.assert_allclose(reindex_dst, reindex_dst_, rtol=1e-05)
         np.testing.assert_allclose(out_nodes, out_nodes_, rtol=1e-05)
 
+    @test_with_pir_api
     def test_reindex_result_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
@@ -370,6 +371,7 @@ class TestGeometricGraphReindex(unittest.TestCase):
         np.testing.assert_allclose(reindex_dst, reindex_dst_, rtol=1e-05)
         np.testing.assert_allclose(out_nodes, out_nodes_, rtol=1e-05)
 
+    @test_with_pir_api
     def test_reindex_result_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):

--- a/test/legacy_test/test_graph_reindex.py
+++ b/test/legacy_test/test_graph_reindex.py
@@ -129,7 +129,6 @@ class TestGraphReindex(unittest.TestCase):
         np.testing.assert_allclose(reindex_dst, reindex_dst_, rtol=1e-05)
         np.testing.assert_allclose(out_nodes, out_nodes_, rtol=1e-05)
 
-    @test_with_pir_api
     def test_reindex_result_static(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Description
<!-- Describe what you’ve done -->
link #58067
PIR API 推全升级
将 paddle.geometric.reindex_graph 迁移升级至 pir，并更新单测
单测覆盖率: 1/1