### PR TITLE
[AutoParallel] Fix subtract magic method inplace convert

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -354,8 +354,8 @@ static PyObject* tensor__sub__method(TensorObject* self,
     auto& self_tensor_ref = self->tensor;
     auto& other_tensor_ref = CastPyArg2Tensor(other_obj, 0);
     const phi::distributed::ProcessMesh* mesh = nullptr;
-    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor_ref)) {
-      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor_ref);
+    if (InputsContainDistTensor(&mesh, self_tensor_ref, other_tensor_ref)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor_ref, other_tensor_ref);
     }
     self_tensor = self_tensor_ref;
     other_tensor = other_tensor_ref;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
PCard-73145
修复之前在修改魔术方法时，subtract失误没有inplace修改的问题