### PR TITLE
[PIR] fix sync_batch_norm_kernel

### DIFF
--- a/paddle/fluid/operators/sync_batch_norm_op.cu
+++ b/paddle/fluid/operators/sync_batch_norm_op.cu
@@ -133,6 +133,13 @@ void SyncBatchNormKernel(const Context& ctx,
     auto* sv_inv_var_data =
         ctx.template Alloc<BatchNormParamType<T>>(saved_variance);
 
+    int64_t reserve_space_size = 0;
+    if (reserve_space == nullptr) {
+      reserve_space = new DenseTensor();
+    }
+    reserve_space->Resize({reserve_space_size});
+    ctx.template Alloc<T>(reserve_space);
+
     // Note, Input('Mean')/Input('Variance') share variable with
     // Output('MeanOut')/Output('VarianceOut')
     KeSyncAndMovingStats<T>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Pcard-67164
The logic of sync_batch_norm_kernel is diffrent from batch_norm_kernel, which makes var 'reserve_space' incorrect.
Fix it in this PR