### PR TITLE
[Dy2St] Use `ENABLE_FALL_BACK=False` outside dy2st uts

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ function(py_test_modules TARGET_NAME)
         NAME ${TARGET_NAME}
         COMMAND
           ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python
-          ${py_test_modules_ENVS} ${PYTHON_EXECUTABLE}
+          ENABLE_FALL_BACK=False ${py_test_modules_ENVS} ${PYTHON_EXECUTABLE}
           ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     endif()

--- a/test/amp/CMakeLists.txt
+++ b/test/amp/CMakeLists.txt
@@ -18,7 +18,7 @@ function(py_test_modules TARGET_NAME)
         NAME ${TARGET_NAME}
         COMMAND
           ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python
-          ${py_test_modules_ENVS}
+          ENABLE_FALL_BACK=False ${py_test_modules_ENVS}
           COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
           ${PYTHON_EXECUTABLE} -m coverage run --branch -p
           ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -299,7 +299,7 @@ function(py_test_modules TARGET_NAME)
           COMMAND
             ${CMAKE_COMMAND} -E env
             PYTHONPATH=${PADDLE_BINARY_DIR}/python:$ENV{PYTHONPATH}
-            ${py_test_modules_ENVS}
+            ENABLE_FALL_BACK=False ${py_test_modules_ENVS}
             COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
             ${PYTHON_EXECUTABLE} -m coverage run --branch -p
             ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}

--- a/test/sot/CMakeLists.txt
+++ b/test/sot/CMakeLists.txt
@@ -4,7 +4,7 @@ file(
   "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 set(SOT_ENVS SOT_LOG_LEVEL=0 COST_MODEL=False MIN_GRAPH_SIZE=0 STRICT_MODE=True
-             FLAGS_cudnn_deterministic=True)
+             ENABLE_FALL_BACK=True FLAGS_cudnn_deterministic=True)
 
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${SOT_ENVS})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

在非动转静单测使用 AST 动转静，以免 SOT 包含 MIN_GRAPH_SIZE 的策略导致部分模型跑到动态图，导致啥也没测到

PCard-66972