### PR TITLE
[PIR] Fix some control flow tests in pir mode

### DIFF
--- a/test/legacy_test/test_device_guard.py
+++ b/test/legacy_test/test_device_guard.py
@@ -16,7 +16,8 @@ import unittest
 import warnings
 
 import paddle
-from paddle.base import core
+from paddle.base import core, in_pir_mode
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -143,6 +144,7 @@ class TestDeviceGuard(unittest.TestCase):
 
         execute(main_program, startup_program)
 
+    @test_with_pir_api
     def test_without_kernel_op(self):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
@@ -158,15 +160,16 @@ class TestDeviceGuard(unittest.TestCase):
                     with while_op.block():
                         i = paddle.increment(x=i, value=1)
                         paddle.assign(paddle.less_than(x=i, y=loop_len), cond)
-
-        warning = "The Op(while) is not support to set device."
-        warning_num = get_vaild_warning_num(warning, w)
-        assert warning_num == 1
+        if not in_pir_mode():
+            warning = "The Op(while) is not support to set device."
+            warning_num = get_vaild_warning_num(warning, w)
+            assert warning_num == 1
 
         all_ops = main_program.global_block().ops
         device_attr_name = core.op_proto_and_checker_maker.kOpDeviceAttrName()
         for op in all_ops:
-            if op.type == 'while':
+            op_name = op.name() if in_pir_mode() else op.type
+            if op_name == 'while':
                 self.assertEqual(op.desc.attr(device_attr_name), "")
 
         execute(main_program, startup_program)

--- a/test/standalone_executor/test_standalone_controlflow.py
+++ b/test/standalone_executor/test_standalone_controlflow.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.base import core
-from paddle.pir_utils import test_with_pir_api
+from paddle.base.framework import Program, program_guard
 
 paddle.enable_static()
 
@@ -49,14 +49,12 @@ class TestCompatibility(unittest.TestCase):
 
         def false_func():
             return paddle.tensor.fill_constant(
-                shape=[3, 4], dtype='int32', value=3
-            ), paddle.tensor.fill_constant(
-                shape=[4, 5], dtype='bool', value=False
-            )
+                shape=[3, 4], dtype='float32', value=3
+            ), paddle.tensor.fill_constant(shape=[4, 5], dtype='int64', value=2)
 
-        main_program = paddle.static.Program()
-        startup_program = paddle.static.Program()
-        with paddle.static.program_guard(main_program, startup_program):
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
             x = paddle.tensor.fill_constant(
                 shape=[1], dtype='float32', value=0.1
             )
@@ -113,7 +111,6 @@ class TestCompatibility(unittest.TestCase):
         out = self._run(feed)
         return out
 
-    @test_with_pir_api
     def test_with_feed(self):
         feed = self._get_feed()
         paddle.enable_static()

--- a/test/standalone_executor/test_standalone_controlflow.py
+++ b/test/standalone_executor/test_standalone_controlflow.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.base import core
-from paddle.base.framework import Program, program_guard
+from paddle.pir_utils import test_with_pir_api
 
 paddle.enable_static()
 
@@ -49,12 +49,12 @@ class TestCompatibility(unittest.TestCase):
 
         def false_func():
             return paddle.tensor.fill_constant(
-                shape=[3, 4], dtype='float32', value=3
-            ), paddle.tensor.fill_constant(shape=[4, 5], dtype='int64', value=2)
+                shape=[3, 4], dtype='int32', value=3
+            ), paddle.tensor.fill_constant(shape=[4, 5], dtype='bool', value=2)
 
-        main_program = Program()
-        startup_program = Program()
-        with program_guard(main_program, startup_program):
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
             x = paddle.tensor.fill_constant(
                 shape=[1], dtype='float32', value=0.1
             )
@@ -111,6 +111,7 @@ class TestCompatibility(unittest.TestCase):
         out = self._run(feed)
         return out
 
+    @test_with_pir_api
     def test_with_feed(self):
         feed = self._get_feed()
         paddle.enable_static()

--- a/test/standalone_executor/test_standalone_controlflow.py
+++ b/test/standalone_executor/test_standalone_controlflow.py
@@ -93,10 +93,10 @@ class TestCompatibility(unittest.TestCase):
         else:
             out = [
                 paddle.tensor.fill_constant(
-                    shape=[3, 4], dtype='int32', value=3
+                    shape=[3, 4], dtype='float32', value=3
                 ).numpy(),
                 paddle.tensor.fill_constant(
-                    shape=[4, 5], dtype='bool', value=False
+                    shape=[4, 5], dtype='int64', value=2
                 ).numpy(),
             ]
         return out

--- a/test/standalone_executor/test_standalone_controlflow.py
+++ b/test/standalone_executor/test_standalone_controlflow.py
@@ -50,7 +50,9 @@ class TestCompatibility(unittest.TestCase):
         def false_func():
             return paddle.tensor.fill_constant(
                 shape=[3, 4], dtype='int32', value=3
-            ), paddle.tensor.fill_constant(shape=[4, 5], dtype='bool', value=2)
+            ), paddle.tensor.fill_constant(
+                shape=[4, 5], dtype='bool', value=False
+            )
 
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
@@ -93,10 +95,10 @@ class TestCompatibility(unittest.TestCase):
         else:
             out = [
                 paddle.tensor.fill_constant(
-                    shape=[3, 4], dtype='float32', value=3
+                    shape=[3, 4], dtype='int32', value=3
                 ).numpy(),
                 paddle.tensor.fill_constant(
-                    shape=[4, 5], dtype='int64', value=2
+                    shape=[4, 5], dtype='bool', value=False
                 ).numpy(),
             ]
         return out


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
This PR fix the following control flow tests in pir mode:
- `TestSundryAPI::test_while_loop`
- `TestSundryAPIStatic::test_while_loop`
- `TestDeviceGuard:test_without_kernel_op`
