### PR TITLE
Add ostream for vector<DimExpr>

### DIFF
--- a/paddle/pir/dialect/shape/utils/dim_expr.cc
+++ b/paddle/pir/dialect/shape/utils/dim_expr.cc
@@ -181,6 +181,19 @@ std::ostream& operator<<(std::ostream& stream, const DimExpr& dim_expr) {
   return stream;
 }
 
+std::ostream& operator<<(std::ostream&, const std::vector<DimExpr>& dim_exprs) {
+  std::stringstream ss;
+  ss << "[";
+  for (size_t i = 0; i < dim_exprs.size(); ++i) {
+    ss << ToString(dim_exprs[i]);
+    if (i < dim_exprs.size() - 1) {
+      ss << ", ";
+    }
+  }
+  ss << "]";
+  return stream << ss.str();
+}
+
 std::ostream& operator<<(std::ostream& stream,
                          const ShapeOrDataDimExprs& shape_or_data) {
   std::string result;

--- a/paddle/pir/dialect/shape/utils/dim_expr.cc
+++ b/paddle/pir/dialect/shape/utils/dim_expr.cc
@@ -181,7 +181,8 @@ std::ostream& operator<<(std::ostream& stream, const DimExpr& dim_expr) {
   return stream;
 }
 
-std::ostream& operator<<(std::ostream&, const std::vector<DimExpr>& dim_exprs) {
+std::ostream& operator<<(std::ostream& stream,
+                         const std::vector<DimExpr>& dim_exprs) {
   std::stringstream ss;
   ss << "[";
   for (size_t i = 0; i < dim_exprs.size(); ++i) {

--- a/paddle/pir/dialect/shape/utils/dim_expr.h
+++ b/paddle/pir/dialect/shape/utils/dim_expr.h
@@ -338,6 +338,9 @@ IR_API std::string ToString(const DimExpr& dim_expr);
 IR_API std::ostream& operator<<(std::ostream&, const DimExpr& dim_expr);
 
 IR_API std::ostream& operator<<(std::ostream&,
+                                const std::vector<DimExpr>& dim_exprs);
+
+IR_API std::ostream& operator<<(std::ostream&,
                                 const ShapeOrDataDimExprs& dim_expr);
 
 IR_API std::size_t GetHashValue(const DimExpr& dim_expr);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73448

为`std::vector<DimExpr>`增加输出流重载函数。