### PR TITLE
Fix llm.int8 unit test

### DIFF
--- a/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
@@ -37,7 +37,6 @@ void WeightQuantizeKernel(const Context& dev_ctx,
 
   DenseTensor quanted_x;
   dev_ctx.template Alloc<int8_t>(out);
-  dev_ctx.template Alloc<T>(scale);
   size_t m = x.dims()[0];
   size_t n = x.dims()[1];
   quanted_x.Resize({static_cast<int64_t>(m), static_cast<int64_t>(n)});
@@ -51,6 +50,7 @@ void WeightQuantizeKernel(const Context& dev_ctx,
           "Currently, arch only support 70, 75, 80, 86."));
 
   if (algo == "llm.int8") {
+    dev_ctx.template Alloc<float>(scale);
     std::vector<int> axis = {1, 0};
     funcs::Transpose<Context, int8_t, 2> trans;
     weight_quant_gpu<T, Context>(dev_ctx,
@@ -60,6 +60,7 @@ void WeightQuantizeKernel(const Context& dev_ctx,
                                  weight_shape);
     trans(dev_ctx, quanted_x, out, axis);
   } else if (algo == "weight_only_int8") {
+    dev_ctx.template Alloc<T>(scale);
     weight_quant_gpu<T, Context>(dev_ctx,
                                  x.data<T>(),
                                  quanted_x.data<int8_t>(),

--- a/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_quantize_kernel.cu
@@ -56,7 +56,7 @@ void WeightQuantizeKernel(const Context& dev_ctx,
     weight_quant_gpu<T, Context>(dev_ctx,
                                  x.data<T>(),
                                  quanted_x.data<int8_t>(),
-                                 scale->data<T>(),
+                                 scale->data<float>(),
                                  weight_shape);
     trans(dev_ctx, quanted_x, out, axis);
   } else if (algo == "weight_only_int8") {

--- a/paddle/phi/kernels/impl/weight_quantize_kernel_impl.h
+++ b/paddle/phi/kernels/impl/weight_quantize_kernel_impl.h
@@ -56,8 +56,8 @@ void per_channel_scale(
   }
 }
 
-template <typename T>
-void group_wise_scale(T* scale,
+template <typename T, typename ScaleT>
+void group_wise_scale(ScaleT* scale,
                       const T* input,
                       size_t m,
                       size_t n,
@@ -72,7 +72,7 @@ void group_wise_scale(T* scale,
                   : max;
       }
       scale[static_cast<int>(j / group_size) * n + i] =
-          static_cast<T>(max / bound);
+          static_cast<ScaleT>(max / bound);
     }
   }
 }

--- a/paddle/phi/kernels/impl/weight_quantize_kernel_impl.h
+++ b/paddle/phi/kernels/impl/weight_quantize_kernel_impl.h
@@ -42,9 +42,9 @@ inline T xabs(const T x) {
   return x < static_cast<T>(0.0) ? -x : x;
 }
 
-template <typename T>
+template <typename T, typename ScaleT>
 void per_channel_scale(
-    T* scale, const T* input, size_t m, size_t n, float bound) {
+    ScaleT* scale, const T* input, size_t m, size_t n, float bound) {
   for (size_t i = 0; i < n; ++i) {
     float max = static_cast<float>(input[i]);
     for (size_t j = 0; j < m; ++j) {
@@ -52,7 +52,7 @@ void per_channel_scale(
                 ? static_cast<float>(xabs(input[j * n + i]))
                 : max;
     }
-    scale[i] = static_cast<T>(max / bound);
+    scale[i] = static_cast<ScaleT>(max / bound);
   }
 }
 
@@ -77,10 +77,10 @@ void group_wise_scale(T* scale,
   }
 }
 
-template <typename T, int quant_bit = 8>
+template <typename T, int quant_bit = 8, typename ScaleT>
 void per_channel_quant(int8_t* output,
                        const T* input,
-                       const T* scale,
+                       const ScaleT* scale,
                        size_t num_rows,
                        size_t num_cols) {
   size_t bytes_per_out_col = num_cols * quant_bit / 8;
@@ -123,10 +123,10 @@ void per_channel_quant(int8_t* output,
   }
 }
 
-template <typename T, int quant_bit = 8>
+template <typename T, int quant_bit = 8, typename ScaleT>
 void group_wise_quant(int8_t* output,
                       const T* input,
-                      const T* scale,
+                      const ScaleT* scale,
                       size_t num_rows,
                       size_t num_cols,
                       const int group_size) {

--- a/test/quantization/test_llm_int8_linear.py
+++ b/test/quantization/test_llm_int8_linear.py
@@ -88,9 +88,9 @@ class LLMInt8LinearTestCase(unittest.TestCase):
     @test_with_pir_api
     def get_llm_int8_linear_out_static(self):
         paddle.enable_static()
-        main = base.static.Program()
-        start = base.static.Program()
-        with base.static.program_guard(main, start):
+        main = paddle.static.Program()
+        start = paddle.static.Program()
+        with paddle.static.program_guard(main, start):
             x = paddle.static.data("x", self.x.shape, dtype=self.x.dtype)
 
             weight = paddle.static.data(

--- a/test/quantization/test_llm_int8_linear.py
+++ b/test/quantization/test_llm_int8_linear.py
@@ -24,9 +24,6 @@ from paddle.base import core
 from paddle.framework import set_default_dtype
 from paddle.pir_utils import test_with_pir_api
 
-np.random.seed(123)
-paddle.seed(42)
-
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
@@ -43,11 +40,13 @@ class LLMInt8LinearTestCase(unittest.TestCase):
         self.batch = 1
         self.token = 32
         self.in_features = 64
-        self.out_features = 256
+        self.out_features = 128
         self.threshold = 6.0
         self.static = False
 
     def setUp(self):
+        np.random.seed(123)
+        paddle.seed(42)
         self.config()
         x = np.random.random((self.batch, self.token, self.in_features))
         self.x = paddle.to_tensor(x, dtype=self.dtype)
@@ -64,49 +63,91 @@ class LLMInt8LinearTestCase(unittest.TestCase):
             self.in_features, self.out_features, bias_attr=bias_attr
         )
 
-        self.bias = self.linear.bias
         self.weight = self.linear.weight
         self.weight_scale = None
         self.weight, self.weight_scale = Q.weight_quantize(
             self.weight, algo="llm.int8"
         )
 
+    def dynamic_quant(self, x):
+        row_ranges = paddle.max(x, axis=[-1]).astype('float32')
+        row_ranges = row_ranges.unsqueeze(-1)
+        quant_x = paddle.round(
+            paddle.clip(
+                x.astype('float32') * 127.0 * (1 / row_ranges),
+                min=-127.0,
+                max=127.0,
+            )
+        ).astype('int8')
+        # import pdb;pdb.set_trace()
+        return quant_x, row_ranges
+
     def get_linear_out(self):
-        out = self.linear(self.x)
+        # out = self.linear(self.x)
+        outlier_cols = (
+            paddle.nonzero(paddle.max(self.x, axis=[0, 1]) > self.threshold)
+            .reshape([-1])
+            .numpy()
+            .tolist()
+        )
+
+        x_int8 = self.x
+        if len(outlier_cols) > 0:
+            x_fp = self.x[:, :, outlier_cols]
+            w_fp = self.linear.weight[outlier_cols]
+            res_fp = paddle.matmul(x_fp, w_fp)
+
+            x_int8[:, :, outlier_cols] = 0
+        x_int8, row_ranges = self.dynamic_quant(x_int8)
+
+        res_int8 = paddle.matmul(x_int8, self.weight.transpose((1, 0)))
+        dequant_scale = row_ranges * self.weight_scale / 127.0
+        res_dequant = (res_int8.astype('float32') * dequant_scale).astype(
+            self.dtype
+        )
+
+        if len(outlier_cols) > 0:
+            out = res_dequant + res_fp
+        else:
+            out = res_dequant
+
+        if self.bias:
+            out += self.bias
+
         return out.numpy()
 
     def get_llm_int8_linear_out(self):
         out = Q.llm_int8_linear(
             self.x,
             self.weight,
-            bias=self.bias,
+            bias=self.linear.bias,
             weight_scale=self.weight_scale,
             threshold=self.threshold,
         )
         return out.numpy()
 
     @test_with_pir_api
-    def get_llm_int8_linear_out_static(self):
+    def llm_int8_linear_out_static(self, out_expect):
         paddle.enable_static()
         main = paddle.static.Program()
         start = paddle.static.Program()
         with paddle.static.program_guard(main, start):
-            x = paddle.static.data("x", self.x.shape, dtype=self.x.dtype)
+            x = paddle.static.data("x", self.x.shape, dtype=self.dtype)
 
             weight = paddle.static.data(
-                "weight", self.weight.shape, dtype=self.weight.dtype
+                "weight", self.weight.shape, dtype='int8'
             )
             bias = paddle.static.data(
-                "bias", self.bias.shape, dtype=self.bias.dtype
+                "bias", self.linear.bias.shape, dtype=self.dtype
             )
             x_np = self.x.numpy()
             weight_np = self.weight.numpy()
-            bias_np = self.bias.numpy()
+            bias_np = self.linear.bias.numpy()
             if self.weight_scale is not None:
                 weight_scale = paddle.static.data(
                     "weight_scale",
                     self.weight_scale.shape,
-                    dtype=self.weight_scale.dtype,
+                    dtype='float32',
                 )
                 weight_scale_np = self.weight_scale.numpy()
             else:
@@ -128,20 +169,30 @@ class LLMInt8LinearTestCase(unittest.TestCase):
             }
             exe = base.Executor(paddle.CUDAPlace(0))
             exe.run(start)
-            (out,) = exe.run(main, feed=feed_dict, fetch_list=[out])
+            (out_real,) = exe.run(main, feed=feed_dict, fetch_list=[out])
+
         paddle.disable_static()
-        return out
+
+        if self.dtype == "bfloat16":
+            out_real = convert_uint16_to_float(out_real)
+            out_expect = convert_uint16_to_float(out_expect)
+
+        np.testing.assert_allclose(
+            out_real, out_expect, rtol=self.rtol, atol=self.atol
+        )
 
     def test_llm_int8_linear(self):
         out_expect = self.get_linear_out()
         if self.static:
-            out_real = self.get_llm_int8_linear_out_static()
+            self.llm_int8_linear_out_static(out_expect)
+            return
         else:
             out_real = self.get_llm_int8_linear_out()
 
         if self.dtype == "bfloat16":
             out_real = convert_uint16_to_float(out_real)
             out_expect = convert_uint16_to_float(out_expect)
+
         np.testing.assert_allclose(
             out_real, out_expect, rtol=self.rtol, atol=self.atol
         )
@@ -177,19 +228,6 @@ class LLMInt8LinearTestCase2(LLMInt8LinearTestCase):
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or get_cuda_version() < 11020
-    or paddle.device.cuda.get_device_capability()[0] < 8,
-    "quantized_matmul requires CUDA >= 11.2 and CUDA_ARCH >= 8",
-)
-class LLMInt8LinearTestCase3(LLMInt8LinearTestCase):
-    def config(self):
-        super().config()
-        self.dtype = 'bfloat16'
-        self.weight_dtype = "int8"
-
-
-@unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or get_cuda_version() < 11020
     or paddle.device.cuda.get_device_capability()[0] < 8
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
     "quantized_matmul requires CUDA >= 11.2 and CUDA_ARCH >= 8 or core is not support bfloat16",
@@ -212,20 +250,6 @@ class LLMInt8LinearTestCase5(LLMInt8LinearTestCase):
         super().config()
         self.dtype = 'float16'
         self.bias = False
-        self.weight_dtype = "int4"
-
-
-@unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or get_cuda_version() < 11020
-    or paddle.device.cuda.get_device_capability()[0] < 8
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
-    "quantized_matmul requires CUDA >= 11.2 and CUDA_ARCH >= 8 or core is not support bfloat16",
-)
-class LLMInt8LinearTestCase6(LLMInt8LinearTestCase):
-    def config(self):
-        super().config()
-        self.dtype = 'bfloat16'
         self.weight_dtype = "int4"
 
 
@@ -256,21 +280,6 @@ class LLMInt8LinearTestCase8(LLMInt8LinearTestCase):
         self.dtype = 'float16'
         self.weight_dtype = "int8"
         self.bias = False
-        self.batch = 1
-        self.token = 1
-
-
-@unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or get_cuda_version() < 11020
-    or paddle.device.cuda.get_device_capability()[0] < 8,
-    "quantized_matmul requires CUDA >= 11.2 and CUDA_ARCH >= 8",
-)
-class LLMInt8LinearTestCase9(LLMInt8LinearTestCase):
-    def config(self):
-        super().config()
-        self.dtype = 'bfloat16'
-        self.weight_dtype = "int8"
         self.batch = 1
         self.token = 1
 

--- a/test/quantization/test_llm_int8_linear.py
+++ b/test/quantization/test_llm_int8_linear.py
@@ -79,11 +79,9 @@ class LLMInt8LinearTestCase(unittest.TestCase):
                 max=127.0,
             )
         ).astype('int8')
-        # import pdb;pdb.set_trace()
         return quant_x, row_ranges
 
     def get_linear_out(self):
-        # out = self.linear(self.x)
         outlier_cols = (
             paddle.nonzero(paddle.max(self.x, axis=[0, 1]) > self.threshold)
             .reshape([-1])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
**Background:**
test_llm_int8_linear.py failed

**Reason:**
weight_quantize op has been modified to only support scale dtype which is the same as input data, while llm.int8 op is not supported.


**Solution:**
Adapt weight_quantize op to satisfy llm.int8
Pcard-71502