### PR TITLE
[CIN+PIR]Fix SplitOpPattern Bug in pd_to_cinn_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -358,8 +358,10 @@ class ConcatOpPattern
       int axis = static_cast<int>(
           full_op.attribute("value").dyn_cast<::pir::FloatAttribute>().data());
 
-      auto input_ops =
-          op->operand(0).owner()->dyn_cast<pir::CombineOp>().inputs();
+      auto input_ops = op->operand_source(0)
+                           .defining_op()
+                           ->dyn_cast<pir::CombineOp>()
+                           .inputs();
 
       auto cinn_concat =
           rewriter.Build<cinn::dialect::ConcatOp>(input_ops, axis);

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -435,7 +435,8 @@ class SplitOpPattern : public pir::OpRewritePattern<paddle::dialect::SplitOp> {
       auto orig_out = op.result(0);
       for (auto it = orig_out.use_begin(); it != orig_out.use_end();) {
         auto slice_op = (it++)->owner();
-        CHECK(slice_op->isa<::pir::SliceOp>());
+        CHECK(slice_op->isa<::pir::SliceOp>())
+            << "Currently only support pir::slice as downstream op";
         int index = slice_op->dyn_cast<::pir::SliceOp>()
                         .attribute("index")
                         .dyn_cast<::pir::Int32Attribute>()

--- a/test/cpp/pir/cinn/pir_all_path_test.cc
+++ b/test/cpp/pir/cinn/pir_all_path_test.cc
@@ -51,6 +51,44 @@ std::vector<::pir::Type> CreateDenseTensorTypes(const phi::DDim& dims) {
   return op_output_types;
 }
 
+static void RunAndCheckResult(::pir::Program* program,
+                              const bool check_result = true,
+                              const float gt_val = 2.0) {
+  ::pir::IrContext* ctx = ::pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
+  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
+
+  cinn::dialect::ir::PdOp2CinnOpConverter(program);
+
+  pir::PassManager pm(ctx);
+  pm.AddPass(
+      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
+
+  pm.AddPass(pir::CreateDeadCodeEliminationPass());
+  pm.AddPass(pir::CreateBuildCinnPass());
+  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
+  CHECK_EQ(pm.Run(program), true);
+
+  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
+
+  auto kernel_program = paddle::dialect::PdOpLowerToKernelPass(program, place);
+
+  paddle::framework::Scope exe_scope;
+
+  paddle::framework::InterpreterCore executor(
+      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
+
+  executor.Run({}, true);
+
+  auto out_tensor =
+      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
+
+  if (check_result) {
+    bool res0 = simple_cmp(out_tensor.data<float>()[0], gt_val);
+    EXPECT_EQ(res0, true);
+  }
+}
+
 std::shared_ptr<::pir::Program> BuildGroupProgram() {
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
@@ -86,35 +124,8 @@ TEST(GroupOp, TestBuild) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildGroupProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 1.0 / 768);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 1.0 / 768);
 }
 
 std::shared_ptr<::pir::Program> BuildLayerNormProgram() {
@@ -193,35 +204,8 @@ TEST(GroupOp, TestBuildLayerNorm) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildLayerNormProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  // TODO(phlrain): fix exec error
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-  //   auto out_tensor =
-  // executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
+  RunAndCheckResult(program.get(), false);
 }
 
 std::shared_ptr<::pir::Program> BuildDropOutProgram() {
@@ -278,32 +262,8 @@ TEST(GroupOp, TestBuildDropout) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildDropOutProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
+  RunAndCheckResult(program.get(), false);
 }
 
 std::shared_ptr<::pir::Program> BuildScaleGroupProgram() {
@@ -332,35 +292,8 @@ TEST(GroupOp, TestBuildScale) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildScaleGroupProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 0.5);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 0.5);
 }
 
 std::shared_ptr<::pir::Program> BuildScaleTensorGroupProgram() {
@@ -395,35 +328,8 @@ TEST(GroupOp, TestBuildScaleTensor) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildScaleTensorGroupProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 0.5);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 0.5);
 }
 
 std::shared_ptr<::pir::Program> BuildPowerProgram() {
@@ -464,35 +370,8 @@ TEST(GroupOp, TestBuildPower) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildPowerProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 16.0);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 16.0);
 }
 
 std::shared_ptr<::pir::Program> BuildLayerNorm2Program() {
@@ -587,33 +466,8 @@ TEST(GroupOp, TestBuildLayerNorm2) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildLayerNorm2Program();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  // TODO(phlrain): fix exec error
-  executor.Run({}, true);
-
-  //   auto out_tensor =
-  //       executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
+  RunAndCheckResult(program.get(), false);
 }
 
 std::shared_ptr<::pir::Program> BuildSum2GroupProgram() {
@@ -649,41 +503,8 @@ TEST(GroupOp, TestBuildSum2Group) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildSum2GroupProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  auto out_tensor2 =
-      executor.local_scope()->FindVar("out2@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 1.0);
-  EXPECT_EQ(res0, true);
-
-  bool res1 = (out_tensor2.data<float>()[0] == 0.0);
-  EXPECT_EQ(res1, true);
+  RunAndCheckResult(program.get(), true, 1.0);
 }
 
 std::shared_ptr<::pir::Program> BuildConcatProgram() {
@@ -719,37 +540,8 @@ TEST(GroupOp, TestBuildConcat) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildConcatProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-
-  pm.AddPass(pir::CreateDeadCodeEliminationPass());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 2.0);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 2.0);
 }
 
 std::shared_ptr<::pir::Program> BuildSliceProgram() {
@@ -778,43 +570,13 @@ std::shared_ptr<::pir::Program> BuildSliceProgram() {
   return program;
 }
 
-// TEST(GroupOp, TestBuildSlice) {
-//   // Step 1: Construct pir::Program
-//   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
-//   std::shared_ptr<::pir::Program> program = BuildSliceProgram();
-//   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-//   ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
+TEST(GroupOp, TestBuildSlice) {
+  // Step 1: Construct pir::Program
+  ::pir::IrContext* ctx = ::pir::IrContext::Instance();
+  std::shared_ptr<::pir::Program> program = BuildSliceProgram();
 
-//   cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-//   pir::PassManager pm(ctx);
-//   pm.AddPass(
-//       std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-
-//   pm.AddPass(pir::CreateDeadCodeEliminationPass());
-//   pm.AddPass(pir::CreateBuildCinnPass());
-//   CHECK_EQ(pm.Run(program.get()), true);
-
-//   auto res = cinn::dialect::ir::CINNGroupLoweringPass(program.get());
-
-//   paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-//   auto kernel_program =
-//       paddle::dialect::PdOpLowerToKernelPass(res.get(), place);
-
-//   paddle::framework::Scope exe_scope;
-
-//   paddle::framework::InterpreterCore executor(
-//       place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-//   executor.Run({}, true);
-
-// //   auto out_tensor =
-// // executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-// //     bool res0 = simple_cmp(out_tensor.data<float>()[0], 2.0);
-// //     EXPECT_EQ(res0, true);
-// }
+  RunAndCheckResult(program.get(), true, 2.0);
+}
 
 std::shared_ptr<::pir::Program> BuildSplitProgram() {
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
@@ -840,39 +602,8 @@ TEST(GroupOp, TestBuildSplit) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildSplitProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-
-  pm.AddPass(pir::CreateDeadCodeEliminationPass());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  // TODO(phlrain): codengen will failed in split op
-  //   auto res = cinn::dialect::ir::CINNGroupLoweringPass(program.get());
-
-  //   paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  //   auto kernel_program =
-  //       paddle::dialect::PdOpLowerToKernelPass(res.get(), place);
-
-  //   paddle::framework::Scope exe_scope;
-
-  //   paddle::framework::InterpreterCore executor(
-  //       place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  // executor.Run({}, true);
-
-  //   auto out_tensor =
-  // executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  //     bool res0 = simple_cmp(out_tensor.data<float>()[0], 2.0);
-  //     EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 2.0);
 }
 
 std::shared_ptr<::pir::Program> BuildAddNProgram() {
@@ -915,38 +646,8 @@ TEST(GroupOp, TestBuildAddN) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildAddNProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-
-  pm.AddPass(pir::CreateDeadCodeEliminationPass());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 6.0);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), true, 6.0);
 }
 
 std::shared_ptr<::pir::Program> BuildSplitSectionProgram() {
@@ -966,8 +667,8 @@ std::shared_ptr<::pir::Program> BuildSplitSectionProgram() {
                        .Build<paddle::dialect::SplitOp>(
                            x, std::vector<int64_t>({3, 5, 8}), -1)
                        .out();
-  auto out_list = builder.Build<pir::SplitOp>(split_arr).outputs();
-  builder.Build<paddle::dialect::FetchOp>(out_list[0], "out", 0);
+  auto out = builder.Build<pir::SliceOp>(split_arr, 0).result(0);
+  builder.Build<paddle::dialect::FetchOp>(out, "out", 0);
   return program;
 }
 
@@ -975,35 +676,6 @@ TEST(GroupOp, TestBuildSplitSection) {
   // Step 1: Construct pir::Program
   ::pir::IrContext* ctx = ::pir::IrContext::Instance();
   std::shared_ptr<::pir::Program> program = BuildSplitSectionProgram();
-  ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
-  ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
-  cinn::dialect::ir::PdOp2CinnOpConverter(program.get());
-
-  pir::PassManager pm(ctx);
-  pm.AddPass(
-      std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
-
-  pm.AddPass(pir::CreateDeadCodeEliminationPass());
-  pm.AddPass(pir::CreateBuildCinnPass());
-  pm.AddPass(cinn::dialect::ir::CreateCinnGroupLoweringPass());
-  CHECK_EQ(pm.Run(program.get()), true);
-
-  paddle::platform::Place place = paddle::platform::CUDAPlace(0);
-
-  auto kernel_program =
-      paddle::dialect::PdOpLowerToKernelPass(program.get(), place);
-
-  paddle::framework::Scope exe_scope;
-
-  paddle::framework::InterpreterCore executor(
-      place, {"out@fetch"}, kernel_program->block(), &exe_scope);
-
-  executor.Run({}, true);
-
-  auto out_tensor =
-      executor.local_scope()->FindVar("out@fetch")->Get<phi::DenseTensor>();
-
-  bool res0 = simple_cmp(out_tensor.data<float>()[0], 2.0);
-  EXPECT_EQ(res0, true);
+  RunAndCheckResult(program.get(), 2.0);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164


修复了SplitOpPattern 处理逻辑问题，精简了pir_all_path_test.cc实现代码复用，并打开了所有注释的单测，解决了TODO