### PR TITLE
[PIR] fix some control flow test in pir mode

### DIFF
--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -527,7 +527,7 @@ def _setitem_static(x, indices, values):
                         ends = paddle.utils.get_int_tensor_list(ends)
                 if isinstance(steps, (list, tuple)):
                     if paddle.utils._contain_var(steps):
-                        ends = paddle.utils.get_int_tensor_list(steps)
+                        steps = paddle.utils.get_int_tensor_list(steps)
 
             if value_tensor is None:
                 output = paddle._C_ops.set_value_(

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -1119,6 +1119,7 @@ class TestLayer(LayerTest):
                 conv3d1.bias.numpy(), conv3d2.bias.numpy()
             )
 
+    @test_with_pir_api
     def test_while_loop(self):
         with self.static_graph():
             i = paddle.tensor.fill_constant(shape=[1], dtype='int64', value=0)

--- a/test/legacy_test/test_set_value_op.py
+++ b/test/legacy_test/test_set_value_op.py
@@ -23,6 +23,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle.base import core
 from paddle.base.layer_helper import LayerHelper
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestSetValueBase(unittest.TestCase):
@@ -57,12 +58,13 @@ class TestSetValueBase(unittest.TestCase):
 class TestSetValueApi(TestSetValueBase):
     def _run_static(self):
         paddle.enable_static()
-        with paddle.static.program_guard(self.program):
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program):
             x = paddle.ones(shape=self.shape, dtype=self.dtype)
             x = self._call_setitem_static_api(x)
 
         exe = paddle.static.Executor(paddle.CPUPlace())
-        out = exe.run(self.program, fetch_list=[x])
+        out = exe.run(main_program, fetch_list=[x])
         paddle.disable_static()
         return out
 
@@ -74,6 +76,7 @@ class TestSetValueApi(TestSetValueBase):
         paddle.enable_static()
         return out
 
+    @test_with_pir_api
     def test_api(self):
         static_out = self._run_static()
         dynamic_out = self._run_dynamic()

--- a/test/legacy_test/test_tensor_array_to_tensor.py
+++ b/test/legacy_test/test_tensor_array_to_tensor.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
+from paddle.pir_utils import test_with_pir_api
 from paddle.tensor.manipulation import tensor_array_to_tensor
 
 paddle.enable_static()
@@ -256,6 +257,7 @@ class TestTensorArrayToTensorAPI(unittest.TestCase):
         for s, d in zip(outs_static, outs_dynamic):
             np.testing.assert_array_equal(s, d.numpy())
 
+    @test_with_pir_api
     def test_while_loop_case(self):
         with base.dygraph.guard():
             zero = paddle.tensor.fill_constant(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
This PR fix the following while loop tests in pir mode:
- `TestTensorArrayToTensorAPI::test_while_loop_case`
- `TestSetValueltemSlicelnWhile`
- `TestLayer::test_while_loop`
