### PR TITLE
[PIR][DynamicShape] Add rms norm, decomped version

### DIFF
--- a/test/ir/pir/cinn/symbolic/test_cinn_sub_graph_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_sub_graph_symbolic.py
@@ -167,5 +167,74 @@ class TestCinnDyShapeBC(TestCinnDyShapeBase):
         # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
 
 
+class LlamaRMSNorm(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.hidden_size = 4096
+        self.weight = paddle.create_parameter(
+            shape=[self.hidden_size],
+            dtype=paddle.get_default_dtype(),
+            default_initializer=paddle.nn.initializer.Constant(1.0),
+        )
+        self.variance_epsilon = 1e-6
+
+    def forward(self, hidden_states):
+        # 1. variance = hidden_states.pow(2).mean(-1, keepdim=True)
+
+        axis_rst = 2
+        # 1.1 decomp pow -> elementwise_pow
+        pow_tensor = paddle.full([1], axis_rst, hidden_states.dtype)
+        pow_rst = paddle.pow(hidden_states, pow_tensor)
+
+        # 1.2 decomp mean -> sum & div
+        sum_rst = paddle.sum(pow_rst, [axis_rst], keepdim=True)
+        shape_rst = paddle.shape(sum_rst)
+        div_by = paddle.full(shape_rst, hidden_states.shape[axis_rst])
+        variance = paddle.divide(sum_rst, div_by)
+
+        # 2. paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+
+        # 2.1 decomp variance + self.variance_epsilon -> full + scale
+        scale_tensor = paddle.full([1], 1.0)
+        scale_rst = paddle.scale(variance, scale_tensor, self.variance_epsilon)
+
+        # 2.2 decomp rsqrt -> pow(-0.5)
+        rsqrt_tensor = paddle.full([1], -0.5)
+        rsqrt_rst = paddle.pow(scale_rst, rsqrt_tensor)
+
+        hidden_states = rsqrt_rst * hidden_states
+
+        # hidden_states = (
+        #     paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+        # )
+
+        return hidden_states * self.weight
+
+
+class TestCinnDyShapeRMSNorm(TestCinnDyShapeBase):
+    def prepare_data(self):
+        self.hidden_states_shape = [1, 300, 4096]
+        self.hidden_states = paddle.randn(
+            self.hidden_states_shape, dtype="float32"
+        )
+        self.hidden_states.stop_gradient = False
+
+    def eval_symbolic(self, use_cinn):
+        paddle.seed(2022)
+        net = LlamaRMSNorm()
+        input_spec = [
+            InputSpec(shape=[None, None, 4096], dtype='float32'),
+        ]
+        net = apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = net(self.hidden_states)
+        return out
+
+    def test_eval_symbolic(self):
+        # cinn_out = self.eval_symbolic(use_cinn=True)
+        dy_out = self.eval_symbolic(use_cinn=False)
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Add rms norm, decomped version


{
 (%0) = "builtin.parameter" () {is_persisable:[true],parameter_name:"parameter_0",stop_gradient:[false]} : () -> pd_op.tensor<4096xf32>
 (%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"hidden_states",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1,-1,4096],stop_gradient:[false]} : () -> pd_op.tensor<-1x-1x4096xf32>
 (%2) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<1xf32>
 (%3) = "pd_op.elementwise_pow" (%1, %2) {stop_gradient:[false]} : (pd_op.tensor<-1x-1x4096xf32>, pd_op.tensor<1xf32>) -> pd_op.tensor<-1x-1x4096xf32>
 (%4) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)2]} : () -> pd_op.tensor<1xi64>
 (%5) = "pd_op.sum" (%3, %4) {dtype:(pd_op.DataType)Undefined,keepdim:true,stop_gradient:[false]} : (pd_op.tensor<-1x-1x4096xf32>, pd_op.tensor<1xi64>) -> pd_op.tensor<-1x-1x1xf32>
 (%6) = "pd_op.shape" (%5) {stop_gradient:[true]} : (pd_op.tensor<-1x-1x1xf32>) -> pd_op.tensor<3xi32>
 (%7) = "pd_op.shape" (%1) {stop_gradient:[true]} : (pd_op.tensor<-1x-1x4096xf32>) -> pd_op.tensor<3xi32>
 (%8) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)0]} : () -> pd_op.tensor<1xi64>
 (%9) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)1]} : () -> pd_op.tensor<1xi64>
 (%10) = "pd_op.slice" (%7, %8, %9) {axes:[(Int64)0],decrease_axis:[(Int64)0],infer_flags:[(Int64)1],stop_gradient:[true]} : (pd_op.tensor<3xi32>, pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<i32>
 (%11) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)1]} : () -> pd_op.tensor<1xi64>
 (%12) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)2]} : () -> pd_op.tensor<1xi64>
 (%13) = "pd_op.slice" (%7, %11, %12) {axes:[(Int64)0],decrease_axis:[(Int64)0],infer_flags:[(Int64)1],stop_gradient:[true]} : (pd_op.tensor<3xi32>, pd_op.tensor<1xi64>, pd_op.tensor<1xi64>) -> pd_op.tensor<i32>
 (%14) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)4096} : () -> pd_op.tensor<1xf32>
 (%15) = "pd_op.full_with_tensor" (%6, %14) {dtype:(pd_op.DataType)float32,stop_gradient:[true]} : (pd_op.tensor<3xi32>, pd_op.tensor<1xf32>) -> pd_op.tensor<-1x-1x-1xf32>
 (%16) = "pd_op.divide" (%5, %15) {stop_gradient:[false]} : (pd_op.tensor<-1x-1x1xf32>, pd_op.tensor<-1x-1x-1xf32>) -> pd_op.tensor<-1x-1x-1xf32>
 (%17) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)1} : () -> pd_op.tensor<1xf32>
 (%18) = "pd_op.scale" (%16, %17) {bias:(Float)1e-06,bias_after_scale:true,stop_gradient:[false]} : (pd_op.tensor<-1x-1x-1xf32>, pd_op.tensor<1xf32>) -> pd_op.tensor<-1x-1x-1xf32>
 (%19) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)-0.5} : () -> pd_op.tensor<1xf32>
 (%20) = "pd_op.elementwise_pow" (%18, %19) {stop_gradient:[false]} : (pd_op.tensor<-1x-1x-1xf32>, pd_op.tensor<1xf32>) -> pd_op.tensor<-1x-1x-1xf32>
 (%21) = "pd_op.multiply" (%20, %1) {stop_gradient:[false]} : (pd_op.tensor<-1x-1x-1xf32>, pd_op.tensor<-1x-1x4096xf32>) -> pd_op.tensor<-1x-1x4096xf32>
 (%22) = "pd_op.multiply" (%21, %0) {stop_gradient:[false]} : (pd_op.tensor<-1x-1x4096xf32>, pd_op.tensor<4096xf32>) -> pd_op.tensor<-1x-1x4096xf32>
 () = "builtin.shadow_output" (%22) {output_name:"output_0"} : (pd_op.tensor<-1x-1x4096xf32>) -> 
}
