### PR TITLE
[XPU] enable memory stat for XPU

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -1345,11 +1345,12 @@ class AllocatorFacadePrivate {
 
   void WrapStatAllocator() {
     for (auto& pair : allocators_) {
-      // Now memory stats is only supported for CPU and GPU
+      // Now memory stats is only supported for CPU, GPU, XPU and CustomDevice
       const platform::Place& place = pair.first;
       if (platform::is_cpu_place(place) ||
           platform::is_cuda_pinned_place(place) ||
-          platform::is_gpu_place(place) || platform::is_custom_place(place)) {
+          platform::is_gpu_place(place) || platform::is_custom_place(place) ||
+          platform::is_xpu_place(place)) {
         pair.second = std::make_shared<StatAllocator>(pair.second);
       }
     }


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Description
参考 https://github.com/PaddlePaddle/Paddle/pull/61030 ，让XPU下面也能使用memory stat相关功能。

示例代码：

```python
import paddle
from paddle.base import core
from paddle import framework

current_device = framework._current_expected_place_()
device_id = current_device.get_device_id()
current_memory_allocated = core.device_memory_stat_current_value("Allocated", device_id)
print(current_memory_allocated)
a = paddle.ones((1024, 1024))
current_memory_allocated_new = core.device_memory_stat_current_value("Allocated", device_id)
print(current_memory_allocated_new)
```

示例输出：

![图片](https://github.com/PaddlePaddle/Paddle/assets/35131887/a367623e-6d65-401e-9bcc-aa5b59cdf780)

这里打出来的占用量是4194304，是`1024*1024*4`byte，符合预期。



