### PR TITLE
[Dy2St] Shrink the eval scope

### DIFF
--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -726,7 +726,7 @@ def convert_var_dtype(var, dtype):
         }
         return paddle.cast(var, dtype=cast_map[dtype])
     else:
-        return eval(f'{dtype}(var)')
+        return eval(dtype)(var)
 
 
 def convert_assert(cond, message=""):

--- a/python/paddle/jit/dy2static/error.py
+++ b/python/paddle/jit/dy2static/error.py
@@ -23,7 +23,7 @@ import numpy as np  # noqa: F401
 from .origin_info import Location, OriginInfo, global_origin_info_map
 from .utils import (
     RE_PYMODULE,
-    _is_api_in_module_helper,  # noqa: F401
+    _is_api_in_module_helper,
 )
 
 __all__ = []
@@ -214,9 +214,8 @@ class ErrorData:
                 func_str = searched_name.group(0)
                 break
         try:
-            module_result = eval(
-                "_is_api_in_module_helper({}, '{}')".format(func_str, "numpy")
-            )
+            fn = eval(func_str)
+            module_result = _is_api_in_module_helper(fn, "numpy")
             is_numpy_api_err = module_result or (
                 func_str.startswith("numpy.") or func_str.startswith("np.")
             )

--- a/python/paddle/jit/dy2static/transformers/call_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/call_transformer.py
@@ -15,7 +15,7 @@
 from paddle.jit.dy2static.utils import ast_to_source_code, is_paddle_api
 from paddle.utils import gast
 
-from ..utils import is_builtin  # noqa: F401
+from ..utils import is_builtin
 from .base import BaseTransformer
 
 PDB_SET = "pdb.set_trace"
@@ -51,9 +51,10 @@ class CallTransformer(BaseTransformer):
                 'enumerate',
                 'print',
             }
-            is_builtin = eval(f"is_builtin({func_str})")  # noqa: F811
+            fn = eval(func_str)
+            is_builtin_fn = is_builtin(fn)
             need_convert = func_str in need_convert_builtin_func_list
-            return is_builtin and not need_convert
+            return is_builtin_fn and not need_convert
         except Exception:
             return False
 

--- a/python/paddle/jit/dy2static/utils_helper.py
+++ b/python/paddle/jit/dy2static/utils_helper.py
@@ -66,7 +66,8 @@ def is_api_in_module(node, module_prefix):
         import paddle.jit.dy2static as _jst  # noqa: F401
         from paddle import to_tensor  # noqa: F401
 
-        return eval(f"_is_api_in_module_helper({func_str}, '{module_prefix}')")
+        fn = eval(func_str)
+        return _is_api_in_module_helper(fn, module_prefix)
     except Exception:
         return False
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

收缩 eval 使用范围，eval 应该仅仅对已经是字符串的部分使用，外部函数不应该使用，否则函数引用不清晰，会引入 F401，而且很难知道 eval 都用到了哪些外部变量

PCard-66972