### PR TITLE
[XPU] avoid pre-allocating gm buffer

### DIFF
--- a/paddle/fluid/distributed/collective/process_group_bkcl.cc
+++ b/paddle/fluid/distributed/collective/process_group_bkcl.cc
@@ -207,6 +207,8 @@ void ProcessGroupBKCL::CreateBKCLEnvCache(const Place& place,
       platform::DeviceContextPool::Instance().Get(place));
   // must use XPUDeviceContext here to make sure XPUContext::Init() is called
   auto comm_ctx = std::make_unique<XPUDeviceContext>(place);
+  // comm_ctx does not require a pre-allocated GM buffer
+  comm_ctx->x_context()->set_option("XPUAPI_DEFAULT_SIZE", "1");
   auto bkcl_comm_ctx = this->GetCommContext();
   comm_ctx->SetBkclContext(bkcl_comm_ctx->GetBKCLComm());
 

--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -200,6 +200,9 @@ struct XPUContext::Impl {
               << tname << " currently " << context_map_.size()
               << " contexts existing";
       xpu::Context* ctx_t = xpu::create_context();
+      // DataLoader does not require a pre-allocated GM buffer
+      // to avoid xpu_wait calls
+      ctx_t->set_option("XPUAPI_DEFAULT_SIZE", "1");
       context_map_[tname] = ctx_t;
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- Avoid pre-allocating XPU gm buffer(default is 128MB) in ProcessGroupBKCL communication XPUContexts and DataLoader XPUContexts as they does not use this pre-allocated GM buffers.
- In hybrid-parallel distributed training, multiple process groups with different XPUContexts will be created for different parallel methods. See [topology.py](https://github.com/PaddlePaddle/Paddle/blob/c8ef957e814aa5c138ad3143528519f23e81d3fd/python/paddle/distributed/fleet/base/topology.py#L216-L254)
- Multi-processes dataloader will also create multiple XPUContexts.

Related PR: https://github.com/PaddlePaddle/Paddle/pull/60260