### PR TITLE
[PIR] Use ConcreteOp::Infermeta in build func

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -201,7 +201,7 @@ def GenBuildInputs(op_input_name_list, op_mutable_attribute_name_list):
     BUILD_INPUT_TEMPLATE = """  argument_inputs = {{{inputs_args}}};
   argument.AddInputs(argument_inputs);
 """
-    build_input_str = '  VLOG(4) << "Builder construction inputs";\n  std::vector<pir::Value> argument_inputs = {{}};\n'
+    build_input_str = '  VLOG(4) << "Builder construction inputs";\n  std::vector<pir::Value> argument_inputs = {};\n'
     input_name_list = op_input_name_list + op_mutable_attribute_name_list
     if len(input_name_list) > 0:
         inputs_args_str = ""
@@ -229,7 +229,7 @@ def GenBuildAttributes(
   pir::Attribute attr_{attr_name} = pir::ArrayAttribute::get(pir::IrContext::Instance(), vec_{attr_name});
 """
     attr_str = '  VLOG(4) << "Builder construction attributes";\n'
-    attr_str += '  pir::AttributeMap argument_attributes = {{}};\n'
+    attr_str += '  pir::AttributeMap argument_attributes = {};\n'
     array_attr_type = "pir::ArrayAttribute<"
     for idx in range(len(op_non_mutable_attribute_name_list)):
         if array_attr_type in op_non_mutable_attribute_type_list[idx]:

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -201,7 +201,7 @@ def GenBuildInputs(op_input_name_list, op_mutable_attribute_name_list):
     BUILD_INPUT_TEMPLATE = """  argument_inputs = {{{inputs_args}}};
   argument.AddInputs(argument_inputs);
 """
-    build_input_str = '  VLOG(4) << "Builder construction inputs";\n  std::vector<pir::Value> argument_inputs;\n'
+    build_input_str = '  VLOG(4) << "Builder construction inputs";\n  std::vector<pir::Value> argument_inputs = {{}};\n'
     input_name_list = op_input_name_list + op_mutable_attribute_name_list
     if len(input_name_list) > 0:
         inputs_args_str = ""
@@ -229,7 +229,7 @@ def GenBuildAttributes(
   pir::Attribute attr_{attr_name} = pir::ArrayAttribute::get(pir::IrContext::Instance(), vec_{attr_name});
 """
     attr_str = '  VLOG(4) << "Builder construction attributes";\n'
-    attr_str += '  pir::AttributeMap argument_attributes;\n'
+    attr_str += '  pir::AttributeMap argument_attributes = {{}};\n'
     array_attr_type = "pir::ArrayAttribute<"
     for idx in range(len(op_non_mutable_attribute_name_list)):
         if array_attr_type in op_non_mutable_attribute_type_list[idx]:

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -198,10 +198,10 @@ def GenBuildInserFullForMutableAttribute(
 
 
 def GenBuildInputs(op_input_name_list, op_mutable_attribute_name_list):
-    BUILD_INPUT_TEMPLATE = """  std::vector<pir::Value> argument_inputs = {{{inputs_args}}};
+    BUILD_INPUT_TEMPLATE = """  argument_inputs = {{{inputs_args}}};
   argument.AddInputs(argument_inputs);
 """
-    build_input_str = '  VLOG(4) << "Builder construction inputs";\n'
+    build_input_str = '  VLOG(4) << "Builder construction inputs";\n  std::vector<pir::Value> argument_inputs;\n'
     input_name_list = op_input_name_list + op_mutable_attribute_name_list
     if len(input_name_list) > 0:
         inputs_args_str = ""
@@ -229,6 +229,7 @@ def GenBuildAttributes(
   pir::Attribute attr_{attr_name} = pir::ArrayAttribute::get(pir::IrContext::Instance(), vec_{attr_name});
 """
     attr_str = '  VLOG(4) << "Builder construction attributes";\n'
+    attr_str += '  pir::AttributeMap argument_attributes;\n'
     array_attr_type = "pir::ArrayAttribute<"
     for idx in range(len(op_non_mutable_attribute_name_list)):
         if array_attr_type in op_non_mutable_attribute_type_list[idx]:
@@ -291,7 +292,7 @@ def GenBuildAttributes(
                 op_attribute_type=op_non_mutable_attribute_type_list[idx],
                 attr=op_non_mutable_attribute_name_list[idx],
             )
-        attr_str += """  argument.AddAttribute("{attr_name}", attr_{attr_name});\n""".format(
+        attr_str += """  argument.AddAttribute("{attr_name}", attr_{attr_name});\n  argument_attributes.insert({{"{attr_name}", attr_{attr_name}}});\n""".format(
             attr_name=op_non_mutable_attribute_name_list[idx]
         )
 
@@ -734,20 +735,26 @@ def gen_build_func_str(
         op_non_mutable_attribute_name_list,
         op_non_mutable_attribute_type_list,
     )
-    build_outputs_str = GenBuildOutputs(
-        op_class_name,
-        op_input_name_list,
-        op_input_type_list,
-        op_input_optional_list,
-        op_mutable_attribute_name_list,
-        op_mutable_attribute_type_list,
-        op_output_name_list,
-        op_output_type_list,
-        op_output_size_list,
-        op_output_optional_list,
-        op_infer_meta_map,
-        op_inplace_map,
-        muta_attr_is_input,
+    # build_outputs_str = GenBuildOutputs(
+    #     op_class_name,
+    #     op_input_name_list,
+    #     op_input_type_list,
+    #     op_input_optional_list,
+    #     op_mutable_attribute_name_list,
+    #     op_mutable_attribute_type_list,
+    #     op_output_name_list,
+    #     op_output_type_list,
+    #     op_output_size_list,
+    #     op_output_optional_list,
+    #     op_infer_meta_map,
+    #     op_inplace_map,
+    #     muta_attr_is_input,
+    # )
+    build_outputs_str = """
+  std::vector<pir::Type> argument_outputs = {op_name}::InferMeta(argument_inputs, argument_attributes);
+  argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  ::pir::PassStopGradientsDefaultly(argument);""".format(
+        op_name=op_class_name
     )
 
     GET_ATTRIBUTES_FROM_MAP_TEMPLATE = """

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -198,10 +198,10 @@ def GenBuildInserFullForMutableAttribute(
 
 
 def GenBuildInputs(op_input_name_list, op_mutable_attribute_name_list):
-    BUILD_INPUT_TEMPLATE = """  argument_inputs = {{{inputs_args}}};
+    BUILD_INPUT_TEMPLATE = """  std::vector<pir::Value> argument_inputs = {{{inputs_args}}};
   argument.AddInputs(argument_inputs);
 """
-    build_input_str = '  VLOG(4) << "Builder construction inputs";\n  std::vector<pir::Value> argument_inputs = {};\n'
+    build_input_str = '  VLOG(4) << "Builder construction inputs";\n'
     input_name_list = op_input_name_list + op_mutable_attribute_name_list
     if len(input_name_list) > 0:
         inputs_args_str = ""
@@ -209,6 +209,8 @@ def GenBuildInputs(op_input_name_list, op_mutable_attribute_name_list):
         build_input_str += BUILD_INPUT_TEMPLATE.format(
             inputs_args=inputs_args_str
         )
+    else:
+        build_input_str += '  std::vector<pir::Value> argument_inputs = {};\n'
     return build_input_str
 
 
@@ -735,21 +737,7 @@ def gen_build_func_str(
         op_non_mutable_attribute_name_list,
         op_non_mutable_attribute_type_list,
     )
-    # build_outputs_str = GenBuildOutputs(
-    #     op_class_name,
-    #     op_input_name_list,
-    #     op_input_type_list,
-    #     op_input_optional_list,
-    #     op_mutable_attribute_name_list,
-    #     op_mutable_attribute_type_list,
-    #     op_output_name_list,
-    #     op_output_type_list,
-    #     op_output_size_list,
-    #     op_output_optional_list,
-    #     op_infer_meta_map,
-    #     op_inplace_map,
-    #     muta_attr_is_input,
-    # )
+
     build_outputs_str = """
   std::vector<pir::Type> argument_outputs = {op_name}::InferMeta(argument_inputs, argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -131,7 +131,7 @@ void AddNOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddInput(inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       AddNOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -237,7 +237,7 @@ void AddN_Op::Build(pir::Builder &builder,
   argument.AddInput(inputs_);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       AddN_Op::InferMeta(argument_inputs, argument_attributes);
 
@@ -400,7 +400,7 @@ void AddNWithKernelOp::Build(pir::Builder &builder,
   argument.AddInput(inputs_);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       AddNWithKernelOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -642,7 +642,7 @@ void AddNArrayOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddInput(inputs_);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       AddNArrayOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -794,7 +794,7 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
   argument.AddInputs({x_, y_, bias_});
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_trans_x =
       pir::BoolAttribute::get(pir::IrContext::Instance(), trans_x);
   argument.AddAttribute("trans_x", attr_trans_x);
@@ -1135,7 +1135,7 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
   argument.AddInputs({x_, y_, reserve_space_, out_grad_});
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_trans_x =
       pir::BoolAttribute::get(pir::IrContext::Instance(), trans_x);
   argument.AddAttribute("trans_x", attr_trans_x);
@@ -1424,7 +1424,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   argument.AddInputs({out_grad_, axis_});
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       SplitGradOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -1443,7 +1443,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   argument.AddInputs({out_grad_, axis_});
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       SplitGradOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -1596,9 +1596,9 @@ void CreateArrayOp::Build(pir::Builder &builder,
                           phi::DataType dtype) {
   VLOG(4) << "Start build CreateArrayOp";
   VLOG(4) << "Builder construction inputs";
-  std::vector<pir::Value> argument_inputs;
+  std::vector<pir::Value> argument_inputs = {};
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_dtype = paddle::dialect::DataTypeAttribute::get(
       pir::IrContext::Instance(), dtype);
   argument.AddAttribute("dtype", attr_dtype);
@@ -1715,7 +1715,7 @@ void CreateArrayLikeOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_val =
       pir::FloatAttribute::get(pir::IrContext::Instance(), val);
   argument.AddAttribute("val", attr_val);
@@ -1848,7 +1848,7 @@ void ArrayLengthOp::Build(pir::Builder &builder,
   std::vector<pir::Value> argument_inputs = {x};
   argument.AddInputs({x});
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ArrayLengthOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -1989,7 +1989,7 @@ void ArrayReadOp::Build(pir::Builder &builder,
   std::vector<pir::Value> argument_inputs = {array, full_i_op.result(0)};
   argument.AddInputs({array, full_i_op.result(0)});
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ArrayReadOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -2006,9 +2006,9 @@ void ArrayReadOp::Build(pir::Builder &builder,
   std::vector<pir::Value> argument_inputs = {array, i};
   argument.AddInputs({array, i});
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      AddNOp::InferMeta(argument_inputs, argument_attributes);
+      ArrayReadOp::InferMeta(argument_inputs, argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -2174,7 +2174,7 @@ void ArrayWrite_Op::Build(pir::Builder &builder,
   std::vector<pir::Value> argument_inputs = {array, x, i};
   argument.AddInputs({array, x, i});
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ArrayWrite_Op::InferMeta(argument_inputs, argument_attributes);
 
@@ -2362,7 +2362,7 @@ void ArrayToTensorOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddInputs({x});
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_axis =
       pir::Int32Attribute::get(pir::IrContext::Instance(), axis);
   argument.AddAttribute("axis", attr_axis);
@@ -2557,7 +2557,7 @@ void TensorToArrayOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddInputs({x_, out_grad_});
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_axis =
       pir::Int32Attribute::get(pir::IrContext::Instance(), axis);
   argument.AddAttribute("axis", attr_axis);
@@ -2640,7 +2640,7 @@ std::vector<pir::Type> TensorToArrayOp::InferMeta(
   pir::Value out_grad_ = input_values[1];
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
 
   IR_ENFORCE(attributes.find("axis") != attributes.end(),
              "'value' Attribute is expected for IncrementOp. ");
@@ -2965,7 +2965,7 @@ void SliceArrayDenseOp::Build(pir::Builder &builder,             // NOLINT
   std::vector<pir::Value> argument_inputs = {input, starts};
   argument.AddInputs({input, starts});
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       SliceArrayDenseOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -3246,7 +3246,7 @@ void ExpandOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ExpandOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -3279,7 +3279,7 @@ void ExpandOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ExpandOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -3298,7 +3298,7 @@ void ExpandOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ExpandOp::InferMeta(argument_inputs, argument_attributes);
 
@@ -3559,7 +3559,7 @@ void IncrementOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
@@ -3586,7 +3586,7 @@ void IncrementOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
@@ -3742,7 +3742,7 @@ void Increment_Op::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
@@ -3769,7 +3769,7 @@ void Increment_Op::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
@@ -3902,7 +3902,7 @@ void ShapeBroadcastOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
-  pir::AttributeMap argument_attributes;
+  pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
       ShapeBroadcastOp::InferMeta(argument_inputs, argument_attributes);
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -127,47 +127,14 @@ void AddNOp::Build(pir::Builder &builder,             // NOLINT
   VLOG(4) << "Start build AddNOp";
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {inputs};
   argument.AddInput(inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      AddNOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  pir::VectorType x = inputs.type().dyn_cast<pir::VectorType>();
-
-  std::vector<paddle::dialect::IrTensor> vec_dense_x;
-  for (size_t i = 0; i < x.size(); i++) {
-    vec_dense_x.push_back(paddle::dialect::IrTensor(
-        TransToPhiDataType(
-            x[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-        x[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-        x[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
-        x[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        x[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
-  }
-  std::vector<paddle::dialect::IrMetaTensor> vec_meta_x;
-  for (size_t i = 0; i < vec_dense_x.size(); i++) {
-    vec_meta_x.push_back(paddle::dialect::IrMetaTensor(&vec_dense_x[i]));
-  }
-
-  std::vector<const phi::MetaTensor *> meta_x;
-  for (size_t i = 0; i < static_cast<size_t>(vec_meta_x.size()); i++) {
-    meta_x.push_back(&vec_meta_x[i]);
-  }
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::AddNInferMeta(meta_x, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -266,46 +233,14 @@ void AddN_Op::Build(pir::Builder &builder,
   VLOG(4) << "Start build AddN_Op";
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {inputs_};
   argument.AddInput(inputs_);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      AddN_Op::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
-  std::vector<paddle::dialect::IrTensor> vec_dense_inputs;
-  for (size_t i = 0; i < static_cast<size_t>(inputs.size()); i++) {
-    vec_dense_inputs.push_back(paddle::dialect::IrTensor(
-        paddle::dialect::TransToPhiDataType(
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
-  }
-  std::vector<paddle::dialect::IrMetaTensor> vec_meta_inputs;
-  for (size_t i = 0; i < vec_dense_inputs.size(); i++) {
-    vec_meta_inputs.push_back(
-        paddle::dialect::IrMetaTensor(&vec_dense_inputs[i]));
-  }
-
-  std::vector<const phi::MetaTensor *> meta_inputs;
-  for (size_t i = 0; i < static_cast<size_t>(vec_meta_inputs.size()); i++) {
-    meta_inputs.push_back(&vec_meta_inputs[i]);
-  }
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::AddNInferMeta(meta_inputs, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
@@ -461,46 +396,14 @@ void AddNWithKernelOp::Build(pir::Builder &builder,
   VLOG(4) << "Start build AddNWithKernelOp";
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {inputs_};
   argument.AddInput(inputs_);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      AddNWithKernelOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
-  std::vector<paddle::dialect::IrTensor> vec_dense_inputs;
-  for (size_t i = 0; i < static_cast<size_t>(inputs.size()); i++) {
-    vec_dense_inputs.push_back(paddle::dialect::IrTensor(
-        paddle::dialect::TransToPhiDataType(
-            inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        inputs[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
-  }
-  std::vector<paddle::dialect::IrMetaTensor> vec_meta_inputs;
-  for (size_t i = 0; i < vec_dense_inputs.size(); i++) {
-    vec_meta_inputs.push_back(
-        paddle::dialect::IrMetaTensor(&vec_dense_inputs[i]));
-  }
-
-  std::vector<const phi::MetaTensor *> meta_inputs;
-  for (size_t i = 0; i < static_cast<size_t>(vec_meta_inputs.size()); i++) {
-    meta_inputs.push_back(&vec_meta_inputs[i]);
-  }
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::AddNInferMeta(meta_inputs, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
@@ -735,50 +638,14 @@ void AddNArrayOp::Build(pir::Builder &builder,             // NOLINT
   VLOG(4) << "Start build AddNArrayOp";
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {inputs_};
   argument.AddInput(inputs_);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      AddNArrayOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  pir::VectorType inputs = inputs_.type().dyn_cast<pir::VectorType>();
-
-  std::vector<paddle::dialect::IrTensor> vec_dense_inputs;
-  for (size_t i = 0; i < inputs.size(); i++) {
-    vec_dense_inputs.push_back(paddle::dialect::IrTensor(
-        TransToPhiDataType(
-            inputs[i]
-                .dyn_cast<paddle::dialect::DenseTensorArrayType>()
-                .dtype()),
-        {},
-        inputs[i]
-            .dyn_cast<paddle::dialect::DenseTensorArrayType>()
-            .data_layout(),
-        {}));
-  }
-
-  std::vector<paddle::dialect::IrMetaTensor> vec_meta_inputs;
-  for (size_t i = 0; i < vec_dense_inputs.size(); i++) {
-    vec_meta_inputs.push_back(
-        paddle::dialect::IrMetaTensor(&vec_dense_inputs[i]));
-  }
-
-  std::vector<const phi::MetaTensor *> meta_inputs;
-  for (size_t i = 0; i < static_cast<size_t>(vec_meta_inputs.size()); i++) {
-    meta_inputs.push_back(&vec_meta_inputs[i]);
-  }
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::AddNTensorArrayInferMeta(
-      meta_inputs, &meta_out, phi::MetaConfig(false, false));
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorArrayType::get(
-      pir::IrContext::Instance(),
-      TransToIrDataType(dense_out.dtype()),
-      dense_out.layout());
-
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -923,95 +790,25 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
       attributes.at("activation").dyn_cast<pir::StrAttribute>().AsString();
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x_, y_, bias_};
   argument.AddInputs({x_, y_, bias_});
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_trans_x =
       pir::BoolAttribute::get(pir::IrContext::Instance(), trans_x);
   argument.AddAttribute("trans_x", attr_trans_x);
+  argument_attributes.insert({"trans_x", attr_trans_x});
   pir::Attribute attr_trans_y =
       pir::BoolAttribute::get(pir::IrContext::Instance(), trans_y);
   argument.AddAttribute("trans_y", attr_trans_y);
+  argument_attributes.insert({"trans_y", attr_trans_y});
   pir::Attribute attr_activation =
       pir::StrAttribute::get(pir::IrContext::Instance(), activation);
   argument.AddAttribute("activation", attr_activation);
-
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-  paddle::dialect::DenseTensorType y =
-      y_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)y;
-  paddle::dialect::DenseTensorType bias =
-      bias_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)bias;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor dense_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&dense_x);
-
-  VLOG(4) << "Builder construction  dense_y";
-  paddle::dialect::IrTensor dense_y(
-      paddle::dialect::TransToPhiDataType(y.dtype()),
-      y.dims(),
-      y.data_layout(),
-      y.lod(),
-      y.offset());
-  VLOG(4) << "Builder construction  meta_y";
-  paddle::dialect::IrMetaTensor meta_y(&dense_y);
-
-  VLOG(4) << "Builder construction  dense_bias";
-  paddle::dialect::IrTensor dense_bias(
-      paddle::dialect::TransToPhiDataType(bias.dtype()),
-      bias.dims(),
-      bias.data_layout(),
-      bias.lod(),
-      bias.offset());
-  VLOG(4) << "Builder construction  meta_bias";
-  paddle::dialect::IrMetaTensor meta_bias(&dense_bias);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-  paddle::dialect::IrTensor dense_reserve_space;
-  paddle::dialect::IrMetaTensor meta_reserve_space(&dense_reserve_space);
-
-  phi::FusedGemmEpilogueInferMeta(
-      meta_x,
-      meta_y,
-      meta_bias,
-      trans_x,
-      trans_y,
-      activation,
-      &meta_out,
-      activation == "none" ? nullptr : &meta_reserve_space);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
-
-  pir::Type reserve_space_dense_tensor_type =
-      activation == "none"
-          ? pir::Type()
-          : paddle::dialect::DenseTensorType::get(
-                pir::IrContext::Instance(),
-                paddle::dialect::TransToIrDataType(dense_reserve_space.dtype()),
-                dense_reserve_space.dims(),
-                dense_reserve_space.layout(),
-                dense_reserve_space.lod(),
-                dense_reserve_space.offset());
-  argument_outputs.push_back(reserve_space_dense_tensor_type);
+  argument_attributes.insert({"activation", attr_activation});
+  std::vector<pir::Type> argument_outputs =
+      FusedGemmEpilogueOp::InferMeta(argument_inputs, argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
@@ -1334,122 +1131,26 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
       attributes.at("activation_grad").dyn_cast<pir::StrAttribute>().AsString();
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x_, y_, reserve_space_, out_grad_};
   argument.AddInputs({x_, y_, reserve_space_, out_grad_});
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_trans_x =
       pir::BoolAttribute::get(pir::IrContext::Instance(), trans_x);
   argument.AddAttribute("trans_x", attr_trans_x);
+  argument_attributes.insert({"trans_x", attr_trans_x});
   pir::Attribute attr_trans_y =
       pir::BoolAttribute::get(pir::IrContext::Instance(), trans_y);
   argument.AddAttribute("trans_y", attr_trans_y);
+  argument_attributes.insert({"trans_y", attr_trans_y});
   pir::Attribute attr_activation_grad =
       pir::StrAttribute::get(pir::IrContext::Instance(), activation_grad);
   argument.AddAttribute("activation_grad", attr_activation_grad);
+  argument_attributes.insert({"activation_grad", attr_activation_grad});
+  std::vector<pir::Type> argument_outputs =
+      FusedGemmEpilogueGradOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-  paddle::dialect::DenseTensorType y =
-      y_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)y;
-  paddle::dialect::DenseTensorType reserve_space =
-      reserve_space_
-          ? reserve_space_.type().dyn_cast<paddle::dialect::DenseTensorType>()
-          : paddle::dialect::DenseTensorType();
-  (void)reserve_space;
-  paddle::dialect::DenseTensorType out_grad =
-      out_grad_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)out_grad;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor dense_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&dense_x);
-
-  VLOG(4) << "Builder construction  dense_y";
-  paddle::dialect::IrTensor dense_y(
-      paddle::dialect::TransToPhiDataType(y.dtype()),
-      y.dims(),
-      y.data_layout(),
-      y.lod(),
-      y.offset());
-  VLOG(4) << "Builder construction  meta_y";
-  paddle::dialect::IrMetaTensor meta_y(&dense_y);
-
-  VLOG(4) << "Builder construction  dense_reserve_space";
-  std::unique_ptr<paddle::dialect::IrTensor> dense_reserve_space =
-      reserve_space_
-          ? std::make_unique<paddle::dialect::IrTensor>(
-                paddle::dialect::TransToPhiDataType(reserve_space.dtype()),
-                reserve_space.dims(),
-                reserve_space.data_layout(),
-                reserve_space.lod(),
-                reserve_space.offset())
-          : nullptr;
-  VLOG(4) << "Builder construction  meta_reserve_space";
-  paddle::dialect::IrMetaTensor meta_reserve_space(dense_reserve_space.get());
-
-  VLOG(4) << "Builder construction  dense_out_grad";
-  paddle::dialect::IrTensor dense_out_grad(
-      paddle::dialect::TransToPhiDataType(out_grad.dtype()),
-      out_grad.dims(),
-      out_grad.data_layout(),
-      out_grad.lod(),
-      out_grad.offset());
-  VLOG(4) << "Builder construction  meta_out_grad";
-  paddle::dialect::IrMetaTensor meta_out_grad(&dense_out_grad);
-  paddle::dialect::IrTensor dense_x_grad;
-  paddle::dialect::IrMetaTensor meta_x_grad(&dense_x_grad);
-  paddle::dialect::IrTensor dense_y_grad;
-  paddle::dialect::IrMetaTensor meta_y_grad(&dense_y_grad);
-  paddle::dialect::IrTensor dense_bias_grad;
-  paddle::dialect::IrMetaTensor meta_bias_grad(&dense_bias_grad);
-
-  phi::FusedGemmEpilogueGradInferMeta(meta_x,
-                                      meta_y,
-                                      meta_reserve_space,
-                                      meta_out_grad,
-                                      trans_x,
-                                      trans_y,
-                                      activation_grad,
-                                      &meta_x_grad,
-                                      &meta_y_grad,
-                                      &meta_bias_grad);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type x_grad_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_x_grad.dtype()),
-      dense_x_grad.dims(),
-      dense_x_grad.layout(),
-      dense_x_grad.lod(),
-      dense_x_grad.offset());
-  argument_outputs.push_back(x_grad_dense_tensor_type);
-
-  pir::Type y_grad_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_y_grad.dtype()),
-      dense_y_grad.dims(),
-      dense_y_grad.layout(),
-      dense_y_grad.lod(),
-      dense_y_grad.offset());
-  argument_outputs.push_back(y_grad_dense_tensor_type);
-
-  pir::Type bias_grad_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_bias_grad.dtype()),
-      dense_bias_grad.dims(),
-      dense_bias_grad.layout(),
-      dense_bias_grad.lod(),
-      dense_bias_grad.offset());
-  argument_outputs.push_back(bias_grad_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
@@ -1719,46 +1420,14 @@ void SplitGradOp::Build(pir::Builder &builder,
   pir::OpResult axis_ = full_axis_op->result(0);
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {out_grad_, axis_};
   argument.AddInputs({out_grad_, axis_});
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      SplitGradOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  pir::VectorType out_grad = out_grad_.type().dyn_cast<pir::VectorType>();
-  std::vector<paddle::dialect::IrTensor> vec_dense_out_grad;
-  for (size_t i = 0; i < static_cast<size_t>(out_grad.size()); i++) {
-    vec_dense_out_grad.push_back(paddle::dialect::IrTensor(
-        paddle::dialect::TransToPhiDataType(
-            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
-  }
-  std::vector<paddle::dialect::IrMetaTensor> vec_meta_out_grad;
-  for (size_t i = 0; i < vec_dense_out_grad.size(); i++) {
-    vec_meta_out_grad.push_back(
-        paddle::dialect::IrMetaTensor(&vec_dense_out_grad[i]));
-  }
-
-  std::vector<const phi::MetaTensor *> meta_out_grad;
-  for (size_t i = 0; i < static_cast<size_t>(vec_meta_out_grad.size()); i++) {
-    meta_out_grad.push_back(&vec_meta_out_grad[i]);
-  }
-  paddle::dialect::IrTensor dense_x_grad;
-  paddle::dialect::IrMetaTensor meta_x_grad(&dense_x_grad);
-
-  phi::ConcatInferMeta(meta_out_grad, axis, &meta_x_grad);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type x_grad_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_x_grad.dtype()),
-      dense_x_grad.dims(),
-      dense_x_grad.layout(),
-      dense_x_grad.lod(),
-      dense_x_grad.offset());
-  argument_outputs.push_back(x_grad_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -1770,53 +1439,14 @@ void SplitGradOp::Build(pir::Builder &builder,
   VLOG(4) << "Start build SplitGradOp";
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {out_grad_, axis_};
   argument.AddInputs({out_grad_, axis_});
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      SplitGradOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  pir::VectorType out_grad = out_grad_.type().dyn_cast<pir::VectorType>();
-  int axis = axis_.dyn_cast<pir::OpResult>()
-                 .owner()
-                 ->dyn_cast<paddle::dialect::FullOp>()
-                 .attribute<paddle::dialect::ScalarAttribute>("value")
-                 .data()
-                 .to<int>();
-
-  std::vector<paddle::dialect::IrTensor> vec_dense_out_grad;
-  for (size_t i = 0; i < static_cast<size_t>(out_grad.size()); i++) {
-    vec_dense_out_grad.push_back(paddle::dialect::IrTensor(
-        TransToPhiDataType(
-            out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dtype()),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().dims(),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().data_layout(),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().lod(),
-        out_grad[i].dyn_cast<paddle::dialect::DenseTensorType>().offset()));
-  }
-  std::vector<paddle::dialect::IrMetaTensor> vec_meta_out_grad;
-  for (size_t i = 0; i < vec_dense_out_grad.size(); i++) {
-    vec_meta_out_grad.push_back(
-        paddle::dialect::IrMetaTensor(&vec_dense_out_grad[i]));
-  }
-
-  std::vector<const phi::MetaTensor *> meta_out_grad;
-  for (size_t i = 0; i < static_cast<size_t>(vec_meta_out_grad.size()); i++) {
-    meta_out_grad.push_back(&vec_meta_out_grad[i]);
-  }
-  paddle::dialect::IrTensor dense_x_grad;
-  paddle::dialect::IrMetaTensor meta_x_grad(&dense_x_grad);
-
-  phi::ConcatInferMeta(meta_out_grad, axis, &meta_x_grad);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type x_grad_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      TransToIrDataType(dense_x_grad.dtype()),
-      dense_x_grad.dims(),
-      dense_x_grad.layout(),
-      dense_x_grad.lod(),
-      dense_x_grad.offset());
-  argument_outputs.push_back(x_grad_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -1966,23 +1596,16 @@ void CreateArrayOp::Build(pir::Builder &builder,
                           phi::DataType dtype) {
   VLOG(4) << "Start build CreateArrayOp";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs;
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_dtype = paddle::dialect::DataTypeAttribute::get(
       pir::IrContext::Instance(), dtype);
   argument.AddAttribute("dtype", attr_dtype);
-  VLOG(4) << "Builder construction outputs";
+  argument_attributes.insert({"dtype", attr_dtype});
+  std::vector<pir::Type> argument_outputs =
+      CreateArrayOp::InferMeta(argument_inputs, argument_attributes);
 
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::CreateArrayInferMeta(dtype, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorArrayType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.layout());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2092,31 +1715,13 @@ void CreateArrayLikeOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_val =
       pir::FloatAttribute::get(pir::IrContext::Instance(), val);
   argument.AddAttribute("val", attr_val);
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType input_type =
-      input_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_input(
-      paddle::dialect::TransToPhiDataType(input_type.dtype()),
-      {},
-      input_type.data_layout(),
-      {});
-
-  paddle::dialect::IrMetaTensor meta_input(&dense_input);
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::CreateArrayLikeInferMeta(meta_input, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorArrayType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.layout());
-  argument_outputs.push_back(out_dense_tensor_type);
+  argument_attributes.insert({"val", attr_val});
+  std::vector<pir::Type> argument_outputs =
+      CreateArrayLikeOp::InferMeta(argument_inputs, argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -2240,33 +1845,13 @@ void ArrayLengthOp::Build(pir::Builder &builder,
                           pir::Value x) {
   VLOG(4) << "Start build ArrayLengthOp";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x};
   argument.AddInputs({x});
   VLOG(4) << "Builder construction attributes";
-  VLOG(4) << "Builder construction outputs";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ArrayLengthOp::InferMeta(argument_inputs, argument_attributes);
 
-  paddle::dialect::DenseTensorArrayType x_type =
-      x.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_x(
-      paddle::dialect::TransToPhiDataType(x_type.dtype()),
-      {},
-      x_type.data_layout(),
-      {});
-  paddle::dialect::IrMetaTensor meta_x(&dense_x);
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ArrayLengthInferMeta(meta_x, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
 
@@ -2401,32 +1986,13 @@ void ArrayReadOp::Build(pir::Builder &builder,
       std::vector<int64_t>{1}, i, phi::DataType::INT64, phi::CPUPlace());
 
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {array, full_i_op.result(0)};
   argument.AddInputs({array, full_i_op.result(0)});
   VLOG(4) << "Builder construction attributes";
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType array_type =
-      array.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_array(
-      paddle::dialect::TransToPhiDataType(array_type.dtype()),
-      {},
-      array_type.data_layout(),
-      {});
-  paddle::dialect::IrMetaTensor meta_array(&dense_array);
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ArrayReadOp::InferMeta(argument_inputs, argument_attributes);
 
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ArrayReadInferMeta(
-      meta_array, i, &meta_out, phi::MetaConfig(false, false));
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod());
-  argument_outputs.push_back(out_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2437,48 +2003,13 @@ void ArrayReadOp::Build(pir::Builder &builder,
                         pir::Value i) {
   VLOG(4) << "Start build ArrayReadOp";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {array, i};
   argument.AddInputs({array, i});
   VLOG(4) << "Builder construction attributes";
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType array_type =
-      array.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_array(
-      paddle::dialect::TransToPhiDataType(array_type.dtype()),
-      {},
-      array_type.data_layout(),
-      {});
-  paddle::dialect::IrMetaTensor meta_array(&dense_array);
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      AddNOp::InferMeta(argument_inputs, argument_attributes);
 
-  phi::Scalar i_scalar;
-  if (i.dyn_cast<pir::OpResult>() &&
-      i.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullOp>()) {
-    i_scalar =
-        std::move(phi::Scalar(i.dyn_cast<pir::OpResult>()
-                                  .owner()
-                                  ->dyn_cast<paddle::dialect::FullOp>()
-                                  .attribute("value")
-                                  .dyn_cast<paddle::dialect::ScalarAttribute>()
-                                  .data()
-                                  .to<int64_t>()));
-  } else {
-    i_scalar = std::move(phi::Scalar(-1));
-    i_scalar.SetFromTensor(true);
-  }
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ArrayReadInferMeta(
-      meta_array, i_scalar, &meta_out, phi::MetaConfig(false, false));
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod());
-  argument_outputs.push_back(out_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2640,40 +2171,13 @@ void ArrayWrite_Op::Build(pir::Builder &builder,
                           pir::Value i) {
   VLOG(4) << "Start build ArrayWrite_Op";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {array, x, i};
   argument.AddInputs({array, x, i});
   VLOG(4) << "Builder construction attributes";
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType array_type =
-      array.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_array(
-      paddle::dialect::TransToPhiDataType(array_type.dtype()),
-      {},
-      array_type.data_layout(),
-      {});
-  paddle::dialect::IrMetaTensor meta_array(&dense_array);
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ArrayWrite_Op::InferMeta(argument_inputs, argument_attributes);
 
-  paddle::dialect::DenseTensorType x_type =
-      x.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  paddle::dialect::IrTensor dense_x(
-      paddle::dialect::TransToPhiDataType(x_type.dtype()),
-      x_type.dims(),
-      x_type.data_layout(),
-      x_type.lod(),
-      x_type.offset());
-  paddle::dialect::IrMetaTensor meta_x(&dense_x);
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ArrayWriteInferMeta(
-      meta_array, meta_x, &meta_out, phi::MetaConfig(false, false));
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_type = paddle::dialect::DenseTensorArrayType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.layout());
-  argument_outputs.push_back(out_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2854,56 +2358,22 @@ void ArrayToTensorOp::Build(pir::Builder &builder,             // NOLINT
                             bool use_stack) {
   VLOG(4) << "Start build ArrayToTensorOp";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x};
   argument.AddInputs({x});
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_axis =
       pir::Int32Attribute::get(pir::IrContext::Instance(), axis);
   argument.AddAttribute("axis", attr_axis);
+  argument_attributes.insert({"axis", attr_axis});
   pir::Attribute attr_use_stack =
       pir::BoolAttribute::get(pir::IrContext::Instance(), use_stack);
   argument.AddAttribute("use_stack", attr_use_stack);
+  argument_attributes.insert({"use_stack", attr_use_stack});
+  std::vector<pir::Type> argument_outputs =
+      ArrayToTensorOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType x_type =
-      x.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_x(
-      paddle::dialect::TransToPhiDataType(x_type.dtype()),
-      {},
-      x_type.data_layout(),
-      {});
-  paddle::dialect::IrMetaTensor meta_x(&dense_x);
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  paddle::dialect::IrTensor dense_out_index;
-  paddle::dialect::IrMetaTensor meta_out_index(&dense_out_index);
-
-  phi::ArrayToTensorInferMeta(meta_x,
-                              axis,
-                              use_stack,
-                              &meta_out,
-                              &meta_out_index,
-                              phi::MetaConfig(false, false));
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
-  pir::Type out_index_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out_index.dtype()),
-      dense_out_index.dims(),
-      dense_out_index.layout(),
-      dense_out_index.lod(),
-      dense_out_index.offset());
-  argument_outputs.push_back(out_index_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2970,7 +2440,6 @@ std::vector<pir::Type> ArrayToTensorOp::InferMeta(
              input_values.size());
   pir::Value x_ = input_values[0];
 
-  VLOG(4) << "Builder construction attributes";
   IR_ENFORCE(attributes.find("axis") != attributes.end(),
              "'value' Attribute is expected for IncrementOp. ");
   int32_t axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
@@ -3084,48 +2553,23 @@ void TensorToArrayOp::Build(pir::Builder &builder,             // NOLINT
                             bool use_stack) {
   VLOG(4) << "Start build TensorToArrayOp";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {x_, out_grad_};
   argument.AddInputs({x_, out_grad_});
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_axis =
       pir::Int32Attribute::get(pir::IrContext::Instance(), axis);
   argument.AddAttribute("axis", attr_axis);
+  argument_attributes.insert({"axis", attr_axis});
+
   pir::Attribute attr_use_stack =
       pir::BoolAttribute::get(pir::IrContext::Instance(), use_stack);
   argument.AddAttribute("use_stack", attr_use_stack);
+  argument_attributes.insert({"use_stack", attr_use_stack});
+  std::vector<pir::Type> argument_outputs =
+      TensorToArrayOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()), {}, x.data_layout(), {});
-
-  paddle::dialect::DenseTensorType out_grad =
-      out_grad_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  paddle::dialect::IrTensor dense_out_grad(
-      paddle::dialect::TransToPhiDataType(out_grad.dtype()),
-      out_grad.dims(),
-      out_grad.data_layout(),
-      out_grad.lod(),
-      out_grad.offset());
-
-  VLOG(4) << "Builder construction  meta_x, meta_out_grad";
-  paddle::dialect::IrMetaTensor meta_out_grad(&dense_out_grad);
-  paddle::dialect::IrMetaTensor meta_x(&dense_x);
-
-  paddle::dialect::IrTensor dense_x_grad;
-  paddle::dialect::IrMetaTensor meta_x_grad(&dense_x_grad);
-
-  phi::TensorToArrayInferMeta(
-      meta_x, meta_out_grad, axis, use_stack, &meta_x_grad);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_array_type =
-      paddle::dialect::DenseTensorArrayType::get(
-          pir::IrContext::Instance(),
-          paddle::dialect::TransToIrDataType(dense_x_grad.dtype()),
-          dense_x_grad.layout());
-  argument_outputs.push_back(out_dense_tensor_array_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -3196,6 +2640,7 @@ std::vector<pir::Type> TensorToArrayOp::InferMeta(
   pir::Value out_grad_ = input_values[1];
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
 
   IR_ENFORCE(attributes.find("axis") != attributes.end(),
              "'value' Attribute is expected for IncrementOp. ");
@@ -3517,62 +2962,13 @@ void SliceArrayDenseOp::Build(pir::Builder &builder,             // NOLINT
                               pir::Value starts) {
   VLOG(4) << "Start build SliceArrayDenseOp";
   VLOG(4) << "Builder construction inputs";
+  std::vector<pir::Value> argument_inputs = {input, starts};
   argument.AddInputs({input, starts});
   VLOG(4) << "Builder construction attributes";
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorArrayType input_type =
-      input.type().dyn_cast<paddle::dialect::DenseTensorArrayType>();
-  paddle::dialect::IrTensor dense_input(
-      paddle::dialect::TransToPhiDataType(input_type.dtype()),
-      {},
-      input_type.data_layout(),
-      {});
-  paddle::dialect::IrMetaTensor meta_input(&dense_input);
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      SliceArrayDenseOp::InferMeta(argument_inputs, argument_attributes);
 
-  phi::IntArray starts_list;
-  if (starts.dyn_cast<pir::OpResult>()
-          .owner()
-          ->isa<paddle::dialect::FullIntArrayOp>()) {
-    starts_list = std::move(phi::IntArray(paddle::dialect::GetInt64Vector(
-        starts.dyn_cast<pir::OpResult>()
-            .owner()
-            ->dyn_cast<paddle::dialect::FullIntArrayOp>()
-            .attribute("value"))));
-  } else if (starts.type().isa<pir::VectorType>()) {
-    size_t starts_size = starts.type().dyn_cast<pir::VectorType>().size();
-    starts_list =
-        std::move(phi::IntArray(std::vector<int64_t>(starts_size, -1)));
-    starts_list.SetFromTensor(true);
-  } else if (starts.type().isa<paddle::dialect::DenseTensorType>()) {
-    common::DDim starts_dim =
-        starts.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
-    size_t starts_size = common::product(starts_dim);
-    if (common::contain_unknown_dim(starts_dim)) {
-      starts_size = 1;
-    }
-    starts_list =
-        std::move(phi::IntArray(std::vector<int64_t>(starts_size, -1)));
-    starts_list.SetFromTensor(true);
-  } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
-        "Only support VectorType or DenseTensorType"));
-  }
-
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::SliceArrayDenseInferMeta(
-      meta_input, starts_list, &meta_out, phi::MetaConfig(false, false));
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -3850,35 +3246,10 @@ void ExpandOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ExpandOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_meta_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_meta_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ExpandInferMeta(meta_x, shape, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -3908,35 +3279,10 @@ void ExpandOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ExpandOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_meta_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_meta_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ExpandInferMeta(meta_x, shape, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -3952,61 +3298,10 @@ void ExpandOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ExpandOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-  phi::IntArray shape;
-  if (shape_.dyn_cast<pir::OpResult>()
-          .owner()
-          ->isa<paddle::dialect::FullIntArrayOp>()) {
-    shape = std::move(phi::IntArray(paddle::dialect::GetInt64Vector(
-        shape_.dyn_cast<pir::OpResult>()
-            .owner()
-            ->dyn_cast<paddle::dialect::FullIntArrayOp>()
-            .attribute("value"))));
-  } else if (shape_.type().isa<pir::VectorType>()) {
-    size_t shape_size = shape_.type().dyn_cast<pir::VectorType>().size();
-    // In ExpandInferMeta use -2 to represent the element in expand_shape is a
-    // var.
-    shape = std::move(phi::IntArray(std::vector<int64_t>(shape_size, -2)));
-    shape.SetFromTensor(true);
-  } else if (shape_.type().isa<paddle::dialect::DenseTensorType>()) {
-    size_t shape_size = common::product(
-        shape_.type().dyn_cast<paddle::dialect::DenseTensorType>().dims());
-    // In ExpandInferMeta use -2 to represent the element in expand_shape is a
-    // var.
-    shape = std::move(phi::IntArray(std::vector<int64_t>(shape_size, -2)));
-    shape.SetFromTensor(true);
-  } else {
-    PADDLE_THROW(phi::errors::Unimplemented(
-        "Only support VectorType or DenseTensorType"));
-  }
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_meta_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_meta_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ExpandInferMeta(meta_x, shape, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -4264,38 +3559,14 @@ void IncrementOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
+  argument_attributes.insert({"value", attr_value});
+  std::vector<pir::Type> argument_outputs =
+      IncrementOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::IncrementInferMeta(meta_x, value, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -4315,38 +3586,14 @@ void IncrementOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
+  argument_attributes.insert({"value", attr_value});
+  std::vector<pir::Type> argument_outputs =
+      IncrementOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::IncrementInferMeta(meta_x, value, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -4495,38 +3742,14 @@ void Increment_Op::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
+  argument_attributes.insert({"value", attr_value});
+  std::vector<pir::Type> argument_outputs =
+      Increment_Op::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::IncrementInferMeta(meta_x, value, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -4546,38 +3769,14 @@ void Increment_Op::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
   pir::Attribute attr_value =
       pir::FloatAttribute::get(pir::IrContext::Instance(), value);
   argument.AddAttribute("value", attr_value);
+  argument_attributes.insert({"value", attr_value});
+  std::vector<pir::Type> argument_outputs =
+      Increment_Op::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  (void)x;
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_tensor_x);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::IncrementInferMeta(meta_x, value, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -4703,82 +3902,16 @@ void ShapeBroadcastOp::Build(pir::Builder &builder,
   argument.AddInputs(argument_inputs);
 
   VLOG(4) << "Builder construction attributes";
+  pir::AttributeMap argument_attributes;
+  std::vector<pir::Type> argument_outputs =
+      ShapeBroadcastOp::InferMeta(argument_inputs, argument_attributes);
 
-  VLOG(4) << "Builder construction outputs";
-  paddle::dialect::DenseTensorType x =
-      x_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-  paddle::dialect::DenseTensorType y =
-      y_.type().dyn_cast<paddle::dialect::DenseTensorType>();
-
-  VLOG(4) << "Builder construction  dense_x";
-  paddle::dialect::IrTensor ir_tensor_x(
-      paddle::dialect::TransToPhiDataType(x.dtype()),
-      x.dims(),
-      x.data_layout(),
-      x.lod(),
-      x.offset());
-  VLOG(4) << "Builder construction  meta_x";
-  paddle::dialect::IrMetaTensor meta_x(&ir_tensor_x);
-
-  VLOG(4) << "Builder construction  dense_y";
-  paddle::dialect::IrTensor ir_tensor_y(
-      paddle::dialect::TransToPhiDataType(y.dtype()),
-      y.dims(),
-      y.data_layout(),
-      y.lod(),
-      y.offset());
-  VLOG(4) << "Builder construction  meta_y";
-  paddle::dialect::IrMetaTensor meta_y(&ir_tensor_y);
-  paddle::dialect::IrTensor dense_out;
-  paddle::dialect::IrMetaTensor meta_out(&dense_out);
-
-  phi::ElementwiseInferMeta(meta_x, meta_y, &meta_out);
-
-  std::vector<pir::Type> argument_outputs;
-  pir::Type out_dense_tensor_type = paddle::dialect::DenseTensorType::get(
-      pir::IrContext::Instance(),
-      paddle::dialect::TransToIrDataType(dense_out.dtype()),
-      dense_out.dims(),
-      dense_out.layout(),
-      dense_out.lod(),
-      dense_out.offset());
-  argument_outputs.push_back(out_dense_tensor_type);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
 
-namespace {
-
-void ShapeBroadcastOpInferMeta(const phi::MetaTensor &x,
-                               const phi::MetaTensor &y,
-                               phi::MetaTensor *out) {
-  PADDLE_ENFORCE_EQ(
-      x.dims().size(),
-      1,
-      phi::errors::PreconditionNotMet(
-          "The size %d of x.dims() must be equal to 1.", x.dims().size()));
-  PADDLE_ENFORCE_EQ(
-      y.dims().size(),
-      1,
-      phi::errors::PreconditionNotMet(
-          "The size %d of y.dims() must be equal to 1.", y.dims().size()));
-  out->set_dims({std::max<int64_t>(x.dims().at(0), y.dims().at(0))});
-  // dtype need promote when meet input dtype with more precision
-  paddle::experimental::DataTypeSet dtype_set{x.dtype()};
-  dtype_set = dtype_set | paddle::experimental::DataTypeSet(y.dtype());
-  DataType promote_result = PromoteTypes(dtype_set);
-  if (promote_result == DataType::UNDEFINED) {
-    promote_result = x.dtype();
-  }
-  out->set_dtype(promote_result);
-  out->set_layout(x.layout());
-  out->share_lod(x);
-}
-
-}  // namespace
-
 void ShapeBroadcastOp::InferMeta(phi::InferMetaContext *infer_meta) {
-  auto fn = PD_INFER_META(ShapeBroadcastOpInferMeta);
+  auto fn = PD_INFER_META(phi::ElementwiseInferMeta);
   fn(infer_meta);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
将InfermetaByValue的逻辑抽取出来，在build函数中调用该函数