### PR TITLE
[PIR] Temporarily disable `TestReduceAPI` in pir mode to avoid hang in mac CI

### DIFF
--- a/test/legacy_test/test_zero_dim_tensor.py
+++ b/test/legacy_test/test_zero_dim_tensor.py
@@ -307,7 +307,8 @@ class TestReduceAPI(unittest.TestCase):
 
         paddle.enable_static()
 
-    @test_with_pir_api
+    # TODO(SigureMo): Temporarily disable this test case in due to hanging in mac CI.
+    # @test_with_pir_api
     def test_static_reduce(self):
         paddle.enable_static()
         for api in reduce_api_list:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

临时 disable 掉 #61575 给 TestReduceAPI 添加的 `test_with_pir_api`，以免 mac CI hang 住的问题（mac 上直接跑复现率大概 50%）

- #61413

Pcard-67164