### PR TITLE
[Custom Device] Add Conv2d Fuse more act support for Custom Device

### DIFF
--- a/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
@@ -175,6 +175,13 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
     all_act_set.insert(cutlass_act_set.begin(), cutlass_act_set.end());
   }
 
+  std::unordered_set<std::string> custom_act_set{};
+  if (Get<bool>("use_custom_device")) {
+    custom_act_set = {
+        "identity", "relu", "sigmoid", "tanh", "swish", "leaky_relu"};
+    all_act_set.insert(custom_act_set.begin(), custom_act_set.end());
+  }
+
   patterns::ConvElementwiseaddAct pattern(gpd.mutable_pattern(), pattern_name);
   pattern(x, all_act_set);
   int found_count = 0;
@@ -197,7 +204,8 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
     // When this fused_conv2d_add_act specified by problem size and act type is
     // not supported by cutlass and not supported by cuDNN, we should not apply
     // this pass.
-    if (!cutlass_can_fuse && !cudnn_can_fuse) {
+    bool custom_can_fuse = custom_act_set.count(act_op_type);
+    if (!cutlass_can_fuse && !cudnn_can_fuse && !custom_can_fuse) {
       return;
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Custom Device可以使用pass conv_elementwise_add_act_fuse_pass
但是激活层融合只有"identity", "relu" 有效。
原因是 conv_elementwise_add_act_fuse_pass判定激活层是否可用取决于cutlass_can_fuse和cudnn_can_fuse
这影响了custom device的使用。

所以添加了
```cpp
    custom_act_set = {
        "identity", "relu", "sigmoid", "tanh", "swish", "leaky_relu"};
```
让Custom Device可以正常使用conv_elementwise_add_act_fuse_pass的全部激活层融合。
这个PR不影响现有的任何实现。

Custom Device想要启用激活层融合则需要在Paddle Inference的config手动添加Pass
```cpp
        config.pass_builder()->AppendPass("silu_fuse_pass");
        config.pass_builder()->AppendPass("conv_bn_fuse_pass");
        config.pass_builder()->AppendPass("conv_eltwiseadd_bn_fuse_pass");
        config.pass_builder()->AppendPass("conv_elementwise_add_act_fuse_pass");
        config.pass_builder()->AppendPass("conv_elementwise_add_fuse_pass");
```
Pass启用后，将会使用fused_conv2d_add_act Kernel.
