### PR TITLE
[clang-tidy] NO.35-37 enable `modernize-use-bool-literals`, `clang-analyzer-core.DivideZero`, `bugprone-integer-division`

### DIFF
--- a/paddle/fluid/distributed/test/graph_node_test.cc
+++ b/paddle/fluid/distributed/test/graph_node_test.cc
@@ -410,8 +410,8 @@ void RunBrpcPushSparse() {
   // testCache();
   setenv("http_proxy", "", 1);
   setenv("https_proxy", "", 1);
-  prepare_file(edge_file_name, 1);
-  prepare_file(node_file_name, 0);
+  prepare_file(edge_file_name, true);
+  prepare_file(node_file_name, false);
   // auto ph_host = paddle::distributed::PSHost(ip_, port_, 0);
   // host_sign_list_.push_back(ph_host.SerializeToString());
 
@@ -541,7 +541,7 @@ void RunBrpcPushSparse() {
   client1.load_node_file(std::string("user"), std::string(node_file_name));
   client1.load_node_file(std::string("item"), std::string(node_file_name));
   client1.load_edge_file(
-      std::string("user2item"), std::string(edge_file_name), 0);
+      std::string("user2item"), std::string(edge_file_name), false);
   nodes.clear();
   VLOG(0) << "start to pull graph list";
   nodes = client1.pull_graph_list(std::string("user"), 0, 1, 4, 1);

--- a/paddle/fluid/inference/utils/table_printer.cc
+++ b/paddle/fluid/inference/utils/table_printer.cc
@@ -78,7 +78,7 @@ TablePrinter::TablePrinter(const std::vector<std::string>& header) {
   }
 
   terminal_witdh = terminal_witdh - (2 * num_cols) - (num_cols + 1);
-  int avg_width = static_cast<int>(terminal_witdh / num_cols);
+  int avg_width = static_cast<int>(terminal_witdh / num_cols);  // NOLINT
 
   for (size_t i = 0; i < num_cols; ++i) {
     shares_.emplace_back(avg_width);

--- a/paddle/fluid/memory/allocation/allocator.h
+++ b/paddle/fluid/memory/allocation/allocator.h
@@ -202,7 +202,7 @@ class Allocator : public phi::Allocator {
 };
 
 inline size_t AlignedSize(size_t size, size_t alignment) {
-  auto remaining = size % alignment;
+  auto remaining = size % alignment;  // NOLINT
   return remaining == 0 ? size : size + alignment - remaining;
 }
 

--- a/paddle/phi/kernels/stride/view_kernel.cc
+++ b/paddle/phi/kernels/stride/view_kernel.cc
@@ -65,7 +65,7 @@ void ViewDtypeKernel(const Context& dev_ctx,
             input.dtype(),
             dtype,
             input.strides()[input.strides().size() - 1]));
-    size_t times = input_dtype_size / output_dtype_size;
+    size_t times = input_dtype_size / output_dtype_size;  // NOLINT
 
     DDim output_dims = input.dims();
     output_dims[output_dims.size() - 1] =

--- a/test/cpp/fluid/pscore/heter_cloud_comm_cpu_test.cc
+++ b/test/cpp/fluid/pscore/heter_cloud_comm_cpu_test.cc
@@ -56,7 +56,7 @@ void InitTensorsOnClient(framework::Scope* scope,
   auto ptr = w_value->mutable_data<float>(*place);
 
   for (int64_t i = 0; i < w_value->numel(); ++i) {
-    ptr[i] = static_cast<float>(i / 10);
+    ptr[i] = static_cast<float>(i) / 10.0;
   }
 
   auto x_var = scope->Var("x")->GetMutable<phi::DenseTensor>();

--- a/test/cpp/fluid/pscore/heter_server_test.cc
+++ b/test/cpp/fluid/pscore/heter_server_test.cc
@@ -149,7 +149,7 @@ void InitTensorsOnServer(framework::Scope* scope,
   auto ptr = w_value->mutable_data<float>(*place);
 
   for (int64_t i = 0; i < w_value->numel(); ++i) {
-    ptr[i] = static_cast<float>(i / 10);
+    ptr[i] = static_cast<float>(i) / 10.0;
   }
 }
 

--- a/test/cpp/fluid/pscore/send_and_recv_op_cpu_test.cc
+++ b/test/cpp/fluid/pscore/send_and_recv_op_cpu_test.cc
@@ -99,7 +99,7 @@ void InitTensorsOnServer(framework::Scope* scope,
   auto ptr = w_value->mutable_data<float>(*place);
 
   for (int64_t i = 0; i < w_value->numel(); ++i) {
-    ptr[i] = static_cast<float>(i / 10);
+    ptr[i] = static_cast<float>(i) / 10.0;
   }
 }
 

--- a/test/cpp/fluid/pscore/send_and_recv_op_gpu_test.cc
+++ b/test/cpp/fluid/pscore/send_and_recv_op_gpu_test.cc
@@ -149,7 +149,7 @@ void InitTensorsOnServer(framework::Scope* scope,
   auto ptr = w_value->mutable_data<float>(*place);
 
   for (int64_t i = 0; i < w_value->numel(); ++i) {
-    ptr[i] = static_cast<float>(i / 10);
+    ptr[i] = static_cast<float>(i) / 10.0;
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/54073
No35 modernize-use-bool-literals
No36 clang-analyzer-core.DivideZero
No37 bugprone-integer-division