### PR TITLE
[Dy2St] Enable `test_lstm` in PIR mode

### DIFF
--- a/test/dygraph_to_static/test_lstm.py
+++ b/test/dygraph_to_static/test_lstm.py
@@ -60,14 +60,14 @@ class TestLstm(Dy2StTestBase):
 
     def run_lstm(self, to_static):
         with enable_to_static_guard(to_static):
-            paddle.static.default_main_program().random_seed = 1001
-            paddle.static.default_startup_program().random_seed = 1001
+            paddle.seed(1001)
 
             net = paddle.jit.to_static(Net(12, 2))
             x = paddle.zeros((2, 10, 12))
             y = net(x)
             return y.numpy()
 
+    @test_legacy_and_pt_and_pir
     def test_lstm_to_static(self):
         dygraph_out = self.run_lstm(to_static=False)
         static_out = self.run_lstm(to_static=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

启用 PIR 下 `test_lstm` 单测，使用 `paddle.seed(xxx)` 替代 `default_main_program().random_seed = xxx` 的方式，后者之后会考虑是否退场还是继续支持

- #60131

PCard-66972