### PR TITLE
[Dy2St] Use hand write unparse instead of astor in Python3.8

### DIFF
--- a/test/dygraph_to_static/check_approval.py
+++ b/test/dygraph_to_static/check_approval.py
@@ -65,6 +65,11 @@ def ast_to_source_code(node: ast.AST):
         return f'({", ".join(ast_to_source_code(elt) for elt in node.elts)})'
     elif isinstance(node, ast.List):
         return f'[{", ".join(ast_to_source_code(elt) for elt in node.elts)}]'
+    elif isinstance(node, ast.Set):
+        return f'{{{", ".join(ast_to_source_code(elt) for elt in node.elts)}}}'
+    elif isinstance(node, ast.Dict):
+        return f'{{{", ".join(f"{ast_to_source_code(k)}: {ast_to_source_code(v)}" for k, v in zip(node.keys, node.values))}}}'
+        return f'{ast_to_source_code(node.value)}[{ast_to_source_code(node.slice)}]'
     elif isinstance(node, ast.Constant):
         return repr(node.value)
     elif isinstance(node, ast.Call):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 #61480 在 Python 3.8 环境下没有 astor 导致挂掉的问题，手写一个简单的 unparse 替代 astor（因为我们的使用场景有限，手写的基本可以满足，全量动转静单测测试也是通过的）

PR-CI-APPROVAL 环境里随机 Python 3.8 和 Python 3.9 就离谱

PCard-66972