### PR TITLE
Fix out-of-range bug for ThreadDataRegistry

### DIFF
--- a/paddle/phi/common/thread_data_registry.h
+++ b/paddle/phi/common/thread_data_registry.h
@@ -124,7 +124,11 @@ class ThreadDataRegistry {
     template <typename Alias = T,
               typename = std::enable_if_t<IsAccumulatable<Alias>::value>>
     void AccumulateToAnotherThread(uint64_t tid) {
-      auto& data = tid_map_.at(tid)->GetData();
+      if (tid_map_.find(tid) == tid_map_.end()) {
+        return;
+      }
+
+      auto& data = tid_map_[tid]->GetData();
       for (auto& kv : tid_map_) {
         if (kv.first != tid) {
           auto& data_in_another_thread = kv.second->GetData();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-76459
PR https://github.com/PaddlePaddle/Paddle/pull/60735 在线程析构时将该线程对应的thread_local数据转移到其它存活线程中进行存储，以解决线程提前析构导致数据统计错误的问题。
但在ppdiffusers sd和sdxl export的场景下，出现线程析构时ThreadDataRegistry中维护每个线程thread_local数据的tid_map_成员消失（size变为0）的现象，在通过该全局map访问线程的thread_local数据时报std::out-of-range越界错误。
经分析相关成员的析构顺序，未发现框架代码问题，怀疑是上层集成模块（FastDeploy或其它部署逻辑）代码中存在内存越界导致数据被污染。通过在ThreadDataRegistry中增加一个不被使用的数据成员改变对象内存布局，相同场景下出现core dump，进一步佐证上层业务问题。
为了不影响使用，本PR临时添加判断，在线程析构时，若相关map数据已被污染消失，则跳过转移操作，已修复本问题。