### PR TITLE
fix slice array in PIR

### DIFF
--- a/python/paddle/base/variable_index.py
+++ b/python/paddle/base/variable_index.py
@@ -761,6 +761,8 @@ def get_tensor_with_basic_indexing(
             else:
                 stride = attrs['strides']
             if use_strided_slice:
+                # TODO(zoooo0820): suppport strided_slice_array until PIR API is ready
+
                 out = paddle._C_ops.strided_slice(x, axes, st, end, stride)
                 if len(decrease_axes) > 0:
                     out = paddle._C_ops.squeeze(out, decrease_axes)
@@ -773,7 +775,16 @@ def get_tensor_with_basic_indexing(
                         if paddle.utils._contain_var(end):
                             end = paddle.utils.get_int_tensor_list(end)
                     if x.is_dense_tensor_array_type():
-                        return paddle._pir_ops.slice_array_dense(x, st), False
+                        if len(decrease_axes) > 0:
+                            return (
+                                paddle._pir_ops.slice_array_dense(x, st),
+                                False,
+                            )
+                        else:
+                            return (
+                                paddle._pir_ops.slice_array(x, st, end),
+                                False,
+                            )
                 out = paddle._C_ops.slice(
                     x,
                     axes,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66985
Fix the slice for tensor_array bug in PIR. Now the return type will be `tensor_array` or `tensor` correctly, as following shows.
```
arr[0:2]:  Value(define_op_name=pd_op.slice_array, index=0, dtype=pd_op.tensor_array<i32>, stop_gradient=True)
arr[0]:  Value(define_op_name=pd_op.slice_array_dense, index=0, dtype=pd_op.tensor<0xi32>, stop_gradient=True)
```
 Still not support case of strided_slice_array