### PR TITLE
Optimize index put preprocess

### DIFF
--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -137,7 +137,7 @@ void IndexPutKernel(const Context& dev_ctx,
   std::vector<int64_t> res_dim_v(common::vectorize(bd_dim));
   std::vector<const phi::DenseTensor*> res_indices_v(x.dims().size(), nullptr);
   std::vector<DenseTensor> tmp_res_indices_v;
-
+  std::vector<DenseTensor> tmp_value_v;
   std::vector<DenseTensor> range_tensor_v;
   const DenseTensor* ptr_value = nullptr;
 
@@ -154,11 +154,13 @@ void IndexPutKernel(const Context& dev_ctx,
                                      range_tensor_v,
                                      bd_dim,
                                      &res_dim_v);
-  phi::DenseTensor tmp_value;
+
   if (value.numel() != 1) {
-    tmp_value = DenseTensor(value.dtype()).Resize(common::make_ddim(res_dim_v));
-    ExpandKernel<T, Context>(dev_ctx, value, IntArray(res_dim_v), &tmp_value);
-    ptr_value = &tmp_value;
+    tmp_value_v.emplace_back(
+        DenseTensor(value.dtype()).Resize(common::make_ddim(res_dim_v)));
+    ExpandKernel<T, Context>(
+        dev_ctx, value, IntArray(res_dim_v), &tmp_value_v[0]);
+    ptr_value = &tmp_value_v[0];
   } else {
     ptr_value = &value;
   }

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -137,7 +137,7 @@ void IndexPutKernel(const Context& dev_ctx,
   std::vector<int64_t> res_dim_v(common::vectorize(bd_dim));
   std::vector<const phi::DenseTensor*> res_indices_v(x.dims().size(), nullptr);
   std::vector<DenseTensor> tmp_res_indices_v;
-  std::vector<DenseTensor> tmp_value_v;
+
   std::vector<DenseTensor> range_tensor_v;
   const DenseTensor* ptr_value = nullptr;
 
@@ -154,13 +154,11 @@ void IndexPutKernel(const Context& dev_ctx,
                                      range_tensor_v,
                                      bd_dim,
                                      &res_dim_v);
-
+  phi::DenseTensor tmp_value;
   if (value.numel() != 1) {
-    tmp_value_v.emplace_back(
-        DenseTensor(value.dtype()).Resize(common::make_ddim(res_dim_v)));
-    ExpandKernel<T, Context>(
-        dev_ctx, value, IntArray(res_dim_v), &tmp_value_v[0]);
-    ptr_value = &tmp_value_v[0];
+    tmp_value = DenseTensor(value.dtype()).Resize(common::make_ddim(res_dim_v));
+    ExpandKernel<T, Context>(dev_ctx, value, IntArray(res_dim_v), &tmp_value);
+    ptr_value = &tmp_value;
   } else {
     ptr_value = &value;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985

Optimize the preprocess cost of index_put op by check if there is bool-index and reducing operators of vector<Tensor>.