### PR TITLE
【CINN】Use another way as equivalent replacement of ceil

### DIFF
--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -118,7 +118,7 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   std::for_each(factors.begin(), factors.end(), [&](int factor) {
     if (factor == -1) {
       process_factors.push_back(
-          cinn::common::AutoSimplify(tot_extent / prod_size + Expr(1)));
+          cinn::common::AutoSimplify((tot_extent + prod_size - 1) / prod_size));
     } else {
       process_factors.push_back(Expr(factor));
     }

--- a/test/cinn/ir/test_llir_schedule_fuse_split.py
+++ b/test/cinn/ir/test_llir_schedule_fuse_split.py
@@ -191,15 +191,15 @@ def test_split_dynamic():
             for i in range(128):
                 for j in range(128):
                     for k_7 in range(16):
-                        for k_8 in range((N / 16) + 1):
-                            if (((N / 16) * k_7) + (k_7 + k_8)) < N:
+                        for k_8 in range((15 + N) / 16):
+                            if ((((15 + N) / 16) * k_7) + k_8) < N:
                                 with ir.ScheduleBlockContext("Y") as Y_block:
                                     i1, j1, k1 = ir.AxisMap(
                                         "SSS",
                                         [
                                             i,
                                             j,
-                                            (((N / 16) * k_7) + (k_7 + k_8)),
+                                            ((((15 + N) / 16) * k_7) + k_8),
                                         ],
                                     )
                                     Y[i1, j1, k1] = X[i1, j1, k1] * 2.0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pcard-72718
This PR use another way as equivalent replacement of ceil, eg
S / 1024 when S can't be divisible to 1024, we can write code like S/1024 + 1 or (S+1023)/1024,
the first is not that good because S/1024 + 1 = 2 when S is 1024 but (S+1023)/1024 = 1 ,so we use the second way