### PR TITLE
[clang-tidy] NO.29 enable bugprone-exception-escape

### DIFF
--- a/paddle/fluid/framework/details/eager_deletion_op_handle.cc
+++ b/paddle/fluid/framework/details/eager_deletion_op_handle.cc
@@ -74,7 +74,7 @@ EagerDeletionOpHandle::EagerDeletionOpHandle(
   }
 }
 
-EagerDeletionOpHandle::~EagerDeletionOpHandle() {
+EagerDeletionOpHandle::~EagerDeletionOpHandle() {  // NOLINT
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   if (event_) {
     auto gpu_place = dev_ctx_->GetPlace();

--- a/paddle/fluid/framework/details/fused_all_reduce_op_handle.cc
+++ b/paddle/fluid/framework/details/fused_all_reduce_op_handle.cc
@@ -60,7 +60,7 @@ FusedAllReduceOpHandle::FusedAllReduceOpHandle(
       num_of_all_reduce_(num_of_all_reduce) {}
 #endif
 
-FusedAllReduceOpHandle::~FusedAllReduceOpHandle() {
+FusedAllReduceOpHandle::~FusedAllReduceOpHandle() {  // NOLINT
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   auto destroy_event = [](gpuEvent_t event) {
     if (event == nullptr) return;

--- a/paddle/fluid/inference/api/resource_manager.cc
+++ b/paddle/fluid/inference/api/resource_manager.cc
@@ -138,7 +138,7 @@ GPUContextResource::GPUContextResource(const phi::Place& place, void* stream)
   InitGPUResource(stream);
 }
 
-GPUContextResource::~GPUContextResource() { DestroyGPUResource(); }
+GPUContextResource::~GPUContextResource() { DestroyGPUResource(); }  // NOLINT
 
 void GPUContextResource::InitGPUResource(void* stream) {
   phi::backends::gpu::GPUDeviceGuard guard(place_.device);

--- a/paddle/phi/backends/onednn/onednn_context.cc
+++ b/paddle/phi/backends/onednn/onednn_context.cc
@@ -40,7 +40,7 @@ OneDNNContextThreadLocals::Body::Body()
 // and other is to start inference
 // TODO(jczaja): Ideally it would be good to clear only part of cache
 // related to thread that is to be terminated
-OneDNNContextThreadLocals::Body::~Body() {
+OneDNNContextThreadLocals::Body::~Body() {  // NOLINT
   auto cpu_place = phi::CPUPlace();
   // TODO(YuanRisheng): we need remove the dependency on fluid device context
   // here

--- a/paddle/phi/core/sparse_coo_tensor.cc
+++ b/paddle/phi/core/sparse_coo_tensor.cc
@@ -22,7 +22,7 @@ SparseCooTensor::SparseCooTensor() {
   this->SetMember(non_zero_indices, non_zero_elements, {1}, true);
 }
 
-SparseCooTensor::SparseCooTensor(SparseCooTensor&& other) noexcept {
+SparseCooTensor::SparseCooTensor(SparseCooTensor&& other) noexcept {  // NOLINT
   this->non_zero_elements_ = other.non_zero_elements_;
   this->non_zero_indices_ = other.non_zero_indices_;
   this->coalesced_ = other.coalesced_;

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -49,7 +49,8 @@ StringTensor& StringTensor::operator=(const StringTensor& other) {
   return *this;
 }
 
-StringTensor& StringTensor::operator=(StringTensor&& other) noexcept {
+StringTensor& StringTensor::operator=(
+    StringTensor&& other) noexcept {  // NOLINT
   meta_ = std::move(other.meta_);
   std::swap(holder_, other.holder_);
   return *this;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/54073
No29 bugprone-exception-escape