### PR TITLE
[Dy2St] Fix `NameloadJstTransformer` missing transform call kwargs

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -167,9 +167,7 @@ def monkey_patch_math_tensor():
     def _T_(var):
         if len(var.shape) == 1:
             return var
-        perm = []
-        for i in range(len(var.shape)):
-            perm.insert(0, i)
+        perm = list(reversed(range(len(var.shape))))
         out = _C_ops.transpose(var, perm)
         return out
 

--- a/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
@@ -152,6 +152,8 @@ class NameloadJstTransformer(BaseTransformer):
         Can't convert name of function call, bacause this will affect CallTransformer.
         """
         node.args = [self.visit(arg) for arg in node.args]
+        for keyword in node.keywords:
+            keyword.value = self.visit(keyword.value)
         node.func = self.visit(node.func)
         return node
 

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -409,7 +409,7 @@ def monkey_patch_value():
     def _T_(self):
         """
 
-        Permute current Variable with its dimensions reversed.
+        Permute current Value with its dimensions reversed.
 
         If `n` is the dimensions of `x` , `x.T` is equivalent to `x.transpose([n-1, n-2, ..., 0])`.
 

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -405,6 +405,35 @@ def monkey_patch_value():
         """
         return paddle.numel(self)
 
+    @property
+    def _T_(self):
+        """
+
+        Permute current Variable with its dimensions reversed.
+
+        If `n` is the dimensions of `x` , `x.T` is equivalent to `x.transpose([n-1, n-2, ..., 0])`.
+
+        Examples:
+            .. code-block:: python
+
+                >>> import paddle
+                >>> paddle.enable_static()
+
+                >>> x = paddle.ones(shape=[2, 3, 5])
+                >>> x_T = x.T
+
+                >>> exe = paddle.static.Executor()
+                >>> x_T_np = exe.run(paddle.static.default_main_program(), fetch_list=[x_T])[0]
+                >>> print(x_T_np.shape)
+                (5, 3, 2)
+
+        """
+        if len(self.shape) == 1:
+            return self
+        perm = list(reversed(range(len(self.shape))))
+
+        return _C_ops.transpose(self, perm)
+
     def clone(self):
         """
         Returns a new static Value, which is the clone of the original static
@@ -511,6 +540,7 @@ def monkey_patch_value():
         ('ndim', _ndim),
         ('astype', astype),
         ('size', _size_),
+        ('T', _T_),
         ('clone', clone),
         ('clear_gradient', clear_gradient),
         ('append', append),

--- a/test/dygraph_to_static/test_load_transformer.py
+++ b/test/dygraph_to_static/test_load_transformer.py
@@ -71,5 +71,27 @@ class TestLoad2(Dy2StTestBase):
         np.testing.assert_allclose(output_dy.numpy(), output_st.numpy())
 
 
+class LoadInCallKwargsNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.extra_inputs = []
+
+    def forward(self, x):
+        for i in range(len(self.extra_inputs)):
+            x = paddle.nn.functional.linear(weight=self.extra_inputs[i].T, x=x)
+        return x
+
+
+class TestLoadInCallKwargs(Dy2StTestBase):
+    @test_legacy_and_pt_and_pir
+    def test_name_load_nograd(self):
+        net = LoadInCallKwargsNet()
+        x = paddle.rand([10, 10])
+        net.extra_inputs.append(paddle.rand([10, 10]))
+        output_st = paddle.jit.to_static(net)(x)
+        output_dy = net(x)
+        np.testing.assert_allclose(output_dy.numpy(), output_st.numpy())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -450,6 +450,16 @@ class TestMathOpPatchesPir(unittest.TestCase):
                 (output_x,) = exe.run(main_program, fetch_list=[x.size])
                 self.assertEqual(output_x, 24)
 
+    def test_T(self):
+        with paddle.pir_utils.IrGuard():
+            main_program, exe, program_guard = new_program()
+            with program_guard:
+                x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
+                x_T = x.T
+                self.assertEqual(x_T.shape, [4, 3, 2])
+                (output_x,) = exe.run(main_program, fetch_list=[x_T])
+                self.assertEqual(output_x.shape, (4, 3, 2))
+
     def test_hash_error(self):
         with paddle.pir_utils.IrGuard():
             _, _, program_guard = new_program()

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -452,13 +452,17 @@ class TestMathOpPatchesPir(unittest.TestCase):
 
     def test_T(self):
         with paddle.pir_utils.IrGuard():
-            main_program, exe, program_guard = new_program()
-            with program_guard:
-                x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
-                x_T = x.T
-                self.assertEqual(x_T.shape, [4, 3, 2])
-                (output_x,) = exe.run(main_program, fetch_list=[x_T])
-                self.assertEqual(output_x.shape, (4, 3, 2))
+            for ndim in range(5):
+                # shape is [], [1], [1, 2], [1, 2, 3], [1, 2, 3, 4]
+                shape = list(range(1, ndim + 1))
+                out_shape = list(reversed(shape))
+                main_program, exe, program_guard = new_program()
+                with program_guard:
+                    x = paddle.rand(shape, dtype="float32")
+                    x_T = x.T
+                    self.assertEqual(x_T.shape, out_shape)
+                    (output_x,) = exe.run(main_program, fetch_list=[x_T])
+                    self.assertEqual(output_x.shape, tuple(out_shape))
 
     def test_hash_error(self):
         with paddle.pir_utils.IrGuard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 https://github.com/PaddleJitLab/jit-exportable-models/pull/10 所述的 `NameloadJstTransformer` 转写缺失对 call 的 kwargs 的处理的问题

问题如下：

`NameloadJstTransformer` 在 `visit_Call` 时仅仅处理了 `node.args` 而未处理 `node.keywords`，因此 `keywords` 里的 node 并未被转写：

```python
x = _jst.Call(_jst.Ld(activation))(input=paddle.nn.functional.linear(weight=w.T, bias=self.encode_b[ind], x=x), kind=self._nl_type)
```

这里的 `input=xxx` 等明显没转写

修复后可转写如下：

```python
x = _jst.Call(_jst.Ld(activation))(input=_jst.Ld(_jst.Ld(_jst.Ld(_jst.Ld(paddle).nn).functional).linear)(weight=_jst.Ld(_jst.Ld(w).T), bias=_jst.Ld(_jst.Ld(_jst.Ld(self).encode_b)[_jst.Ld(ind)]), x=_jst.Ld(x)), kind=_jst.Ld(_jst.Ld(self)._nl_type))
```

Tensor 就不会出现在组网阶段了，就不会错误走到动态图分支了（Tensor 上 patch 的 `T`），注意该问题不会发生在 PIR 下，因为 PIR 在 API 里做了 Tensor -> Value 的转换

将这个 case 加到单测发现 PIR Value 还没支持 `T`，就顺手支持了下 `Value.T`

PCard-66972