### PR TITLE
Pipeline and Virtual-Pipeline Parallelism Using CUDA Graph and Integrate CUDAMallocAsyncAllocator

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1091,6 +1091,34 @@ PHI_DEFINE_EXPORTED_bool(new_executor_use_cuda_graph,
                          "Use CUDA Graph in new executor");
 
 /*
+ * CUDA Graph / Allocator related FLAG
+ * Name: FLAGS_use_cuda_malloc_async_allocator
+ * Since Version: 2.7
+ * Value Range: bool, default=false
+ * Example: FLAGS_use_cuda_malloc_async_allocator=true would allow
+ * CUDAMallocAsyncAllocator replace StreamSafeCUDAAllocator.
+ */
+PHI_DEFINE_EXPORTED_bool(use_cuda_malloc_async_allocator,
+                         false,
+                         "Enable CUDAMallocAsyncAllocator");
+
+/*
+ * CUDA Graph / Allocator related FLAG
+ * Name: FLAGS_auto_free_cudagraph_allocations_on_launch
+ * Since Version: 2.7
+ * Value Range: bool, default=true
+ * Example: When enabling CUDA Graph with CUDAMallocAsyncAllocator, we add
+ * cudaGraphInstantiateFlagAutoFreeOnLaunch so it would automatically
+ * release graph-owned blocks that have not freed before relaunching.
+ */
+PHI_DEFINE_EXPORTED_bool(
+    auto_free_cudagraph_allocations_on_launch,
+    true,
+    "When enabling CUDA Graph with CUDAMallocAsyncAllocator, we add "
+    "cudaGraphInstantiateFlagAutoFreeOnLaunch so it would automatically "
+    "release graph-owned blocks that have not freed before relaunching.");
+
+/*
  * Executor related FLAG
  * Name: FLAGS_executor_log_deps_every_microseconds
  * Since Version: 2.5

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -31,11 +31,12 @@
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/utils/data_type.h"
 
-COMMON_DECLARE_bool(benchmark);
-COMMON_DECLARE_bool(benchmark_nccl);
-COMMON_DECLARE_bool(nccl_blocking_wait);
-COMMON_DECLARE_bool(use_stream_safe_cuda_allocator);
-COMMON_DECLARE_bool(enable_async_trace);
+PHI_DECLARE_bool(benchmark);
+PHI_DECLARE_bool(benchmark_nccl);
+PHI_DECLARE_bool(nccl_blocking_wait);
+PHI_DECLARE_bool(use_stream_safe_cuda_allocator);
+PHI_DECLARE_bool(use_cuda_malloc_async_allocator);
+PHI_DECLARE_bool(enable_async_trace);
 
 // set this flag to `true` and recompile to enable dynamic checks
 constexpr bool FLAGS_enable_nccl_dynamic_check = false;
@@ -859,7 +860,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
   }
 
   if (!use_calc_stream) {
-    if (FLAGS_use_stream_safe_cuda_allocator) {
+    if (FLAGS_use_stream_safe_cuda_allocator || FLAGS_use_cuda_malloc_async_allocator) {
       memory::RecordStream(tensor_tmp.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);
@@ -974,7 +975,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
   }
 
   if (!use_calc_stream) {
-    if (FLAGS_use_stream_safe_cuda_allocator) {
+    if (FLAGS_use_stream_safe_cuda_allocator || FLAGS_use_cuda_malloc_async_allocator) {
       memory::RecordStream(tensor_tmp.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -860,7 +860,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
   }
 
   if (!use_calc_stream) {
-    if (FLAGS_use_stream_safe_cuda_allocator || FLAGS_use_cuda_malloc_async_allocator) {
+    if (FLAGS_use_stream_safe_cuda_allocator ||
+        FLAGS_use_cuda_malloc_async_allocator) {
       memory::RecordStream(tensor_tmp.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);
@@ -975,7 +976,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
   }
 
   if (!use_calc_stream) {
-    if (FLAGS_use_stream_safe_cuda_allocator || FLAGS_use_cuda_malloc_async_allocator) {
+    if (FLAGS_use_stream_safe_cuda_allocator ||
+        FLAGS_use_cuda_malloc_async_allocator) {
       memory::RecordStream(tensor_tmp.Holder(), nccl_stream);
     }
     task->UpdateWaitChain(*comm_ctx);

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -31,12 +31,12 @@
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/utils/data_type.h"
 
-PHI_DECLARE_bool(benchmark);
-PHI_DECLARE_bool(benchmark_nccl);
-PHI_DECLARE_bool(nccl_blocking_wait);
-PHI_DECLARE_bool(use_stream_safe_cuda_allocator);
-PHI_DECLARE_bool(use_cuda_malloc_async_allocator);
-PHI_DECLARE_bool(enable_async_trace);
+COMMON_DECLARE_bool(benchmark);
+COMMON_DECLARE_bool(benchmark_nccl);
+COMMON_DECLARE_bool(nccl_blocking_wait);
+COMMON_DECLARE_bool(use_stream_safe_cuda_allocator);
+COMMON_DECLARE_bool(use_cuda_malloc_async_allocator);
+COMMON_DECLARE_bool(enable_async_trace);
 
 // set this flag to `true` and recompile to enable dynamic checks
 constexpr bool FLAGS_enable_nccl_dynamic_check = false;

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -20,7 +20,7 @@
 
 PD_DECLARE_bool(use_stream_safe_cuda_allocator);
 PD_DECLARE_bool(use_cuda_malloc_async_allocator);
-PHI_DECLARE_string(allocator_strategy);
+COMMON_DECLARE_string(allocator_strategy);
 
 namespace paddle {
 namespace distributed {

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -21,22 +21,12 @@
 PD_DECLARE_bool(use_stream_safe_cuda_allocator);
 COMMON_DECLARE_string(allocator_strategy);
 
-#if defined(PADDLE_WITH_CUDA)
-PD_DECLARE_bool(use_cuda_malloc_async_allocator);
-#endif
-
 namespace paddle {
 namespace distributed {
 
 static bool IsStreamSafeAllocator() {
-#if defined(PADDLE_WITH_CUDA)
-  return (FLAGS_allocator_strategy == "auto_growth" &&
-          FLAGS_use_stream_safe_cuda_allocator) ||
-         (FLAGS_use_cuda_malloc_async_allocator);
-#else
   return (FLAGS_allocator_strategy == "auto_growth" &&
           FLAGS_use_stream_safe_cuda_allocator);
-#endif
 }
 
 static Backend TransToBackend(platform::Place place) {

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -27,7 +27,8 @@ namespace distributed {
 
 static bool IsStreamSafeAllocator() {
   return (FLAGS_allocator_strategy == "auto_growth" &&
-         FLAGS_use_stream_safe_cuda_allocator) || (FLAGS_use_cuda_malloc_async_allocator);
+          FLAGS_use_stream_safe_cuda_allocator) ||
+         (FLAGS_use_cuda_malloc_async_allocator);
 }
 
 static Backend TransToBackend(platform::Place place) {

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -19,16 +19,24 @@
 #include "paddle/phi/backends/device_manager.h"
 
 PD_DECLARE_bool(use_stream_safe_cuda_allocator);
-PD_DECLARE_bool(use_cuda_malloc_async_allocator);
 COMMON_DECLARE_string(allocator_strategy);
+
+#if defined(PADDLE_WITH_CUDA)
+PD_DECLARE_bool(use_cuda_malloc_async_allocator);
+#endif
 
 namespace paddle {
 namespace distributed {
 
 static bool IsStreamSafeAllocator() {
+#if defined(PADDLE_WITH_CUDA)
   return (FLAGS_allocator_strategy == "auto_growth" &&
           FLAGS_use_stream_safe_cuda_allocator) ||
          (FLAGS_use_cuda_malloc_async_allocator);
+#else
+  return (FLAGS_allocator_strategy == "auto_growth" &&
+          FLAGS_use_stream_safe_cuda_allocator);
+#endif
 }
 
 static Backend TransToBackend(platform::Place place) {

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -19,14 +19,15 @@
 #include "paddle/phi/backends/device_manager.h"
 
 PD_DECLARE_bool(use_stream_safe_cuda_allocator);
-COMMON_DECLARE_string(allocator_strategy);
+PD_DECLARE_bool(use_cuda_malloc_async_allocator);
+PHI_DECLARE_string(allocator_strategy);
 
 namespace paddle {
 namespace distributed {
 
 static bool IsStreamSafeAllocator() {
-  return FLAGS_allocator_strategy == "auto_growth" &&
-         FLAGS_use_stream_safe_cuda_allocator;
+  return (FLAGS_allocator_strategy == "auto_growth" &&
+         FLAGS_use_stream_safe_cuda_allocator) || (FLAGS_use_cuda_malloc_async_allocator);
 }
 
 static Backend TransToBackend(platform::Place place) {

--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -25,6 +25,7 @@ if(WITH_GPU OR WITH_ROCM)
     ALLOCATOR_SRCS
     cuda_allocator.cc
     cuda_managed_allocator.cc
+    cuda_malloc_async_allocator.cc
     pinned_allocator.cc
     stream_safe_cuda_allocator.cc
     thread_local_allocator.cc)

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/memory/allocation/allocator_facade.h"
 #include <cstdint>
+#include "paddle/fluid/memory/allocation/allocator_facade.h"
 
 #include "paddle/common/macros.h"
 #include "paddle/fluid/memory/allocation/aligned_allocator.h"
@@ -486,9 +486,12 @@ class AllocatorFacadePrivate {
 
   void RecordStream(std::shared_ptr<phi::Allocation> allocation,
                     gpuStream_t stream) {
-    std::shared_ptr<StreamSafeCUDAAllocation> stream_safe_cuda_allocation =
-        std::dynamic_pointer_cast<StreamSafeCUDAAllocation>(allocation);
-    if (stream_safe_cuda_allocation != nullptr) {
+    if (auto cuda_malloc_async_allocation =
+            std::dynamic_pointer_cast<CUDAMallocAsyncAllocation>(allocation)) {
+      cuda_malloc_async_allocation->RecordStream(stream);
+    } else if (auto stream_safe_cuda_allocation =
+                   std::dynamic_pointer_cast<StreamSafeCUDAAllocation>(
+                       allocation)) {
       stream_safe_cuda_allocation->RecordStream(stream);
     } else {
       VLOG(6) << "RecordStream for a non-StreamSafeCUDAAllocation";

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -1761,8 +1761,6 @@ phi::stream::stream_t AllocatorFacade::GetStream(
 
 void AllocatorFacade::SetDefaultStream(const platform::CustomPlace& place,
                                        phi::stream::stream_t stream) {
-  VLOG(8) << "Set default stream to " << stream << " for AllocatorFacade in "
-          << place;
   if (m_->IsStreamSafeCUDAAllocatorUsed()) {
     m_->SetDefaultStream(place, stream);
   }

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -841,6 +841,7 @@ class AllocatorFacadePrivate {
       VLOG(8) << "[CUDAMallocAsyncAllocator] Init CUDA allocator for stream "
               << stream << " in place " << p;
       InitCUDAMallocAsyncAllocator(p, stream);
+      WrapCUDARetryAllocator(p, stream, FLAGS_gpu_allocator_retry_time);
       WrapStatAllocator(p, stream);
     } else {
       if (LIKELY(!HasCUDAAllocator(p, stream))) {

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -91,27 +91,17 @@ PADDLE_DEFINE_EXPORTED_bool(use_stream_safe_cuda_allocator,
                             true,
                             "Enable StreamSafeCUDAAllocator");
 
-PADDLE_DEFINE_EXPORTED_bool(use_cuda_malloc_async_allocator,
-                            false,
-                            "Enable CUDAMallocAsyncAllocator");
-
-PADDLE_DEFINE_EXPORTED_bool(
-    auto_free_cudagraph_allocations_on_launch,
-    false,
-    "When enabling CUDA Graph with CUDAMallocAsyncAllocator, we add "
-    "cudaGraphInstantiateFlagAutoFreeOnLaunch so it would automatically "
-    "release "
-    "graph-owned blocks that have not freed before relaunching.");
-
 PADDLE_DEFINE_EXPORTED_bool(use_cuda_managed_memory,
                             false,
                             "Whether to use CUDAManagedAllocator to allocate "
                             "managed memory, only available for auto_growth "
                             "strategy");
 
-COMMON_DECLARE_string(allocator_strategy);
-COMMON_DECLARE_uint64(auto_growth_chunk_size_in_mb);
-COMMON_DECLARE_bool(use_auto_growth_pinned_allocator);
+PHI_DECLARE_string(allocator_strategy);
+PHI_DECLARE_uint64(auto_growth_chunk_size_in_mb);
+PHI_DECLARE_bool(use_auto_growth_pinned_allocator);
+PHI_DECLARE_bool(use_cuda_malloc_async_allocator);
+PHI_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
 
 namespace paddle {
 namespace memory {

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -97,11 +97,11 @@ PADDLE_DEFINE_EXPORTED_bool(use_cuda_managed_memory,
                             "managed memory, only available for auto_growth "
                             "strategy");
 
-PHI_DECLARE_string(allocator_strategy);
-PHI_DECLARE_uint64(auto_growth_chunk_size_in_mb);
-PHI_DECLARE_bool(use_auto_growth_pinned_allocator);
-PHI_DECLARE_bool(use_cuda_malloc_async_allocator);
-PHI_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
+COMMON_DECLARE_string(allocator_strategy);
+COMMON_DECLARE_uint64(auto_growth_chunk_size_in_mb);
+COMMON_DECLARE_bool(use_auto_growth_pinned_allocator);
+COMMON_DECLARE_bool(use_cuda_malloc_async_allocator);
+COMMON_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
 
 namespace paddle {
 namespace memory {

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/memory/allocation/allocator_facade.h"
+#include <cstdint>
 
 #include "paddle/common/macros.h"
 #include "paddle/fluid/memory/allocation/aligned_allocator.h"
@@ -93,6 +94,14 @@ PADDLE_DEFINE_EXPORTED_bool(use_stream_safe_cuda_allocator,
 PADDLE_DEFINE_EXPORTED_bool(use_cuda_malloc_async_allocator,
                             false,
                             "Enable CUDAMallocAsyncAllocator");
+
+PADDLE_DEFINE_EXPORTED_bool(
+    auto_free_cudagraph_allocations_on_launch,
+    false,
+    "When enabling CUDA Graph with CUDAMallocAsyncAllocator, we add "
+    "cudaGraphInstantiateFlagAutoFreeOnLaunch so it would automatically "
+    "release "
+    "graph-owned blocks that have not freed before relaunching.");
 
 PADDLE_DEFINE_EXPORTED_bool(use_cuda_managed_memory,
                             false,

--- a/paddle/fluid/memory/allocation/allocator_facade.h
+++ b/paddle/fluid/memory/allocation/allocator_facade.h
@@ -80,6 +80,7 @@ class AllocatorFacade {
                     const phi::Stream& stream);
 
   bool IsStreamSafeCUDAAllocatorUsed();
+  bool IsCUDAMallocAsyncAllocatorUsed();
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   // TODO(zhiqiu): change gpuStream_t to phi::Stream if needed.

--- a/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.cc
@@ -1,0 +1,137 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include "paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h"
+#include "paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h"
+
+#ifdef PADDLE_WITH_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <string>
+
+#include "paddle/fluid/platform/cuda_device_guard.h"
+#include "paddle/fluid/platform/device/gpu/gpu_info.h"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+bool CUDAMallocAsyncAllocator::IsAllocThreadSafe() const { return true; }
+void CUDAMallocAsyncAllocator::FreeImpl(phi::Allocation* allocation) {
+  CUDAMallocAsyncAllocation* allocation_ =
+      dynamic_cast<CUDAMallocAsyncAllocation*>(allocation);
+
+  if ((UNLIKELY(phi::backends::gpu::CUDAGraph::IsThisThreadCapturing()))) {
+    // If the graph is in capturing mode, only the memory blocks owned by the
+    // graph should be freed. Meanwhile, the blocks that are not owned by
+    // the graph are retained and will be released once the capturing is
+    // complete.
+    auto id = phi::backends::gpu::CUDAGraph::CapturingPoolID();
+    if (graph_owned_allocation[id].find(allocation_) ==
+        graph_owned_allocation[id].end()) {
+      VLOG(0) << "Cache block ptr = " << allocation->ptr()
+              << " to release after capturing.";
+      cached_blocks_during_capturing.insert(allocation_);
+      return;
+    }
+  }
+
+  PADDLE_ENFORCE_EQ(
+      allocation->place(),
+      place_,
+      platform::errors::PermissionDenied(
+          "GPU memory is freed in incorrect device. This may be a bug"));
+  platform::RecordedGpuFreeAsync(allocation->ptr(),
+                                 allocation->size(),
+                                 place_.device,
+                                 allocation_->GetOwningStream());
+  delete allocation;
+}
+
+void CUDAMallocAsyncAllocator::FlushCachedBlockDuringCapturing(
+    int64_t graph_id) {
+  if ((UNLIKELY(phi::backends::gpu::CUDAGraph::IsThisThreadCapturing()))) {
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "This API should be called after the graph is captured."));
+  }
+  for (auto allocation : graph_owned_allocation[graph_id]) {
+    FreeImpl(allocation);
+  }
+}
+
+phi::Allocation* CUDAMallocAsyncAllocator::AllocateImpl(size_t size) {
+  std::call_once(once_flag_, [this] { platform::SetDeviceId(place_.device); });
+
+  void* ptr;
+  auto result =
+      platform::RecordedGpuMallocAsync(&ptr, size, place_.device, stream_);
+  if (LIKELY(result == gpuSuccess)) {
+    auto allocation = new CUDAMallocAsyncAllocation(
+        ptr, size, platform::Place(place_), stream_);
+
+    if ((UNLIKELY(phi::backends::gpu::CUDAGraph::IsThisThreadCapturing()))) {
+      auto id = phi::backends::gpu::CUDAGraph::CapturingPoolID();
+      graph_owned_allocation[id].insert(allocation);
+    }
+    return allocation;
+  }
+
+  size_t avail, total, actual_avail, actual_total;
+  bool is_limited = platform::RecordedGpuMemGetInfo(
+      &avail, &total, &actual_avail, &actual_total, place_.device);
+  size_t allocated = total - avail;
+
+  std::string err_msg;
+  if (is_limited) {
+    auto limit_size = (total >> 20);
+    err_msg = string::Sprintf(
+        "Or set environment variable `FLAGS_gpu_memory_limit_mb` to a larger "
+        "value. Currently `FLAGS_gpu_memory_limit_mb` is %d, so the maximum "
+        "GPU memory usage is limited to %d MB.\n"
+        "   The command is `export FLAGS_gpu_memory_limit_mb=xxx`.",
+        limit_size,
+        limit_size);
+  }
+
+  PADDLE_THROW_BAD_ALLOC(platform::errors::ResourceExhausted(
+      "\n\nOut of memory error on GPU %d. "
+      "Cannot allocate %s memory on GPU %d, %s memory has been allocated and "
+      "available memory is only %s.\n\n"
+      "Please check whether there is any other process using GPU %d.\n"
+      "1. If yes, please stop them, or start PaddlePaddle on another GPU.\n"
+      "2. If no, please decrease the batch size of your model. %s\n",
+      place_.device,
+      string::HumanReadableSize(size),
+      place_.device,
+      string::HumanReadableSize(allocated),
+      string::HumanReadableSize(avail),
+      place_.device,
+      err_msg));
+}
+
+gpuStream_t CUDAMallocAsyncAllocator::GetDefaultStream() const {
+  return stream_;
+}
+
+void CUDAMallocAsyncAllocator::SetDefaultStream(gpuStream_t stream) {
+  stream_ = stream;
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h
+++ b/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h
+++ b/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <mutex>  // NOLINT
+#include <unordered_set>
+
+#include "paddle/fluid/memory/allocation/allocator.h"
+#include "paddle/fluid/platform/place.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class CUDAMallocAsyncAllocation : public Allocation {
+ public:
+  CUDAMallocAsyncAllocation(void* ptr,
+                            size_t size,
+                            platform::Place place,
+                            gpuStream_t owning_stream)
+      : Allocation(ptr, size, place), owning_stream_(owning_stream){};
+  gpuStream_t GetOwningStream() const { return owning_stream_; }
+
+ private:
+  gpuStream_t owning_stream_;
+};
+
+class CUDAMallocAsyncAllocator : public Allocator {
+ public:
+  explicit CUDAMallocAsyncAllocator(const platform::CUDAPlace& place,
+                                    gpuStream_t default_stream)
+      : place_(place), stream_(default_stream) {}
+
+  bool IsAllocThreadSafe() const override;
+  gpuStream_t GetDefaultStream() const;
+  void SetDefaultStream(gpuStream_t stream);
+
+  // After capturing, we call this api to ensure the cached blocks are released.
+  void FlushCachedBlockDuringCapturing(int64_t graph_id);
+
+ protected:
+  void FreeImpl(phi::Allocation* allocation) override;
+  phi::Allocation* AllocateImpl(size_t size) override;
+
+ private:
+  platform::CUDAPlace place_;
+  gpuStream_t stream_;
+  std::once_flag once_flag_;
+
+  // a map from graph id to its owned allocations
+  std::unordered_map<int64_t, std::unordered_set<CUDAMallocAsyncAllocation*>>
+      graph_owned_allocation;
+
+  // If the graph is in capturing mode, only the memory blocks owned by the
+  // graph should be freed. Meanwhile, the blocks that are not owned by
+  // the graph are retained and will be released once the capturing is
+  // complete.
+  std::unordered_set<CUDAMallocAsyncAllocation*> cached_blocks_during_capturing;
+};
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h
+++ b/paddle/fluid/memory/allocation/cuda_malloc_async_allocator.h
@@ -24,7 +24,7 @@ namespace paddle {
 namespace memory {
 namespace allocation {
 
-// TODO: It may be beneficial to introduce an abstract class named
+// TODO(eee4017): It may be beneficial to introduce an abstract class named
 // `StreamAllocator` in future developments. This class would serve as a central
 // entity for methods specifically related to stream management, such as
 // `RecordStream` and `EraseStream`. The introduction of `StreamAllocator` would
@@ -46,7 +46,7 @@ class CUDAMallocAsyncAllocation : public Allocation {
 
   gpuStream_t GetOwningStream() const { return malloc_stream_; }
 
-  // TODO: The current implementation of RecordStream is
+  // TODO(eee4017): The current implementation of RecordStream is
   // similar to that in StreamSafeCUDAAllocator. This approach might lead to
   // host execution blocking and redundant EventQuery checks. Considering
   // cudaMallocFree, stream-ordered semantics could be leveraged for more
@@ -93,8 +93,9 @@ class CUDAMallocAsyncAllocator : public Allocator {
   std::shared_ptr<Allocator> underlying_allocator_;
   platform::CUDAPlace place_;   // Specifies the CUDA device context.
   gpuStream_t default_stream_;  // Default stream for memory operations.
-  gpuStream_t memory_stream_;   // TODO: We may use a single stream to
-                                // malloc/free to prevent host blocking
+  // TODO(eee4017): We may use a single stream to malloc/free to prevent host
+  // blocking
+  gpuStream_t memory_stream_;
   std::once_flag once_flag_;
   std::unordered_set<CUDAMallocAsyncAllocation*> graph_owned_allocations_;
   std::list<CUDAMallocAsyncAllocation*> unfreed_allocations_;

--- a/paddle/fluid/platform/cuda_graph_with_memory_pool.cc
+++ b/paddle/fluid/platform/cuda_graph_with_memory_pool.cc
@@ -144,7 +144,7 @@ void BeginCUDAGraphCapture(phi::GPUPlace place,
               << " wait for cuda graph dev_ctx: " << dev_ctx;
     }
   }
-  AddResetCallbackIfCapturingCUDAGraph([pool_id] {
+  AddPostResetCallbackIfCapturingCUDAGraph([pool_id] {
     memory::allocation::AllocatorFacade::Instance().RemoveMemoryPoolOfCUDAGraph(
         pool_id);
   });

--- a/paddle/fluid/platform/cuda_graph_with_memory_pool.h
+++ b/paddle/fluid/platform/cuda_graph_with_memory_pool.h
@@ -43,7 +43,7 @@ inline phi::GPUPlace CUDAGraphCapturingPlace() {
 
 using phi::backends::gpu::IsCUDAGraphCapturing;
 
-using phi::backends::gpu::AddResetCallbackIfCapturingCUDAGraph;
+using phi::backends::gpu::AddPostResetCallbackIfCapturingCUDAGraph;
 
 using phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph;
 

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -247,6 +247,53 @@ class RecordedGpuMallocHelper {
   }
 
   /**
+   * Try to allocate `size` gpu memory. Only cudaErrorMemoryAllocation
+   * or cudaSuccess would be returned, and the cudaGetLastError() flag
+   * would be clear.
+   */
+  gpuError_t MallocAsync(void **ptr, size_t size, gpuStream_t stream) {
+    LockGuardPtr<std::mutex> lock(mtx_);
+    if (UNLIKELY(NeedRecord() && cur_size_.load() + size > limit_size_)) {
+      return gpuErrorOutOfMemory;
+    }
+    CUDADeviceGuard guard(dev_id_);
+
+    std::call_once(set_cudamempoolattr_once_flag_, [&]() {
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          cudaDeviceGetDefaultMemPool(&memPool_, dev_id_));
+      uint64_t thresholdVal = ULLONG_MAX;
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaMemPoolSetAttribute(
+          memPool_, cudaMemPoolAttrReleaseThreshold, (void *)&thresholdVal));
+    });
+
+    gpuError_t result;
+    result = cudaMallocAsync(ptr, size, stream);
+    VLOG(1) << "[cudaMallocAsync] ptr = " << (*ptr)
+            << " size = " << static_cast<double>(size) / (1 << 20)
+            << " MB result = " << result << " stream = " << stream;
+    if (result == gpuSuccess) {
+      cur_size_.fetch_add(size);
+      STAT_INT_ADD("STAT_gpu" + std::to_string(dev_id_) + "_mem_size", size);
+      DEVICE_MEMORY_STAT_UPDATE(Reserved, dev_id_, size);
+      platform::RecordMemEvent(ptr,
+                               GPUPlace(dev_id_),
+                               size,
+                               platform::TracerMemEventType::ReservedAllocate);
+#ifdef PADDLE_WITH_TESTING
+      gpu_ptrs.insert(*ptr);
+#endif
+
+      return gpuSuccess;
+    } else {
+      RaiseNonOutOfMemoryError(&result);
+      // Non out of memory error would be raised inside
+      // RaiseNonOutOfMemoryError. Therefore, we can
+      // return cudaErrorMemoryAllocation directly here.
+      return gpuErrorOutOfMemory;
+    }
+  }
+
+  /**
    * Free gpu memory. Usually, free is not allowed to raise error.
    * If it does raise error, the process should be crashed.
    */
@@ -268,6 +315,36 @@ class RecordedGpuMallocHelper {
 #endif
       PADDLE_ENFORCE_GPU_SUCCESS(err);
       cur_size_.fetch_sub(size);
+      DEVICE_MEMORY_STAT_UPDATE(Reserved, dev_id_, -size);
+      platform::RecordMemEvent(ptr,
+                               GPUPlace(dev_id_),
+                               size,
+                               platform::TracerMemEventType::ReservedFree);
+    } else {
+      platform::GpuGetLastError();  // clear the error flag when
+                                    // cudaErrorCudartUnloading /
+                                    // hipErrorDeinitialized
+    }
+#ifdef PADDLE_WITH_TESTING
+    gpu_ptrs.erase(ptr);
+#endif
+  }
+
+  void FreeAsync(void *ptr, size_t size, gpuStream_t stream) {
+    // Purposefully allow cudaErrorCudartUnloading, because
+    // that is returned if you ever call cudaFree after the
+    // driver has already shutdown. This happens only if the
+    // process is terminating, in which case we don't care if
+    // cudaFree succeeds.
+    CUDADeviceGuard guard(dev_id_);
+    auto err = cudaFreeAsync(ptr, stream);
+    VLOG(1) << "[cudaFreeAsync] ptr = " << ptr
+            << "size =" << static_cast<double>(size) / (1 << 20)
+            << " MB result = "<< err << " stream = " << stream;
+    if (err != cudaErrorCudartUnloading) {
+      PADDLE_ENFORCE_GPU_SUCCESS(err);
+      cur_size_.fetch_sub(size);
+      STAT_INT_SUB("STAT_gpu" + std::to_string(dev_id_) + "_mem_size", size);
       DEVICE_MEMORY_STAT_UPDATE(Reserved, dev_id_, -size);
       platform::RecordMemEvent(ptr,
                                GPUPlace(dev_id_),
@@ -362,15 +439,18 @@ class RecordedGpuMallocHelper {
   const int dev_id_;
   const uint64_t limit_size_;
   std::atomic<uint64_t> cur_size_{0};
+  cudaMemPool_t memPool_;
 
   mutable std::unique_ptr<std::mutex> mtx_;
 
   static std::once_flag once_flag_;
+  static std::once_flag set_cudamempoolattr_once_flag_;
 
   std::set<void *> gpu_ptrs;  // just for testing
 };                            // NOLINT
 
 std::once_flag RecordedGpuMallocHelper::once_flag_;
+std::once_flag RecordedGpuMallocHelper::set_cudamempoolattr_once_flag_;
 
 gpuError_t RecordedGpuMalloc(void **ptr,
                              size_t size,
@@ -382,6 +462,21 @@ gpuError_t RecordedGpuMalloc(void **ptr,
 
 void RecordedGpuFree(void *p, size_t size, int dev_id) {
   return RecordedGpuMallocHelper::Instance(dev_id)->Free(p, size);
+}
+
+gpuError_t RecordedGpuMallocAsync(void **ptr,
+                                  size_t size,
+                                  int dev_id,
+                                  gpuStream_t stream) {
+  return RecordedGpuMallocHelper::Instance(dev_id)->MallocAsync(
+      ptr, size, stream);
+}
+
+void RecordedGpuFreeAsync(void *p,
+                          size_t size,
+                          int dev_id,
+                          gpuStream_t stream) {
+  return RecordedGpuMallocHelper::Instance(dev_id)->FreeAsync(p, size, stream);
 }
 
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -266,6 +266,8 @@ class RecordedGpuMallocHelper {
       PADDLE_ENFORCE_GPU_SUCCESS(
           cudaDeviceGetDefaultMemPool(&memPool_, dev_id_));
       uint64_t thresholdVal = FLAGS_cuda_memory_async_pool_realease_threshold;
+      VLOG(10) << "[cudaMallocAsync] set cudaMemPoolAttrReleaseThreshold to "
+               << thresholdVal;
       PADDLE_ENFORCE_GPU_SUCCESS(
           cudaMemPoolSetAttribute(memPool_,
                                   cudaMemPoolAttrReleaseThreshold,

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -46,11 +46,11 @@ limitations under the License. */
 #endif
 #endif
 
-PHI_DECLARE_double(fraction_of_gpu_memory_to_use);
-PHI_DECLARE_uint64(initial_gpu_memory_in_mb);
-PHI_DECLARE_uint64(reallocate_gpu_memory_in_mb);
-PHI_DECLARE_bool(enable_cublas_tensor_op_math);
-PHI_DECLARE_uint64(gpu_memory_limit_mb);
+COMMON_DECLARE_double(fraction_of_gpu_memory_to_use);
+COMMON_DECLARE_uint64(initial_gpu_memory_in_mb);
+COMMON_DECLARE_uint64(reallocate_gpu_memory_in_mb);
+COMMON_DECLARE_bool(enable_cublas_tensor_op_math);
+COMMON_DECLARE_uint64(gpu_memory_limit_mb);
 
 PHI_DEFINE_EXPORTED_bool(enable_gpu_memory_usage_log,
                          false,

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -281,7 +281,6 @@ class RecordedGpuMallocHelper {
              << " MB result = " << result << " stream = " << stream;
     if (result == gpuSuccess) {
       cur_size_.fetch_add(size);
-      STAT_INT_ADD("STAT_gpu" + std::to_string(dev_id_) + "_mem_size", size);
       DEVICE_MEMORY_STAT_UPDATE(Reserved, dev_id_, size);
       platform::RecordMemEvent(ptr,
                                GPUPlace(dev_id_),
@@ -352,7 +351,6 @@ class RecordedGpuMallocHelper {
     if (err != cudaErrorCudartUnloading) {
       PADDLE_ENFORCE_GPU_SUCCESS(err);
       cur_size_.fetch_sub(size);
-      STAT_INT_SUB("STAT_gpu" + std::to_string(dev_id_) + "_mem_size", size);
       DEVICE_MEMORY_STAT_UPDATE(Reserved, dev_id_, -size);
       platform::RecordMemEvent(ptr,
                                GPUPlace(dev_id_),

--- a/paddle/fluid/platform/device/gpu/gpu_info.h
+++ b/paddle/fluid/platform/device/gpu/gpu_info.h
@@ -134,6 +134,15 @@ gpuError_t RecordedGpuMalloc(void **ptr,
 //! CudaFree with recorded info
 void RecordedGpuFree(void *p, size_t size, int dev_id);
 
+//! CudaMalloc with recorded info
+gpuError_t RecordedGpuMallocAsync(void **ptr,
+                                  size_t size,
+                                  int dev_id,
+                                  gpuStream_t stream);
+
+//! CudaFree with recorded info
+void RecordedGpuFreeAsync(void *p, size_t size, int dev_id, gpuStream_t stream);
+
 gpuError_t GpuGetLastError();
 
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.cc
@@ -226,9 +226,15 @@ void CUDAGraph::EndSegmentCapture() {
   cudaGraphExec_t exec_graph;
   if (FLAGS_use_cuda_malloc_async_allocator &&
       FLAGS_auto_free_cudagraph_allocations_on_launch) {
+#if CUDA_VERSION >= 11040
     VLOG(1) << "cudaGraphInstantiateFlagAutoFreeOnLaunch is enabled!";
     PADDLE_ENFORCE_GPU_SUCCESS(cudaGraphInstantiateWithFlags(
         &exec_graph, graph, cudaGraphInstantiateFlagAutoFreeOnLaunch));
+#else
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "The cudaGraphInstantiateFlagAutoFreeOnLaunch is only supported when "
+        "CUDA version >= 11.4.0"));
+#endif
   } else {
     PADDLE_ENFORCE_GPU_SUCCESS(
         cudaGraphInstantiate(&exec_graph, graph, nullptr, nullptr, 0));

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.cc
@@ -22,8 +22,8 @@ cudaError_t cudaGetFuncBySymbol(cudaFunction_t *functionPtr,
 }
 #endif
 
-PHI_DECLARE_bool(use_cuda_malloc_async_allocator);
-PHI_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
+COMMON_DECLARE_bool(use_cuda_malloc_async_allocator);
+COMMON_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
 
 namespace phi {
 namespace backends {

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.cc
@@ -301,15 +301,15 @@ void CUDAGraph::PrintToDotFiles(const std::string &dirname,
 
 #if CUDA_VERSION >= 11000
 void CUDAGraphNodeLauncher::KernelNodeLaunch(
-    cudaFunction_t cudaFunc,
     parameterSetter_t parameterSetter,
     cudaKernelCallback_t cudakernelCallback) {
-  if (phi::backends::gpu::CUDAGraph::IsThisThreadCapturing()) {
+  if (UNLIKELY(phi::backends::gpu::CUDAGraph::IsThisThreadCapturing())) {
     unsigned int id = GenerateIdentifier();
+    auto cudaFunc = cudakernelCallback(id);
 
     parameterSetters[cudaFunc][id] = parameterSetter;
-    cudakernelCallback(id);
-
+    VLOG(10) << "[KernelNodeLaunch] Launch kernel with cudaFunc = " << cudaFunc
+             << " id = " << id;
   } else {
     cudakernelCallback(0);
   }
@@ -330,16 +330,21 @@ CUDAGraphNodeLauncher::GetParameterSettersForExecGraph(cudaGraph_t graph) {
     PADDLE_ENFORCE_GPU_SUCCESS(dynload::cuGraphNodeGetType(cuNode, &pType));
     if (pType == CU_GRAPH_NODE_TYPE_KERNEL) {
       CUDA_KERNEL_NODE_PARAMS cuParams;
+
       PADDLE_ENFORCE_GPU_SUCCESS(
           dynload::cuGraphKernelNodeGetParams(cuNode, &cuParams));
       CUDAKernelParams kernel_params(cuParams.kernelParams);
       auto kernel =
           parameterSetters.find(static_cast<cudaFunction_t>(cuParams.func));
-
+      VLOG(10) << "[GetParameterSettersForExecGraph] cuParams.func = "
+               << cuParams.func;
       // There exists a parameter setter
       if (kernel != parameterSetters.end()) {
         auto launchSequence = kernel->second;
         unsigned int id = kernel_params.As<int>(0);
+
+        VLOG(10) << "[GetParameterSettersForExecGraph] Find launch kernel id = "
+                 << id;
         auto parameterSetter = launchSequence.find(id);
         if (parameterSetter != launchSequence.end()) {
           auto setter = parameterSetter->second;

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/backends/gpu/cuda/cuda_graph.h"
-#include "paddle/phi/core/flags.h"
+#include "paddle/common/flags.h"
 
 #if CUDA_VERSION < 11000
 cudaError_t cudaGetFuncBySymbol(cudaFunction_t *functionPtr,

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/backends/gpu/cuda/cuda_graph.h"
-#include "paddle/utils/flags.h"
+#include "paddle/phi/core/flags.h"
 
 #if CUDA_VERSION < 11000
 cudaError_t cudaGetFuncBySymbol(cudaFunction_t *functionPtr,
@@ -22,9 +22,8 @@ cudaError_t cudaGetFuncBySymbol(cudaFunction_t *functionPtr,
 }
 #endif
 
-PD_DECLARE_bool(use_cuda_malloc_async_allocator);
-
-PD_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
+PHI_DECLARE_bool(use_cuda_malloc_async_allocator);
+PHI_DECLARE_bool(auto_free_cudagraph_allocations_on_launch);
 
 namespace phi {
 namespace backends {

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.h
@@ -335,12 +335,25 @@ class CUDAGraph {
 
   std::vector<SetSeedFunc> set_seed_funcs_;
 
+  // Holds callbacks that are triggered after the CUDA graph is reset. These
+  // callbacks are used for operations that need to be performed following the
+  // reset of a CUDA graph.
   std::vector<std::function<void()>> cudagraph_post_reset_callbacks_;
+
+  // Contains callbacks that are invoked after the CUDA graph has been captured.
+  // These callbacks are crucial for managing memory allocations related to the
+  // CUDA graph. They ensure that memory blocks not associated with a graph (as
+  // detailed in cuda_malloc_async_allocator) are not erroneously released
+  // during the graph's lifecycle.
   std::vector<std::function<void()>> cudagraph_post_capture_callbacks_;
-  // we collect all callbacks as a sequence of 'prehooks', i.e. these functions
-  // are called prior to the execution of the cudagraph.
+
+  // Maintains a collection of 'pre-hooks' - functions that are executed before
+  // the CUDA graph is replayed. These pre-hooks are essential for setting up
+  // the necessary conditions or states required for the correct execution of
+  // the CUDA graph.
   std::vector<std::vector<cudaGraphExecuterSetter_t>>
       cudagraph_pre_replay_callbacks_;
+
   std::mutex func_mtx_;
 
   bool is_first_run_{true};

--- a/paddle/phi/backends/gpu/cuda/cuda_graph.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.h
@@ -143,24 +143,22 @@ class CUDAGraphNodeLauncher {
   //  [CUDA Kernel Callback]
   //  Acts as the launcher for the kernel. It accepts an `unsigned int`
   //  identifier and uses it for the kernel launch.
-  //
-  //  cudaKernelCallback_t cudaKernelCallback = [=](unsigned int id) {
-  //      kernel<<<>>>(id, ...);  // Launching the kernel with id
-  //  };
-  using cudaKernelCallback_t = std::function<void(unsigned int)>;
-
-  //  [Retrieving CUDA Function]
   //  The `cudaGetFuncBySymbol` method can be used to fetch the `cudaFunction_t`
   //  reference of the kernel from the kernel pointer.
+  //  cudaKernelCallback_t cudaKernelCallback = [=](unsigned int id) {
+  //      // cudaFunction_t is REQUIRED to get here
+  //      cudaFunction_t cudaFunc;
+  //      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetFuncBySymbol(&cudaFunc, &kernel));
   //
-  //  cudaFunction_t cudaFunc;
-  //  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetFuncBySymbol(&cudaFunc, &kernel));
-  //
+  //      kernel<<<>>>(id, ...);  // Launching the kernel with id
+  //      return cudaFunc;
+  //  };
+  using cudaKernelCallback_t = std::function<cudaFunction_t(unsigned int)>;
+
   //  [Kernel Launch]
   //  With the callbacks defined and the CUDA function obtained, the kernel can
   //  be launched using the `KernelNodeLaunch` method.
-  void KernelNodeLaunch(cudaFunction_t cudaFunc,
-                        parameterSetter_t parameterSetter,
+  void KernelNodeLaunch(parameterSetter_t parameterSetter,
                         cudaKernelCallback_t cudakernelCallback);
 
   std::vector<cudaGraphExecuterSetter_t> GetParameterSettersForExecGraph(

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -38,10 +38,10 @@ inline bool IsCUDAGraphCapturing() {
 // Add reset callback if CUDA Graph is capturing.
 // Otherwise, invoke callback directly.
 template <typename Callback>
-inline void AddResetCallbackIfCapturingCUDAGraph(Callback &&callback) {
+inline void AddPostResetCallbackIfCapturingCUDAGraph(Callback &&callback) {
 #ifdef PADDLE_WITH_CUDA
   if (UNLIKELY(IsCUDAGraphCapturing())) {
-    return CUDAGraph::AddResetCallbackDuringCapturing(
+    return CUDAGraph::AddPostResetCallbackDuringCapturing(
         std::forward<Callback>(callback));
   }
 #endif
@@ -57,7 +57,7 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     size_t nbytes = size * sizeof(T);
     void *new_host_mem = new uint8_t[nbytes];
     std::memcpy(new_host_mem, host_mem, nbytes);
-    AddResetCallbackIfCapturingCUDAGraph(
+    AddPostResetCallbackIfCapturingCUDAGraph(
         [new_host_mem] { delete[] reinterpret_cast<uint8_t *>(new_host_mem); });
     return reinterpret_cast<T *>(new_host_mem);
   }

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -238,13 +238,9 @@ class PipelineSublayers(nn.Layer):
     def __init__(self, run_function):
         super().__init__()
         self.run_function = run_function
-        print("PipelineSublayers".center(50, "-"))
         for sublayer in self.run_function:
-            print("PipelineSublayers Layer", sublayer)
             if isinstance(sublayer, nn.Layer):
                 self.add_sublayer(str(len(self.run_function)), sublayer)
-
-        print("".center(50, "-"))
 
     def forward(self, x):
         for layer in self.run_function:
@@ -263,6 +259,7 @@ class PipelineLayer(nn.Layer):
         recompute_interval(int, optional): the number of layers to be used recompute, the value of 0 represents no recompute. default 0.
         recompute_ctx(dict,optional): the context of recompute, when 'recompute_interval' > 0, the context must be given.
         num_virtual_pipeline_stages(int, optional): the num of virtual pipeline stages for interleave pp.
+        use_cudagraph(bool, optional): enable CUDAGraphedLayer in pp layers.
     Examples:
         .. code-block:: python
 
@@ -701,7 +698,7 @@ class PipelineLayer(nn.Layer):
 
         def flush_into_run_function():
             if len(self.groupable_layers) > 0:
-                print(
+                logger.info(
                     f"flush {len(self.groupable_layers)} of layers into run_function"
                 )
                 pipeline_sublayer = PipelineSublayers(

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -221,6 +221,10 @@ class PipelineLayerChunk(nn.Layer):
             self.add_sublayer(str(len(self.run_function)), sublayer)
         self.run_function.append(sublayer)
 
+    def extend(self, layer_list):
+        for layer in layer_list:
+            self.append(layer)
+
     def get_run_function(self):
         return self.run_function
 

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -46,9 +46,9 @@ from functools import partial
 
 import paddle
 from paddle import framework, nn
-from paddle.incubate.distributed.fleet import recompute_hybrid
 from paddle.device.cuda.cuda_graphed_layer import CUDAGraphedLayer
 from paddle.distributed.fleet.utils.log_util import layer_to_str, logger
+from paddle.incubate.distributed.fleet import recompute_hybrid
 
 __all__ = []
 
@@ -233,6 +233,7 @@ class PipelineLayerChunk(nn.Layer):
             "Please call forward function of PipelineLayer."
         )
 
+
 class PipelineSublayers(nn.Layer):
     def __init__(self, run_function):
         super().__init__()
@@ -340,7 +341,7 @@ class PipelineLayer(nn.Layer):
         recompute_interval=0,
         recompute_ctx=None,
         num_virtual_pipeline_stages=None,
-        use_cudagraph=False
+        use_cudagraph=False,
     ):
         super().__init__()
         if num_stages is None and topology is None:
@@ -700,8 +701,12 @@ class PipelineLayer(nn.Layer):
 
         def flush_into_run_function():
             if len(self.groupable_layers) > 0:
-                print(f"flush {len(self.groupable_layers)} of layers into run_function")
-                pipeline_sublayer = PipelineSublayers(self.groupable_layers.copy())
+                print(
+                    f"flush {len(self.groupable_layers)} of layers into run_function"
+                )
+                pipeline_sublayer = PipelineSublayers(
+                    self.groupable_layers.copy()
+                )
                 if self.use_cudagraph:
                     pipeline_sublayer = CUDAGraphedLayer(pipeline_sublayer)
                 run_function.append(pipeline_sublayer)
@@ -716,7 +721,7 @@ class PipelineLayer(nn.Layer):
             paddle.seed(self._base_seed + layer_index)
 
             if isinstance(layer, nn.Layer):
-                self.groupable_layers.append(model)
+                self.groupable_layers.append(layer)
                 if self._num_virtual_pipeline_stages == 1:
                     # Only add sublayer for 1f1b scheduler,
                     # for interleave, PipelineLayerChunk will do this

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -236,21 +236,25 @@ class PipelineLayerChunk(nn.Layer):
             "The forward function of PipelineLayerChunk cannot be called directly. "
             "Please call forward function of PipelineLayer."
         )
-
+    
+    def __iter__(self):
+        return iter(self.run_function)
 
 class PipelineSublayers(nn.Layer):
     def __init__(self, run_function):
         super().__init__()
         self.run_function = run_function
-        for sublayer in self.run_function:
+        for idx, sublayer in enumerate(self.run_function):
             if isinstance(sublayer, nn.Layer):
-                self.add_sublayer(str(len(self.run_function)), sublayer)
+                self.add_sublayer(str(idx), sublayer)
 
     def forward(self, x):
         for layer in self.run_function:
             x = layer(x)
         return x
-
+    
+    def __iter__(self):
+        return iter(self.run_function)
 
 class PipelineLayer(nn.Layer):
     """PipelineLayer

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -236,9 +236,10 @@ class PipelineLayerChunk(nn.Layer):
             "The forward function of PipelineLayerChunk cannot be called directly. "
             "Please call forward function of PipelineLayer."
         )
-    
+
     def __iter__(self):
         return iter(self.run_function)
+
 
 class PipelineSublayers(nn.Layer):
     def __init__(self, run_function):
@@ -252,9 +253,10 @@ class PipelineSublayers(nn.Layer):
         for layer in self.run_function:
             x = layer(x)
         return x
-    
+
     def __iter__(self):
         return iter(self.run_function)
+
 
 class PipelineLayer(nn.Layer):
     """PipelineLayer

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -701,12 +701,14 @@ class PipelineLayer(nn.Layer):
                 logger.info(
                     f"flush {len(self.groupable_layers)} of layers into run_function"
                 )
-                pipeline_sublayer = PipelineSublayers(
-                    self.groupable_layers.copy()
-                )
                 if self.use_cudagraph:
+                    pipeline_sublayer = PipelineSublayers(
+                        self.groupable_layers.copy()
+                    )
                     pipeline_sublayer = CUDAGraphedLayer(pipeline_sublayer)
-                run_function.append(pipeline_sublayer)
+                    run_function.append(pipeline_sublayer)
+                else:
+                    run_function.extend(self.groupable_layers)
                 self.groupable_layers = []
 
         for index, layer in enumerate(self._layers_desc[start:end]):
@@ -762,6 +764,7 @@ class PipelineLayer(nn.Layer):
                     # for interleave, PipelineLayerChunk will do this
                     self.add_sublayer(str(layer_index), model)
             else:
+                flush_into_run_function()
                 run_function.append(layer)
 
         flush_into_run_function()

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -800,6 +800,7 @@ class PipelineParallel(MetaParallelBase):
                         [t.grad for t in input_tensor if not t.stop_gradient]
                     )
                 else:
+                    # assert is not none
                     input_tensor_grad = input_tensor.grad
             if self._enable_timer:
                 self.timers("backward_step").stop()

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -800,7 +800,6 @@ class PipelineParallel(MetaParallelBase):
                         [t.grad for t in input_tensor if not t.stop_gradient]
                     )
                 else:
-                    assert input_tensor.grad is not None
                     input_tensor_grad = input_tensor.grad
             if self._enable_timer:
                 self.timers("backward_step").stop()

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -800,7 +800,7 @@ class PipelineParallel(MetaParallelBase):
                         [t.grad for t in input_tensor if not t.stop_gradient]
                     )
                 else:
-                    # assert is not none
+                    assert input_tensor.grad is not None
                     input_tensor_grad = input_tensor.grad
             if self._enable_timer:
                 self.timers("backward_step").stop()

--- a/test/cpp/fluid/memory/CMakeLists.txt
+++ b/test/cpp/fluid/memory/CMakeLists.txt
@@ -83,12 +83,20 @@ if(WITH_GPU)
     cuda_managed_memory_test
     SRCS cuda_managed_memory_test.cu
     DEPS gpu_info place)
-
+  nv_test(
+    cuda_malloc_async_allocator_test
+    SRCS cuda_malloc_async_allocator_test.cu
+    DEPS cuda_graph_with_memory_pool)
   if(WITH_TESTING AND TEST stream_safe_cuda_alloc_test)
     set_tests_properties(
       stream_safe_cuda_alloc_test
       PROPERTIES ENVIRONMENT "FLAGS_use_stream_safe_cuda_allocator=true; \
         FLAGS_allocator_strategy=auto_growth")
+  endif()
+  if(WITH_TESTING AND TEST cuda_malloc_async_allocator_test)
+    set_tests_properties(
+      cuda_malloc_async_allocator_test
+      PROPERTIES ENVIRONMENT "FLAGS_use_cuda_malloc_async_allocator=true")
   endif()
 endif()
 

--- a/test/cpp/fluid/memory/cuda_malloc_async_allocator_test.cu
+++ b/test/cpp/fluid/memory/cuda_malloc_async_allocator_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ void CheckMemLeak(const platform::CUDAPlace &place) {
       << " there may be a memory leak problem";
 }
 
-#if (defined(PADDLE_WITH_CUDA) && (CUDA_VERSION >= 11000))
+#if (defined(PADDLE_WITH_CUDA) && (CUDA_VERSION >= 12000))
 
 TEST(CUDAMallocAsyncInterfaceTest, AllocInterfaceTest) {
   platform::CUDAPlace place = platform::CUDAPlace();

--- a/test/cpp/fluid/memory/cuda_malloc_async_allocator_test.cu
+++ b/test/cpp/fluid/memory/cuda_malloc_async_allocator_test.cu
@@ -1,0 +1,382 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <thread>  // NOLINT
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paddle/fluid/memory/allocation/allocator_facade.h"
+#include "paddle/fluid/memory/memory.h"
+#include "paddle/fluid/platform/device/gpu/gpu_info.h"
+#include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/stream.h"
+
+#ifdef PADDLE_WITH_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include "paddle/fluid/platform/cuda_graph_with_memory_pool.h"
+#endif
+
+namespace paddle {
+namespace memory {
+
+// y += (x + 1)
+__global__ void add_kernel(int *x, int *y, int n) {
+  int thread_num = gridDim.x * blockDim.x;
+  int thread_id = blockIdx.x * blockDim.x + threadIdx.x;
+  for (int i = thread_id; i < n; i += thread_num) {
+    y[i] += x[i] + 1;
+  }
+}
+
+void CheckMemLeak(const platform::CUDAPlace &place) {
+  uint64_t cuda_malloc_size =
+      platform::RecordedGpuMallocSize(place.GetDeviceId());
+  ASSERT_EQ(cuda_malloc_size, 0)
+      << "Found " << cuda_malloc_size << " bytes memory that not released yet,"
+      << " there may be a memory leak problem";
+}
+
+#if (defined(PADDLE_WITH_CUDA) && (CUDA_VERSION >= 11000))
+
+TEST(CUDAMallocAsyncInterfaceTest, AllocInterfaceTest) {
+  platform::CUDAPlace place = platform::CUDAPlace();
+  size_t alloc_size = 256;
+
+  std::shared_ptr<Allocation> allocation_implicit_stream =
+      AllocShared(place, alloc_size);
+  EXPECT_GE(allocation_implicit_stream->size(), alloc_size);
+
+  void *address = allocation_implicit_stream->ptr();
+  allocation_implicit_stream.reset();
+  gpuStream_t default_stream =
+      dynamic_cast<phi::GPUContext *>(
+          paddle::platform::DeviceContextPool::Instance().Get(place))
+          ->stream();
+  allocation::AllocationPtr allocation_unique =
+      Alloc(place,
+            alloc_size,
+            phi::Stream(reinterpret_cast<phi::StreamId>(default_stream)));
+  EXPECT_GE(allocation_unique->size(), alloc_size);
+  EXPECT_EQ(allocation_unique->ptr(), address);
+  allocation_unique.reset();
+
+  Release(place);
+  CheckMemLeak(place);
+}
+
+TEST(CUDAMallocAsyncInterfaceTest, GetAllocatorInterfaceTest) {
+  platform::CUDAPlace place = platform::CUDAPlace();
+  size_t alloc_size = 256;
+
+  allocation::AllocationPtr allocation_implicit_stream =
+      Alloc(place, alloc_size);
+  EXPECT_GE(allocation_implicit_stream->size(), alloc_size);
+  void *address = allocation_implicit_stream->ptr();
+  allocation_implicit_stream.reset();
+
+  auto &instance = allocation::AllocatorFacade::Instance();
+  const std::shared_ptr<Allocator> &allocator = instance.GetAllocator(place);
+
+  allocation::AllocationPtr allocation_from_allocator =
+      allocator->Allocate(alloc_size);
+  EXPECT_GE(allocation_from_allocator->size(), alloc_size);
+  EXPECT_EQ(allocation_from_allocator->ptr(), address);
+  allocation_from_allocator.reset();
+
+  Release(place);
+  CheckMemLeak(place);
+}
+
+TEST(CUDAMallocAsyncInterfaceTest, GetAllocatorWithDefaultStreamTest) {
+  auto &instance = allocation::AllocatorFacade::Instance();
+  platform::CUDAPlace place = platform::CUDAPlace();
+  const std::shared_ptr<Allocator> allocator_implicit_stream =
+      instance.GetAllocator(place);
+  const std::shared_ptr<Allocator> allocator_default_stream =
+      instance.GetAllocator(
+          place,
+          static_cast<phi::GPUContext *>(
+              platform::DeviceContextPool::Instance().Get(place))
+              ->stream());
+  EXPECT_EQ(allocator_implicit_stream.get(), allocator_default_stream.get());
+}
+
+TEST(CUDAMallocAsyncInterfaceTest, ZeroSizeRecordStreamTest) {
+  platform::CUDAPlace place = platform::CUDAPlace();
+  std::shared_ptr<Allocation> zero_size_allocation = AllocShared(place, 0);
+  EXPECT_EQ(zero_size_allocation->ptr(), nullptr);
+
+  gpuStream_t stream;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreate(&stream));
+
+  EXPECT_NO_THROW(RecordStream(zero_size_allocation, stream));
+
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamDestroy(stream));
+}
+
+TEST(CUDAMallocAsyncInterfaceTest, GetStreamInterfaceTest) {
+  platform::CUDAPlace place = platform::CUDAPlace();
+  size_t alloc_size = 256;
+
+  gpuStream_t default_stream =
+      dynamic_cast<phi::GPUContext *>(
+          paddle::platform::DeviceContextPool::Instance().Get(place))
+          ->stream();
+  std::shared_ptr<Allocation> allocation_implicit_stream =
+      AllocShared(place, alloc_size);
+  EXPECT_EQ(GetStream(allocation_implicit_stream), default_stream);
+
+  gpuStream_t new_stream;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreate(&new_stream));
+
+  std::shared_ptr<Allocation> allocation_new_stream =
+      AllocShared(place,
+                  alloc_size,
+                  phi::Stream(reinterpret_cast<phi::StreamId>(new_stream)));
+  EXPECT_EQ(GetStream(allocation_new_stream), new_stream);
+
+  allocation_implicit_stream.reset();
+  allocation_new_stream.reset();
+  // we should release the block before destroy the stream
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamDestroy(new_stream));
+
+  Release(place);
+  CheckMemLeak(place);
+}
+
+TEST(CUDAMallocAsyncRetryTest, RetryTest) {
+  platform::CUDAPlace place = platform::CUDAPlace();
+  gpuStream_t stream1, stream2;
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreate(&stream1));
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreate(&stream2));
+  size_t available_size = platform::GpuAvailableMemToAlloc();
+  // alloc_size < available_size < 2 * alloc_size,
+  // so the second alloc will fail and retry
+  size_t alloc_size = available_size / 4 * 3;
+
+  allocation::AllocationPtr allocation1 = Alloc(
+      place, alloc_size, phi::Stream(reinterpret_cast<phi::StreamId>(stream1)));
+  allocation::AllocationPtr allocation2;
+
+  std::thread th([&allocation2, &place, &stream2, alloc_size]() {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    allocation2 = Alloc(place,
+                        alloc_size,
+                        phi::Stream(reinterpret_cast<phi::StreamId>(stream2)));
+  });
+  allocation1.reset();  // free but not release
+  th.join();
+  EXPECT_GE(allocation2->size(), alloc_size);
+  allocation2.reset();
+
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaDeviceSynchronize());
+
+  Release(place, stream1);
+  Release(place, stream2);
+  CheckMemLeak(place);
+}
+
+class CUDAMallocAsyncTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    place_ = platform::CUDAPlace();
+    stream_num_ = 64;
+    grid_num_ = 1;
+    block_num_ = 32;
+    data_num_ = 131072;
+    workspace_size_ = data_num_ * sizeof(int);
+
+    for (size_t i = 0; i < stream_num_; ++i) {
+      gpuStream_t stream;
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreate(&stream));
+
+      std::shared_ptr<phi::Allocation> workspace_allocation =
+          AllocShared(place_,
+                      workspace_size_,
+                      phi::Stream(reinterpret_cast<phi::StreamId>(stream)));
+      std::shared_ptr<phi::Allocation> result_allocation =
+          AllocShared(place_,
+                      workspace_size_,
+                      phi::Stream(reinterpret_cast<phi::StreamId>(stream)));
+      std::shared_ptr<phi::Allocation> host_result_allocation =
+          AllocShared(platform::CPUPlace(), workspace_size_);
+
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaMemset(
+          workspace_allocation->ptr(), 0, workspace_allocation->size()));
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          cudaMemset(result_allocation->ptr(), 0, result_allocation->size()));
+
+      streams_.emplace_back(stream);
+      workspaces_.emplace_back(workspace_allocation);
+      results_.emplace_back(result_allocation);
+      host_results_.emplace_back(host_result_allocation);
+    }
+  }
+
+  void SingleStreamRun(size_t idx) {
+    int *y = reinterpret_cast<int *>(results_[idx]->ptr());
+    int neighbouring_idx = idx > 0 ? idx - 1 : idx;
+
+    add_kernel<<<grid_num_, block_num_, 0, streams_[idx]>>>(
+        reinterpret_cast<int *>(workspaces_[idx]->ptr()), y, data_num_);
+    add_kernel<<<grid_num_, block_num_, 0, streams_[idx]>>>(
+        reinterpret_cast<int *>(workspaces_[neighbouring_idx]->ptr()),
+        y,
+        data_num_);
+    RecordStream(workspaces_[neighbouring_idx], streams_[idx]);
+  }
+
+  void MultiStreamRun() {
+    // Must run in reverse order, or the workspace_[i - 1] will be released
+    // before streams_[i]'s kernel launch
+    for (int i = stream_num_ - 1; i >= 0; --i) {
+      SingleStreamRun(i);
+      workspaces_[i].reset();  // fast GC
+    }
+  }
+
+  void MultiThreadMultiStreamRun() {
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < stream_num_; ++i) {
+      threads.emplace_back(&CUDAMallocAsyncTest::SingleStreamRun, this, i);
+    }
+    for (size_t i = 0; i < stream_num_; ++i) {
+      threads[i].join();
+    }
+    workspaces_.clear();
+  }
+
+  void CUDAGraphRun() {
+    testing_cuda_graph_ = true;
+    platform::BeginCUDAGraphCapture(platform::CUDAPlace(),
+                                    cudaStreamCaptureModeGlobal);
+
+    std::shared_ptr<Allocation> data_allocation =
+        AllocShared(platform::CUDAPlace(), workspace_size_);
+    std::shared_ptr<Allocation> result_allocation =
+        AllocShared(platform::CUDAPlace(), workspace_size_);
+
+    int *data = static_cast<int *>(data_allocation->ptr());
+    int *result = static_cast<int *>(result_allocation->ptr());
+
+    gpuStream_t main_stream = GetStream(data_allocation);
+    gpuStream_t other_stream;
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamCreate(&other_stream));
+
+    add_kernel<<<grid_num_, block_num_, 0, main_stream>>>(
+        data, result, data_num_);
+    RecordStream(data_allocation, other_stream);
+
+    std::unique_ptr<phi::backends::gpu::CUDAGraph> cuda_graph =
+        platform::EndCUDAGraphCapture();
+
+    int replay_times = 10;
+    for (int i = 0; i < replay_times; ++i) {
+      cuda_graph->Replay();
+    }
+
+    std::shared_ptr<Allocation> host_result_allocation =
+        AllocShared(platform::CPUPlace(), workspace_size_);
+    Copy(host_result_allocation->place(),
+         host_result_allocation->ptr(),
+         result_allocation->place(),
+         result_allocation->ptr(),
+         workspace_size_,
+         main_stream);
+    cudaStreamSynchronize(main_stream);
+
+    int *host_result = static_cast<int *>(host_result_allocation->ptr());
+    for (int i = 0; i < data_num_; ++i) {
+      EXPECT_EQ(host_result[i], replay_times);
+    }
+
+    data_allocation.reset();
+    result_allocation.reset();
+    cuda_graph.release();
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamDestroy(other_stream));
+  }
+
+  void CheckResult() {
+    for (size_t i = 0; i < stream_num_; ++i) {
+      Copy(host_results_[i]->place(),
+           host_results_[i]->ptr(),
+           results_[i]->place(),
+           results_[i]->ptr(),
+           workspace_size_,
+           streams_[i]);
+    }
+    cudaDeviceSynchronize();
+
+    size_t thread_num = grid_num_ * block_num_;
+    for (size_t i = 0; i < stream_num_; ++i) {
+      int *result = static_cast<int *>(host_results_[i]->ptr());
+      for (size_t j = 0; j < data_num_; ++j) {
+        EXPECT_EQ(result[j], 2);
+      }
+    }
+  }
+
+  void TearDown() override {
+    workspaces_.clear();
+    results_.clear();
+    host_results_.clear();
+    for (gpuStream_t stream : streams_) {
+      Release(place_, stream);
+    }
+
+    for (size_t i = 0; i < stream_num_; ++i) {
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamSynchronize(streams_[i]));
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaStreamDestroy(streams_[i]));
+    }
+
+    // Memory release for CUDA Graph memory pool is forbidden
+    if (!testing_cuda_graph_) {
+      CheckMemLeak(place_);
+    }
+  }
+
+  bool testing_cuda_graph_{0};
+  size_t stream_num_;
+  size_t grid_num_;
+  size_t block_num_;
+  size_t data_num_;
+  size_t workspace_size_;
+  platform::CUDAPlace place_;
+  std::vector<gpuStream_t> streams_;
+  std::vector<std::shared_ptr<phi::Allocation>> workspaces_;
+  std::vector<std::shared_ptr<phi::Allocation>> results_;
+  std::vector<std::shared_ptr<phi::Allocation>> host_results_;
+};
+
+TEST_F(CUDAMallocAsyncTest, CUDAMutilStreamTest) {
+  MultiStreamRun();
+  CheckResult();
+}
+
+TEST_F(CUDAMallocAsyncTest, CUDAMutilThreadMutilStreamTest) {
+  MultiThreadMultiStreamRun();
+  CheckResult();
+}
+
+TEST_F(CUDAMallocAsyncTest, CUDAGraphTest) {
+  MultiStreamRun();
+  CUDAGraphRun();
+  CheckResult();
+}
+#endif
+
+}  // namespace memory
+}  // namespace paddle

--- a/test/cpp/fluid/memory/cuda_malloc_async_allocator_test.cu
+++ b/test/cpp/fluid/memory/cuda_malloc_async_allocator_test.cu
@@ -49,7 +49,7 @@ void CheckMemLeak(const platform::CUDAPlace &place) {
       << " there may be a memory leak problem";
 }
 
-#if (defined(PADDLE_WITH_CUDA) && (CUDA_VERSION >= 12000))
+#if (defined(PADDLE_WITH_CUDA) && (CUDA_VERSION >= 12200))
 
 TEST(CUDAMallocAsyncInterfaceTest, AllocInterfaceTest) {
   platform::CUDAPlace place = platform::CUDAPlace();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description

This PR introduces Pipeline Parallelism (PP) and Virtual-Pipeline Parallelism (VP) training through the integration of CUDA Graph. The following is a detailed breakdown of the challenges encountered and the innovative solutions we have implemented:

### PP/VP + CUDA Graph
Usage: Enable CUDA Graph in PipelineLayer using the `use_cudagraph=true` flag.

- PP and CUDA Graph:
  - **Challenge:** PP layers differ from standard nn.Layer as they are distributed across multiple GPUs. They are of two types: Layer and SharedLayer. SharedLayer's need for synchronous communication conflicts with CUDA Graph's requirements.
  - **Solution:** We have restructured PP layers into multiple capturable sublayers (contiguous Layers), enabling each to be captured into a separate graph. This facilitates efficient multi-GPU execution and mitigates the communication conflicts inherent in SharedLayers.
- VP and CUDA Graph:
  - **Challenge:** VP employs a non-traditional training pattern, executing multiple forward (FW) and backward (BW) stages concurrently. This necessitates continuous access to previous input data for each layer throughout the training cycle.
  - **Solution:** To accommodate this, we've integrated a queue into the CUDAGraphedLayer to store previous inputs. Each virtual pipeline stage is then captured as a separate graph, ensuring efficient and accurate training.

### CUDAMallocAsyncAllocator
Usage: Activate the `CUDAMallocAsyncAllocator` by setting `FLAG_use_cuda_malloc_async_allocator=1`.
- CUDAMallocAsyncAllocator 
  The `CUDAMallocAsyncAllocator` replaced the `StreamSafeCUDAAllocator`. By leveraging the advanced capabilities of `cudaMallocAsync` and `cudaFreeAsync`, the responsibility for stream-ordered memory management is transferred from the framework to CUDA. This transition may lead to better memory utilization and potentially improved application performance by optimizing the way memory is allocated and deallocated within the CUDA. 
  
- CUDAMallocAsyncAllocator + CUDAGraph
  - **Challenge:** The integration of PP/VP with CUDA Graph led to an excessive creation of graphs, and each graph has its own memory pool in Paddle's existing implementation. This resulted in low memory reuse and high memory footprint as allocations were not released until the deletion of the graph.
  - **Solution:** The introduction of the CUDAMallocAsyncAllocator provides a sophisticated solution to this challenge. By capturing memory allocation and deallocation semantics within the operations of CUDAGraph, the allocator significantly optimizes memory management. For instance, in the context of GPT3_1.3B+PP4+BF16 CUDAGraph training using 4 H100-80GB GPUs, the implementation of CUDAMallocAsyncAllocator has been observed to drastically reduce memory usage from a 95% down to 25%.
