### PR TITLE
[PIR] remove BindOpResult

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/program_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.cc
@@ -751,7 +751,7 @@ const VariableDefiningInfo& ProgramTranslator::CreateUndefinedVariable(
   auto var_desc = block.FindVarRecursive(var_name);
   pir::Builder builder(ctx_, program_->block(), program_->block()->begin());
   auto dtype = ::phi::TransToPhiDataType(var_desc->GetDataType());
-  auto val = pir::OpResult(nullptr);
+  auto val = pir::Value(nullptr);
   if (var_desc->GetType() ==
       paddle::framework::proto::VarType::LOD_TENSOR_ARRAY) {
     val = builder.Build<dialect::CreateArrayOp>(dtype).result(0);
@@ -806,17 +806,15 @@ void ProgramTranslator::SetIsPersisableAttributeForAllValue(
   }
 }
 
-std::unordered_map<std::string, std::vector<pir::OpResult>>
-ProgramTranslator::VarDesc2OpResult() {
-  std::unordered_map<std::string, std::vector<pir::OpResult>>
-      var_desc_2_opresult;
+std::unordered_map<std::string, std::vector<pir::Value>>
+ProgramTranslator::VarDesc2Value() {
+  std::unordered_map<std::string, std::vector<pir::Value>> var_desc_2_value;
   for (const auto& [var_name, value_info_list] : param_map_) {
     for (const auto& value_info : value_info_list) {
-      var_desc_2_opresult[var_name].push_back(
-          value_info.value.dyn_cast<pir::OpResult>());
+      var_desc_2_value[var_name].push_back(value_info.value);
     }
   }
-  return var_desc_2_opresult;
+  return var_desc_2_value;
 }
 
 }  // namespace translator

--- a/paddle/fluid/ir_adaptor/translator/program_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/program_translator.h
@@ -89,8 +89,7 @@ class ProgramTranslator {
 
   void Translate();
 
-  std::unordered_map<std::string, std::vector<pir::OpResult>>
-  VarDesc2OpResult();
+  std::unordered_map<std::string, std::vector<pir::Value>> VarDesc2Value();
 
  private:
   const ProgramDesc* legacy_program_;  // not owned

--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -1204,7 +1204,7 @@ def AutoCodeGen(op_info_items, all_op_info_items, namespaces, dialect_name):
         op_interfaces_tmp = op_interfaces
         exclusive_interface_str_tmp = exclusive_interface_str
         decomp_interface_str = "paddle::dialect::DecompInterface"
-        decomp_interface_declare_str = "\n  static std::vector<std::vector<pir::OpResult>> Decomp(pir::Operation* op);"
+        decomp_interface_declare_str = "\n  static std::vector<std::vector<pir::Value>> Decomp(pir::Operation* op);"
 
         # If op has inplace info, we will generate inplace op and non-inplace op.
         for op_name in op_info.op_phi_name:

--- a/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_interface_gen.py
@@ -77,18 +77,18 @@ OP_VJP_CALL_VJP_TEMPLATE = """
         {inputs_list}stop_gradients);"""
 
 OP_VJP_STOPGRADIENT_TEMPLATE = """
-    std::vector<std::vector<pir::OpResult>> res(tensor_res.size());
+    std::vector<std::vector<pir::Value>> res(tensor_res.size());
     for (size_t i = 0; i < tensor_res.size(); ++i) {
         res[i].resize(tensor_res[i].size());
         for (size_t j = 0; j < tensor_res[i].size(); ++j) {
             if(tensor_res[i][j].defined()){
-                res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(tensor_res[i][j].impl())->value().dyn_cast<pir::OpResult>();
+                res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(tensor_res[i][j].impl())->value();
             }
         }
     }"""
 
 OP_VJP_DEFINE_TEMPLATE = """
-std::vector<std::vector<pir::OpResult>> {op_class_name}::Vjp(pir::Operation* op, const std::vector<std::vector<pir::Value>>& inputs_, const std::vector<std::vector<pir::Value>>& outputs, const std::vector<std::vector<pir::Value>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients){{
+std::vector<std::vector<pir::Value>> {op_class_name}::Vjp(pir::Operation* op, const std::vector<std::vector<pir::Value>>& inputs_, const std::vector<std::vector<pir::Value>>& outputs, const std::vector<std::vector<pir::Value>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients){{
 {check_param}
     VLOG(6) << "Prepare inputs of {op_grad_name}";
 {backward_input_code}
@@ -304,5 +304,5 @@ def gen_exclusive_interface_str(op_info, op_info_items):
                 "  static std::vector<pir::Type> InferMeta( const std::vector<pir::Value>& input_values, const pir::AttributeMap& attributes );"
             )
     if op_info.op_phi_name[0] not in vjp_interface_black_list:
-        exclusive_interface_str += "\n  static std::vector<std::vector<pir::OpResult>> Vjp(pir::Operation* op, const std::vector<std::vector<pir::Value>>& inputs_, const std::vector<std::vector<pir::Value>>& outputs, const std::vector<std::vector<pir::Value>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients);"
+        exclusive_interface_str += "\n  static std::vector<std::vector<pir::Value>> Vjp(pir::Operation* op, const std::vector<std::vector<pir::Value>>& inputs_, const std::vector<std::vector<pir::Value>>& outputs, const std::vector<std::vector<pir::Value>>& out_grads, const std::vector<std::vector<bool>>& stop_gradients);"
     return exclusive_interface_str

--- a/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/python_c_gen.py
@@ -144,16 +144,16 @@ INIT_ATTRS_TEMPLATE = """
        {type} {name};
 """
 MUTABLE_ATTR_TEMPLATE = """
-        if (PyObject_CheckIROpResult({name}_obj)){{
+        if (PyObject_CheckIRValue({name}_obj)){{
             {mutable_cast_attrs}
         }}else{{
             {no_mutable_cast_attrs}
         }}"""
 
 MUTABLE_ATTR_LIST_TEMPLATE = """
-        if (PyObject_CheckIROpResult({name}_obj)){{
+        if (PyObject_CheckIRValue({name}_obj)){{
            {mutable_cast_attrs}
-        }}else if (PyObject_CheckIRVectorOfOpResult({name}_obj)){{
+        }}else if (PyObject_CheckIRVectorOfValue({name}_obj)){{
            {mutable_vector_cast_attrs}
         }}else{{
            {no_mutable_cast_attrs}

--- a/paddle/fluid/pir/dialect/operator/interface/decomp.h
+++ b/paddle/fluid/pir/dialect/operator/interface/decomp.h
@@ -21,14 +21,14 @@ class DecompInterface : public pir::OpInterfaceBase<DecompInterface> {
  public:
   struct Concept {
     explicit Concept(
-        std::vector<std::vector<pir::OpResult>> (*decomp)(pir::Operation* op))
+        std::vector<std::vector<pir::Value>> (*decomp)(pir::Operation* op))
         : decomp_(decomp) {}
-    std::vector<std::vector<pir::OpResult>> (*decomp_)(pir::Operation* op);
+    std::vector<std::vector<pir::Value>> (*decomp_)(pir::Operation* op);
   };
 
   template <class ConcreteOp>
   struct Model : public Concept {
-    static std::vector<std::vector<pir::OpResult>> Decomp(pir::Operation* op) {
+    static std::vector<std::vector<pir::Value>> Decomp(pir::Operation* op) {
       return ConcreteOp::Decomp(op);
     }
     Model() : Concept(Decomp) {}
@@ -38,7 +38,7 @@ class DecompInterface : public pir::OpInterfaceBase<DecompInterface> {
   DecompInterface(pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<DecompInterface>(op), impl_(impl) {}
 
-  std::vector<std::vector<pir::OpResult>> Decomp(pir::Operation* op) {
+  std::vector<std::vector<pir::Value>> Decomp(pir::Operation* op) {
     return impl_->decomp_(op);
   }
 

--- a/paddle/fluid/pir/dialect/operator/interface/vjp.h
+++ b/paddle/fluid/pir/dialect/operator/interface/vjp.h
@@ -20,14 +20,14 @@ namespace dialect {
 class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
  public:
   struct Concept {
-    explicit Concept(std::vector<std::vector<pir::OpResult>> (*vjp)(
+    explicit Concept(std::vector<std::vector<pir::Value>> (*vjp)(
         pir::Operation* op,
         const std::vector<std::vector<pir::Value>>& inputs,
         const std::vector<std::vector<pir::Value>>& outputs,
         const std::vector<std::vector<pir::Value>>& out_grads,
         const std::vector<std::vector<bool>>& stop_gradients))
         : vjp_(vjp) {}
-    std::vector<std::vector<pir::OpResult>> (*vjp_)(
+    std::vector<std::vector<pir::Value>> (*vjp_)(
         pir::Operation* op,
         const std::vector<std::vector<pir::Value>>& inputs,
         const std::vector<std::vector<pir::Value>>& outputs,
@@ -37,7 +37,7 @@ class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
 
   template <class ConcreteOp>
   struct Model : public Concept {
-    static std::vector<std::vector<pir::OpResult>> Vjp(
+    static std::vector<std::vector<pir::Value>> Vjp(
         pir::Operation* op,
         const std::vector<std::vector<pir::Value>>& inputs,
         const std::vector<std::vector<pir::Value>>& outputs,
@@ -53,7 +53,7 @@ class VjpInterface : public pir::OpInterfaceBase<VjpInterface> {
   VjpInterface(pir::Operation* op, Concept* impl)
       : pir::OpInterfaceBase<VjpInterface>(op), impl_(impl) {}
 
-  std::vector<std::vector<pir::OpResult>> Vjp(
+  std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation* op,
       const std::vector<std::vector<pir::Value>>& inputs,
       const std::vector<std::vector<pir::Value>>& outputs,

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -250,7 +250,7 @@ void IfOp::VerifyRegion() {
   }
 }
 
-std::vector<std::vector<pir::OpResult>> IfOp::Vjp(
+std::vector<std::vector<pir::Value>> IfOp::Vjp(
     pir::Operation *op,
     const std::vector<std::vector<pir::Value>> &inputs_,
     const std::vector<std::vector<pir::Value>> &outputs,
@@ -281,7 +281,7 @@ std::vector<std::vector<pir::OpResult>> IfOp::Vjp(
   auto if_grad = ApiBuilder::Instance().GetBuilder()->Build<IfOp>(
       cond_val, std::move(output_types));
 
-  std::vector<std::vector<pir::OpResult>> res{inputs_.size()};
+  std::vector<std::vector<pir::Value>> res{inputs_.size()};
   for (size_t i = 0, j = 0; i < inputs_.size(); ++i) {
     res[i].resize(1);
     if (!stop_gradients[i][0]) {
@@ -450,7 +450,7 @@ void WhileOp::VerifyRegion() {
   VLOG(4) << "Successful end verifying sub regions for: WhileOp.";
 }
 
-std::vector<std::vector<pir::OpResult>> WhileOp::Vjp(
+std::vector<std::vector<pir::Value>> WhileOp::Vjp(
     pir::Operation *op,
     const std::vector<std::vector<pir::Value>> &inputs,
     const std::vector<std::vector<pir::Value>> &outputs,
@@ -515,13 +515,13 @@ std::vector<std::vector<pir::OpResult>> WhileOp::Vjp(
   }
   auto while_grad = builder.Build<WhileOp>(cond_val, loop_vars);
 
-  std::vector<std::vector<pir::OpResult>> res(inputs.size());
+  std::vector<std::vector<pir::Value>> res(inputs.size());
   for (size_t i = 0, j = 0; i < inputs.size(); ++i) {
     res[i].push_back(stop_gradients[i][0] ? nullptr : while_grad.result(j++));
   }
   return res;
 }
-std::vector<std::vector<pir::OpResult>> TuplePushOpVjpInterfaceModel::Vjp(
+std::vector<std::vector<pir::Value>> TuplePushOpVjpInterfaceModel::Vjp(
     pir::Operation *op,
     const std::vector<std::vector<pir::Value>> &inputs,
     const std::vector<std::vector<pir::Value>> &outputs,
@@ -537,7 +537,7 @@ std::vector<std::vector<pir::OpResult>> TuplePushOpVjpInterfaceModel::Vjp(
           inputs.size()));
   auto pop_op = ApiBuilder::Instance().GetBuilder()->Build<TuplePopOp>(
       TuplePushOp::dyn_cast(op).outlet());
-  std::vector<std::vector<pir::OpResult>> res{inputs.size()};
+  std::vector<std::vector<pir::Value>> res{inputs.size()};
   res[0].resize(1);
   for (size_t i = 1u; i < inputs.size(); ++i) {
     res[i].resize(1);

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
@@ -49,7 +49,7 @@ class IfOp : public pir::Op<IfOp, VjpInterface> {
   void VerifySig();
   void VerifyRegion();
 
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -85,7 +85,7 @@ class WhileOp : public pir::Op<WhileOp, VjpInterface> {
   void Print(pir::IrPrinter &printer);  // NOLINT
   void VerifySig();
   void VerifyRegion();
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -94,7 +94,7 @@ class WhileOp : public pir::Op<WhileOp, VjpInterface> {
 };
 
 struct TuplePushOpVjpInterfaceModel : public VjpInterface::Concept {
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs,
       const std::vector<std::vector<pir::Value>> &outputs,

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -63,7 +63,7 @@ class AddNOp : public pir::Op<AddNOp,
       const std::vector<std::vector<pir::Value>> &outputs,
       const std::vector<std::vector<pir::Value>> &out_grads,
       const std::vector<std::vector<bool>> &stop_gradients);
-  static std::vector<std::vector<pir::OpResult>> Decomp(pir::Operation *op);
+  static std::vector<std::vector<pir::Value>> Decomp(pir::Operation *op);
 };
 
 class AddN_Op : public pir::Op<AddN_Op,

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -57,7 +57,7 @@ class AddNOp : public pir::Op<AddNOp,
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
 
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -312,7 +312,7 @@ class ArrayReadOp : public pir::Op<ArrayReadOp,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -345,7 +345,7 @@ class ArrayWrite_Op : public pir::Op<ArrayWrite_Op,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -376,7 +376,7 @@ class ArrayToTensorOp : public pir::Op<ArrayToTensorOp,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -569,7 +569,7 @@ class ExpandOp : public pir::Op<ExpandOp,
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -614,7 +614,7 @@ class IncrementOp
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,
@@ -659,7 +659,7 @@ class Increment_Op
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       const pir::AttributeMap &attributes);
-  static std::vector<std::vector<pir::OpResult>> Vjp(
+  static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
       const std::vector<std::vector<pir::Value>> &outputs,

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
@@ -29,8 +29,7 @@ namespace paddle {
 namespace dialect {
 using IntArray = paddle::experimental::IntArray;
 
-std::vector<std::vector<pir::OpResult>> BatchNormOp::Decomp(
-    pir::Operation* op) {
+std::vector<std::vector<pir::Value>> BatchNormOp::Decomp(pir::Operation* op) {
   VLOG(4) << "Decomp call batch_norm's decomp interface begin";
   BatchNormOp op_obj = op->dyn_cast<BatchNormOp>();
   (void)op_obj;
@@ -70,7 +69,7 @@ std::vector<std::vector<pir::OpResult>> BatchNormOp::Decomp(
   VLOG(6) << "Decomp call batch_norm's forward composite rule prepare";
 
   auto org_res = op->results();
-  std::vector<std::vector<pir::OpResult>> res(org_res.size());
+  std::vector<std::vector<pir::Value>> res(org_res.size());
 
   VLOG(6) << "Decomp call batch_norm's forward composite rule begin";
 
@@ -92,33 +91,27 @@ std::vector<std::vector<pir::OpResult>> BatchNormOp::Decomp(
 
   res[0].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<0>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[1].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<1>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[2].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<2>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<3>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[4].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<4>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
-  pir::OpResult reserve_space;
+                       ->value());
+  pir::Value reserve_space;
   res[5].push_back(reserve_space);
 
   VLOG(4) << "Decomp call batch_norm's decomp interface end";
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> BatchNorm_Op::Decomp(
-    pir::Operation* op) {
+std::vector<std::vector<pir::Value>> BatchNorm_Op::Decomp(pir::Operation* op) {
   VLOG(4) << "Decomp call batch_norm_'s decomp interface begin";
   BatchNorm_Op op_obj = op->dyn_cast<BatchNorm_Op>();
   (void)op_obj;
@@ -158,7 +151,7 @@ std::vector<std::vector<pir::OpResult>> BatchNorm_Op::Decomp(
   VLOG(6) << "Decomp call batch_norm_'s forward composite rule prepare";
 
   auto org_res = op->results();
-  std::vector<std::vector<pir::OpResult>> res(org_res.size());
+  std::vector<std::vector<pir::Value>> res(org_res.size());
 
   VLOG(6) << "Decomp call batch_norm_'s forward composite rule begin";
 
@@ -180,25 +173,20 @@ std::vector<std::vector<pir::OpResult>> BatchNorm_Op::Decomp(
 
   res[0].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<0>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[1].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<1>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[2].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<2>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[3].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<3>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
+                       ->value());
   res[4].push_back(std::static_pointer_cast<primitive::LazyTensor>(
                        std::get<4>(op_res).impl())
-                       ->value()
-                       .dyn_cast<pir::OpResult>());
-  pir::OpResult reserve_space;
+                       ->value());
+  pir::Value reserve_space;
   res[5].push_back(reserve_space);
 
   VLOG(4) << "Decomp call batch_norm_'s decomp interface end";

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_vjp.cc
@@ -28,7 +28,7 @@ namespace paddle {
 namespace dialect {
 using IntArray = paddle::experimental::IntArray;
 
-std::vector<std::vector<pir::OpResult>> AddNOp::Vjp(
+std::vector<std::vector<pir::Value>> AddNOp::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -65,22 +65,21 @@ std::vector<std::vector<pir::OpResult>> AddNOp::Vjp(
 
   VLOG(6) << "Vjp prepare stop gradient of add_n_grad";
 
-  std::vector<std::vector<pir::OpResult>> res(tensor_res.size());
+  std::vector<std::vector<pir::Value>> res(tensor_res.size());
   for (size_t i = 0; i < tensor_res.size(); ++i) {
     res[i].resize(tensor_res[i].size());
     for (size_t j = 0; j < tensor_res[i].size(); ++j) {
       if (tensor_res[i][j].defined()) {
         res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(
                         tensor_res[i][j].impl())
-                        ->value()
-                        .dyn_cast<pir::OpResult>();
+                        ->value();
       }
     }
   }
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> ExpandOp::Vjp(
+std::vector<std::vector<pir::Value>> ExpandOp::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -113,22 +112,21 @@ std::vector<std::vector<pir::OpResult>> ExpandOp::Vjp(
 
   VLOG(6) << "Vjp prepare stop gradient of expand_grad";
 
-  std::vector<std::vector<pir::OpResult>> res(tensor_res.size());
+  std::vector<std::vector<pir::Value>> res(tensor_res.size());
   for (size_t i = 0; i < tensor_res.size(); ++i) {
     res[i].resize(tensor_res[i].size());
     for (size_t j = 0; j < tensor_res[i].size(); ++j) {
       if (tensor_res[i][j].defined()) {
         res[i][j] = std::static_pointer_cast<primitive::LazyTensor>(
                         tensor_res[i][j].impl())
-                        ->value()
-                        .dyn_cast<pir::OpResult>();
+                        ->value();
       }
     }
   }
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> IncrementOp::Vjp(
+std::vector<std::vector<pir::Value>> IncrementOp::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -151,14 +149,14 @@ std::vector<std::vector<pir::OpResult>> IncrementOp::Vjp(
 
   VLOG(6) << "Vjp prepare call increment's vjp inteface";
 
-  pir::OpResult tensor_res = paddle::dialect::scale(out_grads[0][0]);
+  pir::Value tensor_res = paddle::dialect::scale(out_grads[0][0]);
 
-  std::vector<std::vector<pir::OpResult>> res{{tensor_res}};
+  std::vector<std::vector<pir::Value>> res{{tensor_res}};
 
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> Increment_Op::Vjp(
+std::vector<std::vector<pir::Value>> Increment_Op::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -185,11 +183,11 @@ std::vector<std::vector<pir::OpResult>> Increment_Op::Vjp(
 
   paddle::dialect::increment_(inputs_[0][0], -value);
 
-  std::vector<std::vector<pir::OpResult>> res;
+  std::vector<std::vector<pir::Value>> res;
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> ArrayWrite_Op::Vjp(
+std::vector<std::vector<pir::Value>> ArrayWrite_Op::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -216,11 +214,11 @@ std::vector<std::vector<pir::OpResult>> ArrayWrite_Op::Vjp(
           outputs.size()));
 
   VLOG(6) << "Vjp prepare call  ArrayWrite_'s vjp inteface";
-  pir::OpResult x_grad =
+  pir::Value x_grad =
       paddle::dialect::array_read(in_grads[0][0], inputs_[2][0]);
-  pir::OpResult zero = paddle::dialect::zeros_like(inputs_[1][0]);
+  pir::Value zero = paddle::dialect::zeros_like(inputs_[1][0]);
   paddle::dialect::array_write_(in_grads[0][0], zero, inputs_[2][0]);
-  std::vector<std::vector<pir::OpResult>> res(1);
+  std::vector<std::vector<pir::Value>> res(1);
   res[0].resize(1);
   if (!stop_gradients[0][0]) {
     res[0][0] = x_grad;
@@ -228,7 +226,7 @@ std::vector<std::vector<pir::OpResult>> ArrayWrite_Op::Vjp(
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> ArrayReadOp::Vjp(
+std::vector<std::vector<pir::Value>> ArrayReadOp::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -264,11 +262,11 @@ std::vector<std::vector<pir::OpResult>> ArrayReadOp::Vjp(
       paddle::dialect::add(array_grad_i_origin, out_grads[0][0]);
   paddle::dialect::array_write_(out_grads[1][0], array_grad_i, inputs_[1][0]);
 
-  std::vector<std::vector<pir::OpResult>> res;
+  std::vector<std::vector<pir::Value>> res;
   return res;
 }
 
-std::vector<std::vector<pir::OpResult>> ArrayToTensorOp::Vjp(
+std::vector<std::vector<pir::Value>> ArrayToTensorOp::Vjp(
     pir::Operation* op,
     const std::vector<std::vector<pir::Value>>& inputs_,
     const std::vector<std::vector<pir::Value>>& outputs,
@@ -301,10 +299,10 @@ std::vector<std::vector<pir::OpResult>> ArrayToTensorOp::Vjp(
 
   VLOG(6) << "Vjp prepare call ArrayToTensor's vjp inteface";
 
-  pir::OpResult tensor_res = paddle::dialect::tensor_to_array(
+  pir::Value tensor_res = paddle::dialect::tensor_to_array(
       inputs_[0][0], out_grads[0][0], axis, use_stack);
 
-  std::vector<std::vector<pir::OpResult>> res(1);
+  std::vector<std::vector<pir::Value>> res(1);
   res[0].resize(1);
   if (!stop_gradients[0][0]) {
     res[0][0] = tensor_res;

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -101,7 +101,7 @@ bool DecompProgram::check_decomp_dynamic_shape(pir::Operation* op) {
     auto value = item.source();
     // check if initialized in case of optional input.
     if (!paddle::dialect::IsEmptyValue(value)) {
-      pir::Operation* prev_op = value.dyn_cast<pir::OpResult>().owner();
+      pir::Operation* prev_op = value.defining_op();
       if (prev_op->name() == "builtin.combine") {
         for (pir::OpOperand& sub_item : prev_op->operands()) {
           if (check_dynamic_shape(sub_item, *op)) {
@@ -121,7 +121,7 @@ bool DecompProgram::check_decomp_dynamic_shape(pir::Operation* op) {
 void DecompProgram::check_decomp_outputs(
     const std::string& op_name,
     const std::vector<pir::OpResult>& orig_outs,
-    const std::vector<pir::OpResult>& decomp_outs) {
+    const std::vector<pir::Value>& decomp_outs) {
   bool skip_invalid_op_check =
       decomp_op_contain_none.find(op_name) != decomp_op_contain_none.end();
   for (size_t i = 0; i < orig_outs.size(); i++) {
@@ -187,10 +187,10 @@ void DecompProgram::check_decomp_outputs(
   return;
 }
 
-std::vector<pir::OpResult> DecompProgram::format_decomp_res(
+std::vector<pir::Value> DecompProgram::format_decomp_res(
     const std::string& op_name,
     const std::vector<pir::OpResult>& orig_outs,
-    const std::vector<std::vector<pir::OpResult>>& decomp_outs) {
+    const std::vector<std::vector<pir::Value>>& decomp_outs) {
   PADDLE_ENFORCE_EQ(
       orig_outs.size(),
       decomp_outs.size(),
@@ -200,7 +200,7 @@ std::vector<pir::OpResult> DecompProgram::format_decomp_res(
           op_name,
           orig_outs.size(),
           decomp_outs.size()));
-  std::vector<pir::OpResult> new_decomp_outs(orig_outs.size());
+  std::vector<pir::Value> new_decomp_outs(orig_outs.size());
   for (size_t i = 0; i < orig_outs.size(); i++) {
     if (orig_outs[i]) {
       PADDLE_ENFORCE_EQ(
@@ -218,12 +218,12 @@ std::vector<pir::OpResult> DecompProgram::format_decomp_res(
   return new_decomp_outs;
 }
 
-std::vector<pir::OpResult> DecompProgram::construct_dst_vars(
+std::vector<pir::Value> DecompProgram::construct_dst_vars(
     const std::string& op_name,
     const std::vector<pir::OpResult>& orig_outs,
-    const std::vector<pir::OpResult>& decomp_outs,
-    std::unordered_map<pir::OpResult, int> orig_vars_dict) {
-  std::vector<pir::OpResult> tar_vars(src_vars_.size());
+    const std::vector<pir::Value>& decomp_outs,
+    std::unordered_map<pir::Value, int> orig_vars_dict) {
+  std::vector<pir::Value> tar_vars(src_vars_.size());
   PADDLE_ENFORCE_EQ(
       orig_outs.size(),
       decomp_outs.size(),
@@ -241,7 +241,7 @@ std::vector<pir::OpResult> DecompProgram::construct_dst_vars(
   return tar_vars;
 }
 
-std::vector<pir::OpResult> DecompProgram::get_dst_vars() {
+std::vector<pir::Value> DecompProgram::get_dst_vars() {
   if (!paddle::prim::PrimCommonUtils::IsFwdPrimEnabled()) {
     return src_vars_;
   } else {
@@ -265,20 +265,19 @@ bool DecompProgram::enable_decomp_by_filter(const std::string& op_name) {
   return flag;
 }
 
-std::vector<std::vector<pir::OpResult>> call_decomp_rule(pir::Operation* op) {
+std::vector<std::vector<pir::Value>> call_decomp_rule(pir::Operation* op) {
   paddle::dialect::DecompInterface decomp_interface =
       op->dyn_cast<paddle::dialect::DecompInterface>();
   PADDLE_ENFORCE(decomp_interface,
                  phi::errors::InvalidArgument(
                      "[Prim] The decomp function is not registered in %s op ",
                      op->name()));
-  std::vector<std::vector<pir::OpResult>> decomp_res =
-      decomp_interface.Decomp(op);
+  std::vector<std::vector<pir::Value>> decomp_res = decomp_interface.Decomp(op);
   return decomp_res;
 }
 
 void DecompProgram::decomp_program() {
-  std::unordered_map<pir::OpResult, int> orig_vars_dict;
+  std::unordered_map<pir::Value, int> orig_vars_dict;
   for (size_t i = 0; i < src_vars_.size(); i++) {
     orig_vars_dict[src_vars_[i]] = static_cast<int>(i);
   }
@@ -290,7 +289,7 @@ void DecompProgram::decomp_program() {
   if (!paddle::prim::PrimCommonUtils::IsFwdPrimEnabled()) {
     return;
   }
-  std::vector<pir::OpResult> tar_vars(src_vars_.size());
+  std::vector<pir::Value> tar_vars(src_vars_.size());
   pir::Block* block = program_->block();
   std::vector<pir::Operation*> ops_list;
   for (auto& op : *block) {
@@ -309,9 +308,9 @@ void DecompProgram::decomp_program() {
       check_decomp_dynamic_shape(op);
       auto& builder = *(paddle::dialect::ApiBuilder::Instance().GetBuilder());
       builder.set_insertion_point(op);
-      std::vector<std::vector<pir::OpResult>> decomp_res = call_decomp_rule(op);
+      std::vector<std::vector<pir::Value>> decomp_res = call_decomp_rule(op);
       std::vector<pir::OpResult> orig_outs = op->results();
-      std::vector<pir::OpResult> standard_decomp_res =
+      std::vector<pir::Value> standard_decomp_res =
           format_decomp_res(op->name(), orig_outs, decomp_res);
       check_decomp_outputs(op->name(), orig_outs, standard_decomp_res);
       tar_vars = construct_dst_vars(

--- a/paddle/fluid/primitive/base/decomp_trans.h
+++ b/paddle/fluid/primitive/base/decomp_trans.h
@@ -29,7 +29,7 @@ class DecompProgram {
   explicit DecompProgram(pir::Program* program) : program_(program) {}
 
   DecompProgram(pir::Program* program,
-                const std::vector<pir::OpResult>& src_vars,
+                const std::vector<pir::Value>& src_vars,
                 const std::set<std::string>& blacklist,
                 const std::set<std::string>& whitelist)
       : program_(program),
@@ -41,18 +41,18 @@ class DecompProgram {
   bool check_decomp_dynamic_shape(pir::Operation* op);
   void check_decomp_outputs(const std::string& op_name,
                             const std::vector<pir::OpResult>& orig_outs,
-                            const std::vector<pir::OpResult>& decomp_outs);
-  std::vector<pir::OpResult> format_decomp_res(
+                            const std::vector<pir::Value>& decomp_outs);
+  std::vector<pir::Value> format_decomp_res(
       const std::string& op_name,
       const std::vector<pir::OpResult>& orig_outs,
-      const std::vector<std::vector<pir::OpResult>>& decomp_outs);
-  std::vector<pir::OpResult> construct_dst_vars(
+      const std::vector<std::vector<pir::Value>>& decomp_outs);
+  std::vector<pir::Value> construct_dst_vars(
       const std::string& op_name,
       const std::vector<pir::OpResult>& orig_outs,
-      const std::vector<pir::OpResult>& decomp_outs,
-      std::unordered_map<pir::OpResult, int> orig_vars_dict);
+      const std::vector<pir::Value>& decomp_outs,
+      std::unordered_map<pir::Value, int> orig_vars_dict);
   bool enable_decomp_by_filter(const std::string& op_name);
-  void set_src_vars(const std::vector<pir::OpResult>& src_vars) {
+  void set_src_vars(const std::vector<pir::Value>& src_vars) {
     src_vars_ = src_vars;
   }
   void set_blacklist(const std::set<std::string>& blacklist) {
@@ -61,18 +61,18 @@ class DecompProgram {
   void set_whitelist(const std::set<std::string>& whitelist) {
     whitelist_ = whitelist;
   }
-  std::vector<pir::OpResult> get_dst_vars();
+  std::vector<pir::Value> get_dst_vars();
 
  private:
   pir::Program* program_;
-  std::vector<pir::OpResult> src_vars_;
-  std::vector<pir::OpResult> dst_vars_;
+  std::vector<pir::Value> src_vars_;
+  std::vector<pir::Value> dst_vars_;
   std::set<std::string> blacklist_;
   std::set<std::string> whitelist_;
 };
 
 bool has_decomp_rule(const pir::Operation& op);
 
-std::vector<std::vector<pir::OpResult>> call_decomp_rule(pir::Operation* op);
+std::vector<std::vector<pir::Value>> call_decomp_rule(pir::Operation* op);
 
 }  // namespace paddle

--- a/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
+++ b/paddle/fluid/primitive/codegen/templates/decomp/generated_decomp.j2
@@ -20,7 +20,7 @@ using IntArray = paddle::experimental::IntArray;
 {% set output_names=[] %}
 {% set output_types=[] %}
 
-std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* op) {
+std::vector<std::vector<pir::Value>> {{class_name}}::Decomp(pir::Operation* op) {
   VLOG(4) << "Decomp call {{fwd_name}}'s decomp interface begin";
 
   {{class_name}} op_obj = op->dyn_cast<{{class_name}}>();
@@ -47,7 +47,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   paddle::optional<std::vector<Tensor>> {{item.name}};
   if (!IsEmptyValue(op_obj.{{item.name}}())){
       pir::CombineOp combine_op_obj =
-          op_obj.{{item.name}}().dyn_cast<pir::OpResult>().owner()->dyn_cast<pir::CombineOp>();
+          op_obj.{{item.name}}().defining_op()->dyn_cast<pir::CombineOp>();
       std::vector<Tensor> optional_{{item.name}};
       for (size_t idx = 0; idx < combine_op_obj.inputs().size(); idx++) {
           optional_{{item.name}}.emplace_back(
@@ -58,7 +58,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
 
         {% else %}
   pir::CombineOp combine_op_obj_{{item.name}} =
-    op_obj.{{item.name}}().dyn_cast<pir::OpResult>().owner()->dyn_cast<pir::CombineOp>();
+    op_obj.{{item.name}}().defining_op()->dyn_cast<pir::CombineOp>();
   std::vector<Tensor> {{item.name}};
   for (size_t idx = 0; idx < combine_op_obj_{{item.name}}.inputs().size(); idx++) {
       {{item.name}}.emplace_back(
@@ -79,8 +79,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   auto* {{item.name}}_define_op =
       std::static_pointer_cast<primitive::LazyTensor>({{item.name}}_.impl())
           ->value()
-          .dyn_cast<pir::OpResult>()
-          .owner();
+          .defining_op();
   if ({{item.name}}_define_op->name() != "pd_op.full") {
     PADDLE_THROW(
         platform::errors::Unimplemented("We don't support dynamic tensors "
@@ -96,8 +95,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   auto* {{item.name}}_define_op =
       std::static_pointer_cast<primitive::LazyTensor>({{item.name}}_.impl())
           ->value()
-          .dyn_cast<pir::OpResult>()
-          .owner();
+          .defining_op();
   if ({{item.name}}_define_op->name() != "pd_op.full_int_array") {
     PADDLE_THROW(
         platform::errors::Unimplemented("We don't support dynamic tensors "
@@ -120,7 +118,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule prepare";
 
   auto org_res = op->results();
-  std::vector<std::vector<pir::OpResult>> res(org_res.size());
+  std::vector<std::vector<pir::Value>> res(org_res.size());
 
   VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule begin";
   {% if outputs|length == 1 %}
@@ -129,8 +127,7 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
 
   res[0].push_back(
     std::static_pointer_cast<primitive::LazyTensor>(op_res.impl())
-        ->value()
-        .dyn_cast<pir::OpResult>());
+        ->value());
   {% else %}
     {% for item in outputs %}
       {% do output_names.append(item.name) %}
@@ -141,10 +138,10 @@ std::vector<std::vector<pir::OpResult>> {{class_name}}::Decomp(pir::Operation* o
   VLOG(6) << "Decomp call {{fwd_name}}'s forward composite rule end";
   {% for k in range(outputs|length) %}
     {% if outputs[k].intermediate and fwd_name in decomp_ops_list_contain_unused_output %}
-  pir::OpResult {{outputs[k].name}};
+  pir::Value {{outputs[k].name}};
   res[{{k}}].push_back({{outputs[k].name}});
     {% else %}
-  res[{{k}}].push_back(std::static_pointer_cast<primitive::LazyTensor>(std::get<{{k}}>(op_res).impl())->value().dyn_cast<pir::OpResult>());
+  res[{{k}}].push_back(std::static_pointer_cast<primitive::LazyTensor>(std::get<{{k}}>(op_res).impl())->value());
     {% endif %}
   {% endfor %}
   {% endif %}

--- a/paddle/fluid/pybind/control_flow_api.cc
+++ b/paddle/fluid/pybind/control_flow_api.cc
@@ -72,7 +72,7 @@ void BindIfOp(py::module* m) {
       .def("results", [](PyIfOp& self) -> py::list {
         py::list op_list;
         for (uint32_t i = 0; i < self->num_results(); i++) {
-          op_list.append(self.result(i));
+          op_list.append(static_cast<pir::Value>(self.result(i)));
         }
         return op_list;
       });

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -58,7 +58,6 @@ extern PyTypeObject* p_tensor_type;
 extern PyTypeObject* p_string_tensor_type;
 
 extern PyTypeObject* g_framework_scope_pytype;
-extern PyTypeObject* g_ir_opresult_pytype;
 extern PyTypeObject* g_ir_value_pytype;
 extern PyTypeObject* g_vartype_pytype;
 extern PyTypeObject* g_data_type_pytype;
@@ -185,10 +184,6 @@ bool PyObject_CheckFloatOrConvertToFloat(PyObject** obj) {
 
 bool PyObject_CheckStr(PyObject* obj) { return PyUnicode_Check(obj); }
 
-bool PyObject_CheckIROpResult(PyObject* obj) {
-  return PyObject_TypeCheck(obj, g_ir_opresult_pytype);
-}
-
 bool PyObject_CheckIRValue(PyObject* obj) {
   return PyObject_TypeCheck(obj, g_ir_value_pytype);
 }
@@ -228,40 +223,6 @@ bool PyObject_CheckIRVectorOfValue(PyObject* obj) {
   }
 }
 
-bool PyObject_CheckIRVectorOfOpResult(PyObject* obj) {
-  if (PyList_Check(obj)) {
-    Py_ssize_t len = PyList_Size(obj);
-    PyObject* item = nullptr;
-    // if obj is [], parse it as std::vector<scalar>
-    if (len == 0) {
-      return false;
-    }
-    for (Py_ssize_t i = 0; i < len; i++) {
-      item = PyList_GetItem(obj, i);
-      if (!PyObject_CheckIROpResult(item)) {
-        return false;
-      }
-    }
-    return true;
-  } else if (PyTuple_Check(obj)) {
-    Py_ssize_t len = PyTuple_Size(obj);
-    PyObject* item = nullptr;
-    if (len == 0) {
-      return false;
-    }
-    for (Py_ssize_t i = 0; i < len; i++) {
-      item = PyTuple_GetItem(obj, i);
-      if (!PyObject_CheckIROpResult(item)) {
-        return false;
-      }
-    }
-    return true;
-  } else if (PyObject_TypeCheck(obj, g_ir_opresult_pytype)) {
-    return true;
-  } else {
-    return false;
-  }
-}
 bool CastPyArg2AttrBoolean(PyObject* obj, ssize_t arg_pos) {
   if (obj == Py_None || obj == Py_False) {
     return false;  // To be compatible with QA integration testing. Some
@@ -1115,10 +1076,20 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
   return obj.ptr();
 }
 
-PyObject* ToPyObject(const pir::OpResult& value) {
+PyObject* ToPyObject(const pir::Value& value) {
   auto obj = ::pybind11::cast(value);
   obj.inc_ref();
   return obj.ptr();
+}
+
+PyObject* ToPyObject(const std::vector<pir::Value>& value) {
+  PyObject* result = PyList_New((Py_ssize_t)value.size());
+
+  for (size_t i = 0; i < value.size(); i++) {
+    PyList_SET_ITEM(result, static_cast<Py_ssize_t>(i), ToPyObject(value[i]));
+  }
+
+  return result;
 }
 
 PyObject* ToPyObject(const std::vector<pir::OpResult>& value) {
@@ -1987,7 +1958,7 @@ PyObject* GetEmptyTensorsWithVarDesc(PyObject* self, PyObject* args) {
   return ToPyObject(result);
 }
 
-paddle::Tensor CreateTensorFromOpResult(const pir::OpResult& op_result) {
+paddle::Tensor CreateTensorFromValue(const pir::Value& op_result) {
   auto tensor = paddle::Tensor();
 
   auto dims = phi::vectorize(GetValueDims(op_result));
@@ -2028,9 +1999,9 @@ paddle::Tensor CreateTensorFromOpResult(const pir::OpResult& op_result) {
   return tensor;
 }
 
-PyObject* GetEmptyTensorsWithOpResult(PyObject* self, PyObject* args) {
+PyObject* GetEmptyTensorsWithValue(PyObject* self, PyObject* args) {
   std::vector<paddle::Tensor> result;
-  std::unordered_map<pir::OpResult, paddle::Tensor> out_tensor_map;
+  std::unordered_map<pir::Value, paddle::Tensor> out_tensor_map;
 
   auto op_result_list = PyTuple_GetItem(args, 0);
 
@@ -2038,9 +2009,9 @@ PyObject* GetEmptyTensorsWithOpResult(PyObject* self, PyObject* args) {
     Py_ssize_t len = PyList_Size(op_result_list);
     for (Py_ssize_t i = 0; i < len; i++) {
       auto op_result =
-          PyObjectCast<pir::OpResult>(PyList_GetItem(op_result_list, i));
+          PyObjectCast<pir::Value>(PyList_GetItem(op_result_list, i));
       if (out_tensor_map.find(op_result) == out_tensor_map.end()) {
-        paddle::Tensor tensor = CreateTensorFromOpResult(op_result);
+        paddle::Tensor tensor = CreateTensorFromValue(op_result);
         out_tensor_map[op_result] = tensor;
         result.emplace_back(tensor);
       } else {
@@ -2051,9 +2022,9 @@ PyObject* GetEmptyTensorsWithOpResult(PyObject* self, PyObject* args) {
     Py_ssize_t len = PyTuple_Size(op_result_list);
     for (Py_ssize_t i = 0; i < len; i++) {
       auto op_result =
-          PyObjectCast<pir::OpResult>(PyTuple_GetItem(op_result_list, i));
+          PyObjectCast<pir::Value>(PyTuple_GetItem(op_result_list, i));
       if (out_tensor_map.find(op_result) == out_tensor_map.end()) {
-        paddle::Tensor tensor = CreateTensorFromOpResult(op_result);
+        paddle::Tensor tensor = CreateTensorFromValue(op_result);
         out_tensor_map[op_result] = tensor;
         result.emplace_back(tensor);
       } else {
@@ -2062,7 +2033,7 @@ PyObject* GetEmptyTensorsWithOpResult(PyObject* self, PyObject* args) {
     }
   } else if (op_result_list != Py_None) {
     PADDLE_THROW(platform::errors::InvalidArgument(
-        "Argument of GetTensorsWithOpResultInArgs must be list of OpResult, "
+        "Argument of GetTensorsWithValueInArgs must be list of Value, "
         "but got "
         "%s",
         (reinterpret_cast<PyTypeObject*>(op_result_list->ob_type))->tp_name));
@@ -2143,14 +2114,12 @@ pir::Value CastPyArg2Value(PyObject* obj,
                            const std::string& op_type,
                            size_t arg_pos) {
   obj = CastPyArg2ValuePreHook(obj);
-  if (PyObject_TypeCheck(obj, g_ir_opresult_pytype)) {
-    return ::pybind11::handle(obj).cast<pir::OpResult>();
-  } else if (PyObject_TypeCheck(obj, g_ir_value_pytype)) {
+  if (PyObject_TypeCheck(obj, g_ir_value_pytype)) {
     return ::pybind11::handle(obj).cast<pir::Value>();
   } else {
     PADDLE_THROW(platform::errors::InvalidType(
         "%s(): argument (position %d) must be "
-        "OpResult, but got %s",
+        "Value, but got %s",
         op_type,
         arg_pos + 1,
         ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
@@ -2764,9 +2733,9 @@ static PyMethodDef EagerUtilMethods[] = {
      METH_VARARGS,
      "GetEmptyTensorsWithVarDesc"},
     {"create_empty_tensors_with_op_results",
-     (PyCFunction)(void (*)(void))GetEmptyTensorsWithOpResult,
+     (PyCFunction)(void (*)(void))GetEmptyTensorsWithValue,
      METH_VARARGS,
-     "GetEmptyTensorsWithOpResult."},
+     "GetEmptyTensorsWithValue."},
     {"set_static_op_arg_pre_cast_hook",
      (PyCFunction)SetStaticOpArgPreCastHook,
      METH_O,

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -71,9 +71,7 @@ int TensorDtype2NumpyDtype(phi::DataType dtype);
 bool PyObject_CheckLongOrConvertToLong(PyObject** obj);
 bool PyObject_CheckFloatOrConvertToFloat(PyObject** obj);
 bool PyObject_CheckStr(PyObject* obj);
-bool PyObject_CheckIROpResult(PyObject* obj);
 bool PyObject_CheckIRValue(PyObject* obj);
-bool PyObject_CheckIRVectorOfOpResult(PyObject* obj);
 bool PyObject_CheckIRVectorOfValue(PyObject* obj);
 bool CastPyArg2AttrBoolean(PyObject* obj, ssize_t arg_pos);
 int CastPyArg2AttrInt(PyObject* obj, ssize_t arg_pos);
@@ -157,7 +155,8 @@ PyObject* ToPyObject(
 PyObject* ToPyObject(const paddle::framework::Vocab& value);
 
 PyObject* ToPyObject(std::shared_ptr<egr::GradNodeBase> grad_node);
-PyObject* ToPyObject(const pir::OpResult& value);
+PyObject* ToPyObject(const pir::Value& value);
+PyObject* ToPyObject(const std::vector<pir::Value>& value);
 PyObject* ToPyObject(const std::vector<pir::OpResult>& value);
 
 class PyTensorHook : public egr::TensorHook {
@@ -397,7 +396,7 @@ paddle::Tensor& UnSafeGetTensorFromPyObject(PyObject* obj);
 
 PyObject* GetEmptyTensorsWithVarDesc(PyObject* self, PyObject* args);
 
-PyObject* GetEmptyTensorsWithOpResult(PyObject* self, PyObject* args);
+PyObject* GetEmptyTensorsWithValue(PyObject* self, PyObject* args);
 
 // end of Slice related methods
 

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -83,9 +83,9 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
     phi::DataType dtype = CastPyArg2DataTypeDirectly(dtype_obj, "full", 2);
     Place place = CastPyArg2Place(place_obj, "full", 3);
 
-    if (!PyObject_CheckIROpResult(shape_obj) &&
-        !PyObject_CheckIRVectorOfOpResult(shape_obj) &&
-        !PyObject_CheckIROpResult(value_obj)) {
+    if (!PyObject_CheckIRValue(shape_obj) &&
+        !PyObject_CheckIRVectorOfValue(shape_obj) &&
+        !PyObject_CheckIRValue(value_obj)) {
       std::vector<int64_t> shape = CastPyArg2Longs(shape_obj, "full", 0);
       float value = CastPyArg2Float(value_obj, "full", 1);
       auto static_api_out = paddle::dialect::full(shape, value, dtype, place);
@@ -93,9 +93,9 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
     } else {
       pir::Value shape, value;
 
-      if (PyObject_CheckIROpResult(shape_obj)) {
+      if (PyObject_CheckIRValue(shape_obj)) {
         shape = CastPyArg2Value(shape_obj, "full", 0);
-      } else if (PyObject_CheckIRVectorOfOpResult(shape_obj)) {
+      } else if (PyObject_CheckIRVectorOfValue(shape_obj)) {
         std::vector<pir::Value> shape_tmp =
             CastPyArg2VectorOfValue(shape_obj, "full", 0);
         shape = paddle::dialect::stack(shape_tmp, 0);
@@ -105,7 +105,7 @@ PyObject *static_api_full(PyObject *self, PyObject *args, PyObject *kwargs) {
             shape_tmp, phi::DataType::INT64, phi::CPUPlace());
       }
 
-      if (PyObject_CheckIROpResult(value_obj)) {
+      if (PyObject_CheckIRValue(value_obj)) {
         value = CastPyArg2Value(value_obj, "full", 1);
       } else {
         float value_tmp = CastPyArg2Float(value_obj, "full", 1);
@@ -270,9 +270,9 @@ static PyObject *static_api_array_to_tensor(PyObject *self,
     // Get Value from args
     PyObject *x_obj = PyTuple_GET_ITEM(args, 0);
     pir::Value x;
-    if (PyObject_CheckIROpResult(x_obj)) {
+    if (PyObject_CheckIRValue(x_obj)) {
       x = CastPyArg2Value(x_obj, "array_to_tensor", 0);
-    } else if (PyObject_CheckIRVectorOfOpResult(x_obj)) {
+    } else if (PyObject_CheckIRVectorOfValue(x_obj)) {
       std::vector<pir::Value> x_tmp =
           CastPyArg2VectorOfValue(x_obj, "array_to_tensor", 0);
       if (x_tmp.size() != 1) {
@@ -334,9 +334,9 @@ static PyObject *static_api_slice_array_dense(PyObject *self,
 
     PyObject *starts_obj = PyTuple_GET_ITEM(args, 1);
     pir::Value starts;
-    if (PyObject_CheckIROpResult(starts_obj)) {
+    if (PyObject_CheckIRValue(starts_obj)) {
       starts = CastPyArg2Value(starts_obj, "slice_array_dense", 1);
-    } else if (PyObject_CheckIRVectorOfOpResult(starts_obj)) {
+    } else if (PyObject_CheckIRVectorOfValue(starts_obj)) {
       std::vector<pir::Value> starts_tmp =
           CastPyArg2VectorOfValue(starts_obj, "slice_array_dense", 1);
       starts = paddle::dialect::stack(starts_tmp, /*axis*/ 0);

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -416,7 +416,7 @@ void BindBlock(py::module *m) {
                    bool is_persistable =
                        attrs[i].dyn_cast<pir::BoolAttribute>().data();
                    if (is_persistable) {
-                     param_list.append(op.result(i));
+                     param_list.append(static_cast<pir::Value>(op.result(i)));
                    }
                  }
                }

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -135,7 +135,6 @@ PHI_DECLARE_bool(print_ir);
 namespace paddle {
 namespace pybind {
 
-PyTypeObject *g_ir_opresult_pytype = nullptr;
 PyTypeObject *g_ir_value_pytype = nullptr;
 
 void BindOpsAPI(pybind11::module *module);
@@ -449,10 +448,20 @@ void BindOperation(py::module *m) {
       .def("num_operands", &Operation::num_operands)
       .def("num_results", &Operation::num_results)
       .def("operand", &Operation::operand)
-      .def("result", &Operation::result)
+      .def("result",
+           [](Operation &self, uint32_t index) {
+             return static_cast<pir::Value>(self.result(index));
+           })
       .def("operand_source", &Operation::operand_source)
       .def("operands", &Operation::operands)
-      .def("results", &Operation::results)
+      .def("results",
+           [](Operation &self) -> py::list {
+             py::list op_list;
+             for (uint32_t i = 0; i < self.num_results(); i++) {
+               op_list.append(static_cast<pir::Value>(self.result(i)));
+             }
+             return op_list;
+           })
       .def(
           "blocks",
           [](Operation &self) { return &self.blocks(); },
@@ -608,7 +617,7 @@ const phi::DDim &GetValueDims(Value value) {
   }
 }
 
-pir::OpResult apply(Value self, py::object func) {
+pir::Value apply(Value self, py::object func) {
   py::gil_scoped_acquire gil;
   auto stop_gradient = self.attribute<BoolAttribute>(kAttrStopGradients);
   if (stop_gradient && !stop_gradient.data()) {
@@ -632,12 +641,12 @@ pir::OpResult apply(Value self, py::object func) {
         "Apply function of Tensor raises an unknown exception."));
   }
   if (res == Py_None) {
-    return self.dyn_cast<OpResult>();
+    return self;
   }
   auto out = CastPyArg2Value(res, "", 0);
   Py_DECREF(py_func);
   Py_DECREF(res);
-  return out.dyn_cast<OpResult>();
+  return out;
 }
 
 void BindValue(py::module *m) {
@@ -754,12 +763,7 @@ void BindValue(py::module *m) {
            })
       .def(
           "get_defining_op",
-          [](Value self) -> pir::Operation * {
-            if (auto op_result = self.dyn_cast<pir::OpResult>()) {
-              return op_result.owner();
-            }
-            return nullptr;
-          },
+          [](Value self) -> pir::Operation * { return self.defining_op(); },
           return_value_policy::reference)
       .def("numel", [](Value self) { return phi::product(GetValueDims(self)); })
       .def("type", &Value::type)
@@ -822,13 +826,10 @@ void BindOpOperand(py::module *m) {
         when build network.
 
   )DOC");
-  op_operand
-      .def("source",
-           [](OpOperand &self) { return self.source().dyn_cast<OpResult>(); })
-      .def("set_source",
-           [](OpOperand &self, const OpResult &result) {
-             self.set_source(result);
-           })
+  op_operand.def("source", [](OpOperand &self) { return self.source(); })
+      .def(
+          "set_source",
+          [](OpOperand &self, const Value &result) { self.set_source(result); })
       .def("owner", &OpOperand::owner, return_value_policy::reference)
       .def("index", &OpOperand::index);
 }
@@ -836,21 +837,6 @@ void BindOpOperand(py::module *m) {
 bool GetValueBoolAttr(Value value, const std::string &attr_name) {
   auto bool_attr = value.attribute<BoolAttribute>(attr_name);
   return !bool_attr || bool_attr.data();
-}
-
-void BindOpResult(py::module *m) {
-  py::class_<OpResult, Value> op_result(*m, "OpResult", R"DOC(
-    OpResult class represents the value(output) defined by a result of operation.
-
-    Notes:
-        The constructor of OpResult should not be invoked directly. OpResult can be automatically constructed
-        when build network.
-  )DOC");
-  g_ir_opresult_pytype = reinterpret_cast<PyTypeObject *>(op_result.ptr());
-  op_result.def(
-      "__init__",
-      [](OpResult &self) { new (&self) OpResult(); },
-      pybind11::return_value_policy::reference);
 }
 
 void BindType(py::module *m) {
@@ -1023,18 +1009,17 @@ static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
                                    no_need_buffer_values.end());
 }
 
-using OpResultMap =
-    std::pair<std::vector<pir::OpResult>, std::vector<pir::OpResult>>;
-std::pair<std::shared_ptr<Program>, OpResultMap> CloneProgram(
+using ValueMap = std::pair<std::vector<pir::Value>, std::vector<pir::Value>>;
+std::pair<std::shared_ptr<Program>, ValueMap> CloneProgram(
     const Program &program) {
   // Limitation of this function:
   // 1. don't support Parameters.
   pir::IrMapping mapper;
   auto cloned_program = program.Clone(mapper);
-  std::vector<pir::OpResult> associated_array_key, associated_array_value;
+  std::vector<pir::Value> associated_array_key, associated_array_value;
   for (auto &pair : mapper.GetMap<pir::Value>()) {
-    associated_array_key.push_back(pair.first.dyn_cast<pir::OpResult>());
-    associated_array_value.push_back(pair.second.dyn_cast<pir::OpResult>());
+    associated_array_key.push_back(pair.first);
+    associated_array_value.push_back(pair.second);
   }
   return std::make_pair(
       cloned_program,
@@ -1471,10 +1456,10 @@ void BindUtils(pybind11::module *m) {
         translator::ProgramTranslator program_translator(&legacy_program,
                                                          program.get());
         program_translator.Translate();
-        return std::make_pair(program, program_translator.VarDesc2OpResult());
+        return std::make_pair(program, program_translator.VarDesc2Value());
       },
       R"DOC(
-        Convert Fluid Program to New IR Program and get the mappings of VarDesc -> pir::OpResult.
+        Convert Fluid Program to New IR Program and get the mappings of VarDesc -> pir::Value.
 
         Args:
 
@@ -1482,7 +1467,7 @@ void BindUtils(pybind11::module *m) {
 
         Returns:
             Program: The New IR Program
-            dict[str, pir::OpResult]: Mapping between VarDesc(by name) and pir::OpResult.
+            dict[str, pir::Value]: Mapping between VarDesc(by name) and pir::Value.
 
         Raises:
             PreconditionNotMet: If legacy_program has multi block will raise error.
@@ -1653,7 +1638,6 @@ void BindPir(pybind11::module *module) {
   BindOperation(&ir_module);
   BindValue(&ir_module);
   BindOpOperand(&ir_module);
-  BindOpResult(&ir_module);
   BindType(&ir_module);
   BindAttribute(&ir_module);
   BindInsertionPoint(&ir_module);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -720,7 +720,7 @@ void BindVjp(pybind11::module *m) {
             vjp_interface,
             phi::errors::InvalidArgument(
                 "The vjp function is not registered in %s op ", fwd_op.name()));
-        std::vector<std::vector<pir::OpResult>> vjp_res = vjp_interface.Vjp(
+        std::vector<std::vector<pir::Value>> vjp_res = vjp_interface.Vjp(
             &fwd_op, inputs, outputs, out_grads, stop_gradients);
         PADDLE_ENFORCE_EQ(
             stop_gradients.size(),
@@ -749,9 +749,9 @@ void BindVjp(pybind11::module *m) {
           py::list sub_res;
           for (size_t j = 0; j < vjp_res[i].size(); ++j) {
             if (!vjp_res[i][j]) {
-              sub_res.append(pir::Value(nullptr));
+              sub_res.append(nullptr);
             } else {
-              sub_res.append(static_cast<pir::Value>(vjp_res[i][j]));
+              sub_res.append(vjp_res[i][j]);
             }
           }
           res.append(sub_res);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -749,9 +749,9 @@ void BindVjp(pybind11::module *m) {
           py::list sub_res;
           for (size_t j = 0; j < vjp_res[i].size(); ++j) {
             if (!vjp_res[i][j]) {
-              sub_res.append(nullptr);
+              sub_res.append(pir::Value(nullptr));
             } else {
-              sub_res.append(vjp_res[i][j]);
+              sub_res.append(static_cast<pir::Value>(vjp_res[i][j]));
             }
           }
           res.append(sub_res);
@@ -787,14 +787,14 @@ void BindVjp(pybind11::module *m) {
 void BindDecomp(pybind11::module *m) {
   m->def("sinking_decomp",
          [](pir::Program *program,
-            std::vector<pir::OpResult> &src_vars,
+            std::vector<pir::Value> &src_vars,
             std::set<std::string> &blacklist,
             std::set<std::string> &whitelist) {
            VLOG(4) << "[Prim] Bind Decomp sinking_decomp begin.";
            py::list res;
            DecompProgram decomp_object(program, src_vars, blacklist, whitelist);
            decomp_object.decomp_program();
-           std::vector<pir::OpResult> tar_vars = decomp_object.get_dst_vars();
+           std::vector<pir::Value> tar_vars = decomp_object.get_dst_vars();
            for (size_t i = 0; i < tar_vars.size(); ++i) {
              if (!tar_vars[i]) {
                res.append(nullptr);
@@ -808,8 +808,7 @@ void BindDecomp(pybind11::module *m) {
 
   m->def("call_decomp", [](pir::Operation &fwd_op) {
     py::list res;
-    std::vector<std::vector<pir::OpResult>> decomp_res =
-        call_decomp_rule(&fwd_op);
+    std::vector<std::vector<pir::Value>> decomp_res = call_decomp_rule(&fwd_op);
     for (size_t i = 0; i < decomp_res.size(); ++i) {
       py::list sub_res;
       for (size_t j = 0; j < decomp_res[i].size(); ++j) {

--- a/test/dygraph_to_static/test_set_static_op_arg_pre_cast_hook.py
+++ b/test/dygraph_to_static/test_set_static_op_arg_pre_cast_hook.py
@@ -36,7 +36,7 @@ class TestSetStaticOpArgPreCastHook(Dy2StTestBase):
         with static_guard():
             with self.assertRaisesRegex(
                 TypeError,
-                r"abs\(\): argument \(position 1\) must be OpResult, but got Tensor",
+                r"abs\(\): argument \(position 1\) must be Value, but got Tensor",
             ):
                 paddle.abs(eager_tensor)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- #60909 的拆分 PR
- 移除 BindOpResult 和相关 pybind 接口
- 替换相关 OpResult 用法
