### PR TITLE
[CI] Remove redundant execution of unittests in CI_AutoParallel

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3368,7 +3368,7 @@ function distribute_test() {
     rm -rf ./paddlenlp/upload/*
     rm -rf ./paddlenlp/models/bigscience/*
 
-    sed -i -e 's/case_list=(\$(awk/case_list=(auto_unit_test) # /g' ./tools/auto_parallel/ci_auto_parallel.sh
+    sed -i -e 's/case_list=(\$(awk/case_list=(auto_unit_test dygraph_unit_test) # /g' ./tools/auto_parallel/ci_auto_parallel.sh
     export FLAGS_dynamic_static_unified_comm=True
 
     echo "Start LLM Test"

--- a/tools/auto_parallel/ci_auto_parallel.sh
+++ b/tools/auto_parallel/ci_auto_parallel.sh
@@ -49,7 +49,6 @@ for element in "${target_lists_for_dygraph_ci[@]}";do
   fi
   count=$((count+1))
 done
-case_list[${#case_list[*]}]=test_semi_auto_parallel_hybrid_strategy
 for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
     arr_file_name=(${file_name//// })
     dir1=${arr_file_name[0]}
@@ -65,13 +64,16 @@ for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{pri
     elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
         continue
     else
+        # auto_unit_test中除llama单测外的其他单测，已在流水线PR-CI-Distribute-stable中PR级别监测，这里不再冗余执行，只监测llama单测
         for ((i=0; i<${#target_lists_for_semi_auto_ci[@]}; i++)); do
             if [[ $i != ${test_auto_num} ]] && [[ ${file_item} == *${target_lists_for_semi_auto_ci[i]}* ]];then
                 case_list[${#case_list[*]}]=gpt-3_auto
-                case_list[${#case_list[*]}]=auto_unit_test
+                # case_list[${#case_list[*]}]=auto_unit_test
+                case_list[${#case_list[*]}]="test_semi_auto_parallel_llama_model test_semi_auto_parallel_llama_model_amp"
                 break
             elif [[ $i == ${test_auto_num} ]] && [[ ${file_item} == *${target_lists_for_semi_auto_ci[i]}* ]];then
-                case_list[${#case_list[*]}]=auto_unit_test
+                # case_list[${#case_list[*]}]=auto_unit_test
+                case_list[${#case_list[*]}]="test_semi_auto_parallel_llama_model test_semi_auto_parallel_llama_model_amp"
                 break
             else
                 continue
@@ -85,13 +87,14 @@ for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{pri
                 continue
             fi
         done
+        # dygraph_unit_test中的单测，已在流水线PR-CI-Distribute-stable中PR级别监测，这里不再冗余执行
         for ((i=0; i<${#target_lists_for_dygraph_ci[@]}; i++)); do
             if [[ $i != ${test_dygraph_num} ]] && [[ ${file_item} == *${target_lists_for_dygraph_ci[i]}* ]];then
                 case_list[${#case_list[*]}]=gpt-3_dygraph
-                case_list[${#case_list[*]}]=dygraph_unit_test
+                # case_list[${#case_list[*]}]=dygraph_unit_test
                 break
             elif [[ $i == ${test_dygraph_num} ]] && [[ ${file_item} == *${target_lists_for_dygraph_ci[i]}* ]];then
-                case_list[${#case_list[*]}]=dygraph_unit_test
+                # case_list[${#case_list[*]}]=dygraph_unit_test
                 break
             else
                 continue
@@ -130,11 +133,12 @@ if [[ "${case_list[*]}" == *"gpt-3_auto"* ]] && [[ "${case_list[*]}" == *"gpt-3_
     echo ${case_list[*]}
 fi
 ####################
-if [[ "${case_list[*]}" == *"auto_unit_test"* ]]; then
-    echo "命中auto_unit_test, 不再单独执行test_semi_auto_parallel_hybrid_strategy"
-    case_list=("${case_list[@]/*test_semi_auto_parallel_hybrid_strategy*/}")
-    echo ${case_list[*]}
-fi
+# auto_unit_test中除llama单测外的其他单测，已在流水线PR-CI-Distribute-stable中PR级别监测，这里不再冗余执行
+# if [[ "${case_list[*]}" == *"auto_unit_test"* ]]; then
+#     echo "命中auto_unit_test, 不再单独执行test_semi_auto_parallel_llama_model"
+#     case_list=("${case_list[@]/*test_semi_auto_parallel_llama_model*/}")
+#     echo ${case_list[*]}
+# fi
 case_list=($(awk -v RS=' ' '!a[$1]++' <<< ${case_list[*]}))
 if [[ ${#case_list[*]} -ne 0 ]];then
     echo -e "\033[31m =======CI Check case========= \033"
@@ -172,8 +176,12 @@ if [[ ${#case_list[*]} -ne 0 ]];then
             bash /workspace/Paddle/tools/auto_parallel/ci_case_unit.sh dygraph_unit_test
             print_info $? `ls -lt ${log_path} | grep "test" | head -n 1 | awk '{print $9}'` ${case}
             let case_num++
-        elif [[ ${case} == "test_semi_auto_parallel_hybrid_strategy" ]];then
-            bash /workspace/Paddle/tools/auto_parallel/ci_case_unit.sh test_semi_auto_parallel_hybrid_strategy
+        elif [[ ${case} == "test_semi_auto_parallel_llama_model" ]];then
+            bash /workspace/Paddle/tools/auto_parallel/ci_case_unit.sh test_semi_auto_parallel_llama_model
+            print_info $? `ls -lt ${log_path} | grep "test" | head -n 1 | awk '{print $9}'` ${case}
+            let case_num++
+        elif [[ ${case} == "test_semi_auto_parallel_llama_model_amp" ]];then
+            bash /workspace/Paddle/tools/auto_parallel/ci_case_unit.sh test_semi_auto_parallel_llama_model_amp
             print_info $? `ls -lt ${log_path} | grep "test" | head -n 1 | awk '{print $9}'` ${case}
             let case_num++
         else

--- a/tools/auto_parallel/ci_auto_parallel.sh
+++ b/tools/auto_parallel/ci_auto_parallel.sh
@@ -64,15 +64,14 @@ for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{pri
     elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
         continue
     else
-        # auto_unit_test中除llama单测外的其他单测，已在流水线PR-CI-Distribute-stable中PR级别监测，这里不再冗余执行，只监测llama单测
+        # The most auto unittests have been monitored in PR-CI-Distribute-stable, 
+        # while the other tests of llama model will be executed in PR-CI-Auto-Parallel.
         for ((i=0; i<${#target_lists_for_semi_auto_ci[@]}; i++)); do
             if [[ $i != ${test_auto_num} ]] && [[ ${file_item} == *${target_lists_for_semi_auto_ci[i]}* ]];then
                 case_list[${#case_list[*]}]=gpt-3_auto
-                # case_list[${#case_list[*]}]=auto_unit_test
                 case_list[${#case_list[*]}]="test_semi_auto_parallel_llama_model test_semi_auto_parallel_llama_model_amp"
                 break
             elif [[ $i == ${test_auto_num} ]] && [[ ${file_item} == *${target_lists_for_semi_auto_ci[i]}* ]];then
-                # case_list[${#case_list[*]}]=auto_unit_test
                 case_list[${#case_list[*]}]="test_semi_auto_parallel_llama_model test_semi_auto_parallel_llama_model_amp"
                 break
             else
@@ -87,14 +86,11 @@ for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{pri
                 continue
             fi
         done
-        # dygraph_unit_test中的单测，已在流水线PR-CI-Distribute-stable中PR级别监测，这里不再冗余执行
+        # The dynamic unittests have been monitored in PR-CI-Distribute-stable
+        # and will be no longer redundantly executed in PR-CI-Auto-Parallel.
         for ((i=0; i<${#target_lists_for_dygraph_ci[@]}; i++)); do
             if [[ $i != ${test_dygraph_num} ]] && [[ ${file_item} == *${target_lists_for_dygraph_ci[i]}* ]];then
                 case_list[${#case_list[*]}]=gpt-3_dygraph
-                # case_list[${#case_list[*]}]=dygraph_unit_test
-                break
-            elif [[ $i == ${test_dygraph_num} ]] && [[ ${file_item} == *${target_lists_for_dygraph_ci[i]}* ]];then
-                # case_list[${#case_list[*]}]=dygraph_unit_test
                 break
             else
                 continue
@@ -133,12 +129,6 @@ if [[ "${case_list[*]}" == *"gpt-3_auto"* ]] && [[ "${case_list[*]}" == *"gpt-3_
     echo ${case_list[*]}
 fi
 ####################
-# auto_unit_test中除llama单测外的其他单测，已在流水线PR-CI-Distribute-stable中PR级别监测，这里不再冗余执行
-# if [[ "${case_list[*]}" == *"auto_unit_test"* ]]; then
-#     echo "命中auto_unit_test, 不再单独执行test_semi_auto_parallel_llama_model"
-#     case_list=("${case_list[@]/*test_semi_auto_parallel_llama_model*/}")
-#     echo ${case_list[*]}
-# fi
 case_list=($(awk -v RS=' ' '!a[$1]++' <<< ${case_list[*]}))
 if [[ ${#case_list[*]} -ne 0 ]];then
     echo -e "\033[31m =======CI Check case========= \033"

--- a/tools/auto_parallel/ci_case_unit.sh
+++ b/tools/auto_parallel/ci_case_unit.sh
@@ -52,10 +52,17 @@ main() {
     elif [[ $exec_case =~ "dygraph_unit_test" ]];then
         cd ${dygraph_case_path}
         case_list_unit
-    elif [[ $exec_case =~ "test_semi_auto_parallel_hybrid_strategy" ]];then
+    elif [[ $exec_case =~ "test_semi_auto_parallel_llama_model" ]];then
         cd ${auto_case_path}
         export PYTHONPATH=../..:$PYTHNPATH
-        python test_semi_auto_parallel_hybrid_strategy.py >>${log_path}/$exec_case 2>&1
+        python test_semi_auto_parallel_llama_model.py >>${log_path}/$exec_case 2>&1
+        if [ $? -eq 0 ]; then
+            tail -n 10 ${log_path}/$exec_case
+        fi
+    elif [[ $exec_case =~ "test_semi_auto_parallel_llama_model_amp" ]];then
+        cd ${auto_case_path}
+        export PYTHONPATH=../..:$PYTHNPATH
+        python test_semi_auto_parallel_llama_model_amp.py >>${log_path}/$exec_case 2>&1
         if [ $? -eq 0 ]; then
             tail -n 10 ${log_path}/$exec_case
         fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[CI] Remove redundant execution of unittests in CI_AutoParallel (PCard-73145)