### PR TITLE
[Dy2St] Add check for Tensor attributes consistency in dygraph and static mode

### DIFF
--- a/test/dygraph_to_static/check_approval.py
+++ b/test/dygraph_to_static/check_approval.py
@@ -148,6 +148,7 @@ ALLOW_LIST: dict[type[Diagnostic], list[str]] = {
         "test_logging_utils.py",
         "test_move_cuda_pinned_tensor.py",
         "test_pylayer.py",
+        "test_tensor_attr_consistency.py",
     ],
     TestCaseWithoutDecoratorDiagnostic: [
         "test_logical.py",

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -17,8 +17,96 @@ import unittest
 import paddle
 from paddle.jit.utils import OrderedSet
 
-DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet([])
-STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet([])
+DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
+    [
+        '__array__',
+        '__array_ufunc__',
+        '__deepcopy__',
+        '__index__',
+        '__len__',
+        '__long__',
+        '__nonzero__',
+        'apply_',
+        'backward',
+        'clear_grad',
+        'coalesce',
+        'cols',
+        'copy_',
+        'crows',
+        'data',
+        'data_ptr',
+        'detach_',
+        'element_size',
+        'fill_',
+        'fill_diagonal_',
+        'fill_diagonal_tensor',
+        'fill_diagonal_tensor_',
+        'get_map_tensor',
+        'get_selected_rows',
+        'get_strides',
+        'get_tensor',
+        'grad',
+        'grad_',
+        'grad_fn',
+        'gradient',
+        'indices',
+        'inplace_version',
+        'is_dense',
+        'is_dist',
+        'is_leaf',
+        'is_same_shape',
+        'is_selected_rows',
+        'is_sparse',
+        'is_sparse_coo',
+        'is_sparse_csr',
+        'layout',
+        'nnz',
+        'num_shard',
+        'numpy',
+        'offset',
+        'pin_memory',
+        'placements',
+        'process_mesh',
+        'reconstruct_from_',
+        'register_hook',
+        'retain_grads',
+        'rows',
+        'set_string_list',
+        'set_value',
+        'set_vocab',
+        'strides',
+        'to',
+        'to_dense',
+        'to_sparse_coo',
+        'to_sparse_csr',
+        'tolist',
+        'value',
+        'values',
+        'zero_',
+    ]
+)
+STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
+    [
+        '__dict__',
+        'all_used_ops',
+        'append',
+        'first_use',
+        'get_defining_op',
+        'has_one_use',
+        'hash',
+        'id',
+        'initialized',
+        'is_dense_tensor_array_type',
+        'is_dense_tensor_type',
+        'is_same',
+        'is_selected_row_type',
+        'pop',
+        'replace_all_uses_with',
+        'set_shape',
+        'set_type',
+        'use_empty',
+    ]
+)
 
 
 def is_magic_method(attr):
@@ -54,8 +142,8 @@ class TestTensorAttrConsistency(unittest.TestCase):
         self.assertEqual(
             len(not_allow_dygraph_only_attrs),
             0,
-            f"Value should have same attributes as Tensor, but found dygraph only tensor attributes: {not_allow_dygraph_only_attrs}\n."
-            + "If you these attributes are not supported in static graph, please add them to DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST in test_dygraph_to_static/test_tensor_attr_consistency.py.",
+            f"Value should have same attributes as Tensor, but found dygraph only tensor attributes: {not_allow_dygraph_only_attrs}.\n"
+            + "If you believe these attributes are not supported in static graph, please add them to DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST in test_dygraph_to_static/test_tensor_attr_consistency.py.",
         )
 
     def test_static_tensor_attr_consistency_check(self):
@@ -71,8 +159,8 @@ class TestTensorAttrConsistency(unittest.TestCase):
         self.assertEqual(
             len(not_allow_static_only_attrs),
             0,
-            f"Tensor should have same attributes as Value, but found static only tensor attributes: {not_allow_static_only_attrs}\n."
-            + "If you these attributes are not supported in dygraph, please add them to STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST in test_dygraph_to_static/test_tensor_attr_consistency.py.",
+            f"Tensor should have same attributes as Value, but found static only tensor attributes: {not_allow_static_only_attrs}.\n"
+            + "If you believe these attributes are not supported in dygraph, please add them to STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST in test_dygraph_to_static/test_tensor_attr_consistency.py.",
         )
 
 

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.jit.utils import OrderedSet
+
+DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet([])
+STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet([])
+
+
+def is_magic_method(attr):
+    return attr.startswith('__') and attr.endswith('__')
+
+
+def get_public_attributes(cls):
+    return [
+        attr
+        for attr in dir(cls)
+        if not attr.startswith('_') or is_magic_method(attr)
+    ]
+
+
+class TestTensorAttrConsistency(unittest.TestCase):
+    def get_tensor_dygraph_and_static_attrs(self):
+        dygraph_tensor_cls = paddle.Tensor
+        static_tensor_cls = paddle.pir.Value
+        dygraph_tensor_attrs = get_public_attributes(dygraph_tensor_cls)
+        static_tensor_attrs = get_public_attributes(static_tensor_cls)
+        return OrderedSet(dygraph_tensor_attrs), OrderedSet(static_tensor_attrs)
+
+    def test_dygraph_tensor_attr_consistency_check(self):
+        (
+            dygraph_tensor_attrs,
+            static_tensor_attrs,
+        ) = self.get_tensor_dygraph_and_static_attrs()
+        dygraph_only_attrs = dygraph_tensor_attrs - static_tensor_attrs
+        not_allow_dygraph_only_attrs = (
+            dygraph_only_attrs - DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST
+        )
+
+        self.assertEqual(
+            len(not_allow_dygraph_only_attrs),
+            0,
+            f"Value should have same attributes as Tensor, but found dygraph only tensor attributes: {not_allow_dygraph_only_attrs}\n."
+            + "If you these attributes are not supported in static graph, please add them to DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST in test_dygraph_to_static/test_tensor_attr_consistency.py.",
+        )
+
+    def test_static_tensor_attr_consistency_check(self):
+        (
+            dygraph_tensor_attrs,
+            static_tensor_attrs,
+        ) = self.get_tensor_dygraph_and_static_attrs()
+        static_only_attrs = static_tensor_attrs - dygraph_tensor_attrs
+        not_allow_static_only_attrs = (
+            static_only_attrs - STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST
+        )
+
+        self.assertEqual(
+            len(not_allow_static_only_attrs),
+            0,
+            f"Tensor should have same attributes as Value, but found static only tensor attributes: {not_allow_static_only_attrs}\n."
+            + "If you these attributes are not supported in dygraph, please add them to STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST in test_dygraph_to_static/test_tensor_attr_consistency.py.",
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -442,7 +442,7 @@ fi
 HAS_MODIFIED_DY2ST_TEST_TENSOR_ATTR_CONSISTENCY=$(git diff --name-only upstream/$BRANCH | grep "test/dygraph_to_static/test_tensor_attr_consistency.py" || true)
 if [ "${HAS_MODIFIED_DY2ST_TEST_TENSOR_ATTR_CONSISTENCY}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     echo_line="You must have one RD (SigureMo, Aurelius84, 2742195759 or gouzil) approval for file changes in test/dygraph_to_static/test_tensor_attr_consistency.py.\n"
-    check_approval 1 SigureMo Aurelius84 2742195759
+    check_approval 1 SigureMo Aurelius84 2742195759 gouzil
 fi
 
 HAS_MODIFIED_PHI_FILES=`git diff --name-only upstream/$BRANCH | grep "paddle/phi/" || true`

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -439,6 +439,12 @@ if [ "${HAS_MODIFIED_DY2ST_TEST_FILES}" != "" ] && [ "${GIT_PR_ID}" != "" ]; the
     fi
 fi
 
+HAS_MODIFIED_DY2ST_TEST_TENSOR_ATTR_CONSISTENCY=$(git diff --name-only upstream/$BRANCH | grep "test/dygraph_to_static/test_tensor_attr_consistency.py" || true)
+if [ "${HAS_MODIFIED_DY2ST_TEST_TENSOR_ATTR_CONSISTENCY}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
+    echo_line="You must have one RD (SigureMo, Aurelius84, 2742195759 or gouzil) approval for file changes in test/dygraph_to_static/test_tensor_attr_consistency.py.\n"
+    check_approval 1 SigureMo Aurelius84 2742195759
+fi
+
 HAS_MODIFIED_PHI_FILES=`git diff --name-only upstream/$BRANCH | grep "paddle/phi/" || true`
 PHI_INCLUDE_FLUID_FILES=""
 for CHANGE_FILE in ${HAS_MODIFIED_PHI_FILES}; do


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

添加单测用于检查 Tensor 和 Value 属性动静统一，以免其中一个添加新属性，另一个没加

可通过白名单绕过，并且添加该单测的 CI 检查项，如果改 allow list，需动转静同学的 review 才行

PCard-66972