### PR TITLE
[Prim][PIR] add test case for rms_norm prim cinn  static shape

### DIFF
--- a/test/prim/pir_prim/CMakeLists.txt
+++ b/test/prim/pir_prim/CMakeLists.txt
@@ -21,22 +21,24 @@ foreach(target ${TEST_PRIM_PURE_PIR_CASES})
     FLAGS_prim_enable_dynamic=true)
 endforeach()
 
-set(TEST_PRIM_PURE_PIR_DY_SHAPE_CASES test_prim_jit_dynamic)
+set(TEST_PRIM_PURE_PIR_DY_SHAPE_CASES test_prim_jit_dynamic
+                                      test_prim_rms_norm_st_shape)
 
-foreach(target ${TEST_PRIM_PURE_PIR_DY_SHAPE_CASES})
-  py_test_modules(
-    ${target}
-    MODULES
-    ${target}
-    ENVS
-    GLOG_v=1
-    FLAGS_enable_pir_api=true
-    FLAGS_prim_enable_dynamic=true
-    FLAGS_cinn_bucket_compile=True
-    FLAGS_pir_apply_shape_optimization_pass=1)
-endforeach()
-
-set_tests_properties(test_prim_jit_dynamic PROPERTIES LABELS "RUN_TYPE=CINN")
+if(WITH_CINN)
+  foreach(target ${TEST_PRIM_PURE_PIR_CINN})
+    py_test_modules(
+      ${target}
+      MODULES
+      ${target}
+      ENVS
+      GLOG_v=1
+      FLAGS_enable_pir_api=true
+      FLAGS_prim_enable_dynamic=true
+      FLAGS_cinn_bucket_compile=True
+      FLAGS_pir_apply_shape_optimization_pass=1)
+  endforeach()
+  set_tests_properties(${target} PROPERTIES LABELS "RUN_TYPE=CINN")
+endif()
 
 set(TEST_PRIM_TRANS_PIR_CASES test_custom_vjp_trait test_decomp_op
                               test_decompose_op test_vjp_prim)

--- a/test/prim/pir_prim/CMakeLists.txt
+++ b/test/prim/pir_prim/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_PRIM_PURE_PIR_CASES
     test_sink_decomp
     test_prim_skip_dynamic
     test_prim_dynamic
+    test_prim_jit_dynamic
     test_prim_sub_graph_dynamic_shape
     test_decompose_control_flow)
 
@@ -21,8 +22,7 @@ foreach(target ${TEST_PRIM_PURE_PIR_CASES})
     FLAGS_prim_enable_dynamic=true)
 endforeach()
 
-set(TEST_PRIM_PURE_PIR_DY_SHAPE_CASES test_prim_jit_dynamic
-                                      test_prim_rms_norm_st_shape)
+set(TEST_PRIM_PURE_PIR_CINN test_prim_rms_norm_st_shape)
 
 if(WITH_CINN)
   foreach(target ${TEST_PRIM_PURE_PIR_CINN})
@@ -36,8 +36,8 @@ if(WITH_CINN)
       FLAGS_prim_enable_dynamic=true
       FLAGS_cinn_bucket_compile=True
       FLAGS_pir_apply_shape_optimization_pass=1)
+    set_tests_properties(${target} PROPERTIES LABELS "RUN_TYPE=CINN")
   endforeach()
-  set_tests_properties(${target} PROPERTIES LABELS "RUN_TYPE=CINN")
 endif()
 
 set(TEST_PRIM_TRANS_PIR_CASES test_custom_vjp_trait test_decomp_op

--- a/test/prim/pir_prim/test_prim_rms_norm_st_shape.py
+++ b/test/prim/pir_prim/test_prim_rms_norm_st_shape.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.framework import core
+from paddle.static import InputSpec
+
+
+def apply_to_static(net, use_cinn, input_spec=None):
+    build_strategy = paddle.static.BuildStrategy()
+    build_strategy.build_cinn_pass = use_cinn
+    return paddle.jit.to_static(
+        net,
+        input_spec=input_spec,
+        build_strategy=build_strategy,
+        full_graph=True,
+    )
+
+
+def rms_norm1(hidden_states, weight):
+    # From llama2, reduce dim is not equal to dynamic shape dim
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = paddle.rsqrt(variance + 1e-5) * hidden_states
+    return hidden_states * weight
+
+
+def rms_norm2(hidden_states, weight):
+    # reduce dim is not equal to dynamic shape dim
+    variance = hidden_states.pow(2).mean((0, 1), keepdim=True)
+    hidden_states = paddle.rsqrt(variance + 1e-5) * hidden_states
+    return hidden_states * weight
+
+
+class TestPrimMode1(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.shape_x = [1, 300, 4096]
+        self.shape_y = [4096]
+        self.x = np.random.random(self.shape_x).astype("float32")
+        self.y = np.random.random(self.shape_y).astype("float32")
+        self.net = rms_norm1
+        self.enable_cinn = True
+
+    def base_net(self, flag=None):
+        x = paddle.to_tensor(self.x)
+        y = paddle.to_tensor(self.y)
+        if flag == "prim":
+            core._set_prim_all_enabled(True)
+            fn = apply_to_static(
+                self.net,
+                use_cinn=self.enable_cinn,
+                input_spec=[
+                    InputSpec(shape=[1, 300, 4096], dtype='float32'),
+                    InputSpec(shape=[4096], dtype='float32'),
+                ],
+            )
+            fn.eval()
+        else:
+            fn = self.net
+        res = fn(x, y)
+
+        if flag == "prim":
+            ops = [
+                op.name()
+                for op in fn.program_cache.last()[-1][-1]
+                .infer_program.program.global_block()
+                .ops
+            ]
+            assert "pd_op.mean" not in ops
+            core._set_prim_all_enabled(False)
+        return res
+
+    def test_prim_all_dynamic(self):
+        res_ref = self.base_net()
+        res = self.base_net("prim")
+        for ref, actual in zip(res_ref, res):
+            np.testing.assert_allclose(ref, actual, rtol=1e-6)
+
+
+class TestPrimMode2(TestPrimMode1):
+    def setUp(self):
+        np.random.seed(2023)
+        self.shape_x = [1, 300, 4096]
+        self.shape_y = [4096]
+        self.x = np.random.random(self.shape_x).astype("float32")
+        self.y = np.random.random(self.shape_y).astype("float32")
+        self.net = rms_norm2
+        self.enable_cinn = True
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-66975
add test case for rms_norm prim cinn  static shape.
Relative PR: https://github.com/PaddlePaddle/Paddle/pull/61576
```
静态shape：
cd Paddle/test/prim/pir_prim/
FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true GLOG_vmodule=decomp_trans=4 FLAGS_enable_pir_api=true FLAGS_pir_apply_shape_optimization_pass=1 python test_prim_rms_norm_st_shape.py
I0204 03:47:13.374720 31673 decomp_trans.cc:336] [Prim] New program after decomp :
{
    (%0) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"hidden_states",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1,300,4096],stop_gradient:[true]} : () -> pd_op.tensor<1x300x4096xf32>
    (%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"weight",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[4096],stop_gradient:[true]} : () -> pd_op.tensor<4096xf32>
    (%2) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<f32>
    (%3) = "pd_op.elementwise_pow" (%0, %2) {stop_gradient:[true]} : (pd_op.tensor<1x300x4096xf32>, pd_op.tensor<f32>) -> pd_op.tensor<1x300x4096xf32>
    (%4) = "pd_op.full_int_array" () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)2]} : () -> pd_op.tensor<1xi64>
    (%5) = "pd_op.sum" (%3, %4) {dtype:(pd_op.DataType)float32,keepdim:true,stop_gradient:[true]} : (pd_op.tensor<1x300x4096xf32>, pd_op.tensor<1xi64>) -> pd_op.tensor<1x300x1xf32>
    (%6) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[],stop_gradient:[true],value:(Float)4096} : () -> pd_op.tensor<f32>
    (%7) = "pd_op.divide" (%5, %6) {stop_gradient:[true]} : (pd_op.tensor<1x300x1xf32>, pd_op.tensor<f32>) -> pd_op.tensor<1x300x1xf32>
    (%8) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)1} : () -> pd_op.tensor<1xf32>
    (%9) = "pd_op.scale" (%7, %8) {bias:(Float)1e-05,bias_after_scale:true,stop_gradient:[true]} : (pd_op.tensor<1x300x1xf32>, pd_op.tensor<1xf32>) -> pd_op.tensor<1x300x1xf32>
    (%10) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[],stop_gradient:[true],value:(Float)-0.5} : () -> pd_op.tensor<f32>
    (%11) = "pd_op.elementwise_pow" (%9, %10) {stop_gradient:[true]} : (pd_op.tensor<1x300x1xf32>, pd_op.tensor<f32>) -> pd_op.tensor<1x300x1xf32>
    (%12) = "pd_op.multiply" (%11, %0) {stop_gradient:[true]} : (pd_op.tensor<1x300x1xf32>, pd_op.tensor<1x300x4096xf32>) -> pd_op.tensor<1x300x4096xf32>
    (%13) = "pd_op.multiply" (%12, %1) {stop_gradient:[true]} : (pd_op.tensor<1x300x4096xf32>, pd_op.tensor<4096xf32>) -> pd_op.tensor<1x300x4096xf32>
    () = "builtin.shadow_output" (%13) {output_name:"output_0"} : (pd_op.tensor<1x300x4096xf32>) -> 
}
W0204 03:47:15.031559 31673 lower_cinn_fusion_op_pass.cc:671] No shape_data for cinn_op.fusion_result_0
W0204 03:47:15.032336 31673 tensor.cc:399] The `is_initialized` method is deprecated since version 2.3, and will be removed in version 2.4! Please use `initialized` method instead.
I0204 03:47:15.032944 31673 pir_interpreter.cc:1395] New Executor is Running ...
I0204 03:47:15.033299 31673 pir_interpreter.cc:1419] pir interpreter is running by trace mode ...
F0204 03:47:15.033398 31673 cuda_util.cc:130] CUDA Driver Error: cuLaunchKernel(static_cast<CUfunction>(kernel_fn), grid_x, grid_y, grid_z, block_x, block_y, block_z, 0, static_cast<CUstream>(stream), kernel_args.data(), nullptr) failed with error: invalid argument
*** Check failure stack trace: ***
    @     0x7f60311bb92d  google::LogMessage::Fail()
    @     0x7f60311bdbdd  google::LogMessage::SendToLog()
    @     0x7f60311bb41d  google::LogMessage::Flush()
    @     0x7f60311be6d9  google::LogMessageFatal::~LogMessageFatal()
    @     0x7f609bbbaa21  cinn::runtime::cuda::cinn_call_cuda_kernel()
    @     0x7f609a91e86e  (unknown)
    @     0x7f60312c70b8  paddle::framework::CinnJitInstruction::Run()
    @     0x7f6031284b5d  paddle::framework::PirInterpreter::RunInstructionBase()
    @     0x7f6031285bb9  paddle::framework::PirInterpreter::TraceRunInstructionList()
    @     0x7f60312862d2  paddle::framework::PirInterpreter::TraceRunImpl()
    @     0x7f6031294e4b  paddle::framework::PirInterpreter::Run()
    @     0x7f603125f488  paddle::framework::InterpreterCore::Run()
    @     0x7f6030cc7453  PirRunProgramAPI()
    @     0x7f6030cc8a8f  pir_run_program_ad_func()
    @     0x7f6030cca0d1  paddle::pybind::pir_eager_api_run_program()
    @     0x5625d26207ae  cfunction_call_varargs
    @     0x5625d26bf6a6  _PyEval_EvalFrameDefault
    @     0x5625d26b13d7  _PyFunction_Vectorcall
    @     0x5625d264270f  _PyObject_FastCallDict
    @     0x5625d2678bbb  slot_tp_call
    @     0x5625d261525f  _PyObject_MakeTpCall
    @     0x5625d26be940  _PyEval_EvalFrameDefault
    @     0x5625d26b01f0  _PyEval_EvalCodeWithName
    @     0x5625d26b17b4  _PyFunction_Vectorcall
    @     0x5625d264aca8  method_vectorcall
    @     0x5625d261b57d  PyObject_Call
    @     0x5625d26bb823  _PyEval_EvalFrameDefault
    @     0x5625d26b01f0  _PyEval_EvalCodeWithName
    @     0x5625d26b17b4  _PyFunction_Vectorcall
    @     0x5625d264270f  _PyObject_FastCallDict
    @     0x5625d2678bbb  slot_tp_call
    @     0x5625d261525f  _PyObject_MakeTpCall

``` 
``` 
