### PR TITLE
[Bug fixes] fix error in Categorcial.probs

### DIFF
--- a/python/paddle/distribution/categorical.py
+++ b/python/paddle/distribution/categorical.py
@@ -117,8 +117,7 @@ class Categorical(distribution.Distribution):
             self.logits = self._to_tensor(logits)[0]
             if self.dtype != convert_dtype(self.logits.dtype):
                 self.logits = paddle.cast(self.logits, dtype=self.dtype)
-        dist_sum = paddle.sum(self.logits, axis=-1, keepdim=True)
-        self._prob = self.logits / dist_sum
+        self._prob = paddle.nn.functional.softmax(self.logits, axis=-1)
 
     def sample(self, shape):
         """Generate samples of the specified shape.

--- a/test/distribution/test_distribution_categorical.py
+++ b/test/distribution/test_distribution_categorical.py
@@ -140,8 +140,9 @@ class CategoricalTest(unittest.TestCase):
             kl, np_kl, rtol=log_tolerance, atol=log_tolerance
         )
 
-        sum_dist = np.sum(self.logits_np, axis=-1, keepdims=True)
-        probability = self.logits_np / sum_dist
+        probability = np.exp(self.logits_np) / np.sum(
+            np.exp(self.logits_np), axis=-1, keepdims=True
+        )
         np_probs = self.get_numpy_selected_probs(probability)
         np_log_prob = np.log(np_probs)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
Since `logits = log(probs)`, so we should use `probs = softmax(logits)` to calculate instead of `probs = logits / sum(logits)`.
#### Others
Pcard-67164