### PR TITLE
Add TestOpWithBackWardTranslator

### DIFF
--- a/test/ir/pir/translator/test_c_reduce_min_translator.py
+++ b/test/ir/pir/translator/test_c_reduce_min_translator.py
@@ -34,6 +34,9 @@ class TestCReduceMinOpTranslator(test_op_translator.TestOpTranslator):
             attrs=attrs,
         )
 
+    def test_translator(self):
+        self.check()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/ir/pir/translator/test_c_reduce_min_translator.py
+++ b/test/ir/pir/translator/test_c_reduce_min_translator.py
@@ -34,9 +34,6 @@ class TestCReduceMinOpTranslator(test_op_translator.TestOpTranslator):
             attrs=attrs,
         )
 
-    def test_translator(self):
-        self.check()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/ir/pir/translator/test_op_translator.py
+++ b/test/ir/pir/translator/test_op_translator.py
@@ -17,6 +17,7 @@ import unittest
 import paddle
 from paddle import pir
 from paddle.base import core
+from paddle.base.backward import append_backward
 
 paddle.enable_static()
 
@@ -38,11 +39,57 @@ class TestOpTranslator(unittest.TestCase):
 
     def check(self):
         self.build_model()
-        l = pir.translate_to_pir(self.main_program.desc)
+        pir_program = pir.translate_to_pir(self.main_program.desc)
         assert hasattr(self, "op_type"), "Op_type should be specified!"
-        assert self.op_type in str(l), (
+        assert self.op_type in str(pir_program), (
             self.op_type
             + " should be translated to pd_op."
             + self.op_type
             + '!'
         )
+
+    def test_translator(self):
+        self.check()
+
+
+class TestOpWithBackWardTranslator(unittest.TestCase):
+    def setUp(self):
+        self.place = core.Place()
+        self.place.set_place(paddle.CPUPlace())
+        self.new_scope = paddle.static.Scope()
+        self.main_program = paddle.static.Program()
+
+    def append_op(self):
+        raise Exception("Define the op to be tested here!")
+
+    def build_model(self):
+        with paddle.static.scope_guard(self.new_scope):
+            with paddle.static.program_guard(self.main_program):
+                out = self.append_op()
+                append_backward(out)
+
+    def check(self):
+        self.build_model()
+        pir_program = pir.translate_to_pir(self.main_program.desc)
+        assert hasattr(
+            self, "forward_op_type"
+        ), "forward_op_type should be specified!"
+        assert hasattr(
+            self, "backward_op_type"
+        ), "backward_op_type should be specified!"
+        serialized_pir_program = str(pir_program)
+        assert self.forward_op_type in serialized_pir_program, (
+            self.forward_op_type
+            + " should be translated to pd_op."
+            + self.forward_op_type
+            + '!'
+        )
+        assert self.backward_op_type in serialized_pir_program, (
+            self.backward_op_type
+            + " should be translated to pd_op."
+            + self.backward_op_type
+            + '!'
+        )
+
+    def test_translator(self):
+        self.check()

--- a/test/ir/pir/translator/test_op_translator.py
+++ b/test/ir/pir/translator/test_op_translator.py
@@ -48,9 +48,6 @@ class TestOpTranslator(unittest.TestCase):
             + '!'
         )
 
-    def test_translator(self):
-        self.check()
-
 
 class TestOpWithBackWardTranslator(unittest.TestCase):
     def setUp(self):
@@ -76,7 +73,7 @@ class TestOpWithBackWardTranslator(unittest.TestCase):
         ), "forward_op_type should be specified!"
         assert hasattr(
             self, "backward_op_type"
-        ), "backward_op_type should be specified!"
+        ), "forward_op_type should be specified!"
         serialized_pir_program = str(pir_program)
         assert self.forward_op_type in serialized_pir_program, (
             self.forward_op_type
@@ -90,6 +87,3 @@ class TestOpWithBackWardTranslator(unittest.TestCase):
             + self.backward_op_type
             + '!'
         )
-
-    def test_translator(self):
-        self.check()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
增加`TestOpWithBackWardTranslator`支持对反向算子的翻译测试
这里没有把
```Python
    def test_translator(self):
        self.check()
```
放到基类里，因为在一些CI会执行`test_op_translator`