### PR TITLE
paddle.equal doesn't support int8 and uint8 dtype

### DIFF
--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -512,8 +512,8 @@ def equal(x, y, name=None):
         The output has no gradient.
 
     Args:
-        x (Tensor): Tensor, data type is bool, float16, float32, float64, uint8, int8, int16, int32, int64.
-        y (Tensor): Tensor, data type is bool, float16, float32, float64, uint8, int8, int16, int32, int64.
+        x (Tensor): Tensor, data type is bool, float16, float32, float64, bfloat16, int16, int32, int64.
+        y (Tensor): Tensor, data type is bool, float16, float32, float64, bfloat16, int16, int32, int64.
         name (str, optional): The default value is None. Normally there is no need for
             user to set this property.  For more information, please refer to :ref:`api_guide_Name`.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Description
<!-- Describe what you’ve done -->
The paddle.equal is not supported `int8` and `uint8` but in docs it's mention that it support these dtype and also it support `bfloat16` that i have added also.

```python
import paddle 
x = paddle.to_tensor([1, 2, 3], dtype='int8')
y = paddle.to_tensor([1, 3, 2], dtype='int8')
result1 = paddle.equal(x, y)
print(result1)
```
# Output

```text
return _C_ops.equal(x, y)
RuntimeError: (NotFound) The kernel with key (CPU, Undefined(AnyLayout), uint8) of kernel `equal` is not registered. Selected wrong DataType `uint8`. Paddle support following DataTypes: int64, int16, float64, float16, float32, int32, bfloat16, bool.
  [Hint: Expected kernel_iter == iter->second.end() && kernel_key.backend() == Backend::CPU != true, but received kernel_iter == iter->second.end() && kernel_key.backend() == Backend::CPU:1 == true:1.] (at /paddle/paddle/phi/core/kernel_factory.cc:199)
```

