### PR TITLE
[cmake] clean findnumpy

### DIFF
--- a/cmake/FindNumPy.cmake
+++ b/cmake/FindNumPy.cmake
@@ -3,8 +3,6 @@
 # NUMPY_FOUND
 # will be set by this script
 
-cmake_minimum_required(VERSION 2.6)
-
 if(NOT PYTHON_EXECUTABLE)
   if(NumPy_FIND_QUIETLY)
     find_package(PythonInterp QUIET)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

清除在`FindNumPy.cmake`指定cmake最小版本

具体警告如下
```bash
CMake Deprecation Warning at cmake/FindNumPy.cmake:6 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
Call Stack (most recent call first):
  cmake/external/python.cmake:76 (find_package)
  cmake/third_party.cmake:376 (include)
  CMakeLists.txt:601 (include)
```