### PR TITLE
[xpu] multi_encoder_xpu supoort int8

### DIFF
--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -321,6 +321,7 @@ if(WITH_XPU)
   pass_library(elementwise_mul_add_fuse_pass inference DIR xpu DEPS
                ${XPU_PASS_DEPS})
   pass_library(sine_pos_fuse_pass inference DIR xpu DEPS ${XPU_PASS_DEPS})
+  pass_library(quant_dequant_xpu_pass inference DIR xpu DEPS ${XPU_PASS_DEPS})
 endif()
 
 cc_library(

--- a/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.cc
@@ -15,6 +15,7 @@
 #include "paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.h"
 #include <string>
 #include "paddle/fluid/framework/ir/graph_pattern_detector.h"
+#include "paddle/fluid/framework/ir/quantize_helper.h"
 #include "paddle/fluid/framework/ir/xpu/pass_utils.h"
 #include "paddle/fluid/framework/ir/xpu/quant_utils.h"
 #include "paddle/fluid/framework/op_version_registry.h"
@@ -523,65 +524,196 @@ void MultiEncoderXPUFusePass::ApplyImpl(ir::Graph* graph) const {
   AddStatis(cast_mask_counts);
 }
 
-void MultiEncoderXPUFusePass::PrepareQKVWeight(Graph* graph,
-                                               Scope* scope,
-                                               BlockDesc* block,
-                                               Node* q_w,
-                                               Node* k_w,
-                                               Node* v_w,
-                                               Node** qkv_w_int16,
-                                               Node** qkv_w_max) const {
-  phi::DenseTensor q_w_fp32_t;
-  phi::DenseTensor k_w_fp32_t;
-  phi::DenseTensor v_w_fp32_t;
-  Assign(scope->Var(q_w->Name())->Get<phi::DenseTensor>(), &q_w_fp32_t);
-  Assign(scope->Var(k_w->Name())->Get<phi::DenseTensor>(), &k_w_fp32_t);
-  Assign(scope->Var(v_w->Name())->Get<phi::DenseTensor>(), &v_w_fp32_t);
+void MultiEncoderXPUFusePass::PrepareInputMax(
+    Graph* graph,
+    Scope* scope,
+    BlockDesc* block,
+    std::unordered_map<std::string, std::vector<Node*>>* node_maps,
+    std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
+    std::vector<Node*>* input_max_nodes) const {
+  // mul input_max, output_max * 6 + matmul x_max,y_max,output_max * 2
+  auto quant_mul_ops = node_maps->find("quant_mul_ops")->second;
+  auto matmul_ops = node_maps->find("matmul_ops")->second;
+  auto mul_add_ops = node_maps->find("mul_add_ops")->second;
+  auto softmax_ops = node_maps->find("softmax_ops")->second;
+  std::vector<float> input_max(quant_mul_ops.size() * 2 + matmul_ops.size() * 3,
+                               0);
+  for (size_t i = 0; i < quant_mul_ops.size(); ++i) {
+    auto input_name = quant_mul_ops[i]->Op()->Input("X")[0];
+    auto output_name = mul_add_ops[i]->Op()->Output("Out")[0];
+    if (var_quant_scales->find(input_name) != var_quant_scales->end() &&
+        var_quant_scales->find(output_name) != var_quant_scales->end()) {
+      input_max[i * 2] = var_quant_scales->at(input_name)[0];
+      input_max[i * 2 + 1] = var_quant_scales->at(output_name)[0];
+      VLOG(3) << quant_mul_ops[i] << " input_max: " << input_max[i * 2]
+              << ", output_max(ew_add): " << input_max[i * 2 + 1];
+    }
+  }
+  float max_qkv_input = std::max(input_max[0], input_max[2]);
+  max_qkv_input = std::max(max_qkv_input, input_max[4]);
+  input_max[0] = max_qkv_input;
+  input_max[2] = max_qkv_input;
+  input_max[4] = max_qkv_input;
+  float max_qkv_output = std::max(input_max[1], input_max[3]);
+  max_qkv_output = std::max(max_qkv_output, input_max[5]);
+  input_max[1] = max_qkv_output;
+  input_max[3] = max_qkv_output;
+  input_max[5] = max_qkv_output;
+  VLOG(3) << "max_qkv_input: " << max_qkv_input
+          << ", max_qkv_output: " << max_qkv_output;
 
-  CastToFp32(&q_w_fp32_t);
-  CastToFp32(&k_w_fp32_t);
-  CastToFp32(&v_w_fp32_t);
+  auto input_x_name = matmul_ops[0]->Op()->Input("X")[0];
+  auto input_y_name = matmul_ops[0]->Op()->Input("Y")[0];
+  auto output_name = softmax_ops[0]->Op()->Output("Out")[0];
+  auto matmul_offset = quant_mul_ops.size();
+  std::vector<bool> matmul_quants(2, false);
+  if (matmul_ops[0]->Op()->HasAttr("enable_int8") &&
+      PADDLE_GET_CONST(bool, matmul_ops[0]->Op()->GetAttr("enable_int8")) &&
+      var_quant_scales->find(input_x_name) != var_quant_scales->end() &&
+      var_quant_scales->find(input_y_name) != var_quant_scales->end() &&
+      var_quant_scales->find(output_name) != var_quant_scales->end()) {
+    input_max[matmul_offset * 2 + 0] =
+        max_qkv_output != 0 ? max_qkv_output
+                            : var_quant_scales->at(input_x_name)[0];
+    input_max[matmul_offset * 2 + 1] =
+        max_qkv_output != 0 ? max_qkv_output
+                            : var_quant_scales->at(input_y_name)[0];
+    input_max[matmul_offset * 2 + 2] = var_quant_scales->at(output_name)[0];
+    VLOG(3) << "qk_matmul X_max: " << input_max[matmul_offset * 2 + 0]
+            << "          Y_max: " << input_max[matmul_offset * 2 + 1]
+            << "        Out_max: " << input_max[matmul_offset * 2 + 2];
+    matmul_quants[0] = true;
+  }
+  input_x_name = matmul_ops[1]->Op()->Input("X")[0];
+  input_y_name = matmul_ops[1]->Op()->Input("Y")[0];
+  output_name = matmul_ops[1]->Op()->Output("Out")[0];
+  if (matmul_ops[1]->Op()->HasAttr("enable_int8") &&
+      PADDLE_GET_CONST(bool, matmul_ops[1]->Op()->GetAttr("enable_int8")) &&
+      var_quant_scales->find(input_x_name) != var_quant_scales->end() &&
+      var_quant_scales->find(input_y_name) != var_quant_scales->end() &&
+      var_quant_scales->find(output_name) != var_quant_scales->end()) {
+    input_max[matmul_offset * 2 + 3] = var_quant_scales->at(input_x_name)[0];
+    input_max[matmul_offset * 2 + 4] = var_quant_scales->at(input_y_name)[0];
+    input_max[matmul_offset * 2 + 5] = var_quant_scales->at(output_name)[0];
+    VLOG(3) << "qk_matmul X_max: " << input_max[matmul_offset * 2 + 3]
+            << "          Y_max: " << input_max[matmul_offset * 2 + 4]
+            << "        Out_max: " << input_max[matmul_offset * 2 + 5];
+    matmul_quants[1] = true;
+  }
+  if (matmul_quants[0] == false || matmul_quants[1] == false) {
+    // For backward compatible, API uses the size of input_max vector to
+    // check whether it is mul quant or mul+matmul quant.
+    input_max.resize(quant_mul_ops.size() * 2);
+    input_max_nodes->resize(quant_mul_ops.size() * 2, nullptr);
+  }
+  std::string base_name = quant_mul_ops[0]->Op()->Input("X")[0];
+  for (size_t i = 0; i < input_max.size(); i++) {
+    std::string fc_input_max_name =
+        base_name + "_" + std::to_string(i) + "_max_in";
+    int max_ptr_size = phi::backends::xpu::get_xpu_max_ptr_size(-1);
+    VarDesc fc_input_max_desc(fc_input_max_name);
+    fc_input_max_desc.SetPersistable(true);
+    fc_input_max_desc.SetShape({static_cast<int64_t>(max_ptr_size)});
+    fc_input_max_desc.SetDataType(proto::VarType::Type::VarType_Type_FP32);
+    Node* fc_input_max_in = graph->CreateVarNode(&fc_input_max_desc);
+    auto* block_input_max_in_desc = block->Var(fc_input_max_name);
+    block_input_max_in_desc->SetPersistable(fc_input_max_desc.Persistable());
+    block_input_max_in_desc->SetShape(fc_input_max_desc.GetShape());
+    block_input_max_in_desc->SetDataType(fc_input_max_desc.GetDataType());
+    (*input_max_nodes)[i] = fc_input_max_in;
 
-  Transpose2D(&q_w_fp32_t);
-  Transpose2D(&k_w_fp32_t);
-  Transpose2D(&v_w_fp32_t);
+    phi::DenseTensor fc_max_in_cpu_tensor;
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(
+        platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
+    fc_max_in_cpu_tensor.set_type(phi::DataType::FLOAT32);
+    fc_max_in_cpu_tensor.Resize({max_ptr_size});
+    std::vector<float> output_scales(max_ptr_size, input_max[i]);
+    memcpy(cpu_ctx->Alloc<float>(&fc_max_in_cpu_tensor),
+           output_scales.data(),
+           max_ptr_size * sizeof(float));
+    Assign(fc_max_in_cpu_tensor,
+           scope->Var(fc_input_max_name)->GetMutable<phi::DenseTensor>());
+  }
+}
 
-  phi::DenseTensor qkv_w_int16_t;
+void MultiEncoderXPUFusePass::PrepareQKVWeight(
+    Graph* graph,
+    Scope* scope,
+    BlockDesc* block,
+    Node* q_w,
+    Node* k_w,
+    Node* v_w,
+    bool enable_int8,
+    std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
+    Node** qkv_w_intx,
+    Node** qkv_w_max,
+    Node** qkv_scale_max) const {
+  phi::DenseTensor qkv_w_intx_t;
   phi::DenseTensor qkv_w_max_t;
   phi::DenseTensor qkv_scale_max_t;
-  qkv_w_int16_t.Resize(
-      DDim({q_w_fp32_t.dims()[0] + k_w_fp32_t.dims()[0] + v_w_fp32_t.dims()[0],
-            q_w_fp32_t.dims()[1]}));
-  qkv_w_int16_t.set_type(q_w_fp32_t.type());
+  size_t qkv_w_intx_hash;
+  phi::DenseTensor q_w_t;
+  phi::DenseTensor k_w_t;
+  phi::DenseTensor v_w_t;
+  Assign(scope->Var(q_w->Name())->Get<phi::DenseTensor>(), &q_w_t);
+  Assign(scope->Var(k_w->Name())->Get<phi::DenseTensor>(), &k_w_t);
+  Assign(scope->Var(v_w->Name())->Get<phi::DenseTensor>(), &v_w_t);
+  Transpose2D(&q_w_t);
+  Transpose2D(&k_w_t);
+  Transpose2D(&v_w_t);
+  qkv_w_intx_t.Resize(DDim(
+      {q_w_t.dims()[0] + k_w_t.dims()[0] + v_w_t.dims()[0], q_w_t.dims()[1]}));
+  qkv_w_intx_t.set_type(q_w_t.type());
   auto* cpu_ctx = static_cast<phi::CPUContext*>(
       platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
-  paddle::experimental::CheckAndTrans2Contiguous(&q_w_fp32_t);
-  paddle::experimental::CheckAndTrans2Contiguous(&k_w_fp32_t);
-  paddle::experimental::CheckAndTrans2Contiguous(&v_w_fp32_t);
-  std::vector<const phi::DenseTensor*> in_tensors{
-      &q_w_fp32_t, &k_w_fp32_t, &v_w_fp32_t};
-  phi::ConcatKernel<float>(*cpu_ctx, in_tensors, 0, &qkv_w_int16_t);
-
-  ConvertWithQuant<float, int16_t>(
-      &qkv_w_int16_t, &qkv_w_max_t, &qkv_scale_max_t, false);
-  size_t qkv_w_int16_hash = HashTensor<int16_t>(qkv_w_int16_t);
+  paddle::experimental::CheckAndTrans2Contiguous(&q_w_t);
+  paddle::experimental::CheckAndTrans2Contiguous(&k_w_t);
+  paddle::experimental::CheckAndTrans2Contiguous(&v_w_t);
+  std::vector<const phi::DenseTensor*> in_tensors{&q_w_t, &k_w_t, &v_w_t};
+  bool is_per_channel = false;
+  if (!enable_int8) {
+    CastToFp32(&q_w_t);
+    CastToFp32(&k_w_t);
+    CastToFp32(&v_w_t);
+    phi::ConcatKernel<float>(*cpu_ctx, in_tensors, 0, &qkv_w_intx_t);
+    ConvertWithQuant<float, int16_t>(
+        &qkv_w_intx_t, &qkv_w_max_t, &qkv_scale_max_t, false);
+    qkv_w_intx_hash = HashTensor<int16_t>(qkv_w_intx_t);
+  } else {
+    phi::ConcatKernel<int8_t>(*cpu_ctx, in_tensors, 0, &qkv_w_intx_t);
+    std::unordered_map<std::string, std::vector<float>> var_quant_scales =
+        GetQuantInfoFromTheGraph(graph, "has_quant_info", "var_quant_scales");
+    std::vector<float> q_scales = var_quant_scales.at(q_w->Name());
+    if (q_scales.size() != 1) {
+      is_per_channel = true;
+      std::vector<float> k_scales = var_quant_scales.at(k_w->Name());
+      std::vector<float> v_scales = var_quant_scales.at(v_w->Name());
+      q_scales.insert(q_scales.end(), k_scales.begin(), k_scales.end());
+      q_scales.insert(q_scales.end(), v_scales.begin(), v_scales.end());
+    }
+    ConvertWithoutQuant<int8_t>(
+        &qkv_w_intx_t, &qkv_w_max_t, &qkv_scale_max_t, false, q_scales);
+    qkv_w_intx_hash = HashTensor<int8_t>(qkv_w_intx_t);
+  }
   size_t qkv_w_max_hash = HashTensor<float>(qkv_w_max_t);
-  std::string qkv_w_int16_name = std::to_string(qkv_w_int16_hash);
+  std::string qkv_w_intx_name = std::to_string(qkv_w_intx_hash);
   std::string qkv_w_max_name = std::to_string(qkv_w_max_hash);
-  *qkv_w_int16 = FindNodeWithName(graph, qkv_w_int16_name);
-  if (*qkv_w_int16 == nullptr) {
-    // Create qkv_w_int16 node
-    // Update qkv_w_int16 var_desc in block
-    VarDesc qkv_w_int16_desc(qkv_w_int16_name);
-    qkv_w_int16_desc.SetPersistable(true);
-    qkv_w_int16_desc.SetShape(common::vectorize(qkv_w_int16_t.dims()));
-    qkv_w_int16_desc.SetDataType(
-        framework::TransToProtoVarType(qkv_w_int16_t.dtype()));
-    *qkv_w_int16 = graph->CreateVarNode(&qkv_w_int16_desc);
-    auto* block_qkv_w_int16_desc = block->Var(qkv_w_int16_name);
-    block_qkv_w_int16_desc->SetPersistable(qkv_w_int16_desc.Persistable());
-    block_qkv_w_int16_desc->SetShape(qkv_w_int16_desc.GetShape());
-    block_qkv_w_int16_desc->SetDataType(qkv_w_int16_desc.GetDataType());
+  std::string qkv_scale_max_name;
+
+  *qkv_w_intx = FindNodeWithName(graph, qkv_w_intx_name);
+  if (*qkv_w_intx == nullptr) {
+    // Create qkv_w_intx node
+    // Update qkv_w_intx var_desc in block
+    VarDesc qkv_w_intx_desc(qkv_w_intx_name);
+    qkv_w_intx_desc.SetPersistable(true);
+    qkv_w_intx_desc.SetShape(common::vectorize(qkv_w_intx_t.dims()));
+    qkv_w_intx_desc.SetDataType(
+        framework::TransToProtoVarType(qkv_w_intx_t.dtype()));
+    *qkv_w_intx = graph->CreateVarNode(&qkv_w_intx_desc);
+    auto* block_qkv_w_intx_desc = block->Var(qkv_w_intx_name);
+    block_qkv_w_intx_desc->SetPersistable(qkv_w_intx_desc.Persistable());
+    block_qkv_w_intx_desc->SetShape(qkv_w_intx_desc.GetShape());
+    block_qkv_w_intx_desc->SetDataType(qkv_w_intx_desc.GetDataType());
     // Create qkv_w_max node
     // Update qkv_w_max var_desc in block
     VarDesc qkv_w_max_desc(qkv_w_max_name);
@@ -594,33 +726,63 @@ void MultiEncoderXPUFusePass::PrepareQKVWeight(Graph* graph,
     block_qkv_w_max_desc->SetShape(qkv_w_max_desc.GetShape());
     block_qkv_w_max_desc->SetDataType(qkv_w_max_desc.GetDataType());
 
-    // Find qkv_w_int16/qkv_w_max variable in scope
-    auto* qkv_w_int16_var = scope->FindVar(qkv_w_int16_name);
-    if (qkv_w_int16_var == nullptr) {
-      // Create qkv_w_int16/qkv_w_max variable/tensor
-      Assign(qkv_w_int16_t,
-             scope->Var(qkv_w_int16_name)->GetMutable<phi::DenseTensor>());
+    if (is_per_channel) {
+      size_t qkv_scale_max_hash = HashTensor<float>(qkv_scale_max_t);
+      qkv_scale_max_name = std::to_string(qkv_scale_max_hash);
+      // Create qkv_scale_max_t node
+      // Update qkv_scale_max_t var_desc in block
+      VarDesc qkv_scale_max_desc(qkv_scale_max_name);
+      qkv_scale_max_desc.SetPersistable(true);
+      qkv_scale_max_desc.SetShape(common::vectorize(qkv_scale_max_t.dims()));
+      qkv_scale_max_desc.SetDataType(proto::VarType::Type::VarType_Type_FP32);
+      *qkv_scale_max = graph->CreateVarNode(&qkv_scale_max_desc);
+      auto* block_qkv_scale_max_desc = block->Var(qkv_scale_max_name);
+      block_qkv_scale_max_desc->SetPersistable(
+          qkv_scale_max_desc.Persistable());
+      block_qkv_scale_max_desc->SetShape(qkv_scale_max_desc.GetShape());
+      block_qkv_scale_max_desc->SetDataType(qkv_scale_max_desc.GetDataType());
+    }
+
+    // Find qkv_w_intx/qkv_w_max variable in scope
+    auto* qkv_w_intx_var = scope->FindVar(qkv_w_intx_name);
+    if (qkv_w_intx_var == nullptr) {
+      // Create qkv_w_intx/qkv_w_max variable/tensor
+      Assign(qkv_w_intx_t,
+             scope->Var(qkv_w_intx_name)->GetMutable<phi::DenseTensor>());
       Assign(qkv_w_max_t,
              scope->Var(qkv_w_max_name)->GetMutable<phi::DenseTensor>());
+      if (is_per_channel) {
+        Assign(qkv_scale_max_t,
+               scope->Var(qkv_scale_max_name)->GetMutable<phi::DenseTensor>());
+      }
     } else {
       // Share the same variable
       PADDLE_ENFORCE_NOT_NULL(
           scope->FindVar(qkv_w_max_name),
           platform::errors::Fatal(
-              "qkv_w_max(%s) variable should not be nullptr if qkv_w_int16(%s) "
+              "qkv_w_max(%s) variable should not be nullptr if qkv_w_intx(%s) "
               "variable is exist.",
               qkv_w_max_name,
-              qkv_w_int16_name));
+              qkv_w_intx_name));
+      if (is_per_channel) {
+        PADDLE_ENFORCE_NOT_NULL(
+            scope->FindVar(qkv_scale_max_name),
+            platform::errors::Fatal("qkv_scale_max(%s) variable should not be "
+                                    "nullptr if qkv_w_intx(%s) "
+                                    "variable is exist.",
+                                    qkv_scale_max_name,
+                                    qkv_w_intx_name));
+      }
     }
   } else {
     *qkv_w_max = FindNodeWithName(graph, qkv_w_max_name);
     PADDLE_ENFORCE_NOT_NULL(
         *qkv_w_max,
         platform::errors::Fatal(
-            "qkv_w_max(%s) variable should not be nullptr if qkv_w_int16(%s) "
+            "qkv_w_max(%s) variable should not be nullptr if qkv_w_intx(%s) "
             "variable is exist.",
             qkv_w_max_name,
-            qkv_w_int16_name));
+            qkv_w_intx_name));
   }
 }
 
@@ -800,34 +962,83 @@ int MultiEncoderXPUFusePass::ApplySingleEncoderXPUFuse(
 
     auto* block = q_matmul->Op()->Block();
     auto* scope = param_scope();
-    bool enable_fp16 =
-        scope->FindVar(q_matmul_w->Name())->Get<phi::DenseTensor>().dtype() ==
-        phi::DataType::FLOAT16;
+    auto weight_dtype =
+        scope->FindVar(q_matmul_w->Name())->Get<phi::DenseTensor>().dtype();
+    std::string use_precision = "float32";
+    if (weight_dtype == phi::DataType::INT8) {
+      use_precision = "int8";
+    } else if (weight_dtype == phi::DataType::FLOAT16) {
+      use_precision = "float16";
+    }
+    bool is_per_channel = false;
+    std::vector<Node*> input_max;
+    std::unordered_map<std::string, std::vector<float>> var_quant_scales =
+        GetQuantInfoFromTheGraph(graph, "has_quant_info", "var_quant_scales");
+    if (use_precision == "int8") {
+      std::unordered_map<std::string, std::vector<Node*>> node_maps;
+      std::vector<Node*> quant_mul_ops = {q_matmul,
+                                          k_matmul,
+                                          v_matmul,
+                                          qkv_matmul_1,
+                                          qkv_matmul_2,
+                                          qkv_matmul_3};
+      node_maps.insert(std::make_pair("quant_mul_ops", quant_mul_ops));
+      std::vector<Node*> mul_add_ops = {
+          q_add, k_add, v_add, qkv_add_0, qkv_act, qkv_add_3};
+      node_maps.insert(std::make_pair("mul_add_ops", mul_add_ops));
+      std::vector<Node*> matmul_ops = {qk_matmul, qkv_matmul_0};
+      node_maps.insert(std::make_pair("matmul_ops", matmul_ops));
+      std::vector<Node*> softmax_ops = {qk_softmax};
+      node_maps.insert(std::make_pair("softmax_ops", softmax_ops));
+      input_max.resize((quant_mul_ops.size() * 2 + quant_mul_ops.size() * 3),
+                       nullptr);
+      PrepareInputMax(
+          graph, scope, block, &node_maps, &var_quant_scales, &input_max);
+    }
 
-    Node* qkv_w_int16 = nullptr;
+    Node* qkv_w_intx = nullptr;
     Node* qkv_w_max = nullptr;
+    Node* qkv_scale_max = nullptr;
     PrepareQKVWeight(graph,
                      scope,
                      block,
                      q_matmul_w,
                      k_matmul_w,
                      v_matmul_w,
-                     &qkv_w_int16,
-                     &qkv_w_max);
+                     (use_precision == "int8"),
+                     &var_quant_scales,
+                     &qkv_w_intx,
+                     &qkv_w_max,
+                     &qkv_scale_max);
 
-#define PREPARE_QKV_MATMUL_W(idx_)                              \
-  Node* qkv_matmul_##idx_##_w_int16 = nullptr;                  \
-  Node* qkv_matmul_##idx_##_w_max = nullptr;                    \
-  Node* qkv_matmul_##idx_##_scale_max = nullptr;                \
-  PrepareWeight<float, int16_t>(graph,                          \
-                                scope,                          \
-                                block,                          \
-                                qkv_matmul_##idx_##_w,          \
-                                &qkv_matmul_##idx_##_w_int16,   \
-                                &qkv_matmul_##idx_##_w_max,     \
-                                &qkv_matmul_##idx_##_scale_max, \
-                                true,                           \
-                                std::vector<float>({}));
+#define PREPARE_QKV_MATMUL_W(idx_)                                \
+  Node* qkv_matmul_##idx_##_w_intx = nullptr;                     \
+  Node* qkv_matmul_##idx_##_w_max = nullptr;                      \
+  Node* qkv_matmul_##idx_##_scale_max = nullptr;                  \
+  if (use_precision != "int8") {                                  \
+    PrepareWeight<float, int16_t>(graph,                          \
+                                  scope,                          \
+                                  block,                          \
+                                  qkv_matmul_##idx_##_w,          \
+                                  &qkv_matmul_##idx_##_w_intx,    \
+                                  &qkv_matmul_##idx_##_w_max,     \
+                                  &qkv_matmul_##idx_##_scale_max, \
+                                  true,                           \
+                                  std::vector<float>({}));        \
+  } else {                                                        \
+    std::vector<float> weight_scales =                            \
+        var_quant_scales.at(qkv_matmul_##idx_##_w->Name());       \
+    is_per_channel = (weight_scales.size() != 1);                 \
+    PrepareWeight<int8_t, int8_t>(graph,                          \
+                                  scope,                          \
+                                  block,                          \
+                                  qkv_matmul_##idx_##_w,          \
+                                  &qkv_matmul_##idx_##_w_intx,    \
+                                  &qkv_matmul_##idx_##_w_max,     \
+                                  &qkv_matmul_##idx_##_scale_max, \
+                                  true,                           \
+                                  weight_scales);                 \
+  }
     PREPARE_QKV_MATMUL_W(1);
     PREPARE_QKV_MATMUL_W(2);
     PREPARE_QKV_MATMUL_W(3);
@@ -853,16 +1064,31 @@ int MultiEncoderXPUFusePass::ApplySingleEncoderXPUFuse(
     framework::OpDesc op_desc(block);
     op_desc.SetType("single_encoder_xpu");
     op_desc.SetInput("x", {ln_0_x->Name()});
+    std::vector<std::string> fc_input_max_names;
+    for (auto* node : input_max) {
+      if (node) {
+        fc_input_max_names.push_back(node->Name());
+      }
+    }
+    op_desc.SetInput("fc_input_max", fc_input_max_names);
     op_desc.SetInput("fc_weight",
-                     {qkv_w_int16->Name(),
-                      qkv_matmul_1_w_int16->Name(),
-                      qkv_matmul_2_w_int16->Name(),
-                      qkv_matmul_3_w_int16->Name()});
-    op_desc.SetInput("fc_weight_max",
-                     {qkv_w_max->Name(),
-                      qkv_matmul_1_w_max->Name(),
-                      qkv_matmul_2_w_max->Name(),
-                      qkv_matmul_3_w_max->Name()});
+                     {qkv_w_intx->Name(),
+                      qkv_matmul_1_w_intx->Name(),
+                      qkv_matmul_2_w_intx->Name(),
+                      qkv_matmul_3_w_intx->Name()});
+    if (!is_per_channel) {
+      op_desc.SetInput("fc_weight_max",
+                       {qkv_w_max->Name(),
+                        qkv_matmul_1_w_max->Name(),
+                        qkv_matmul_2_w_max->Name(),
+                        qkv_matmul_3_w_max->Name()});
+    } else {
+      op_desc.SetInput("fc_weight_max",
+                       {qkv_scale_max->Name(),
+                        qkv_matmul_1_scale_max->Name(),
+                        qkv_matmul_2_scale_max->Name(),
+                        qkv_matmul_3_scale_max->Name()});
+    }
     op_desc.SetInput("fc_bias",
                      {qkv_add_bias_fp32->Name(),
                       qkv_add_0_bias_fp32->Name(),
@@ -891,7 +1117,8 @@ int MultiEncoderXPUFusePass::ApplySingleEncoderXPUFuse(
         static_cast<int>(qkv_matmul_2_w_shape[1] / qkv_matmul_2_w_shape[0]));
     op_desc.SetAttr("act_type", ConvertActivationType(act_type));
     op_desc.SetAttr("relative_type", static_cast<int>(0));
-    op_desc.SetAttr("enable_fp16", enable_fp16);
+    op_desc.SetAttr("use_precision", use_precision);
+    op_desc.SetAttr("is_per_channel", is_per_channel);
     if (norm_before) {
       op_desc.SetOutput("out", {qkv_add_4_out->Name()});
     } else {
@@ -900,13 +1127,24 @@ int MultiEncoderXPUFusePass::ApplySingleEncoderXPUFuse(
     auto* single_encoder_xpu = graph->CreateOpNode(&op_desc);
     // Link nodes
     IR_NODE_LINK_TO(ln_0_x, single_encoder_xpu);
-    IR_NODE_LINK_TO(qkv_w_int16, single_encoder_xpu);
+    for (auto* node : input_max) {
+      if (node) {
+        IR_NODE_LINK_TO(node, single_encoder_xpu);
+      }
+    }
+    if (is_per_channel) {
+      IR_NODE_LINK_TO(qkv_scale_max, single_encoder_xpu);
+      IR_NODE_LINK_TO(qkv_matmul_1_scale_max, single_encoder_xpu);
+      IR_NODE_LINK_TO(qkv_matmul_2_scale_max, single_encoder_xpu);
+      IR_NODE_LINK_TO(qkv_matmul_3_scale_max, single_encoder_xpu);
+    }
+    IR_NODE_LINK_TO(qkv_w_intx, single_encoder_xpu);
     IR_NODE_LINK_TO(qkv_w_max, single_encoder_xpu);
-    IR_NODE_LINK_TO(qkv_matmul_1_w_int16, single_encoder_xpu);
+    IR_NODE_LINK_TO(qkv_matmul_1_w_intx, single_encoder_xpu);
     IR_NODE_LINK_TO(qkv_matmul_1_w_max, single_encoder_xpu);
-    IR_NODE_LINK_TO(qkv_matmul_2_w_int16, single_encoder_xpu);
+    IR_NODE_LINK_TO(qkv_matmul_2_w_intx, single_encoder_xpu);
     IR_NODE_LINK_TO(qkv_matmul_2_w_max, single_encoder_xpu);
-    IR_NODE_LINK_TO(qkv_matmul_3_w_int16, single_encoder_xpu);
+    IR_NODE_LINK_TO(qkv_matmul_3_w_intx, single_encoder_xpu);
     IR_NODE_LINK_TO(qkv_matmul_3_w_max, single_encoder_xpu);
     IR_NODE_LINK_TO(qkv_add_bias_fp32, single_encoder_xpu);
     IR_NODE_LINK_TO(qkv_add_0_bias_fp32, single_encoder_xpu);
@@ -1045,8 +1283,12 @@ bool MultiEncoderXPUFusePass::ApplyMultiEncoderXPUFuse(ir::Graph* graph) const {
 
   // Prepare inputs/outputs names/nodes
   std::string x_name = single_encoders[0]->Op()->Inputs().at("x")[0];
-  std::vector<std::string> arg_names{
-      "fc_weight", "fc_weight_max", "fc_bias", "ln_scale", "ln_bias"};
+  std::vector<std::string> arg_names{"fc_input_max",
+                                     "fc_weight",
+                                     "fc_weight_max",
+                                     "fc_bias",
+                                     "ln_scale",
+                                     "ln_bias"};
   std::map<std::string, std::vector<std::string>> arg_names_map;
   std::string mask_name = single_encoders[0]->Op()->Inputs().count("mask") > 0
                               ? single_encoders[0]->Op()->Inputs().at("mask")[0]
@@ -1126,8 +1368,13 @@ bool MultiEncoderXPUFusePass::ApplyMultiEncoderXPUFuse(ir::Graph* graph) const {
   }
   op_desc.SetAttr("slice_idx", static_cast<int>(-1));
   op_desc.SetAttr(
-      "enable_fp16",
-      PADDLE_GET_CONST(bool, single_encoders[0]->Op()->GetAttr("enable_fp16")));
+      "use_precision",
+      PADDLE_GET_CONST(std::string,
+                       single_encoders[0]->Op()->GetAttr("use_precision")));
+  op_desc.SetAttr(
+      "is_per_channel",
+      PADDLE_GET_CONST(bool,
+                       single_encoders[0]->Op()->GetAttr("is_per_channel")));
   op_desc.SetOutput("out", {out_name});
   op_desc.SetOutput("x_fp16", {x_fp16_name});
   op_desc.SetOutput("out_fp16", {out_fp16_name});
@@ -1161,9 +1408,10 @@ int MultiEncoderXPUFusePass::CastMask(ir::Graph* graph) const {
   for (auto node : nodes) {
     if (node->IsVar()) continue;
     auto op_desc = node->Op();
+    auto use_precision = op_desc->GetAttrIfExists<std::string>("use_precision");
     if (node->IsVar() ||  //
         op_desc->Type() != "multi_encoder_xpu" ||
-        !op_desc->GetAttrIfExists<bool>("enable_fp16") ||
+        (use_precision != "float16" && use_precision != "int8") ||
         op_desc->Inputs().count("mask") == 0)
       continue;
 

--- a/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.h
+++ b/paddle/fluid/framework/ir/xpu/multi_encoder_xpu_fuse_pass.h
@@ -153,14 +153,25 @@ class MultiEncoderXPUFusePass : public FusePassBase {
   // 2. Concat q_w, k_w, v_w
   // 3. Generate qkv_w_max tensor
   // 4. Quant qkv_w to int16
-  void PrepareQKVWeight(Graph* graph,
-                        Scope* scope,
-                        BlockDesc* block,
-                        Node* q_w,
-                        Node* k_w,
-                        Node* v_w,
-                        Node** qkv_w,
-                        Node** qkv_w_max) const;
+  void PrepareQKVWeight(
+      Graph* graph,
+      Scope* scope,
+      BlockDesc* block,
+      Node* q_w,
+      Node* k_w,
+      Node* v_w,
+      bool enable_int8,
+      std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
+      Node** qkv_w,
+      Node** qkv_w_max,
+      Node** qkv_scale_max) const;
+  void PrepareInputMax(
+      Graph* graph,
+      Scope* scope,
+      BlockDesc* block,
+      std::unordered_map<std::string, std::vector<Node*>>* node_maps,
+      std::unordered_map<std::string, std::vector<float>>* var_quant_scales,
+      std::vector<Node*>* input_max_nodes) const;
 
   // 1. Cast bias to fp32
   // 2. Concat q/k/v bias

--- a/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.cc
@@ -1,0 +1,509 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.h"
+
+#include <string>
+
+#include "paddle/fluid/framework/ir/graph_helper.h"
+#include "paddle/fluid/framework/ir/mkldnn/mkldnn_pass_util.h"
+#include "paddle/fluid/framework/ir/quantize_helper.h"
+#include "paddle/fluid/framework/op_version_registry.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+void QuantDequantXPUPass::CollectWeightScalesInfoFromDequantize(
+    ir::Graph* graph,
+    Scope* scope,
+    const std::unordered_set<std::string>& fake_dequantize_types,
+    std::unordered_map<std::string, std::vector<float>>* weight_thresholds)
+    const {
+  VLOG(3) << "gather weight_thresholds from fake dequantized ops";
+  for (auto* op_node :
+       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+    if (!op_node->IsOp()) continue;
+
+    if (fake_dequantize_types.count(op_node->Name())) {
+      auto* op_desc = op_node->Op();
+      auto x_var_name = op_desc->Input("X")[0];
+      // find the var name of weight node to be dequantized
+      std::string weight_var_name;
+      for (auto* in : op_node->inputs) {
+        if (in->Name() == x_var_name) {
+          auto cal_op_node = in->inputs[0];
+          if (cal_op_node->Name() == "conv2d" ||
+              cal_op_node->Name() == "depthwise_conv2d" ||
+              cal_op_node->Name() == "fused_conv2d") {
+            weight_var_name = cal_op_node->Op()->Input("Filter")[0];
+          } else if (cal_op_node->Name() == "mul" ||
+                     cal_op_node->Name() == "matmul" ||
+                     cal_op_node->Name() == "matmul_v2") {
+            weight_var_name = cal_op_node->Op()->Input("Y")[0];
+          }
+        }
+      }
+
+      if (op_desc->HasAttr("max_range")) {
+        const float max_range =
+            PADDLE_GET_CONST(float, op_desc->GetAttr("max_range"));
+        std::vector<float> thresholds = {127 * 127 / max_range};
+        weight_thresholds->insert(std::make_pair(weight_var_name, thresholds));
+      } else {
+        auto scale_name = op_desc->Input("Scales")[0];
+        auto* var = scope->FindVar(scale_name);
+        PADDLE_ENFORCE_NOT_NULL(
+            var,
+            platform::errors::NotFound(
+                "The Scales variable [%s] of dequantize op is not found.",
+                var));
+
+        auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
+        auto* scale_data = scale_tensor->data<float>();
+        std::vector<float> thresholds{};
+        for (int i = 0; i < scale_tensor->numel(); i++) {
+          thresholds.push_back(scale_data[i]);
+        }
+        weight_thresholds->insert(std::make_pair(weight_var_name, thresholds));
+      }
+    }
+  }
+}
+
+void QuantDequantXPUPass::CollectWeightScalesInfoFromONNXFormatDequantize(
+    ir::Graph* graph,
+    Scope* scope,
+    std::unordered_map<std::string, std::vector<float>>* weight_thresholds,
+    std::unordered_map<std::string, std::vector<float>>* var_quant_scales)
+    const {
+  VLOG(3) << "gather weight_thresholds from onnx format dequantized ops";
+  for (auto* op_node :
+       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+    if (!op_node->IsOp()) continue;
+
+    if (op_node->Name() == "dequantize_linear") {
+      auto* op_desc = op_node->Op();
+
+      auto scale_name = op_desc->Input("Scale")[0];
+      auto* var = scope->FindVar(scale_name);
+      PADDLE_ENFORCE_NOT_NULL(
+          var,
+          platform::errors::NotFound(
+              "The Scales variable [%s] of dequantize op is not found.", var));
+
+      auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
+      auto* scale_data = scale_tensor->data<float>();
+
+      auto x_var_name = op_desc->Input("X")[0];
+      auto* weight_var = scope->FindVar(x_var_name);
+      if (!weight_var) {
+        auto out_var_name = op_desc->Output("Y")[0];
+        float scale = scale_data[0];
+        if (std::isinf(scale) || std::isnan(scale)) {
+          scale = 0.0;
+        }
+        std::vector<float> scale_v = {scale};
+        if (!var_quant_scales->count(out_var_name)) {
+          var_quant_scales->insert(std::make_pair(out_var_name, scale_v));
+        }
+        if (!var_quant_scales->count(x_var_name)) {
+          var_quant_scales->insert(std::make_pair(x_var_name, scale_v));
+        }
+      } else {
+        std::vector<float> thresholds(scale_data,
+                                      scale_data + scale_tensor->numel());
+        weight_thresholds->insert(std::make_pair(x_var_name, thresholds));
+      }
+    }
+  }
+}
+
+void QuantDequantXPUPass::CollectInputScalesFromQuantize(
+    ir::Graph* graph,
+    Scope* scope,
+    const std::unordered_set<std::string>& fake_quantize_types,
+    std::unordered_map<std::string, std::vector<float>>* var_quant_scales)
+    const {
+  VLOG(3) << "gather input scales from fake quantized ops";
+  for (auto* op_node :
+       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+    if (!op_node->IsOp()) continue;
+
+    if (op_node->Name() == "fake_quantize_dequantize_moving_average_abs_max" ||
+        op_node->Name() == "quantize_linear" ||
+        fake_quantize_types.count(op_node->Name())) {
+      auto* op_desc = op_node->Op();
+      const int bit_length =
+          PADDLE_GET_CONST(int, op_desc->GetAttr("bit_length"));
+      PADDLE_ENFORCE_EQ(bit_length,
+                        8,
+                        platform::errors::InvalidArgument(
+                            "Unsupported number quantization "
+                            "bits: %d, only 8 is supported now.",
+                            bit_length));
+
+      std::string scale_name = "InScale";
+      std::string out_name = "Out";
+      if (op_node->Name() == "quantize_linear") {
+        scale_name = "Scale";
+        out_name = "Y";
+      }
+      auto x_var_name = op_desc->Input("X")[0];
+      auto scale_var_name = op_desc->Input(scale_name)[0];
+      auto out_var_name = op_desc->Output(out_name)[0];
+
+      auto* var = scope->FindVar(scale_var_name);
+      PADDLE_ENFORCE_NOT_NULL(
+          var,
+          platform::errors::NotFound(
+              "The InScale variable [%s] of quantize op is not found.", var));
+
+      auto* scale_tensor = var->GetMutable<phi::DenseTensor>();
+      auto* scale_data = scale_tensor->data<float>();
+      float scale = scale_data[0];
+      if (std::isinf(scale) || std::isnan(scale)) {
+        continue;
+      }
+
+      if (!var_quant_scales->count(x_var_name)) {
+        std::vector<float> scale_v = {scale};
+        var_quant_scales->insert(std::make_pair(x_var_name, scale_v));
+      }
+
+      if (!var_quant_scales->count(out_var_name)) {
+        std::vector<float> scale_v = {scale};
+        var_quant_scales->insert(std::make_pair(out_var_name, scale_v));
+      }
+
+      for (auto* out : op_node->outputs) {
+        if (out->Name() == out_var_name) {
+          for (auto* var : out->outputs) {
+            auto op_desc = var->Op();
+            std::string quantized_op_type = op_desc->Type();
+            op_desc->SetAttr("enable_int8", true);
+            op_desc->Flush();
+          }
+        }
+      }
+    }
+  }
+}
+
+void QuantDequantXPUPass::CollectOutputScalesFromAttr(
+    ir::Graph* graph,
+    std::unordered_map<std::string, std::vector<float>>* var_quant_scales)
+    const {
+  VLOG(3) << "gather output scales from op's attr";
+  for (auto* op_node :
+       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+    if (!op_node->IsOp()) continue;
+
+    auto* op_desc = op_node->Op();
+    if (op_desc->HasAttr("out_threshold")) {
+      const float attr_scale =
+          PADDLE_GET_CONST(float, op_desc->GetAttr("out_threshold"));
+      if (attr_scale == 0.0) continue;
+      float scale = attr_scale;
+      std::vector<float> scale_v = {scale};
+
+      auto var_name_map = op_desc->Outputs();
+      for (auto& item : var_name_map) {
+        for (auto const& var_name : item.second) {
+          var_quant_scales->insert(std::make_pair(var_name, scale_v));
+        }
+      }
+    }
+  }
+}
+
+void QuantDequantXPUPass::CollectFakeQuantizeOps(
+    ir::Graph* graph,
+    Node* op_node,
+    std::unordered_set<const Node*>* nodes2rm) const {
+  auto* op_desc = op_node->Op();
+  auto x_var_name = op_desc->Input("X")[0];
+  auto in_scale_name = op_desc->Input("InScale")[0];
+  auto out_var_name = op_desc->Output("Out")[0];
+  auto out_scale_name = op_desc->Output("OutScale")[0];
+
+  Node* fake_quant_in = nullptr;
+  Node* fake_quant_in_scale = nullptr;
+  for (auto* node_input : op_node->inputs) {
+    if (node_input->Name() == x_var_name) {
+      fake_quant_in = node_input;
+    } else if (node_input->Name() == in_scale_name) {
+      fake_quant_in_scale = node_input;
+    }
+  }
+
+  Node* fake_quant_out = nullptr;
+  Node* fake_quant_out_scale = nullptr;
+  for (auto* node_output : op_node->outputs) {
+    if (node_output->Name() == out_var_name) {
+      fake_quant_out = node_output;
+    } else if (node_output->Name() == out_scale_name) {
+      fake_quant_out_scale = node_output;
+    }
+  }
+
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_quant_in,
+      platform::errors::NotFound(
+          "The input var [%s] of quantize op is not found.", x_var_name));
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_quant_out,
+      platform::errors::NotFound(
+          "The output var [%s] of quantize op is not found.", out_var_name));
+
+  std::string input_act_name = fake_quant_in->Var()->Name();
+  std::string output_act_name = fake_quant_out->Var()->Name();
+  auto outlinks = fake_quant_out->outputs;
+  for (auto* next_node : outlinks) {
+    if (!next_node->IsOp()) continue;
+    next_node->Op()->RenameInput(output_act_name, input_act_name);
+    IR_NODE_LINK_TO(fake_quant_in, next_node);
+  }
+
+  nodes2rm->insert(op_node);
+  nodes2rm->insert(fake_quant_in_scale);
+  nodes2rm->insert(fake_quant_out);
+  nodes2rm->insert(fake_quant_out_scale);
+}
+
+void QuantDequantXPUPass::CollectFakeDequantizeOps(
+    ir::Graph* graph,
+    Node* op_node,
+    std::unordered_set<const Node*>* nodes2rm) const {
+  auto* op_desc = op_node->Op();
+  auto x_var_name = op_desc->Input("X")[0];
+  auto out_var_name = op_desc->Output("Out")[0];
+
+  Node* fake_dequant_in = nullptr;
+  for (auto* node_input : op_node->inputs) {
+    if (node_input->Name() == x_var_name) {
+      fake_dequant_in = node_input;
+      break;
+    }
+  }
+
+  Node* fake_dequant_out = nullptr;
+  for (auto* node_output : op_node->outputs) {
+    if (node_output->Name() == out_var_name) {
+      fake_dequant_out = node_output;
+      break;
+    }
+  }
+
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_dequant_in,
+      platform::errors::NotFound(
+          "The input var [%s] of dequantize op is not found.", x_var_name));
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_dequant_out,
+      platform::errors::NotFound(
+          "The output var [%s] of dequantize op is not found.", out_var_name));
+
+  std::string input_act_name = fake_dequant_in->Var()->Name();
+  std::string output_act_name = fake_dequant_out->Var()->Name();
+  auto outlinks = fake_dequant_out->outputs;
+  for (auto* next_node : outlinks) {
+    next_node->Op()->RenameInput(output_act_name, input_act_name);
+    IR_NODE_LINK_TO(fake_dequant_in, next_node);
+  }
+
+  nodes2rm->insert(op_node);
+  nodes2rm->insert(fake_dequant_out);
+}
+
+void QuantDequantXPUPass::CollectQuantizeDequantizeOpsFromONNXFormat(
+    ir::Graph* graph,
+    Node* op_node,
+    std::unordered_set<const Node*>* nodes2rm) const {
+  auto* op_desc = op_node->Op();
+  auto x_var_name = op_desc->Input("X")[0];
+  auto in_scale_name = op_desc->Input("Scale")[0];
+  auto in_zero_name = op_desc->Input("ZeroPoint")[0];
+  auto out_var_name = op_desc->Output("Y")[0];
+
+  Node* fake_quant_in = nullptr;
+  Node* fake_quant_in_scale = nullptr;
+  for (auto* node_input : op_node->inputs) {
+    if (node_input->Name() == x_var_name) {
+      fake_quant_in = node_input;
+    } else if (node_input->Name() == in_scale_name) {
+      fake_quant_in_scale = node_input;
+    }
+  }
+
+  Node* fake_quant_out = nullptr;
+  for (auto* node_output : op_node->outputs) {
+    if (node_output->Name() == out_var_name) {
+      fake_quant_out = node_output;
+    }
+  }
+
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_quant_in,
+      platform::errors::NotFound(
+          "The input var [%s] of quantize op is not found.", x_var_name));
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_quant_in_scale,
+      platform::errors::NotFound(
+          "The scale var [%s] of quantize op is not found.", in_scale_name));
+  PADDLE_ENFORCE_NOT_NULL(
+      fake_quant_out,
+      platform::errors::NotFound(
+          "The output var [%s] of quantize op is not found.", out_var_name));
+
+  std::string input_act_name = fake_quant_in->Var()->Name();
+  std::string output_act_name = fake_quant_out->Var()->Name();
+  for (auto* next_node : fake_quant_out->outputs) {
+    if (!next_node->IsOp()) continue;
+    next_node->Op()->RenameInput(output_act_name, input_act_name);
+    IR_NODE_LINK_TO(fake_quant_in, next_node);
+  }
+
+  nodes2rm->insert(op_node);
+  nodes2rm->insert(fake_quant_in_scale);
+  nodes2rm->insert(fake_quant_out);
+}
+
+void QuantDequantXPUPass::RemoveFakeOps(
+    ir::Graph* graph,
+    const std::unordered_set<std::string>& fake_quantize_types,
+    const std::unordered_set<std::string>& fake_dequantize_types,
+    const std::unordered_set<std::string>& fake_quantize_dequantize_types,
+    const std::unordered_set<std::string>&
+        onnx_format_quantize_dequantize_types) const {
+  VLOG(3) << "remove fake quantize and dequantize ops";
+
+  std::unordered_set<const Node*> nodes2rm = {};
+  for (auto* op_node :
+       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+    if (!op_node->IsOp()) continue;
+
+    if (fake_quantize_types.count(op_node->Name())) {
+      CollectFakeQuantizeOps(graph, op_node, &nodes2rm);
+    } else if (fake_dequantize_types.count(op_node->Name()) ||
+               fake_quantize_dequantize_types.count(op_node->Name())) {
+      CollectFakeDequantizeOps(graph, op_node, &nodes2rm);
+    } else if (onnx_format_quantize_dequantize_types.count(op_node->Name())) {
+      CollectQuantizeDequantizeOpsFromONNXFormat(graph, op_node, &nodes2rm);
+    }
+  }
+
+  GraphSafeRemoveNodes(graph, nodes2rm);
+}
+
+void QuantDequantXPUPass::RestoreWeightsToInt8(
+    Scope* scope,
+    const std::unordered_map<std::string, std::vector<float>>&
+        weight_thresholds) const {
+  std::vector<float> scales;
+  for (auto it : weight_thresholds) {
+    auto weight_var_name = it.first;
+    auto* var = scope->FindVar(weight_var_name);
+    PADDLE_ENFORCE_NOT_NULL(
+        var,
+        platform::errors::NotFound(
+            "The input persistable [%s] var of [%s] op is not found.",
+            weight_var_name));
+    auto* weight_tensor = var->GetMutable<phi::DenseTensor>();
+    float* fp32_weight_data = weight_tensor->data<float>();
+    std::vector<int8_t> weight_data;
+    weight_data.resize(weight_tensor->numel());
+    for (int i = 0; i < weight_tensor->numel(); i++) {
+      weight_data[i] = static_cast<int8_t>(fp32_weight_data[i]);
+    }
+    const auto weight_dims = weight_tensor->dims();
+    weight_tensor->clear();  // clear int weight
+    weight_tensor->set_type(phi::DataType::INT8);
+    weight_tensor->Resize(common::make_ddim(common::vectorize(weight_dims)));
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(
+        platform::DeviceContextPool::Instance().Get(phi::CPUPlace()));
+    auto* new_weight_data = cpu_ctx->Alloc<int8_t>(weight_tensor);
+    memcpy(new_weight_data,
+           weight_data.data(),
+           weight_tensor->numel() * sizeof(int8_t));
+  }
+}
+
+void QuantDequantXPUPass::ApplyImpl(ir::Graph* graph) const {
+  VLOG(3) << "Convert (old) paddle slim quantized model to quantized model.";
+  const std::string pattern_name = "quant_dequant_xpu_pass";
+  FusePassBase::Init(pattern_name, graph);
+
+  const std::unordered_set<std::string> skip_ops = {"conv2d",
+                                                    "depthwise_conv2d",
+                                                    "fused_conv2d",
+                                                    "mul",
+                                                    "matmul",
+                                                    "matmul_v2"};
+
+  const std::unordered_set<std::string> fake_quantize_types = {
+      "fake_quantize_moving_average_abs_max", "fake_quantize_range_abs_max"};
+
+  const std::unordered_set<std::string> fake_dequantize_types = {
+      "fake_dequantize_max_abs", "fake_channel_wise_dequantize_max_abs"};
+
+  const std::unordered_set<std::string> fake_quantize_dequantize_types = {
+      "fake_quantize_dequantize_abs_max",
+      "fake_quantize_dequantize_moving_average_abs_max",
+      "fake_channel_wise_quantize_dequantize_abs_max"};
+
+  const std::unordered_set<std::string> onnx_format_quantize_dequantize_types =
+      {"quantize_linear", "dequantize_linear"};
+
+  std::unordered_map<std::string, std::vector<float>> weight_thresholds{};
+  std::unordered_map<std::string, std::vector<float>> var_quant_scales{};
+  auto* scope = param_scope();
+  CollectWeightScalesInfoFromDequantize(
+      graph, scope, fake_dequantize_types, &weight_thresholds);
+  CollectWeightScalesInfoFromONNXFormatDequantize(
+      graph, scope, &weight_thresholds, &var_quant_scales);
+  CollectInputScalesFromQuantize(
+      graph, scope, fake_quantize_types, &var_quant_scales);
+  CollectOutputScalesFromAttr(graph, &var_quant_scales);
+  RemoveFakeOps(graph,
+                fake_quantize_types,
+                fake_dequantize_types,
+                fake_quantize_dequantize_types,
+                onnx_format_quantize_dequantize_types);
+  RestoreWeightsToInt8(scope, weight_thresholds);
+
+  SaveQuantInfoInTheGraph(
+      graph, "has_quant_info", "var_quant_scales", weight_thresholds);
+  SaveQuantInfoInTheGraph(
+      graph, "has_quant_info", "var_quant_scales", var_quant_scales);
+}
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
+
+REGISTER_PASS(quant_dequant_xpu_pass,
+              paddle::framework::ir::QuantDequantXPUPass);
+
+REGISTER_PASS_CAPABILITY(quant_dequant_xpu_pass)
+    .AddCombination(
+        paddle::framework::compatible::OpVersionComparatorCombination()
+            .LE("conv2d", 1)
+            .EQ("fc", 0)
+            .LE("conv2d_transpose", 2)
+            .EQ("fake_quantize_abs_max", 0)
+            .EQ("fake_quantize_range_abs_max", 0)
+            .EQ("fake_quantize_moving_average_abs_max", 0)
+            .LE("fake_channel_wise_quantize_abs_max", 1)
+            .EQ("fake_dequantize_max_abs", 0));

--- a/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.h
+++ b/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "paddle/fluid/framework/ir/fuse_pass_base.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+class QuantDequantXPUPass : public FusePassBase {
+ public:
+  QuantDequantXPUPass() = default;
+  virtual ~QuantDequantXPUPass() {}
+
+ protected:
+  void ApplyImpl(ir::Graph* graph) const override;
+
+ private:
+  void CollectWeightScalesInfoFromDequantize(
+      ir::Graph* graph,
+      Scope* scope,
+      const std::unordered_set<std::string>& fake_dequantize_types,
+      std::unordered_map<std::string, std::vector<float>>* weight_thresholds)
+      const;
+
+  void CollectWeightScalesInfoFromONNXFormatDequantize(
+      ir::Graph* graph,
+      Scope* scope,
+      std::unordered_map<std::string, std::vector<float>>* weight_thresholds,
+      std::unordered_map<std::string, std::vector<float>>* var_quant_scales)
+      const;
+
+  void CollectInputScalesFromQuantize(
+      ir::Graph* graph,
+      Scope* scope,
+      const std::unordered_set<std::string>& fake_quantize_types,
+      std::unordered_map<std::string, std::vector<float>>* var_quant_scales)
+      const;
+
+  void CollectOutputScalesFromAttr(
+      ir::Graph* graph,
+      std::unordered_map<std::string, std::vector<float>>* var_quant_scales)
+      const;
+
+  void CollectFakeQuantizeOps(ir::Graph* graph,
+                              Node* op_node,
+                              std::unordered_set<const Node*>* nodes2rm) const;
+
+  void CollectFakeDequantizeOps(
+      ir::Graph* graph,
+      Node* op_node,
+      std::unordered_set<const Node*>* nodes2rm) const;
+
+  void CollectQuantizeDequantizeOpsFromONNXFormat(
+      ir::Graph* graph,
+      Node* op_node,
+      std::unordered_set<const Node*>* nodes2rm) const;
+
+  void RemoveFakeOps(
+      ir::Graph* graph,
+      const std::unordered_set<std::string>& fake_quantize_types,
+      const std::unordered_set<std::string>& fake_dequantize_types,
+      const std::unordered_set<std::string>& fake_quantize_dequantize_types,
+      const std::unordered_set<std::string>&
+          onnx_format_quantize_dequantize_types) const;
+
+  void RestoreWeightsToInt8(
+      Scope* scope,
+      const std::unordered_map<std::string, std::vector<float>>&
+          weight_thresholds) const;
+};
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -521,6 +521,7 @@ void CpuPassStrategy::EraseFcMkldnnPasses() {
 
 XpuPassStrategy::XpuPassStrategy() : PassStrategy({}) {
   passes_.assign({
+      "quant_dequant_xpu_pass",
       "delete_quant_dequant_linear_op_pass",
       "delete_weight_dequant_linear_op_pass",
       "delete_assign_op_pass",

--- a/paddle/phi/api/yaml/fused_ops.yaml
+++ b/paddle/phi/api/yaml/fused_ops.yaml
@@ -399,7 +399,7 @@
   backward : max_pool2d_v2_grad
 
 - op : multi_encoder_xpu
-  args : (Tensor x, Tensor[] fc_weight, Tensor[] fc_weight_max, Tensor[] fc_bias, Tensor[] ln_scale, Tensor[] ln_bias, Tensor mask, Tensor seq_lod, Tensor max_seq_len, int layer_num, bool norm_before, int hidden_dim, int head_num, int size_per_head, int ffn_hidden_dim_scale, int act_type, int relative_type, int slice_idx)
+  args : (Tensor x, Tensor[] fc_input_max, Tensor[] fc_weight, Tensor[] fc_weight_max, Tensor[] fc_bias, Tensor[] ln_scale, Tensor[] ln_bias, Tensor mask, Tensor seq_lod, Tensor max_seq_len, int layer_num, bool norm_before, int hidden_dim, int head_num, int size_per_head, int ffn_hidden_dim_scale, int act_type, int relative_type, int slice_idx, bool is_per_channel)
   output : Tensor(out), Tensor(x_fp16), Tensor(out_fp16)
   infer_meta :
     func : MultiEncoderXPUInferMeta

--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -1440,6 +1440,7 @@ void GenerateSequenceXPUInferMeta(const MetaTensor& x,
 
 void MultiEncoderXPUInferMeta(
     const MetaTensor& x,
+    const std::vector<const MetaTensor*>& fc_input_max,
     const std::vector<const MetaTensor*>& fc_weight,
     const std::vector<const MetaTensor*>& fc_weight_max,
     const std::vector<const MetaTensor*>& fc_bias,
@@ -1457,6 +1458,7 @@ void MultiEncoderXPUInferMeta(
     int act_type,
     int relative_type,
     int slice_idx,
+    bool is_per_channel,
     MetaTensor* out,
     MetaTensor* x_fp16,
     MetaTensor* out_fp16) {

--- a/paddle/phi/infermeta/fusion.h
+++ b/paddle/phi/infermeta/fusion.h
@@ -144,6 +144,7 @@ void GenerateSequenceXPUInferMeta(const MetaTensor& x,
 
 void MultiEncoderXPUInferMeta(
     const MetaTensor& x,
+    const std::vector<const MetaTensor*>& fc_input_max,
     const std::vector<const MetaTensor*>& fc_weight,
     const std::vector<const MetaTensor*>& fc_weight_max,
     const std::vector<const MetaTensor*>& fc_bias,
@@ -161,6 +162,7 @@ void MultiEncoderXPUInferMeta(
     int act_type,
     int relative_type,
     int slice_idx,
+    bool is_per_channel,
     MetaTensor* out,
     MetaTensor* x_fp16,
     MetaTensor* out_fp16);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Description
1. xpu支持旧paddle slim的量化格式，fake_xxx_ops等
2. multi_encoder_xpu大算子支持int8量化模型。支持mul量化，mul+matmul量化，per_channel量化。