### PR TITLE
[CINN] fix kernel func args bug

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -158,7 +158,7 @@ BucketLoweredFuncsWrapper OpLowererImpl::BucketLower(const GroupPtr& group,
   std::vector<ir::Argument> group_func_args;
   std::vector<ir::LoweredFunc> funcs = PostProcess(group,
                                                    tensor_map,
-                                                   apply_op_schedule,
+                                                   apply_group_schedule,
                                                    {scheduled_func_bodies},
                                                    &group_func_arg_tensors_copy,
                                                    &group_func_args);
@@ -411,7 +411,7 @@ std::vector<ir::LoweredFunc> OpLowererImpl::LowerCustomCall(
 std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
     const GroupPtr& group,
     const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
-    bool done_op_schedule,
+    bool is_remove_tmp_buffer_in_args,
     std::vector<ir::Expr> func_bodies,
     std::vector<ir::Tensor>* group_func_arg_tensors,
     std::vector<ir::Argument>* group_func_args) {
@@ -451,7 +451,7 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
     }
   }
 
-  if (!done_op_schedule) {
+  if (!is_remove_tmp_buffer_in_args) {
     std::unordered_set<std::string> args_set;
     for (auto arg : (*group_func_args)) {
       args_set.insert(arg.name());
@@ -516,7 +516,7 @@ std::vector<ir::LoweredFunc> OpLowererImpl::PostProcess(
     // 3.Building LoweredFunc
     auto func = ir::_LoweredFunc_::Make(
         group->FuncName(), *group_func_args, func_body, temp_buffers);
-    if (!done_op_schedule) {
+    if (!is_remove_tmp_buffer_in_args) {
       func->PrepareBufferCastExprs();
     }
     // 4.Apply low level pass

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -105,8 +105,8 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
    * variables, applying low-level optimization passes, etc.
    * @param group The group to be lowered.
    * @param tensor_map All tensors used for calculating the group.
-   * @param done_op_schedule Mark whether the Op level schedule has been
-   * applied.
+   * @param is_remove_tmp_buffer_in_args Determine whether to remove
+   * intermediate variables as func args.
    * @param func_bodies The scheduled func bodies of group.
    * @param group_func_arg_tensors Tensors used as the group function arguments.
    * @param group_func_args Arguments used as the group function arguments.
@@ -115,7 +115,7 @@ class OpLowererImpl : public OpLowererImplBase<GroupPtr> {
   std::vector<ir::LoweredFunc> PostProcess(
       const GroupPtr& group,
       const std::unordered_map<::pir::Value, ir::Tensor>& tensor_map,
-      bool done_op_schedule,
+      bool is_remove_tmp_buffer_in_args,
       std::vector<ir::Expr> func_bodies,
       std::vector<ir::Tensor>* group_func_arg_tensors,
       std::vector<ir::Argument>* group_func_args);


### PR DESCRIPTION
### PR types
Others 

### PR changes
Others

### Description
Pcard-72511
Fix kernel func args bug. 
When using group scheduler to optimize intermediate variables, remove intermediate variables from kernel function arguments.
