### PR TITLE
[PIR] Replace OpResult usage in Operation::result(s)

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -134,7 +134,7 @@ class IR_API GenerateShapeOp
 
   void VerifySig() {}
 
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   bool InferSymbolicShape(pir::ShapeConstraintIRAnalysis *shape_analysis);
 

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -418,11 +418,10 @@ void OpTranscriber::InsertSliceOperationForInput(
   }
 }
 
-pir::OpResult OpTranscriber::GetAttributeAsInput(
-    pir::IrContext* ctx,
-    pir::Block* block,
-    const OpDesc& op_desc,
-    const OpInputInfo& input_info) {
+pir::Value OpTranscriber::GetAttributeAsInput(pir::IrContext* ctx,
+                                              pir::Block* block,
+                                              const OpDesc& op_desc,
+                                              const OpInputInfo& input_info) {
   auto& attribute_translator = AttributeTranslator::instance();
   auto& op_normalizer = OpNameNormalizer::instance();
 
@@ -485,7 +484,7 @@ std::vector<pir::Value> OpTranscriber::GenerateOperationInput(
              << legacy_input_name;
 
     std::vector<std::string> legacy_input_vars;
-    // return empty OpResult if this arg is optional and not shown in OpDesc
+    // return empty Value if this arg is optional and not shown in OpDesc
     if (op_desc.HasInput(legacy_input_name, true)) {
       legacy_input_vars = op_desc.Input(legacy_input_name, true);
     }
@@ -785,7 +784,7 @@ void OpTranscriber::RecordOpResultMapping(pir::IrContext* ctx,
     VLOG(10) << "[output recording]"
              << "[" << op_desc.Type() << "]" << arg_name << " " << idx_in_op
              << " " << idx_in_vec;
-    pir::OpResult value = operation->result(idx_in_op);
+    pir::Value value = operation->result(idx_in_op);
     bool generated_by_vector = value.type().isa<pir::VectorType>();
 
     param_map->PushValue(
@@ -1037,12 +1036,12 @@ struct AssignValueOpTranscriber : public OpTranscriber {
 // So we generate an input by `full` with same type of output `DropoutState` of
 // OpDesc And we still should be aware that `DropoutState` is an optional output
 // in static graph.
-pir::OpResult TranslateDropOutStateIn(pir::IrContext* ctx,
-                                      TranslationContext* param_map,
-                                      const OpDesc& op_desc,
-                                      const std::string& normalized_op_name,
-                                      const OpInputInfo& input_info,
-                                      pir::Block* block) {
+pir::Value TranslateDropOutStateIn(pir::IrContext* ctx,
+                                   TranslationContext* param_map,
+                                   const OpDesc& op_desc,
+                                   const std::string& normalized_op_name,
+                                   const OpInputInfo& input_info,
+                                   pir::Block* block) {
   const std::string legacy_output_name = "DropoutState";
   std::vector<std::string> legacy_output_vars;
   if (op_desc.HasOutput(legacy_output_name)) {
@@ -1051,7 +1050,7 @@ pir::OpResult TranslateDropOutStateIn(pir::IrContext* ctx,
 
   if (legacy_output_vars.empty()) {
     VLOG(3) << "[input translating] not find output variable: DropoutState";
-    return pir::OpResult(nullptr);
+    return pir::Value(nullptr);
   }
 
   // `DropoutState` is a tensor
@@ -1416,7 +1415,7 @@ struct TrilAndTriuGradOpTranscriber : public OpTranscriber {
 };
 
 using ValueInfo =
-    std::tuple<std::vector<int64_t>, dialect::DenseTensorType, pir::OpResult>;
+    std::tuple<std::vector<int64_t>, dialect::DenseTensorType, pir::Value>;
 
 ValueInfo GetTensorInfoByVarName(const OpDesc& op_desc,
                                  const std::vector<std::string>& names,
@@ -1434,7 +1433,7 @@ ValueInfo GetTensorInfoByVarName(const OpDesc& op_desc,
              name);
   const auto& defining_info = param_map->at(name);
 
-  pir::OpResult value = defining_info.value.dyn_cast<pir::OpResult>();
+  pir::Value value = defining_info.value;
   IR_ENFORCE(
       value, "Expected op[%s]'s input %s is not null", op_desc.Type(), name);
   const pir::Type& type = value.type();
@@ -1529,7 +1528,7 @@ struct MulOpTranscriber : public OpTranscriber {
     });
     dialect::ReshapeOp reshape_op_x =
         builder.Build<dialect::ReshapeOp>(x_value, x_new_shape);
-    pir::OpResult x_new = reshape_op_x.out();
+    pir::Value x_new = reshape_op_x.out();
     VLOG(6) << "[" << op_desc.Type() << "] x_shape change from "
             << x_tensor_type.dims() << " to " << common::make_ddim(x_new_shape);
 
@@ -1547,7 +1546,7 @@ struct MulOpTranscriber : public OpTranscriber {
 
     dialect::ReshapeOp reshape_op_y =
         builder.Build<dialect::ReshapeOp>(y_value, y_new_shape);
-    pir::OpResult y_new = reshape_op_y.out();
+    pir::Value y_new = reshape_op_y.out();
     VLOG(6) << "[" << op_desc.Type() << "] y_shape change from "
             << y_tensor_type.dims() << " to " << common::make_ddim(y_new_shape);
 
@@ -1566,7 +1565,7 @@ struct MulOpTranscriber : public OpTranscriber {
           op_desc, op_desc.Output("Out"), param_map, "Out");
 
       const dialect::DenseTensorType& out_tensor_type = std::get<1>(out_info);
-      pir::OpResult& out_value = std::get<2>(out_info);
+      pir::Value& out_value = std::get<2>(out_info);
 
       const auto& output_vars = op_desc.Output("Out");
       const auto& output_name = output_vars[0];
@@ -1594,7 +1593,7 @@ struct MulOpTranscriber : public OpTranscriber {
       pir::Builder builder(ctx, operation->GetParent());
       dialect::ReshapeOp reshape_op_out =
           builder.Build<dialect::ReshapeOp>(out_value, out_new_shape);
-      pir::OpResult out_new = reshape_op_out.out().dyn_cast<pir::OpResult>();
+      pir::Value out_new = reshape_op_out.out();
       VLOG(6) << "[" << op_desc.Type() << "] out_shape change from "
               << out_tensor_type.dims() << " to "
               << common::make_ddim(out_new_shape);
@@ -1674,7 +1673,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
 
     const dialect::DenseTensorType& out_grad_tensor_type =
         std::get<1>(out_grad_info);
-    pir::OpResult& out_grad_value = std::get<2>(out_grad_info);
+    pir::Value& out_grad_value = std::get<2>(out_grad_info);
 
     pir::Builder builder(ctx, block);
 
@@ -1692,7 +1691,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
     });
     dialect::ReshapeOp reshape_op_x =
         builder.Build<dialect::ReshapeOp>(x_value, x_new_shape);
-    pir::OpResult x_new = reshape_op_x.out();
+    pir::Value x_new = reshape_op_x.out();
     VLOG(6) << "[" << op_desc.Type() << "] x_shape change from "
             << x_tensor_type.dims() << " to " << common::make_ddim(x_new_shape);
 
@@ -1710,7 +1709,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
 
     dialect::ReshapeOp reshape_op_y =
         builder.Build<dialect::ReshapeOp>(y_value, y_new_shape);
-    pir::OpResult y_new = reshape_op_y.out();
+    pir::Value y_new = reshape_op_y.out();
     VLOG(6) << "[" << op_desc.Type() << "] y_shape change from "
             << y_tensor_type.dims() << " to " << common::make_ddim(y_new_shape);
 
@@ -1719,7 +1718,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
 
     dialect::ReshapeOp reshape_op_out_grad =
         builder.Build<dialect::ReshapeOp>(out_grad_value, out_grad_new_shape);
-    pir::OpResult out_grad_new = reshape_op_out_grad.out();
+    pir::Value out_grad_new = reshape_op_out_grad.out();
     VLOG(6) << "[" << op_desc.Type() << "] out_grad_shape change from "
             << out_grad_tensor_type.dims() << " to "
             << common::make_ddim(out_grad_new_shape);
@@ -1770,7 +1769,7 @@ struct MulGradOpTranscriber : public OpTranscriber {
       std::vector<int64_t> shape = var_desc->GetShape();
       DenseTensorTypeStorage::Dim dim = common::make_ddim(shape);
 
-      pir::OpResult value_res = operation->result(idx_in_op);
+      pir::Value value_res = operation->result(idx_in_op);
       auto reshape_op = builder.Build<dialect::ReshapeOp>(value_res, shape);
 
       IR_ENFORCE(value_res,
@@ -2160,13 +2159,12 @@ struct SelectOutputOpTranscriber : public OpTranscriber {
   }
 };
 
-pir::OpResult TranslateNumClassesForOneHot(
-    pir::IrContext* ctx,
-    TranslationContext* param_map,
-    const OpDesc& op_desc,
-    const std::string& normalized_op_name,
-    const OpInputInfo& input_info,
-    pir::Block* block) {
+pir::Value TranslateNumClassesForOneHot(pir::IrContext* ctx,
+                                        TranslationContext* param_map,
+                                        const OpDesc& op_desc,
+                                        const std::string& normalized_op_name,
+                                        const OpInputInfo& input_info,
+                                        pir::Block* block) {
   const std::string legacy_attr_name = "depth";
   const std::string legacy_tensor_name = "depth_tensor";
   std::vector<std::string> legacy_vars;
@@ -2182,7 +2180,7 @@ pir::OpResult TranslateNumClassesForOneHot(
                "%s should be existed in one_hot_v2 as input depth_tensor.",
                legacy_vars[0]);
     auto defining_info = param_map->at(legacy_vars[0]);
-    return defining_info.value.dyn_cast<pir::OpResult>();
+    return defining_info.value;
   }
 
   auto& attribute_translator = AttributeTranslator::instance();
@@ -2300,7 +2298,7 @@ struct ElementwiseTranscriber : public OpTranscriber {
           ctx, param_map, block, x_defining_info, x_name);
       x_defining_info = param_map->at(x_name);
     }
-    pir::OpResult x_value = x_defining_info.value.dyn_cast<pir::OpResult>();
+    pir::Value x_value = x_defining_info.value;
     IR_ENFORCE(x_value,
                "Expected op[%s]'s input %s is not null",
                op_desc.Type(),
@@ -2331,7 +2329,7 @@ struct ElementwiseTranscriber : public OpTranscriber {
           ctx, param_map, block, y_defining_info, y_name);
       y_defining_info = param_map->at(y_name);
     }
-    pir::OpResult y_value = y_defining_info.value.dyn_cast<pir::OpResult>();
+    pir::Value y_value = y_defining_info.value;
     IR_ENFORCE(y_value,
                "Expected op[%s]'s input %s is not null",
                op_desc.Type(),
@@ -2362,7 +2360,7 @@ struct ElementwiseTranscriber : public OpTranscriber {
                append_size);
 
     pir::Builder builder(ctx, block);
-    pir::OpResult y_new;
+    pir::Value y_new;
     if (std::find(y_shape.begin(), y_shape.end(), -1) == y_shape.end()) {
       std::vector<int64_t> y_new_shape(y_shape);
       for (int i = 0; i < append_size; i++) {
@@ -2451,7 +2449,7 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
                op_desc.Type(),
                y_name);
     auto y_defining_info = param_map->at(y_name);
-    pir::OpResult y_value = y_defining_info.value.dyn_cast<pir::OpResult>();
+    pir::Value y_value = y_defining_info.value;
     IR_ENFORCE(y_value,
                "Expected op[%s]'s input %s is not null",
                op_desc.Type(),
@@ -2465,7 +2463,7 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
     dialect::DenseTensorType y_tensor_type =
         y_type.dyn_cast<dialect::DenseTensorType>();
 
-    pir::OpResult value = operation->result(idx_in_op);
+    pir::Value value = operation->result(idx_in_op);
 
     // if y_grad' shape is same with y, we don't need a reshape
     pir::Type y_grad_type = value.type();
@@ -2489,10 +2487,10 @@ struct ElementwiseGradTranscriber : public OpTranscriber {
 };
 
 struct SetValueOpTranscriber : public OpTranscriber {
-  pir::OpResult GetAttributeAsInput(pir::IrContext* ctx,
-                                    pir::Block* block,
-                                    const OpDesc& op_desc,
-                                    const OpInputInfo& input_info) override {
+  pir::Value GetAttributeAsInput(pir::IrContext* ctx,
+                                 pir::Block* block,
+                                 const OpDesc& op_desc,
+                                 const OpInputInfo& input_info) override {
     auto& attribute_translator = AttributeTranslator::instance();
     auto& op_normalizer = OpNameNormalizer::instance();
 
@@ -3062,7 +3060,7 @@ struct LegacyMatmulOpTranscriber : public OpTranscriber {
              << idx_in_op << " " << idx_in_vec;
 
     pir::Builder builder(ctx, operation->GetParent());
-    pir::OpResult value = operation->result(idx_in_op);
+    pir::Value value = operation->result(idx_in_op);
     auto scale_op = builder.Build<dialect::ScaleOp>(value, alpha);
     param_map->PushValue(output_vars[0],
                          VariableDefiningInfo(scale_op.out(), false, -1));

--- a/paddle/fluid/ir_adaptor/translator/op_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.h
@@ -85,10 +85,10 @@ struct OpTranscriber {
       const std::string& normalized_op_name,
       const OpAttributeInfoList& op_attr_infos,
       const OpDesc& op_desc);
-  virtual pir::OpResult GetAttributeAsInput(pir::IrContext* ctx,
-                                            pir::Block* block,
-                                            const OpDesc& op_desc,
-                                            const OpInputInfo& input_info);
+  virtual pir::Value GetAttributeAsInput(pir::IrContext* ctx,
+                                         pir::Block* block,
+                                         const OpDesc& op_desc,
+                                         const OpInputInfo& input_info);
 
   virtual void RecordOpResultMapping(pir::IrContext* ctx,
                                      TranslationContext* param_map,

--- a/paddle/fluid/ir_adaptor/translator/utils.cc
+++ b/paddle/fluid/ir_adaptor/translator/utils.cc
@@ -69,7 +69,7 @@ pir::Operation* InsertSliceOperationForTarget(
                              {src_vec_type[defining_info.idx_in_vector]},
                              op_info);
   block->push_back(operation);
-  pir::OpResult target_op_result = operation->result(0);
+  pir::Value target_op_result = operation->result(0);
   param_map->PushValue(arg_name, VariableDefiningInfo(target_op_result));
   return operation;
 }

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -166,11 +166,11 @@ def GenBuildInserFullForMutableAttribute(
     build_mutable_attribute = ""
     BUILD_INTARRAY_ATTRIBUTE_TEMPLATE = """  // Generate int_array mutable attribute: {attr_name}
   paddle::dialect::FullIntArrayOp full_{attr_name}_op = builder.Build<paddle::dialect::FullIntArrayOp>({attr_name}, {phi_dtype}, phi::CPUPlace());
-  pir::OpResult {attr_name}_ = full_{attr_name}_op->result(0);
+  pir::Value {attr_name}_ = full_{attr_name}_op->result(0);
     """
     BUILD_SCALAR_ATTRIBUTE_TEMPLATE = """  // Generate scalar mutable attribute: {attr_name}
   paddle::dialect::FullOp full_{attr_name}_op = builder.Build<paddle::dialect::FullOp>(std::vector<int64_t>{{1}}, {attr_name}, {phi_dtype}, phi::CPUPlace());
-  pir::OpResult {attr_name}_ = full_{attr_name}_op->result(0);
+  pir::Value {attr_name}_ = full_{attr_name}_op->result(0);
     """
     for idx in range(len(op_mutable_attribute_name_list)):
         attr_name = op_mutable_attribute_name_list[idx]
@@ -389,9 +389,9 @@ def GenBuildOutputs(
 """
 
     CREATE_INTARRAY_MUTABLE_ATTRIBUE_WITH_UNKONW_DATA_TEMPLATE = """  phi::IntArray {name};
-  if ({name}_.dyn_cast<pir::OpResult>() && {name}_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullIntArrayOp>()) {{
+  if ({name}_.isa<pir::OpResult>() && {name}_.defining_op()->isa<paddle::dialect::FullIntArrayOp>()) {{
     {name} = std::move(phi::IntArray(paddle::dialect::GetInt64Vector(
-                          {name}_.dyn_cast<pir::OpResult>().owner()
+                          {name}_.defining_op()
                           ->dyn_cast<paddle::dialect::FullIntArrayOp>()
                           .attribute("value"))));
   }} else if ({name}_.type().isa<pir::VectorType>()) {{
@@ -411,9 +411,9 @@ def GenBuildOutputs(
   }}\n"""
 
     CREATE_VECTOR_INT_MUTABLE_ATTRIBUE_WITH_UNKONW_DATA_TEMPLATE = """  std::vector<int64_t> {name};
-  if ({name}_.dyn_cast<pir::OpResult>() && {name}_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullIntArrayOp>()) {{
+  if ({name}_.isa<pir::OpResult>() && {name}_.defining_op()->isa<paddle::dialect::FullIntArrayOp>()) {{
     {name} = paddle::dialect::GetInt64Vector(
-                    {name}_.dyn_cast<pir::OpResult>().owner()
+                    {name}_.defining_op()
                     ->dyn_cast<paddle::dialect::FullIntArrayOp>()
                     .attribute("value"));
   }} else if ({name}_.type().isa<pir::VectorType>()) {{
@@ -431,8 +431,8 @@ def GenBuildOutputs(
   }}\n"""
 
     CREATE_SCALAR_MUTABLE_ATTRIBUE_WITH_UNKONW_DATA_TEMPLATE = """  phi::Scalar {name};
-  if ({name}_.dyn_cast<pir::OpResult>() && {name}_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullOp>()) {{
-    {name} = std::move(phi::Scalar({name}_.dyn_cast<pir::OpResult>().owner()
+  if ({name}_.isa<pir::OpResult>() && {name}_.defining_op()->isa<paddle::dialect::FullOp>()) {{
+    {name} = std::move(phi::Scalar({name}_.defining_op()
                                   ->dyn_cast<paddle::dialect::FullOp>()
                                   .attribute("value")
                                   .dyn_cast<paddle::dialect::ScalarAttribute>()

--- a/paddle/fluid/pir/dialect/op_generator/op_member_func_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_member_func_gen.py
@@ -16,7 +16,7 @@
 
 OP_GET_INPUT_TEMPLATE = """  pir::Value {input_name}() {{ return operand_source({input_index}); }}
 """
-OP_GET_OUTPUT_TEMPLATE = """  pir::OpResult {output_name}() {{ return result({output_index}); }}
+OP_GET_OUTPUT_TEMPLATE = """  pir::Value {output_name}() {{ return result({output_index}); }}
 """
 
 

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
@@ -67,7 +67,7 @@ bool SameOperandsAndResultShape(
   op->set_attribute("symbolic_shape",
                     pir::shape::SymbolAttribute::get(pir::IrContext::Instance(),
                                                      operand_shape_or_data));
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, operand_shape_or_data);
   return true;
 }
@@ -120,7 +120,7 @@ bool InferSymbolicShapeElementWiseBinary(
   // TODO(lanxianghit): fill data when the operation is on shape computation
   // std::vector<symbol::DimExpr> data;
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   symbol::ShapeOrDataDimExprs shape_data{shapes};
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
   op->set_attribute(
@@ -167,7 +167,7 @@ bool DataOpInferSymbolicShape(pir::Operation *op,
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
 
   return true;
@@ -216,7 +216,7 @@ bool Subtract_OpInferSymbolicShape(
 bool ShapeOpInferSymbolicShape(pir::Operation *op,
                                pir::ShapeConstraintIRAnalysis *shape_analysis) {
   pir::Value operand_source = op->operand_source(0);
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
 
   symbol::ShapeOrDataDimExprs operand_shape_or_data =
       shape_analysis->GetShapeOrDataForValue(operand_source);
@@ -275,7 +275,7 @@ bool StackOpInferSymbolicShape(pir::Operation *op,
   op->set_attribute(
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
   return true;
 }
@@ -333,7 +333,7 @@ bool ReduceInferDim(pir::Operation *op,
     }
   }
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   symbol::ShapeOrDataDimExprs shape_data{shapes};
   op->set_attribute(
       "symbolic_shape",
@@ -387,8 +387,8 @@ bool ReshapeOpInferSymbolicShape(
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
 
-  pir::OpResult res0 = op->result(0);
-  pir::OpResult res1 = op->result(1);
+  pir::Value res0 = op->result(0);
+  pir::Value res1 = op->result(1);
   shape_analysis->SetShapeOrDataForValue(res0, shape_data);
   shape_analysis->SetShapeOrDataForValue(
       res1, shape_analysis->GetShapeOrDataForValue(operand_source_shape));
@@ -421,7 +421,7 @@ bool FullIntArrayOpInferSymbolicShape(
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
   return true;
 }
@@ -432,7 +432,7 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
   pir::Value operand_source = op->operand_source(0);
   pir::Value operand_starts = op->operand_source(1);
   pir::Value operand_ends = op->operand_source(2);
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
 
   symbol::ShapeOrDataDimExprs operand_shape_or_data =
       shape_analysis->GetShapeOrDataForValue(operand_source);
@@ -522,7 +522,7 @@ bool FullOpInferSymbolicShape(pir::Operation *op,
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
   return true;
 }
@@ -654,7 +654,7 @@ bool TileOpInferSymbolicShape(pir::Operation *op,
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
 
   return true;
@@ -718,7 +718,7 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
       "symbolic_shape",
       pir::shape::SymbolAttribute::get(pir::IrContext::Instance(), shape_data));
 
-  pir::OpResult res = op->result(0);
+  pir::Value res = op->result(0);
   shape_analysis->SetShapeOrDataForValue(res, shape_data);
   return true;
 }

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.h
@@ -169,7 +169,7 @@ class SelectInputOp : public pir::Op<SelectInputOp> {
   static constexpr uint32_t attributes_num = 0;
   void VerifySig();
   pir::Value mask() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 };
 
 class SelectOutputOp : public pir::Op<SelectOutputOp> {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -22,15 +22,15 @@
 namespace paddle {
 namespace dialect {
 
-pir::OpResult builtin_combine(const std::vector<pir::Value>& x) {
+pir::Value builtin_combine(const std::vector<pir::Value>& x) {
   auto combine_op =
       ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(x);
   return combine_op.out();
 }
 
-std::vector<pir::OpResult> add_n_grad(const std::vector<pir::Value>& inputs,
-                                      const pir::Value& out_grad) {
-  std::vector<pir::OpResult> inputs_grad;
+std::vector<pir::Value> add_n_grad(const std::vector<pir::Value>& inputs,
+                                   const pir::Value& out_grad) {
+  std::vector<pir::Value> inputs_grad;
   for (size_t i = 0; i < inputs.size(); i++) {
     paddle::dialect::ScaleOp scale_op =
         ApiBuilder::Instance().GetBuilder()->Build<paddle::dialect::ScaleOp>(
@@ -40,13 +40,13 @@ std::vector<pir::OpResult> add_n_grad(const std::vector<pir::Value>& inputs,
   return inputs_grad;
 }
 
-pir::OpResult zeros_like(const pir::Value& x,
-                         const phi::DataType dtype,
-                         const Place& place) {
+pir::Value zeros_like(const pir::Value& x,
+                      const phi::DataType dtype,
+                      const Place& place) {
   return paddle::dialect::full_like(x, 0, dtype, place);
 }
 
-pir::OpResult parameter(const std::string& name) {
+pir::Value parameter(const std::string& name) {
   pir::Parameter* param = ApiBuilder::Instance().GetParameter(name);
   pir::ParameterOp parameter_op =
       ApiBuilder::Instance().GetBuilder()->Build<pir::ParameterOp>(
@@ -62,11 +62,11 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
                                                                   name);
 }
 
-pir::OpResult embedding_grad(const pir::Value& x,
-                             const pir::Value& weight,
-                             const pir::Value& out_grad,
-                             int64_t padding_idx,
-                             bool sparse) {
+pir::Value embedding_grad(const pir::Value& x,
+                          const pir::Value& weight,
+                          const pir::Value& out_grad,
+                          int64_t padding_idx,
+                          bool sparse) {
   if (weight.type().isa<paddle::dialect::DenseTensorType>()) {
     if (sparse) {
       auto embedding_grad_op =
@@ -88,8 +88,8 @@ pir::OpResult embedding_grad(const pir::Value& x,
   }
 }
 
-pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
-                                  int axis) {
+pir::Value split_with_num_grad(const std::vector<pir::Value>& out_grad,
+                               int axis) {
   auto out_grad_combine_op =
       ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(out_grad);
   paddle::dialect::SplitGradOp split_grad_op =
@@ -98,8 +98,8 @@ pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
   return split_grad_op.result(0);
 }
 
-pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
-                                  const pir::Value& axis) {
+pir::Value split_with_num_grad(const std::vector<pir::Value>& out_grad,
+                               const pir::Value& axis) {
   auto out_grad_combine_op =
       ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(out_grad);
   paddle::dialect::SplitGradOp split_grad_op =
@@ -108,32 +108,30 @@ pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
   return split_grad_op.result(0);
 }
 
-pir::OpResult ones(const std::vector<int64_t>& shape,
-                   phi::DataType dtype,
-                   const Place& place) {
+pir::Value ones(const std::vector<int64_t>& shape,
+                phi::DataType dtype,
+                const Place& place) {
   return paddle::dialect::full(shape, 1, dtype, place);
 }
 
-pir::OpResult ones_like(pir::Value x_,
-                        phi::DataType dtype,
-                        const Place& place) {
+pir::Value ones_like(pir::Value x_, phi::DataType dtype, const Place& place) {
   return paddle::dialect::full_like(x_, 1, dtype, place);
 }
 
-pir::OpResult zeros(const std::vector<int64_t>& shape,
-                    phi::DataType dtype,
-                    const Place& place) {
+pir::Value zeros(const std::vector<int64_t>& shape,
+                 phi::DataType dtype,
+                 const Place& place) {
   return paddle::dialect::full(shape, 0, dtype, place);
 }
 
-pir::OpResult create_array(phi::DataType dtype) {
+pir::Value create_array(phi::DataType dtype) {
   auto create_array_op = ApiBuilder::Instance()
                              .GetBuilder()
                              ->Build<paddle::dialect::CreateArrayOp>(dtype);
   return create_array_op.out();
 }
 
-pir::OpResult create_array_like(pir::Value input, float value) {
+pir::Value create_array_like(pir::Value input, float value) {
   auto create_array_like_op =
       ApiBuilder::Instance()
           .GetBuilder()
@@ -141,21 +139,21 @@ pir::OpResult create_array_like(pir::Value input, float value) {
   return create_array_like_op.out();
 }
 
-pir::OpResult array_length(pir::Value x) {
+pir::Value array_length(pir::Value x) {
   auto array_length_op = ApiBuilder::Instance()
                              .GetBuilder()
                              ->Build<paddle::dialect::ArrayLengthOp>(x);
   return array_length_op.out();
 }
 
-pir::OpResult array_read(pir::Value array, pir::Value i) {
+pir::Value array_read(pir::Value array, pir::Value i) {
   auto array_read_op =
       ApiBuilder::Instance().GetBuilder()->Build<paddle::dialect::ArrayReadOp>(
           array, i);
   return array_read_op.out();
 }
 
-pir::OpResult array_write_(pir::Value array, pir::Value x, pir::Value i) {
+pir::Value array_write_(pir::Value array, pir::Value x, pir::Value i) {
   auto array_write_op =
       ApiBuilder::Instance()
           .GetBuilder()
@@ -163,9 +161,9 @@ pir::OpResult array_write_(pir::Value array, pir::Value x, pir::Value i) {
   return array_write_op.out();
 }
 
-std::tuple<pir::OpResult, pir::OpResult> array_to_tensor(pir::Value x,
-                                                         int axis,
-                                                         bool use_stack) {
+std::tuple<pir::Value, pir::Value> array_to_tensor(pir::Value x,
+                                                   int axis,
+                                                   bool use_stack) {
   auto array_to_tensor =
       ApiBuilder::Instance()
           .GetBuilder()
@@ -173,10 +171,10 @@ std::tuple<pir::OpResult, pir::OpResult> array_to_tensor(pir::Value x,
   return std::make_tuple(array_to_tensor.result(0), array_to_tensor.result(1));
 }
 
-pir::OpResult tensor_to_array(pir::Value x,
-                              pir::Value out_grad,
-                              int axis,
-                              bool use_stack) {
+pir::Value tensor_to_array(pir::Value x,
+                           pir::Value out_grad,
+                           int axis,
+                           bool use_stack) {
   auto tensor_to_array = ApiBuilder::Instance()
                              .GetBuilder()
                              ->Build<paddle::dialect::TensorToArrayOp>(
@@ -184,7 +182,7 @@ pir::OpResult tensor_to_array(pir::Value x,
   return tensor_to_array.result(0);
 }
 
-pir::OpResult add_n_array(const std::vector<pir::Value>& inputs) {
+pir::Value add_n_array(const std::vector<pir::Value>& inputs) {
   auto inputs_combine_op =
       ApiBuilder::Instance().GetBuilder()->Build<pir::CombineOp>(inputs);
   paddle::dialect::AddNArrayOp add_n_array_op =
@@ -193,14 +191,14 @@ pir::OpResult add_n_array(const std::vector<pir::Value>& inputs) {
   return add_n_array_op.result(0);
 }
 
-pir::OpResult slice_array_dense(pir::Value input, pir::Value starts) {
+pir::Value slice_array_dense(pir::Value input, pir::Value starts) {
   auto op = ApiBuilder::Instance()
                 .GetBuilder()
                 ->Build<paddle::dialect::SliceArrayDenseOp>(input, starts);
   return op.result(0);
 }
 
-pir::OpResult assign(const pir::Value& x) {
+pir::Value assign(const pir::Value& x) {
   CheckValueDataType(x, "x", "assign");
   if (x.type().isa<paddle::dialect::DenseTensorType>()) {
     paddle::dialect::AssignOp assign_op =

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -23,67 +23,67 @@
 namespace paddle {
 namespace dialect {
 
-pir::OpResult builtin_combine(const std::vector<pir::Value>& x);
+pir::Value builtin_combine(const std::vector<pir::Value>& x);
 
-std::vector<pir::OpResult> add_n_grad(const std::vector<pir::Value>& inputs,
-                                      const pir::Value& out_grad);
+std::vector<pir::Value> add_n_grad(const std::vector<pir::Value>& inputs,
+                                   const pir::Value& out_grad);
 
-pir::OpResult zeros_like(const pir::Value& x,
-                         phi::DataType dtype = phi::DataType::UNDEFINED,
-                         const Place& place = {});
+pir::Value zeros_like(const pir::Value& x,
+                      phi::DataType dtype = phi::DataType::UNDEFINED,
+                      const Place& place = {});
 
-pir::OpResult parameter(const std::string& name);
+pir::Value parameter(const std::string& name);
 
 void set_parameter(const pir::Value& parameter, const std::string& name);
 
-pir::OpResult embedding_grad(const pir::Value& x,
-                             const pir::Value& weight,
-                             const pir::Value& out_grad,
-                             int64_t padding_idx = -1,
-                             bool sparse = false);
+pir::Value embedding_grad(const pir::Value& x,
+                          const pir::Value& weight,
+                          const pir::Value& out_grad,
+                          int64_t padding_idx = -1,
+                          bool sparse = false);
 
-pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
-                                  int axis);
+pir::Value split_with_num_grad(const std::vector<pir::Value>& out_grad,
+                               int axis);
 
-pir::OpResult split_with_num_grad(const std::vector<pir::Value>& out_grad,
-                                  const pir::Value& axis);
+pir::Value split_with_num_grad(const std::vector<pir::Value>& out_grad,
+                               const pir::Value& axis);
 
-pir::OpResult ones(const std::vector<int64_t>& shape,
-                   phi::DataType dtype = phi::DataType::FLOAT32,
-                   const Place& place = phi::CPUPlace());
+pir::Value ones(const std::vector<int64_t>& shape,
+                phi::DataType dtype = phi::DataType::FLOAT32,
+                const Place& place = phi::CPUPlace());
 
-pir::OpResult ones_like(pir::Value x_,
-                        phi::DataType dtype = phi::DataType::UNDEFINED,
-                        const Place& place = {});
+pir::Value ones_like(pir::Value x_,
+                     phi::DataType dtype = phi::DataType::UNDEFINED,
+                     const Place& place = {});
 
-pir::OpResult zeros(const std::vector<int64_t>& shape,
-                    phi::DataType dtype = phi::DataType::FLOAT32,
-                    const Place& place = phi::CPUPlace());
+pir::Value zeros(const std::vector<int64_t>& shape,
+                 phi::DataType dtype = phi::DataType::FLOAT32,
+                 const Place& place = phi::CPUPlace());
 
-pir::OpResult create_array(phi::DataType dtype);
+pir::Value create_array(phi::DataType dtype);
 
-pir::OpResult create_array_like(pir::Value input, float value);
+pir::Value create_array_like(pir::Value input, float value);
 
-pir::OpResult array_length(pir::Value x);
+pir::Value array_length(pir::Value x);
 
-pir::OpResult array_read(pir::Value array, pir::Value i);
+pir::Value array_read(pir::Value array, pir::Value i);
 
-pir::OpResult array_write_(pir::Value array, pir::Value x, pir::Value i);
+pir::Value array_write_(pir::Value array, pir::Value x, pir::Value i);
 
-std::tuple<pir::OpResult, pir::OpResult> array_to_tensor(pir::Value x,
-                                                         int axis,
-                                                         bool use_stack);
+std::tuple<pir::Value, pir::Value> array_to_tensor(pir::Value x,
+                                                   int axis,
+                                                   bool use_stack);
 
-pir::OpResult tensor_to_array(pir::Value x,
-                              pir::Value out_grad,
-                              int axis,
-                              bool use_stack);
+pir::Value tensor_to_array(pir::Value x,
+                           pir::Value out_grad,
+                           int axis,
+                           bool use_stack);
 
-pir::OpResult add_n_array(const std::vector<pir::Value>& inputs);
+pir::Value add_n_array(const std::vector<pir::Value>& inputs);
 
-pir::OpResult slice_array_dense(pir::Value input, pir::Value starts);
+pir::Value slice_array_dense(pir::Value input, pir::Value starts);
 
-pir::OpResult assign(const pir::Value& x);
+pir::Value assign(const pir::Value& x);
 
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -1417,7 +1417,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   // Generate scalar mutable attribute: axis
   paddle::dialect::FullOp full_axis_op = builder.Build<paddle::dialect::FullOp>(
       std::vector<int64_t>{1}, axis, phi::DataType::FLOAT32, phi::CPUPlace());
-  pir::OpResult axis_ = full_axis_op->result(0);
+  pir::Value axis_ = full_axis_op->result(0);
 
   VLOG(4) << "Builder construction inputs";
   std::vector<pir::Value> argument_inputs = {out_grad_, axis_};
@@ -1521,8 +1521,7 @@ std::vector<pir::Type> SplitGradOp::InferMeta(
 
   VLOG(4) << "Builder construction outputs";
   pir::VectorType out_grad = out_grad_.type().dyn_cast<pir::VectorType>();
-  int axis = axis_.dyn_cast<pir::OpResult>()
-                 .owner()
+  int axis = axis_.defining_op()
                  ->dyn_cast<paddle::dialect::FullOp>()
                  .attribute<paddle::dialect::ScalarAttribute>("value")
                  .data()
@@ -2100,11 +2099,10 @@ std::vector<pir::Type> ArrayReadOp::InferMeta(
   paddle::dialect::IrMetaTensor meta_array(&dense_array);
 
   phi::Scalar i_scalar;
-  if (i_.dyn_cast<pir::OpResult>() &&
-      i_.dyn_cast<pir::OpResult>().owner()->isa<paddle::dialect::FullOp>()) {
+  if (i_.isa<pir::OpResult>() &&
+      i_.defining_op()->isa<paddle::dialect::FullOp>()) {
     i_scalar =
-        std::move(phi::Scalar(i_.dyn_cast<pir::OpResult>()
-                                  .owner()
+        std::move(phi::Scalar(i_.defining_op()
                                   ->dyn_cast<paddle::dialect::FullOp>()
                                   .attribute("value")
                                   .dyn_cast<paddle::dialect::ScalarAttribute>()
@@ -3022,12 +3020,9 @@ std::vector<pir::Type> SliceArrayDenseOp::InferMeta(
   paddle::dialect::IrMetaTensor meta_input(&dense_input);
 
   phi::IntArray starts_list;
-  if (starts.dyn_cast<pir::OpResult>()
-          .owner()
-          ->isa<paddle::dialect::FullIntArrayOp>()) {
+  if (starts.defining_op()->isa<paddle::dialect::FullIntArrayOp>()) {
     starts_list = std::move(phi::IntArray(paddle::dialect::GetInt64Vector(
-        starts.dyn_cast<pir::OpResult>()
-            .owner()
+        starts.defining_op()
             ->dyn_cast<paddle::dialect::FullIntArrayOp>()
             .attribute("value"))));
   } else if (starts.type().isa<pir::VectorType>()) {
@@ -3410,7 +3405,7 @@ void ExpandOp::Build(pir::Builder &builder,
   paddle::dialect::FullIntArrayOp full_shape_op =
       builder.Build<paddle::dialect::FullIntArrayOp>(
           shape, phi::DataType::INT64, phi::CPUPlace());
-  pir::OpResult shape_ = full_shape_op->result(0);
+  pir::Value shape_ = full_shape_op->result(0);
 
   VLOG(4) << "Builder construction inputs";
   std::vector<pir::Value> argument_inputs = {x_, shape_};
@@ -3443,7 +3438,7 @@ void ExpandOp::Build(pir::Builder &builder,
   paddle::dialect::FullIntArrayOp full_shape_op =
       builder.Build<paddle::dialect::FullIntArrayOp>(
           shape, phi::DataType::INT64, phi::CPUPlace());
-  pir::OpResult shape_ = full_shape_op->result(0);
+  pir::Value shape_ = full_shape_op->result(0);
 
   VLOG(4) << "Builder construction inputs";
   std::vector<pir::Value> argument_inputs = {x_, shape_};
@@ -3570,12 +3565,9 @@ std::vector<pir::Type> ExpandOp::InferMeta(
   }
 
   phi::IntArray shape;
-  if (shape_.dyn_cast<pir::OpResult>()
-          .owner()
-          ->isa<paddle::dialect::FullIntArrayOp>()) {
+  if (shape_.defining_op()->isa<paddle::dialect::FullIntArrayOp>()) {
     shape = std::move(phi::IntArray(paddle::dialect::GetInt64Vector(
-        shape_.dyn_cast<pir::OpResult>()
-            .owner()
+        shape_.defining_op()
             ->dyn_cast<paddle::dialect::FullIntArrayOp>()
             .attribute("value"))));
   } else if (shape_.type().isa<pir::VectorType>()) {
@@ -4153,7 +4145,7 @@ bool ShapeBroadcastOp::InferSymbolicShape(
     output_data.emplace_back(GetBroadcastDimExpr(x_data.at(i), y_data.at(i)));
   }
 
-  pir::OpResult res = result(0);
+  pir::Value res = result(0);
   // TODO(HongyuJia): use op->result(0) to infer the shape
   std::vector<symbol::DimExpr> shape(std::int64_t(output_data.size()));
   symbol::ShapeOrDataDimExprs output_data_shape{shape, output_data};

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -51,7 +51,7 @@ class AddNOp : public pir::Op<AddNOp,
 
   void VerifySig();
   pir::Value inputs() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -82,7 +82,7 @@ class AddN_Op : public pir::Op<AddN_Op,
 
   void VerifySig();
   pir::Value inputs() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -105,7 +105,7 @@ class AddNWithKernelOp : public pir::Op<AddNWithKernelOp,
 
   void VerifySig();
   pir::Value inputs() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -128,7 +128,7 @@ class AddNArrayOp : public pir::Op<AddNArrayOp,
 
   void VerifySig();
   pir::Value inputs() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -157,8 +157,8 @@ class FusedGemmEpilogueOp
   pir::Value x() { return operand_source(0); }
   pir::Value y() { return operand_source(1); }
   pir::Value bias() { return operand_source(2); }
-  pir::OpResult out() { return result(0); }
-  pir::OpResult reserve_space() { return result(1); }
+  pir::Value out() { return result(0); }
+  pir::Value reserve_space() { return result(1); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -189,9 +189,9 @@ class FusedGemmEpilogueGradOp
   pir::Value y() { return operand_source(1); }
   pir::Value reserve_space() { return operand_source(2); }
   pir::Value out_grad() { return operand_source(3); }
-  pir::OpResult x_grad() { return result(0); }
-  pir::OpResult y_grad() { return result(1); }
-  pir::OpResult bias_grad() { return result(2); }
+  pir::Value x_grad() { return result(0); }
+  pir::Value y_grad() { return result(1); }
+  pir::Value bias_grad() { return result(2); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -218,7 +218,7 @@ class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
   void VerifySig();
   pir::Value out_grad() { return operand_source(0); }
   pir::Value axis() { return operand_source(1); }
-  pir::OpResult x_grad() { return result(0); }
+  pir::Value x_grad() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -237,7 +237,7 @@ class CreateArrayOp
                     pir::OperationArgument &argument,  // NOLINT
                     phi::DataType dtype = phi::DataType::FLOAT32);
   void VerifySig();
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -259,7 +259,7 @@ class CreateArrayLikeOp : public pir::Op<CreateArrayLikeOp,
                     float &val);                       // NOLINT
   void VerifySig();
   pir::Value input() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -279,7 +279,7 @@ class ArrayLengthOp
                     pir::Value x);
   void VerifySig();
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -307,7 +307,7 @@ class ArrayReadOp : public pir::Op<ArrayReadOp,
   void VerifySig();
   pir::Value array() { return operand_source(0); }
   pir::Value i() { return operand_source(1); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -340,7 +340,7 @@ class ArrayWrite_Op : public pir::Op<ArrayWrite_Op,
   pir::Value array() { return operand_source(0); }
   pir::Value x() { return operand_source(1); }
   pir::Value i() { return operand_source(2); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -370,8 +370,8 @@ class ArrayToTensorOp : public pir::Op<ArrayToTensorOp,
                     bool use_stack);
   void VerifySig();
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
-  pir::OpResult out_index() { return result(1); }
+  pir::Value out() { return result(0); }
+  pir::Value out_index() { return result(1); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -401,7 +401,7 @@ class TensorToArrayOp
   void VerifySig();
   pir::Value x() { return operand_source(0); }
   pir::Value out_grad() { return operand_source(1); }
-  pir::OpResult x_grad() { return result(0); }
+  pir::Value x_grad() { return result(0); }
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
@@ -428,7 +428,7 @@ class SliceArrayOp
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value input() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -460,7 +460,7 @@ class SliceArrayDenseOp
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value input() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -491,7 +491,7 @@ class AssignArrayOp
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -519,7 +519,7 @@ class AssignArray_Op
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -563,7 +563,7 @@ class ExpandOp : public pir::Op<ExpandOp,
 
   pir::Value x() { return operand_source(0); }
   pir::Value shape() { return operand_source(1); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -608,7 +608,7 @@ class IncrementOp
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -653,7 +653,7 @@ class Increment_Op
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -696,7 +696,7 @@ class MemcpyD2hMultiIoOp
       const phi::DataType &expected_kernel_dtype);
 
   pir::Value x() { return operand_source(0); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
@@ -722,7 +722,7 @@ class IR_API ShapeBroadcastOp
 
   pir::Value x() { return operand_source(0); }
   pir::Value y() { return operand_source(1); }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -97,7 +97,7 @@ struct ParameterOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(
       pir::Operation* op, pir::ShapeConstraintIRAnalysis* shape_analysis) {
-    pir::OpResult res0 = op->result(0);
+    pir::Value res0 = op->result(0);
 
     std::vector<int64_t> dims =
         common::vectorize(res0.type().dyn_cast<pir::DenseTensorType>().dims());

--- a/paddle/fluid/pir/transforms/fusion/conv2d_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/conv2d_add_act_fuse_pass.cc
@@ -39,13 +39,13 @@ class Conv2dAddActFusePattern
             ->dyn_cast<paddle::dialect::Conv2dOp>();
     if (!conv2d_op) return false;
 
-    pir::OpResult conv2d_out = conv2d_op.out();
+    pir::Value conv2d_out = conv2d_op.out();
     if (!conv2d_out.HasOneUse()) return false;
 
     pir::Value add_input = op.x();
     IR_ENFORCE(add_input == conv2d_out);
 
-    pir::OpResult add_out = op.out();
+    pir::Value add_out = op.out();
     if (!add_out.HasOneUse()) return false;
 
     auto next_op_list = pir::GetUseOpsForOutput(op, 0);
@@ -72,12 +72,12 @@ class Conv2dAddActFusePattern
     op_attributes["exhaustive_search"] = rewriter.bool_attr(false);
     op_attributes["workspace_size_MB"] = rewriter.int32_attr(32);
     op_attributes["fuse_alpha"] = rewriter.float_attr(0.0f);
-    auto conv2d_fuse_op = rewriter.Build<paddle::dialect::FusedConv2dAddActOp>(
-        conv2d_op.input().dyn_cast<pir::OpResult>(),
-        conv2d_op.filter().dyn_cast<pir::OpResult>(),
-        op.y().dyn_cast<pir::OpResult>(),
-        pir::Value{}.dyn_cast<pir::OpResult>(),
-        op_attributes);
+    auto conv2d_fuse_op =
+        rewriter.Build<paddle::dialect::FusedConv2dAddActOp>(conv2d_op.input(),
+                                                             conv2d_op.filter(),
+                                                             op.y(),
+                                                             pir::Value{},
+                                                             op_attributes);
     rewriter.ReplaceOp(next_op,
                        std::vector<pir::Value>{conv2d_fuse_op.output()});
     rewriter.EraseOp(op);
@@ -98,7 +98,7 @@ class Conv2dAdd2ActFusePattern
                                          ->dyn_cast<paddle::dialect::AddOp>();
     if (!add1_op) return false;
 
-    pir::OpResult add1_out = add1_op.out();
+    pir::Value add1_out = add1_op.out();
     if (!add1_out.HasOneUse()) return false;
 
     paddle::dialect::Conv2dOp conv2d_op =
@@ -106,7 +106,7 @@ class Conv2dAdd2ActFusePattern
             ->dyn_cast<paddle::dialect::Conv2dOp>();
     if (!conv2d_op) return false;
 
-    pir::OpResult conv2d_out = conv2d_op.out();
+    pir::Value conv2d_out = conv2d_op.out();
     if (!conv2d_out.HasOneUse()) return false;
 
     auto next_op_list = pir::GetUseOpsForOutput(add2_op, 0);
@@ -135,12 +135,12 @@ class Conv2dAdd2ActFusePattern
     op_attributes["exhaustive_search"] = rewriter.bool_attr(false);
     op_attributes["workspace_size_MB"] = rewriter.int32_attr(32);
     op_attributes["fuse_alpha"] = rewriter.float_attr(0.0f);
-    auto conv2d_fuse_op = rewriter.Build<paddle::dialect::FusedConv2dAddActOp>(
-        conv2d_op.input().dyn_cast<pir::OpResult>(),
-        conv2d_op.filter().dyn_cast<pir::OpResult>(),
-        add1_op.y().dyn_cast<pir::OpResult>(),
-        add2_op.x().dyn_cast<pir::OpResult>(),
-        op_attributes);
+    auto conv2d_fuse_op =
+        rewriter.Build<paddle::dialect::FusedConv2dAddActOp>(conv2d_op.input(),
+                                                             conv2d_op.filter(),
+                                                             add1_op.y(),
+                                                             add2_op.x(),
+                                                             op_attributes);
     rewriter.ReplaceOp(next_op,
                        std::vector<pir::Value>{conv2d_fuse_op.output()});
 

--- a/paddle/fluid/pir/transforms/fusion/conv2d_bn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/fusion/conv2d_bn_fuse_pass.cc
@@ -36,13 +36,12 @@ class Conv2dBnFusePattern
             ->dyn_cast<paddle::dialect::Conv2dOp>();
     if (!conv2d_op) return false;
 
-    pir::OpResult conv2d_out = conv2d_op.out();
+    pir::Value conv2d_out = conv2d_op.out();
     if (!conv2d_out.HasOneUse()) return false;
 
     pir::Value conv2d_filter = conv2d_op.filter();
 
-    pir::OpResult conv2d_filter_result =
-        conv2d_filter.dyn_cast<pir::OpResult>();
+    pir::Value conv2d_filter_result = conv2d_filter;
     IR_ENFORCE(conv2d_filter_result);
 
     pir::Value bn_input = op.x();
@@ -60,13 +59,12 @@ class Conv2dBnFusePattern
     float epsilon = op.attribute<pir::FloatAttribute>("epsilon").data();
     paddle::dialect::FullOp full_op = rewriter.Build<paddle::dialect::FullOp>(
         common::vectorize(bn_variance_shape), epsilon);
-    paddle::dialect::AddOp add_op = rewriter.Build<paddle::dialect::AddOp>(
-        bn_variance.dyn_cast<pir::OpResult>(), full_op.out());
+    paddle::dialect::AddOp add_op =
+        rewriter.Build<paddle::dialect::AddOp>(bn_variance, full_op.out());
     paddle::dialect::SqrtOp sqrt_op =
         rewriter.Build<paddle::dialect::SqrtOp>(add_op.out());
     paddle::dialect::DivideOp div_op =
-        rewriter.Build<paddle::dialect::DivideOp>(
-            bn_scale.dyn_cast<pir::OpResult>(), sqrt_op.out());
+        rewriter.Build<paddle::dialect::DivideOp>(bn_scale, sqrt_op.out());
     // reshape scale
     auto conv2d_filter_shape = pir::GetShapeFromValue(conv2d_filter);
     auto bn_scale_shape = pir::GetShapeFromValue(bn_scale);
@@ -82,18 +80,14 @@ class Conv2dBnFusePattern
 
     auto conv2d_attributes = conv2d_op->attributes();
     auto new_conv2d_op = rewriter.Build<paddle::dialect::Conv2dOp>(
-        conv2d_op.input().dyn_cast<pir::OpResult>(),
-        mul_op.out(),
-        conv2d_attributes);
+        conv2d_op.input(), mul_op.out(), conv2d_attributes);
 
     // --- deal with bias ---
     paddle::dialect::MultiplyOp mul_bias_op =
-        rewriter.Build<paddle::dialect::MultiplyOp>(
-            bn_mean.dyn_cast<pir::OpResult>(), div_op.out());
+        rewriter.Build<paddle::dialect::MultiplyOp>(bn_mean, div_op.out());
     // new bias --> sub_op.out()
     paddle::dialect::SubtractOp sub_op =
-        rewriter.Build<paddle::dialect::SubtractOp>(
-            bn_bias.dyn_cast<pir::OpResult>(), mul_bias_op.out());
+        rewriter.Build<paddle::dialect::SubtractOp>(bn_bias, mul_bias_op.out());
     // reshape new bias
     auto new_conv2d_out_shape = pir::GetShapeFromValue(new_conv2d_op.out());
     std::vector<int64_t> new_bias_new_shape(new_conv2d_out_shape.size(), 1);
@@ -124,13 +118,13 @@ class BatchNormReplacePattern
   bool MatchAndRewrite(
       paddle::dialect::BatchNormOp op,
       pir::PatternRewriter &rewriter) const override {  // NOLINT
-    auto bn_op = rewriter.Build<paddle::dialect::BatchNorm_Op>(
-        op.x().dyn_cast<pir::OpResult>(),
-        op.mean().dyn_cast<pir::OpResult>(),
-        op.variance().dyn_cast<pir::OpResult>(),
-        op.scale().dyn_cast<pir::OpResult>(),
-        op.bias().dyn_cast<pir::OpResult>(),
-        op->attributes());
+    auto bn_op =
+        rewriter.Build<paddle::dialect::BatchNorm_Op>(op.x(),
+                                                      op.mean(),
+                                                      op.variance(),
+                                                      op.scale(),
+                                                      op.bias(),
+                                                      op->attributes());
     rewriter.ReplaceAllUsesWith(op.out(), bn_op.out());
     rewriter.EraseOp(op);
     return true;

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -355,12 +355,12 @@ static std::vector<std::shared_ptr<phi::TensorBase>> PrepareFakeTensors(
   return res;
 }
 
-static pir::OpResult AddPlaceTransferOp(pir::Value in,
-                                        pir::Type out_type,
-                                        const phi::Place& src_place,
-                                        const phi::Place& dst_place,
-                                        const phi::KernelKey& kernel_key,
-                                        pir::Block* block) {
+static pir::Value AddPlaceTransferOp(pir::Value in,
+                                     pir::Type out_type,
+                                     const phi::Place& src_place,
+                                     const phi::Place& dst_place,
+                                     const phi::KernelKey& kernel_key,
+                                     pir::Block* block) {
   pir::IrContext* ctx = pir::IrContext::Instance();
 
   auto copy_kernel_key = kernel_key;
@@ -393,7 +393,7 @@ static pir::OpResult AddPlaceTransferOp(pir::Value in,
   pir::OpInfo kernel_op_info = ctx->GetRegisteredOpInfo(PhiKernelOp::name());
   pir::Operation* op =
       pir::Operation::Create({in}, op_attribute, {out_type}, kernel_op_info);
-  auto in_op = in.dyn_cast<pir::OpResult>().owner();
+  auto in_op = in.defining_op();
   if (in_op && in_op->HasAttribute(kAttrIsPersisable)) {
     op->set_attribute(kAttrIsPersisable, in_op->attribute(kAttrIsPersisable));
   }
@@ -403,7 +403,7 @@ static pir::OpResult AddPlaceTransferOp(pir::Value in,
 }
 
 #ifdef PADDLE_WITH_DNNL
-static pir::OpResult AddOneDNN2PaddleLayoutTransferOp(
+static pir::Value AddOneDNN2PaddleLayoutTransferOp(
     pir::Value in, const phi::DataLayout& dst_layout, pir::Block* block) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   auto in_alloc_type = in.type().dyn_cast<AllocatedDenseTensorType>();
@@ -433,7 +433,7 @@ static pir::OpResult AddOneDNN2PaddleLayoutTransferOp(
   pir::Operation* op =
       pir::Operation::Create({in}, op_attribute, {out_type}, kernel_op_info);
 
-  auto in_op = in.dyn_cast<pir::OpResult>().owner();
+  auto in_op = in.defining_op();
   if (in_op && in_op->HasAttribute(kAttrIsPersisable)) {
     op->set_attribute(kAttrIsPersisable, in_op->attribute(kAttrIsPersisable));
   }
@@ -572,13 +572,13 @@ static pir::Type BuildOutputType(pir::Type type,
 }
 #endif
 
-pir::OpResult AddDtypeTransferOp(pir::Value in,
-                                 pir::Block* block,
-                                 const phi::KernelKey& kernel_key,
-                                 const phi::Place& origin_place,
-                                 const phi::Place& out_place,
-                                 const phi::DataType& src_dtype,
-                                 const phi::DataType& dst_dtype) {
+pir::Value AddDtypeTransferOp(pir::Value in,
+                              pir::Block* block,
+                              const phi::KernelKey& kernel_key,
+                              const phi::Place& origin_place,
+                              const phi::Place& out_place,
+                              const phi::DataType& src_dtype,
+                              const phi::DataType& dst_dtype) {
   pir::IrContext* ctx = pir::IrContext::Instance();
 
   pir::OpInfo kernel_op_info = ctx->GetRegisteredOpInfo(PhiKernelOp::name());
@@ -620,12 +620,12 @@ pir::OpResult AddDtypeTransferOp(pir::Value in,
   pir::Operation* op = pir::Operation::Create(
       {in}, op_attribute, {output_types}, kernel_op_info);
 
-  auto in_op = in.dyn_cast<pir::OpResult>().owner();
+  auto in_op = in.defining_op();
   if (in_op && in_op->HasAttribute(kAttrIsPersisable)) {
     op->set_attribute(kAttrIsPersisable, in_op->attribute(kAttrIsPersisable));
   }
   block->push_back(op);
-  pir::OpResult new_in = op->result(0);
+  pir::Value new_in = op->result(0);
   return new_in;
 }
 
@@ -980,7 +980,7 @@ phi::KernelKey GetKernelKey(
         continue;
       }
       if (op_res.owner()->isa<DataOp>()) {
-        auto data_op = op->operand_source(i).dyn_cast<pir::OpResult>().owner();
+        auto data_op = op->operand_source(i).defining_op();
         auto data_place = data_op->attribute<PlaceAttribute>("place").data();
 
         auto data_op_backend = paddle::experimental::ParseBackend(data_place);
@@ -1995,7 +1995,7 @@ std::vector<pir::Value> BuildInputs(
       } else if (new_in_type.isa<pir::VectorType>()) {
         // [ todo need update here, support combine data transfomer]
         // deal with pre combine op
-        auto pre_define_op = cur_in.dyn_cast<pir::OpResult>().owner();
+        auto pre_define_op = cur_in.defining_op();
         if (pre_define_op->isa<::pir::CombineOp>()) {
           std::vector<pir::Value> inner_inputs;
           std::vector<pir::Type> types_in_vec;

--- a/paddle/fluid/pir/transforms/shape_optimization_pass.cc
+++ b/paddle/fluid/pir/transforms/shape_optimization_pass.cc
@@ -38,7 +38,7 @@ void DebugPrintOpInfo(
   for (auto& res : op->results()) {
     std::ostringstream print_stream;
 
-    print_stream << "  result(" << res.index() << ") "
+    print_stream << "  result(" << res.dyn_cast<pir::OpResult>().index() << ") "
                  << "ShapeOrData: {";
 
     if (shape_analysis != nullptr) {

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -496,7 +496,7 @@ void ReplaceWithGroupOp(pir::Block* block,
   }
 
   // step 3: Replace outputs of inner ops
-  std::vector<pir::OpResult> group_outs = new_group_op->results();
+  std::vector<pir::Value> group_outs = new_group_op->results();
   std::unordered_set<pir::Operation*> inner_ops(group_ops.begin(),
                                                 group_ops.end());
   for (size_t i = 0; i < outputs.size(); ++i) {

--- a/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
+++ b/paddle/fluid/primitive/backend/manual/manual_static_backend.cc
@@ -36,12 +36,10 @@ std::vector<Tensor> add_n_grad<LazyTensor>(const std::vector<Tensor>& x,
   auto op_res = paddle::dialect::add_n_grad(x_res, out_grad_res);
 
   std::vector<Tensor> x_grad(op_res.size());
-  std::transform(op_res.begin(),
-                 op_res.end(),
-                 x_grad.begin(),
-                 [](const pir::OpResult& res) {
-                   return Tensor(std::make_shared<LazyTensor>(res));
-                 });
+  std::transform(
+      op_res.begin(), op_res.end(), x_grad.begin(), [](const pir::Value& res) {
+        return Tensor(std::make_shared<LazyTensor>(res));
+      });
   return x_grad;
 }
 

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -120,7 +120,7 @@ bool DecompProgram::check_decomp_dynamic_shape(pir::Operation* op) {
 
 void DecompProgram::check_decomp_outputs(
     const std::string& op_name,
-    const std::vector<pir::OpResult>& orig_outs,
+    const std::vector<pir::Value>& orig_outs,
     const std::vector<pir::Value>& decomp_outs) {
   bool skip_invalid_op_check =
       decomp_op_contain_none.find(op_name) != decomp_op_contain_none.end();
@@ -189,7 +189,7 @@ void DecompProgram::check_decomp_outputs(
 
 std::vector<pir::Value> DecompProgram::format_decomp_res(
     const std::string& op_name,
-    const std::vector<pir::OpResult>& orig_outs,
+    const std::vector<pir::Value>& orig_outs,
     const std::vector<std::vector<pir::Value>>& decomp_outs) {
   PADDLE_ENFORCE_EQ(
       orig_outs.size(),
@@ -220,7 +220,7 @@ std::vector<pir::Value> DecompProgram::format_decomp_res(
 
 std::vector<pir::Value> DecompProgram::construct_dst_vars(
     const std::string& op_name,
-    const std::vector<pir::OpResult>& orig_outs,
+    const std::vector<pir::Value>& orig_outs,
     const std::vector<pir::Value>& decomp_outs,
     std::unordered_map<pir::Value, int> orig_vars_dict) {
   std::vector<pir::Value> tar_vars(src_vars_.size());
@@ -309,7 +309,7 @@ void DecompProgram::decomp_program() {
       auto& builder = *(paddle::dialect::ApiBuilder::Instance().GetBuilder());
       builder.set_insertion_point(op);
       std::vector<std::vector<pir::Value>> decomp_res = call_decomp_rule(op);
-      std::vector<pir::OpResult> orig_outs = op->results();
+      std::vector<pir::Value> orig_outs = op->results();
       std::vector<pir::Value> standard_decomp_res =
           format_decomp_res(op->name(), orig_outs, decomp_res);
       check_decomp_outputs(op->name(), orig_outs, standard_decomp_res);

--- a/paddle/fluid/primitive/base/decomp_trans.h
+++ b/paddle/fluid/primitive/base/decomp_trans.h
@@ -40,15 +40,15 @@ class DecompProgram {
   void decomp_program();
   bool check_decomp_dynamic_shape(pir::Operation* op);
   void check_decomp_outputs(const std::string& op_name,
-                            const std::vector<pir::OpResult>& orig_outs,
+                            const std::vector<pir::Value>& orig_outs,
                             const std::vector<pir::Value>& decomp_outs);
   std::vector<pir::Value> format_decomp_res(
       const std::string& op_name,
-      const std::vector<pir::OpResult>& orig_outs,
+      const std::vector<pir::Value>& orig_outs,
       const std::vector<std::vector<pir::Value>>& decomp_outs);
   std::vector<pir::Value> construct_dst_vars(
       const std::string& op_name,
-      const std::vector<pir::OpResult>& orig_outs,
+      const std::vector<pir::Value>& orig_outs,
       const std::vector<pir::Value>& decomp_outs,
       std::unordered_map<pir::Value, int> orig_vars_dict);
   bool enable_decomp_by_filter(const std::string& op_name);

--- a/paddle/fluid/primitive/codegen/templates/backend/generated/generated_static_backend.cc.j2
+++ b/paddle/fluid/primitive/codegen/templates/backend/generated/generated_static_backend.cc.j2
@@ -59,7 +59,7 @@ if(op_res){
 return {{outputs[0].name}};
     {%- elif outputs[0].typename == 'Tensor[]' and not outputs[0].optional -%}
 std::vector<Tensor> {{outputs[0].name}}(op_res.size());
-std::transform(op_res.begin(), op_res.end(), {{outputs[0].name}}.begin(), [](const pir::OpResult& res) {
+std::transform(op_res.begin(), op_res.end(), {{outputs[0].name}}.begin(), [](const pir::Value& res) {
 return Tensor(std::make_shared<LazyTensor>(res));
   });
 return {{outputs[0].name}};
@@ -67,7 +67,7 @@ return {{outputs[0].name}};
 paddle::optional<std::vector<Tensor>> {{outputs[0].name}};
 if({{op_res}}) {
   std::vector<pir::Value> {{outputs[0].name}}_inner(op_res.get().size());
-  std::transform(op_res.get().begin(), op_res.get().end(), {{outputs[0].name}}_inner.begin(), [](const pir::OpResult& res) {
+  std::transform(op_res.get().begin(), op_res.get().end(), {{outputs[0].name}}_inner.begin(), [](const pir::Value& res) {
     return Tensor(std::make_shared<LazyTensor>(res));
   });
   {{outputs[0].name}} = paddle::make_optional<std::vector<Tensor>>({{outputs[0].name}}_inner);
@@ -87,14 +87,14 @@ if(op_res_{{i}}){
 }
       {% elif outputs[i].typename == 'Tensor[]' and not outputs[i].optional %}
 std::vector<Tensor> {{outputs[i].name}}(op_res_{{i}}.size());
-std::transform(op_res_{{i}}.begin(), op_res_{{i}}.end(), {{outputs[i].name}}.begin(), [](const pir::OpResult& res) {
+std::transform(op_res_{{i}}.begin(), op_res_{{i}}.end(), {{outputs[i].name}}.begin(), [](const pir::Value& res) {
 return Tensor(std::make_shared<LazyTensor>(res));
   });
       {% elif outputs[i].typename == 'Tensor[]' and outputs[i].optional %}
 paddle::optional<std::vector<Tensor>> {{outputs[i].name}};
 if(op_res_{{i}}){
   std::vector<Tensor> {{outputs[i].name}}_inner(op_res_{{i}}.get().size());
-  std::transform(op_res_{{i}}.get().begin(), op_res_{{i}}.get().end(), {{outputs[i].name}}_inner.begin(), [](const pir::OpResult& res) {
+  std::transform(op_res_{{i}}.get().begin(), op_res_{{i}}.get().end(), {{outputs[i].name}}_inner.begin(), [](const pir::Value& res) {
     return Tensor(std::make_shared<LazyTensor>(res));
   });
   {{outputs[i].name}} = paddle::make_optional<std::vector<Tensor>>({{outputs[i].name}}_inner);
@@ -113,7 +113,7 @@ return std::make_tuple({%- for i in range(outputs|length) -%}{{outputs[i].name}}
 {{prepare_ir_api_inputs(inputs)}}
   {%- for attr in attrs %}
     {% if mutable_attribute_as_inputs and attr is mutable_attribute %}
-pir::OpResult {{attr.name}}_res = std::static_pointer_cast<LazyTensor>({{attr.name~'_'}}.impl())->value().dyn_cast<pir::OpResult>();
+pir::Value {{attr.name}}_res = std::static_pointer_cast<LazyTensor>({{attr.name~'_'}}.impl())->value();
     {% endif %}
   {% endfor %}
   {%- set input_names = [] -%}

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1092,16 +1092,6 @@ PyObject* ToPyObject(const std::vector<pir::Value>& value) {
   return result;
 }
 
-PyObject* ToPyObject(const std::vector<pir::OpResult>& value) {
-  PyObject* result = PyList_New((Py_ssize_t)value.size());
-
-  for (size_t i = 0; i < value.size(); i++) {
-    PyList_SET_ITEM(result, static_cast<Py_ssize_t>(i), ToPyObject(value[i]));
-  }
-
-  return result;
-}
-
 PyObject* ToPyObject(const phi::distributed::DistTensor* value) {
 #ifdef PADDLE_WITH_DISTRIBUTE
   auto obj = ::pybind11::cast(value, py::return_value_policy::reference);

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -157,7 +157,6 @@ PyObject* ToPyObject(const paddle::framework::Vocab& value);
 PyObject* ToPyObject(std::shared_ptr<egr::GradNodeBase> grad_node);
 PyObject* ToPyObject(const pir::Value& value);
 PyObject* ToPyObject(const std::vector<pir::Value>& value);
-PyObject* ToPyObject(const std::vector<pir::OpResult>& value);
 
 class PyTensorHook : public egr::TensorHook {
  public:

--- a/paddle/pir/core/builtin_op.h
+++ b/paddle/pir/core/builtin_op.h
@@ -123,7 +123,7 @@ class IR_API CombineOp : public pir::Op<CombineOp> {
     }
     return inputs;
   }
-  pir::OpResult out() { return result(0); }
+  pir::Value out() { return result(0); }
 };
 
 ///
@@ -172,8 +172,8 @@ class IR_API SplitOp : public pir::Op<SplitOp> {
 
   void VerifySig() const;
   pir::Value input() { return operand_source(0); }
-  std::vector<OpResult> outputs() {
-    std::vector<OpResult> res;
+  std::vector<Value> outputs() {
+    std::vector<Value> res;
     for (uint32_t idx = 0; idx < num_results(); idx++) {
       res.push_back(result(idx));
     }
@@ -208,7 +208,7 @@ class IR_API ConstantOp : public Op<ConstantOp, ConstantLikeTrait> {
                     Type output_type);
 
   void VerifySig() const;
-  OpResult out() { return result(0); }
+  Value out() { return result(0); }
   Attribute value() const;
 };
 

--- a/paddle/pir/core/ir_printer.cc
+++ b/paddle/pir/core/ir_printer.cc
@@ -236,7 +236,7 @@ void IrPrinter::PrintValue(Value v) {
 void IrPrinter::PrintOpResult(Operation* op) {
   os << " (";
   auto num_op_result = op->num_results();
-  std::vector<OpResult> op_results;
+  std::vector<Value> op_results;
   op_results.reserve(num_op_result);
   for (size_t idx = 0; idx < num_op_result; idx++) {
     op_results.push_back(op->result(idx));

--- a/paddle/pir/core/op_base.h
+++ b/paddle/pir/core/op_base.h
@@ -66,7 +66,7 @@ class IR_API OpBase {
     return operation()->operand_type(index);
   }
 
-  OpResult result(uint32_t index) const { return operation()->result(index); }
+  Value result(uint32_t index) const { return operation()->result(index); }
 
   template <typename T = Type>
   T result_type(uint32_t index) const {

--- a/paddle/pir/core/op_trait.cc
+++ b/paddle/pir/core/op_trait.cc
@@ -55,7 +55,7 @@ void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
              op->num_results());
 
   std::vector<pir::OpOperand> operands = op->operands();
-  std::vector<pir::OpResult> results = op->results();
+  std::vector<pir::Value> results = op->results();
 
   std::vector<pir::Type> types;
 
@@ -63,7 +63,7 @@ void VerifySameOperandsAndResultShapeTrait(pir::Operation *op) {
     types.push_back(op.type());
   });
 
-  std::for_each(results.begin(), results.end(), [&types](pir::OpResult op) {
+  std::for_each(results.begin(), results.end(), [&types](pir::Value op) {
     types.push_back(op.type());
   });
 

--- a/paddle/pir/core/operation.cc
+++ b/paddle/pir/core/operation.cc
@@ -251,8 +251,8 @@ Operation::Operation(const AttributeMap &attributes,
 ///
 /// \brief op ouput related public interfaces implementation
 ///
-std::vector<OpResult> Operation::results() const {
-  std::vector<OpResult> res;
+std::vector<Value> Operation::results() const {
+  std::vector<Value> res;
   for (uint32_t i = 0; i < num_results(); ++i) {
     res.push_back(result(i));
   }
@@ -351,9 +351,8 @@ void Operation::Erase() {
 
 bool Operation::use_empty() {
   auto res = results();
-  return std::all_of(res.begin(), res.end(), [](OpResult result) {
-    return result.use_empty();
-  });
+  return std::all_of(
+      res.begin(), res.end(), [](Value result) { return result.use_empty(); });
 }
 
 void Operation::ReplaceAllUsesWith(const std::vector<Value> &values) {
@@ -361,14 +360,6 @@ void Operation::ReplaceAllUsesWith(const std::vector<Value> &values) {
              "the num of result should be the same.");
   for (uint32_t i = 0; i < num_results_; ++i) {
     result(i).ReplaceAllUsesWith(values[i]);
-  }
-}
-
-void Operation::ReplaceAllUsesWith(const std::vector<OpResult> &op_results) {
-  IR_ENFORCE(num_results_ == op_results.size(),
-             "the num of result should be the same.");
-  for (uint32_t i = 0; i < num_results_; ++i) {
-    result(i).ReplaceAllUsesWith(op_results[i]);
   }
 }
 

--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -121,12 +121,12 @@ class IR_API alignas(8) Operation final
   /// \brief op ouput related public interfaces
   ///
   uint32_t num_results() const { return num_results_; }
-  OpResult result(uint32_t index) const { return op_result_impl(index); }
+  Value result(uint32_t index) const { return OpResult(op_result_impl(index)); }
   template <typename T = Type>
   T result_type(uint32_t index) const {
     return result(index).type().dyn_cast<T>();
   }
-  std::vector<OpResult> results() const;
+  std::vector<Value> results() const;
 
   ///
   /// \brief op input related public interfaces

--- a/paddle/pir/dialect/shape/ir/shape_op.h
+++ b/paddle/pir/dialect/shape/ir/shape_op.h
@@ -37,7 +37,7 @@ class IR_API DimOp : public Op<DimOp> {
 
   const std::string GetName();
   void SetName(std::string attrValue);
-  OpResult out() { return result(0); }
+  Value out() { return result(0); }
   void VerifySig() {}
 };
 

--- a/test/cpp/pir/cinn/adt/map_expr_test.cc
+++ b/test/cpp/pir/cinn/adt/map_expr_test.cc
@@ -62,10 +62,10 @@ TEST(MapExpr, ElementWise_Fusion_0) {
   ctx->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
 
   phi::DDim dims_D_2 = {-1, 1};
-  pir::OpResult value1 =
+  pir::Value value1 =
       test::CreateDenseTensorOp(ctx, dims_D_2, {"op1_attr"}, {"op1_name"})
           ->result(0);
-  pir::OpResult value2 =
+  pir::Value value2 =
       test::CreateDenseTensorOp(ctx, dims_D_2, {"op2_attr"}, {"op2_name"})
           ->result(0);
   ::pir::Builder builder = ::pir::Builder(ctx, program.block());

--- a/test/cpp/pir/cinn/ir_op_fusion_test.cc
+++ b/test/cpp/pir/cinn/ir_op_fusion_test.cc
@@ -24,10 +24,10 @@
 #include "paddle/pir/core/ir_context.h"
 #include "paddle/pir/core/program.h"
 
-std::vector<pir::OpResult> BuildInput(
+std::vector<pir::Value> BuildInput(
     ::pir::Builder* builder,
     const std::vector<std::vector<int64_t>>& vec_shapes) {
-  std::vector<pir::OpResult> vec_res;
+  std::vector<pir::Value> vec_res;
   for (size_t i = 0; i < vec_shapes.size(); ++i) {
     auto op = builder->Build<paddle::dialect::FullOp>(
         vec_shapes[i], 1.0, phi::DataType::FLOAT32, phi::CPUPlace());

--- a/test/cpp/pir/cinn/pir_compiler_test.cc
+++ b/test/cpp/pir/cinn/pir_compiler_test.cc
@@ -122,13 +122,13 @@ ProgramInfo BuildSoftmax() {
 
   std::vector<GroupPtr> groups;
   groups.emplace_back(std::make_shared<Group>(
-      std::initializer_list<::pir::Operation*>({max.owner(),
-                                                broadcast_1.owner(),
-                                                sub.owner(),
-                                                exp.owner(),
-                                                sum.owner(),
-                                                broadcast_2.owner(),
-                                                divide.owner()})));
+      std::initializer_list<::pir::Operation*>({max.defining_op(),
+                                                broadcast_1.defining_op(),
+                                                sub.defining_op(),
+                                                exp.defining_op(),
+                                                sum.defining_op(),
+                                                broadcast_2.defining_op(),
+                                                divide.defining_op()})));
   groups[0]->output_ops.insert(groups[0]->ops.back());
 
   groups[0]->op_pattern_kind = cinn::hlir::framework::kReduction;

--- a/test/cpp/pir/core/ir_region_test.cc
+++ b/test/cpp/pir/core/ir_region_test.cc
@@ -35,10 +35,8 @@ TEST(region, erase_op_test) {
   // (3) Def a = ConstantOp("2.0"); b = ConstantOp("2.0");
   pir::FloatAttribute fp_attr = builder.float_attr(2.0f);
   pir::Float32Type fp32_type = builder.float32_type();
-  pir::OpResult a =
-      builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
-  pir::OpResult b =
-      builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
+  pir::Value a = builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
+  pir::Value b = builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
 
   // (6) Def c = CombineOp(a, b)
   builder.Build<pir::CombineOp>(std::vector<pir::Value>{a, b});
@@ -68,10 +66,8 @@ TEST(region, clone_op_test) {
   // (3) Def a = ConstantOp("2.0"); b = ConstantOp("2.0");
   pir::FloatAttribute fp_attr = builder.float_attr(2.0f);
   pir::Float32Type fp32_type = builder.float32_type();
-  pir::OpResult a =
-      builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
-  pir::OpResult b =
-      builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
+  pir::Value a = builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
+  pir::Value b = builder.Build<pir::ConstantOp>(fp_attr, fp32_type)->result(0);
 
   // (6) Def c = CombineOp(a, b)
   builder.Build<pir::CombineOp>(std::vector<pir::Value>{a, b});

--- a/test/cpp/pir/core/ir_value_test.cc
+++ b/test/cpp/pir/core/ir_value_test.cc
@@ -52,7 +52,7 @@ TEST(value_test, value_test) {
       op1_output_types,
       pir::OpInfo());
   op1->Print(std::cout);
-  pir::OpResult a = op1->result(0);
+  pir::Value a = op1->result(0);
   EXPECT_TRUE(a.use_empty());
   // 2. Construct OP2: b = OP2();
   std::vector<pir::Value> op2_inputs = {};
@@ -63,7 +63,7 @@ TEST(value_test, value_test) {
       op2_output_types,
       pir::OpInfo());
   op2->Print(std::cout);
-  pir::OpResult b = op2->result(0);
+  pir::Value b = op2->result(0);
   EXPECT_TRUE(b.use_empty());
   // 3. Construct OP3: c = OP3(a, b);
   std::vector<pir::Value> op3_inputs{a, b};
@@ -77,7 +77,7 @@ TEST(value_test, value_test) {
   EXPECT_TRUE(op1->result(0).HasOneUse());
   EXPECT_TRUE(op2->result(0).HasOneUse());
   op3->Print(std::cout);
-  pir::OpResult c = op3->result(0);
+  pir::Value c = op3->result(0);
   // 4. Construct OP4: d, e, f, g, h, i, j = OP4(a, c);
   std::vector<pir::Value> op4_inputs = {a, c};
   std::vector<pir::Type> op4_output_types;
@@ -92,13 +92,13 @@ TEST(value_test, value_test) {
   op4->Print(std::cout);
 
   // Test 1:
-  EXPECT_EQ(op1->result(0).owner(), op1);
-  EXPECT_EQ(op2->result(0).owner(), op2);
-  EXPECT_EQ(op3->result(0).owner(), op3);
-  EXPECT_EQ(op4->result(6).owner(), op4);
+  EXPECT_EQ(op1->result(0).defining_op(), op1);
+  EXPECT_EQ(op2->result(0).defining_op(), op2);
+  EXPECT_EQ(op3->result(0).defining_op(), op3);
+  EXPECT_EQ(op4->result(6).defining_op(), op4);
 
   // Test 2: op1_first_output -> op4_first_input
-  pir::OpResult op1_first_output = op1->result(0);
+  pir::Value op1_first_output = op1->result(0);
   pir::OpOperand op4_first_input = op4->operand(0);
 
   EXPECT_EQ(op1_first_output.first_use(), op4_first_input);

--- a/test/cpp/pir/pass/pass_manager_test.cc
+++ b/test/cpp/pir/pass/pass_manager_test.cc
@@ -73,8 +73,8 @@ class AddOp : public pir::Op<AddOp> {
   void VerifySig();
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    pir::OpResult l_operand,
-                    pir::OpResult r_operand,
+                    pir::Value l_operand,
+                    pir::Value r_operand,
                     pir::Type sum_type);
 };
 void AddOp::VerifySig() {
@@ -87,8 +87,8 @@ void AddOp::VerifySig() {
 }
 void AddOp::Build(pir::Builder &,
                   pir::OperationArgument &argument,
-                  pir::OpResult l_operand,
-                  pir::OpResult r_operand,
+                  pir::Value l_operand,
+                  pir::Value r_operand,
                   pir::Type sum_type) {
   argument.AddInput(l_operand);
   argument.AddInput(r_operand);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- #60909 的拆分 PR
- 将 Operation::result(s) 的返回值替换为 Value，同时替换相关用法
