### PR TITLE
[TRT-9.2 feature] Remove skiplayernorm and related IR pass

### DIFF
--- a/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.h
+++ b/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.h
@@ -125,9 +125,19 @@ struct ElementWise : public PatternBase {
 
   void operator()();
 
-  PATTERN_DECL_NODE(elementwise_input);
+  PATTERN_DECL_NODE(elementwise_x);
+  PATTERN_DECL_NODE(elementwise_y);
   PATTERN_DECL_NODE(elementwise_op);
   PATTERN_DECL_NODE(elementwise_out);
+};
+
+struct LayerNormInference : public PatternBase {
+  LayerNormInference(PDPattern *pattern, const std::string &name_scope)
+      : PatternBase(pattern, name_scope, "layernorm") {}
+  void operator()();
+  PATTERN_DECL_NODE(layernorm_input);
+  PATTERN_DECL_NODE(layernorm_op);
+  PATTERN_DECL_NODE(layernorm_output);
 };
 }  // namespace patterns
 

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -124,10 +124,14 @@ const std::vector<std::string> kTRTSubgraphPasses({
 #endif
 #if defined _WIN32  // Windows CI is TensorRT7.0. Remove this after upgrading.
 #else
+#if IS_TRT_VERSION_LT(9205)
       "trt_skip_layernorm_fuse_pass",          //
+#endif
       "preln_skip_layernorm_fuse_pass",        //
 #endif
-      "preln_residual_bias_fuse_pass",   //
+#if IS_TRT_VERSION_LT(9205)
+      "preln_residual_bias_fuse_pass",  //
+#endif
       "preln_layernorm_x_fuse_pass",     //
       "reverse_roll_fuse_pass",          //
       "conv_bn_fuse_pass",               //

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -663,6 +663,8 @@ class TrtLayerAutoScanTest(AutoScanTest):
                     self.dynamic_shape.opt_input_shape,
                     self.dynamic_shape.disable_trt_plugin_fp16,
                 )
+            if self.optimization_level is not None:
+                config.set_trt_optimization_level(self.optimization_level)
         return config
 
     def assert_tensors_near(

--- a/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
+++ b/test/ir/inference/test_trt_convert_flash_multihead_matmul.py
@@ -24,6 +24,10 @@ import paddle.inference as paddle_infer
 
 
 class TrtConvertFlashMultiHeadMatmulTest(TrtLayerAutoScanTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.optimization_level = 5
+
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         ver = paddle_infer.get_trt_compile_version()
         if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 8520:

--- a/test/ir/inference/test_trt_convert_preln_residual_bias.py
+++ b/test/ir/inference/test_trt_convert_preln_residual_bias.py
@@ -20,6 +20,7 @@ import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
+import paddle
 import paddle.inference as paddle_infer
 
 
@@ -158,7 +159,9 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if dynamic_shape:
+            trt_compile_version = paddle.inference.get_trt_compile_version()
+            valid_version = (9, 2, 0)
+            if trt_compile_version >= valid_version or dynamic_shape:
                 return 1, 4
             else:
                 return 0, 5

--- a/test/ir/inference/test_trt_convert_preln_residual_no_bias.py
+++ b/test/ir/inference/test_trt_convert_preln_residual_no_bias.py
@@ -20,6 +20,7 @@ import numpy as np
 from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
+import paddle
 import paddle.inference as paddle_infer
 
 
@@ -146,7 +147,9 @@ class TrtConvertSkipLayernormTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if dynamic_shape:
+            trt_compile_version = paddle.inference.get_trt_compile_version()
+            valid_version = (9, 2, 0)
+            if trt_compile_version >= valid_version or dynamic_shape:
                 return 1, 4
             else:
                 return 0, 5


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

**Paddle CI cannot cover the change in this PR since the PR is for TRT version >= 9.2.**
**Please don't merge this MR. Wait for Paddle to upgrade TRT version for testing.**

This PR removes skiplayernorm plugin and fix some bugs for TRT version 9.2.0.5.
- Support elementwise_add with two temporary variables in remove_padding_recover_padding IR pass
- Support layernorm in remove_padding_recover_padding IR pass
- Skip trt_skip_layernorm_fuse_pass and preln_residual_bias_fuse_pass if TRT version >= 9.2.0.5
- Set optimization level to be 5 for flash_multihead_matmul UT