### PR TITLE
[Paddle Inference]fix predictor_id_per_thread

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -28,7 +28,7 @@ namespace paddle {
 namespace inference {
 namespace tensorrt {
 
-thread_local int TensorRTEngine::predictor_id_per_thread = -1;
+thread_local int TensorRTEngine::predictor_id_per_thread = 0;
 
 void TensorRTEngine::Weight::SetDataType(phi::DataType type) {
   nvinfer1::DataType nv_type = nvinfer1::DataType::kFLOAT;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501
fix predictor_id_per_thread, predictor_id_per_thread default is 0 