### PR TITLE
[clang-tidy] NO.14 enable misc-unused-alias-decls

### DIFF
--- a/paddle/fluid/distributed/test/brpc_service_dense_sgd_test.cc
+++ b/paddle/fluid/distributed/test/brpc_service_dense_sgd_test.cc
@@ -42,9 +42,6 @@ class DenseTensor;
 
 namespace framework = paddle::framework;
 namespace platform = paddle::platform;
-namespace operators = paddle::operators;
-namespace memory = paddle::memory;
-namespace distributed = paddle::distributed;
 
 void CreateVarsOnScope(framework::Scope* scope, platform::CPUPlace* place) {
   auto x_var = scope->Var("x");

--- a/paddle/fluid/distributed/test/brpc_service_sparse_sgd_test.cc
+++ b/paddle/fluid/distributed/test/brpc_service_sparse_sgd_test.cc
@@ -43,9 +43,6 @@ class DenseTensor;
 
 namespace framework = paddle::framework;
 namespace platform = paddle::platform;
-namespace operators = paddle::operators;
-namespace memory = paddle::memory;
-namespace distributed = paddle::distributed;
 
 void CreateVarsOnScope(framework::Scope* scope, platform::CPUPlace* place) {
   auto x_var = scope->Var("x");

--- a/paddle/fluid/distributed/test/brpc_utils_test.cc
+++ b/paddle/fluid/distributed/test/brpc_utils_test.cc
@@ -76,19 +76,19 @@ void RunMultiVarMsg(platform::Place place) {
   LOG(INFO) << "begin SerializeToMultiVarMsg";
 
   butil::IOBuf io_buf;
-  distributed::SerializeToMultiVarMsgAndIOBuf(message_name,
-                                              send_var_name,
-                                              recv_var_name,
-                                              ctx,
-                                              &scope,
-                                              &multi_msg,
-                                              &io_buf);
+  ::paddle::distributed::SerializeToMultiVarMsgAndIOBuf(message_name,
+                                                        send_var_name,
+                                                        recv_var_name,
+                                                        ctx,
+                                                        &scope,
+                                                        &multi_msg,
+                                                        &io_buf);
   EXPECT_GT(multi_msg.ByteSizeLong(), static_cast<size_t>(0));
 
   // deserialize
   framework::Scope scope_recv;
   LOG(INFO) << "begin DeserializeFromMultiVarMsg";
-  distributed::DeserializeFromMultiVarMsgAndIOBuf(
+  ::paddle::distributed::DeserializeFromMultiVarMsgAndIOBuf(
       multi_msg, &io_buf, ctx, &scope_recv);
 
   // check var1

--- a/paddle/fluid/distributed/test/brpc_utils_test.cc
+++ b/paddle/fluid/distributed/test/brpc_utils_test.cc
@@ -27,9 +27,6 @@ class Variable;
 
 namespace framework = paddle::framework;
 namespace platform = paddle::platform;
-namespace operators = paddle::operators;
-namespace memory = paddle::memory;
-namespace distributed = paddle::distributed;
 
 void CreateVarsOnScope(framework::Scope* scope,
                        platform::Place* place,

--- a/paddle/fluid/distributed/test/graph_node_split_test.cc
+++ b/paddle/fluid/distributed/test/graph_node_split_test.cc
@@ -42,10 +42,6 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace framework = paddle::framework;
-namespace platform = paddle::platform;
-namespace operators = paddle::operators;
-namespace memory = paddle::memory;
-namespace distributed = paddle::distributed;
 
 std::vector<std::string> edges = {std::string("37\t45\t0.34"),
                                   std::string("37\t145\t0.31"),

--- a/paddle/fluid/distributed/test/graph_node_test.cc
+++ b/paddle/fluid/distributed/test/graph_node_test.cc
@@ -43,9 +43,6 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace framework = paddle::framework;
-namespace platform = paddle::platform;
-namespace operators = paddle::operators;
-namespace memory = paddle::memory;
 namespace distributed = paddle::distributed;
 
 // void testSampleNodes(

--- a/paddle/fluid/distributed/test/graph_table_sample_test.cc
+++ b/paddle/fluid/distributed/test/graph_table_sample_test.cc
@@ -27,10 +27,7 @@
 #include "gtest/gtest.h"
 #include "paddle/fluid/distributed/ps/table/common_graph_table.h"
 #include "paddle/fluid/distributed/the_one_ps.pb.h"
-namespace framework = paddle::framework;
-namespace platform = paddle::platform;
-namespace operators = paddle::operators;
-namespace memory = paddle::memory;
+
 namespace distributed = paddle::distributed;
 
 std::vector<std::string> edges = {std::string("37\t45\t0.34"),

--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -58,7 +58,7 @@
 #include "paddle/phi/infermeta/spmd_rules/rules.h"
 #endif
 
-namespace py = pybind11;
+namespace py = pybind11;  // NOLINT
 
 namespace paddle {
 namespace pybind {

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -51,7 +51,7 @@
 #include "paddle/fluid/inference/api/onnxruntime_predictor.h"
 #endif
 
-namespace py = pybind11;
+namespace py = pybind11;  // NOLINT
 
 namespace pybind11 {
 namespace detail {

--- a/test/cpp/fluid/framework/details/exception_holder_test.cc
+++ b/test/cpp/fluid/framework/details/exception_holder_test.cc
@@ -20,8 +20,6 @@
 namespace paddle {
 namespace framework {
 namespace details {
-namespace f = paddle::framework;
-namespace p = paddle::platform;
 
 TEST(ExceptionHolderTester, TestEnforceNotMetCatch) {
   ExceptionHolder exception_holder;

--- a/test/cpp/fluid/framework/op_registry_test.cc
+++ b/test/cpp/fluid/framework/op_registry_test.cc
@@ -17,8 +17,6 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-namespace pd = paddle::framework;
-
 namespace paddle {
 namespace framework {
 

--- a/test/cpp/fluid/framework/tensor_test.cc
+++ b/test/cpp/fluid/framework/tensor_test.cc
@@ -19,7 +19,6 @@
 
 #include <string>
 
-namespace framework = paddle::framework;
 namespace platform = paddle::platform;
 
 TEST(DenseTensor, Dims) {

--- a/test/cpp/imperative/test_gradient_accmulator.cc
+++ b/test/cpp/imperative/test_gradient_accmulator.cc
@@ -23,9 +23,6 @@
 #include "paddle/fluid/memory/memcpy.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
-namespace imperative = paddle::imperative;
-namespace platform = paddle::platform;
-namespace framework = paddle::framework;
 namespace paddle {
 namespace imperative {
 

--- a/test/cpp/imperative/test_hooks.cc
+++ b/test/cpp/imperative/test_hooks.cc
@@ -32,10 +32,6 @@ PD_DECLARE_KERNEL(add_grad, CPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(matmul_with_flatten, CPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(matmul_with_flatten_grad, CPU, ALL_LAYOUT);
 
-namespace platform = paddle::platform;
-namespace framework = paddle::framework;
-namespace memory = paddle::memory;
-
 COMMON_DECLARE_bool(sort_sum_gradient);
 
 namespace paddle {

--- a/test/cpp/imperative/test_layer.cc
+++ b/test/cpp/imperative/test_layer.cc
@@ -28,10 +28,6 @@
 #include "paddle/fluid/imperative/infer_var_type_context.h"
 #include "paddle/fluid/imperative/layer.h"
 
-namespace imperative = paddle::imperative;
-namespace platform = paddle::platform;
-namespace framework = paddle::framework;
-
 namespace paddle {
 namespace imperative {
 

--- a/test/cpp/imperative/test_prepare_op.cc
+++ b/test/cpp/imperative/test_prepare_op.cc
@@ -34,10 +34,6 @@ PD_DECLARE_KERNEL(relu, CPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(relu, GPU, ALL_LAYOUT);
 #endif
 
-namespace imperative = paddle::imperative;
-namespace platform = paddle::platform;
-namespace framework = paddle::framework;
-
 namespace paddle {
 namespace imperative {
 

--- a/test/cpp/imperative/test_tracer.cc
+++ b/test/cpp/imperative/test_tracer.cc
@@ -44,10 +44,6 @@ PD_DECLARE_KERNEL(matmul_with_flatten, GPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(matmul_with_flatten_grad, GPU, ALL_LAYOUT);
 #endif
 
-namespace imperative = paddle::imperative;
-namespace platform = paddle::platform;
-namespace framework = paddle::framework;
-
 namespace paddle {
 namespace imperative {
 

--- a/test/cpp/phi/api/test_to_api.cc
+++ b/test/cpp/phi/api/test_to_api.cc
@@ -25,7 +25,6 @@ limitations under the License. */
 namespace paddle {
 namespace tests {
 
-namespace framework = paddle::framework;
 using DDim = phi::DDim;
 
 paddle::Tensor CreateInputTensor() {

--- a/test/cpp/phi/kernels/test_memcpy_dev_api.cc
+++ b/test/cpp/phi/kernels/test_memcpy_dev_api.cc
@@ -27,7 +27,6 @@
 namespace phi {
 namespace tests {
 
-namespace framework = paddle::framework;
 using DDim = phi::DDim;
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/test/cpp/phi/kernels/test_strings_lower_upper_dev_api.cc
+++ b/test/cpp/phi/kernels/test_strings_lower_upper_dev_api.cc
@@ -31,7 +31,6 @@ limitations under the License. */
 namespace phi {
 namespace tests {
 
-namespace framework = paddle::framework;
 using DDim = phi::DDim;
 using pstring = ::phi::dtype::pstring;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/54073
No14 misc-unused-alias-decls