### PR TITLE
Fix typo (`EVENT_NOT_SWTICH` -> `EVENT_NOT_SWITCH`)

### DIFF
--- a/paddle/fluid/framework/data_feed.cu
+++ b/paddle/fluid/framework/data_feed.cu
@@ -3106,9 +3106,9 @@ int FillWalkBuf(const std::vector<uint64_t> &h_device_keys_len,
   int total_samples = 0;
 
   // Definition of variables related to multi machine sampling
-  int switch_flag = EVENT_NOT_SWTICH;  // Mark whether the local machine needs
+  int switch_flag = EVENT_NOT_SWITCH;  // Mark whether the local machine needs
                                        // to switch metapath
-  int switch_command = EVENT_NOT_SWTICH;    // Mark whether to switch metapath,
+  int switch_command = EVENT_NOT_SWITCH;    // Mark whether to switch metapath,
                                             // after multi node sync
   int sample_flag = EVENT_CONTINUE_SAMPLE;  // Mark whether the local machine
                                             // needs to continue sampling
@@ -3182,7 +3182,7 @@ int FillWalkBuf(const std::vector<uint64_t> &h_device_keys_len,
               << " switch_flag:" << switch_flag << "," << switch_command;
       if (switch_command) {
         cursor += 1;
-        switch_flag = EVENT_NOT_SWTICH;
+        switch_flag = EVENT_NOT_SWITCH;
         continue;
       }
 

--- a/paddle/fluid/framework/data_feed.h
+++ b/paddle/fluid/framework/data_feed.h
@@ -932,7 +932,7 @@ struct BufState {
 const int EVENT_FINISH_EPOCH = 0;     // End of sampling single epoch
 const int EVENT_CONTINUE_SAMPLE = 1;  // Continue sampling
 const int EVENT_WALKBUF_FULL = 2;  // d_walk is full, end current pass sampling
-const int EVENT_NOT_SWTICH = 0;    // Continue sampling on the current metapath.
+const int EVENT_NOT_SWITCH = 0;    // Continue sampling on the current metapath.
 const int EVENT_SWTICH_METAPATH =
     1;  // Switch to the next metapath to perform sampling
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Fix typo (`EVENT_NOT_SWTICH` -> `EVENT_NOT_SWITCH`)