### PR TITLE
【CINN】Complete dsl test case for dynamic schedule primitive

### DIFF
--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -114,7 +114,8 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   for (auto factor : factors) prod_size = prod_size * Expr(factor);
   std::for_each(factors.begin(), factors.end(), [&](int factor) {
     if (factor == -1) {
-      process_factors.push_back(tot_extent / prod_size + Expr(1));
+      process_factors.push_back(
+          cinn::common::AutoSimplify(tot_extent / prod_size + Expr(1)));
     } else {
       process_factors.push_back(Expr(factor));
     }

--- a/test/cinn/ir/test_llir_schedule_compute_at.py
+++ b/test/cinn/ir/test_llir_schedule_compute_at.py
@@ -106,6 +106,99 @@ def test_reverse_compute_at():
     assert_llir_equal(reverse_compute_at_tiled, reverse_compute_at_tiled_gt)
 
 
+def test_compute_at_elementwise_dynamic():
+    @to_cinn_llir
+    def elementwise_add(
+        X: DataArray((-1, 128)),
+        Y: DataArray((-1, 128)),
+        A: DataArray((-1, 128)),
+        N: ir.Var(),
+    ):
+        for i in range(N):
+            for j in range(128):
+                with ir.ScheduleBlockContext("A") as A_block:
+                    i1, j1 = ir.AxisMap("SS", [i, j])
+                    A[i1, j1] = X[i1, j1] * 2.0
+        for i in range(N):
+            for j in range(128):
+                with ir.ScheduleBlockContext("Y"):
+                    i1, j1 = ir.AxisMap("SS", [i, j])
+                    sch.compute_at(A_block.block, i, False)
+                    Y[i1, j1] = A[i1, j1] + 2.0
+
+    @to_cinn_llir
+    def elementwise_add_gt(
+        X: DataArray((-1, 128)),
+        Y: DataArray((-1, 128)),
+        A: DataArray((-1, 128)),
+        N: ir.Var(),
+    ):
+        for i in range(N):
+            for j in range(128):
+                with ir.ScheduleBlockContext("A"):
+                    i1, j1 = ir.AxisMap("SS", [i, 0 + j])
+                    A[i1, j1] = X[i1, j1] * 2.0
+            for k in range(128):
+                with ir.ScheduleBlockContext("Y"):
+                    i2, k1 = ir.AxisMap("SS", [i, k])
+                    Y[i2, k1] = A[i2, k1] + 2.0
+
+    assert_llir_equal(elementwise_add, elementwise_add_gt)
+
+
+def test_reverse_compute_at_dynamic():
+    @to_cinn_llir
+    def reverse_compute_at_tiled(
+        A: DataArray((-1, 128)),
+        B: DataArray((-1, 128)),
+        C: DataArray((-1, 128)),
+        N: ir.Var(),
+    ):
+        for i0 in range(N / 16):
+            for j0 in range(8):
+                for i1 in range(16):
+                    for j1 in range(16):
+                        with ir.ScheduleBlockContext("B") as B_block:
+                            vi, vj = ir.AxisMap(
+                                "SS", [i0 * 16 + i1, j0 * 16 + j1]
+                            )
+                            B[vi, vj] = A[vi, vj] * 2.0
+        for i in range(N):
+            for j in range(128):
+                with ir.ScheduleBlockContext("C") as C_block:
+                    vi, vj = ir.AxisMap("SS", [i, j])
+                    C[vi, vj] = B[vi, vj] + 1.0
+
+        sch.reverse_compute_at(C_block.block, B_block.i1)
+
+    @to_cinn_llir
+    def reverse_compute_at_tiled_gt(
+        A: DataArray((-1, 128)),
+        B: DataArray((-1, 128)),
+        C: DataArray((-1, 128)),
+        N: ir.Var(),
+    ):
+        for i0 in range(N / 16):
+            for j0 in range(8):
+                for i1 in range(16):
+                    for j1 in range(16):
+                        with ir.ScheduleBlockContext("B") as B_block:
+                            vi, vj = ir.AxisMap(
+                                "SS", [i0 * 16 + i1, j0 * 16 + j1]
+                            )
+                            B[vi, vj] = A[vi, vj] * 2.0
+                    for j2 in range(16):
+                        with ir.ScheduleBlockContext("C") as C_block:
+                            vi, vj = ir.AxisMap(
+                                "SS", [16 * i0 + i1, 16 * j0 + j2]
+                            )
+                            C[vi, vj] = B[vi, vj] + 1.0
+
+    assert_llir_equal(reverse_compute_at_tiled, reverse_compute_at_tiled_gt)
+
+
 if __name__ == '__main__':
     test_compute_at_elementwise()
     test_reverse_compute_at()
+    test_compute_at_elementwise_dynamic()
+    test_reverse_compute_at_dynamic()

--- a/test/cinn/ir/test_llir_schedule_fuse_split.py
+++ b/test/cinn/ir/test_llir_schedule_fuse_split.py
@@ -125,7 +125,91 @@ def test_split_predicate():
     )
 
 
+def test_fuse_dynamic():
+    class origin:
+        @to_cinn_llir
+        def elementwise_fuse_assign_loop(
+            X: DataArray((-1, 128, 128)),
+            Y: DataArray((-1, 128, 128)),
+            N: ir.Var(),
+        ):
+            for i in range(N):
+                for j in range(128):
+                    for k in range(128):
+                        with ir.ScheduleBlockContext("Y") as block_y:
+                            sch.fuse([i, j, k])
+                            i1, j1, k1 = ir.AxisMap("SSS", [i, j, k])
+                            Y[i1, j1, k1] = X[i1, j1, k1] * 2.0
+
+    class expected:
+        @to_cinn_llir
+        def elementwise_fuse_assign_loop(
+            X: DataArray((-1, 128, 128)),
+            Y: DataArray((-1, 128, 128)),
+            N: ir.Var(),
+        ):
+            for i_j_k_fused in range(((1 * N) * 128) * 128):
+                with ir.ScheduleBlockContext("Y") as block_y:
+                    i1, j1, k1 = ir.AxisMap(
+                        "SSS",
+                        [
+                            (i_j_k_fused / 128) / 128,
+                            (i_j_k_fused / 128) % 128,
+                            i_j_k_fused % 128,
+                        ],
+                    )
+                    Y[i1, j1, k1] = 2.0 * X[i1, j1, k1]
+
+    assert str(origin.elementwise_fuse_assign_loop) == str(
+        expected.elementwise_fuse_assign_loop
+    )
+
+
+def test_split_dynamic():
+    class origin:
+        @to_cinn_llir
+        def elementwise_split(
+            X: DataArray((128, 128, -1)),
+            Y: DataArray((128, 128, -1)),
+            N: ir.Var(),
+        ):
+            for i in range(128):
+                for j in range(128):
+                    for k in range(N):
+                        with ir.ScheduleBlockContext("Y") as Y_block:
+                            i1, j1, k1 = ir.AxisMap("SSS", [i, j, k])
+                            sch.split(Y_block.k, factors=[16, -1])
+                            Y[i1, j1, k1] = X[i1, j1, k1] * 2.0
+
+    class expected:
+        @to_cinn_llir
+        def elementwise_split(
+            X: DataArray((128, 128, -1)),
+            Y: DataArray((128, 128, -1)),
+            N: ir.Var(),
+        ):
+            for i in range(128):
+                for j in range(128):
+                    for k_7 in range(16):
+                        for k_8 in range((N / 16) + 1):
+                            if (((N / 16) * k_7) + (k_7 + k_8)) < N:
+                                with ir.ScheduleBlockContext("Y") as Y_block:
+                                    i1, j1, k1 = ir.AxisMap(
+                                        "SSS",
+                                        [
+                                            i,
+                                            j,
+                                            (((N / 16) * k_7) + (k_7 + k_8)),
+                                        ],
+                                    )
+                                    Y[i1, j1, k1] = X[i1, j1, k1] * 2.0
+
+    assert_llir_equal(origin.elementwise_split, expected.elementwise_split)
+
+
 if __name__ == "__main__":
     test_fuse()
     test_split()
     test_split_predicate()
+    test_fuse_dynamic()
+    test_split_dynamic()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR complete dsl test case for dynamic schedule primitive, now the dsl is completely using dynamic schedule and owns static and dynamic test cases
(attention: some primitive such as bind、vectorize、rfactor is only using on static shape, so we don't need to add new test case for them, just make sure that the original test case will run correctly on dynamic schedule)