### PR TITLE
Add test_with_pir_api in error test

### DIFF
--- a/test/legacy_test/test_arange.py
+++ b/test/legacy_test/test_arange.py
@@ -132,6 +132,7 @@ class TestZeroSizeArangeOp(TestArangeOp):
 
 
 class TestArangeOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_static_errors(self):
         with program_guard(Program(), Program()):
             paddle.enable_static()

--- a/test/legacy_test/test_assign_op.py
+++ b/test/legacy_test/test_assign_op.py
@@ -152,6 +152,7 @@ class TestAssignOpWithLoDTensorArray(unittest.TestCase):
 
 
 class TestAssignOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_cast_op.py
+++ b/test/legacy_test/test_cast_op.py
@@ -195,6 +195,7 @@ class TestCastOpFp32ToBf16(OpTest):
 
 
 class TestCastOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_compare_op.py
+++ b/test/legacy_test/test_compare_op.py
@@ -524,6 +524,7 @@ create_bf16_case('not_equal', lambda _a, _b: _a != _b, True)
 
 
 class TestCompareOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_int16_support(self):
         paddle.enable_static()
         with paddle.static.program_guard(

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -25,6 +25,7 @@ import paddle.distributed as dist
 from paddle import base
 from paddle.base import core
 from paddle.base.layer_helper import LayerHelper
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestElementwiseAddOp(OpTest):
@@ -692,6 +693,7 @@ class TestAddInplaceBroadcastError(unittest.TestCase):
         self.x_numpy = np.random.rand(3, 4).astype('float')
         self.y_numpy = np.random.rand(2, 3, 4).astype('float')
 
+    @test_with_pir_api
     def test_broadcast_errors(self):
         paddle.disable_static()
         self.init_data()

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -25,7 +25,6 @@ import paddle.distributed as dist
 from paddle import base
 from paddle.base import core
 from paddle.base.layer_helper import LayerHelper
-from paddle.pir_utils import test_with_pir_api
 
 
 class TestElementwiseAddOp(OpTest):
@@ -693,7 +692,6 @@ class TestAddInplaceBroadcastError(unittest.TestCase):
         self.x_numpy = np.random.rand(3, 4).astype('float')
         self.y_numpy = np.random.rand(2, 3, 4).astype('float')
 
-    @test_with_pir_api
     def test_broadcast_errors(self):
         paddle.disable_static()
         self.init_data()

--- a/test/legacy_test/test_numel_op.py
+++ b/test/legacy_test/test_numel_op.py
@@ -188,6 +188,7 @@ class TestNumelAPI(unittest.TestCase):
         np.testing.assert_array_equal(out_2.numpy().item(0), np.size(input_2))
         paddle.enable_static()
 
+    @test_with_pir_api
     def test_error(self):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()

--- a/test/legacy_test/test_numel_op.py
+++ b/test/legacy_test/test_numel_op.py
@@ -201,16 +201,6 @@ class TestNumelAPI(unittest.TestCase):
 
             self.assertRaises(TypeError, test_x_type)
 
-    def test_pir_error(self):
-        with paddle.pir_utils.IrGuard():
-
-            def test_x_type():
-                shape = [1, 4, 5]
-                input_1 = np.random.random(shape).astype("int32")
-                out_1 = paddle.numel(input_1)
-
-            self.assertRaises(TypeError, test_x_type)
-
 
 if __name__ == '__main__':
     paddle.enable_static()

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -560,6 +560,7 @@ class TestReshapeOpError(unittest.TestCase):
         self.data = paddle.static.data
         self.reshape = paddle.reshape
 
+    @test_with_pir_api
     def _test_errors(self):
         paddle.enable_static()
         with program_guard(Program(), Program()):

--- a/test/legacy_test/test_scale_op.py
+++ b/test/legacy_test/test_scale_op.py
@@ -132,6 +132,7 @@ class TestScaleOpSelectedRows(unittest.TestCase):
 
 
 class TestScaleRaiseError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
 

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -465,6 +465,7 @@ class API_Test_Add_n(unittest.TestCase):
 
 
 class TestRaiseSumError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         def test_type():
             paddle.add_n([11, 22])
@@ -486,6 +487,7 @@ class TestRaiseSumError(unittest.TestCase):
 
 
 class TestRaiseSumsError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         def test_type():
             paddle.add_n([11, 22])
@@ -531,6 +533,7 @@ class TestRaiseSumsError(unittest.TestCase):
 
 
 class TestSumOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         def test_empty_list_input():
             with base.dygraph.guard():

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -467,69 +467,89 @@ class API_Test_Add_n(unittest.TestCase):
 class TestRaiseSumError(unittest.TestCase):
     @test_with_pir_api
     def test_errors(self):
-        def test_type():
-            paddle.add_n([11, 22])
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
 
-        self.assertRaises(TypeError, test_type)
+            def test_type():
+                paddle.add_n([11, 22])
 
-        def test_dtype():
-            data1 = paddle.static.data(name="input1", shape=[10], dtype="int8")
-            data2 = paddle.static.data(name="input2", shape=[10], dtype="int8")
-            paddle.add_n([data1, data2])
+            self.assertRaises(TypeError, test_type)
 
-        self.assertRaises(TypeError, test_dtype)
+            def test_dtype():
+                data1 = paddle.static.data(
+                    name="input1", shape=[10], dtype="int8"
+                )
+                data2 = paddle.static.data(
+                    name="input2", shape=[10], dtype="int8"
+                )
+                paddle.add_n([data1, data2])
 
-        def test_dtype1():
-            data1 = paddle.static.data(name="input1", shape=[10], dtype="int8")
-            paddle.add_n(data1)
+            self.assertRaises(TypeError, test_dtype)
 
-        self.assertRaises(TypeError, test_dtype1)
+            def test_dtype1():
+                data1 = paddle.static.data(
+                    name="input1", shape=[10], dtype="int8"
+                )
+                paddle.add_n(data1)
+
+            self.assertRaises(TypeError, test_dtype1)
 
 
 class TestRaiseSumsError(unittest.TestCase):
     @test_with_pir_api
     def test_errors(self):
-        def test_type():
-            paddle.add_n([11, 22])
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
 
-        self.assertRaises(TypeError, test_type)
+            def test_type():
+                paddle.add_n([11, 22])
 
-        def test_dtype():
-            data1 = paddle.static.data(name="input1", shape=[10], dtype="int8")
-            data2 = paddle.static.data(name="input2", shape=[10], dtype="int8")
-            paddle.add_n([data1, data2])
+            self.assertRaises(TypeError, test_type)
 
-        self.assertRaises(TypeError, test_dtype)
+            def test_dtype():
+                data1 = paddle.static.data(
+                    name="input1", shape=[10], dtype="int8"
+                )
+                data2 = paddle.static.data(
+                    name="input2", shape=[10], dtype="int8"
+                )
+                paddle.add_n([data1, data2])
 
-        def test_dtype1():
-            data1 = paddle.static.data(name="input1", shape=[10], dtype="int8")
-            paddle.add_n(data1)
+            self.assertRaises(TypeError, test_dtype)
 
-        self.assertRaises(TypeError, test_dtype1)
+            def test_dtype1():
+                data1 = paddle.static.data(
+                    name="input1", shape=[10], dtype="int8"
+                )
+                paddle.add_n(data1)
 
-        def test_out_type():
-            data1 = paddle.static.data(
-                name="input1", shape=[10], dtype="flaot32"
-            )
-            data2 = paddle.static.data(
-                name="input2", shape=[10], dtype="float32"
-            )
-            out = [10]
-            out = paddle.add_n([data1, data2])
+            self.assertRaises(TypeError, test_dtype1)
 
-        self.assertRaises(TypeError, test_out_type)
+            def test_out_type():
+                data1 = paddle.static.data(
+                    name="input1", shape=[10], dtype="flaot32"
+                )
+                data2 = paddle.static.data(
+                    name="input2", shape=[10], dtype="float32"
+                )
+                out = [10]
+                out = paddle.add_n([data1, data2])
 
-        def test_out_dtype():
-            data1 = paddle.static.data(
-                name="input1", shape=[10], dtype="flaot32"
-            )
-            data2 = paddle.static.data(
-                name="input2", shape=[10], dtype="float32"
-            )
-            out = paddle.static.data(name="out", shape=[10], dtype="int8")
-            out = paddle.add_n([data1, data2])
+            self.assertRaises(TypeError, test_out_type)
 
-        self.assertRaises(TypeError, test_out_dtype)
+            def test_out_dtype():
+                data1 = paddle.static.data(
+                    name="input1", shape=[10], dtype="flaot32"
+                )
+                data2 = paddle.static.data(
+                    name="input2", shape=[10], dtype="float32"
+                )
+                out = paddle.static.data(name="out", shape=[10], dtype="int8")
+                out = paddle.add_n([data1, data2])
+
+            self.assertRaises(TypeError, test_out_dtype)
 
 
 class TestSumOpError(unittest.TestCase):

--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -533,7 +533,6 @@ class TestRaiseSumsError(unittest.TestCase):
 
 
 class TestSumOpError(unittest.TestCase):
-    @test_with_pir_api
     def test_errors(self):
         def test_empty_list_input():
             with base.dygraph.guard():

--- a/test/legacy_test/test_uniform_random_op.py
+++ b/test/legacy_test/test_uniform_random_op.py
@@ -203,6 +203,7 @@ class TestUniformRandomBF16Op(TestUniformRandomOp):
 
 
 class TestUniformRandomOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         paddle.enable_static()
         main_prog = Program()

--- a/test/legacy_test/test_unsqueeze2_op.py
+++ b/test/legacy_test/test_unsqueeze2_op.py
@@ -297,6 +297,7 @@ class TestUnsqueezeAPI(unittest.TestCase):
         np.testing.assert_array_equal(res_4, input.reshape([3, 2, 5, 1]))
         np.testing.assert_array_equal(res_5, input.reshape([3, 1, 1, 2, 5, 1]))
 
+    @test_with_pir_api
     def test_error(self):
         def test_axes_type():
             x2 = paddle.static.data(name="x2", shape=[2, 25], dtype="int32")

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -672,6 +672,7 @@ class TestWhereDygraphAPI(unittest.TestCase):
 
 
 class TestWhereOpError(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
         with paddle.static.program_guard(
             paddle.static.Program(), paddle.static.Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/60488
大部分的 test_error 添加 test_with_pir_api 已经在之前的pr中进行了总结和测试，本 PR 先将可直接添加装饰器不需要额外修改的部分合入。

下列 API 单测 test_errors 适配 PIR：
<img width="256" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/46243324/9b3f7801-1932-4ba0-ac37-96c5513f8ccf">
- numel
- unsqueeze
- arrange
- greater_equal
- reshape

