### PR TITLE
add _is_run_in_backward

### DIFF
--- a/paddle/fluid/eager/api/utils/global_utils.cc
+++ b/paddle/fluid/eager/api/utils/global_utils.cc
@@ -44,4 +44,10 @@ bool Controller::UseLayoutAutoTune() {
   return use_autotune;
 }
 
+void Controller::SetIsInBackward(bool is_in_backward) {
+  is_in_backward_ = is_in_backward;
+}
+
+bool Controller::GetIsInBackward() const { return is_in_backward_; }
+
 }  // namespace egr

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -132,6 +132,9 @@ class Controller {
     return force_sequential_nodes_;
   }
 
+  TEST_API void SetIsInBackward(bool is_in_backward);
+  TEST_API bool GetIsInBackward() const;
+
  private:
   Controller() = default;
   static Controller* controller_;
@@ -145,6 +148,7 @@ class Controller {
       custom_edges_slot_map_;
   std::vector<std::shared_ptr<VoidHook>> final_backward_hooks_;
   std::queue<GradNodeBase*> force_sequential_nodes_;
+  bool is_in_backward_{false};
   DISABLE_COPY_AND_ASSIGN(Controller);
 };
 

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -154,11 +154,9 @@ class Controller {
 
 class EagerBackwardStateGuard {
  public:
-  EagerBackwardStateGuard() { Controller::GetInstance().SetIsInBackward(true); }
+  EagerBackwardStateGuard() { Controller::Instance().SetIsInBackward(true); }
 
-  ~EagerBackwardStateGuard() {
-    Controller::GetInstance().SetIsInBackward(false);
-  }
+  ~EagerBackwardStateGuard() { Controller::Instance().SetIsInBackward(false); }
 };
 
 }  // namespace egr

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -152,4 +152,13 @@ class Controller {
   DISABLE_COPY_AND_ASSIGN(Controller);
 };
 
+class EagerBackwardStateGuard {
+ public:
+  EagerBackwardStateGuard() { Controller::GetInstance().SetIsInBackward(true); }
+
+  ~EagerBackwardStateGuard() {
+    Controller::GetInstance().SetIsInBackward(false);
+  }
+};
+
 }  // namespace egr

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -113,6 +113,7 @@ std::vector<paddle::Tensor> RunBackward(
   VLOG(3) << "Start Backward";
 
   auto place = egr::Controller::Instance().GetExpectedPlace();
+  egr::Controller::Instance().SetIsInBackward(true);
 
   // *Gradient Hook should happen at node-level
   // *Inplace version check should perform at node-level
@@ -420,6 +421,7 @@ std::vector<paddle::Tensor> RunBackward(
     (*hook)();
   }
   egr::Controller::Instance().ClearFinalBackwardHooks();
+  egr::Controller::Instance().SetIsInBackward(false);
   if (!is_general_grad) return {};
   VLOG(3) << "Finish Backward";
   return GeneralGrad::Instance().GetResults(inputs, allow_unused, create_graph);

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -112,8 +112,8 @@ std::vector<paddle::Tensor> RunBackward(
     const std::vector<paddle::Tensor>& no_grad_vars = {}) {
   VLOG(3) << "Start Backward";
 
+  egr::EagerBackwardStateGuard guard;
   auto place = egr::Controller::Instance().GetExpectedPlace();
-  egr::Controller::Instance().SetIsInBackward(true);
 
   // *Gradient Hook should happen at node-level
   // *Inplace version check should perform at node-level
@@ -421,7 +421,6 @@ std::vector<paddle::Tensor> RunBackward(
     (*hook)();
   }
   egr::Controller::Instance().ClearFinalBackwardHooks();
-  egr::Controller::Instance().SetIsInBackward(false);
   if (!is_general_grad) return {};
   VLOG(3) << "Finish Backward";
   return GeneralGrad::Instance().GetResults(inputs, allow_unused, create_graph);

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -1350,6 +1350,16 @@ static PyObject* eager_api_set_master_grads(PyObject* self,
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
+PyObject* eager__is_run_in_backward(PyObject* self,
+                                    PyObject* args,
+                                    PyObject* kwargs) {
+  EAGER_TRY
+
+  return ToPyObject(egr::Controller::Instance().GetIsInBackward());
+
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
+
 PyMethodDef variable_functions[] = {  // NOLINT
     // TODO(jiabin): Remove scale when we have final state tests
     {"scale",
@@ -1421,6 +1431,10 @@ PyMethodDef variable_functions[] = {  // NOLINT
     /**amp functions**/
     {"set_master_grads",
      (PyCFunction)(void (*)())eager_api_set_master_grads,
+     METH_VARARGS | METH_KEYWORDS,
+     nullptr},
+    {"_is_run_in_backward",
+     (PyCFunction)(void (*)())eager__is_run_in_backward,
      METH_VARARGS | METH_KEYWORDS,
      nullptr},
 /**sparse functions**/


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
添加获取动态图状态，当前是否在反向图执行中的接口。

Python端可以通过 core.eager._is_run_in_backward()调用。

Pcard-74613