### PR TITLE
[Thread Data] do not reserve string data in thread

### DIFF
--- a/paddle/phi/common/thread_data_registry.h
+++ b/paddle/phi/common/thread_data_registry.h
@@ -34,6 +34,9 @@ using void_t = void;
 template <typename T, typename = void>
 struct IsAccumulatable : std::false_type {};
 
+template <>
+struct IsAccumulatable<std::string, void> : std::false_type {};
+
 template <typename T>
 struct IsAccumulatable<T,
                        void_t<decltype(std::declval<T>() += std::declval<T>())>>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
do not reserve string data in thread, avoid following log:
```
I0129 11:21:01.220558  5208 pir_interpreter.cc:1746] 
done: RunInstructionBase OP id:23 name:pd_op.fused_conv2d_add_act type:kGpuAsync runs on MainThreadDeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0DeviceKernelLaunch_thread_0HostTasks_thread_0...
After: Place(gpu:0) Op(pd_op.fused_conv2d_add_act), inputs:{...}, outputs:{...}.
```
#### Others
Pcard-67164