### PR TITLE
[Bug Fix] Rerun ShapeOptimizationPass

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1565,6 +1565,9 @@ void AddCinnPass(std::shared_ptr<PassManager> &pass_manager,  // NOLINT
                         : nullptr;
 
   pass_manager->AddPass(cinn::dialect::ir::CreatePdOpToCinnOpPass());
+  if (has_dynamic_shape) {
+    pass_manager->AddPass(pir::CreateShapeOptimizationPass());
+  }
   pass_manager->AddPass(
       std::make_unique<cinn::dialect::ir::AddBroadcastToElementwisePass>());
   pass_manager->AddPass(pir::CreateDeadCodeEliminationPass());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

Rerun ShapeOptimizationPass after PdOpToCinnOpPass, since it changes Op and Value

PdOpToCinnOpPass 后 program 内的 Value 会发生改变，因此需要重新进行符号推导