### PR TITLE
[CodeStyle][ruff] fix some `RUF100`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,6 @@ select = [
 
     # Pygrep-hooks
     "PGH004",
-
-    # yeseq
-    "RUF100",
 ]
 unfixable = [
     "NPY001"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ select = [
 
     # Pygrep-hooks
     "PGH004",
+
+    # yeseq
+    "RUF100",
 ]
 unfixable = [
     "NPY001"

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -71,8 +71,8 @@ from .framework.dtype import (
 Tensor = framework.core.eager.Tensor
 Tensor.__qualname__ = 'Tensor'
 
-import paddle.distributed.fleet  # noqa: F401
-import paddle.text  # noqa: F401
+import paddle.distributed.fleet
+import paddle.text
 import paddle.vision  # noqa: F401
 from paddle import (  # noqa: F401
     amp,
@@ -130,7 +130,7 @@ from .device import (  # noqa: F401
     set_device,
 )
 from .distributed import DataParallel
-from .framework import (  # noqa: F401  # noqa: F401
+from .framework import (  # noqa: F401
     CPUPlace,
     CUDAPinnedPlace,
     CUDAPlace,
@@ -157,7 +157,7 @@ from .hapi import (
     flops,
     summary,
 )
-from .nn.functional.distance import (  # noqa: F401
+from .nn.functional.distance import (
     pdist,
 )
 from .nn.initializer.lazy_init import LazyGuard
@@ -222,7 +222,7 @@ from .tensor.linalg import (  # noqa: F401
     transpose,
     transpose_,
 )
-from .tensor.logic import (  # noqa: F401
+from .tensor.logic import (
     allclose,
     bitwise_and,
     bitwise_and_,
@@ -253,11 +253,11 @@ from .tensor.logic import (  # noqa: F401
     logical_or,
     logical_or_,
     logical_xor,
-    logical_xor_,
+    logical_xor_,  # noqa: F401
     not_equal,
-    not_equal_,
+    not_equal_,  # noqa: F401
 )
-from .tensor.manipulation import (  # noqa: F401
+from .tensor.manipulation import (
     as_complex,
     as_real,
     as_strided,

--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -92,7 +92,7 @@ from .auto_parallel.api import (
 
 from .fleet import BoxPSDataset  # noqa: F401
 
-from .entry_attr import (  # noqa: F401
+from .entry_attr import (
     ProbabilityEntry,
     CountFilterEntry,
     ShowClickEntry,

--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -251,9 +251,7 @@ class ProgramHelper:
 
         # NOTE(dev): Because @to_static is a Lazy mechanism, so we explicitly call this to trigger
         # generating Program IR immediately.
-        concrete_program = getattr(
-            self.proxy_layer, func_name
-        ).concrete_program  # noqa: B018
+        concrete_program = getattr(self.proxy_layer, func_name).concrete_program
         prepare_op_amp_options(
             concrete_program.main_program,
             ProgramTranslator.get_instance()._amp_records,

--- a/python/paddle/distributed/auto_parallel/static/operators/__init__.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-import os  # noqa: F401
+import os
 
 from . import (  # noqa: F401
     dist_assign,

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -450,7 +450,7 @@ class ListVariable(ContainerVariable):
         # Note(SigureMo): Why not use isinstance?
         # Because user may define a class that inherit from list.
         # We should convert it to ObjectVariable instead of ListVariable.
-        if type(value) is list:  # noqa: E721
+        if type(value) is list:
             return ListVariable(value, graph=graph, tracker=tracker)
         return None
 

--- a/python/paddle/jit/sot/symbolic/interpreter.py
+++ b/python/paddle/jit/sot/symbolic/interpreter.py
@@ -188,7 +188,7 @@ def prepare_state(SIR, inputs):
     state = {}
 
     # update free vars if exsits
-    if SIRRuntimeCache().has_key(SIR.name):  # noqa: W601
+    if SIRRuntimeCache().has_key(SIR.name):
         free_var_seeker = SIRRuntimeCache().get_free_vars(SIR.name)
         if free_var_seeker:
             state = free_var_seeker()

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..base.framework import require_version  # noqa: F401
+from ..base.framework import require_version
 from . import (  # noqa: F401
     cpp_extension,
     dlpack,

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -30,7 +30,7 @@ from .datasets import (  # noqa: F401
     Flowers,
     ImageFolder,
 )
-from .image import (  # noqa: F401
+from .image import (
     get_image_backend,
     image_load,
     set_image_backend,

--- a/test/auto_parallel/custom_op/semi_auto_parallel_for_custom_op.py
+++ b/test/auto_parallel/custom_op/semi_auto_parallel_for_custom_op.py
@@ -24,7 +24,7 @@ import paddle
 import paddle.distributed as dist
 from paddle.framework import core
 
-import custom_relu  # noqa: F401 # pylint: disable=unused-import # isort:skip
+import custom_relu  # pylint: disable=unused-import # isort:skip
 
 assert core.contains_spmd_rule("custom_relu")
 

--- a/test/dygraph_to_static/test_legacy_error.py
+++ b/test/dygraph_to_static/test_legacy_error.py
@@ -95,7 +95,7 @@ class LayerErrorInCompiletime2(paddle.nn.Layer):
         NOTE: The next line has a tab. And this test to check the IndentationError when spaces and tabs are mixed.
 	A tab here.
         """  # fmt: skip
-        return  # noqa: PLR1711
+        return
 
 
 @paddle.jit.to_static(full_graph=True)

--- a/test/legacy_test/test_fuse_relu_depthwise_conv_pass.py
+++ b/test/legacy_test/test_fuse_relu_depthwise_conv_pass.py
@@ -91,7 +91,7 @@ class TestMNIST(TestParallelExecutorBase):
             return optimizer
 
         if only_forward:
-            _optimizer = None  # noqa: F811
+            _optimizer = None
 
         (
             fuse_op_first_loss,

--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -603,7 +603,7 @@ def get_docstring(full_test=False):
     '''
     this function will get the docstring for test.
     '''
-    import paddle  # noqa: F401
+    import paddle
     import paddle.static.quantization  # noqa: F401
 
     if full_test:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

使用`RUF100`规则去除无用的`noqa`

`RUF100`会在 ruff v0.2.0 去除 flake8 后引入，详见：#60244

相关链接：
* [RUF100](https://docs.astral.sh/ruff/rules/unused-noqa/)