### PR TITLE
flash attn with basic functionality

### DIFF
--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
@@ -217,12 +217,17 @@ int SubMeshDim(const ProcessMesh &global_mesh, const ProcessMesh &sub_mesh) {
     return -1;
   }
 
-  auto it = std::find(sub_shape.begin(), sub_shape.end(), 1);
-  if (it == sub_shape.end()) {
+  // e.g.
+  //  global_mesh: shape = [1,2], process_ids = [0,1]; sub_mesh: shape = [1, 1],
+  //  process_ids = [0] global_mesh: shape = [2,2], process_ids = [0,1,2,3];
+  //  sub_mesh: shape = [2, 1], process_ids = [0, 2]
+  auto it =
+      std::mismatch(sub_shape.begin(), sub_shape.end(), global_shape.begin());
+  if (it.first == sub_shape.end()) {
     return -1;
   }
 
-  sub_dim = it - sub_shape.begin();
+  sub_dim = it.first - sub_shape.begin();
   std::vector<ProcessMesh> sub_meshes = SplitMesh(global_mesh, sub_dim);
   if (std::find(sub_meshes.begin(), sub_meshes.end(), sub_mesh) !=
       sub_meshes.end()) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] --> Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] --> Others

### Description
<!-- Describe what you’ve done -->

Pcard-79155

**背景**：flash-attn的基础功能随Paddle发布。高级功能如：attn_mask功能， 反向确定算法（用于逐位对齐精度调试）需要用户手动安装paddle_flash_attn的whl包。该whl包实际为完成版本的flash-attn，即包含了基础+高级功能。

**介绍**：
优先级：使用Paddle时，会自动查找paddle_flash_attn package，并设置Paddle的flash-attn动态链接库。因此如果用户安装了paddle_flash_attn，则会设置为libflashattn_advanced.so，否则则依然会使用Paddle whl包中本身包含的libflashattn.so。

区别：
- libflashattn_advanced.so包含基础功能+高级功能，libflashattn.so仅包含基础功能
- 用户使用Paddle的flash_attention和scaled_dot_product_attention接口时，如果涉及到高级功能，Paddle会自动检查高级功能是否可用，如不可用，则报错提示用户安装paddle_flash_attn的whl包。

**更多介绍**：https://github.com/PaddlePaddle/flash-attention/pull/33

**使用效果**：用test/legacy_test/test_flash_attention.py，和test/legacy_test/test_flash_attention_deterministic.py 2个单测进行测试。 PR编包的Paddle仅包含基础功能，涉及到高级功能时报错如下。安装完paddle_flash_attn后则运行成功。
<img width="1065" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/26615455/28c1951e-6e4f-4f28-9154-15b557c3b888">
<img width="1440" alt="d6536aad007e04ed97c99a7f66623565" src="https://github.com/PaddlePaddle/Paddle/assets/26615455/a773e5a3-3e24-4820-be7b-dc919b2db47c">

**编译时间和大小**
||PR前|PR后|
|---|---|---|
|单架构 80| 12m58s，149M | 6min30s，80M|
|双架构 80-90| 20m55s，299M | 11m32s，158M|
