### PR TITLE
[NPU] fix storage_properties type mismatch with OneDNN and NPU

### DIFF
--- a/paddle/phi/common/place.cc
+++ b/paddle/phi/common/place.cc
@@ -37,6 +37,8 @@ const char *AllocationTypeStr(AllocationType type) {
       return "xpu";
     case AllocationType::IPU:
       return "ipu";
+    case AllocationType::CUSTOM:
+      return "custom_device";
     default:
       PD_THROW("Invalid phi device type.");
       return {};


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix to https://github.com/PaddlePaddle/Paddle/pull/60024

当NPU和OneDNN同时打开编译的时候，PR#60024 在Intel CPU下会对 storage_properties 进行初始化，NPU在调用storage_properties_initialized 的时候返回true，但是实际 storage_properties 的类型是 OneDNNStorageProperties 不是 NPUStorageProperties，因此修改 storage_properties_initialized，需要判断 storage_properties 类型和tensor place 的类型一致的情况下才返回true。

Pcard-77889
