### PR TITLE
[CINN+PIR]Fix Fetch XShape Variable logic

### DIFF
--- a/paddle/fluid/framework/new_executor/feed_fetch_utils.cc
+++ b/paddle/fluid/framework/new_executor/feed_fetch_utils.cc
@@ -113,7 +113,12 @@ void FetchTensors(const std::vector<std::string>& job_fetch_names,
     auto& src = var->Get<phi::DenseTensor>();
     auto* dst =
         &(PADDLE_GET(phi::DenseTensor, fetch_list->at(micro_batch_id)[col]));
-    TensorCopy(src, platform::CPUPlace(), dst);
+    if (src.IsInitialized()) {
+      TensorCopy(src, platform::CPUPlace(), dst);
+    } else {
+      VLOG(6) << "Found " << var_name
+              << " is not initialized and skip TensorCopy.";
+    }
   }
 }
 

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -128,6 +128,23 @@ const std::unordered_set<std::string> SpecialLowerOps = {
     SelectInputOp::name(),
     "cinn_runtime.jit_kernel"};
 
+const std::unordered_map<std::string, uint32_t> XShapeRelatedOps = {
+    {paddle::dialect::ReshapeOp::name(), /*xshape_idx*/ 1U},
+    {paddle::dialect::SqueezeOp::name(), /*xshape_idx*/ 1U},
+    {paddle::dialect::FlattenOp::name(), /*xshape_idx*/ 1U},
+};
+
+static bool NeedSkipPlaceTransfer(const pir::Operation* op) {
+  bool need_skip = false;
+  if (op->isa<paddle::dialect::FetchOp>()) {
+    auto define_op_name = op->operand_source(0).defining_op()->name();
+    uint32_t index = op->operand_source(0).dyn_cast<pir::OpResult>().index();
+    need_skip = XShapeRelatedOps.count(define_op_name) > 0 &&
+                (XShapeRelatedOps.at(define_op_name) == index);
+  }
+  return need_skip;
+}
+
 static bool NeedFallBackCpu(const pir::Operation* op,
                             const std::string& kernel,
                             const phi::KernelKey& kernel_key) {
@@ -1756,6 +1773,11 @@ std::vector<pir::Value> BuildInputs(
     bool check_place_transfer =
         (op_item->isa<::pir::SetParameterOp>()) ||
         (kernel.IsValid() && (!UnchangeOutputOps.count(op_item->name())));
+
+    // NOTE(Aurelius84): In case of Reshape/Squeeze/Flatten.XShape,
+    // Skip insert memcpyd2h for fetch op
+    check_place_transfer =
+        check_place_transfer && !NeedSkipPlaceTransfer(op_item);
 
     if (check_place_transfer) {
       if (new_in_type.isa<AllocatedDenseTensorType>()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164 

在Python API 层面是不会出现fetch XShape 的场景。但如果通过其他方式（比如name等）对XShape进行了fetch，则会默认插入一个pd_op.memcpyd2h的算子，导致报错，此PR修复了此问题。