### PR TITLE
open warning with `paddle.utils.deprecated`

### DIFF
--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -27,8 +27,8 @@ __all__ = []
 class VisibleDeprecationWarning(UserWarning):
     """Visible deprecation warning.
 
-    After Python 3.7, Python hide the DeprecationWarning if the module is not
-    __main__. So we use this warning to make the deprecation warning visible.
+    Since Python 3.7, Python only show the DeprecationWarning if the module
+    is __main__. So we use this warning to make the deprecation warning visible.
 
     See more details from https://peps.python.org/pep-0565/
     """

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -47,8 +47,6 @@ def deprecated(update_to="", since="", reason="", level=0):
     """
 
     def decorator(func):
-        # TODO(zhiqiu): temporally disable the warnings
-        # return func
         """construct warning message, and return a decorated function or class."""
         assert isinstance(update_to, str), 'type of "update_to" must be str.'
         assert isinstance(since, str), 'type of "since" must be str.'

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -48,7 +48,7 @@ def deprecated(update_to="", since="", reason="", level=0):
 
     def decorator(func):
         # TODO(zhiqiu): temporally disable the warnings
-        return func
+        # return func
         """construct warning message, and return a decorated function or class."""
         assert isinstance(update_to, str), 'type of "update_to" must be str.'
         assert isinstance(since, str), 'type of "since" must be str.'

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -85,9 +85,11 @@ def deprecated(update_to="", since="", reason="", level=0):
             )
             msg += f' Please use "{_update_to}" instead.'
         if len(_reason) > 0:
-            msg += f"\nreason: {_reason}"
+            msg += f"\n        Reason: {_reason}"
         if func.__doc__:
-            func.__doc__ = ('\n\nWarning: ' + msg + '\n') + func.__doc__
+            func.__doc__ = (
+                '\n\n    Warning:\n        ' + msg + '\n'
+            ) + func.__doc__
 
         if level == 0:
             return func

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -24,6 +24,18 @@ import paddle
 __all__ = []
 
 
+class VisibleDeprecationWarning(UserWarning):
+    """Visible deprecation warning.
+
+    After Python 3.7, Python hide the DeprecationWarning if the module is not
+    __main__. So we use this warning to make the deprecation warning visible.
+
+    See more details from https://peps.python.org/pep-0565/
+    """
+
+    ...
+
+
 def deprecated(update_to="", since="", reason="", level=0):
     """Decorate a function to signify its deprecation.
 
@@ -108,7 +120,7 @@ def deprecated(update_to="", since="", reason="", level=0):
                 or v_current >= v_since
             ):
                 warnings.warn(
-                    warningmsg, category=DeprecationWarning, stacklevel=2
+                    warningmsg, category=VisibleDeprecationWarning, stacklevel=2
                 )
 
             return func(*args, **kwargs)

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -16,6 +16,7 @@ decorator to deprecate a function or class
 """
 
 import functools
+import inspect
 import sys
 import warnings
 
@@ -85,11 +86,11 @@ def deprecated(update_to="", since="", reason="", level=0):
             )
             msg += f' Please use "{_update_to}" instead.'
         if len(_reason) > 0:
-            msg += f"\n        Reason: {_reason}"
+            msg += f"\n    Reason: {_reason}"
         if func.__doc__:
             func.__doc__ = (
-                '\n\n    Warning:\n        ' + msg + '\n'
-            ) + func.__doc__
+                '\n\nWarning:\n    ' + msg + '\n\n'
+            ) + inspect.cleandoc(func.__doc__)
 
         if level == 0:
             return func

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -118,8 +118,6 @@ if(((NOT WITH_ROCM) AND (NOT WITH_GPU)) OR WIN32)
   list(REMOVE_ITEM TEST_OPS test_fleet_executor_cond_interceptor)
 endif()
 
-# list(REMOVE_ITEM TEST_OPS test_deprecated_decorator)
-
 if(WIN32)
   list(REMOVE_ITEM TEST_OPS test_multiprocess_reader_exception)
   list(REMOVE_ITEM TEST_OPS test_trainer_desc)

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -118,7 +118,7 @@ if(((NOT WITH_ROCM) AND (NOT WITH_GPU)) OR WIN32)
   list(REMOVE_ITEM TEST_OPS test_fleet_executor_cond_interceptor)
 endif()
 
-list(REMOVE_ITEM TEST_OPS test_deprecated_decorator)
+# list(REMOVE_ITEM TEST_OPS test_deprecated_decorator)
 
 if(WIN32)
   list(REMOVE_ITEM TEST_OPS test_multiprocess_reader_exception)

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -63,7 +63,6 @@ class TestDeprecatedDocorator(unittest.TestCase):
     """
     tests for paddle's Deprecated Docorator.
     test_new_multiply: test for new api, which should not insert warning information.
-    test_ops_elementwise_mul: test for C++ elementwise_mul op, which should not insert warning information.
     """
 
     def test_new_multiply(self):

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -46,13 +46,16 @@ def get_warning_index(api):
         index (int): the index of the Warinng information in its doc string if exists.
     """
 
-    doc_lst = api.__doc__.splitlines()
-    for idx, val in enumerate(doc_lst):
-        next_val = doc_lst[idx + 1] if idx + 1 < len(doc_lst) else ""
+    doc_list = api.__doc__.splitlines()
+    if len(doc_list) < 2:
+        return ERROR_WARNING_POSTION
+    for idx, (current_line, next_line) in enumerate(
+        zip(doc_list[:-1], doc_list[1:])
+    ):
         if (
-            val == ("Warning:")
-            and next_val.endswith(" instead.")
-            and "and will be removed in future versions." in next_val
+            current_line == "Warning:"
+            and next_line.endswith(" instead.")
+            and "and will be removed in future versions." in next_line
         ):
             return idx
     return ERROR_WARNING_POSTION
@@ -89,7 +92,6 @@ class TestDeprecatedDecorator(unittest.TestCase):
         dataset = paddle.base.DatasetFactory().create_dataset("InMemoryDataset")
         with warnings.catch_warnings(record=True):
             dataset.set_merge_by_lineid()
-            print(paddle.base.InMemoryDataset.set_merge_by_lineid.__doc__)
             assert (
                 '\nSet merge by'
                 in paddle.base.InMemoryDataset.set_merge_by_lineid.__doc__

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -70,25 +70,25 @@ class TestDeprecatedDocorator(unittest.TestCase):
     test_new_multiply: test for new api, which should not insert warning information.
     """
 
-    # def test_new_multiply(self):
-    #     """
-    #     Test for new multiply api, expected result should be False.
-    #     """
+    def test_new_multiply(self):
+        """
+        Test for new multiply api, expected result should be False.
+        """
 
-    #     a = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
-    #     b = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
-    #     x = paddle.to_tensor(a)
-    #     y = paddle.to_tensor(b)
-    #     res = paddle.multiply(x, y)
+        a = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
+        b = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
+        x = paddle.to_tensor(a)
+        y = paddle.to_tensor(b)
+        res = paddle.multiply(x, y)
 
-    #     # expected
-    #     expected = LOWEST_WARNING_POSTION
+        # expected
+        expected = LOWEST_WARNING_POSTION
 
-    #     # captured
-    #     captured = get_warning_index(paddle.multiply)
+        # captured
+        captured = get_warning_index(paddle.multiply)
 
-    #     # testting
-    #     self.assertLess(expected, captured)
+        # testting
+        self.assertLess(expected, captured)
 
     def test_tensor_gradient(self):
         paddle.__version__ = '2.1.0'

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -34,13 +34,6 @@ paddle.version.full_version = '0.0.0'
 print("current paddle version: ", paddle.__version__)
 
 
-# NOTE(SigureMo): After Python 3.7, Python hide the DeprecationWarning if the
-# module is not __main__. So we need to enables warnings manually.
-# See more details from https://peps.python.org/pep-0565/#recommended-filter-settings-for-test-runners
-if not sys.warnoptions:
-    warnings.simplefilter("default")
-
-
 def get_warning_index(api):
     """
     Given an paddle API, return the index of the Warinng information in its doc string if exists;

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -57,9 +57,9 @@ def get_warning_index(api):
     return ERROR_WARNING_POSTION
 
 
-class TestDeprecatedDocorator(unittest.TestCase):
+class TestDeprecatedDecorator(unittest.TestCase):
     """
-    tests for paddle's Deprecated Docorator.
+    tests for paddle's deprecated decorator.
     test_new_multiply: test for new api, which should not insert warning information.
     """
 

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -50,7 +50,7 @@ def get_warning_index(api):
     for idx, val in enumerate(doc_lst):
         next_val = doc_lst[idx + 1] if idx + 1 < len(doc_lst) else ""
         if (
-            val == ("    Warning:")
+            val == ("Warning:")
             and next_val.endswith(" instead.")
             and "and will be removed in future versions." in next_val
         ):
@@ -83,6 +83,17 @@ class TestDeprecatedDecorator(unittest.TestCase):
 
         # testting
         self.assertLess(expected, captured)
+
+    def test_indent_level(self):
+        # test for different indent_level
+        dataset = paddle.base.DatasetFactory().create_dataset("InMemoryDataset")
+        with warnings.catch_warnings(record=True):
+            dataset.set_merge_by_lineid()
+            print(paddle.base.InMemoryDataset.set_merge_by_lineid.__doc__)
+            assert (
+                '\nSet merge by'
+                in paddle.base.InMemoryDataset.set_merge_by_lineid.__doc__
+            )
 
     def test_tensor_gradient(self):
         paddle.__version__ = '2.1.0'

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -47,11 +47,13 @@ def get_warning_index(api):
     """
 
     doc_lst = api.__doc__.splitlines()
-    for idx, val in enumerate(doc_lst):
+    doc_iter = iter(doc_lst)
+    for idx, val in enumerate(doc_iter):
+        next_val = next(doc_iter, None)
         if (
-            val.startswith("Warning: ")
-            and val.endswith(" instead.")
-            and "and will be removed in future versions." in val
+            val.startswith("    Warning:")
+            and next_val.endswith(" instead.")
+            and "and will be removed in future versions." in next_val
         ):
             return idx
     return ERROR_WARNING_POSTION

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -25,12 +25,12 @@ LOWEST_WARNING_POSTION = 3
 ERROR_WARNING_POSTION = sys.maxsize
 
 # custom paddle version
-paddle.version.major = '2'
-paddle.version.minor = '6'
+paddle.version.major = '0'
+paddle.version.minor = '0'
 paddle.version.patch = '0'
 paddle.version.rc = '0'
-paddle.__version__ = '2.6.0'
-paddle.version.full_version = '2.6.0'
+paddle.__version__ = '0.0.0'
+paddle.version.full_version = '0.0.0'
 print("current paddle version: ", paddle.__version__)
 
 paddle.disable_static()

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -47,11 +47,10 @@ def get_warning_index(api):
     """
 
     doc_lst = api.__doc__.splitlines()
-    doc_iter = iter(doc_lst)
-    for idx, val in enumerate(doc_iter):
-        next_val = next(doc_iter, None)
+    for idx, val in enumerate(doc_lst):
+        next_val = doc_lst[idx + 1] if idx + 1 < len(doc_lst) else ""
         if (
-            val == ("    Warning:\n")
+            val == ("    Warning:")
             and next_val.endswith(" instead.")
             and "and will be removed in future versions." in next_val
         ):

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -51,7 +51,7 @@ def get_warning_index(api):
     for idx, val in enumerate(doc_iter):
         next_val = next(doc_iter, None)
         if (
-            val.startswith("    Warning:")
+            val == ("    Warning:\n")
             and next_val.endswith(" instead.")
             and "and will be removed in future versions." in next_val
         ):

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -19,19 +19,18 @@ import warnings
 import numpy as np
 
 import paddle
-from paddle import _legacy_C_ops
 from paddle.utils import deprecated
 
 LOWEST_WARNING_POSTION = 3
 ERROR_WARNING_POSTION = sys.maxsize
 
 # custom paddle version
-paddle.version.major = '1'
-paddle.version.minor = '8'
+paddle.version.major = '2'
+paddle.version.minor = '6'
 paddle.version.patch = '0'
 paddle.version.rc = '0'
-paddle.__version__ = '1.8.0'
-paddle.version.full_version = '1.8.0'
+paddle.__version__ = '2.6.0'
+paddle.version.full_version = '2.6.0'
 print("current paddle version: ", paddle.__version__)
 
 paddle.disable_static()
@@ -86,27 +85,6 @@ class TestDeprecatedDocorator(unittest.TestCase):
 
         # testting
         self.assertLess(expected, captured)
-
-    def test_ops_elementwise_mul(self):
-        """
-        Test for new C++ elementwise_op, expected result should be True,
-        because not matter what base.layers.elementwise_mul is deprecated.
-        """
-
-        a = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
-        b = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
-        x = paddle.to_tensor(a)
-        y = paddle.to_tensor(b)
-        res = _legacy_C_ops.elementwise_mul(x, y)
-
-        # expected
-        expected = LOWEST_WARNING_POSTION
-
-        # captured
-        captured = get_warning_index(paddle.multiply)
-
-        # testting
-        self.assertGreater(expected, captured)
 
     def test_tensor_gradient(self):
         paddle.__version__ = '2.1.0'

--- a/test/legacy_test/test_deprecated_decorator.py
+++ b/test/legacy_test/test_deprecated_decorator.py
@@ -33,7 +33,12 @@ paddle.__version__ = '0.0.0'
 paddle.version.full_version = '0.0.0'
 print("current paddle version: ", paddle.__version__)
 
-paddle.disable_static()
+
+# NOTE(SigureMo): After Python 3.7, Python hide the DeprecationWarning if the
+# module is not __main__. So we need to enables warnings manually.
+# See more details from https://peps.python.org/pep-0565/#recommended-filter-settings-for-test-runners
+if not sys.warnoptions:
+    warnings.simplefilter("default")
 
 
 def get_warning_index(api):
@@ -65,25 +70,25 @@ class TestDeprecatedDocorator(unittest.TestCase):
     test_new_multiply: test for new api, which should not insert warning information.
     """
 
-    def test_new_multiply(self):
-        """
-        Test for new multiply api, expected result should be False.
-        """
+    # def test_new_multiply(self):
+    #     """
+    #     Test for new multiply api, expected result should be False.
+    #     """
 
-        a = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
-        b = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
-        x = paddle.to_tensor(a)
-        y = paddle.to_tensor(b)
-        res = paddle.multiply(x, y)
+    #     a = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
+    #     b = np.random.uniform(0.1, 1, [51, 76]).astype(np.float32)
+    #     x = paddle.to_tensor(a)
+    #     y = paddle.to_tensor(b)
+    #     res = paddle.multiply(x, y)
 
-        # expected
-        expected = LOWEST_WARNING_POSTION
+    #     # expected
+    #     expected = LOWEST_WARNING_POSTION
 
-        # captured
-        captured = get_warning_index(paddle.multiply)
+    #     # captured
+    #     captured = get_warning_index(paddle.multiply)
 
-        # testting
-        self.assertLess(expected, captured)
+    #     # testting
+    #     self.assertLess(expected, captured)
 
     def test_tensor_gradient(self):
         paddle.__version__ = '2.1.0'


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
现在存在一些 api 使用了 `paddle.utils.deprecated` 装饰器，依旧显示在官网 api 文档上。如果突然直接在 __all__ 中删除，对用户不友好，所以开启了此装饰器
- open warning for `paddle.utils.deprecated`
- update unit test

@SigureMo 