### PR TITLE
[Paddle Inference] Fix blockmha bfloat16 compile error.

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -49,7 +49,7 @@ __forceinline__ __device__ half add_mul<half>(half a, half b, half c) {
   return __hmul(__hadd(a, b), c);
 }
 
-#if CUDA_VERSION >= 11000 && defined(CUDA_BFLOAT16_AVALIABLE)
+#if CUDA_VERSION >= 11000
 template <>
 __forceinline__ __device__ __nv_bfloat16
 add_mul<__nv_bfloat16>(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c) {
@@ -688,7 +688,7 @@ void BlockMultiheadAttentionKernel(
                                                       key_cache_out,
                                                       value_cache_out);
     } else if (compute_dtype == "bf16") {
-#if CUDA_VERSION >= 11000 && defined(CUDA_BFLOAT16_AVALIABLE)
+#if CUDA_VERSION >= 11000
       DispatchWithDtype<phi::dtype::bfloat16, Context>(dev_ctx,
                                                        qkv,
                                                        key_cache,
@@ -771,7 +771,7 @@ void BlockMultiheadAttentionKernel(
                                                       key_cache_out,
                                                       value_cache_out);
     } else if (std::is_same<T, phi::dtype::bfloat16>::value) {
-#if CUDA_VERSION >= 11000 && defined(CUDA_BFLOAT16_AVALIABLE)
+#if CUDA_VERSION >= 11000
       DispatchWithDtype<phi::dtype::bfloat16, Context>(dev_ctx,
                                                        qkv,
                                                        key_cache,
@@ -818,7 +818,7 @@ void BlockMultiheadAttentionKernel(
 }  // namespace fusion
 }  // namespace phi
 
-#if CUDA_VERSION >= 11000 && defined(CUDA_BFLOAT16_AVALIABLE)
+#if CUDA_VERSION >= 11000
 PD_REGISTER_KERNEL(block_multihead_attention,
                    GPU,
                    ALL_LAYOUT,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Fix blockmha bfloat16 compile error.
Pcard-71502