### PR TITLE
[PIR] Remove duplicate `Value.is_tensorarray` API

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -735,14 +735,6 @@ void BindValue(py::module *m) {
                   "is persistable"));
             }
           })
-      .def("is_tensorarray",
-           [](Value self) {
-             if (self.type().isa<DenseTensorArrayType>()) {
-               return true;
-             } else {
-               return false;
-             }
-           })
       .def_property(
           "shape",
           [](Value self) { return phi::vectorize(GetValueDims(self)); },
@@ -803,29 +795,11 @@ void BindValue(py::module *m) {
       .def("numel", [](Value self) { return phi::product(GetValueDims(self)); })
       .def("type", &Value::type)
       .def("is_dense_tensor_type",
-           [](Value self) {
-             if (self.type().isa<DenseTensorType>()) {
-               return true;
-             } else {
-               return false;
-             }
-           })
+           [](Value self) { return self.type().isa<DenseTensorType>(); })
       .def("is_selected_row_type",
-           [](Value self) {
-             if (self.type().isa<SelectedRowsType>()) {
-               return true;
-             } else {
-               return false;
-             }
-           })
+           [](Value self) { return self.type().isa<SelectedRowsType>(); })
       .def("is_dense_tensor_array_type",
-           [](Value self) {
-             if (self.type().isa<DenseTensorArrayType>()) {
-               return true;
-             } else {
-               return false;
-             }
-           })
+           [](Value self) { return self.type().isa<DenseTensorArrayType>(); })
       .def("replace_all_uses_with",
            [](Value self, Value value) { self.ReplaceAllUsesWith(value); })
       .def("set_type", [](Value self, Type type) { self.set_type(type); })

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -56,7 +56,7 @@ def append_full_like(float_value, copy_value, value, state, backward_ops):
     if paddle.pir.is_fake_value(value):
         state.value_to_valuegrad[value] = [[paddle.pir.fake_value()]]
         return
-    if copy_value.is_tensorarray():
+    if copy_value.is_dense_tensor_array_type():
         value_grad = paddle._pir_ops.create_array_like(
             copy_value,
             float_value,
@@ -93,7 +93,7 @@ def append_add_n(
             return_map_value(item[0], bwd_value_to_block_argument_map)
         )
 
-    if value.is_tensorarray():
+    if value.is_dense_tensor_array_type():
         add_n_value = paddle._pir_ops.add_n_array(add_n_list)
     else:
         add_n_value = paddle.add_n(add_n_list)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2043,7 +2043,9 @@ def stack(x, axis=0, name=None):
         if (
             isinstance(x, Variable)
             and x.desc.type() == core.VarDesc.VarType.LOD_TENSOR_ARRAY
-        ) or (isinstance(x, paddle.pir.Value) and x.is_tensorarray()):
+        ) or (
+            isinstance(x, paddle.pir.Value) and x.is_dense_tensor_array_type()
+        ):
             x = [x]
         else:
             raise TypeError(
@@ -2056,7 +2058,7 @@ def stack(x, axis=0, name=None):
             )
 
     if in_pir_mode():
-        if x[0].is_tensorarray():
+        if x[0].is_dense_tensor_array_type():
             assert len(x) == 1, (
                 "If the elements of 'x' in stack are Variable(LoDTensorArray), "
                 "number of the elements must be 1, but received %s." % len(x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Value 上同时 bind 了两个同样的用于表示是否是 TensorArray 的 API，因此删掉 `is_tensorarray`，保留 `is_dense_tensor_array_type`

Pcard-67164