### PR TITLE
[CodeStyle] Use `itertools.product` reorganize deep nested loops

### DIFF
--- a/test/ir/inference/test_trt_convert_batch_norm.py
+++ b/test/ir/inference/test_trt_convert_batch_norm.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -29,7 +31,7 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             if self.dims == 4:
                 if attrs[0]['data_layout'] == "NCHW":
                     return np.ones([batch, 3, 24, 24]).astype(np.float32)
@@ -40,19 +42,19 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
             elif self.dims == 2:
                 return np.ones([batch, 3]).astype(np.float32)
 
-        def generate_bias(attrs: List[Dict[str, Any]], batch):
+        def generate_bias(attrs: list[dict[str, Any]], batch):
             return np.full((3), 0.9).astype("float32")
 
-        def generate_mean(attrs: List[Dict[str, Any]], batch):
+        def generate_mean(attrs: list[dict[str, Any]], batch):
             return np.full((3), 0.9).astype("float32")
 
-        def generate_scale(attrs: List[Dict[str, Any]], batch):
+        def generate_scale(attrs: list[dict[str, Any]], batch):
             return np.full((3), 1.1).astype("float32")
 
-        def generate_variance(attrs: List[Dict[str, Any]], batch):
+        def generate_variance(attrs: list[dict[str, Any]], batch):
             return np.full((3), 1.2).astype("float32")
 
-        def generate_MomentumTensor(attrs: List[Dict[str, Any]], batch):
+        def generate_MomentumTensor(attrs: list[dict[str, Any]], batch):
             return np.full((3), 0.9).astype("float32")
 
         for dims, num_input, batch, epsilon, data_layout, momentum in product(
@@ -156,7 +158,7 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:

--- a/test/ir/inference/test_trt_convert_batch_norm.py
+++ b/test/ir/inference/test_trt_convert_batch_norm.py
@@ -14,7 +14,8 @@
 
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from itertools import product
+from typing import Any, Dict, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -54,130 +55,109 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
         def generate_MomentumTensor(attrs: List[Dict[str, Any]], batch):
             return np.full((3), 0.9).astype("float32")
 
-        for dims in [2, 3, 4]:
-            for num_input in [0, 1]:
-                for batch in [1, 4]:
-                    for epsilon in [1e-6, 1e-5, 1e-4]:
-                        for data_layout in ["NCHW"]:
-                            for momentum in [0.9, 0.8]:
-                                self.num_input = num_input
-                                self.dims = dims
-                                dics = [
-                                    {
-                                        "epsilon": epsilon,
-                                        "data_layout": data_layout,
-                                        "momentum": momentum,
-                                        "is_test": True,
-                                        "trainable_statistics": False,
-                                    },
-                                    {},
-                                ]
-                                dics_intput = [
-                                    {
-                                        "X": ["batch_norm_input"],
-                                        "Bias": ["Bias"],
-                                        "Mean": ["Mean"],
-                                        "Scale": ["Scale"],
-                                        "Variance": ["Variance"],
-                                        "MomentumTensor": ["MomentumTensor"],
-                                    },
-                                    {
-                                        "X": ["batch_norm_input"],
-                                        "Bias": ["Bias"],
-                                        "Mean": ["Mean"],
-                                        "Scale": ["Scale"],
-                                        "Variance": ["Variance"],
-                                    },
-                                ]
-                                dics_intputs = [
-                                    {
-                                        "Bias": TensorConfig(
-                                            data_gen=partial(
-                                                generate_bias, dics, batch
-                                            )
-                                        ),
-                                        "Mean": TensorConfig(
-                                            data_gen=partial(
-                                                generate_mean, dics, batch
-                                            )
-                                        ),
-                                        "Scale": TensorConfig(
-                                            data_gen=partial(
-                                                generate_scale, dics, batch
-                                            )
-                                        ),
-                                        "Variance": TensorConfig(
-                                            data_gen=partial(
-                                                generate_variance, dics, batch
-                                            )
-                                        ),
-                                        "MomentumTensor": TensorConfig(
-                                            data_gen=partial(
-                                                generate_MomentumTensor,
-                                                dics,
-                                                batch,
-                                            )
-                                        ),
-                                    },
-                                    {
-                                        "Bias": TensorConfig(
-                                            data_gen=partial(
-                                                generate_bias, dics, batch
-                                            )
-                                        ),
-                                        "Mean": TensorConfig(
-                                            data_gen=partial(
-                                                generate_mean, dics, batch
-                                            )
-                                        ),
-                                        "Scale": TensorConfig(
-                                            data_gen=partial(
-                                                generate_scale, dics, batch
-                                            )
-                                        ),
-                                        "Variance": TensorConfig(
-                                            data_gen=partial(
-                                                generate_variance, dics, batch
-                                            )
-                                        ),
-                                    },
-                                ]
-                                ops_config = [
-                                    {
-                                        "op_type": "batch_norm",
-                                        "op_inputs": dics_intput[num_input],
-                                        "op_outputs": {
-                                            "Y": ["batch_norm_out"],
-                                            "MeanOut": ["Mean"],
-                                            "VarianceOut": ["Variance"],
-                                            "SavedMean": ["SavedMean"],
-                                            "SavedVariance": ["SavedVariance"],
-                                        },
-                                        "op_attrs": dics[0],
-                                    }
-                                ]
-                                ops = self.generate_op_config(ops_config)
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights=dics_intputs[num_input],
-                                    inputs={
-                                        "batch_norm_input": TensorConfig(
-                                            data_gen=partial(
-                                                generate_input1, dics, batch
-                                            )
-                                        )
-                                    },
-                                    outputs=["batch_norm_out"],
-                                    no_cast_list=list(
-                                        dics_intputs[num_input].keys()
-                                    ),
-                                )
+        for dims, num_input, batch, epsilon, data_layout, momentum in product(
+            [2, 3, 4], [0, 1], [1, 4], [1e-6, 1e-5, 1e-4], ["NCHW"], [0.9, 0.8]
+        ):
+            self.num_input = num_input
+            self.dims = dims
+            dics = [
+                {
+                    "epsilon": epsilon,
+                    "data_layout": data_layout,
+                    "momentum": momentum,
+                    "is_test": True,
+                    "trainable_statistics": False,
+                },
+                {},
+            ]
+            dics_intput = [
+                {
+                    "X": ["batch_norm_input"],
+                    "Bias": ["Bias"],
+                    "Mean": ["Mean"],
+                    "Scale": ["Scale"],
+                    "Variance": ["Variance"],
+                    "MomentumTensor": ["MomentumTensor"],
+                },
+                {
+                    "X": ["batch_norm_input"],
+                    "Bias": ["Bias"],
+                    "Mean": ["Mean"],
+                    "Scale": ["Scale"],
+                    "Variance": ["Variance"],
+                },
+            ]
+            dics_intputs = [
+                {
+                    "Bias": TensorConfig(
+                        data_gen=partial(generate_bias, dics, batch)
+                    ),
+                    "Mean": TensorConfig(
+                        data_gen=partial(generate_mean, dics, batch)
+                    ),
+                    "Scale": TensorConfig(
+                        data_gen=partial(generate_scale, dics, batch)
+                    ),
+                    "Variance": TensorConfig(
+                        data_gen=partial(generate_variance, dics, batch)
+                    ),
+                    "MomentumTensor": TensorConfig(
+                        data_gen=partial(
+                            generate_MomentumTensor,
+                            dics,
+                            batch,
+                        )
+                    ),
+                },
+                {
+                    "Bias": TensorConfig(
+                        data_gen=partial(generate_bias, dics, batch)
+                    ),
+                    "Mean": TensorConfig(
+                        data_gen=partial(generate_mean, dics, batch)
+                    ),
+                    "Scale": TensorConfig(
+                        data_gen=partial(generate_scale, dics, batch)
+                    ),
+                    "Variance": TensorConfig(
+                        data_gen=partial(generate_variance, dics, batch)
+                    ),
+                },
+            ]
+            ops_config = [
+                {
+                    "op_type": "batch_norm",
+                    "op_inputs": dics_intput[num_input],
+                    "op_outputs": {
+                        "Y": ["batch_norm_out"],
+                        "MeanOut": ["Mean"],
+                        "VarianceOut": ["Variance"],
+                        "SavedMean": ["SavedMean"],
+                        "SavedVariance": ["SavedVariance"],
+                    },
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
+            program_config = ProgramConfig(
+                ops=ops,
+                weights=dics_intputs[num_input],
+                inputs={
+                    "batch_norm_input": TensorConfig(
+                        data_gen=partial(generate_input1, dics, batch)
+                    )
+                },
+                outputs=["batch_norm_out"],
+                no_cast_list=list(dics_intputs[num_input].keys()),
+            )
 
-                                yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 if attrs[0]['data_layout'] == "NCHW":

--- a/test/ir/inference/test_trt_convert_depthwise_conv2d_transpose.py
+++ b/test/ir/inference/test_trt_convert_depthwise_conv2d_transpose.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -56,12 +58,12 @@ class TrtConvertDepthwiseConv2dTransposeTest(TrtLayerAutoScanTest):
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
 
-        def generate_input1(batch, attrs: List[Dict[str, Any]]):
+        def generate_input1(batch, attrs: list[dict[str, Any]]):
             return np.ones([batch, attrs[0]['groups'], 64, 64]).astype(
                 np.float32
             )
 
-        def generate_weight1(attrs: List[Dict[str, Any]]):
+        def generate_weight1(attrs: list[dict[str, Any]]):
             return np.random.random([attrs[0]['groups'], 1, 3, 3]).astype(
                 np.float32
             )
@@ -130,7 +132,7 @@ class TrtConvertDepthwiseConv2dTransposeTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_nearest_interp.py
+++ b/test/ir/inference/test_trt_convert_nearest_interp.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -42,7 +44,7 @@ class TrtConvertNearestInterpTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
         for (
@@ -97,7 +99,7 @@ class TrtConvertNearestInterpTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}

--- a/test/ir/inference/test_trt_convert_nearest_interp.py
+++ b/test/ir/inference/test_trt_convert_nearest_interp.py
@@ -14,7 +14,8 @@
 
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from itertools import product
+from typing import Any, Dict, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -44,55 +45,60 @@ class TrtConvertNearestInterpTest(TrtLayerAutoScanTest):
         def generate_input1(attrs: List[Dict[str, Any]]):
             return np.ones([1, 3, 64, 64]).astype(np.float32)
 
-        for data_layout in ["NCHW", "NHWC"]:
-            for interp_method in ["nearest"]:
-                for align_corners in [True, False]:
-                    for scale in [2.0, -1.0, 0.0]:
-                        for out_h in [32, 64, 128 - 32]:
-                            for out_w in [32, -32]:
-                                dics = [
-                                    {
-                                        "data_layout": data_layout,
-                                        "interp_method": interp_method,
-                                        "align_corners": align_corners,
-                                        "scale": scale,
-                                        "out_h": out_h,
-                                        "out_w": out_w,
-                                    }
-                                ]
+        for (
+            data_layout,
+            interp_method,
+            align_corners,
+            scale,
+            out_h,
+            out_w,
+        ) in product(
+            ["NCHW", "NHWC"],
+            ["nearest"],
+            [True, False],
+            [2.0, -1.0, 0.0],
+            [32, 64, 128 - 32],
+            [32, -32],
+        ):
+            dics = [
+                {
+                    "data_layout": data_layout,
+                    "interp_method": interp_method,
+                    "align_corners": align_corners,
+                    "scale": scale,
+                    "out_h": out_h,
+                    "out_w": out_w,
+                }
+            ]
 
-                                ops_config = [
-                                    {
-                                        "op_type": "nearest_interp",
-                                        "op_inputs": {"X": ["input_data"]},
-                                        "op_outputs": {
-                                            "Out": [
-                                                "nearest_interp_output_data"
-                                            ]
-                                        },
-                                        "op_attrs": dics[0],
-                                    }
-                                ]
-                                ops = self.generate_op_config(ops_config)
+            ops_config = [
+                {
+                    "op_type": "nearest_interp",
+                    "op_inputs": {"X": ["input_data"]},
+                    "op_outputs": {"Out": ["nearest_interp_output_data"]},
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
 
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights={},
-                                    inputs={
-                                        "input_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_input1, dics
-                                            )
-                                        )
-                                    },
-                                    outputs=["nearest_interp_output_data"],
-                                )
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={},
+                inputs={
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1, dics)
+                    )
+                },
+                outputs=["nearest_interp_output_data"],
+            )
 
-                                yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}

--- a/test/ir/inference/test_trt_convert_rnn.py
+++ b/test/ir/inference/test_trt_convert_rnn.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -205,7 +207,7 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))

--- a/test/ir/inference/test_trt_convert_rnn.py
+++ b/test/ir/inference/test_trt_convert_rnn.py
@@ -15,7 +15,8 @@
 import os
 import unittest
 from functools import partial
-from typing import List
+from itertools import product
+from typing import Any, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -30,194 +31,182 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
 
     def sample_program_configs(self):
         self.trt_param.workspace_size = 1073741824
-        for hidden_size in [30]:
-            for input_size in [30]:
-                for batch in [2]:
-                    for seq_len in [5]:
-                        for num_layers in [1, 2]:
-                            for is_bidirec in [True, False]:
-                                dics = []
-                                dics.append(
-                                    {
-                                        "hidden_size": hidden_size,
-                                        "input_size": input_size,
-                                        "num_layers": num_layers,
-                                        "mode": "LSTM",
-                                        "is_bidirec": is_bidirec,
-                                        "is_test": True,
-                                        "dropout_prob": 0.0,
-                                        # for my convenience
-                                        "batch": batch,
-                                        "seq_len": seq_len,
-                                    }
-                                )
+        for (
+            hidden_size,
+            input_size,
+            batch,
+            seq_len,
+            num_layers,
+            is_bidirec,
+        ) in product([30], [30], [2], [5], [1, 2], [True, False]):
+            dics = []
+            dics.append(
+                {
+                    "hidden_size": hidden_size,
+                    "input_size": input_size,
+                    "num_layers": num_layers,
+                    "mode": "LSTM",
+                    "is_bidirec": is_bidirec,
+                    "is_test": True,
+                    "dropout_prob": 0.0,
+                    # for my convenience
+                    "batch": batch,
+                    "seq_len": seq_len,
+                }
+            )
 
-                                K = 1
-                                if dics[0]["is_bidirec"]:
-                                    K = 2
+            K = 1
+            if dics[0]["is_bidirec"]:
+                K = 2
 
-                                def generate_input1():
-                                    return (
-                                        np.random.random(
-                                            [batch, seq_len, input_size]
-                                        ).astype(np.float32)
-                                        * 2
-                                        - 1
-                                    )
+            def generate_input1():
+                return (
+                    np.random.random([batch, seq_len, input_size]).astype(
+                        np.float32
+                    )
+                    * 2
+                    - 1
+                )
 
-                                # initial input -> hidden
-                                def generate_w0():
-                                    return (
-                                        np.random.random(
-                                            [4 * hidden_size, input_size]
-                                        ).astype(np.float32)
-                                        * 2
-                                        - 1
-                                    )
+            # initial input -> hidden
+            def generate_w0():
+                return (
+                    np.random.random([4 * hidden_size, input_size]).astype(
+                        np.float32
+                    )
+                    * 2
+                    - 1
+                )
 
-                                # prev layer's output -> hidden
-                                def generate_w1():
-                                    return (
-                                        np.random.random(
-                                            [4 * hidden_size, K * hidden_size]
-                                        ).astype(np.float32)
-                                        * 2
-                                        - 1
-                                    )
+            # prev layer's output -> hidden
+            def generate_w1():
+                return (
+                    np.random.random([4 * hidden_size, K * hidden_size]).astype(
+                        np.float32
+                    )
+                    * 2
+                    - 1
+                )
 
-                                #
-                                def generate_w2():
-                                    return (
-                                        np.random.random(
-                                            [4 * hidden_size, hidden_size]
-                                        ).astype(np.float32)
-                                        * 2
-                                        - 1
-                                    )
+            #
+            def generate_w2():
+                return (
+                    np.random.random([4 * hidden_size, hidden_size]).astype(
+                        np.float32
+                    )
+                    * 2
+                    - 1
+                )
 
-                                def generate_b():
-                                    return (
-                                        np.random.random(
-                                            [4 * hidden_size]
-                                        ).astype(np.float32)
-                                        * 2
-                                        - 1
-                                    )
+            def generate_b():
+                return (
+                    np.random.random([4 * hidden_size]).astype(np.float32) * 2
+                    - 1
+                )
 
-                                dics.append(
-                                    {
-                                        "dtype": 5,
-                                        "input_dim_idx": 0,
-                                        "str_value": "",
-                                        "value": 0.0,
-                                        "shape": [
-                                            K * num_layers,
-                                            -1,
-                                            hidden_size,
-                                        ],
-                                        "output_dim_idx": 1,
-                                    }
-                                )
-                                dics.append({"axis": [1, 0, 2]})
-                                # set  weights
-                                WeightList = [
-                                    "weight" + str(i)
-                                    for i in range(
-                                        4 * K * dics[0]["num_layers"]
-                                    )
-                                ]
-                                weights = {}
-                                for i in range((int)(len(WeightList) / 2)):
-                                    # mean this weight : input->hidden
-                                    # input has 2 case: initial input input_size, K * hidden form the prev layer.
-                                    if i % 2 == 0:
-                                        if i <= K:
-                                            weights[
-                                                WeightList[i]
-                                            ] = TensorConfig(
-                                                data_gen=partial(generate_w0)
-                                            )
-                                        else:
-                                            weights[
-                                                WeightList[i]
-                                            ] = TensorConfig(
-                                                data_gen=partial(generate_w1)
-                                            )
-                                    # mean this weight : hidden->hidden
-                                    if i % 2 == 1:
-                                        weights[WeightList[i]] = TensorConfig(
-                                            data_gen=partial(generate_w2)
-                                        )
-                                for i in range(
-                                    (int)(len(WeightList) / 2), len(WeightList)
-                                ):
-                                    weights[WeightList[i]] = TensorConfig(
-                                        data_gen=partial(generate_b)
-                                    )
-                                ops_config = [
-                                    {
-                                        "op_type": "fill_constant_batch_size_like",
-                                        "op_inputs": {"Input": ["input_data"]},
-                                        "op_outputs": {"Out": ["prestate1"]},
-                                        "op_attrs": dics[1],
-                                    },
-                                    {
-                                        "op_type": "fill_constant_batch_size_like",
-                                        "op_inputs": {"Input": ["input_data"]},
-                                        "op_outputs": {"Out": ["prestate2"]},
-                                        "op_attrs": dics[1],
-                                    },
-                                    {
-                                        "op_type": "transpose2",
-                                        "op_inputs": {"X": ["input_data"]},
-                                        "op_outputs": {
-                                            "Out": ["rnn_input_data"]
-                                        },
-                                        "op_attrs": dics[2],
-                                    },
-                                    {
-                                        "op_type": "rnn",
-                                        "op_inputs": {
-                                            "Input": ["rnn_input_data"],
-                                            # prev_c, prev_h
-                                            "PreState": [
-                                                "prestate1",
-                                                "prestate2",
-                                            ],
-                                            "WeightList": WeightList,
-                                        },
-                                        "op_outputs": {
-                                            "Out": ["rnn_output_data"],
-                                            "State": [
-                                                "state_output_data0",
-                                                "state_output_data1",
-                                            ],
-                                            "Reserve": ["reserve_data"],
-                                            "DropoutState": [
-                                                "DropoutState_data"
-                                            ],
-                                        },
-                                        "op_attrs": dics[0],
-                                    },
-                                ]
-                                ops = self.generate_op_config(ops_config)
+            dics.append(
+                {
+                    "dtype": 5,
+                    "input_dim_idx": 0,
+                    "str_value": "",
+                    "value": 0.0,
+                    "shape": [
+                        K * num_layers,
+                        -1,
+                        hidden_size,
+                    ],
+                    "output_dim_idx": 1,
+                }
+            )
+            dics.append({"axis": [1, 0, 2]})
+            # set  weights
+            WeightList = [
+                "weight" + str(i) for i in range(4 * K * dics[0]["num_layers"])
+            ]
+            weights = {}
+            for i in range((int)(len(WeightList) / 2)):
+                # mean this weight : input->hidden
+                # input has 2 case: initial input input_size, K * hidden form the prev layer.
+                if i % 2 == 0:
+                    if i <= K:
+                        weights[WeightList[i]] = TensorConfig(
+                            data_gen=partial(generate_w0)
+                        )
+                    else:
+                        weights[WeightList[i]] = TensorConfig(
+                            data_gen=partial(generate_w1)
+                        )
+                # mean this weight : hidden->hidden
+                if i % 2 == 1:
+                    weights[WeightList[i]] = TensorConfig(
+                        data_gen=partial(generate_w2)
+                    )
+            for i in range((int)(len(WeightList) / 2), len(WeightList)):
+                weights[WeightList[i]] = TensorConfig(
+                    data_gen=partial(generate_b)
+                )
+            ops_config = [
+                {
+                    "op_type": "fill_constant_batch_size_like",
+                    "op_inputs": {"Input": ["input_data"]},
+                    "op_outputs": {"Out": ["prestate1"]},
+                    "op_attrs": dics[1],
+                },
+                {
+                    "op_type": "fill_constant_batch_size_like",
+                    "op_inputs": {"Input": ["input_data"]},
+                    "op_outputs": {"Out": ["prestate2"]},
+                    "op_attrs": dics[1],
+                },
+                {
+                    "op_type": "transpose2",
+                    "op_inputs": {"X": ["input_data"]},
+                    "op_outputs": {"Out": ["rnn_input_data"]},
+                    "op_attrs": dics[2],
+                },
+                {
+                    "op_type": "rnn",
+                    "op_inputs": {
+                        "Input": ["rnn_input_data"],
+                        # prev_c, prev_h
+                        "PreState": [
+                            "prestate1",
+                            "prestate2",
+                        ],
+                        "WeightList": WeightList,
+                    },
+                    "op_outputs": {
+                        "Out": ["rnn_output_data"],
+                        "State": [
+                            "state_output_data0",
+                            "state_output_data1",
+                        ],
+                        "Reserve": ["reserve_data"],
+                        "DropoutState": ["DropoutState_data"],
+                    },
+                    "op_attrs": dics[0],
+                },
+            ]
+            ops = self.generate_op_config(ops_config)
 
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights=weights,
-                                    inputs={
-                                        "input_data": TensorConfig(
-                                            data_gen=partial(generate_input1)
-                                        )
-                                    },
-                                    outputs=["rnn_output_data"],
-                                )
+            program_config = ProgramConfig(
+                ops=ops,
+                weights=weights,
+                inputs={
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1)
+                    )
+                },
+                outputs=["rnn_output_data"],
+            )
 
-                                yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]

--- a/test/ir/inference/test_trt_convert_roi_align.py
+++ b/test/ir/inference/test_trt_convert_roi_align.py
@@ -14,7 +14,8 @@
 
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from itertools import product
+from typing import Any, Dict, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -50,93 +51,93 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
             if batch == 4:
                 return [[0, 1, 2, 2, 3]]
 
-        for num_input in [0, 1]:
-            for batch in [1, 2, 4]:
-                for spatial_scale in [0.5, 0.6]:
-                    for pooled_height in [7, 1]:
-                        for pooled_width in [7, 1]:
-                            for sampling_ratio in [-1, 4, 8]:
-                                for aligned in [True, False]:
-                                    self.num_input = num_input
-                                    if num_input == 1:
-                                        batch = 1
-                                    dics = [
-                                        {
-                                            "spatial_scale": spatial_scale,
-                                            "pooled_height": pooled_height,
-                                            "pooled_width": pooled_width,
-                                            "sampling_ratio": sampling_ratio,
-                                            "aligned": aligned,
-                                        },
-                                        {},
-                                    ]
-                                    dics_input = [
-                                        {
-                                            "X": ["roi_align_input"],
-                                            "ROIs": ["ROIs"],
-                                            "RoisNum": ["RoisNum"],
-                                        },
-                                        {
-                                            "X": ["roi_align_input"],
-                                            "ROIs": ["ROIs"],
-                                        },
-                                    ]
-                                    program_input = [
-                                        {
-                                            "roi_align_input": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input1, dics, batch
-                                                )
-                                            ),
-                                            "ROIs": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input2, dics, batch
-                                                )
-                                            ),
-                                            "RoisNum": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input3, dics, batch
-                                                )
-                                            ),
-                                        },
-                                        {
-                                            "roi_align_input": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input1, dics, batch
-                                                )
-                                            ),
-                                            "ROIs": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input2, dics, batch
-                                                ),
-                                                lod=generate_lod(batch),
-                                            ),
-                                        },
-                                    ]
-                                    ops_config = [
-                                        {
-                                            "op_type": "roi_align",
-                                            "op_inputs": dics_input[num_input],
-                                            "op_outputs": {
-                                                "Out": ["roi_align_out"]
-                                            },
-                                            "op_attrs": dics[0],
-                                        }
-                                    ]
-                                    ops = self.generate_op_config(ops_config)
-                                    program_config = ProgramConfig(
-                                        ops=ops,
-                                        weights={},
-                                        inputs=program_input[num_input],
-                                        outputs=["roi_align_out"],
-                                        no_cast_list=["RoisNum"],
-                                    )
+        for (
+            num_input,
+            batch,
+            spatial_scale,
+            pooled_height,
+            pooled_width,
+            sampling_ratio,
+            aligned,
+        ) in product(
+            [0, 1],
+            [1, 2, 4],
+            [0.5, 0.6],
+            [7, 1],
+            [7, 1],
+            [-1, 4, 8],
+            [True, False],
+        ):
+            self.num_input = num_input
+            if num_input == 1:
+                batch = 1
+            dics = [
+                {
+                    "spatial_scale": spatial_scale,
+                    "pooled_height": pooled_height,
+                    "pooled_width": pooled_width,
+                    "sampling_ratio": sampling_ratio,
+                    "aligned": aligned,
+                },
+                {},
+            ]
+            dics_input = [
+                {
+                    "X": ["roi_align_input"],
+                    "ROIs": ["ROIs"],
+                    "RoisNum": ["RoisNum"],
+                },
+                {
+                    "X": ["roi_align_input"],
+                    "ROIs": ["ROIs"],
+                },
+            ]
+            program_input = [
+                {
+                    "roi_align_input": TensorConfig(
+                        data_gen=partial(generate_input1, dics, batch)
+                    ),
+                    "ROIs": TensorConfig(
+                        data_gen=partial(generate_input2, dics, batch)
+                    ),
+                    "RoisNum": TensorConfig(
+                        data_gen=partial(generate_input3, dics, batch)
+                    ),
+                },
+                {
+                    "roi_align_input": TensorConfig(
+                        data_gen=partial(generate_input1, dics, batch)
+                    ),
+                    "ROIs": TensorConfig(
+                        data_gen=partial(generate_input2, dics, batch),
+                        lod=generate_lod(batch),
+                    ),
+                },
+            ]
+            ops_config = [
+                {
+                    "op_type": "roi_align",
+                    "op_inputs": dics_input[num_input],
+                    "op_outputs": {"Out": ["roi_align_out"]},
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={},
+                inputs=program_input[num_input],
+                outputs=["roi_align_out"],
+                no_cast_list=["RoisNum"],
+            )
 
-                                    yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs):
             if self.num_input == 0:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_roi_align.py
+++ b/test/ir/inference/test_trt_convert_roi_align.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -29,13 +31,13 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch):
+        def generate_input1(attrs: list[dict[str, Any]], batch):
             return np.ones([batch, 256, 32, 32]).astype(np.float32)
 
-        def generate_input2(attrs: List[Dict[str, Any]], batch):
+        def generate_input2(attrs: list[dict[str, Any]], batch):
             return np.random.random([3, 4]).astype(np.float32)
 
-        def generate_input3(attrs: List[Dict[str, Any]], batch):
+        def generate_input3(attrs: list[dict[str, Any]], batch):
             if batch == 1:
                 return np.array([3]).astype(np.int32)
             if batch == 2:
@@ -136,7 +138,7 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             if self.num_input == 0:

--- a/test/ir/inference/test_trt_convert_scale.py
+++ b/test/ir/inference/test_trt_convert_scale.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -29,7 +31,7 @@ class TrtConvertScaleTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch, is_int):
+        def generate_input1(attrs: list[dict[str, Any]], batch, is_int):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(
                     np.int32 if is_int else np.float32
@@ -47,7 +49,7 @@ class TrtConvertScaleTest(TrtLayerAutoScanTest):
             elif self.dims == 0:
                 return np.ones([]).astype(np.int32 if is_int else np.float32)
 
-        def generate_weight1(attrs: List[Dict[str, Any]], is_int):
+        def generate_weight1(attrs: list[dict[str, Any]], is_int):
             return np.ones([1]).astype(np.int32 if is_int else np.float32)
 
         for (
@@ -130,7 +132,7 @@ class TrtConvertScaleTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:

--- a/test/ir/inference/test_trt_convert_scale.py
+++ b/test/ir/inference/test_trt_convert_scale.py
@@ -14,7 +14,8 @@
 
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from itertools import product
+from typing import Any, Dict, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -49,80 +50,88 @@ class TrtConvertScaleTest(TrtLayerAutoScanTest):
         def generate_weight1(attrs: List[Dict[str, Any]], is_int):
             return np.ones([1]).astype(np.int32 if is_int else np.float32)
 
-        for num_input in [0, 1]:
-            for dims in [0, 1, 2, 3, 4]:
-                for batch in [1, 2]:
-                    for scale in [0.1, -1.0]:
-                        for bias in [0.0, 1.2]:
-                            for bias_after_scale in [False, True]:
-                                for is_int in [False, True]:
-                                    self.num_input = num_input
-                                    self.dims = dims
-                                    self.is_int = is_int
-                                    dics = [
-                                        {
-                                            "scale": scale,
-                                            "bias": bias,
-                                            "bias_after_scale": bias_after_scale,
-                                        },
-                                        {},
-                                    ]
+        for (
+            num_input,
+            dims,
+            batch,
+            scale,
+            bias,
+            bias_after_scale,
+            is_int,
+        ) in product(
+            [0, 1],
+            [0, 1, 2, 3, 4],
+            [1, 2],
+            [0.1, -1.0],
+            [0.0, 1.2],
+            [False, True],
+            [False, True],
+        ):
+            self.num_input = num_input
+            self.dims = dims
+            self.is_int = is_int
+            dics = [
+                {
+                    "scale": scale,
+                    "bias": bias,
+                    "bias_after_scale": bias_after_scale,
+                },
+                {},
+            ]
 
-                                    dics_intput = [
-                                        {
-                                            "X": ["scale_input"],
-                                            "ScaleTensor": ["ScaleTensor"],
-                                        },
-                                        {"X": ["scale_input"]},
-                                    ]
-                                    dics_intputs = [
-                                        {
-                                            "ScaleTensor": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_weight1,
-                                                    dics,
-                                                    is_int,
-                                                )
-                                            )
-                                        },
-                                        {},
-                                    ]
+            dics_intput = [
+                {
+                    "X": ["scale_input"],
+                    "ScaleTensor": ["ScaleTensor"],
+                },
+                {"X": ["scale_input"]},
+            ]
+            dics_intputs = [
+                {
+                    "ScaleTensor": TensorConfig(
+                        data_gen=partial(
+                            generate_weight1,
+                            dics,
+                            is_int,
+                        )
+                    )
+                },
+                {},
+            ]
 
-                                    ops_config = [
-                                        {
-                                            "op_type": "scale",
-                                            "op_inputs": dics_intput[num_input],
-                                            "op_outputs": {
-                                                "Out": ["scale_out"]
-                                            },
-                                            "op_attrs": dics[0],
-                                        }
-                                    ]
-                                    ops = self.generate_op_config(ops_config)
-                                    program_config = ProgramConfig(
-                                        ops=ops,
-                                        weights=dics_intputs[num_input],
-                                        inputs={
-                                            "scale_input": TensorConfig(
-                                                data_gen=partial(
-                                                    generate_input1,
-                                                    dics,
-                                                    batch,
-                                                    is_int,
-                                                )
-                                            )
-                                        },
-                                        outputs=["scale_out"],
-                                        no_cast_list=["scale_input"]
-                                        if is_int
-                                        else [],
-                                    )
+            ops_config = [
+                {
+                    "op_type": "scale",
+                    "op_inputs": dics_intput[num_input],
+                    "op_outputs": {"Out": ["scale_out"]},
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
+            program_config = ProgramConfig(
+                ops=ops,
+                weights=dics_intputs[num_input],
+                inputs={
+                    "scale_input": TensorConfig(
+                        data_gen=partial(
+                            generate_input1,
+                            dics,
+                            batch,
+                            is_int,
+                        )
+                    )
+                },
+                outputs=["scale_out"],
+                no_cast_list=["scale_input"] if is_int else [],
+            )
 
-                                    yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_strided_slice.py
+++ b/test/ir/inference/test_trt_convert_strided_slice.py
@@ -14,7 +14,8 @@
 
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from itertools import product
+from typing import Any, Dict, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -36,53 +37,53 @@ class TrtConvertStridedSliceTest(TrtLayerAutoScanTest):
         def generate_input1(attrs: List[Dict[str, Any]]):
             return np.random.random([1, 56, 56, 192]).astype(np.float32)
 
-        for axes in [[1, 2]]:
-            for starts in [[1, 1]]:
-                for ends in [[10000000, 10000000]]:
-                    for decrease_axis in [[]]:
-                        for infer_flags in [[1, 1]]:
-                            for strides in [[2, 2]]:
-                                dics = [
-                                    {
-                                        "axes": axes,
-                                        "starts": starts,
-                                        "ends": ends,
-                                        "decrease_axis": decrease_axis,
-                                        "infer_flags": infer_flags,
-                                        "strides": strides,
-                                    }
-                                ]
+        for axes, starts, ends, decrease_axis, infer_flags, strides in product(
+            [[1, 2]],
+            [[1, 1]],
+            [[10000000, 10000000]],
+            [[]],
+            [[1, 1]],
+            [[2, 2]],
+        ):
+            dics = [
+                {
+                    "axes": axes,
+                    "starts": starts,
+                    "ends": ends,
+                    "decrease_axis": decrease_axis,
+                    "infer_flags": infer_flags,
+                    "strides": strides,
+                }
+            ]
 
-                                ops_config = [
-                                    {
-                                        "op_type": "strided_slice",
-                                        "op_inputs": {"Input": ["input_data"]},
-                                        "op_outputs": {
-                                            "Out": ["slice_output_data"]
-                                        },
-                                        "op_attrs": dics[0],
-                                    }
-                                ]
-                                ops = self.generate_op_config(ops_config)
+            ops_config = [
+                {
+                    "op_type": "strided_slice",
+                    "op_inputs": {"Input": ["input_data"]},
+                    "op_outputs": {"Out": ["slice_output_data"]},
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
 
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights={},
-                                    inputs={
-                                        "input_data": TensorConfig(
-                                            data_gen=partial(
-                                                generate_input1, dics
-                                            )
-                                        )
-                                    },
-                                    outputs=["slice_output_data"],
-                                )
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={},
+                inputs={
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1, dics)
+                    )
+                },
+                outputs=["slice_output_data"],
+            )
 
-                                yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 56, 56, 192]

--- a/test/ir/inference/test_trt_convert_strided_slice.py
+++ b/test/ir/inference/test_trt_convert_strided_slice.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -34,7 +36,7 @@ class TrtConvertStridedSliceTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.random.random([1, 56, 56, 192]).astype(np.float32)
 
         for axes, starts, ends, decrease_axis, infer_flags, strides in product(
@@ -82,7 +84,7 @@ class TrtConvertStridedSliceTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
@@ -145,7 +147,7 @@ class TrtConvertStridedSliceTest2(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]]):
+        def generate_input1(attrs: list[dict[str, Any]]):
             return np.random.random([1, 56, 56, 192]).astype(np.float32)
 
         for axes in [[1, 2], [2, 3], [1, 3]]:
@@ -200,7 +202,9 @@ class TrtConvertStridedSliceTest2(TrtLayerAutoScanTest):
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
+    ]:
         def generate_dynamic_shape():
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 56, 56, 192]

--- a/test/ir/inference/test_trt_convert_trans_layernorm.py
+++ b/test/ir/inference/test_trt_convert_trans_layernorm.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 import unittest
 from functools import partial
-from typing import List
+from itertools import product
+from typing import Any, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -51,142 +52,132 @@ class TrtConvertTransLayernormTest(TrtLayerAutoScanTest):
             x = (x - np.mean(x)) / (np.std(x))
             return x.astype(np.float32)
 
-        for batch in [2]:
-            for begin_norm_axis in [2]:
-                for h in [32, 64]:
-                    for w in [32, 64]:
-                        for c in [128, 320, 255, 133]:
-                            for reshape in ["flatten", "reshape"]:
-                                dics = {
-                                    "batch": batch,
-                                    "begin_norm_axis": begin_norm_axis,
-                                    "h": h,
-                                    "w": w,
-                                    "c": c,
-                                    "flatten": {
-                                        "op_type": "flatten_contiguous_range",
-                                        "op_inputs": {
-                                            "X": ["transpose2_out"],
-                                        },
-                                        "op_outputs": {
-                                            "Out": ["reshape_out"],
-                                        },
-                                        "op_attrs": {
-                                            "start_axis": 1,
-                                            "stop_axis": 2,
-                                        },
-                                    },
-                                    "reshape": {
-                                        "op_type": "reshape2",
-                                        "op_inputs": {
-                                            "X": ["transpose2_out"],
-                                        },
-                                        "op_outputs": {
-                                            "Out": ["reshape_out"],
-                                        },
-                                        "op_attrs": {"shape": [-1, h * w, c]},
-                                    },
-                                }
-                                ops_config = [
-                                    {
-                                        "op_type": "conv2d",
-                                        "op_inputs": {
-                                            "Input": ["conv2d_input"],
-                                            "Filter": ["conv2d_filter"],
-                                        },
-                                        "op_outputs": {
-                                            "Output": ["conv2d_output"],
-                                        },
-                                        "op_attrs": {
-                                            "dilations": [1, 1],
-                                            "padding_algorithm": "EXPLICIT",
-                                            "groups": 1,
-                                            "paddings": [0, 0],
-                                            "strides": [1, 1],
-                                            "data_format": "NCHW",
-                                        },
-                                    },
-                                    {
-                                        "op_type": "elementwise_add",
-                                        "op_inputs": {
-                                            "X": ["conv2d_output"],
-                                            "Y": ["elementwise_bias"],
-                                        },
-                                        "op_outputs": {
-                                            "Out": ["elementwise_out"]
-                                        },
-                                        "op_attrs": {"axis": 1},
-                                    },
-                                    {
-                                        "op_type": "transpose2",
-                                        "op_inputs": {
-                                            "X": ["elementwise_out"],
-                                        },
-                                        "op_outputs": {
-                                            "Out": ["transpose2_out"],
-                                        },
-                                        "op_attrs": {"axis": [0, 2, 3, 1]},
-                                    },
-                                    dics[reshape],
-                                    {
-                                        "op_type": "layer_norm",
-                                        "op_inputs": {
-                                            "X": ["reshape_out"],
-                                            "Bias": ["layernorm_bias"],
-                                            "Scale": ["layernorm_scale"],
-                                        },
-                                        "op_outputs": {
-                                            "Y": ["layernorm_out"],
-                                            "Mean": ["layernorm_mean"],
-                                            "Variance": ["layernorm_variance"],
-                                        },
-                                        "op_attrs": {
-                                            "epsilon": 1e-5,
-                                            "begin_norm_axis": dics[
-                                                "begin_norm_axis"
-                                            ],
-                                        },
-                                    },
-                                ]
-                                ops = self.generate_op_config(ops_config)
-                                program_config = ProgramConfig(
-                                    ops=ops,
-                                    weights={
-                                        "conv2d_filter": TensorConfig(
-                                            data_gen=partial(
-                                                conv_filter_datagen, dics
-                                            )
-                                        ),
-                                        "elementwise_bias": TensorConfig(
-                                            data_gen=partial(
-                                                elementwise_bias_datagen, dics
-                                            )
-                                        ),
-                                        "layernorm_bias": TensorConfig(
-                                            data_gen=partial(
-                                                layernorm_bias_datagen, dics
-                                            )
-                                        ),
-                                        "layernorm_scale": TensorConfig(
-                                            data_gen=partial(
-                                                layernorm_scale_datagen, dics
-                                            )
-                                        ),
-                                    },
-                                    inputs={
-                                        "conv2d_input": TensorConfig(
-                                            data_gen=partial(
-                                                conv2d_input_datagen, dics
-                                            )
-                                        ),
-                                    },
-                                    outputs=["reshape_out", "layernorm_out"],
-                                )
-                                yield program_config
+        for batch, begin_norm_axis, h, w, c, reshape in product(
+            [2],
+            [2],
+            [32, 64],
+            [32, 64],
+            [128, 320, 255, 133],
+            ["flatten", "reshape"],
+        ):
+            dics = {
+                "batch": batch,
+                "begin_norm_axis": begin_norm_axis,
+                "h": h,
+                "w": w,
+                "c": c,
+                "flatten": {
+                    "op_type": "flatten_contiguous_range",
+                    "op_inputs": {
+                        "X": ["transpose2_out"],
+                    },
+                    "op_outputs": {
+                        "Out": ["reshape_out"],
+                    },
+                    "op_attrs": {
+                        "start_axis": 1,
+                        "stop_axis": 2,
+                    },
+                },
+                "reshape": {
+                    "op_type": "reshape2",
+                    "op_inputs": {
+                        "X": ["transpose2_out"],
+                    },
+                    "op_outputs": {
+                        "Out": ["reshape_out"],
+                    },
+                    "op_attrs": {"shape": [-1, h * w, c]},
+                },
+            }
+            ops_config = [
+                {
+                    "op_type": "conv2d",
+                    "op_inputs": {
+                        "Input": ["conv2d_input"],
+                        "Filter": ["conv2d_filter"],
+                    },
+                    "op_outputs": {
+                        "Output": ["conv2d_output"],
+                    },
+                    "op_attrs": {
+                        "dilations": [1, 1],
+                        "padding_algorithm": "EXPLICIT",
+                        "groups": 1,
+                        "paddings": [0, 0],
+                        "strides": [1, 1],
+                        "data_format": "NCHW",
+                    },
+                },
+                {
+                    "op_type": "elementwise_add",
+                    "op_inputs": {
+                        "X": ["conv2d_output"],
+                        "Y": ["elementwise_bias"],
+                    },
+                    "op_outputs": {"Out": ["elementwise_out"]},
+                    "op_attrs": {"axis": 1},
+                },
+                {
+                    "op_type": "transpose2",
+                    "op_inputs": {
+                        "X": ["elementwise_out"],
+                    },
+                    "op_outputs": {
+                        "Out": ["transpose2_out"],
+                    },
+                    "op_attrs": {"axis": [0, 2, 3, 1]},
+                },
+                dics[reshape],
+                {
+                    "op_type": "layer_norm",
+                    "op_inputs": {
+                        "X": ["reshape_out"],
+                        "Bias": ["layernorm_bias"],
+                        "Scale": ["layernorm_scale"],
+                    },
+                    "op_outputs": {
+                        "Y": ["layernorm_out"],
+                        "Mean": ["layernorm_mean"],
+                        "Variance": ["layernorm_variance"],
+                    },
+                    "op_attrs": {
+                        "epsilon": 1e-5,
+                        "begin_norm_axis": dics["begin_norm_axis"],
+                    },
+                },
+            ]
+            ops = self.generate_op_config(ops_config)
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={
+                    "conv2d_filter": TensorConfig(
+                        data_gen=partial(conv_filter_datagen, dics)
+                    ),
+                    "elementwise_bias": TensorConfig(
+                        data_gen=partial(elementwise_bias_datagen, dics)
+                    ),
+                    "layernorm_bias": TensorConfig(
+                        data_gen=partial(layernorm_bias_datagen, dics)
+                    ),
+                    "layernorm_scale": TensorConfig(
+                        data_gen=partial(layernorm_scale_datagen, dics)
+                    ),
+                },
+                inputs={
+                    "conv2d_input": TensorConfig(
+                        data_gen=partial(conv2d_input_datagen, dics)
+                    ),
+                },
+                outputs=["reshape_out", "layernorm_out"],
+            )
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs, inputs):
             conv2d_c = inputs['conv2d_input'].shape[1]
             self.dynamic_shape.min_input_shape = {

--- a/test/ir/inference/test_trt_convert_trans_layernorm.py
+++ b/test/ir/inference/test_trt_convert_trans_layernorm.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -176,7 +179,7 @@ class TrtConvertTransLayernormTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs, inputs):
             conv2d_c = inputs['conv2d_input'].shape[1]

--- a/test/ir/inference/test_trt_convert_yolo_box.py
+++ b/test/ir/inference/test_trt_convert_yolo_box.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import unittest
 from functools import partial
 from itertools import product
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -30,7 +32,7 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input1(attrs: List[Dict[str, Any]], batch, channel):
+        def generate_input1(attrs: list[dict[str, Any]], batch, channel):
             if attrs[0]['iou_aware']:
                 return np.ones([batch, 3 * (channel + 6), 13, 13]).astype(
                     np.float32
@@ -40,7 +42,7 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
                     np.float32
                 )
 
-        def generate_input2(attrs: List[Dict[str, Any]], batch):
+        def generate_input2(attrs: list[dict[str, Any]], batch):
             return np.random.random([batch, 2]).astype(np.int32)
 
         for (
@@ -120,7 +122,7 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
     def sample_predictor_configs(
         self, program_config
     ) -> Generator[
-        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+        Any, Any, tuple[paddle_infer.Config, list[int], float] | None
     ]:
         def generate_dynamic_shape(attrs):
             if attrs[0]['iou_aware']:

--- a/test/ir/inference/test_trt_convert_yolo_box.py
+++ b/test/ir/inference/test_trt_convert_yolo_box.py
@@ -15,7 +15,8 @@
 import os
 import unittest
 from functools import partial
-from typing import Any, Dict, List
+from itertools import product
+from typing import Any, Dict, Generator, List, Tuple
 
 import numpy as np
 from program_config import ProgramConfig, TensorConfig
@@ -42,73 +43,85 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
         def generate_input2(attrs: List[Dict[str, Any]], batch):
             return np.random.random([batch, 2]).astype(np.int32)
 
-        for batch in [1, 4]:
-            for class_num in [80, 30]:
-                for anchors in [[10, 13, 16, 30, 33, 23]]:
-                    for downsample_ratio in [32, 16]:
-                        for conf_thresh in [0.01, 0.02]:
-                            for clip_bbox in [True, False]:
-                                for scale_x_y in [1.0, 0.9]:
-                                    for iou_aware in [False, True]:
-                                        for iou_aware_factor in [0.5]:
-                                            dics = [
-                                                {
-                                                    "class_num": class_num,
-                                                    "anchors": anchors,
-                                                    "downsample_ratio": downsample_ratio,
-                                                    "conf_thresh": conf_thresh,
-                                                    "clip_bbox": clip_bbox,
-                                                    "scale_x_y": scale_x_y,
-                                                    "iou_aware": iou_aware,
-                                                    "iou_aware_factor": iou_aware_factor,
-                                                },
-                                                {},
-                                            ]
-                                            ops_config = [
-                                                {
-                                                    "op_type": "yolo_box",
-                                                    "op_inputs": {
-                                                        "X": ["yolo_box_input"],
-                                                        "ImgSize": ["imgsize"],
-                                                    },
-                                                    "op_outputs": {
-                                                        "Boxes": ["boxes"],
-                                                        "Scores": ["scores"],
-                                                    },
-                                                    "op_attrs": dics[0],
-                                                }
-                                            ]
-                                            ops = self.generate_op_config(
-                                                ops_config
-                                            )
-                                            program_config = ProgramConfig(
-                                                ops=ops,
-                                                weights={},
-                                                inputs={
-                                                    "yolo_box_input": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_input1,
-                                                            dics,
-                                                            batch,
-                                                            class_num,
-                                                        )
-                                                    ),
-                                                    "imgsize": TensorConfig(
-                                                        data_gen=partial(
-                                                            generate_input2,
-                                                            dics,
-                                                            batch,
-                                                        )
-                                                    ),
-                                                },
-                                                outputs=["boxes", "scores"],
-                                            )
+        for (
+            batch,
+            class_num,
+            anchors,
+            downsample_ratio,
+            conf_thresh,
+            clip_bbox,
+            scale_x_y,
+            iou_aware,
+            iou_aware_factor,
+        ) in product(
+            [1, 4],
+            [80, 30],
+            [[10, 13, 16, 30, 33, 23]],
+            [32, 16],
+            [0.01, 0.02],
+            [True, False],
+            [1.0, 0.9],
+            [False, True],
+            [0.5],
+        ):
+            dics = [
+                {
+                    "class_num": class_num,
+                    "anchors": anchors,
+                    "downsample_ratio": downsample_ratio,
+                    "conf_thresh": conf_thresh,
+                    "clip_bbox": clip_bbox,
+                    "scale_x_y": scale_x_y,
+                    "iou_aware": iou_aware,
+                    "iou_aware_factor": iou_aware_factor,
+                },
+                {},
+            ]
+            ops_config = [
+                {
+                    "op_type": "yolo_box",
+                    "op_inputs": {
+                        "X": ["yolo_box_input"],
+                        "ImgSize": ["imgsize"],
+                    },
+                    "op_outputs": {
+                        "Boxes": ["boxes"],
+                        "Scores": ["scores"],
+                    },
+                    "op_attrs": dics[0],
+                }
+            ]
+            ops = self.generate_op_config(ops_config)
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={},
+                inputs={
+                    "yolo_box_input": TensorConfig(
+                        data_gen=partial(
+                            generate_input1,
+                            dics,
+                            batch,
+                            class_num,
+                        )
+                    ),
+                    "imgsize": TensorConfig(
+                        data_gen=partial(
+                            generate_input2,
+                            dics,
+                            batch,
+                        )
+                    ),
+                },
+                outputs=["boxes", "scores"],
+            )
 
-                                            yield program_config
+            yield program_config
 
     def sample_predictor_configs(
         self, program_config
-    ) -> (paddle_infer.Config, List[int], float):
+    ) -> Generator[
+        Any, Any, Tuple[paddle_infer.Config, List[int], float] | None
+    ]:
         def generate_dynamic_shape(attrs):
             if attrs[0]['iou_aware']:
                 channel = 3 * (attrs[0]['class_num'] + 6)

--- a/test/legacy_test/test_deformable_conv_op.py
+++ b/test/legacy_test/test_deformable_conv_op.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from itertools import product
 
 import numpy as np
 from op_test import OpTest
@@ -73,47 +74,26 @@ def dconv_im2col_gemm(input, offset, mask, filter, group, conv_param):
     assert out_w == in_w
 
     col_buffer = np.zeros((in_n, in_c * f_h * f_w, in_h * in_w))
-    for n in range(in_n):
-        for c in range(in_c):
-            for h in range(out_h):
-                for w in range(out_w):
-                    for kh in range(f_h):
-                        for kw in range(f_w):
-                            offset_h_table = offset[n, ::2, h, w].reshape(
-                                f_h, f_w
-                            )
-                            offset_w_table = offset[n, 1::2, h, w].reshape(
-                                f_h, f_w
-                            )
-                            mask_table = mask[n, :, h, w].reshape(f_h, f_w)
-                            offset_h = offset_h_table[kh, kw]
-                            offset_w = offset_w_table[kh, kw]
-                            val = 0
-                            im_h = (
-                                h * stride[0]
-                                + kh * dilation[0]
-                                + offset_h
-                                - pad[0]
-                            )
-                            im_w = (
-                                w * stride[0]
-                                + kw * dilation[0]
-                                + offset_w
-                                - pad[1]
-                            )
-                            if (
-                                im_h > -1
-                                and im_w > -1
-                                and im_h < in_h
-                                and im_w < in_h
-                            ):
-                                val = dmc_bilinear(
-                                    input[n, c], in_h, in_w, im_h, im_w
-                                )
-                            val_out = val * mask_table[kh, kw]
-                            col_buffer[
-                                n, c * f_h * f_w + kh * f_w + kw, h * in_w + w
-                            ] = val_out
+    for n, c, h, w, kh, kw in product(
+        range(in_n),
+        range(in_c),
+        range(out_h),
+        range(out_w),
+        range(f_h),
+        range(f_w),
+    ):
+        offset_h_table = offset[n, ::2, h, w].reshape(f_h, f_w)
+        offset_w_table = offset[n, 1::2, h, w].reshape(f_h, f_w)
+        mask_table = mask[n, :, h, w].reshape(f_h, f_w)
+        offset_h = offset_h_table[kh, kw]
+        offset_w = offset_w_table[kh, kw]
+        val = 0
+        im_h = h * stride[0] + kh * dilation[0] + offset_h - pad[0]
+        im_w = w * stride[0] + kw * dilation[0] + offset_w - pad[1]
+        if im_h > -1 and im_w > -1 and im_h < in_h and im_w < in_h:
+            val = dmc_bilinear(input[n, c], in_h, in_w, im_h, im_w)
+        val_out = val * mask_table[kh, kw]
+        col_buffer[n, c * f_h * f_w + kh * f_w + kw, h * in_w + w] = val_out
 
     out = np.zeros((in_n, group, int(out_c // group), out_h * out_w))
     weight = filter.reshape(group, int(out_c // group), f_c * f_h * f_w)

--- a/test/legacy_test/test_deformable_conv_v1_op.py
+++ b/test/legacy_test/test_deformable_conv_v1_op.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from itertools import product
 
 import numpy as np
 from op_test import OpTest
@@ -69,47 +70,26 @@ def dconv_im2col_gemm(input, offset, filter, group, conv_param):
     assert out_w == in_w
 
     col_buffer = np.zeros((in_n, in_c * f_h * f_w, in_h * in_w))
-    for n in range(in_n):
-        for c in range(in_c):
-            for h in range(out_h):
-                for w in range(out_w):
-                    for kh in range(f_h):
-                        for kw in range(f_w):
-                            offset_h_table = offset[n, ::2, h, w].reshape(
-                                f_h, f_w
-                            )
-                            offset_w_table = offset[n, 1::2, h, w].reshape(
-                                f_h, f_w
-                            )
-                            offset_h = offset_h_table[kh, kw]
-                            offset_w = offset_w_table[kh, kw]
-                            val = 0
-                            im_h = (
-                                h * stride[0]
-                                + kh * dilation[0]
-                                + offset_h
-                                - pad[0]
-                            )
-                            im_w = (
-                                w * stride[0]
-                                + kw * dilation[0]
-                                + offset_w
-                                - pad[1]
-                            )
-                            if (
-                                im_h > -1
-                                and im_w > -1
-                                and im_h < in_h
-                                and im_w < in_h
-                            ):
-                                val = dmc_bilinear(
-                                    input[n, c], in_h, in_w, im_h, im_w
-                                )
-                            val_out = val
+    for n, c, h, w, kh, kw in product(
+        range(in_n),
+        range(in_c),
+        range(out_h),
+        range(out_w),
+        range(f_h),
+        range(f_w),
+    ):
+        offset_h_table = offset[n, ::2, h, w].reshape(f_h, f_w)
+        offset_w_table = offset[n, 1::2, h, w].reshape(f_h, f_w)
+        offset_h = offset_h_table[kh, kw]
+        offset_w = offset_w_table[kh, kw]
+        val = 0
+        im_h = h * stride[0] + kh * dilation[0] + offset_h - pad[0]
+        im_w = w * stride[0] + kw * dilation[0] + offset_w - pad[1]
+        if im_h > -1 and im_w > -1 and im_h < in_h and im_w < in_h:
+            val = dmc_bilinear(input[n, c], in_h, in_w, im_h, im_w)
+        val_out = val
 
-                            col_buffer[
-                                n, c * f_h * f_w + kh * f_w + kw, h * in_w + w
-                            ] = val_out
+        col_buffer[n, c * f_h * f_w + kh * f_w + kw, h * in_w + w] = val_out
 
     out = np.zeros((in_n, group, int(out_c // group), out_h * out_w))
     weight = filter.reshape(group, int(out_c // group), f_c * f_h * f_w)

--- a/test/legacy_test/test_embedding_deterministic.py
+++ b/test/legacy_test/test_embedding_deterministic.py
@@ -16,6 +16,7 @@ import contextlib
 import random
 import sys
 import unittest
+from itertools import product
 
 import numpy as np
 
@@ -178,20 +179,29 @@ class TestEmbeddingBase(unittest.TestCase):
         ranks = [None, 0, 2, 4, 8]
         allow_duplicate_ids = [False, True]
         allow_pure_randoms = [False, True]
-        for weight_dtype in weight_dtypes:
-            for ids_dtype in ids_dtypes:
-                for deterministic_level in deterministic_levels:
-                    for rank in ranks:
-                        for allow_duplicate_id in allow_duplicate_ids:
-                            for allow_pure_random in allow_pure_randoms:
-                                self.check_main(
-                                    weight_dtype,
-                                    ids_dtype,
-                                    deterministic_level,
-                                    rank,
-                                    allow_duplicate_id,
-                                    allow_pure_random,
-                                )
+        for (
+            weight_dtype,
+            ids_dtype,
+            deterministic_level,
+            rank,
+            allow_duplicate_id,
+            allow_pure_random,
+        ) in product(
+            weight_dtypes,
+            ids_dtypes,
+            deterministic_levels,
+            ranks,
+            allow_duplicate_ids,
+            allow_pure_randoms,
+        ):
+            self.check_main(
+                weight_dtype,
+                ids_dtype,
+                deterministic_level,
+                rank,
+                allow_duplicate_id,
+                allow_pure_random,
+            )
 
 
 class TestEmbedding2(TestEmbeddingBase):

--- a/test/xpu/test_deformable_conv_op_xpu.py
+++ b/test/xpu/test_deformable_conv_op_xpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from itertools import product
 
 import numpy as np
 from get_test_cover_info import (
@@ -76,47 +77,26 @@ def dconv_im2col_gemm(input, offset, mask, filter, group, conv_param):
     assert out_w == in_w
 
     col_buffer = np.zeros((in_n, in_c * f_h * f_w, in_h * in_w))
-    for n in range(in_n):
-        for c in range(in_c):
-            for h in range(out_h):
-                for w in range(out_w):
-                    for kh in range(f_h):
-                        for kw in range(f_w):
-                            offset_h_table = offset[n, ::2, h, w].reshape(
-                                f_h, f_w
-                            )
-                            offset_w_table = offset[n, 1::2, h, w].reshape(
-                                f_h, f_w
-                            )
-                            mask_table = mask[n, :, h, w].reshape(f_h, f_w)
-                            offset_h = offset_h_table[kh, kw]
-                            offset_w = offset_w_table[kh, kw]
-                            val = 0
-                            im_h = (
-                                h * stride[0]
-                                + kh * dilation[0]
-                                + offset_h
-                                - pad[0]
-                            )
-                            im_w = (
-                                w * stride[0]
-                                + kw * dilation[0]
-                                + offset_w
-                                - pad[1]
-                            )
-                            if (
-                                im_h > -1
-                                and im_w > -1
-                                and im_h < in_h
-                                and im_w < in_h
-                            ):
-                                val = dmc_bilinear(
-                                    input[n, c], in_h, in_w, im_h, im_w
-                                )
-                            val_out = val * mask_table[kh, kw]
-                            col_buffer[
-                                n, c * f_h * f_w + kh * f_w + kw, h * in_w + w
-                            ] = val_out
+    for n, c, h, w, kh, kw in product(
+        range(in_n),
+        range(in_c),
+        range(in_h),
+        range(in_w),
+        range(f_h),
+        range(f_w),
+    ):
+        offset_h_table = offset[n, ::2, h, w].reshape(f_h, f_w)
+        offset_w_table = offset[n, 1::2, h, w].reshape(f_h, f_w)
+        mask_table = mask[n, :, h, w].reshape(f_h, f_w)
+        offset_h = offset_h_table[kh, kw]
+        offset_w = offset_w_table[kh, kw]
+        val = 0
+        im_h = h * stride[0] + kh * dilation[0] + offset_h - pad[0]
+        im_w = w * stride[0] + kw * dilation[0] + offset_w - pad[1]
+        if im_h > -1 and im_w > -1 and im_h < in_h and im_w < in_h:
+            val = dmc_bilinear(input[n, c], in_h, in_w, im_h, im_w)
+        val_out = val * mask_table[kh, kw]
+        col_buffer[n, c * f_h * f_w + kh * f_w + kw, h * in_w + w] = val_out
 
     out = np.zeros((in_n, group, int(out_c // group), out_h * out_w))
     weight = filter.reshape(group, int(out_c // group), f_c * f_h * f_w)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

使用 `itertools.product` 重新组织深层循环，减少缩进，提高格式化后代码可读性

比如

```python
for i in a:
    for j in b:
        for k in c:
            loop_body(i, j, k)

# 可改写为
for i, j, k in product(a, b, c):
    loop_body(i, j, k)
```

仅 5 层及以上循环修改，低于 5 层在可接受范围内，无需修改

PCard-66972