### PR TITLE
[PIR+CINN]Fix cinn_op.pool2d Attribute and open subgraph0 UT

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -273,10 +273,8 @@ class Pool2dOpPattern
         pir::ArrayAttribute::get(pir::IrContext::Instance(), kernel_size);
     attrs["stride_size"] = attrs.at("strides");
     attrs["padding_size"] = attrs.at("paddings");
-    attrs["pool_type"] = attrs.at("pooling_type");
     attrs.erase("strides");
     attrs.erase("paddings");
-    attrs.erase("pooling_type");
 
     auto cinn_reshape =
         rewriter.Build<cinn::dialect::Pool2dOp>(op->operand_source(0), attrs);

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_0.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_0.py
@@ -96,8 +96,11 @@ class TestLayer(unittest.TestCase):
     # NOTE prim + cinn lead to error
     def test_ast_prim_cinn(self):
         st_out = self.train(self.net, to_static=True)
+        # NOTE(Aurelius84): cinn_op.pool2d only support pool_type='avg' under adaptive=True
+        paddle.set_flags({"FLAGS_deny_cinn_ops": "pool2d"})
+        # TODO(Aurelius84): Fix LoopAligment eror under with_prim=True
         cinn_out = self.train(
-            self.net, to_static=True, with_prim=True, with_cinn=False
+            self.net, to_static=True, with_prim=False, with_cinn=True
         )
         for st, cinn in zip(
             paddle.utils.flatten(st_out), paddle.utils.flatten(cinn_out)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164

目前被CINN自动代码生成的有：reshape、full+pow 两类：

```cpp
 __global__
 void __launch_bounds__(1024) fn_reshape_kernel(const float* __restrict__ var, float* __restrict__ var_0)
 {
   if (((int)blockIdx.x < 2)) {
     if (((int)threadIdx.x < 1024)) {
       if ((((1024 * (int)blockIdx.x) + (int)threadIdx.x) < 1078)) {
         var_0[((1024 * (int)blockIdx.x) + (int)threadIdx.x)] = var[((7 * ((((((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 49) - (((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 7)) / 7) % 7)) + ((((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 7) + (49 * (((((((-1 * (((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 7)) + (((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 49)) / 7) - ((((-1 * (((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 7)) + (((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 49)) / 7) % 7)) / 7) + (((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 49)) % 22))))];
       };
     };
   };
 }


 __global__
 void __launch_bounds__(1024) fn_fill_constant_0_pow_0_kernel(const float* __restrict__ var_0, float* __restrict__ var_1)
 {
   if (((int)blockIdx.x < 4312)) {
     if (((int)threadIdx.x < 1024)) {
       var_1[(((((((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 56) / 56) / 64) * 200704) + ((56 * ((((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 56) % 56)) + ((((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 56) + (3136 * (((((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 56) / 56) & 63)))))] = cinn_nvgpu_pow_fp32(var_0[(((((((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 56) / 56) / 64) * 200704) + ((56 * ((((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 56) % 56)) + ((((1024 * (int)blockIdx.x) + (int)threadIdx.x) % 56) + (3136 * (((((1024 * (int)blockIdx.x) + (int)threadIdx.x) / 56) / 56) & 63)))))], 2.00000000f);
     };
   };
 }
```

开启prim后，mean算子会被拆解为：sum+divide。其中sum对应一个reduce操作，在LoopAligment里报错，分析中：

```cpp
619:     (%48) = cinn_op.fusion () -> pd_op.tensor<22x1x14x14xf32> {
619:     (%49) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[22,256,14,14],stop_gradient:[true],value:(Float)2} : () -> pd_op.tensor<22x256x14x14xf32>
619:     (%50) = "pd_op.elementwise_pow" (%5, %49) {stop_gradient:[true]} : (pd_op.tensor<22x256x14x14xf32>, pd_op.tensor<22x256x14x14xf32>) -> pd_op.tensor<22x256x14x14xf32>
619:     (%51) = "pd_op.full" () {dtype:(pd_op.DataType)float32,place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[22,1,14,14],stop_gradient:[true],value:(Float)256} : () -> pd_op.tensor<22x1x14x14xf32>
619:     (%52) = "cinn_op.reduce_sum" (%50) {dim:[(Int64)1],keep_dim:true,stop_gradient:[true]} : (pd_op.tensor<22x256x14x14xf32>) -> pd_op.tensor<22x1x14x14xf32>
619:     (%53) = "pd_op.divide" (%52, %51) {stop_gradient:[true]} : (pd_op.tensor<22x1x14x14xf32>, pd_op.tensor<22x1x14x14xf32>) -> pd_op.tensor<22x1x14x14xf32>
619:     () = "cf.yield" (%53) {} : (pd_op.tensor<22x1x14x14xf32>) ->  
619:  }
```
最小复现case：

```python
import unittest
import numpy as np
import paddle


class LayerCase(paddle.nn.Layer):
    def __init__(self):
        super().__init__()

    def forward(
        self,
        var_0,  # (shape: [22, 64, 56, 56], dtype: paddle.float32, stop_gradient: False)
    ):
  
        return var_0.mean(1, keepdim=True)

class TestLayer(unittest.TestCase):
    def setUp(self):
        self.inputs = (
            paddle.rand(shape=[22, 64, 56, 56], dtype=paddle.float32),
        )
        self.net = LayerCase()

    def train(self, net, to_static, with_prim=False, with_cinn=False):
        if to_static:
            paddle.set_flags({'FLAGS_prim_all': with_prim})
            if with_cinn:
                build_strategy = paddle.static.BuildStrategy()
                build_strategy.build_cinn_pass = True
                net = paddle.jit.to_static(
                    net, build_strategy=build_strategy, full_graph=True
                )
            else:
                net = paddle.jit.to_static(net, full_graph=True)
        paddle.seed(123)
        outs = net(*self.inputs)
        return outs

    # NOTE prim + cinn lead to error
    def test_ast_prim_cinn(self):
        # NOTE(Aurelius84): cinn_op.pool2d only support pool_type='avg' under adaptive=True
        paddle.set_flags({"FLAGS_deny_cinn_ops": "pool2d"})
        # TODO(Aurelius84): Fix LoopAligment eror under with_prim=True
        cinn_out = self.train(
            self.net, to_static=True, with_prim=True, with_cinn=True
        )
    

if __name__ == '__main__':
    unittest.main()

```