### PR TITLE
fix core dump when fallback gather_nd_grad and MemoryAllocateHost condition

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -986,8 +986,6 @@
     func : gather_nd_grad
   composite : gather_nd_grad(x, index, out_grad, x_grad)
   no_need_buffer : x
-  data_transform :
-    skip_transform : index
 
 - backward_op : gaussian_inplace_grad
   forward : gaussian_inplace(Tensor x, float mean=0, float std=1.0, int seed=0) -> Tensor(out)

--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -383,7 +383,7 @@ class CustomDevice : public DeviceInterface {
     void* ptr = nullptr;
     const auto device = &devices_pool[dev_id];
 
-    if (!pimpl_->unified_memory_allocate) {
+    if (!pimpl_->host_memory_allocate) {
       PADDLE_THROW(phi::errors::Unavailable(
           "MemoryAllocateHost is not supported on %s.", Type()));
     } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
1. gather_nd_grad算子的输入index被设置为skip_transform，当fallback该算子时，index无法被正常拷贝回CPU，而index在计算中又是需要的，所以会出现segment fault。这里为index去除skip_transform属性，可解决这个bug。https://github.com/PaddlePaddle/Paddle/pull/57272 中为index引入skip_transform是因为当输入类型为complex时index被错误地提升为complex，而https://github.com/PaddlePaddle/Paddle/pull/59287 已修改transform datatype的逻辑使得int32、int64不会被错误提升为complex，所以这里删除index的skip_transform属性应该也不会有问题。使用npu复现的脚本如下，复现时需设置环境变量 `export CUSTOM_DEVICE_BLACK_LIST=gather_nd_grad`

> import paddle
x1 = paddle.to_tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], stop_gradient=False)
index1 = paddle.full([1], 1, "int64")
out1 = paddle.gather_nd(x1, index1)
print(out1)
out1.retain_grads()
out1.backward()

2. custom device的MemoryAllocateHost接口判断是否调用插件实现时判断的条件不对，这里改成正确的实现