### PR TITLE
[Cleanup][B-18] clean some `to_variable` for test 

### DIFF
--- a/test/dygraph_to_static/test_word2vec.py
+++ b/test/dygraph_to_static/test_word2vec.py
@@ -300,9 +300,9 @@ def train():
         for center_words, target_words, label, eval_words in build_batch(
             dataset, batch_size, epoch_num
         ):
-            center_words_var = base.dygraph.to_variable(center_words)
-            target_words_var = base.dygraph.to_variable(target_words)
-            label_var = base.dygraph.to_variable(label)
+            center_words_var = paddle.to_tensor(center_words)
+            target_words_var = paddle.to_tensor(target_words)
+            label_var = paddle.to_tensor(label)
             pred, loss = skip_gram_model(
                 center_words_var, target_words_var, label_var
             )

--- a/test/dygraph_to_static/transformer_dygraph_model.py
+++ b/test/dygraph_to_static/transformer_dygraph_model.py
@@ -17,7 +17,6 @@ import numpy as np
 import paddle
 import paddle.nn.functional as F
 from paddle import base
-from paddle.base.dygraph import to_variable
 from paddle.nn import Layer, Linear
 
 
@@ -790,28 +789,31 @@ class Transformer(Layer):
         vocab_size_tensor = paddle.tensor.fill_constant(
             shape=[1], dtype="int64", value=self.trg_vocab_size
         )
-        end_token_tensor = to_variable(
+        end_token_tensor = paddle.to_tensor(
             np.full([batch_size, beam_size], eos_id, dtype="int64")
         )
         noend_array = [-inf] * self.trg_vocab_size
         noend_array[eos_id] = 0
-        noend_mask_tensor = to_variable(np.array(noend_array, dtype="float32"))
+        noend_mask_tensor = paddle.to_tensor(
+            np.array(noend_array, dtype="float32")
+        )
         batch_pos = paddle.expand(
             paddle.unsqueeze(
-                to_variable(np.arange(0, batch_size, 1, dtype="int64")), [1]
+                paddle.to_tensor(np.arange(0, batch_size, 1, dtype="int64")),
+                [1],
             ),
             [-1, beam_size],
         )
         predict_ids = []
         parent_ids = []
         # initialize states of beam search
-        log_probs = to_variable(
+        log_probs = paddle.to_tensor(
             np.array(
                 [[0.0] + [-inf] * (beam_size - 1)] * batch_size, dtype="float32"
             )
         )
 
-        finished = to_variable(
+        finished = paddle.to_tensor(
             np.full([batch_size, beam_size], 0, dtype="bool")
         )
 

--- a/test/legacy_test/test_unstack_op.py
+++ b/test/legacy_test/test_unstack_op.py
@@ -257,7 +257,7 @@ class TestUnstackZeroInputOp(unittest.TestCase):
                     data = (
                         np.random.random([0]) + 1j * np.random.random([0])
                     ).astype(dtype)
-                x = base.dygraph.to_variable(data)
+                x = paddle.to_tensor(data)
                 paddle.unstack(x, axis=1)
 
     def test_type_error(self):

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -493,9 +493,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             x_i = np.array([0.9383, 0.1983, 3.2, 1.2]).astype('float64')
             y_i = np.array([1.0, 1.0, 1.0, 1.0]).astype('float64')
             cond_i = np.array([False, False, True, True]).astype('bool')
-            x = base.dygraph.to_variable(x_i)
-            y = base.dygraph.to_variable(y_i)
-            cond = base.dygraph.to_variable(cond_i)
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             np.testing.assert_array_equal(
                 out.numpy(), np.where(cond_i, x_i, y_i)
@@ -506,7 +506,7 @@ class TestWhereDygraphAPI(unittest.TestCase):
             cond_i = np.array([False, False, True, True]).astype('bool')
             x = 1.0
             y = 2.0
-            cond = base.dygraph.to_variable(cond_i)
+            cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             np.testing.assert_array_equal(out.numpy(), np.where(cond_i, x, y))
 

--- a/test/xpu/test_where_op_xpu.py
+++ b/test/xpu/test_where_op_xpu.py
@@ -184,9 +184,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             x_i = np.array([0.9383, 0.1983, 3.2, 1.2]).astype("float32")
             y_i = np.array([1.0, 1.0, 1.0, 1.0]).astype("float32")
             cond_i = np.array([False, False, True, True]).astype("bool")
-            x = base.dygraph.to_variable(x_i)
-            y = base.dygraph.to_variable(y_i)
-            cond = base.dygraph.to_variable(cond_i)
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             np.testing.assert_array_equal(
                 out.numpy(), np.where(cond_i, x_i, y_i)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
link #61385 
清理 `paddle.base.dygraph.to_variable`
@gouzil 