### PR TITLE
Fix typo (`with_hierachy` -> `with_hierarchy`) 

### DIFF
--- a/paddle/fluid/framework/data_set.cc
+++ b/paddle/fluid/framework/data_set.cc
@@ -752,7 +752,7 @@ void MultiSlotDataset::TDMSample(const std::string tree_name,
                                  const std::string tree_path,
                                  const std::vector<uint16_t> tdm_layer_counts,
                                  const uint16_t start_sample_layer,
-                                 const bool with_hierachy,
+                                 const bool with_hierarchy,
                                  const uint16_t seed_,
                                  const uint16_t sample_slot) {
 #if (defined PADDLE_WITH_DISTRIBUTE) && (defined PADDLE_WITH_PSCORE)

--- a/paddle/fluid/framework/data_set.h
+++ b/paddle/fluid/framework/data_set.h
@@ -57,7 +57,7 @@ class Dataset {
                          const std::string tree_path UNUSED,
                          const std::vector<uint16_t> tdm_layer_counts UNUSED,
                          const uint16_t start_sample_layer UNUSED,
-                         const bool with_hierachy UNUSED,
+                         const bool with_hierarchy UNUSED,
                          const uint16_t seed_ UNUSED,
                          const uint16_t sample_slot UNUSED) {}
   // set file list
@@ -388,7 +388,7 @@ class MultiSlotDataset : public DatasetImpl<Record> {
                          const std::string tree_path,
                          const std::vector<uint16_t> tdm_layer_counts,
                          const uint16_t start_sample_layer,
-                         const bool with_hierachy,
+                         const bool with_hierarchy,
                          const uint16_t seed_,
                          const uint16_t sample_slot);
   virtual void MergeByInsId();

--- a/python/paddle/distributed/fleet/dataset/dataset.py
+++ b/python/paddle/distributed/fleet/dataset/dataset.py
@@ -843,7 +843,7 @@ class InMemoryDataset(DatasetBase):
         tree_path,
         tdm_layer_counts,
         start_sample_layer,
-        with_hierachy,
+        with_hierarchy,
         seed,
         id_slot,
     ):
@@ -852,7 +852,7 @@ class InMemoryDataset(DatasetBase):
             tree_path,
             tdm_layer_counts,
             start_sample_layer,
-            with_hierachy,
+            with_hierarchy,
             seed,
             id_slot,
         )

--- a/test/legacy_test/test_dist_tree_index.py
+++ b/test/legacy_test/test_dist_tree_index.py
@@ -163,7 +163,7 @@ class TestIndexSampler(unittest.TestCase):
             tree_path=path,
             tdm_layer_counts=tdm_layer_counts,
             start_sample_layer=1,
-            with_hierachy=False,
+            with_hierarchy=False,
             seed=0,
             id_slot=2,
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Fix typo (`with_hierachy` -> `with_hierarchy`) 