### PR TITLE
Refine print log for symbolic shape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -173,12 +173,14 @@ void IfOp::Print(pir::IrPrinter &printer) {
   printer.AddIndentation();
   for (auto &item : true_block()) {
     printer.PrintOperation(&item);
+    os << "\n";
   }
   printer.DecreaseIndentation();
   os << printer.indentation() << "} else {\n";
   printer.AddIndentation();
   for (auto &item : false_block()) {
     printer.PrintOperation(&item);
+    os << "\n";
   }
   printer.DecreaseIndentation();
   os << printer.indentation() << "}";
@@ -371,6 +373,7 @@ void WhileOp::Print(pir::IrPrinter &printer) {
   printer.AddIndentation();
   for (auto &item : body()) {
     printer.PrintOperation(&item);
+    os << "\n";
   }
   printer.DecreaseIndentation();
   os << printer.indentation() << "}";

--- a/paddle/fluid/pir/transforms/shape_optimization_pass.cc
+++ b/paddle/fluid/pir/transforms/shape_optimization_pass.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/fluid/pir/transforms/shape_optimization_pass.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/core/dialect.h"
 #include "paddle/pir/dialect/shape/ir/shape_attribute.h"
 #include "paddle/pir/pass/pass_manager.h"
 #include "paddle/pir/pass/pass_registry.h"
@@ -25,12 +26,10 @@ using PassPipelineRunner =
     std::function<bool(pir::PassManager&, pir::ModuleOp)>;
 
 void PrintProgram(pir::ModuleOp m, std::string mgs) {
-  std::ostringstream print_stream;
-  print_stream << "\n\n";
-  m.program()->Print(print_stream);
-  print_stream << "\n\n";
+  ShapeConstraintIRAnalysis& shape_analysis =
+      ShapeAnalysisManager::Instance().Get(m.program());
   VLOG(3) << "===================== " << mgs << " =====================\n"
-          << print_stream.str();
+          << pir::CustomPrintHelper(*m.program(), shape_analysis.PrintHook());
 }
 
 void DebugPrintOpInfo(

--- a/paddle/pir/core/ir_printer.cc
+++ b/paddle/pir/core/ir_printer.cc
@@ -168,14 +168,11 @@ void IrPrinter::PrintOperation(Operation* op) {
   if (auto* dialect = op->dialect()) {
     if (auto print_fn = dialect->PrintOperation(op)) {
       print_fn(op, *this);
-      os << newline;
       return;
     }
   }
 
   PrintGeneralOperation(op);
-
-  os << newline;
 }
 
 void IrPrinter::PrintOperationWithNoRegion(Operation* op) {
@@ -221,6 +218,7 @@ void IrPrinter::PrintBlock(const Block& block) {
   AddIndentation();
   for (auto& item : block) {
     PrintOperation(&item);
+    os << "\n";
   }
   DecreaseIndentation();
   os << indentation() << "}\n";

--- a/paddle/pir/dialect/shape/ir/shape_dialect.cc
+++ b/paddle/pir/dialect/shape/ir/shape_dialect.cc
@@ -29,33 +29,7 @@ void ShapeDialect::initialize() {
 }
 
 void ShapeDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
-  if (attr.isa<SymbolAttribute>()) {
-    SymbolAttribute symbol_attr = attr.dyn_cast<SymbolAttribute>();
-    if (symbol_attr.data().isa<symbol::TensorListShapeOrDataDimExprs>()) return;
-    os << "(shape_data)";
-    os << "[";
-    for (size_t i = 0; i < symbol_attr.data().shape().size(); ++i) {
-      if (i != symbol_attr.data().shape().size() - 1) {
-        os << symbol::ToString(symbol_attr.data().shape()[i]) << ",";
-      } else {
-        os << symbol::ToString(symbol_attr.data().shape()[i]);
-      }
-    }
-    os << "]_[";
-    if (symbol_attr.data().data().has_value()) {
-      for (size_t i = 0; i < symbol_attr.data().data().value().size(); ++i) {
-        if (i != symbol_attr.data().data().value().size() - 1) {
-          os << symbol::ToString(symbol_attr.data().data().value()[i]) << ",";
-        } else {
-          os << symbol::ToString(symbol_attr.data().data().value()[i]);
-        }
-      }
-    } else {
-      os << "nullopt";
-    }
-
-    os << "]";
-  }
+  return;
 }
 
 }  // namespace pir::shape

--- a/paddle/pir/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/dialect/shape/utils/shape_analysis.cc
@@ -213,7 +213,7 @@ pir::PrintHooks ShapeConstraintIRAnalysis::PrintHook() const {
   print_hook.op_print_hook = [&](Operation* op, IrPrinter& printer) {
     printer.IrPrinter::PrintOperation(op);
     printer.os << " { ";
-    for (int i = 0; i < op->num_results(); ++i) {
+    for (uint32_t i = 0; i < op->num_results(); ++i) {
       if (this->HasShapeOrDataForValue(op->result(i))) {
         printer.os << "(" << this->GetShapeOrDataForValue(op->result(i)) << ")";
       } else {

--- a/paddle/pir/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/dialect/shape/utils/shape_analysis.cc
@@ -28,14 +28,6 @@ static std::string GetValueId(Value val) {
 
 ShapeConstraintIRAnalysis::ShapeConstraintIRAnalysis(ModuleOp m) : m_(m) {}
 
-ShapeConstraintIRAnalysis::ShapeConstraintIRAnalysis(
-    std::shared_ptr<pir::Program>&& program)
-    : ShapeConstraintIRAnalysis(program->module_op()) {
-  program_ = std::move(program);
-}
-ShapeConstraintIRAnalysis::ShapeConstraintIRAnalysis(pir::IrContext* ctx)
-    : ShapeConstraintIRAnalysis(std::make_shared<pir::Program>(ctx)) {}
-
 void ShapeConstraintIRAnalysis::Init() {
   value_to_shape_or_data_.clear();
   next_sym_idx_ = 0;
@@ -214,6 +206,26 @@ bool ShapeConstraintIRAnalysis::IsSameNumel(Value lhs, Value rhs) const {
                         rhs,
                         0,
                         static_cast<int>(rhs_type.GetRank()));
+}
+
+pir::PrintHooks ShapeConstraintIRAnalysis::PrintHook() const {
+  pir::PrintHooks print_hook;
+  print_hook.op_print_hook = [&](Operation* op, IrPrinter& printer) {
+    printer.IrPrinter::PrintOperation(op);
+    printer.os << " { ";
+    for (int i = 0; i < op->num_results(); ++i) {
+      if (this->HasShapeOrDataForValue(op->result(i))) {
+        printer.os << "(" << this->GetShapeOrDataForValue(op->result(i)) << ")";
+      } else {
+        printer.os << "()";
+      }
+      if (i < op->num_results() - 1) {
+        printer.os << ", ";
+      }
+    }
+    printer.os << " }";
+  };
+  return print_hook;
 }
 
 ShapeAnalysisManager& ShapeAnalysisManager::Instance() {

--- a/paddle/pir/dialect/shape/utils/shape_analysis.h
+++ b/paddle/pir/dialect/shape/utils/shape_analysis.h
@@ -30,10 +30,6 @@ class IR_API ShapeConstraintIRAnalysis {
  public:
   explicit ShapeConstraintIRAnalysis(ModuleOp m);
 
-  explicit ShapeConstraintIRAnalysis(std::shared_ptr<pir::Program>&& program);
-
-  explicit ShapeConstraintIRAnalysis(pir::IrContext* ctx);
-
   void Init();
 
   const std::string GetNextSymName();
@@ -77,9 +73,10 @@ class IR_API ShapeConstraintIRAnalysis {
   // Returns true if the two value have the same number elements.
   bool IsSameNumel(Value lhs, Value rhs) const;
 
+  pir::PrintHooks PrintHook() const;
+
  private:
   ModuleOp m_;
-  std::shared_ptr<pir::Program> program_;
 
   int64_t next_sym_idx_ = 0;
 

--- a/test/cpp/pir/cinn/adt/map_expr_test.cc
+++ b/test/cpp/pir/cinn/adt/map_expr_test.cc
@@ -73,7 +73,6 @@ TEST(MapExpr, ElementWise_Fusion_0) {
       value1, builder.Build<paddle::dialect::ExpOp>(value2).result(0));
 
   ::pir::PassManager pass_manager(ctx);
-  auto shape_analysis = std::make_shared<pir::ShapeConstraintIRAnalysis>(ctx);
 
   // TODO(@jiahy0825): use CreateShapeOptimizationPass() instead of
   // CreateInferSymbolicShapePass() which is a fake pass

--- a/test/cpp/pir/core/add_dialect_parser_test.cc
+++ b/test/cpp/pir/core/add_dialect_parser_test.cc
@@ -102,7 +102,7 @@ TEST(IrParserTest, AddAttribute) {
   std::string op_str =
       "(%0) = \"builtin.parameter\" () "
       "{parameter_name:\"conv2d_0.w_0\",test:(tp.char)a} : () -> "
-      "pd_op.tensor<64x3x7x7xf32>\n";
+      "pd_op.tensor<64x3x7x7xf32>";
   std::stringstream ss;
   ss << op_str;
   pir::IrParser* parser = new pir::IrParser(ctx, ss);

--- a/test/cpp/pir/core/ir_op_test.cc
+++ b/test/cpp/pir/core/ir_op_test.cc
@@ -64,7 +64,7 @@ TEST(op_test, region_test) {
   // (3) Test custom operation printer
   std::stringstream ss;
   op1->Print(ss);
-  EXPECT_EQ(ss.str(), "(%0) = \"test.operation1\" ()\n");
+  EXPECT_EQ(ss.str(), "(%0) = \"test.operation1\" ()");
 
   region.push_back(new pir::Block());
   region.push_front(new pir::Block());

--- a/test/cpp/pir/core/ir_printer_test.cc
+++ b/test/cpp/pir/core/ir_printer_test.cc
@@ -61,7 +61,6 @@ TEST(printer_test, custom_hooks) {
     printer.PrintAttributeMap(op);
     printer.os << " :";
     printer.PrintOpReturnType(op);
-    printer.os << "\n";
   };
 
   hooks.attribute_print_hook = [](pir::Attribute attr,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-73448

引入`PrintHook`优化Program中符号维度的信息打印。打印效果如下：
<img width="1373" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/13048366/438c3d2c-f5af-4f7c-af79-80c48ca0fec5">


优化前：
```
(%0) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"x",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1,128],stop_gradient:[false],sym_shape_str:"shape[S0, 128], data[NULL]",symbolic_shape:(shape_data)[S0,128]_[nullopt]} : () -> pd_op.tensor<-1x128xf32>
(%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"y",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1,128],stop_gradient:[false],sym_shape_str:"shape[S1, 128], data[NULL]",symbolic_shape:(shape_data)[S1,128]_[nullopt]} : () -> pd_op.tensor<-1x128xf32>
(%2) = "pd_op.exp" (%0) {stop_gradient:[false],sym_shape_str:"shape[S0, 128], data[NULL]",symbolic_shape:(shape_data)[S0,128]_[nullopt]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<-1x128xf32>
(%3) = "pd_op.shape" (%2) {stop_gradient:[false],sym_shape_str:"shape[2], data[S0, 128]",symbolic_shape:(shape_data)[2]_[S0,128]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32>
(%4) = "pd_op.shape" (%1) {stop_gradient:[false],sym_shape_str:"shape[2], data[S1, 128]",symbolic_shape:(shape_data)[2]_[S1,128]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32>
(%5) = "pd_op.shape_broadcast" (%3, %4) {stop_gradient:[false],sym_shape_str:"shape[2], data[Broadcast(S1, S0), 128]"} : (pd_op.tensor<2xi32>, pd_op.tensor<2xi32>) -> pd_op.tensor<2xi32>
(%6) = "pd_op.expand" (%1, %5) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S1, S0), 128], data[NULL]"} : (pd_op.tensor<-1x128xf32>, pd_op.tensor<2xi32>) -> pd_op.tensor<-1x-1xf32>
(%7) = "pd_op.shape" (%2) {stop_gradient:[false],sym_shape_str:"shape[2], data[S0, 128]",symbolic_shape:(shape_data)[2]_[S0,128]} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32>
(%8) = "pd_op.shape" (%6) {stop_gradient:[false],sym_shape_str:"shape[2], data[Broadcast(S1, S0), 128]",symbolic_shape:(shape_data)[2]_[Broadcast(S1, S0),128]} : (pd_op.tensor<-1x-1xf32>) -> pd_op.tensor<2xi32>
(%9) = "pd_op.shape_broadcast" (%7, %8) {stop_gradient:[false],sym_shape_str:"shape[2], data[Broadcast(Broadcast(S1, S0), S0), 128]"} : (pd_op.tensor<2xi32>, pd_op.tensor<2xi32>) -> pd_op.tensor<2xi32>
(%10) = "pd_op.subtract" (%2, %6) {stop_gradient:[false],sym_shape_str:"shape[S0, 128], data[NULL]",symbolic_shape:(shape_data)[S0,128]_[nullopt]} : (pd_op.tensor<-1x128xf32>, pd_op.tensor<-1x-1xf32>) -> pd_op.tensor<-1x128xf32>
() = "builtin.shadow_output" (%10) {output_name:"output_0",sym_shape_str:"shape[S0, 128], data[NULL]"} : (pd_op.tensor<-1x128xf32>) -> 
```

优化后：(移除了`symbolic_shape`在op属性上的打印信息，并将该信息放置在 output value 对应位置)
```
(%0) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"x",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1,128],stop_gradient:[false],sym_shape_str:"shape[S0, 128], data[NULL]",symbolic_shape:} : () -> pd_op.tensor<-1x128xf32> { (shape[S0, 128], data[NULL]) }
(%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"y",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[-1,128],stop_gradient:[false],sym_shape_str:"shape[S1, 128], data[NULL]",symbolic_shape:} : () -> pd_op.tensor<-1x128xf32> { (shape[S1, 128], data[NULL]) }
(%2) = "pd_op.exp" (%0) {stop_gradient:[false],sym_shape_str:"shape[S0, 128], data[NULL]",symbolic_shape:} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<-1x128xf32> { (shape[S0, 128], data[NULL]) }
(%3) = "pd_op.shape" (%2) {stop_gradient:[false],sym_shape_str:"shape[2], data[S0, 128]",symbolic_shape:} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32> { (shape[2], data[S0, 128]) }
(%4) = "pd_op.shape" (%1) {stop_gradient:[false],sym_shape_str:"shape[2], data[S1, 128]",symbolic_shape:} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32> { (shape[2], data[S1, 128]) }
(%5) = "pd_op.shape_broadcast" (%3, %4) {stop_gradient:[false],sym_shape_str:"shape[2], data[Broadcast(S1, S0), 128]"} : (pd_op.tensor<2xi32>, pd_op.tensor<2xi32>) -> pd_op.tensor<2xi32> { (shape[2], data[Broadcast(S1, S0), 128]) }
(%6) = "pd_op.expand" (%1, %5) {stop_gradient:[false],sym_shape_str:"shape[Broadcast(S1, S0), 128], data[NULL]"} : (pd_op.tensor<-1x128xf32>, pd_op.tensor<2xi32>) -> pd_op.tensor<-1x-1xf32> { (shape[Broadcast(S1, S0), 128], data[NULL]) }
(%7) = "pd_op.shape" (%2) {stop_gradient:[false],sym_shape_str:"shape[2], data[S0, 128]",symbolic_shape:} : (pd_op.tensor<-1x128xf32>) -> pd_op.tensor<2xi32> { (shape[2], data[S0, 128]) }
(%8) = "pd_op.shape" (%6) {stop_gradient:[false],sym_shape_str:"shape[2], data[Broadcast(S1, S0), 128]",symbolic_shape:} : (pd_op.tensor<-1x-1xf32>) -> pd_op.tensor<2xi32> { (shape[2], data[Broadcast(S1, S0), 128]) }
(%9) = "pd_op.shape_broadcast" (%7, %8) {stop_gradient:[false],sym_shape_str:"shape[2], data[Broadcast(Broadcast(S1, S0), S0), 128]"} : (pd_op.tensor<2xi32>, pd_op.tensor<2xi32>) -> pd_op.tensor<2xi32> { (shape[2], data[Broadcast(Broadcast(S1, S0), S0), 128]) }
(%10) = "pd_op.subtract" (%2, %6) {stop_gradient:[false],sym_shape_str:"shape[S0, 128], data[NULL]",symbolic_shape:} : (pd_op.tensor<-1x128xf32>, pd_op.tensor<-1x-1xf32>) -> pd_op.tensor<-1x128xf32> { (shape[S0, 128], data[NULL]) }
() = "builtin.shadow_output" (%10) {output_name:"output_0",sym_shape_str:"shape[S0, 128], data[NULL]"} : (pd_op.tensor<-1x128xf32>) ->  {  }
```