### PR TITLE
[Distributed] modify collective UTs to support various accelerators

### DIFF
--- a/test/collective/fleet/test_auto_parallel_parallelizer.py
+++ b/test/collective/fleet/test_auto_parallel_parallelizer.py
@@ -14,13 +14,15 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestParallelizer(TestMultipleGpus):
+class TestParallelizer(TestMultipleAccelerators):
     # check sharding logic as well as the accuracy with single mode
     def test_parallelizer_logic(self):
-        self.run_mnist_2gpu('auto_parallel_parallelizer.py')
+        self.run_mnist_2accelerators('auto_parallel_parallelizer.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_dataparallel_bf16.py
+++ b/test/collective/fleet/test_dygraph_dataparallel_bf16.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphDataParallel(TestMultipleGpus):
+class TestDygraphDataParallel(TestMultipleAccelerators):
     def test_dygraph_dataparallel_bf16(self):
-        self.run_mnist_2gpu('dygraph_dataparallel_bf16.py')
+        self.run_mnist_2accelerators('dygraph_dataparallel_bf16.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_group_sharded_api_for_eager.py
+++ b/test/collective/fleet/test_dygraph_group_sharded_api_for_eager.py
@@ -14,17 +14,19 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphGroupSharded(TestMultipleGpus):
+class TestDygraphGroupSharded(TestMultipleAccelerators):
     # check group sharded logic as well as the accuracy with single mode
     def test_dygraph_group_sharded(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_api_eager.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_api_eager.py')
 
     # check stage3 for some functions.
     def test_dygraph_group_sharded_stage3(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage3_eager.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage3_eager.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_sharding_stage1_bf16.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage1_bf16.py
@@ -14,13 +14,15 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphShardingStage1(TestMultipleGpus):
+class TestDygraphShardingStage1(TestMultipleAccelerators):
     # check sharding logic as well as the accuracy with single mode
     def test_dygraph_sharding_stage1_bf16(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage1_bf16.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage1_bf16.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_sharding_stage1_fp16.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage1_fp16.py
@@ -14,13 +14,15 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphShardingStage1(TestMultipleGpus):
+class TestDygraphShardingStage1(TestMultipleAccelerators):
     # check sharding logic as well as the accuracy with single mode
     def test_dygraph_sharding_stage1_fp16(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage1_fp16.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage1_fp16.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_sharding_stage2.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage2.py
@@ -14,19 +14,23 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphShardingStage2(TestMultipleGpus):
+class TestDygraphShardingStage2(TestMultipleAccelerators):
     # check sharding logic as well as the accuracy with single mode
     def test_dygraph_sharding_stage2(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage2.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage2.py')
 
     def test_dygraph_sharding_stage2_offload(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage2_offload.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage2_offload.py')
 
     def test_dygraph_sharding_stage2_with_comm_overlap(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage2_comm_overlap.py')
+        self.run_mnist_2accelerators(
+            'dygraph_group_sharded_stage2_comm_overlap.py'
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_sharding_stage2_bf16.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage2_bf16.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphShardingStage2(TestMultipleGpus):
+class TestDygraphShardingStage2(TestMultipleAccelerators):
     def test_dygraph_sharding_stage2_bf16(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage2_bf16.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage2_bf16.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_sharding_stage3_bf16.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage3_bf16.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphShardingStage3(TestMultipleGpus):
+class TestDygraphShardingStage3(TestMultipleAccelerators):
     def test_dygraph_sharding_stage3_bf16(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage3_bf16.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage3_bf16.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_dygraph_sharding_stage3_for_eager.py
+++ b/test/collective/fleet/test_dygraph_sharding_stage3_for_eager.py
@@ -14,16 +14,18 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDygraphShardingStage3(TestMultipleGpus):
+class TestDygraphShardingStage3(TestMultipleAccelerators):
     # check sharding logic as well as the accuracy with single mode
     def test_dygraph_sharding_stage3(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage3.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage3.py')
 
     def test_dygraph_sharding_stage3_offload(self):
-        self.run_mnist_2gpu('dygraph_group_sharded_stage3_offload.py')
+        self.run_mnist_2accelerators('dygraph_group_sharded_stage3_offload.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_hybrid_parallel_inference_helper.py
+++ b/test/collective/fleet/test_hybrid_parallel_inference_helper.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestHybridParallelInferenceHelper(TestMultipleGpus):
+class TestHybridParallelInferenceHelper(TestMultipleAccelerators):
     def test_hybrid_parallel_inference_helper(self):
-        self.run_mnist_2gpu('hybrid_parallel_inference_helper.py')
+        self.run_mnist_2accelerators('hybrid_parallel_inference_helper.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_class_center_sample.py
+++ b/test/collective/fleet/test_parallel_class_center_sample.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestParallelClassCenterSample(TestMultipleGpus):
+class TestParallelClassCenterSample(TestMultipleAccelerators):
     def test_parallel_class_center_sample(self):
-        self.run_mnist_2gpu('parallel_class_center_sample.py')
+        self.run_mnist_2accelerators('parallel_class_center_sample.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_dygraph_mp_layers.py
+++ b/test/collective/fleet/test_parallel_dygraph_mp_layers.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestModelParallelLayer(TestMultipleGpus):
+class TestModelParallelLayer(TestMultipleAccelerators):
     def test_hybrid_parallel_mp_layer(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_layers.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_layers.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_dygraph_no_sync_gradient_check.py
+++ b/test/collective/fleet/test_parallel_dygraph_no_sync_gradient_check.py
@@ -14,12 +14,16 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestDataParallelLayer(TestMultipleGpus):
+class TestDataParallelLayer(TestMultipleAccelerators):
     def test_parallel_dygraph_dataparallel_no_sync(self):
-        self.run_mnist_2gpu('parallel_dygraph_no_sync_gradient_check.py')
+        self.run_mnist_2accelerators(
+            'parallel_dygraph_no_sync_gradient_check.py'
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_dygraph_pipeline_parallel.py
+++ b/test/collective/fleet/test_parallel_dygraph_pipeline_parallel.py
@@ -15,46 +15,50 @@
 import os
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 import paddle
 
 
-class TestHybridPipeParallel(TestMultipleGpus):
+class TestHybridPipeParallel(TestMultipleAccelerators):
     def test_hybrid_parallel_pp_layer(self):
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
             os.path.abspath('../../legacy_test/hybrid_parallel_pp_layer.py')
         )
 
     def test_hybrid_parallel_pp_tuple_inputs(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_embedding.py')
 
     def test_hybrid_parallel_shared_weight(self):
-        self.run_mnist_2gpu('hybrid_parallel_shared_weight.py')
+        self.run_mnist_2accelerators('hybrid_parallel_shared_weight.py')
 
     def test_pipeline_parallel_amp(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_amp.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_amp.py')
 
     def test_pipeline_parallel_fp16(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_fp16.py')
 
     def test_pipeline_parallel_bf16(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_bf16.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_bf16.py')
 
     def test_hybrid_parallel_transformer(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_transformer.py')
 
     def test_hybrid_parallel_save_load(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_save_load.py')
 
     def test_hybrid_parallel_recompute(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_recompute.py')
 
     def test_hybrid_parallel_pp_clip_grad(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_clip_grad.py')
 
     def test_hybrid_parallel_transformer_unbalanced_data(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_transformer_unbalanced_data.py')
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_pp_transformer_unbalanced_data.py'
+        )
 
 
 class TestFakeMicroDataSet(unittest.TestCase):

--- a/test/collective/fleet/test_parallel_dygraph_pipeline_parallel_sync_send.py
+++ b/test/collective/fleet/test_parallel_dygraph_pipeline_parallel_sync_send.py
@@ -15,12 +15,14 @@
 import os
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestHybridPipeParallel(TestMultipleGpus):
+class TestHybridPipeParallel(TestMultipleAccelerators):
     def test_hybrid_parallel_pp_layer(self):
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
             os.path.abspath('../../legacy_test/hybrid_parallel_pp_layer.py'),
             need_envs={
                 "PADDLE_P2P_SYNC_SEND": "1",
@@ -28,7 +30,7 @@ class TestHybridPipeParallel(TestMultipleGpus):
         )
 
     def test_hybrid_parallel_pp_tuple_inputs(self):
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
             'hybrid_parallel_pp_embedding.py',
             need_envs={
                 "PADDLE_P2P_SYNC_SEND": "1",
@@ -36,7 +38,7 @@ class TestHybridPipeParallel(TestMultipleGpus):
         )
 
     def test_hybrid_parallel_shared_weight(self):
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
             'hybrid_parallel_shared_weight.py',
             need_envs={
                 "PADDLE_P2P_SYNC_SEND": "1",
@@ -44,7 +46,7 @@ class TestHybridPipeParallel(TestMultipleGpus):
         )
 
     def test_pipeline_parallel_amp(self):
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
             'hybrid_parallel_pp_amp.py',
             need_envs={
                 "PADDLE_P2P_SYNC_SEND": "1",

--- a/test/collective/fleet/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
+++ b/test/collective/fleet/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
@@ -14,22 +14,24 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestHybridPipeParallelWithVirtualStage(TestMultipleGpus):
+class TestHybridPipeParallelWithVirtualStage(TestMultipleAccelerators):
     def test_hybrid_parallel_pp_layer_with_virtual_stage(self):
-        # self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py')
+        # self.run_mnist_2accelerators('hybrid_parallel_pp_layer_with_virtual_stage.py')
         pass
 
     def test_hybrid_parallel_pp_transformer_with_virtual_stage(self):
-        # self.run_mnist_2gpu(
+        # self.run_mnist_2accelerators(
         #    'hybrid_parallel_pp_transformer_with_virtual_stage.py'
         # )
         pass
 
     def test_hybrid_parallel_save_load_with_virtual_stage(self):
-        # self.run_mnist_2gpu(
+        # self.run_mnist_2accelerators(
         #    'hybrid_parallel_pp_save_load_with_virtual_stage.py'
         # )
         pass

--- a/test/collective/fleet/test_parallel_dygraph_pp_adaptor.py
+++ b/test/collective/fleet/test_parallel_dygraph_pp_adaptor.py
@@ -16,7 +16,9 @@ import os
 import shutil
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 import paddle
 from paddle.distributed.fleet.utils.pp_parallel_adaptor import (
@@ -27,7 +29,7 @@ from paddle.distributed.fleet.utils.pp_parallel_adaptor import (
 )
 
 
-class TestPPAdaptor(TestMultipleGpus):
+class TestPPAdaptor(TestMultipleAccelerators):
     def test_parse_args(self):
         args = parse_args()
         self.assertEqual(args.src_mp, args.dst_mp)
@@ -36,8 +38,8 @@ class TestPPAdaptor(TestMultipleGpus):
 
     def test_hybrid_parallel_transformer_unbalanced_data(self):
         print(f"pwd {os.getcwd()}")
-        self.run_mnist_2gpu('hybrid_parallel_pp_transformer_save.py')
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators('hybrid_parallel_pp_transformer_save.py')
+        self.run_mnist_2accelerators(
             'hybrid_parallel_pp_transformer_save_with_virtual_stage.py'
         )
         # test pp adaptor

--- a/test/collective/fleet/test_parallel_dygraph_sep_parallel.py
+++ b/test/collective/fleet/test_parallel_dygraph_sep_parallel.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestHybridParallel(TestMultipleGpus):
+class TestHybridParallel(TestMultipleAccelerators):
     def test_hybrid_parallel_hcg(self):
-        self.run_mnist_2gpu('hybrid_parallel_sep_model.py')
+        self.run_mnist_2accelerators('hybrid_parallel_sep_model.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_dygraph_sharding_parallel.py
+++ b/test/collective/fleet/test_parallel_dygraph_sharding_parallel.py
@@ -15,42 +15,50 @@
 import os
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestHybridParallel(TestMultipleGpus):
+class TestHybridParallel(TestMultipleAccelerators):
     # check sharding logic as well as the accuracy with single mode
     def test_hybrid_parallel_sharding_logic(self):
         # test shard v2
         os.environ["FLAGS_shard_use_reduce"] = "1"
         os.environ["FLAGS_shard_norm_align_dp"] = "0"
         os.environ["FLAGS_shard_split_param"] = "1"
-        self.run_mnist_2gpu('hybrid_parallel_sharding_model.py')
+        self.run_mnist_2accelerators('hybrid_parallel_sharding_model.py')
         # test shard grad reduce
         os.environ["FLAGS_shard_use_reduce"] = "1"
         os.environ["FLAGS_shard_norm_align_dp"] = "0"
         os.environ["FLAGS_shard_split_param"] = "0"
-        self.run_mnist_2gpu('hybrid_parallel_sharding_model.py')
+        self.run_mnist_2accelerators('hybrid_parallel_sharding_model.py')
         # test shard grad allreduce
         os.environ["FLAGS_shard_use_reduce"] = "0"
         os.environ["FLAGS_shard_norm_align_dp"] = "1"
         os.environ["FLAGS_shard_split_param"] = "0"
-        self.run_mnist_2gpu('hybrid_parallel_sharding_model.py')
+        self.run_mnist_2accelerators('hybrid_parallel_sharding_model.py')
 
     def test_hybrid_parallel_sharding_tensor_fusion(self):
         os.environ["FLAGS_shard_split_param"] = "0"
-        self.run_mnist_2gpu('hybrid_parallel_sharding_model_with_fusion.py')
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_sharding_model_with_fusion.py'
+        )
 
     def test_hybrid_parallel_sharding_tensor_fusion_amp(self):
         os.environ["FLAGS_shard_split_param"] = "0"
-        self.run_mnist_2gpu('hybrid_parallel_sharding_model_with_fusion_amp.py')
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_sharding_model_with_fusion_amp.py'
+        )
 
     def test_hybrid_parallel_sharding_state_dict(self):
         os.environ["FLAGS_shard_split_param"] = "0"
-        self.run_mnist_2gpu('hybrid_parallel_sharding_state_dict.py')
+        self.run_mnist_2accelerators('hybrid_parallel_sharding_state_dict.py')
 
     def test_group_param_tensor_fusion(self):
-        self.run_mnist_2gpu('hybrid_parallel_tensor_fusion_with_group.py')
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_tensor_fusion_with_group.py'
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_dygraph_tensor_parallel.py
+++ b/test/collective/fleet/test_parallel_dygraph_tensor_parallel.py
@@ -14,35 +14,37 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestHybridParallel(TestMultipleGpus):
+class TestHybridParallel(TestMultipleAccelerators):
     def test_hybrid_parallel_mp_random(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_random.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_random.py')
 
     def test_hybrid_parallel_mp_model(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_model.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_model.py')
 
     def test_hybrid_parallel_mp_model_with_sequence_parallel(self):
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
             'hybrid_parallel_mp_model_with_sequence_parallel.py'
         )
 
     def test_hybrid_parallel_mp_amp(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_amp.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_amp.py')
 
     def test_hybrid_parallel_mp_fp16(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_fp16.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_fp16.py')
 
     def test_hybrid_parallel_mp_bf16(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_bf16.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_bf16.py')
 
     def test_hybrid_parallel_mp_clip_grad(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_clip_grad.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_clip_grad.py')
 
     def test_hybrid_parallel_mp_broadcast_obj(self):
-        self.run_mnist_2gpu('hybrid_parallel_mp_broadcast_obj.py')
+        self.run_mnist_2accelerators('hybrid_parallel_mp_broadcast_obj.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/test_parallel_margin_cross_entropy.py
+++ b/test/collective/fleet/test_parallel_margin_cross_entropy.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestParallelMarginSoftmaxWithCrossEntropy(TestMultipleGpus):
+class TestParallelMarginSoftmaxWithCrossEntropy(TestMultipleAccelerators):
     def test_parallel_margin_cross_entropy(self):
-        self.run_mnist_2gpu('parallel_margin_cross_entropy.py')
+        self.run_mnist_2accelerators('parallel_margin_cross_entropy.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/test_collective_alltoall_single.py
+++ b/test/collective/test_collective_alltoall_single.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestCollectiveAllToAllSingle(TestMultipleGpus):
+class TestCollectiveAllToAllSingle(TestMultipleAccelerators):
     def test_collective_alltoall_single(self):
-        self.run_mnist_2gpu('collective_alltoall_single.py')
+        self.run_mnist_2accelerators('collective_alltoall_single.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/test_collective_batch_isend_irecv.py
+++ b/test/collective/test_collective_batch_isend_irecv.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestCollectiveBatchIsendIrecv(TestMultipleGpus):
+class TestCollectiveBatchIsendIrecv(TestMultipleAccelerators):
     def test_collective_batch_isend_irecv(self):
-        self.run_mnist_2gpu('collective_batch_isend_irecv.py')
+        self.run_mnist_2accelerators('collective_batch_isend_irecv.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/test_collective_process_group.py
+++ b/test/collective/test_collective_process_group.py
@@ -14,18 +14,20 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestProcessGroup(TestMultipleGpus):
+class TestProcessGroup(TestMultipleAccelerators):
     def test_process_group_nccl(self):
-        self.run_mnist_2gpu('process_group_nccl.py')
+        self.run_mnist_2accelerators('process_group_nccl.py')
 
     def test_process_group_gloo(self):
-        self.run_mnist_2gpu('process_group_gloo.py')
+        self.run_mnist_2accelerators('process_group_gloo.py')
 
     def test_init_process_group(self):
-        self.run_mnist_2gpu('init_process_group.py')
+        self.run_mnist_2accelerators('init_process_group.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/test_collective_reduce_scatter.py
+++ b/test/collective/test_collective_reduce_scatter.py
@@ -14,12 +14,14 @@
 
 import unittest
 
-from legacy_test.test_parallel_dygraph_dataparallel import TestMultipleGpus
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
 
 
-class TestCollectiveReduceScatter(TestMultipleGpus):
+class TestCollectiveReduceScatter(TestMultipleAccelerators):
     def test_collective_reduce_scatter(self):
-        self.run_mnist_2gpu('collective_reduce_scatter.py')
+        self.run_mnist_2accelerators('collective_reduce_scatter.py')
 
 
 if __name__ == "__main__":

--- a/test/collective/test_eager_dist_api.py
+++ b/test/collective/test_eager_dist_api.py
@@ -14,18 +14,18 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestProcessGroup(TestMultipleGpus):
+class TestProcessGroup(TestMultipleAccelerators):
     def test_process_group_nccl(self):
-        self.run_mnist_2gpu('process_group_nccl.py')
+        self.run_mnist_2accelerators('process_group_nccl.py')
 
     def test_process_group_gloo(self):
-        self.run_mnist_2gpu('process_group_gloo.py')
+        self.run_mnist_2accelerators('process_group_gloo.py')
 
     def test_init_process_group(self):
-        self.run_mnist_2gpu('init_process_group.py')
+        self.run_mnist_2accelerators('init_process_group.py')
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_auto_parallel_autoconvert.py
+++ b/test/legacy_test/test_auto_parallel_autoconvert.py
@@ -14,12 +14,12 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestAutoParallelAutoConvert(TestMultipleGpus):
+class TestAutoParallelAutoConvert(TestMultipleAccelerators):
     def test_auto_parallel_autoconvert(self):
-        self.run_mnist_2gpu('auto_parallel_autoconvert.py')
+        self.run_mnist_2accelerators('auto_parallel_autoconvert.py')
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_auto_parallel_data_unshard.py
+++ b/test/legacy_test/test_auto_parallel_data_unshard.py
@@ -14,12 +14,12 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestAutoParallelDataUnshard(TestMultipleGpus):
+class TestAutoParallelDataUnshard(TestMultipleAccelerators):
     def test_auto_parallel_data_unshard(self):
-        self.run_mnist_2gpu('auto_parallel_data_unshard.py')
+        self.run_mnist_2accelerators('auto_parallel_data_unshard.py')
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_auto_parallel_save_load.py
+++ b/test/legacy_test/test_auto_parallel_save_load.py
@@ -14,12 +14,12 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestAutoParallelSaveLoad(TestMultipleGpus):
+class TestAutoParallelSaveLoad(TestMultipleAccelerators):
     def test_auto_parallel_save_load(self):
-        self.run_mnist_2gpu('auto_parallel_save_load.py')
+        self.run_mnist_2accelerators('auto_parallel_save_load.py')
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_dist_dygraph_apis.py
+++ b/test/legacy_test/test_dist_dygraph_apis.py
@@ -14,12 +14,12 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestDygraphFleetApi(TestMultipleGpus):
+class TestDygraphFleetApi(TestMultipleAccelerators):
     def test_dygraph_fleet_api(self):
-        self.run_mnist_2gpu('dygraph_fleet_api.py')
+        self.run_mnist_2accelerators('dygraph_fleet_api.py')
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_fleet_perf_test.py
+++ b/test/legacy_test/test_fleet_perf_test.py
@@ -14,12 +14,12 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestFleetPerfTest(TestMultipleGpus):
+class TestFleetPerfTest(TestMultipleAccelerators):
     def test_fleet_perf_test(self):
-        self.run_mnist_2gpu('hybrid_parallel_perf_test.py')
+        self.run_mnist_2accelerators('hybrid_parallel_perf_test.py')
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_parallel_dygraph_dataparallel.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel.py
@@ -27,7 +27,7 @@ from paddle.distributed.utils.launch_utils import (
 )
 
 
-def get_cluster_from_args(selected_gpus):
+def get_cluster_from_args(selected_devices):
     cluster_node_ips = '127.0.0.1'
     node_ip = '127.0.0.1'
 
@@ -37,19 +37,19 @@ def get_cluster_from_args(selected_gpus):
 
     free_ports = None
 
-    free_ports = find_free_ports(len(selected_gpus))
+    free_ports = find_free_ports(len(selected_devices))
     if free_ports is not None:
         free_ports = list(free_ports)
 
     trainer_endpoints = []
     for ip in node_ips:
         trainer_endpoints.append(["%s:%d" % (ip, port) for port in free_ports])
-    return get_cluster(node_ips, node_ip, trainer_endpoints, selected_gpus)
+    return get_cluster(node_ips, node_ip, trainer_endpoints, selected_devices)
 
 
-def get_gpus(selected_gpus):
-    selected_gpus = [x.strip() for x in selected_gpus.split(',')]
-    return selected_gpus
+def get_devices(selected_devices):
+    selected_devices = [x.strip() for x in selected_devices.split(',')]
+    return selected_devices
 
 
 def start_local_trainers_cpu(
@@ -105,6 +105,7 @@ def start_local_trainers(
     allocator_strategy="auto_growth",
     log_dir=None,
     need_envs={},
+    accelerator_type="gpu",
 ):
     current_env = copy.copy(os.environ.copy())
     # paddle broadcast ncclUniqueId use socket, and
@@ -117,7 +118,8 @@ def start_local_trainers(
     procs = []
     for t in pod.trainers:
         proc_env = {
-            "FLAGS_selected_gpus": "%s" % ",".join([str(g) for g in t.gpus]),
+            f"FLAGS_selected_{accelerator_type}s": "%s"
+            % ",".join([str(g) for g in t.gpus]),
             "PADDLE_TRAINER_ID": "%d" % t.rank,
             "PADDLE_CURRENT_ENDPOINT": "%s" % t.endpoint,
             "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
@@ -156,24 +158,38 @@ def start_local_trainers(
     return procs
 
 
-class TestMultipleGpus(unittest.TestCase):
-    def run_mnist_2gpu(
+class TestMultipleAccelerators(unittest.TestCase):
+    def run_mnist_2accelerators(
         self,
         target_file_name,
         allocator_strategy="auto_growth",
         need_envs={},
+        accelerator_type="gpu",
     ):
-        if (
-            not base.core.is_compiled_with_cuda()
-            or base.core.get_cuda_device_count() == 0
-        ):
-            return
+        if accelerator_type == "gpu":
+            if (
+                not base.core.is_compiled_with_cuda()
+                or base.core.get_cuda_device_count() == 0
+            ):
+                return
+        elif accelerator_type == "xpu":
+            if (
+                not base.core.is_compiled_with_xpu()
+                or base.core.get_xpu_device_count() == 0
+            ):
+                return
+        else:
+            if (
+                not base.core.is_compiled_with_custom_device(accelerator_type)
+                or base.core.get_custom_device_count(accelerator_type) == 0
+            ):
+                return
 
-        selected_gpus = get_gpus('0,1')
+        selected_devices = get_devices('0,1')
         cluster = None
         pod = None
 
-        cluster, pod = get_cluster_from_args(selected_gpus)
+        cluster, pod = get_cluster_from_args(selected_devices)
 
         procs = start_local_trainers(
             cluster,
@@ -214,18 +230,22 @@ class TestMultipleWithGloo(unittest.TestCase):
             time.sleep(3)
 
 
-class TestDataParallelWithPyLayer(TestMultipleGpus):
+class TestDataParallelWithPyLayer(TestMultipleAccelerators):
     def test_parallel_dygraph_dataparallel_with_pylayer(self):
-        self.run_mnist_2gpu('parallel_dygraph_dataparallel_with_pylayer.py')
-        self.run_mnist_2gpu(
+        self.run_mnist_2accelerators(
+            'parallel_dygraph_dataparallel_with_pylayer.py'
+        )
+        self.run_mnist_2accelerators(
             'parallel_dygraph_dataparallel_with_pylayer.py',
             allocator_strategy="naive_best_fit",
         )
 
 
-class TestGradientCheckInEagerMode(TestMultipleGpus):
+class TestGradientCheckInEagerMode(TestMultipleAccelerators):
     def test_multiple_gpus_dynamic(self):
-        self.run_mnist_2gpu('parallel_dygraph_gradient_check_in_eager_mode.py')
+        self.run_mnist_2accelerators(
+            'parallel_dygraph_gradient_check_in_eager_mode.py'
+        )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_pipeline_parallel.py
+++ b/test/legacy_test/test_pipeline_parallel.py
@@ -14,17 +14,17 @@
 
 import unittest
 
-from test_parallel_dygraph_dataparallel import TestMultipleGpus
+from test_parallel_dygraph_dataparallel import TestMultipleAccelerators
 
 
-class TestPipelineParallel(TestMultipleGpus):
+class TestPipelineParallel(TestMultipleAccelerators):
     def test_pipeline_parallel(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_alexnet.py')
+        self.run_mnist_2accelerators('hybrid_parallel_pp_alexnet.py')
 
 
-class TestModelParallelWithRecompute(TestMultipleGpus):
+class TestModelParallelWithRecompute(TestMultipleAccelerators):
     def test_model_parallel_with_recompute(self):
-        self.run_mnist_2gpu("dygraph_recompute_hybrid.py")
+        self.run_mnist_2accelerators("dygraph_recompute_hybrid.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[PCard-79653]
Modify collective UTs to support various accelerators instead of "gpus-only". Use accelerator_type (default as "gpu") to assign designated device for tests.