### PR TITLE
Fix typo (`LoopkUpOpInfo` -> `LookUpOpInfo`)

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -273,8 +273,8 @@ inline std::string GetPrefix(pir::IrContext* ctx, const OpDesc& op_desc) {
 }
 }  // namespace
 
-pir::OpInfo OpTranscriber::LoopkUpOpInfo(pir::IrContext* ctx,
-                                         const OpDesc& op_desc) {
+pir::OpInfo OpTranscriber::LookUpOpInfo(pir::IrContext* ctx,
+                                        const OpDesc& op_desc) {
   std::string target_op_name =
       GetPrefix(ctx, op_desc) + OpNameCompatibleMapping(op_desc.Type());
   if (IsInplace(op_desc) && *target_op_name.rbegin() != '_') {
@@ -800,7 +800,7 @@ pir::Operation* OpTranscriber::operator()(pir::IrContext* ctx,
                                           TranslationContext* param_map,
                                           const OpDesc& op_desc,
                                           pir::Block* block) {
-  auto op_info = this->LoopkUpOpInfo(ctx, op_desc);
+  auto op_info = this->LookUpOpInfo(ctx, op_desc);
   auto* op_info_concept =
       op_info.GetInterfaceImpl<dialect::OpYamlInfoInterface>();
 
@@ -838,8 +838,8 @@ pir::Operation* OpTranscriber::operator()(pir::IrContext* ctx,
 }
 
 struct AssignOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name;
 
     IR_ENFORCE(
@@ -853,7 +853,7 @@ struct AssignOpTranscriber : public OpTranscriber {
     if (input_var->GetType() == framework::proto::VarType::LOD_TENSOR_ARRAY) {
       target_op_name = dialect::AssignArray_Op::name();
     } else {
-      return OpTranscriber::LoopkUpOpInfo(ctx, op_desc);
+      return OpTranscriber::LookUpOpInfo(ctx, op_desc);
     }
 
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
@@ -930,8 +930,8 @@ struct IncrementOpTranscriber : public OpTranscriber {
 // `legacy_ops.yaml`. For this op we simulate the logic in
 // python/paddle/tensor/creation.py::assign(x, output)
 struct AssignValueOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = "pd_op.assign_value";
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -948,7 +948,7 @@ struct AssignValueOpTranscriber : public OpTranscriber {
                              const OpDesc& op_desc,
                              pir::Block* block) override {
     VLOG(10) << "[op assign_value] start transcribing";
-    auto op_info = this->LoopkUpOpInfo(ctx, op_desc);
+    auto op_info = this->LookUpOpInfo(ctx, op_desc);
     auto* op_info_concept =
         op_info.GetInterfaceImpl<dialect::OpYamlInfoInterface>();
     OpInputInfoList input_infos;
@@ -1100,8 +1100,8 @@ struct EmbeddingGradOpTranscriber : public OpTranscriber {
     }
   }
 
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name =
         GetPrefix(ctx, op_desc) + OpNameCompatibleMapping(op_desc.Type());
 
@@ -1259,8 +1259,8 @@ struct SplitOpTranscriber : public OpTranscriber {
     return {};
   }
 
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     int num = paddle::get<int>(op_desc.GetAttr("num"));
     std::string target_op_name;
     if (num > 0) {
@@ -1284,7 +1284,7 @@ struct FetchOpTranscriber : public OpTranscriber {
                              TranslationContext* param_map,
                              const OpDesc& op_desc,
                              pir::Block* block) override {
-    auto op_info = this->LoopkUpOpInfo(ctx, op_desc);
+    auto op_info = this->LookUpOpInfo(ctx, op_desc);
 
     auto* op_info_concept =
         op_info.GetInterfaceImpl<paddle::dialect::OpYamlInfoInterface>();
@@ -1353,8 +1353,8 @@ struct ShadowOutputOpTranscriber : public OpTranscriber {
 
 // NOTE, add_n op in legacy ops don't have a kernel, so we use a new op for now
 struct AddNOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name =
         GetPrefix(ctx, op_desc) + OpNameCompatibleMapping(op_desc.Type());
     if (IsInplace(op_desc)) {
@@ -1372,8 +1372,8 @@ struct AddNOpTranscriber : public OpTranscriber {
 };
 
 struct TrilAndTriuOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     bool lower = PADDLE_GET_CONST(bool, op_desc.GetAttr("lower"));
     std::string target_op_name = "";
     if (lower) {
@@ -1393,8 +1393,8 @@ struct TrilAndTriuOpTranscriber : public OpTranscriber {
 };
 
 struct TrilAndTriuGradOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     bool lower = PADDLE_GET_CONST(bool, op_desc.GetAttr("lower"));
     std::string target_op_name = "";
     if (lower) {
@@ -1451,8 +1451,8 @@ ValueInfo GetTensorInfoByVarName(const OpDesc& op_desc,
 }
 
 struct MulOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     const std::string& target_op_name = paddle::dialect::MatmulOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -1605,8 +1605,8 @@ struct MulOpTranscriber : public OpTranscriber {
 };
 
 struct MulGradOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     const std::string& target_op_name = paddle::dialect::MatmulGradOp::name();
     VLOG(6) << "[op name normalizing: " << op_desc.Type() << " to "
             << target_op_name;
@@ -1803,8 +1803,8 @@ struct MulGradOpTranscriber : public OpTranscriber {
 };
 
 struct FillConstant2FullTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     const auto& op_info = ctx->GetRegisteredOpInfo(dialect::FullOp::name());
     if (!op_info) {
       IR_THROW("Op fill_constant should have corresponding OpInfo pd_op.full");
@@ -1884,8 +1884,8 @@ struct FillConstant2FullTranscriber : public OpTranscriber {
 };
 
 struct FillConstant2FullWithTensorTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     const auto& op_info = ctx->GetRegisteredOpInfo("pd_op.full_with_tensor");
     if (!op_info) {
       IR_THROW(
@@ -1984,7 +1984,7 @@ struct SelectInputOpTranscriber : public OpTranscriber {
                              const OpDesc& op_desc,
                              pir::Block* block) override {
     VLOG(10) << "[op select_input] start transcribing";
-    auto op_info = this->LoopkUpOpInfo(ctx, op_desc);
+    auto op_info = this->LookUpOpInfo(ctx, op_desc);
 
     std::vector<pir::Value> op_inputs = {};
     auto Mask_name = op_desc.Input("Mask")[0];
@@ -2121,7 +2121,7 @@ struct SelectOutputOpTranscriber : public OpTranscriber {
                              const OpDesc& op_desc,
                              pir::Block* block) override {
     VLOG(10) << "[op select_output] start transcribing";
-    auto op_info = this->LoopkUpOpInfo(ctx, op_desc);
+    auto op_info = this->LookUpOpInfo(ctx, op_desc);
 
     std::vector<pir::Value> op_inputs = {};
     auto Mask_name = op_desc.Input("Mask")[0];
@@ -2393,8 +2393,8 @@ struct ElementwiseTranscriber : public OpTranscriber {
 };
 
 struct GradAddOpTranscriber : public ElementwiseTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = "pd_op.add";
     if (IsInplace(op_desc) && *target_op_name.rbegin() != '_') {
       target_op_name += "_";
@@ -2517,8 +2517,8 @@ struct SetValueOpTranscriber : public OpTranscriber {
 };
 
 struct SetValueWithTensorOpTranscriber : public SetValueOpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::SetValueWithTensorOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -2562,8 +2562,8 @@ struct SetValueWithTensorOpTranscriber : public SetValueOpTranscriber {
 };
 
 struct SetValueGradOpTranscriber : public SetValueWithTensorOpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::SetValueWithTensorGradOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -2658,8 +2658,8 @@ struct FusedFeedForwardOpTranscriber : public OpTranscriber {
 };
 
 struct ShareBufferOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::ShareDataOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -2712,8 +2712,8 @@ struct RandIntOpTranscriber : public OpTranscriber {
 };
 
 struct RepeatInterLeaveOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name;
     if (op_desc.HasInput("RepeatsTensor") &&
         !op_desc.Input("RepeatsTensor").empty()) {
@@ -2747,8 +2747,8 @@ struct RepeatInterLeaveOpTranscriber : public OpTranscriber {
 };
 
 struct RepeatInterLeaveGradOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name;
     if (op_desc.HasInput("RepeatsTensor") &&
         !op_desc.Input("RepeatsTensor").empty()) {
@@ -2801,8 +2801,8 @@ struct FusedElemwiseAddActivationOpTranscriber : public OpTranscriber {
 
 struct FusedElemwiseAddActivationGradOpTranscriber
     : public FusedElemwiseAddActivationOpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     const auto inter_out_grad = op_desc.Output("IntermediateOut@GRAD");
     if (inter_out_grad.size() > 0) {
       IR_THROW(
@@ -2810,13 +2810,13 @@ struct FusedElemwiseAddActivationGradOpTranscriber
           "Intermediate_out_grad output");
     }
 
-    return OpTranscriber::LoopkUpOpInfo(ctx, op_desc);
+    return OpTranscriber::LookUpOpInfo(ctx, op_desc);
   }
 };
 
 struct MatrixRankOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = "";
     if (op_desc.HasInput("TolTensor") && !op_desc.Input("TolTensor").empty()) {
       target_op_name = "pd_op.matrix_rank_tol";
@@ -2835,8 +2835,8 @@ struct MatrixRankOpTranscriber : public OpTranscriber {
 };
 
 struct LodArrayLengthOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::ArrayLengthOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -2888,8 +2888,8 @@ struct LodArrayLengthOpTranscriber : public OpTranscriber {
 };
 
 struct WriteArrayOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::ArrayWrite_Op::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -2941,8 +2941,8 @@ struct WriteArrayOpTranscriber : public OpTranscriber {
 };
 
 struct ReadArrayOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::ArrayReadOp::name();
     const auto& op_info = ctx->GetRegisteredOpInfo(target_op_name);
     if (!op_info) {
@@ -2956,8 +2956,8 @@ struct ReadArrayOpTranscriber : public OpTranscriber {
 };
 
 struct SliceOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     std::string target_op_name = dialect::SliceOp::name();
 
     IR_ENFORCE(op_desc.HasInput("Input"),
@@ -3002,8 +3002,8 @@ struct SliceOpTranscriber : public OpTranscriber {
 };
 
 struct LegacyMatmulOpTranscriber : public OpTranscriber {
-  pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx,
-                            const OpDesc& op_desc) override {
+  pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
+                           const OpDesc& op_desc) override {
     auto enforce_not_occur = [&](const std::string& attr_name,
                                  float expected_value) -> void {
       if (!op_desc.HasAttr(attr_name)) {

--- a/paddle/fluid/ir_adaptor/translator/op_translator.h
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.h
@@ -65,7 +65,7 @@ struct OpTranscriber {
                                      pir::Block* block);
 
  public:
-  virtual pir::OpInfo LoopkUpOpInfo(pir::IrContext* ctx, const OpDesc& op_desc);
+  virtual pir::OpInfo LookUpOpInfo(pir::IrContext* ctx, const OpDesc& op_desc);
   virtual std::vector<pir::Value> GenerateOperationInput(
       pir::IrContext* ctx,
       TranslationContext* param_map,

--- a/paddle/fluid/ir_adaptor/translator/utils.cc
+++ b/paddle/fluid/ir_adaptor/translator/utils.cc
@@ -94,7 +94,7 @@ std::vector<std::string> CheckUnregisteredOperationInBlock(
     }
     OpTranscriber general_handler;
     try {
-      general_handler.LoopkUpOpInfo(ctx, *op);
+      general_handler.LookUpOpInfo(ctx, *op);
     } catch (pir::IrNotMetException& e) {
       unregistered_ops.push_back(op->Type());
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Fix typo (`LoopkUpOpInfo` -> `LookUpOpInfo`)