### PR TITLE
[PIR] test_loop.TestForLoopMeetDict error in pir mode

### DIFF
--- a/paddle/fluid/pybind/eager.cc
+++ b/paddle/fluid/pybind/eager.cc
@@ -1082,6 +1082,12 @@ int TensorInit(PyObject* self, PyObject* args, PyObject* kwargs) {
         paddle::framework::proto::VarType::Type var_type =
             CastPyArg2ProtoType(PyTuple_GET_ITEM(args, 3), 3);
         bool persistable = CastPyArg2AttrBoolean(PyTuple_GET_ITEM(args, 4), 4);
+        PADDLE_ENFORCE_NOT_NULL(egr::Controller::Instance().GetCurrentTracer(),
+                                paddle::platform::errors::Fatal(
+                                    "Calling __init__ of Eager Tensor with "
+                                    "NULL tracer is forbidden. Please check "
+                                    "your code and make sure you new a tracer "
+                                    "before calling this constructor."));
         EmptyTensorInitializer(py_tensor_ptr,
                                act_name,
                                egr::Controller::Instance().GetExpectedPlace(),

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from dygraph_to_static_utils import (
     Dy2StTestBase,
+    test_legacy_and_pt_and_pir,
 )
 
 import paddle
@@ -463,6 +464,7 @@ class Net(paddle.nn.Layer):
 
 
 class TestForLoopMeetDict(Dy2StTestBase):
+    @test_legacy_and_pt_and_pir
     def test_start(self):
         net = Net()
         model = paddle.jit.to_static(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- 单测 test_loop.TestForLoopMeetDict 在 pir 模式下报错如下：
![05A78E6ABE29EAABD5C9162C08F2CF12](https://github.com/PaddlePaddle/Paddle/assets/43315610/0f8275f6-e6b6-4533-a11f-b94766e94319)

