### PR TITLE
refine logs of reshard

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -111,7 +111,6 @@ phi::DenseTensor ReshardXToReplicated(
     std::vector<int64_t> dims_mapping(dist_tensor->dims().size(), -1);
     dist_attr.set_dims_mapping(dims_mapping);
     dist_attr.clean_partial_status();
-    VLOG(1) << 11111;
     // reshard to replicate dist tensor
     VLOG(4) << "Reshard tensor: "
             << paddle::experimental::ReshardDebugInfo(*dist_tensor, dist_attr);

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -43,6 +43,7 @@ typedef SSIZE_T ssize_t;
 #include "paddle/fluid/pybind/slice_utils.h"
 #include "paddle/fluid/pybind/uva_utils.h"
 #include "paddle/phi/api/include/api.h"
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -60,7 +61,6 @@ typedef SSIZE_T ssize_t;
 #include "paddle/fluid/framework/python_headers.h"
 #include "paddle/fluid/memory/allocation/mmap_allocator.h"
 #include "paddle/fluid/pybind/tensor_py.h"
-#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_function.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_function_registry.h"
@@ -111,8 +111,10 @@ phi::DenseTensor ReshardXToReplicated(
     std::vector<int64_t> dims_mapping(dist_tensor->dims().size(), -1);
     dist_attr.set_dims_mapping(dims_mapping);
     dist_attr.clean_partial_status();
-
+    VLOG(1) << 11111;
     // reshard to replicate dist tensor
+    VLOG(4) << "Reshard tensor: "
+            << paddle::experimental::ReshardDebugInfo(*dist_tensor, dist_attr);
     auto* func =
         phi::distributed::ChooseProperReshardFunction(*dist_tensor, dist_attr);
     auto* dev_ctx =

--- a/paddle/phi/api/lib/data_transform.h
+++ b/paddle/phi/api/lib/data_transform.h
@@ -281,5 +281,8 @@ PrepareDataForDistTensor(
     const TransformFlag& transform_flag,
     bool is_stride_kernel);
 
+std::string ReshardDebugInfo(const phi::distributed::DistTensor& src_tensor,
+                             const phi::distributed::TensorDistAttr& dist_attr);
+
 }  // namespace experimental
 }  // namespace paddle

--- a/paddle/phi/api/lib/data_transform.h
+++ b/paddle/phi/api/lib/data_transform.h
@@ -191,23 +191,27 @@ inline bool NeedTransformPlace(const phi::Place& src_place,
 std::shared_ptr<phi::distributed::DistTensor> ReshardApiInputToKernelInput(
     phi::DeviceContext* dev_ctx,
     const Tensor& tensor,
-    const phi::distributed::ArgDistAttr& dist_attr);
+    const phi::distributed::ArgDistAttr& dist_attr,
+    const std::string& arg_name = "");
 
 std::vector<std::shared_ptr<phi::distributed::DistTensor>>
 ReshardApiInputToKernelInput(phi::DeviceContext* dev_ctx,
                              const std::vector<Tensor>& tensor,
-                             const phi::distributed::ArgDistAttr& dist_attr);
+                             const phi::distributed::ArgDistAttr& dist_attr,
+                             const std::string& arg_name = "");
 
 paddle::optional<std::shared_ptr<phi::distributed::DistTensor>>
 ReshardApiInputToKernelInput(phi::DeviceContext* dev_ctx,
                              const paddle::optional<Tensor>& tensor,
-                             const phi::distributed::ArgDistAttr& dist_attr);
+                             const phi::distributed::ArgDistAttr& dist_attr,
+                             const std::string& arg_name = "");
 
 paddle::optional<std::vector<std::shared_ptr<phi::distributed::DistTensor>>>
 ReshardApiInputToKernelInput(
     phi::DeviceContext* dev_ctx,
     const paddle::optional<std::vector<Tensor>>& tensors,
-    const phi::distributed::ArgDistAttr& dist_attr);
+    const phi::distributed::ArgDistAttr& dist_attr,
+    const std::string& arg_name = "");
 
 void SetInplaceOutputCorrectDistAttr(
     phi::DeviceContext* dev_ctx,
@@ -239,13 +243,15 @@ void ReshardOutputPartialAxisToReplicated(
 void ReshardKernelOutputToApiOutput(
     phi::DeviceContext* dev_ctx,
     const std::shared_ptr<phi::distributed::DistTensor>& src_tensor,
-    Tensor* dst_tensor);
+    Tensor* dst_tensor,
+    const std::string& arg_name = "");
 
 void ReshardKernelOutputToApiOutput(
     phi::DeviceContext* dev_ctx,
     const std::vector<std::shared_ptr<phi::distributed::DistTensor>>&
         src_tensors,
-    const std::vector<Tensor*>& dst_tensors);
+    const std::vector<Tensor*>& dst_tensors,
+    const std::string& arg_name = "");
 
 std::shared_ptr<phi::distributed::DistTensor> PrepareDataForDistTensor(
     std::shared_ptr<phi::distributed::DistTensor> input,

--- a/paddle/phi/api/lib/tensor_utils.cc
+++ b/paddle/phi/api/lib/tensor_utils.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 #include "glog/logging.h"
 
 #include "paddle/phi/api/lib/api_registry.h"
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_utils.h"
 #include "paddle/phi/core/enforce.h"
@@ -137,7 +138,7 @@ PADDLE_API std::shared_ptr<phi::distributed::DistTensor> reshard(
           phi::errors::InvalidArgument(
               "Only "
               "uninitialized ``phi::distributed::DistTensor`` is allowed. "));
-      VLOG(3) << "reshard tensor which is not in current mesh, just set its "
+      VLOG(4) << "reshard tensor which is not in current mesh, just set its "
                  "dist_attr "
               << "from " << dist_tensor->dist_attr() << " to " << dist_attr;
 
@@ -151,8 +152,10 @@ PADDLE_API std::shared_ptr<phi::distributed::DistTensor> reshard(
     }
 
     if (dist_tensor->dist_attr() != dist_attr) {
-      VLOG(6) << "reshard func, reshard tensor from "
-              << dist_tensor->dist_attr() << " to " << dist_attr;
+      auto tensor_name = (input.name() == "" ? "None" : input.name());
+      VLOG(4) << "Reshard func: tensor(" << tensor_name << ") "
+              << paddle::experimental::ReshardDebugInfo(*dist_tensor,
+                                                        dist_attr);
       auto* func = phi::distributed::ChooseProperReshardFunction(*dist_tensor,
                                                                  dist_attr);
       dist_out_ptr = func->Eval(dev_ctx, *dist_tensor, dist_attr);

--- a/paddle/phi/api/yaml/generator/dist_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_api_gen.py
@@ -280,9 +280,9 @@ KERNEL_SELECTION_TEMPLATE = """
 # Both Tensor, std::vector<Tensor>, paddle::optional<Tensor> and
 # paddle::optional<std::vector<Tensor>> use the same template
 INPUT_RESHARD_TEMPLATE = """
-      auto dist_input_{name} = ReshardApiInputToKernelInput(dev_ctx, {name}, spmd_info.first[{idx}]);"""
+      auto dist_input_{name} = ReshardApiInputToKernelInput(dev_ctx, {name}, spmd_info.first[{idx}], "{name}");"""
 GENERAL_INPUT_RESHARD_TEMPLATE = """
-      auto dist_input_{name} = ReshardApiInputToReplicatedKernelInput(dev_ctx, {name}, spmd_info.first[{idx}]);"""
+      auto dist_input_{name} = ReshardApiInputToReplicatedKernelInput(dev_ctx, {name}, spmd_info.first[{idx}], "{name}");"""
 UNSUPPORTED_RESHARD_INPUT_COMMENT_TEMPLATE = """
       // API `{}` does not need to support ReshardInput at this time
 """

--- a/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_bw_api_gen.py
@@ -169,13 +169,13 @@ MULTI_VECTOR_OUT_CREATION_TEMPLATE = """
 
 # 9. Reshard Output
 RESHARD_SINGLE_OUTPUT_TEMPLATE = """
-      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out, {});"""
+      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out, {}, "{}");"""
 
 RESHARD_MULTI_SINGLE_OUTPUT_TEMPLATE = """
-      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out_{}, {});"""
+      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out_{}, {}, "{}");"""
 
 RESHARD_VECTOR_OUTPUT_TEMPLATE = """
-      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out, {});"""
+      ReshardKernelOutputToApiOutput(dev_ctx, shared_dist_out, {}, "{}");"""
 
 NONEED_TO_RESHARD_OUTPUT_TEMPLATE = """
     // API `{}` does not need to reshard output."""
@@ -321,13 +321,13 @@ class DistBackwardAPI(DistForwardAPI, BackwardAPI):
                 if self.outputs['types'][0] == 'Tensor':
                     reshard_output_code += (
                         RESHARD_SINGLE_OUTPUT_TEMPLATE.format(
-                            self.outputs['names'][0]
+                            self.outputs['names'][0], self.outputs['names'][0]
                         )
                     )
                 elif self.outputs['types'][0] == 'std::vector<Tensor>':
                     reshard_output_code += (
                         RESHARD_VECTOR_OUTPUT_TEMPLATE.format(
-                            self.outputs['names'][0]
+                            self.outputs['names'][0], self.outputs['names'][0]
                         )
                     )
                 else:
@@ -337,7 +337,9 @@ class DistBackwardAPI(DistForwardAPI, BackwardAPI):
                     if out_type == 'Tensor':
                         reshard_output_code += (
                             RESHARD_MULTI_SINGLE_OUTPUT_TEMPLATE.format(
-                                i, self.outputs['names'][i]
+                                i,
+                                self.outputs['names'][i],
+                                self.outputs['names'][i],
                             )
                         )
                     else:

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
@@ -229,7 +229,7 @@ DistTensor::DistTensor(const DDim& dims, const TensorDistAttr& dist_attr)
 
 void DistTensor::unsafe_set_dims(const DDim& dims) {
   if (this->initialized()) {
-    VLOG(3) << "You try to set an initialized DistTensor's global dims. "
+    VLOG(6) << "You try to set an initialized DistTensor's global dims. "
                "Make sure you are aware of where you change its dims.";
   }
   global_dims_ = dims;
@@ -237,7 +237,7 @@ void DistTensor::unsafe_set_dims(const DDim& dims) {
 
 void DistTensor::unsafe_set_dist_attr(const TensorDistAttr& dist_attr) {
   if (this->initialized()) {
-    VLOG(3) << "You try to set an initialized DistTensor's dist attr. "
+    VLOG(6) << "You try to set an initialized DistTensor's dist attr. "
                "Make sure you are aware of where you change its dist attr.";
   }
   dist_attr_ = dist_attr;

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 
 #include "glog/logging.h"
+#include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_function.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_function_registry.h"
@@ -132,6 +133,9 @@ DistTensor::DistTensor(const std::shared_ptr<phi::DenseTensor>& global_value,
       DistTensor replicated_tensor(global_value, replicated_dist_attr);
 
       // 2. reshard from replicated to other state
+      VLOG(4) << "Reshard tensor: "
+              << paddle::experimental::ReshardDebugInfo(replicated_tensor,
+                                                        dist_attr);
       auto* func = ChooseProperReshardFunction(replicated_tensor, dist_attr);
       auto* dev_ctx = DeviceContextPool::Instance().Get(global_value->place());
       func->Eval(dev_ctx, replicated_tensor, dist_attr, this);
@@ -198,6 +202,9 @@ DistTensor::DistTensor(const std::shared_ptr<phi::DenseTensor>& global_value,
         DistTensor replicated_tensor(global_value, replicated_dist_attr);
 
         // 2. reshard from replicated to other state
+        VLOG(4) << "Reshard tensor: "
+                << paddle::experimental::ReshardDebugInfo(replicated_tensor,
+                                                          dist_attr_);
         auto* func = ChooseProperReshardFunction(replicated_tensor, dist_attr_);
         auto* dev_ctx =
             DeviceContextPool::Instance().Get(global_value->place());

--- a/paddle/phi/core/distributed/auto_parallel/reshard/nd_mesh_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/nd_mesh_reshard_function.cc
@@ -90,7 +90,7 @@ void SameNdMeshReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                      const DistTensor& in,
                                      const TensorDistAttr& out_dist_attr,
                                      DistTensor* out) {
-  VLOG(3) << "Call SameNdMeshReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& process_mesh = out_dist_attr.process_mesh();
 
@@ -287,7 +287,7 @@ void CrossNdMeshReshardFunction::Eval(DeviceContext* dev_ctx,
                                       const DistTensor& in,
                                       const TensorDistAttr& out_dist_attr,
                                       DistTensor* out) {
-  VLOG(3) << "Call CrossNdMeshReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
 
   DistTensor tmp_result;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.cc
@@ -47,7 +47,7 @@ void PToRReshardFunction::Eval(DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call PToRReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
@@ -116,7 +116,7 @@ void PToRReshardFunctionCrossMesh::Eval(phi::DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call PToRReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
 
   DistTensor tmp_result;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -47,7 +47,7 @@ void PToSReshardFunction::Eval(DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call PToSReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
@@ -112,7 +112,7 @@ void PToSReshardFunctionCrossMesh::Eval(DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call PToSReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
 
   DistTensor tmp_result;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_p_reshard_function.cc
@@ -48,7 +48,7 @@ void RToPReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call RToPReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   int64_t local_rank = GetCurRankCoordInMesh(out_process_mesh)[0];
   const auto& in_reduce_type = out_dist_attr.partial_status().at(0);
@@ -95,7 +95,7 @@ void RToPReshardFunctionCrossMesh::Eval(phi::DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call RToPReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
 
   DistTensor tmp_result;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_s_reshard_function.cc
@@ -46,7 +46,7 @@ void RToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call RToSReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_dims_mapping = out_dist_attr.dims_mapping();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
   const DenseTensor& in_physical_tensor_cur_rank = in.value();
@@ -110,7 +110,7 @@ void RToSReshardFunctionCrossMesh::Eval(phi::DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call RToSReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
 
   DistTensor tmp_result;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/r_to_x_reshard_function.cc
@@ -51,7 +51,7 @@ void RToXExpandReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                      const DistTensor& in,
                                      const TensorDistAttr& out_dist_attr,
                                      DistTensor* out) {
-  VLOG(3) << "Call RToXExpandReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& out_dims_mapping = out_dist_attr.dims_mapping();
   const auto& in_mesh = in_dist_attr.process_mesh();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/reshard_function_registry.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/reshard_function_registry.cc
@@ -14,6 +14,8 @@
 
 #include "paddle/phi/core/distributed/auto_parallel/reshard/reshard_function_registry.h"
 
+#include "glog/logging.h"
+
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/nd_mesh_reshard_function.h"
 #include "paddle/phi/core/distributed/auto_parallel/reshard/p_to_r_reshard_function.h"
@@ -34,6 +36,7 @@ ReshardFunction* ChooseProperReshardFunction(
     const DistTensor& in, const TensorDistAttr& out_dist_attr) {
   for (const auto& func : GetReshardFunctionList()) {
     if (func->IsSuitable(in, out_dist_attr)) {
+      VLOG(4) << "Choose ReshardFunction: " << func->Name();
       return func.get();
     }
   }

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_p_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_p_reshard_function.cc
@@ -48,7 +48,7 @@ void SToPReshardFunction::Eval(DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call SToPReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
 
   // step 1, create tmp dist attr and tmp dist tensor
   TensorDistAttr tmp_attr(out_dist_attr);
@@ -85,7 +85,7 @@ void SToPReshardFunctionCrossMesh::Eval(DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call SToPReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
 
   DistTensor tmp_result;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_r_reshard_function.cc
@@ -58,7 +58,7 @@ void SToRReshardFunction::Eval(DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call SToRReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& in_dims_mapping = in_dist_attr.dims_mapping();
   const auto& in_process_mesh = in_dist_attr.process_mesh();
@@ -151,7 +151,7 @@ void SToRReshardFunctionCrossMesh::Eval(DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call SToRReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
 
   SameStatusReshardFunction same_status_func;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -49,7 +49,7 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                const DistTensor& in,
                                const TensorDistAttr& out_dist_attr,
                                DistTensor* out) {
-  VLOG(3) << "Call SToSReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_process_mesh = in.dist_attr().process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();
   auto dtype = in.dtype();
@@ -158,7 +158,7 @@ void SToSReshardFunctionCrossMesh::Eval(DeviceContext* dev_ctx,
                                         const DistTensor& in,
                                         const TensorDistAttr& out_dist_attr,
                                         DistTensor* out) {
-  VLOG(3) << "Call SToSReshardFunctionCrossMesh Eval";
+  VLOG(3) << "Call " << Name();
   const auto& out_process_mesh = out_dist_attr.process_mesh();
 
   SameStatusReshardFunction same_status_func;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/same_status_reshard_function.cc
@@ -49,7 +49,7 @@ void SameStatusReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                      const DistTensor& in,
                                      const TensorDistAttr& out_dist_attr,
                                      DistTensor* out) {
-  VLOG(3) << "Call SameStatusReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& in_process_mesh = in_dist_attr.process_mesh();
   const auto& in_process_ids = in_process_mesh.process_ids();

--- a/paddle/phi/core/distributed/auto_parallel/reshard/x_to_r_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/x_to_r_reshard_function.cc
@@ -49,7 +49,7 @@ void XToRShrinkReshardFunction::Eval(phi::DeviceContext* dev_ctx,
                                      const DistTensor& in,
                                      const TensorDistAttr& out_dist_attr,
                                      DistTensor* out) {
-  VLOG(3) << "Call XToRShrinkReshardFunction Eval";
+  VLOG(3) << "Call " << Name();
   const auto& in_dist_attr = in.dist_attr();
   const auto& in_dims_mapping = in_dist_attr.dims_mapping();
   const auto& in_mesh = in_dist_attr.process_mesh();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
refine logs of reshard

There are four types of reshard,
- reshard tensor, called by `shard_tensor()`
- reshard func, called by `paddle.distributed.reshard()`
- reshard input, called inside dygraph api, like `paddle.matmul`, when the inputs not match the dist_attr infered by spmd rules
- reshard output, called inside `loss.backward()`, when the grad outputs not match the dist_attr required 

<img width="1386" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/7b30d786-c376-4391-bb20-689b5be8119e">
<img width="1378" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/96e1a2ce-afca-4c3f-96c1-b834f71feb76">

Pcard-76459