### PR TITLE
[Custom Device]enable custom device to use silu_fuse_pass

### DIFF
--- a/paddle/fluid/framework/ir/silu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/silu_fuse_pass.cc
@@ -23,7 +23,8 @@ namespace ir {
 void SiluFusePass::ApplyImpl(ir::Graph* graph) const {
   // This pass is used for cutlass, because cutlass can fuse conv + bias + silu
   bool cutlass_enable = Get<bool>("use_cutlass");
-  if (!cutlass_enable) {
+  bool use_custom_device = Get<bool>("use_custom_device");
+  if (!cutlass_enable && !use_custom_device) {
     return;
   }
 

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -103,6 +103,7 @@ void IRPassManager::CreatePasses(Argument *argument,
         "mixed_white_list",
         new std::unordered_set<std::string>(argument->mixed_white_list()));
     pass->Set("enable_gpu_mixed", new bool(argument->enable_gpu_mixed()));
+    pass->Set("use_custom_device", new bool(argument->use_custom_device()));
     pass->Set("enable_custom_device_mixed",
               new bool(argument->enable_custom_device_mixed()));
     pass->Set("mixed_precision_mode",

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1678,8 +1678,8 @@ void AnalysisPredictor::PrepareArgument() {
   }
 #endif
 
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
   argument_->SetUseCustomDevice(config_.use_custom_device());
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
   if (config_.use_custom_device()) {
     LOG(INFO) << "CustomDevice is enabled";
     argument_->SetCustomDeviceType(config_.custom_device_type());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
silu_fuse_pass是一个通用的融合sigmoid和mul的pass，本质上和device没有关系。
但是有一个判定flag
```cpp
bool cutlass_enable = Get<bool>("use_cutlass");
```
导致只有use_cutlass才能使用。
然而, custom device没有cutlass的说法，所以即使在Paddle Inference中append这个pass，也不会有任何效果。
所以，这个PR是使Custom Device能用silu_fuse_pass 这个pass，融合算子成swish提升性能。

另外，这个PR对已有的Custom Device代码不会有任何影响。
只有在Paddle Inference的config调用
```cpp
config.pass_builder()->AppendPass("silu_fuse_pass");
```
才能使用这个Pass。
User可以自行控制。