### PR TITLE
Fix shape error in combined-indexing setitem

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -398,9 +398,8 @@ static paddle::Tensor dealWithAdvancedIndex(
     std::vector<paddle::Tensor>* transed_index,
     std::vector<int>* trans_back_dim,
     int* pos_of_new_dim,
-    int* rank_of_new_dim) {
-  std::vector<int> trans_dim;
-
+    int* rank_of_new_dim,
+    std::vector<int>* trans_dim) {
   int p = 0;
   for (size_t i = 0; i < advanced_index_dim->size(); ++i) {
     auto index_dim = (*advanced_index_dim)[i];
@@ -409,30 +408,28 @@ static paddle::Tensor dealWithAdvancedIndex(
       // advanced_index_dim
       auto index = (*advanced_index)[p++];
 
-      if (!is_for_setitem) {
-        if (index_dim == 0) {
-          // case 1: advanced indices at axis 0, the new dim will be at first.
-          *pos_of_new_dim = 0;
-        } else if (index_dim > 0 && trans_dim.size() > 0 &&
-                   trans_dim[trans_dim.size() - 1] != index_dim - 1) {
-          // case 2: there are not adjacent advanced indices, the new dim will
-          // be at first.
-          *pos_of_new_dim = 0;
-        } else {
-          *pos_of_new_dim = std::min(index_dim, *pos_of_new_dim);
-        }
-        *rank_of_new_dim =
-            std::max(*rank_of_new_dim, static_cast<int>(index.shape().size()));
+      if (index_dim == 0) {
+        // case 1: advanced indices at axis 0, the new dim will be at first.
+        *pos_of_new_dim = 0;
+      } else if (index_dim > 0 && trans_dim->size() > 0 &&
+                 (*trans_dim)[trans_dim->size() - 1] != index_dim - 1) {
+        // case 2: there are not adjacent advanced indices, the new dim will
+        // be at first.
+        *pos_of_new_dim = 0;
+      } else {
+        *pos_of_new_dim = std::min(index_dim, *pos_of_new_dim);
       }
+      *rank_of_new_dim =
+          std::max(*rank_of_new_dim, static_cast<int>(index.shape().size()));
 
-      trans_dim.push_back(index_dim);
+      trans_dim->push_back(index_dim);
       transed_index->push_back(std::move(index));
     }
   }
 
   for (size_t i = 0; i < tensor.shape().size(); ++i) {
     if ((*advanced_index_dim)[i] == -1) {
-      trans_dim.push_back(i);
+      trans_dim->push_back(i);
     }
   }
 
@@ -442,19 +439,19 @@ static paddle::Tensor dealWithAdvancedIndex(
   std::vector<int> original_dim_order(tensor.shape().size());
   std::iota(original_dim_order.begin(), original_dim_order.end(), 0);
 
-  if (original_dim_order == trans_dim) {
+  if (original_dim_order == *trans_dim) {
     transed_tensor = tensor;
   } else {
-    transed_tensor = transpose_ad_func(tensor, trans_dim);
+    transed_tensor = transpose_ad_func(tensor, *trans_dim);
   }
 
   if (is_for_setitem) {
-    trans_back_dim->resize(trans_dim.size());
+    trans_back_dim->resize(trans_dim->size());
     std::iota(trans_back_dim->begin(), trans_back_dim->end(), 0);
     std::sort(trans_back_dim->begin(),
               trans_back_dim->end(),
               [&trans_dim](int left, int right) {
-                return trans_dim[left] < trans_dim[right];
+                return (*trans_dim)[left] < (*trans_dim)[right];
               });
   }
   return transed_tensor;

--- a/test/indexing/test_setitem.py
+++ b/test/indexing/test_setitem.py
@@ -229,6 +229,56 @@ class TestSetitemInDygraph(unittest.TestCase):
 
         np.testing.assert_allclose(x.numpy(), np_data)
 
+    def test_combined_indexing_and_value_is_tensor_1(self):
+        # value is tensor and index will be adjusted
+        np_data = np.ones((3, 3)).astype(self.ndtype)
+        value_data = np.array([-1, -1, -1]).astype(self.ndtype)
+
+        if self.dtype == 'bfloat16':
+            np_data = convert_uint16_to_float(convert_float_to_uint16(np_data))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_data = np_data + 1j * np_data
+
+        x = paddle.to_tensor(np_data, dtype=self.dtype)
+        v = paddle.to_tensor(value_data, dtype=self.dtype)
+
+        np_data[:, [0, 2]] = np_data[:, [0, 2]] * np.expand_dims(value_data, -1)
+        x[:, [0, 2]] = x[:, [0, 2]] * v.unsqueeze(-1)
+
+        np.testing.assert_allclose(x.numpy(), np_data)
+
+    def test_combined_indexing_and_value_is_tensor_2(self):
+        # value is tensor needed to broadcast and index will be adjusted
+        # with broadcast and backward test
+        np_data = np.ones((3, 4, 5, 6)).astype(self.ndtype)
+        value_data = np.arange(3 * 4 * 2 * 1).reshape((3, 4, 2, 1))
+
+        if self.dtype == 'bfloat16':
+            np_data = convert_uint16_to_float(convert_float_to_uint16(np_data))
+        if self.dtype == 'complex64' or self.dtype == 'complex128':
+            np_data = np_data + 1j * np_data
+
+        x = paddle.to_tensor(np_data, dtype=self.dtype)
+        v = paddle.to_tensor(value_data, dtype=self.dtype)
+        x.stop_gradient = False
+        v.stop_gradient = False
+
+        y = x * 1
+        vv = v * 1
+        y[..., [1, 4], ::2] = vv
+
+        loss = y.sum()
+        loss.backward()
+
+        np_data[..., [1, 4], ::2] = value_data
+        expected_x_grad = np.ones((3, 4, 5, 6))
+        expected_x_grad[..., [1, 4], ::2] = 0
+
+        expected_v_grad = np.ones((3, 4, 2, 3)) * 3
+        np.testing.assert_allclose(y.numpy(), np_data)
+        np.testing.assert_allclose(x.grad.numpy(), expected_x_grad)
+        np.testing.assert_allclose(v.grad.numpy(), expected_v_grad)
+
     def test_inplace_with_stride(self):
         np_v = np.random.randn(3, 1).astype(self.ndtype)
         if self.dtype == 'bfloat16':
@@ -587,6 +637,54 @@ class TestSetitemInStatic(unittest.TestCase):
             res = self.exe.run(fetch_list=[y])
 
         np.testing.assert_allclose(res[0], np_data)
+
+    @test_with_pir_api
+    def test_combined_indexing_and_value_is_tensor_1(self):
+        # value is tensor and index will be adjusted
+        np_data = np.ones((3, 3), dtype='int32')
+        value_data = np.array([-1, -1, -1])
+        np_data[:, [0, 2]] = np_data[:, [0, 2]] * np.expand_dims(value_data, -1)
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            x = paddle.ones((3, 3), dtype='int32')
+            v = paddle.to_tensor([-1, -1, -1])
+            y = _setitem_static(
+                x,
+                (slice(None), [0, 1]),
+                x[:, [0, 2]] * v.unsqueeze(-1),
+            )
+            res = self.exe.run(fetch_list=[y])
+
+        np.testing.assert_allclose(res[0], np_data)
+
+    @test_with_pir_api
+    def test_combined_indexing_and_value_is_tensor_2(self):
+        # value is tensor needed to broadcast and index will be adjusted
+        # with broadcast and backward test
+        np_data = np.ones((3, 4, 5, 6), dtype='int32')
+        value_data = np.arange(3 * 4 * 2 * 1).reshape((3, 4, 2, 1))
+
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            x = paddle.ones((3, 4, 5, 6), dtype='int32')
+            v = paddle.arange(3 * 4 * 2 * 1).reshape((3, 4, 2, 1))
+            y = _setitem_static(
+                x,
+                (..., [1, 4], slice(None, None, 2)),
+                v,
+            )
+            res = self.exe.run(fetch_list=[y, x.grad_name, v.grad_name])
+
+        np_data[..., [1, 4], ::2] = value_data
+        expected_x_grad = np.ones((3, 4, 5, 6))
+        expected_x_grad[..., [1, 4], ::2] = 0
+
+        expected_v_grad = np.ones((3, 4, 2, 3)) * 3
+        np.testing.assert_allclose(res[0], np_data)
+        np.testing.assert_allclose(res[1], expected_x_grad)
+        np.testing.assert_allclose(res[2], expected_v_grad)
 
 
 if __name__ == '__main__':

--- a/test/indexing/test_setitem.py
+++ b/test/indexing/test_setitem.py
@@ -236,14 +236,21 @@ class TestSetitemInDygraph(unittest.TestCase):
 
         if self.dtype == 'bfloat16':
             np_data = convert_uint16_to_float(convert_float_to_uint16(np_data))
+            value_data = convert_uint16_to_float(
+                convert_float_to_uint16(value_data)
+            )
         if self.dtype == 'complex64' or self.dtype == 'complex128':
             np_data = np_data + 1j * np_data
+            value_data = value_data + 1j * value_data
 
         x = paddle.to_tensor(np_data, dtype=self.dtype)
         v = paddle.to_tensor(value_data, dtype=self.dtype)
 
         np_data[:, [0, 2]] = np_data[:, [0, 2]] + np.expand_dims(value_data, -1)
         x[:, [0, 2]] = x[:, [0, 2]] + v.unsqueeze(-1)
+
+        if self.dtype == 'bfloat16':
+            x = paddle.cast(x, dtype='float32')
 
         np.testing.assert_allclose(x.numpy(), np_data)
 
@@ -254,14 +261,20 @@ class TestSetitemInDygraph(unittest.TestCase):
 
         if self.dtype == 'bfloat16':
             np_data = convert_uint16_to_float(convert_float_to_uint16(np_data))
+            value_data = convert_uint16_to_float(
+                convert_float_to_uint16(value_data)
+            )
         if self.dtype == 'complex64' or self.dtype == 'complex128':
             np_data = np_data + 1j * np_data
+            value_data = value_data + 1j * value_data
 
         x = paddle.to_tensor(np_data, dtype=self.dtype)
         v = paddle.to_tensor(value_data, dtype=self.dtype)
         x[..., [1, 4], ::2] = v
 
         np_data[..., [1, 4], ::2] = value_data
+        if self.dtype == 'bfloat16':
+            x = paddle.cast(x, dtype='float32')
         np.testing.assert_allclose(x.numpy(), np_data)
 
     def test_combined_indexing_and_value_is_tensor_3(self):
@@ -272,14 +285,21 @@ class TestSetitemInDygraph(unittest.TestCase):
 
         if self.dtype == 'bfloat16':
             np_data = convert_uint16_to_float(convert_float_to_uint16(np_data))
+            value_data = convert_uint16_to_float(
+                convert_float_to_uint16(value_data)
+            )
         if self.dtype == 'complex64' or self.dtype == 'complex128':
             np_data = np_data + 1j * np_data
+            value_data = value_data + 1j * value_data
 
         x = paddle.to_tensor(np_data, dtype=self.dtype)
         v = paddle.to_tensor(value_data, dtype=self.dtype)
         x[:, [1, 3], :, [3, 4]] = v
 
         np_data[:, [1, 3], :, [3, 4]] = value_data
+
+        if self.dtype == 'bfloat16':
+            x = paddle.cast(x, dtype='float32')
         np.testing.assert_allclose(x.numpy(), np_data)
 
     def test_inplace_with_stride(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Pcard-66985

This PR is to fix problem mentioned at https://github.com/PaddlePaddle/Paddle/issues/60376 .

In combined-indexing, if the first output dim of advanced-indexing is not at zero (i.e. the first). The value tensor should also be transposed to adapt the index_put input.