### PR TITLE
【pir】modify test_optimizer_grad.py

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -502,11 +502,18 @@ class Optimizer:
                     else:
                         place = _current_expected_place()
                         if not isinstance(_lr_dtype, paddle.base.core.DataType):
-                            lr_dtype = (
-                                paddle.pir.core.convert_np_dtype_to_dtype_(
+                            if isinstance(
+                                _lr_dtype, paddle.base.libpaddle.VarDesc.VarType
+                            ):
+                                _lr_dtype = paddle.pir.core.vartype_to_datatype[
                                     _lr_dtype
+                                ]
+                            else:
+                                _lr_dtype = (
+                                    paddle.pir.core.convert_np_dtype_to_dtype_(
+                                        _lr_dtype
+                                    )
                                 )
-                            )
                         self._learning_rate_map[
                             paddle.static.default_main_program()
                         ] = paddle.pir.core.create_parameter(

--- a/test/legacy_test/test_optimizer_grad.py
+++ b/test/legacy_test/test_optimizer_grad.py
@@ -129,14 +129,36 @@ class SimpleNetWithCond:
                 use_pure_bf16=True,
             )
 
-        self.optimizer.minimize(mean_out)
+        _, params_grads = self.optimizer.minimize(mean_out)
 
-        fetch_list = (
-            ["param_x", "param_z"]
-            if self.y_no_grad
-            else ["param_x", "param_y", "param_z"]
-        )
-        fetch_list += [_append_grad_suffix_(param) for param in fetch_list]
+        if paddle.framework.in_pir_mode():
+            for param, grad in params_grads:
+                if param.is_same(param_x):
+                    param_x_grad = grad
+                elif param.is_same(param_y):
+                    param_y_grad = grad
+                elif param.is_same(param_z):
+                    param_z_grad = grad
+            fetch_list = (
+                [param_x, param_z, param_x_grad, param_z_grad]
+                if self.y_no_grad
+                else [
+                    param_x,
+                    param_y,
+                    param_z,
+                    param_x_grad,
+                    param_y_grad,
+                    param_z_grad,
+                ]
+            )
+        else:
+            fetch_list = (
+                ["param_x", "param_z"]
+                if self.y_no_grad
+                else ["param_x", "param_y", "param_z"]
+            )
+            fetch_list += [_append_grad_suffix_(param) for param in fetch_list]
+
         return fetch_list, self.optimizer
 
 
@@ -159,6 +181,7 @@ class TestOptimizer(unittest.TestCase):
         self.cond_i = [0.1, 3]
         self.y_no_grad = [True, False]
 
+    # @test_with_pir_api
     def test_optimizer(self):
         self._check_grads()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Description
<!-- Describe what you’ve done -->
pcard-67164

修复test_optimizer_grad.py中单测，if 中的输入如果被if外的op使用，在if_grad创建时state中有对应的梯度，此梯度在if 的两个block 中都会被add_n 成一个结果作为if 的输出，因此需要在子block 处理反向前保存，下一个子block 处理前恢复。同时在if_grad处理完成后将state清空，只更新if_grad 产生的梯度值，否则会导致if外op 产生的梯度多累加一次。 此处的处理和之前inplace 的输入本质相同，因此归一处理

todo 目前当单测命中true分支后，梯度计算正确，但参数更新精度有误，原因是pir 的parameters 没有optimizer_attr属性，使得学习率的倍数没有奏效