### PR TITLE
[Bug Fix]: fix 0.0 to -0.0 failed when neg

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -98,7 +98,8 @@ def monkey_patch_math_tensor():
             return _legacy_C_ops.scale(var, 'scale', scale, 'bias', bias)
 
     def _neg_(var):
-        return _scalar_elementwise_op_(var, -1.0, 0.0)
+        neg_zero_x = float(np.copysign(1, -var.numpy())[0])
+        return _scalar_elementwise_op_(var, -1.0, neg_zero_x * 0.0)
 
     def _float_(var):
         numel = np.prod(var.shape)

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -98,7 +98,7 @@ def monkey_patch_math_tensor():
             return _legacy_C_ops.scale(var, 'scale', scale, 'bias', bias)
 
     def _neg_(var):
-        neg_zero_x = float(np.copysign(1, -var.numpy())[0])
+        neg_zero_x = float(np.copysign(1, -var.numpy()))
         return _scalar_elementwise_op_(var, -1.0, neg_zero_x * 0.0)
 
     def _float_(var):

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -15,8 +15,6 @@
 import inspect
 import warnings
 
-import numpy as np
-
 from .. import core
 from ..dygraph.base import in_to_static_mode
 from ..framework import Variable, default_main_program, static_only
@@ -384,7 +382,13 @@ def monkey_patch_variable():
         return out
 
     def _neg_(var):
-        neg_zero_x = float(np.copysign([1], -var.numpy())[0])
+        one = (
+            paddle.base.Program()
+            .current_block()
+            .create_var(name='one', shape=[1], dtype='float32')
+        )
+        one = paddle.static.setitem(one, 0, 1)
+        neg_zero_x = float(paddle._C_ops.copysign(one, -var.numpy())[0])
         return _scalar_op_(var, -1.0, neg_zero_x * 0.0)
 
     @property

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -15,6 +15,8 @@
 import inspect
 import warnings
 
+import numpy as np
+
 from .. import core
 from ..dygraph.base import in_to_static_mode
 from ..framework import Variable, default_main_program, static_only
@@ -382,7 +384,8 @@ def monkey_patch_variable():
         return out
 
     def _neg_(var):
-        return _scalar_op_(var, -1.0, 0.0)
+        neg_zero_x = float(np.copysign(1, -var.numpy())[0])
+        return _scalar_op_(var, -1.0, neg_zero_x * 0.0)
 
     @property
     def _ndim(self):

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -384,7 +384,7 @@ def monkey_patch_variable():
         return out
 
     def _neg_(var):
-        neg_zero_x = float(np.copysign(1, -var.numpy())[0])
+        neg_zero_x = float(np.copysign([1], -var.numpy())[0])
         return _scalar_op_(var, -1.0, neg_zero_x * 0.0)
 
     @property

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -15,8 +15,6 @@
 
 import warnings
 
-import numpy as np
-
 from paddle import _C_ops
 from paddle.base.libpaddle import DataType
 from paddle.base.wrapped_decorator import wrap_decorator
@@ -284,7 +282,13 @@ def monkey_patch_value():
         return paddle.scale(var, 1.0 / value, 0.0)
 
     def _scalar_neg_(var):
-        neg_zero_x = float(np.copysign([1], -var.numpy())[0])
+        one = (
+            paddle.base.Program()
+            .current_block()
+            .create_var(name='one', shape=[1], dtype='float32')
+        )
+        one = paddle.static.setitem(one, 0, 1)
+        neg_zero_x = float(_C_ops.copysign(one, -var.numpy())[0])
         return paddle.scale(var, -1.0, neg_zero_x * 0.0)
 
     def _binary_creator_(

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -284,7 +284,7 @@ def monkey_patch_value():
         return paddle.scale(var, 1.0 / value, 0.0)
 
     def _scalar_neg_(var):
-        neg_zero_x = float(np.copysign(1, -var.numpy())[0])
+        neg_zero_x = float(np.copysign([1], -var.numpy())[0])
         return paddle.scale(var, -1.0, neg_zero_x * 0.0)
 
     def _binary_creator_(

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -15,6 +15,8 @@
 
 import warnings
 
+import numpy as np
+
 from paddle import _C_ops
 from paddle.base.libpaddle import DataType
 from paddle.base.wrapped_decorator import wrap_decorator
@@ -282,7 +284,8 @@ def monkey_patch_value():
         return paddle.scale(var, 1.0 / value, 0.0)
 
     def _scalar_neg_(var):
-        return paddle.scale(var, -1.0, 0.0)
+        neg_zero_x = float(np.copysign(1, -var.numpy())[0])
+        return paddle.scale(var, -1.0, neg_zero_x * 0.0)
 
     def _binary_creator_(
         method_name,

--- a/python/paddle/sparse/unary.py
+++ b/python/paddle/sparse/unary.py
@@ -635,7 +635,10 @@ def neg(x, name=None):
                 indices=[[0, 2]],
                 values=[ 2., -3.])
     """
-    return _C_ops.sparse_scale(x, -1.0, 0.0, True)
+    neg_zero_x = paddle.to_tensor(
+        np.copysign([1], -x.numpy()), dtype=x.dtype
+    ).tolist()[0]
+    return _C_ops.sparse_scale(x, -1.0, neg_zero_x * 0.0, True)
 
 
 @dygraph_only

--- a/python/paddle/sparse/unary.py
+++ b/python/paddle/sparse/unary.py
@@ -635,9 +635,7 @@ def neg(x, name=None):
                 indices=[[0, 2]],
                 values=[ 2., -3.])
     """
-    neg_zero_x = paddle.to_tensor(
-        np.copysign([1], -x.numpy()), dtype=x.dtype
-    ).tolist()[0]
+    neg_zero_x = float(np.copysign([1], -x.numpy())[0])
     return _C_ops.sparse_scale(x, -1.0, neg_zero_x * 0.0, True)
 
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5220,8 +5220,14 @@ def neg(x, name=None):
             [ 0.40000001,  0.20000000, -0.10000000, -0.30000001])
     """
 
+    neg_zero_x = float(np.copysign(1, -x.numpy())[0])
     return scale(
-        x, scale=-1.0, bias=0.0, bias_after_scale=True, act=None, name=name
+        x,
+        scale=-1.0,
+        bias=neg_zero_x * 0.0,
+        bias_after_scale=True,
+        act=None,
+        name=name,
     )
 
 
@@ -5231,8 +5237,13 @@ def neg_(x, name=None):
     Inplace version of ``neg`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_neg`.
     """
+    neg_zero_x = float(np.copysign(1, -x.numpy())[0])
     return x.scale_(
-        scale=-1.0, bias=0.0, bias_after_scale=True, act=None, name=name
+        scale=-1.0,
+        bias=neg_zero_x * 0.0,
+        bias_after_scale=True,
+        act=None,
+        name=name,
     )
 
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5220,7 +5220,7 @@ def neg(x, name=None):
             [ 0.40000001,  0.20000000, -0.10000000, -0.30000001])
     """
 
-    neg_zero_x = float(np.copysign(1, -x.numpy())[0])
+    neg_zero_x = float(np.copysign([1], -x.numpy())[0])
     return scale(
         x,
         scale=-1.0,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5237,7 +5237,7 @@ def neg_(x, name=None):
     Inplace version of ``neg`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_neg`.
     """
-    neg_zero_x = float(np.copysign(1, -x.numpy())[0])
+    neg_zero_x = float(np.copysign([1], -x.numpy())[0])
     return x.scale_(
         scale=-1.0,
         bias=neg_zero_x * 0.0,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Description
<!-- Describe what you’ve done -->

在paddle中，一些`__neg__`以及`paddle.neg`等，都通过`paddle.scale`的方式来实现，例如：
```python
    def _scalar_neg_(var):
        return paddle.scale(var, -1.0, 0.0)
```
但是当输入为`0.0`时，`var * (-1.0) + 0.0`计算时，代入就是 `0.0 * (-1.0) + 0.0`，`-0.0 + 0.0`，结果是`0.0`，发现最后符号会由`bias`的符号决定。所以会有如下的情况，不论当`x`为`+0.`或者`-0.`，`-x`都为`+0.`，因为`scale`的`bias`写死了`0.0`：

```python
>>> import paddle
>>> x = paddle.to_tensor(-0.0)
>>> x
Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
       -0.)
>>> -x
Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
       0.)
>>> x = paddle.to_tensor(0.0)
>>> x
Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
       0.)
>>> -x
Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
       0.)
>>> 
```

参考了[`signbit`的实现](https://github.com/cocoshe/Paddle/blob/f3277e99ec95e416926046f15831cc3b70d13097/python/paddle/tensor/math.py#L7576-L7578)，利用`copysign`（其强制区分了`+0.0`和`-0.0`）


```python
    neg_zero_x = paddle.to_tensor(np.copysign(1, x.numpy()), dtype=x.dtype)
    x = paddle.sign(neg_zero_x)
    out = paddle.cast(x < 0, dtype='bool')
```

所以在尽量复用原实现的情况下，对`scale`的`bias`区分了`+0.0`和`-0.0`。
修改后：
```python
>>> import paddle
>>> x = paddle.to_tensor(0.)
>>> -x
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       -0.)
>>> x
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       0.)
>>> -x
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       -0.)
>>> --x
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       0.)
>>> x.neg()
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       -0.)
>>> x.neg().neg()
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       0.)
>>> x.neg().neg().neg()
Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       -0.)
>>> x = paddle.to_tensor([0.])
>>> -x
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [-0.])
>>> --x
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [0.])
>>> x.neg()
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [-0.])
>>> x.neg().neg()
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [0.])
>>> 

```