### PR TITLE
为 paddle.linalg.norm 进行功能升级与对齐- 添加 vector_norm

### DIFF
--- a/python/paddle/linalg.py
+++ b/python/paddle/linalg.py
@@ -40,11 +40,13 @@ from .tensor.linalg import (
     solve,
     svd,
     triangular_solve,
+    vector_norm,
 )
 
 __all__ = [
     'cholesky',
     'norm',
+    'vector_norm',
     'cond',
     'cov',
     'corrcoef',

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -285,6 +285,7 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
     Calculate the p-order vector norm for certain  dimension of Tensor `input`.
     Returns the vector norm (the 1-norm, the Euclidean or 2-norm, and in general the p-norm)
     of a given tensor.
+
     Args:
         x (Tensor): Tensor, data type float32, float64.
         p (int|float, optional): None for porder=2.0. Default None.
@@ -292,9 +293,11 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
         keepdim (bool, optional): Whether keep the dimensions as the `input`, Default False.
         name (str, optional): The default value is None. Normally there is no need for
             user to set this property. For more information, please refer to :ref:`api_guide_Name`.
+
     Returns:
         Tensor: results of vector_norm operation on the specified axis of input tensor,
         it's data type is the same as input's Tensor.
+
     Examples:
         .. code-block:: python
             >>> import paddle

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -298,6 +298,7 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
     Examples:
         .. code-block:: python
             >>> import paddle
+            >>> import numpy as np
             >>> x = paddle.arange(24, dtype="float32").reshape([2, 3, 4]) - 12
             >>> print(x)
             Tensor(shape=[2, 3, 4], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -315,7 +316,7 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
             >>> print(out_vector_norm)
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
             [5., 6., 6., 6.])
-            >>> out_vector_norm = paddle.linalg.vector_norm(x=x,p=np.inf,axis=[1,2],keepdim=False)
+            >>> out_vector_norm = paddle.linalg.vector_norm(x=x,p=float("inf"),axis=[1,2],keepdim=False)
             >>> print(out_vector_norm)
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [12., 11.])

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -300,7 +300,7 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
             >>> import paddle
             >>> x = paddle.arange(24, dtype="float32").reshape([2, 3, 4]) - 12
             >>> print(x)
-            Tensor(shape=[2, 3, 4], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+            Tensor(shape=[2, 3, 4], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[[-12., -11., -10., -9. ],
               [-8. , -7. , -6. , -5. ],
               [-4. , -3. , -2. , -1. ]],
@@ -309,19 +309,19 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
               [ 8. ,  9. ,  10.,  11.]]])
             >>> out_vector_norm = paddle.linalg.vector_norm(x=x,p=2,axis=None,keepdim=False)
             >>> print(out_vector_norm)
-            Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+            Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             34.)
             >>> out_vector_norm = paddle.linalg.vector_norm(x=x,p=0,axis=[0,1],keepdim=False)
             >>> print(out_vector_norm)
-            Tensor(shape=[4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
-            [5, 6, 6, 6])
+            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [5., 6., 6., 6.])
             >>> out_vector_norm = paddle.linalg.vector_norm(x=x,p=np.inf,axis=[1,2],keepdim=False)
             >>> print(out_vector_norm)
-            Tensor(shape=[2], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+            Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [12., 11.])
             >>> out_vector_norm = paddle.linalg.vector_norm(x=x,p=1,axis=1,keepdim=False)
             >>> print(out_vector_norm)
-            Tensor(shape=[2, 4], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+            Tensor(shape=[2, 4], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[24., 21., 18., 15.],
              [12., 15., 18., 21.]])
     """
@@ -331,7 +331,7 @@ def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
     ):
         return paddle.count_nonzero(
             input, axis=axis, keepdim=keepdim, name=name
-        )
+        ).astype(input.dtype)
 
     def inf_norm(
         input, porder=None, axis=axis, keepdim=False, asvector=False, name=None

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -746,7 +746,6 @@ def norm(x, p='fro', axis=None, keepdim=False, name=None):
 
         return out
 
-
     def inf_norm(
         input, porder=None, axis=axis, keepdim=False, asvector=False, name=None
     ):

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -1048,6 +1048,7 @@ class API_NormTest(unittest.TestCase):
         paddle.enable_static()
 
     def test_name(self):
+        paddle.enable_static()
         with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[10, 10], dtype="float32")
             y_1 = paddle.norm(x, p='fro', name='frobenius_name')
@@ -1058,6 +1059,7 @@ class API_NormTest(unittest.TestCase):
             self.assertEqual(('nuclear_name' in y_3.name), True)
 
     def test_errors(self):
+        paddle.enable_static()
         with base.program_guard(base.Program(), base.Program()):
 
             def err_dtype(p, shape_x, xdtype, out=None):

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -31,6 +31,56 @@ def p_norm_python_api(
         return _C_ops.p_norm(x, p, axis, epsilon, keepdim, as_vector)
 
 
+def np_linalg_vector_norm(x, axis, porder, keepdims=False):
+    x_shape = list(x.shape)
+
+    origin_axis = axis
+    if origin_axis is None:
+        pass
+    elif isinstance(origin_axis, int):
+        origin_axis = [origin_axis]
+    else:
+        origin_axis = list(origin_axis)
+
+    if axis is None:
+        x = x.ravel()
+        axis = -1
+
+    if not isinstance(axis, int) and len(axis) > 1:
+        for i in range(len(axis)):
+            if axis[i] < 0:
+                axis[i] += len(x.shape)
+        tmp_axis = []
+        for i in range(len(axis)):
+            tmp_axis.append(-1 - i)
+        x = np.moveaxis(x, axis, tmp_axis)
+
+        front_dim = x.shape[0 : len(x.shape) - len(axis)]
+        back_dim = 1
+        for i in range(len(x.shape) - len(axis), len(x.shape)):
+            back_dim = back_dim * x.shape[i]
+        front_dim = list(front_dim)
+        front_dim.append(back_dim)
+        x = x.reshape(front_dim)
+        axis = -1
+    if isinstance(axis, list):
+        axis = tuple(axis)
+
+    r = np.linalg.norm(x, ord=porder, axis=axis, keepdims=keepdims)
+
+    r_shape = r.shape
+
+    if keepdims:
+        if origin_axis is None:
+            r_shape = np.ones_like(x_shape)
+        elif len(origin_axis) > 1:
+            r_shape = x_shape
+            for i in origin_axis:
+                r_shape[i] = 1
+    r = r.reshape(r_shape)
+    return r
+
+
 def p_norm(x, axis, porder, keepdims=False, reduce_all=False):
     r = []
     if axis is None or reduce_all:
@@ -529,6 +579,43 @@ def run_graph(self, p, axis, shape_x, dtype):
     paddle.enable_static()
 
 
+def check_linalg_vector_static(
+    self, p, axis, shape_x, dtype, keep_dim, check_dim=False
+):
+    with base.program_guard(base.Program()):
+        data = paddle.static.data(name="X", shape=shape_x, dtype=dtype)
+        out = paddle.linalg.vector_norm(
+            x=data, p=p, axis=axis, keepdim=keep_dim
+        )
+        place = base.CPUPlace()
+        exe = base.Executor(place)
+        np_input = (np.random.rand(*shape_x) + 1.0).astype(dtype)
+        expected_result = np_linalg_vector_norm(
+            np_input, porder=p, axis=axis, keepdims=keep_dim
+        ).astype(dtype)
+        (result,) = exe.run(feed={"X": np_input}, fetch_list=[out])
+    np.testing.assert_allclose(result, expected_result, rtol=1e-6, atol=1e-8)
+    if keep_dim and check_dim:
+        np.testing.assert_equal(result.shape, expected_result.shape)
+
+
+def check_linalg_vector_dygraph(
+    self, p, axis, shape_x, dtype, keep_dim, check_dim=False
+):
+    x_numpy = (np.random.random(shape_x) + 1.0).astype(dtype)
+    expected_result = np_linalg_vector_norm(
+        x_numpy, porder=p, axis=axis, keepdims=keep_dim
+    )
+    x_paddle = paddle.to_tensor(x_numpy)
+    result = paddle.linalg.vector_norm(
+        x=x_paddle, p=p, axis=axis, keepdim=keep_dim
+    )
+    result = result.numpy()
+    np.testing.assert_allclose(result, expected_result, rtol=1e-6, atol=1e-8)
+    if keep_dim and check_dim:
+        np.testing.assert_equal(result.shape, expected_result.shape)
+
+
 class API_NormTest(unittest.TestCase):
     def test_basic(self):
         keep_dims = {False, True}
@@ -684,6 +771,131 @@ class API_NormTest(unittest.TestCase):
                 check_dim=True,
             )
 
+            check_linalg_vector_static(
+                self,
+                p=2,
+                axis=None,
+                shape_x=[3, 4],
+                dtype="float32",
+                keep_dim=keep,
+            )
+            check_linalg_vector_static(
+                self,
+                p=4,
+                axis=1,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=np.inf,
+                axis=0,
+                shape_x=[2, 3, 4],
+                dtype="float32",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=np.inf,
+                axis=None,
+                shape_x=[2, 3, 4],
+                dtype="float32",
+                keep_dim=keep,
+            )
+            check_linalg_vector_static(
+                self,
+                p=-np.inf,
+                axis=0,
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=-np.inf,
+                axis=None,
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+            )
+            check_linalg_vector_static(
+                self,
+                p=0,
+                axis=1,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+
+            check_linalg_vector_static(
+                self,
+                p=1,
+                axis=1,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=0,
+                axis=None,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=2,
+                axis=[0, 1],
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=2,
+                axis=-1,
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=1,
+                axis=[0, 1],
+                shape_x=[2, 3, 4, 5],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=np.inf,
+                axis=[0, 1],
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_static(
+                self,
+                p=-np.inf,
+                axis=[0, 1, 2],
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+
     def test_dygraph(self):
         run_graph(self, p='fro', axis=None, shape_x=[2, 3, 4], dtype="float32")
 
@@ -705,6 +917,131 @@ class API_NormTest(unittest.TestCase):
                 axis=[1, 2],
                 shape_x=[2, 3, 4, 5],
                 dtype='float64',
+                keep_dim=keep,
+                check_dim=True,
+            )
+
+            check_linalg_vector_dygraph(
+                self,
+                p=2,
+                axis=None,
+                shape_x=[3, 4],
+                dtype="float32",
+                keep_dim=keep,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=2,
+                axis=1,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=np.inf,
+                axis=0,
+                shape_x=[2, 3, 4],
+                dtype="float32",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=np.inf,
+                axis=None,
+                shape_x=[2, 3, 4],
+                dtype="float32",
+                keep_dim=keep,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=-np.inf,
+                axis=0,
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=-np.inf,
+                axis=None,
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=0,
+                axis=1,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+
+            check_linalg_vector_dygraph(
+                self,
+                p=1,
+                axis=1,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=0,
+                axis=None,
+                shape_x=[3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=2,
+                axis=[0, 1],
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=2,
+                axis=-1,
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=1,
+                axis=[0, 1],
+                shape_x=[2, 3, 4, 5],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=np.inf,
+                axis=[0, 1],
+                shape_x=[2, 3, 4],
+                dtype="float64",
+                keep_dim=keep,
+                check_dim=True,
+            )
+            check_linalg_vector_dygraph(
+                self,
+                p=-np.inf,
+                axis=[0, 1, 2],
+                shape_x=[2, 3, 4],
+                dtype="float64",
                 keep_dim=keep,
                 check_dim=True,
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->

暴露内部函数vector_norm为`paddle.linalg.vector_norm`

```python
def vector_norm(x, p=2.0, axis=None, keepdim=False, name=None):
``` 
