### PR TITLE
[PIR] Raise `NotImplementedError` in JIT save&load API

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -51,7 +51,7 @@ from paddle.base.framework import (
     dygraph_only,
 )
 from paddle.base.wrapped_decorator import wrap_decorator
-from paddle.framework import in_dynamic_mode
+from paddle.framework import in_dynamic_mode, use_pir_api
 from paddle.nn import Layer
 from paddle.static.io import save_inference_model
 from paddle.utils.environments import (
@@ -914,6 +914,11 @@ def save(layer, path, input_spec=None, **configs):
             >>> save_function()
     """
 
+    if use_pir_api():
+        raise NotImplementedError(
+            "Currently, `paddle.jit.save` is not supported in PIR mode."
+        )
+
     # 1. input build & check
     prog_translator = ProgramTranslator()
     is_prim_infer = core._is_fwd_prim_enabled() and core._is_bwd_prim_enabled()
@@ -1508,6 +1513,10 @@ def load(path, **configs):
                 ...         print("Epoch {} batch {}: loss = {}".format(
                 ...             epoch_id, batch_id, np.mean(loss.numpy())))
     """
+    if use_pir_api():
+        raise NotImplementedError(
+            "Currently, `paddle.jit.load` is not supported in PIR mode."
+        )
     # 1. construct correct config
     config = _parse_load_config(configs)
     model_path, config = _build_load_path_and_config(path, config)

--- a/test/dygraph_to_static/test_fallback.py
+++ b/test/dygraph_to_static/test_fallback.py
@@ -117,11 +117,11 @@ class TestFallback(Dy2StTestBase):
         np.testing.assert_allclose(u_net(self.x).numpy(), [1, 1])
         assert u_net.training is False, "Training must be false."
 
-    @test_legacy_and_pt_and_pir
     def test_case_save_error(self):
         """
         test the save will raise error.
         """
+        # TODO(pir-save-load): Open this case after pir support save and load.
         u_net = UnsupportNet()
         u_net = paddle.jit.to_static(
             u_net, input_spec=[paddle.static.InputSpec(name='x', shape=[1])]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

在 save load API 的 PIR 模式添加一个 NotImplementedError，以便最快定位到是遇到 save load 挂了，而不是直接段错误

暂时关闭 `test_fallback` 中 error case 的 PIR 验证，虽然能跑到后面动转静组网部分正确报 TypeError，但那需要将本 PR 添加的报错逻辑放到后面去，这会导致代码不易阅读，而且前半部分也是有错误的风险的，不如直接全部禁掉，待支持后再验证该 case，另外这个逻辑与 PIR 相关性不高，有老 IR 验证就够了

Pcard-67164