### PR TITLE
fix_eigen3_patch_error

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -57,7 +57,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/eigen/Complex.h.patch
          complex_header)
     set(EIGEN_PATCH_COMMAND
-        ${EIGEN_PATCH_COMMAND} && patch -Nd
+        ${EIGEN_PATCH_COMMAND} && patch -d
         ${SOURCE_DIR}/Eigen/src/Core/arch/SSE/ < ${complex_header})
   endif()
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

-N选项告诉patch如果一个patch已经应用过了，那么就跳过它。-d选项用于指定在哪个目录下运行patch。例如，patch -N -d /my/dir < /path/to/your.patch会在/my/dir目录下应用patch。此处跳过了patch，所以导致eigen第三方库编译过不了

Pcard-67164