### PR TITLE
[ApiCleanup] Replace `to_variable` with `to_tensor` part2

### DIFF
--- a/test/dygraph_to_static/ifelse_simple_func.py
+++ b/test/dygraph_to_static/ifelse_simple_func.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle
-from paddle import base
 
 
 def add_fn(x):
@@ -406,7 +405,7 @@ def if_with_class_var(x, y=None):
 
 
 def if_tensor_case(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.assign(x)
     mean = paddle.mean(x)
     # It is equivalent to `if mean != 0`
     if mean:

--- a/test/dygraph_to_static/test_assert.py
+++ b/test/dygraph_to_static/test_assert.py
@@ -26,7 +26,7 @@ from paddle import base
 
 
 def dyfunc_assert_variable(x):
-    x_v = base.dygraph.to_variable(x)
+    x_v = paddle.to_tensor(x)
     assert x_v
 
 

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -25,7 +25,6 @@ from dygraph_to_static_utils import (
 from test_fetch_feed import Linear, Pool2D
 
 import paddle
-from paddle import base
 from paddle.jit.dy2static import convert_to_static
 
 
@@ -137,7 +136,7 @@ class TestCacheProgramWithOptimizer(Dy2StTestBase):
 
 
 def simple_func(x):
-    inputs = base.dygraph.to_variable(x)
+    inputs = paddle.assign(x)
     mean = paddle.mean(inputs)
     return mean
 
@@ -152,7 +151,7 @@ class TestConvertWithCache(Dy2StTestBase):
 
 
 def sum_even_until_limit(max_len, limit):
-    ret_sum = base.dygraph.to_variable(np.zeros(1).astype('int32'))
+    ret_sum = paddle.to_tensor(np.zeros(1).astype('int32'))
     for i in range(max_len):
         if i % 2 > 0:
             continue
@@ -164,8 +163,8 @@ def sum_even_until_limit(max_len, limit):
 
 
 def sum_under_while(limit):
-    i = base.dygraph.to_variable(np.zeros(1).astype('int32'))
-    ret_sum = base.dygraph.to_variable(np.zeros(1).astype('int32'))
+    i = paddle.to_tensor(np.zeros(1).astype('int32'))
+    ret_sum = paddle.to_tensor(np.zeros(1).astype('int32'))
     while i <= limit:
         ret_sum += i
         i += 1

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -25,7 +25,6 @@ from dygraph_to_static_utils import (
 
 import paddle
 import paddle.jit.dy2static as _jst
-from paddle import base
 from paddle.jit.dy2static.convert_call_func import CONVERSION_OPTIONS
 from paddle.jit.dy2static.utils import func_to_source_code
 
@@ -47,7 +46,7 @@ def dyfunc_with_if(x_v):
 
 @paddle.jit.to_static(full_graph=True)
 def nested_func(x_v):
-    x_v = base.dygraph.to_variable(x_v)
+    x_v = paddle.assign(x_v)
 
     def fn1():
         return x_v
@@ -175,7 +174,7 @@ class TestRecursiveCall2(Dy2StTestBase):
         self.dygraph_func = MyLayer()
 
     def _run(self):
-        data = base.dygraph.to_variable(self.input)
+        data = paddle.to_tensor(self.input)
         res = self.dygraph_func(data)
 
         return res.numpy()

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -28,7 +28,6 @@ from dygraph_to_static_utils import (
 from ifelse_simple_func import (
     NetWithControlFlowIf,
     add_fn,
-    base,
     dyfunc_empty_nonlocal,
     dyfunc_ifelse_ret_int1,
     dyfunc_ifelse_ret_int2,
@@ -56,11 +55,6 @@ import paddle.nn.functional as F
 from paddle.jit.dy2static.utils import Dygraph2StaticException
 
 np.random.seed(1)
-
-if base.is_compiled_with_cuda():
-    place = base.CUDAPlace(0)
-else:
-    place = base.CPUPlace()
 
 
 class TestDy2staticException(Dy2StTestBase):
@@ -94,13 +88,12 @@ class TestDygraphIfElse(Dy2StTestBase):
         return self._run_dygraph(to_static=True)
 
     def _run_dygraph(self, to_static=False):
-        with base.dygraph.guard(place):
-            x_v = base.dygraph.to_variable(self.x)
-            if to_static:
-                ret = paddle.jit.to_static(self.dyfunc)(x_v)
-            else:
-                ret = self.dyfunc(x_v)
-            return ret.numpy()
+        x_v = paddle.to_tensor(self.x)
+        if to_static:
+            ret = paddle.jit.to_static(self.dyfunc)(x_v)
+        else:
+            ret = self.dyfunc(x_v)
+        return ret.numpy()
 
     @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
@@ -128,13 +121,12 @@ class TestDygraphIfElse3(Dy2StTestBase):
         return self._run_dygraph(to_static=True)
 
     def _run_dygraph(self, to_static=False):
-        with base.dygraph.guard(place):
-            x_v = base.dygraph.to_variable(self.x)
-            if to_static:
-                ret = paddle.jit.to_static(self.dyfunc)(x_v)
-            else:
-                ret = self.dyfunc(x_v)
-            return ret.numpy()
+        x_v = paddle.to_tensor(self.x)
+        if to_static:
+            ret = paddle.jit.to_static(self.dyfunc)(x_v)
+        else:
+            ret = self.dyfunc(x_v)
+        return ret.numpy()
 
     @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
@@ -166,13 +158,12 @@ class TestDygraphNestedIfElse(Dy2StTestBase):
         return self._run_dygraph(to_static=True)
 
     def _run_dygraph(self, to_static=False):
-        with base.dygraph.guard(place):
-            x_v = paddle.to_tensor(self.x)
-            if to_static:
-                ret = paddle.jit.to_static(self.dyfunc)(x_v)
-            else:
-                ret = self.dyfunc(x_v)
-            return ret.numpy()
+        x_v = paddle.to_tensor(self.x)
+        if to_static:
+            ret = paddle.jit.to_static(self.dyfunc)(x_v)
+        else:
+            ret = self.dyfunc(x_v)
+        return ret.numpy()
 
     @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
@@ -198,13 +189,12 @@ class TestDygraphNestedIfElse3(Dy2StTestBase):
         return self._run_dygraph(to_static=True)
 
     def _run_dygraph(self, to_static=False):
-        with base.dygraph.guard(place):
-            x_v = paddle.to_tensor(self.x)
-            if to_static:
-                ret = paddle.jit.to_static(self.dyfunc)(x_v)
-            else:
-                ret = self.dyfunc(x_v)
-            return ret.numpy()
+        x_v = paddle.to_tensor(self.x)
+        if to_static:
+            ret = paddle.jit.to_static(self.dyfunc)(x_v)
+        else:
+            ret = self.dyfunc(x_v)
+        return ret.numpy()
 
     @test_legacy_and_pt_and_pir
     def test_ast_to_func(self):
@@ -312,13 +302,12 @@ class TestDygraphIfTensor(Dy2StTestBase):
         return self._run_dygraph(to_static=True)
 
     def _run_dygraph(self, to_static=False):
-        with base.dygraph.guard(place):
-            x_v = paddle.to_tensor(self.x)
-            if to_static:
-                ret = paddle.jit.to_static(self.dyfunc)(x_v)
-            else:
-                ret = self.dyfunc(x_v)
-            return ret.numpy()
+        x_v = paddle.to_tensor(self.x)
+        if to_static:
+            ret = paddle.jit.to_static(self.dyfunc)(x_v)
+        else:
+            ret = self.dyfunc(x_v)
+        return ret.numpy()
 
     # Why add test_legacy_only? : PIR not support if true and false branch output with different dtype
     @test_legacy_and_pt_and_pir
@@ -329,7 +318,7 @@ class TestDygraphIfTensor(Dy2StTestBase):
 class TestDygraphIfElseNet(Dy2StTestBase):
     """
     TestCase for the transformation from control flow `if/else`
-    dependent on tensor in Dygraph into Static `base.layers.cond`.
+    dependent on tensor in Dygraph into Static `paddle.static.nn.cond`.
     """
 
     def setUp(self):
@@ -344,11 +333,10 @@ class TestDygraphIfElseNet(Dy2StTestBase):
 
     def _run(self, to_static=False):
         with enable_to_static_guard(to_static):
-            with base.dygraph.guard(place):
-                net = paddle.jit.to_static(self.Net())
-                x_v = paddle.to_tensor(self.x)
-                ret = net(x_v)
-                return ret.numpy()
+            net = paddle.jit.to_static(self.Net())
+            x_v = paddle.to_tensor(self.x)
+            ret = net(x_v)
+            return ret.numpy()
 
     # Why add test_legacy_only? : PIR not support if true and false branch output with different rank
     @test_legacy_only

--- a/test/dygraph_to_static/test_legacy_error.py
+++ b/test/dygraph_to_static/test_legacy_error.py
@@ -19,7 +19,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import base
 from paddle.jit.dy2static import error
 
 
@@ -30,7 +29,7 @@ def inner_func():
 
 @paddle.jit.to_static(full_graph=True)
 def func_error_in_compile_time(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     inner_func()
     if paddle.mean(x) < 0:
         x_v = x - 1
@@ -41,14 +40,14 @@ def func_error_in_compile_time(x):
 
 @paddle.jit.to_static(full_graph=True)
 def func_error_in_compile_time_2(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     x = paddle.reshape(x, shape=[1, 2])
     return x
 
 
 @paddle.jit.to_static(full_graph=True)
 def func_error_in_runtime(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     two = paddle.tensor.fill_constant(shape=[1], value=2, dtype="int32")
     x = paddle.reshape(x, shape=[1, two])
     return x
@@ -100,7 +99,7 @@ class LayerErrorInCompiletime2(paddle.nn.Layer):
 
 @paddle.jit.to_static(full_graph=True)
 def func_error_in_runtime_with_empty_line(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     two = paddle.tensor.fill_constant(shape=[1], value=2, dtype="int32")
 
     x = paddle.reshape(x, shape=[1, two])
@@ -283,7 +282,7 @@ class TestErrorStaticLayerCallInCompiletime_2(
     def set_message(self):
         self.expected_message = [
             'def func_error_in_compile_time_2(x):',
-            'x = base.dygraph.to_variable(x)',
+            'x = paddle.to_tensor(x)',
             'x = paddle.reshape(x, shape=[1, 2])',
             '<--- HERE',
             'return x',
@@ -328,7 +327,7 @@ class TestErrorStaticLayerCallInRuntime(TestErrorStaticLayerCallInCompiletime):
 
     def set_message(self):
         self.expected_message = [
-            'x = base.dygraph.to_variable(x)',
+            'x = paddle.to_tensor(x)',
             'two = paddle.tensor.fill_constant(shape=[1], value=2, dtype="int32")',
             'x = paddle.reshape(x, shape=[1, two])',
             '<--- HERE',

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -48,18 +48,16 @@ def test_list_append_in_if(x):
     if x.numpy()[0] > 0:
         a.append(x)
     else:
-        a.append(
-            paddle.tensor.fill_constant(shape=[1, 2], value=9, dtype="int64")
-        )
+        a.append(paddle.full(shape=[1, 2], fill_value=9, dtype="int64"))
     # TODO(Aurelius84): Currently, run_program_op doesn't support output LoDTensorArray.
     return a[0]
 
 
 def test_list_append_in_for_loop(x, iter_num):
     x = paddle.assign(x)
-    # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
-    iter_num = paddle.tensor.fill_constant(
-        shape=[1], value=iter_num, dtype="int32"
+    # Use `full` so that static analysis can analyze the type of iter_num is Tensor
+    iter_num = paddle.full(
+        shape=[1], fill_value=iter_num, dtype="int32"
     )  # TODO(liym27): Delete it if the type of parameter iter_num can be resolved
     a = []
     for i in range(iter_num):
@@ -94,9 +92,9 @@ def test_list_append_in_while_loop_subscript(x):
 def test_list_append_in_for_loop_with_concat(x, iter_num):
     x = paddle.assign(x)
     a = []
-    # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
-    iter_num = paddle.tensor.fill_constant(
-        shape=[1], value=iter_num, dtype="int32"
+    # Use `full` so that static analysis can analyze the type of iter_num is Tensor
+    iter_num = paddle.full(
+        shape=[1], fill_value=iter_num, dtype="int32"
     )  # TODO(liym27): Delete it if the type of parameter iter_num can be resolved
     for i in range(iter_num):
         a.append(x)
@@ -106,9 +104,7 @@ def test_list_append_in_for_loop_with_concat(x, iter_num):
 
 def test_list_append_in_while_loop(x, iter_num):
     x = paddle.assign(x)
-    iter_num = paddle.tensor.fill_constant(
-        shape=[1], value=iter_num, dtype="int32"
-    )
+    iter_num = paddle.full(shape=[1], fill_value=iter_num, dtype="int32")
     a = []
     i = 0
     while i < iter_num:
@@ -119,9 +115,7 @@ def test_list_append_in_while_loop(x, iter_num):
 
 def test_list_append_in_while_loop_with_stack(x, iter_num):
     x = paddle.assign(x)
-    iter_num = paddle.tensor.fill_constant(
-        shape=[1], value=iter_num, dtype="int32"
-    )
+    iter_num = paddle.full(shape=[1], fill_value=iter_num, dtype="int32")
     a = []
     i = 0
     while i < iter_num.numpy()[0]:
@@ -166,20 +160,20 @@ def test_list_pop_in_if(x):
     if x.numpy()[0] > 0:
         a.append(x)
         b.append(x + 1)
-        a.append(paddle.tensor.fill_constant(shape=[1], value=1, dtype="int64"))
+        a.append(paddle.full(shape=[1], fill_value=1, dtype="int64"))
     else:
         a.append(x + 1)
         b.append(x - 1)
-        a.append(paddle.tensor.fill_constant(shape=[2], value=2, dtype="int64"))
+        a.append(paddle.full(shape=[2], fill_value=2, dtype="int64"))
     item1 = a.pop(1)
     return item1, b[-1]
 
 
 def test_list_pop_in_for_loop(x, iter_num):
     x = paddle.assign(x)
-    # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
-    iter_num = paddle.tensor.fill_constant(
-        shape=[1], value=iter_num, dtype="int32"
+    # Use `full` so that static analysis can analyze the type of iter_num is Tensor
+    iter_num = paddle.full(
+        shape=[1], fill_value=iter_num, dtype="int32"
     )  # TODO(liym27): Delete it if the type of parameter iter_num can be resolved
 
     a = []
@@ -196,9 +190,7 @@ def test_list_pop_in_for_loop(x, iter_num):
 
 def test_list_pop_in_while_loop(x, iter_num):
     x = paddle.assign(x)
-    iter_num = paddle.tensor.fill_constant(
-        shape=[1], value=iter_num, dtype="int32"
-    )
+    iter_num = paddle.full(shape=[1], fill_value=iter_num, dtype="int32")
     a = []
     b = [x]
     b.append(x)

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -34,7 +34,7 @@ np.random.seed(SEED)
 # Situation 1: Test list append
 def test_list_append_without_control_flow(x):
     # Python list will not be transformed.
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     a = []
     # It's a plain python control flow which won't be transformed
     if 2 > 1:
@@ -43,7 +43,7 @@ def test_list_append_without_control_flow(x):
 
 
 def test_list_append_in_if(x):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     a = []
     if x.numpy()[0] > 0:
         a.append(x)
@@ -56,7 +56,7 @@ def test_list_append_in_if(x):
 
 
 def test_list_append_in_for_loop(x, iter_num):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
@@ -68,7 +68,7 @@ def test_list_append_in_for_loop(x, iter_num):
 
 
 def test_list_append_in_for_subscript(x):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     iter_num = paddle.shape(x)[0]
     a = []
     for i in range(iter_num):
@@ -79,7 +79,7 @@ def test_list_append_in_for_subscript(x):
 
 
 def test_list_append_in_while_loop_subscript(x):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     iter_num = paddle.shape(x)[0]
     a = []
     i = 0
@@ -92,7 +92,7 @@ def test_list_append_in_while_loop_subscript(x):
 
 
 def test_list_append_in_for_loop_with_concat(x, iter_num):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     a = []
     # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
     iter_num = paddle.tensor.fill_constant(
@@ -105,7 +105,7 @@ def test_list_append_in_for_loop_with_concat(x, iter_num):
 
 
 def test_list_append_in_while_loop(x, iter_num):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
     )
@@ -118,7 +118,7 @@ def test_list_append_in_while_loop(x, iter_num):
 
 
 def test_list_append_in_while_loop_with_stack(x, iter_num):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
     )
@@ -141,7 +141,7 @@ def test_tensor_array_slice(x, iter_num):
 
 # Situation 2: Test list pop
 def test_list_pop_without_control_flow_1(x):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     a = []
     if 2 > 1:
         a.append(x)
@@ -150,7 +150,7 @@ def test_list_pop_without_control_flow_1(x):
 
 
 def test_list_pop_without_control_flow_2(x):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     a = []
     if 2 > 1:
         a.append(x)
@@ -160,7 +160,7 @@ def test_list_pop_without_control_flow_2(x):
 
 
 def test_list_pop_in_if(x):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     a = []
     b = [x * 2 + (x + 1)]
     if x.numpy()[0] > 0:
@@ -176,7 +176,7 @@ def test_list_pop_in_if(x):
 
 
 def test_list_pop_in_for_loop(x, iter_num):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
@@ -195,7 +195,7 @@ def test_list_pop_in_for_loop(x, iter_num):
 
 
 def test_list_pop_in_while_loop(x, iter_num):
-    x = paddle.to_tensor(x)
+    x = paddle.assign(x)
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
     )
@@ -249,13 +249,11 @@ class TestListWithoutControlFlowConfig(Dy2StTestBase):
         return self.train(to_static=False)
 
     def train(self, to_static=False):
-        # deep copy to avoid inplace operation
-        input = np.copy(self.input)
         with base.dygraph.guard():
             if to_static:
-                res = paddle.jit.to_static(self.dygraph_func)(input)
+                res = paddle.jit.to_static(self.dygraph_func)(self.input)
             else:
-                res = self.dygraph_func(input)
+                res = self.dygraph_func(self.input)
             return self.result_to_numpy(res)
 
     def compare_transformed_static_result(self):

--- a/test/dygraph_to_static/test_list.py
+++ b/test/dygraph_to_static/test_list.py
@@ -34,7 +34,7 @@ np.random.seed(SEED)
 # Situation 1: Test list append
 def test_list_append_without_control_flow(x):
     # Python list will not be transformed.
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     a = []
     # It's a plain python control flow which won't be transformed
     if 2 > 1:
@@ -43,7 +43,7 @@ def test_list_append_without_control_flow(x):
 
 
 def test_list_append_in_if(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     a = []
     if x.numpy()[0] > 0:
         a.append(x)
@@ -56,7 +56,7 @@ def test_list_append_in_if(x):
 
 
 def test_list_append_in_for_loop(x, iter_num):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
@@ -68,7 +68,7 @@ def test_list_append_in_for_loop(x, iter_num):
 
 
 def test_list_append_in_for_subscript(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     iter_num = paddle.shape(x)[0]
     a = []
     for i in range(iter_num):
@@ -79,7 +79,7 @@ def test_list_append_in_for_subscript(x):
 
 
 def test_list_append_in_while_loop_subscript(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     iter_num = paddle.shape(x)[0]
     a = []
     i = 0
@@ -92,7 +92,7 @@ def test_list_append_in_while_loop_subscript(x):
 
 
 def test_list_append_in_for_loop_with_concat(x, iter_num):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     a = []
     # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
     iter_num = paddle.tensor.fill_constant(
@@ -105,7 +105,7 @@ def test_list_append_in_for_loop_with_concat(x, iter_num):
 
 
 def test_list_append_in_while_loop(x, iter_num):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
     )
@@ -118,7 +118,7 @@ def test_list_append_in_while_loop(x, iter_num):
 
 
 def test_list_append_in_while_loop_with_stack(x, iter_num):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
     )
@@ -141,7 +141,7 @@ def test_tensor_array_slice(x, iter_num):
 
 # Situation 2: Test list pop
 def test_list_pop_without_control_flow_1(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     a = []
     if 2 > 1:
         a.append(x)
@@ -150,7 +150,7 @@ def test_list_pop_without_control_flow_1(x):
 
 
 def test_list_pop_without_control_flow_2(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     a = []
     if 2 > 1:
         a.append(x)
@@ -160,7 +160,7 @@ def test_list_pop_without_control_flow_2(x):
 
 
 def test_list_pop_in_if(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     a = []
     b = [x * 2 + (x + 1)]
     if x.numpy()[0] > 0:
@@ -176,7 +176,7 @@ def test_list_pop_in_if(x):
 
 
 def test_list_pop_in_for_loop(x, iter_num):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     # Use `fill_constant` so that static analysis can analyze the type of iter_num is Tensor
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
@@ -195,7 +195,7 @@ def test_list_pop_in_for_loop(x, iter_num):
 
 
 def test_list_pop_in_while_loop(x, iter_num):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     iter_num = paddle.tensor.fill_constant(
         shape=[1], value=iter_num, dtype="int32"
     )
@@ -249,11 +249,13 @@ class TestListWithoutControlFlowConfig(Dy2StTestBase):
         return self.train(to_static=False)
 
     def train(self, to_static=False):
+        # deep copy to avoid inplace operation
+        input = np.copy(self.input)
         with base.dygraph.guard():
             if to_static:
-                res = paddle.jit.to_static(self.dygraph_func)(self.input)
+                res = paddle.jit.to_static(self.dygraph_func)(input)
             else:
-                res = self.dygraph_func(self.input)
+                res = self.dygraph_func(input)
             return self.result_to_numpy(res)
 
     def compare_transformed_static_result(self):
@@ -298,7 +300,6 @@ class TestListInWhileLoop(TestListWithoutControlFlowConfig):
     def train(self, to_static=False):
         with base.dygraph.guard():
             if to_static:
-                # print(paddle.jit.to_static(self.dygraph_func).code)
                 res = paddle.jit.to_static(self.dygraph_func)(
                     self.input, self.iter_num
                 )

--- a/test/dygraph_to_static/test_loop.py
+++ b/test/dygraph_to_static/test_loop.py
@@ -87,7 +87,7 @@ def for_loop_dyfunc(max_len):
 
 def for_loop_dyfunc2(max_len):
     # Test case: a variable is used and created in loop, but used before created
-    x = paddle.tensor.fill_constant(shape=[1, 2], dtype="int32", value=1)
+    x = paddle.full(shape=[1, 2], fill_value=1, dtype="int32")
 
     for i in range(max_len):
         if i > 1:
@@ -95,7 +95,7 @@ def for_loop_dyfunc2(max_len):
         a = 1
         q, _ = x.shape  # test var x.shape only used but not created in loop
 
-    ret = paddle.tensor.fill_constant(shape=[1], dtype="int32", value=s + q)
+    ret = paddle.full(shape=[1], fill_value=s + q, dtype="int32")
     return ret
 
 
@@ -186,9 +186,7 @@ def for_loop_class_var(max_len):
 
     foo = Foo()
 
-    max_len = paddle.tensor.fill_constant(
-        shape=[1], value=max_len, dtype="int32"
-    )
+    max_len = paddle.full(shape=[1], fill_value=max_len, dtype="int32")
 
     for i in range(max_len):
         foo.b = paddle.zeros(shape=[1], dtype='float32')
@@ -203,8 +201,8 @@ def var_create_in_for_loop(max_len):
 
 
 def nested_for_loop_dyfunc():
-    two = paddle.tensor.fill_constant(shape=[1], value=2, dtype="int32")
-    three = paddle.tensor.fill_constant(shape=[1], value=3, dtype="int32")
+    two = paddle.full(shape=[1], fill_value=2, dtype="int32")
+    three = paddle.full(shape=[1], fill_value=3, dtype="int32")
     for j in range(two):
         for i in range(10):
             a = 2 + j

--- a/test/dygraph_to_static/test_tensor_shape.py
+++ b/test/dygraph_to_static/test_tensor_shape.py
@@ -23,11 +23,10 @@ from dygraph_to_static_utils import (
 )
 
 import paddle
-from paddle import base
 
 
 def dyfunc_tensor_shape_1(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     res = paddle.reshape(x, shape=x.shape)
     return res
 
@@ -42,14 +41,14 @@ def dyfunc_tensor_shape_2(x):
 
 def dyfunc_tensor_shape_3(x):
     # Transform y.shape but run y.shape actually because y is not Tensor
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     y = paddle.ones([1, 5])
     res = paddle.reshape(x, shape=y.shape)
     return res
 
 
 def dyfunc_tensor_shape_4(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     res = paddle.reshape(x, shape=(-1, x.shape[0], len(x.shape)))
     return res
 
@@ -58,7 +57,7 @@ def dyfunc_tensor_shape_5(x):
     # `res = base.layers.reshape(x, shape=(-1, s))` to
     # `res = base.layers.reshape(x, shape=(-1,
     #           paddle.jit.dy2static.convert_var_shape(x)[0]))`
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     s = x.shape[0]
     res = paddle.reshape(x, shape=(-1, s))
     return res
@@ -68,7 +67,7 @@ def dyfunc_tensor_shape_6(x):
     # `res = base.layers.reshape(x, shape=(-1, s))` to
     # `res = base.layers.reshape(x, shape=(-1,
     #           paddle.jit.dy2static.convert_var_shape(x)[0:]))`
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     s = x.shape[0:]
     res = paddle.reshape(x, shape=s)
     return res
@@ -108,7 +107,7 @@ def dyfunc_paddle_shape_api(x):
 
 
 def dyfunc_with_if_1(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     res = paddle.reshape(x, [-1, 1])
     x_shape_0 = x.shape[0]
     if x_shape_0 < 1:
@@ -126,7 +125,7 @@ def dyfunc_with_if_1(x):
 
 
 def dyfunc_with_if_2(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     # `len(x.shape)` will not be transformed because x.shape is not used by Paddle api.
     if len(x.shape) < 1:
         res = x
@@ -137,7 +136,7 @@ def dyfunc_with_if_2(x):
 
 
 def dyfunc_with_for_1(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
     # `x.shape[0]` is transformed into `paddle.jit.dy2static.convert_var_shape(x)[0]`
     for i in range(x.shape[0]):
@@ -146,7 +145,7 @@ def dyfunc_with_for_1(x):
 
 
 def dyfunc_with_for_2(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     x_shape_0 = x.shape[0]
     res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
 
@@ -157,7 +156,7 @@ def dyfunc_with_for_2(x):
 
 
 def dyfunc_with_for_3(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
     # `len(x.shape)` is not transformed.
     for i in range(len(x.shape)):
@@ -167,7 +166,7 @@ def dyfunc_with_for_3(x):
 
 
 def dyfunc_with_while_1(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
     # `x.shape[0]` is transformed into `paddle.jit.dy2static.convert_var_shape(x)[0]`
     i = 1
@@ -178,7 +177,7 @@ def dyfunc_with_while_1(x):
 
 
 def dyfunc_with_while_2(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     x_shape_0 = x.shape[0]
     res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
     i = 1
@@ -190,7 +189,7 @@ def dyfunc_with_while_2(x):
 
 
 def dyfunc_with_while_3(x):
-    x = base.dygraph.to_variable(x)
+    x = paddle.to_tensor(x)
     x_shape = x.shape
     res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
     i = 1
@@ -276,12 +275,12 @@ class TestTensorShapeBasic(Dy2StTestBase):
 
     def _set_expected_op_num(self):
         # TODO(cleanup-legacy-ir): Remove _set_expected_op_num related code
-        self.expected_op_num = 2
+        self.expected_op_num = 1
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 4
+        self.pir_expected_op_num = 3
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 0
 
@@ -356,12 +355,12 @@ class TestTensorShapeBasic3(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_tensor_shape_3
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 3
+        self.expected_op_num = 2
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 5
+        self.pir_expected_op_num = 4
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 0
 
@@ -376,12 +375,12 @@ class TestTensorShapeBasic5(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_tensor_shape_5
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 2
+        self.expected_op_num = 1
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 4
+        self.pir_expected_op_num = 3
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 0
 
@@ -391,12 +390,12 @@ class TestTensorShapeBasic6(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_tensor_shape_6
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 2
+        self.expected_op_num = 1
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 4
+        self.pir_expected_op_num = 3
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 0
 
@@ -479,12 +478,12 @@ class TestTensorShapeInIf1(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_with_if_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 2
+        self.expected_op_num = 1
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 4
+        self.pir_expected_op_num = 3
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 0
 
@@ -494,12 +493,12 @@ class TestTensorShapeInIf2(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_with_if_2
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 2
+        self.expected_op_num = 1
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 3
+        self.pir_expected_op_num = 2
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -510,12 +509,12 @@ class TestTensorShapeInFor1(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_with_for_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 7
+        self.expected_op_num = 6
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 13
+        self.pir_expected_op_num = 12
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -525,12 +524,12 @@ class TestTensorShapeInFor2(TestTensorShapeInFor1):
         self.dygraph_func = dyfunc_with_for_2
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 7
+        self.expected_op_num = 6
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 13
+        self.pir_expected_op_num = 12
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -540,12 +539,12 @@ class TestTensorShapeInFor3(TestTensorShapeInFor1):
         self.dygraph_func = dyfunc_with_for_3
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 3
+        self.expected_op_num = 2
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 5
+        self.pir_expected_op_num = 4
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -556,12 +555,12 @@ class TestTensorShapeInWhile1(TestTensorShapeInFor1):
         self.dygraph_func = dyfunc_with_while_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 4
+        self.expected_op_num = 3
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 7
+        self.pir_expected_op_num = 6
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -571,12 +570,12 @@ class TestTensorShapeInWhile2(TestTensorShapeInFor1):
         self.dygraph_func = dyfunc_with_while_2
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 4
+        self.expected_op_num = 3
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 7
+        self.pir_expected_op_num = 6
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -586,12 +585,12 @@ class TestTensorShapeInWhile3(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_with_while_3
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 2
+        self.expected_op_num = 1
         self.expected_shape_op_num = 0
         self.expected_slice_op_num = 0
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 3
+        self.pir_expected_op_num = 2
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -628,12 +627,12 @@ class TestOpNumBasicWithTensorShape(Dy2StTestBase):
         self.dygraph_func = dyfunc_tensor_shape_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 5
+        self.expected_op_num = 4
         self.expected_shape_op_num = 1
         self.expected_slice_op_num = 1
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 11
+        self.pir_expected_op_num = 10
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 1
 
@@ -697,12 +696,12 @@ class TestOpNumBasicWithTensorShape4(TestOpNumBasicWithTensorShape):
         self.dygraph_func = dyfunc_tensor_shape_4
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 8
+        self.expected_op_num = 7
         self.expected_shape_op_num = 2
         self.expected_slice_op_num = 2
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 16
+        self.pir_expected_op_num = 15
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 2
 
@@ -727,12 +726,12 @@ class TestOpNumWithTensorShapeInIf1(TestOpNumBasicWithTensorShape):
         self.dygraph_func = dyfunc_with_if_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 32
+        self.expected_op_num = 31
         self.expected_shape_op_num = 4
         self.expected_slice_op_num = 4
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 42
+        self.pir_expected_op_num = 41
         self.pir_expected_shape_op_num = 1
         self.pir_expected_slice_op_num = 1
 
@@ -742,12 +741,12 @@ class TestOpNumWithTensorShapeInFor1(TestOpNumBasicWithTensorShape):
         self.dygraph_func = dyfunc_with_for_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 27
+        self.expected_op_num = 26
         self.expected_shape_op_num = 2
         self.expected_slice_op_num = 3
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 3
+        self.pir_expected_op_num = 2
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 0
 
@@ -763,12 +762,12 @@ class TestOpNumWithTensorShapeInWhile1(TestOpNumBasicWithTensorShape):
         self.dygraph_func = dyfunc_with_while_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 21
+        self.expected_op_num = 20
         self.expected_shape_op_num = 3
         self.expected_slice_op_num = 3
 
     def _set_pir_expected_op_num(self):
-        self.pir_expected_op_num = 28
+        self.pir_expected_op_num = 27
         self.pir_expected_shape_op_num = 0
         self.pir_expected_slice_op_num = 2
 

--- a/test/dygraph_to_static/test_tensor_shape.py
+++ b/test/dygraph_to_static/test_tensor_shape.py
@@ -114,13 +114,9 @@ def dyfunc_with_if_1(x):
         # `res.shape[0]` is transformed into
         #   `paddle.jit.dy2static.convert_var_shape(res)[0]`
         if res.shape[0] > 1:
-            res = paddle.tensor.fill_constant(
-                value=2, shape=x.shape, dtype="int32"
-            )
+            res = paddle.full(shape=x.shape, fill_value=2, dtype="int32")
         else:
-            res = paddle.tensor.fill_constant(
-                value=3, shape=x.shape, dtype="int32"
-            )
+            res = paddle.full(shape=x.shape, fill_value=3, dtype="int32")
     return res
 
 
@@ -130,14 +126,14 @@ def dyfunc_with_if_2(x):
     if len(x.shape) < 1:
         res = x
     else:
-        res = paddle.tensor.fill_constant(value=8, shape=x.shape, dtype="int32")
+        res = paddle.full(shape=x.shape, fill_value=8, dtype="int32")
 
     return res
 
 
 def dyfunc_with_for_1(x):
     x = paddle.to_tensor(x)
-    res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
+    res = paddle.full(shape=[1], fill_value=0, dtype="int32")
     # `x.shape[0]` is transformed into `paddle.jit.dy2static.convert_var_shape(x)[0]`
     for i in range(x.shape[0]):
         res += 1
@@ -147,7 +143,7 @@ def dyfunc_with_for_1(x):
 def dyfunc_with_for_2(x):
     x = paddle.to_tensor(x)
     x_shape_0 = x.shape[0]
-    res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
+    res = paddle.full(shape=[1], fill_value=0, dtype="int32")
 
     # `x_shape_0` is transformed into `paddle.jit.dy2static.convert_var_shape(x)[0]`
     for i in range(x_shape_0):
@@ -157,7 +153,7 @@ def dyfunc_with_for_2(x):
 
 def dyfunc_with_for_3(x):
     x = paddle.to_tensor(x)
-    res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
+    res = paddle.full(shape=[1], fill_value=0, dtype="int32")
     # `len(x.shape)` is not transformed.
     for i in range(len(x.shape)):
         res += 1
@@ -167,7 +163,7 @@ def dyfunc_with_for_3(x):
 
 def dyfunc_with_while_1(x):
     x = paddle.to_tensor(x)
-    res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
+    res = paddle.full(shape=[1], fill_value=0, dtype="int32")
     # `x.shape[0]` is transformed into `paddle.jit.dy2static.convert_var_shape(x)[0]`
     i = 1
     while i < x.shape[0]:
@@ -179,7 +175,7 @@ def dyfunc_with_while_1(x):
 def dyfunc_with_while_2(x):
     x = paddle.to_tensor(x)
     x_shape_0 = x.shape[0]
-    res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
+    res = paddle.full(shape=[1], fill_value=0, dtype="int32")
     i = 1
     # `x_shape_0` is transformed into `paddle.jit.dy2static.convert_var_shape(x)[0]`
     while i < x_shape_0:
@@ -191,7 +187,7 @@ def dyfunc_with_while_2(x):
 def dyfunc_with_while_3(x):
     x = paddle.to_tensor(x)
     x_shape = x.shape
-    res = paddle.tensor.fill_constant(value=0, shape=[1], dtype="int32")
+    res = paddle.full(shape=[1], fill_value=0, dtype="int32")
     i = 1
 
     # `len(x.shape)` is not transformed.
@@ -799,9 +795,7 @@ def dyfunc_with_static_convert_var_shape(x):
     else:
         # Test for correctly to find `batch_size__static_convert_var_shape_suffix_0` in
         # deeply nested scope.
-        res = paddle.tensor.fill_constant(
-            value=8, shape=[batch_size], dtype="int32"
-        )
+        res = paddle.full(shape=[batch_size], fill_value=8, dtype="int32")
 
     return res
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #61244 根据 #61243 修改动转静单测中可能的坑，部分单测中不能替换为 `to_tensor`，因为 `to_tensor` 传入一个 Variable 后什么也不做，不会产生新的 Variable，因此分场景替换为 `assign` 和 `to_tensor`

- 动转静组网代码外，直接 `to_tensor`
- 动转静组网代码內
   - 如果是想将 NumPy 数据转为 Tensor，则用 `to_tensor`
   - 如果是想创建一个和之前不一样的 Tensor，则用 `assign`

剩余场景基本都可以安全替换为 `to_tensor`

并顺带替换了一部分 `fill_constant` 为 `full`（这个暂时不需要作为任务统一处理，看到了换换就好，`fill_constant` 没暴露到 `paddle` 下，应该也是 fluid 迁移过来的旧 API）

PCard-66972