### PR TITLE
[PIR] einsum's inner_cache and xshape set to optional

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -395,7 +395,7 @@
     param : [x, equation]
   kernel :
     func : einsum
-  intermediate : inner_cache, xshape
+  optional : inner_cache, xshape
   backward : einsum_grad
 
 - op : elementwise_pow

--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -395,6 +395,7 @@
     param : [x, equation]
   kernel :
     func : einsum
+  intermediate : inner_cache, xshape
   backward : einsum_grad
 
 - op : elementwise_pow


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
- einsum's inner_cache and xshape set to intermediate
### Others
Pcard-71500