### PR TITLE
Remove wrong test case in `test_sum_op`

### DIFF
--- a/test/legacy_test/test_sum_op.py
+++ b/test/legacy_test/test_sum_op.py
@@ -521,35 +521,11 @@ class TestRaiseSumsError(unittest.TestCase):
 
             def test_dtype1():
                 data1 = paddle.static.data(
-                    name="input1", shape=[10], dtype="int8"
+                    name="input3", shape=[10], dtype="int8"
                 )
                 paddle.add_n(data1)
 
             self.assertRaises(TypeError, test_dtype1)
-
-            def test_out_type():
-                data1 = paddle.static.data(
-                    name="input1", shape=[10], dtype="flaot32"
-                )
-                data2 = paddle.static.data(
-                    name="input2", shape=[10], dtype="float32"
-                )
-                out = [10]
-                out = paddle.add_n([data1, data2])
-
-            self.assertRaises(TypeError, test_out_type)
-
-            def test_out_dtype():
-                data1 = paddle.static.data(
-                    name="input1", shape=[10], dtype="flaot32"
-                )
-                data2 = paddle.static.data(
-                    name="input2", shape=[10], dtype="float32"
-                )
-                out = paddle.static.data(name="out", shape=[10], dtype="int8")
-                out = paddle.add_n([data1, data2])
-
-            self.assertRaises(TypeError, test_out_dtype)
 
 
 class TestSumOpError(unittest.TestCase):

--- a/test/xpu/test_sum_op_xpu.py
+++ b/test/xpu/test_sum_op_xpu.py
@@ -160,34 +160,10 @@ class TestRaiseSumsError(unittest.TestCase):
         self.assertRaises(TypeError, test_dtype)
 
         def test_dtype1():
-            data1 = paddle.static.data(name="input1", shape=[10], dtype="int8")
+            data1 = paddle.static.data(name="input3", shape=[10], dtype="int8")
             paddle.add_n(data1)
 
         self.assertRaises(TypeError, test_dtype1)
-
-        def test_out_type():
-            data1 = paddle.static.data(
-                name="input1", shape=[10], dtype="flaot32"
-            )
-            data2 = paddle.static.data(
-                name="input2", shape=[10], dtype="float32"
-            )
-            out = [10]
-            out = paddle.add_n([data1, data2])
-
-        self.assertRaises(TypeError, test_out_type)
-
-        def test_out_dtype():
-            data1 = paddle.static.data(
-                name="input1", shape=[10], dtype="flaot32"
-            )
-            data2 = paddle.static.data(
-                name="input2", shape=[10], dtype="float32"
-            )
-            out = paddle.static.data(name="out", shape=[10], dtype="int8")
-            out = paddle.add_n([data1, data2])
-
-        self.assertRaises(TypeError, test_out_dtype)
 
 
 class TestSumOpError(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

清理掉 #61681 提到的单测 case，根据 #23762（如下）：

```python

        def test_out_type():
            data1 = fluid.data(name="input1", shape=[10], dtype="flaot32")
            data2 = fluid.data(name="input2", shape=[10], dtype="float32")
            fluid.layers.sums([data1, data2], out=[10])

        self.assertRaises(TypeError, test_out_type)

        def test_out_dtype():
            data1 = fluid.data(name="input1", shape=[10], dtype="flaot32")
            data2 = fluid.data(name="input2", shape=[10], dtype="float32")
            out = fluid.data(name="out", shape=[10], dtype="int8")
            fluid.layers.sums([data1, data2], out=out)

        self.assertRaises(TypeError, test_out_dtype)
```

这里的单测原本是用来测试 `fluid.layers.sums` 的 out 的 type 和 dtype 是否正常报错的，但应该是后来 fluid 清理时候发现并没有等效的 out 参数就没传，但恰巧这里 `flaot32` 引发了 TypeError 导致问题被隐藏了

等效 API add_n 没有 out，因此不需要测 out，直接删除即可

cc @co63oc

Pcard-67164