### PR TITLE
[Dynamic Shape] Use ShapeAnalysis Formal Interface

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -139,9 +139,8 @@ bool ProcessOp(paddle::dialect::ExpandOp op, pir::PatternRewriter* rewriter) {
     pir::ShapeConstraintIRAnalysis& shape_analysis =
         pir::ShapeAnalysisManager::Instance().Get(
             op.x().defining_op()->GetParentProgram());
-    CHECK(shape_analysis.value_id_to_shapeordata_.find(GetValueId(&value)) !=
-          shape_analysis.value_id_to_shapeordata_.end());
-    return shape_analysis.value_id_to_shapeordata_.at(GetValueId(&value));
+    CHECK(shape_analysis.HasShapeOrDataForValue(&value));
+    return shape_analysis.GetShapeOrDataForValue(&value);
   };
   std::optional<pir::Value> opt_generated_shape =
       GetOutOfRewritedGenerateShapeOp(

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3004,15 +3004,13 @@ bool ShapeBroadcastOp::InferSymbolicShape(
     pir::ShapeConstraintIRAnalysis *shape_analysis) {
   pir::Value x = operand_source(0);
   pir::Value y = operand_source(1);
-  std::string x_id = pir::GetValueId(&x);
-  std::string y_id = pir::GetValueId(&y);
 
-  IR_ENFORCE(shape_analysis->value_id_to_shapeordata_.count(x_id) > 0,
-             "x_id does not exist.");
-  IR_ENFORCE(shape_analysis->value_id_to_shapeordata_.count(y_id) > 0,
-             "y_id does not exist.");
-  const auto &x_data_shape = shape_analysis->value_id_to_shapeordata_.at(x_id);
-  const auto &y_data_shape = shape_analysis->value_id_to_shapeordata_.at(y_id);
+  IR_ENFORCE(shape_analysis->HasShapeOrDataForValue(&x),
+             "Value x does not exist.");
+  IR_ENFORCE(shape_analysis->HasShapeOrDataForValue(&y) > 0,
+             "Value y does not exist.");
+  const auto &x_data_shape = shape_analysis->GetShapeOrDataForValue(&x);
+  const auto &y_data_shape = shape_analysis->GetShapeOrDataForValue(&y);
   IR_ENFORCE(x_data_shape.data().has_value(),
              "Value x comes from ShapeOp, it must have data");
   IR_ENFORCE(y_data_shape.data().has_value(),
@@ -3027,10 +3025,9 @@ bool ShapeBroadcastOp::InferSymbolicShape(
   }
 
   pir::OpResult res = result(0);
-  std::string res_id = pir::GetValueId(&res);
   symbol::ShapeOrDataDimExprs output_data_shape =
       symbol::ShapeOrDataDimExprs::MakeConsistentShapeOrData(output_data);
-  shape_analysis->value_id_to_shapeordata_[res_id] = output_data_shape;
+  shape_analysis->SetShapeOrDataForValue(&res, output_data_shape);
   return true;
 }
 

--- a/paddle/pir/dialect/shape/utils/shape_utils.cc
+++ b/paddle/pir/dialect/shape/utils/shape_utils.cc
@@ -172,6 +172,11 @@ std::string GetValueId(Value* val) {
   return "op_" + std::to_string(op_id) + "_rst_" + std::to_string(val_idx);
 }
 
+bool ShapeConstraintIRAnalysis::HasShapeOrDataForValue(Value* val) {
+  auto val_id = GetValueId(val);
+  return value_id_to_shapeordata_.count(val_id) > 0;
+}
+
 const symbol::ShapeOrDataDimExprs&
 ShapeConstraintIRAnalysis::GetShapeOrDataForValue(Value* val) {
   auto val_id = GetValueId(val);

--- a/paddle/pir/dialect/shape/utils/shape_utils.h
+++ b/paddle/pir/dialect/shape/utils/shape_utils.h
@@ -80,6 +80,7 @@ class IR_API ShapeConstraintIRAnalysis : public ShapeAnalysis {
     return "S" + std::to_string(next_sym_idx_++);
   }
 
+  bool HasShapeOrDataForValue(Value* val);
   const symbol::ShapeOrDataDimExprs& GetShapeOrDataForValue(Value* val);
 
   void SetShapeOrDataForValue(Value* val,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

使用 `ShapeAnalysis` 正式化接口，并为其提供 `HasShapeOrDataForValue` 接口

- Use formal interface of `ShapeAnalysis` instead of visiting public member.
- Provide `HasShapeOrDataForValue` interface for `ShapeAnalysis`