### PR TITLE
[Dy2St] Cleanup `BasicApiTransformer`

### DIFF
--- a/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
@@ -174,10 +174,10 @@ def is_to_variable(node):
     assert isinstance(node, gast.Call)
     api_name = utils.ast_to_source_code(node.func).strip()
 
-    if utils.is_dygraph_api(node):
-        return api_name.endswith("to_variable")
-
-    return False
+    api_parts = api_name.split(".")
+    if not api_parts:
+        return False
+    return api_name.split(".")[-1] == "to_variable"
 
 
 def to_assign_node(node):

--- a/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
@@ -16,7 +16,6 @@
 from paddle.utils import gast
 
 from .. import utils
-from ..ast_utils import ast_to_source_code
 from .base import BaseTransformer
 
 __all__ = []
@@ -29,7 +28,6 @@ class BasicApiTransformer(BaseTransformer):
 
     def __init__(self, root):
         self.root = root
-        self.class_node_dict = {}
 
     def transform(self):
         to_tensor_transformer = ToTensorTransformer(self.root)
@@ -38,63 +36,6 @@ class BasicApiTransformer(BaseTransformer):
         attribute_transformer.transform()
         self.visit(self.root)
         return self.root
-
-    def visit_Assign(self, node):
-        if self._update_class_node_dict(node):
-            return None
-
-        for child_node in gast.walk(node.value):
-            if isinstance(child_node, gast.Call):
-                self._visit_Call(child_node)
-        return node
-
-    def visit_Expr(self, node):
-        value_node = node.value
-        for child_node in gast.walk(value_node):
-            if isinstance(child_node, gast.Call):
-                # TODO(liym27):
-                #  Considers that a dygraph api which modifies the input or has a output.
-                if utils.is_dygraph_api(child_node):
-                    return
-                else:
-                    self._visit_Call(child_node)
-        return node
-
-    def _visit_Call(self, node):
-        assert isinstance(node, gast.Call)
-        func_name = ast_to_source_code(node.func)
-
-        if self._is_dygraph_forward(func_name):
-            class_node = self._get_class_node(func_name)
-            static_node = utils.to_static_ast(node, class_node)
-            return static_node
-        else:
-            return node
-
-    def _is_dygraph_forward(self, func_id):
-        return func_id in self.class_node_dict
-
-    def _get_class_node(self, func_id):
-        return self.class_node_dict[func_id]
-
-    def _update_class_node_dict(self, node):
-        assert isinstance(node, gast.Assign)
-        node_value = node.value
-        if isinstance(node_value, gast.Call):
-            if is_to_variable(node_value):
-                return False
-
-            if utils.is_dygraph_api(node_value):
-                dygraph_api = node_value.func.attr
-                if not utils.dygraph_class_to_static_api.get(dygraph_api):
-                    return False
-
-                utils.update_args_of_func(node_value, node_value, "__init__")
-                target_str = ast_to_source_code(node.targets[0])
-                self.class_node_dict[target_str] = node_value
-                return True
-            # TODO: node.value is not dygraph class
-        return False
 
 
 class ToTensorTransformer(BaseTransformer):

--- a/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/basic_api_transformer.py
@@ -174,9 +174,6 @@ def is_to_variable(node):
     assert isinstance(node, gast.Call)
     api_name = utils.ast_to_source_code(node.func).strip()
 
-    api_parts = api_name.split(".")
-    if not api_parts:
-        return False
     return api_name.split(".")[-1] == "to_variable"
 
 

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -42,13 +42,10 @@ from paddle.utils import flatten, gast
 
 from .ast_utils import ast_to_source_code
 from .utils_helper import (  # noqa: F401
-    DYGRAPH_MODULE_PREFIX,
-    DYGRAPH_TO_STATIC_MODULE_PREFIX,
     PADDLE_MODULE_PREFIX,
     _is_api_in_module_helper,
     index_in_list,
     is_api_in_module,
-    is_dygraph_api,
     is_paddle_api,
 )
 

--- a/python/paddle/jit/dy2static/utils_helper.py
+++ b/python/paddle/jit/dy2static/utils_helper.py
@@ -18,9 +18,6 @@ import inspect
 import numpy as np  # noqa: F401
 
 import paddle
-from paddle import base  # noqa: F401
-from paddle.base import dygraph, layers  # noqa: F401
-from paddle.base.dygraph import to_variable  # noqa: F401
 from paddle.utils import gast
 
 from .ast_utils import ast_to_source_code
@@ -37,19 +34,6 @@ def index_in_list(array_list, item):
 # Note(Aurelius): Do not forget the dot `.` to distinguish other
 # module such as paddlenlp.
 PADDLE_MODULE_PREFIX = 'paddle.'
-DYGRAPH_TO_STATIC_MODULE_PREFIX = 'paddle.jit.dy2static'
-DYGRAPH_MODULE_PREFIX = 'paddle.base.dygraph'
-
-
-def is_dygraph_api(node):
-    # TODO(SigureMo): Cleanup this function after we remove the BasicApiTransformer
-    # Note: A api in module dygraph_to_static is not a real dygraph api.
-    if is_api_in_module(node, DYGRAPH_TO_STATIC_MODULE_PREFIX):
-        return False
-
-    # TODO(liym27): A better way to determine whether it is a dygraph api.
-    #  Consider the decorator @dygraph_only
-    return is_api_in_module(node, DYGRAPH_MODULE_PREFIX)
 
 
 def is_api_in_module(node, module_prefix):

--- a/test/dygraph_to_static/test_basic_api_transformation.py
+++ b/test/dygraph_to_static/test_basic_api_transformation.py
@@ -29,9 +29,6 @@ from paddle.jit.api import to_static
 SEED = 2020
 np.random.seed(SEED)
 
-# TODO(zhhsplendid): This test is old so that use a static graph style
-# mark it as TODO, to refactoring the code of this file.
-
 
 def dyfunc_to_variable(x):
     res = base.dygraph.to_variable(x, name=None, zero_copy=None)
@@ -104,11 +101,11 @@ class TestDygraphBasicApi_ToVariable(Dy2StTestBase):
             np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-05)
 
 
-# 1. test Apis that inherit from layers.Layer
-def dyfunc_BilinearTensorProduct(bilinearTensorProduct, layer1, layer2):
+# test Apis that inherit from layers.Layer
+def dyfunc_BilinearTensorProduct(bilinearTensorProduct, x1, x2):
     res = bilinearTensorProduct(
-        base.dygraph.base.to_variable(layer1),
-        base.dygraph.base.to_variable(layer2),
+        paddle.to_tensor(x1),
+        paddle.to_tensor(x2),
     )
     return res
 
@@ -459,15 +456,6 @@ class TestDygraphBasicApi_PolynomialDecay(TestDygraphBasicApi_CosineDecay):
         paddle.seed(SEED)
         res = self.dygraph_func()
         return res
-
-
-def _dygraph_fn():
-    from paddle import base
-
-    x = np.random.random((1, 3)).astype('float32')
-    with base.dygraph.guard():
-        base.dygraph.to_variable(x)
-        np.random.random(1)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_basic_api_transformation.py
+++ b/test/dygraph_to_static/test_basic_api_transformation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import unittest
 
 import numpy as np
@@ -26,8 +25,6 @@ from paddle import base, to_tensor
 from paddle.base import dygraph
 from paddle.base.dygraph import to_variable
 from paddle.jit.api import to_static
-from paddle.jit.dy2static.utils import is_dygraph_api
-from paddle.utils import gast
 
 SEED = 2020
 np.random.seed(SEED)
@@ -471,23 +468,6 @@ def _dygraph_fn():
     with base.dygraph.guard():
         base.dygraph.to_variable(x)
         np.random.random(1)
-
-
-class TestDygraphApiRecognition(Dy2StTestBase):
-    def setUp(self):
-        self.src = inspect.getsource(_dygraph_fn)
-        self.root = gast.parse(self.src)
-
-    def _get_dygraph_ast_node(self):
-        return self.root.body[0].body[2].body[0].value
-
-    def _get_static_ast_node(self):
-        return self.root.body[0].body[2].body[1].value
-
-    @test_default_and_pir
-    def test_dygraph_api(self):
-        self.assertTrue(is_dygraph_api(self._get_dygraph_ast_node()) is True)
-        self.assertTrue(is_dygraph_api(self._get_static_ast_node()) is False)
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_yolov3.py
+++ b/test/dygraph_to_static/test_yolov3.py
@@ -133,7 +133,6 @@ def train():
         start_time = time.time()
         img = np.array([x[0] for x in data]).astype('float32')
         img = paddle.to_tensor(img)
-        # img = paddle.base.dygraph.to_variable(img)
 
         gt_box = np.array([x[1] for x in data]).astype('float32')
         gt_box = paddle.to_tensor(gt_box)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

清理动转静静态分析动静转换模块 `BasicApiTransformer`，主要是针对 `paddle.base.dygraph` 下的 API 转换，但随着 fluid 清理，这部分 API 已经基本消除了，剩下的 `to_variable` 会在之后清理

PCard-66972