### PR TITLE
cinn(backends): generate infer shape kernel to infer shape of output tensor

### DIFF
--- a/paddle/cinn/backends/codegen_cuda_host.cc
+++ b/paddle/cinn/backends/codegen_cuda_host.cc
@@ -200,7 +200,7 @@ llvm::Value* CodeGenCUDA_Host::LowerHostFunc(const ir::_LoweredFunc_* func) {
 
   // Set local scope table
   CHECK_EQ(ll_function_args.size(), func->args.size());
-  for (int i = 0; i < ll_function_args.size(); i++) {
+  for (int i = 0; i < ll_function_args.size(); ++i) {
     SetVar(func->args[i].name(), ll_function_args[i]);
   }
   llvm::BasicBlock* entry = llvm::BasicBlock::Create(

--- a/paddle/cinn/backends/codegen_cuda_host.cc
+++ b/paddle/cinn/backends/codegen_cuda_host.cc
@@ -198,6 +198,11 @@ llvm::Value* CodeGenCUDA_Host::LowerHostFunc(const ir::_LoweredFunc_* func) {
                  [](auto& arg) { return std::addressof(arg); });
   // @}
 
+  // Set local scope table
+  CHECK_EQ(ll_function_args.size(), func->args.size());
+  for (int i = 0; i < ll_function_args.size(); i++) {
+    SetVar(func->args[i].name(), ll_function_args[i]);
+  }
   llvm::BasicBlock* entry = llvm::BasicBlock::Create(
       /*Context=*/b_->getContext(),
       /*Name=*/"entry",
@@ -205,6 +210,11 @@ llvm::Value* CodeGenCUDA_Host::LowerHostFunc(const ir::_LoweredFunc_* func) {
       /*InsertBefore=*/nullptr);
   b_->SetInsertPoint(entry);
   CodeGenLLVM::Visit(&func->body);
+
+  // Reset local scope table
+  for (const ir::Argument& func_arg : func->args) {
+    symbol_table_->Erase(func_arg.name());
+  }
   RetVoid();
 
   return f_;

--- a/paddle/cinn/backends/codegen_cuda_host.h
+++ b/paddle/cinn/backends/codegen_cuda_host.h
@@ -53,7 +53,7 @@ class CodeGenCUDA_Host : public CodeGenLLVM {
     } else if (op->name == runtime::intrinsic::call_cuda_kernel) {
       return LowerCUDAKernelCall(op);
     } else {
-      CINN_NOT_IMPLEMENTED;
+      return CodeGenLLVM::Visit(op);
     }
   }
 

--- a/paddle/cinn/backends/llvm/codegen_llvm.cc
+++ b/paddle/cinn/backends/llvm/codegen_llvm.cc
@@ -818,7 +818,8 @@ llvm::Value *CodeGenLLVM::Visit(const ir::_Var_ *op) {
   // TODO(fc500110) hard coding
   if (LLVM_WillVarLowerAsPointer(op->name)) {
     result = value;
-  } else if (value->getType()->isPointerTy()) {
+  } else if (value->getType()->isPointerTy() &&
+             !value->getType()->getPointerElementType()->isPointerTy()) {
     result = Load(value, op->name + "_load");
   } else {
     result = value;

--- a/paddle/cinn/common/type.h
+++ b/paddle/cinn/common/type.h
@@ -251,6 +251,18 @@ inline Type type_of<uint8_t*>() {
   return x;
 }
 template <>
+inline Type type_of<int32_t*>() {
+  Type x = Int(32);
+  x.set_cpp_handle();
+  return x;
+}
+template <>
+inline Type type_of<int32_t**>() {
+  Type x = Int(32);
+  x.set_cpp_handle2();
+  return x;
+}
+template <>
 inline Type type_of<void*>() {
   Type x = type_of<void>();
   x.set_cpp_handle();

--- a/paddle/cinn/hlir/framework/op_lowering.h
+++ b/paddle/cinn/hlir/framework/op_lowering.h
@@ -47,11 +47,12 @@ class OpLowerer {
         group, apply_op_schedule, apply_group_schedule, apply_pass);
   }
 
-  std::vector<std::pair<ir::SymbolicPredicate, ir::LoweredFunc>> BucketLower(
-      const T& group,
-      bool apply_op_schedule = false,
-      bool apply_group_schedule = true,
-      bool apply_pass = true) {
+  std::vector<std::pair<ir::SymbolicPredicate,
+                        std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
+  BucketLower(const T& group,
+              bool apply_op_schedule = false,
+              bool apply_group_schedule = true,
+              bool apply_pass = true) {
     return impl_->BucketLower(
         group, apply_op_schedule, apply_group_schedule, apply_pass);
   }

--- a/paddle/cinn/hlir/framework/op_lowering.h
+++ b/paddle/cinn/hlir/framework/op_lowering.h
@@ -47,8 +47,8 @@ class OpLowerer {
         group, apply_op_schedule, apply_group_schedule, apply_pass);
   }
 
-  std::vector<std::pair<ir::SymbolicPredicate,
-                        std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
+  std::vector<
+      std::pair<ir::SymbolicPredicate, pir::OpLowererImpl::WrapLoweredFunc>>
   BucketLower(const T& group,
               bool apply_op_schedule = false,
               bool apply_group_schedule = true,

--- a/paddle/cinn/hlir/framework/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/op_lowering_impl.h
@@ -60,11 +60,12 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
                                      bool apply_group_schedule = true,
                                      bool apply_pass = true);
 
-  std::vector<std::pair<ir::SymbolicPredicate, ir::LoweredFunc>> BucketLower(
-      const GroupPtr& group,
-      bool apply_op_schedule = false,
-      bool apply_group_schedule = true,
-      bool apply_pass = true) {
+  std::vector<std::pair<ir::SymbolicPredicate,
+                        std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
+  BucketLower(const GroupPtr& group,
+              bool apply_op_schedule = false,
+              bool apply_group_schedule = true,
+              bool apply_pass = true) {
     CINN_NOT_IMPLEMENTED;
   }
 

--- a/paddle/cinn/hlir/framework/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/op_lowering_impl.h
@@ -60,12 +60,11 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
                                      bool apply_group_schedule = true,
                                      bool apply_pass = true);
 
-  std::vector<std::pair<ir::SymbolicPredicate,
-                        std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
-  BucketLower(const GroupPtr& group,
-              bool apply_op_schedule = false,
-              bool apply_group_schedule = true,
-              bool apply_pass = true) {
+  std::vector<std::pair<ir::SymbolicPredicate, WrapLoweredFunc>> BucketLower(
+      const GroupPtr& group,
+      bool apply_op_schedule = false,
+      bool apply_group_schedule = true,
+      bool apply_pass = true) {
     CINN_NOT_IMPLEMENTED;
   }
 

--- a/paddle/cinn/hlir/framework/op_lowering_impl_base.h
+++ b/paddle/cinn/hlir/framework/op_lowering_impl_base.h
@@ -30,6 +30,10 @@ namespace framework {
 template <typename T>
 class OpLowererImplBase {
  public:
+  struct WrapLoweredFunc {
+    ir::LoweredFunc infer_shape_func;
+    ir::LoweredFunc kernel_func;
+  };
   OpLowererImplBase() = default;
   ~OpLowererImplBase() = default;
 
@@ -38,8 +42,7 @@ class OpLowererImplBase {
                                              bool apply_group_schedule = true,
                                              bool apply_pass = true) = 0;
 
-  virtual std::vector<std::pair<ir::SymbolicPredicate,
-                                std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
+  virtual std::vector<std::pair<ir::SymbolicPredicate, WrapLoweredFunc>>
   BucketLower(const T& group,
               bool apply_op_schedule = false,
               bool apply_group_schedule = true,

--- a/paddle/cinn/hlir/framework/op_lowering_impl_base.h
+++ b/paddle/cinn/hlir/framework/op_lowering_impl_base.h
@@ -38,7 +38,8 @@ class OpLowererImplBase {
                                              bool apply_group_schedule = true,
                                              bool apply_pass = true) = 0;
 
-  virtual std::vector<std::pair<ir::SymbolicPredicate, ir::LoweredFunc>>
+  virtual std::vector<std::pair<ir::SymbolicPredicate,
+                                std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
   BucketLower(const T& group,
               bool apply_op_schedule = false,
               bool apply_group_schedule = true,

--- a/paddle/cinn/hlir/framework/op_lowering_impl_base.h
+++ b/paddle/cinn/hlir/framework/op_lowering_impl_base.h
@@ -31,8 +31,11 @@ template <typename T>
 class OpLowererImplBase {
  public:
   struct WrapLoweredFunc {
-    ir::LoweredFunc infer_shape_func;
     ir::LoweredFunc kernel_func;
+    ir::LoweredFunc infer_shape_func;
+    WrapLoweredFunc(ir::LoweredFunc kernel_func,
+                    ir::LoweredFunc infer_shape_func = ir::LoweredFunc())
+        : infer_shape_func(infer_shape_func), kernel_func(kernel_func) {}
   };
   OpLowererImplBase() = default;
   ~OpLowererImplBase() = default;

--- a/paddle/cinn/hlir/framework/pir/compilation_task.cc
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.cc
@@ -114,6 +114,7 @@ pir::CINNKernelInfo CompilationTask::BuildPirCINNKernelInfo() {
   CHECK(infer_shape_fn_ptr);
   pir::CINNKernelInfo cinn_kernel_info;
   cinn_kernel_info.fn_ptr = fn_ptr;
+  cinn_kernel_info.infer_shape_fn_ptr = infer_shape_fn_ptr;
   cinn_kernel_info.int_args_map = context_->group_->int_args_map;
   return cinn_kernel_info;
 }

--- a/paddle/cinn/hlir/framework/pir/compilation_task.cc
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.cc
@@ -25,14 +25,13 @@ namespace framework {
 
 void GroupCompilationContext::SetLoweredFuncs(
     std::vector<std::pair<ir::SymbolicPredicate,
-                          std::pair<ir::LoweredFunc, ir::LoweredFunc>>>&&
-        funcs) {
-  for (std::pair<ir::SymbolicPredicate,
-                 std::pair<ir::LoweredFunc, ir::LoweredFunc>>& predicate2func :
-       funcs) {
+                          pir::OpLowererImpl::WrapLoweredFunc>>&& funcs) {
+  for (std::pair<ir::SymbolicPredicate, pir::OpLowererImpl::WrapLoweredFunc>&
+           predicate2func : funcs) {
     predicates_.push_back(predicate2func.first);
-    lowered_funcs_.push_back(predicate2func.second.second);
-    infer_shape_lowered_funcs_.push_back(predicate2func.second.first);
+    lowered_funcs_.push_back(predicate2func.second.kernel_func);
+    infer_shape_lowered_funcs_.push_back(
+        predicate2func.second.infer_shape_func);
     ++func_size_;
   }
 }

--- a/paddle/cinn/hlir/framework/pir/compilation_task.cc
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.cc
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "paddle/cinn/hlir/framework/pir/compilation_task.h"
+#include "paddle/cinn/common/target.h"
 #include "paddle/cinn/hlir/framework/op_lowering.h"
 #include "paddle/cinn/ir/module.h"
 
@@ -23,11 +24,15 @@ namespace hlir {
 namespace framework {
 
 void GroupCompilationContext::SetLoweredFuncs(
-    std::vector<std::pair<ir::SymbolicPredicate, ir::LoweredFunc>>&& funcs) {
-  for (std::pair<ir::SymbolicPredicate, ir::LoweredFunc>& predicate2func :
+    std::vector<std::pair<ir::SymbolicPredicate,
+                          std::pair<ir::LoweredFunc, ir::LoweredFunc>>>&&
+        funcs) {
+  for (std::pair<ir::SymbolicPredicate,
+                 std::pair<ir::LoweredFunc, ir::LoweredFunc>>& predicate2func :
        funcs) {
     predicates_.push_back(predicate2func.first);
-    lowered_funcs_.push_back(predicate2func.second);
+    lowered_funcs_.push_back(predicate2func.second.second);
+    infer_shape_lowered_funcs_.push_back(predicate2func.second.first);
     ++func_size_;
   }
 }
@@ -67,12 +72,13 @@ void CompilationTask::CodegenAndJit() {
   ir::Module::Builder builder(cinn::common::UniqName("module"),
                               context_->target_);
   CHECK_EQ(context_->predicates_.size(), context_->lowered_funcs_.size());
-  for (const ir::Expr predicate : context_->predicates_) {
+  for (const ir::Expr& predicate : context_->predicates_) {
     builder.AddPredicate(predicate);
   }
   for (const ir::LoweredFunc& func : context_->lowered_funcs_) {
     builder.AddFunction(func);
   }
+  builder.AddInferShapeFunc(context_->infer_shape_lowered_funcs_[0]);
   ir::Module ir_module = builder.Build();
 
   context_->backend_compiler_ = backends::Compiler::Create(context_->target_);
@@ -90,6 +96,9 @@ std::unique_ptr<Instruction> CompilationTask::BuildInstruction() {
   VLOG(4) << "Lookup kernel name: " << fn_name;
   auto* fn_ptr = context_->backend_compiler_->Lookup(fn_name);
   CHECK(fn_ptr);
+  auto* infer_shape_fn_ptr =
+      context_->backend_compiler_->Lookup(fn_name + "_infer_shape" + fn_name);
+  CHECK(infer_shape_fn_ptr);
   instr->SetLoweredFunc(reinterpret_cast<void*>(fn_ptr), fn_name);
   instr->Finalize();
   return instr;
@@ -100,6 +109,9 @@ pir::CINNKernelInfo CompilationTask::BuildPirCINNKernelInfo() {
   VLOG(4) << "Lookup kernel name: " << fn_name;
   auto* fn_ptr = context_->backend_compiler_->Lookup(fn_name);
   CHECK(fn_ptr);
+  auto* infer_shape_fn_ptr =
+      context_->backend_compiler_->Lookup(fn_name + "_infer_shape");
+  CHECK(infer_shape_fn_ptr);
   pir::CINNKernelInfo cinn_kernel_info;
   cinn_kernel_info.fn_ptr = fn_ptr;
   cinn_kernel_info.int_args_map = context_->group_->int_args_map;

--- a/paddle/cinn/hlir/framework/pir/compilation_task.h
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.h
@@ -33,8 +33,7 @@ class GroupCompilationContext {
 
   void SetLoweredFuncs(
       std::vector<std::pair<ir::SymbolicPredicate,
-                            std::pair<ir::LoweredFunc, ir::LoweredFunc>>>&&
-          funcs);
+                            pir::OpLowererImpl::WrapLoweredFunc>>&& funcs);
   std::string PrintPredicate2Funcs() const;
   void* FuncPtr();
   std::shared_ptr<backends::Compiler> BackendCompiler();

--- a/paddle/cinn/hlir/framework/pir/compilation_task.h
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.h
@@ -32,7 +32,9 @@ class GroupCompilationContext {
       : target_(target), group_(group), scope_(scope) {}
 
   void SetLoweredFuncs(
-      std::vector<std::pair<ir::SymbolicPredicate, ir::LoweredFunc>>&& funcs);
+      std::vector<std::pair<ir::SymbolicPredicate,
+                            std::pair<ir::LoweredFunc, ir::LoweredFunc>>>&&
+          funcs);
   std::string PrintPredicate2Funcs() const;
   void* FuncPtr();
   std::shared_ptr<backends::Compiler> BackendCompiler();
@@ -47,6 +49,7 @@ class GroupCompilationContext {
   size_t func_size_ = 0;
   std::vector<ir::SymbolicPredicate> predicates_;
   std::vector<ir::LoweredFunc> lowered_funcs_;
+  std::vector<ir::LoweredFunc> infer_shape_lowered_funcs_;
   std::string host_func_name_;
   std::string host_code_;
   std::vector<std::string> device_code_;

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -1042,7 +1042,7 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
   std::vector<ir::Expr> ir_bodys;
   int output_tensor_idx = 0;
   for (int tensor_arg_idx = 0; tensor_arg_idx < group_func_arg_tensors.size();
-       tensor_arg_idx++) {
+       ++tensor_arg_idx) {
     if (group_func_args[tensor_arg_idx].is_input()) {
       continue;
     }

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -477,22 +477,22 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
 
     ir::Var tensor_shape_args(TENSOR_SHAPE_ARGS, type_of<int32_t**>());
 
-    if (group_func_args[tensor_arg_idx].is_output()) {
-      for (int i = 0; i < tensor_shape.size(); i++) {
-        ir::Expr call_set_infer_shape_value =
-            ir::Call::Make(type_of<void>(),
-                           runtime::intrinsic::set_value,
-                           {tensor_shape_args,
-                            ir::Expr(tensor_arg_idx),
-                            ir::Expr(i),
-                            tensor_shape[i]},
-                           {},
-                           ir::CallType::Extern,
-                           ir::FunctionRef(),
-                           0);
-        ir_bodys.push_back(call_set_infer_shape_value);
-      }
+    // if (group_func_args[tensor_arg_idx].is_output()) {
+    for (int i = 0; i < tensor_shape.size(); i++) {
+      ir::Expr call_set_infer_shape_value =
+          ir::Call::Make(type_of<void>(),
+                         runtime::intrinsic::set_value,
+                         {tensor_shape_args,
+                          ir::Expr(tensor_arg_idx),
+                          ir::Expr(i),
+                          tensor_shape[i]},
+                         {},
+                         ir::CallType::Extern,
+                         ir::FunctionRef(),
+                         0);
+      ir_bodys.push_back(call_set_infer_shape_value);
     }
+    // }
     for (int tensor_arg_dim_idx = 0; tensor_arg_dim_idx < tensor_dim_size;
          tensor_arg_dim_idx++) {
       if (tensor_dim[tensor_arg_dim_idx]->IsDynamic()) {

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -1064,8 +1064,12 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
     const std::vector<ir::Argument> group_func_args) {
   // CHECK_EQ(group_func_arg_tensors.size(), group_func_args.size());
   std::vector<ir::Expr> ir_bodys;
+  int output_tensor_idx = 0;
   for (int tensor_arg_idx = 0; tensor_arg_idx < group_func_arg_tensors.size();
        tensor_arg_idx++) {
+    if (group_func_args[tensor_arg_idx].is_input()) {
+      continue;
+    }
     auto tensor_dim = group_func_arg_tensors[tensor_arg_idx]->sym_shape;
     int tensor_dim_size = tensor_dim.size();
     auto tensor_shape = group_func_arg_tensors[tensor_arg_idx]->shape;
@@ -1076,7 +1080,7 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
           ir::Call::Make(type_of<void>(),
                          runtime::intrinsic::set_value,
                          {tensor_shape_args,
-                          ir::Expr(tensor_arg_idx),
+                          ir::Expr(output_tensor_idx),
                           ir::Expr(i),
                           tensor_shape[i]},
                          {},
@@ -1085,6 +1089,7 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
                          0);
       ir_bodys.push_back(call_set_infer_shape_value);
     }
+    ++output_tensor_idx;
   }
   ir::LoweredFunc infer_shape_func =
       ir::_LoweredFunc_::Make(group->FuncName() + "_infer_shape",

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -1054,11 +1054,11 @@ ir::LoweredFunc OpLowererImpl::GenerateInferShapeFunc(
     for (int i = 0; i < tensor_shape.size(); i++) {
       ir::Expr call_set_infer_shape_value =
           ir::Call::Make(type_of<void>(),
-                         runtime::intrinsic::set_value,
-                         {tensor_shape_args,
-                          ir::Expr(output_tensor_idx),
+                         runtime::intrinsic::infer_shape_set_value,
+                         {ir::Expr(output_tensor_idx),
                           ir::Expr(i),
-                          tensor_shape[i]},
+                          tensor_shape[i],
+                          tensor_shape_args},
                          {},
                          ir::CallType::Extern,
                          ir::FunctionRef(),

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -70,8 +70,7 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
    * @param apply_group_schedule Whether to schedule at group level.
    * @return The lowered funcs.
    */
-  std::vector<std::pair<ir::SymbolicPredicate,
-                        std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
+  std::vector<std::pair<ir::SymbolicPredicate, OpLowererImpl::WrapLoweredFunc>>
   BucketLower(const GroupPtr& group,
               bool apply_op_schedule = false,
               bool apply_group_schedule = true,
@@ -111,6 +110,7 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
    * applied.
    * @param func_body The scheduled func body of group.
    * @param group_func_arg_tensors Tensors used as the group function arguments.
+   * @param group_func_args Arguments used as the group function arguments.
    * @return The lowered funcs after the post processing.
    */
   std::vector<ir::LoweredFunc> PostProcess(
@@ -118,7 +118,8 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
       const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
       bool done_op_schedule,
       ir::Expr func_body,
-      std::vector<ir::Tensor>* group_func_arg_tensors);
+      std::vector<ir::Tensor>* group_func_arg_tensors,
+      std::vector<ir::Argument>* group_func_args);
 
   /**
    * @brief Lower an Op set to CINN IR.
@@ -214,6 +215,11 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
       const GroupPtr& group,
       const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
       const std::unordered_map<std::string, ir::Tensor>& tmp_tensor_info);
+
+  ir::LoweredFunc GenerateInferShapeFunc(
+      const GroupPtr& group,
+      const std::vector<ir::Tensor> group_func_arg_tensors,
+      const std::vector<ir::Argument> group_func_args);
 
   // Functions used to determine which Ops to schedule at op level, define a
   // policy for each type of group.

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -70,11 +70,12 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
    * @param apply_group_schedule Whether to schedule at group level.
    * @return The lowered funcs.
    */
-  std::vector<std::pair<ir::SymbolicPredicate, ir::LoweredFunc>> BucketLower(
-      const GroupPtr& group,
-      bool apply_op_schedule = false,
-      bool apply_group_schedule = true,
-      bool apply_pass = true);
+  std::vector<std::pair<ir::SymbolicPredicate,
+                        std::pair<ir::LoweredFunc, ir::LoweredFunc>>>
+  BucketLower(const GroupPtr& group,
+              bool apply_op_schedule = false,
+              bool apply_group_schedule = true,
+              bool apply_pass = true);
 
   void InsertNameGeneToScope(std::shared_ptr<Scope> scope);
 

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -216,6 +216,13 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
       const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
       const std::unordered_map<std::string, ir::Tensor>& tmp_tensor_info);
 
+  /**
+   * @brief  Generates the output tensor infer shape function.
+   * @param group The group to be lowered.
+   * @param group_func_arg_tensors Tensors used as the group function arguments.
+   * @param group_func_args Arguments used as the group function arguments.
+   * @return The lowered func to infer output tensor's shape.
+   */
   ir::LoweredFunc GenerateInferShapeFunc(
       const GroupPtr& group,
       const std::vector<ir::Tensor> group_func_arg_tensors,

--- a/paddle/cinn/hlir/framework/pir/utils.h
+++ b/paddle/cinn/hlir/framework/pir/utils.h
@@ -31,6 +31,7 @@ namespace pir {
 
 struct CINNKernelInfo {
   void* fn_ptr;
+  void* infer_shape_fn_ptr;
 
   struct ArgDimIdx {
     int arg_idx;

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -1018,6 +1018,7 @@ struct _Module_ : public ExprNode<_Module_> {
   std::vector<Expr> functions;
   std::vector<Expr> submodules;
   std::vector<Expr> predicates;
+  Expr infer_shape_func;
 
   static ir::Module Make(const std::string& name, Target target);
 

--- a/paddle/cinn/ir/lowered_func.cc
+++ b/paddle/cinn/ir/lowered_func.cc
@@ -398,11 +398,21 @@ void _LoweredFunc_::PrepareArgumentExprs() {
     } else if (arg.type() == type_of<void*>()) {
       pod_cast_expr =
           ir::intrinsics::PodValueToX::Make(load_expr, type_of<void*>());
+    } else if (arg.type() == type_of<int32_t*>()) {
+      pod_cast_expr =
+          ir::intrinsics::PodValueToX::Make(load_expr, type_of<int32_t*>());
+    } else if (arg.type() == type_of<int32_t**>()) {
+      pod_cast_expr =
+          ir::intrinsics::PodValueToX::Make(load_expr, type_of<int32_t**>());
+    } else if (arg.type() == type_of<void**>()) {
+      pod_cast_expr =
+          ir::intrinsics::PodValueToX::Make(load_expr, type_of<void**>());
     } else {
       LOG(ERROR) << "Not supported type [" << arg.type() << "]";
       CINN_NOT_IMPLEMENTED
     }
 
+    VLOG(6) << "args " << i << "convert";
     Expr let_expr = Let::Make(_arg, pod_cast_expr);
     CHECK(let_expr.type().valid());
     argument_prepare_exprs.push_back(let_expr);

--- a/paddle/cinn/ir/module.cc
+++ b/paddle/cinn/ir/module.cc
@@ -53,6 +53,10 @@ void Module::Builder::AddPredicate(ir::Expr predicate) {
   module_->predicates.push_back(predicate);
 }
 
+void Module::Builder::AddInferShapeFunc(ir::Expr infer_shape_func) {
+  module_->infer_shape_func = infer_shape_func;
+}
+
 void Module::Builder::Clear() {
   module_->buffers.clear();
   module_->functions.clear();

--- a/paddle/cinn/ir/module.h
+++ b/paddle/cinn/ir/module.h
@@ -45,6 +45,7 @@ class Module : public ir::IrNodeRef {
     void AddFunctionWithoutOptim(const ir::LoweredFunc& func);
     void AddBuffer(ir::Buffer buffer);
     void AddPredicate(ir::Expr predicate);
+    void AddInferShapeFunc(ir::Expr infer_shape_func);
     void Clear();
     Target::Arch GetTargetArch();
 

--- a/paddle/cinn/ir/utils/ir_copy.cc
+++ b/paddle/cinn/ir/utils/ir_copy.cc
@@ -242,7 +242,7 @@ struct IRCopyVisitor : public ir::IRVisitorRequireReImpl<Expr> {
     std::vector<Expr> functions;
     std::vector<Expr> submodules;
     std::vector<Expr> predicates;
-
+    Expr infer_shape_func;
     for (auto& expr : op->buffers) {
       buffers.push_back(Visit(&expr));
     }
@@ -258,12 +258,16 @@ struct IRCopyVisitor : public ir::IRVisitorRequireReImpl<Expr> {
     for (auto& expr : op->predicates) {
       predicates.push_back(Visit(&expr));
     }
+    if (op->infer_shape_func.defined()) {
+      infer_shape_func = Visit(&op->infer_shape_func);
+    }
 
     auto res = ir::_Module_::Make(op->name, op->target);
     res->buffers = buffers;
     res->functions = functions;
     res->submodules = submodules;
     res->predicates = predicates;
+    res->infer_shape_func = infer_shape_func;
 
     return Expr(res);
   }

--- a/paddle/cinn/runtime/cinn_runtime.cc
+++ b/paddle/cinn/runtime/cinn_runtime.cc
@@ -375,6 +375,9 @@ uint8_t cinn_pod_value_to_uint8(cinn_pod_value_t* value) { return *value; }
 bool cinn_pod_value_to_bool(cinn_pod_value_t* value) { return *value; }
 
 void* cinn_pod_value_to_void_p(cinn_pod_value_t* value) { return *value; }
+int32_t* cinn_pod_value_to_int32_p(cinn_pod_value_t* value) {
+  return reinterpret_cast<int32_t*>(value->data_addr());
+}
 cinn_buffer_t* cinn_pod_value_to_buffer_p(cinn_pod_value_t* value) {
   return *value;
 }

--- a/paddle/cinn/runtime/cinn_runtime.h
+++ b/paddle/cinn/runtime/cinn_runtime.h
@@ -561,6 +561,7 @@ uint8_t cinn_pod_value_to_uint8(cinn_pod_value_t* value);
 bool cinn_pod_value_to_bool(cinn_pod_value_t* value);
 
 void* cinn_pod_value_to_void_p(cinn_pod_value_t* value);
+int32_t* cinn_pod_value_to_int32_p(cinn_pod_value_t* value);
 cinn_buffer_t* cinn_pod_value_to_buffer_p(cinn_pod_value_t* value);
 // @}
 

--- a/paddle/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/paddle/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -434,6 +434,15 @@ CINN_REGISTER_HELPER(cinn_cuda_host_api) {
       .AddInputType<int>()     // index
       .End();
 
+  using cinn::runtime::cuda::set_value;
+  REGISTER_EXTERN_FUNC_HELPER(set_value, cinn::common::DefaultHostTarget())
+      .SetRetType<void>()
+      .AddInputType<int32_t **>()
+      .AddInputType<int>()
+      .AddInputType<int>()
+      .AddInputType<int32_t>()
+      .End();
+
   using cinn::runtime::cuda::cinn_call_cuda_kernel;
   REGISTER_EXTERN_FUNC_HELPER(cinn_call_cuda_kernel,
                               cinn::common::DefaultHostTarget())

--- a/paddle/cinn/runtime/cuda/cuda_intrinsics.cc
+++ b/paddle/cinn/runtime/cuda/cuda_intrinsics.cc
@@ -434,13 +434,14 @@ CINN_REGISTER_HELPER(cinn_cuda_host_api) {
       .AddInputType<int>()     // index
       .End();
 
-  using cinn::runtime::cuda::set_value;
-  REGISTER_EXTERN_FUNC_HELPER(set_value, cinn::common::DefaultHostTarget())
+  using cinn::runtime::cuda::infer_shape_set_value;
+  REGISTER_EXTERN_FUNC_HELPER(infer_shape_set_value,
+                              cinn::common::DefaultHostTarget())
       .SetRetType<void>()
-      .AddInputType<int32_t **>()
       .AddInputType<int>()
       .AddInputType<int>()
       .AddInputType<int32_t>()
+      .AddInputType<int32_t **>()
       .End();
 
   using cinn::runtime::cuda::cinn_call_cuda_kernel;

--- a/paddle/cinn/runtime/cuda/cuda_util.cc
+++ b/paddle/cinn/runtime/cuda/cuda_util.cc
@@ -2748,6 +2748,9 @@ void cinn_gpu_cudnn_pool2d(const std::vector<int> &attrs,
   cudnnDestroyPoolingDescriptor(pooling_desc);
 }
 
+void set_value(int32_t **v, int row, int col, int32_t value) {
+  v[row][col] = value;
+}
 void cinn_gpu_cudnn_softmax(const std::vector<int> &attrs,
                             cinn_buffer_t *input,
                             cinn_buffer_t *output,

--- a/paddle/cinn/runtime/cuda/cuda_util.cc
+++ b/paddle/cinn/runtime/cuda/cuda_util.cc
@@ -2748,7 +2748,7 @@ void cinn_gpu_cudnn_pool2d(const std::vector<int> &attrs,
   cudnnDestroyPoolingDescriptor(pooling_desc);
 }
 
-void set_value(int32_t **v, int row, int col, int32_t value) {
+void infer_shape_set_value(int row, int col, int32_t value, int32_t **v) {
   v[row][col] = value;
 }
 void cinn_gpu_cudnn_softmax(const std::vector<int> &attrs,

--- a/paddle/cinn/runtime/cuda/cuda_util.h
+++ b/paddle/cinn/runtime/cuda/cuda_util.h
@@ -96,7 +96,7 @@ void cinn_call_cuda_memcpy(void* v_args,
                            void* stream = nullptr);
 
 int32_t cinn_get_value_in_cuda_kernel_args(void* v_args, int idx);
-void set_value(int32_t** v, int row, int col, int32_t value);
+void infer_shape_set_value(int row, int col, int32_t value, int32_t** v);
 
 /**
  * Call a CUDA compiled kernel.

--- a/paddle/cinn/runtime/cuda/cuda_util.h
+++ b/paddle/cinn/runtime/cuda/cuda_util.h
@@ -96,6 +96,7 @@ void cinn_call_cuda_memcpy(void* v_args,
                            void* stream = nullptr);
 
 int32_t cinn_get_value_in_cuda_kernel_args(void* v_args, int idx);
+void set_value(int32_t** v, int row, int col, int32_t value);
 
 /**
  * Call a CUDA compiled kernel.

--- a/paddle/cinn/runtime/intrinsic.h
+++ b/paddle/cinn/runtime/intrinsic.h
@@ -107,6 +107,8 @@ static const char* call_cuda_kernel = "cinn_call_cuda_kernel";
 static const char* get_value_in_cuda_kernel_args =
     "cinn_get_value_in_cuda_kernel_args";
 
+static const char* set_value = "set_value";
+
 static const char* pod_values_to_array_repr = "pod_values_to_array";
 
 static const char* get_address_repr = "get_address";

--- a/paddle/cinn/runtime/intrinsic.h
+++ b/paddle/cinn/runtime/intrinsic.h
@@ -107,7 +107,7 @@ static const char* call_cuda_kernel = "cinn_call_cuda_kernel";
 static const char* get_value_in_cuda_kernel_args =
     "cinn_get_value_in_cuda_kernel_args";
 
-static const char* set_value = "set_value";
+static const char* infer_shape_set_value = "infer_shape_set_value";
 
 static const char* pod_values_to_array_repr = "pod_values_to_array";
 

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -84,7 +84,7 @@ class CinnJitInstruction::FnPtrImpl {
 
     // 3. Define an array of Pointers to hold the output tensor shape
     int32_t* output_tensor_shapes[output_tensor_size];
-    for (int i = 0; i < output_tensor_size; i++) {
+    for (int i = 0; i < output_tensor_size; ++i) {
       output_tensor_shapes[i] = reinterpret_cast<int32_t*>(
           malloc(kernel_args[input_tensor_size + i]->dims().size() *
                  sizeof(int32_t*)));
@@ -97,7 +97,7 @@ class CinnJitInstruction::FnPtrImpl {
         output_tensor_shapes);
 
     // 5. Resize shape of output tensor
-    for (int i = 0; i < output_tensor_size; i++) {
+    for (int i = 0; i < output_tensor_size; ++i) {
       DDim dim(output_tensor_shapes[i],
                kernel_args[input_tensor_size + i]->dims().size());
       kernel_args[input_tensor_size + i]->Resize(dim);

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
@@ -49,7 +49,8 @@ class CinnJitInstruction : public InstructionBase {
 
   phi::DeviceContext* dev_ctx_;
 
-  phi::DenseTensor* out_tensor_;
+  int32_t input_tensor_size;
+  int32_t output_tensor_size;
 
   std::vector<phi::DenseTensor*> tensor_args_;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

Pcard-78120

通过二维指针来返回后端infer shape的结果。生成的cinn ir如下。tensor_shape_args是一个二维指针。  infer_shape_set_value(0, 0, S1, tensor_shape_args) 表示将第0个output tensor的第0维设置为S1。
```cpp
|| 633: function fn_exp_subtract_infer_shape (kernel_args, kernel_args_num, tensor_shape_args)
|| 633: {
|| 633:   int32 S0 = cinn_get_value_in_cuda_kernel_args(kernel_args, 3)
|| 633:   int32 S1 = cinn_get_value_in_cuda_kernel_args(kernel_args, 4)
|| 633:   {
|| 633:     infer_shape_set_value(0, 0, S1, tensor_shape_args)
|| 633:     infer_shape_set_value(0, 1, 128, tensor_shape_args)
|| 633:     infer_shape_set_value(1, 0, S1, tensor_shape_args)
|| 633:     infer_shape_set_value(1, 1, 128, tensor_shape_args)
|| 633:   }
|| 633: }

```