### PR TITLE
[Paddle Inference] fix identity_op_clean_pass, add_support_int8_pass

### DIFF
--- a/paddle/fluid/framework/ir/add_support_int8_pass.cc
+++ b/paddle/fluid/framework/ir/add_support_int8_pass.cc
@@ -22,6 +22,11 @@ namespace ir {
 #define GET_NODES GET_IR_NODE(quant_op);
 
 void AddSupportInt8Pass::ApplyImpl(ir::Graph* graph) const {
+  bool enable_int8 = Get<bool>("enable_int8");
+  if (!enable_int8) {
+    VLOG(3) << "add_support_int8_pass need Predictor'Config set int8, skip";
+    return;
+  }
   const std::string pattern_name = "add_support_int8";
   FusePassBase::Init(pattern_name, graph);
 

--- a/paddle/fluid/framework/ir/identity_op_clean_pass.cc
+++ b/paddle/fluid/framework/ir/identity_op_clean_pass.cc
@@ -164,6 +164,7 @@ int IdentityOpCleanPass::CleanUselessOp(ir::Graph* graph) const {
           after_op->Op()->Flush();
           IR_NODE_LINK_TO(useless_op_in, after_op);
         }
+
         GraphSafeRemoveNodes(graph, {useless_op, useless_op_out});
         found_count++;
       };

--- a/paddle/fluid/framework/ir/identity_op_clean_pass.cc
+++ b/paddle/fluid/framework/ir/identity_op_clean_pass.cc
@@ -155,8 +155,13 @@ int IdentityOpCleanPass::CleanUselessOp(ir::Graph* graph) const {
         CHECK_EQ(useless_op->IsOp(), true);
 
         for (auto* after_op : useless_op_out->outputs) {
+          if (after_op->Name() == "fetch") {
+            VLOG(3) << "The OP is model'output, skip";
+            return;
+          }
           after_op->Op()->RenameInput(useless_op_out->Var()->Name(),
                                       useless_op_in->Var()->Name());
+          after_op->Op()->Flush();
           IR_NODE_LINK_TO(useless_op_in, after_op);
         }
         GraphSafeRemoveNodes(graph, {useless_op, useless_op_out});
@@ -190,6 +195,7 @@ int IdentityOpCleanPass::CleanTwoCastOp(ir::Graph* graph) const {
             CHECK_EQ(prev_op->IsOp(), true);
             prev_op->Op()->RenameOutput(pre_op_out->Var()->Name(),
                                         cast_op_2_out->Var()->Name());
+            prev_op->Op()->Flush();
             IR_NODE_LINK_TO(prev_op, cast_op_2_out);
           }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501
fix identity_op_clean_pass,  add_support_int8_pass