### PR TITLE
Register bf16 type for c_reduce_sum op

### DIFF
--- a/paddle/fluid/operators/collective/c_reduce_sum_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_sum_op.cu.cc
@@ -31,4 +31,5 @@ PD_REGISTER_STRUCT_KERNEL(c_reduce_sum,
                           double,
                           int,
                           int64_t,
-                          plat::float16) {}
+                          plat::float16,
+                          plat::bfloat16) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
OPs

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Register bf16 type for c_reduce_sum op.