### PR TITLE
Fix multi-thread bug for memory stats

### DIFF
--- a/paddle/fluid/memory/stats.cc
+++ b/paddle/fluid/memory/stats.cc
@@ -118,6 +118,11 @@ void LogDeviceMemoryStats(const platform::Place& place,
                    "Allocated", place.device)) /
                    1024 / 1024
             << " MB, "
+            << "memory_reserved: "
+            << static_cast<double>(memory::DeviceMemoryStatCurrentValue(
+                   "Reserved", place.device)) /
+                   1024 / 1024
+            << " MB, "
             << "max_memory_allocated: "
             << static_cast<double>(memory::DeviceMemoryStatPeakValue(
                    "Allocated", place.device)) /

--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -33,6 +33,18 @@ using phi::ThreadDataRegistry;
 struct ThreadLocalStatBase {
   int64_t current{0};
   int64_t peak{0};
+
+  ThreadLocalStatBase operator+=(const ThreadLocalStatBase& other) {
+    current += other.current;
+    peak = std::max(peak, other.peak);
+    return *this;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ThreadLocalStatBase& stat) {
+    os << "{cuerrent : " << stat.current << ", peak : " << stat.peak << "}";
+    return os;
+  }
 };
 
 class StatBase {

--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -36,7 +36,7 @@ struct ThreadLocalStatBase {
 
   ThreadLocalStatBase operator+=(const ThreadLocalStatBase& other) {
     current += other.current;
-    peak = std::max(peak, other.peak);
+    peak = std::max({current, peak, other.peak});
     return *this;
   }
 

--- a/paddle/phi/common/thread_data_registry.h
+++ b/paddle/phi/common/thread_data_registry.h
@@ -24,13 +24,19 @@
 
 namespace phi {
 
+#ifdef __cpp_lib_void_t
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
 template <typename T, typename = void>
 struct IsAccumulatable : std::false_type {};
 
 template <typename T>
-struct IsAccumulatable<
-    T,
-    std::void_t<decltype(std::declval<T>() += std::declval<T>())>>
+struct IsAccumulatable<T,
+                       void_t<decltype(std::declval<T>() += std::declval<T>())>>
     : std::true_type {};
 
 template <typename T>

--- a/paddle/phi/common/thread_data_registry.h
+++ b/paddle/phi/common/thread_data_registry.h
@@ -105,6 +105,17 @@ class ThreadDataRegistry {
 
     void UnregisterData(uint64_t tid) {
       std::lock_guard<LockType> guard(lock_);
+      // Add the data to another thread before erasing.
+      data_to_erased = tid_map_.at(tid)->GetData();
+      for (auto& kv : tid_map_) {
+        if (kv.first != tid) {
+          kv.second->GetData() += data_to_erased;
+          VLOG(2) << "Add data " << data_to_erased << " from thread " << tid
+                  << " to " << kv.first << " , after update, data is "
+                  << kv.second->GetData() << ".";
+          break;
+        }
+      }
       tid_map_.erase(tid);
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-76459

框架显存模块通过`thread_local`变量记录tensor申请和释放信息以实现无锁化显存统计，但在多线程场景下，可能由于部分线程提前析构引起`thread_local`信息丢失，从而导致统计结果错误。
此bug在动态图调用`copy_to`接口时被触发，因`copy_to`中使用`callback`机制延迟tensor生命周期，在CUDA `callback`函数实际回调时才触发tensor释放。`callback`函数在一个临时的子线程中运行，在运行结束之后该子线程立即析构，这导致记录在该子线程`thread_local`变量中的tensor释放操作数据丢失，从而引起统计结果错误。
本PR对此问题进行修复，在线程析构时将该线程对应的`thread_local`数据转移到其它存活线程中进行存储。