### PR TITLE
[PIR] refactor log simply name mechnism from phi to common.

### DIFF
--- a/paddle/common/enforce.cc
+++ b/paddle/common/enforce.cc
@@ -1,0 +1,103 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/common/enforce.h"
+
+#include <array>
+#include <map>
+#include <string>
+#include <vector>
+
+REGISTER_LOG_SIMPLY_STR(std::string);
+
+namespace {
+class StrSizeCmp {
+ public:
+  bool operator()(const std::string& lhs, const std::string& rhs) const {
+    return lhs.size() > rhs.size();
+  }
+};
+
+using LogSimplyStrMap = std::map<std::string, std::string, StrSizeCmp>;
+
+LogSimplyStrMap& GetLogStrSimplyMap() {
+  static LogSimplyStrMap str_simply_map;
+  return str_simply_map;
+}
+
+std::string SimplifyDemangleStr(std::string str) {
+  auto& str_map = GetLogStrSimplyMap();
+  for (auto& value : str_map) {
+    size_t start_pos = 0;
+    while ((start_pos = str.find(value.first, start_pos)) !=
+           std::string::npos) {
+      str.replace(start_pos, value.first.length(), value.second);
+      start_pos += value.second.length();
+    }
+  }
+  return str;
+}
+}  // namespace
+
+namespace common {
+namespace enforce {
+
+bool RegisterLogSimplyStr(const std::string& type_name,
+                          const std::string& simply_name) {
+  return GetLogStrSimplyMap()
+      .emplace(std::make_pair(type_name, simply_name))
+      .second;
+}
+
+std::string GetCurrentTraceBackString(bool for_signal) {
+  std::ostringstream sout;
+
+  if (!for_signal) {
+    sout << "\n\n--------------------------------------\n";
+    sout << "C++ Traceback (most recent call last):";
+    sout << "\n--------------------------------------\n";
+  }
+#if !defined(_WIN32) && !defined(PADDLE_WITH_MUSL)
+  static constexpr int TRACE_STACK_LIMIT = 100;
+
+  std::array<void*, TRACE_STACK_LIMIT> call_stack;
+  auto size = backtrace(call_stack.data(), TRACE_STACK_LIMIT);
+  auto symbols = backtrace_symbols(call_stack.data(), size);
+  Dl_info info;
+  int idx = 0;
+  // `for_signal` used to remove the stack trace introduced by
+  // obtaining the error stack trace when the signal error occurred,
+  // that is not related to the signal error self, remove it to
+  // avoid misleading users and developers
+  int end_idx = for_signal ? 2 : 0;
+  for (int i = size - 1; i >= end_idx; --i) {
+    if (dladdr(call_stack[i], &info) && info.dli_sname) {
+      auto demangled = common::demangle(info.dli_sname);
+      std::string path(info.dli_fname);
+      // C++ traceback info are from core.so
+      if (path.substr(path.length() - 3).compare(".so") == 0) {
+        sout << paddle::string::Sprintf(
+            "%-3d %s\n", idx++, SimplifyDemangleStr(demangled));
+      }
+    }
+  }
+  free(symbols);  // NOLINT
+#else
+  sout << "Not support stack backtrace yet.\n";
+#endif
+  return sout.str();
+}
+
+}  // namespace enforce
+}  // namespace common

--- a/paddle/common/enforce.h
+++ b/paddle/common/enforce.h
@@ -31,6 +31,7 @@
 
 #include "paddle/common/errors.h"
 #include "paddle/common/macros.h"
+#include "paddle/utils/test_macros.h"
 
 #if !defined(_WIN32) && !defined(PADDLE_WITH_MUSL)
 #include <execinfo.h>
@@ -40,10 +41,20 @@
 #define GLOG_NO_ABBREVIATED_SEVERITIES
 #include "paddle/utils/string/printf.h"
 #include "paddle/utils/string/to_string.h"
-#include "paddle/utils/test_macros.h"
 #include "paddle/utils/variant.h"
 
 namespace common {
+#ifdef __GNUC__
+inline std::string demangle(std::string name) {
+  int status = -4;  // some arbitrary value to eliminate the compiler warning
+  std::unique_ptr<char, void (*)(void*)> res{
+      abi::__cxa_demangle(name.c_str(), NULL, NULL, &status), std::free};
+  return (status == 0) ? res.get() : name;
+}
+#else
+inline std::string demangle(std::string name) { return name; }
+#endif
+
 class CommonNotMetException : public std::exception {
  public:
   explicit CommonNotMetException(const std::string& str) : err_str_(str) {}
@@ -53,9 +64,7 @@ class CommonNotMetException : public std::exception {
  private:
   std::string err_str_;
 };
-}  // namespace common
 
-namespace common {
 namespace enforce {
 
 /** HELPER MACROS AND FUNCTIONS **/
@@ -161,6 +170,20 @@ using CommonType2 = typename std::add_lvalue_reference<
 #define COMMON_ENFORCE_LE(__VAL0, __VAL1, ...) \
   __COMMON_BINARY_COMPARE(__VAL0, __VAL1, <=, >, __VA_ARGS__)
 
+TEST_API bool RegisterLogSimplyStr(const std::string& type,
+                                   const std::string& simply);
+TEST_API std::string GetCurrentTraceBackString(bool for_signal = false);
+template <typename T>
+class LogSimplyStrRegistrar {
+ public:
+  static bool success;
+};
+
+#define REGISTER_LOG_SIMPLY_STR(Type)                            \
+  template <>                                                    \
+  bool ::common::enforce::LogSimplyStrRegistrar<Type>::success = \
+      ::common::enforce::RegisterLogSimplyStr(                   \
+          ::common::demangle(typeid(Type).name()), #Type);
 }  // namespace enforce
 }  // namespace common
 
@@ -172,53 +195,10 @@ inline bool is_error(const T& stat) {
 }
 
 namespace pir {
-
-#ifdef __GNUC__
-inline std::string demangle(std::string name) {
-  int status = -4;  // some arbitrary value to eliminate the compiler warning
-  std::unique_ptr<char, void (*)(void*)> res{
-      abi::__cxa_demangle(name.c_str(), NULL, NULL, &status), std::free};
-  return (status == 0) ? res.get() : name;
-}
-#else
-inline std::string demangle(std::string name) { return name; }
-#endif
-
-static std::string GetCurrentTraceBackString() {
-  std::ostringstream sout;
-  sout << "\n\n--------------------------------------\n";
-  sout << "C++ Traceback (most recent call last):";
-  sout << "\n--------------------------------------\n";
-#if !defined(_WIN32) && !defined(PADDLE_WITH_MUSL)
-  static constexpr int TRACE_STACK_LIMIT = 100;
-
-  void* call_stack[TRACE_STACK_LIMIT];
-  auto size = backtrace(call_stack, TRACE_STACK_LIMIT);
-  auto symbols = backtrace_symbols(call_stack, size);
-  Dl_info info;
-  int idx = 0;
-  int end_idx = 0;
-  for (int i = size - 1; i >= end_idx; --i) {
-    if (dladdr(call_stack[i], &info) && info.dli_sname) {
-      auto demangled = demangle(info.dli_sname);
-      std::string path(info.dli_fname);
-      // C++ traceback info are from core.so
-      if (path.substr(path.length() - 3).compare(".so") == 0) {
-        sout << idx++ << " " << demangled << "\n";
-      }
-    }
-  }
-  free(symbols);
-#else
-  sout << "Not support stack backtrace yet.\n";
-#endif
-  return sout.str();
-}
-
 class IrNotMetException : public std::exception {
  public:
   explicit IrNotMetException(const std::string& str)
-      : err_str_(str + GetCurrentTraceBackString()) {}
+      : err_str_(str + ::common::enforce::GetCurrentTraceBackString()) {}
 
   const char* what() const noexcept override { return err_str_.c_str(); }
 

--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -947,7 +947,10 @@ cc_library(
        imperative_flag
        layer)
 
-cc_library(type_info SRCS type_info.cc)
+cc_library(
+  type_info
+  SRCS type_info.cc type_defs.cc
+  DEPS common)
 target_link_libraries(type_info pir op_dialect)
 add_dependencies(type_info framework_proto auto_parallel_proto xxhash)
 if(WITH_MKLDNN)

--- a/paddle/fluid/framework/type_defs.cc
+++ b/paddle/fluid/framework/type_defs.cc
@@ -1,0 +1,45 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/framework/type_defs.h"
+
+#include "paddle/common/enforce.h"
+
+namespace paddle {
+
+using namespace framework;  // NOLINT
+template class variant<paddle::blank,
+                       int,
+                       float,
+                       std::string,
+                       std::vector<int>,
+                       std::vector<float>,
+                       std::vector<std::string>,
+                       bool,
+                       std::vector<bool>,
+                       BlockDesc*,
+                       int64_t,
+                       std::vector<BlockDesc*>,
+                       std::vector<int64_t>,
+                       std::vector<double>,
+                       VarDesc*,
+                       std::vector<VarDesc*>,
+                       double,
+                       paddle::experimental::Scalar,
+                       std::vector<paddle::experimental::Scalar>,
+                       ::pir::Block*,
+                       std::vector<::pir::Value>>;
+}  // namespace paddle
+REGISTER_LOG_SIMPLY_STR(paddle::framework::AttributeMap);
+REGISTER_LOG_SIMPLY_STR(paddle::framework::Attribute);

--- a/paddle/fluid/imperative/CMakeLists.txt
+++ b/paddle/fluid/imperative/CMakeLists.txt
@@ -4,7 +4,7 @@ cc_library(
   DEPS phi common)
 cc_library(
   var_helper
-  SRCS var_helper.cc
+  SRCS var_helper.cc type_defs.cc
   DEPS tensor phi common)
 if(WITH_XPU)
   cc_library(

--- a/paddle/fluid/imperative/type_defs.cc
+++ b/paddle/fluid/imperative/type_defs.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/imperative/type_defs.h"
+
+#include "paddle/common/enforce.h"
+
+REGISTER_LOG_SIMPLY_STR(paddle::imperative::NameTensorMap);
+REGISTER_LOG_SIMPLY_STR(paddle::imperative::NameVarBaseMap);
+REGISTER_LOG_SIMPLY_STR(paddle::imperative::NameVariableWrapperMap);

--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -77,8 +77,7 @@ class Stat : public StatBase {
     thread_local_stat->current += increment;
 
     VLOG(8) << string::split_string(
-                   phi::enforce::demangle(typeid(*thread_local_stat).name()),
-                   "::")
+                   common::demangle(typeid(*thread_local_stat).name()), "::")
                    .back()
             << ": Update current_value with " << increment
             << ", after update, current value = " << GetCurrentValue();
@@ -91,8 +90,7 @@ class Stat : public StatBase {
              !peak_value_.compare_exchange_weak(prev_value, current_value)) {
       }
       VLOG(8) << string::split_string(
-                     phi::enforce::demangle(typeid(*thread_local_stat).name()),
-                     "::")
+                     common::demangle(typeid(*thread_local_stat).name()), "::")
                      .back()
               << ": Update current_value with " << increment
               << ", after update, peak_value = " << peak_value_.load()

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -108,6 +108,7 @@ PHI_DECLARE_int32(call_stack_level);
 namespace paddle {
 namespace platform {
 using namespace ::phi::enforce;  // NOLINT
+using ::common::demangle;
 
 /** HELPER MACROS AND FUNCTIONS **/
 

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -51,6 +51,7 @@ limitations under the License. */
 #include "paddle/fluid/platform/device/ipu/ipu_info.h"
 #endif
 
+#include "paddle/common/enforce.h"
 #include "paddle/fluid/memory/allocation/allocator_facade.h"
 #include "paddle/fluid/memory/memory.h"
 #include "paddle/fluid/platform/flags.h"
@@ -310,7 +311,8 @@ void SignalHandle(const char *data, int size) {
       sout << "\n\n--------------------------------------\n";
       sout << "C++ Traceback (most recent call last):";
       sout << "\n--------------------------------------\n";
-      auto traceback = platform::GetCurrentTraceBackString(/*for_signal=*/true);
+      auto traceback =
+          ::common::enforce::GetCurrentTraceBackString(/*for_signal=*/true);
       if (traceback.empty()) {
         sout
             << "No stack trace in paddle, may be caused by external reasons.\n";

--- a/paddle/phi/core/enforce.cc
+++ b/paddle/phi/core/enforce.cc
@@ -21,6 +21,7 @@ limitations under the License. */
 #include <vector>
 
 #include "glog/logging.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/utils/blank.h"
 #include "paddle/utils/flags.h"
@@ -30,145 +31,10 @@ limitations under the License. */
 #endif  // PADDLE_WITH_CUDA
 
 PD_DECLARE_int32(call_stack_level);
-
-namespace egr {
-class EagerVariable;
-}
-namespace paddle {
-namespace framework {
-class VarDesc;
-class BlockDesc;
-using Attribute = paddle::variant<paddle::blank,
-                                  int,
-                                  float,
-                                  std::string,
-                                  std::vector<int>,
-                                  std::vector<float>,
-                                  std::vector<std::string>,
-                                  bool,
-                                  std::vector<bool>,
-                                  BlockDesc*,
-                                  int64_t,
-                                  std::vector<BlockDesc*>,
-                                  std::vector<int64_t>,
-                                  std::vector<double>,
-                                  VarDesc*,
-                                  std::vector<VarDesc*>,
-                                  double,
-                                  paddle::experimental::Scalar,
-                                  std::vector<paddle::experimental::Scalar>>;
-using AttributeMap = std::unordered_map<std::string, Attribute>;
-}  // namespace framework
-namespace imperative {
-class VariableWrapper;
-class SavedVariableWrapperList;
-class VarBase;
-
-namespace details {
-template <typename T>
-struct NameVarMapTrait {};
-
-template <>
-struct NameVarMapTrait<VarBase> {
-  using Type = std::map<std::string, std::vector<std::shared_ptr<VarBase>>>;
-};
-
-template <>
-struct NameVarMapTrait<VariableWrapper> {
-  using Type = std::map<std::string, SavedVariableWrapperList>;
-};
-
-template <>
-struct NameVarMapTrait<egr::EagerVariable> {
-  using Type =
-      std::map<std::string, std::vector<std::shared_ptr<egr::EagerVariable>>>;
-};
-
-}  // namespace details
-
-template <typename T>
-using NameVarMap = typename details::NameVarMapTrait<T>::Type;
-
-using NameVarBaseMap = NameVarMap<VarBase>;
-using NameVariableWrapperMap = NameVarMap<VariableWrapper>;
-using NameTensorMap = NameVarMap<egr::EagerVariable>;
-
-}  // namespace imperative
-}  // namespace paddle
-
 namespace phi {
 namespace enforce {
 
 TEST_API int GetCallStackLevel() { return FLAGS_call_stack_level; }
-
-template <typename T>
-static std::string ReplaceComplexTypeStr(std::string str,
-                                         const std::string& type_name) {
-  auto demangle_type_str = demangle(typeid(T).name());
-  size_t start_pos = 0;
-  while ((start_pos = str.find(demangle_type_str, start_pos)) !=
-         std::string::npos) {
-    str.replace(start_pos, demangle_type_str.length(), type_name);
-    start_pos += type_name.length();
-  }
-  return str;
-}
-
-#define __REPLACE_COMPLEX_TYPE_STR__(__TYPENAME, __STR)                      \
-  do {                                                                       \
-    __STR =                                                                  \
-        phi::enforce::ReplaceComplexTypeStr<__TYPENAME>(__STR, #__TYPENAME); \
-  } while (0)
-
-static std::string SimplifyDemangleStr(std::string str) {
-  // the older is important, you have to put complex types in front
-  __REPLACE_COMPLEX_TYPE_STR__(paddle::framework::AttributeMap, str);
-  __REPLACE_COMPLEX_TYPE_STR__(paddle::framework::Attribute, str);
-  __REPLACE_COMPLEX_TYPE_STR__(paddle::imperative::NameVariableWrapperMap, str);
-  __REPLACE_COMPLEX_TYPE_STR__(paddle::imperative::NameVarBaseMap, str);
-  __REPLACE_COMPLEX_TYPE_STR__(paddle::imperative::NameTensorMap, str);
-  __REPLACE_COMPLEX_TYPE_STR__(std::string, str);
-  return str;
-}
-
-TEST_API std::string GetCurrentTraceBackString(bool for_signal) {
-  std::ostringstream sout;
-
-  if (!for_signal) {
-    sout << "\n\n--------------------------------------\n";
-    sout << "C++ Traceback (most recent call last):";
-    sout << "\n--------------------------------------\n";
-  }
-#if !defined(_WIN32) && !defined(PADDLE_WITH_MUSL)
-  static constexpr int TRACE_STACK_LIMIT = 100;
-
-  std::array<void*, TRACE_STACK_LIMIT> call_stack;
-  auto size = backtrace(call_stack.data(), TRACE_STACK_LIMIT);
-  auto symbols = backtrace_symbols(call_stack.data(), size);
-  Dl_info info;
-  int idx = 0;
-  // `for_signal` used to remove the stack trace introduced by
-  // obtaining the error stack trace when the signal error occurred,
-  // that is not related to the signal error self, remove it to
-  // avoid misleading users and developers
-  int end_idx = for_signal ? 2 : 0;
-  for (int i = size - 1; i >= end_idx; --i) {
-    if (dladdr(call_stack[i], &info) && info.dli_sname) {
-      auto demangled = demangle(info.dli_sname);
-      std::string path(info.dli_fname);
-      // C++ traceback info are from core.so
-      if (path.substr(path.length() - 3).compare(".so") == 0) {
-        sout << paddle::string::Sprintf(
-            "%-3d %s\n", idx++, SimplifyDemangleStr(demangled));
-      }
-    }
-  }
-  free(symbols);  // NOLINT
-#else
-  sout << "Not support stack backtrace yet.\n";
-#endif
-  return sout.str();
-}
 
 void ThrowWarnInternal(const std::string& msg) {
   LOG(WARNING) << "WARNING :" << msg;
@@ -276,7 +142,9 @@ std::string GetExternalErrorMsg(T status) {
     std::string search_path_3;
 #if !defined(_WIN32)
     Dl_info info;
-    if (dladdr(reinterpret_cast<void*>(GetCurrentTraceBackString), &info)) {
+    if (dladdr(
+            reinterpret_cast<void*>(common::enforce::GetCurrentTraceBackString),
+            &info)) {
       std::string phi_so_path(info.dli_fname);
       const size_t last_slash_idx = phi_so_path.find_last_of('/');
       if (std::string::npos != last_slash_idx) {
@@ -297,7 +165,9 @@ std::string GetExternalErrorMsg(T status) {
     char buf[512];
     MEMORY_BASIC_INFORMATION mbi;
     HMODULE h_module =
-        (::VirtualQuery(GetCurrentTraceBackString, &mbi, sizeof(mbi)) != 0)
+        (::VirtualQuery(common::enforce::GetCurrentTraceBackString,
+                        &mbi,
+                        sizeof(mbi)) != 0)
             ? (HMODULE)mbi.AllocationBase
             : NULL;
     GetModuleFileName(h_module, buf, 512);

--- a/paddle/utils/variant_test.cc
+++ b/paddle/utils/variant_test.cc
@@ -18,7 +18,7 @@
 #include "paddle/phi/core/enforce.h"
 
 TEST(interface_test, type) {
-  using phi::enforce::demangle;
+  using common::demangle;
 
   paddle::variant<bool, int, float> var;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

 Others

### Description
<!-- Describe what you’ve done -->
[PIR] remove log simply name mechnism from phi to common.

为了统一paddle中的日志体系，需要将PaddleEnforce\*相关宏下沉到common库，方便pir、phi、fluid等共用。
由于PaddleEnforce\*相关宏依赖了GetCurrentTraceBackString接口，本pr先将该接口从phi算子库下沉到了common库。

同时，重构升级了GetCurrentTraceBackString中对于类型名化简的机制，通过下层提供注册接口、上层进行注册的方式，避免了在底层库中包含上层fluid库中的头文件及数据结构。



### Other

Pcard-67164
