### PR TITLE
[PIR][DynamicShape] Infer symbolic shape for sub_graph repeate_kv

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
@@ -508,6 +508,14 @@ bool FullOpInferSymbolicShape(pir::Operation *op,
     sym_shape.push_back(dim_expr);
   }
 
+  // DimExpr only keep shape info, which always be int type
+  int64_t value = attributes.at("value")
+                      .dyn_cast<paddle::dialect::ScalarAttribute>()
+                      .data()
+                      .to<int64_t>();
+  std::vector<symbol::DimExpr> sym_data;
+  sym_data.emplace_back(value);
+
   symbol::ShapeOrDataDimExprs shape_data{sym_shape};
 
   op->set_attribute(
@@ -601,6 +609,54 @@ bool Unsqueeze_OpInferSymbolicShape(
 
 bool TileOpInferSymbolicShape(pir::Operation *op,
                               pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  pir::Value operand_x = op->operand_source(0);
+  symbol::ShapeOrDataDimExprs x_shape_or_data =
+      shape_analysis->GetShapeOrDataForValue(operand_x);
+  pir::Value operand_repeat_times = op->operand_source(1);
+  symbol::ShapeOrDataDimExprs repeat_times_shape_or_data =
+      shape_analysis->GetShapeOrDataForValue(operand_repeat_times);
+
+  std::vector<symbol::DimExpr> x_dimexpr;
+  if (x_shape_or_data.data().has_value()) {
+    x_dimexpr = x_shape_or_data.data().value();
+  } else {
+    x_dimexpr = x_shape_or_data.shape();
+  }
+
+  std::vector<symbol::DimExpr> repeat_times_dimexpr;
+  if (repeat_times_shape_or_data.data().has_value()) {
+    repeat_times_dimexpr = repeat_times_shape_or_data.data().value();
+  } else {
+    repeat_times_dimexpr = repeat_times_shape_or_data.shape();
+  }
+  if (repeat_times_dimexpr.empty()) {
+    repeat_times_dimexpr = std::vector<symbol::DimExpr>(x_dimexpr.size(), 1);
+  }
+
+  auto out_rank = std::max(static_cast<size_t>(x_dimexpr.size()),
+                           repeat_times_dimexpr.size());
+  std::vector<symbol::DimExpr> out_shape(out_rank);
+  if (x_dimexpr.size() > repeat_times_dimexpr.size()) {
+    auto diff = x_dimexpr.size() - repeat_times_dimexpr.size();
+    repeat_times_dimexpr.insert(repeat_times_dimexpr.begin(), diff, 1);
+  } else {
+    auto diff = repeat_times_dimexpr.size() - x_dimexpr.size();
+    x_dimexpr.insert(x_dimexpr.begin(), diff, 1);
+  }
+
+  for (size_t i = 0; i < repeat_times_dimexpr.size(); ++i) {
+    out_shape[i] = x_dimexpr[i] * repeat_times_dimexpr[i];
+  }
+
+  symbol::ShapeOrDataDimExprs shape_data{out_shape};
+
+  op->set_attribute(
+      "symbolic_shape",
+      pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
+
+  pir::OpResult res = op->result(0);
+  shape_analysis->SetShapeOrDataForValue(res, shape_data);
+
   return true;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Infer symbolic shape for sub_graph repeate_kv

