### PR TITLE
fix view grad kernel name error

### DIFF
--- a/paddle/phi/kernels/stride/view_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/view_grad_kernel.cc
@@ -39,7 +39,7 @@ void ViewDtypeGradKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE_EXCEPT_CUSTOM(
-    view_grad_shape, STRIDED, phi::ViewShapeGradKernel) {}
+    view_shape_grad, STRIDED, phi::ViewShapeGradKernel) {}
 
 PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE_EXCEPT_CUSTOM(
-    view_grad_dtype, STRIDED, phi::ViewDtypeGradKernel) {}
+    view_dtype_grad, STRIDED, phi::ViewDtypeGradKernel) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-74613

view grad kernel命名错误导致反向找不到kernel。