### PR TITLE
Add infer symbolic shape interface for generate_shape

### DIFF
--- a/paddle/cinn/common/arithmatic_test.cc
+++ b/paddle/cinn/common/arithmatic_test.cc
@@ -33,8 +33,8 @@ using namespace ir;  // NOLINT
 
 TEST(GiNaC, simplify) {
   using namespace GiNaC;  // NOLINT
-  symbol x("x");
-  symbol y("y");
+  GiNaC::symbol x("x");
+  GiNaC::symbol y("y");
 
   ex e = x * 0 + 1 + 2 + 3 - 100 + 30 * y - y * 21 + 0 * x;
   LOG(INFO) << "e: " << e;
@@ -42,7 +42,7 @@ TEST(GiNaC, simplify) {
 
 TEST(GiNaC, diff) {
   using namespace GiNaC;  // NOLINT
-  symbol x("x"), y("y");
+  GiNaC::symbol x("x"), y("y");
   ex e = (x + 1);
   ex e1 = (y + 1);
 
@@ -54,7 +54,7 @@ TEST(GiNaC, diff) {
 
 TEST(GiNaC, solve) {
   using namespace GiNaC;  // NOLINT
-  symbol x("x"), y("y");
+  GiNaC::symbol x("x"), y("y");
 
   lst eqns{2 * x + 3 == 19};
   lst vars{x};

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -16,6 +16,8 @@
 
 #include <vector>
 #include "glog/logging.h"
+#include "paddle/cinn/common/dim_expr_simplify.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h"
 #include "paddle/common/ddim.h"
 #include "paddle/common/enforce.h"
 #include "paddle/fluid/pir/dialect/operator/ir/ir_meta_tensor.h"
@@ -190,7 +192,13 @@ void GenerateShapeOp::Build(
     const std::vector<pir::Value>& inputs,
     const std::vector<pir::Attribute>& output_dim_exprs,
     const GenerateShapeOp::SymbolBindings& symbol_bindings) {
-  CHECK(!inputs.empty());
+  CHECK(!inputs.empty()) << ". output_dim_exprs: " << [&] {
+    std::stringstream ss;
+    for (const auto& attr : output_dim_exprs) {
+      ss << attr;
+    }
+    return ss.str();
+  }();
   argument.AddInputs(inputs);
   argument.AddAttribute("output_dim_exprs",
                         builder.array_attr(output_dim_exprs));
@@ -343,6 +351,61 @@ GenerateShapeOp::ConvertAttributeToSymbolBindings(
     ret.emplace_back(opt_symbol_binding.value());
   }
   return std::move(ret);
+}
+
+bool GenerateShapeOp::InferSymbolicShape(
+    pir::ShapeConstraintIRAnalysis* shape_analysis) {
+  auto GetShapeOrDataDimExprs =
+      [&](pir::Value value) -> const symbol::ShapeOrDataDimExprs& {
+    return shape_analysis->GetShapeOrDataForValue(value);
+  };
+  auto SetShapeOrDataDimExprs =
+      [&](pir::Value value, const symbol::ShapeOrDataDimExprs& dim_exprs) {
+        shape_analysis->SetShapeOrDataForValue(value, dim_exprs);
+      };
+  const auto attr_dim_exprs = [&] {
+    std::vector<symbol::DimExpr> dim_exprs{};
+    pir::Attribute dim_expr_attr = this->attributes().at("output_dim_exprs");
+    CHECK(dim_expr_attr.isa<pir::ArrayAttribute>());
+    auto array = dim_expr_attr.dyn_cast<pir::ArrayAttribute>();
+    for (int i = 0; i < array.size(); ++i) {
+      const auto& dim_expr = ConvertAttributeToDimExpr(array.at(i));
+      CHECK(dim_expr.has_value());
+      dim_exprs.push_back(dim_expr.value());
+    }
+    return dim_exprs;
+  }();
+  const auto symbol_bindings = [&] {
+    pir::Attribute symbol_bindings_attr =
+        this->attributes().at("symbol_bindings");
+    auto symbol_bindings =
+        ConvertAttributeToSymbolBindings(symbol_bindings_attr);
+    CHECK(symbol_bindings.has_value());
+    return symbol_bindings.value();
+  }();
+  auto DimExprs4InputDim =
+      [&](int input_idx) -> const symbol::ShapeOrDataDimExprs& {
+    pir::Value input = this->operand_source(input_idx);
+    return GetShapeOrDataDimExprs(input);
+  };
+  auto DimExprs4SymbolName =
+      MakeGetterDimExpr4SymbolName(symbol_bindings, DimExprs4InputDim);
+  const auto substituted_dim_exprs = [&] {
+    std::vector<symbol::DimExpr> dim_exprs{};
+    dim_exprs.reserve(attr_dim_exprs.size());
+    for (const auto& attr_dim_expr : attr_dim_exprs) {
+      const auto& substituted =
+          SubstituteDimExpr(attr_dim_expr, DimExprs4SymbolName);
+      const auto& simplified = common::SimplifyDimExpr(substituted);
+      dim_exprs.push_back(simplified);
+    }
+    return dim_exprs;
+  }();
+  const auto shape_or_data_dim_exprs =
+      symbol::ShapeOrDataDimExprs::MakeConsistentShapeOrData(
+          substituted_dim_exprs);
+  SetShapeOrDataDimExprs(this->out(), shape_or_data_dim_exprs);
+  return true;
 }
 
 }  // namespace dialect

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <variant>
+#include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.h"
 #include "paddle/phi/core/infermeta_utils.h"
 #include "paddle/pir/core/builder.h"
 #include "paddle/pir/core/dll_decl.h"
@@ -21,6 +22,7 @@
 #include "paddle/pir/core/op_base.h"
 #include "paddle/pir/core/operation.h"
 #include "paddle/pir/core/operation_utils.h"
+#include "paddle/pir/dialect/shape/utils/shape_utils.h"
 
 namespace cinn {
 namespace dialect {
@@ -83,7 +85,9 @@ class IR_API SplitOp : public pir::Op<SplitOp> {
   void VerifySig() const {}
 };
 
-class IR_API GenerateShapeOp : public pir::Op<GenerateShapeOp> {
+class IR_API GenerateShapeOp
+    : public pir::Op<GenerateShapeOp,
+                     paddle::dialect::InferSymbolicShapeInterface> {
  public:
   using Op::Op;
   static const char *name() { return "cinn_op.generate_shape"; }
@@ -112,6 +116,8 @@ class IR_API GenerateShapeOp : public pir::Op<GenerateShapeOp> {
   void VerifySig() {}
 
   pir::OpResult out() { return result(0); }
+
+  bool InferSymbolicShape(pir::ShapeConstraintIRAnalysis *shape_analysis);
 
   static pir::Attribute ConvertSymbolBindingsToAttribute(
       pir::Builder &builder, const SymbolBindings &symbol_bindings);  // NOLINT


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73448

为`generate_shape_op`添加`InferSymbolicShape`接口。
