### PR TITLE
refine cast

### DIFF
--- a/paddle/phi/kernels/cpu/cast_kernel.cc
+++ b/paddle/phi/kernels/cpu/cast_kernel.cc
@@ -25,6 +25,13 @@ void CastKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 DataType out_dtype,
                 DenseTensor* out) {
+  if (x.dtype() == out_dtype) {
+    if (!out->IsSharedWith(x)) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   if (out->IsSharedWith(x)) {
     PD_VISIT_ALL_TYPES(out_dtype, "CastInplaceKernelImpl", ([&] {
                          CastInplaceKernelImpl<T, data_t>(

--- a/paddle/phi/kernels/gpu/cast_kernel.cu
+++ b/paddle/phi/kernels/gpu/cast_kernel.cu
@@ -24,6 +24,13 @@ void CastKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 DataType out_dtype,
                 DenseTensor* out) {
+  if (x.dtype() == out_dtype) {
+    if (!out->IsSharedWith(x)) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   if (out->IsSharedWith(x)) {
     auto x_origin = x;
     CastCUDAKernel<T>(dev_ctx, x_origin, out_dtype, out);

--- a/paddle/phi/kernels/onednn/cast_kernel.cc
+++ b/paddle/phi/kernels/onednn/cast_kernel.cc
@@ -37,6 +37,8 @@ void CastKernel(const Context& dev_ctx,
   if (x.dtype() == out_dtype) {
     if (!out->IsSharedWith(x)) {
       phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+      out->set_lod(x.lod());
+      out->set_mem_desc(x.mem_desc());
     }
     return;
   }

--- a/paddle/phi/kernels/onednn/cast_kernel.cc
+++ b/paddle/phi/kernels/onednn/cast_kernel.cc
@@ -34,6 +34,13 @@ void CastKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 DataType out_dtype,
                 DenseTensor* out) {
+  if (x.dtype() == out_dtype) {
+    if (!out->IsSharedWith(x)) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   DataType in_dtype = x.dtype();
 
   dnnl::memory::data_type in_dnnl_dtype = funcs::ToOneDNNDataType(in_dtype);

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -76,6 +76,12 @@ void CastKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 DataType out_dtype,
                 DenseTensor* out) {
+  if (x.dtype() == out_dtype) {
+    if (!out->IsSharedWith(x)) {
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
   switch (out_dtype) {
     case DataType::INT32:
       CastXPUKernelImpl<T, int, Context>(dev_ctx, x, out);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-74613

优化cast的实现：input的dtype和目标dtype相同时，如果是inplace的则直接返回，如果不是inplace的则使用Copy。性能会比elementwise好。
这种改法没有改变原有cast的行为：
如果是inplace的，虽然直接返回，但inplace version count仍然会加1。
如果是非inplace的，仍然需要mutable_data，产生新的Tensor。

如果有新的硬件接入，需要单独做该优化。