### PR TITLE
[Dynamic Shape] Split ReduceMean to ReduceSum+Scale

### DIFF
--- a/test/ir/pir/cinn/test_rms_norm.py
+++ b/test/ir/pir/cinn/test_rms_norm.py
@@ -32,7 +32,7 @@ class LlamaRMSNorm(nn.Layer):
         self.variance_epsilon = 1e-6
 
     def forward(self, hidden_states):
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        variance = hidden_states.pow(2).sum(-1, keepdim=True) / 768
         hidden_states = (
             paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[Dynamic Shape] Split ReduceMean to ReduceSum+Scale

提供 ReduceMean 拆分成 ReduceSum + Scale 的单测脚本，此脚本会挂在后端的 `dy_shape_group_scheduler.cc` 文件

## 报错截图
<img width="1217" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/17810795/8bf07f2d-97f6-4a71-8cb3-e154c198b142">

## Program 
```
I0122 12:31:23.416226 43619 divide_group_op_to_fusion_op_pass.cc:266] Before GroupOpPattern: {
 (%0) = "builtin.parameter" () {is_persisable:[true],parameter_name:"parameter_0",stop_gradient:[false]} : () -> pd_op.tensor<768xf32>
 (%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"_jst.0.hidden_states.0",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1,2048,768],stop_gradient:[false]} : () -> pd_op.tensor<1x2048x768xf32>
 (%2) = cinn_op.group () -> pd_op.tensor<1x2048x768xf32> {
 (%3) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1,2048,768],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<1x2048x768xf32>
 (%4) = "pd_op.elementwise_pow" (%1, %3) {stop_gradient:[false]} : (pd_op.tensor<1x2048x768xf32>, pd_op.tensor<1x2048x768xf32>) -> pd_op.tensor<1x2048x768xf32>
 (%5) = "cinn_op.reduce_sum" (%4) {dim:[(Int64)-1],keep_dim:true,stop_gradient:[false]} : (pd_op.tensor<1x2048x768xf32>) -> pd_op.tensor<1x2048x1xf32>
 (%6) = "cinn_op.scale" (%5) {bias:(Float)0,bias_after_scale:true,scale:(Float)0.00130208,stop_gradient:[false]} : (pd_op.tensor<1x2048x1xf32>) -> pd_op.tensor<1x2048x1xf32>
 (%7) = "cinn_op.scale" (%6) {bias:(Float)1e-06,bias_after_scale:true,scale:(Float)1,stop_gradient:[false]} : (pd_op.tensor<1x2048x1xf32>) -> pd_op.tensor<1x2048x1xf32>
 (%8) = "pd_op.rsqrt" (%7) {stop_gradient:[false]} : (pd_op.tensor<1x2048x1xf32>) -> pd_op.tensor<1x2048x1xf32>
 (%9) = "cinn_op.broadcast" (%8) {broadcast_axes:[(Int64)0,(Int64)1,(Int64)2],out_shape:[(Int64)1,(Int64)2048,(Int64)768],stop_gradient:[false]} : (pd_op.tensor<1x2048x1xf32>) -> pd_op.tensor<1x2048x768xf32>
 (%10) = "pd_op.multiply" (%9, %1) {stop_gradient:[false]} : (pd_op.tensor<1x2048x768xf32>, pd_op.tensor<1x2048x768xf32>) -> pd_op.tensor<1x2048x768xf32>
 (%11) = "cinn_op.broadcast" (%0) {broadcast_axes:[(Int64)2],out_shape:[(Int64)1,(Int64)2048,(Int64)768],stop_gradient:[false]} : (pd_op.tensor<768xf32>) -> pd_op.tensor<1x2048x768xf32>
 (%12) = "pd_op.multiply" (%10, %11) {stop_gradient:[false]} : (pd_op.tensor<1x2048x768xf32>, pd_op.tensor<1x2048x768xf32>) -> pd_op.tensor<1x2048x768xf32>
 () = "cf.yield" (%12) {} : (pd_op.tensor<1x2048x768xf32>) ->  
 }
 () = "builtin.shadow_output" (%2) {output_name:"output_0"} : (pd_op.tensor<1x2048x768xf32>) -> 
}
```