### PR TITLE
[Dy2St][PIR] Enable `test_convert_call` in PIR mode

### DIFF
--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -187,6 +187,7 @@ class TestRecursiveCall2(Dy2StTestBase):
         with enable_to_static_guard(True):
             return self._run()
 
+    @test_legacy_and_pir
     def test_transformed_static_result(self):
         self.set_func()
         dygraph_res = self.get_dygraph_output()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

启用 `test_convert_call` PIR 模式监控

- #60131

- 完全开启 `test_convert_call` 单测

PCard-66972