### PR TITLE
[Dynamic Shape] Add MoveGenerateShapeOpsToProloguePass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.cc
@@ -1,0 +1,138 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/pir/core/block.h"
+#include "paddle/pir/core/value.h"
+
+namespace cinn::dialect {
+
+namespace {
+
+bool RunningFirst(cinn::dialect::GenerateShapeOp op,
+                  const std::vector<pir::Value>& block_args) {
+  for (int i = 0; i < op->num_operands(); ++i) {
+    pir::Value input = op->operand_source(i);
+    if (std::find(block_args.begin(), block_args.end(), input) ==
+        block_args.end())
+      return false;
+  }
+  return true;
+}
+
+const std::vector<symbol::DimExpr>& GetDimExprs(
+    pir::Value value, const ShapeOrDataDimExprsAccessor& dim_exprs_accessor) {
+  const auto& shape_or_data_dim_exprs =
+      dim_exprs_accessor.GetShapeOrDataDimExprs(value);
+  CHECK(shape_or_data_dim_exprs.data().has_value());
+  return shape_or_data_dim_exprs.data().value();
+}
+
+std::vector<pir::Value> GetBlockArgs(pir::Block* block) {
+  std::unordered_set<pir::Value> values_produced_by_block_op;
+  for (auto op = block->begin(); op != block->end(); ++op) {
+    for (int i = 0; i < op->num_results(); ++i) {
+      values_produced_by_block_op.insert(op->result(i));
+    }
+  }
+  std::vector<pir::Value> ret{};
+  for (auto op = block->begin(); op != block->end(); ++op) {
+    for (int i = 0; i < op->num_operands(); ++i) {
+      pir::Value input = op->operand_source(i);
+      if (values_produced_by_block_op.count(input) == 0) {
+        if (std::find(ret.begin(), ret.end(), input) == ret.end()) {
+          ret.push_back(input);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+// Returns `out` of GenerateShapeOp
+pir::Value InsertGenerateShapeOpToRunFirst(
+    pir::Builder* builder,
+    const std::vector<pir::Value>& block_args,
+    pir::Value value,
+    const ShapeOrDataDimExprsAccessor& dim_exprs_accessor) {
+  const auto& out_dim_exprs = GetDimExprs(value, dim_exprs_accessor);
+  std::vector<pir::Value> minial_inputs{};
+  std::vector<pir::Attribute> output_dim_expr_attrs{};
+  cinn::dialect::GenerateShapeOp::SymbolBindings symbol_bindings{};
+  MakeGenerateShapeOpAttribute(builder->ir_context(),
+                               dim_exprs_accessor.GetShapeOrDataDimExprs,
+                               out_dim_exprs,
+                               block_args,
+                               &minial_inputs,
+                               &output_dim_expr_attrs,
+                               &symbol_bindings);
+  return builder
+      ->Build<cinn::dialect::GenerateShapeOp>(
+          minial_inputs, output_dim_expr_attrs, symbol_bindings)
+      .out();
+}
+
+void CloneDimExprInfo(pir::Value from,
+                      pir::Value to,
+                      const ShapeOrDataDimExprsAccessor& ctx) {
+  ctx.SetShapeOrDataDimExprs(to, ctx.GetShapeOrDataDimExprs(from));
+}
+
+void ReplaceAllUses(pir::Value from, pir::Value to) {
+  from.ReplaceAllUsesWith(to);
+}
+
+void EraseGenerateShapeOp(pir::Block::ConstIterator op_iter,
+                          pir::Block* block) {
+  block->erase(op_iter);
+}
+
+bool RewriteOneGenerateShapeOpToRunFirst(
+    pir::IrContext* ir_context,
+    pir::Block* block,
+    const ShapeOrDataDimExprsAccessor& dim_exprs_accessor) {
+  std::vector<pir::Value> block_args = GetBlockArgs(block);
+  for (auto op_iter = block->begin(); op_iter != block->end(); ++op_iter) {
+    if (!op_iter->isa<cinn::dialect::GenerateShapeOp>()) continue;
+    auto op = op_iter->dyn_cast<cinn::dialect::GenerateShapeOp>();
+    if (RunningFirst(op, block_args)) continue;
+    pir::Builder builder(ir_context, block);
+    builder.set_insertion_point(op);
+    pir::Value new_shape = InsertGenerateShapeOpToRunFirst(
+        &builder, block_args, op.out(), dim_exprs_accessor);
+    CloneDimExprInfo(op.out(), new_shape, dim_exprs_accessor);
+    ReplaceAllUses(op.out(), new_shape);
+    EraseGenerateShapeOp(op_iter, block);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+bool RewriteGenerateShapeOpToRunFirst(
+    pir::IrContext* ir_context,
+    pir::Block* block,
+    const ShapeOrDataDimExprsAccessor& dim_exprs_accessor) {
+  bool rewrited = false;
+  while (RewriteOneGenerateShapeOpToRunFirst(
+      ir_context, block, dim_exprs_accessor)) {
+    rewrited = true;
+  }
+  return rewrited;
+}
+
+}  // namespace cinn::dialect

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+#include "paddle/pir/core/block.h"
+#include "paddle/pir/dialect/shape/utils/dim_expr.h"
+
+namespace pir {
+
+class Block;
+class IrContext;
+
+}  // namespace pir
+
+namespace cinn::dialect {
+
+struct ShapeOrDataDimExprsAccessor {
+  std::function<const symbol::ShapeOrDataDimExprs&(pir::Value)>
+      GetShapeOrDataDimExprs;
+  std::function<void(pir::Value, const symbol::ShapeOrDataDimExprs&)>
+      SetShapeOrDataDimExprs;
+};
+
+// Returns true if at least one GenerateShapeOp rewrited.
+bool RewriteGenerateShapeOpToRunFirst(
+    pir::IrContext* ir_context,
+    pir::Block* block,
+    const ShapeOrDataDimExprsAccessor& shape_or_data_dim_expr_accessor);
+
+}  // namespace cinn::dialect

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/move_generate_shape_ops_to_prologue_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/move_generate_shape_ops_to_prologue_pass.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/move_generate_shape_ops_to_prologue_pass.h"
+
+#include <unordered_map>
+
+#include "paddle/cinn/adt/generate_map_expr.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/op_attribute.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/generate_shape_util.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_pass.h"
+#include "paddle/cinn/hlir/dialect/runtime/ir/jit_kernel_op.h"
+#include "paddle/cinn/hlir/dialect/runtime/ir/runtime_dialect.h"
+#include "paddle/cinn/hlir/framework/pir_compiler.h"
+#include "paddle/cinn/runtime/flags.h"
+#include "paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/core/program.h"
+#include "paddle/pir/dialect/control_flow/ir/cf_op.h"
+#include "paddle/pir/dialect/shape/utils/shape_utils.h"
+#include "paddle/pir/pass/pass_registry.h"
+#include "paddle/pir/pattern_rewrite/frozen_rewrite_pattern_set.h"
+
+namespace cinn {
+namespace dialect {
+
+namespace {
+
+class GroupOpGenerateShapeOpsPattern
+    : public pir::OpRewritePattern<cinn::dialect::GroupOp> {
+ public:
+  explicit GroupOpGenerateShapeOpsPattern(::pir::IrContext* context)
+      : pir::OpRewritePattern<cinn::dialect::GroupOp>(context) {}
+
+  bool MatchAndRewrite(cinn::dialect::GroupOp group_op,
+                       pir::PatternRewriter& rewriter) const override {
+    ::pir::IrContext* ctx = ::pir::IrContext::Instance();
+    pir::ShapeConstraintIRAnalysis& shape_analysis =
+        pir::ShapeAnalysisManager::Instance().Get(group_op->GetParentProgram());
+    ShapeOrDataDimExprsAccessor dim_exprs_accessor{
+        .GetShapeOrDataDimExprs =
+            [&](pir::Value value) -> const symbol::ShapeOrDataDimExprs& {
+          return shape_analysis.GetShapeOrDataForValue(value);
+        },
+        .SetShapeOrDataDimExprs =
+            [&](pir::Value value,
+                const symbol::ShapeOrDataDimExprs& dim_exprs) {
+              shape_analysis.SetShapeOrDataForValue(value, dim_exprs);
+            }};
+    return RewriteGenerateShapeOpToRunFirst(
+        ctx, group_op.block(), dim_exprs_accessor);
+  }
+};
+
+class MoveGenerateShapeOpsToProloguePass : public pir::PatternRewritePass {
+ public:
+  MoveGenerateShapeOpsToProloguePass()
+      : pir::PatternRewritePass("move_generate_shape_ops_to_prologue", 1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add<GroupOpGenerateShapeOpsPattern>(context);
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation* op) const override {
+    if (!(op->isa<pir::ModuleOp>() && op->num_regions() > 0)) return false;
+    auto* program = op->GetParentProgram();
+    VLOG(4) << "Before MoveGenerateShapeOpsToProloguePass: " << *program;
+    return true;
+  }
+};
+
+}  // namespace
+
+namespace ir {
+
+std::unique_ptr<::pir::Pass> CreateMoveGenerateShapeOpsToProloguePass() {
+  return std::make_unique<MoveGenerateShapeOpsToProloguePass>();
+}
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn
+
+// REGISTER_IR_PASS(cinn_group_lowering, CinnGroupLoweringPass);

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/move_generate_shape_ops_to_prologue_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/move_generate_shape_ops_to_prologue_pass.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/pass/pass.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+std::unique_ptr<::pir::Pass> CreateMoveGenerateShapeOpsToProloguePass();
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[Dynamic Shape] Add MoveGenerateShapeOpsToProloguePass

将 GenerateShape 算子移到 block 前面