### PR TITLE
[Cleanup][B-5] clean some `to_variable` for test

### DIFF
--- a/test/contrib/test_correlation.py
+++ b/test/contrib/test_correlation.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import paddle
 from paddle import base
-from paddle.base.dygraph.base import to_variable
 
 paddle.enable_static()
 
@@ -176,8 +175,8 @@ class TestCorrelationOpDyGraph(unittest.TestCase):
                 stride2=1,
             )
 
-            x1 = to_variable(x1_np)
-            x2 = to_variable(x2_np)
+            x1 = paddle.to_tensor(x1_np)
+            x2 = paddle.to_tensor(x2_np)
             corr_pd = Net('corr_pd')
             y = corr_pd(x1, x2)
             out = y.numpy()

--- a/test/dygraph_to_static/test_cycle_gan.py
+++ b/test/dygraph_to_static/test_cycle_gan.py
@@ -33,7 +33,6 @@ from dygraph_to_static_utils import (
 )
 
 import paddle
-from paddle.base.dygraph import to_variable
 from paddle.nn import BatchNorm
 
 # Note: Set True to eliminate randomness.
@@ -584,8 +583,8 @@ def train(args):
                 data_B = np.array(
                     [data_B[0].reshape(3, IMAGE_SIZE, IMAGE_SIZE)]
                 ).astype("float32")
-                data_A = to_variable(data_A)
-                data_B = to_variable(data_B)
+                data_A = paddle.to_tensor(data_A)
+                data_B = paddle.to_tensor(data_B)
 
                 # optimize the g_A network
                 (
@@ -610,13 +609,13 @@ def train(args):
                 fake_pool_B = np.array(
                     [fake_pool_B[0].reshape(3, IMAGE_SIZE, IMAGE_SIZE)]
                 ).astype("float32")
-                fake_pool_B = to_variable(fake_pool_B)
+                fake_pool_B = paddle.to_tensor(fake_pool_B)
 
                 fake_pool_A = A_pool.pool_image(fake_A).numpy()
                 fake_pool_A = np.array(
                     [fake_pool_A[0].reshape(3, IMAGE_SIZE, IMAGE_SIZE)]
                 ).astype("float32")
-                fake_pool_A = to_variable(fake_pool_A)
+                fake_pool_A = paddle.to_tensor(fake_pool_A)
 
                 # optimize the d_A network
                 discriminatorA_to_static = paddle.jit.to_static(

--- a/test/dygraph_to_static/test_dict.py
+++ b/test/dygraph_to_static/test_dict.py
@@ -55,7 +55,7 @@ class SubNetWithDict(paddle.nn.Layer):
         )
 
     def forward(self, input, cache=None):
-        input = base.dygraph.to_variable(input)
+        input = paddle.to_tensor(input)
 
         q = self.q_fc(input)
         k = self.k_fc(input)
@@ -83,7 +83,7 @@ class MainNetWithDict(paddle.nn.Layer):
         self.sub_net = SubNetWithDict(hidden_size, output_size)
 
     def forward(self, input, max_len=4):
-        input = base.dygraph.to_variable(input)
+        input = paddle.to_tensor(input)
         cache = {
             "k": paddle.tensor.fill_constant(
                 shape=[self.batch_size, self.output_size],

--- a/test/legacy_test/test_conv2d_transpose_layer.py
+++ b/test/legacy_test/test_conv2d_transpose_layer.py
@@ -176,7 +176,7 @@ class Conv2DTransposeTestCase(unittest.TestCase):
         return y_np
 
     def paddle_nn_layer(self):
-        x_var = dg.to_variable(self.input)
+        x_var = paddle.to_tensor(self.input)
 
         if self.output_padding != 0:
             output_size = None

--- a/test/legacy_test/test_conv3d_transpose_layer.py
+++ b/test/legacy_test/test_conv3d_transpose_layer.py
@@ -163,7 +163,7 @@ class Conv3DTransposeTestCase(unittest.TestCase):
         return y_np
 
     def paddle_nn_layer(self):
-        x_var = dg.to_variable(self.input)
+        x_var = paddle.to_tensor(self.input)
         conv = nn.Conv3DTranspose(
             self.num_channels,
             self.num_filters,

--- a/test/legacy_test/test_cross_op.py
+++ b/test/legacy_test/test_cross_op.py
@@ -197,8 +197,8 @@ class TestCrossAPI(unittest.TestCase):
         self.input_data()
         # case 1:
         # with base.dygraph.guard():
-        #     x = base.dygraph.to_variable(self.data_x)
-        #     y = base.dygraph.to_variable(self.data_y)
+        #     x = paddle.to_tensor(self.data_x)
+        #     y = paddle.to_tensor(self.data_y)
         #     z = paddle.cross(x, y)
         #     np_z = z.numpy()
         # expect_out = np.array([[-1.0, -1.0, -1.0], [2.0, 2.0, 2.0],
@@ -207,8 +207,8 @@ class TestCrossAPI(unittest.TestCase):
 
         # case 2:
         with base.dygraph.guard():
-            x = base.dygraph.to_variable(self.data_x)
-            y = base.dygraph.to_variable(self.data_y)
+            x = paddle.to_tensor(self.data_x)
+            y = paddle.to_tensor(self.data_y)
             z = paddle.cross(x, y, axis=1)
             np_z = z.numpy()
         expect_out = np.array(

--- a/test/legacy_test/test_detach.py
+++ b/test/legacy_test/test_detach.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import paddle
 from paddle import base
-from paddle.base.dygraph.base import to_variable
 from paddle.nn import Linear
 
 
@@ -68,7 +67,7 @@ class Test_Detach(unittest.TestCase):
                 weight_attr=linear2_w_param_attrs,
                 bias_attr=linear2_b_param_attrs,
             )
-            data = to_variable(data)
+            data = paddle.to_tensor(data)
             x = linear(data)
             x1 = linear1(x)
             x2 = linear2(x)
@@ -104,7 +103,7 @@ class Test_Detach(unittest.TestCase):
                 weight_attr=linear1_w_param_attrs,
                 bias_attr=linear1_b_param_attrs,
             )
-            data = to_variable(data)
+            data = paddle.to_tensor(data)
             x = linear(data)
             x.retain_grads()
             x1 = linear1(x)
@@ -152,7 +151,7 @@ class Test_Detach(unittest.TestCase):
                 weight_attr=linear2_w_param_attrs,
                 bias_attr=linear2_b_param_attrs,
             )
-            data = to_variable(data)
+            data = paddle.to_tensor(data)
             x = linear(data)
             x.retain_grads()
             x_detach = x.detach()

--- a/test/legacy_test/test_detection.py
+++ b/test/legacy_test/test_detection.py
@@ -20,7 +20,6 @@ import numpy as np
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.base.dygraph import base as imperative_base
 from paddle.base.framework import Program, program_guard
 from paddle.pir_utils import test_with_pir_api
 
@@ -138,11 +137,11 @@ class TestGenerateProposals(LayerTest):
             )
 
         with self.dynamic_graph():
-            scores_dy = imperative_base.to_variable(scores_np)
-            bbox_deltas_dy = imperative_base.to_variable(bbox_deltas_np)
-            im_info_dy = imperative_base.to_variable(im_info_np)
-            anchors_dy = imperative_base.to_variable(anchors_np)
-            variances_dy = imperative_base.to_variable(variances_np)
+            scores_dy = paddle.to_tensor(scores_np)
+            bbox_deltas_dy = paddle.to_tensor(bbox_deltas_np)
+            im_info_dy = paddle.to_tensor(im_info_np)
+            anchors_dy = paddle.to_tensor(anchors_np)
+            variances_dy = paddle.to_tensor(variances_np)
             rois, roi_probs, rois_num = paddle.vision.ops.generate_proposals(
                 scores_dy,
                 bbox_deltas_dy,
@@ -219,8 +218,8 @@ class TestDistributeFpnProposals(LayerTest):
 
     def dynamic_distribute_fpn_proposals(self, rois_np, rois_num_np):
         with self.dynamic_graph():
-            rois_dy = imperative_base.to_variable(rois_np)
-            rois_num_dy = imperative_base.to_variable(rois_num_np)
+            rois_dy = paddle.to_tensor(rois_np)
+            rois_num_dy = paddle.to_tensor(rois_num_np)
             (
                 multi_rois_dy,
                 restore_ind_dy,


### PR DESCRIPTION
### PR types

Others

### PR changes

Others

### Description
https://github.com/PaddlePaddle/Paddle/issues/61385

- test_conv2d_transpose_layer.py : √
- test_conv3d_transpose_layer.py : √
- test_correlation.py : √
- test_cross_op.py : √
- test_cycle_gan.py : √
- test_declarative.py : ?
- test_detach.py : √
- test_detection.py : √
- test_dict.py : √
- test_directory_migration.py : ?

-----------------------------

test_declarative.py 中的 `to_variable` 都是 `dyfunc_to_variable`
```python
from test_basic_api_transformation import dyfunc_to_variable
```
`dyfunc_to_variable` 在 test_basic_api_transformation.py 中（B-2）

-----------------------------

test_directory_migration.py 好像是比较api迁移前后有没有问题，不知道需不需要改动这里的


@gouzil

