### PR TITLE
[PIR] Remove the restrictions of communication operators on multi-thread scheduling

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -1322,8 +1322,8 @@ paddle::framework::FetchList PirInterpreter::Run(
     VLOG(4) << "Done PreAnalysis";
 
     // Run
-    if (FLAGS_enable_pir_in_executor_trace_run || nccl_op_num_ > 1 ||
-        onednn_op_num_ || execution_config_.used_for_inference ||
+    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
+        execution_config_.used_for_inference ||
         ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
          (sync_op_num_ == 0))) {
       LOG_FIRST_N(INFO, 1) << "pir interpreter is running by trace mode ...";
@@ -1343,8 +1343,8 @@ paddle::framework::FetchList PirInterpreter::Run(
       VLOG(4) << "Done BuildInstruction";
     }
 #endif
-    if (FLAGS_enable_pir_in_executor_trace_run || nccl_op_num_ > 1 ||
-        onednn_op_num_ || execution_config_.used_for_inference ||
+    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
+        execution_config_.used_for_inference ||
         ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
          (sync_op_num_ == 0))) {
       TraceRunImpl();
@@ -1412,8 +1412,8 @@ FetchList PirInterpreter::Run(const std::vector<std::string>& feed_names,
     VLOG(4) << "Done PreAnalysis";
 
     // Run
-    if (FLAGS_enable_pir_in_executor_trace_run || nccl_op_num_ > 1 ||
-        onednn_op_num_ || execution_config_.used_for_inference ||
+    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
+        execution_config_.used_for_inference ||
         ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
          (sync_op_num_ == 0))) {
       LOG_FIRST_N(INFO, 1) << "pir interpreter is running by trace mode ...";
@@ -1433,8 +1433,8 @@ FetchList PirInterpreter::Run(const std::vector<std::string>& feed_names,
       VLOG(4) << "Done BuildInstruction";
     }
 #endif
-    if (FLAGS_enable_pir_in_executor_trace_run || nccl_op_num_ > 1 ||
-        onednn_op_num_ || execution_config_.used_for_inference ||
+    if (FLAGS_enable_pir_in_executor_trace_run || onednn_op_num_ ||
+        execution_config_.used_for_inference ||
         ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
          (sync_op_num_ == 0))) {
       TraceRunImpl();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Remove the restrictions of communication operators on multi-thread scheduling.
Pcard-67164