### PR TITLE
[CustomDevice] remove restrain of device of group_sharded_parallel api

### DIFF
--- a/python/paddle/distributed/sharding/group_sharded.py
+++ b/python/paddle/distributed/sharding/group_sharded.py
@@ -110,7 +110,8 @@ def group_sharded_parallel(
     assert device in [
         "gpu",
         "xpu",
-    ], "group_sharded_parallel only support gpu and xpu now"
+        paddle.device.get_all_custom_device_type(),
+    ], "group_sharded_parallel only support gpu, xpu and custom_device now"
     # check optition type
     assert isinstance(
         model, paddle.nn.Layer

--- a/python/paddle/distributed/sharding/group_sharded.py
+++ b/python/paddle/distributed/sharding/group_sharded.py
@@ -107,11 +107,14 @@ def group_sharded_parallel(
     """
 
     device = paddle.get_device().split(":")[0]
-    assert device in [
-        "gpu",
-        "xpu",
-        paddle.device.get_all_custom_device_type(),
-    ], "group_sharded_parallel only support gpu, xpu and custom_device now"
+    assert (
+        device
+        in [
+            "gpu",
+            "xpu",
+        ]
+        or device in paddle.device.get_all_custom_device_type()
+    ), "group_sharded_parallel only support gpu, xpu and custom_device now"
     # check optition type
     assert isinstance(
         model, paddle.nn.Layer


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
由于CustomDevice已经支持sharding stage2/stage3，解除group_sharded_parallel接口对CustomDevice的限制