### PR TITLE
[CINN] Fix GatherNd Compute Int64 Shape

### DIFF
--- a/paddle/cinn/hlir/op/contrib/gather_nd.cc
+++ b/paddle/cinn/hlir/op/contrib/gather_nd.cc
@@ -54,7 +54,7 @@ ir::Tensor GatherNd(const ir::Tensor &x,
   std::vector<Expr> out_shape;
   out_shape.insert(out_shape.end(), index_shape.begin(), index_shape.end() - 1);
   out_shape.insert(out_shape.end(),
-                   x_shape.begin() + index_shape.back().as_int32(),
+                   x_shape.begin() + index_shape.back().as_int64(),
                    x_shape.end());
   auto res = Compute(
       out_shape,
@@ -62,17 +62,59 @@ ir::Tensor GatherNd(const ir::Tensor &x,
         std::vector<Expr> indices_position;
         for (size_t i = 0; i < index_shape_size - 1; ++i) {
           indices_position.push_back(
-              ir::Cast::Make(cinn::common::Int(32), indices[i]));
+              ir::Cast::Make(cinn::common::Int(64), indices[i]));
         }
         indices_position.push_back(
-            ir::Cast::Make(cinn::common::Int(32), Expr(0)));
+            ir::Cast::Make(cinn::common::Int(64), Expr(0)));
         size_t indices_position_size = indices_position.size();
         std::vector<Expr> real_indices;
-        for (size_t i = 0; i < index_shape.back().as_int32(); ++i) {
+        for (size_t i = 0; i < index_shape.back().as_int64(); ++i) {
           indices_position[indices_position_size - 1] =
-              ir::Cast::Make(cinn::common::Int(32), Expr(i));
+              ir::Cast::Make(cinn::common::Int(64), Expr(i));
           real_indices.push_back(
-              ir::Cast::Make(cinn::common::Int(32), index(indices_position)));
+              ir::Cast::Make(cinn::common::Int(64), index(indices_position)));
+        }
+        if (real_indices.size() == x_shape_size) {
+          return x(real_indices);
+        }
+        for (size_t i = index_shape_size - 1; i < indices.size(); ++i) {
+          real_indices.push_back(indices[i]);
+        }
+        return x(real_indices);
+      },
+      name);
+  return res;
+}
+
+ir::Tensor GatherNdSymbolic(const ir::Tensor &x,
+                            const ir::Tensor &index,
+                            const std::string &name) {
+  std::vector<Expr> x_shape = x->shape;
+  std::vector<Expr> index_shape = index->shape;
+  size_t x_shape_size = x_shape.size();
+  size_t index_shape_size = index_shape.size();
+  std::vector<Expr> out_shape;
+  out_shape.insert(out_shape.end(), index_shape.begin(), index_shape.end() - 1);
+  out_shape.insert(out_shape.end(),
+                   x_shape.begin() + index_shape.back().as_int64(),
+                   x_shape.end());
+  auto res = Compute(
+      out_shape,
+      [=](const std::vector<Expr> &indices) {
+        std::vector<Expr> indices_position;
+        for (size_t i = 0; i < index_shape_size - 1; ++i) {
+          indices_position.push_back(
+              ir::Cast::Make(cinn::common::Int(64), indices[i]));
+        }
+        indices_position.push_back(
+            ir::Cast::Make(cinn::common::Int(64), Expr(0)));
+        size_t indices_position_size = indices_position.size();
+        std::vector<Expr> real_indices;
+        for (size_t i = 0; i < index_shape.back().as_int64(); ++i) {
+          indices_position[indices_position_size - 1] =
+              ir::Cast::Make(cinn::common::Int(64), Expr(i));
+          real_indices.push_back(
+              ir::Cast::Make(cinn::common::Int(64), index(indices_position)));
         }
         if (real_indices.size() == x_shape_size) {
           return x(real_indices);
@@ -190,7 +232,7 @@ std::shared_ptr<framework::OpStrategy> StrategyForGatherNdSymbolic(
                 << ", output_shapes: " << utils::Join(output_shapes[0], ", ");
         CHECK_EQ(pack_args.size(), 3U);
         std::string tensor_name = pack_args[2].operator std::string();
-        ir::Tensor out = GatherNd(tensor_x, tensor_index, tensor_name);
+        ir::Tensor out = GatherNdSymbolic(tensor_x, tensor_index, tensor_name);
         std::vector<CINNValue> res;
         stages->InsertLazily(out);
         res.push_back(CINNValue(out));

--- a/paddle/cinn/hlir/op/contrib/gather_nd.cc
+++ b/paddle/cinn/hlir/op/contrib/gather_nd.cc
@@ -96,7 +96,7 @@ ir::Tensor GatherNdSymbolic(const ir::Tensor &x,
   std::vector<Expr> out_shape;
   out_shape.insert(out_shape.end(), index_shape.begin(), index_shape.end() - 1);
   out_shape.insert(out_shape.end(),
-                   x_shape.begin() + index_shape.back().as_int64(),
+                   x_shape.begin() + index_shape.back().as_int32(),
                    x_shape.end());
   auto res = Compute(
       out_shape,
@@ -104,17 +104,17 @@ ir::Tensor GatherNdSymbolic(const ir::Tensor &x,
         std::vector<Expr> indices_position;
         for (size_t i = 0; i < index_shape_size - 1; ++i) {
           indices_position.push_back(
-              ir::Cast::Make(cinn::common::Int(64), indices[i]));
+              ir::Cast::Make(cinn::common::Int(32), indices[i]));
         }
         indices_position.push_back(
-            ir::Cast::Make(cinn::common::Int(64), Expr(0)));
+            ir::Cast::Make(cinn::common::Int(32), Expr(0)));
         size_t indices_position_size = indices_position.size();
         std::vector<Expr> real_indices;
         for (size_t i = 0; i < index_shape.back().as_int64(); ++i) {
           indices_position[indices_position_size - 1] =
-              ir::Cast::Make(cinn::common::Int(64), Expr(i));
+              ir::Cast::Make(cinn::common::Int(32), Expr(i));
           real_indices.push_back(
-              ir::Cast::Make(cinn::common::Int(64), index(indices_position)));
+              ir::Cast::Make(cinn::common::Int(32), index(indices_position)));
         }
         if (real_indices.size() == x_shape_size) {
           return x(real_indices);

--- a/paddle/cinn/hlir/op/contrib/gather_nd.cc
+++ b/paddle/cinn/hlir/op/contrib/gather_nd.cc
@@ -54,7 +54,7 @@ ir::Tensor GatherNd(const ir::Tensor &x,
   std::vector<Expr> out_shape;
   out_shape.insert(out_shape.end(), index_shape.begin(), index_shape.end() - 1);
   out_shape.insert(out_shape.end(),
-                   x_shape.begin() + index_shape.back().as_int64(),
+                   x_shape.begin() + index_shape.back().as_int32(),
                    x_shape.end());
   auto res = Compute(
       out_shape,
@@ -62,17 +62,17 @@ ir::Tensor GatherNd(const ir::Tensor &x,
         std::vector<Expr> indices_position;
         for (size_t i = 0; i < index_shape_size - 1; ++i) {
           indices_position.push_back(
-              ir::Cast::Make(cinn::common::Int(64), indices[i]));
+              ir::Cast::Make(cinn::common::Int(32), indices[i]));
         }
         indices_position.push_back(
-            ir::Cast::Make(cinn::common::Int(64), Expr(0)));
+            ir::Cast::Make(cinn::common::Int(32), Expr(0)));
         size_t indices_position_size = indices_position.size();
         std::vector<Expr> real_indices;
-        for (size_t i = 0; i < index_shape.back().as_int64(); ++i) {
+        for (size_t i = 0; i < index_shape.back().as_int32(); ++i) {
           indices_position[indices_position_size - 1] =
-              ir::Cast::Make(cinn::common::Int(64), Expr(i));
+              ir::Cast::Make(cinn::common::Int(32), Expr(i));
           real_indices.push_back(
-              ir::Cast::Make(cinn::common::Int(64), index(indices_position)));
+              ir::Cast::Make(cinn::common::Int(32), index(indices_position)));
         }
         if (real_indices.size() == x_shape_size) {
           return x(real_indices);
@@ -96,7 +96,7 @@ ir::Tensor GatherNdSymbolic(const ir::Tensor &x,
   std::vector<Expr> out_shape;
   out_shape.insert(out_shape.end(), index_shape.begin(), index_shape.end() - 1);
   out_shape.insert(out_shape.end(),
-                   x_shape.begin() + index_shape.back().as_int32(),
+                   x_shape.begin() + index_shape.back().as_int64(),
                    x_shape.end());
   auto res = Compute(
       out_shape,
@@ -104,17 +104,17 @@ ir::Tensor GatherNdSymbolic(const ir::Tensor &x,
         std::vector<Expr> indices_position;
         for (size_t i = 0; i < index_shape_size - 1; ++i) {
           indices_position.push_back(
-              ir::Cast::Make(cinn::common::Int(32), indices[i]));
+              ir::Cast::Make(cinn::common::Int(64), indices[i]));
         }
         indices_position.push_back(
-            ir::Cast::Make(cinn::common::Int(32), Expr(0)));
+            ir::Cast::Make(cinn::common::Int(64), Expr(0)));
         size_t indices_position_size = indices_position.size();
         std::vector<Expr> real_indices;
         for (size_t i = 0; i < index_shape.back().as_int64(); ++i) {
           indices_position[indices_position_size - 1] =
-              ir::Cast::Make(cinn::common::Int(32), Expr(i));
+              ir::Cast::Make(cinn::common::Int(64), Expr(i));
           real_indices.push_back(
-              ir::Cast::Make(cinn::common::Int(32), index(indices_position)));
+              ir::Cast::Make(cinn::common::Int(64), index(indices_position)));
         }
         if (real_indices.size() == x_shape_size) {
           return x(real_indices);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function Optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->
In new CINN shape dialect, share will be int64. GatherNd compute didn't handle it well. This PR fixed it.
