### PR TITLE
[PIR+CINN]Support Check Subgraph fusion number and structure

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1566,6 +1566,7 @@ void AddCinnPass(std::shared_ptr<PassManager> &pass_manager,  // NOLINT
   ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
 
   bool has_dynamic_shape = HasDynamicShape(program);
+  pass_manager->EnableIRPrinting();
 
   pass_manager->AddPass(cinn::dialect::ir::CreatePdOpToCinnOpPass());
   pass_manager->AddPass(

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1566,7 +1566,6 @@ void AddCinnPass(std::shared_ptr<PassManager> &pass_manager,  // NOLINT
   ctx->GetOrRegisterDialect<pir::shape::ShapeDialect>();
 
   bool has_dynamic_shape = HasDynamicShape(program);
-  pass_manager->EnableIRPrinting();
 
   pass_manager->AddPass(cinn::dialect::ir::CreatePdOpToCinnOpPass());
   pass_manager->AddPass(

--- a/test/ir/pir/cinn/CMakeLists.txt
+++ b/test/ir/pir/cinn/CMakeLists.txt
@@ -9,7 +9,7 @@ if(WITH_GPU)
     "test_*.py")
   string(REPLACE ".py" "" CINN_PIR_TEST "${CINN_PIR_TEST}")
 
-  # The following UT is enable by manually add_test
+  # The following UT is enabled manually by add_test
   list(REMOVE_ITEM CINN_PIR_TEST test_subgraph_checker test_rms_norm test_rope)
 
   foreach(cinn_pir_test_name ${CINN_PIR_TEST})

--- a/test/ir/pir/cinn/CMakeLists.txt
+++ b/test/ir/pir/cinn/CMakeLists.txt
@@ -9,7 +9,8 @@ if(WITH_GPU)
     "test_*.py")
   string(REPLACE ".py" "" CINN_PIR_TEST "${CINN_PIR_TEST}")
 
-  list(REMOVE_ITEM CINN_PIR_TEST test_subgraph_checker test_rms_norm)
+  # The following UT is enable by manually add_test
+  list(REMOVE_ITEM CINN_PIR_TEST test_subgraph_checker test_rms_norm test_rope)
 
   foreach(cinn_pir_test_name ${CINN_PIR_TEST})
     add_test(

--- a/test/ir/pir/cinn/test_cinn_ops.py
+++ b/test/ir/pir/cinn/test_cinn_ops.py
@@ -33,7 +33,7 @@ class TestOpsBase(unittest.TestCase):
     def prepare_info(self):
         self.fn = None
         self.expected_fuison_number = 1
-        self.expected_fuison_structure = {"fusion": 1}
+        self.expected_fuison_structure = {utils.JIT_KERNEL_NAME: 1}
 
     def prepare_data(self):
         self.shape = [64, 128]
@@ -49,15 +49,17 @@ class TestOpsBase(unittest.TestCase):
         dy_out = self.fn(self.x, self.y)
         np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
 
-        utils.check_fusion_number(static_fn, self.expected_fuison_number)
-        utils.check_fusion_structure(static_fn, self.expected_fuison_structure)
+        utils.check_jit_kernel_number(static_fn, self.expected_fuison_number)
+        utils.check_jit_kernel_structure(
+            static_fn, self.expected_fuison_structure
+        )
 
 
 class TestAddOp(TestOpsBase):
     def prepare_info(self):
         self.fn = paddle.add
         self.expected_fuison_number = 1
-        self.expected_fuison_structure = {utils.FUSION_KEY_STR: 1}
+        self.expected_fuison_structure = {utils.JIT_KERNEL_NAME: 1}
 
     def test_eval(self):
         self.check_eval()
@@ -67,7 +69,7 @@ class TestIsCloseOp(TestOpsBase):
     def prepare_info(self):
         self.fn = paddle.isclose
         self.expected_fuison_number = 1
-        self.expected_fuison_structure = {utils.FUSION_KEY_STR: 1}
+        self.expected_fuison_structure = {utils.JIT_KERNEL_NAME: 1}
 
     def test_eval(self):
         self.check_eval()

--- a/test/ir/pir/cinn/test_cinn_ops.py
+++ b/test/ir/pir/cinn/test_cinn_ops.py
@@ -44,7 +44,7 @@ class TestOpsBase(unittest.TestCase):
         self.y.stop_gradient = False
 
     def check_eval(self):
-        static_fn = utils.apply_to_static(self.fn)
+        static_fn = utils.apply_to_static(self.fn, use_cinn=True)
         cinn_out = static_fn(self.x, self.y)
         dy_out = self.fn(self.x, self.y)
         np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)

--- a/test/ir/pir/cinn/test_cinn_ops.py
+++ b/test/ir/pir/cinn/test_cinn_ops.py
@@ -57,7 +57,7 @@ class TestAddOp(TestOpsBase):
     def prepare_info(self):
         self.fn = paddle.add
         self.expected_fuison_number = 1
-        self.expected_fuison_structure = {"fusion": 1}
+        self.expected_fuison_structure = {utils.FUSION_KEY_STR: 1}
 
     def test_eval(self):
         self.check_eval()
@@ -67,7 +67,7 @@ class TestIsCloseOp(TestOpsBase):
     def prepare_info(self):
         self.fn = paddle.isclose
         self.expected_fuison_number = 1
-        self.expected_fuison_structure = {"fusion": 1}
+        self.expected_fuison_structure = {utils.FUSION_KEY_STR: 1}
 
     def test_eval(self):
         self.check_eval()

--- a/test/ir/pir/cinn/test_cinn_ops.py
+++ b/test/ir/pir/cinn/test_cinn_ops.py
@@ -32,8 +32,8 @@ class TestOpsBase(unittest.TestCase):
 
     def prepare_info(self):
         self.fn = None
-        self.expected_fuison_number = 1
-        self.expected_fuison_structure = {utils.JIT_KERNEL_NAME: 1}
+        self.expected_jit_kernel_number = 1
+        self.expected_jit_kernel_structure = {utils.JIT_KERNEL_NAME: 1}
 
     def prepare_data(self):
         self.shape = [64, 128]
@@ -49,17 +49,19 @@ class TestOpsBase(unittest.TestCase):
         dy_out = self.fn(self.x, self.y)
         np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
 
-        utils.check_jit_kernel_number(static_fn, self.expected_fuison_number)
+        utils.check_jit_kernel_number(
+            static_fn, self.expected_jit_kernel_number
+        )
         utils.check_jit_kernel_structure(
-            static_fn, self.expected_fuison_structure
+            static_fn, self.expected_jit_kernel_structure
         )
 
 
 class TestAddOp(TestOpsBase):
     def prepare_info(self):
         self.fn = paddle.add
-        self.expected_fuison_number = 1
-        self.expected_fuison_structure = {utils.JIT_KERNEL_NAME: 1}
+        self.expected_jit_kernel_number = 1
+        self.expected_jit_kernel_structure = {utils.JIT_KERNEL_NAME: 1}
 
     def test_eval(self):
         self.check_eval()
@@ -68,8 +70,8 @@ class TestAddOp(TestOpsBase):
 class TestIsCloseOp(TestOpsBase):
     def prepare_info(self):
         self.fn = paddle.isclose
-        self.expected_fuison_number = 1
-        self.expected_fuison_structure = {utils.JIT_KERNEL_NAME: 1}
+        self.expected_jit_kernel_number = 1
+        self.expected_jit_kernel_structure = {utils.JIT_KERNEL_NAME: 1}
 
     def test_eval(self):
         self.check_eval()

--- a/test/ir/pir/cinn/test_cinn_ops.py
+++ b/test/ir/pir/cinn/test_cinn_ops.py
@@ -15,16 +15,9 @@
 import unittest
 
 import numpy as np
+import utils
 
 import paddle
-
-
-def apply_to_static(fn, use_cinn=True):
-    build_strategy = paddle.static.BuildStrategy()
-    build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(
-        fn, build_strategy=build_strategy, full_graph=True
-    )
 
 
 class TestOpsBase(unittest.TestCase):
@@ -35,6 +28,12 @@ class TestOpsBase(unittest.TestCase):
     def setUp(self):
         paddle.seed(2022)
         self.prepare_data()
+        self.prepare_info()
+
+    def prepare_info(self):
+        self.fn = None
+        self.expected_fuison_number = 1
+        self.expected_fuison_structure = {"fusion": 1}
 
     def prepare_data(self):
         self.shape = [64, 128]
@@ -44,21 +43,34 @@ class TestOpsBase(unittest.TestCase):
         self.y = paddle.randn(self.shape, dtype="float32")
         self.y.stop_gradient = False
 
-
-class TestAddOp(TestOpsBase):
-    def test_eval(self):
-        self.fn = paddle.add
-        cinn_out = apply_to_static(self.fn)(self.x, self.y)
+    def check_eval(self):
+        static_fn = utils.apply_to_static(self.fn)
+        cinn_out = static_fn(self.x, self.y)
         dy_out = self.fn(self.x, self.y)
         np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+
+        utils.check_fusion_number(static_fn, self.expected_fuison_number)
+        utils.check_fusion_structure(static_fn, self.expected_fuison_structure)
+
+
+class TestAddOp(TestOpsBase):
+    def prepare_info(self):
+        self.fn = paddle.add
+        self.expected_fuison_number = 1
+        self.expected_fuison_structure = {"fusion": 1}
+
+    def test_eval(self):
+        self.check_eval()
 
 
 class TestIsCloseOp(TestOpsBase):
-    def test_eval(self):
+    def prepare_info(self):
         self.fn = paddle.isclose
-        cinn_out = apply_to_static(self.fn)(self.x, self.y)
-        dy_out = self.fn(self.x, self.y)
-        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+        self.expected_fuison_number = 1
+        self.expected_fuison_structure = {"fusion": 1}
+
+    def test_eval(self):
+        self.check_eval()
 
 
 if __name__ == '__main__':

--- a/test/ir/pir/cinn/test_cinn_sub_graph.py
+++ b/test/ir/pir/cinn/test_cinn_sub_graph.py
@@ -134,7 +134,7 @@ class TestCinnSubGraphBase(unittest.TestCase):
 
     def check_fusion_info(self, static_fn):
         utils.check_fusion_number(static_fn, 1)
-        utils.check_fusion_structure(static_fn, {'fusion': 1})
+        utils.check_fusion_structure(static_fn, {utils.FUSION_KEY_STR: 1})
 
     def eval(self, use_cinn):
         paddle.seed(2022)

--- a/test/ir/pir/cinn/test_cinn_sub_graph.py
+++ b/test/ir/pir/cinn/test_cinn_sub_graph.py
@@ -132,9 +132,9 @@ class TestCinnSubGraphBase(unittest.TestCase):
         self.x = paddle.randn(self.shape, dtype="float32")
         self.x.stop_gradient = False
 
-    def check_fusion_info(self, static_fn):
-        utils.check_fusion_number(static_fn, 1)
-        utils.check_fusion_structure(static_fn, {utils.FUSION_KEY_STR: 1})
+    def check_jit_kernel_info(self, static_fn):
+        utils.check_jit_kernel_number(static_fn, 1)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 1})
 
     def eval(self, use_cinn):
         paddle.seed(2022)
@@ -143,7 +143,7 @@ class TestCinnSubGraphBase(unittest.TestCase):
         net.eval()
         out = net(self.x)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
 
         return out
 
@@ -162,7 +162,7 @@ class TestCinnSoftmax(TestCinnSubGraphBase):
         loss = out.mean()
         loss.backward()
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_forward(self):
@@ -199,7 +199,7 @@ class TestAddDropoutLayerNorm(TestCinnSubGraphBase):
         bias = paddle.ones(shape=[self.shape[-1]], dtype="float32")
         out = net(self.x, self.x, weight, bias)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_forward(self):
@@ -221,7 +221,7 @@ class TestCinnDropout(TestCinnSubGraphBase):
         loss = out.mean()
         loss.backward()
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_forward(self):
@@ -256,7 +256,7 @@ class TestCinnEvalPrim(TestCinnSubGraphBase):
             assert (
                 "pd_op.exp" in ops
             ), f"after prim, pd_op.softmax should not exist, but got {ops}"
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
 
         return out
 

--- a/test/ir/pir/cinn/test_cinn_sub_graph.py
+++ b/test/ir/pir/cinn/test_cinn_sub_graph.py
@@ -15,16 +15,9 @@
 import unittest
 
 import numpy as np
+import utils
 
 import paddle
-
-
-def apply_to_static(net, use_cinn):
-    build_strategy = paddle.static.BuildStrategy()
-    build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(
-        net, build_strategy=build_strategy, full_graph=True
-    )
 
 
 def exp_sub(x):
@@ -139,12 +132,19 @@ class TestCinnSubGraphBase(unittest.TestCase):
         self.x = paddle.randn(self.shape, dtype="float32")
         self.x.stop_gradient = False
 
+    def check_fusion_info(self, static_fn):
+        utils.check_fusion_number(static_fn, 1)
+        utils.check_fusion_structure(static_fn, {'fusion': 1})
+
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = CINNSubGraphNet()
-        net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
         out = net(self.x)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
+
         return out
 
     def test_eval(self):
@@ -157,11 +157,12 @@ class TestCinnSoftmax(TestCinnSubGraphBase):
     def train(self, use_cinn):
         paddle.seed(2022)
         net = CINNSoftmaxSubGraphNet()
-        net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         out = net(self.x, self.axis)
-
         loss = out.mean()
         loss.backward()
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_forward(self):
@@ -174,7 +175,7 @@ class TestCinnSoftmax(TestCinnSubGraphBase):
 #     def train(self, use_cinn):
 #         paddle.seed(2022)
 #         net = CINNLayerNormSubGraphNet(self.shape[-1])
-#         net = apply_to_static(net, use_cinn)
+#         net = utils.apply_to_static(net, use_cinn)
 #         # net.eval()
 #         weight = paddle.ones(shape=[self.shape[-1]], dtype="float32")
 #         bias = paddle.ones(shape=[self.shape[-1]], dtype="float32")
@@ -192,11 +193,13 @@ class TestAddDropoutLayerNorm(TestCinnSubGraphBase):
     def train(self, use_cinn):
         paddle.seed(2022)
         net = CINNAddDropoutLayerNormSubGraphNet(self.shape[-1])
-        net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
         weight = paddle.ones(shape=[self.shape[-1]], dtype="float32")
         bias = paddle.ones(shape=[self.shape[-1]], dtype="float32")
         out = net(self.x, self.x, weight, bias)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_forward(self):
@@ -212,12 +215,13 @@ class TestCinnDropout(TestCinnSubGraphBase):
     def train(self, use_cinn):
         paddle.seed(2022)
         net = CINNDropoutSubGraphNet()
-        net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         out = net(self.x)
 
         loss = out.mean()
         loss.backward()
-
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_forward(self):
@@ -235,8 +239,7 @@ class TestCinnEvalPrim(TestCinnSubGraphBase):
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = CINNSoftmaxSubGraphNet()
-        if use_cinn:
-            net = apply_to_static(net, True)
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
         out = net(self.hidden_states)
 
@@ -253,6 +256,7 @@ class TestCinnEvalPrim(TestCinnSubGraphBase):
             assert (
                 "pd_op.exp" in ops
             ), f"after prim, pd_op.softmax should not exist, but got {ops}"
+            self.check_fusion_info(net.forward)
 
         return out
 

--- a/test/ir/pir/cinn/test_llama_sub_graph.py
+++ b/test/ir/pir/cinn/test_llama_sub_graph.py
@@ -54,7 +54,7 @@ class TestLlamaRMSNorm(TestCinnSubGraphBase):
         net.eval()
         out = net(self.hidden_states)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_eval(self):
@@ -110,7 +110,7 @@ class TestRotaryPosEmb(TestCinnSubGraphBase):
         net.eval()
         out = net(self.q, self.k, self.cos, self.sin, self.position_ids)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_eval(self):
@@ -149,10 +149,10 @@ class TestRepeatKV(TestCinnSubGraphBase):
         self.hidden_states.stop_gradient = False
         self.n_rep = 4
 
-    def check_fusion_info(self, static_fn):
-        utils.check_fusion_number(static_fn, 2)
+    def check_jit_kernel_info(self, static_fn):
+        utils.check_jit_kernel_number(static_fn, 2)
         # pd_op.tile is not fused into GroupOp
-        utils.check_fusion_structure(static_fn, {'fusion': 2})
+        utils.check_jit_kernel_structure(static_fn, {'jit_kernel': 2})
 
     def eval(self, use_cinn):
         paddle.seed(2022)
@@ -161,7 +161,7 @@ class TestRepeatKV(TestCinnSubGraphBase):
         net.eval()
         out = net(self.hidden_states, self.n_rep)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_eval(self):

--- a/test/ir/pir/cinn/test_llama_sub_graph.py
+++ b/test/ir/pir/cinn/test_llama_sub_graph.py
@@ -14,7 +14,8 @@
 import unittest
 
 import numpy as np
-from test_cinn_sub_graph import TestCinnSubGraphBase, apply_to_static
+import utils
+from test_cinn_sub_graph import TestCinnSubGraphBase
 
 import paddle
 from paddle import nn
@@ -49,10 +50,11 @@ class TestLlamaRMSNorm(TestCinnSubGraphBase):
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = LlamaRMSNorm()
-        if use_cinn:
-            net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
         out = net(self.hidden_states)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_eval(self):
@@ -104,11 +106,11 @@ class TestRotaryPosEmb(TestCinnSubGraphBase):
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = RotaryPosEmb()
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
-        if use_cinn:
-            net = apply_to_static(net, use_cinn)
-
         out = net(self.q, self.k, self.cos, self.sin, self.position_ids)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_eval(self):
@@ -145,16 +147,21 @@ class TestRepeatKV(TestCinnSubGraphBase):
         self.shape = [1, 2048, 8, 96]
         self.hidden_states = paddle.randn(self.shape, dtype="float32")
         self.hidden_states.stop_gradient = False
-
         self.n_rep = 4
+
+    def check_fusion_info(self, static_fn):
+        utils.check_fusion_number(static_fn, 2)
+        # pd_op.tile is not fused into GroupOp
+        utils.check_fusion_structure(static_fn, {'fusion': 2})
 
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = RepeatKV()
-        if use_cinn:
-            net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
         out = net(self.hidden_states, self.n_rep)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_eval(self):

--- a/test/ir/pir/cinn/test_rms_norm.py
+++ b/test/ir/pir/cinn/test_rms_norm.py
@@ -14,7 +14,8 @@
 import unittest
 
 import numpy as np
-from test_cinn_sub_graph import TestCinnSubGraphBase, apply_to_static
+import utils
+from test_cinn_sub_graph import TestCinnSubGraphBase
 
 import paddle
 from paddle import nn
@@ -45,14 +46,18 @@ class TestLlamaRMSNorm(TestCinnSubGraphBase):
         self.hidden_states = paddle.randn(self.shape, dtype="float32")
         self.hidden_states.stop_gradient = False
 
+    def check_fusion_info(self, static_fn):
+        utils.check_fusion_number(static_fn, 1)
+        utils.check_fusion_structure(static_fn, {"fusion": 1})
+
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = LlamaRMSNorm()
-        # TODO(Aurelius84): Need to remove it after verify CINN
-        if use_cinn:
-            net = apply_to_static(net, use_cinn)
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
         out = net(self.hidden_states)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_eval(self):

--- a/test/ir/pir/cinn/test_rms_norm.py
+++ b/test/ir/pir/cinn/test_rms_norm.py
@@ -46,9 +46,9 @@ class TestLlamaRMSNorm(TestCinnSubGraphBase):
         self.hidden_states = paddle.randn(self.shape, dtype="float32")
         self.hidden_states.stop_gradient = False
 
-    def check_fusion_info(self, static_fn):
-        utils.check_fusion_number(static_fn, 1)
-        utils.check_fusion_structure(static_fn, {utils.FUSION_KEY_STR: 1})
+    def check_jit_kernel_info(self, static_fn):
+        utils.check_jit_kernel_number(static_fn, 1)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 1})
 
     def eval(self, use_cinn):
         paddle.seed(2022)
@@ -57,7 +57,7 @@ class TestLlamaRMSNorm(TestCinnSubGraphBase):
         net.eval()
         out = net(self.hidden_states)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_eval(self):

--- a/test/ir/pir/cinn/test_rms_norm.py
+++ b/test/ir/pir/cinn/test_rms_norm.py
@@ -48,7 +48,7 @@ class TestLlamaRMSNorm(TestCinnSubGraphBase):
 
     def check_fusion_info(self, static_fn):
         utils.check_fusion_number(static_fn, 1)
-        utils.check_fusion_structure(static_fn, {"fusion": 1})
+        utils.check_fusion_structure(static_fn, {utils.FUSION_KEY_STR: 1})
 
     def eval(self, use_cinn):
         paddle.seed(2022)

--- a/test/ir/pir/cinn/test_rope.py
+++ b/test/ir/pir/cinn/test_rope.py
@@ -61,9 +61,9 @@ class TestRotaryPosEmb(unittest.TestCase):
         self.position_ids = paddle.arange(end=2048, dtype="int64").unsqueeze(0)
         self.position_ids.stop_gradient = False
 
-    def check_fusion_info(self, static_fn):
-        utils.check_fusion_number(static_fn, 1)
-        utils.check_fusion_structure(static_fn, {utils.FUSION_KEY_STR: 1})
+    def check_jit_kernel_info(self, static_fn):
+        utils.check_jit_kernel_number(static_fn, 1)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 1})
 
     def eval(self, use_cinn):
         paddle.seed(2022)
@@ -72,7 +72,7 @@ class TestRotaryPosEmb(unittest.TestCase):
         net.eval()
         out = net(self.q, self.k, self.cos, self.sin, self.position_ids)
         if use_cinn:
-            self.check_fusion_info(net.forward)
+            self.check_jit_kernel_info(net.forward)
         return out
 
     def test_eval(self):

--- a/test/ir/pir/cinn/test_rope.py
+++ b/test/ir/pir/cinn/test_rope.py
@@ -63,7 +63,7 @@ class TestRotaryPosEmb(unittest.TestCase):
 
     def check_fusion_info(self, static_fn):
         utils.check_fusion_number(static_fn, 1)
-        utils.check_fusion_structure(static_fn, {"fusion": 1})
+        utils.check_fusion_structure(static_fn, {utils.FUSION_KEY_STR: 1})
 
     def eval(self, use_cinn):
         paddle.seed(2022)

--- a/test/ir/pir/cinn/test_rope.py
+++ b/test/ir/pir/cinn/test_rope.py
@@ -13,19 +13,10 @@
 # limitations under the License.
 import unittest
 
+import utils
+
 import paddle
 from paddle import nn
-
-
-def apply_to_static(net, use_cinn, input_spec=None):
-    build_strategy = paddle.static.BuildStrategy()
-    build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(
-        net,
-        input_spec=input_spec,
-        build_strategy=build_strategy,
-        full_graph=True,
-    )
 
 
 class RotaryPosEmb(nn.Layer):
@@ -70,14 +61,18 @@ class TestRotaryPosEmb(unittest.TestCase):
         self.position_ids = paddle.arange(end=2048, dtype="int64").unsqueeze(0)
         self.position_ids.stop_gradient = False
 
+    def check_fusion_info(self, static_fn):
+        utils.check_fusion_number(static_fn, 1)
+        utils.check_fusion_structure(static_fn, {"fusion": 1})
+
     def eval(self, use_cinn):
         paddle.seed(2022)
         net = RotaryPosEmb()
+        net = utils.apply_to_static(net, use_cinn)
         net.eval()
-        if use_cinn:
-            net = apply_to_static(net, use_cinn)
-
         out = net(self.q, self.k, self.cos, self.sin, self.position_ids)
+        if use_cinn:
+            self.check_fusion_info(net.forward)
         return out
 
     def test_eval(self):

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -81,7 +81,7 @@ def get_jit_kernel_structure_helper(block, map_info):
 
             false_key = f"else_{if_op_idx}"
             get_jit_kernel_structure_helper(
-                op.true_block(), map_info[false_key]
+                op.false_block(), map_info[false_key]
             )
             if_op_idx += 1
         elif op.name() == __WHILE_OP_NAME:

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 
+FUSION_KEY_STR = "fusion_number"
 __FUSION_KERNEL_NAME = "cinn_runtime.jit_kernel"
 __IF_OP_NAME = "pd_op.if"
 __WHILE_OP_NAME = "pd_op.while"
@@ -73,7 +74,7 @@ def get_fusion_structure_helper(block, map_info):
     for op in block.ops:
         op_name = op.name()
         if op_name == __FUSION_KERNEL_NAME:
-            map_info["fusion"] += 1
+            map_info[FUSION_KEY_STR] += 1
         elif op_name == __IF_OP_NAME:
             true_key = f"if_{if_op_idx}"
             map_info[true_key] = {}
@@ -101,22 +102,22 @@ def check_fusion_structure(static_fn, expected_structure):
     Check whether fuse subgraph structre in Program is same with expected_structure.
     For examaple:
     expected_structure = {
-        "fusion": 3,
+        FUSION_KEY_STR: 3,
         "if_0": {
-            "fusion": 1
+            FUSION_KEY_STR: 1
         }
         "else_0": {
-            "fusion": 1
+            FUSION_KEY_STR: 1
         }
          "if_1": {
-            "fusion": 0
+            FUSION_KEY_STR: 0
         }
         "else_1": {
-            "fusion": 0
+            FUSION_KEY_STR: 0
         }
 
         "while_0":{
-            "fusion" 2
+            FUSION_KEY_STR: 2
         }
     }
     """

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+import numpy as np
+
+import paddle
+
+__FUSION_KERNEL_NAME = "cinn_runtime.jit_kernel"
+__IF_OP_NAME = "pd_op.if"
+__WHILE_OP_NAME = "pd_op.while"
+
+
+def apply_to_static(fn, use_cinn=True):
+    build_strategy = paddle.static.BuildStrategy()
+    build_strategy.build_cinn_pass = use_cinn
+    return paddle.jit.to_static(
+        fn, build_strategy=build_strategy, full_graph=True
+    )
+
+
+def get_pir_program(static_fn):
+    assert hasattr(static_fn, "program_cache")
+    runnable_program = static_fn.program_cache.last()[1][1].program
+    return runnable_program.forward_program
+
+
+def get_fusion_number(block):
+    fusion_number = 0
+    for op in block.ops:
+        op_name = op.name()
+        if op_name == __FUSION_KERNEL_NAME:
+            fusion_number += 1
+        elif op_name == __IF_OP_NAME:
+            fusion_number = (
+                fusion_number
+                + get_fusion_number(op.true_block())
+                + get_fusion_number(op.false_block())
+            )
+        elif op_name == __WHILE_OP_NAME:
+            fusion_number += get_fusion_number(op.body())
+
+    return fusion_number
+
+
+def check_fusion_number(static_fn, expected_number):
+    """
+    Check whether total number of __FUSION_KERNEL_NAME in Program
+    is equal to expected_number.
+    """
+    program = get_pir_program(static_fn)
+    fusion_number = get_fusion_number(program.global_block())
+    np.testing.assert_equal(fusion_number, expected_number)
+
+
+def get_fusion_structure_helper(block, map_info):
+    if_op_idx, while_op_idx = 0, 0
+    for op in block.ops:
+        op_name = op.name()
+        if op_name == __FUSION_KERNEL_NAME:
+            map_info["fusion"] += 1
+        elif op_name == __IF_OP_NAME:
+            true_key = f"if_{if_op_idx}_true"
+            map_info[true_key] = {}
+            get_fusion_structure_helper(op.true_block(), map_info[true_key])
+
+            false_key = f"if_{if_op_idx}_false"
+            get_fusion_structure_helper(op.true_block(), map_info[false_key])
+            if_op_idx += 1
+        elif op.name() == __WHILE_OP_NAME:
+            key = f"while_{while_op_idx}"
+            map_info[key] = {}
+            get_fusion_structure_helper(op.body(), map_info[key])
+
+
+def get_fusion_structure(static_fn):
+    program = get_pir_program(static_fn)
+    map_info = defaultdict(int)
+    get_fusion_structure_helper(program.global_block(), map_info)
+    return dict(map_info)
+
+
+def check_fusion_structure(static_fn, expected_structure):
+    """
+    Check whether fuse subgraph structre in Program is same with expected_structure.
+    For examaple:
+    expected_structure = {
+        "fusion": 3,
+        "if_0_true": {
+            "fusion": 1
+        }
+        "if_0_false": {
+            "fusion": 1
+        }
+         "if_1_true": {
+            "fusion": 0
+        }
+        "if_1_false": {
+            "fusion": 0
+        }
+
+        "while_0":{
+            "fusion" 2
+        }
+    }
+    """
+    map_info = get_fusion_structure(static_fn)
+    print(map_info)
+    np.testing.assert_equal(map_info, expected_structure)

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -75,17 +75,18 @@ def get_fusion_structure_helper(block, map_info):
         if op_name == __FUSION_KERNEL_NAME:
             map_info["fusion"] += 1
         elif op_name == __IF_OP_NAME:
-            true_key = f"if_{if_op_idx}_true"
+            true_key = f"if_{if_op_idx}"
             map_info[true_key] = {}
             get_fusion_structure_helper(op.true_block(), map_info[true_key])
 
-            false_key = f"if_{if_op_idx}_false"
+            false_key = f"else_{if_op_idx}"
             get_fusion_structure_helper(op.true_block(), map_info[false_key])
             if_op_idx += 1
         elif op.name() == __WHILE_OP_NAME:
             key = f"while_{while_op_idx}"
             map_info[key] = {}
             get_fusion_structure_helper(op.body(), map_info[key])
+            while_op_idx += 1
 
 
 def get_fusion_structure(static_fn):
@@ -101,16 +102,16 @@ def check_fusion_structure(static_fn, expected_structure):
     For examaple:
     expected_structure = {
         "fusion": 3,
-        "if_0_true": {
+        "if_0": {
             "fusion": 1
         }
-        "if_0_false": {
+        "else_0": {
             "fusion": 1
         }
-         "if_1_true": {
+         "if_1": {
             "fusion": 0
         }
-        "if_1_false": {
+        "else_1": {
             "fusion": 0
         }
 

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -23,11 +23,14 @@ __IF_OP_NAME = "pd_op.if"
 __WHILE_OP_NAME = "pd_op.while"
 
 
-def apply_to_static(fn, use_cinn=True):
+def apply_to_static(net, use_cinn, input_spec=None):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
     return paddle.jit.to_static(
-        fn, build_strategy=build_strategy, full_graph=True
+        net,
+        input_spec=input_spec,
+        build_strategy=build_strategy,
+        full_graph=True,
     )
 
 
@@ -117,5 +120,4 @@ def check_fusion_structure(static_fn, expected_structure):
     }
     """
     map_info = get_fusion_structure(static_fn)
-    print(map_info)
     np.testing.assert_equal(map_info, expected_structure)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164 


增加了CINN+PIR下的单测检查逻辑，开启了第一波核心单测：
<img width="556" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/9301846/f231e2ce-233d-43fc-a0b5-eac1c78fd86c">


##### 1. check_fusion_number
**用法：** `check_fusion_number(net.forward, 1)`
**效果：** 会检查被to_static装饰的函数对应的 Program里包含的`cinn_op.jit_kernel` 数量是否满足给定的expected_number。
**注意：** 从图结构上来看，一个Fusion的子图只对应一个`cinn_op.jit_kernel`


##### 1. check_fusion_structure
**用法：**`check_fusion_number(net.forward, {'fusion': 1})`
**效果：** 会检查被to_static装饰的函数对应的 Program里的fusion 层次结构是否符合给定的expected_structure

对于如下program
```python
{
 %1 = cinn_op.jit_kernel(%0)
 %2 = pd_op.if{
       %3 = cinn_op.jit_kernel(%1)
       yiled %3
    } else {
       %4 = cinn_op.jit_kernel(%1)
       yiled %4
    }

 %5 = pd_op.if{
       %6 = pd_op.main(%2)
       yiled %6
    } else {
       %7 = cinn_op.jit_kernel(%2)
       yiled %7
    }
}
```

则expected_structure为:
+ 支持控制流无限嵌套（面向动态shape场景）

```python
{
  "fusion" : 1      # 对应global block
  "if_0" : {  # 对应idx为0的if true分支
        "fusion" : 1 
    }
  "else_0" : {  # 对应idx为0的if false分支
        "fusion" : 1 
    }

  "if_1" : {  # 对应idx为1的if true分支
        "fusion" : 0
    }
  "else_1" : {  # 对应idx为1的if false分支
        "fusion" : 1 
    }
}
```