### PR TITLE
[Dy2St] Move some transformer specific utilities into transformer dir

### DIFF
--- a/python/paddle/jit/dy2static/__init__.py
+++ b/python/paddle/jit/dy2static/__init__.py
@@ -26,6 +26,7 @@ from .convert_operators import (  # noqa: F401
     convert_shape as Shape,
     convert_var_dtype as AsDtype,
     convert_while_loop as While,
+    create_bool_as_type,
     indexable as Indexable,
     unpack_by_structure as Unpack,
 )
@@ -33,7 +34,6 @@ from .program_translator import convert_to_static  # noqa: F401
 from .transformers import DygraphToStaticAst  # noqa: F401
 from .utils import UndefinedVar, ast_to_source_code, saw  # noqa: F401
 from .variable_trans_func import (  # noqa: F401
-    create_bool_as_type,
     to_static_variable,
 )
 

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -877,3 +877,13 @@ def _run_python_pop(target, *args):
     else:
         idx = args[0] if args else -1
         return target.pop(idx)
+
+
+def create_bool_as_type(x, value=True):
+    '''
+    Create a bool variable, which type is the same as x.
+    '''
+    if isinstance(x, (Variable, Value)):
+        return paddle.full(shape=[], fill_value=value, dtype="bool")
+    else:
+        return value

--- a/python/paddle/jit/dy2static/transformers/base.py
+++ b/python/paddle/jit/dy2static/transformers/base.py
@@ -22,9 +22,10 @@ from paddle.jit.dy2static.utils import (
     FOR_ITER_ZIP_TO_LIST_PREFIX,
     ORIGI_INFO,
     ast_to_source_code,
-    create_assign_node,
 )
 from paddle.utils import gast
+
+from .utils import create_assign_node
 
 __all__ = []
 

--- a/python/paddle/jit/dy2static/transformers/break_continue_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/break_continue_transformer.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from paddle.base import unique_name
-from paddle.jit.dy2static.utils import BaseNodeVisitor, index_in_list
-from paddle.jit.dy2static.variable_trans_func import create_bool_node
+from paddle.jit.dy2static.utils import index_in_list
 from paddle.utils import gast
 
 from .base import BaseTransformer, ForNodeVisitor
+from .utils import BaseNodeVisitor, create_bool_node
 
 __all__ = []
 

--- a/python/paddle/jit/dy2static/transformers/create_variable_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/create_variable_transformer.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from ..utils import FunctionNameLivenessAnalysis
-from ..variable_trans_func import create_undefined_var
 from .base import BaseTransformer
+from .utils import create_undefined_var
 
 __all__ = []
 

--- a/python/paddle/jit/dy2static/transformers/ifelse_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/ifelse_transformer.py
@@ -28,9 +28,7 @@ from paddle.jit.dy2static.utils import (
     FunctionNameLivenessAnalysis,
     GetterSetterHelper,
     ast_to_source_code,
-    create_funcDef_node,
     create_get_args_node,
-    create_name_str,
     create_nonlocal_stmt_nodes,
     create_set_args_node,
 )
@@ -43,6 +41,7 @@ from paddle.utils import gast
 
 from ..utils import FALSE_FUNC_PREFIX, TRUE_FUNC_PREFIX
 from .base import BaseTransformer
+from .utils import create_function_def_node, create_name_str
 
 __all__ = []
 
@@ -374,13 +373,13 @@ def transform_if_else(node, root):
         defaults=[],
     )
 
-    true_func_node = create_funcDef_node(
+    true_func_node = create_function_def_node(
         nonlocal_stmt_node + node.body,
         name=unique_name.generate(TRUE_FUNC_PREFIX),
         input_args=empty_arg_node,
         return_name_ids=[],
     )
-    false_func_node = create_funcDef_node(
+    false_func_node = create_function_def_node(
         nonlocal_stmt_node + node.orelse,
         name=unique_name.generate(FALSE_FUNC_PREFIX),
         input_args=empty_arg_node,

--- a/python/paddle/jit/dy2static/transformers/loop_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/loop_transformer.py
@@ -27,11 +27,8 @@ from ..utils import (
     GetterSetterHelper,
     ast_to_source_code,
     create_get_args_node,
-    create_name_str,
     create_nonlocal_stmt_nodes,
     create_set_args_node,
-    get_attribute_full_name,
-    get_parent_mapping,
 )
 from .base import (
     BaseTransformer,
@@ -39,6 +36,7 @@ from .base import (
     ForNodeVisitor,
 )
 from .ifelse_transformer import ARGS_NAME
+from .utils import create_name_str, get_attribute_full_name, get_parent_mapping
 
 __all__ = []
 

--- a/python/paddle/jit/dy2static/transformers/return_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/return_transformer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from paddle.base import unique_name
-from paddle.jit.dy2static.variable_trans_func import create_bool_node
 from paddle.utils import gast
 
 from ..utils import (
@@ -24,6 +23,7 @@ from ..utils import (
 )
 from .base import BaseTransformer
 from .break_continue_transformer import ForToWhileTransformer
+from .utils import create_bool_node
 
 __all__ = []
 

--- a/python/paddle/jit/dy2static/transformers/utils.py
+++ b/python/paddle/jit/dy2static/transformers/utils.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+
+from paddle.jit.dy2static.ast_utils import ast_to_source_code
+from paddle.utils import gast
+
+
+class BaseNodeVisitor(gast.NodeVisitor):
+    """
+    Implement customized NodeVisitor inherited from gast.NodeVisitor.
+    Ancestor nodes are traced to easily support more operations of currently
+    visited node.
+    """
+
+    def __init__(self):
+        self.ancestor_nodes = []
+
+    def visit(self, node):
+        """Visit a node."""
+        self.ancestor_nodes.append(node)
+
+        method = 'visit_' + node.__class__.__name__
+        visitor = getattr(self, method, self.generic_visit)
+        ret = visitor(node)
+        self.ancestor_nodes.pop()
+        return ret
+
+
+def create_undefined_var(name):
+    func_code = f"{name} = _jst.UndefinedVar('{name}')"
+    return gast.parse(func_code).body[0]
+
+
+def create_bool_node(name, value):
+    '''
+    Create a assign stmt for name = value .
+    '''
+    assert isinstance(value, bool)
+    node = f"{name} = {value}"
+    return gast.parse(node).body[0]
+
+
+def get_parent_mapping(root):
+    to_parent: dict[gast.AST, gast.AST] = {}
+    for node in gast.walk(root):
+        for child in gast.iter_child_nodes(node):
+            to_parent[child] = node
+    return to_parent
+
+
+def create_name_str(name_ids):
+    """
+    Return "('x', 'y')" for [x, y]
+    """
+    if not name_ids:
+        return 'None'
+
+    names_str = ["'%s'" % (name.replace("'", "\\'")) for name in name_ids]
+    return "(%s, )" % ','.join(names_str)
+
+
+def create_function_def_node(nodes, name, input_args, return_name_ids):
+    """
+    Wrapper all statements of nodes into one ast.FunctionDef, which can be
+    called by ast.Call.
+    """
+    nodes = copy.copy(nodes)
+    # add return statement
+    if return_name_ids:
+        nodes.append(gast.Return(value=generate_name_node(return_name_ids)))
+    else:
+        nodes.append(gast.Return(value=None))
+    func_def_node = gast.FunctionDef(
+        name=name,
+        args=input_args,
+        body=nodes,
+        decorator_list=[],
+        returns=None,
+        type_comment=None,
+    )
+    return func_def_node
+
+
+def create_assign_node(name, node):
+    """
+    Creates a `gast.Assign` node by given name_id as target and node as value.
+    """
+    targets = generate_name_node(name, ctx=gast.Store())
+    assign_node = gast.Assign(targets=[targets], value=node)
+    return targets, assign_node
+
+
+def generate_name_node(name_ids, ctx=gast.Load(), gen_tuple_if_single=False):
+    """
+    If name_ids is list or tuple or set with multiple strings, this function
+    generates gast.Tuple of gast.Name.
+    If the name_ids is single string or contains only 1 string, this function
+    returns gast.Name if gen_tuple_if_single==False else returns gast.Tuple
+    with only one gast.Name
+
+    This function is used at several gast.Return statements.
+    """
+    if isinstance(name_ids, str):
+        name_ids = [name_ids]
+    if not isinstance(name_ids, (list, tuple, set)):
+        raise TypeError(
+            'name_ids must be list or tuple or set, but received %s'
+            % type(type(name_ids))
+        )
+
+    def create_node_for_name(name):
+        if '.' not in name:
+            return gast.Name(
+                id=name, ctx=ctx, annotation=None, type_comment=None
+            )
+        return gast.parse(name).body[0].value
+
+    gast_names = [create_node_for_name(name_id) for name_id in name_ids]
+    if len(gast_names) == 1 and not gen_tuple_if_single:
+        name_node = gast_names[0]
+    else:
+        name_node = gast.Tuple(elts=gast_names, ctx=ctx)
+    return name_node
+
+
+def get_attribute_full_name(node):
+    assert isinstance(
+        node, gast.Attribute
+    ), "Input non-Attribute node to get attribute full name"
+    return ast_to_source_code(node).strip()

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import atexit
 import builtins
-import copy
 import functools
 import importlib.util
 import inspect
@@ -94,35 +93,6 @@ NO_SHAPE_VAR_TYPE = [
     core.VarDesc.VarType.FEED_MINIBATCH,
     core.VarDesc.VarType.FETCH_LIST,
 ]
-
-
-class BaseNodeVisitor(gast.NodeVisitor):
-    """
-    Implement customized NodeVisitor inherited from gast.NodeVisitor.
-    Ancestor nodes are traced to easily support more operations of currently
-    visited node.
-    """
-
-    def __init__(self):
-        self.ancestor_nodes = []
-
-    def visit(self, node):
-        """Visit a node."""
-        self.ancestor_nodes.append(node)
-
-        method = 'visit_' + node.__class__.__name__
-        visitor = getattr(self, method, self.generic_visit)
-        ret = visitor(node)
-        self.ancestor_nodes.pop()
-        return ret
-
-
-def get_parent_mapping(root):
-    to_parent: dict[gast.AST, gast.AST] = {}
-    for node in gast.walk(root):
-        for child in gast.iter_child_nodes(node):
-            to_parent[child] = node
-    return to_parent
 
 
 def data_layer_not_check(name, shape, dtype='float32', lod_level=0):
@@ -310,110 +280,6 @@ def is_paddle_func(func, ignore_white_list=True):
         return flag
     except Exception:
         return False
-
-
-def create_api_shape_node(tensor_shape_node):
-    assert isinstance(
-        tensor_shape_node, (gast.Name, gast.Attribute, gast.Subscript)
-    )
-
-    if isinstance(tensor_shape_node, gast.Name):
-        api_shape_node = gast.Call(
-            func=gast.parse('paddle.shape').body[0].value,
-            args=[tensor_shape_node],
-            keywords=[],
-        )
-        return api_shape_node
-
-    if isinstance(tensor_shape_node, gast.Attribute):
-        api_shape_node = gast.Call(
-            func=gast.parse('paddle.shape').body[0].value,
-            args=[tensor_shape_node.value],
-            keywords=[],
-        )
-        return api_shape_node
-
-    if isinstance(tensor_shape_node, gast.Subscript):
-        result_node = copy.deepcopy(tensor_shape_node)
-        result_node.value = create_api_shape_node(result_node.value)
-        return result_node
-
-
-def get_constant_variable_node(name, value, shape=[1], dtype='int64'):
-    return gast.parse(
-        f'{name} = paddle.full({str(shape)}, "{str(value)}", {dtype})'
-    )
-
-
-def get_attribute_full_name(node):
-    assert isinstance(
-        node, gast.Attribute
-    ), "Input non-Attribute node to get attribute full name"
-    return ast_to_source_code(node).strip()
-
-
-def generate_name_node(name_ids, ctx=gast.Load(), gen_tuple_if_single=False):
-    """
-    If name_ids is list or tuple or set with multiple strings, this function
-    generates gast.Tuple of gast.Name.
-    If the name_ids is single string or contains only 1 string, this function
-    returns gast.Name if gen_tuple_if_single==False else returns gast.Tuple
-    with only one gast.Name
-
-    This function is used at several gast.Return statements.
-    """
-    if isinstance(name_ids, str):
-        name_ids = [name_ids]
-    if not isinstance(name_ids, (list, tuple, set)):
-        raise TypeError(
-            'name_ids must be list or tuple or set, but received %s'
-            % type(type(name_ids))
-        )
-
-    def create_node_for_name(name):
-        if '.' not in name:
-            return gast.Name(
-                id=name, ctx=ctx, annotation=None, type_comment=None
-            )
-        return gast.parse(name).body[0].value
-
-    gast_names = [create_node_for_name(name_id) for name_id in name_ids]
-    if len(gast_names) == 1 and not gen_tuple_if_single:
-        name_node = gast_names[0]
-    else:
-        name_node = gast.Tuple(elts=gast_names, ctx=ctx)
-    return name_node
-
-
-def create_funcDef_node(nodes, name, input_args, return_name_ids):
-    """
-    Wrapper all statements of nodes into one ast.FunctionDef, which can be
-    called by ast.Call.
-    """
-    nodes = copy.copy(nodes)
-    # add return statement
-    if return_name_ids:
-        nodes.append(gast.Return(value=generate_name_node(return_name_ids)))
-    else:
-        nodes.append(gast.Return(value=None))
-    func_def_node = gast.FunctionDef(
-        name=name,
-        args=input_args,
-        body=nodes,
-        decorator_list=[],
-        returns=None,
-        type_comment=None,
-    )
-    return func_def_node
-
-
-def create_assign_node(name, node):
-    """
-    Creates a `gast.Assign` node by given name_id as target and node as value.
-    """
-    targets = generate_name_node(name, ctx=gast.Store())
-    assign_node = gast.Assign(targets=[targets], value=node)
-    return targets, assign_node
 
 
 def get_temp_dir():
@@ -1084,17 +950,6 @@ class GetterSetterHelper:
         for i, v in zip(indices, values):
             vars[i] = v
         self.setter(vars)
-
-
-def create_name_str(name_ids):
-    """
-    Return "('x', 'y')" for [x, y]
-    """
-    if not name_ids:
-        return 'None'
-
-    names_str = ["'%s'" % (name.replace("'", "\\'")) for name in name_ids]
-    return "(%s, )" % ','.join(names_str)
 
 
 def prim_or_cinn_is_enabled(build_strategy, backend):

--- a/python/paddle/jit/dy2static/variable_trans_func.py
+++ b/python/paddle/jit/dy2static/variable_trans_func.py
@@ -13,19 +13,12 @@
 # limitations under the License.
 
 import paddle
-from paddle.base.framework import Variable
 from paddle.framework import use_pir_api
-from paddle.pir import Value
-from paddle.utils import gast, is_sequence, map_structure
+from paddle.utils import is_sequence, map_structure
 
 from .utils import UndefinedVar, create_undefined_variable
 
 __all__ = []
-
-
-def create_undefined_var(name):
-    func_code = f"{name} = _jst.UndefinedVar('{name}')"
-    return gast.parse(func_code).body[0]
 
 
 def to_static_variable(x):
@@ -46,22 +39,3 @@ def to_static_variable(x):
     if is_sequence(x):
         return map_structure(to_static_variable, x)
     return x
-
-
-def create_bool_as_type(x, value=True):
-    '''
-    Create a bool variable, which type is the same as x.
-    '''
-    if isinstance(x, (Variable, Value)):
-        return paddle.full(shape=[], fill_value=value, dtype="bool")
-    else:
-        return value
-
-
-def create_bool_node(name, value):
-    '''
-    Create a assign stmt for name = value .
-    '''
-    assert isinstance(value, bool)
-    node = f"{name} = {value}"
-    return gast.parse(node).body[0]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

将部分仅转写相关 utilities 放到 `transformers/utils.py`，剩余的之后移动，准备移除 `utils_helper.py` 和 `variable_trans_func.py`

PCard-66972