### PR TITLE
[Dy2St] Fix Tensor hook error on multiple load_attr

### DIFF
--- a/python/paddle/jit/dy2static/transformers/tensorhook_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/tensorhook_transformer.py
@@ -46,7 +46,6 @@ class RegisterHookTransformer(BaseTransformer):
         ]
         # Analyze the register_hook nodes name dependency
         dependents = {}
-        print(dependents)
         for n in regisiter_hook_nodes:
             if n not in stmts:
                 continue

--- a/python/paddle/jit/dy2static/transformers/tensorhook_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/tensorhook_transformer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 
 from paddle.utils import gast
 
@@ -30,8 +29,6 @@ def get_loads(node: gast.AST):
 
 class RegisterHookTransformer(BaseTransformer):
     def __init__(self, root):
-        self.register_hook_pos_map = collections.defaultdict(list)
-        self.assignment_pos_map = collections.defaultdict(list)
         self.root = root
 
     def transform(self):

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -363,6 +363,14 @@ def recover_globals_attribute(src_obj, dst_obj):
         if not (k.startswith('__') and k.endswith('__')):
             dst_globals[k] = v
 
+    # Inject source function closure into destination function globals
+    # Because the destination function is a standalone function, the original
+    # closure of the source function is compiled as LOAD_GLOBAL in the
+    # destination function.
+    src_closure = inspect.getclosurevars(src_obj)
+    for k, v in src_closure.nonlocals.items():
+        dst_globals[k] = v
+
 
 def func_to_source_code(function, dedent=True):
     """

--- a/test/dygraph_to_static/test_tensor_hook.py
+++ b/test/dygraph_to_static/test_tensor_hook.py
@@ -51,6 +51,43 @@ class TestTensorHook(Dy2StTestBase):
         loss.backward()
         np.testing.assert_allclose(x.grad.numpy(), x_jit.grad.numpy())
 
+    def test_hook_sub_attr(self):
+        IMAGE_SIZE = 784
+        CLASS_NUM = 10
+
+        def hook(grad):
+            return grad * 2
+
+        class Layer(nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self._linear = nn.Linear(IMAGE_SIZE, CLASS_NUM)
+
+            def forward(self, x):
+                # breakpoint()
+                self._linear.weight.register_hook(hook)
+                y = self._linear(x)
+                return y
+
+        paddle.seed(0)
+        data = np.random.random([IMAGE_SIZE]).astype('float32')
+        x = paddle.to_tensor(data)
+        x.stop_gradient = False
+        layer = Layer()
+        loss = layer(x)
+        loss.backward()
+
+        paddle.seed(0)
+        x_jit = paddle.to_tensor(data)
+        x_jit.stop_gradient = False
+        jit_layer = to_static(Layer())
+        loss = jit_layer(x_jit)
+        loss.backward()
+        np.testing.assert_allclose(
+            layer._linear.weight.grad.numpy(),
+            jit_layer._linear.weight.grad.numpy(),
+        )
+
     def test_hook_for_reassignment_parameter(self):
         def f(x):
             def h(g):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

问题的起因是目前 TensorHookTransformer 仅支持 `x.register_hook(h)` 的形式，`x.y.register_hook(h)` 必挂

TensorHookTransformer 存在诸多问题，随随便便一个 case 都会挂<!-- 写的一坨 -->，在不修改主体思想的前提下对代码重构，提升鲁棒性

另外将源函数的闭包变量注入到生成的目标函数 globals 里，因为生成的目标函数只是单个独立函数，非局部变量就会被当作外部 global 来处理，也就是会生成 LOAD_GLOBAL，因此应当将相应的变量注入到 globals 中

PCard-66972