### PR TITLE
fix cmake submodule sync for third party dependencies

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -35,14 +35,23 @@ if(NOT WITH_SETUP_INSTALL)
     STATUS
       "Check submodules of paddle, and run 'git submodule sync --recursive && git submodule update --init --recursive'"
   )
+
+  # execute_process does not support sequential commands, so we execute echo command separately
   execute_process(
-    COMMAND
-      $ENV{SHELL} -c
-      "git submodule sync --recursive && git submodule update --init --recursive"
+    COMMAND git submodule sync --recursive
     WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
     RESULT_VARIABLE result_var)
   if(NOT result_var EQUAL 0)
-    message(FATAL_ERROR "Failed to get submodule, please check your network !")
+    message(FATAL_ERROR "Failed to sync submodule, please check your network !")
+  endif()
+
+  execute_process(
+    COMMAND git submodule update --init --recursive
+    WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
+    RESULT_VARIABLE result_var)
+  if(NOT result_var EQUAL 0)
+    message(
+      FATAL_ERROR "Failed to update submodule, please check your network !")
   endif()
 
 endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -36,8 +36,9 @@ if(NOT WITH_SETUP_INSTALL)
       "Check submodules of paddle, and run 'git submodule sync --recursive && git submodule update --init --recursive'"
   )
   execute_process(
-    COMMAND git submodule sync --recursive
-    COMMAND git submodule update --init --recursive
+    COMMAND
+      $ENV{SHELL} -c
+      "git submodule sync --recursive && git submodule update --init --recursive"
     WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
     RESULT_VARIABLE result_var)
   if(NOT result_var EQUAL 0)

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -33,9 +33,10 @@ if(NOT WITH_SETUP_INSTALL)
   #NOTE(risemeup1):Initialize any submodules.
   message(
     STATUS
-      "Check submodules of paddle, and run 'git submodule update --init --recursive'"
+      "Check submodules of paddle, and run 'git submodule sync --recursive && git submodule update --init --recursive'"
   )
   execute_process(
+    COMMAND git submodule sync --recursive
     COMMAND git submodule update --init --recursive
     WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
     RESULT_VARIABLE result_var)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
更改 CMake 命令，在构建第三方依赖前更新 Git 子模块