### PR TITLE
[PIR] Set detached `Value.stop_gradient` to True

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -819,7 +819,7 @@ void BindValue(py::module *m) {
              auto out = share_data_op.out();
              out.set_attribute(
                  kAttrStopGradients,
-                 BoolAttribute::get(pir::IrContext::Instance(), false));
+                 BoolAttribute::get(pir::IrContext::Instance(), true));
              return out;
            })
       .def("__repr__", &Value2String);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

detach 的 Value 默认的 `stop_gradient` 应当是 `True`

Pcard-67164