### PR TITLE
[PIR] Fix `test_stack_op` error type

### DIFF
--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -301,15 +301,13 @@ class API_test(unittest.TestCase):
             expected_result = np.stack([input1, input2, input3], axis=0)
             np.testing.assert_allclose(expected_result, result, rtol=1e-05)
 
+    @test_with_pir_api
     def test_single_tensor_error(self):
-        with base.program_guard(base.Program(), base.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             x = paddle.rand([2, 3])
             self.assertRaises(TypeError, paddle.stack, x)
-
-    def test_pir_single_tensor_error(self):
-        with paddle.pir_utils.IrGuard():
-            x = paddle.rand([2, 3])
-            self.assertRaises(ValueError, paddle.stack, x)
 
 
 class API_DygraphTest(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 `test_stack_op` 捕获类型不匹配的问题

PCard-66972