### PR TITLE
【PIR OpTest Fix No.16】 fix test_lookup_table_v2_bf16_op

### DIFF
--- a/test/legacy_test/test_lookup_table_v2_bf16_op.py
+++ b/test/legacy_test/test_lookup_table_v2_bf16_op.py
@@ -15,14 +15,8 @@
 import unittest
 
 import numpy as np
+import test_lookup_table_bf16_op
 from op_test import convert_uint16_to_float
-from test_lookup_table_bf16_op import (
-    TestLookupTableBF16Op,
-    TestLookupTableBF16OpIds4D,
-    TestLookupTableBF16OpWIsSelectedRows,
-    TestLookupTableBF16OpWIsSelectedRows4DIds,
-    _lookup,
-)
 
 import paddle
 from paddle import base
@@ -30,7 +24,7 @@ from paddle.base import core
 from paddle.pir_utils import test_with_pir_api
 
 
-class TestLookupTableV2BF16Op(TestLookupTableBF16Op):
+class TestLookupTableV2BF16Op(test_lookup_table_bf16_op.TestLookupTableBF16Op):
     def init_test(self):
         self.op_type = "lookup_table_v2"
         self.python_api = paddle.nn.functional.embedding
@@ -38,7 +32,9 @@ class TestLookupTableV2BF16Op(TestLookupTableBF16Op):
         self.mkldnn_data_type = "bfloat16"
 
 
-class TestLookupTableV2BF16OpIds4D(TestLookupTableBF16OpIds4D):
+class TestLookupTableV2BF16OpIds4D(
+    test_lookup_table_bf16_op.TestLookupTableBF16OpIds4D
+):
     def init_test(self):
         self.op_type = "lookup_table_v2"
         self.python_api = paddle.nn.functional.embedding
@@ -47,7 +43,7 @@ class TestLookupTableV2BF16OpIds4D(TestLookupTableBF16OpIds4D):
 
 
 class TestLookupTableV2BF16OpWIsSelectedRows(
-    TestLookupTableBF16OpWIsSelectedRows
+    test_lookup_table_bf16_op.TestLookupTableBF16OpWIsSelectedRows
 ):
     def init_test(self):
         self.op_type = "lookup_table_v2"
@@ -56,7 +52,7 @@ class TestLookupTableV2BF16OpWIsSelectedRows(
 
 
 class TestLookupTableV2BF16OpWIsSelectedRows4DIds(
-    TestLookupTableBF16OpWIsSelectedRows4DIds
+    test_lookup_table_bf16_op.TestLookupTableBF16OpWIsSelectedRows4DIds
 ):
     def init_test(self):
         self.op_type = "lookup_table_v2"
@@ -134,7 +130,9 @@ class TestEmbeddingLayerBF16ConstantInitializer(unittest.TestCase):
     @test_with_pir_api
     def test_lookup_results(self):
         lookup_result = convert_uint16_to_float(self.result[1])
-        lookup_ref = _lookup(self.w_fp32, self.ids, self.flat_ids, self.op_type)
+        lookup_ref = test_lookup_table_bf16_op._lookup(
+            self.w_fp32, self.ids, self.flat_ids, self.op_type
+        )
         np.testing.assert_array_equal(lookup_result, lookup_ref)
 
 

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -184,6 +184,7 @@ test_logcumsumexp_op
 test_logit_op
 test_logspace
 test_logsumexp
+test_lookup_table_v2_bf16_op
 test_lookup_table_v2_op
 test_lookup_table_v2_op_static_build
 test_lrn_mkldnn_op


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PIR Op单测修复
修复单测 `test_lookup_table_v2_bf16_op`
修复后打开`FLAGS_enable_pir_in_executor`单测是否通过：否
```
1008: 5   paddle::operators::DataOp::GetExpectedKernelType(paddle::framework::ExecutionContext const&) const
1008: 
1008: ----------------------
1008: Error Message Summary:
1008: ----------------------
1008: FatalError: `Segmentation fault` is detected by the operating system.
1008:   [TimeInfo: *** Aborted at 1703510913 (unix time) try "date -d @1703510913" if you are using GNU date ***]
1008:   [SignalInfo: *** SIGSEGV (@0x0) received by PID 433839 (TID 0x7fc2d2026740) from PID 0 ***]
1008: 
1008: Segmentation fault
```
单测`test_lookup_table_v2_bf16_op`在执行时会执行`test_lookup_table_bf16_op`里import进来的单测导致执行失败，单测`test_lookup_table_bf16_op`主要是对`lookup_table`算子的测试，现在该算子已经废弃，所以这里直接修改`test_lookup_table_v2_bf16_op`不再执行`test_lookup_table_bf16_op`里面的相关单测