### PR TITLE
fix as_complex,as_real strided kernel bug

### DIFF
--- a/paddle/phi/kernels/stride/as_real_kernel.cc
+++ b/paddle/phi/kernels/stride/as_real_kernel.cc
@@ -21,7 +21,13 @@ template <typename T, typename Context>
 void AsRealStridedKernel(const Context& dev_ctx,
                          const DenseTensor& x,
                          DenseTensor* out) {
-  out->set_strides(DenseTensorMeta::calc_strides(out->dims()));
+  auto out_stride_v = common::vectorize(x.strides());
+  for (size_t i = 0; i < out_stride_v.size(); ++i) {
+    out_stride_v[i] *= 2;
+  }
+  out_stride_v.push_back(1);
+  out->set_strides(common::make_ddim(out_stride_v));
+
   if (x.dtype() == DataType::COMPLEX64) {
     out->set_type(DataType::FLOAT32);
   } else if (x.dtype() == DataType::COMPLEX128) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
as_complex,as_real Strided kernel计算stride时，没有考虑传入的Tensor为非连续的情况。修复这个bug。
Pcard-74613