### PR TITLE
[AutoParallel] Fit allreduce_matmul_grad_overlapping when using master grad

### DIFF
--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -119,7 +119,6 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
             ctx=self.dist_context,
             chunk_id=x_dist_attr.chunk_id,
         )
-        block._sync_with_cpp()
 
         return out
 
@@ -242,5 +241,5 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
                 matmul_op, matmul_grad_dist_attr
             )
 
-            block._remove_op(matmul_grad_id)
-            block._sync_with_cpp()
+            block._remove_op(matmul_grad_id, sync=False)
+        block._sync_with_cpp()

--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -216,7 +216,12 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
                 matmul_op, matmul_grad_dist_attr
             )
 
-            # move the cast op to the back of matmul_grad
+            # NOTE(Sonder): Why move the cast operation to the back of matmul_v2?
+            # When using amp_master_grad, the cast operation is inserted after matmul_grad.
+            # However, when employing allreduce_matmul_grad_overlapping, the matmul_grad is
+            # split into two matmul operations. In this case, the cast operation would access
+            # uninitialized tensors. Therefore, we move the cast operation to the back of the
+            # second matmul operation to avoid this problem.
             if (
                 ops[matmul_grad_id + 1].type == 'cast'
                 and ops[matmul_grad_id + 1].input('X')[0]

--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -133,6 +133,53 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
             matmul_grad_op = ops[matmul_grad_id]
             allreduce_op = ops[allreduce_id]
 
+            # NOTE(Sonder): Why move those operations to the back of matmul_v2?
+            # When using amp_master_grad, the cast operation is inserted after matmul_grad.
+            # However, when employing allreduce_matmul_grad_overlapping, the matmul_grad is
+            # split into two matmul operations. In this case, some operations would access
+            # uninitialized tensors. Therefore, we move the cast operation to the back of the
+            # second matmul operation to avoid this problem.
+            skip_overlapping = False
+            moved_ops_idx = []
+            moved_ops_output = []
+            matmul_grad_output = matmul_grad_op.output('Y@GRAD')[0]
+
+            for idx in range(matmul_grad_id + 1, allreduce_id):
+                if matmul_grad_output in ops[idx].desc.input_arg_names():
+                    moved_ops_idx.append(idx)
+                    moved_ops_output.extend(ops[idx].desc.output_arg_names())
+                else:
+                    for input_name in ops[idx].desc.input_arg_names():
+                        if input_name in moved_ops_output:
+                            skip_overlapping = True
+
+            if skip_overlapping:
+                continue
+
+            for i, idx in enumerate(moved_ops_idx):
+                op = ops[idx]
+                dist_attr = self.dist_context.get_op_dist_attr_for_program(op)
+
+                op_inputs = op.desc.input_names()
+                op_outputs = op.desc.output_names()
+
+                op_inputs = {name: op.input(name) for name in op_inputs}
+                op_outputs = {name: op.output(name) for name in op_outputs}
+
+                op = block._insert_op_without_sync(
+                    index=allreduce_id + 1 + i,
+                    type=op.type,
+                    inputs=op_inputs,
+                    outputs=op_outputs,
+                    attrs=op.all_attrs(),
+                )
+
+                self.dist_context.set_op_dist_attr_for_program(op, dist_attr)
+
+            for i, idx in enumerate(moved_ops_idx):
+                block._remove_op(idx - i, sync=False)
+                allreduce_id -= 1
+
             tran_x = matmul_grad_op.attr("trans_x")
             assert (
                 not tran_x
@@ -215,35 +262,6 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
             self.dist_context.set_op_dist_attr_for_program(
                 matmul_op, matmul_grad_dist_attr
             )
-
-            # NOTE(Sonder): Why move the cast operation to the back of matmul_v2?
-            # When using amp_master_grad, the cast operation is inserted after matmul_grad.
-            # However, when employing allreduce_matmul_grad_overlapping, the matmul_grad is
-            # split into two matmul operations. In this case, the cast operation would access
-            # uninitialized tensors. Therefore, we move the cast operation to the back of the
-            # second matmul operation to avoid this problem.
-            if (
-                ops[matmul_grad_id + 1].type == 'cast'
-                and ops[matmul_grad_id + 1].input('X')[0]
-                == matmul_grad_op.output('Y@GRAD')[0]
-            ):
-                cast_op = ops[matmul_grad_id + 1]
-                cast_dist_attr = self.dist_context.get_op_dist_attr_for_program(
-                    cast_op
-                )
-
-                cast_op = block._insert_op_without_sync(
-                    index=allreduce_id + 4,
-                    type="cast",
-                    inputs={"X": cast_op.input('X')},
-                    outputs={"Out": cast_op.output('Out')},
-                    attrs=cast_op.all_attrs(),
-                )
-                self.dist_context.set_op_dist_attr_for_program(
-                    cast_op, cast_dist_attr
-                )
-                block._remove_op(matmul_grad_id + 1, sync=False)
-                allreduce_id -= 1
 
             self._insert_reshape_op(
                 block,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

当下 allreduce_matmul_grad_overlapping 和 master_grad 同时开启的情况下，会出现 cast op 位置错误的情况，导致 cast op 将没有初始化的tensor作为输入，进而导致选Kernel报错：

![d80d57d926ad5295509fa639a06ee606](https://github.com/PaddlePaddle/Paddle/assets/55493212/e8744921-5334-43f0-8a1e-c8c6eb215789)

为了适配这种情况，我们需要需要将依赖 dy 的 op 移动到 allreduce_matmul_grad_overlapping 的第二个 matmul 之后：

![576e399cbdc2f4810c3de80b07583b81](https://github.com/PaddlePaddle/Paddle/assets/55493212/c6db63a8-29c7-4057-8998-7c6e009f6316)

依赖环境：

- PaddleNLP develop llama 模型 （hidden_layer 修改为 4）
- 4 卡 1080 Ti 服务器

经过测试，llama 模型的loss和pr修改前可以对齐
