### PR TITLE
[PIR] Fix Deepcopy: new-push_back

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -97,9 +97,9 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     auto* dst_tensor_array = dst_var->GetMutable<phi::TensorArray>();
     if (src_tensor_array.size() == 0) return;
     dst_tensor_array->resize(src_tensor_array.size());
-    for (auto src_tensor : src_tensor_array) {
+    for (int i = 0; i < src_tensor_array.size(); ++i) {
       phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
-      if (src_tensor.numel() == 0) {
+      if (src_tensor_array.at(i).numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor.meta());
       } else {
         tmp_dst_tensor.ShareDataWith(src_tensor);

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -96,15 +96,15 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     auto src_tensor_array = src_var->Get<phi::TensorArray>();
     auto* dst_tensor_array = dst_var->GetMutable<phi::TensorArray>();
     if (src_tensor_array.size() == 0) return;
-    dst_tensor_array->clear();
+    dst_tensor_array->resize(0);
     for (auto src_tensor : src_tensor_array) {
-      phi::DenseTensor* tmp_dst_tensor = new phi::DenseTensor();
+      phi::DenseTensor tmp_dst_tensor = std::move(phi::DenseTensor());
       if (src_tensor.numel() == 0) {
-        tmp_dst_tensor->set_meta(src_tensor.meta());
+        tmp_dst_tensor.set_meta(src_tensor.meta());
       } else {
-        tmp_dst_tensor->ShareDataWith(src_tensor);
+        tmp_dst_tensor.ShareDataWith(src_tensor);
       }
-      dst_tensor_array->push_back(*tmp_dst_tensor);
+      dst_tensor_array->push_back(tmp_dst_tensor);
     }
   } else {
     PADDLE_THROW(phi::errors::PreconditionNotMet(

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -97,7 +97,7 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     auto* dst_tensor_array = dst_var->GetMutable<phi::TensorArray>();
     if (src_tensor_array.size() == 0) return;
     dst_tensor_array->resize(src_tensor_array.size());
-    for (int i = 0; i < src_tensor_array.size(); ++i) {
+    for (size_t i = 0; i < src_tensor_array.size(); ++i) {
       phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
       if (src_tensor_array.at(i).numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor_array.at(i).meta());

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -96,15 +96,14 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     auto src_tensor_array = src_var->Get<phi::TensorArray>();
     auto* dst_tensor_array = dst_var->GetMutable<phi::TensorArray>();
     if (src_tensor_array.size() == 0) return;
-    dst_tensor_array->resize(0);
+    dst_tensor_array->resize(src_tensor_array.size());
     for (auto src_tensor : src_tensor_array) {
-      phi::DenseTensor tmp_dst_tensor = phi::DenseTensor();
+      phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
       if (src_tensor.numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor.meta());
       } else {
         tmp_dst_tensor.ShareDataWith(src_tensor);
       }
-      dst_tensor_array->push_back(tmp_dst_tensor);
     }
   } else {
     PADDLE_THROW(phi::errors::PreconditionNotMet(

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -100,9 +100,9 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     for (int i = 0; i < src_tensor_array.size(); ++i) {
       phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
       if (src_tensor_array.at(i).numel() == 0) {
-        tmp_dst_tensor.set_meta(src_tensor.meta());
+        tmp_dst_tensor.set_meta(src_tensor_array.at(i).meta());
       } else {
-        tmp_dst_tensor.ShareDataWith(src_tensor);
+        tmp_dst_tensor.ShareDataWith(src_tensor_array.at(i));
       }
     }
   } else {

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -98,7 +98,7 @@ void ShareVarData(const Variable* src_var, Variable* dst_var) {
     if (src_tensor_array.size() == 0) return;
     dst_tensor_array->resize(0);
     for (auto src_tensor : src_tensor_array) {
-      phi::DenseTensor tmp_dst_tensor = std::move(phi::DenseTensor());
+      phi::DenseTensor tmp_dst_tensor = phi::DenseTensor();
       if (src_tensor.numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor.meta());
       } else {

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -348,15 +348,14 @@ void DeepCopyVariable(const Variable* src_var,
             "TensorArray shouldn't be null"));
       }
     }
-    dst_tensor_array->resize(0);
-    for (auto src_tensor : src_tensor_array) {
-      phi::DenseTensor tmp_dst_tensor = phi::DenseTensor();
-      if (src_tensor.numel() == 0) {
+    dst_tensor_array->resize(src_tensor_array.size());
+    for (int i = 0; i < src_tensor_array.size(); ++i) {
+      phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
+      if (src_tensor_array.at(i).numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor.meta());
         continue;
       }
       framework::TensorCopy(src_tensor, src_tensor.place(), &tmp_dst_tensor);
-      dst_tensor_array->push_back(tmp_dst_tensor);
     }
   } else if (src_var->IsType<VariableRefArray>()) {
     auto src_ref_array = src_var->Get<VariableRefArray>();

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -355,7 +355,9 @@ void DeepCopyVariable(const Variable* src_var,
         tmp_dst_tensor.set_meta(src_tensor_array.at(i).meta());
         continue;
       }
-      framework::TensorCopy(src_tensor_array.at(i), src_tensor_array.at(i).place(), &tmp_dst_tensor);
+      framework::TensorCopy(src_tensor_array.at(i),
+                            src_tensor_array.at(i).place(),
+                            &tmp_dst_tensor);
     }
   } else if (src_var->IsType<VariableRefArray>()) {
     auto src_ref_array = src_var->Get<VariableRefArray>();

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -350,7 +350,7 @@ void DeepCopyVariable(const Variable* src_var,
     }
     dst_tensor_array->resize(0);
     for (auto src_tensor : src_tensor_array) {
-      phi::DenseTensor tmp_dst_tensor = std::move(phi::DenseTensor());
+      phi::DenseTensor tmp_dst_tensor = phi::DenseTensor();
       if (src_tensor.numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor.meta());
         continue;

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -349,7 +349,7 @@ void DeepCopyVariable(const Variable* src_var,
       }
     }
     dst_tensor_array->resize(src_tensor_array.size());
-    for (int i = 0; i < src_tensor_array.size(); ++i) {
+    for (size_t i = 0; i < src_tensor_array.size(); ++i) {
       phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
       if (src_tensor_array.at(i).numel() == 0) {
         tmp_dst_tensor.set_meta(src_tensor_array.at(i).meta());

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -352,10 +352,10 @@ void DeepCopyVariable(const Variable* src_var,
     for (int i = 0; i < src_tensor_array.size(); ++i) {
       phi::DenseTensor& tmp_dst_tensor = dst_tensor_array->at(i);
       if (src_tensor_array.at(i).numel() == 0) {
-        tmp_dst_tensor.set_meta(src_tensor.meta());
+        tmp_dst_tensor.set_meta(src_tensor_array.at(i).meta());
         continue;
       }
-      framework::TensorCopy(src_tensor, src_tensor.place(), &tmp_dst_tensor);
+      framework::TensorCopy(src_tensor_array.at(i), src_tensor_array.at(i).place(), &tmp_dst_tensor);
     }
   } else if (src_var->IsType<VariableRefArray>()) {
     auto src_ref_array = src_var->Get<VariableRefArray>();

--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -348,15 +348,15 @@ void DeepCopyVariable(const Variable* src_var,
             "TensorArray shouldn't be null"));
       }
     }
-    dst_tensor_array->clear();
+    dst_tensor_array->resize(0);
     for (auto src_tensor : src_tensor_array) {
-      phi::DenseTensor* tmp_dst_tensor = new phi::DenseTensor();
+      phi::DenseTensor tmp_dst_tensor = std::move(phi::DenseTensor());
       if (src_tensor.numel() == 0) {
-        tmp_dst_tensor->set_meta(src_tensor.meta());
+        tmp_dst_tensor.set_meta(src_tensor.meta());
         continue;
       }
-      framework::TensorCopy(src_tensor, src_tensor.place(), tmp_dst_tensor);
-      dst_tensor_array->push_back(*tmp_dst_tensor);
+      framework::TensorCopy(src_tensor, src_tensor.place(), &tmp_dst_tensor);
+      dst_tensor_array->push_back(tmp_dst_tensor);
     }
   } else if (src_var->IsType<VariableRefArray>()) {
     auto src_ref_array = src_var->Get<VariableRefArray>();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复new新建对象后调用push_back进行拷贝构造，导致原有对象没有被销毁的问题