### PR TITLE
reduce warning in static auto parallel

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -267,9 +267,11 @@ class ProgramHelper:
         """
         Create and Sync parameters into startup program.
         """
-        if len(self.startup_program.global_block().ops) > 1:
+        startup_program = self.startup_program
+        if len(startup_program.global_block().ops) > 1:
             self.lazy_init = True
             return
+
         for param in self.concrete_program.parameters:
             Parameter(
                 name=param.name,
@@ -278,7 +280,7 @@ class ProgramHelper:
                 shape=param.shape,
                 dtype=param.dtype,
                 stop_gradient=param.stop_gradient,
-                block=self.startup_program.global_block(),
+                block=startup_program.global_block(),
             )
 
     def apply_optimizer(self, optimizer):
@@ -409,7 +411,9 @@ class ProgramHelper:
         try:
             return self.proxy_layer.startup_program
         except Exception as err:
-            self._logger.warning("`lazy init` failed.")
+            self._logger.warning(
+                "The startup_program is not built by `lazy init`."
+            )
             if isinstance(err, AssertionError):
                 return self.concrete_program.startup_program
             raise err


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
reduce warning in static auto parallel
eg,
<img width="634" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/3ba07ff4-1753-489b-8e9e-3d166e068d76">

Pcard-76459