### PR TITLE
[Paddle Inference]support tgt_mask in block_multihead_attention

### DIFF
--- a/test/legacy_test/test_block_multihead_attention.py
+++ b/test/legacy_test/test_block_multihead_attention.py
@@ -306,6 +306,12 @@ class TestBlockMultiHeadAttnEncDec(unittest.TestCase):
             ]
             * self.batch_size,
         )
+
+        self.tgt_mask = paddle.randn(
+            [self.batch_size, self.num_head, 1, self.seq_len + 1],
+            dtype=self.dtype,
+        )
+
         self.scale = 1.0 / np.sqrt(self.shape[-1])
         self.cache_k = paddle.zeros(shape=self.cache_shape, dtype=self.dtype)
         self.cache_v = paddle.zeros(shape=self.cache_shape, dtype=self.dtype)
@@ -462,7 +468,7 @@ class TestBlockMultiHeadAttnEncDec(unittest.TestCase):
                 naive_cache_v,
                 None,
                 None,
-                None,
+                self.tgt_mask,
                 self.scale,
             )
             .transpose([0, 2, 1, 3])
@@ -492,7 +498,7 @@ class TestBlockMultiHeadAttnEncDec(unittest.TestCase):
             None,  # out_smooth
             None,  # rotary_embs
             None,  # attn_mask
-            None,  # tgt_mask
+            self.tgt_mask,  # tgt_mask
             1,  # seq_len,
             self.blocksize,
             False,  # use_neox_rotary_style


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-71502
support tgt_mask in block_multihead_attention