### PR TITLE
paddle.add 等二元API易用性提升

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -149,17 +149,17 @@ def _get_reduce_axis_with_tensor(axis, x):
 
 
 def _convert_binary_tensor_number_inputs(x, y):
-    if isinstance(x, (Variable, paddle.pir.Value)):
+    if isinstance(x, (paddle.Tensor, paddle.pir.Value)):
         y = paddle.to_tensor(y, dtype=x.dtype)
-    elif isinstance(y, (Variable, paddle.pir.Value)):
+    elif isinstance(y, (paddle.Tensor, paddle.pir.Value)):
         x = paddle.to_tensor(x, dtype=y.dtype)
     return x, y
 
 
 def _convert_binary_inputs(x, y):
     # number_number_case
-    if not isinstance(x, (Variable, paddle.pir.Value)) and not isinstance(
-        y, (Variable, paddle.pir.Value)
+    if not isinstance(x, (paddle.Tensor, paddle.pir.Value)) and not isinstance(
+        y, (paddle.Tensor, paddle.pir.Value)
     ):
         _x = paddle.to_tensor(x)
         _y = paddle.to_tensor(y)
@@ -721,8 +721,8 @@ def add(x, y, name=None):
 
     if in_dynamic_or_pir_mode():
         if not (
-            isinstance(x, (Variable, paddle.pir.Value))
-            and isinstance(y, (Variable, paddle.pir.Value))
+            isinstance(x, (paddle.Tensor, paddle.pir.Value))
+            and isinstance(y, (paddle.Tensor, paddle.pir.Value))
         ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.add(x, y)
@@ -867,8 +867,8 @@ def subtract(x, y, name=None):
 
     if in_dynamic_or_pir_mode():
         if not (
-            isinstance(x, (Variable, paddle.pir.Value))
-            and isinstance(y, (Variable, paddle.pir.Value))
+            isinstance(x, (paddle.Tensor, paddle.pir.Value))
+            and isinstance(y, (paddle.Tensor, paddle.pir.Value))
         ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.subtract(x, y)
@@ -931,8 +931,8 @@ def divide(x, y, name=None):
 
     if in_dynamic_or_pir_mode():
         if not (
-            isinstance(x, (Variable, paddle.pir.Value))
-            and isinstance(y, (Variable, paddle.pir.Value))
+            isinstance(x, (paddle.Tensor, paddle.pir.Value))
+            and isinstance(y, (paddle.Tensor, paddle.pir.Value))
         ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.divide(x, y)
@@ -998,8 +998,8 @@ def floor_divide(x, y, name=None):
 
     if in_dynamic_or_pir_mode():
         if not (
-            isinstance(x, (Variable, paddle.pir.Value))
-            and isinstance(y, (Variable, paddle.pir.Value))
+            isinstance(x, (paddle.Tensor, paddle.pir.Value))
+            and isinstance(y, (paddle.Tensor, paddle.pir.Value))
         ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.floor_divide(x, y)
@@ -1154,8 +1154,8 @@ def multiply(x, y, name=None):
 
     if in_dynamic_or_pir_mode():
         if not (
-            isinstance(x, (Variable, paddle.pir.Value))
-            and isinstance(y, (Variable, paddle.pir.Value))
+            isinstance(x, (paddle.Tensor, paddle.pir.Value))
+            and isinstance(y, (paddle.Tensor, paddle.pir.Value))
         ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.multiply(x, y)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -147,6 +147,28 @@ def _get_reduce_axis_with_tensor(axis, x):
             axis = paddle.utils._convert_to_tensor_list(axis)
     return reduce_all, axis
 
+def _convert_binary_tensor_number_inputs(x, y):
+    if isinstance(x, (Variable, paddle.pir.Value)):
+        y = paddle.to_tensor(y, dtype=x.dtype)
+    elif isinstance(y, (Variable, paddle.pir.Value)):
+        x = paddle.to_tensor(x, dtype=y.dtype)
+    return x, y
+
+def _convert_binary_inputs(x, y):
+    if isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value)):
+        return x, y
+    # number_number_case
+    elif not isinstance(x, (Variable, paddle.pir.Value)) and not isinstance(y, (Variable, paddle.pir.Value)):
+        _x = paddle.to_tensor(x)
+        _y = paddle.to_tensor(y)
+        if isinstance(x, float) and isinstance(y, int):
+            _y = paddle.cast(_y, dtype=_x.dtype)
+        elif isinstance(x, int) and isinstance(y, float):
+            _x = paddle.cast(_x, dtype=_y.dtype)
+    # tensor_number_case
+    else:
+        _x, _y = _convert_binary_tensor_number_inputs(x, y)
+    return _x, _y
 
 def log(x, name=None):
     r"""
@@ -694,6 +716,7 @@ def add(x, y, name=None):
             [3., 8., 6.])
     """
 
+    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
         return _C_ops.add(x, y)
     else:
@@ -834,6 +857,8 @@ def subtract(x, y, name=None):
             Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
             [ 4.  ,  inf., -inf.])
     """
+
+    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
         return _C_ops.subtract(x, y)
     else:
@@ -892,6 +917,8 @@ def divide(x, y, name=None):
             [2.        , 0.60000000, 2.        ])
 
     """
+
+    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
         return _C_ops.divide(x, y)
     else:
@@ -953,6 +980,8 @@ def floor_divide(x, y, name=None):
             [2, 0, 2, 2])
 
     """
+
+    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
         return _C_ops.floor_divide(x, y)
     else:
@@ -1103,6 +1132,8 @@ def multiply(x, y, name=None):
               [2, 4, 6]]])
 
     """
+
+    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
         return _C_ops.multiply(x, y)
     else:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -147,6 +147,7 @@ def _get_reduce_axis_with_tensor(axis, x):
             axis = paddle.utils._convert_to_tensor_list(axis)
     return reduce_all, axis
 
+
 def _convert_binary_tensor_number_inputs(x, y):
     if isinstance(x, (Variable, paddle.pir.Value)):
         y = paddle.to_tensor(y, dtype=x.dtype)
@@ -154,9 +155,12 @@ def _convert_binary_tensor_number_inputs(x, y):
         x = paddle.to_tensor(x, dtype=y.dtype)
     return x, y
 
+
 def _convert_binary_inputs(x, y):
     # number_number_case
-    if not isinstance(x, (Variable, paddle.pir.Value)) and not isinstance(y, (Variable, paddle.pir.Value)):
+    if not isinstance(x, (Variable, paddle.pir.Value)) and not isinstance(
+        y, (Variable, paddle.pir.Value)
+    ):
         _x = paddle.to_tensor(x)
         _y = paddle.to_tensor(y)
         if isinstance(x, float) and isinstance(y, int):
@@ -167,6 +171,7 @@ def _convert_binary_inputs(x, y):
     else:
         _x, _y = _convert_binary_tensor_number_inputs(x, y)
     return _x, _y
+
 
 def log(x, name=None):
     r"""
@@ -715,7 +720,10 @@ def add(x, y, name=None):
     """
 
     if in_dynamic_or_pir_mode():
-        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+        if not (
+            isinstance(x, (Variable, paddle.pir.Value))
+            and isinstance(y, (Variable, paddle.pir.Value))
+        ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.add(x, y)
     else:
@@ -858,7 +866,10 @@ def subtract(x, y, name=None):
     """
 
     if in_dynamic_or_pir_mode():
-        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+        if not (
+            isinstance(x, (Variable, paddle.pir.Value))
+            and isinstance(y, (Variable, paddle.pir.Value))
+        ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.subtract(x, y)
     else:
@@ -919,7 +930,10 @@ def divide(x, y, name=None):
     """
 
     if in_dynamic_or_pir_mode():
-        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+        if not (
+            isinstance(x, (Variable, paddle.pir.Value))
+            and isinstance(y, (Variable, paddle.pir.Value))
+        ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.divide(x, y)
     else:
@@ -983,7 +997,10 @@ def floor_divide(x, y, name=None):
     """
 
     if in_dynamic_or_pir_mode():
-        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+        if not (
+            isinstance(x, (Variable, paddle.pir.Value))
+            and isinstance(y, (Variable, paddle.pir.Value))
+        ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.floor_divide(x, y)
     else:
@@ -1136,7 +1153,10 @@ def multiply(x, y, name=None):
     """
 
     if in_dynamic_or_pir_mode():
-        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+        if not (
+            isinstance(x, (Variable, paddle.pir.Value))
+            and isinstance(y, (Variable, paddle.pir.Value))
+        ):
             x, y = _convert_binary_inputs(x, y)
         return _C_ops.multiply(x, y)
     else:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -155,10 +155,8 @@ def _convert_binary_tensor_number_inputs(x, y):
     return x, y
 
 def _convert_binary_inputs(x, y):
-    if isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value)):
-        return x, y
     # number_number_case
-    elif not isinstance(x, (Variable, paddle.pir.Value)) and not isinstance(y, (Variable, paddle.pir.Value)):
+    if not isinstance(x, (Variable, paddle.pir.Value)) and not isinstance(y, (Variable, paddle.pir.Value)):
         _x = paddle.to_tensor(x)
         _y = paddle.to_tensor(y)
         if isinstance(x, float) and isinstance(y, int):
@@ -716,8 +714,9 @@ def add(x, y, name=None):
             [3., 8., 6.])
     """
 
-    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
+        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+            x, y = _convert_binary_inputs(x, y)
         return _C_ops.add(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_add', **locals()))
@@ -858,8 +857,9 @@ def subtract(x, y, name=None):
             [ 4.  ,  inf., -inf.])
     """
 
-    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
+        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+            x, y = _convert_binary_inputs(x, y)
         return _C_ops.subtract(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_sub', **locals()))
@@ -918,8 +918,9 @@ def divide(x, y, name=None):
 
     """
 
-    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
+        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+            x, y = _convert_binary_inputs(x, y)
         return _C_ops.divide(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_div', **locals()))
@@ -981,8 +982,9 @@ def floor_divide(x, y, name=None):
 
     """
 
-    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
+        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+            x, y = _convert_binary_inputs(x, y)
         return _C_ops.floor_divide(x, y)
     else:
         return _elementwise_op(LayerHelper('elementwise_floordiv', **locals()))
@@ -1133,8 +1135,9 @@ def multiply(x, y, name=None):
 
     """
 
-    x, y = _convert_binary_inputs(x, y)
     if in_dynamic_or_pir_mode():
+        if not (isinstance(x, (Variable, paddle.pir.Value)) and isinstance(y, (Variable, paddle.pir.Value))):
+            x, y = _convert_binary_inputs(x, y)
         return _C_ops.multiply(x, y)
     else:
         if x.dtype != y.dtype:

--- a/test/legacy_test/test_multiply.py
+++ b/test/legacy_test/test_multiply.py
@@ -142,6 +142,7 @@ class TestMultiplyApi(unittest.TestCase):
         res = self._run_dynamic_graph_python_number_case(x, y_data)
         np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
 
+
 class TestMultiplyError(unittest.TestCase):
     def test_errors(self):
         # test static computation graph: dtype can not be int8

--- a/test/legacy_test/test_multiply.py
+++ b/test/legacy_test/test_multiply.py
@@ -54,6 +54,11 @@ class TestMultiplyApi(unittest.TestCase):
         res = paddle.multiply(x, y)
         return res.numpy()
 
+    def _run_dynamic_graph_python_number_case(self, x, y):
+        paddle.disable_static()
+        res = paddle.multiply(x, y)
+        return res.numpy()
+
     def test_multiply(self):
         np.random.seed(7)
 
@@ -105,6 +110,37 @@ class TestMultiplyApi(unittest.TestCase):
         res = self._run_dynamic_graph_case(x_data, y_data)
         np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
 
+        # test dynamic computation graph: python number
+        x_data = int(np.random.randn())
+        y_data = np.random.randn()
+        res = self._run_dynamic_graph_python_number_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
+
+        # test dynamic computation graph: python number
+        x_data = np.random.randn()
+        y_data = int(np.random.randn())
+        res = self._run_dynamic_graph_python_number_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
+
+        # test dynamic computation graph: python number
+        x_data = np.random.randn()
+        y_data = np.random.randn()
+        res = self._run_dynamic_graph_python_number_case(x_data, y_data)
+        np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
+
+        # test dynamic computation graph: python number
+        x_data = np.random.randn()
+        y_data = np.random.randn()
+        y = paddle.to_tensor(y_data)
+        res = self._run_dynamic_graph_python_number_case(x_data, y)
+        np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
+
+        # test dynamic computation graph: python number
+        x_data = np.random.randn()
+        y_data = np.random.randn()
+        x = paddle.to_tensor(x_data)
+        res = self._run_dynamic_graph_python_number_case(x, y_data)
+        np.testing.assert_allclose(res, np.multiply(x_data, y_data), rtol=1e-05)
 
 class TestMultiplyError(unittest.TestCase):
     def test_errors(self):
@@ -150,35 +186,6 @@ class TestMultiplyError(unittest.TestCase):
         x = paddle.to_tensor(x_data)
         y = paddle.to_tensor(y_data)
         self.assertRaises(ValueError, paddle.multiply, x, y)
-
-        # test dynamic computation graph: dtype must be Tensor type
-        x_data = np.random.randn(200).astype(np.int64)
-        y_data = np.random.randn(200).astype(np.float64)
-        y = paddle.to_tensor(y_data)
-        self.assertRaises(ValueError, paddle.multiply, x_data, y)
-
-        # test dynamic computation graph: dtype must be Tensor type
-        x_data = np.random.randn(200).astype(np.int64)
-        y_data = np.random.randn(200).astype(np.float64)
-        x = paddle.to_tensor(x_data)
-        self.assertRaises(ValueError, paddle.multiply, x, y_data)
-
-        # test dynamic computation graph: dtype must be Tensor type
-        x_data = np.random.randn(200).astype(np.float32)
-        y_data = np.random.randn(200).astype(np.float32)
-        x = paddle.to_tensor(x_data)
-        self.assertRaises(ValueError, paddle.multiply, x, y_data)
-
-        # test dynamic computation graph: dtype must be Tensor type
-        x_data = np.random.randn(200).astype(np.float32)
-        y_data = np.random.randn(200).astype(np.float32)
-        x = paddle.to_tensor(x_data)
-        self.assertRaises(ValueError, paddle.multiply, x_data, y)
-
-        # test dynamic computation graph: dtype must be Tensor type
-        x_data = np.random.randn(200).astype(np.float32)
-        y_data = np.random.randn(200).astype(np.float32)
-        self.assertRaises(ValueError, paddle.multiply, x_data, y_data)
 
 
 class TestMultiplyInplaceApi(TestMultiplyApi):


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Description
二元 API 支持 python number
添加支持的 API 包括：
- paddle.add
- paddle.subtract
- paddle.divide
- paddle.floor_divide
- paddle.multiply

以上 API 在动态图下添加的可支持调用类型 x, y 分别为: (number, number), (tensor, number), (number, tensor)

其他 API 还有：paddle.add_, paddle.subtract_. paddle.multiply_, paddle.divide_, paddle.remainder, paddle.pow, paddle.greater_equal, paddle.greater_than, paddle.less_equal, paddle.less_than, paddle.equal, paddle.not_equal
这些 API 在 torch 中的调用支持 (tensor, number) 或 (number, tensor)
若这样改合理则继续修改其他 API
