### PR TITLE
[AutoParallel] Optimize all_reduce_matmul_grad_overlapping

### DIFF
--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -119,7 +119,6 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
             ctx=self.dist_context,
             chunk_id=x_dist_attr.chunk_id,
         )
-        block._sync_with_cpp()
 
         return out
 
@@ -242,5 +241,5 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
                 matmul_op, matmul_grad_dist_attr
             )
 
-            block._remove_op(matmul_grad_id)
-            block._sync_with_cpp()
+            block._remove_op(matmul_grad_id, sync=False)
+        block._sync_with_cpp()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

去除 overlap 中多余的 `sync_with_cpp`

```
优化前 （单位：秒）：

1    0.000    0.000    0.212    0.212 pass_base.py:91(apply)
1    0.000    0.000    0.211    0.211 pass_base.py:111(_apply_impl)
1    0.000    0.000    0.211    0.211 allreduce_matmul_grad_overlapping.py:52(_apply_single_impl)
1    0.000    0.000    0.207    0.207 allreduce_matmul_grad_overlapping.py:126

优化后（单位：秒）：

1    0.000    0.000    0.046    0.046 pass_base.py:91(apply)
1    0.000    0.000    0.046    0.046 pass_base.py:111(_apply_impl)
1    0.000    0.000    0.046    0.046 allreduce_matmul_grad_overlapping.py:52(_apply_single_impl)
1    0.000    0.000    0.040    0.040 allreduce_matmul_grad_overlapping.py:125
```

优化前耗时分布：

![out1](https://github.com/PaddlePaddle/Paddle/assets/55493212/2f7d1521-5dd3-4805-8b2d-d760515c5933)

优化后耗时分布：

![out2](https://github.com/PaddlePaddle/Paddle/assets/55493212/760cd4ff-22e2-44e3-9dd5-57166e4c31f1)


依赖环境：

- PaddleNLP develop llama 模型 （hidden_layer 修改为 4）
- 4 卡 1080 Ti 服务器

运行脚本如下

```
set -x
unset CUDA_VISIBLE_DEVICES

task_name="llama_auto_static_dp2sharding2mp2pp2_vpp2"
# rm -rf output/$task_name/  # ckpt is saved in 'output/''
rm -rf "output/$task_name""_log"

# export PARALLEL_CROSS_ENTROPY=true
export FLAGS_call_stack_level=2
export PYTHONPATH=../../../:$PYTHONPATH

python -u -m paddle.distributed.launch \
    --gpus "0,1,2,3" \
    --log_dir "output/$task_name""_log" \
    run_pretrain_auto_static.py \
    --model_type "llama" \
    --model_name_or_path "facebook/llama-7b" \
    --tokenizer_name_or_path "facebook/llama-7b" \
    --input_dir "../data" \
    --output_dir "output/$task_name" \
    --split 949,50,1 \
    --max_seq_length 2048 \
    --per_device_train_batch_size 1 \
    --per_device_eval_batch_size 2 \
    --gradient_accumulation_steps 16 \
    --use_flash_attention 0 \
    --use_fused_rms_norm 0 \
    --fp16 1 \
    --fp16_opt_level "O2"  \
    --scale_loss 1024 \
    --tensor_parallel_degree 2 \
    --pipeline_parallel_degree 2 \
    --virtual_pp_degree 2 \
    --pipeline_schedule_mode "VPP" \
    --sharding_parallel_degree 1 \
    --sharding "stage1" \
    --learning_rate 0.0001 \
    --min_learning_rate 0.00001 \
    --max_steps 10 \
    --save_steps 5000 \
    --weight_decay 0.01 \
    --warmup_ratio 0.01 \
    --max_grad_norm 1.0 \
    --logging_steps 1 \
    --dataloader_num_workers 1 \
    --eval_steps 1000 \
    --report_to "visualdl" \
    --disable_tqdm true \
    --continue_training 0 \
    --recompute 1 \
    --recompute_granularity full \
    --do_train \
    --do_eval \
    --device "gpu" \
    --data_impl "mmap" \
    --enable_auto_parallel 1 \
    --tensor_parallel_config "enable_mp_async_allreduce" \
```
