### PR TITLE
【auto parallel】剔除切分推导相关的头文件对proto 的依赖

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/fluid/distributed/auto_parallel/dist_attr.cc
@@ -17,11 +17,11 @@ limitations under the License. */
 #include <iterator>
 
 #include "paddle/fluid/distributed/auto_parallel/dist_attr.h"
-#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/framework/var_desc.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
 namespace paddle {
 namespace distributed {
@@ -407,14 +407,17 @@ OperatorDistAttrProto OperatorDistAttr::to_proto() const {
   for (const auto& item : input_dist_attrs_) {
     auto proto_item = proto.mutable_input_dist_attrs()->Add();
     proto_item->set_name(item.first);
-    proto_item->mutable_tensor_dist_attr()->CopyFrom(phi::distributed::to_proto(item.second));
+    proto_item->mutable_tensor_dist_attr()->CopyFrom(
+        phi::distributed::to_proto(item.second));
   }
   for (const auto& item : output_dist_attrs_) {
     auto proto_item = proto.mutable_output_dist_attrs()->Add();
     proto_item->set_name(item.first);
-    proto_item->mutable_tensor_dist_attr()->CopyFrom(phi::distributed::to_proto(item.second));
+    proto_item->mutable_tensor_dist_attr()->CopyFrom(
+        phi::distributed::to_proto(item.second));
   }
-  proto.mutable_process_mesh()->CopyFrom(phi::distributed::to_proto(process_mesh_));
+  proto.mutable_process_mesh()->CopyFrom(
+      phi::distributed::to_proto(process_mesh_));
   proto.set_impl_type(impl_type_);
   proto.set_impl_idx(impl_idx_);
   proto.set_chunk_id(chunk_id_);

--- a/paddle/fluid/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/fluid/distributed/auto_parallel/dist_attr.cc
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <iterator>
 
 #include "paddle/fluid/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/program_desc.h"
@@ -406,14 +407,14 @@ OperatorDistAttrProto OperatorDistAttr::to_proto() const {
   for (const auto& item : input_dist_attrs_) {
     auto proto_item = proto.mutable_input_dist_attrs()->Add();
     proto_item->set_name(item.first);
-    proto_item->mutable_tensor_dist_attr()->CopyFrom(item.second.to_proto());
+    proto_item->mutable_tensor_dist_attr()->CopyFrom(phi::distributed::to_proto(item.second));
   }
   for (const auto& item : output_dist_attrs_) {
     auto proto_item = proto.mutable_output_dist_attrs()->Add();
     proto_item->set_name(item.first);
-    proto_item->mutable_tensor_dist_attr()->CopyFrom(item.second.to_proto());
+    proto_item->mutable_tensor_dist_attr()->CopyFrom(phi::distributed::to_proto(item.second));
   }
-  proto.mutable_process_mesh()->CopyFrom(process_mesh_.to_proto());
+  proto.mutable_process_mesh()->CopyFrom(phi::distributed::to_proto(process_mesh_));
   proto.set_impl_type(impl_type_);
   proto.set_impl_idx(impl_idx_);
   proto.set_chunk_id(chunk_id_);

--- a/paddle/phi/core/distributed/auto_parallel/CMakeLists.txt
+++ b/paddle/phi/core/distributed/auto_parallel/CMakeLists.txt
@@ -9,6 +9,7 @@ collect_srcs(
   dist_mapper.cc
   dist_tensor.cc
   dist_meta_tensor.cc
+  proto_helper.cc
   placement_types.cc
   inferspmd_utils.cc)
 

--- a/paddle/phi/core/distributed/auto_parallel/device_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/device_mesh.cc
@@ -17,7 +17,7 @@ limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
 #include "paddle/phi/core/distributed/auto_parallel/utils.h"
-
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 namespace phi {
 namespace distributed {
 namespace auto_parallel {
@@ -41,13 +41,11 @@ DeviceCapability DeviceCapability::from_proto(
   return capability;
 }
 
-DeviceCapabilityProto DeviceCapability::to_proto() const {
-  DeviceCapabilityProto proto;
-  proto.set_single_precision_flops(single_precision_flops);
-  proto.set_double_precision_flops(double_precision_flops);
-  proto.set_memory_size_in_bytes(memory_size_in_bytes);
-  proto.set_clock_rate_in_ghz(clock_rate_in_ghz);
-  return proto;
+void DeviceCapability::to_proto(DeviceCapabilityProto* proto) const {
+  proto->set_single_precision_flops(single_precision_flops);
+  proto->set_double_precision_flops(double_precision_flops);
+  proto->set_memory_size_in_bytes(memory_size_in_bytes);
+  proto->set_clock_rate_in_ghz(clock_rate_in_ghz);
 }
 
 std::string Device::to_string() const {
@@ -69,14 +67,12 @@ Device Device::from_proto(const DeviceProto &proto) {
   return device;
 }
 
-DeviceProto Device::to_proto() const {
-  DeviceProto proto;
-  proto.set_global_id(global_id_);
-  proto.set_local_id(local_id_);
-  proto.set_machine_id(machine_id_);
-  proto.set_type(type_);
-  proto.mutable_capability()->CopyFrom(capability_.to_proto());
-  return proto;
+void Device::to_proto(DeviceProto* proto) const {
+  proto->set_global_id(global_id_);
+  proto->set_local_id(local_id_);
+  proto->set_machine_id(machine_id_);
+  proto->set_type(type_);
+  proto->mutable_capability()->CopyFrom(phi::distributed::to_proto(capability_));
 }
 
 bool operator==(const Device &lhs, const Device &rhs) {
@@ -109,11 +105,9 @@ LinkCapability LinkCapability::from_proto(const LinkCapabilityProto &proto) {
   return capability;
 }
 
-LinkCapabilityProto LinkCapability::to_proto() const {
-  LinkCapabilityProto proto;
-  proto.set_bandwidth(bandwidth);
-  proto.set_latency(latency);
-  return proto;
+void LinkCapability::to_proto(LinkCapabilityProto* proto) const {
+  proto->set_bandwidth(bandwidth);
+  proto->set_latency(latency);
 }
 
 std::string Link::to_string() const {
@@ -133,13 +127,11 @@ Link Link::from_proto(const LinkProto &proto) {
   return link;
 }
 
-LinkProto Link::to_proto() const {
-  LinkProto proto;
-  proto.set_source_id(source_id_);
-  proto.set_target_id(target_id_);
-  proto.set_type(type_);
-  proto.mutable_capability()->CopyFrom(capability_.to_proto());
-  return proto;
+void Link::to_proto(LinkProto* proto) const {
+  proto->set_source_id(source_id_);
+  proto->set_target_id(target_id_);
+  proto->set_type(type_);
+  proto->mutable_capability()->CopyFrom(phi::distributed::to_proto(capability_));
 }
 
 bool operator==(const Link &lhs, const Link &rhs) {
@@ -355,34 +347,30 @@ DeviceMesh DeviceMesh::from_proto(const DeviceMeshProto &proto) {
   return mesh;
 }
 
-DeviceMeshProto DeviceMesh::to_proto() const {
-  DeviceMeshProto proto;
-
-  proto.set_name(name_);
+void DeviceMesh::to_proto(DeviceMeshProto* proto) const {
+  proto->set_name(name_);
 
   for (const auto &i : shape_) {
-    proto.add_shape(i);
+    proto->add_shape(i);
   }
 
   for (const auto &i : device_ids_) {
-    proto.add_device_ids(i);
+    proto->add_device_ids(i);
   }
 
   for (const auto &i : dim_names_) {
-    proto.add_dim_names(i);
+    proto->add_dim_names(i);
   }
 
   for (const auto &device : devices_) {
-    proto.mutable_devices()->Add()->CopyFrom(device.second.to_proto());
+    proto->mutable_devices()->Add()->CopyFrom(phi::distributed::to_proto(device.second));
   }
 
   for (const auto &neighbors : links_) {
     for (const auto &link : neighbors.second) {
-      proto.mutable_links()->Add()->CopyFrom(link.second.to_proto());
+      proto->mutable_links()->Add()->CopyFrom(phi::distributed::to_proto(link.second));
     }
   }
-
-  return proto;
 }
 
 bool operator==(const DeviceMesh &lhs, const DeviceMesh &rhs) {

--- a/paddle/phi/core/distributed/auto_parallel/device_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/device_mesh.cc
@@ -16,8 +16,8 @@ limitations under the License. */
 #include <iterator>
 
 #include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
-#include "paddle/phi/core/distributed/auto_parallel/utils.h"
 #include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
 namespace phi {
 namespace distributed {
 namespace auto_parallel {
@@ -41,7 +41,7 @@ DeviceCapability DeviceCapability::from_proto(
   return capability;
 }
 
-void DeviceCapability::to_proto(DeviceCapabilityProto* proto) const {
+void DeviceCapability::to_proto(DeviceCapabilityProto *proto) const {
   proto->set_single_precision_flops(single_precision_flops);
   proto->set_double_precision_flops(double_precision_flops);
   proto->set_memory_size_in_bytes(memory_size_in_bytes);
@@ -67,12 +67,13 @@ Device Device::from_proto(const DeviceProto &proto) {
   return device;
 }
 
-void Device::to_proto(DeviceProto* proto) const {
+void Device::to_proto(DeviceProto *proto) const {
   proto->set_global_id(global_id_);
   proto->set_local_id(local_id_);
   proto->set_machine_id(machine_id_);
   proto->set_type(type_);
-  proto->mutable_capability()->CopyFrom(phi::distributed::to_proto(capability_));
+  proto->mutable_capability()->CopyFrom(
+      phi::distributed::to_proto(capability_));
 }
 
 bool operator==(const Device &lhs, const Device &rhs) {
@@ -105,7 +106,7 @@ LinkCapability LinkCapability::from_proto(const LinkCapabilityProto &proto) {
   return capability;
 }
 
-void LinkCapability::to_proto(LinkCapabilityProto* proto) const {
+void LinkCapability::to_proto(LinkCapabilityProto *proto) const {
   proto->set_bandwidth(bandwidth);
   proto->set_latency(latency);
 }
@@ -127,11 +128,12 @@ Link Link::from_proto(const LinkProto &proto) {
   return link;
 }
 
-void Link::to_proto(LinkProto* proto) const {
+void Link::to_proto(LinkProto *proto) const {
   proto->set_source_id(source_id_);
   proto->set_target_id(target_id_);
   proto->set_type(type_);
-  proto->mutable_capability()->CopyFrom(phi::distributed::to_proto(capability_));
+  proto->mutable_capability()->CopyFrom(
+      phi::distributed::to_proto(capability_));
 }
 
 bool operator==(const Link &lhs, const Link &rhs) {
@@ -347,7 +349,7 @@ DeviceMesh DeviceMesh::from_proto(const DeviceMeshProto &proto) {
   return mesh;
 }
 
-void DeviceMesh::to_proto(DeviceMeshProto* proto) const {
+void DeviceMesh::to_proto(DeviceMeshProto *proto) const {
   proto->set_name(name_);
 
   for (const auto &i : shape_) {
@@ -363,12 +365,14 @@ void DeviceMesh::to_proto(DeviceMeshProto* proto) const {
   }
 
   for (const auto &device : devices_) {
-    proto->mutable_devices()->Add()->CopyFrom(phi::distributed::to_proto(device.second));
+    proto->mutable_devices()->Add()->CopyFrom(
+        phi::distributed::to_proto(device.second));
   }
 
   for (const auto &neighbors : links_) {
     for (const auto &link : neighbors.second) {
-      proto->mutable_links()->Add()->CopyFrom(phi::distributed::to_proto(link.second));
+      proto->mutable_links()->Add()->CopyFrom(
+          phi::distributed::to_proto(link.second));
     }
   }
 }

--- a/paddle/phi/core/distributed/auto_parallel/device_mesh.h
+++ b/paddle/phi/core/distributed/auto_parallel/device_mesh.h
@@ -30,6 +30,13 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 namespace auto_parallel {
+
+class DeviceCapabilityProto;
+class DeviceProto;
+class LinkCapabilityProto;
+class LinkProto;
+class DeviceMeshProto;
+
 struct DeviceCapability {
   double single_precision_flops = 0.0;
   double double_precision_flops = 0.0;
@@ -40,7 +47,7 @@ struct DeviceCapability {
   std::string to_string() const;
 
   static DeviceCapability from_proto(const DeviceCapabilityProto& proto);
-  DeviceCapabilityProto to_proto() const;
+  void to_proto(DeviceCapabilityProto* proto) const;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const DeviceCapability& obj) {
@@ -74,7 +81,7 @@ class Device {
   std::string to_string() const;
 
   static Device from_proto(const DeviceProto& proto);
-  DeviceProto to_proto() const;
+  void to_proto(DeviceProto* proto) const;
 
  private:
   int64_t global_id_;
@@ -103,7 +110,7 @@ struct LinkCapability {
   std::string to_string() const;
 
   static LinkCapability from_proto(const LinkCapabilityProto& proto);
-  LinkCapabilityProto to_proto() const;
+  void to_proto(LinkCapabilityProto* proto) const;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const LinkCapability& obj) {
@@ -131,7 +138,7 @@ class Link {
   std::string to_string() const;
 
   static Link from_proto(const LinkProto& proto);
-  LinkProto to_proto() const;
+  void to_proto(LinkProto* proto) const;
 
  private:
   int64_t source_id_;
@@ -273,7 +280,7 @@ class DeviceMesh {
   std::string to_string() const;
 
   static DeviceMesh from_proto(const DeviceMeshProto& proto);
-  DeviceMeshProto to_proto() const;
+  void to_proto(DeviceMeshProto* proto) const;
 
  private:
   std::string name_;

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
 #include <algorithm>
 #include <iostream>
@@ -308,25 +309,23 @@ void TensorDistAttr::from_proto(const TensorDistAttrProto& proto) {
   }
 }
 
-TensorDistAttrProto TensorDistAttr::to_proto() const {
-  TensorDistAttrProto proto;
-  proto.mutable_process_mesh()->CopyFrom(process_mesh_.to_proto());
+void TensorDistAttr::to_proto(TensorDistAttrProto* proto) const {
+  proto->mutable_process_mesh()->CopyFrom(phi::distributed::to_proto(process_mesh_));
   for (const auto& i : dims_mapping_) {
-    proto.add_dims_mapping(i);
+    proto->add_dims_mapping(i);
   }
-  proto.set_batch_dim(batch_dim_);
-  proto.set_chunk_id(chunk_id_);
+  proto->set_batch_dim(batch_dim_);
+  proto->set_chunk_id(chunk_id_);
   for (const auto& i : dynamic_dims_) {
-    proto.add_dynamic_dims(i);
+    proto->add_dynamic_dims(i);
   }
-  return proto;
 }
 
 std::string TensorDistAttr::serialize_to_string() {
   std::string data;
-  auto proto = to_proto();
+  auto proto = phi::distributed::to_proto(*this);
   proto.SerializeToString(&data);
-  PADDLE_ENFORCE_EQ(to_proto().SerializeToString(&data),
+  PADDLE_ENFORCE_EQ(phi::distributed::to_proto(*this).SerializeToString(&data),
                     true,
                     errors::InvalidArgument(
                         "Failed to serialize tensor dist attr to string."));

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
@@ -13,13 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
-#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
 #include <algorithm>
 #include <iostream>
 #include <iterator>
 
 #include "glog/logging.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
 namespace phi {
 namespace distributed {
@@ -310,7 +310,8 @@ void TensorDistAttr::from_proto(const TensorDistAttrProto& proto) {
 }
 
 void TensorDistAttr::to_proto(TensorDistAttrProto* proto) const {
-  proto->mutable_process_mesh()->CopyFrom(phi::distributed::to_proto(process_mesh_));
+  proto->mutable_process_mesh()->CopyFrom(
+      phi::distributed::to_proto(process_mesh_));
   for (const auto& i : dims_mapping_) {
     proto->add_dims_mapping(i);
   }

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.h
@@ -22,7 +22,6 @@ limitations under the License. */
 #include <vector>
 
 #include "paddle/phi/common/reduce_type.h"
-#include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
 #include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
 #include "paddle/phi/core/distributed/auto_parallel/utils.h"
 #include "paddle/phi/core/enforce.h"
@@ -31,6 +30,10 @@ limitations under the License. */
 
 namespace phi {
 namespace distributed {
+
+namespace auto_parallel{
+  class TensorDistAttrProto;
+}  
 
 constexpr int kReplicateDim = -1;
 
@@ -169,7 +172,7 @@ class TEST_API TensorDistAttr {
   // future partial-support-stage-II.
   void from_proto(const auto_parallel::TensorDistAttrProto& proto);
 
-  auto_parallel::TensorDistAttrProto to_proto() const;
+  void to_proto(auto_parallel::TensorDistAttrProto* proto) const;
 
   std::string serialize_to_string();
 

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.h
@@ -31,9 +31,9 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-namespace auto_parallel{
-  class TensorDistAttrProto;
-}  
+namespace auto_parallel {
+class TensorDistAttrProto;
+}
 
 constexpr int kReplicateDim = -1;
 

--- a/paddle/phi/core/distributed/auto_parallel/dist_mapper.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_mapper.cc
@@ -15,9 +15,8 @@ limitations under the License. */
 #include <algorithm>
 
 #include "paddle/phi/core/distributed/auto_parallel/dist_mapper.h"
-#include "paddle/phi/core/distributed/auto_parallel/utils.h"
 #include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
-
+#include "paddle/phi/core/distributed/auto_parallel/utils.h"
 
 namespace phi {
 namespace distributed {
@@ -95,7 +94,8 @@ DistributedMapper DistributedMapper::from_proto(
 
 void DistributedMapper::to_proto(DistributedMapperProto* proto) const {
   for (const auto& item : device_meshes_) {
-    proto->mutable_device_meshes()->Add()->CopyFrom(phi::distributed::to_proto(item.second));
+    proto->mutable_device_meshes()->Add()->CopyFrom(
+        phi::distributed::to_proto(item.second));
   }
   for (const auto& outer : process_id_to_device_ids_) {
     auto proto_item = proto->mutable_process_id_to_device_ids()->Add();

--- a/paddle/phi/core/distributed/auto_parallel/dist_mapper.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_mapper.cc
@@ -16,6 +16,8 @@ limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/dist_mapper.h"
 #include "paddle/phi/core/distributed/auto_parallel/utils.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
+
 
 namespace phi {
 namespace distributed {
@@ -91,20 +93,18 @@ DistributedMapper DistributedMapper::from_proto(
   return dist_mapper;
 }
 
-DistributedMapperProto DistributedMapper::to_proto() const {
-  DistributedMapperProto proto;
+void DistributedMapper::to_proto(DistributedMapperProto* proto) const {
   for (const auto& item : device_meshes_) {
-    proto.mutable_device_meshes()->Add()->CopyFrom(item.second.to_proto());
+    proto->mutable_device_meshes()->Add()->CopyFrom(phi::distributed::to_proto(item.second));
   }
   for (const auto& outer : process_id_to_device_ids_) {
-    auto proto_item = proto.mutable_process_id_to_device_ids()->Add();
+    auto proto_item = proto->mutable_process_id_to_device_ids()->Add();
     proto_item->set_process_id(outer.first);
     proto_item->set_device_mesh_name(outer.second.first);
     for (const auto& inner : outer.second.second) {
       proto_item->add_device_ids(inner);
     }
   }
-  return proto;
 }
 
 std::string DistributedMapper::to_string() const {

--- a/paddle/phi/core/distributed/auto_parallel/dist_mapper.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_mapper.h
@@ -15,13 +15,14 @@ limitations under the License. */
 
 #include <utility>
 
-#include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
 #include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
 #include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
 
 namespace phi {
 namespace distributed {
 namespace auto_parallel {
+
+class DistributedMapperProto;  
 
 class DistributedMapper {
  public:
@@ -52,7 +53,7 @@ class DistributedMapper {
   std::string to_string() const;
 
   static DistributedMapper from_proto(const DistributedMapperProto& proto);
-  DistributedMapperProto to_proto() const;
+  void to_proto(DistributedMapperProto* proto) const;
 
  private:
   std::map<std::string, DeviceMesh> device_meshes_;

--- a/paddle/phi/core/distributed/auto_parallel/dist_mapper.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_mapper.h
@@ -22,7 +22,7 @@ namespace phi {
 namespace distributed {
 namespace auto_parallel {
 
-class DistributedMapperProto;  
+class DistributedMapperProto;
 
 class DistributedMapper {
  public:

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
@@ -16,7 +16,6 @@ limitations under the License. */
 
 #include <algorithm>
 #include <iterator>
-
 #include "paddle/phi/core/distributed/auto_parallel/utils.h"
 
 namespace phi {
@@ -105,22 +104,18 @@ ProcessMesh ProcessMesh::from_proto(const ProcessMeshProto &proto) {
   return mesh;
 }
 
-ProcessMeshProto ProcessMesh::to_proto() const {
-  ProcessMeshProto proto;
-
+void ProcessMesh::to_proto(ProcessMeshProto* proto) const {
   for (const auto &i : shape_) {
-    proto.add_shape(i);
+    proto->add_shape(i);
   }
 
   for (const auto &i : process_ids_) {
-    proto.add_process_ids(i);
+    proto->add_process_ids(i);
   }
 
   for (const auto &i : dim_names_) {
-    proto.add_dim_names(i);
+    proto->add_dim_names(i);
   }
-
-  return proto;
 }
 
 bool operator==(const ProcessMesh &lhs, const ProcessMesh &rhs) {

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
@@ -104,7 +104,7 @@ ProcessMesh ProcessMesh::from_proto(const ProcessMeshProto &proto) {
   return mesh;
 }
 
-void ProcessMesh::to_proto(ProcessMeshProto* proto) const {
+void ProcessMesh::to_proto(ProcessMeshProto *proto) const {
   for (const auto &i : shape_) {
     proto->add_shape(i);
   }

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.h
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.h
@@ -28,6 +28,10 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
+namespace auto_parallel{
+  class ProcessMeshProto;
+}
+
 class ProcessMesh {
  public:
   ProcessMesh() = default;
@@ -68,7 +72,7 @@ class ProcessMesh {
   std::string to_string() const;
 
   static ProcessMesh from_proto(const auto_parallel::ProcessMeshProto& proto);
-  auto_parallel::ProcessMeshProto to_proto() const;
+  void to_proto(auto_parallel::ProcessMeshProto* proto) const;
 
  private:
   std::vector<int64_t> shape_;

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.h
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.h
@@ -28,8 +28,8 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-namespace auto_parallel{
-  class ProcessMeshProto;
+namespace auto_parallel {
+class ProcessMeshProto;
 }
 
 class ProcessMesh {

--- a/paddle/phi/core/distributed/auto_parallel/proto_helper.cc
+++ b/paddle/phi/core/distributed/auto_parallel/proto_helper.cc
@@ -1,49 +1,65 @@
-#include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
-#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
 #include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_mapper.h"
 
-# define TO_PROTO_HELPER(object, proto_type) \
-  proto_type proto; \
-  object.to_proto(&proto); \
+#define TO_PROTO_HELPER(object, proto_type) \
+  proto_type proto;                         \
+  object.to_proto(&proto);                  \
   return proto
 
 namespace phi {
 namespace distributed {
 
-
-     auto_parallel::TensorDistAttrProto to_proto(const TensorDistAttr& dist_attr){
-        TO_PROTO_HELPER(dist_attr, auto_parallel::TensorDistAttrProto);
-    }
-
-    auto_parallel::ProcessMeshProto to_proto(const ProcessMesh& process_mesh){
-        TO_PROTO_HELPER(process_mesh, auto_parallel::ProcessMeshProto);
-    }
-
-    
-    auto_parallel::DeviceCapabilityProto to_proto(const auto_parallel::DeviceCapability& device_capibilty){
-        TO_PROTO_HELPER(device_capibilty, auto_parallel::DeviceCapabilityProto);
-    }
-
-    auto_parallel::DeviceProto to_proto(const auto_parallel::Device& device){
-        TO_PROTO_HELPER(device, auto_parallel::DeviceProto);
-    }
-
-    auto_parallel::LinkCapabilityProto to_proto(const auto_parallel::LinkCapability& link_capibilty){
-        TO_PROTO_HELPER(link_capibilty, auto_parallel::LinkCapabilityProto);
-    }
-
-    auto_parallel::LinkProto to_proto(const auto_parallel::Link& link){
-        TO_PROTO_HELPER(link, auto_parallel::LinkProto);
-    }
-
-    auto_parallel::DeviceMeshProto to_proto(const auto_parallel::DeviceMesh& device_mesh){
-        TO_PROTO_HELPER(device_mesh, auto_parallel::DeviceMeshProto);
-    }
-
-    auto_parallel::DistributedMapperProto to_proto(const auto_parallel::DistributedMapper& dist_mapper){
-        TO_PROTO_HELPER(dist_mapper, auto_parallel::DistributedMapperProto);
-    }
+auto_parallel::TensorDistAttrProto to_proto(const TensorDistAttr& dist_attr) {
+  TO_PROTO_HELPER(dist_attr, auto_parallel::TensorDistAttrProto);
 }
+
+auto_parallel::ProcessMeshProto to_proto(const ProcessMesh& process_mesh) {
+  TO_PROTO_HELPER(process_mesh, auto_parallel::ProcessMeshProto);
 }
+
+auto_parallel::DeviceCapabilityProto to_proto(
+    const auto_parallel::DeviceCapability& device_capibilty) {
+  TO_PROTO_HELPER(device_capibilty, auto_parallel::DeviceCapabilityProto);
+}
+
+auto_parallel::DeviceProto to_proto(const auto_parallel::Device& device) {
+  TO_PROTO_HELPER(device, auto_parallel::DeviceProto);
+}
+
+auto_parallel::LinkCapabilityProto to_proto(
+    const auto_parallel::LinkCapability& link_capibilty) {
+  TO_PROTO_HELPER(link_capibilty, auto_parallel::LinkCapabilityProto);
+}
+
+auto_parallel::LinkProto to_proto(const auto_parallel::Link& link) {
+  TO_PROTO_HELPER(link, auto_parallel::LinkProto);
+}
+
+auto_parallel::DeviceMeshProto to_proto(
+    const auto_parallel::DeviceMesh& device_mesh) {
+  TO_PROTO_HELPER(device_mesh, auto_parallel::DeviceMeshProto);
+}
+
+auto_parallel::DistributedMapperProto to_proto(
+    const auto_parallel::DistributedMapper& dist_mapper) {
+  TO_PROTO_HELPER(dist_mapper, auto_parallel::DistributedMapperProto);
+}
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/auto_parallel/proto_helper.cc
+++ b/paddle/phi/core/distributed/auto_parallel/proto_helper.cc
@@ -1,0 +1,49 @@
+#include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_attr.h"
+#include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
+#include "paddle/phi/core/distributed/auto_parallel/dist_mapper.h"
+
+# define TO_PROTO_HELPER(object, proto_type) \
+  proto_type proto; \
+  object.to_proto(&proto); \
+  return proto
+
+namespace phi {
+namespace distributed {
+
+
+     auto_parallel::TensorDistAttrProto to_proto(const TensorDistAttr& dist_attr){
+        TO_PROTO_HELPER(dist_attr, auto_parallel::TensorDistAttrProto);
+    }
+
+    auto_parallel::ProcessMeshProto to_proto(const ProcessMesh& process_mesh){
+        TO_PROTO_HELPER(process_mesh, auto_parallel::ProcessMeshProto);
+    }
+
+    
+    auto_parallel::DeviceCapabilityProto to_proto(const auto_parallel::DeviceCapability& device_capibilty){
+        TO_PROTO_HELPER(device_capibilty, auto_parallel::DeviceCapabilityProto);
+    }
+
+    auto_parallel::DeviceProto to_proto(const auto_parallel::Device& device){
+        TO_PROTO_HELPER(device, auto_parallel::DeviceProto);
+    }
+
+    auto_parallel::LinkCapabilityProto to_proto(const auto_parallel::LinkCapability& link_capibilty){
+        TO_PROTO_HELPER(link_capibilty, auto_parallel::LinkCapabilityProto);
+    }
+
+    auto_parallel::LinkProto to_proto(const auto_parallel::Link& link){
+        TO_PROTO_HELPER(link, auto_parallel::LinkProto);
+    }
+
+    auto_parallel::DeviceMeshProto to_proto(const auto_parallel::DeviceMesh& device_mesh){
+        TO_PROTO_HELPER(device_mesh, auto_parallel::DeviceMeshProto);
+    }
+
+    auto_parallel::DistributedMapperProto to_proto(const auto_parallel::DistributedMapper& dist_mapper){
+        TO_PROTO_HELPER(dist_mapper, auto_parallel::DistributedMapperProto);
+    }
+}
+}

--- a/paddle/phi/core/distributed/auto_parallel/proto_helper.h
+++ b/paddle/phi/core/distributed/auto_parallel/proto_helper.h
@@ -1,0 +1,25 @@
+#include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
+namespace phi {
+namespace distributed {
+    class TensorDistAttr;
+    class ProcessMesh;
+    namespace auto_parallel{
+        class DeviceCapability;
+        class Device;
+        class LinkCapability;
+        class Link;
+        class DeviceMesh;
+        class DistributedMapper;
+    }
+    auto_parallel::TensorDistAttrProto to_proto(const TensorDistAttr& dist_attr);
+    auto_parallel::ProcessMeshProto to_proto(const ProcessMesh& dist_attr);
+
+    auto_parallel::DeviceCapabilityProto to_proto(const auto_parallel::DeviceCapability& device_capibilty);
+    auto_parallel::DeviceProto to_proto(const auto_parallel::Device& device);
+    auto_parallel::LinkCapabilityProto to_proto(const auto_parallel::LinkCapability& link_capibilty);
+    auto_parallel::LinkProto to_proto(const auto_parallel::Link& link);
+    auto_parallel::DeviceMeshProto to_proto(const auto_parallel::DeviceMesh& link);
+    auto_parallel::DistributedMapperProto to_proto(const auto_parallel::DistributedMapper& dist_mapper);
+
+}
+}

--- a/paddle/phi/core/distributed/auto_parallel/proto_helper.h
+++ b/paddle/phi/core/distributed/auto_parallel/proto_helper.h
@@ -19,9 +19,9 @@ namespace distributed {
 class TensorDistAttr;
 class ProcessMesh;
 namespace auto_parallel {
-class DeviceCapability;
+struct DeviceCapability;
 class Device;
-class LinkCapability;
+struct LinkCapability;
 class Link;
 class DeviceMesh;
 class DistributedMapper;

--- a/paddle/phi/core/distributed/auto_parallel/proto_helper.h
+++ b/paddle/phi/core/distributed/auto_parallel/proto_helper.h
@@ -1,25 +1,43 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
 #include "paddle/phi/core/distributed/auto_parallel/auto_parallel.pb.h"
 namespace phi {
 namespace distributed {
-    class TensorDistAttr;
-    class ProcessMesh;
-    namespace auto_parallel{
-        class DeviceCapability;
-        class Device;
-        class LinkCapability;
-        class Link;
-        class DeviceMesh;
-        class DistributedMapper;
-    }
-    auto_parallel::TensorDistAttrProto to_proto(const TensorDistAttr& dist_attr);
-    auto_parallel::ProcessMeshProto to_proto(const ProcessMesh& dist_attr);
+class TensorDistAttr;
+class ProcessMesh;
+namespace auto_parallel {
+class DeviceCapability;
+class Device;
+class LinkCapability;
+class Link;
+class DeviceMesh;
+class DistributedMapper;
+}  // namespace auto_parallel
+auto_parallel::TensorDistAttrProto to_proto(const TensorDistAttr& dist_attr);
+auto_parallel::ProcessMeshProto to_proto(const ProcessMesh& dist_attr);
 
-    auto_parallel::DeviceCapabilityProto to_proto(const auto_parallel::DeviceCapability& device_capibilty);
-    auto_parallel::DeviceProto to_proto(const auto_parallel::Device& device);
-    auto_parallel::LinkCapabilityProto to_proto(const auto_parallel::LinkCapability& link_capibilty);
-    auto_parallel::LinkProto to_proto(const auto_parallel::Link& link);
-    auto_parallel::DeviceMeshProto to_proto(const auto_parallel::DeviceMesh& link);
-    auto_parallel::DistributedMapperProto to_proto(const auto_parallel::DistributedMapper& dist_mapper);
+auto_parallel::DeviceCapabilityProto to_proto(
+    const auto_parallel::DeviceCapability& device_capibilty);
+auto_parallel::DeviceProto to_proto(const auto_parallel::Device& device);
+auto_parallel::LinkCapabilityProto to_proto(
+    const auto_parallel::LinkCapability& link_capibilty);
+auto_parallel::LinkProto to_proto(const auto_parallel::Link& link);
+auto_parallel::DeviceMeshProto to_proto(const auto_parallel::DeviceMesh& link);
+auto_parallel::DistributedMapperProto to_proto(
+    const auto_parallel::DistributedMapper& dist_mapper);
 
-}
-}
+}  // namespace distributed
+}  // namespace phi

--- a/test/cpp/auto_parallel/device_mesh_test.cc
+++ b/test/cpp/auto_parallel/device_mesh_test.cc
@@ -12,11 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include <iostream>
+#include <sstream>
+
 #include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
 #include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
-#include <iostream>
-#include <sstream>
 #include "gtest/gtest.h"
 
 namespace phi {

--- a/test/cpp/auto_parallel/device_mesh_test.cc
+++ b/test/cpp/auto_parallel/device_mesh_test.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/device_mesh.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
+
 #include <iostream>
 #include <sstream>
 #include "gtest/gtest.h"
@@ -83,7 +85,7 @@ TEST(DeviceMesh, Ctor) {
   std::stringstream sstream;
   sstream << device_mesh;
   EXPECT_EQ(sstream.str(), device_mesh.to_string());
-  auto proto = device_mesh.to_proto();
+  auto proto = phi::distributed::to_proto(device_mesh);
   DeviceMesh new_device_mesh = DeviceMesh::from_proto(proto);
   EXPECT_EQ(device_mesh, new_device_mesh);
 }

--- a/test/cpp/auto_parallel/dist_attr_test.cc
+++ b/test/cpp/auto_parallel/dist_attr_test.cc
@@ -24,7 +24,6 @@ limitations under the License. */
 #include "paddle/fluid/framework/var_desc.h"
 #include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
-
 namespace phi {
 namespace distributed {
 namespace auto_parallel {
@@ -101,7 +100,7 @@ TEST(DistAttr, ctor) {
   std::stringstream x_sstream;
   x_sstream << x_dist_attr;
   EXPECT_EQ(x_sstream.str(), x_dist_attr.to_string());
-  auto x_proto = phi::distributed::to_proto(x_dist_attr); //.to_proto();
+  auto x_proto = phi::distributed::to_proto(x_dist_attr);
   TensorDistAttr new_x_dist_attr = get_dist_attr(x);
   new_x_dist_attr.from_proto(x_proto);
   EXPECT_EQ(x_dist_attr, new_x_dist_attr);

--- a/test/cpp/auto_parallel/dist_attr_test.cc
+++ b/test/cpp/auto_parallel/dist_attr_test.cc
@@ -22,6 +22,8 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/framework/var_desc.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
+
 
 namespace phi {
 namespace distributed {
@@ -99,7 +101,7 @@ TEST(DistAttr, ctor) {
   std::stringstream x_sstream;
   x_sstream << x_dist_attr;
   EXPECT_EQ(x_sstream.str(), x_dist_attr.to_string());
-  auto x_proto = x_dist_attr.to_proto();
+  auto x_proto = phi::distributed::to_proto(x_dist_attr); //.to_proto();
   TensorDistAttr new_x_dist_attr = get_dist_attr(x);
   new_x_dist_attr.from_proto(x_proto);
   EXPECT_EQ(x_dist_attr, new_x_dist_attr);

--- a/test/cpp/auto_parallel/dist_mapper_test.cc
+++ b/test/cpp/auto_parallel/dist_mapper_test.cc
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/dist_mapper.h"
-#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include <map>
 #include <sstream>
 #include "gtest/gtest.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
 namespace phi {
 namespace distributed {

--- a/test/cpp/auto_parallel/dist_mapper_test.cc
+++ b/test/cpp/auto_parallel/dist_mapper_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/dist_mapper.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include <map>
 #include <sstream>
 #include "gtest/gtest.h"
@@ -62,7 +63,7 @@ TEST(DistributedMapper, Ctor) {
   std::stringstream sstream;
   sstream << dist_mapper;
   EXPECT_EQ(sstream.str(), dist_mapper.to_string());
-  auto proto = dist_mapper.to_proto();
+  auto proto = phi::distributed::to_proto(dist_mapper);
   DistributedMapper new_dist_mapper = DistributedMapper::from_proto(proto);
   EXPECT_EQ(dist_mapper, new_dist_mapper);
 }

--- a/test/cpp/auto_parallel/process_mesh_test.cc
+++ b/test/cpp/auto_parallel/process_mesh_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include <iostream>
 #include <sstream>
 #include "gtest/gtest.h"
@@ -43,7 +44,7 @@ TEST(ProcessMesh, Ctor) {
   std::stringstream sstream;
   sstream << process_mesh;
   EXPECT_EQ(sstream.str(), process_mesh.to_string());
-  auto proto = process_mesh.to_proto();
+  auto proto = phi::distributed::to_proto(process_mesh);
   ProcessMesh new_process_mesh = ProcessMesh::from_proto(proto);
   EXPECT_EQ(process_mesh, new_process_mesh);
 }

--- a/test/cpp/auto_parallel/process_mesh_test.cc
+++ b/test/cpp/auto_parallel/process_mesh_test.cc
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
-#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 #include <iostream>
 #include <sstream>
 #include "gtest/gtest.h"
+#include "paddle/phi/core/distributed/auto_parallel/proto_helper.h"
 
 namespace phi {
 namespace distributed {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* card-79276 剔除切分推导相关的头文件对proto 的依赖， 方便给外部算子导出头文件