### PR TITLE
[PIR] dce pass disable custom op

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.cc
@@ -177,12 +177,14 @@ PhiKernelInstruction::~PhiKernelInstruction() {
 }
 
 void PhiKernelInstruction::Run() {
+  VLOG(6) << "Begin run op " << phi_op_name_ << " infer meta.";
   if (infer_meta_interface_) {
     infer_meta_interface_->infer_meta_(&(infer_meta_context_));
   }
-  VLOG(6) << "Run op " << phi_op_name_ << " infer meta.";
+  VLOG(6) << "End run op " << phi_op_name_ << " infer meta.";
+  VLOG(6) << "Begin run op " << phi_op_name_ << " kernel.";
   (*(phi_kernel_))(&(kernel_context_));
-  VLOG(6) << "Run op " << phi_op_name_ << " kernel.";
+  VLOG(6) << "End run op " << phi_op_name_ << " kernel.";
 }
 
 }  // namespace framework

--- a/paddle/fluid/pir/transforms/dead_code_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/dead_code_elimination_pass.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
 
+#include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/pir/core/block.h"
 #include "paddle/pir/core/builtin_op.h"
@@ -39,27 +40,30 @@ class DeadCodeEliminationPass : public pir::Pass {
     std::vector<pir::Operation*> deleted_ops;
     for (auto& op : block) {
       if (op.HasTrait<pir::SideEffectTrait>() ||
-          op.isa<paddle::dialect::DataOp>()) {
+          op.isa<paddle::dialect::DataOp>() ||
+          paddle::dialect::IsCustomOp(&op)) {
         continue;
       }
       if (op.use_empty()) {
         deleted_ops.push_back(&op);
       }
     }
+
     for (auto* op : deleted_ops) {
       op->Erase();
       (*num_erasers)++;
     }
-    for (auto& op : block) {
-      for (size_t i = 0; i < op.num_regions(); ++i) {
-        auto& inner_region = op.region(i);
-        for (auto& inner_block : inner_region) {
-          EraseOp(inner_block, num_erasers);
+
+    if (deleted_ops.empty()) {
+      for (auto& op : block) {
+        for (size_t i = 0; i < op.num_regions(); ++i) {
+          auto& inner_region = op.region(i);
+          for (auto& inner_block : inner_region) {
+            EraseOp(inner_block, num_erasers);
+          }
         }
       }
-    }
-
-    if (!deleted_ops.empty()) {
+    } else {
       EraseOp(block, num_erasers);
     }
   }

--- a/test/ir/pir/fused_pass/test_pir_matmul_scale_fuse_pass.py
+++ b/test/ir/pir/fused_pass/test_pir_matmul_scale_fuse_pass.py
@@ -85,10 +85,5 @@ class TestMatmulScaleFusePattern(PassTest):
         self.check_pass_correct()
 
 
-class TestMatmulScaleFusePatternWtihCpu(TestMatmulScaleFusePattern):
-    def setUp(self):
-        self.place_runtime = "cpu"
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
- dce pass disable custom op
- 优化死代码消除pass的递归调用逻辑，极大减少递归调用次数
- paddlenlp中细粒度大模型推理存在无输出的自定义算子场景，故在死代码消除pass中禁止掉
### Others
Pcard-71500