### PR TITLE
[AutoParallel] support spmd for squared_l2_norm

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -490,6 +490,10 @@ PD_REGISTER_SPMD_RULE(
     reduce_sum,  // static
     PD_INFER_SPMD(phi::distributed::ReductionInferSpmd),
     PD_INFER_SPMD(phi::distributed::ReductionInferSpmdReverse));
+PD_REGISTER_SPMD_RULE(
+    squared_l2_norm,
+    PD_INFER_SPMD(phi::distributed::ReductionInferSpmd),
+    PD_INFER_SPMD(phi::distributed::ReductionInferSpmdReverse));
 
 // layer_norm
 PD_REGISTER_SPMD_RULE(

--- a/test/auto_parallel/spmd_rules/test_reduction_rule.py
+++ b/test/auto_parallel/spmd_rules/test_reduction_rule.py
@@ -28,9 +28,12 @@ class TestReductionSPMDRule(unittest.TestCase):
     Unit tests for reduction spmd rule.
     """
 
+    def config(self):
+        self.kernel = "max"
+
     def setUp(self):
-        self.kernels = ["max", "squared_l2_norm"]
-        self.rules = [core.get_phi_spmd_rule(kernel) for kernel in self.kernels]
+        self.config()
+        self.rule = core.get_phi_spmd_rule(self.kernel)
 
         x_shape = [64, 32]
         process_mesh = auto.ProcessMesh(mesh=[0, 1, 2, 3])
@@ -44,13 +47,13 @@ class TestReductionSPMDRule(unittest.TestCase):
 
         self.attrs = OrderedDict([('axis', [0]), ('keep_dim', False)])
 
-    def check_single_mesh_dim(self, spmd_rule):
+    def test_single_mesh_dim(self):
         # reduce on dim 0, keep_dim = false
         # [0, -1] --> [0, -1], [-1], partial_on_dim:[0]
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [0]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -64,12 +67,13 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
         self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
+
         # reduce on dim 0, keep_dim = true
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [0]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -85,7 +89,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -100,7 +104,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -115,7 +119,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [0, 1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -131,7 +135,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [0, 1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -142,7 +146,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
 
-    def check_multi_mesh_dim(self, spmd_rule):
+    def test_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
         self.x_dist_tensor_spec.set_process_mesh(process_mesh)
         self.x_dist_tensor_spec.shape = [96, 24, 48]
@@ -152,7 +156,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -171,7 +175,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([-1, 0, 1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -189,7 +193,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -204,7 +208,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -222,7 +226,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
-        result_dist_attrs = spmd_rule.infer_forward(
+        result_dist_attrs = self.rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -233,14 +237,14 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
 
-    def check_backward_single_mesh_dim(self, spmd_rule):
+    def test_backward_single_mesh_dim(self):
         # reduce on dim 0, keep_dim = false
         # [-1] --> [-1, -1], [-1] (output --> input, output)
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [0]
         self.out_dist_tensor_spec.shape = [32]
         self.out_dist_tensor_spec.set_dims_mapping([-1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -262,7 +266,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [0]
         self.out_dist_tensor_spec.shape = [1, 32]
         self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -280,7 +284,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1]
         self.out_dist_tensor_spec.shape = [64]
         self.out_dist_tensor_spec.set_dims_mapping([0])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -298,7 +302,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1]
         self.out_dist_tensor_spec.shape = [64, 1]
         self.out_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -316,7 +320,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [0, 1]
         self.out_dist_tensor_spec.shape = []
         self.out_dist_tensor_spec.set_dims_mapping([])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -334,7 +338,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [0, 1]
         self.out_dist_tensor_spec.shape = [1, 1]
         self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -346,7 +350,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
 
-    def check_backward_multi_mesh_dim(self, spmd_rule):
+    def test_backward_multi_mesh_dim(self):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
         self.x_dist_tensor_spec.set_process_mesh(process_mesh)
         self.x_dist_tensor_spec.shape = [96, 24, 48]
@@ -358,7 +362,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96]
         self.out_dist_tensor_spec.set_dims_mapping([0])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -380,7 +384,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96]
         self.out_dist_tensor_spec.set_dims_mapping([-1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -398,7 +402,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96]
         self.out_dist_tensor_spec.set_dims_mapping([1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -416,7 +420,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96, 1, 1]
         self.out_dist_tensor_spec.set_dims_mapping([0, -1, -1])
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -428,7 +432,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
 
-    def check_backward_multi_mesh_dim_parital(self, spmd_rule):
+    def test_backward_multi_mesh_dim_parital(self):
         # reduction on dim 1, 2, keep_dim = true, partial_dim=[1]
         # [0, -1, -1] --> [0, -1, -1], [0, -1, -1] (output --> input, output)
         # output parital_dim: [1], input parital_dim: []
@@ -447,7 +451,7 @@ class TestReductionSPMDRule(unittest.TestCase):
 
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [1, 2]
-        result_dist_attrs = spmd_rule.infer_backward(
+        result_dist_attrs = self.rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -460,25 +464,14 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
         self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
 
-    def test_single_mesh_dim(self):
-        for rule in self.rules:
-            self.check_single_mesh_dim(rule)
 
-    def test_multi_mesh_dim(self):
-        for rule in self.rules:
-            self.check_multi_mesh_dim(rule)
+class TestSquaredL2NormSPMDRule(TestReductionSPMDRule):
+    """
+    Unit tests for squared_l2_norm spmd rule.
+    """
 
-    def test_backward_single_mesh_dim(self):
-        for rule in self.rules:
-            self.check_backward_single_mesh_dim(rule)
-
-    def test_backward_multi_mesh_dim(self):
-        for rule in self.rules:
-            self.check_backward_multi_mesh_dim(rule)
-
-    def test_backward_multi_mesh_dim_parital(self):
-        for rule in self.rules:
-            self.check_backward_multi_mesh_dim_parital(rule)
+    def config(self):
+        self.kernel = "squared_l2_norm"
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/spmd_rules/test_reduction_rule.py
+++ b/test/auto_parallel/spmd_rules/test_reduction_rule.py
@@ -29,7 +29,8 @@ class TestReductionSPMDRule(unittest.TestCase):
     """
 
     def setUp(self):
-        self.rule = core.get_phi_spmd_rule("max")
+        self.kernels = ["max", "squared_l2_norm"]
+        self.rules = [core.get_phi_spmd_rule(kernel) for kernel in self.kernels]
 
         x_shape = [64, 32]
         process_mesh = auto.ProcessMesh(mesh=[0, 1, 2, 3])
@@ -43,13 +44,13 @@ class TestReductionSPMDRule(unittest.TestCase):
 
         self.attrs = OrderedDict([('axis', [0]), ('keep_dim', False)])
 
-    def test_single_mesh_dim(self):
+    def check_single_mesh_dim(self, spmd_rule):
         # reduce on dim 0, keep_dim = false
         # [0, -1] --> [0, -1], [-1], partial_on_dim:[0]
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [0]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -63,13 +64,12 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1])
         self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
-
         # reduce on dim 0, keep_dim = true
         # [0, -1] --> [0, -1], [-1, -1], partial_on_dim:[0]
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [0]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -85,7 +85,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -100,7 +100,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -115,7 +115,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [0, 1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -131,7 +131,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [0, 1]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -142,7 +142,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {0})
 
-    def test_multi_mesh_dim(self):
+    def check_multi_mesh_dim(self, spmd_rule):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
         self.x_dist_tensor_spec.set_process_mesh(process_mesh)
         self.x_dist_tensor_spec.shape = [96, 24, 48]
@@ -152,7 +152,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([0, -1, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -171,7 +171,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([-1, 0, 1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -189,7 +189,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([1, -1, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -204,7 +204,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -222,7 +222,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [1, 2]
         self.x_dist_tensor_spec.set_dims_mapping([0, 1, -1])
-        result_dist_attrs = self.rule.infer_forward(
+        result_dist_attrs = spmd_rule.infer_forward(
             self.x_dist_tensor_spec, self.attrs['axis'], self.attrs['keep_dim']
         )
         infered_input_dist_attrs = result_dist_attrs[0]
@@ -233,14 +233,14 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_output_dist_attrs[0]._is_partial(), True)
         self.assertEqual(infered_output_dist_attrs[0]._partial_dims(), {1})
 
-    def test_backward_single_mesh_dim(self):
+    def check_backward_single_mesh_dim(self, spmd_rule):
         # reduce on dim 0, keep_dim = false
         # [-1] --> [-1, -1], [-1] (output --> input, output)
         self.attrs['keep_dim'] = False
         self.attrs['axis'] = [0]
         self.out_dist_tensor_spec.shape = [32]
         self.out_dist_tensor_spec.set_dims_mapping([-1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -262,7 +262,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [0]
         self.out_dist_tensor_spec.shape = [1, 32]
         self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -280,7 +280,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1]
         self.out_dist_tensor_spec.shape = [64]
         self.out_dist_tensor_spec.set_dims_mapping([0])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -298,7 +298,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1]
         self.out_dist_tensor_spec.shape = [64, 1]
         self.out_dist_tensor_spec.set_dims_mapping([0, -1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -316,7 +316,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [0, 1]
         self.out_dist_tensor_spec.shape = []
         self.out_dist_tensor_spec.set_dims_mapping([])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -334,7 +334,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [0, 1]
         self.out_dist_tensor_spec.shape = [1, 1]
         self.out_dist_tensor_spec.set_dims_mapping([-1, -1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -346,7 +346,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [-1, -1])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [-1, -1])
 
-    def test_backward_multi_mesh_dim(self):
+    def check_backward_multi_mesh_dim(self, spmd_rule):
         process_mesh = auto.ProcessMesh(mesh=[[0, 1, 2], [3, 4, 5]])
         self.x_dist_tensor_spec.set_process_mesh(process_mesh)
         self.x_dist_tensor_spec.shape = [96, 24, 48]
@@ -358,7 +358,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96]
         self.out_dist_tensor_spec.set_dims_mapping([0])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -380,7 +380,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96]
         self.out_dist_tensor_spec.set_dims_mapping([-1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -398,7 +398,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96]
         self.out_dist_tensor_spec.set_dims_mapping([1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -416,7 +416,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.attrs['axis'] = [1, 2]
         self.out_dist_tensor_spec.shape = [96, 1, 1]
         self.out_dist_tensor_spec.set_dims_mapping([0, -1, -1])
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -428,7 +428,7 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
 
-    def test_backward_multi_mesh_dim_parital(self):
+    def check_backward_multi_mesh_dim_parital(self, spmd_rule):
         # reduction on dim 1, 2, keep_dim = true, partial_dim=[1]
         # [0, -1, -1] --> [0, -1, -1], [0, -1, -1] (output --> input, output)
         # output parital_dim: [1], input parital_dim: []
@@ -447,7 +447,7 @@ class TestReductionSPMDRule(unittest.TestCase):
 
         self.attrs['keep_dim'] = True
         self.attrs['axis'] = [1, 2]
-        result_dist_attrs = self.rule.infer_backward(
+        result_dist_attrs = spmd_rule.infer_backward(
             self.x_dist_tensor_spec,
             self.out_dist_tensor_spec,
             self.attrs['axis'],
@@ -459,6 +459,26 @@ class TestReductionSPMDRule(unittest.TestCase):
         self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, -1])
         self.assertEqual(infered_output_dist_attrs[0].dims_mapping, [0, -1, -1])
         self.assertEqual(infered_input_dist_attrs[0]._is_partial(), False)
+
+    def test_single_mesh_dim(self):
+        for rule in self.rules:
+            self.check_single_mesh_dim(rule)
+
+    def test_multi_mesh_dim(self):
+        for rule in self.rules:
+            self.check_multi_mesh_dim(rule)
+
+    def test_backward_single_mesh_dim(self):
+        for rule in self.rules:
+            self.check_backward_single_mesh_dim(rule)
+
+    def test_backward_multi_mesh_dim(self):
+        for rule in self.rules:
+            self.check_backward_multi_mesh_dim(rule)
+
+    def test_backward_multi_mesh_dim_parital(self):
+        for rule in self.rules:
+            self.check_backward_multi_mesh_dim_parital(rule)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
support spmd for `squared_l2_norm`
Pcard-76459