### PR TITLE
[InferSymbolicShape] Rerun ShapeOptimizationPass and provide SumOpInferSymbolicShape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
@@ -222,9 +222,9 @@ bool StackOpInferSymbolicShape(pir::Operation *op,
 
 bool SumOpInferSymbolicShape(pir::Operation *op,
                              pir::ShapeConstraintIRAnalysis *shape_analysis) {
-  std::vector<symbol::DimExpr> input_shapes{
-      shape_analysis->GetShapeOrDataForValue(op->operand_source(0)).shape()};
-  symbol::ShapeOrDataDimExprs axis_exprs =
+  const std::vector<symbol::DimExpr> &input_shapes =
+      shape_analysis->GetShapeOrDataForValue(op->operand_source(0)).shape();
+  const symbol::ShapeOrDataDimExprs &axis_exprs =
       shape_analysis->GetShapeOrDataForValue(op->operand_source(1));
   IR_ENFORCE(axis_exprs.data().has_value(),
              "The ShapeOrDataDimExprs of axis should have data");
@@ -240,9 +240,10 @@ bool SumOpInferSymbolicShape(pir::Operation *op,
     axis_set.insert(axis);
   }
 
-  auto attributes = op->attributes();
-  pir::Attribute attr = attributes["keepdim"];
-  bool keepdim = attr.dyn_cast<pir::BoolAttribute>().data();
+  const auto &attributes = op->attributes();
+  IR_ENFORCE(attributes.find("keepdim") != attributes.end(),
+             "SumOp must have keepdim attribute");
+  bool keepdim = attributes.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
 
   std::vector<symbol::DimExpr> output_shapes;
   for (std::int64_t i = 0; i < input_shapes.size(); ++i) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
@@ -235,8 +235,9 @@ bool SumOpInferSymbolicShape(pir::Operation *op,
     if (axis < 0) {
       axis += input_shapes.size();
     }
-    IR_ENFORCE(axis >= 0 && axis < input_shapes.size(),
-               "Invalid axis, please check again");
+    IR_ENFORCE(
+        axis >= 0 && axis < static_cast<std::int64_t>(input_shapes.size()),
+        "Invalid axis, please check again");
     axis_set.insert(axis);
   }
 
@@ -246,7 +247,7 @@ bool SumOpInferSymbolicShape(pir::Operation *op,
   bool keepdim = attributes.at("keepdim").dyn_cast<pir::BoolAttribute>().data();
 
   std::vector<symbol::DimExpr> output_shapes;
-  for (std::int64_t i = 0; i < input_shapes.size(); ++i) {
+  for (std::size_t i = 0; i < input_shapes.size(); ++i) {
     if (axis_set.find(i) != axis_set.end()) {
       if (keepdim) {
         output_shapes.emplace_back(1);

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1565,6 +1565,9 @@ void AddCinnPass(std::shared_ptr<PassManager> &pass_manager,  // NOLINT
                         : nullptr;
 
   pass_manager->AddPass(cinn::dialect::ir::CreatePdOpToCinnOpPass());
+  if (has_dynamic_shape) {
+    pass_manager->AddPass(pir::CreateShapeOptimizationPass());
+  }
   pass_manager->AddPass(
       std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
   pass_manager->AddPass(pir::CreateDeadCodeEliminationPass());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[InferSymbolicShape] Rerun ShapeOptimizationPass and provide SumOpInferSymbolicShape

PdOpToCinnOpPass 后 program 内的 Value 会发生改变，因此需要重新进行符号推导