### PR TITLE
【CINN】Add compute_inline_tactics for dynamic group schedule

### DIFF
--- a/paddle/cinn/ir/group_schedule/st_shape_group_scheduler.cc
+++ b/paddle/cinn/ir/group_schedule/st_shape_group_scheduler.cc
@@ -47,9 +47,12 @@ static const std::unordered_set<std::string>
 
         GEN_FUNC_NAME(GEN_FUNC_NAME_WITH_TYPE, CINN_NVGPU_FUNC_TYPE)
 #undef GEN_FUNC_NAME
+#undef GEN_FUNC_NAME_WITH_TYPE
+#undef CINN_NVGPU_FUNC_TYPE
+#undef CINN_NVGPU_FUNC2STRING
 };
 
-bool IsProhibitScheduleExternCallBlock(ir::Expr block) {
+static bool IsProhibitScheduleExternCallBlock(ir::Expr block) {
   ir::ScheduleBlockRealize* sch_block_realize =
       block.As<ir::ScheduleBlockRealize>();
   CHECK_NOTNULL(sch_block_realize);

--- a/paddle/cinn/ir/group_schedule/tactic/CMakeLists.txt
+++ b/paddle/cinn/ir/group_schedule/tactic/CMakeLists.txt
@@ -1,3 +1,4 @@
 core_gather_headers()
 
 gather_srcs(cinnapi_src SRCS arrange_storage_tactic.cc)
+gather_srcs(cinnapi_src SRCS compute_inline_tactic.cc)

--- a/paddle/cinn/ir/group_schedule/tactic/compute_inline_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/compute_inline_tactic.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 CINN Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/ir/group_schedule/tactic/compute_inline_tactic.h"
+
+#include <string>
+#include <vector>
+
+#include "paddle/cinn/auto_schedule/search_space/auto_gen_rule/auto_inline.h"
+#include "paddle/cinn/ir/ir.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/schedule/ir_schedule.h"
+
+namespace cinn {
+namespace ir {
+
+ComputeInlineTactic::ComputeInlineTactic(
+    const std::unordered_set<std::string>& output_names, const Target& target)
+    : output_names_(output_names), target_(target) {}
+
+void ComputeInlineTactic::Apply(ir::IRSchedule* sch,
+                                const std::string& block_id) {
+  VLOG(5) << "[Start DoComputeInline] func body: "
+          << sch->GetModule().GetExprs().front();
+
+  // TODO(LiuYang): Compute of ops will be rewrited so that we
+  // don't use it in dynamic group_schedule rules temporarily.
+  // if (IsProhibitScheduleExternCallBlock(node->Block())) {
+  //    return;
+  // }
+  auto_schedule::AutoInline inliner(target_, output_names_);
+  VLOG(6) << "try ComputeInline on: " << block_id
+          << ", before ComputeInline, func body: "
+          << sch->GetModule().GetExprs().front();
+  ir::Expr schedule_block = sch->GetBlock(block_id);
+  inliner.Apply(sch, schedule_block);
+  VLOG(6) << "try ComputeInline on: " << block_id
+          << ", after ComputeInline, func body: "
+          << sch->GetModule().GetExprs().front();
+}
+
+}  // namespace ir
+}  // namespace cinn

--- a/paddle/cinn/ir/group_schedule/tactic/compute_inline_tactic.h
+++ b/paddle/cinn/ir/group_schedule/tactic/compute_inline_tactic.h
@@ -16,20 +16,23 @@
 
 #include <string>
 #include <unordered_set>
+#include "paddle/cinn/common/target.h"
 #include "paddle/cinn/ir/group_schedule/tactic/schedule_tactic.h"
 
 namespace cinn {
 namespace ir {
 
-class ArrangeStorageTactic final : public ScheduleTactic {
+class ComputeInlineTactic final : public ScheduleTactic {
  public:
-  explicit ArrangeStorageTactic(
-      const std::unordered_set<std::string>& output_names);
+  explicit ComputeInlineTactic(
+      const std::unordered_set<std::string>& output_names,
+      const cinn::common::Target& target);
 
   void Apply(ir::IRSchedule* sch, const std::string& block_id) override;
 
  private:
   std::unordered_set<std::string> output_names_;
+  cinn::common::Target target_;
 };
 
 }  // namespace ir

--- a/paddle/cinn/ir/group_schedule/tactic/schedule_tactic.h
+++ b/paddle/cinn/ir/group_schedule/tactic/schedule_tactic.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <string>
+
 #include "paddle/cinn/ir/schedule/ir_schedule.h"
 
 namespace cinn {

--- a/paddle/cinn/pybind/schedule.cc
+++ b/paddle/cinn/pybind/schedule.cc
@@ -35,18 +35,18 @@ void BindSchedule(py::module *m) {
            py::arg("debug_flag") = false,
            py::arg("err_msg_level") = utils::ErrorMessageLevel::kGeneral,
            py::arg("is_dynamic_shape") = false)
-      .def_static("make",
-                  [](ir::LoweredFunc &ir_func) {
-                    ir::ModuleExpr *module_expr =
-                        new ir::ModuleExpr({ir_func->body});
-                    auto scheduler = std::make_unique<ir::IRSchedule>(
-                        *module_expr,
-                        -1,
-                        false,
-                        utils::ErrorMessageLevel::kGeneral,
-                        true);
-                    return scheduler;
-                  })
+      .def_static(
+          "make",
+          [](ir::LoweredFunc &ir_func) {
+            ir::ModuleExpr *module_expr = new ir::ModuleExpr({ir_func->body});
+            auto scheduler = std::make_unique<ir::IRSchedule>(
+                *module_expr,
+                /* rand_seed = */ -1,
+                /* debug_flag = */ false,
+                /* err_msg_level = */ utils::ErrorMessageLevel::kGeneral,
+                /* is_dynamic_shape = */ true);
+            return scheduler;
+          })
       .def("fuse",
            py::overload_cast<const std::vector<Expr> &>(&ir::IRSchedule::Fuse))
       .def("split",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR add compute_inline_tactics for dynamic group schedule