### PR TITLE
Refactor implemnet of ostream function for ShapeOrDataDimExprs

### DIFF
--- a/paddle/pir/dialect/shape/utils/shape_or_data_expr.cc
+++ b/paddle/pir/dialect/shape/utils/shape_or_data_expr.cc
@@ -18,64 +18,30 @@ namespace symbol {
 
 std::ostream& operator<<(std::ostream& stream,
                          const ShapeOrDataDimExprs& shape_or_data) {
-  std::string result;
   auto lambdas = Overloaded{
-      [&result](const TensorShapeOrDataDimExprs& tensor_shape_data) {
-        result += "shape[";
-        for (size_t i = 0; i < tensor_shape_data.shape().size(); ++i) {
-          result += ToString(tensor_shape_data.shape()[i]);
-          if (i < tensor_shape_data.shape().size() - 1) {
-            result += ", ";
-          }
-        }
-        result += "]";
+      [&](const TensorShapeOrDataDimExprs& tensor_shape_data) {
+        stream << "shape" << tensor_shape_data.shape();
         if (tensor_shape_data.data()) {
-          result += ", data[";
-          for (size_t i = 0; i < tensor_shape_data.data()->size(); ++i) {
-            result += ToString(tensor_shape_data.data()->at(i));
-            if (i < tensor_shape_data.data()->size() - 1) {
-              result += ", ";
-            }
-          }
-          result += "]";
+          stream << ", data" << tensor_shape_data.data().value();
         } else {
-          result += ", data[NULL]";
+          stream << ", data[NULL]";
         }
       },
-      [&result](const TensorListShapeOrDataDimExprs& tensor_list_shape_data) {
+      [&](const TensorListShapeOrDataDimExprs& tensor_list_shape_data) {
         for (size_t i = 0; i < tensor_list_shape_data.size(); ++i) {
-          result += "shape[";
-          for (size_t i = 0; i < tensor_list_shape_data[i].shape().size();
-               ++i) {
-            result += ToString(tensor_list_shape_data[i].shape()[i]);
-            if (i < tensor_list_shape_data[i].shape().size() - 1) {
-              result += ", ";
-            }
-          }
-          result += "]";
+          stream << "shape" << tensor_list_shape_data[i].shape();
           if (tensor_list_shape_data[i].data()) {
-            result += ", data[";
-            for (size_t i = 0; i < tensor_list_shape_data[i].data()->size();
-                 ++i) {
-              result += ToString(tensor_list_shape_data[i].data()->at(i));
-              if (i < tensor_list_shape_data[i].data()->size() - 1) {
-                result += ", ";
-              }
-            }
-            result += "]";
+            stream << ", data" << tensor_list_shape_data[i].data().value();
           } else {
-            result += ", data[NULL]";
+            stream << ", data[NULL]";
           }
-
           if (i < tensor_list_shape_data.size() - 1) {
-            result += ", ";
+            stream << ", ";
           }
         }
       }};
 
   std::visit(lambdas, shape_or_data.variant());
-
-  stream << result;
 
   return stream;
 }

--- a/paddle/pir/dialect/shape/utils/shape_or_data_expr.h
+++ b/paddle/pir/dialect/shape/utils/shape_or_data_expr.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
+#include "paddle/pir/dialect/shape/utils/dim_expr.h"
 #include "paddle/pir/dialect/shape/utils/dim_expr_simplify.h"
-#include "paddle/pir/dialect/shape/utils/shape_or_data_expr.h"
 
 namespace symbol {
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73448

重构`ShapeOrDataDimExprs`的输出流重载实现，修复`TensorListShapeOrDataDimExprs`输出打印时下标异常的bug。