### PR TITLE
【PIR API adaptor No.202、205、254、262】Migrate laplace、sequence_mask、L1Decay to PIR

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -100,7 +100,6 @@ NEED_GEN_STATIC_ONLY_APIS = [
     'self_dp_attention',
     'get_tensor_from_selected_rows',
     'print',
-    'sequence_mask',
     'number_count',
     'assign_value',
 ]

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -582,7 +582,9 @@ const phi::DDim &GetValueDims(Value value) {
 }
 
 void BindValue(py::module *m) {
-  py::class_<Value> value(*m, "Value", R"DOC(
+  py::class_<Value> value(*m,
+                          "Value",
+                          R"DOC(
     Value class represents the SSA value in the IR system. It is a directed edge
     and a base class.
 
@@ -590,7 +592,8 @@ void BindValue(py::module *m) {
         The constructor of Value should not be invoked directly. Value can be automatically constructed
         when build network.
 
-  )DOC");
+  )DOC",
+                          pybind11::dynamic_attr());
   g_ir_value_pytype = reinterpret_cast<PyTypeObject *>(value.ptr());
   value.def(py::init<>())
       .def_property_readonly(

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -979,6 +979,15 @@
   intermediate : noise
   backward : rrelu_grad
 
+- op : sequence_mask
+  args: (Tensor x, Scalar(int) max_len, int out_dtype)
+  output: Tensor(y)
+  infer_meta:
+    func: SequenceMaskScalarInferMeta
+  kernel:
+    func: sequence_mask_scalar
+    data_type : x
+
 - op : set_value
   args : (Tensor x, IntArray starts, IntArray ends, IntArray steps, int64_t[] axes, int64_t[] decrease_axes, int64_t[] none_axes, int64_t[] shape, Scalar[] values)
   output : Tensor(out)

--- a/python/paddle/distribution/laplace.py
+++ b/python/paddle/distribution/laplace.py
@@ -54,12 +54,16 @@ class Laplace(distribution.Distribution):
     """
 
     def __init__(self, loc, scale):
-        if not isinstance(loc, (numbers.Real, framework.Variable)):
+        if not isinstance(
+            loc, (numbers.Real, framework.Variable, paddle.pir.Value)
+        ):
             raise TypeError(
                 f"Expected type of loc is Real|Variable, but got {type(loc)}"
             )
 
-        if not isinstance(scale, (numbers.Real, framework.Variable)):
+        if not isinstance(
+            scale, (numbers.Real, framework.Variable, paddle.pir.Value)
+        ):
             raise TypeError(
                 f"Expected type of scale is Real|Variable, but got {type(scale)}"
             )

--- a/python/paddle/nn/functional/extension.py
+++ b/python/paddle/nn/functional/extension.py
@@ -15,7 +15,7 @@
 # TODO: define the extention functions
 
 
-from paddle import _C_ops, _legacy_C_ops, in_dynamic_mode, tensor
+from paddle import _C_ops, tensor
 from paddle.utils import deprecated
 
 from ...base.data_feeder import check_type, check_variable_and_dtype
@@ -100,16 +100,11 @@ def sequence_mask(x, maxlen=None, dtype='int64', name=None):
 
     """
 
-    if in_dynamic_mode():
-        if not isinstance(dtype, core.VarDesc.VarType):
+    if in_dynamic_or_pir_mode():
+        if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
             dtype = convert_np_dtype_to_dtype_(dtype)
         if maxlen is not None:
-            if isinstance(maxlen, core.eager.Tensor):
-                attrs = ('out_dtype', dtype)
-                out = _legacy_C_ops.sequence_mask(x, maxlen, *attrs)
-            else:
-                attrs = ('out_dtype', dtype, 'maxlen', maxlen)
-                out = _legacy_C_ops.sequence_mask(x, None, *attrs)
+            out = _C_ops.sequence_mask(x, maxlen, dtype)
             out.stop_gradient = True
             return out
 

--- a/python/paddle/pir/core.py
+++ b/python/paddle/pir/core.py
@@ -273,10 +273,13 @@ def create_parameter(
     name=None,
     **kwargs,
 ):
+    regularizer = None
     if 'initializer' not in kwargs:
         raise ValueError(
             "initializer is None, if you want to create parameter, please pass its initializer."
         )
+    if 'regularizer' in kwargs:
+        regularizer = kwargs['regularizer']
     if dtype is not None:
         if not isinstance(dtype, DataType):
             dtype = convert_np_dtype_to_dtype_(dtype)
@@ -302,6 +305,7 @@ def create_parameter(
         param.stop_gradient = not trainable
         param.persistable = True
 
+    param.regularizer = regularizer
     return param
 
 

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -858,7 +858,7 @@ def uniform(shape, dtype=None, min=-1.0, max=1.0, seed=0, name=None):
                 )
             )
 
-    if not isinstance(dtype, core.VarDesc.VarType):
+    if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_mode():

--- a/test/distribution/parameterize.py
+++ b/test/distribution/parameterize.py
@@ -47,7 +47,7 @@ def place(devices, key='place'):
     return decorate
 
 
-def parameterize_cls(fields, values=None):
+def parameterize_cls(fields, values=None, test_pir=False):
     fields = [fields] if isinstance(fields, str) else fields
     params = [dict(zip(fields, vals)) for vals in values]
 
@@ -56,10 +56,15 @@ def parameterize_cls(fields, values=None):
         for k, v in enumerate(params):
             test_cls = dict(cls.__dict__)
             test_cls.update(v)
+            test_cls["test_pir"] = False
             name = cls.__name__ + str(k)
             name = name + '.' + v.get('suffix') if v.get('suffix') else name
-
             test_cls_module[name] = type(name, (cls,), test_cls)
+            if test_pir:
+                name = name + ".pir"
+                test_cls["test_pir"] = True
+                pir_type = type(name, (cls,), test_cls)
+                test_cls_module[name] = pir_type
 
         for m in list(cls.__dict__):
             if m.startswith("test"):

--- a/test/sequence/test_sequence_mask.py
+++ b/test/sequence/test_sequence_mask.py
@@ -71,7 +71,7 @@ class SequenceMaskTestBase(OpTest):
         return (index_broadcast < x_broadcast).astype(self.mask_dtype)
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class SequenceMaskTest1(SequenceMaskTestBase):
@@ -139,7 +139,7 @@ class SequenceMaskTestBase_tensor_attr(OpTest):
         return (index_broadcast < x_broadcast).astype(self.mask_dtype)
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_pir=True)
 
 
 class SequenceMaskTest1_tensor_attr(SequenceMaskTestBase_tensor_attr):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
sequence_mask，L1Decay，laplace适配新IR，CyclicLR无需适配
单测全部开启