### PR TITLE
fix nvrtc usage

### DIFF
--- a/paddle/fluid/platform/dynload/nvrtc.h
+++ b/paddle/fluid/platform/dynload/nvrtc.h
@@ -39,6 +39,8 @@ extern bool HasNVRTC();
   __macro(nvrtcCompileProgram);     \
   __macro(nvrtcCreateProgram);      \
   __macro(nvrtcDestroyProgram);     \
+  __macro(nvrtcGetCUBIN);           \
+  __macro(nvrtcGetCUBINSize);       \
   __macro(nvrtcGetPTX);             \
   __macro(nvrtcGetPTXSize);         \
   __macro(nvrtcGetProgramLog);      \

--- a/paddle/phi/backends/device_code.cc
+++ b/paddle/phi/backends/device_code.cc
@@ -335,7 +335,7 @@ bool GPUDeviceCode::Compile(bool include_path) {
       DeviceContextPool::Instance().Get(place_));
   int compute_capability = dev_ctx->GetComputeCapability();
   std::string compute_flag =
-      "--gpu-architecture=compute_" + std::to_string(compute_capability);
+      "--gpu-architecture=sm_" + std::to_string(compute_capability);
   std::vector<const char*> options = {"--std=c++11", compute_flag.c_str()};
   std::string include_option;
   if (include_path) {
@@ -369,15 +369,15 @@ bool GPUDeviceCode::Compile(bool include_path) {
     return false;
   }
 
-  // Obtain PTX from the program
-  size_t ptx_size;
-  if (!CheckNVRTCResult(dynload::nvrtcGetPTXSize(program, &ptx_size),
-                        "nvrtcGetPTXSize")) {
+  // Obtain cubin from the program
+  size_t cubin_size;
+  if (!CheckNVRTCResult(dynload::nvrtcGetCUBINSize(program, &cubin_size),
+                        "nvrtcGetCUBINSize")) {
     return false;
   }
-  ptx_.resize(ptx_size + 1);
-  if (!CheckNVRTCResult(dynload::nvrtcGetPTX(program, ptx_.data()),
-                        "nvrtcGetPTX")) {
+  cubin_.resize(cubin_size + 1);
+  if (!CheckNVRTCResult(dynload::nvrtcGetCUBIN(program, cubin_.data()),
+                        "nvrtcGetCUBIN")) {
     return false;
   }
 
@@ -386,7 +386,7 @@ bool GPUDeviceCode::Compile(bool include_path) {
     return false;
   }
 
-  if (!CheckCUDADriverResult(dynload::cuModuleLoadData(&module_, ptx_.data()),
+  if (!CheckCUDADriverResult(dynload::cuModuleLoadData(&module_, cubin_.data()),
                              "cuModuleLoadData",
                              name_)) {
     return false;

--- a/paddle/phi/backends/device_code.h
+++ b/paddle/phi/backends/device_code.h
@@ -78,6 +78,7 @@ class GPUDeviceCode : public DeviceCode {
   int max_threads_{0};
   int num_threads_{1024};
   int workload_per_thread_{1};
+  std::vector<char> cubin_;
   std::vector<char> ptx_;
 #ifdef PADDLE_WITH_HIP
   hipModule_t module_;

--- a/paddle/phi/backends/dynload/nvrtc.h
+++ b/paddle/phi/backends/dynload/nvrtc.h
@@ -51,6 +51,8 @@ extern bool HasNVRTC();
   __macro(nvrtcCompileProgram);     \
   __macro(nvrtcCreateProgram);      \
   __macro(nvrtcDestroyProgram);     \
+  __macro(nvrtcGetCUBIN);           \
+  __macro(nvrtcGetCUBINSize);       \
   __macro(nvrtcGetPTX);             \
   __macro(nvrtcGetPTXSize);         \
   __macro(nvrtcGetProgramLog);      \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
The phi uses nvrtc to implement JIT-compilation. However, it uses `--gpu-architecture=cmopute_` rather than `--gpu-architecture=sm_`. The difference is that compute_ only generates PTX code instead of machine code (ie, SASS). The sm_ has both.

So, the workflow is nvrtc generates PTX code, then invokes the driver to generate machine code.

The problem is if the driver version doesn't match CUDA version, the driver cannot recognize the format of PTX code, so it triggers “provided ptx was compiled with an unsupported toolchain” error. This issue cannot be resolved by “CUDA forward compatibility enabled”.

The only solutions are two:
1. Upgrade driver version. 
2. Let nvrtc generate machine code instead of PTX code

Many peoples cannot upgrade the driver frequently, so this patch is the 2nd solution. 
