### PR TITLE
support convert fp16 to numpy

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 import numpy as np
 
 from paddle import pir
+from paddle.base.data_feeder import convert_uint16_to_float
 
 from ..pir import (
     Program as PirProgram,
@@ -166,12 +167,12 @@ def as_numpy(tensor, copy=False):
     if tensor._is_initialized():
         if copy:
             if tensor._dtype() == core.VarDesc.VarType.BF16:
-                return np.array(tensor._as_type(core.VarDesc.VarType.FP32))
+                return convert_uint16_to_float(np.array(tensor))
             else:
                 return np.array(tensor)
         else:
             if tensor._dtype() == core.VarDesc.VarType.BF16:
-                return np.asarray(tensor._as_type(core.VarDesc.VarType.FP32))
+                return convert_uint16_to_float(np.asarray(tensor))
             else:
                 return np.asarray(tensor)
     else:

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -165,9 +165,15 @@ def as_numpy(tensor, copy=False):
         )
     if tensor._is_initialized():
         if copy:
-            return np.array(tensor)
+            if tensor._dtype() == core.VarDesc.VarType.BF16:
+                return np.array(tensor._as_type(core.VarDesc.VarType.FP32))
+            else:
+                return np.array(tensor)
         else:
-            return np.asarray(tensor)
+            if tensor._dtype() == core.VarDesc.VarType.BF16:
+                return np.asarray(tensor._as_type(core.VarDesc.VarType.FP32))
+            else:
+                return np.asarray(tensor)
     else:
         return None
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-76459
Support log loss of dtype `bfloat16` in static graph.