### PR TITLE
[SOT] Break When Call Unsupported Layer

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -530,6 +530,10 @@ class PaddleLayerVariable(LayerVariable):
         super().__init__(layer, graph, tracker)
 
     def call_function(self, /, *args, **kwargs):
+        if is_not_supported_paddle_layer(type(self.value)):
+            raise BreakGraphError(
+                f"[BreakGraph] calling is_not_supported_paddle_layer with type {type(self.value)}"
+            )
         self.graph.add_global_guarded_variable(self)
         # when layer is created in forward function, we use strong ref because it can't have
         # weigths and buffers, see PaddleLayerClassVariable for details.
@@ -563,7 +567,6 @@ class PaddleLayerVariable(LayerVariable):
                 and value._forward_pre_hooks
                 or hasattr(value, "_forward_post_hooks")
                 and value._forward_post_hooks
-                or is_not_supported_paddle_layer(type(value))
             ):
                 return None
             if value.__module__.startswith("paddle.nn."):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Trigger break graph when call unsuppoted paddle layer (we give up using call_layer before this PR)
PCard-66972