### PR TITLE
reduce runtime of unit-tests in windows-trt

### DIFF
--- a/test/ir/inference/test_trt_convert_einsum.py
+++ b/test/ir/inference/test_trt_convert_einsum.py
@@ -266,19 +266,6 @@ class TrtConvertEinsumTest_DoubuleOperand_Vector_Matrix(TrtLayerAutoScanTest):
                     "operands_data0": [2],
                     "operands_data1": [2],
                 }
-            elif self.dims == 2:
-                self.dynamic_shape.min_input_shape = {
-                    "operands_data0": [1, 3],
-                    "operands_data1": [1],
-                }
-                self.dynamic_shape.max_input_shape = {
-                    "operands_data0": [4, 3],
-                    "operands_data1": [4],
-                }
-                self.dynamic_shape.opt_input_shape = {
-                    "operands_data0": [2, 3],
-                    "operands_data1": [3],
-                }
             elif self.dims == 3:
                 self.dynamic_shape.min_input_shape = {
                     "operands_data0": [1, 2, 3],
@@ -359,11 +346,6 @@ class TrtConvertEinsumTest_DoubuleOperand_Matrix_Matrix(TrtLayerAutoScanTest):
             [[3, 4, 5], [4, 5], "ijk,jk->i"],
             [[3, 4, 5], [2, 5], "ijk,lk->ijl"],
             [[2, 4, 5, 3], [3, 4, 5], "ijkl,lmn->ijkmn"],
-            [[4, 5], [4, 2, 5], "ik,ijk->j"],
-            [[4, 2, 5], [4, 5], "ijk,ik->jk"],
-            [[2, 4, 5, 3], [3, 2, 4], "ijkl,lmn->kmn"],
-            [[2, 4, 5, 3], [3, 2, 4], "ijkl,lmn->ijn"],
-            [[1, 3, 5], [1, 2, 3, 4], "blq,bhlk->bhlqk"],
         ]:
             self.x_shape = item[0]
             self.y_shape = item[1]

--- a/test/ir/inference/test_trt_convert_einsum.py
+++ b/test/ir/inference/test_trt_convert_einsum.py
@@ -36,17 +36,12 @@ class TrtConvertEinsumTest_SingleOperand(TrtLayerAutoScanTest):
         def generate_input1(dims, batch):
             if dims == 1:
                 return np.ones(shape=[batch]).astype(np.float32)
-            elif dims == 2:
-                return np.ones(shape=[batch, 3]).astype(np.float32)
             elif dims == 3:
                 return np.ones((batch, 2, 3)).astype(np.float32)
 
         def generate_equation1(dims):
             if dims == 1:
                 return ["i->"]
-            elif dims == 2:
-                # "ij->"
-                return ["ij->ji", "ij->i", "ij->j"]
             elif dims == 3:
                 # "ijk->","ijk->j","ijk->k"
                 # error: The current implementation of Einsum doesn't support mask dimensions on multiple contracting/free dimensions
@@ -60,7 +55,7 @@ class TrtConvertEinsumTest_SingleOperand(TrtLayerAutoScanTest):
                 ]
 
         # Single operand: transpose, sum
-        for dims in [1, 2, 3]:
+        for dims in [1, 3]:
             for batch in [2]:
                 equation_list = generate_equation1(dims)
                 for equation in equation_list:
@@ -108,16 +103,7 @@ class TrtConvertEinsumTest_SingleOperand(TrtLayerAutoScanTest):
                 self.dynamic_shape.opt_input_shape = {
                     "operands_data0": [2],
                 }
-            elif self.dims == 2:
-                self.dynamic_shape.min_input_shape = {
-                    "operands_data0": [1, 3],
-                }
-                self.dynamic_shape.max_input_shape = {
-                    "operands_data0": [4, 3],
-                }
-                self.dynamic_shape.opt_input_shape = {
-                    "operands_data0": [2, 3],
-                }
+
             elif self.dims == 3:
                 self.dynamic_shape.min_input_shape = {
                     "operands_data0": [1, 2, 3],
@@ -219,18 +205,12 @@ class TrtConvertEinsumTest_DoubuleOperand_Vector_Matrix(TrtLayerAutoScanTest):
         # Doubule operands vector
         for dims in [1]:
             self.dims = dims
-            for vec_shape in [[2], [3]]:
+            for vec_shape in [[2]]:
                 for batch in [2]:
                     equation_list = generate_equation_matrix_vector(
                         dims, vec_shape
                     )
                     for equation in equation_list:
-                        if (
-                            dims == 1
-                            and vec_shape != [2]
-                            and equation != "i,j->ij"
-                        ) or ((dims == 2 or dims == 3) and vec_shape != [3]):
-                            continue
                         self.equation = equation
                         self.dims = dims
                         dics = [{"equation": equation}, {}]
@@ -379,8 +359,6 @@ class TrtConvertEinsumTest_DoubuleOperand_Matrix_Matrix(TrtLayerAutoScanTest):
             [[3, 4, 5], [4, 5], "ijk,jk->i"],
             [[3, 4, 5], [2, 5], "ijk,lk->ijl"],
             [[2, 4, 5, 3], [3, 4, 5], "ijkl,lmn->ijkmn"],
-            [[3, 4, 5], [4, 5], "ijk,jk->ik"],
-            [[3, 4, 5], [4, 5], "ijk,jk->ij"],
             [[4, 5], [4, 2, 5], "ik,ijk->j"],
             [[4, 2, 5], [4, 5], "ijk,ik->jk"],
             [[2, 4, 5, 3], [3, 2, 4], "ijkl,lmn->kmn"],

--- a/test/ir/inference/test_trt_convert_grid_sampler.py
+++ b/test/ir/inference/test_trt_convert_grid_sampler.py
@@ -46,8 +46,8 @@ class TrtConvertGridSampler(TrtLayerAutoScanTest):
                 return np.random.random([1, 3, 3, 2, 3]).astype(np.float32)
 
         mode = ["bilinear", "nearest"]
-        padding_mode = ["zeros", "reflection", "border"]
-        align_corners = [True, False]
+        padding_mode = ["zeros", "reflection"]
+        align_corners = [True]
         descs = []
         for m in mode:
             for p in padding_mode:

--- a/test/ir/inference/test_trt_convert_squeeze2.py
+++ b/test/ir/inference/test_trt_convert_squeeze2.py
@@ -34,8 +34,8 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        for dims in [2, 3, 4]:
-            for batch in [3, 4]:
+        for dims in [4]:
+            for batch in [4]:
                 for axes in [[2], [2, 3], [-1]]:
                     for attr_axis in [True, False]:
                         self.batch = batch

--- a/test/ir/inference/test_trt_convert_stack.py
+++ b/test/ir/inference/test_trt_convert_stack.py
@@ -44,42 +44,24 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
-            elif self.dims == 3:
-                return np.random.random([batch, 3, 24]).astype(np.float32)
-            elif self.dims == 2:
-                return np.random.random([batch, 24]).astype(np.float32)
-            elif self.dims == 1:
-                return np.random.random([24]).astype(np.float32)
-            elif self.dims == 0:
+            else:
                 return np.random.random([]).astype(np.float32)
 
         def generate_input2(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
-            elif self.dims == 3:
-                return np.random.random([batch, 3, 24]).astype(np.float32)
-            elif self.dims == 2:
-                return np.random.random([batch, 24]).astype(np.float32)
-            elif self.dims == 1:
-                return np.random.random([24]).astype(np.float32)
-            elif self.dims == 0:
+            else:
                 return np.random.random([]).astype(np.float32)
 
         def generate_input3(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
-            elif self.dims == 3:
-                return np.random.random([batch, 3, 24]).astype(np.float32)
-            elif self.dims == 2:
-                return np.random.random([batch, 24]).astype(np.float32)
-            elif self.dims == 1:
-                return np.random.random([24]).astype(np.float32)
-            elif self.dims == 0:
+            else:
                 return np.random.random([]).astype(np.float32)
 
-        for dims in [0, 1, 2, 3, 4]:
-            for batch in [1, 4]:
-                for axis in [-2, -1, 0, 1, 2, 3]:
+        for dims in [0, 4]:
+            for batch in [1]:
+                for axis in [-1, 0, 1]:
                     self.dims = dims
                     dics = [{"axis": axis}, {}]
                     ops_config = [
@@ -136,55 +118,7 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
                     "stack_input2": [1, 3, 24, 24],
                     "stack_input3": [1, 3, 24, 24],
                 }
-            elif self.dims == 3:
-                self.dynamic_shape.min_input_shape = {
-                    "stack_input1": [1, 3, 24],
-                    "stack_input2": [1, 3, 24],
-                    "stack_input3": [1, 3, 24],
-                }
-                self.dynamic_shape.max_input_shape = {
-                    "stack_input1": [4, 3, 48],
-                    "stack_input2": [4, 3, 48],
-                    "stack_input3": [4, 3, 48],
-                }
-                self.dynamic_shape.opt_input_shape = {
-                    "stack_input1": [1, 3, 24],
-                    "stack_input2": [1, 3, 24],
-                    "stack_input3": [1, 3, 24],
-                }
-            elif self.dims == 2:
-                self.dynamic_shape.min_input_shape = {
-                    "stack_input1": [1, 24],
-                    "stack_input2": [1, 24],
-                    "stack_input3": [1, 24],
-                }
-                self.dynamic_shape.max_input_shape = {
-                    "stack_input1": [4, 48],
-                    "stack_input2": [4, 48],
-                    "stack_input3": [4, 48],
-                }
-                self.dynamic_shape.opt_input_shape = {
-                    "stack_input1": [1, 24],
-                    "stack_input2": [1, 24],
-                    "stack_input3": [1, 24],
-                }
-            elif self.dims == 1:
-                self.dynamic_shape.min_input_shape = {
-                    "stack_input1": [24],
-                    "stack_input2": [24],
-                    "stack_input3": [24],
-                }
-                self.dynamic_shape.max_input_shape = {
-                    "stack_input1": [48],
-                    "stack_input2": [48],
-                    "stack_input3": [48],
-                }
-                self.dynamic_shape.opt_input_shape = {
-                    "stack_input1": [24],
-                    "stack_input2": [24],
-                    "stack_input3": [24],
-                }
-            elif self.dims == 0:
+            else:
                 self.dynamic_shape.min_input_shape = {
                     "stack_input1": [],
                     "stack_input2": [],

--- a/test/ir/inference/test_trt_convert_unsqueeze2.py
+++ b/test/ir/inference/test_trt_convert_unsqueeze2.py
@@ -28,9 +28,9 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        for dims in [2, 3, 4]:
-            for batch in [3, 4]:
-                for axes in [[-2, 3], [1], [2], [2, 3]]:
+        for dims in [2, 4]:
+            for batch in [4]:
+                for axes in [[-2, 3], [1]]:
                     self.batch = batch
                     self.dims = dims
                     self.axes = axes


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501
优化了trt单测 Timeout 问题，优化单测及效果如下表：
测试环境：T4，cuda11.6，cudnn8.4，trt8.6.1.6

单测 | 优化前时长 | 优化后时长
-- | -- | --
test_trt_convert_grid_sampler | 388.841s | 132.216s
test_trt_convert_stack | 671.266s | 76.367s
test_trt_convert_top_k_v2 | failed | 45.309s
test_trt_convert_einsum(3个case) | 434.383s | 267.905s
test_trt_convert_unsqueeze2 | 689.616s | 116.763s
test_trt_convert_squeeze2 | 703.340s | 173.682s


