### PR TITLE
add PD_ConfigEnableCustomDevice new param

### DIFF
--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -187,9 +187,11 @@ int32_t PD_ConfigXpuDeviceId(__pd_keep PD_Config* pd_config) {
 
 void PD_ConfigEnableCustomDevice(__pd_keep PD_Config* pd_config,
                                  char* device_type,
-                                 int32_t device_id) {
+                                 int32_t device_id,
+                                 PD_PrecisionType precision) {
   CHECK_AND_CONVERT_PD_CONFIG;
-  config->EnableCustomDevice(device_type, device_id);
+  config->EnableCustomDevice(
+      device_type, device_id, ConvertToCxxPrecisionType(precision));
 }
 PD_Bool PD_ConfigUseCustomDevice(__pd_keep PD_Config* pd_config) {
   CHECK_AND_CONVERT_PD_CONFIG;

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -245,7 +245,10 @@ PADDLE_CAPI_EXPORT extern int32_t PD_ConfigXpuDeviceId(
 /// \param[in] device_id device_id the custome device card to use.
 ///
 PADDLE_CAPI_EXPORT extern void PD_ConfigEnableCustomDevice(
-    __pd_keep PD_Config* pd_config, char* device_type, int32_t device_id);
+    __pd_keep PD_Config* pd_config,
+    char* device_type,
+    int32_t device_id,
+    PD_PrecisionType precision);
 ///
 /// \brief A boolean state telling whether the custom device is turned on.
 ///


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Description
与C++ enbale_custom_device接口相较, C 接口(PD_ConfigEnableCustomDevice)缺少precision参数;
增加C API 中PD_ConfigEnableCustomDevice缺少的precision参数;
