### PR TITLE
 Fix test_conv2d_op_depthwise_conv

### DIFF
--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -319,3 +319,4 @@ test_warprnnt_op
 test_where_op
 test_yolo_box_op
 test_yolov3_loss_op
+test_conv2d_op_depthwise_conv


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
#### 遇到的问题
```
832: Mismatched elements: 212 / 216 (98.1%)
832: Max absolute difference: 1.064
832: Max relative difference: 707.
832:  x: array([[[[-0.04807 , -0.2198  ,  0.5723  ],
832:          [-0.5093  , -0.5244  , -0.4734  ],
832:          [ 0.      ,  0.1121  , -0.1953  ]],...
832:  y: array([[[[ 1.2459e-02, -1.3098e-01,  1.6123e+00],
832:          [-5.5811e-01, -3.7170e-02, -5.1300e-02],
832:          [ 2.7222e-02,  1.1768e+00, -7.8796e-02]],...
832: 
832: ----------------------------------------------------------------------
832: Ran 184 tests in 14.636s
832: 
832: FAILED (failures=35, skipped=40)
832: 
```
#### 原因分析
在GPU下执行时，新旧IR执行的是同一个`Kernel`
```C++
void DepthwiseConvKernel(const Context& dev_ctx,
                         const DenseTensor& input,
                         const DenseTensor& filter,
                         const std::vector<int>& strides_t,
                         const std::vector<int>& paddings_t,
                         const std::string& padding_algorithm,
                         int groups,
                         const std::vector<int>& dilations_t,
                         const std::string& data_format,
                         DenseTensor* out) {
  DenseTensor* output = out;
  dev_ctx.template Alloc<T>(output);
  const std::vector<int> strides = strides_t;
  std::vector<int> dilations = dilations_t;
  std::vector<int> paddings = paddings_t;

  const bool channel_last = (data_format == "NHWC" || data_format == "NDHWC");

  bool has_fuse_relu = dev_ctx.HasDnnAttr("fuse_relu_before_depthwise_conv");
  bool fuse_relu =
      has_fuse_relu
          ? PADDLE_GET_CONST(
                bool, dev_ctx.GetDnnAttr("fuse_relu_before_depthwise_conv"))
          : false;
   ......
 if (fuse_relu) {
    paddle::operators::math::DepthwiseConvFunctor<Context, T, true>
        depthwiseConv;
    depthwiseConv(dev_ctx,
                  input,
                  filter,
                  strides,
                  paddings,
                  dilations,
                  output,
                  data_layout);
  } else {
    paddle::operators::math::DepthwiseConvFunctor<Context, T, false>
        depthwiseConv;
    depthwiseConv(dev_ctx,
                  input,
                  filter,
                  strides,
                  paddings,
                  dilations,
                  output,
                  data_layout);
  }
}
```
但是在旧IR下执行`fuse_relu`为`True`,新IR下执行`fuse_relu`值为`False`导致最终执行的计算逻辑不同，造成精度误差。