### PR TITLE
[DimExpr] Add utils for DimExpr, convert between DimExpr and pir::Attribute

### DIFF
--- a/paddle/pir/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.cc
@@ -1,0 +1,208 @@
+#include "paddle/pir/dialect/shape/utils/dim_expr_util.h"
+#include "paddle/pir/core/builtin_attribute.h"
+
+namespace symbol {
+
+namespace {
+
+template <typename T>
+std::string GetSerializedTag();
+
+template<>
+std::string GetSerializedTag<Negative<DimExpr>>() {
+  return "Negative";
+}
+
+template<>
+std::string GetSerializedTag<Reciprocal<DimExpr>>() {
+  return "Reciprocal";
+}
+
+template<>
+std::string GetSerializedTag<Add<DimExpr>>() {
+  return "Add";
+}
+
+template<>
+std::string GetSerializedTag<Mul<DimExpr>>() {
+  return "Mul";
+}
+
+template<>
+std::string GetSerializedTag<Max<DimExpr>>() {
+  return "Max";
+}
+
+template<>
+std::string GetSerializedTag<Min<DimExpr>>() {
+  return "Min";
+}
+
+template<>
+std::string GetSerializedTag<Broadcast<DimExpr>>() {
+  return "Broadcast";
+}
+
+template<>
+std::string GetSerializedTag<Min<DimExpr>>() {
+  return "Min";
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const std::int64_t& dim_expr) {
+  return builder->int64_attr(dim_expr);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const std::string& dim_expr) {
+  return builder->str_attr(dim_expr);
+}
+
+template <typename T>
+::pir::Attribute ConvertUnaryDimExprToAttributeImpl(::pir::Builder* builder, const T& dim_expr) {
+  std::vector<::pir::Attribute> attr_vecs{};
+  attr_vecs.push_back(builder->str_attr(GetSerializedTag<T>()));
+  const auto& [operand] = *dim_expr;
+  attr_vecs.push_back(ConvertDimExprToAttribute(builder, operand));
+  return builder->array_attr(attr_vecs);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Negative<DimExpr>& dim_expr) {
+  return ConvertUnaryDimExprToAttributeImpl(builder, dim_expr);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Reciprocal<DimExpr>& dim_expr) {
+  return ConvertUnaryDimExprToAttributeImpl(builder, dim_expr);
+}
+
+template<typename T>
+::pir::Attribute ConvertVariadicDimExprToAttribute(::pir::Builder* builder, const T& dim_expr) {
+  std::vector<::pir::Attribute> attr_vecs{};
+  attr_vecs.push_back(builder->str_attr(GetSerializedTag<T>()));
+  const auto& operands = *dim_expr;
+  for (const auto& operand : operands) {
+    attr_vecs.push_back(ConvertDimExprToAttribute(builder, operand));
+  }
+  return builder->array_attr(attr_vecs);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Add<DimExpr>& dim_expr) {
+  return ConvertVariadicDimExprToAttribute(builder, dim_expr);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Mul<DimExpr>& dim_expr) {
+  return ConvertVariadicDimExprToAttribute(builder, dim_expr);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Max<DimExpr>& dim_expr) {
+  return ConvertVariadicDimExprToAttribute(builder, dim_expr);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Min<DimExpr>& dim_expr) {
+  return ConvertVariadicDimExprToAttribute(builder, dim_expr);
+}
+
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Broadcast<DimExpr>& dim_expr) {
+  return ConvertVariadicDimExprToAttribute(builder, dim_expr);
+}
+
+std::optional<DimExpr> ConvertInt64AttributeToDimExpr(const ::pir::Int64Attribute& attribute) {
+  return DimExpr{attribute.data()};
+}
+
+
+std::optional<DimExpr> ConvertStrAttributeToDimExpr(const ::pir::StrAttribute& attribute) {
+  return DimExpr{attribute.AsString()};
+}
+
+template <typename T>
+std::optional<DimExpr> ConvertArrayAttributeToUnaryDimExpr(const ::pir::ArrayAttribute& attribute) {
+  if (attribute.size() != 2) {
+    return std::nullopt;
+  }
+  std::optional<DimExpr> operand = ConvertAttributeToDimExpr(attribute.at(1));
+  if (!operand.has_value()) {
+    return std::nullopt;
+  }
+  return T{operand.value()};
+}
+
+
+template <typename T>
+std::optional<DimExpr> ConvertArrayAttributeToVariadicDimExpr(const ::pir::ArrayAttribute& attribute) {
+  if (attribute.size() < 2) {
+    return std::nullopt;
+  }
+  List<DimExpr> operands{};
+  for (std::size_t i = 1; i < attribute.size(); ++i) {
+    std::optional<DimExpr> operand = ConvertAttributeToDimExpr(attribute.at(i));
+    if (!operand.has_value()) {
+      return std::nullopt;
+    }
+    operands.push_back(operand.value());
+  }
+  return T{operands};
+}
+
+typedef std::optional<DimExpr> (*ArrayAttributeConverterT)(const ::pir::ArrayAttribute& attribute);
+
+std::optional<ArrayAttributeConverterT> GetArrayAttributeConverter(const std::string& tag) {
+  static std::unordered_map<std::string, ArrayAttributeConverterT> map{
+    {GetSerializedTag<Negative<DimExpr>>(),
+      &ConvertArrayAttributeToUnaryDimExpr<Negative<DimExpr>>},
+    {GetSerializedTag<Reciprocal<DimExpr>>(),
+      &ConvertArrayAttributeToUnaryDimExpr<Reciprocal<DimExpr>>},
+    {GetSerializedTag<Add<DimExpr>>(),
+      &ConvertArrayAttributeToVariadicDimExpr<Add<DimExpr>>},
+    {GetSerializedTag<Mul<DimExpr>>(),
+      &ConvertArrayAttributeToVariadicDimExpr<Mul<DimExpr>>},
+    {GetSerializedTag<Max<DimExpr>>(),
+      &ConvertArrayAttributeToVariadicDimExpr<Max<DimExpr>>},
+    {GetSerializedTag<Min<DimExpr>>(),
+      &ConvertArrayAttributeToVariadicDimExpr<Min<DimExpr>>},
+    {GetSerializedTag<Broadcast<DimExpr>>(),
+      &ConvertArrayAttributeToVariadicDimExpr<Broadcast<DimExpr>>},
+  };
+  const auto& iter = map.find(tag);
+  if (iter == map.end()) {
+    return std::nullopt;
+  }
+  return iter->second;
+}
+
+std::optional<DimExpr> ConvertArrayAttributeToDimExpr(const ::pir::ArrayAttribute& attribute) {
+  if (attribute.empty()) {
+    return std::nullopt;
+  }
+  if (!attribute.at(0).isa<::pir::StrAttribute>()) {
+    return std::nullopt;
+  }
+  const auto& tag = attribute.at(0).dyn_cast<::pir::StrAttribute>().AsString();
+  auto opt_func = GetArrayAttributeConverter(tag);
+  if (!opt_func.has_value()) {
+    return std::nullopt;
+  }
+  return opt_func.value()(attribute);
+}
+
+}
+
+::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder, const DimExpr& dim_expr) {
+  return std::visit([&](const auto& impl){
+    return ConvertDimExprToAttributeImpl(builder, impl);
+  }, dim_expr.variant());
+}
+
+std::optional<DimExpr> ConvertAttributeToDimExpr(::pir::Attribute attribute) {
+  if (attribute.isa<::pir::Int64Attribute>()) {
+    return ConvertInt64AttributeToDimExpr(attribute.dyn_cast<::pir::Int64Attribute>());
+  }
+  if (attribute.isa<::pir::StrAttribute>()) {
+    return ConvertStrAttributeToDimExpr(attribute.dyn_cast<::pir::StrAttribute>());
+  }
+  if (attribute.isa<::pir::ArrayAttribute>()) {
+    return ConvertArrayAttributeToDimExpr(attribute.dyn_cast<::pir::ArrayAttribute>());
+  }
+  return std::nullopt;
+}
+
+
+}

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.cc
@@ -1,4 +1,19 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "paddle/pir/dialect/shape/utils/dim_expr_util.h"
+#include "paddle/pir/core/builder.h"
 #include "paddle/pir/core/builtin_attribute.h"
 
 namespace symbol {
@@ -8,56 +23,54 @@ namespace {
 template <typename T>
 std::string GetSerializedTag();
 
-template<>
+template <>
 std::string GetSerializedTag<Negative<DimExpr>>() {
   return "Negative";
 }
 
-template<>
+template <>
 std::string GetSerializedTag<Reciprocal<DimExpr>>() {
   return "Reciprocal";
 }
 
-template<>
+template <>
 std::string GetSerializedTag<Add<DimExpr>>() {
   return "Add";
 }
 
-template<>
+template <>
 std::string GetSerializedTag<Mul<DimExpr>>() {
   return "Mul";
 }
 
-template<>
+template <>
 std::string GetSerializedTag<Max<DimExpr>>() {
   return "Max";
 }
 
-template<>
+template <>
 std::string GetSerializedTag<Min<DimExpr>>() {
   return "Min";
 }
 
-template<>
+template <>
 std::string GetSerializedTag<Broadcast<DimExpr>>() {
   return "Broadcast";
 }
 
-template<>
-std::string GetSerializedTag<Min<DimExpr>>() {
-  return "Min";
-}
-
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const std::int64_t& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder,
+                                               const std::int64_t& dim_expr) {
   return builder->int64_attr(dim_expr);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const std::string& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder,
+                                               const std::string& dim_expr) {
   return builder->str_attr(dim_expr);
 }
 
 template <typename T>
-::pir::Attribute ConvertUnaryDimExprToAttributeImpl(::pir::Builder* builder, const T& dim_expr) {
+::pir::Attribute ConvertUnaryDimExprToAttributeImpl(::pir::Builder* builder,
+                                                    const T& dim_expr) {
   std::vector<::pir::Attribute> attr_vecs{};
   attr_vecs.push_back(builder->str_attr(GetSerializedTag<T>()));
   const auto& [operand] = *dim_expr;
@@ -65,56 +78,66 @@ template <typename T>
   return builder->array_attr(attr_vecs);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Negative<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(
+    ::pir::Builder* builder, const Negative<DimExpr>& dim_expr) {
   return ConvertUnaryDimExprToAttributeImpl(builder, dim_expr);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Reciprocal<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(
+    ::pir::Builder* builder, const Reciprocal<DimExpr>& dim_expr) {
   return ConvertUnaryDimExprToAttributeImpl(builder, dim_expr);
 }
 
-template<typename T>
-::pir::Attribute ConvertVariadicDimExprToAttribute(::pir::Builder* builder, const T& dim_expr) {
+template <typename T>
+::pir::Attribute ConvertVariadicDimExprToAttribute(::pir::Builder* builder,
+                                                   const T& dim_expr) {
   std::vector<::pir::Attribute> attr_vecs{};
   attr_vecs.push_back(builder->str_attr(GetSerializedTag<T>()));
-  const auto& operands = *dim_expr;
+  const auto& operands = *(dim_expr.operands);
   for (const auto& operand : operands) {
     attr_vecs.push_back(ConvertDimExprToAttribute(builder, operand));
   }
   return builder->array_attr(attr_vecs);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Add<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder,
+                                               const Add<DimExpr>& dim_expr) {
   return ConvertVariadicDimExprToAttribute(builder, dim_expr);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Mul<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder,
+                                               const Mul<DimExpr>& dim_expr) {
   return ConvertVariadicDimExprToAttribute(builder, dim_expr);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Max<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder,
+                                               const Max<DimExpr>& dim_expr) {
   return ConvertVariadicDimExprToAttribute(builder, dim_expr);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Min<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder,
+                                               const Min<DimExpr>& dim_expr) {
   return ConvertVariadicDimExprToAttribute(builder, dim_expr);
 }
 
-::pir::Attribute ConvertDimExprToAttributeImpl(::pir::Builder* builder, const Broadcast<DimExpr>& dim_expr) {
+::pir::Attribute ConvertDimExprToAttributeImpl(
+    ::pir::Builder* builder, const Broadcast<DimExpr>& dim_expr) {
   return ConvertVariadicDimExprToAttribute(builder, dim_expr);
 }
 
-std::optional<DimExpr> ConvertInt64AttributeToDimExpr(const ::pir::Int64Attribute& attribute) {
+std::optional<DimExpr> ConvertInt64AttributeToDimExpr(
+    const ::pir::Int64Attribute& attribute) {
   return DimExpr{attribute.data()};
 }
 
-
-std::optional<DimExpr> ConvertStrAttributeToDimExpr(const ::pir::StrAttribute& attribute) {
+std::optional<DimExpr> ConvertStrAttributeToDimExpr(
+    const ::pir::StrAttribute& attribute) {
   return DimExpr{attribute.AsString()};
 }
 
 template <typename T>
-std::optional<DimExpr> ConvertArrayAttributeToUnaryDimExpr(const ::pir::ArrayAttribute& attribute) {
+std::optional<DimExpr> ConvertArrayAttributeToUnaryDimExpr(
+    const ::pir::ArrayAttribute& attribute) {
   if (attribute.size() != 2) {
     return std::nullopt;
   }
@@ -125,9 +148,9 @@ std::optional<DimExpr> ConvertArrayAttributeToUnaryDimExpr(const ::pir::ArrayAtt
   return T{operand.value()};
 }
 
-
 template <typename T>
-std::optional<DimExpr> ConvertArrayAttributeToVariadicDimExpr(const ::pir::ArrayAttribute& attribute) {
+std::optional<DimExpr> ConvertArrayAttributeToVariadicDimExpr(
+    const ::pir::ArrayAttribute& attribute) {
   if (attribute.size() < 2) {
     return std::nullopt;
   }
@@ -137,29 +160,31 @@ std::optional<DimExpr> ConvertArrayAttributeToVariadicDimExpr(const ::pir::Array
     if (!operand.has_value()) {
       return std::nullopt;
     }
-    operands.push_back(operand.value());
+    operands->push_back(operand.value());
   }
   return T{operands};
 }
 
-typedef std::optional<DimExpr> (*ArrayAttributeConverterT)(const ::pir::ArrayAttribute& attribute);
+typedef std::optional<DimExpr> (*ArrayAttributeConverterT)(
+    const ::pir::ArrayAttribute& attribute);
 
-std::optional<ArrayAttributeConverterT> GetArrayAttributeConverter(const std::string& tag) {
+std::optional<ArrayAttributeConverterT> GetArrayAttributeConverter(
+    const std::string& tag) {
   static std::unordered_map<std::string, ArrayAttributeConverterT> map{
-    {GetSerializedTag<Negative<DimExpr>>(),
-      &ConvertArrayAttributeToUnaryDimExpr<Negative<DimExpr>>},
-    {GetSerializedTag<Reciprocal<DimExpr>>(),
-      &ConvertArrayAttributeToUnaryDimExpr<Reciprocal<DimExpr>>},
-    {GetSerializedTag<Add<DimExpr>>(),
-      &ConvertArrayAttributeToVariadicDimExpr<Add<DimExpr>>},
-    {GetSerializedTag<Mul<DimExpr>>(),
-      &ConvertArrayAttributeToVariadicDimExpr<Mul<DimExpr>>},
-    {GetSerializedTag<Max<DimExpr>>(),
-      &ConvertArrayAttributeToVariadicDimExpr<Max<DimExpr>>},
-    {GetSerializedTag<Min<DimExpr>>(),
-      &ConvertArrayAttributeToVariadicDimExpr<Min<DimExpr>>},
-    {GetSerializedTag<Broadcast<DimExpr>>(),
-      &ConvertArrayAttributeToVariadicDimExpr<Broadcast<DimExpr>>},
+      {GetSerializedTag<Negative<DimExpr>>(),
+       &ConvertArrayAttributeToUnaryDimExpr<Negative<DimExpr>>},
+      {GetSerializedTag<Reciprocal<DimExpr>>(),
+       &ConvertArrayAttributeToUnaryDimExpr<Reciprocal<DimExpr>>},
+      {GetSerializedTag<Add<DimExpr>>(),
+       &ConvertArrayAttributeToVariadicDimExpr<Add<DimExpr>>},
+      {GetSerializedTag<Mul<DimExpr>>(),
+       &ConvertArrayAttributeToVariadicDimExpr<Mul<DimExpr>>},
+      {GetSerializedTag<Max<DimExpr>>(),
+       &ConvertArrayAttributeToVariadicDimExpr<Max<DimExpr>>},
+      {GetSerializedTag<Min<DimExpr>>(),
+       &ConvertArrayAttributeToVariadicDimExpr<Min<DimExpr>>},
+      {GetSerializedTag<Broadcast<DimExpr>>(),
+       &ConvertArrayAttributeToVariadicDimExpr<Broadcast<DimExpr>>},
   };
   const auto& iter = map.find(tag);
   if (iter == map.end()) {
@@ -168,7 +193,8 @@ std::optional<ArrayAttributeConverterT> GetArrayAttributeConverter(const std::st
   return iter->second;
 }
 
-std::optional<DimExpr> ConvertArrayAttributeToDimExpr(const ::pir::ArrayAttribute& attribute) {
+std::optional<DimExpr> ConvertArrayAttributeToDimExpr(
+    const ::pir::ArrayAttribute& attribute) {
   if (attribute.empty()) {
     return std::nullopt;
   }
@@ -183,38 +209,45 @@ std::optional<DimExpr> ConvertArrayAttributeToDimExpr(const ::pir::ArrayAttribut
   return opt_func.value()(attribute);
 }
 
-}
+}  // namespace
 
-::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder, const DimExpr& dim_expr) {
-  return std::visit([&](const auto& impl){
-    return ConvertDimExprToAttributeImpl(builder, impl);
-  }, dim_expr.variant());
+::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder,
+                                           const DimExpr& dim_expr) {
+  return std::visit(
+      [&](const auto& impl) {
+        return ConvertDimExprToAttributeImpl(builder, impl);
+      },
+      dim_expr.variant());
 }
 
 std::optional<DimExpr> ConvertAttributeToDimExpr(::pir::Attribute attribute) {
   if (attribute.isa<::pir::Int64Attribute>()) {
-    return ConvertInt64AttributeToDimExpr(attribute.dyn_cast<::pir::Int64Attribute>());
+    return ConvertInt64AttributeToDimExpr(
+        attribute.dyn_cast<::pir::Int64Attribute>());
   }
   if (attribute.isa<::pir::StrAttribute>()) {
-    return ConvertStrAttributeToDimExpr(attribute.dyn_cast<::pir::StrAttribute>());
+    return ConvertStrAttributeToDimExpr(
+        attribute.dyn_cast<::pir::StrAttribute>());
   }
   if (attribute.isa<::pir::ArrayAttribute>()) {
-    return ConvertArrayAttributeToDimExpr(attribute.dyn_cast<::pir::ArrayAttribute>());
+    return ConvertArrayAttributeToDimExpr(
+        attribute.dyn_cast<::pir::ArrayAttribute>());
   }
   return std::nullopt;
 }
 
 class SubstituteDimExprHelper final {
- using DimExpr4SymbolNameT =
-  std::function<std::optional<DimExpr>(const std::string& symbol_name)>;
- 
- explicit SubstituteDimExprHelper(const DimExpr4SymbolNameT& DimExpr4SymbolName)
-    : DimExpr4SymbolName_(DimExpr4SymbolName) {}
+ public:
+  using DimExpr4SymbolNameT =
+      std::function<std::optional<DimExpr>(const std::string& symbol_name)>;
+
+  explicit SubstituteDimExprHelper(
+      const DimExpr4SymbolNameT& DimExpr4SymbolName)
+      : DimExpr4SymbolName_(DimExpr4SymbolName) {}
 
   std::optional<DimExpr> Substitute(const DimExpr& dim_expr) {
-    return std::visit([&](const auto& impl) {
-      return SubstituteImpl(impl);
-    }, dim_expr.variant());
+    return std::visit([&](const auto& impl) { return SubstituteImpl(impl); },
+                      dim_expr.variant());
   }
 
  private:
@@ -264,14 +297,14 @@ class SubstituteDimExprHelper final {
 
   template <typename T>
   std::optional<DimExpr> SubstituteVariadic(const T& dim_expr) {
-    const auto& [operands] = *dim_expr;
+    const auto& operands = *(dim_expr.operands);
     List<DimExpr> substituted_operands{};
     for (const auto& operand : operands) {
       const auto& substituted_operand = Substitute(operand);
       if (!substituted_operand.has_value()) {
         return std::nullopt;
       }
-      substituted_operands.push_back(substituted_operand.has_value());
+      substituted_operands->push_back(substituted_operand.has_value());
     }
     return T{substituted_operands};
   }
@@ -281,20 +314,27 @@ class SubstituteDimExprHelper final {
 
 std::optional<DimExpr> SubstituteDimExpr(
     const DimExpr& dim_expr,
-    const std::function<std::optional<DimExpr>(const std::string& symbol_name)>& DimExpr4SymbolName) {
+    const std::function<std::optional<DimExpr>(const std::string& symbol_name)>&
+        DimExpr4SymbolName) {
   return SubstituteDimExprHelper(DimExpr4SymbolName).Substitute(dim_expr);
 }
 
 std::function<std::optional<DimExpr>(const std::string& symbol_name)>
 MakeGetterDimExpr4SymbolName(
-    const std::vector<std::tuple<std::string/*symbol_name*/, int/*in_tensor_idx*/, int/*in_tensor_dim_idx*/>>& symbol_bindings,
-    const std::function<std::optional<DimExpr>(int in_tensor_idx, int in_tensor_dim_idx)>& DimExpr4InputDim) {
-  std::unordered_map<std::string, std::vector<std::pair<int, int>>> symbol_name2in_tensor_dim_pos;
+    const std::vector<std::tuple<std::string /*symbol_name*/,
+                                 int /*in_tensor_idx*/,
+                                 int /*in_tensor_dim_idx*/>>& symbol_bindings,
+    const std::function<std::optional<DimExpr>(
+        int in_tensor_idx, int in_tensor_dim_idx)>& DimExpr4InputDim) {
+  std::unordered_map<std::string, std::vector<std::pair<int, int>>>
+      symbol_name2in_tensor_dim_pos;
   for (const auto& tuple : symbol_bindings) {
     const auto& [symbol_name, in_tensor_idx, in_tensor_dim_idx] = tuple;
-    symbol_name2in_tensor_dim_pos[symbol_name].emplace_back(std::pair{in_tensor_idx, in_tensor_dim_idx});
+    symbol_name2in_tensor_dim_pos[symbol_name].emplace_back(
+        std::pair{in_tensor_idx, in_tensor_dim_idx});
   }
-  return [map=std::move(symbol_name2in_tensor_dim_pos), DimExpr4InputDim](const std::string& symbol_name) {
+  return [map = std::move(symbol_name2in_tensor_dim_pos), DimExpr4InputDim](
+             const std::string& symbol_name) -> std::optional<DimExpr> {
     const auto& iter = map.find(symbol_name);
     if (iter == map.end()) {
       return std::nullopt;
@@ -319,4 +359,4 @@ MakeGetterDimExpr4SymbolName(
   };
 }
 
-}
+}  // namespace symbol

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.cc
@@ -73,7 +73,7 @@ template <typename T>
                                                     const T& dim_expr) {
   std::vector<::pir::Attribute> attr_vecs{};
   attr_vecs.push_back(builder->str_attr(GetSerializedTag<T>()));
-  const auto& [operand] = *dim_expr;
+  const auto& operand = dim_expr->data;
   attr_vecs.push_back(ConvertDimExprToAttribute(builder, operand));
   return builder->array_attr(attr_vecs);
 }
@@ -267,7 +267,7 @@ class SubstituteDimExprHelper final {
 
   template <typename T>
   std::optional<DimExpr> SubstituteUnary(const T& dim_expr) {
-    const auto& [operand] = *dim_expr;
+    const auto& operand = dim_expr->data;
     const auto& substituted_operand = Substitute(operand);
     if (!substituted_operand.has_value()) {
       return std::nullopt;

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.cc
@@ -304,7 +304,7 @@ class SubstituteDimExprHelper final {
       if (!substituted_operand.has_value()) {
         return std::nullopt;
       }
-      substituted_operands->push_back(substituted_operand.has_value());
+      substituted_operands->push_back(substituted_operand.value());
     }
     return T{substituted_operands};
   }

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.h
@@ -10,4 +10,13 @@ namespace symbol {
 ::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder, const DimExpr& dim_expr);
 std::optional<DimExpr> ConvertAttributeToDimExpr(::pir::Attribute attribute);
 
+std::optional<DimExpr> SubstituteDimExpr(
+    const DimExpr& dim_expr,
+    const std::function<std::optional<DimExpr>(const std::string& symbol_name)>& DimExpr4SymbolName);
+
+std::function<std::optional<DimExpr>(const std::string& symbol_name)>
+MakeGetterDimExpr4SymbolName(
+    const std::vector<std::tuple<std::string/*symbol_name*/, int/*in_tensor_idx*/, int/*in_tensor_dim_idx*/>>& symbol_bindings,
+    const std::function<std::optional<DimExpr>(int in_tensor_idx, int in_tensor_dim_idx)>& DimExpr4InputDim);
+
 }

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <optional>
+#include "paddle/pir/core/builder.h"
+#include "paddle/pir/dialect/shape/utils/dim_expr.h"
+
+
+namespace symbol {
+
+::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder, const DimExpr& dim_expr);
+std::optional<DimExpr> ConvertAttributeToDimExpr(::pir::Attribute attribute);
+
+}

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.h
@@ -1,22 +1,40 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <optional>
 #include "paddle/pir/core/builder.h"
 #include "paddle/pir/dialect/shape/utils/dim_expr.h"
 
-
 namespace symbol {
 
-::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder, const DimExpr& dim_expr);
+::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder,
+                                           const DimExpr& dim_expr);
 std::optional<DimExpr> ConvertAttributeToDimExpr(::pir::Attribute attribute);
 
 std::optional<DimExpr> SubstituteDimExpr(
     const DimExpr& dim_expr,
-    const std::function<std::optional<DimExpr>(const std::string& symbol_name)>& DimExpr4SymbolName);
+    const std::function<std::optional<DimExpr>(const std::string& symbol_name)>&
+        DimExpr4SymbolName);
 
 std::function<std::optional<DimExpr>(const std::string& symbol_name)>
 MakeGetterDimExpr4SymbolName(
-    const std::vector<std::tuple<std::string/*symbol_name*/, int/*in_tensor_idx*/, int/*in_tensor_dim_idx*/>>& symbol_bindings,
-    const std::function<std::optional<DimExpr>(int in_tensor_idx, int in_tensor_dim_idx)>& DimExpr4InputDim);
+    const std::vector<std::tuple<std::string /*symbol_name*/,
+                                 int /*in_tensor_idx*/,
+                                 int /*in_tensor_dim_idx*/>>& symbol_bindings,
+    const std::function<std::optional<DimExpr>(
+        int in_tensor_idx, int in_tensor_dim_idx)>& DimExpr4InputDim);
 
-}
+}  // namespace symbol

--- a/paddle/pir/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/dialect/shape/utils/dim_expr_util.h
@@ -16,20 +16,22 @@
 
 #include <optional>
 #include "paddle/pir/core/builder.h"
+#include "paddle/pir/core/dll_decl.h"
 #include "paddle/pir/dialect/shape/utils/dim_expr.h"
 
 namespace symbol {
 
-::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder,
-                                           const DimExpr& dim_expr);
-std::optional<DimExpr> ConvertAttributeToDimExpr(::pir::Attribute attribute);
+IR_API ::pir::Attribute ConvertDimExprToAttribute(::pir::Builder* builder,
+                                                  const DimExpr& dim_expr);
+IR_API std::optional<DimExpr> ConvertAttributeToDimExpr(
+    ::pir::Attribute attribute);
 
-std::optional<DimExpr> SubstituteDimExpr(
+IR_API std::optional<DimExpr> SubstituteDimExpr(
     const DimExpr& dim_expr,
     const std::function<std::optional<DimExpr>(const std::string& symbol_name)>&
         DimExpr4SymbolName);
 
-std::function<std::optional<DimExpr>(const std::string& symbol_name)>
+IR_API std::function<std::optional<DimExpr>(const std::string& symbol_name)>
 MakeGetterDimExpr4SymbolName(
     const std::vector<std::tuple<std::string /*symbol_name*/,
                                  int /*in_tensor_idx*/,

--- a/test/cpp/pir/shape_dialect/CMakeLists.txt
+++ b/test/cpp/pir/shape_dialect/CMakeLists.txt
@@ -4,6 +4,9 @@ paddle_test(shape_struct_test SRCS shape_struct_test.cc DEPS gtest)
 
 paddle_test(symbol_dim_expr_test SRCS symbol_dim_expr_test.cc DEPS gtest)
 
+paddle_test(symbol_dim_expr_util_test SRCS symbol_dim_expr_util_test.cc DEPS
+            gtest)
+
 if(WITH_CINN)
   paddle_test(
     shape_optimization_test

--- a/test/cpp/pir/shape_dialect/symbol_dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/symbol_dim_expr_util_test.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
+#include "paddle/pir/dialect/shape/utils/dim_expr_builder.h"
+#include "paddle/pir/dialect/shape/utils/dim_expr_util.h"
+
+#include "test/cpp/pir/tools/test_pir_utils.h"
+
+namespace symbol {
+
+namespace {
+DimExpr CreateExampleDimExpr() {
+  DimExprBuilder dim_expr_builder{nullptr};
+  DimExpr sym0 = DimExpr("S0");
+  DimExpr sym1 = DimExpr("S1");
+  DimExpr constant = DimExpr(2);
+  DimExpr expr1 = (sym0 - sym1) * constant / sym0;
+  DimExpr expr2 = dim_expr_builder.Max(expr1, sym0);
+  DimExpr output = dim_expr_builder.Min(expr2, sym1);
+  return output;
+}
+}  // namespace
+
+TEST(DimExprUtil, Convert) {
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  pir::Program program(ctx);
+  pir::Builder builder = pir::Builder(ctx, program.block());
+
+  DimExpr dim_expr = CreateExampleDimExpr();
+  ::pir::Attribute attr = ConvertDimExprToAttribute(&builder, dim_expr);
+  std::optional<DimExpr> opt_expr = ConvertAttributeToDimExpr(attr);
+  ASSERT_TRUE(opt_expr.has_value());
+  ASSERT_EQ(opt_expr.value(), dim_expr);
+}
+
+TEST(DimExprUtil, Substitute) {
+  DimExpr dim_expr = CreateExampleDimExpr();
+  const auto& opt_expr = SubstituteDimExpr(
+      dim_expr, [](const std::string& str) -> std::optional<DimExpr> {
+        if (str == "S0") {
+          return DimExpr("symbol0");
+        } else if (str == "S1") {
+          return DimExpr("symbol1");
+        } else {
+          return std::nullopt;
+        }
+      });
+  ASSERT_TRUE(opt_expr.has_value());
+  const auto& ret_expr = SubstituteDimExpr(
+      opt_expr.value(), [](const std::string& str) -> std::optional<DimExpr> {
+        if (str == "symbol0") {
+          return DimExpr("S0");
+        } else if (str == "symbol1") {
+          return DimExpr("S1");
+        } else {
+          return std::nullopt;
+        }
+      });
+  ASSERT_TRUE(ret_expr.has_value());
+  ASSERT_TRUE((ret_expr.value() == dim_expr));
+}
+
+TEST(DimExprUtil, MakeGetterDimExpr4SymbolName) {
+  std::vector<std::tuple<std::string /*symbol_name*/,
+                         int /*in_tensor_idx*/,
+                         int /*in_tensor_dim_idx*/>>
+      symbol_bindings{};
+  symbol_bindings.push_back(std::make_tuple("Symbol", 0, 0));
+  const auto& dim_expr = CreateExampleDimExpr();
+  const auto& DimExpr4SymbolName = MakeGetterDimExpr4SymbolName(
+      symbol_bindings,
+      [dim_expr](int in_tensor_idx,
+                 int in_tensor_dim_idx) -> std::optional<DimExpr> {
+        if (in_tensor_idx == 0 && in_tensor_dim_idx == 0) {
+          return dim_expr;
+        } else {
+          return std::nullopt;
+        }
+      });
+  const auto& opt_dim_expr = DimExpr4SymbolName("Symbol");
+  ASSERT_TRUE(opt_dim_expr.has_value());
+  ASSERT_EQ(opt_dim_expr.value(), dim_expr);
+}
+
+}  // namespace symbol

--- a/test/cpp/pir/shape_dialect/symbol_dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/symbol_dim_expr_util_test.cc
@@ -71,7 +71,7 @@ TEST(DimExprUtil, Substitute) {
         }
       });
   ASSERT_TRUE(ret_expr.has_value());
-  ASSERT_TRUE((ret_expr.value() == dim_expr));
+  ASSERT_EQ(ret_expr.value(), dim_expr);
 }
 
 TEST(DimExprUtil, MakeGetterDimExpr4SymbolName) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[DimExpr] Add utils for DimExpr, convert between DimExpr and pir::Attribute

提供四个 DimExpr util 接口：
- ConvertDimExprToAttribute: DimExpr 转 pir::Attribute
- ConvertAttributeToDimExpr: pir::Attribute 转 DimExpr
- SubstituteDimExpr: 替换 DimExpr 中的符号
- MakeGetterDimExpr4SymbolName: 根据 symbol_name 得到 DimExpr