### PR TITLE
[PIR] migrate DataFeeder into pir

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -582,7 +582,9 @@ const phi::DDim &GetValueDims(Value value) {
 }
 
 void BindValue(py::module *m) {
-  py::class_<Value> value(*m, "Value", R"DOC(
+  py::class_<Value> value(*m,
+                          "Value",
+                          R"DOC(
     Value class represents the SSA value in the IR system. It is a directed edge
     and a base class.
 
@@ -590,7 +592,8 @@ void BindValue(py::module *m) {
         The constructor of Value should not be invoked directly. Value can be automatically constructed
         when build network.
 
-  )DOC");
+  )DOC",
+                          pybind11::dynamic_attr());
   g_ir_value_pytype = reinterpret_cast<PyTypeObject *>(value.ptr());
   value.def(py::init<>())
       .def_property_readonly(

--- a/python/paddle/base/data_feeder.py
+++ b/python/paddle/base/data_feeder.py
@@ -16,6 +16,8 @@ import struct
 
 import numpy as np
 
+from paddle import pir
+
 from ..pir import Value
 from ..pir.core import ParameterMeta
 from . import core
@@ -419,19 +421,40 @@ class DataFeeder:
         self.feed_names = []
         self.feed_shapes = []
         self.feed_lod_level = []
-        if program is None:
-            program = default_main_program()
-        for each_var in feed_list:
-            if isinstance(each_var, str):
-                each_var = program.block(0).var(each_var)
-            if not isinstance(each_var, Variable):
-                raise TypeError("Feed list should contain a list of variable")
-            self.feed_dtypes.append(each_var.dtype)
-            self.feed_names.append(each_var.name)
-            self.feed_lod_level.append(each_var.lod_level)
-            self.feed_shapes.append(each_var.shape)
-
         self.place = place
+        if in_pir_mode():
+            if program is None:
+                program = pir.core.default_main_program()
+            for each_var in feed_list:
+                if isinstance(each_var, str):
+                    each_var = pir.core.get_value_by_name_from_block(
+                        program.global_block(), each_var
+                    )
+                    if each_var is None:
+                        raise ValueError(
+                            "Value %s is not in program or can't be got name from Python."
+                            % each_var
+                        )
+                if not isinstance(each_var, Value):
+                    raise TypeError("Feed list should contain a list of Value")
+                self.feed_dtypes.append(each_var.dtype)
+                self.feed_names.append(each_var.name)
+                self.feed_lod_level.append(each_var.lod_level)
+                self.feed_shapes.append(each_var.shape)
+        else:
+            if program is None:
+                program = default_main_program()
+            for each_var in feed_list:
+                if isinstance(each_var, str):
+                    each_var = program.block(0).var(each_var)
+                if not isinstance(each_var, Variable):
+                    raise TypeError(
+                        "Feed list should contain a list of variable"
+                    )
+                self.feed_dtypes.append(each_var.dtype)
+                self.feed_names.append(each_var.name)
+                self.feed_lod_level.append(each_var.lod_level)
+                self.feed_shapes.append(each_var.shape)
 
     def feed(self, iterable):
         """

--- a/python/paddle/base/data_feeder.py
+++ b/python/paddle/base/data_feeder.py
@@ -427,14 +427,9 @@ class DataFeeder:
                 program = pir.core.default_main_program()
             for each_var in feed_list:
                 if isinstance(each_var, str):
-                    each_var = pir.core.get_value_by_name_from_block(
-                        program.global_block(), each_var
+                    raise ValueError(
+                        "In PIR Mode, Not supported string input yet"
                     )
-                    if each_var is None:
-                        raise ValueError(
-                            "Value %s is not in program or can't be got name from Python."
-                            % each_var
-                        )
                 if not isinstance(each_var, Value):
                     raise TypeError("Feed list should contain a list of Value")
                 self.feed_dtypes.append(each_var.dtype)

--- a/python/paddle/pir/core.py
+++ b/python/paddle/pir/core.py
@@ -332,3 +332,14 @@ def static_op_arg_cast_guard(hook):
         yield
     finally:
         set_static_op_arg_pre_cast_hook(original_callback)
+
+
+def get_value_by_name_from_block(block, value_name):
+    for op in block.ops:
+        if op.name() == "pd_op.data":
+            if op.attr()["name"] == value_name:
+                return op.result(0)
+        elif op.name() == "builtin.parameter":
+            if op.attr()["parameter_name"] == value_name:
+                return op.result(0)
+    return None

--- a/python/paddle/pir/core.py
+++ b/python/paddle/pir/core.py
@@ -332,14 +332,3 @@ def static_op_arg_cast_guard(hook):
         yield
     finally:
         set_static_op_arg_pre_cast_hook(original_callback)
-
-
-def get_value_by_name_from_block(block, value_name):
-    for op in block.ops:
-        if op.name() == "pd_op.data":
-            if op.attr()["name"] == value_name:
-                return op.result(0)
-        elif op.name() == "builtin.parameter":
-            if op.attr()["parameter_name"] == value_name:
-                return op.result(0)
-    return None

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -134,6 +134,7 @@ def data(name, shape, dtype=None, lod_level=0):
             ir_dtype = paddle.pir.core.convert_np_dtype_to_dtype_(dtype)
         _reset_data_op_insertion_point()
         out = paddle._pir_ops.data(name, shape, ir_dtype, core.Place())
+        out.lod_level = lod_level
         paddle.pir.reset_insertion_point_to_end()
         return out
 

--- a/test/legacy_test/test_data_feeder.py
+++ b/test/legacy_test/test_data_feeder.py
@@ -16,74 +16,109 @@ import unittest
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
 
 class TestDataFeeder(unittest.TestCase):
+    @test_with_pir_api
     def test_lod_level_0_converter(self):
-        img = paddle.static.data(name='image', shape=[-1, 1, 28, 28])
-        label = paddle.static.data(name='label', shape=[-1, 1], dtype='int64')
-        feeder = base.DataFeeder([img, label], base.CPUPlace())
-        result = feeder.feed([([0] * 784, [9]), ([1] * 784, [1])])
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            img = paddle.static.data(name='image', shape=[-1, 1, 28, 28])
+            label = paddle.static.data(
+                name='label', shape=[-1, 1], dtype='int64'
+            )
+            feeder = base.DataFeeder([img, label], base.CPUPlace())
+            result = feeder.feed([([0] * 784, [9]), ([1] * 784, [1])])
 
-        self.assertEqual(result['image'].shape(), [2, 1, 28, 28])
-        self.assertEqual(result['label'].shape(), [2, 1])
-        self.assertEqual(result['image'].recursive_sequence_lengths(), [])
-        self.assertEqual(result['label'].recursive_sequence_lengths(), [])
+            self.assertEqual(result['image'].shape(), [2, 1, 28, 28])
+            self.assertEqual(result['label'].shape(), [2, 1])
+            self.assertEqual(result['image'].recursive_sequence_lengths(), [])
+            self.assertEqual(result['label'].recursive_sequence_lengths(), [])
 
-        try:
-            result = feeder.feed([([0] * 783, [9]), ([1] * 783, [1])])
-            self.assertTrue(False)
-        except ValueError:
-            self.assertTrue(True)
+            try:
+                result = feeder.feed([([0] * 783, [9]), ([1] * 783, [1])])
+                self.assertTrue(False)
+            except ValueError:
+                self.assertTrue(True)
 
+    @test_with_pir_api
     def test_lod_level_1_converter(self):
-        # lod_level = 1
-        # each sentence has a different number of words
-        sentences = paddle.static.data(
-            name='sentences', shape=[-1, 1], dtype='int64', lod_level=1
-        )
-        label = paddle.static.data(name='label', shape=[-1, 1], dtype='int64')
-        feeder = base.DataFeeder([sentences, label], base.CPUPlace())
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            # lod_level = 1
+            # each sentence has a different number of words
+            sentences = paddle.static.data(
+                name='sentences', shape=[-1, 1], dtype='int64', lod_level=1
+            )
+            label = paddle.static.data(
+                name='label', shape=[-1, 1], dtype='int64'
+            )
+            feeder = base.DataFeeder([sentences, label], base.CPUPlace())
 
-        # lod = [[0, 3, 5, 9]]
-        # data = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
-        # label = [1] * len(data)
-        result = feeder.feed(
-            [([1, 2, 3], [1]), ([4, 5], [1]), ([6, 7, 8, 9], [1])]
-        )
+            # lod = [[0, 3, 5, 9]]
+            # data = [[1, 2, 3], [4, 5], [6, 7, 8, 9]]
+            # label = [1] * len(data)
+            result = feeder.feed(
+                [([1, 2, 3], [1]), ([4, 5], [1]), ([6, 7, 8, 9], [1])]
+            )
 
-        self.assertEqual(result['sentences'].shape(), [9, 1])
-        self.assertEqual(result['label'].shape(), [3, 1])
-        self.assertEqual(
-            result['sentences'].recursive_sequence_lengths(), [[3, 2, 4]]
-        )
-        self.assertEqual(result['label'].recursive_sequence_lengths(), [])
+            self.assertEqual(result['sentences'].shape(), [9, 1])
+            self.assertEqual(result['label'].shape(), [3, 1])
+            self.assertEqual(
+                result['sentences'].recursive_sequence_lengths(), [[3, 2, 4]]
+            )
+            self.assertEqual(result['label'].recursive_sequence_lengths(), [])
 
+    @test_with_pir_api
     def test_lod_level_2_converter(self):
-        # lod_level = 2
-        # paragraphs -> sentences -> words
-        paragraphs = paddle.static.data(
-            name='paragraphs', shape=[-1, 1], dtype='int64', lod_level=2
-        )
-        label = paddle.static.data(name='label', shape=[-1, 1], dtype='int64')
-        feeder = base.DataFeeder([paragraphs, label], base.CPUPlace())
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            # lod_level = 2
+            # paragraphs -> sentences -> words
+            paragraphs = paddle.static.data(
+                name='paragraphs', shape=[-1, 1], dtype='int64', lod_level=2
+            )
+            label = paddle.static.data(
+                name='label', shape=[-1, 1], dtype='int64'
+            )
+            feeder = base.DataFeeder([paragraphs, label], base.CPUPlace())
 
-        # lod = [[0, 2, 3], [0, 3, 5, 9]]
-        # data = [[[1, 2, 3], [4, 5]], [[6, 7, 8, 9]]]
-        # label = [1] * len(data)
-        result = feeder.feed(
-            [([[1, 2, 3], [4, 5]], [1]), ([[6, 7, 8, 9]], [1])]
-        )
+            # lod = [[0, 2, 3], [0, 3, 5, 9]]
+            # data = [[[1, 2, 3], [4, 5]], [[6, 7, 8, 9]]]
+            # label = [1] * len(data)
+            result = feeder.feed(
+                [([[1, 2, 3], [4, 5]], [1]), ([[6, 7, 8, 9]], [1])]
+            )
 
-        self.assertEqual(result['paragraphs'].shape(), [9, 1])
-        self.assertEqual(result['label'].shape(), [2, 1])
-        self.assertEqual(
-            result['paragraphs'].recursive_sequence_lengths(),
-            [[2, 1], [3, 2, 4]],
-        )
-        self.assertEqual(result['label'].recursive_sequence_lengths(), [])
+            self.assertEqual(result['paragraphs'].shape(), [9, 1])
+            self.assertEqual(result['label'].shape(), [2, 1])
+            self.assertEqual(
+                result['paragraphs'].recursive_sequence_lengths(),
+                [[2, 1], [3, 2, 4]],
+            )
+            self.assertEqual(result['label'].recursive_sequence_lengths(), [])
+
+    def test_errors(self):
+        def pir_mode_not_supported_str_feed():
+            with paddle.pir_utils.IrGuard():
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    img = paddle.static.data(
+                        name='image', shape=[-1, 1, 28, 28]
+                    )
+                    label = paddle.static.data(
+                        name='label', shape=[-1, 1], dtype='int64'
+                    )
+                    feeder = base.DataFeeder(['image', label], base.CPUPlace())
+
+        self.assertRaises(ValueError, pir_mode_not_supported_str_feed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
**main works**
1. Set `pybind11::dynamic_attr()` when using pybind11 to bind C++ pir::Value. In this way, we can dynamically set `pir.Value` attribute `lod_level` in python.
2.  Adapt `DataFeeder` in PIR mode. Because `DataFeeder` appears in many of the optimizers' unittest.

**NOTE**
`pir.Value` doesn't really support `lod_level` settings yet. It's only a dynamic attribute in Python Object.
Because of dynamic attribute in Python Object, this will happen:
```python
import paddle
with paddle.pir_utils.IrGuard():
    main_program = paddle.static.Program()
    startup_program = paddle.static.Program()
    with paddle.static.program_guard(main_program, startup_program):
        x = paddle.static.data(name="x", shape=[6, 1], dtype="float32", lod_level=1)
        y = paddle.mean(x)
        
        assert x.lod_level == 1  # <---- okay!
        x_temp = main_program.global_block().ops[0].result(0)
        assert x.is_same(x_temp)
        print(x_temp.lod_level) # <---- Raising AttributeError: 'paddle.base.libpaddle.pir.OpResult' object has no attribute 'lod_level'
```