### PR TITLE
[CINN] remove insert_name_gene of bucket lower

### DIFF
--- a/paddle/cinn/hlir/framework/pir/compilation_task.cc
+++ b/paddle/cinn/hlir/framework/pir/compilation_task.cc
@@ -59,10 +59,7 @@ void CompilationTask::operator()() {
 void CompilationTask::Lowering() {
   auto op_lowerer = CreateOpLowerer<pir::GroupPtr>(context_->target_);
   context_->SetLoweredFuncs(
-      op_lowerer.BucketLower(context_->group_, false, true, false));
-  // context_->SetLoweredFuncs(
-  //     op_lowerer.BucketLower(context_->group_, false, false, false));
-  op_lowerer.InsertNameGeneToScope(context_->scope_);
+      op_lowerer.BucketLower(context_->group_, false, true, true));
 }
 
 void CompilationTask::CodegenAndJit() {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-72511
remove InsertNameGeneToScope of bucket lower
