### PR TITLE
[CINN] Support reduce fuse broadcast in dynamic shape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_pass.cc
@@ -161,7 +161,7 @@ phi::DDim GetFirstInputShape(const ::pir::Operation* op) {
   return in.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
 }
 
-phi::DDim GetValueShape(const ::pir::Value& value) {
+const phi::DDim& GetValueShape(const ::pir::Value& value) {
   return value.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
 }
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_util.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_util.h
@@ -21,8 +21,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "paddle/cinn/hlir/dialect/operator/ir/cinn_op.h"
 #include "paddle/cinn/hlir/framework/pir/group.h"
 #include "paddle/cinn/hlir/framework/pir/utils.h"
+#include "paddle/fluid/pir/dialect/operator/ir/manual_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/pir/core/operation.h"
@@ -65,7 +67,7 @@ std::vector<T> GetVectorAttr(const ::pir::Operation* op,
 
 phi::DDim GetFirstInputShape(const ::pir::Operation* op);
 
-phi::DDim GetValueShape(const ::pir::Value& value);
+const phi::DDim& GetValueShape(const ::pir::Value& value);
 
 bool WithoutLastDimInReduce(const std::vector<int64_t>& inshape,
                             const std::vector<int64_t>& axes);
@@ -179,6 +181,7 @@ inline bool reduce_fuse_reduce(
 
 inline bool is_horizontal_relation(::pir::Operation* producer,
                                    const std::shared_ptr<Group>& consumer) {
+  VLOG(0) << "#### is_horizontal_relation ######";
   auto check_depency = [&](::pir::Operation* op) {
     std::queue<::pir::Operation*> candidates;
     std::unordered_set<::pir::Operation*> visited_set;
@@ -334,6 +337,28 @@ inline bool horizontal_with_same_size(
          is_same_size(producer, consumer, shape_analysis);
 }
 
+inline std::vector<int64_t> GetBroadcastAxes(
+    ::pir::Operation* bcast_op,
+    const ::pir::ShapeConstraintIRAnalysis& shape_analysis) {  // NOLINT
+  if (bcast_op->isa<cinn::dialect::BroadcastOp>()) {
+    return GetVectorAttr(bcast_op, "broadcast_axes");
+  } else if (bcast_op->isa<paddle::dialect::ExpandOp>()) {
+    const auto& input_shape =
+        shape_analysis.GetShapeOrDataForValue(bcast_op->operand_source(0))
+            .shape();
+    const auto& output_shape =
+        shape_analysis.GetShapeOrDataForValue(bcast_op->result(0)).shape();
+    std::vector<int64_t> broadcast_axes(input_shape.size(), 0);
+    size_t index_gap = output_shape.size() - input_shape.size();
+    for (size_t i = 0; i < input_shape.size(); ++i) {
+      broadcast_axes[i] = i + index_gap;
+    }
+    return broadcast_axes;
+  } else {
+    IR_THROW("Not support broadcast op: %s", bcast_op->name());
+  }
+}
+
 inline bool reduce_fuse_broadcast(
     ::pir::Operation* producer,
     const std::shared_ptr<Group>& consumer,
@@ -349,8 +374,9 @@ inline bool reduce_fuse_broadcast(
   //   return true;
   // }
 
-  auto rinput_shape =
-      ::common::vectorize<int64_t>(GetFirstInputShape(producer));
+  const auto& rinput_shape =
+      shape_analysis.GetShapeOrDataForValue(producer->operand_source(0))
+          .shape();
   auto reduce_axes = GetVectorAttr(producer, "dim");
   auto keep_dim = producer->attributes()
                       .at("keep_dim")
@@ -362,20 +388,6 @@ inline bool reduce_fuse_broadcast(
     }
   }
 
-  int reduce_size = rinput_shape.back();
-  for (auto idx = reduce_axes.size() - 1; idx >= 1; --idx) {
-    if (reduce_axes[idx] != reduce_axes[idx - 1] + 1) {
-      return false;
-    }
-    reduce_size *= rinput_shape[idx - 1];
-  }
-
-  // if (reduce_size > helper->target_.max_num_threads()) {
-  //   return false;
-  // }
-
-  auto routput_shape =
-      ::common::vectorize<int64_t>(GetValueShape(producer->result(0)));
   auto find_reducer =
       [&](::pir::Operation* op,
           ::pir::Operation* reducer,
@@ -402,7 +414,8 @@ inline bool reduce_fuse_broadcast(
         return false;
       };
 
-  for (auto op : consumer->ops_set) {
+  const auto& routput_shape =
+      GetValueShape(producer->result(0)) for (auto op : consumer->ops_set) {
     if (hlir::framework::pir::CompatibleInfo::OpKind(*op) !=
         OpPatternKind::kBroadcast) {
       continue;
@@ -411,9 +424,9 @@ inline bool reduce_fuse_broadcast(
     if (!find_reducer(op, producer, consumer->ops_set)) {
       continue;
     }
-
-    auto broadcast_shape = GetVectorAttr(op, "out_shape");
-    auto broadcast_axes = GetVectorAttr(op, "broadcast_axes");
+    const auto& broadcast_shape =
+        shape_analysis.GetShapeOrDataForValue(op->result(0)).shape();
+    auto broadcast_axes = GetBroadcastAxes(op, shape_analysis);
 
     for (auto& axis : broadcast_axes) {
       if (axis < 0) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_util.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_util.h
@@ -181,7 +181,6 @@ inline bool reduce_fuse_reduce(
 
 inline bool is_horizontal_relation(::pir::Operation* producer,
                                    const std::shared_ptr<Group>& consumer) {
-  VLOG(0) << "#### is_horizontal_relation ######";
   auto check_depency = [&](::pir::Operation* op) {
     std::queue<::pir::Operation*> candidates;
     std::unordered_set<::pir::Operation*> visited_set;
@@ -414,8 +413,8 @@ inline bool reduce_fuse_broadcast(
         return false;
       };
 
-  const auto& routput_shape =
-      GetValueShape(producer->result(0)) for (auto op : consumer->ops_set) {
+  const auto& routput_shape = GetValueShape(producer->result(0));
+  for (auto op : consumer->ops_set) {
     if (hlir::framework::pir::CompatibleInfo::OpKind(*op) !=
         OpPatternKind::kBroadcast) {
       continue;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73448

修改 reduce 类与 broadcast 类算子融合策略，支持两类算子在动态 shape 场景的融合。

原先融合策略中 broadcast 类算子只支持 broadcast_to ，本PR中添加了对 expand 算子的支持