### PR TITLE
[Eager] Skip initialized check for 0-size Tensor in `_share_buffer_to`

### DIFF
--- a/test/legacy_test/test_egr_python_api.py
+++ b/test/legacy_test/test_egr_python_api.py
@@ -738,6 +738,11 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         np.testing.assert_array_equal(tensor3.numpy(), arr2)
         self.assertTrue(tensor3._is_shared_buffer_with(tensor))
 
+    def test_0_size_tensor_share_buffert_to(self):
+        x = paddle.rand([0, 4])
+        y = paddle.rand([0, 4])
+        x._share_buffer_to(y)
+
     def test_share_underline_tensor_to(self):
         arr = np.ones([4, 16, 16, 32]).astype('float32')
         arr1 = np.zeros([4, 16]).astype('float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 0-size Tensor 在调用 `_share_buffer_to` 的时候会报错的问题，0-size Tensor `initialized` 永远为 false

PCard-66972