### PR TITLE
Fix Paddle-TRT UT fails

### DIFF
--- a/test/ir/inference/test_trt_convert_assign.py
+++ b/test/ir/inference/test_trt_convert_assign.py
@@ -120,9 +120,8 @@ class TrtConvertAssignTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if not dynamic_shape and (
-                self.has_bool_dtype or self.dims == 1 or self.dims == 0
-            ):
+            # Static shape does not support 0 or 1 dim's input
+            if not dynamic_shape and (self.dims == 1 or self.dims == 0):
                 return 0, 4
             return 1, 2
 

--- a/test/ir/inference/test_trt_convert_cast.py
+++ b/test/ir/inference/test_trt_convert_cast.py
@@ -96,6 +96,7 @@ class TrtConvertCastTest(TrtLayerAutoScanTest):
                         )
                     },
                     outputs=["cast_output_data"],
+                    no_cast_list=["input_data"],
                 )
 
                 yield program_config


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Modifications
- No data type conversion for input of non-floating precision at default if `self.input_type` is set
- Align the constraint in UTs with Paddle-TRT op teller

Fix the following UTs:
- test_trt_convert_bitwise_or
- test_trt_convert_bitwise_and
- test_trt_convert_assign
- test_trt_convert_scatter
- test_trt_convert_cast