### PR TITLE
[PIR] Support Operation::Clone Interface

### DIFF
--- a/paddle/cinn/hlir/framework/pir/group.h
+++ b/paddle/cinn/hlir/framework/pir/group.h
@@ -59,7 +59,7 @@ struct Group {
       : ops(group_ops) {}
 
   Group& Clone(::pir::Block* target_block,
-               ::pir::IRMapping& ir_mapping,
+               ::pir::IrMapping& ir_mapping,
                const Options& option = Options()) const {
     CHECK_EQ(option.OnlyCloneOps(), true)
         << "Only Support Clone Group ops information.";
@@ -68,7 +68,10 @@ struct Group {
     std::unordered_map<::pir::Operation*, ::pir::Operation*> ops_mapper;
     ::pir::CloneOptions clone_options(false, true);
     for (auto* op : this->ops_set) {
-      auto* new_op = op->Clone(target_block, ir_mapping, clone_options);
+      auto* new_op = op->Clone(ir_mapping, clone_options);
+      // NOTE(dev): Must call MoveTo to deal with ownership, otherwise it
+      // will lead memory-leak.
+      new_op->MoveTo(target_block);
       new_ops.push_back(new_op);
       ops_mapper[op] = new_op;
     }

--- a/paddle/cinn/hlir/framework/pir/group.h
+++ b/paddle/cinn/hlir/framework/pir/group.h
@@ -71,7 +71,7 @@ struct Group {
       auto* new_op = op->Clone(ir_mapping, clone_options);
       // NOTE(dev): Must call MoveTo to deal with ownership, otherwise it
       // will lead memory-leak.
-      new_op->MoveTo(target_block);
+      new_op->MoveTo(target_block, target_block->end());
       new_ops.push_back(new_op);
       ops_mapper[op] = new_op;
     }

--- a/paddle/cinn/hlir/framework/pir/group.h
+++ b/paddle/cinn/hlir/framework/pir/group.h
@@ -14,7 +14,9 @@
 
 #pragma once
 #include <string>
+#include <unordered_map>
 #include <vector>
+#include "glog/logging.h"
 
 #include "paddle/cinn/adt/graph_symbolic_dim_infer_ctx.h"
 #include "paddle/cinn/hlir/framework/op.h"
@@ -34,8 +36,17 @@ namespace framework {
 namespace pir {
 using framework::OpPatternKind;
 
-// TODO(Aurelius84): Need to be replaced with CinnGroupOp
 struct Group {
+  // Control the clone strategy for Group.
+  class Options {
+   public:
+    Options() : only_clone_ops(true) {}
+    bool OnlyCloneOps() const { return only_clone_ops; }
+
+   private:
+    bool only_clone_ops = false;
+  };
+
  public:
   Group() = default;
   Group(const Group&) = delete;
@@ -46,6 +57,33 @@ struct Group {
 
   explicit Group(std::initializer_list<::pir::Operation*> group_ops)
       : ops(group_ops) {}
+
+  Group& Clone(::pir::Block* target_block,
+               ::pir::IRMapping& ir_mapping,
+               const Options& option = Options()) const {
+    CHECK_EQ(option.OnlyCloneOps(), true)
+        << "Only Support Clone Group ops information.";
+    std::vector<::pir::Operation*> new_ops;
+    // Mapper from original to new ops.
+    std::unordered_map<::pir::Operation*, ::pir::Operation*> ops_mapper;
+    ::pir::CloneOptions clone_options(false, true);
+    for (auto* op : this->ops_set) {
+      auto* new_op = op->Clone(target_block, ir_mapping, clone_options);
+      new_ops.push_back(new_op);
+      ops_mapper[op] = new_op;
+    }
+    // Construct Base information for new Group
+    Group new_group(new_ops);
+    this->CollectOps();
+    for (auto& iter : this->input_ops) {
+      new_group.input_ops[ops_mapper[iter.first]] = iter.second;
+    }
+    for (auto* op : this->output_ops) {
+      new_group.output_ops.insert(ops_mapper[op]);
+    }
+
+    return new_group;
+  }
 
   // distance to last group.
   int depth{0};

--- a/paddle/cinn/hlir/framework/pir/group.h
+++ b/paddle/cinn/hlir/framework/pir/group.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -58,9 +59,9 @@ struct Group {
   explicit Group(std::initializer_list<::pir::Operation*> group_ops)
       : ops(group_ops) {}
 
-  Group& Clone(::pir::Block* target_block,
-               ::pir::IrMapping& ir_mapping,
-               const Options& option = Options()) const {
+  std::shared_ptr<Group> Clone(::pir::Block* target_block,
+                               ::pir::IrMapping& ir_mapping,
+                               const Options& option = Options()) const {
     CHECK_EQ(option.OnlyCloneOps(), true)
         << "Only Support Clone Group ops information.";
     std::vector<::pir::Operation*> new_ops;
@@ -76,13 +77,13 @@ struct Group {
       ops_mapper[op] = new_op;
     }
     // Construct Base information for new Group
-    Group new_group(new_ops);
+    auto new_group = std::make_shared<Group>(new_ops);
     this->CollectOps();
     for (auto& iter : this->input_ops) {
-      new_group.input_ops[ops_mapper[iter.first]] = iter.second;
+      new_group->input_ops[ops_mapper[iter.first]] = iter.second;
     }
     for (auto* op : this->output_ops) {
-      new_group.output_ops.insert(ops_mapper[op]);
+      new_group->output_ops.insert(ops_mapper[op]);
     }
 
     return new_group;

--- a/paddle/pir/core/ir_mapping.h
+++ b/paddle/pir/core/ir_mapping.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <unordered_map>
+#include "paddle/common/enforce.h"
+#include "paddle/pir/core/block.h"
+
+namespace pir {
+
+class IRMapping {
+ public:
+  void map(Value from, Value to) { value_map_[from] = to; }
+
+  Value lookup(Value from) const {
+    IR_ENFORCE(value_map_.count(from) > 0, "Not Found Value in IRMapping.");
+    return value_map_.at(from);
+  }
+  void earse(Value from) { value_map_.erase(from); }
+
+  void clear() { value_map_.clear(); }
+
+ private:
+  std::unordered_map<Value, Value> value_map_;
+};
+
+}  // namespace pir

--- a/paddle/pir/core/ir_mapping.h
+++ b/paddle/pir/core/ir_mapping.h
@@ -18,17 +18,17 @@
 
 namespace pir {
 
-class IRMapping {
+class IrMapping {
  public:
-  void map(Value from, Value to) { value_map_[from] = to; }
+  void Add(Value from, Value to) { value_map_[from] = to; }
 
-  Value lookup(Value from) const {
+  Value Lookup(Value from) const {
     IR_ENFORCE(value_map_.count(from) > 0, "Not Found Value in IRMapping.");
     return value_map_.at(from);
   }
-  void earse(Value from) { value_map_.erase(from); }
+  void Earse(Value from) { value_map_.erase(from); }
 
-  void clear() { value_map_.clear(); }
+  void Clear() { value_map_.clear(); }
 
  private:
   std::unordered_map<Value, Value> value_map_;

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -157,7 +157,7 @@ Operation *Operation::Clone(IrMapping &ir_mapping, CloneOptions options) {
   }
   auto *new_op = Create(inputs, attributes_, output_types, info_, num_regions_);
   // record outputs mapping info
-  for (int i = 0; i < num_results_; ++i) {
+  for (uint32_t i = 0; i < num_results_; ++i) {
     ir_mapping.Add(result(i), new_op->result(i));
   }
   return new_op;

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -137,9 +137,7 @@ Operation *Operation::Create(const std::vector<Value> &inputs,
   return op;
 }
 
-Operation *Operation::Clone(Block *target_block,
-                            IRMapping &ir_mapping,
-                            CloneOptions options) {
+Operation *Operation::Clone(IrMapping &ir_mapping, CloneOptions options) {
   IR_ENFORCE(options.IsCloneRegions() || num_regions_ > 0,
              "Operation CloneOperands is unimplemented currently.");
   IR_ENFORCE(num_successors_ == 0,
@@ -162,8 +160,6 @@ Operation *Operation::Clone(Block *target_block,
   for (int i = 0; i < num_results_; ++i) {
     ir_mapping.map(result(i), new_op->result(i));
   }
-  // transfer ownership into target block
-  new_op->MoveTo(target_block, target_block->end());
   return new_op;
 }
 

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -147,7 +147,7 @@ Operation *Operation::Clone(IrMapping &ir_mapping, CloneOptions options) {
   if (options.IsCloneOperands()) {
     // replace value by IRMapping inplacely.
     for (auto &value : inputs) {
-      value = ir_mapping.lookup(value);
+      value = ir_mapping.Lookup(value);
     }
   }
 
@@ -158,7 +158,7 @@ Operation *Operation::Clone(IrMapping &ir_mapping, CloneOptions options) {
   auto *new_op = Create(inputs, attributes_, output_types, info_, num_regions_);
   // record outputs mapping info
   for (int i = 0; i < num_results_; ++i) {
-    ir_mapping.map(result(i), new_op->result(i));
+    ir_mapping.Add(result(i), new_op->result(i));
   }
   return new_op;
 }

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -70,10 +70,8 @@ class IR_API alignas(8) Operation final
 
   ///
   /// \brief Deep copy all information and create a new operation.
-  /// TODO(dev): Need hidden target_block argument in the future.
   ///
-  Operation *Clone(Block *target_block,
-                   IRMapping &ir_mapping,
+  Operation *Clone(IrMapping &ir_mapping,
                    CloneOptions options = CloneOptions());
   ///
   /// \brief Destroy the operation objects and free memory by create().


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164

## What's New?

给Operation 添加了Clone接口，并增加了`IRMapping` 和`CloneOptions` 分别管理Value映射和Clone策略。

此PR为支持CINN的动态shape需求，提供的初级Clone功能，尚需完善如下维度：
+ IRMapping 成员扩充对Block、Operation的映射关系管理
+ IRMapping 丰富更多增删改的方法，并通过便捷的模版函数精简代码
+ CloneOptions 里丰富更多的策略控制
+ Clone 接口里添加对复杂Operation的Region、Successors 信息clone的支持