### PR TITLE
[PIR] Remove most usage of OpResult [Part 2]

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/api_gen.py
@@ -137,13 +137,13 @@ OPTIONAL_VALUE_INPUT_TEMPLATE = """
         optional_{name} = {name};
     }}"""
 
-OPTIONAL_OPRESULT_OUTPUT_TEMPLATE = """
+OPTIONAL_VALUE_OUTPUT_TEMPLATE = """
     paddle::optional<pir::Value> optional_{name};
     if (!IsEmptyValue({op_name}_op.result({index}))) {{
         optional_{name} = paddle::make_optional<pir::Value>({op_name}_op.result({index}));
     }}"""
 
-OPTIONAL_VECTOR_OPRESULT_OUTPUT_TEMPLATE = """
+OPTIONAL_VECTOR_VALUE_OUTPUT_TEMPLATE = """
     paddle::optional<std::vector<pir::Value>> optional_{name};
     if (!IsEmptyValue({op_name}_op.result({index}))) {{
         auto optional_{name}_slice_op = ApiBuilder::Instance().GetBuilder()->Build<pir::SplitOp>({op_name}_op.result({index}));
@@ -423,13 +423,13 @@ class CodeGen:
                 continue
             if self._is_optional_output(op_info, name):
                 if VECTOR_TYPE in type:
-                    ret += OPTIONAL_VECTOR_OPRESULT_OUTPUT_TEMPLATE.format(
+                    ret += OPTIONAL_VECTOR_VALUE_OUTPUT_TEMPLATE.format(
                         name=name,
                         op_name=op_name,
                         index=i,
                     )
                 else:
-                    ret += OPTIONAL_OPRESULT_OUTPUT_TEMPLATE.format(
+                    ret += OPTIONAL_VALUE_OUTPUT_TEMPLATE.format(
                         name=name,
                         op_name=op_name,
                         index=i,

--- a/paddle/fluid/pir/drr/ir_operation_factory.cc
+++ b/paddle/fluid/pir/drr/ir_operation_factory.cc
@@ -35,10 +35,7 @@ void OperationFactory::RegisterManualOpCreator() {
          const pir::AttributeMap& attrs,
          pir::PatternRewriter& rewriter) {
         return rewriter.Build<paddle::dialect::FusedGemmEpilogueOp>(
-            inputs[0].dyn_cast<pir::OpResult>(),
-            inputs[1].dyn_cast<pir::OpResult>(),
-            inputs[2].dyn_cast<pir::OpResult>(),
-            attrs);
+            inputs[0], inputs[1], inputs[2], attrs);
       });
   RegisterOperationCreator(
       "pd_op.fused_gemm_epilogue_grad",
@@ -46,11 +43,7 @@ void OperationFactory::RegisterManualOpCreator() {
          const pir::AttributeMap& attrs,
          pir::PatternRewriter& rewriter) {
         return rewriter.Build<paddle::dialect::FusedGemmEpilogueGradOp>(
-            inputs[0].dyn_cast<pir::OpResult>(),
-            inputs[1].dyn_cast<pir::OpResult>(),
-            inputs[2].dyn_cast<pir::OpResult>(),
-            inputs[3].dyn_cast<pir::OpResult>(),
-            attrs);
+            inputs[0], inputs[1], inputs[2], inputs[3], attrs);
       });
   RegisterOperationCreator("builtin.combine",
                            [](const std::vector<pir::Value>& inputs,
@@ -64,8 +57,8 @@ void OperationFactory::RegisterManualOpCreator() {
          const pir::AttributeMap& attrs,
          pir::PatternRewriter& rewriter) {
         return rewriter.Build<paddle::dialect::ScaleOp>(
-            inputs[0].dyn_cast<pir::OpResult>(),
-            inputs[1].dyn_cast<pir::OpResult>(),
+            inputs[0],
+            inputs[1],
             attrs.at("bias").dyn_cast<pir::FloatAttribute>().data(),
             attrs.at("bias_after_scale").dyn_cast<pir::BoolAttribute>().data());
       });

--- a/paddle/fluid/pir/transforms/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/constant_folding_pass.cc
@@ -346,8 +346,7 @@ class ConstantFoldingPattern : public pir::RewritePattern {
                                           prev_op->name()));
         }
       } else {
-        op_inputs.push_back(
-            op->operand_source(i).dyn_cast<pir::OpResult>() /*nullptr*/);
+        op_inputs.push_back(nullptr);
       }
     }
 

--- a/paddle/fluid/pir/transforms/replace_fetch_with_shadow_output_pass.cc
+++ b/paddle/fluid/pir/transforms/replace_fetch_with_shadow_output_pass.cc
@@ -29,7 +29,7 @@ class ReplaceFetchWithShadowOutputPattern
       paddle::dialect::FetchOp op,
       pir::PatternRewriter& rewriter) const override {  // NOLINT
     rewriter.Build<pir::ShadowOutputOp>(
-        op->operand_source(0).dyn_cast<pir::OpResult>(),
+        op->operand_source(0),
         op->attributes().at("name").dyn_cast<pir::StrAttribute>().AsString());
     rewriter.EraseOp(op);
     return true;

--- a/paddle/fluid/pir/transforms/transform_general_functions.cc
+++ b/paddle/fluid/pir/transforms/transform_general_functions.cc
@@ -61,7 +61,7 @@ void GetUsedExternalValueImpl(
 namespace pir {
 
 std::string GetParameterNameFromValue(pir::Value value) {
-  pir::Operation* owner = value.dyn_cast<OpResult>().owner();
+  pir::Operation* owner = value.defining_op();
   std::string name;
   if (owner->isa<ParameterOp>()) {
     pir::ParameterOp op = owner->dyn_cast<pir::ParameterOp>();
@@ -104,7 +104,7 @@ Operation* GetDefiningOpForInput(const Operation* op, uint32_t index) {
       index < op->num_operands() && op->operand_source(index),
       true,
       phi::errors::InvalidArgument("Intput operand's index must be valid."));
-  return op->operand_source(index).dyn_cast<OpResult>().owner();
+  return op->operand_source(index).defining_op();
 }
 
 std::vector<std::pair<Operation*, int32_t>> GetUseOpsForOutput(

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -52,7 +52,7 @@ static PyObject *static_api_set_parameter(PyObject *self,
     VLOG(6) << "Add set_parameter op into program";
     VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
 
-    // Get OpResult from args
+    // Get Value from args
     PyObject *parameter_obj = PyTuple_GET_ITEM(args, 0);
     auto parameter = CastPyArg2Value(parameter_obj, "parameter", 0);
 

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -865,18 +865,14 @@ void CastPyArg2AttrValues(PyObject* obj,
     Py_ssize_t len = PyList_Size(obj);
     PyObject* item = nullptr;
     for (Py_ssize_t i = 0; i < len; i++) {
-      // TODO(xiongkun): judge OpResult or Value;
+      // TODO(xiongkun): judge Value;
       item = PyList_GetItem(obj, i);
       ::pybind11::detail::instance* inst =
           (::pybind11::detail::instance*)item;  // NOLINT
       void** vh = inst->simple_layout ? inst->simple_value_holder
                                       : &inst->nonsimple.values_and_holders[0];
-      ::pir::OpResult* opresult = reinterpret_cast<::pir::OpResult*>(vh[0]);
-      if (opresult->impl() == nullptr) {
-        results.emplace_back(pir::Value(nullptr));
-      } else {
-        results.emplace_back(pir::Value(opresult->Value::impl()));
-      }
+      ::pir::Value* value = reinterpret_cast<::pir::Value*>(vh[0]);
+      results.emplace_back(pir::Value(value->impl()));
     }
   } else {
     PADDLE_THROW(platform::errors::InvalidType(

--- a/paddle/pir/core/builtin_op.cc
+++ b/paddle/pir/core/builtin_op.cc
@@ -253,8 +253,8 @@ void SliceOp::Build(Builder &builder,
 void SliceOp::PassStopGradients(OperationArgument &argument, int index) {
   std::vector<pir::Attribute> outs_stop_gradient(
       1, pir::BoolAttribute::get(pir::IrContext::Instance(), true));
-  if (auto input = argument.inputs[0].dyn_cast<pir::OpResult>()) {
-    auto *defining_op = input.owner();
+  if (auto input = argument.inputs[0]) {
+    auto *defining_op = input.defining_op();
     if (defining_op && defining_op->isa<CombineOp>()) {
       IR_ENFORCE(defining_op->HasAttribute(kStopGradientAttrName),
                  "Required CombineOp must have attribute %s",
@@ -274,8 +274,8 @@ void SliceOp::RefreshStopGradients() {
   std::vector<pir::Attribute> outs_stop_gradient(
       1, pir::BoolAttribute::get(pir::IrContext::Instance(), true));
   auto index = attribute("index").dyn_cast<pir::Int32Attribute>().data();
-  if (auto input = (*this)->operand_source(0).dyn_cast<pir::OpResult>()) {
-    auto *defining_op = input.owner();
+  if (auto input = (*this)->operand_source(0)) {
+    auto *defining_op = input.defining_op();
     if (defining_op && defining_op->isa<CombineOp>()) {
       IR_ENFORCE(defining_op->HasAttribute(kStopGradientAttrName),
                  "Required CombineOp must have attribute %s",
@@ -350,8 +350,8 @@ void SplitOp::Build(Builder &builder,
 
 void SplitOp::PassStopGradients(OperationArgument &argument) {
   std::vector<bool> defaut_stop_gradients(argument.output_types.size(), true);
-  if (auto input = argument.inputs[0].dyn_cast<OpResult>()) {
-    auto *defining_op = input.owner();
+  if (auto input = argument.inputs[0]) {
+    auto *defining_op = input.defining_op();
     if (defining_op && defining_op->isa<CombineOp>()) {
       IR_ENFORCE(argument.output_types.size(),
                  defining_op->num_operands(),
@@ -391,8 +391,8 @@ void SplitOp::PassStopGradients(OperationArgument &argument) {
 
 void SplitOp::RefreshStopGradients() {
   std::vector<bool> default_stop_gradients((*this)->num_results(), true);
-  if (auto input = (*this)->operand_source(0).dyn_cast<OpResult>()) {
-    auto *defining_op = input.owner();
+  if (auto input = (*this)->operand_source(0)) {
+    auto *defining_op = input.defining_op();
     if (defining_op && defining_op->isa<CombineOp>()) {
       IR_ENFORCE((*this)->num_results(),
                  defining_op->num_operands(),
@@ -403,7 +403,7 @@ void SplitOp::RefreshStopGradients() {
       for (uint32_t i = 0; i < defining_op->num_operands(); ++i) {
         auto value = defining_op->operand_source(i);
         if (!value) continue;
-        auto *operand_defining_op = value.dyn_cast<OpResult>().owner();
+        auto *operand_defining_op = value.defining_op();
         if (operand_defining_op->HasAttribute(kStopGradientAttrName)) {
           auto attrs = operand_defining_op->attribute(kStopGradientAttrName)
                            .dyn_cast<pir::ArrayAttribute>()

--- a/paddle/pir/core/ir_context.h
+++ b/paddle/pir/core/ir_context.h
@@ -30,7 +30,6 @@ class TypeId;
 class Dialect;
 class OpInfo;
 class Type;
-class OpResult;
 class Attribute;
 class Operation;
 class InterfaceValue;

--- a/paddle/pir/core/op_info.h
+++ b/paddle/pir/core/op_info.h
@@ -21,7 +21,6 @@
 namespace pir {
 class OpInfoImpl;
 class IrContext;
-class OpResult;
 class Type;
 class Attribute;
 class Dialect;

--- a/test/cpp/pir/core/block_operand_test.cc
+++ b/test/cpp/pir/core/block_operand_test.cc
@@ -40,8 +40,7 @@ TEST(block_operand_test, type_block) {
   region.push_back(block_3);
 
   builder.SetInsertionPointToBlockEnd(block_1);
-  auto op1 =
-      builder.Build<test::BranchOp>(std::vector<pir::OpResult>{}, block_2);
+  auto op1 = builder.Build<test::BranchOp>(std::vector<pir::Value>{}, block_2);
   EXPECT_TRUE(block_2->HasOneUse());
   EXPECT_FALSE(block_2->use_empty());
 
@@ -55,8 +54,7 @@ TEST(block_operand_test, type_block) {
   EXPECT_EQ(iter_curr->owner(), op1);
 
   builder.SetInsertionPointToBlockEnd(block_3);
-  auto op3 =
-      builder.Build<test::BranchOp>(std::vector<pir::OpResult>{}, block_1);
+  auto op3 = builder.Build<test::BranchOp>(std::vector<pir::Value>{}, block_1);
   block_operand = op3->block_operand(0);
   block_operand.set_source(block_2);
   EXPECT_EQ(block_2, block_operand.source());

--- a/test/cpp/pir/tools/test_op.cc
+++ b/test/cpp/pir/tools/test_op.cc
@@ -23,7 +23,7 @@ void RegionOp::Build(pir::Builder &builder, pir::OperationArgument &argument) {
 
 void BranchOp::Build(pir::Builder &builder,             // NOLINT
                      pir::OperationArgument &argument,  // NOLINT
-                     const std::vector<pir::OpResult> &target_operands,
+                     const std::vector<pir::Value> &target_operands,
                      pir::Block *target) {
   argument.AddInputs(target_operands.begin(), target_operands.end());
   argument.AddSuccessor(target);

--- a/test/cpp/pir/tools/test_op.h
+++ b/test/cpp/pir/tools/test_op.h
@@ -49,7 +49,7 @@ class BranchOp : public pir::Op<BranchOp> {
   static constexpr const char **attributes_name = nullptr;
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT
-                    const std::vector<pir::OpResult> &target_operands,
+                    const std::vector<pir::Value> &target_operands,
                     pir::Block *target);
   void VerifySig() const;
 };

--- a/test/ir/pir/test_symbol_overload.py
+++ b/test/ir/pir/test_symbol_overload.py
@@ -73,7 +73,7 @@ class SimbolCompareNet(nn.Layer):
         return z1, z2, z3, z4
 
 
-class TestOpresultSymbol(unittest.TestCase):
+class TestValueSymbol(unittest.TestCase):
     def setUp(self):
         np.random.seed(2023)
         self.shape_x = [2, 1024, 1024]
@@ -133,7 +133,7 @@ class TestOpresultSymbol(unittest.TestCase):
         self.assertEqual(ops_ref, ops)
 
 
-class TestOpresultCompareSymbol(unittest.TestCase):
+class TestValueCompareSymbol(unittest.TestCase):
     def setUp(self):
         np.random.seed(2023)
         self.shape_x = [2, 1024, 1024]

--- a/test/legacy_test/test_expand_v2_op.py
+++ b/test/legacy_test/test_expand_v2_op.py
@@ -541,8 +541,8 @@ class TestExpandV2CompOpInt64_t(OpTest):
         self.check_output(check_prim=True)
 
 
-class TestExpandPirOpResultListShape(unittest.TestCase):
-    def test_opresult_list_shape(self):
+class TestExpandPirValueListShape(unittest.TestCase):
+    def test_value_list_shape(self):
         with paddle.pir_utils.IrGuard():
             x = paddle.static.data('x', [1, 3])
             shape = [2, paddle.full([], 4)]

--- a/test/legacy_test/test_reshape_op.py
+++ b/test/legacy_test/test_reshape_op.py
@@ -734,8 +734,8 @@ class TestReshapeAPI_ZeroDim(unittest.TestCase):
             self.assertEqual(result[3].shape, (1,))
 
 
-class TestReshapePirOpResultListShape(unittest.TestCase):
-    def test_opresult_list_shape(self):
+class TestReshapePirValueListShape(unittest.TestCase):
+    def test_value_list_shape(self):
         with paddle.pir_utils.IrGuard():
             x = paddle.static.data(
                 'x',

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -798,11 +798,11 @@ class TestWhereOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_Variable)
 
-            def test_OpResult():
+            def test_Value():
                 with paddle.pir_utils.IrGuard():
                     paddle.where(cond_i, x_i, y_i)
 
-            self.assertRaises(TypeError, test_OpResult)
+            self.assertRaises(TypeError, test_Value)
 
             def test_type():
                 x = paddle.static.data(name='x', shape=[-1, 4], dtype='bool')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- Remove most usage of OpResult [Part 2]
