### PR TITLE
[AutoParallel] Fix tensor method double grad missing to convert inplace

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -840,6 +840,10 @@ static PyObject* tensor__rdiv__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 place);
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -973,6 +977,10 @@ static PyObject* tensor__gt__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 place);
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1078,6 +1086,10 @@ static PyObject* tensor__ge__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 place);
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1184,6 +1196,10 @@ static PyObject* tensor__mod__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1289,6 +1305,10 @@ static PyObject* tensor__matmul__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1410,6 +1430,10 @@ static PyObject* tensor__lt__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1515,6 +1539,10 @@ static PyObject* tensor__le__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1621,6 +1649,10 @@ static PyObject* tensor__floordiv__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1828,6 +1860,10 @@ static PyObject* tensor__rpow__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -1933,6 +1969,10 @@ static PyObject* tensor__ne__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
@@ -2036,6 +2076,10 @@ static PyObject* tensor__eq__method(TensorObject* self,
                                 phi::Scalar(other_double),
                                 self_tensor.dtype(),
                                 self_tensor.place());
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
   } else if (PyCheckTensor(other_obj)) {
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

Pcard-73145

在修复tensor的各种math方法在做dense_tensor到dist_tensor的inplace转换时，做了值拷贝的问题时，漏改了double_grad分支