### PR TITLE
[Cleanup] clean `random_seed` for test path - Part 1

### DIFF
--- a/python/paddle/framework/random.py
+++ b/python/paddle/framework/random.py
@@ -14,7 +14,6 @@
 
 # TODO: define random api
 import paddle
-from paddle import base
 from paddle.base import core
 
 __all__ = []
@@ -43,14 +42,14 @@ def seed(seed):
 
     seed = int(seed)
 
-    if core.is_compiled_with_cuda():
+    if paddle.is_compiled_with_cuda():
         for i in range(core.get_cuda_device_count()):
             core.default_cuda_generator(i).manual_seed(seed)
-    elif core.is_compiled_with_xpu():
+    elif paddle.is_compiled_with_xpu():
         for i in range(core.get_xpu_device_count()):
             core.default_xpu_generator(i).manual_seed(seed)
-    place = base.framework._current_expected_place()
-    if isinstance(place, core.CustomPlace):
+    place = paddle.framework._current_expected_place()
+    if isinstance(place, paddle.CustomPlace):
         dev_cnt = sum(
             [
                 place.get_device_type() == s.split(':')[0]
@@ -59,7 +58,7 @@ def seed(seed):
         )
         for i in range(dev_cnt):
             core.default_custom_device_generator(
-                core.CustomPlace(place.get_device_type(), i)
+                paddle.CustomPlace(place.get_device_type(), i)
             ).manual_seed(seed)
     return core.default_cpu_generator().manual_seed(seed)
 
@@ -84,19 +83,19 @@ def get_rng_state(device=None):
     """
     state_list = []
     if device is None:
-        place = base.framework._current_expected_place()
+        place = paddle.framework._current_expected_place()
     else:
         place = paddle.device._convert_to_place(device)
 
-    if isinstance(place, core.CPUPlace):
+    if isinstance(place, paddle.CPUPlace):
         state_list.append(core.default_cpu_generator().get_state())
-    elif isinstance(place, core.CUDAPlace):
+    elif isinstance(place, paddle.CUDAPlace):
         for i in range(core.get_cuda_device_count()):
             state_list.append(core.default_cuda_generator(i).get_state())
-    elif isinstance(place, core.XPUPlace):
+    elif isinstance(place, paddle.XPUPlace):
         for i in range(core.get_xpu_device_count()):
             state_list.append(core.default_xpu_generator(i).get_state())
-    elif isinstance(place, core.CustomPlace):
+    elif isinstance(place, paddle.CustomPlace):
         dev_cnt = sum(
             [
                 place.get_device_type() == s.split(':')[0]
@@ -136,7 +135,7 @@ def get_cuda_rng_state():
 
     """
     state_list = []
-    if core.is_compiled_with_cuda():
+    if paddle.is_compiled_with_cuda():
         for i in range(core.get_cuda_device_count()):
             state_list.append(core.default_cuda_generator(i).get_state())
 
@@ -166,25 +165,25 @@ def set_rng_state(state_list, device=None):
 
     """
     if device is None:
-        place = base.framework._current_expected_place()
+        place = paddle.framework._current_expected_place()
     else:
         place = device._convert_to_place(device)
 
-    if isinstance(place, core.CUDAPlace):
+    if isinstance(place, paddle.CUDAPlace):
         if not len(state_list) == core.get_cuda_device_count():
             raise ValueError(
                 "Length of gpu state list shoule be equal to the gpu device count"
             )
         for i in range(core.get_cuda_device_count()):
             core.default_cuda_generator(i).set_state(state_list[i])
-    elif isinstance(place, core.XPUPlace):
+    elif isinstance(place, paddle.XPUPlace):
         if not len(state_list) == core.get_xpu_device_count():
             raise ValueError(
                 "Length of xpu state list shoule be equal to the xpu device count"
             )
         for i in range(core.get_xpu_device_count()):
             core.default_xpu_generator(i).set_state(state_list[i])
-    elif isinstance(place, core.CustomPlace):
+    elif isinstance(place, paddle.CustomPlace):
         dev_cnt = sum(
             [
                 place.get_device_type() == s.split(':')[0]
@@ -197,7 +196,7 @@ def set_rng_state(state_list, device=None):
             )
         for i in range(dev_cnt):
             core.default_custom_device_generator(
-                core.CustomPlace(place.get_device_type(), i)
+                paddle.CustomPlace(place.get_device_type(), i)
             ).set_state(state_list[i])
     elif isinstance(place, core.CPUPlace):
         if not len(state_list) == 1:
@@ -228,7 +227,7 @@ def set_cuda_rng_state(state_list):
             >>> paddle.set_cuda_rng_state(sts)
 
     """
-    if core.is_compiled_with_cuda():
+    if paddle.is_compiled_with_cuda():
         if not len(state_list) == core.get_cuda_device_count():
             raise ValueError(
                 "Length of cuda state list shoule be equal to the cuda device count"

--- a/test/collective/fleet/dist_mnist_gradient_merge.py
+++ b/test/collective/fleet/dist_mnist_gradient_merge.py
@@ -26,8 +26,7 @@ DTYPE = "float32"
 paddle.dataset.mnist.fetch()
 
 # Fix seed for test
-base.default_startup_program().random_seed = 1
-base.default_main_program().random_seed = 1
+paddle.seed(1)
 
 
 class TestDistMnist2x2(TestDistRunnerBase):

--- a/test/collective/fleet/fused_attention_pass_with_mp.py
+++ b/test/collective/fleet/fused_attention_pass_with_mp.py
@@ -143,9 +143,8 @@ class TestFusedAttentionPassWithMP(unittest.TestCase):
             ).astype('float32')
 
         main_prog = paddle.static.Program()
-        main_prog.random_seed = 1234
         startup_prog = paddle.static.Program()
-        startup_prog.random_seed = 1234
+        paddle.seed(1234)
 
         with paddle.static.program_guard(main_prog, startup_prog):
             data = paddle.static.data(

--- a/test/collective/fleet/fused_attention_pass_with_mp.py
+++ b/test/collective/fleet/fused_attention_pass_with_mp.py
@@ -143,8 +143,9 @@ class TestFusedAttentionPassWithMP(unittest.TestCase):
             ).astype('float32')
 
         main_prog = paddle.static.Program()
+        main_prog.random_seed = 1234
         startup_prog = paddle.static.Program()
-        paddle.seed(1234)
+        startup_prog.random_seed = 1234
 
         with paddle.static.program_guard(main_prog, startup_prog):
             data = paddle.static.data(

--- a/test/collective/fleet/parallel_dygraph_no_sync.py
+++ b/test/collective/fleet/parallel_dygraph_no_sync.py
@@ -75,8 +75,7 @@ class TestNoSync(TestParallelDyGraphRunnerBase):
             assert "Only support CUDAPlace for now."
 
         with base.dygraph.guard(place):
-            base.default_startup_program().random_seed = seed
-            base.default_main_program().random_seed = seed
+            paddle.seed(seed)
             np.random.seed(seed)
             random.seed(seed)
             model, train_reader, opt = self.get_model()
@@ -101,8 +100,7 @@ class TestNoSync(TestParallelDyGraphRunnerBase):
 
         # 2. init seed
         seed = 90
-        paddle.static.default_startup_program().random_seed = seed
-        paddle.static.default_main_program().random_seed = seed
+        paddle.seed(seed)
         np.random.seed(seed)
         random.seed(seed)
         # get trainer id

--- a/test/collective/fleet/pipeline_mnist.py
+++ b/test/collective/fleet/pipeline_mnist.py
@@ -27,8 +27,7 @@ DTYPE = "float32"
 paddle.dataset.mnist.fetch()
 
 # Fix seed for test
-base.default_startup_program().random_seed = 1
-base.default_main_program().random_seed = 1
+paddle.seed(1)
 
 
 def cnn_model(data):

--- a/test/collective/fleet/pipeline_mnist_multi_device.py
+++ b/test/collective/fleet/pipeline_mnist_multi_device.py
@@ -27,8 +27,7 @@ DTYPE = "float32"
 paddle.dataset.mnist.fetch()
 
 # Fix seed for test
-base.default_startup_program().random_seed = 1
-base.default_main_program().random_seed = 1
+paddle.seed(1)
 
 
 def cnn_model(data):

--- a/test/collective/fleet/pipeline_mnist_one_device.py
+++ b/test/collective/fleet/pipeline_mnist_one_device.py
@@ -27,8 +27,7 @@ DTYPE = "float32"
 paddle.dataset.mnist.fetch()
 
 # Fix seed for test
-base.default_startup_program().random_seed = 1
-base.default_main_program().random_seed = 1
+paddle.seed(1)
 
 
 def cnn_model(data):

--- a/test/collective/fleet/static_model_parallel_by_col.py
+++ b/test/collective/fleet/static_model_parallel_by_col.py
@@ -26,10 +26,6 @@ MODEL_PARALLEL_SIZE = 2
 IN_SIZE = 2 * MODEL_PARALLEL_SIZE
 OUT_SIZE = 2 * MODEL_PARALLEL_SIZE
 
-# Fix seed for test
-# base.default_startup_program().random_seed = 1
-# base.default_main_program().random_seed = 1
-
 
 def get_param_attr(weight, bias):
     weight_attr = paddle.ParamAttr(

--- a/test/collective/fleet/static_model_parallel_by_row.py
+++ b/test/collective/fleet/static_model_parallel_by_row.py
@@ -26,10 +26,6 @@ MODEL_PARALLEL_SIZE = 2
 IN_SIZE = 2 * MODEL_PARALLEL_SIZE
 OUT_SIZE = 2 * MODEL_PARALLEL_SIZE
 
-# Fix seed for test
-# base.default_startup_program().random_seed = 1
-# base.default_main_program().random_seed = 1
-
 
 def get_param_attr(weight, bias):
     weight_attr = paddle.ParamAttr(

--- a/test/collective/fleet/static_model_parallel_embedding.py
+++ b/test/collective/fleet/static_model_parallel_embedding.py
@@ -26,10 +26,6 @@ MODEL_PARALLEL_SIZE = 2
 IN_SIZE = 2 * MODEL_PARALLEL_SIZE
 OUT_SIZE = 2 * MODEL_PARALLEL_SIZE
 
-# Fix seed for test
-# base.default_startup_program().random_seed = 1
-# base.default_main_program().random_seed = 1
-
 
 def create_model(data, rank):
     np.random.seed(2021)

--- a/test/contrib/test_image_classification_fp16.py
+++ b/test/contrib/test_image_classification_fp16.py
@@ -112,8 +112,7 @@ def train(net_type, use_cuda, save_dirname, is_local):
 
     train_program = base.Program()
     startup_prog = base.Program()
-    train_program.random_seed = 123
-    startup_prog.random_seed = 456
+    paddle.seed(123)
     with base.program_guard(train_program, startup_prog):
         images = paddle.static.data(
             name='pixel', shape=[-1] + data_shape, dtype='float32'

--- a/test/contrib/test_multi_precision_fp16_train.py
+++ b/test/contrib/test_multi_precision_fp16_train.py
@@ -101,8 +101,7 @@ def train(use_pure_fp16=True, use_nesterov=False, optimizer=""):
 
     train_program = base.Program()
     startup_prog = base.Program()
-    train_program.random_seed = 123
-    startup_prog.random_seed = 456
+    paddle.seed(123)
     with base.program_guard(train_program, startup_prog):
         images = paddle.static.data(
             name='pixel', shape=[-1] + data_shape, dtype='float32'

--- a/test/dygraph_to_static/test_basic_api_transformation.py
+++ b/test/dygraph_to_static/test_basic_api_transformation.py
@@ -162,8 +162,7 @@ class TestDygraphBasicApi(Dy2StTestBase):
         self.dygraph_func = dyfunc_pool2d
 
     def get_dygraph_output(self):
-        paddle.static.default_startup_program.random_seed = SEED
-        paddle.static.default_main_program.random_seed = SEED
+        paddle.seed(SEED)
         data = paddle.to_tensor(self.input)
         res = self.dygraph_func(data).numpy()
 
@@ -204,8 +203,7 @@ class TestDygraphBasicApi_BilinearTensorProduct(TestDygraphBasicApi):
         )
 
     def get_dygraph_output(self):
-        paddle.static.default_startup_program.random_seed = SEED
-        paddle.static.default_main_program.random_seed = SEED
+        paddle.seed(SEED)
         res = self.dygraph_func(self.input1, self.input2).numpy()
         return res
 
@@ -406,8 +404,7 @@ class TestDygraphBasicApi_ExponentialDecay(TestDygraphBasicApi_CosineDecay):
         self.dygraph_func = dyfunc_exponential_decay
 
     def get_dygraph_output(self):
-        paddle.static.default_startup_program.random_seed = SEED
-        paddle.static.default_main_program.random_seed = SEED
+        paddle.seed(SEED)
         res = self.dygraph_func()
         return res
 
@@ -422,8 +419,7 @@ class TestDygraphBasicApi_InverseTimeDecay(TestDygraphBasicApi_CosineDecay):
         self.dygraph_func = dyfunc_inverse_time_decay
 
     def get_dygraph_output(self):
-        paddle.static.default_startup_program.random_seed = SEED
-        paddle.static.default_main_program.random_seed = SEED
+        paddle.seed(SEED)
         res = self.dygraph_func()
         return res
 
@@ -438,8 +434,7 @@ class TestDygraphBasicApi_NaturalExpDecay(TestDygraphBasicApi_CosineDecay):
         self.dygraph_func = dyfunc_natural_exp_decay
 
     def get_dygraph_output(self):
-        paddle.static.default_startup_program.random_seed = SEED
-        paddle.static.default_main_program.random_seed = SEED
+        paddle.seed(SEED)
         res = self.dygraph_func()
         return res
 
@@ -464,8 +459,7 @@ class TestDygraphBasicApi_PolynomialDecay(TestDygraphBasicApi_CosineDecay):
         self.dygraph_func = dyfunc_polynomial_decay
 
     def get_dygraph_output(self):
-        paddle.static.default_startup_program.random_seed = SEED
-        paddle.static.default_main_program.random_seed = SEED
+        paddle.seed(SEED)
         res = self.dygraph_func()
         return res
 

--- a/test/dygraph_to_static/test_bert.py
+++ b/test/dygraph_to_static/test_bert.py
@@ -101,8 +101,7 @@ class TestBert(Dy2StTestBase):
 
     def train(self, bert_config, data_reader, to_static):
         with unique_name.guard():
-            base.default_main_program().random_seed = SEED
-            base.default_startup_program().random_seed = SEED
+            paddle.seed(SEED)
 
             fake_dataset = FakeBertDataset(data_reader, STEP_NUM)
             data_loader = paddle.io.DataLoader(

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -549,8 +549,7 @@ def train(args):
 
         random.seed(SEED)
         np.random.seed(SEED)
-        base.default_startup_program().random_seed = SEED
-        base.default_main_program().random_seed = SEED
+        paddle.seed(SEED)
 
         A_pool = ImagePool()
         B_pool = ImagePool()

--- a/test/dygraph_to_static/test_mnist.py
+++ b/test/dygraph_to_static/test_mnist.py
@@ -191,8 +191,7 @@ class TestMNISTWithToStatic(TestMNIST):
 
     def train(self, to_static=False):
         loss_data = []
-        base.default_main_program().random_seed = SEED
-        base.default_startup_program().random_seed = SEED
+        paddle.seed(SEED)
         mnist = MNIST()
         if to_static:
             mnist = paddle.jit.to_static(mnist, full_graph=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

清除部分 test 目录的`random_seed`

问题记录:
* `test/collective/fleet/fused_attention_pass_with_mp.py` - 精度不足

相关链接:
* #60787