### PR TITLE
[Util] Parse FLAGS_pd_unittest_use_cinn from python

### DIFF
--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import defaultdict
 
 import numpy as np
@@ -24,8 +25,6 @@ __WHILE_OP_NAME = "pd_op.while"
 
 
 def unittest_use_cinn():
-    import os
-
     use_cinn = os.getenv("FLAGS_pd_unittest_use_cinn", False)
     true_value_set = {True, 1, "True", "true"}
     false_value_set = {False, 0, "False", "false"}

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -26,7 +26,11 @@ __WHILE_OP_NAME = "pd_op.while"
 def unittest_use_cinn():
     import os
 
-    return os.getenv("FLAGS_pd_unittest_use_cinn", False)
+    use_cinn = os.getenv("FLAGS_pd_unittest_use_cinn", False)
+    true_value_set = {True, 1, "True", "true"}
+    false_value_set = {False, 0, "False", "false"}
+    assert use_cinn in (true_value_set | false_value_set)
+    return use_cinn in true_value_set
 
 
 def apply_to_static(net, use_cinn, input_spec=None):

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -26,8 +26,8 @@ __WHILE_OP_NAME = "pd_op.while"
 
 def unittest_use_cinn():
     use_cinn = os.getenv("FLAGS_pd_unittest_use_cinn", False)
-    true_value_set = {True, 1, "True", "true"}
-    false_value_set = {False, 0, "False", "false"}
+    true_value_set = {True, 1, "1", "True", "true"}
+    false_value_set = {False, 0, "0", "False", "false"}
     assert use_cinn in (true_value_set | false_value_set)
     return use_cinn in true_value_set
 

--- a/test/ir/pir/cinn/utils.py
+++ b/test/ir/pir/cinn/utils.py
@@ -23,6 +23,12 @@ __IF_OP_NAME = "pd_op.if"
 __WHILE_OP_NAME = "pd_op.while"
 
 
+def unittest_use_cinn():
+    import os
+
+    return os.getenv("FLAGS_pd_unittest_use_cinn", False)
+
+
 def apply_to_static(net, use_cinn, input_spec=None):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

提供工具函数 `unittest_use_cinn`，判断单测是否进入 cinn 的执行逻辑