### PR TITLE
tensor_array slice in PIR

### DIFF
--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -250,7 +250,19 @@ def slice_is_same_to_original(start, end, step):
 
 
 def parse_index(x, indices):
-    advanced_index = [None] * 2 * len(x.shape)  # content is (dim, index)
+    from .framework import in_pir_mode
+
+    if in_pir_mode():
+        is_tensor_array = x.is_dense_tensor_array_type()
+    else:
+        is_tensor_array = (
+            hasattr(x, "desc")
+            and x.desc.type() == core.VarDesc.VarType.LOD_TENSOR_ARRAY
+        )
+
+    advanced_index = (
+        [] if is_tensor_array else [None] * 2 * len(x.shape)
+    )  # content is (dim, index)
     # for set_value / slice / strided_slice OP
     decrease_axes = []
     axes = []
@@ -266,11 +278,6 @@ def parse_index(x, indices):
     indices = replace_ndarray_and_range(indices)
     indices = replace_ellipsis(x, indices)
     indices, none_axes = replace_none(indices)
-
-    is_tensor_array = (
-        hasattr(x, "desc")
-        and x.desc.type() == core.VarDesc.VarType.LOD_TENSOR_ARRAY
-    )
 
     estimated_dim = 0
     dim = 0
@@ -740,6 +747,8 @@ def get_tensor_with_basic_indexing(
                     if isinstance(end, (list, tuple)):
                         if paddle.utils._contain_var(end):
                             end = paddle.utils.get_int_tensor_list(end)
+                    if x.is_dense_tensor_array_type():
+                        return paddle._pir_ops.slice_array_dense(x, st)
                 out = paddle._C_ops.slice(
                     x,
                     axes,

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -18,11 +18,13 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
+    IrMode,
+    ToStaticMode,
+    disable_test_case,
 )
 
 import paddle
 from paddle import base
-from paddle.pir_utils import test_with_pir_api
 
 SEED = 2020
 np.random.seed(SEED)
@@ -290,7 +292,7 @@ class TestListInWhileLoop(TestListWithoutControlFlowConfig):
             test_list_pop_in_while_loop,
         ]
 
-    @test_with_pir_api
+    # TODO(zhangbo): Refine BuildOpFrom for op with sub_block
     def train(self, to_static=False):
         with base.dygraph.guard():
             if to_static:
@@ -302,6 +304,7 @@ class TestListInWhileLoop(TestListWithoutControlFlowConfig):
                 res = self.dygraph_func(self.input, self.iter_num)
             return self.result_to_numpy(res)
 
+    @disable_test_case((ToStaticMode.AST, IrMode.PT))
     def test_transformed_static_result(self):
         self.compare_transformed_static_result()
 

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -18,13 +18,11 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
-    IrMode,
-    ToStaticMode,
-    disable_test_case,
 )
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 SEED = 2020
 np.random.seed(SEED)
@@ -292,6 +290,7 @@ class TestListInWhileLoop(TestListWithoutControlFlowConfig):
             test_list_pop_in_while_loop,
         ]
 
+    @test_with_pir_api
     def train(self, to_static=False):
         with base.dygraph.guard():
             if to_static:
@@ -303,7 +302,6 @@ class TestListInWhileLoop(TestListWithoutControlFlowConfig):
                 res = self.dygraph_func(self.input, self.iter_num)
             return self.result_to_numpy(res)
 
-    @disable_test_case((ToStaticMode.AST, IrMode.PT))
     def test_transformed_static_result(self):
         self.compare_transformed_static_result()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985

Support tensor array slice in PIR, using SliceArrayDense OP introduced in https://github.com/PaddlePaddle/Paddle/pull/60433 . 

Since there are still some problems about dy2st, we delay to make PIR test available until them fixed.