### PR TITLE
[PIR][Inference] pir support multihead_matmul_fuse_pass to fuse a multihead_matmul op and other Important works

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -107,13 +107,13 @@
 #include "paddle/fluid/ir_adaptor/translator/translate.h"
 #include "paddle/fluid/pir/transforms/constant_folding_pass.h"
 #include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
-#include "paddle/fluid/pir/transforms/fusion/attention_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_add_act_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_add_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_bn_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/fc_elementwise_layernorm_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/fc_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/matmul_scale_fuse_pass.h"
+#include "paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/identity_op_clean_pass.h"
 #include "paddle/fluid/pir/transforms/inplace_pass.h"
 #include "paddle/fluid/pir/transforms/params_sync_among_devices_pass.h"
@@ -805,7 +805,7 @@ bool AnalysisPredictor::PrepareExecutor() {
         gpu_pm.AddPass(::pir::CreateConv2dBnFusePass());
         gpu_pm.AddPass(::pir::CreateConv2dAddActFusePass());
         gpu_pm.AddPass(::pir::CreateConv2dAddFusePass());
-        gpu_pm.AddPass(::pir::CreateAttentionFusePass());
+        gpu_pm.AddPass(::pir::CreateMultiHeadMatmulFusePass());
         gpu_pm.AddPass(::pir::CreateFcFusePass());
         gpu_pm.AddPass(::pir::CreateFcElementwiseLayerNormFusePass());
         gpu_pm.AddPass(::pir::CreateMatmulScaleFusePass());

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -107,6 +107,7 @@
 #include "paddle/fluid/ir_adaptor/translator/translate.h"
 #include "paddle/fluid/pir/transforms/constant_folding_pass.h"
 #include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
+#include "paddle/fluid/pir/transforms/fusion/attention_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_add_act_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_add_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_bn_fuse_pass.h"
@@ -804,6 +805,7 @@ bool AnalysisPredictor::PrepareExecutor() {
         gpu_pm.AddPass(::pir::CreateConv2dBnFusePass());
         gpu_pm.AddPass(::pir::CreateConv2dAddActFusePass());
         gpu_pm.AddPass(::pir::CreateConv2dAddFusePass());
+        gpu_pm.AddPass(::pir::CreateAttentionFusePass());
         gpu_pm.AddPass(::pir::CreateFcFusePass());
         gpu_pm.AddPass(::pir::CreateFcElementwiseLayerNormFusePass());
         gpu_pm.AddPass(::pir::CreateMatmulScaleFusePass());

--- a/paddle/fluid/pir/drr/README.md
+++ b/paddle/fluid/pir/drr/README.md
@@ -182,14 +182,10 @@ class FusedLinearPattern : public paddle::drr::DrrPatternBase {
     // Define ResultPattern
     paddle::drr::ResultPattern res = pat.ResultPattern();
     // Define Constrain
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "none";
-        });
     const auto &fused_gemm_epilogue = res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                                              {{{"trans_x", pat.Attr("trans_x")},
                                                {"trans_y", pat.Attr("trans_y")},
-                                               {"activation", act_attr}}});
+                                               {"activation", res.StrAttr("none")}}});
     fused_gemm_epilogue(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out")});

--- a/paddle/fluid/pir/drr/README_cn.md
+++ b/paddle/fluid/pir/drr/README_cn.md
@@ -185,14 +185,10 @@ class FusedLinearPattern : public paddle::drr::DrrPatternBase {
     // 定义 Result Pattern
     paddle::drr::ResultPattern res = pat.ResultPattern();
     // 定义 Constrain
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "none";
-        });
     const auto &fused_gemm_epilogue = res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                                              {{{"trans_x", pat.Attr("trans_x")},
                                                {"trans_y", pat.Attr("trans_y")},
-                                               {"activation", act_attr}}});
+                                               {"activation", res.StrAttr("none")}}});
     fused_gemm_epilogue(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out")});

--- a/paddle/fluid/pir/drr/include/drr_pattern_context.h
+++ b/paddle/fluid/pir/drr/include/drr_pattern_context.h
@@ -283,39 +283,39 @@ class ResultPattern {
 
   Attribute StrAttr(const std::string& value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> std::string { return value; });
+        [=](const MatchContext& match_ctx) -> std::string { return value; });
   }
 
   Attribute BoolAttr(bool value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> bool { return value; });
+        [=](const MatchContext& match_ctx) -> bool { return value; });
   }
 
   Attribute Int32Attr(int32_t value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> int32_t { return value; });
+        [=](const MatchContext& match_ctx) -> int32_t { return value; });
   }
 
   Attribute Int64Attr(int64_t value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> int64_t { return value; });
+        [=](const MatchContext& match_ctx) -> int64_t { return value; });
   }
 
   Attribute Float32Attr(float value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> float { return value; });
+        [=](const MatchContext& match_ctx) -> float { return value; });
   }
 
   Attribute VectorInt64Attr(const std::vector<int64_t>& value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> std::vector<int64_t> {
+        [=](const MatchContext& match_ctx) -> std::vector<int64_t> {
           return value;
         });
   }
 
   Attribute VectorInt32Attr(const std::vector<int32_t>& value) const {
     return ComputeAttr(
-        [&](const MatchContext& match_ctx) -> std::vector<int32_t> {
+        [=](const MatchContext& match_ctx) -> std::vector<int32_t> {
           return value;
         });
   }

--- a/paddle/fluid/pir/drr/include/drr_pattern_context.h
+++ b/paddle/fluid/pir/drr/include/drr_pattern_context.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <any>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -280,10 +281,46 @@ class ResultPattern {
     return ctx_->ResultTensorPattern(Tensor::NONE_TENSOR_NAME);
   }
 
-  Attribute Attr(const std::string& attr_name) const {
-    return NormalAttribute(attr_name);
+  Attribute StrAttr(const std::string& value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> std::string { return value; });
   }
-  Attribute Attr(const AttrComputeFunc& attr_compute_func) const {
+
+  Attribute BoolAttr(bool value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> bool { return value; });
+  }
+
+  Attribute Int32Attr(int32_t value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> int32_t { return value; });
+  }
+
+  Attribute Int64Attr(int64_t value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> int64_t { return value; });
+  }
+
+  Attribute Float32Attr(float value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> float { return value; });
+  }
+
+  Attribute VectorInt64Attr(const std::vector<int64_t>& value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> std::vector<int64_t> {
+          return value;
+        });
+  }
+
+  Attribute VectorInt32Attr(const std::vector<int32_t>& value) const {
+    return ComputeAttr(
+        [&](const MatchContext& match_ctx) -> std::vector<int32_t> {
+          return value;
+        });
+  }
+
+  Attribute ComputeAttr(const AttrComputeFunc& attr_compute_func) const {
     return ComputeAttribute(attr_compute_func);
   }
 

--- a/paddle/fluid/pir/drr/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/ir_operation_factory.cc
@@ -19,6 +19,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/drr/attr_type_uilts.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_context.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/pir/core/builtin_op.h"
 #include "paddle/pir/core/operation.h"

--- a/paddle/fluid/pir/transforms/fusion/attention_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/attention_fuse_pass.cc
@@ -170,7 +170,7 @@ class MultiHeadMatmulFuseNoBiasQKPattern : public paddle::drr::DrrPatternBase {
     paddle::drr::ResultPattern res = src.ResultPattern();
 
     // W reshape.
-    const auto &reshape_w_shape_attr = res.Attr(
+    const auto &reshape_w_shape_attr = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
           auto matmul_1_in_2 =
               pir::GetShapeFromValue(match_ctx.Tensor("matmul_1_in_2"));
@@ -195,14 +195,12 @@ class MultiHeadMatmulFuseNoBiasQKPattern : public paddle::drr::DrrPatternBase {
                &res.Tensor("reshape_6_out"),
                &res.Tensor("reshape_7_out")},
               {&res.Tensor("combine_1_out")});
-    const auto &concat_1_axis_attr = res.Attr(
-        [](const paddle::drr::MatchContext &match_ctx) -> int { return 1; });
-    const auto &concat_1 =
-        res.Op("pd_op.concat", {{"axis", concat_1_axis_attr}});
+
+    const auto &concat_1 = res.Op("pd_op.concat", {{"axis", res.Int32Attr(1)}});
     res.Tensor("concat_1_out") = concat_1(res.Tensor("combine_1_out"));
 
     // Bias reshape.
-    const auto &reshape_b_shape_attr = res.Attr(
+    const auto &reshape_b_shape_attr = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
           auto add_1_in_2 =
               pir::GetShapeFromValue(match_ctx.Tensor("add_1_in_2"));
@@ -227,38 +225,26 @@ class MultiHeadMatmulFuseNoBiasQKPattern : public paddle::drr::DrrPatternBase {
                &res.Tensor("reshape_9_out"),
                &res.Tensor("reshape_10_out")},
               {&res.Tensor("combine_2_out")});
-    const auto &concat_2_axis_attr = res.Attr(
-        [](const paddle::drr::MatchContext &match_ctx) -> int { return 0; });
-    const auto &concat_2 =
-        res.Op("pd_op.concat", {{"axis", concat_2_axis_attr}});
+
+    const auto &concat_2 = res.Op("pd_op.concat", {{"axis", res.Int32Attr(0)}});
     res.Tensor("concat_2_out") = concat_2(res.Tensor("combine_2_out"));
 
     const auto &head_number =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> int {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> int {
           const auto &full_int_array_1_value =
               match_ctx.Attr<std::vector<int64_t>>("full_int_array_1_value");
           return full_int_array_1_value.at(2);
         });
-    const auto &alpha =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+    const auto &alpha = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
           return match_ctx.Attr<float>("full_1_value");
         });
-    const auto &multihead_matmul =
-        res.Op("pd_op.multihead_matmul",
-               {{"transpose_q",
-                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
-                   return false;
-                 })},
-                {"transpose_k",
-                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
-                   return true;
-                 })},
-                {"transpose_v",
-                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
-                   return false;
-                 })},
-                {"head_number", head_number},
-                {"alpha", alpha}});
+    const auto &multihead_matmul = res.Op("pd_op.multihead_matmul",
+                                          {{"transpose_q", res.BoolAttr(false)},
+                                           {"transpose_k", res.BoolAttr(true)},
+                                           {"transpose_v", res.BoolAttr(false)},
+                                           {"head_number", head_number},
+                                           {"alpha", alpha}});
     multihead_matmul({&res.Tensor("matmul_1_in_1"),
                       &res.Tensor("concat_1_out"),
                       &res.Tensor("concat_2_out"),
@@ -423,7 +409,7 @@ class MultiHeadMatmulFuseWithBiasQKPattern
     paddle::drr::ResultPattern res = src.ResultPattern();
 
     // W reshape.
-    const auto &reshape_w_shape_attr = res.Attr(
+    const auto &reshape_w_shape_attr = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
           auto matmul_1_in_2 =
               pir::GetShapeFromValue(match_ctx.Tensor("matmul_1_in_2"));
@@ -448,14 +434,12 @@ class MultiHeadMatmulFuseWithBiasQKPattern
                &res.Tensor("reshape_6_out"),
                &res.Tensor("reshape_7_out")},
               {&res.Tensor("combine_1_out")});
-    const auto &concat_1_axis_attr = res.Attr(
-        [](const paddle::drr::MatchContext &match_ctx) -> int { return 1; });
-    const auto &concat_1 =
-        res.Op("pd_op.concat", {{"axis", concat_1_axis_attr}});
+
+    const auto &concat_1 = res.Op("pd_op.concat", {{"axis", res.Int32Attr(1)}});
     res.Tensor("concat_1_out") = concat_1(res.Tensor("combine_1_out"));
 
     // Bias reshape.
-    const auto &reshape_b_shape_attr = res.Attr(
+    const auto &reshape_b_shape_attr = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
           auto add_1_in_2 =
               pir::GetShapeFromValue(match_ctx.Tensor("add_1_in_2"));
@@ -480,38 +464,26 @@ class MultiHeadMatmulFuseWithBiasQKPattern
                &res.Tensor("reshape_9_out"),
                &res.Tensor("reshape_10_out")},
               {&res.Tensor("combine_2_out")});
-    const auto &concat_2_axis_attr = res.Attr(
-        [](const paddle::drr::MatchContext &match_ctx) -> int { return 0; });
-    const auto &concat_2 =
-        res.Op("pd_op.concat", {{"axis", concat_2_axis_attr}});
+
+    const auto &concat_2 = res.Op("pd_op.concat", {{"axis", res.Int32Attr(0)}});
     res.Tensor("concat_2_out") = concat_2(res.Tensor("combine_2_out"));
 
     const auto &head_number =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> int {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> int {
           const auto &full_int_array_1_value =
               match_ctx.Attr<std::vector<int64_t>>("full_int_array_1_value");
           return full_int_array_1_value.at(2);
         });
-    const auto &alpha =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+    const auto &alpha = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
           return match_ctx.Attr<float>("full_1_value");
         });
-    const auto &multihead_matmul =
-        res.Op("pd_op.multihead_matmul",
-               {{"transpose_q",
-                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
-                   return false;
-                 })},
-                {"transpose_k",
-                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
-                   return true;
-                 })},
-                {"transpose_v",
-                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
-                   return false;
-                 })},
-                {"head_number", head_number},
-                {"alpha", alpha}});
+    const auto &multihead_matmul = res.Op("pd_op.multihead_matmul",
+                                          {{"transpose_q", res.BoolAttr(false)},
+                                           {"transpose_k", res.BoolAttr(true)},
+                                           {"transpose_v", res.BoolAttr(false)},
+                                           {"head_number", head_number},
+                                           {"alpha", alpha}});
     multihead_matmul({&res.Tensor("matmul_1_in_1"),
                       &res.Tensor("concat_1_out"),
                       &res.Tensor("concat_2_out"),

--- a/paddle/fluid/pir/transforms/fusion/attention_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/attention_fuse_pass.cc
@@ -21,7 +21,258 @@
 
 namespace {
 
-class MultiHeadMatmulFusePattern : public paddle::drr::DrrPatternBase {
+class MultiHeadMatmulFuseNoBiasQKPattern : public paddle::drr::DrrPatternBase {
+ public:
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    //
+    // Source Pattern.
+    //
+    paddle::drr::SourcePattern src = ctx->SourcePattern();
+    // The first path to matmul with scale (q).
+    const auto &matmul_1 =
+        src.Op("pd_op.matmul",
+               {{"transpose_x", src.Attr("matmul_1_transpose_x")},
+                {"transpose_y", src.Attr("matmul_1_transpose_y")}});
+    src.Tensor("matmul_1_out") =
+        matmul_1(src.Tensor("matmul_1_in_1"), src.Tensor("matmul_1_in_2"));
+    const auto &add_1 = src.Op("pd_op.add");
+    src.Tensor("add_1_out") =
+        add_1(src.Tensor("matmul_1_out"), src.Tensor("add_1_in_2"));
+    const auto &full_int_array_1 =
+        src.Op("pd_op.full_int_array",
+               {{"value", src.Attr("full_int_array_1_value")}});
+    const auto &reshape_1 = src.Op("pd_op.reshape");
+    reshape_1({&src.Tensor("add_1_out"), &full_int_array_1()},
+              {&src.Tensor("reshape_1_out"), &src.Tensor("reshape_1_xshape")});
+    const auto &transpose_1 = src.Op("pd_op.transpose");
+    src.Tensor("transpose_1_out") = transpose_1(src.Tensor("reshape_1_out"));
+    const auto &full_1 =
+        src.Op("pd_op.full", {{"value", src.Attr("full_1_value")}});
+    const auto &scale = src.Op("pd_op.scale");
+    src.Tensor("scale_out") = scale(src.Tensor("transpose_1_out"), full_1());
+
+    // The second path to matmul (k).
+    const auto &matmul_2 =
+        src.Op("pd_op.matmul",
+               {{"transpose_x", src.Attr("matmul_2_transpose_x")},
+                {"transpose_y", src.Attr("matmul_2_transpose_y")}});
+    src.Tensor("matmul_2_out") =
+        matmul_2(src.Tensor("matmul_1_in_1"), src.Tensor("matmul_2_in_2"));
+    const auto &add_2 = src.Op("pd_op.add");
+    src.Tensor("add_2_out") =
+        add_2(src.Tensor("matmul_2_out"), src.Tensor("add_2_in_2"));
+    const auto &full_int_array_2 = src.Op("pd_op.full_int_array");
+    const auto &reshape_2 = src.Op("pd_op.reshape");
+    reshape_2({&src.Tensor("add_2_out"), &full_int_array_2()},
+              {&src.Tensor("reshape_2_out"), &src.Tensor("reshape_2_xshape")});
+    const auto &transpose_2 = src.Op("pd_op.transpose");
+    src.Tensor("transpose_2_out") = transpose_2(src.Tensor("reshape_2_out"));
+
+    // The third path to matmul (v).
+    const auto &matmul_3 =
+        src.Op("pd_op.matmul",
+               {{"transpose_x", src.Attr("matmul_3_transpose_x")},
+                {"transpose_y", src.Attr("matmul_3_transpose_y")}});
+    src.Tensor("matmul_3_out") =
+        matmul_3(src.Tensor("matmul_1_in_1"), src.Tensor("matmul_3_in_2"));
+    const auto &add_3 = src.Op("pd_op.add");
+    src.Tensor("add_3_out") =
+        add_3(src.Tensor("matmul_3_out"), src.Tensor("add_3_in_2"));
+    const auto &full_int_array_3 = src.Op("pd_op.full_int_array");
+    const auto &reshape_3 = src.Op("pd_op.reshape");
+    reshape_3({&src.Tensor("add_3_out"), &full_int_array_3()},
+              {&src.Tensor("reshape_3_out"), &src.Tensor("reshape_3_xshape")});
+    const auto &transpose_3 = src.Op("pd_op.transpose");
+    src.Tensor("transpose_3_out") = transpose_3(src.Tensor("reshape_3_out"));
+
+    // softmax(qk)v
+    const auto &matmul_4 =
+        src.Op("pd_op.matmul",
+               {{"transpose_x", src.Attr("matmul_4_transpose_x")},
+                {"transpose_y", src.Attr("matmul_4_transpose_y")}});
+    src.Tensor("matmul_4_out") =
+        matmul_4(src.Tensor("scale_out"), src.Tensor("transpose_2_out"));
+
+    const auto &softmax =
+        src.Op("pd_op.softmax", {{"axis", src.Attr("softmax_axis")}});
+    src.Tensor("softmax_out") = softmax(src.Tensor("matmul_4_out"));
+    const auto &matmul_5 =
+        src.Op("pd_op.matmul",
+               {{"transpose_x", src.Attr("matmul_5_transpose_x")},
+                {"transpose_y", src.Attr("matmul_5_transpose_y")}});
+    src.Tensor("matmul_5_out") =
+        matmul_5(src.Tensor("softmax_out"), src.Tensor("transpose_3_out"));
+    const auto &transpose_4 = src.Op("pd_op.transpose");
+    src.Tensor("transpose_4_out") = transpose_4(src.Tensor("matmul_5_out"));
+    const auto &full_int_array_4 = src.Op("pd_op.full_int_array");
+    const auto &reshape_4 = src.Op("pd_op.reshape");
+    reshape_4({&src.Tensor("transpose_4_out"), &full_int_array_4()},
+              {&src.Tensor("reshape_4_out"), &src.Tensor("reshape_4_xshape")});
+
+    //
+    // Constraints.
+    //
+    src.RequireNativeCall([](const paddle::drr::MatchContext &match_ctx)
+                              -> bool {
+      const auto &softmax_axis = match_ctx.Attr<int>("softmax_axis");
+      if (softmax_axis != -1 && softmax_axis != 3) return false;
+
+      bool matmul_1_transpose_x = match_ctx.Attr<bool>("matmul_1_transpose_x");
+      bool matmul_1_transpose_y = match_ctx.Attr<bool>("matmul_1_transpose_y");
+      if (matmul_1_transpose_x || matmul_1_transpose_y) return false;
+
+      bool matmul_2_transpose_x = match_ctx.Attr<bool>("matmul_2_transpose_x");
+      bool matmul_2_transpose_y = match_ctx.Attr<bool>("matmul_2_transpose_y");
+      if (matmul_2_transpose_x || matmul_2_transpose_y) return false;
+
+      bool matmul_3_transpose_x = match_ctx.Attr<bool>("matmul_3_transpose_x");
+      bool matmul_3_transpose_y = match_ctx.Attr<bool>("matmul_3_transpose_y");
+      if (matmul_3_transpose_x || matmul_3_transpose_y) return false;
+
+      bool matmul_4_transpose_x = match_ctx.Attr<bool>("matmul_4_transpose_x");
+      bool matmul_4_transpose_y = match_ctx.Attr<bool>("matmul_4_transpose_y");
+      if (matmul_4_transpose_x || !matmul_4_transpose_y) return false;
+
+      bool matmul_5_transpose_x = match_ctx.Attr<bool>("matmul_5_transpose_x");
+      bool matmul_5_transpose_y = match_ctx.Attr<bool>("matmul_5_transpose_y");
+      if (matmul_5_transpose_x || matmul_5_transpose_y) return false;
+
+      auto matmul_1_in_2 =
+          pir::GetShapeFromValue(match_ctx.Tensor("matmul_1_in_2"));
+      auto matmul_2_in_2 =
+          pir::GetShapeFromValue(match_ctx.Tensor("matmul_2_in_2"));
+      auto matmul_3_in_2 =
+          pir::GetShapeFromValue(match_ctx.Tensor("matmul_3_in_2"));
+      if (matmul_1_in_2.size() != 2 || matmul_2_in_2.size() != 2 ||
+          matmul_3_in_2.size() != 2 ||
+          matmul_1_in_2.at(0) != matmul_2_in_2.at(0) ||
+          matmul_1_in_2.at(0) != matmul_3_in_2.at(0) ||
+          matmul_1_in_2.at(1) != matmul_2_in_2.at(1) ||
+          matmul_1_in_2.at(1) != matmul_3_in_2.at(1)) {
+        return false;
+      }
+
+      auto add_1_in_2 = pir::GetShapeFromValue(match_ctx.Tensor("add_1_in_2"));
+      auto add_2_in_2 = pir::GetShapeFromValue(match_ctx.Tensor("add_2_in_2"));
+      auto add_3_in_2 = pir::GetShapeFromValue(match_ctx.Tensor("add_3_in_2"));
+      if (add_1_in_2.size() != 1 || add_2_in_2.size() != 1 ||
+          add_3_in_2.size() != 1 || add_1_in_2.at(0) != add_2_in_2.at(0) ||
+          add_1_in_2.at(0) != add_3_in_2.at(0)) {
+        return false;
+      }
+
+      return true;
+    });
+
+    //
+    // Result Pattern.
+    //
+    paddle::drr::ResultPattern res = src.ResultPattern();
+
+    // W reshape.
+    const auto &reshape_w_shape_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
+          auto matmul_1_in_2 =
+              pir::GetShapeFromValue(match_ctx.Tensor("matmul_1_in_2"));
+          return {matmul_1_in_2.at(0), 1, matmul_1_in_2.at(1)};
+        });
+    const auto &reshape_5 =
+        res.Op("pd_op.reshape", {{"shape", reshape_w_shape_attr}});
+    reshape_5({&res.Tensor("matmul_1_in_2")},
+              {&res.Tensor("reshape_5_out"), &res.NoneTensor()});
+    const auto &reshape_6 =
+        res.Op("pd_op.reshape", {{"shape", reshape_w_shape_attr}});
+    reshape_6({&res.Tensor("matmul_2_in_2")},
+              {&res.Tensor("reshape_6_out"), &res.NoneTensor()});
+    const auto &reshape_7 =
+        res.Op("pd_op.reshape", {{"shape", reshape_w_shape_attr}});
+    reshape_7({&res.Tensor("matmul_3_in_2")},
+              {&res.Tensor("reshape_7_out"), &res.NoneTensor()});
+
+    // W combine.
+    const auto &combine_1 = res.Op("builtin.combine");
+    combine_1({&res.Tensor("reshape_5_out"),
+               &res.Tensor("reshape_6_out"),
+               &res.Tensor("reshape_7_out")},
+              {&res.Tensor("combine_1_out")});
+    const auto &concat_1_axis_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> int { return 1; });
+    const auto &concat_1 =
+        res.Op("pd_op.concat", {{"axis", concat_1_axis_attr}});
+    res.Tensor("concat_1_out") = concat_1(res.Tensor("combine_1_out"));
+
+    // Bias reshape.
+    const auto &reshape_b_shape_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
+          auto add_1_in_2 =
+              pir::GetShapeFromValue(match_ctx.Tensor("add_1_in_2"));
+          return {1, add_1_in_2.at(0)};
+        });
+    const auto &reshape_8 =
+        res.Op("pd_op.reshape", {{"shape", reshape_b_shape_attr}});
+    reshape_8({&res.Tensor("add_1_in_2")},
+              {&res.Tensor("reshape_8_out"), &res.NoneTensor()});
+    const auto &reshape_9 =
+        res.Op("pd_op.reshape", {{"shape", reshape_b_shape_attr}});
+    reshape_9({&res.Tensor("add_2_in_2")},
+              {&res.Tensor("reshape_9_out"), &res.NoneTensor()});
+    const auto &reshape_10 =
+        res.Op("pd_op.reshape", {{"shape", reshape_b_shape_attr}});
+    reshape_10({&res.Tensor("add_3_in_2")},
+               {&res.Tensor("reshape_10_out"), &res.NoneTensor()});
+
+    // Bias combine.
+    const auto &combine_2 = res.Op("builtin.combine");
+    combine_2({&res.Tensor("reshape_8_out"),
+               &res.Tensor("reshape_9_out"),
+               &res.Tensor("reshape_10_out")},
+              {&res.Tensor("combine_2_out")});
+    const auto &concat_2_axis_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> int { return 0; });
+    const auto &concat_2 =
+        res.Op("pd_op.concat", {{"axis", concat_2_axis_attr}});
+    res.Tensor("concat_2_out") = concat_2(res.Tensor("combine_2_out"));
+
+    const auto &head_number =
+        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> int {
+          const auto &full_int_array_1_value =
+              match_ctx.Attr<std::vector<int64_t>>("full_int_array_1_value");
+          return full_int_array_1_value.at(2);
+        });
+    const auto &alpha =
+        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+          return match_ctx.Attr<float>("full_1_value");
+        });
+    const auto &multihead_matmul =
+        res.Op("pd_op.multihead_matmul",
+               {{"transpose_q",
+                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
+                   return false;
+                 })},
+                {"transpose_k",
+                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
+                   return true;
+                 })},
+                {"transpose_v",
+                 res.Attr([](const paddle::drr::MatchContext &match_ctx) {
+                   return false;
+                 })},
+                {"head_number", head_number},
+                {"alpha", alpha}});
+    multihead_matmul({&res.Tensor("matmul_1_in_1"),
+                      &res.Tensor("concat_1_out"),
+                      &res.Tensor("concat_2_out"),
+                      &res.NoneTensor()},
+                     {&res.Tensor("reshape_4_out")});
+  }
+
+  std::string name() const override {
+    return "MultiHeadMatmulFuseNoBiasQKPattern";
+  }
+};
+
+class MultiHeadMatmulFuseWithBiasQKPattern
+    : public paddle::drr::DrrPatternBase {
  public:
   void operator()(paddle::drr::DrrPatternContext *ctx) const override {
     //
@@ -139,6 +390,30 @@ class MultiHeadMatmulFusePattern : public paddle::drr::DrrPatternBase {
       bool matmul_5_transpose_y = match_ctx.Attr<bool>("matmul_5_transpose_y");
       if (matmul_5_transpose_x || matmul_5_transpose_y) return false;
 
+      auto matmul_1_in_2 =
+          pir::GetShapeFromValue(match_ctx.Tensor("matmul_1_in_2"));
+      auto matmul_2_in_2 =
+          pir::GetShapeFromValue(match_ctx.Tensor("matmul_2_in_2"));
+      auto matmul_3_in_2 =
+          pir::GetShapeFromValue(match_ctx.Tensor("matmul_3_in_2"));
+      if (matmul_1_in_2.size() != 2 || matmul_2_in_2.size() != 2 ||
+          matmul_3_in_2.size() != 2 ||
+          matmul_1_in_2.at(0) != matmul_2_in_2.at(0) ||
+          matmul_1_in_2.at(0) != matmul_3_in_2.at(0) ||
+          matmul_1_in_2.at(1) != matmul_2_in_2.at(1) ||
+          matmul_1_in_2.at(1) != matmul_3_in_2.at(1)) {
+        return false;
+      }
+
+      auto add_1_in_2 = pir::GetShapeFromValue(match_ctx.Tensor("add_1_in_2"));
+      auto add_2_in_2 = pir::GetShapeFromValue(match_ctx.Tensor("add_2_in_2"));
+      auto add_3_in_2 = pir::GetShapeFromValue(match_ctx.Tensor("add_3_in_2"));
+      if (add_1_in_2.size() != 1 || add_2_in_2.size() != 1 ||
+          add_3_in_2.size() != 1 || add_1_in_2.at(0) != add_2_in_2.at(0) ||
+          add_1_in_2.at(0) != add_3_in_2.at(0)) {
+        return false;
+      }
+
       return true;
     });
 
@@ -146,43 +421,70 @@ class MultiHeadMatmulFusePattern : public paddle::drr::DrrPatternBase {
     // Result Pattern.
     //
     paddle::drr::ResultPattern res = src.ResultPattern();
-    // W combine.
-    const auto &combine_1 = res.Op("builtin.combine");
-    combine_1({&res.Tensor("matmul_1_in_2"),
-               &res.Tensor("matmul_2_in_2"),
-               &res.Tensor("matmul_3_in_2")},
-              {&res.Tensor("combine_1_out")});
-    const auto &concat_axis = res.Attr(
-        [](const paddle::drr::MatchContext &match_ctx) -> int { return 0; });
-    const auto &concat_1 = res.Op("pd_op.concat", {{"axis", concat_axis}});
-    res.Tensor("concat_1_out") = concat_1(res.Tensor("combine_1_out"));
-    const auto &reshape_5_shape = res.Attr(
+
+    // W reshape.
+    const auto &reshape_w_shape_attr = res.Attr(
         [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
           auto matmul_1_in_2 =
               pir::GetShapeFromValue(match_ctx.Tensor("matmul_1_in_2"));
-          return {-1, 3, matmul_1_in_2.at(1)};
+          return {matmul_1_in_2.at(0), 1, matmul_1_in_2.at(1)};
         });
     const auto &reshape_5 =
-        res.Op("pd_op.reshape", {{"shape", reshape_5_shape}});
-    reshape_5({&res.Tensor("concat_1_out")},
+        res.Op("pd_op.reshape", {{"shape", reshape_w_shape_attr}});
+    reshape_5({&res.Tensor("matmul_1_in_2")},
               {&res.Tensor("reshape_5_out"), &res.NoneTensor()});
+    const auto &reshape_6 =
+        res.Op("pd_op.reshape", {{"shape", reshape_w_shape_attr}});
+    reshape_6({&res.Tensor("matmul_2_in_2")},
+              {&res.Tensor("reshape_6_out"), &res.NoneTensor()});
+    const auto &reshape_7 =
+        res.Op("pd_op.reshape", {{"shape", reshape_w_shape_attr}});
+    reshape_7({&res.Tensor("matmul_3_in_2")},
+              {&res.Tensor("reshape_7_out"), &res.NoneTensor()});
+
+    // W combine.
+    const auto &combine_1 = res.Op("builtin.combine");
+    combine_1({&res.Tensor("reshape_5_out"),
+               &res.Tensor("reshape_6_out"),
+               &res.Tensor("reshape_7_out")},
+              {&res.Tensor("combine_1_out")});
+    const auto &concat_1_axis_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> int { return 1; });
+    const auto &concat_1 =
+        res.Op("pd_op.concat", {{"axis", concat_1_axis_attr}});
+    res.Tensor("concat_1_out") = concat_1(res.Tensor("combine_1_out"));
+
+    // Bias reshape.
+    const auto &reshape_b_shape_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
+          auto add_1_in_2 =
+              pir::GetShapeFromValue(match_ctx.Tensor("add_1_in_2"));
+          return {1, add_1_in_2.at(0)};
+        });
+    const auto &reshape_8 =
+        res.Op("pd_op.reshape", {{"shape", reshape_b_shape_attr}});
+    reshape_8({&res.Tensor("add_1_in_2")},
+              {&res.Tensor("reshape_8_out"), &res.NoneTensor()});
+    const auto &reshape_9 =
+        res.Op("pd_op.reshape", {{"shape", reshape_b_shape_attr}});
+    reshape_9({&res.Tensor("add_2_in_2")},
+              {&res.Tensor("reshape_9_out"), &res.NoneTensor()});
+    const auto &reshape_10 =
+        res.Op("pd_op.reshape", {{"shape", reshape_b_shape_attr}});
+    reshape_10({&res.Tensor("add_3_in_2")},
+               {&res.Tensor("reshape_10_out"), &res.NoneTensor()});
 
     // Bias combine.
     const auto &combine_2 = res.Op("builtin.combine");
-    combine_2({&res.Tensor("add_1_in_2"),
-               &res.Tensor("add_2_in_2"),
-               &res.Tensor("add_3_in_2")},
+    combine_2({&res.Tensor("reshape_8_out"),
+               &res.Tensor("reshape_9_out"),
+               &res.Tensor("reshape_10_out")},
               {&res.Tensor("combine_2_out")});
-    const auto &concat_2 = res.Op("pd_op.concat", {{"axis", concat_axis}});
+    const auto &concat_2_axis_attr = res.Attr(
+        [](const paddle::drr::MatchContext &match_ctx) -> int { return 0; });
+    const auto &concat_2 =
+        res.Op("pd_op.concat", {{"axis", concat_2_axis_attr}});
     res.Tensor("concat_2_out") = concat_2(res.Tensor("combine_2_out"));
-    const auto &reshape_6_shape = res.Attr(
-        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int64_t> {
-          return {3, -1};
-        });
-    const auto &reshape_6 =
-        res.Op("pd_op.reshape", {{"shape", reshape_6_shape}});
-    reshape_6({&res.Tensor("concat_2_out")},
-              {&res.Tensor("reshape_6_out"), &res.NoneTensor()});
 
     const auto &head_number =
         res.Attr([](const paddle::drr::MatchContext &match_ctx) -> int {
@@ -211,13 +513,15 @@ class MultiHeadMatmulFusePattern : public paddle::drr::DrrPatternBase {
                 {"head_number", head_number},
                 {"alpha", alpha}});
     multihead_matmul({&res.Tensor("matmul_1_in_1"),
-                      &res.Tensor("reshape_5_out"),
-                      &res.Tensor("reshape_6_out"),
+                      &res.Tensor("concat_1_out"),
+                      &res.Tensor("concat_2_out"),
                       &res.Tensor("add_4_in_2")},
                      {&res.Tensor("reshape_4_out")});
   }
 
-  std::string name() const override { return "MultiHeadMatmulFusePattern"; }
+  std::string name() const override {
+    return "MultiHeadMatmulFuseWithBiasQKPattern";
+  }
 };
 
 class AttentionFusePass : public pir::PatternRewritePass {
@@ -226,7 +530,8 @@ class AttentionFusePass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    ps.Add(MultiHeadMatmulFusePattern().Build(context));
+    ps.Add(MultiHeadMatmulFuseNoBiasQKPattern().Build(context));
+    ps.Add(MultiHeadMatmulFuseWithBiasQKPattern().Build(context));
     // Add other attention variant fuse pattern.
 
     return ps;

--- a/paddle/fluid/pir/transforms/fusion/conv2d_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/conv2d_add_fuse_pass.cc
@@ -41,34 +41,21 @@ class Conv2dAddFusePattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
-    const auto &fused_conv2d_add_act = res.Op(
-        paddle::dialect::FusedConv2dAddActOp::name(),
-        {{
-            {"strides", pat.Attr("strides")},
-            {"paddings", pat.Attr("paddings")},
-            {"padding_algorithm", pat.Attr("padding_algorithm")},
-            {"dilations", pat.Attr("dilations")},
-            {"groups", pat.Attr("groups")},
-            {"data_format", pat.Attr("data_format")},
-            {"activation",
-             res.Attr([](const paddle::drr::MatchContext &match_ctx)
-                          -> std::string { return "identity"; })},
-            {"split_channels",
-             res.Attr([](const paddle::drr::MatchContext &match_ctx)
-                          -> std::vector<int> { return {}; })},
-            {"exhaustive_search",
-             res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-               return false;
-             })},
-            {"workspace_size_MB",
-             res.Attr([](const paddle::drr::MatchContext &match_ctx) -> int {
-               return 32;
-             })},
-            {"fuse_alpha",
-             res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
-               return 0.0f;
-             })},
-        }});
+    const auto &fused_conv2d_add_act =
+        res.Op(paddle::dialect::FusedConv2dAddActOp::name(),
+               {{
+                   {"strides", pat.Attr("strides")},
+                   {"paddings", pat.Attr("paddings")},
+                   {"padding_algorithm", pat.Attr("padding_algorithm")},
+                   {"dilations", pat.Attr("dilations")},
+                   {"groups", pat.Attr("groups")},
+                   {"data_format", pat.Attr("data_format")},
+                   {"activation", res.StrAttr("identity")},
+                   {"split_channels", res.VectorInt32Attr({})},
+                   {"exhaustive_search", res.BoolAttr(false)},
+                   {"workspace_size_MB", res.Int32Attr(32)},
+                   {"fuse_alpha", res.Float32Attr(0.0f)},
+               }});
 
     fused_conv2d_add_act({&res.Tensor("input"),
                           &res.Tensor("filter"),

--- a/paddle/fluid/pir/transforms/fusion/fc_elementwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/fc_elementwise_layernorm_fuse_pass.cc
@@ -65,14 +65,8 @@ class FcElementwiseLayerNormFusePattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
-    const auto &x_num_col_dims_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return 1;
-        });
-    const auto &false_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
-        });
+    const auto &x_num_col_dims_attr = res.Int32Attr(1);
+    const auto &false_attr = res.BoolAttr(false);
 
     const auto &fused_fc_elementwise_op =
         res.Op(paddle::dialect::FusedFcElementwiseLayernormOp::name(),

--- a/paddle/fluid/pir/transforms/fusion/fused_dot_product_attention_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/fused_dot_product_attention_pass.cc
@@ -105,29 +105,17 @@ class FusedDotProductAttentionPattern : public paddle::drr::DrrPatternBase {
 
     // Result pattern
     paddle::drr::ResultPattern res = src.ResultPattern();
-    const auto &scaling_factor =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+    const auto &scaling_factor = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
           return match_ctx.Attr<float>("q_scale_value");
-        });
-    const auto &dropout_prob =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
-          return static_cast<float>(0.0);
-        });
-    const auto &is_training =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &is_causal_masking =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
         });
 
     const auto &dot_product_attention =
         res.Op(paddle::dialect::FusedDotProductAttentionOp::name(),
                {{{"scaling_factor", scaling_factor},
-                 {"dropout_probability", dropout_prob},
-                 {"is_training", is_training},
-                 {"is_causal_masking", is_causal_masking}}});
+                 {"dropout_probability", res.Float32Attr(0.0)},
+                 {"is_training", res.BoolAttr(true)},
+                 {"is_causal_masking", res.BoolAttr(false)}}});
 
     dot_product_attention({&res.Tensor("q"),
                            &res.Tensor("k"),
@@ -270,29 +258,17 @@ class FusedDotProductAttentionGradPattern : public paddle::drr::DrrPatternBase {
 
     // Result pattern
     paddle::drr::ResultPattern res = src.ResultPattern();
-    const auto &scaling_factor =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+    const auto &scaling_factor = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
           return match_ctx.Attr<float>("q_scale_value");
-        });
-    const auto &dropout_prob =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
-          return static_cast<float>(0.0);
-        });
-    const auto &is_training =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &is_causal_masking =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
         });
 
     const auto &dot_product_attention =
         res.Op(paddle::dialect::FusedDotProductAttentionOp::name(),
                {{{"scaling_factor", scaling_factor},
-                 {"dropout_probability", dropout_prob},
-                 {"is_training", is_training},
-                 {"is_causal_masking", is_causal_masking}}});
+                 {"dropout_probability", res.Float32Attr(0.0)},
+                 {"is_training", res.BoolAttr(true)},
+                 {"is_causal_masking", res.BoolAttr(false)}}});
 
     dot_product_attention({&res.Tensor("q"),
                            &res.Tensor("k"),
@@ -304,8 +280,8 @@ class FusedDotProductAttentionGradPattern : public paddle::drr::DrrPatternBase {
     const auto &dot_product_attention_grad =
         res.Op(paddle::dialect::FusedDotProductAttentionGradOp::name(),
                {{{"scaling_factor", scaling_factor},
-                 {"dropout_probability", dropout_prob},
-                 {"is_causal_masking", is_causal_masking}}});
+                 {"dropout_probability", res.Float32Attr(0.0)},
+                 {"is_causal_masking", res.BoolAttr(false)}}});
     dot_product_attention_grad(
         {&res.Tensor("q"),
          &res.Tensor("k"),
@@ -415,29 +391,17 @@ class FusedDotProductAttentionWithDropoutPattern
 
     // Result pattern
     paddle::drr::ResultPattern res = src.ResultPattern();
-    const auto &scaling_factor =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+    const auto &scaling_factor = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
           return match_ctx.Attr<float>("q_scale_value");
-        });
-    const auto &dropout_prob =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
-          return static_cast<float>(0.0);
-        });
-    const auto &is_training =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &is_causal_masking =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
         });
 
     const auto &dot_product_attention =
         res.Op(paddle::dialect::FusedDotProductAttentionOp::name(),
                {{{"scaling_factor", scaling_factor},
-                 {"dropout_probability", src.Attr("dropout_prob")},
-                 {"is_training", is_training},
-                 {"is_causal_masking", is_causal_masking}}});
+                 {"dropout_probability", res.Float32Attr(0.0)},
+                 {"is_training", res.BoolAttr(true)},
+                 {"is_causal_masking", res.BoolAttr(false)}}});
 
     dot_product_attention({&res.Tensor("q"),
                            &res.Tensor("k"),
@@ -595,25 +559,17 @@ class FusedDotProductAttentionGradWithDropoutPattern
 
     // Result pattern
     paddle::drr::ResultPattern res = src.ResultPattern();
-    const auto &scaling_factor =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
+    const auto &scaling_factor = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
           return match_ctx.Attr<float>("q_scale_value");
-        });
-    const auto &is_training =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &is_causal_masking =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
         });
 
     const auto &dot_product_attention =
         res.Op(paddle::dialect::FusedDotProductAttentionOp::name(),
                {{{"scaling_factor", scaling_factor},
                  {"dropout_probability", src.Attr("dropout_prob")},
-                 {"is_training", is_training},
-                 {"is_causal_masking", is_causal_masking}}});
+                 {"is_training", res.BoolAttr(true)},
+                 {"is_causal_masking", res.BoolAttr(false)}}});
 
     dot_product_attention({&res.Tensor("q"),
                            &res.Tensor("k"),
@@ -626,7 +582,7 @@ class FusedDotProductAttentionGradWithDropoutPattern
         res.Op(paddle::dialect::FusedDotProductAttentionGradOp::name(),
                {{{"scaling_factor", scaling_factor},
                  {"dropout_probability", src.Attr("dropout_prob")},
-                 {"is_causal_masking", is_causal_masking}}});
+                 {"is_causal_masking", res.BoolAttr(false)}}});
     dot_product_attention_grad(
         {&res.Tensor("q"),
          &res.Tensor("k"),

--- a/paddle/fluid/pir/transforms/fusion/fused_gemm_epilogue_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/fused_gemm_epilogue_pass.cc
@@ -44,15 +44,11 @@ class FusedLinearPattern : public paddle::drr::DrrPatternBase {
     });
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "none";
-        });
     const auto &fused_gemm_epilogue =
         res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                {{{"trans_x", pat.Attr("trans_x")},
                  {"trans_y", pat.Attr("trans_y")},
-                 {"activation", act_attr}}});
+                 {"activation", res.StrAttr("none")}}});
     fused_gemm_epilogue(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out")});
@@ -90,20 +86,17 @@ class FusedLinearGradPattern : public paddle::drr::DrrPatternBase {
     });
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "none";
-        });
+
     const auto &fused_gemm_epilogue =
         res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                {{{"trans_x", pat.Attr("trans_x")},
                  {"trans_y", pat.Attr("trans_y")},
-                 {"activation", act_attr}}});
+                 {"activation", res.StrAttr("none")}}});
     const auto &fused_gemm_epilogue_grad =
         res.Op(paddle::dialect::FusedGemmEpilogueGradOp::name(),
                {{{"trans_x", pat.Attr("trans_x")},
                  {"trans_y", pat.Attr("trans_y")},
-                 {"activation_grad", act_attr}}});
+                 {"activation_grad", res.StrAttr("none")}}});
     fused_gemm_epilogue(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out")});
@@ -142,15 +135,11 @@ class FusedLinearGeluPattern : public paddle::drr::DrrPatternBase {
 
     // Result pattern
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "gelu";
-        });
     const auto &fused_gemm_epilogue_gelu =
         res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                {{{"trans_x", pat.Attr("trans_x")},
                  {"trans_y", pat.Attr("trans_y")},
-                 {"activation", act_attr}}});
+                 {"activation", res.StrAttr("gelu")}}});
     fused_gemm_epilogue_gelu(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out"), &res.Tensor("reserve_space")});
@@ -182,15 +171,11 @@ class FusedLinearReluPattern : public paddle::drr::DrrPatternBase {
 
     // Result pattern
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "relu";
-        });
     const auto &fused_gemm_epilogue_relu =
         res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                {{{"trans_x", pat.Attr("trans_x")},
                  {"trans_y", pat.Attr("trans_y")},
-                 {"activation", act_attr}}});
+                 {"activation", res.StrAttr("relu")}}});
     fused_gemm_epilogue_relu(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out"), &res.Tensor("reserve_space")});
@@ -235,24 +220,16 @@ class FusedLinearGeluGradPattern : public paddle::drr::DrrPatternBase {
     });
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &act_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "gelu";
-        });
     const auto &fused_gemm_epilogue_new =
         res.Op(paddle::dialect::FusedGemmEpilogueOp::name(),
                {{{"trans_x", pat.Attr("trans_x1")},
                  {"trans_y", pat.Attr("trans_y1")},
-                 {"activation", act_attr}}});
-    const auto &act_grad_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "gelu_grad";
-        });
+                 {"activation", res.StrAttr("gelu")}}});
     const auto &fused_gemm_epilogue_grad_new =
         res.Op(paddle::dialect::FusedGemmEpilogueGradOp::name(),
                {{{"trans_x", pat.Attr("trans_x2")},
                  {"trans_y", pat.Attr("trans_y2")},
-                 {"activation_grad", act_grad_attr}}});
+                 {"activation_grad", res.StrAttr("gelu_grad")}}});
     fused_gemm_epilogue_new(
         {&res.Tensor("x"), &res.Tensor("w"), &res.Tensor("bias")},
         {&res.Tensor("out"), &res.Tensor("reserve_space2")});
@@ -315,15 +292,11 @@ class FusedLinearReluGradPattern : public paddle::drr::DrrPatternBase {
     });
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &act_grad_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> std::any {
-          return "relu_grad";
-        });
     const auto &res_fused_gemm_epilogue_grad1 =
         res.Op(paddle::dialect::FusedGemmEpilogueGradOp::name(),
                {{{"trans_x", pat.Attr("trans_x3")},
                  {"trans_y", pat.Attr("trans_y3")},
-                 {"activation_grad", act_grad_attr}}});
+                 {"activation_grad", res.StrAttr("relu_grad")}}});
 
     res_fused_gemm_epilogue_grad1({&res.Tensor("x1"),
                                    &res.Tensor("w1"),

--- a/paddle/fluid/pir/transforms/fusion/fused_linear_param_grad_add_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/fused_linear_param_grad_add_pass.cc
@@ -66,26 +66,18 @@ class FusedMatmulAddGradAddPattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
     const auto &muti_precision_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> bool {
           return !(pir::GetDataTypeFromValue(match_ctx.Tensor("dweight")) ==
                    pir::GetDataTypeFromValue(match_ctx.Tensor("weight_grad")));
         });
 
-    const auto &true_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &false_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
-        });
-
-    const auto &matmul =
-        res.Op(paddle::dialect::MatmulOp::name(),
-               {{"transpose_x", false_attr}, {"transpose_y", true_attr}});
-    const auto &fused_linear_param_grad_add = res.Op(
-        paddle::dialect::FusedLinearParamGradAddOp::name(),
-        {{{"multi_precision", muti_precision_attr}, {"has_bias", true_attr}}});
+    const auto &matmul = res.Op(paddle::dialect::MatmulOp::name(),
+                                {{"transpose_x", res.BoolAttr(false)},
+                                 {"transpose_y", res.BoolAttr(true)}});
+    const auto &fused_linear_param_grad_add =
+        res.Op(paddle::dialect::FusedLinearParamGradAddOp::name(),
+               {{{"multi_precision", muti_precision_attr},
+                 {"has_bias", res.BoolAttr(true)}}});
 
     matmul({&res.Tensor("fwd_add_out_grad"), &res.Tensor("weight")},
            {&res.Tensor("x_grad")});
@@ -128,26 +120,18 @@ class FusedMatmulGradAddPattern : public paddle::drr::DrrPatternBase {
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
     const auto &muti_precision_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> bool {
           return !(pir::GetDataTypeFromValue(match_ctx.Tensor("dweight")) ==
                    pir::GetDataTypeFromValue(match_ctx.Tensor("weight_grad")));
         });
 
-    const auto &true_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &false_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
-        });
-
-    const auto &matmul =
-        res.Op(paddle::dialect::MatmulOp::name(),
-               {{"transpose_x", false_attr}, {"transpose_y", true_attr}});
-    const auto &fused_linear_param_grad_add = res.Op(
-        paddle::dialect::FusedLinearParamGradAddOp::name(),
-        {{{"multi_precision", muti_precision_attr}, {"has_bias", false_attr}}});
+    const auto &matmul = res.Op(paddle::dialect::MatmulOp::name(),
+                                {{"transpose_x", res.BoolAttr(false)},
+                                 {"transpose_y", res.BoolAttr(true)}});
+    const auto &fused_linear_param_grad_add =
+        res.Op(paddle::dialect::FusedLinearParamGradAddOp::name(),
+               {{{"multi_precision", muti_precision_attr},
+                 {"has_bias", res.BoolAttr(false)}}});
 
     matmul({&res.Tensor("out_grad"), &res.Tensor("weight")},
            {&res.Tensor("x_grad")});
@@ -186,23 +170,15 @@ class FusedMatmulAddaPattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
     const auto &muti_precision_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> bool {
           return !(pir::GetDataTypeFromValue(match_ctx.Tensor("dweight")) ==
                    pir::GetDataTypeFromValue(match_ctx.Tensor("weight_grad")));
         });
 
-    const auto &true_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &false_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
-        });
-
-    const auto &fused_linear_param_grad_add = res.Op(
-        paddle::dialect::FusedLinearParamGradAddOp::name(),
-        {{{"multi_precision", muti_precision_attr}, {"has_bias", false_attr}}});
+    const auto &fused_linear_param_grad_add =
+        res.Op(paddle::dialect::FusedLinearParamGradAddOp::name(),
+               {{{"multi_precision", muti_precision_attr},
+                 {"has_bias", res.BoolAttr(false)}}});
     fused_linear_param_grad_add(
         {&res.Tensor("x"),
          &res.Tensor("out_grad"),
@@ -238,23 +214,15 @@ class FusedMatmulAddbPattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
     const auto &muti_precision_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> bool {
           return !(pir::GetDataTypeFromValue(match_ctx.Tensor("dweight")) ==
                    pir::GetDataTypeFromValue(match_ctx.Tensor("weight_grad")));
         });
 
-    const auto &true_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &false_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return false;
-        });
-
-    const auto &fused_linear_param_grad_add = res.Op(
-        paddle::dialect::FusedLinearParamGradAddOp::name(),
-        {{{"multi_precision", muti_precision_attr}, {"has_bias", false_attr}}});
+    const auto &fused_linear_param_grad_add =
+        res.Op(paddle::dialect::FusedLinearParamGradAddOp::name(),
+               {{{"multi_precision", muti_precision_attr},
+                 {"has_bias", res.BoolAttr(false)}}});
     fused_linear_param_grad_add(
         {&res.Tensor("x"),
          &res.Tensor("out_grad"),
@@ -304,17 +272,15 @@ class FusedMatmulAddGradAddaPattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
     const auto &muti_precision_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> bool {
           return !(pir::GetDataTypeFromValue(match_ctx.Tensor("dweight")) ==
                    pir::GetDataTypeFromValue(match_ctx.Tensor("weight_grad")));
         });
-    const auto &true_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &fused_linear_param_grad_add = res.Op(
-        paddle::dialect::FusedLinearParamGradAddOp::name(),
-        {{{"multi_precision", muti_precision_attr}, {"has_bias", true_attr}}});
+
+    const auto &fused_linear_param_grad_add =
+        res.Op(paddle::dialect::FusedLinearParamGradAddOp::name(),
+               {{{"multi_precision", muti_precision_attr},
+                 {"has_bias", res.BoolAttr(true)}}});
     fused_linear_param_grad_add(
         {&res.Tensor("x"),
          &res.Tensor("dadd_out"),
@@ -364,17 +330,14 @@ class FusedMatmulAddGradAddbPattern : public paddle::drr::DrrPatternBase {
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
     const auto &muti_precision_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
+        res.ComputeAttr([](const paddle::drr::MatchContext &match_ctx) -> bool {
           return !(pir::GetDataTypeFromValue(match_ctx.Tensor("dweight")) ==
                    pir::GetDataTypeFromValue(match_ctx.Tensor("weight_grad")));
         });
-    const auto &true_attr =
-        res.Attr([](const paddle::drr::MatchContext &match_ctx) -> bool {
-          return true;
-        });
-    const auto &fused_linear_param_grad_add = res.Op(
-        paddle::dialect::FusedLinearParamGradAddOp::name(),
-        {{{"multi_precision", muti_precision_attr}, {"has_bias", true_attr}}});
+    const auto &fused_linear_param_grad_add =
+        res.Op(paddle::dialect::FusedLinearParamGradAddOp::name(),
+               {{{"multi_precision", muti_precision_attr},
+                 {"has_bias", res.BoolAttr(true)}}});
     fused_linear_param_grad_add(
         {&res.Tensor("x"),
          &res.Tensor("dadd_out"),

--- a/paddle/fluid/pir/transforms/fusion/matmul_scale_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/matmul_scale_fuse_pass.cc
@@ -55,13 +55,10 @@ class MatmulScaleFusePattern : public paddle::drr::DrrPatternBase {
                                       {"value", pat.Attr("value")},
                                       {"dtype", pat.Attr("dtype")},
                                       {"place", pat.Attr("place")}});
-    const auto &scale_op_res = res.Op(
-        paddle::dialect::ScaleOp::name(),
-        {{"bias",
-          res.Attr([](const paddle::drr::MatchContext &match_ctx) -> float {
-            return 0.0;
-          })},
-         {"bias_after_scale", pat.Attr("bias_after_scale")}});
+    const auto &scale_op_res =
+        res.Op(paddle::dialect::ScaleOp::name(),
+               {{"bias", res.Float32Attr(0.0)},
+                {"bias_after_scale", pat.Attr("bias_after_scale")}});
     const auto &matmul_op_res =
         res.Op(paddle::dialect::MatmulOp::name(),
                {{"transpose_x", pat.Attr("transpose_x")},

--- a/paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/pir/transforms/fusion/attention_fuse_pass.h"
+#include "paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.h"
 
 #include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
 #include "paddle/fluid/pir/transforms/transform_general_functions.h"
@@ -496,9 +496,10 @@ class MultiHeadMatmulFuseWithBiasQKPattern
   }
 };
 
-class AttentionFusePass : public pir::PatternRewritePass {
+class MultiHeadMatmulFusePass : public pir::PatternRewritePass {
  public:
-  AttentionFusePass() : pir::PatternRewritePass("attention_fuse_pass", 2) {}
+  MultiHeadMatmulFusePass()
+      : pir::PatternRewritePass("multihead_matmul_fuse_pass", 2) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
@@ -513,9 +514,9 @@ class AttentionFusePass : public pir::PatternRewritePass {
 }  // namespace
 
 namespace pir {
-std::unique_ptr<Pass> CreateAttentionFusePass() {
-  return std::make_unique<AttentionFusePass>();
+std::unique_ptr<Pass> CreateMultiHeadMatmulFusePass() {
+  return std::make_unique<MultiHeadMatmulFusePass>();
 }
 }  // namespace pir
 
-REGISTER_IR_PASS(attention_fuse_pass, AttentionFusePass);
+REGISTER_IR_PASS(multihead_matmul_fuse_pass, MultiHeadMatmulFusePass);

--- a/paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.h
@@ -21,6 +21,6 @@ namespace pir {
 
 class Pass;
 
-IR_API std::unique_ptr<Pass> CreateAttentionFusePass();
+IR_API std::unique_ptr<Pass> CreateMultiHeadMatmulFusePass();
 
 }  // namespace pir

--- a/paddle/fluid/pir/transforms/params_sync_among_devices_pass.cc
+++ b/paddle/fluid/pir/transforms/params_sync_among_devices_pass.cc
@@ -89,6 +89,10 @@ class ParamsSyncAmongDevicesPass : public pir::Pass {
           param_tensor->clear();
           paddle::framework::TensorCopySync(temp_tensor, place_, param_tensor);
           num_rewrites_++;
+        } else {
+          PADDLE_THROW(phi::errors::Unimplemented(
+              "params_sync_among_devices_pass only support DenseTensor type of "
+              "parameter var."));
         }
       }
     }

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -43,7 +43,6 @@
 #include "paddle/fluid/pir/dialect/operator/utils/op_yaml_info_parser.h"
 #include "paddle/fluid/pir/dialect/operator/utils/utils.h"
 #include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
-#include "paddle/fluid/pir/transforms/fusion/attention_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_add_act_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_add_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/conv2d_bn_fuse_pass.h"
@@ -55,6 +54,7 @@
 #include "paddle/fluid/pir/transforms/fusion/fused_linear_param_grad_add_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/fused_weight_only_linear_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/matmul_scale_fuse_pass.h"
+#include "paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/identity_op_clean_pass.h"
 #include "paddle/fluid/pir/transforms/inplace_pass.h"
 #include "paddle/fluid/pir/transforms/replace_fetch_with_shadow_output_pass.h"
@@ -112,7 +112,7 @@ using pir::Value;
 using pybind11::return_value_policy;
 
 USE_PIR_PASS(dead_code_elimination_pass);
-USE_PIR_PASS(attention_fuse_pass);
+USE_PIR_PASS(multihead_matmul_fuse_pass);
 USE_PIR_PASS(fused_gemm_epilogue_pass);
 USE_PIR_PASS(fused_dropout_add_pass);
 USE_PIR_PASS(fused_weight_only_linear_pass);

--- a/paddle/pir/core/builtin_op.h
+++ b/paddle/pir/core/builtin_op.h
@@ -223,6 +223,11 @@ class IR_API ConstantTensorOp : public ConstantOp {
   static ConstantTensorOp dyn_cast(Operation *op);
   static bool classof(const Operation *op);
 
+  static void Build(Builder &builder,             // NOLINT
+                    OperationArgument &argument,  // NOLINT
+                    const std::string &name,
+                    Type output_type);
+
   void VerifySig() const;
 
   std::string tensor_name();

--- a/test/cpp/pir/pattern_rewrite/CMakeLists.txt
+++ b/test/cpp/pir/pattern_rewrite/CMakeLists.txt
@@ -23,7 +23,9 @@ cc_test(
   SRCS drr_fuse_linear_param_grad_add_test.cc
   DEPS pir_transforms drr gtest op_dialect_vjp pir)
 
-cc_test(
-  drr_attention_fuse_test
-  SRCS drr_attention_fuse_test.cc
-  DEPS pir_transforms drr gtest op_dialect_vjp pir)
+if(WITH_GPU)
+  cc_test(
+    drr_attention_fuse_test
+    SRCS drr_attention_fuse_test.cc
+    DEPS pir_transforms drr gtest op_dialect_vjp pir)
+endif()

--- a/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
@@ -22,7 +22,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/transforms/constant_folding_pass.h"
 #include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
-#include "paddle/fluid/pir/transforms/fusion/attention_fuse_pass.h"
+#include "paddle/fluid/pir/transforms/fusion/multihead_matmul_fuse_pass.h"
 
 #include "paddle/phi/common/place.h"
 #include "paddle/pir/core/builtin_dialect.h"
@@ -146,7 +146,7 @@ TEST(DrrTest, AttentionFuse) {
   EXPECT_EQ(program.block()->size(), 33u);
 
   pir::PassManager pm(ctx);
-  pm.AddPass(pir::CreateAttentionFusePass());
+  pm.AddPass(pir::CreateMultiHeadMatmulFusePass());
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
   constant_folding_pass->Set(pir::kPlaceAttr, new phi::Place{phi::GPUPlace{}});

--- a/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
@@ -21,8 +21,10 @@
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/fluid/pir/transforms/constant_folding_pass.h"
+#include "paddle/fluid/pir/transforms/dead_code_elimination_pass.h"
 #include "paddle/fluid/pir/transforms/fusion/attention_fuse_pass.h"
 
+#include "paddle/phi/common/place.h"
 #include "paddle/pir/core/builtin_dialect.h"
 #include "paddle/pir/pass/pass_manager.h"
 
@@ -147,13 +149,13 @@ TEST(DrrTest, AttentionFuse) {
   pm.AddPass(pir::CreateAttentionFusePass());
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
-  phi::Place place = phi::CPUPlace();
-  constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place);
+  constant_folding_pass->Set(pir::kPlaceAttr, new phi::Place{phi::GPUPlace{}});
   constant_folding_pass->Set(pir::kParamScopeAttr,
-                             new paddle::framework::Scope());
+                             new paddle::framework::Scope{});
   pm.AddPass(std::move(constant_folding_pass));
+  pm.AddPass(pir::CreateDeadCodeEliminationPass());
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);
-  EXPECT_EQ(program.block()->size(), 20u);
+  EXPECT_EQ(program.block()->size(), 2u);
 }

--- a/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
@@ -28,6 +28,10 @@
 #include "paddle/pir/core/builtin_dialect.h"
 #include "paddle/pir/pass/pass_manager.h"
 
+#include "paddle/phi/core/kernel_registry.h"
+
+PD_DECLARE_KERNEL(multihead_matmul, GPU, ALL_LAYOUT);
+
 void BuildProgram(pir::Builder &builder) {  // NOLINT
   paddle::dialect::FullOp matmul_1_in_1 =
       builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{1, 300, 256},

--- a/test/cpp/pir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_test.cc
@@ -65,7 +65,7 @@ class FoldExpandToConstantPattern : public paddle::drr::DrrPatternBase {
 
     // Result patterns
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &new_perm_attr = res.Attr(
+    const auto &new_perm_attr = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> phi::IntArray {
           auto shape =
               match_ctx.Attr<std::vector<int64_t>>("expand_shape_value");
@@ -95,7 +95,7 @@ class RemoveRedundentTransposePattern : public paddle::drr::DrrPatternBase {
     pat.Tensor("ret") = transpose2(transpose1(pat.Tensor("arg_transpose")));
 
     paddle::drr::ResultPattern res = pat.ResultPattern();
-    const auto &new_perm_attr = res.Attr(
+    const auto &new_perm_attr = res.ComputeAttr(
         [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int> {
           const auto &perm1 = match_ctx.Attr<std::vector<int>>("perm_1");
           const auto &perm2 = match_ctx.Attr<std::vector<int>>("perm_2");

--- a/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
@@ -445,10 +445,8 @@ void BuildConstantFoldingProgram(pir::Program *program,
       paddle::platform::DeviceContextPool::Instance().Get(
           paddle::platform::CPUPlace());
 
-  auto op1 = builder.Build<pir::ConstantTensorOp>(builder.tensor_name_attr("a"),
-                                                  dense_tensor_dtype);
-  auto op2 = builder.Build<pir::ConstantTensorOp>(builder.tensor_name_attr("b"),
-                                                  dense_tensor_dtype);
+  auto op1 = builder.Build<pir::ConstantTensorOp>("a", dense_tensor_dtype);
+  auto op2 = builder.Build<pir::ConstantTensorOp>("b", dense_tensor_dtype);
 
   auto op3 =
       builder.Build<paddle::dialect::AddOp>(op1->result(0), op2->result(0));

--- a/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
@@ -583,7 +583,7 @@ TEST(constant_folding, ConstantFolding_Combine) {
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);
-  EXPECT_EQ(program.block()->size(), 12u);
+  EXPECT_EQ(program.block()->size(), 2u);
 }
 
 void BuildMultiOutputProgram(pir::Program *program, pir::IrContext *ctx) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
本PR主要做了如下工作：

1. 升级了常量折叠pass，支持builtin.combine op的折叠，思路是将其与下一个op一起打包去执行；

3. 添加了multihead_matmul_fuse_pass，支持两种pattern的fuse；
实现中，关于weights和biases都是通过算子组合的形式（这里是reshape+combine+concat）的形式模拟计算，之后再借助常量折叠pass将插入的用于模拟计算的op给折叠起来。

4. 为DRR的ResultPattern添加了一些简单常用的属性，书写简洁清晰；

5. 相关修改已在多个关键模型上验证过，均没有问题。

TOOD:
1. 未来可能要支持builtin.slice等其他内建op的折叠

### Others
Pcard-71500