### PR TITLE
[InferSymbolicShape] Delete redundant value_id_to_shapeordata_

### DIFF
--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -178,13 +178,13 @@ std::string GetValueId(Value* val) {
 const symbol::ShapeOrDataDimExprs&
 ShapeConstraintIRAnalysis::GetShapeOrDataForValue(Value* val) {
   auto val_id = GetValueId(val);
-  return value_id_to_shapeordata[val_id];
+  return value_id_to_shapeordata_[val_id];
 }
 
 void ShapeConstraintIRAnalysis::SetShapeOrDataForValue(
     Value* val, const symbol::ShapeOrDataDimExprs& shape_or_data) {
   auto val_id = GetValueId(val);
-  value_id_to_shapeordata[val_id] = shape_or_data;
+  value_id_to_shapeordata_[val_id] = shape_or_data;
 }
 
 }  // namespace pir

--- a/paddle/pir/dialect/shape/utils/shape_utils.h
+++ b/paddle/pir/dialect/shape/utils/shape_utils.h
@@ -105,9 +105,6 @@ class IR_API ShapeConstraintIRAnalysis : public ShapeAnalysis {
   int64_t next_sym_idx_ = 0;
   std::vector<symbol::DimExprConstraint> constraints_;
 
-  std::unordered_map<std::string, symbol::ShapeOrDataDimExprs>
-      value_id_to_shapeordata;
-
  public:
   explicit ShapeConstraintIRAnalysis(std::shared_ptr<pir::Program>&& program)
       : ShapeConstraintIRAnalysis(program->module_op()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

ShapeConstraintIRAnalysis 内部有两个成员变量：`public value_id_to_shapeordata_` 和 `private value_id_to_shapeordata`，这两个概念上容易混淆：
- SymbolicShape 推导时使用的是 public 的 `value_id_to_shapeordata_`
- 接口 `GetShapeOrDataForValue` 里调用的是 private 的 `value_id_to_shapeordata`

CINN 前端写 pass 时调用的正式版 `GetShapeOrDataForValue` 接口，发现获取不到推导的结果。因此本 PR 将这两个数据结构统一，`GetShapeOrDataForValue` 接口暂时从 public 的 `value_id_to_shapeordata_` 里面获取数据。
后续完整流程应该是根据 https://github.com/PaddlePaddle/Paddle/pull/60371#discussion_r1436694807 里的建议，将 `value_id_to_shapeordata_` 修改为 private 成员并统一使用正式的接口。