### PR TITLE
[PIR] open pir mode for some tests in test_loop.py

### DIFF
--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -360,7 +360,6 @@ class TestTransformWhileLoopWithConflicVar(TestTransformWhileLoop):
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
-        print(static_numpy, dygraph_numpy)
         np.testing.assert_allclose(dygraph_numpy, static_numpy, rtol=1e-05)
 
 

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -25,6 +25,7 @@ from dygraph_to_static_utils import (
 import paddle
 import paddle.nn.functional as F
 from paddle import base
+from paddle.base.framework import use_pir_api
 from paddle.jit.dy2static.transformers.loop_transformer import NameVisitor
 from paddle.utils import gast
 
@@ -354,8 +355,6 @@ class TestTransformWhileLoopWithConflicVar(TestTransformWhileLoop):
     def _init_dyfunc(self):
         self.dyfunc = while_loop_dyfun_with_conflict_var
 
-    # This test raises an error about UndefinedVar in pir mode,
-    # it can be removed after the bug is fixed.
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
@@ -445,8 +444,6 @@ class TestClassVarInForLoop(TestTransformForLoop):
     def _init_dyfunc(self):
         self.dyfunc = for_loop_class_var
 
-    # This test raises an error about UndefinedVar in pir mode,
-    # it can be removed after the bug is fixed.
     def test_ast_to_func(self):
         np.testing.assert_allclose(
             self._run_dygraph(), self._run_static(), rtol=1e-05
@@ -483,6 +480,7 @@ class Net(paddle.nn.Layer):
 
 
 class TestForLoopMeetDict(Dy2StTestBase):
+    @test_legacy_and_pt_and_pir
     def test_start(self):
         net = Net()
         model = paddle.jit.to_static(
@@ -494,7 +492,9 @@ class TestForLoopMeetDict(Dy2StTestBase):
             ],
         )
         temp_dir = tempfile.TemporaryDirectory()
-        paddle.jit.save(model, temp_dir.name)
+        # TODO(pir-save-load): Fix this after we support save/load in PIR
+        if not use_pir_api():
+            paddle.jit.save(model, temp_dir.name)
         temp_dir.cleanup()
 
 

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -355,6 +355,8 @@ class TestTransformWhileLoopWithConflicVar(TestTransformWhileLoop):
     def _init_dyfunc(self):
         self.dyfunc = while_loop_dyfun_with_conflict_var
 
+    # This test raises an error about UndefinedVar in pir mode,
+    # it can be removed after the bug is fixed.
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
@@ -444,6 +446,8 @@ class TestClassVarInForLoop(TestTransformForLoop):
     def _init_dyfunc(self):
         self.dyfunc = for_loop_class_var
 
+    # This test raises an error about UndefinedVar in pir mode,
+    # it can be removed after the bug is fixed.
     def test_ast_to_func(self):
         np.testing.assert_allclose(
             self._run_dygraph(), self._run_static(), rtol=1e-05


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- 将 `test_loop.py` 中的单测开启 pir 模式
- 没开启 pir 模式的单测：`TestTransformWhileLoopWithConflicVar` 和 `TestClassVarInForLoop` 会出现 `UndefinedVar` 相关的问题

