### PR TITLE
Fix bug in index_put kernel when fallbacking to cpu

### DIFF
--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -64,9 +64,15 @@ void LaunchIndexPutKernel(const Context& dev_ctx,
   auto* x_data = x.data<T>();
   auto* val_data = value.data<T>();
   bool is_initialized = out->initialized();
+  bool is_same_place = true;
+
+  if (is_initialized) {
+    is_same_place = (x.place() == out->place());
+  }
+
   T* out_data = dev_ctx.template Alloc<T>(out);
 
-  if (!is_initialized) {
+  if (!is_initialized || !is_same_place) {
     phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复IndexPutKernel的bug：当其他设备如npu调用index_put_时，因为index_put_是原地修改，所以输入x和out会指向同一个地址，当npu检查到缺少index_put_算子而fallback到cpu时，此时输入x被copy到cpu，而输出out仍留在npu，IndexPutKerne中并未对这种情况进行判断，导致out的数据并未被拷贝过来。于是加上判断并将数据拷贝到cpu，问题修复。