### PR TITLE
fix third_party patch bug

### DIFF
--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -33,7 +33,8 @@ if(WIN32)
       "<SOURCE_DIR>/")
 else()
   set(WARPCTC_PATCH_CUDA_COMMAND
-      patch -Nd ${SOURCE_DIR} <
+      git checkout -- . && git checkout ${WARPCTC_TAG} && patch -Nd
+      ${SOURCE_DIR} <
       ${PADDLE_SOURCE_DIR}/patches/warpctc/CMakeLists.txt.cuda.patch)
 endif()
 
@@ -42,7 +43,8 @@ if(NOT WIN32 AND WITH_GPU)
                                                   VERSION_GREATER 12.0)
     file(TO_NATIVE_PATH
          ${PADDLE_SOURCE_DIR}/patches/warpctc/CMakeLists.txt.patch native_src)
-    set(WARPCTC_PATCH_COMMAND patch -Nd ${SOURCE_DIR} < ${native_src} &&)
+    set(WARPCTC_PATCH_COMMAND git checkout -- . && git checkout ${WARPCTC_TAG}
+                              && patch -Nd ${SOURCE_DIR} < ${native_src} &&)
     set(WARPCTC_CCBIN_OPTION -DCCBIN_COMPILER=${CCBIN_COMPILER})
   endif()
 endif()

--- a/cmake/external/warprnnt.cmake
+++ b/cmake/external/warprnnt.cmake
@@ -26,8 +26,7 @@ set(WARPRNNT_PATCH_COMMAND "")
 set(WARPRNNT_CCBIN_OPTION "")
 if(WIN32)
   set(WARPCTC_PATCH_CUDA_COMMAND
-      git checkout -- . && git checkout ${WARPRNNT_TAG} && ${CMAKE_COMMAND} -E
-      copy_if_different
+      ${CMAKE_COMMAND} -E copy_if_different
       ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.cuda.patch
       "<SOURCE_DIR>/")
 else()

--- a/cmake/external/warprnnt.cmake
+++ b/cmake/external/warprnnt.cmake
@@ -26,12 +26,14 @@ set(WARPRNNT_PATCH_COMMAND "")
 set(WARPRNNT_CCBIN_OPTION "")
 if(WIN32)
   set(WARPCTC_PATCH_CUDA_COMMAND
-      ${CMAKE_COMMAND} -E copy_if_different
+      git checkout -- . && git checkout ${WARPRNNT_TAG} && ${CMAKE_COMMAND} -E
+      copy_if_different
       ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.cuda.patch
       "<SOURCE_DIR>/")
 else()
   set(WARPCTC_PATCH_CUDA_COMMAND
-      patch -Nd ${SOURCE_DIR} <
+      git checkout -- . && git checkout ${WARPRNNT_TAG} && patch -Nd
+      ${SOURCE_DIR} <
       ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.cuda.patch)
 endif()
 
@@ -40,7 +42,9 @@ if(NOT WIN32 AND WITH_GPU)
                                                   VERSION_GREATER 12.0)
     file(TO_NATIVE_PATH
          ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.patch native_src)
-    set(WARPRNNT_PATCH_COMMAND patch -Nd ${SOURCE_DIR} < ${native_src})
+    set(WARPRNNT_PATCH_COMMAND
+        git checkout -- . && git checkout ${WARPRNNT_TAG} && patch -Nd
+        ${SOURCE_DIR} < ${native_src})
     set(WARPRNNT_CCBIN_OPTION -DCCBIN_COMPILER=${CCBIN_COMPILER})
   endif()
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
虽然 patch 命令的 -N 选项可以跳过已经应用的更改，但 exit code 仍然不为 0，这会导致 CMake 认为该命令执行失败，从而报错。

通过 git 丢弃对子模块的修改可以规避此问题。
Pcard-67164