### PR TITLE
[AutoConfig]Add multi prune

### DIFF
--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -197,7 +197,7 @@ def prune_by_mp_pp_history(tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs):
     use_recompute = cur_cfg.get("recompute", None)
 
     if mp_degree is None or pp_degree is None or use_recompute is None:
-        return False, None
+        return False
 
     history_cfgs.extend(pruned_cfgs)
     cfgs = same_cfgs_beside(["mp_degree", "pp_degree"], cur_cfg, history_cfgs)
@@ -217,9 +217,9 @@ def prune_by_mp_pp_history(tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs):
                 pruned_reason = f"mp_degree {mp_degree}, pp_degree {pp_degree} may cause oom because {cfg['mp_degree']}, {cfg['pp_degree']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["max_mem_usage"] = "OOM"
-                return True, cur_cfg
+                return True
 
-    return False, None
+    return False
 
 
 @register_prune
@@ -274,7 +274,7 @@ def prune_by_vpp(tuner_cfg, cur_cfg, history_cfgs=[]):
 def prune_by_vpp_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
     vpp_degree = cur_cfg.get("vpp_degree", None)
     if vpp_degree is None:
-        return False, None
+        return False
 
     history_cfgs.extend(pruned_cfgs)
 
@@ -296,7 +296,7 @@ def prune_by_vpp_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
                 cur_cfg["max_mem_usage"] = "OOM"
                 return True, cur_cfg
 
-    return False, None
+    return False
 
 
 @register_prune
@@ -354,7 +354,7 @@ def prune_by_mbs(tuner_cfg, cur_cfg, history_cfgs=[]):
 def prune_by_mbs_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
     micro_batch_size = cur_cfg.get("micro_batch_size", None)
     if micro_batch_size is None:
-        return False, None
+        return False
 
     history_cfgs.extend(pruned_cfgs)
 
@@ -385,7 +385,7 @@ def prune_by_mbs_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
                 cur_cfg["max_mem_usage"] = "OOM"
                 return True, cur_cfg
 
-    return False, None
+    return False
 
 
 @register_prune
@@ -441,11 +441,11 @@ def prune_by_sharding_history(
 ):
     sharding_degree = cur_cfg.get("sharding_degree", None)
     if sharding_degree is None:
-        return False, None
+        return False
 
     sharding_stage = cur_cfg.get("sharding_stage", None)
     if sharding_stage is None:
-        return False, None
+        return False
 
     history_cfgs.extend(pruned_cfgs)
 
@@ -471,7 +471,7 @@ def prune_by_sharding_history(
                 cur_cfg["max_mem_usage"] = "OOM"
                 return True, cur_cfg
 
-    return False, None
+    return False
 
 
 @register_prune
@@ -542,7 +542,7 @@ def prune_by_recompute_history(
     recompute_level = get_config_recompute_level(cur_cfg)
 
     if recompute_level is None:
-        return False, None
+        return False
 
     history_cfgs.extend(pruned_cfgs)
 
@@ -578,7 +578,7 @@ def prune_by_recompute_history(
                 cur_cfg["max_mem_usage"] = "OOM"
                 return True, cur_cfg
 
-    return False, None
+    return False
 
 
 @register_prune
@@ -714,7 +714,7 @@ def prune_by_sharding_overlap(
             tuner_cfg, cur_cfg, history_cfgs
         )
         if not result:
-            return True, None
+            return True
         if not result[tuner_cfg['metric_cfg']['name']]:
-            return True, None
-    return False, None
+            return True
+    return False

--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -491,6 +491,44 @@ def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
     return False
 
 
+@register_prune_history
+def prune_by_mp_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
+    recompute_level = get_config_recompute_level(cur_cfg)
+    micro_batch_size = cur_cfg.get("micro_batch_size", None)
+
+    if recompute_level is None or micro_batch_size is None:
+        return False
+
+    cfgs = same_cfgs_beside(
+        ["micro_batch_size", "use_recompute", "recompute_granularity"],
+        cur_cfg,
+        history_cfgs,
+    )
+    if cfgs:
+        for cfg in cfgs:
+            cfg["recompute_level"] = get_config_recompute_level(cfg)
+
+            if (
+                cfg["micro_batch_size"] > micro_batch_size
+                and cfg["recompute_level"] <= recompute_level
+                and cfg.get("time", -1) > 0
+            ):
+                pruned_reason = f"use_recompute may be slower because {cfg['micro_batch_size']}  and {cfg['use_recompute']} has been already runnable."
+                log_pruned_info(cur_cfg, pruned_reason)
+                return True
+
+            if (
+                cfg["micro_batch_size"] < micro_batch_size
+                and cfg["recompute_level"] >= recompute_level
+                and cfg.get("max_mem_usage") == "OOM"
+            ):
+                pruned_reason = f"use_recompute may be slower because {cfg['micro_batch_size']}  and {cfg['use_recompute']} has been already runnable."
+                log_pruned_info(cur_cfg, pruned_reason)
+                return True
+
+    return False
+
+
 @register_prune
 def prune_by_num_gpus(tuner_cfg, cur_cfg, history_cfgs=[]):
     num_gpus = (

--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -47,7 +47,7 @@ def log_pruned_info(cur_cfg, pruned_reason):
     )
 
 
-def same_cfgs_beside(attr, cur_cfg, history_cfgs=[]):
+def same_cfgs_beside(attrs, cur_cfg, history_cfgs=[]):
     """
     Compare the current configuration with the history configuration,
     and obtain the same configurations as the current configuration except for the given attr.
@@ -56,7 +56,7 @@ def same_cfgs_beside(attr, cur_cfg, history_cfgs=[]):
     same = True
     for cfg in history_cfgs:
         for key in cur_cfg:
-            if key == attr:
+            if key in attrs:
                 continue
             if key not in cfg or (
                 cfg[key] != cur_cfg[key]
@@ -447,15 +447,31 @@ def prune_by_recompute(tuner_cfg, cur_cfg, history_cfgs=[]):
 
 @register_prune_history
 def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
+    recompute_granularity_level = {"full": 3, "full_attn": 2, "core_attn": 1}
+
     use_recompute = cur_cfg.get("use_recompute", None)
+    recompute_granularity = cur_cfg.get("recompute_granularity", None)
+
     if use_recompute is None:
         return False
+
+    if not use_recompute:
+        recompute_level = 0
+    else:
+        recompute_level = recompute_granularity_level[recompute_granularity]
+
     cfgs = same_cfgs_beside("use_recompute", cur_cfg, history_cfgs)
     if cfgs:
         for cfg in cfgs:
+            if not cfg["use_recompute"]:
+                cfg["recompute_level"] = 0
+            else:
+                cfg["recompute_level"] = recompute_granularity_level[
+                    cfg["recompute_granularity"]
+                ]
+
             if (
-                not cfg["use_recompute"]
-                and use_recompute
+                cfg["recompute_level"] < recompute_level
                 and cfg.get("time", -1) > 0
             ):
                 pruned_reason = f"use_recompute {use_recompute} may be slower because {cfg['use_recompute']} has been already runnable."
@@ -463,14 +479,12 @@ def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
                 return True
 
             if (
-                cfg["use_recompute"]
-                and not use_recompute
+                cfg["recompute_level"] > recompute_level
                 and cfg.get("max_mem_usage") == "OOM"
             ):
                 pruned_reason = f"use_recompute {use_recompute} may cause oom because {cfg['use_recompute']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 return True
-
     if not use_recompute:
         cfgs = same_cfgs_beside("recompute_granularity", cur_cfg, history_cfgs)
         if cfgs:

--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -294,7 +294,7 @@ def prune_by_vpp_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
                 pruned_reason = f"vpp_degree {vpp_degree} may cause oom because { cfg['vpp_degree']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["max_mem_usage"] = "OOM"
-                return True, cur_cfg
+                return True
 
     return False
 
@@ -358,10 +358,14 @@ def prune_by_mbs_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
 
     history_cfgs.extend(pruned_cfgs)
 
-    cfgs = same_cfgs_beside("micro_batch_size", cur_cfg, history_cfgs)
+    cfgs = same_cfgs_beside(
+        ["micro_batch_size", "acc_steps"], cur_cfg, history_cfgs
+    )
     if cur_cfg.get("sharding_degree") == 1:
         cfgs = same_cfgs_beside(
-            ["micro_batch_size", "sharding_satge"], cur_cfg, history_cfgs
+            ["micro_batch_size", "sharding_satge", "acc_steps"],
+            cur_cfg,
+            history_cfgs,
         )
 
     if cfgs:
@@ -373,8 +377,7 @@ def prune_by_mbs_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
                 pruned_reason = f"micro_batch_size {micro_batch_size} may be slower because {cfg['micro_batch_size']} has been already runnable."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["time"] = cfg["time"]
-                return True, cur_cfg
-
+                return True
             # memory prune
             if (
                 cfg["micro_batch_size"] < micro_batch_size
@@ -383,8 +386,7 @@ def prune_by_mbs_history(tuner_cfg, cur_cfg, history_cfgs=[], pruned_cfgs=[]):
                 pruned_reason = f"micro_batch_size {micro_batch_size} may cause oom because {cfg['micro_batch_size']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["max_mem_usage"] = "OOM"
-                return True, cur_cfg
-
+                return True
     return False
 
 
@@ -459,7 +461,7 @@ def prune_by_sharding_history(
                 pruned_reason = f"sharding_stage {sharding_stage} may be slower because {cfg['sharding_stage'] } has been already runnable."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["time"] = cfg["time"]
-                return True, cur_cfg
+                return True
 
             # memory prune
             if (
@@ -469,7 +471,7 @@ def prune_by_sharding_history(
                 pruned_reason = f"sharding_stage {sharding_stage} may cause oom because {cfg['sharding_stage']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["max_mem_usage"] = "OOM"
-                return True, cur_cfg
+                return True
 
     return False
 
@@ -567,7 +569,7 @@ def prune_by_recompute_history(
                 pruned_reason = f"use_recompute may be slower because {cfg['use_recompute']} has been already runnable."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["time"] = cfg["time"]
-                return True, cur_cfg
+                return True
 
             if (
                 cfg["recompute_level"] > recompute_level
@@ -576,7 +578,7 @@ def prune_by_recompute_history(
                 pruned_reason = f"use_recompute may cause oom because {cfg['use_recompute']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 cur_cfg["max_mem_usage"] = "OOM"
-                return True, cur_cfg
+                return True
 
     return False
 

--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -242,7 +242,13 @@ def prune_by_vpp_history(tuner_cfg, cur_cfg, history_cfgs=[]):
     vpp_degree = cur_cfg.get("vpp_degree", None)
     if vpp_degree is None:
         return False
+
     cfgs = same_cfgs_beside("vpp_degree", cur_cfg, history_cfgs)
+    if cur_cfg.get("sharding_degree") == 1:
+        cfgs = same_cfgs_beside(
+            ["vpp_degree", "sharding_satge"], cur_cfg, history_cfgs
+        )
+
     if cfgs:
         for cfg in cfgs:
             # memory prune
@@ -312,7 +318,13 @@ def prune_by_mbs_history(tuner_cfg, cur_cfg, history_cfgs=[]):
     micro_batch_size = cur_cfg.get("micro_batch_size", None)
     if micro_batch_size is None:
         return False
+
     cfgs = same_cfgs_beside("micro_batch_size", cur_cfg, history_cfgs)
+    if cur_cfg.get("sharding_degree") == 1:
+        cfgs = same_cfgs_beside(
+            ["micro_batch_size", "sharding_satge"], cur_cfg, history_cfgs
+        )
+
     if cfgs:
         for cfg in cfgs:
             if (
@@ -342,6 +354,7 @@ def prune_by_sharding(tuner_cfg, cur_cfg, history_cfgs=[]):
     2. Sharding stage and degree should be in the candidates of user defined.
     3. If PP (pipeline-parallelism) degree is not 1, sharding stage must be 1.
     4. Prune if a similar configuration with a lower sharding stage resulted in a valid run.
+    5. If sharding degree is 1, sharding stage is invalid.
     """
     sharding_stage = cur_cfg.get("sharding_stage", None)
     sharding_degree = cur_cfg.get("sharding_degree", None)
@@ -371,6 +384,11 @@ def prune_by_sharding(tuner_cfg, cur_cfg, history_cfgs=[]):
 
     if pp_degree and pp_degree != 1 and sharding_stage != 1:
         return True
+
+    if sharding_degree == 1:
+        cfgs = same_cfgs_beside("sharding_stage", cur_cfg, history_cfgs)
+        if cfgs:
+            return True
 
     return False
 
@@ -405,11 +423,6 @@ def prune_by_sharding_history(tuner_cfg, cur_cfg, history_cfgs=[]):
                 log_pruned_info(cur_cfg, pruned_reason)
                 return True
 
-    if sharding_degree == 1:
-        cfgs = same_cfgs_beside("sharding_stage", cur_cfg, history_cfgs)
-        if cfgs:
-            return True
-
     return False
 
 
@@ -421,9 +434,12 @@ def prune_by_recompute(tuner_cfg, cur_cfg, history_cfgs=[]):
     2. Usage of recompute and recompute granularity should be in the candidates of user defined.
     3. If recompute is not used, but recompute granularity is set, return True for pruning.
     4. Prune if a similar configuration without using recompute resulted in a valid run.
+    5. If recompute is false, prune redundant recompute granularity
     """
     recompute_granularity = cur_cfg.get("recompute_granularity", None)
     use_recompute = cur_cfg.get("use_recompute", None)
+    recompute_level = get_config_recompute_level(cur_cfg)
+
     if use_recompute is None:
         return False
 
@@ -441,6 +457,18 @@ def prune_by_recompute(tuner_cfg, cur_cfg, history_cfgs=[]):
     if recompute_granularity_candidates and recompute_granularity:
         if recompute_granularity not in recompute_granularity_candidates:
             return True
+
+    if not use_recompute:
+        if recompute_granularity != "full":
+            return True
+
+        cfgs = same_cfgs_beside(
+            ["use_recompute", "recompute_granularity"], cur_cfg, history_cfgs
+        )
+        if cfgs:
+            for cfg in cfgs:
+                if recompute_level == get_config_recompute_level(cfg):
+                    return True
 
     return False
 
@@ -469,12 +497,19 @@ def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
     cfgs = same_cfgs_beside(
         ["use_recompute", "recompute_granularity"], cur_cfg, history_cfgs
     )
+    if cur_cfg.get("sharding_degree") == 1:
+        cfgs = same_cfgs_beside(
+            ["use_recompute", "recompute_granularity", "sharding_satge"],
+            cur_cfg,
+            history_cfgs,
+        )
+
     if cfgs:
         for cfg in cfgs:
             cfg["recompute_level"] = get_config_recompute_level(cfg)
 
             if (
-                cfg["recompute_level"] <= recompute_level
+                cfg["recompute_level"] < recompute_level
                 and cfg.get("time", -1) > 0
             ):
                 pruned_reason = f"use_recompute may be slower because {cfg['use_recompute']} has been already runnable."
@@ -482,50 +517,12 @@ def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
                 return True
 
             if (
-                cfg["recompute_level"] >= recompute_level
+                cfg["recompute_level"] > recompute_level
                 and cfg.get("max_mem_usage") == "OOM"
             ):
                 pruned_reason = f"use_recompute may cause oom because {cfg['use_recompute']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 return True
-    return False
-
-
-@register_prune_history
-def prune_by_mp_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
-    recompute_level = get_config_recompute_level(cur_cfg)
-    micro_batch_size = cur_cfg.get("micro_batch_size", None)
-
-    if recompute_level is None or micro_batch_size is None:
-        return False
-
-    cfgs = same_cfgs_beside(
-        ["micro_batch_size", "use_recompute", "recompute_granularity"],
-        cur_cfg,
-        history_cfgs,
-    )
-    if cfgs:
-        for cfg in cfgs:
-            cfg["recompute_level"] = get_config_recompute_level(cfg)
-
-            if (
-                cfg["micro_batch_size"] > micro_batch_size
-                and cfg["recompute_level"] <= recompute_level
-                and cfg.get("time", -1) > 0
-            ):
-                pruned_reason = f"use_recompute may be slower because {cfg['micro_batch_size']}  and {cfg['use_recompute']} has been already runnable."
-                log_pruned_info(cur_cfg, pruned_reason)
-                return True
-
-            if (
-                cfg["micro_batch_size"] < micro_batch_size
-                and cfg["recompute_level"] >= recompute_level
-                and cfg.get("max_mem_usage") == "OOM"
-            ):
-                pruned_reason = f"use_recompute may be slower because {cfg['micro_batch_size']}  and {cfg['use_recompute']} has been already runnable."
-                log_pruned_info(cur_cfg, pruned_reason)
-                return True
-
     return False
 
 

--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -445,52 +445,49 @@ def prune_by_recompute(tuner_cfg, cur_cfg, history_cfgs=[]):
     return False
 
 
-@register_prune_history
-def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
+def get_config_recompute_level(cfg):
     recompute_granularity_level = {"full": 3, "full_attn": 2, "core_attn": 1}
-
-    use_recompute = cur_cfg.get("use_recompute", None)
-    recompute_granularity = cur_cfg.get("recompute_granularity", None)
+    use_recompute = cfg.get("use_recompute", None)
+    recompute_granularity = cfg.get("recompute_granularity", None)
 
     if use_recompute is None:
+        return None
+
+    if not use_recompute:
+        return 0
+    else:
+        return recompute_granularity_level[recompute_granularity]
+
+
+@register_prune_history
+def prune_by_recompute_history(tuner_cfg, cur_cfg, history_cfgs=[]):
+    recompute_level = get_config_recompute_level(cur_cfg)
+
+    if recompute_level is None:
         return False
 
-    if not use_recompute:
-        recompute_level = 0
-    else:
-        recompute_level = recompute_granularity_level[recompute_granularity]
-
-    cfgs = same_cfgs_beside("use_recompute", cur_cfg, history_cfgs)
+    cfgs = same_cfgs_beside(
+        ["use_recompute", "recompute_granularity"], cur_cfg, history_cfgs
+    )
     if cfgs:
         for cfg in cfgs:
-            if not cfg["use_recompute"]:
-                cfg["recompute_level"] = 0
-            else:
-                cfg["recompute_level"] = recompute_granularity_level[
-                    cfg["recompute_granularity"]
-                ]
+            cfg["recompute_level"] = get_config_recompute_level(cfg)
 
             if (
-                cfg["recompute_level"] < recompute_level
+                cfg["recompute_level"] <= recompute_level
                 and cfg.get("time", -1) > 0
             ):
-                pruned_reason = f"use_recompute {use_recompute} may be slower because {cfg['use_recompute']} has been already runnable."
+                pruned_reason = f"use_recompute may be slower because {cfg['use_recompute']} has been already runnable."
                 log_pruned_info(cur_cfg, pruned_reason)
                 return True
 
             if (
-                cfg["recompute_level"] > recompute_level
+                cfg["recompute_level"] >= recompute_level
                 and cfg.get("max_mem_usage") == "OOM"
             ):
-                pruned_reason = f"use_recompute {use_recompute} may cause oom because {cfg['use_recompute']} already oom."
+                pruned_reason = f"use_recompute may cause oom because {cfg['use_recompute']} already oom."
                 log_pruned_info(cur_cfg, pruned_reason)
                 return True
-    if not use_recompute:
-        cfgs = same_cfgs_beside("recompute_granularity", cur_cfg, history_cfgs)
-        if cfgs:
-            pruned_reason = f"recompute_granularity invalid because use_recompute is {use_recompute}."
-            log_pruned_info(cur_cfg, pruned_reason)
-            return True
     return False
 
 

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -31,17 +31,18 @@ logger = logging.getLogger('auto_tuner')
 class SearchAlgo(ABC):
     def __init__(self, tuner_cfg):
         self.tuner_cfg = tuner_cfg
+        self.pruned_cfgs = []
 
     @abstractmethod
     def search_once(self, history_cfgs):
         pass
 
-    def prune(self, tuner_cfg, cur_cfg, history_cfgs):
+    def prune(self, tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs):
         for func in _PRUNE_HISTORY_FUNC:
-            result = func(tuner_cfg, cur_cfg, history_cfgs)
+            result, _ = func(tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs)
             if result:
-                return True
-        return False
+                return True, _
+        return False, _
 
 
 class GridSearch(SearchAlgo):
@@ -57,7 +58,12 @@ class GridSearch(SearchAlgo):
             if self.idx < len(self.all_tasks):
                 new_cfg = self.all_tasks[self.idx]
                 self.idx += 1
-                stop = not self.prune(self.tuner_cfg, new_cfg, history_cfgs)
+                stop, pruned_cfg = self.prune(
+                    self.tuner_cfg, new_cfg, history_cfgs, self.pruned_cfgs
+                )
+                stop = not stop
+                if pruned_cfg is not None:
+                    self.pruned_cfgs.append(pruned_cfg)
             else:
                 return None
         return new_cfg

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -61,8 +61,7 @@ class GridSearch(SearchAlgo):
                 stop = not self.prune(
                     self.tuner_cfg, new_cfg, history_cfgs, self.pruned_cfgs
                 )
-                if stop:
-                    self.pruned_cfgs.append(new_cfg)
+                self.pruned_cfgs.append(new_cfg)
             else:
                 return None
         return new_cfg

--- a/python/paddle/distributed/auto_tuner/search.py
+++ b/python/paddle/distributed/auto_tuner/search.py
@@ -39,10 +39,10 @@ class SearchAlgo(ABC):
 
     def prune(self, tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs):
         for func in _PRUNE_HISTORY_FUNC:
-            result, _ = func(tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs)
+            result = func(tuner_cfg, cur_cfg, history_cfgs, pruned_cfgs)
             if result:
-                return True, _
-        return False, _
+                return True
+        return False
 
 
 class GridSearch(SearchAlgo):
@@ -58,12 +58,11 @@ class GridSearch(SearchAlgo):
             if self.idx < len(self.all_tasks):
                 new_cfg = self.all_tasks[self.idx]
                 self.idx += 1
-                stop, pruned_cfg = self.prune(
+                stop = not self.prune(
                     self.tuner_cfg, new_cfg, history_cfgs, self.pruned_cfgs
                 )
-                stop = not stop
-                if pruned_cfg is not None:
-                    self.pruned_cfgs.append(pruned_cfg)
+                if stop:
+                    self.pruned_cfgs.append(new_cfg)
             else:
                 return None
         return new_cfg

--- a/python/paddle/distributed/auto_tuner/utils.py
+++ b/python/paddle/distributed/auto_tuner/utils.py
@@ -406,7 +406,7 @@ def search_all(tuner_cfg):
     for cur_cfg in new_all_cfgs:
         pruned = False
         for func in _PRUNE_FUNC:
-            result = func(tuner_cfg, cur_cfg, [])
+            result = func(tuner_cfg, cur_cfg, pruned_all_cfgs)
             if result:
                 pruned = True
                 break


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PCard-80218
This feature aims to enhance the search performance of the Autotuner. 
The main idea is to introduce "pruned_cfgs" in the search class to record historical pruning information. This assists the Autotuner in making multi-dimensional pruning decisions during the search process, optimizing the search space and improving the overall speed.
#### experimental results
model | cluster | GBS | before acceleration | after acceleration |
--| ----- | -- | ------ | -- |
LLaMA2-7B | V100 32G*8 | 16 | 12h | 4.8h | 