### PR TITLE
[PIR] fix_test_conv_pir

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1776,8 +1776,7 @@ def cov(x, rowvar=True, ddof=True, fweights=None, aweights=None, name=None):
         norm_factor = w_sum - (w * aweights).sum() / w_sum
     else:
         norm_factor = w_sum - ddof
-    if norm_factor <= 0:
-        norm_factor = paddle.to_tensor(0, dtype=nx.dtype)
+    norm_factor = paddle.clip(norm_factor, min=0)
     nx = nx - avg.unsqueeze(1)
     xxt = paddle.mm(nx, nx_w.t().conj())
     cov = paddle.divide(xxt, norm_factor).squeeze()

--- a/test/legacy_test/test_zero_dim_tensor.py
+++ b/test/legacy_test/test_zero_dim_tensor.py
@@ -5275,28 +5275,29 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[2].shape, (4, 5))
         self.assertEqual(res[3].shape, (5,))
 
+    @test_with_pir_api
     @prog_scope()
     def test_cov(self):
         xt_1 = paddle.randn((12,))
         xt_1.stop_gradient = False
-
         out = paddle.linalg.cov(xt_1)
-        paddle.static.append_backward(out)
-
+        _, xt_1_grad = paddle.static.append_backward(
+            out, parameter_list=[xt_1]
+        )[0]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out, xt_1.grad_name])
+        res = self.exe.run(prog, fetch_list=[out, xt_1_grad])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, (12,))
 
+    @test_with_pir_api
     @prog_scope()
     def test_corrcoef(self):
         x = paddle.randn((12,))
         x.stop_gradient = False
         out = paddle.linalg.corrcoef(x)
-        paddle.static.append_backward(out)
-
+        _, x_grad = paddle.static.append_backward(out, parameter_list=[x])[0]
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out, x.grad_name])
+        res = self.exe.run(prog, fetch_list=[out, x_grad])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, (12,))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->

修复 
- https://github.com/PaddlePaddle/Paddle/pull/61577
中合并 develop 分支的新问题

```
2024-02-04 19:16:37   File "/home/Paddle/build/test/legacy_test/decorator_helper.py", line 39, in __fn__
2024-02-04 19:16:37     fn(*args, **kwargs)
2024-02-04 19:16:37   File "/home/Paddle/build/test/legacy_test/test_zero_dim_tensor.py", line 5572, in test_corrcoef
2024-02-04 19:16:37     out = paddle.linalg.corrcoef(x)
2024-02-04 19:16:37   File "/home/Paddle/build/python/paddle/tensor/linalg.py", line 4084, in corrcoef
2024-02-04 19:16:37     c = cov(x, rowvar)
2024-02-04 19:16:37   File "/home/Paddle/build/python/paddle/tensor/linalg.py", line 1779, in cov
2024-02-04 19:16:37     if norm_factor <= 0:
2024-02-04 19:16:37   File "/home/Paddle/build/python/paddle/pir/math_op_patch.py", line 474, in _bool_
2024-02-04 19:16:37     raise TypeError(
2024-02-04 19:16:37 TypeError: bool(Value) is not supported in static graph mode. If you are using @to_static, you can try this:
2024-02-04 19:16:37 1. If you want to get the value of Value, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).
2024-02-04 19:16:37 2. If you want to run it in full graph mode, you need use Value.astype(paddle.bool), and do not use bool(Value).
2024-02-04 19:16:37 ======================================================================
2024-02-04 19:16:37 ERROR: test_cov (test_zero_dim_tensor.TestSundryAPIStatic)
2024-02-04 19:16:37 ----------------------------------------------------------------------
2024-02-04 19:16:37 Traceback (most recent call last):
2024-02-04 19:16:37   File "/home/Paddle/build/python/paddle/pir_utils.py", line 115, in impl
2024-02-04 19:16:37     func(*args, **kwargs)
2024-02-04 19:16:37   File "/home/Paddle/build/test/legacy_test/decorator_helper.py", line 39, in __fn__
2024-02-04 19:16:37     fn(*args, **kwargs)
2024-02-04 19:16:37   File "/home/Paddle/build/test/legacy_test/test_zero_dim_tensor.py", line 5557, in test_cov
2024-02-04 19:16:37     out = paddle.linalg.cov(xt_1)
2024-02-04 19:16:37   File "/home/Paddle/build/python/paddle/tensor/linalg.py", line 1779, in cov
2024-02-04 19:16:37     if norm_factor <= 0:
2024-02-04 19:16:37   File "/home/Paddle/build/python/paddle/pir/math_op_patch.py", line 474, in _bool_
2024-02-04 19:16:37     raise TypeError(
2024-02-04 19:16:37 TypeError: bool(Value) is not supported in static graph mode. If you are using @to_static, you can try this:
2024-02-04 19:16:37 1. If you want to get the value of Value, you can switch to non-fullgraph mode by setting @to_static(full_graph=True).
2024-02-04 19:16:37 2. If you want to run it in full graph mode, you need use Value.astype(paddle.bool), and do not use bool(Value).
2024-02-04 19:16:37 ----------------------------------------------------------------------
```