### PR TITLE
Add SwiGLU operator

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -2386,6 +2386,17 @@
     func : svd_grad
   optional: u_grad, vh_grad, s_grad
 
+- backward_op : swiglu_grad
+  forward : swiglu (Tensor x, Tensor y) -> Tensor(out)
+  args: (Tensor x, Tensor y, Tensor out_grad)
+  output : Tensor(x_grad), Tensor(y_grad)
+  infer_meta:
+    func: SwiGLUGradInferMeta
+    param: [x, y]
+  kernel:
+    func: swiglu_grad
+  optional: y
+
 - backward_op : take_along_axis_grad
   forward : take_along_axis (Tensor arr, Tensor indices, int axis) -> Tensor(out)
   args : (Tensor arr, Tensor indices, Tensor out_grad, int axis)

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2693,6 +2693,16 @@
     func : svd
   backward : svd_grad
 
+- op : swiglu
+  args : (Tensor x, Tensor y)
+  output : Tensor(out)
+  infer_meta:
+     func: SwiGLUInferMeta
+  kernel:
+     func : swiglu
+  optional : y
+  backward: swiglu_grad
+
 - op : take_along_axis
   args : (Tensor arr, Tensor indices, int axis)
   output : Tensor

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -1158,6 +1158,18 @@ void StackGradInferMeta(const MetaTensor& out_grad,
   }
 }
 
+void SwiGLUGradInferMeta(const MetaTensor& x,
+                         const MetaTensor& y,
+                         MetaTensor* x_grad,
+                         MetaTensor* y_grad) {
+  if (x_grad) {
+    x_grad->share_meta(x);
+  }
+  if (y && y_grad) {
+    y_grad->share_meta(y);
+  }
+}
+
 void TransposeGradInferMeta(const MetaTensor& x,
                             const std::vector<int>& axis,
                             MetaTensor* out) {

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -463,6 +463,11 @@ void StackGradInferMeta(const MetaTensor& out_grad,
                         int axis,
                         std::vector<MetaTensor*> x_grad);
 
+void SwiGLUGradInferMeta(const MetaTensor& x,
+                         const MetaTensor& y,
+                         MetaTensor* x_grad,
+                         MetaTensor* y_grad);
+
 void TransposeInferMeta(const MetaTensor& x,
                         const std::vector<int>& axis,
                         MetaTensor* out);

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3384,6 +3384,31 @@ void SolveInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
   out->share_lod(x);
 }
 
+void SwiGLUInferMeta(const MetaTensor& x,
+                     const MetaTensor& y,
+                     MetaTensor* out) {
+  if (y) {
+    PADDLE_ENFORCE_EQ(
+        x.dims(),
+        y.dims(),
+        phi::errors::InvalidArgument(
+            "The shape of Input(X) should be equal of the shape of Input(Y)."));
+    out->share_meta(x);
+  } else {
+    auto dims = x.dims();
+    PADDLE_ENFORCE_EQ(
+        dims[dims.size() - 1] % 2,
+        0,
+        phi::errors::InvalidArgument(
+            "The last dim of Input(X) should be exactly divided by 2."));
+    dims[dims.size() - 1] /= 2;
+    out->set_dims(dims);
+    out->set_dtype(x.dtype());
+    out->set_layout(x.layout());
+    out->share_lod(x);
+  }
+}
+
 void UnpoolInferMeta(const MetaTensor& x,
                      const MetaTensor& indices,
                      const std::vector<int>& ksize,

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -545,6 +545,8 @@ void ValueCompareInferMeta(const MetaTensor& x,
 
 void SolveInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out);
 
+void SwiGLUInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out);
+
 void UnpoolInferMeta(const MetaTensor& x,
                      const MetaTensor& indices,
                      const std::vector<int>& ksize,

--- a/paddle/phi/kernels/cpu/swiglu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/swiglu_grad_kernel.cc
@@ -29,29 +29,28 @@ void SwiGLUGradKernelImpl(const Context &ctx,
                           int64_t m,
                           int64_t n) {
   funcs::SwiGLUGradFunctor<T> functor;
+  int64_t stride;
   if (y) {
-    int64_t numel = m * n;
-    for (int64_t i = 0; i < numel; ++i) {
-      T dx_tmp, dy_tmp;
-      functor(x[i], y[i], dz[i], &dx_tmp, &dy_tmp);
-      if (dx) {
-        dx[i] = dx_tmp;
-      }
-      if (dy) {
-        dy[i] = dy_tmp;
-      }
-    }
+    stride = n;
   } else {
-    int64_t stride = 2 * n;
+    stride = 2 * n;
     y = x + n;
     dy = dx + n;
-    for (int64_t i = 0; i < m; ++i) {
-      for (int64_t j = 0; j < n; ++j) {
-        functor(x[i * stride + j],
-                y[i * stride + j],
-                dz[i * n + j],
-                &dx[i * stride + j],
-                &dy[i * stride + j]);
+  }
+
+  for (int64_t i = 0; i < m; ++i) {
+    for (int64_t j = 0; j < n; ++j) {
+      T dx_tmp, dy_tmp;
+      functor(x[i * stride + j],
+              y[i * stride + j],
+              dz[i * n + j],
+              &dx_tmp,
+              &dy_tmp);
+      if (dx) {
+        dx[i * stride + j] = dx_tmp;
+      }
+      if (dy) {
+        dy[i * stride + j] = dy_tmp;
       }
     }
   }

--- a/paddle/phi/kernels/cpu/swiglu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/swiglu_grad_kernel.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/swiglu_grad_kernel.h"
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/activation_functor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void SwiGLUGradKernelImpl(const Context &ctx,
+                          const T *x,
+                          const T *y,
+                          const T *dz,
+                          T *dx,
+                          T *dy,
+                          int64_t m,
+                          int64_t n) {
+  funcs::SwiGLUGradFunctor<T> functor;
+  if (y) {
+    int64_t numel = m * n;
+    for (int64_t i = 0; i < numel; ++i) {
+      T dx_tmp, dy_tmp;
+      functor(x[i], y[i], dz[i], &dx_tmp, &dy_tmp);
+      if (dx) {
+        dx[i] = dx_tmp;
+      }
+      if (dy) {
+        dy[i] = dy_tmp;
+      }
+    }
+  } else {
+    int64_t stride = 2 * n;
+    y = x + n;
+    dy = dx + n;
+    for (int64_t i = 0; i < m; ++i) {
+      for (int64_t j = 0; j < n; ++j) {
+        functor(x[i * stride + j],
+                y[i * stride + j],
+                dz[i * n + j],
+                &dx[i * stride + j],
+                &dy[i * stride + j]);
+      }
+    }
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(
+    swiglu_grad, CPU, ALL_LAYOUT, phi::SwiGLUGradKernel, float, double) {}

--- a/paddle/phi/kernels/cpu/swiglu_kernel.cc
+++ b/paddle/phi/kernels/cpu/swiglu_kernel.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/swiglu_kernel.h"
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/activation_functor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void SwiGLUKernelImpl(
+    const Context &ctx, const T *x, const T *y, T *z, int64_t m, int64_t n) {
+  funcs::SwiGLUFunctor<T> functor;
+  if (y) {
+    int64_t numel = m * n;
+    for (int64_t i = 0; i < numel; ++i) {
+      z[i] = functor(x[i], y[i]);
+    }
+  } else {
+    int64_t stride = 2 * n;
+    y = x + n;
+    for (int64_t i = 0; i < m; ++i) {
+      for (int64_t j = 0; j < n; ++j) {
+        z[i * n + j] = functor(x[i * stride + j], y[i * stride + j]);
+      }
+    }
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(swiglu, CPU, ALL_LAYOUT, phi::SwiGLUKernel, float, double) {}

--- a/paddle/phi/kernels/cpu/swiglu_kernel.cc
+++ b/paddle/phi/kernels/cpu/swiglu_kernel.cc
@@ -23,18 +23,17 @@ template <typename T, typename Context>
 void SwiGLUKernelImpl(
     const Context &ctx, const T *x, const T *y, T *z, int64_t m, int64_t n) {
   funcs::SwiGLUFunctor<T> functor;
+  int64_t stride;
   if (y) {
-    int64_t numel = m * n;
-    for (int64_t i = 0; i < numel; ++i) {
-      z[i] = functor(x[i], y[i]);
-    }
+    stride = n;
   } else {
-    int64_t stride = 2 * n;
+    stride = 2 * n;
     y = x + n;
-    for (int64_t i = 0; i < m; ++i) {
-      for (int64_t j = 0; j < n; ++j) {
-        z[i * n + j] = functor(x[i * stride + j], y[i * stride + j]);
-      }
+  }
+
+  for (int64_t i = 0; i < m; ++i) {
+    for (int64_t j = 0; j < n; ++j) {
+      z[i * n + j] = functor(x[i * stride + j], y[i * stride + j]);
     }
   }
 }

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5011,5 +5011,39 @@ struct CudaCELUGradFunctor : public BaseActivationFunctor<T> {
 
 #endif
 
+template <typename T>
+struct SwiGLUFunctor {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+  HOSTDEVICE T operator()(T x, T y) const {
+    MPType mp_x = static_cast<MPType>(x);
+    MPType mp_y = static_cast<MPType>(y);
+    MPType one = static_cast<MPType>(1);
+    return static_cast<T>(mp_y * mp_x / (one + exp(-mp_x)));
+  }
+};
+
+template <typename T, bool HasDX = true, bool HasDY = true>
+struct SwiGLUGradFunctor {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+  HOSTDEVICE void operator()(T x, T y, T dz, T* dx, T* dy) const {
+    MPType one = static_cast<MPType>(1);
+
+    MPType mp_x = static_cast<MPType>(x);
+    MPType mp_dz = static_cast<MPType>(dz);
+
+    MPType sigmoid = one / (one + exp(-mp_x));
+    MPType tmp = mp_x * sigmoid;
+    if (HasDX) {
+      MPType mp_y = static_cast<MPType>(y);
+      *dx = static_cast<T>(mp_dz * mp_y * sigmoid * (one + mp_x - tmp));
+    }
+    if (HasDY) {
+      *dy = static_cast<T>(mp_dz * tmp);
+    }
+  }
+};
+
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/swiglu_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/swiglu_grad_kernel.cu
@@ -1,0 +1,200 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/swiglu_grad_kernel.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/activation_functor.h"
+
+#include "paddle/phi/kernels/funcs/aligned_vector.h"
+#include "paddle/phi/kernels/primitive/kernel_primitives.h"
+
+namespace phi {
+
+template <typename T, int VecSize, bool IsCombine, bool HasDX, bool HasDY>
+__global__ void SwiGLUGradCUDAKernel(const T *__restrict__ x,
+                                     const T *__restrict__ y,
+                                     const T *__restrict__ dz,
+                                     T *__restrict__ dx,
+                                     T *__restrict__ dy,
+                                     int64_t m,
+                                     int64_t n,
+                                     int64_t n_vec_piece) {
+  funcs::SwiGLUGradFunctor<T, HasDX, HasDY> functor;
+  if constexpr (IsCombine) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    int64_t valid_num = m * n_vec_piece;
+    int64_t col_limit = n - VecSize;
+    dy = dx + n;
+
+    while (idx < valid_num) {
+      int64_t row_offset = idx / n_vec_piece * n;
+      int64_t col_offset = idx % n_vec_piece * VecSize;
+
+      int64_t dz_offset = row_offset + col_offset;
+      int64_t x_offset = dz_offset + row_offset;
+      phi::AlignedVector<T, VecSize> x_vec;
+      phi::AlignedVector<T, VecSize> y_vec;
+      phi::AlignedVector<T, VecSize> dz_vec;
+
+      phi::Load<T, VecSize>(x + x_offset, &x_vec);
+      phi::Load<T, VecSize>(y + x_offset, &y_vec);
+      phi::Load<T, VecSize>(dz + dz_offset, &dz_vec);
+
+#pragma unroll
+      for (int i = 0; i < VecSize; ++i) {
+        functor(x_vec[i], y_vec[i], dz_vec[i], &x_vec[i], &y_vec[i]);
+      }
+
+      phi::Store<T, VecSize>(x_vec, dx + x_offset);
+      phi::Store<T, VecSize>(y_vec, dy + x_offset);
+      idx += stride;
+    }
+  } else {
+    int64_t idx =
+        (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * VecSize;
+    int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x * VecSize;
+    int64_t numel = m * n;
+    int64_t limit = numel - VecSize;
+
+    while (idx <= limit) {
+      phi::AlignedVector<T, VecSize> x_vec;
+      phi::AlignedVector<T, VecSize> y_vec;
+      phi::AlignedVector<T, VecSize> dz_vec;
+
+      phi::Load<T, VecSize>(x + idx, &x_vec);
+      if constexpr (HasDX) {
+        phi::Load<T, VecSize>(y + idx, &y_vec);
+      }
+      phi::Load<T, VecSize>(dz + idx, &dz_vec);
+
+#pragma unroll
+      for (int i = 0; i < VecSize; ++i) {
+        functor(x_vec[i],
+                HasDX ? y_vec[i] : x_vec[i],
+                dz_vec[i],
+                &x_vec[i],
+                &dz_vec[i]);
+      }
+      if constexpr (HasDX) {
+        phi::Store<T, VecSize>(x_vec, dx + idx);
+      }
+      if constexpr (HasDY) {
+        phi::Store<T, VecSize>(dz_vec, dy + idx);
+      }
+      idx += stride;
+    }
+
+    while (idx < numel) {
+      functor(x[idx],
+              HasDX ? y[idx] : x[idx],
+              dz[idx],
+              HasDX ? &dx[idx] : nullptr,
+              HasDY ? &dy[idx] : nullptr);
+      ++idx;
+    }
+  }
+}
+
+template <typename T, typename Context>
+void SwiGLUGradKernelImpl(const Context &ctx,
+                          const T *x,
+                          const T *y,
+                          const T *dz,
+                          T *dx,
+                          T *dy,
+                          int64_t m,
+                          int64_t n) {
+  int vec_size =
+      std::min(phi::GetVectorizedSize<T>(x), phi::GetVectorizedSize<T>(dz));
+  if (y) {
+    vec_size = std::min(vec_size, phi::GetVectorizedSize<T>(y));
+  }
+  if (dx) {
+    vec_size = std::min(vec_size, phi::GetVectorizedSize<T>(dx));
+  }
+  if (dy) {
+    vec_size = std::min(vec_size, phi::GetVectorizedSize<T>(dy));
+  }
+
+#define PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL_BASE(                                \
+    __vec_size, __is_combine, __has_dx, __has_dy)                              \
+  case __vec_size: {                                                           \
+    SwiGLUGradCUDAKernel<T, __vec_size, __is_combine, __has_dx, __has_dy>      \
+        <<<config.block_per_grid, config.thread_per_block, 0, ctx.stream()>>>( \
+            x, y, dz, dx, dy, m, n, n_vec_piece);                              \
+    break;                                                                     \
+  }
+
+#define PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL(__is_combine, __has_dx, __has_dy) \
+  do {                                                                      \
+    switch (vec_size) {                                                     \
+      PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL_BASE(                               \
+          VecSizeL, __is_combine, __has_dx, __has_dy);                      \
+      PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL_BASE(                               \
+          VecSizeM, __is_combine, __has_dx, __has_dy);                      \
+      PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL_BASE(                               \
+          VecSizeS, __is_combine, __has_dx, __has_dy);                      \
+      default:                                                              \
+        PADDLE_THROW(phi::errors::Unimplemented(                            \
+            "Unsupported vectorized size: %d !", vec_size));                \
+        break;                                                              \
+    }                                                                       \
+  } while (0)
+
+  if (y) {
+    int64_t n_vec_piece = 1;
+    auto config =
+        phi::backends::gpu::GetGpuLaunchConfig1D(ctx, m * n, vec_size);
+    if (dx) {
+      if (dy) {
+        PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL(false, true, true);
+      } else {
+        PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL(false, true, false);
+      }
+    } else {
+      PADDLE_ENFORCE_NOT_NULL(
+          dy,
+          phi::errors::InvalidArgument(
+              "Both gradients of Input(X) and Input(Y) is None."));
+      PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL(false, false, true);
+    }
+  } else {
+    PADDLE_ENFORCE_NOT_NULL(
+        dx,
+        phi::errors::InvalidArgument(
+            "Both gradients of Input(X) and Input(Y) is None."));
+    while (n % vec_size != 0) {
+      vec_size /= 2;
+    }
+    y = x + n;
+    int64_t n_vec_piece = n / vec_size;
+    auto config =
+        phi::backends::gpu::GetGpuLaunchConfig1D(ctx, m * n_vec_piece, 1);
+    PD_LAUNCH_SWIGLU_GRAD_CUDA_KERNEL(true, true, true);
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(swiglu_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::SwiGLUGradKernel,
+                   float,
+                   double,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/gpu/swiglu_kernel.cu
+++ b/paddle/phi/kernels/gpu/swiglu_kernel.cu
@@ -1,0 +1,135 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/swiglu_kernel.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/activation_functor.h"
+#include "paddle/phi/kernels/funcs/aligned_vector.h"
+#include "paddle/phi/kernels/primitive/kernel_primitives.h"
+
+namespace phi {
+
+template <typename T, int VecSize, bool IsCombine>
+__global__ void SwiGLUCUDAKernel(const T *__restrict__ x,
+                                 const T *__restrict__ y,
+                                 T *__restrict__ z,
+                                 int64_t m,
+                                 int64_t n,
+                                 int64_t n_vec_piece) {
+  funcs::SwiGLUFunctor<T> functor;
+  if constexpr (IsCombine) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+    int64_t valid_num = m * n_vec_piece;
+    int64_t col_limit = n - VecSize;
+    while (idx < valid_num) {
+      int64_t row_offset = idx / n_vec_piece * n;
+      int64_t col_offset = idx % n_vec_piece * VecSize;
+      int64_t z_offset = row_offset + col_offset;
+      int64_t x_offset = z_offset + row_offset;
+      phi::AlignedVector<T, VecSize> x_vec;
+      phi::AlignedVector<T, VecSize> y_vec;
+      phi::Load<T, VecSize>(x + x_offset, &x_vec);
+      phi::Load<T, VecSize>(y + x_offset, &y_vec);
+#pragma unroll
+      for (int i = 0; i < VecSize; ++i) {
+        y_vec[i] = functor(x_vec[i], y_vec[i]);
+      }
+      phi::Store<T, VecSize>(y_vec, z + z_offset);
+      idx += stride;
+    }
+  } else {
+    int64_t idx =
+        (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) * VecSize;
+    int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x * VecSize;
+    int64_t numel = m * n;
+    int64_t limit = numel - VecSize;
+
+    while (idx <= limit) {
+      phi::AlignedVector<T, VecSize> x_vec;
+      phi::AlignedVector<T, VecSize> y_vec;
+      phi::Load<T, VecSize>(x + idx, &x_vec);
+      phi::Load<T, VecSize>(y + idx, &y_vec);
+#pragma unroll
+      for (int i = 0; i < VecSize; ++i) {
+        y_vec[i] = functor(x_vec[i], y_vec[i]);
+      }
+      phi::Store<T, VecSize>(y_vec, z + idx);
+      idx += stride;
+    }
+
+    while (idx < numel) {
+      z[idx] = functor(x[idx], y[idx]);
+      ++idx;
+    }
+  }
+}
+
+template <typename T, typename Context>
+void SwiGLUKernelImpl(
+    const Context &ctx, const T *x, const T *y, T *z, int64_t m, int64_t n) {
+  int vec_size =
+      std::min(phi::GetVectorizedSize<T>(x), phi::GetVectorizedSize<T>(z));
+
+#define PD_LAUNCH_SWIGLU_CUDA_KERNEL_BASE(__vec_size, __is_combine)            \
+  case __vec_size: {                                                           \
+    SwiGLUCUDAKernel<T, __vec_size, __is_combine>                              \
+        <<<config.block_per_grid, config.thread_per_block, 0, ctx.stream()>>>( \
+            x, y, z, m, n, n_vec_piece);                                       \
+    break;                                                                     \
+  }
+
+#define PD_LAUNCH_SWIGLU_CUDA_KERNEL(__is_combine)               \
+  do {                                                           \
+    switch (vec_size) {                                          \
+      PD_LAUNCH_SWIGLU_CUDA_KERNEL_BASE(VecSizeL, __is_combine); \
+      PD_LAUNCH_SWIGLU_CUDA_KERNEL_BASE(VecSizeM, __is_combine); \
+      PD_LAUNCH_SWIGLU_CUDA_KERNEL_BASE(VecSizeS, __is_combine); \
+      default:                                                   \
+        PADDLE_THROW(phi::errors::Unimplemented(                 \
+            "Unsupported vectorized size: %d !", vec_size));     \
+        break;                                                   \
+    }                                                            \
+  } while (0)
+
+  if (y) {
+    vec_size = std::min(vec_size, phi::GetVectorizedSize<T>(y));
+    int64_t n_vec_piece = 1;
+    auto config =
+        phi::backends::gpu::GetGpuLaunchConfig1D(ctx, m * n, vec_size);
+    PD_LAUNCH_SWIGLU_CUDA_KERNEL(false);
+  } else {
+    while (n % vec_size != 0) {
+      vec_size /= 2;
+    }
+    y = x + n;
+    int64_t n_vec_piece = n / vec_size;
+    auto config =
+        phi::backends::gpu::GetGpuLaunchConfig1D(ctx, m * n_vec_piece, 1);
+    PD_LAUNCH_SWIGLU_CUDA_KERNEL(true);
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(swiglu,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::SwiGLUKernel,
+                   float,
+                   double,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/swiglu_grad_kernel.h
+++ b/paddle/phi/kernels/swiglu_grad_kernel.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void SwiGLUGradKernelImpl(const Context &ctx,
+                          const T *x,
+                          const T *y,
+                          const T *dz,
+                          T *dx,
+                          T *dy,
+                          int64_t m,
+                          int64_t n);
+
+template <typename T, typename Context>
+void SwiGLUGradKernel(const Context &ctx,
+                      const DenseTensor &x,
+                      const paddle::optional<DenseTensor> &y,
+                      const DenseTensor &dz,
+                      DenseTensor *dx,
+                      DenseTensor *dy) {
+  const auto *x_ptr = x.data<T>();
+  const auto *dz_ptr = dz.data<T>();
+  auto *dx_ptr = dx ? ctx.template Alloc<T>(dx) : nullptr;
+  auto *dy_ptr = y && dy ? ctx.template Alloc<T>(dy) : nullptr;
+  const auto &dims = x.dims();
+
+  if (y) {
+    const auto &y_tensor = y.get();
+    const auto &y_dims = y_tensor.dims();
+    PADDLE_ENFORCE_EQ(
+        y_dims,
+        dims,
+        phi::errors::InvalidArgument("The shape of Input(Y):[%s] must be equal "
+                                     "to the shape of Input(X):[%s].",
+                                     y_dims,
+                                     dims));
+    SwiGLUGradKernelImpl<T, Context>(
+        ctx, x_ptr, y_tensor.data<T>(), dz_ptr, dx_ptr, dy_ptr, x.numel(), 1);
+  } else {
+    auto dims_2d = flatten_to_2d(dims, dims.size() - 1);
+    int64_t m = dims_2d[0], n = dims_2d[1];
+    PADDLE_ENFORCE_EQ(n % 2,
+                      0,
+                      phi::errors::InvalidArgument(
+                          "The last dim of Input(X) should be exactly divided "
+                          "by 2 when Input(Y) is None, but got %d",
+                          n));
+    SwiGLUGradKernelImpl<T, Context>(
+        ctx, x_ptr, nullptr, dz_ptr, dx_ptr, nullptr, m, n / 2);
+  }
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/swiglu_kernel.h
+++ b/paddle/phi/kernels/swiglu_kernel.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void SwiGLUKernelImpl(
+    const Context &ctx, const T *x, const T *y, T *z, int64_t m, int64_t n);
+
+template <typename T, typename Context>
+void SwiGLUKernel(const Context &ctx,
+                  const DenseTensor &x,
+                  const paddle::optional<DenseTensor> &y,
+                  DenseTensor *z) {
+  const auto *x_ptr = x.data<T>();
+  auto *z_ptr = ctx.template Alloc<T>(z);
+  const auto &dims = x.dims();
+
+  if (y) {
+    const auto &y_tensor = y.get();
+    const auto &y_dims = y_tensor.dims();
+    PADDLE_ENFORCE_EQ(
+        y_dims,
+        dims,
+        phi::errors::InvalidArgument("The shape of Input(Y):[%s] must be equal "
+                                     "to the shape of Input(X):[%s].",
+                                     y_dims,
+                                     dims));
+    SwiGLUKernelImpl<T, Context>(
+        ctx, x_ptr, y_tensor.data<T>(), z_ptr, x.numel(), 1);
+  } else {
+    auto dims_2d = flatten_to_2d(dims, dims.size() - 1);
+    int64_t m = dims_2d[0], n = dims_2d[1];
+    PADDLE_ENFORCE_EQ(n % 2,
+                      0,
+                      phi::errors::InvalidArgument(
+                          "The last dim of Input(X) should be exactly divided "
+                          "by 2 when Input(Y) is None, but got %d",
+                          n));
+    SwiGLUKernelImpl<T, Context>(ctx, x_ptr, nullptr, z_ptr, m, n / 2);
+  }
+}
+
+}  // namespace phi

--- a/python/paddle/incubate/nn/functional/__init__.py
+++ b/python/paddle/incubate/nn/functional/__init__.py
@@ -34,6 +34,7 @@ from .fused_transformer import (
     fused_multi_transformer,
 )
 from .masked_multihead_attention import masked_multihead_attention
+from .swiglu import swiglu
 from .variable_length_memory_efficient_attention import (
     variable_length_memory_efficient_attention,
 )
@@ -54,4 +55,5 @@ __all__ = [
     "fused_layer_norm",
     "masked_multihead_attention",
     "block_multihead_attention",
+    "swiglu",
 ]

--- a/python/paddle/incubate/nn/functional/swiglu.py
+++ b/python/paddle/incubate/nn/functional/swiglu.py
@@ -24,7 +24,7 @@ def swiglu(x, y=None, name=None):
     .. math::
 
         out = silu(x) * y when y is not None
-        out = silu(xs[0]) * xs[1] when y is None, where xs = paddle.chunk(2, axis=-1)
+        out = silu(xs[0]) * xs[1] when y is None, where xs = paddle.chunk(x, 2, axis=-1)
 
     Args:
         x (Tensor): The first input Tensor of SwiGLU.

--- a/python/paddle/incubate/nn/functional/swiglu.py
+++ b/python/paddle/incubate/nn/functional/swiglu.py
@@ -28,7 +28,8 @@ def swiglu(x, y=None, name=None):
 
     Args:
         x (Tensor): The first input Tensor of SwiGLU.
-        y (Tensor): The second input Tensor of SwiGLU.
+        y (Tensor, optional): The second input Tensor of SwiGLU. Default: None.
+        name (str, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Returns:
         A Tensor with the same data type with x and y.

--- a/python/paddle/incubate/nn/functional/swiglu.py
+++ b/python/paddle/incubate/nn/functional/swiglu.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle import _C_ops
+
+from ....framework import LayerHelper, in_dynamic_or_pir_mode
+
+
+def swiglu(x, y=None, name=None):
+    """
+    This function performs SwiGLU activation to the input Tensor.
+
+    .. math::
+
+        out = silu(x) * y when y is not None
+        out = silu(xs[0]) * xs[1] when y is None, where xs = paddle.chunk(2, axis=-1)
+
+    Args:
+        x (Tensor): The first input Tensor of SwiGLU.
+        y (Tensor): The second input Tensor of SwiGLU.
+
+    Returns:
+        A Tensor with the same data type with x and y.
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.swiglu(x, y)
+    else:
+        helper = LayerHelper("swiglu", **locals())
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        helper.append_op(
+            type="swiglu", inputs={"x": x, "y": y}, outputs={"out": out}
+        )
+        return out

--- a/python/paddle/incubate/nn/functional/swiglu.py
+++ b/python/paddle/incubate/nn/functional/swiglu.py
@@ -32,6 +32,18 @@ def swiglu(x, y=None, name=None):
 
     Returns:
         A Tensor with the same data type with x and y.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> import paddle.incubate.nn.functional as F
+            >>> x = paddle.to_tensor([1, 2], dtype='float32')
+            >>> out1, out2 = F.swiglu(x), F.swiglu(x, x)
+            >>> print(out1, out2)
+            Tensor(shape=[1], dtype=float32, place=Place(cpu), stop_gradient=True,
+                   [1.46211720]) Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
+                   [0.73105860, 3.52318811])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.swiglu(x, y)

--- a/test/legacy_test/test_swiglu.py
+++ b/test/legacy_test/test_swiglu.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.nn.functional as F
+from paddle.incubate.nn.functional import swiglu as fused_swiglu_impl
+
+
+def swiglu(x, y, out_grad):
+    origin_x = x.detach().clone()
+    origin_x.stop_gradient = False
+    x = origin_x
+
+    origin_y = y.detach().clone()
+    origin_y.stop_gradient = False
+    y = origin_y
+
+    dtype = x.dtype
+    need_convert = False
+    assert dtype == y.dtype
+    output_dtype = dtype
+    if paddle.is_compiled_with_cuda():
+        if dtype in [paddle.float16, paddle.bfloat16]:
+            output_dtype = paddle.float32
+            x = x.astype(output_dtype)
+            y = y.astype(output_dtype)
+            need_convert = True
+
+    out = F.silu(x) * y
+    if need_convert:
+        out = out.astype(dtype)
+    out.backward(out_grad)
+    ret = [
+        out.astype(output_dtype),
+        origin_x.grad.astype(output_dtype),
+        origin_y.grad.astype(output_dtype),
+    ]
+    return ret
+
+
+def fused_swiglu(x, y, out_grad):
+    x = x.detach().clone()
+    x.stop_gradient = False
+    if y is not None:
+        y = y.detach().clone()
+        y.stop_gradient = False
+    out = fused_swiglu_impl(x, y)
+    out.backward(out_grad)
+
+    output_dtype = x.dtype
+    if paddle.is_compiled_with_cuda():
+        if x.dtype in [paddle.float16, paddle.bfloat16]:
+            output_dtype = paddle.float32
+    ret = [
+        out.astype(output_dtype),
+    ]
+    if y is not None:
+        x_grad, y_grad = x.grad, y.grad
+    else:
+        x_grad, y_grad = paddle.split(x.grad, 2, axis=-1)
+
+    ret.append(x_grad.astype(output_dtype))
+    ret.append(y_grad.astype(output_dtype))
+    return ret
+
+
+tol_map = {
+    paddle.float64: [1e-8, 1e-8],
+    paddle.float32: [1e-6, 1e-6],
+    paddle.float16: [1e-3, 1e-3],
+    paddle.bfloat16: [1e-3, 1e-3],
+}
+
+
+class TestSwiGLUDygraph(unittest.TestCase):
+    def check_dygraph_impl(self, device, shape, dtype):
+        x = paddle.randn(shape, dtype=dtype)
+        y = paddle.randn(shape, dtype=dtype)
+        out_grad = paddle.randn(shape, dtype=dtype)
+
+        ret1 = swiglu(x, y, out_grad)
+        ret2 = fused_swiglu(x, y, out_grad)
+        ret3 = fused_swiglu(paddle.concat([x, y], axis=-1), None, out_grad)
+
+        atol, rtol = tol_map[dtype]
+        err_msg = (
+            f"Failed when device = {device}, dtype = {dtype}, shape = {shape}"
+        )
+        for t1, t2, t3 in zip(ret1, ret2, ret3):
+            t1, t2, t3 = t1.numpy(), t2.numpy(), t3.numpy()
+            np.testing.assert_allclose(
+                t1, t2, atol=atol, rtol=rtol, err_msg=err_msg
+            )
+            np.testing.assert_equal(t2, t3, err_msg=err_msg)
+
+    def check_dygraph(self, shape):
+        metas = [('cpu', paddle.float32), ('cpu', paddle.float64)]
+        if paddle.is_compiled_with_cuda():
+            metas.append(('gpu', paddle.float32))
+            metas.append(('gpu', paddle.float64))
+            metas.append(('gpu', paddle.float16))
+            prop = paddle.device.cuda.get_device_properties()
+            if prop.major >= 8:
+                metas.append(('gpu', paddle.bfloat16))
+
+        for device, dtype in metas:
+            origin_device = paddle.get_device()
+            paddle.set_device(device)
+            for with_split in [True]:
+                self.check_dygraph_impl(device, shape, dtype)
+            paddle.set_device(origin_device)
+
+    def check_static_graph(self, shape, dtype="float32"):
+        x = paddle.static.data(name='x', shape=shape, dtype=dtype)
+        y = paddle.static.data(name='y', shape=shape, dtype=dtype)
+        concated_x = paddle.static.data(
+            name='concated_x',
+            shape=list(shape[:-1]) + [shape[-1] * 2],
+            dtype=dtype,
+        )
+        out1 = fused_swiglu_impl(x, y)
+        out2 = fused_swiglu_impl(concated_x)
+
+        concated_x_np = np.random.random(concated_x.shape).astype(dtype)
+        x_np, y_np = np.split(concated_x_np, 2, axis=-1)
+
+        exe = paddle.static.Executor()
+        t1, t2 = exe.run(
+            feed={'x': x_np, 'y': y_np, 'concated_x': concated_x_np},
+            fetch_list=[out1, out2],
+        )
+        np.testing.assert_equal(t1, t2)
+
+    def check_main(self, shape):
+        self.check_dygraph(shape)
+        paddle.enable_static()
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            self.check_static_graph(shape)
+        paddle.disable_static()
+
+    def test_main(self):
+        self.check_main([8, 100])
+        self.check_main([4, 101])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
OPs

### Description
Add `SwiGLU` operator to save memory access and occupation instead of using `silu(x) * y`.

Pcard-70426