### PR TITLE
Fix typo (`TopologyVarientSort` -> `TopologyVariantSort`) 

### DIFF
--- a/paddle/fluid/framework/ir/constant_folding_pass.cc
+++ b/paddle/fluid/framework/ir/constant_folding_pass.cc
@@ -71,7 +71,7 @@ void ConstantFoldingPass::ApplyImpl(ir::Graph *graph) const {
                                      "dequantize_linear"};
   int folded_op_num = 0;
 
-  auto op_node_sorted = framework::ir::TopologyVarientSort(
+  auto op_node_sorted = framework::ir::TopologyVariantSort(
       *graph, static_cast<framework::ir::SortKind>(0));
   for (auto *op_node : op_node_sorted) {
     if (!op_node->IsOp()) continue;

--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -416,7 +416,7 @@ void CleanIndividualNodes(Graph *graph) {
   }
 }
 
-std::vector<Node *> TopologyVarientSort(const Graph &graph,
+std::vector<Node *> TopologyVariantSort(const Graph &graph,
                                         SortKind sort_kind) {
   switch (sort_kind) {
     case SortKind::TS:
@@ -788,7 +788,7 @@ static void GraphToBlock(const Graph &graph,
   std::vector<Node *> nodes;
   if (sort_kind != nullptr) {
     // Inference Memory Optimize relays on this branch.
-    nodes = TopologyVarientSort(graph, *sort_kind);
+    nodes = TopologyVariantSort(graph, *sort_kind);
   } else {
     if (FLAGS_convert_all_blocks) {
       nodes = TopologySortGraphByDescOrder(graph);

--- a/paddle/fluid/framework/ir/graph_helper.h
+++ b/paddle/fluid/framework/ir/graph_helper.h
@@ -76,7 +76,7 @@ enum class SortKind {
 };
 
 // Several kinds of topological sort.
-std::vector<Node *> TopologyVarientSort(const Graph &graph, SortKind sort_kind);
+std::vector<Node *> TopologyVariantSort(const Graph &graph, SortKind sort_kind);
 
 // Clean the nodes that doesn't connect to others.
 void CleanIndividualNodes(Graph *graph);

--- a/paddle/fluid/framework/ir/mkldnn/compute_propagate_scales_mkldnn_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/compute_propagate_scales_mkldnn_pass.cc
@@ -99,7 +99,7 @@ void ComputePropagateScalesMkldnnPass::ComputeVarScales(
     const int axis,
     StringPairMap* var_quant_scales) const {
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     auto* op_desc = op_node->Op();
@@ -208,7 +208,7 @@ void ComputePropagateScalesMkldnnPass::ComputeGruWeightScales(
     const std::string& wh_name,
     StringPairMap* var_quant_scales) const {
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     auto* op_desc = op_node->Op();
@@ -286,7 +286,7 @@ void ComputePropagateScalesMkldnnPass::ComputeLstmWeightScales(
     const std::string& wh_name,
     StringPairMap* var_quant_scales) const {
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     auto* op_desc = op_node->Op();
@@ -384,7 +384,7 @@ std::unordered_set<std::string> ComputePropagateScalesMkldnnPass::UpdateScales(
     const std::unordered_set<std::string>& scale_immutable_ops) const {
   std::unordered_set<std::string> waiting_for_scale{};
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     const auto op_name = op_node->Name();
@@ -437,7 +437,7 @@ std::unordered_set<std::string> ComputePropagateScalesMkldnnPass::UpdateScales(
 void ComputePropagateScalesMkldnnPass::UpdateReluOutputScales(
     ir::Graph* graph, StringPairMap* var_quant_scales) const {
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
     auto op = op_node->Op();
     bool is_unsigned = false;

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_pass_util.h
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_pass_util.h
@@ -74,7 +74,7 @@ static void GetInfoFromTheTmpOp(
 
   const std::string suffix = "_" + key_suffix + "_" + flag;
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp() || op_node->Op()->Type() != "save") continue;
 
     auto* op_desc = op_node->Op();
@@ -106,7 +106,7 @@ static void GetInfoFromTheTmpOp(ir::Graph* graph,
   const std::string suffix = "_" + key_suffix + "_" + flag;
   const std::string suffix_is_unsigned = suffix + unsigned_flag;
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp() || op_node->Op()->Type() != "save") continue;
 
     auto* op_desc = op_node->Op();

--- a/paddle/fluid/framework/ir/mkldnn/quant_dequant_mkldnn_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/quant_dequant_mkldnn_pass.cc
@@ -28,7 +28,7 @@ void QuantDequantMkldnnPass::MarkSkipQuantizedOps(
     ir::Graph* graph, const std::unordered_set<std::string>& skip_ops) const {
   VLOG(3) << "mark skip quantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (skip_ops.count(op_node->Name())) {
@@ -63,7 +63,7 @@ void QuantDequantMkldnnPass::CollectInfoFromFake(
     const {
   VLOG(3) << "gather weight_thresholds from fake dequantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (fake_dequantize_types.count(op_node->Name())) {
@@ -104,7 +104,7 @@ void QuantDequantMkldnnPass::CollectWeightScalesInfoFromONNXFormatDequantize(
     bool* onnx_format_quantize_model) const {
   VLOG(3) << "gather weight_thresholds from onnx format dequantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (op_node->Name() == "dequantize_linear") {
@@ -153,7 +153,7 @@ void QuantDequantMkldnnPass::CollectInputScalesFromQuantize(
     const {
   VLOG(3) << "gather input scales from fake quantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (op_node->Name() == "fake_quantize_dequantize_moving_average_abs_max" ||
@@ -211,7 +211,7 @@ void QuantDequantMkldnnPass::CollectOutputScalesFromAttr(
     const {
   VLOG(3) << "gather output scales from op's attr";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     auto* op_desc = op_node->Op();
@@ -395,7 +395,7 @@ void QuantDequantMkldnnPass::RemoveFakeOps(
 
   std::unordered_set<const Node*> nodes2rm = {};
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (fake_quantize_types.count(op_node->Name())) {
@@ -644,7 +644,7 @@ void QuantDequantMkldnnPass::DequantizeWeights(
   }
   std::vector<std::string> dequantized_weights_names;
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
     if (op_node->Name() == "conv2d" || op_node->Name() == "depthwise_conv2d" ||
         op_node->Name() == "fused_conv2d") {
@@ -673,7 +673,7 @@ void QuantDequantMkldnnPass::DequantizeWeights(
 void QuantDequantMkldnnPass::UpdateActivations(ir::Graph* graph) const {
   VLOG(3) << "update conv2d or depthwise_conv2d fused activation";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (op_node->Name() == "conv2d" || op_node->Name() == "depthwise_conv2d") {
@@ -693,7 +693,7 @@ void QuantDequantMkldnnPass::RemoveCtrlVars(ir::Graph* graph) const {
   VLOG(3) << "remove control flow variable";
   std::unordered_set<const Node*> nodes2rm = {};
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (op_node->IsCtrlVar()) {
       nodes2rm.insert(op_node);
     }

--- a/paddle/fluid/framework/ir/transfer_layout_elim_pass.cc
+++ b/paddle/fluid/framework/ir/transfer_layout_elim_pass.cc
@@ -251,7 +251,7 @@ void TransferLayoutElimPass::ApplyImpl(ir::Graph *graph) const {
   int elim_count = 0;
 
   while (true) {
-    auto op_node_sorted = framework::ir::TopologyVarientSort(
+    auto op_node_sorted = framework::ir::TopologyVariantSort(
         *graph, static_cast<framework::ir::SortKind>(0));
     bool modify = false;
     for (auto *op_node : op_node_sorted) {

--- a/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.cc
+++ b/paddle/fluid/framework/ir/xpu/quant_dequant_xpu_pass.cc
@@ -33,7 +33,7 @@ void QuantDequantXPUPass::CollectWeightScalesInfoFromDequantize(
     const {
   VLOG(3) << "gather weight_thresholds from fake dequantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (fake_dequantize_types.count(op_node->Name())) {
@@ -90,7 +90,7 @@ void QuantDequantXPUPass::CollectWeightScalesInfoFromONNXFormatDequantize(
     const {
   VLOG(3) << "gather weight_thresholds from onnx format dequantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (op_node->Name() == "dequantize_linear") {
@@ -138,7 +138,7 @@ void QuantDequantXPUPass::CollectInputScalesFromQuantize(
     const {
   VLOG(3) << "gather input scales from fake quantized ops";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (op_node->Name() == "fake_quantize_dequantize_moving_average_abs_max" ||
@@ -207,7 +207,7 @@ void QuantDequantXPUPass::CollectOutputScalesFromAttr(
     const {
   VLOG(3) << "gather output scales from op's attr";
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     auto* op_desc = op_node->Op();
@@ -391,7 +391,7 @@ void QuantDequantXPUPass::RemoveFakeOps(
 
   std::unordered_set<const Node*> nodes2rm = {};
   for (auto* op_node :
-       ir::TopologyVarientSort(*graph, static_cast<ir::SortKind>(0))) {
+       ir::TopologyVariantSort(*graph, static_cast<ir::SortKind>(0))) {
     if (!op_node->IsOp()) continue;
 
     if (fake_quantize_types.count(op_node->Name())) {

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -243,7 +243,7 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
 
   // some ops are only implemented in paddle-trt,
   // but not in paddle ,we should revert it.
-  for (auto *op_node : framework::ir::TopologyVarientSort(
+  for (auto *op_node : framework::ir::TopologyVariantSort(
            *graph, static_cast<framework::ir::SortKind>(0))) {
     if (op_node->Op()->Type() == "matrix_multiply") {
       auto origin_type =

--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -39,7 +39,7 @@ namespace analysis {
 
 using framework::ir::Graph;
 using framework::ir::Node;
-using framework::ir::TopologyVarientSort;
+using framework::ir::TopologyVariantSort;
 using space_table_t = MemoryOptimizePass::space_table_t;
 
 typedef struct {
@@ -60,7 +60,7 @@ void MemoryOptimizePass::CollectLifeCycle(
     int sort_kind) const {
   int max_lifecycle = 0;
   double persis_byte = 0;
-  for (auto* op_node : framework::ir::TopologyVarientSort(
+  for (auto* op_node : framework::ir::TopologyVariantSort(
            *graph, static_cast<framework::ir::SortKind>(sort_kind))) {
     if (!op_node->IsOp()) continue;
     auto reads = op_node->inputs;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Fix typo (`TopologyVarientSort` -> `TopologyVariantSort`) 