### PR TITLE
[Dy2St] Make translator logger lazy format and add error message for builtin type conversion methods

### DIFF
--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -331,7 +331,10 @@ def inverse_sort_op(ops):
     sorted_list = []
     for op in ops:
         for x in get_real_op_inputs(op):
-            if x and x.get_defining_op() in ops_set:
+            if (
+                not paddle.pir.is_fake_value(x)
+                and x.get_defining_op() in ops_set
+            ):
                 pending_count[x.get_defining_op()] += 1
 
     queue = collections.deque()

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -614,6 +614,20 @@ def monkey_patch_variable():
         __impl__.__name__ = method_name
         return __impl__
 
+    def _int_(self):
+        raise TypeError(
+            "int(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Variable.astype(paddle.int32), and do not use int(Variable)."
+        )
+
+    def _float_(self):
+        raise TypeError(
+            "float(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Variable directly, and do not use float(Variable)."
+        )
+
     def values(var):
         block = current_block(var)
         out = create_new_tmp_var(block, var.dtype)
@@ -739,6 +753,8 @@ def monkey_patch_variable():
         ('__le__', _binary_creator_('__le__', 'less_equal', False, None)),
         ('__gt__', _binary_creator_('__gt__', 'greater_than', False, None)),
         ('__ge__', _binary_creator_('__ge__', 'greater_equal', False, None)),
+        ('__float__', _float_),
+        ('__int__', _int_),
         ('values', values),
         ('indices', indices),
         ('to_dense', to_dense),

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -140,7 +140,8 @@ def is_unsupported(func):
     if is_paddle_func(func):
         translator_logger.log(
             2,
-            f"Whitelist: {func} is part of Paddle module and does not have to be transformed.",
+            "Whitelist: %s is part of Paddle module and does not have to be transformed.",
+            func,
         )
         return True
 
@@ -182,7 +183,7 @@ def convert_call(func):
              [1. 1. 1.]]
 
     """
-    translator_logger.log(1, f"Convert callable object: convert {func}.")
+    translator_logger.log(1, "Convert callable object: convert %s.", func)
     func_self = None
     converted_call = None
 
@@ -194,7 +195,8 @@ def convert_call(func):
     if options is not None and options.not_convert:
         translator_logger.log(
             2,
-            f"{func} is not converted when it is decorated by 'paddle.jit.not_to_static'.",
+            "%s is not converted when it is decorated by 'paddle.jit.not_to_static'.",
+            func,
         )
         return func
 
@@ -274,7 +276,8 @@ def convert_call(func):
                 # If func is not in __globals__, it does not need to be transformed
                 # because it has been transformed before.
                 translator_logger.warn(
-                    f"{func} doesn't have to be transformed to static function because it has been transformed before, it will be run as-is."
+                    "%s doesn't have to be transformed to static function because it has been transformed before, it will be run as-is.",
+                    func,
                 )
                 converted_call = func
         except AttributeError:
@@ -326,7 +329,8 @@ def convert_call(func):
 
     if converted_call is None:
         translator_logger.warn(
-            f"{func} doesn't have to be transformed to static function, and it will be run as-is."
+            "%s doesn't have to be transformed to static function, and it will be run as-is.",
+            func,
         )
         return func
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py
@@ -862,6 +862,7 @@ for binary_fn in BINARY_OPS:
 fallback_tensor_unary_method = {
     int,
     bool,
+    float,
     operator.truth,
 }
 

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -434,6 +434,27 @@ def monkey_patch_value():
 
         return _C_ops.transpose(self, perm)
 
+    def _int_(self):
+        raise TypeError(
+            "int(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Variable.astype(paddle.int32), and do not use int(Variable)."
+        )
+
+    def _float_(self):
+        raise TypeError(
+            "float(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Variable directly, and do not use float(Variable)."
+        )
+
+    def _bool_(self):
+        raise TypeError(
+            "bool(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Variable.astype(paddle.bool), and do not use bool(Variable)."
+        )
+
     def clone(self):
         """
         Returns a new static Value, which is the clone of the original static
@@ -653,6 +674,9 @@ def monkey_patch_value():
                 '__ge__', paddle.tensor.greater_equal, False, None
             ),
         ),
+        ('__float__', _float_),
+        ('__int__', _int_),
+        ('__bool__', _bool_),
     ]
 
     global _already_patch_value

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -436,23 +436,16 @@ def monkey_patch_value():
 
     def _int_(self):
         raise TypeError(
-            "int(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
-            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
-            "2. If you want to run it in full graph mode, you need use Variable.astype(paddle.int32), and do not use int(Variable)."
+            "int(Value) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Value, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Value.astype(paddle.int32), and do not use int(Value)."
         )
 
     def _float_(self):
         raise TypeError(
-            "float(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
-            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
-            "2. If you want to run it in full graph mode, you need use Variable directly, and do not use float(Variable)."
-        )
-
-    def _bool_(self):
-        raise TypeError(
-            "bool(Variable) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
-            "1. If you want to get the value of Variable, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
-            "2. If you want to run it in full graph mode, you need use Variable.astype(paddle.bool), and do not use bool(Variable)."
+            "float(Value) is not supported in static graph mode. If you are using @to_static, you can try this:\n"
+            "1. If you want to get the value of Value, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).\n"
+            "2. If you want to run it in full graph mode, you need use Value directly, and do not use float(Value)."
         )
 
     def clone(self):
@@ -676,7 +669,6 @@ def monkey_patch_value():
         ),
         ('__float__', _float_),
         ('__int__', _int_),
-        ('__bool__', _bool_),
     ]
 
     global _already_patch_value

--- a/test/legacy_test/test_math_op_patch.py
+++ b/test/legacy_test/test_math_op_patch.py
@@ -385,6 +385,14 @@ class TestMathOpPatches(unittest.TestCase):
         )
         np.testing.assert_allclose(a_np @ b_np, c_np, rtol=1e-05)
 
+    @prog_scope()
+    def test_builtin_type_conversion(self):
+        a = paddle.static.data(name="a", shape=[])
+        with self.assertRaises(TypeError):
+            int(a)
+        with self.assertRaises(TypeError):
+            float(a)
+
 
 class TestDygraphMathOpPatches(unittest.TestCase):
     def init_data(self):

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -524,6 +524,18 @@ class TestMathOpPatchesPir(unittest.TestCase):
                 np.testing.assert_array_equal(res, a_np)
                 np.testing.assert_array_equal(res, b_np)
 
+    def test_builtin_type_conversion(self):
+        with paddle.pir_utils.IrGuard():
+            _, _, program_guard = new_program()
+            with program_guard:
+                x = paddle.static.data(name='x', shape=[], dtype="float32")
+                with self.assertRaises(TypeError):
+                    int(x)
+                with self.assertRaises(TypeError):
+                    float(x)
+                with self.assertRaises(TypeError):
+                    bool(x)
+
     def test_math_exists(self):
         with paddle.pir_utils.IrGuard():
             a = paddle.static.data(name='a', shape=[1], dtype='float32')

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -533,8 +533,6 @@ class TestMathOpPatchesPir(unittest.TestCase):
                     int(x)
                 with self.assertRaises(TypeError):
                     float(x)
-                with self.assertRaises(TypeError):
-                    bool(x)
 
     def test_math_exists(self):
         with paddle.pir_utils.IrGuard():

--- a/test/sot/test_builtin_dispatch.py
+++ b/test/sot/test_builtin_dispatch.py
@@ -325,5 +325,19 @@ class TestWeakref(TestCaseBase):
         self.assert_results(weakref_breakgraph, obj)
 
 
+def test_builtin_type_conversion_breakgraph(x):
+    return int(x), bool(x), float(x)
+
+
+class TestBuiltinTypeConversion(TestCaseBase):
+    def test_builtin_type_conversion_breakgraph(self):
+        self.assert_results(
+            test_builtin_type_conversion_breakgraph, paddle.to_tensor(1.2)
+        )
+        self.assert_results(
+            test_builtin_type_conversion_breakgraph, paddle.to_tensor(0)
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

logger 里直接 format 的话，如果用户自定义了一个 callable object，而且 `__str__` 写了动转静运行不了的代码，则会报错，比如

```python
class CustomLayer(paddle.nn.Layer):
    def __init__(self):
        super().__init__()
        self.expr = paddle.to_tensor(1)

    def __str__(self):
        return f"{float(self.expr)}"
```

为 Variable、Value 添加 float、~~bool~~、int 等 builtin 类型转换方法，均为直接报错，引导替换写法（bool 由于现有框架里有大量错误用法，因此单独提一个 PR，以不阻塞本 PR 推进）

并为 SOT 添加了遗漏的应当 breakgraph 的方法 float

PCard-66972