### PR TITLE
[PIR] add test_loop time from 120s to 180s.

### DIFF
--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -45,6 +45,7 @@ set_tests_properties(test_cycle_gan PROPERTIES TIMEOUT 150)
 set_tests_properties(test_basic_api_transformation PROPERTIES TIMEOUT 240)
 set_tests_properties(test_reinforcement_learning PROPERTIES TIMEOUT 120)
 set_tests_properties(test_bmn PROPERTIES TIMEOUT 300)
+set_tests_properties(test_loop PROPERTIES TIMEOUT 180)
 
 if(NOT WIN32)
   set_tests_properties(test_tsm PROPERTIES TIMEOUT 900)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

由于 test_loop单测增加了pir_api模式的执行[PR](https://github.com/PaddlePaddle/Paddle/pull/61177)，单测时间在120s左右摆动[超时日志链接](https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/9998726/job/25169328)。当超过120s时就会超时失败。
因此，将其超时时间从120s增加到180s。

### Other

Pcard-67164 
