### PR TITLE
fix unique kernel variable name

### DIFF
--- a/paddle/phi/kernels/gpu/unique_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_kernel.cu
@@ -388,9 +388,9 @@ static void ComputeUniqueDims(const Context& context,
   // 3. counts: 'counts'
   counts->Resize(common::make_ddim({num_out}));
   auto* count_data = context.template Alloc<IndexT>(counts);
-  thrust::fill(exec_policy, count_data, count_data + row, 0);
+  thrust::fill(exec_policy, count_data, count_data + num_out, 0);
   thrust::adjacent_difference(
-      exec_policy, range_data_ptr + 1, range_data_ptr + row + 1, count_data);
+      exec_policy, range_data_ptr + 1, range_data_ptr + num_out + 1, count_data);
 }
 
 // Calculate unique when 'axis' is set


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
Fix the wrong variable name in unique kernel in pr #59000 which causes cuda error (719) in model training and evaluation.
