### PR TITLE
[Fix] fix worker port conflicts when running with numa bind

### DIFF
--- a/python/paddle/distributed/launch/context/node.py
+++ b/python/paddle/distributed/launch/context/node.py
@@ -43,9 +43,16 @@ class Node:
         except:
             return '127.0.0.1'
 
-    def get_free_ports(self, n=1):
-        free_ports = [self.get_free_port() for i in range(n)]
-        self.free_ports += free_ports
+    def get_free_ports(self, n=1, rank=0):
+        if os.environ.get('FLAGS_FIXED_PORT') is None:
+            free_ports = [self.get_free_port() for i in range(n)]
+            self.free_ports += free_ports
+        else:
+            start_port = int(os.environ.get('FLAGS_FIXED_PORT'))
+            free_ports = list(
+                range(start_port + rank, start_port + rank + n, 1)
+            )
+            self.free_ports += free_ports
         return free_ports
 
     def get_ports_occupied(self):

--- a/python/paddle/distributed/launch/controllers/collective.py
+++ b/python/paddle/distributed/launch/controllers/collective.py
@@ -161,7 +161,9 @@ class CollectiveController(Controller):
         # compatible
         endpoints = [
             f"{self.ctx.node.ip}:{p}"
-            for p in self.ctx.node.get_free_ports(self.pod.replicas)
+            for p in self.ctx.node.get_free_ports(
+                self.pod.replicas, self.pod.rank
+            )
         ]
 
         data = json.dumps(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

分布式有一种启动方式是通过numa bind的方式启动，例如脚本如下

```bash
for ((rank_id=0;rank_id<$NUM_RANKS;rank_id++)); do
    device_id=${RANK_DEVICE_ID[${rank_id}]}
    numa_node=${DEVICE_NUMA_NODE[${device_id}]}
    if [ "$rank_id" == "0" ]; then
        numactl --cpunodebind=${numa_node} --membind ${numa_node} \
            python -m paddle.distributed.launch \
                --log_dir log/worker_${rank_id} \
                --master 127.0.0.1:${NUMA_PORT} \
                --rank ${rank_id} \
                --devices ${device_id} \
                --nnodes ${NUM_RANKS} \
                ${infer_cmd} > /opt/worker_$rank_id.log 2>&1 &
    else
        numactl --cpunodebind=${numa_node} --membind ${numa_node} \
            python -m paddle.distributed.launch \
                --log_dir log/worker_${rank_id} \
                --master 127.0.0.1:${NUMA_PORT} \
                --rank ${rank_id} \
                --devices ${device_id} \
                --nnodes ${NUM_RANKS} \
                ${infer_cmd} > /opt/worker_$rank_id.log 2>&1 &
    fi
    task_pids[${rank_id}]=$!
    echo "Rank ID: $rank_id, Device ID: $device_id, bind to NUMA node: ${numa_node}, PID: ${task_pids[${rank_id}]}"
done
```

这种情况下启动命令会分8次分别向 node.py 中的get_free_ports来请求端口，当进程之间存在race condition的情况下，会偶发其中2个进程被分配了同一个端口，就会导致2个worker端口冲突而启动失败。

这里的修复办法是，当配置 FLAGS_FIXED_PORT 环境变量的时候，默认根据 FLAGS_FIXED_PORT + rank_id 来给8个worker分配端口，避免8个worker之间的端口冲突，这个配置需要提前保证环境中的这8个端口是不被占用的。


Pcard-77889


