### PR TITLE
Fix typo (`precending` -> `preceding`) 

### DIFF
--- a/paddle/cinn/poly/isl_utils.cc
+++ b/paddle/cinn/poly/isl_utils.cc
@@ -136,9 +136,7 @@ isl::set SetGetDims(isl::set set, const std::vector<int> &dims) {
   return set.apply(transform);
 }
 
-isl_set *isl_get_precending_axis(isl_set *set,
-                                 int level,
-                                 bool with_tuple_name) {
+isl_set *isl_get_preceding_axis(isl_set *set, int level, bool with_tuple_name) {
   int n = isl_set_dim(set, isl_dim_set);
   CHECK_LT(level, n);
 
@@ -189,7 +187,7 @@ int isl_get_original_axes_from_optimized_level(isl_set __isl_keep *a,
   return original_level;
 }
 
-int isl_get_precending_removed_axes_counts(isl_set __isl_keep *a, int level) {
+int isl_get_preceding_removed_axes_counts(isl_set __isl_keep *a, int level) {
   int removed_axes_counts = 0;
   std::vector<std::tuple<int, int>> iden_dim_offsets;
   for (int i = 0; i <= level; i++) {
@@ -233,9 +231,9 @@ int isl_max_level_compatible(isl_set *a, isl_set *b) {
   int compatible_level = -1;
   for (int i = 0; i < std::min(an, bn); i++) {
     isl::set a_prefix =
-        isl::manage(isl_get_precending_axis(isl_set_copy(a), i, false));
+        isl::manage(isl_get_preceding_axis(isl_set_copy(a), i, false));
     isl::set b_prefix =
-        isl::manage(isl_get_precending_axis(isl_set_copy(b), i, false));
+        isl::manage(isl_get_preceding_axis(isl_set_copy(b), i, false));
 
     a_prefix = isl::manage(isl_set_set_tuple_name(a_prefix.release(), "s"));
     b_prefix = isl::manage(isl_set_set_tuple_name(b_prefix.release(), "s"));

--- a/paddle/cinn/poly/isl_utils.h
+++ b/paddle/cinn/poly/isl_utils.h
@@ -56,13 +56,13 @@ isl::union_set isl_sets_to_union_set(const std::vector<isl::set>& sets);
 std::string isl_map_get_statement_repr(__isl_keep isl_map* map,
                                        isl_dim_type type);
 
-isl_set* __isl_give isl_get_precending_axis(isl_set* set,
-                                            int level,
-                                            bool with_tuple_name);
+isl_set* __isl_give isl_get_preceding_axis(isl_set* set,
+                                           int level,
+                                           bool with_tuple_name);
 
 //! If the min and max bounds of the axis are same, isl will remove this axis
 //! after ast_build. Counts the removed axes before the given axis.
-int isl_get_precending_removed_axes_counts(isl_set __isl_keep* a, int level);
+int isl_get_preceding_removed_axes_counts(isl_set __isl_keep* a, int level);
 
 //! Get the original level from the level after removing axes.
 int isl_get_original_axes_from_optimized_level(isl_set __isl_keep* a,

--- a/paddle/cinn/poly/stage.cc
+++ b/paddle/cinn/poly/stage.cc
@@ -432,7 +432,7 @@ void Stage::EditTempTensor(Stage *other, int level) {
     if (isl_is_removed_axis(this->transformed_domain().get(), i)) {
       continue;
     }
-    int new_i = i - isl_get_precending_removed_axes_counts(
+    int new_i = i - isl_get_preceding_removed_axes_counts(
                         this->transformed_domain().get(), i);
     if (bind_info.count(new_i) != 0) {
       if (bind_info[new_i].for_type == ir::ForType::GPUThread &&
@@ -454,7 +454,7 @@ void Stage::EditTempTensor(Stage *other, int level) {
     if (isl_is_removed_axis(this->transformed_domain().get(), i)) {
       continue;
     }
-    int new_i = i - isl_get_precending_removed_axes_counts(
+    int new_i = i - isl_get_preceding_removed_axes_counts(
                         this->transformed_domain().get(), i);
     if (bind_info.count(new_i) != 0) {
       if (bind_info[new_i].for_type == ir::ForType::GPUBlock &&
@@ -1133,7 +1133,7 @@ void Stage::Vectorize(int level, int factor) {
     return;
   }
   int removed_axes_counts =
-      isl_get_precending_removed_axes_counts(transformed_domain.get(), level);
+      isl_get_preceding_removed_axes_counts(transformed_domain.get(), level);
   VLOG(3) << "removed_axes_counts are " << removed_axes_counts
           << " before axis " << ith_dim_name(level);
   VLOG(3) << "vectorize level: " << level - removed_axes_counts
@@ -1171,7 +1171,7 @@ void Stage::Parallel(int level) {
     return;
   }
   int removed_axes_counts =
-      isl_get_precending_removed_axes_counts(transformed_domain.get(), level);
+      isl_get_preceding_removed_axes_counts(transformed_domain.get(), level);
   VLOG(3) << "removed_axes_counts are " << removed_axes_counts
           << " before axis " << ith_dim_name(level);
   parallel_info_.insert(level - removed_axes_counts);
@@ -1186,7 +1186,7 @@ void Stage::Unroll(int level) {
     return;
   }
   int removed_axes_counts =
-      isl_get_precending_removed_axes_counts(transformed_domain.get(), level);
+      isl_get_preceding_removed_axes_counts(transformed_domain.get(), level);
   VLOG(3) << "removed_axes_counts are " << removed_axes_counts
           << " before axis " << ith_dim_name(level);
   unroll_info_.insert(level - removed_axes_counts);
@@ -1609,7 +1609,7 @@ void Stage::AddForloopInfo(int level, const StageForloopInfo &info) {
   CHECK_LT(level, num_levels);
   auto transformed_domain = this->transformed_domain();
   int removed_axes_counts =
-      isl_get_precending_removed_axes_counts(transformed_domain.get(), level);
+      isl_get_preceding_removed_axes_counts(transformed_domain.get(), level);
 
   if (isl_is_removed_axis(transformed_domain.get(), level)) {
     // For scalar case, forloop info will be lost after for-1 and reduce-axis


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Fix typo (`precending` -> `preceding`) 