### PR TITLE
[clang-tidy] NO.26 enable misc-unused-using-decls

### DIFF
--- a/paddle/fluid/platform/profiler/dump/test_serialization_logger.cc
+++ b/paddle/fluid/platform/profiler/dump/test_serialization_logger.cc
@@ -20,10 +20,8 @@
 #include "paddle/fluid/platform/profiler/event_python.h"
 
 using paddle::framework::AttributeMap;
-using paddle::platform::CudaRuntimeTraceEventNode;
 using paddle::platform::DeserializationReader;
 using paddle::platform::DeviceTraceEvent;
-using paddle::platform::DeviceTraceEventNode;
 using paddle::platform::HostTraceEvent;
 using paddle::platform::HostTraceEventNode;
 using paddle::platform::KernelEventInfo;
@@ -32,7 +30,6 @@ using paddle::platform::MemsetEventInfo;
 using paddle::platform::MemTraceEvent;
 using paddle::platform::NodeTrees;
 using paddle::platform::OperatorSupplementEvent;
-using paddle::platform::ProfilerResult;
 using paddle::platform::RuntimeTraceEvent;
 using paddle::platform::SerializationLogger;
 using paddle::platform::TracerEventType;

--- a/paddle/phi/infermeta/spmd_rules/concat.cc
+++ b/paddle/phi/infermeta/spmd_rules/concat.cc
@@ -25,8 +25,6 @@ limitations under the License. */
 namespace phi {
 namespace distributed {
 
-using phi::distributed::auto_parallel::str_join;
-
 std::tuple<std::string, std::string> FillConcatNotation(int64_t n_axis,
                                                         int64_t concat_axis) {
   PADDLE_ENFORCE_GT(

--- a/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
@@ -20,9 +20,6 @@
 
 namespace phi {
 
-using phi::funcs::gpc_free_polygon;
-using phi::funcs::gpc_polygon_clip;
-
 template <class T>
 class Point_ {
  public:

--- a/paddle/phi/kernels/onednn/matmul_kernel.cc
+++ b/paddle/phi/kernels/onednn/matmul_kernel.cc
@@ -23,7 +23,6 @@ using dnnl::engine;
 using dnnl::inner_product_forward;
 using dnnl::memory;
 using dnnl::prop_kind;
-using phi::ReshapeToMatrix;
 
 namespace phi {
 

--- a/test/cpp/auto_parallel/dist_attr_test.cc
+++ b/test/cpp/auto_parallel/dist_attr_test.cc
@@ -28,8 +28,6 @@ namespace phi {
 namespace distributed {
 namespace auto_parallel {
 
-using paddle::framework::BlockDesc;
-using paddle::framework::OpDesc;
 using paddle::framework::ProgramDesc;
 using paddle::framework::VarDesc;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/54073
No26 misc-unused-using-decls