### PR TITLE
[Cleanup][B-6] clean some `to_variable` for test

### DIFF
--- a/test/legacy_test/test_dot_op.py
+++ b/test/legacy_test/test_dot_op.py
@@ -157,18 +157,14 @@ class TestDotOpError(unittest.TestCase):
 class TestDygraph(unittest.TestCase):
     def test_dygraph(self):
         with base.dygraph.guard():
-            x1 = base.dygraph.to_variable(np.array([1, 3]).astype(np.float32))
-            y1 = base.dygraph.to_variable(np.array([2, 5]).astype(np.float32))
+            x1 = paddle.to_tensor(np.array([1, 3]).astype(np.float32))
+            y1 = paddle.to_tensor(np.array([2, 5]).astype(np.float32))
             np.testing.assert_allclose(
                 paddle.dot(x1, y1).numpy(), np.array([17]), rtol=1e-05
             )
 
-            x1 = base.dygraph.to_variable(
-                np.array([[1, 3], [3, 5]]).astype(np.float32)
-            )
-            y1 = base.dygraph.to_variable(
-                np.array([[2, 5], [6, 8]]).astype(np.float32)
-            )
+            x1 = paddle.to_tensor(np.array([[1, 3], [3, 5]]).astype(np.float32))
+            y1 = paddle.to_tensor(np.array([[2, 5], [6, 8]]).astype(np.float32))
             np.testing.assert_array_equal(
                 paddle.dot(x1, y1).numpy(), np.array([17, 58])
             )

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -690,7 +690,7 @@ class TestDropoutFAPI(unittest.TestCase):
                 in_np = np.random.random([40, 40]).astype("float32")
                 res_np = in_np
                 res_np2 = np.zeros_like(in_np)
-                input = base.dygraph.to_variable(in_np)
+                input = paddle.to_tensor(in_np)
 
                 res1 = paddle.nn.functional.dropout(
                     x=input, p=0.0, training=False
@@ -907,7 +907,7 @@ class TestDropoutCAPI(unittest.TestCase):
             with base.dygraph.guard(place):
                 input_np = np.random.random([40, 40]).astype("float32")
                 result_np = input_np
-                input = base.dygraph.to_variable(input_np)
+                input = paddle.to_tensor(input_np)
                 m = paddle.nn.Dropout(p=0.0)
                 m.eval()
                 result = m(input)
@@ -961,7 +961,7 @@ class TestDropout2DFAPI(unittest.TestCase):
             with base.dygraph.guard(place):
                 in_np = np.random.random([2, 3, 4, 5]).astype("float32")
                 res_np = in_np
-                input = base.dygraph.to_variable(in_np)
+                input = paddle.to_tensor(in_np)
 
                 res1 = paddle.nn.functional.dropout2d(
                     x=input, p=0.0, training=False, data_format='NCHW'
@@ -1014,7 +1014,7 @@ class TestDropout2DCAPI(unittest.TestCase):
             with base.dygraph.guard(place):
                 input_np = np.random.random([2, 3, 4, 5]).astype("float32")
                 result_np = input_np
-                input = base.dygraph.to_variable(input_np)
+                input = paddle.to_tensor(input_np)
                 m = paddle.nn.Dropout2D(p=0.0)
                 m.eval()
                 result = m(input)
@@ -1093,7 +1093,7 @@ class TestDropout3DFAPI(unittest.TestCase):
             with base.dygraph.guard(place):
                 in_np = np.random.random([2, 3, 4, 5, 6]).astype("float32")
                 res_np = in_np
-                input = base.dygraph.to_variable(in_np)
+                input = paddle.to_tensor(in_np)
 
                 res1 = paddle.nn.functional.dropout3d(
                     x=input, p=0.0, training=False, data_format='NCDHW'
@@ -1146,7 +1146,7 @@ class TestDropout3DCAPI(unittest.TestCase):
             with base.dygraph.guard(place):
                 input_np = np.random.random([2, 3, 4, 5, 6]).astype("float32")
                 result_np = input_np
-                input = base.dygraph.to_variable(input_np)
+                input = paddle.to_tensor(input_np)
                 m = paddle.nn.Dropout3D(p=0.0)
                 m.eval()
                 result = m(input)
@@ -1202,7 +1202,7 @@ class TestAlphaDropoutFAPI(unittest.TestCase):
                 in_np = np.random.random([40, 40]).astype("float32")
                 res_np = in_np
                 res_np3 = np.zeros_like(in_np)
-                input = base.dygraph.to_variable(in_np)
+                input = paddle.to_tensor(in_np)
 
                 res1 = paddle.nn.functional.alpha_dropout(x=input, p=0.0)
                 res2 = paddle.nn.functional.alpha_dropout(
@@ -1276,7 +1276,7 @@ class TestAlphaDropoutCAPI(unittest.TestCase):
             with base.dygraph.guard(place):
                 input_np = np.random.random([40, 40]).astype("float32")
                 result_np = input_np
-                input = base.dygraph.to_variable(input_np)
+                input = paddle.to_tensor(input_np)
                 m = paddle.nn.AlphaDropout(p=0.0)
                 m.eval()
                 result = m(input)

--- a/test/legacy_test/test_dygraph_mnist_fp16.py
+++ b/test/legacy_test/test_dygraph_mnist_fp16.py
@@ -126,8 +126,8 @@ class TestMnist(unittest.TestCase):
         y = np.random.randint(10, size=[1, 1], dtype="int64")
         with base.dygraph.guard(base.CUDAPlace(0)):
             model = MNIST(dtype="float32")
-            x = base.dygraph.to_variable(x)
-            y = base.dygraph.to_variable(y)
+            x = paddle.to_tensor(x)
+            y = paddle.to_tensor(y)
 
             # using amp.auto_cast because paddle.nn.Conv2D doesn't suppport setting dtype
             with paddle.amp.auto_cast(dtype='float16'):

--- a/test/legacy_test/test_dygraph_multi_forward.py
+++ b/test/legacy_test/test_dygraph_multi_forward.py
@@ -20,7 +20,6 @@ from test_imperative_base import new_program_scope
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.base.dygraph.base import to_variable
 from paddle.nn import Linear
 
 SEED = 123123111
@@ -132,8 +131,8 @@ class TestDygraphMultiForward(unittest.TestCase):
                         .reshape(128, 1)
                     )
 
-                    img = to_variable(dy_x_data)
-                    label = to_variable(y_data)
+                    img = paddle.to_tensor(dy_x_data)
+                    label = paddle.to_tensor(y_data)
                     label.stop_gradient = True
 
                     cost = mnist(img)

--- a/test/legacy_test/test_dygraph_weight_norm.py
+++ b/test/legacy_test/test_dygraph_weight_norm.py
@@ -132,7 +132,7 @@ class TestDygraphWeightNorm(unittest.TestCase):
         wn = weight_norm(linear, dim=self.dim)
         outputs = []
         for name, data in self.data.items():
-            output = linear(base.dygraph.to_variable(data))
+            output = linear(paddle.to_tensor(data))
             outputs.append(output.numpy())
         after_weight = linear.weight
         self.actual_outputs = [linear.weight_g.numpy(), linear.weight_v.numpy()]

--- a/test/legacy_test/test_egr_python_api.py
+++ b/test/legacy_test/test_egr_python_api.py
@@ -953,10 +953,10 @@ class EagerParamBaseUsageTestCase(unittest.TestCase):
         base = paddle.base.layer_helper_base.LayerHelperBase(
             "test_layer", "test_layer"
         )
-        return base.to_variable(value).numpy()
+        return paddle.to_tensor(value).numpy()
 
     def func_base_to_variable(self, value):
-        paddle.base.dygraph.base.to_variable(value)
+        paddle.to_tensor(value)
 
     def test_backward_with_single_tensor(self):
         arr4 = np.random.rand(4, 16, 16, 32).astype('float32')

--- a/test/legacy_test/test_eig_op.py
+++ b/test/legacy_test/test_eig_op.py
@@ -329,7 +329,7 @@ class TestEigDyGraph(unittest.TestCase):
         grad_x = eig_backward(real_w, real_v, grad_w, grad_v)
 
         with base.dygraph.guard():
-            x = base.dygraph.to_variable(input_np)
+            x = paddle.to_tensor(input_np)
             x.stop_gradient = False
             w, v = paddle.linalg.eig(x)
             (w.sum() + v.sum()).backward()

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -650,8 +650,8 @@ class TestAddApi(unittest.TestCase):
         with base.dygraph.guard():
             np_x = np.array([2, 3, 4]).astype('float64')
             np_y = np.array([1, 5, 2]).astype('float64')
-            x = base.dygraph.to_variable(np_x)
-            y = base.dygraph.to_variable(np_y)
+            x = paddle.to_tensor(np_x)
+            y = paddle.to_tensor(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
             z_expected = np.array([3.0, 8.0, 6.0])

--- a/test/xpu/test_dropout_op_xpu.py
+++ b/test/xpu/test_dropout_op_xpu.py
@@ -155,7 +155,7 @@ class XPUTestDropoutOp(XPUOpTestWrapper):
                 with base.dygraph.guard(place):
                     input_np = np.random.random([40, 40]).astype(self.in_type)
                     result_np = input_np
-                    input = base.dygraph.to_variable(input_np)
+                    input = paddle.to_tensor(input_np)
                     m = paddle.nn.Dropout(p=0.0)
                     m.eval()
                     result = m(input)

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -291,8 +291,8 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
             with base.dygraph.guard():
                 np_x = np.array([2, 3, 4]).astype('float32')
                 np_y = np.array([1, 5, 2]).astype('float32')
-                x = base.dygraph.to_variable(np_x)
-                y = base.dygraph.to_variable(np_y)
+                x = paddle.to_tensor(np_x)
+                y = paddle.to_tensor(np_y)
                 z = paddle.add(x, y)
                 np_z = z.numpy()
                 z_expected = np.array([3.0, 8.0, 6.0])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
清理 `paddle.base.dygraph.to_variable`

[B-6]:

- test_dot_op.py
- test_dropout_op.py
- test_dropout_op_xpu.py
- test_dygraph_mnist_fp16.py
- test_dygraph_multi_forward.py
- test_dygraph_weight_norm.py
- test_egr_python_api.py
- test_eig_op.py
- test_elementwise_add_op.py
- test_elementwise_add_op_xpu.py

关联 ISSUE： https://github.com/PaddlePaddle/Paddle/issues/61385

@gouzil 请评审 ～

