### PR TITLE
[AutoParallel] Fit send_recv overlap for vpp

### DIFF
--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -665,8 +665,13 @@ def _program_for_fthenb_and_1f1b(program, enable_send_recv_overlap=False):
     return [fwd_prog, bwd_prog, opt_prog]
 
 
-def _program_for_vpp(program, num_model_chunks, dist_context):
-    _insert_sync_for_fthenb_1f1b(program, dist_context)
+def _program_for_vpp(
+    program, num_model_chunks, dist_context, enable_send_recv_overlap=False
+):
+    if enable_send_recv_overlap:
+        _overlap_send_recv(program)
+    else:
+        _insert_sync_for_fthenb_1f1b(program, dist_context)
 
     oprole_type = {0: "forward", 1: "backward", 2: "optimizer"}
 

--- a/python/paddle/distributed/passes/pipeline_scheduler_pass.py
+++ b/python/paddle/distributed/passes/pipeline_scheduler_pass.py
@@ -552,8 +552,9 @@ class PipelineVirtualPipelinePass(PipelinePassBase):
     def _partial_programs(self, program):
         dist_context = self.get_attr("dist_context")
         num_model_chunks = self.get_attr("vpp_degree")
+        enable_send_recv_overlap = self.get_attr("enable_send_recv_overlap")
         types, sub_program_list = _program_for_vpp(
-            program, num_model_chunks, dist_context
+            program, num_model_chunks, dist_context, enable_send_recv_overlap
         )
         return types, sub_program_list
 

--- a/test/auto_parallel/pipeline_scheduler_vpp_unittest.py
+++ b/test/auto_parallel/pipeline_scheduler_vpp_unittest.py
@@ -108,7 +108,7 @@ def loss_fn(pred, label):
     return loss
 
 
-def apply_pass(schedule_mode, acc_step):
+def apply_pass(schedule_mode, acc_step, enable_send_recv_overlap=False):
     strategy = auto.Strategy()
     strategy.auto_mode = "semi"
     strategy.reinit = True
@@ -119,6 +119,7 @@ def apply_pass(schedule_mode, acc_step):
     pipeline.accumulate_steps = acc_step
     pipeline.vpp_degree = 2
     pipeline.vpp_seg_method = "MyLinear"
+    pipeline.enable_send_recv_overlap = enable_send_recv_overlap
 
     return strategy
 
@@ -158,10 +159,16 @@ class TestVPPPass(unittest.TestCase):
         place = paddle.base.CUDAPlace(ParallelEnv().dev_id)
         engine._executor = paddle.static.Executor(place)
 
-    def get_engine(self, schedule_mode, acc_step, manual=True):
+    def get_engine(
+        self,
+        schedule_mode,
+        acc_step,
+        manual=True,
+        enable_send_recv_overlap=False,
+    ):
         reset_prog()
 
-        strategy = apply_pass(schedule_mode, acc_step)
+        strategy = apply_pass(schedule_mode, acc_step, enable_send_recv_overlap)
         clip = paddle.nn.ClipGradByGlobalNorm(self.clip_norm)
         opt = paddle.optimizer.AdamW(learning_rate=0.00001, grad_clip=clip)
         model = MLPLayer(manual=manual)
@@ -223,10 +230,83 @@ class TestVPPPass(unittest.TestCase):
             self.assertEqual(sum(fw_chunk_ids), 13)
             self.assertEqual(sum(bw_chunk_ids), 19)
 
+        # pp2-vpp-manual-overlap
+        engine = self.get_engine(
+            schedule_mode="VPP",
+            acc_step=4,
+            manual=True,
+            enable_send_recv_overlap=True,
+        )
+        out_manual_overlap = engine.fit(
+            self.dataset, batch_size=self.batch_size, log_freq=1
+        )
+        assert engine._strategy.pipeline.schedule_mode == "VPP"
+        assert engine._strategy.pipeline.enable_send_recv_overlap is True
+
+        fw_chunk_ids = []
+        bw_chunk_ids = []
+        for op in engine.main_program.global_block().ops:
+            if is_optimize_op(op):
+                break
+
+            dist_op = engine.dist_context.get_dist_op_for_program(op)
+            if is_forward_op(op):
+                fw_chunk_ids.append(dist_op.dist_attr.chunk_id)
+            if is_backward_op(op):
+                bw_chunk_ids.append(dist_op.dist_attr.chunk_id)
+
+        if paddle.distributed.get_rank() == 0:
+            self.assertEqual(sum(fw_chunk_ids), 8)
+            self.assertEqual(sum(bw_chunk_ids), 13)
+        else:
+            self.assertEqual(sum(fw_chunk_ids), 12)
+            self.assertEqual(sum(bw_chunk_ids), 19)
+
+        # pp2-vpp-auto-overlap
+        engine = self.get_engine(
+            schedule_mode="VPP",
+            acc_step=4,
+            manual=False,
+            enable_send_recv_overlap=True,
+        )
+        out_auto_overlap = engine.fit(
+            self.dataset, batch_size=self.batch_size, log_freq=1
+        )
+        assert engine._strategy.pipeline.schedule_mode == "VPP"
+        assert engine._strategy.pipeline.enable_send_recv_overlap is True
+
+        fw_chunk_ids = []
+        bw_chunk_ids = []
+
+        for op in engine.main_program.global_block().ops:
+            if is_optimize_op(op):
+                break
+
+            dist_op = engine.dist_context.get_dist_op_for_program(op)
+            if is_forward_op(op):
+                fw_chunk_ids.append(dist_op.dist_attr.chunk_id)
+            if is_backward_op(op):
+                bw_chunk_ids.append(dist_op.dist_attr.chunk_id)
+
+        if paddle.distributed.get_rank() == 0:
+            self.assertEqual(sum(fw_chunk_ids), 9)
+            self.assertEqual(sum(bw_chunk_ids), 13)
+        else:
+            self.assertEqual(sum(fw_chunk_ids), 13)
+            self.assertEqual(sum(bw_chunk_ids), 19)
+
         if paddle.distributed.get_rank() == 1:
             self.assertEqual(
                 np.mean(out_manual.history["loss"][0]),
                 np.mean(out_auto.history["loss"][0]),
+            )
+            self.assertEqual(
+                np.mean(out_manual.history["loss"][0]),
+                np.mean(out_manual_overlap.history["loss"][0]),
+            )
+            self.assertEqual(
+                np.mean(out_manual.history["loss"][0]),
+                np.mean(out_auto_overlap.history["loss"][0]),
             )
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

为 VPP 编排添加 send_recv overlap, 经验，Llama2 下静态图模式打开 vpp 该 PR 不会更改模型精度
