### PR TITLE
[CINN] Add Convert0DTo1DPass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
@@ -57,7 +57,6 @@ class FullOpPattern : public pir::OpRewritePattern<paddle::dialect::FullOp> {
 
     auto full_op = rewriter.Build<paddle::dialect::FullOp>(
         std::vector<int64_t>({1}), factor, dtype, place);
-
     rewriter.ReplaceAllUsesWith(op.result(0), full_op.result(0));
     rewriter.EraseOp(op);
   }

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
@@ -1,0 +1,90 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h"
+
+#include "paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
+#include "paddle/cinn/hlir/dialect/runtime/ir/runtime_dialect.h"
+#include "paddle/cinn/runtime/flags.h"
+#include "paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h"
+#include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/core/builtin_type.h"
+#include "paddle/pir/dialect/shape/utils/dim_expr.h"
+#include "paddle/utils/flags.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+namespace {
+
+class FullOpPattern : public pir::OpRewritePattern<paddle::dialect::FullOp> {
+ public:
+  using pir::OpRewritePattern<paddle::dialect::FullOp>::OpRewritePattern;
+
+  bool Match(paddle::dialect::FullOp op) const override {
+    return op.attribute("shape")
+               .dyn_cast<paddle::dialect::IntArrayAttribute>()
+               .data()
+               .size() == 0;
+  }
+
+  void Rewrite(paddle::dialect::FullOp op,
+               pir::PatternRewriter &rewriter) const override {
+    float factor =
+        op->attribute("value").dyn_cast<::pir::FloatAttribute>().data();
+    phi::DataType dtype = op->attribute("dtype")
+                              .dyn_cast<paddle::dialect::DataTypeAttribute>()
+                              .data();
+    phi::Place place = op->attribute("place")
+                           .dyn_cast<paddle::dialect::PlaceAttribute>()
+                           .data();
+
+    auto full_op = rewriter.Build<paddle::dialect::FullOp>(
+        std::vector<int64_t>({1}), factor, dtype, place);
+
+    rewriter.ReplaceAllUsesWith(op.result(0), full_op.result(0));
+    rewriter.EraseOp(op);
+  }
+};
+
+class Convert0DTo1DPass : public pir::PatternRewritePass {
+ public:
+  Convert0DTo1DPass() : pir::PatternRewritePass("convert_0D_to_1D", 1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add<FullOpPattern>(context);
+
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation *op) const override {
+    return op->isa<pir::ModuleOp>() && op->num_regions() > 0;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<::pir::Pass> CreateConvert0DTo1DPass() {
+  return std::make_unique<Convert0DTo1DPass>();
+}
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
@@ -16,16 +16,12 @@
 
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h"
 
-#include "paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
 #include "paddle/cinn/hlir/dialect/runtime/ir/runtime_dialect.h"
-#include "paddle/cinn/runtime/flags.h"
 #include "paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/pir/core/builtin_type.h"
-#include "paddle/pir/dialect/shape/utils/dim_expr.h"
-#include "paddle/utils/flags.h"
 
 namespace cinn {
 namespace dialect {

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/pass/pass.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+// This is a helper pass for substitute zero-dim tensor to one-dim tensor
+std::unique_ptr<::pir::Pass> CreateConvert0DTo1DPass();
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h
@@ -21,7 +21,7 @@ namespace cinn {
 namespace dialect {
 namespace ir {
 
-// This is a helper pass for substitute zero-dim tensor to one-dim tensor
+// This is a helper pass for converting zero-dim tensor to one-dim tensor
 std::unique_ptr<::pir::Pass> CreateConvert0DTo1DPass();
 }  // namespace ir
 }  // namespace dialect

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -31,6 +31,7 @@
 #include "paddle/fluid/pybind/control_flow_api.h"
 #include "paddle/fluid/pybind/pybind_variant_caster.h"
 
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.h"
 #include "paddle/fluid/pir/dialect/kernel/ir/kernel_type.h"
 #include "paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h"
 #include "paddle/fluid/pir/dialect/operator/ir/api_builder.h"
@@ -1560,6 +1561,7 @@ void AddCinnPass(std::shared_ptr<PassManager> &pass_manager,  // NOLINT
     pass_manager->EnableIRPrinting();
   }
 
+  pass_manager->AddPass(cinn::dialect::ir::CreateConvert0DTo1DPass());
   if (!has_dynamic_shape && FLAGS_check_infer_symbolic) {
     pass_manager->AddPass(pir::CreateShapeOptimizationPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateCheckInferSymbolicPass());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[CINN] Add Convert0DTo1DPass

进入 CINN 的 Tensor 输入可能为 0D-Tensor，如果 0D-Tensor 的处理从 CINN 前端贯穿到后端，需要补足的机制较多，因此暂时添加 Convert0DTo1DPass，将进入到 CINN 的 Tensor 处理为 1D-Tensor。长远来看，有充足人力时，应该去掉这个 pass，CINN 原生支持 0D-Tensor 的处理。

PS：目前只发现了通过 FullOp 创建 0D-Tensor 的例子，因此 pass 内仅对 FullOp 做 PatternMatch

Before:
```
(%2) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<f32>
```

After:
```
(%2) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<1xf32>
```

