### PR TITLE
[Prim][PIR] add any、log_softmax op forward prim

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -20,6 +20,7 @@
 # manual decomp interface declare are located in manual_op.h
 decomp_interface_declare_gen_op_list = [
     "add_n",
+    "any",
     "batch_norm",
     "batch_norm_",
     "dropout",
@@ -32,6 +33,7 @@ decomp_interface_declare_gen_op_list = [
     "instance_norm",
     "layer_norm",
     "leaky_relu",
+    "log_softmax",
     "mean",
     "pow",
     "relu",
@@ -59,6 +61,7 @@ decomp_interface_implementation_gen_op_list = [
     "instance_norm",
     "layer_norm",
     "leaky_relu",
+    "log_softmax",
     "mean",
     "pow",
     "relu",

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op_decomp.cc
@@ -193,5 +193,54 @@ std::vector<std::vector<pir::Value>> BatchNorm_Op::Decomp(pir::Operation* op) {
   return res;
 }
 
+std::vector<std::vector<pir::Value>> AnyOp::Decomp(pir::Operation* op) {
+  VLOG(4) << "Decomp call any's decomp interface begin";
+
+  AnyOp op_obj = op->dyn_cast<AnyOp>();
+  (void)op_obj;
+
+  FLAGS_tensor_operants_mode = "static";
+
+  VLOG(6) << "Decomp Prepare inputs of any";
+
+  Tensor x(std::make_shared<primitive::LazyTensor>(op_obj.x()));
+
+  VLOG(6) << "Decomp prepare attributes of any";
+  // const std::vector<int64_t>& axis =
+  // op->attribute("axis").dyn_cast<pir::ArrayAttribute<pir::Int64Attribute>>().data();
+  auto array_list =
+      op->attribute("axis").dyn_cast<pir::ArrayAttribute>().AsVector();
+
+  std::vector<int64_t> axis;
+  if (array_list.size() > 0) {
+    PADDLE_ENFORCE_EQ(
+        array_list[0].isa<pir::Int64Attribute>(),
+        true,
+        phi::errors::PreconditionNotMet(
+            "Element in array list MUST be pir::Int64Attribute "));
+
+    for (size_t i = 0; i < array_list.size(); ++i) {
+      axis.push_back(array_list[i].dyn_cast<pir::Int64Attribute>().data());
+    }
+  }
+  bool keepdim = op->attribute("keepdim").dyn_cast<pir::BoolAttribute>().data();
+
+  VLOG(6) << "Decomp call any's forward composite rule prepare";
+
+  auto org_res = op->results();
+  std::vector<std::vector<pir::Value>> res(org_res.size());
+
+  VLOG(6) << "Decomp call any's forward composite rule begin";
+  Tensor op_res = paddle::primitive::details::any_decomp<primitive::LazyTensor>(
+      x, axis, keepdim);
+  VLOG(6) << "Decomp call any's forward composite rule end";
+
+  res[0].push_back(
+      std::static_pointer_cast<primitive::LazyTensor>(op_res.impl())->value());
+
+  VLOG(4) << "Decomp call any's decomp interface end";
+  return res;
+}
+
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -568,11 +568,10 @@ Tensor hardswish_decomp(const Tensor& x) {
   const double SCALE = 6.0;
 
   // out = minimum(maxmum(x + offset, 0), threshold) * x / scale
-  auto org_dim = common::vectorize(x.dims());
   auto minimun_out =
-      minimum<T>(maximum<T>(x + full<T>(org_dim, OFFSET, x.dtype()),
-                            full<T>(org_dim, 0.0, x.dtype())),
-                 full<T>(org_dim, THRESHOLD, x.dtype()));
+      minimum<T>(maximum<T>(x + full<T>(empty_shape, OFFSET, x.dtype()),
+                            full<T>(empty_shape, 0.0, x.dtype())),
+                 full<T>(empty_shape, THRESHOLD, x.dtype()));
   return (minimun_out * x) / full<T>(empty_shape, SCALE, x.dtype());
 }
 

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -26,6 +26,18 @@ namespace details {
 static std::vector<int64_t> empty_shape;
 
 template <typename T>
+Tensor any_decomp(const Tensor& x, const IntArray& axis, bool keepdim) {
+  auto org_dtype = x.dtype();
+
+  auto res = cast<T>(sum<T>(x, axis, org_dtype, keepdim), DataType::BOOL);
+  if (org_dtype != DataType::BOOL) {
+    return cast<T>(res, org_dtype);
+  } else {
+    return res;
+  }
+}
+
+template <typename T>
 Tensor mean_decomp(const Tensor& x, const IntArray& axis, bool keepdim) {
   auto org_dtype = x.dtype();
   auto x_tmp = x;
@@ -248,6 +260,24 @@ Tensor softmax_decomp(const Tensor& x, const int& axis) {
   auto molecular = exp<T>(x_tmp - max_tmp);
   auto res = molecular / sum<T>(molecular, {axis}, molecular.dtype(), true);
 
+  if (need_cast) {
+    return cast<T>(res, org_dtype);
+  } else {
+    return res;
+  }
+}
+
+template <typename T>
+Tensor log_softmax_decomp(const Tensor& x, const int& axis) {
+  auto org_dtype = x.dtype();
+  auto x_tmp = x;
+
+  bool need_cast = is_half_dtype(org_dtype);
+  if (need_cast) {
+    x_tmp = cast<T>(x, DataType::FLOAT32);
+  }
+
+  auto res = log<T>(softmax_decomp<T>(x_tmp, axis));
   if (need_cast) {
     return cast<T>(res, org_dtype);
   } else {
@@ -543,7 +573,7 @@ Tensor hardswish_decomp(const Tensor& x) {
       minimum<T>(maximum<T>(x + full<T>(org_dim, OFFSET, x.dtype()),
                             full<T>(org_dim, 0.0, x.dtype())),
                  full<T>(org_dim, THRESHOLD, x.dtype()));
-  return (minimun_out * x) / full<T>(org_dim, SCALE, x.dtype());
+  return (minimun_out * x) / full<T>(empty_shape, SCALE, x.dtype());
 }
 
 template <typename T>

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -319,8 +319,8 @@ class TestGroupNormBF16Op(OpTest):
         self.rev_comp_rtol = 1e-2
         # prim bf16 has diff in windows
         if sys.platform == "win32":
-            self.rev_comp_atol = 1e-1
-            self.rev_comp_rtol = 1e-1
+            self.rev_comp_atol = 5e-2
+            self.rev_comp_rtol = 5e-2
         place = core.CUDAPlace(0)
         self.check_grad_with_place(
             place,

--- a/test/legacy_test/test_log_softmax.py
+++ b/test/legacy_test/test_log_softmax.py
@@ -46,7 +46,9 @@ def ref_log_softmax_grad(x, axis):
 class TestLogSoftmaxOp(OpTest):
     def setUp(self):
         self.op_type = 'log_softmax'
+        self.prim_op_type = "comp"
         self.python_api = F.log_softmax
+        self.public_python_api = F.log_softmax
         self.dtype = 'float64'
         self.shape = [2, 3, 4, 5]
         self.axis = -1
@@ -64,7 +66,7 @@ class TestLogSoftmaxOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -75,7 +77,9 @@ class TestLogSoftmaxOp(OpTest):
 class TestLogSoftmaxOp_ZeroDim(TestLogSoftmaxOp):
     def setUp(self):
         self.op_type = 'log_softmax'
+        self.prim_op_type = "comp"
         self.python_api = F.log_softmax
+        self.public_python_api = F.log_softmax
         self.dtype = 'float64'
 
         x = np.random.uniform(0.1, 1.0, []).astype(self.dtype)
@@ -86,7 +90,7 @@ class TestLogSoftmaxOp_ZeroDim(TestLogSoftmaxOp):
         self.attrs = {'axis': -1}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
     def test_check_grad(self):
         self.check_grad(['X'], ['Out'], check_pir=True)
@@ -107,7 +111,7 @@ class TestLogSoftmaxFP16OP(TestLogSoftmaxOp):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output(atol=1e-3, check_pir=True)
+        self.check_output(atol=1e-3, check_pir=True, check_prim_pir=True)
 
     def test_check_grad(self):
         self.check_grad(['X'], ['Out'], max_relative_error=1e-2, check_pir=True)
@@ -131,7 +135,9 @@ class TestLogSoftmaxAxisFP16OP(TestLogSoftmaxFP16OP):
 class TestLogSoftmaxBF16Op(OpTest):
     def setUp(self):
         self.op_type = 'log_softmax'
+        self.prim_op_type = "comp"
         self.python_api = F.log_softmax
+        self.public_python_api = F.log_softmax
         self.dtype = np.uint16
         self.shape = [2, 3, 4, 5]
         self.axis = -1
@@ -146,7 +152,7 @@ class TestLogSoftmaxBF16Op(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, check_pir=True)
+        self.check_output_with_place(place, check_pir=True, check_prim_pir=True)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)

--- a/test/legacy_test/test_reduce_op.py
+++ b/test/legacy_test/test_reduce_op.py
@@ -977,55 +977,65 @@ def reduce_any_wrapper(x, axis=None, keepdim=False, reduce_all=True, name=None):
 class TestAnyOp(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = reduce_any_wrapper
+        self.public_python_api = reduce_any_wrapper
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
         self.outputs = {'Out': self.inputs['X'].any()}
         self.attrs = {'reduce_all': True}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAnyFloatOp(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = reduce_any_wrapper
+        self.public_python_api = reduce_any_wrapper
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("float")}
         self.outputs = {'Out': self.inputs['X'].any()}
         self.attrs = {'reduce_all': True}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAnyIntOp(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = reduce_any_wrapper
+        self.public_python_api = reduce_any_wrapper
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("int")}
         self.outputs = {'Out': self.inputs['X'].any()}
         self.attrs = {'reduce_all': True}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAnyOp_ZeroDim(OpTest):
     def setUp(self):
-        self.python_api = paddle.any
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
+        self.python_api = paddle.any
+        self.public_python_api = paddle.any
         self.inputs = {'X': np.random.randint(0, 2, []).astype("bool")}
         self.outputs = {'Out': self.inputs['X'].any()}
         self.attrs = {'dim': []}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAny8DOp(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = paddle.any
+        self.public_python_api = paddle.any
         self.inputs = {
             'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
                 "bool"
@@ -1035,25 +1045,29 @@ class TestAny8DOp(OpTest):
         self.outputs = {'Out': self.inputs['X'].any(axis=self.attrs['dim'])}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAnyOpWithDim(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = paddle.any
+        self.public_python_api = paddle.any
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
         self.attrs = {'dim': [1]}
         self.outputs = {'Out': self.inputs['X'].any(axis=1)}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAny8DOpWithDim(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = paddle.any
+        self.public_python_api = paddle.any
         self.inputs = {
             'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
                 "bool"
@@ -1063,13 +1077,15 @@ class TestAny8DOpWithDim(OpTest):
         self.outputs = {'Out': self.inputs['X'].any(axis=self.attrs['dim'])}
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAnyOpWithKeepDim(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = paddle.any
+        self.public_python_api = paddle.any
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
         self.attrs = {'dim': (1,), 'keep_dim': True}
         self.outputs = {
@@ -1079,13 +1095,15 @@ class TestAnyOpWithKeepDim(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAny8DOpWithKeepDim(OpTest):
     def setUp(self):
         self.op_type = "reduce_any"
+        self.prim_op_type = "comp"
         self.python_api = paddle.any
+        self.public_python_api = paddle.any
         self.inputs = {
             'X': np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype(
                 "bool"
@@ -1099,7 +1117,7 @@ class TestAny8DOpWithKeepDim(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_pir=True)
+        self.check_output(check_pir=True, check_prim_pir=True)
 
 
 class TestAnyOpError(unittest.TestCase):

--- a/test/prim/pir_prim/test_prim_jit_dynamic.py
+++ b/test/prim/pir_prim/test_prim_jit_dynamic.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+import paddle.nn.functional as F
 from paddle.framework import core
 from paddle.static import InputSpec
 
@@ -44,6 +45,14 @@ def rms_norm2(hidden_states, weight):
     variance = hidden_states.pow(2).mean((0, 1), keepdim=True)
     hidden_states = paddle.rsqrt(variance + 1e-5) * hidden_states
     return hidden_states * weight
+
+
+def log_softmax_net(x):
+    return F.log_softmax(x)
+
+
+def any_net(x):
+    return paddle.any(x)
 
 
 class TestPrimMode1(unittest.TestCase):
@@ -98,6 +107,58 @@ class TestPrimMode2(TestPrimMode1):
         self.x = np.random.random(self.shape_x).astype("float32")
         self.y = np.random.random(self.shape_y).astype("float32")
         self.net = rms_norm2
+
+
+class TestPrimOne(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.shape_x = [1, 300, 4096]
+        self.x = np.random.random(self.shape_x).astype(self.dtype)
+        self.net = log_softmax_net
+        self.necessary_ops = "pd_op.log_softmax"
+
+    def base_net(self, flag=None):
+        if flag == "prim":
+            core._set_prim_all_enabled(True)
+        x = paddle.to_tensor(self.x)
+        fn = apply_to_static(
+            self.net,
+            use_cinn=False,
+            input_spec=[
+                InputSpec(shape=[None, None, 4096], dtype=self.dtype),
+            ],
+        )
+        res = fn(x)
+        ops = [
+            op.name()
+            for op in fn.program_cache.last()[-1][-1]
+            .infer_program.program.global_block()
+            .ops
+        ]
+
+        if flag == "prim":
+            assert self.necessary_ops not in ops
+            core._set_prim_all_enabled(False)
+        else:
+            assert self.necessary_ops in ops
+        return res
+
+    def test_prim_all_dynamic(self):
+        res_ref = self.base_net()
+        res = self.base_net("prim")
+        for ref, actual in zip(res_ref, res):
+            np.testing.assert_allclose(ref, actual, rtol=1e-6)
+
+
+class TestPrimOne2(TestPrimOne):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "bool"
+        self.shape_x = [1, 300, 4096]
+        self.x = np.random.random(self.shape_x).astype(self.dtype)
+        self.net = any_net
+        self.necessary_ops = "pd_op.any"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66975
1. add any、log_softmax op forward prim and dynamic shape test case
2. modify hardswish `org_dim -> empty_shape`. [add hardswish op forward prim](https://github.com/PaddlePaddle/Paddle/pull/60981)
3. modify group_norm BF16 test case `rev_comp_rtol` in win32. [add group_norm op backward prim](https://github.com/PaddlePaddle/Paddle/pull/60781)