### PR TITLE
Fix some PADDLE_THROW error type and change test cases

### DIFF
--- a/paddle/common/errors.h
+++ b/paddle/common/errors.h
@@ -87,7 +87,7 @@ enum ErrorCode {
   EXTERNAL = 12,
 
   // Client specified an unmatched type.
-  // Error type string: "INVALID_TYPE"
+  // Error type string: "InvalidTypeError"
   INVALID_TYPE = 13,
 };
 

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -268,7 +268,7 @@ bool CastPyArg2AttrBoolean(PyObject* obj, ssize_t arg_pos) {
   } else if (obj == Py_True) {
     return true;
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "bool, but got %s",
         arg_pos + 1,
@@ -280,7 +280,7 @@ int CastPyArg2AttrInt(PyObject* obj, ssize_t arg_pos) {
   if (PyObject_CheckLongOrConvertToLong(&obj)) {
     return static_cast<int>(PyLong_AsLong(obj));
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "int, but got %s",
         arg_pos + 1,
@@ -292,7 +292,7 @@ int64_t CastPyArg2AttrLong(PyObject* obj, ssize_t arg_pos) {
   if (PyObject_CheckLongOrConvertToLong(&obj)) {
     return (int64_t)PyLong_AsLong(obj);  // NOLINT
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "long, but got %s",
         arg_pos + 1,
@@ -304,7 +304,7 @@ size_t CastPyArg2AttrSize_t(PyObject* obj, ssize_t arg_pos) {
   if (PyObject_CheckLongOrConvertToLong(&obj)) {
     return PyLong_AsSize_t(obj);
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "long, but got %s",
         arg_pos + 1,
@@ -316,7 +316,7 @@ float CastPyArg2AttrFloat(PyObject* obj, ssize_t arg_pos) {
   if (PyObject_CheckFloatOrConvertToFloat(&obj)) {
     return static_cast<float>(PyFloat_AsDouble(obj));
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "float, but got %s",
         arg_pos + 1,
@@ -331,7 +331,7 @@ std::string CastPyArg2AttrString(PyObject* obj, ssize_t arg_pos) {
     data = PyUnicode_AsUTF8AndSize(obj, &size);
     return std::string(data, static_cast<size_t>(size));
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "str, but got %s",
         arg_pos + 1,
@@ -366,7 +366,7 @@ std::shared_ptr<jit::Function> CastPyArg2JitFunction(PyObject* obj,
   if (PyObject_TypeCheck(obj, g_jit_function_pytype)) {
     return ::pybind11::handle(obj).cast<std::shared_ptr<jit::Function>>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "BaseEngine, but got %s",
         arg_pos + 1,
@@ -403,7 +403,7 @@ std::vector<paddle::Tensor> CastPyArg2VectorOfTensor(
         // emplace empty Tensor for None
         result.emplace_back();
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of Tensor, but got %s at pos %d",
             arg_pos + 1,
@@ -443,7 +443,7 @@ std::vector<paddle::Tensor> CastPyArg2VectorOfTensor(
         // emplace empty Tensor for None
         result.emplace_back();
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of Tensor, but got %s at pos %d",
             arg_pos + 1,
@@ -464,7 +464,7 @@ std::vector<paddle::Tensor> CastPyArg2VectorOfTensor(
   } else if (PyObject_TypeCheck(obj, p_tensor_type)) {
     return {reinterpret_cast<TensorObject*>(obj)->tensor};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list or tuple, but got %s",
         arg_pos + 1,
@@ -483,7 +483,7 @@ std::vector<int> CastPyArg2VectorOfInt(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckLongOrConvertToLong(&item)) {
         result.emplace_back(static_cast<int>(PyLong_AsLong(item)));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of int, but got %s at pos %d",
             arg_pos + 1,
@@ -499,7 +499,7 @@ std::vector<int> CastPyArg2VectorOfInt(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckLongOrConvertToLong(&item)) {
         result.emplace_back(static_cast<int>(PyLong_AsLong(item)));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of int, but got %s at pos %d",
             arg_pos + 1,
@@ -512,7 +512,7 @@ std::vector<int> CastPyArg2VectorOfInt(PyObject* obj, size_t arg_pos) {
   } else if (PyObject_CheckLongOrConvertToLong(&obj)) {
     return {static_cast<int>(PyLong_AsLong(obj))};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list or tuple, but got %s",
         arg_pos + 1,
@@ -531,7 +531,7 @@ std::vector<int64_t> CastPyArg2VectorOfInt64(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckLongOrConvertToLong(&item)) {
         result.emplace_back(static_cast<int64_t>(PyLong_AsLong(item)));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of int, but got %s at pos %d",
             arg_pos + 1,
@@ -547,7 +547,7 @@ std::vector<int64_t> CastPyArg2VectorOfInt64(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckLongOrConvertToLong(&item)) {
         result.emplace_back(static_cast<int64_t>(PyLong_AsLong(item)));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of int, but got %s at pos %d",
             arg_pos + 1,
@@ -560,7 +560,7 @@ std::vector<int64_t> CastPyArg2VectorOfInt64(PyObject* obj, size_t arg_pos) {
   } else if (PyObject_CheckLongOrConvertToLong(&obj)) {
     return {static_cast<int64_t>(PyLong_AsLong(obj))};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list or tuple, but got %s",
         arg_pos + 1,
@@ -579,7 +579,7 @@ std::vector<size_t> CastPyArg2VectorOfSize_t(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckLongOrConvertToLong(&item)) {
         result.emplace_back(PyLong_AsSize_t(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of int, but got %s at pos %d",
             arg_pos + 1,
@@ -595,7 +595,7 @@ std::vector<size_t> CastPyArg2VectorOfSize_t(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckLongOrConvertToLong(&item)) {
         result.emplace_back(PyLong_AsSize_t(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of size_t, but got %s at pos %d",
             arg_pos + 1,
@@ -608,7 +608,7 @@ std::vector<size_t> CastPyArg2VectorOfSize_t(PyObject* obj, size_t arg_pos) {
   } else if (PyObject_CheckLongOrConvertToLong(&obj)) {
     return {PyLong_AsSize_t(obj)};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list of size_t, but got %s",
         arg_pos + 1,
@@ -627,7 +627,7 @@ std::vector<float> CastPyArg2VectorOfFloat(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckFloatOrConvertToFloat(&item)) {
         result.emplace_back(static_cast<float>(PyFloat_AsDouble(item)));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of float, but got %s at pos %d",
             arg_pos + 1,
@@ -643,7 +643,7 @@ std::vector<float> CastPyArg2VectorOfFloat(PyObject* obj, size_t arg_pos) {
       if (PyObject_CheckFloatOrConvertToFloat(&item)) {
         result.emplace_back(static_cast<float>(PyFloat_AsDouble(item)));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of float, but got %s at pos %d",
             arg_pos + 1,
@@ -656,7 +656,7 @@ std::vector<float> CastPyArg2VectorOfFloat(PyObject* obj, size_t arg_pos) {
   } else if (PyObject_CheckFloatOrConvertToFloat(&obj)) {
     return {static_cast<float>(PyFloat_AsDouble(obj))};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list of float, but got %s",
         arg_pos + 1,
@@ -676,7 +676,7 @@ std::vector<std::vector<size_t>> CastPyArg2VectorOfVectorOfSize_t(
       result.emplace_back(CastPyArg2VectorOfSize_t(item, arg_pos));
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list but got %s",
         arg_pos + 1,
@@ -700,7 +700,7 @@ platform::Place CastPyArg2Place(PyObject* obj, ssize_t arg_pos) {
   } else if (PyObject_TypeCheck(obj, g_customplace_pytype)) {
     place = ::pybind11::handle(obj).cast<platform::CustomPlace>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "one "
         "of(Place,CUDAPlace,CPUPlace,XPUPlace,CUDAPinnedPlace,"
@@ -719,7 +719,7 @@ TensorDistAttr CastPyArg2DistAttr(PyObject* obj, ssize_t arg_pos) {
           obj, reinterpret_cast<PyObject*>(g_tensor_dist_attr_pytype))) {
     return ::pybind11::handle(obj).cast<TensorDistAttr>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "TensorDistAttr, but got %s",
         arg_pos + 1,
@@ -740,7 +740,7 @@ ProcessMesh CastPyArg2ProcessMesh(PyObject* obj, ssize_t arg_pos) {
                           reinterpret_cast<PyObject*>(g_process_mesh_pytype))) {
     return ::pybind11::handle(obj).cast<ProcessMesh>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "ProcessMesh, but got %s",
         arg_pos + 1,
@@ -758,7 +758,7 @@ phi::DenseTensor CastPyArg2FrameworkTensor(PyObject* obj, ssize_t arg_pos) {
   if (PyObject_TypeCheck(obj, g_framework_tensor_pytype)) {
     return ::pybind11::handle(obj).cast<phi::DenseTensor>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "DenseTensor, but got %s",
         arg_pos + 1,
@@ -777,7 +777,7 @@ std::vector<phi::DenseTensor> CastPyArg2VectorOfTensorBase(PyObject* obj,
       if (PyObject_TypeCheck(item, g_framework_tensor_pytype)) {
         result.emplace_back(::pybind11::handle(item).cast<phi::DenseTensor>());
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of LoDTensor, but got %s at pos %d",
             arg_pos + 1,
@@ -793,7 +793,7 @@ std::vector<phi::DenseTensor> CastPyArg2VectorOfTensorBase(PyObject* obj,
       if (PyObject_TypeCheck(item, g_framework_tensor_pytype)) {
         result.emplace_back(::pybind11::handle(item).cast<phi::DenseTensor>());
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "argument (position %d) must be "
             "list of LoDTensor, but got %s at pos %d",
             arg_pos + 1,
@@ -811,7 +811,7 @@ std::vector<phi::DenseTensor> CastPyArg2VectorOfTensorBase(PyObject* obj,
   } else if (PyObject_TypeCheck(obj, g_framework_tensor_pytype)) {
     return {::pybind11::handle(obj).cast<phi::DenseTensor>()};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "list or tuple, but got %s",
         arg_pos + 1,
@@ -838,7 +838,7 @@ Placements CastPyArg2VectorOfPlacement(PyObject* obj, ssize_t arg_pos) {
       result.emplace_back(
           std::make_shared<Partial>(::pybind11::handle(item).cast<Partial>()));
     } else {
-      PADDLE_THROW(platform::errors::InvalidArgument(
+      PADDLE_THROW(platform::errors::InvalidType(
           "argument (position %d) must be list of Placement, but got %s at pos "
           "%d",
           arg_pos + 1,
@@ -869,7 +869,7 @@ paddle::framework::proto::VarType::Type CastPyArg2ProtoType(PyObject* obj,
     dtype =
         ::pybind11::handle(obj).cast<paddle::framework::proto::VarType::Type>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be "
         "one of core.VarDesc.VarType, "
         "but got %s",
@@ -890,7 +890,7 @@ paddle::DataType CastPyArg2DataTypeDirectly(PyObject* obj,
   if (PyObject_TypeCheck(obj, g_data_type_pytype)) {
     dtype = ::pybind11::handle(obj).cast<paddle::DataType>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s: argument (position %d) must be "
         "one of paddle::DataType, "
         "but got %s",
@@ -908,7 +908,7 @@ paddle::framework::Vocab CastPyArg2Vocab(PyObject* obj, ssize_t arg_pos) {
                 .cast<std::unordered_map<std::wstring, std::int32_t>>();
     return vocab;
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be dict, but got %s",
         arg_pos + 1,
         reinterpret_cast<PyTypeObject*>(obj->ob_type)->tp_name));
@@ -920,7 +920,7 @@ std::vector<std::string> CastPyArg2VectorOfString(PyObject* obj,
   if (PyList_Check(obj)) {
     return ::pybind11::handle(obj).cast<std::vector<std::string>>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "argument (position %d) must be list, but got %s",
         arg_pos + 1,
         reinterpret_cast<PyTypeObject*>(obj->ob_type)->tp_name));
@@ -2159,7 +2159,7 @@ pir::Value CastPyArg2Value(PyObject* obj,
   } else if (PyObject_TypeCheck(obj, g_ir_value_pytype)) {
     return ::pybind11::handle(obj).cast<pir::Value>();
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "OpResult, but got %s",
         op_type,
@@ -2193,7 +2193,7 @@ std::vector<pir::Value> CastPyArg2VectorOfValue(PyObject* obj,
       } else if (item == Py_None) {
         continue;
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "vector<OpResult>, but got vector<%s>",
             op_type,
@@ -2213,7 +2213,7 @@ std::vector<pir::Value> CastPyArg2VectorOfValue(PyObject* obj,
       } else if (item == Py_None) {
         continue;
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "vector<OpResult>, but got vector<%s>",
             op_type,
@@ -2223,7 +2223,7 @@ std::vector<pir::Value> CastPyArg2VectorOfValue(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "Vector<>, but got %s",
         op_type,
@@ -2246,7 +2246,7 @@ paddle::experimental::Scalar CastPyArg2Scalar(PyObject* obj,
                                               const std::string& op_type,
                                               ssize_t arg_pos) {
   if (obj == Py_None) {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "int, float, bool or Tensor, but got %s",
         op_type,
@@ -2283,7 +2283,7 @@ paddle::experimental::Scalar CastPyArg2Scalar(PyObject* obj,
     std::string value = CastPyArg2String(obj, op_type, arg_pos);
     return paddle::experimental::Scalar(value);
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "int, float, bool or Tensor, but got %s",
         op_type,
@@ -2299,7 +2299,7 @@ std::vector<phi::Scalar> CastPyArg2ScalarArray(PyObject* obj,
                                                const std::string& op_type,
                                                ssize_t arg_pos) {
   if (obj == Py_None) {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "a list of int, float, or bool, but got %s",
         op_type,
@@ -2339,7 +2339,7 @@ std::vector<phi::Scalar> CastPyArg2ScalarArray(PyObject* obj,
       return value;
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "a list of int, float, complex, or bool, but got %s",
         op_type,
@@ -2373,7 +2373,7 @@ paddle::experimental::IntArray CastPyArg2IntArray(PyObject* obj,
     return paddle::experimental::IntArray(
         {static_cast<int64_t>(PyLong_AsLong(obj))});
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or int, but got %s",
         op_type,

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -135,7 +135,7 @@ bool CastPyArg2Boolean(PyObject* obj,
   } else if (obj == Py_True) {
     return true;
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "bool, but got %s",
         op_type,
@@ -158,7 +158,7 @@ int CastPyArg2Int(PyObject* obj, const std::string& op_type, ssize_t arg_pos) {
   if (PyObject_CheckLongOrToLong(&obj)) {
     return (int)PyLong_AsLong(obj);  // NOLINT
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "int, but got %s",
         op_type,
@@ -183,7 +183,7 @@ int64_t CastPyArg2Long(PyObject* obj,
   if (PyObject_CheckLongOrToLong(&obj)) {
     return (int64_t)PyLong_AsLongLong(obj);  // NOLINT
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "long, but got %s",
         op_type,
@@ -236,7 +236,7 @@ double CastPyArg2Double(PyObject* obj,
   if (PyObject_CheckFloatOrToFloat(&obj)) {
     return PyFloat_AsDouble(obj);  // NOLINT
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "double, but got %s",
         op_type,
@@ -260,7 +260,7 @@ phi::dtype::complex<float> CastPyArg2Complex(PyObject* obj,
     Py_complex v = PyComplex_AsCComplex(obj);
     return phi::dtype::complex<float>(v.real, v.imag);
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "complex, but got %s",
         op_type,
@@ -279,7 +279,7 @@ phi::dtype::complex<double> CastPyArg2Complex128(PyObject* obj,
     double imag = PyComplex_ImagAsDouble(obj);
     return phi::dtype::complex<double>(real, imag);
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "complex, but got %s",
         op_type,
@@ -307,7 +307,7 @@ std::string CastPyArg2String(PyObject* obj,
     data = PyUnicode_AsUTF8AndSize(obj, &size);
     return std::string(data, (size_t)size);  // NOLINT
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "str, but got %s",
         op_type,
@@ -338,7 +338,7 @@ std::vector<bool> CastPyArg2Booleans(PyObject* obj,
       if (PyObject_CheckBool(&item)) {
         value.emplace_back(PyLong_AsLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of bool, but got %s at pos %d",
             op_type,
@@ -355,7 +355,7 @@ std::vector<bool> CastPyArg2Booleans(PyObject* obj,
       if (PyObject_CheckBool(&item)) {
         value.emplace_back(PyLong_AsLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of bool, but got %s at pos %d",
             op_type,
@@ -365,7 +365,7 @@ std::vector<bool> CastPyArg2Booleans(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or tuple, but got %s",
         op_type,
@@ -397,7 +397,7 @@ std::vector<int> CastPyArg2Ints(PyObject* obj,
       if (PyObject_CheckLongOrToLong(&item)) {
         value.emplace_back(PyLong_AsLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of int, but got %s at pos %d",
             op_type,
@@ -415,7 +415,7 @@ std::vector<int> CastPyArg2Ints(PyObject* obj,
       if (PyObject_CheckLongOrToLong(&item)) {
         value.emplace_back(PyLong_AsLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of int, but got %s at pos %d",
             op_type,
@@ -433,7 +433,7 @@ std::vector<int> CastPyArg2Ints(PyObject* obj,
       if (PyObject_CheckLongOrToLong(&item)) {
         value.emplace_back(PyLong_AsLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of int, but got %s at pos %d",
             op_type,
@@ -443,7 +443,7 @@ std::vector<int> CastPyArg2Ints(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or tuple, but got %s",
         op_type,
@@ -474,7 +474,7 @@ std::vector<int64_t> CastPyArg2Longs(PyObject* obj,
       if (PyObject_CheckLongOrToLong(&item)) {
         value.emplace_back((int64_t)PyLong_AsLongLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of int, but got %s at pos %d",
             op_type,
@@ -491,7 +491,7 @@ std::vector<int64_t> CastPyArg2Longs(PyObject* obj,
       if (PyObject_CheckLongOrToLong(&item)) {
         value.emplace_back((int64_t)PyLong_AsLongLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of int, but got %s at pos %d",
             op_type,
@@ -508,7 +508,7 @@ std::vector<int64_t> CastPyArg2Longs(PyObject* obj,
       if (PyObject_CheckLongOrToLong(&item)) {
         value.emplace_back((int64_t)PyLong_AsLongLong(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of int, but got %s at pos %d",
             op_type,
@@ -522,7 +522,7 @@ std::vector<int64_t> CastPyArg2Longs(PyObject* obj,
   } else if (PyObject_CheckLongOrToLong(&obj)) {
     return {(int64_t)PyLong_AsLongLong(obj)};
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or tuple, but got %s",
         op_type,
@@ -553,7 +553,7 @@ std::vector<float> CastPyArg2Floats(PyObject* obj,
       if (PyObject_CheckFloatOrToFloat(&item)) {
         value.emplace_back(PyFloat_AsDouble(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of float, but got %s at pos %d",
             op_type,
@@ -570,7 +570,7 @@ std::vector<float> CastPyArg2Floats(PyObject* obj,
       if (PyObject_CheckFloatOrToFloat(&item)) {
         value.emplace_back(PyFloat_AsDouble(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of float, but got %s at pos %d",
             op_type,
@@ -587,7 +587,7 @@ std::vector<float> CastPyArg2Floats(PyObject* obj,
       if (PyObject_CheckFloatOrToFloat(&item)) {
         value.emplace_back(PyFloat_AsDouble(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of float, but got %s at pos %d",
             op_type,
@@ -597,7 +597,7 @@ std::vector<float> CastPyArg2Floats(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or tuple, but got %s",
         op_type,
@@ -628,7 +628,7 @@ std::vector<double> CastPyArg2Float64s(PyObject* obj,
       if (PyObject_CheckFloatOrToFloat(&item)) {
         value.emplace_back(PyFloat_AsDouble(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of float, but got %s at pos %d",
             op_type,
@@ -645,7 +645,7 @@ std::vector<double> CastPyArg2Float64s(PyObject* obj,
       if (PyObject_CheckFloatOrToFloat(&item)) {
         value.emplace_back(PyFloat_AsDouble(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of float, but got %s at pos %d",
             op_type,
@@ -662,7 +662,7 @@ std::vector<double> CastPyArg2Float64s(PyObject* obj,
       if (PyObject_CheckFloatOrToFloat(&item)) {
         value.emplace_back(PyFloat_AsDouble(item));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of float, but got %s at pos %d",
             op_type,
@@ -672,7 +672,7 @@ std::vector<double> CastPyArg2Float64s(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or tuple, but got %s",
         op_type,
@@ -714,7 +714,7 @@ std::vector<std::string> CastPyArg2Strings(PyObject* obj,
         data = PyUnicode_AsUTF8AndSize(item, &size);
         value.emplace_back(std::string(data, (size_t)size));  // NOLINT
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of str, but got %s at pos %d",
             op_type,
@@ -734,7 +734,7 @@ std::vector<std::string> CastPyArg2Strings(PyObject* obj,
         data = PyUnicode_AsUTF8AndSize(item, &size);
         value.emplace_back(std::string(data, (size_t)size));  // NOLINT
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
+        PADDLE_THROW(platform::errors::InvalidType(
             "%s(): argument (position %d) must be "
             "list of str, but got %s at pos %d",
             op_type,
@@ -744,7 +744,7 @@ std::vector<std::string> CastPyArg2Strings(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "list or tuple, but got %s",
         op_type,
@@ -766,7 +766,7 @@ void CastPyArg2AttrStrings(PyObject* obj,
 std::vector<paddle::experimental::Scalar> CastPyArg2Scalars(
     PyObject* obj, const std::string& op_type, ssize_t arg_pos) {
   if (obj == Py_None) {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "a list of int, float, or bool, but got %s",
         op_type,
@@ -808,7 +808,7 @@ std::vector<paddle::experimental::Scalar> CastPyArg2Scalars(
       return value;
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "a list of int, float, complex, or bool, but got %s",
         op_type,
@@ -830,7 +830,7 @@ void CastPyArg2AttrBlock(PyObject* obj,
       (::pybind11::detail::instance*)obj;  // NOLINT
 
   if (!PyObject_TypeCheck((PyObject*)inst, g_blockdesc_pytype)) {  // NOLINT
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "BlockDesc, but got %s",
         op_type,
@@ -879,7 +879,7 @@ void CastPyArg2AttrValues(PyObject* obj,
       }
     }
   } else {
-    PADDLE_THROW(platform::errors::InvalidArgument(
+    PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
         "a list of int, float, complex, or bool, but got %s",
         op_type,

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -74,7 +74,7 @@ def affine_grid(theta, out_shape, align_corners=True, name=None):
                [-0.43333334,  2.23333335]]]])
     """
     if not isinstance(theta, (Variable, paddle.pir.Value)):
-        raise ValueError("The theta should be a Tensor.")
+        raise TypeError("The theta should be a Tensor.")
 
     cudnn_version = get_cudnn_version()
     if cudnn_version is not None and cudnn_version >= 6000 and align_corners:

--- a/test/dygraph_to_static/test_set_static_op_arg_pre_cast_hook.py
+++ b/test/dygraph_to_static/test_set_static_op_arg_pre_cast_hook.py
@@ -35,7 +35,7 @@ class TestSetStaticOpArgPreCastHook(Dy2StTestBase):
 
         with static_guard():
             with self.assertRaisesRegex(
-                ValueError,
+                TypeError,
                 r"abs\(\): argument \(position 1\) must be OpResult, but got Tensor",
             ):
                 paddle.abs(eager_tensor)

--- a/test/legacy_test/test_affine_grid_function.py
+++ b/test/legacy_test/test_affine_grid_function.py
@@ -158,7 +158,7 @@ class AffineGridErrorTestCase(AffineGridTestCase):
     def runTest(self):
         place = base.CPUPlace()
         with dg.guard(place):
-            with self.assertRaises(ValueError):
+            with self.assertRaises(TypeError):
                 self.paddle_dygraph_layer()
 
 

--- a/test/legacy_test/test_deformable_conv_op.py
+++ b/test/legacy_test/test_deformable_conv_op.py
@@ -474,10 +474,7 @@ class TestModulatedDeformableConvInvalidInput(unittest.TestCase):
                 in_channels=input[1], out_channels=4, kernel_size=1
             )(input, offset, mask)
 
-        err_type = (
-            ValueError if paddle.base.framework.in_pir_mode() else TypeError
-        )
-        self.assertRaises(err_type, test_invalid_input)
+        self.assertRaises(TypeError, test_invalid_input)
 
         def test_invalid_offset():
             paddle.enable_static()

--- a/test/legacy_test/test_fill_constant_op.py
+++ b/test/legacy_test/test_fill_constant_op.py
@@ -501,7 +501,7 @@ class TestFillConstantOpError(unittest.TestCase):
             )
 
             self.assertRaises(
-                ValueError,
+                TypeError,
                 paddle.tensor.fill_constant,
                 shape=[1.1],
                 value=5,
@@ -511,7 +511,7 @@ class TestFillConstantOpError(unittest.TestCase):
 
             x3 = np.random.randn(100, 100).astype('int32')
             self.assertRaises(
-                ValueError,
+                TypeError,
                 paddle.tensor.fill_constant,
                 shape=[100, 100],
                 value=5,

--- a/test/legacy_test/test_gumbel_softmax_op.py
+++ b/test/legacy_test/test_gumbel_softmax_op.py
@@ -278,7 +278,7 @@ class TestGumbelSoftmaxOpError(unittest.TestCase):
             x = paddle.to_tensor([0.2, 0.3, 0.4])
             paddle.nn.functional.gumbel_softmax(x, axis=1.1)
 
-        self.assertRaises(ValueError, test_argument2)
+        self.assertRaises(TypeError, test_argument2)
 
         paddle.enable_static()
 

--- a/test/legacy_test/test_layer_norm_op.py
+++ b/test/legacy_test/test_layer_norm_op.py
@@ -862,7 +862,7 @@ class TestDygraphLayerNormAPIError(unittest.TestCase):
             layer_norm = paddle.nn.LayerNorm([32, 32])
             # the input of LayerNorm must be Variable.
             x1 = np.random.random((3, 32, 32)).astype('float32')
-            self.assertRaises(ValueError, layer_norm, x1)
+            self.assertRaises(TypeError, layer_norm, x1)
 
 
 @unittest.skipIf(

--- a/test/legacy_test/test_mean_op.py
+++ b/test/legacy_test/test_mean_op.py
@@ -102,7 +102,7 @@ class TestMeanOpError(unittest.TestCase):
 
         with paddle.pir_utils.IrGuard(), program_guard(Program(), Program()):
             input1 = 12
-            self.assertRaises(ValueError, paddle.mean, input1)
+            self.assertRaises(TypeError, paddle.mean, input1)
 
             input2 = paddle.static.data(
                 name='input2', shape=[2, 3, 4, 5], dtype="int32"

--- a/test/legacy_test/test_numel_op.py
+++ b/test/legacy_test/test_numel_op.py
@@ -208,7 +208,7 @@ class TestNumelAPI(unittest.TestCase):
                 input_1 = np.random.random(shape).astype("int32")
                 out_1 = paddle.numel(input_1)
 
-            self.assertRaises(ValueError, test_x_type)
+            self.assertRaises(TypeError, test_x_type)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_randint_op.py
+++ b/test/legacy_test/test_randint_op.py
@@ -73,7 +73,7 @@ class TestRandintOpError(unittest.TestCase):
             self.assertRaises(TypeError, paddle.randint, 5, dtype='float32')
             self.assertRaises(ValueError, paddle.randint, 5, 5)
             self.assertRaises(ValueError, paddle.randint, -5)
-            self.assertRaises(ValueError, paddle.randint, 5, shape=['2'])
+            self.assertRaises(TypeError, paddle.randint, 5, shape=['2'])
 
 
 class TestRandintOp_attr_tensorlist(OpTest):

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -1627,7 +1627,7 @@ class TestReduceSumOpError(unittest.TestCase):
                 x1 = base.create_lod_tensor(
                     np.array([[-1]]), [[1]], base.CPUPlace()
                 )
-                self.assertRaises(ValueError, paddle.sum, x1)
+                self.assertRaises(TypeError, paddle.sum, x1)
 
 
 class API_TestSumOp(unittest.TestCase):

--- a/test/legacy_test/test_squeeze2_op.py
+++ b/test/legacy_test/test_squeeze2_op.py
@@ -299,7 +299,7 @@ class TestSqueezeAPI(unittest.TestCase):
                 )
                 self.squeeze(x2, axis=2.1)
 
-        self.assertRaises(ValueError, test_axes_type)
+        self.assertRaises(TypeError, test_axes_type)
 
 
 class TestSqueezeInplaceAPI(TestSqueezeAPI):

--- a/test/legacy_test/test_unsqueeze2_op.py
+++ b/test/legacy_test/test_unsqueeze2_op.py
@@ -309,7 +309,7 @@ class TestUnsqueezeAPI(unittest.TestCase):
                 x2 = paddle.static.data(name="x2", shape=[2, 25], dtype="int32")
                 self.unsqueeze(x2, axis=2.1)
 
-        self.assertRaises(ValueError, test_pir_axes_type)
+        self.assertRaises(TypeError, test_pir_axes_type)
 
 
 class TestUnsqueezeInplaceAPI(TestUnsqueezeAPI):

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -689,7 +689,7 @@ class TestWhereOpError(unittest.TestCase):
                 with paddle.pir_utils.IrGuard():
                     paddle.where(cond_i, x_i, y_i)
 
-            self.assertRaises(ValueError, test_OpResult)
+            self.assertRaises(TypeError, test_OpResult)
 
             def test_type():
                 x = paddle.static.data(name='x', shape=[-1, 4], dtype='bool')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
#### 报错类型不统一问题
在之前添加的 PIR 单测中，部分错误类型与静态图不一致，例如下面这种情况，
![image](https://github.com/PaddlePaddle/Paddle/assets/46243324/f20b7835-efe0-4422-a219-d424b2e22f28)
PIR是ValueError，而静态图是TyperError，因此如果要使用 @test_with_pir_api 统一pir和静态图的单测，就需要将类型统一。

#### 解决方法
一些 `[A-z<>:0-9]+\sCastPyArg2[A-z0-9]+\(` 函数 platform::errors::InvalidArgument 需要改为 platform::errors::InvalidType

`paddle/fluid/pybind/eager_utils.cc` 34处
`paddle/fluid/pybind/op_function_common.cc` 33 处

这里可以使用 ast-grep 替换
```yaml
id: cast-pyarg
message: Find a function definition used to cast a Python argument.
severity: info
language: C++
rule:
  kind: qualified_identifier
  regex: ^(platform::errors::InvalidArgument)
  inside:
    kind: function_definition
    has:
      kind: function_declarator
      regex: 'CastPyArg2[A-z0-9]+'
    stopBy:
      kind: function_declarator

fix:
  platform::errors::InvalidType
```
