### PR TITLE
[Custom Device]Remove ClearPass to allow Custom Device use fusion under fp16

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1781,7 +1781,6 @@ void AnalysisPredictor::PrepareArgument() {
   argument_->SetEnableCustomDeviceMixed(config_.enable_custom_device_mixed());
   if (config_.enable_custom_device_mixed_) {
     argument_->SetEnableIrOptim(true);
-    pass_builder->ClearPasses();
     pass_builder->AppendPass("auto_mixed_precision_pass");
     LOG(INFO) << "This model run in Custom Device mixed precision mode.";
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
鉴于https://github.com/PaddlePaddle/Paddle/issues/60476

Custom Device已经可以通过在Paddle Inference启用算子融合
```cpp
        config.pass_builder()->AppendPass("conv_bn_fuse_pass");
        config.pass_builder()->AppendPass("conv_eltwiseadd_bn_fuse_pass");
        config.pass_builder()->AppendPass("conv_elementwise_add_act_fuse_pass");
        config.pass_builder()->AppendPass("conv_elementwise_add_fuse_pass");
```
只需要完成对应的kernel即可。

但是这里有一个古老的问题存在
Custom Device在FP16模式下，会进行ClearPass的操作。
当时，未考虑Custom Device支持Fusion的情况。
导致使用FP16混合精度时，算子融合Pass会被清除，只能在FP32使用。

现在，这个ClearPass已经是多余的了。删除后，可以让Custom Device正常使用FP16的融合算子。
