### PR TITLE
【PIR API adaptor No.294】Migrate RandomAffine to pir

### DIFF
--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -38,7 +38,7 @@ def _is_tensor_image(img):
     """
     Return True if img is a Tensor for dynamic mode or Variable for static graph mode.
     """
-    return isinstance(img, (paddle.Tensor, Variable))
+    return isinstance(img, (paddle.Tensor, Variable, paddle.pir.Value))
 
 
 def _is_numpy_image(img):

--- a/python/paddle/vision/transforms/functional_tensor.py
+++ b/python/paddle/vision/transforms/functional_tensor.py
@@ -19,6 +19,7 @@ import numpy as np
 
 import paddle
 import paddle.nn.functional as F
+from paddle.framework import in_dynamic_or_pir_mode
 
 from ...base.framework import Variable
 
@@ -223,7 +224,7 @@ def _affine_grid(theta, w, h, ow, oh):
 
     x_grid = paddle.linspace(-ow * 0.5 + d, ow * 0.5 + d - 1, ow)
 
-    if paddle.in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         y_grid = paddle.linspace(
             -oh * 0.5 + d, oh * 0.5 + d - 1, oh
         ).unsqueeze_(-1)
@@ -269,7 +270,7 @@ def _grid_transform(img, grid, mode, fill):
         mask = mask.tile([1, img.shape[1], 1, 1])
         len_fill = len(fill) if isinstance(fill, (tuple, list)) else 1
 
-        if paddle.in_dynamic_mode():
+        if in_dynamic_or_pir_mode():
             fill_img = (
                 paddle.to_tensor(fill)
                 .reshape((1, len_fill, 1, 1))

--- a/test/legacy_test/test_transforms.py
+++ b/test/legacy_test/test_transforms.py
@@ -182,6 +182,11 @@ class TestTransformsCV2(unittest.TestCase):
         )
         self.do_transform(trans)
 
+    def test_pir_affine(self):
+        with paddle.pir_utils.IrGuard():
+            with paddle.static.program_guard(paddle.static.Program()):
+                self.test_affine()
+
     def test_rotate(self):
         trans = transforms.Compose(
             [
@@ -517,8 +522,13 @@ class TestTransformsTensor(TestTransformsCV2):
 
     def test_affine(self):
         trans = transforms.RandomAffine(15, translate=[0.1, 0.1])
-        batch_input = paddle.rand((2, 3, 4, 4), dtype=paddle.float32)
+        batch_input = paddle.rand((2, 3, 4, 4), dtype='float32')
         result = trans(batch_input)
+
+    def test_pir_affine(self):
+        with paddle.pir_utils.IrGuard():
+            with paddle.static.program_guard(paddle.static.Program()):
+                self.test_affine()
 
     def test_pad(self):
         trans = transforms.Compose([transforms.Pad(2)])
@@ -1037,6 +1047,55 @@ class TestFunctional(unittest.TestCase):
             tensor_affined_img.numpy().transpose((1, 2, 0)),
             decimal=4,
         )
+
+    def test_pir_affine(self):
+        np_img = (np.random.rand(32, 26, 3) * 255).astype('uint8')
+        pil_img = Image.fromarray(np_img).convert('RGB')
+        tensor_img = F.to_tensor(pil_img, data_format='CHW') * 255
+
+        np.testing.assert_almost_equal(
+            np_img, tensor_img.transpose((1, 2, 0)), decimal=4
+        )
+        np_affined_img = F.affine(
+            np_img, 45, translate=[0.2, 0.2], scale=0.5, shear=[-10, 10]
+        )
+        pil_affined_img = F.affine(
+            pil_img, 45, translate=[0.2, 0.2], scale=0.5, shear=[-10, 10]
+        )
+        paddle.enable_static()
+        with paddle.pir_utils.IrGuard():
+            with paddle.static.program_guard(paddle.static.Program()):
+                tensor_img = (
+                    F.to_tensor(
+                        np.array(pil_img).astype('float32'), data_format='CHW'
+                    ).astype('uint8')
+                    * 255
+                )
+                tensor_affined_img = F.affine(
+                    tensor_img,
+                    45,
+                    translate=[0.2, 0.2],
+                    scale=0.5,
+                    shear=[-10, 10],
+                )
+                exe = paddle.static.Executor()
+                tensor_affined_img = exe.run(
+                    feed={}, fetch_list=[tensor_affined_img]
+                )
+
+            np.testing.assert_equal(
+                np_affined_img.shape, np.array(pil_affined_img).shape
+            )
+            np.testing.assert_equal(
+                np_affined_img.shape,
+                tensor_affined_img.transpose((1, 2, 0)).shape,
+            )
+
+            np.testing.assert_almost_equal(
+                np.array(pil_affined_img),
+                tensor_affined_img.numpy().transpose((1, 2, 0)),
+                decimal=4,
+            )
 
     def test_rotate(self):
         np_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- https://github.com/PaddlePaddle/Paddle/issues/58067

尝试在PIR下适配class RandomAffine，但是发现其_apply_image函数中所调用的F.affine无法在静态图下正常组网，也就是说该API无法在静态图下使用，下面的demo可以体现老静态图下的问题：

```python
import paddle
import re
import numpy as np
from PIL import Image

from paddle import base
import paddle.vision.transforms.functional as F

paddle.enable_static()

np_img = (np.random.rand(32, 26, 3) * 255).astype('float32')
tensor_img = F.to_tensor(np_img, data_format='CHW') * 255
tensor_affined_img = F.affine(tensor_img, 45, translate=[0.2, 0.2], scale=0.5, shear=[-10, 10])
```

具体问题在于静态图的place调用
![image](https://github.com/PaddlePaddle/Paddle/assets/23097963/a27da99f-0fec-4f55-b380-924832e7612a)
