### PR TITLE
[PIR] adjust the value == function.

### DIFF
--- a/paddle/pir/core/operation.h
+++ b/paddle/pir/core/operation.h
@@ -277,7 +277,7 @@ class IR_API alignas(8) Operation final
   const uint32_t num_operands_ = 0;
   const uint32_t num_regions_ = 0;
   const uint32_t num_successors_ = 0;
-  const uint64_t id_ = 0;
+  const uint64_t id_;
 
   detail::BlockOperandImpl *block_operands_{nullptr};
   Region *regions_{nullptr};

--- a/paddle/pir/core/value.cc
+++ b/paddle/pir/core/value.cc
@@ -31,11 +31,12 @@
 
 namespace pir {
 bool Value::operator==(const Value &other) const {
-  return impl_ == other.impl_;
+  return impl_ == other.impl_ &&
+         (impl_ == nullptr || impl_->id() == other.impl_->id());
 }
 
 bool Value::operator!=(const Value &other) const {
-  return impl_ != other.impl_;
+  return !(operator==(other));
 }
 
 bool Value::operator!() const { return impl_ == nullptr; }

--- a/paddle/pir/core/value_impl.cc
+++ b/paddle/pir/core/value_impl.cc
@@ -13,6 +13,12 @@
 // limitations under the License.
 #include "paddle/pir/core/value_impl.h"
 
+namespace {
+uint64_t GenerateId() {
+  static std::atomic<std::uint64_t> uid{0};
+  return ++uid;
+}
+}  // namespace
 namespace pir {
 
 namespace detail {
@@ -40,7 +46,7 @@ std::string ValueImpl::PrintUdChain() {
   result << "nullptr";
   return result.str();
 }
-ValueImpl::ValueImpl(Type type, uint32_t kind) {
+ValueImpl::ValueImpl(Type type, uint32_t kind) : id_(GenerateId()) {
   if (kind > BLOCK_ARG_IDX) {
     LOG(FATAL) << "The kind of value_impl(" << kind
                << "), is bigger than BLOCK_ARG_IDX(7)";

--- a/paddle/pir/core/value_impl.h
+++ b/paddle/pir/core/value_impl.h
@@ -71,6 +71,8 @@ class alignas(8) ValueImpl {
     return T::classof(*this);
   }
 
+  uint64_t id() const { return id_; }
+
  protected:
   ///
   /// \brief Only can be constructed by derived classes such as OpResultImpl.
@@ -92,6 +94,8 @@ class alignas(8) ValueImpl {
   /// outline output(OpOutlineResultImpl); (3) index = 7 is reserved.
   ///
   OpOperandImpl *first_use_offseted_by_kind_ = nullptr;
+
+  const uint64_t id_ = 0;
 };
 
 }  // namespace detail


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others 

### Description
<!-- Describe what you’ve done -->
value增加互斥的id成员变量。 保证了value的判等的绝对正确性。

在一起特殊情况下，value被析构后又被新建在了同样的内存地址。会导致新旧value的判等失败，反回true。本pr在这种情况下，会判等成功，反回false。

### Other

Pcard-67164