### PR TITLE
[Dy2St] Trans to contiguous in PIR mode

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -289,8 +289,10 @@ inline void pir_run_program_ad_func(
     int64_t device_type = static_cast<int64_t>(tensor.place().GetType());
     place_hash_key = hash_with_seed(place_hash_key, device_type);
   }
-  PirRunProgramAPI(x,
-                   params,
+  auto x_tmp = Trans2ContiguousTensors(x);
+  auto params_tmp = Trans2ContiguousTensors(params);
+  PirRunProgramAPI(x_tmp,
+                   params_tmp,
                    out,
                    middles,
                    step_scope,
@@ -305,11 +307,11 @@ inline void pir_run_program_ad_func(
     grad_node->SetAttrMap(attrs);
 
     // Clear unused x vars
-    auto filter_x = pir_filter_unused_input_var_in_backward(x, "bx", attrs);
+    auto filter_x = pir_filter_unused_input_var_in_backward(x_tmp, "bx", attrs);
     // Set TensorWrappers
     grad_node->SetFwdX(filter_x);
 
-    grad_node->SetFwdParams(params);
+    grad_node->SetFwdParams(params_tmp);
 
     grad_node->SetStepScope(step_scope);  // just for set useable.
 

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -1066,6 +1066,8 @@ inline void PirRunProgramGradAPI(
   auto p_grad_values =
       PADDLE_GET_CONST(std::vector<::pir::Value>, attrs.at("bp_g"));
 
+  details::Trans2ContiguousTensorsInplace(out_grad);
+
   // share x, param, middles, output_grads, out into scope.
   details::ShareTensorsIntoScopeByValue(
       backward_global_block, out_grad, output_grad_values, global_inner_scope);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #57431，在 PIR run_program OP 里增加 trans 为 contiguous 的逻辑

PCard-66972