### PR TITLE
Add CanProveDivisible for symbolic calculation

### DIFF
--- a/paddle/cinn/common/integer_set.cc
+++ b/paddle/cinn/common/integer_set.cc
@@ -340,7 +340,6 @@ ir::Expr SymbolicExprAnalyzer::LowerBound(const ir::Expr& expr) const {
   BoundReplacer bound_replacer(var_intervals_, true);
   ir::Expr bound = ir::ir_utils::IRCopy(expr);
   bound_replacer(&bound);
-  std::cout << "bound is " << bound << std::endl;
   return AutoSimplify(bound);
 }
 

--- a/paddle/cinn/common/integer_set.h
+++ b/paddle/cinn/common/integer_set.h
@@ -41,6 +41,8 @@ class SymbolicExprAnalyzer {
   std::optional<bool> ProveLE(const ir::Expr& lhs, const ir::Expr& rhs) const;
   std::optional<bool> ProveGT(const ir::Expr& lhs, const ir::Expr& rhs) const;
   std::optional<bool> ProveLT(const ir::Expr& lhs, const ir::Expr& rhs) const;
+  std::optional<bool> ProveDivisible(const ir::Expr& lhs,
+                                     const ir::Expr& rhs) const;
 
   ir::Expr LowerBound(const ir::Expr& expr) const;
   ir::Expr UpperBound(const ir::Expr& expr) const;

--- a/paddle/cinn/common/integer_set_test.cc
+++ b/paddle/cinn/common/integer_set_test.cc
@@ -171,8 +171,13 @@ TEST_F(TestSymbolicExprAnalyzer, Divisible) {
   // case 4
   ir::Expr e6 = S * x / 4 + x * y;
 
-  EXPECT_TRUE(divisible_analyzer.ProveDivisible(e6, e2).value_or(false));
+  EXPECT_FALSE(divisible_analyzer.ProveDivisible(e6, e2).value_or(false));
   EXPECT_FALSE(divisible_analyzer.ProveDivisible(e6, e3).value_or(false));
+
+  ir::Expr e7 = 16 * x / 4 + x * y;
+
+  EXPECT_TRUE(divisible_analyzer.ProveDivisible(e7, e2).value_or(false));
+  EXPECT_FALSE(divisible_analyzer.ProveDivisible(e7, e3).value_or(false));
 }
 
 TEST(SingleIntervalIntSet, constant) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR add CanProveDivisible for symbolic calculation
We need this because sometimes we need to split a for loop with extent like M * N, and the factors is like [M, -1], so if We can make sure that M * N can be divisible by M, so that we don't need to add a extra if to ensure no cross-border access and get a new loop with extent like M * N  /  M +1 to ensure M*N can be divisible by M.

TODO: now the dsl don't support constructing case like above,  corresponding case should be added in the future.