### PR TITLE
[Prim] Optimize composite OP add_double_grad

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -533,17 +533,16 @@ void add_double_grad(const Tensor& y,
                      Tensor* grad_out_grad) {
   if (grad_out_grad) {
     // ddout = ddx + ddy
-    Tensor ddout = full<T>(common::vectorize(grad_out.dims()), 0.0, y.dtype());
     if (!grad_x_grad && !grad_y_grad) {
+      Tensor ddout =
+          full<T>(common::vectorize(grad_out.dims()), 0.0, y.dtype());
       set_output<T>(ddout, grad_out_grad);
+    } else if (grad_x_grad && !grad_y_grad) {
+      set_output<T>(grad_x_grad.get(), grad_out_grad);
+    } else if (grad_y_grad && !grad_x_grad) {
+      set_output<T>(grad_y_grad.get(), grad_out_grad);
     } else {
-      if (grad_x_grad) {
-        ddout = ddout + grad_x_grad.get();
-      }
-      if (grad_y_grad) {
-        ddout = ddout + grad_y_grad.get();
-      }
-      set_output<T>(ddout, grad_out_grad);
+      set_output<T>(grad_x_grad.get() + grad_y_grad.get(), grad_out_grad);
     }
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->
Pcard-75624

Optimize performance of `add_double_grad`


算子名 | 阶数 | 优化前耗时(ms) | 优化后耗时(ms) | 优化前显存(GB) | 优化后显存(GB)
-- | -- | -- | -- | -- | --
add | 2 | 0.89 | 0.24 | 0.08 | 0.094
add | 3 | 1.71 | 0.44 | 0.088 | 0.104

``` sh
python test_prim_speed.py --order 2 --operator add --prim -bl add_grad
python test_prim_speed.py --order 3 --operator add --prim -bl add_grad

```
``` py
import argparse
import functools
import time
from contextlib import ContextDecorator

import numpy as np
import paddle
from paddle.nn import functional as F
from paddle import profiler


class PaddleProfiler(ContextDecorator):
    """
    Profiler list how many kinds of C++ API is called.
    """
    def __init__(self, scheduler=None):
        super().__init__()
        self.prof = profiler.Profiler(
            targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.GPU],
            scheduler=scheduler,
            on_trace_ready=profiler.export_chrome_tracing("./log"),
        )

    def __enter__(self):
        self.prof.start()
        return self

    def step(self):
        print("step")
        self.prof.step()

    def __exit__(self, type, value, traceback):
        self.prof.stop()

        self.prof.summary(
            sorted_by=profiler.SortedKeys.GPUTotal,
            op_detail=False,
            thread_sep=False,
            time_unit="ms",
            views=profiler.SummaryView.OperatorView,
        )
        print(
            "[Warning] This profiler mainly for count how many kinds of C++ API is called. "
            "It is recommend to exit after 1 step for it is enough to gather called C++ API information."
        )


def speed_test(op_name, func, inputs, order: int, prim: bool, backward_blacklist: list[str] = None, show_ops: bool = False):
    paddle.framework.core.set_prim_eager_enabled(prim)

    if backward_blacklist is None:
        backward_blacklist = []

    if prim:
        if op_name == "tanh":
            if backward_blacklist:
                # tanh 单独测试黑名单
                paddle.framework.core._set_prim_backward_blacklist(*backward_blacklist)
        else:
            # 非tanh算子，默认加上tanh所有反向到黑名单，全部走大算子，控制变量
            paddle.framework.core._set_prim_backward_blacklist(*backward_blacklist, "tanh_grad", "tanh_double_grad", "tanh_triple_grad")


    if show_ops:
        with PaddleProfiler() as pf:
            z = func(*inputs)
            pf.step()
            test_grad(z, inputs[0] if isinstance(inputs, (tuple, list)) else inputs, order)

        return

    while True:
        costs = []
        warmup = 100
        for i in range(500):

            z = func(*inputs)

            paddle.device.synchronize()
            t = time.perf_counter()

            test_grad(z, inputs[0] if isinstance(inputs, (tuple, list)) else inputs, order)

            paddle.device.synchronize()
            cost = time.perf_counter() - t

            if i >= warmup:
                costs.append(cost * 1000)

        costs = np.array(costs)
        if (np.std(costs) / np.mean(costs)) > 0.1:
            continue
        print(f"[{op_name}] # order = {order}, prim = {prim}, Avg = {np.mean(costs):.5f} ms, Std = {np.std(costs):.5f} ms, mem = {paddle.device.cuda.max_memory_allocated() / (1 << 30):.3f} GB, backward_blacklist = {backward_blacklist}")
        break


def test_grad(y_, x_, order):
    if order >= 1:
        g = paddle.grad(y_, x_, create_graph=order>1)
    if order >= 2:
        gg = paddle.grad(g, x_, create_graph=order>2)
    if order >= 3:
        ggg = paddle.grad(gg, x_, create_graph=order>3)
    if order >= 4:
        gggg = paddle.grad(ggg, x_, create_graph=order>3)


def func_wrapper(func):

    @functools.wraps(func)
    def wrapped_func(*args, **kwargs):
        out = func(*args, **kwargs)
        if isinstance(out, paddle.Tensor):
            return paddle.tanh(out)
        else:
            return [paddle.tanh(out_) for out_ in out]

    return wrapped_func


func_map = {
    "add": func_wrapper(paddle.add),
}


def gen_data(shape):
    return np.random.randn(*shape).astype("float32")


inputs_map = {
    "add": [
        paddle.to_tensor(gen_data([1024, 512]), stop_gradient=False),
        paddle.to_tensor(gen_data([1024, 512]), stop_gradient=False),
    ],
}


def parse_args():
    parser = argparse.ArgumentParser("Prim benchmark")
    parser.add_argument("-o", "--order", type=int, help="grad order", required=True)
    parser.add_argument("-op", "--operator", type=str, help="output directory", required=True)
    parser.add_argument("-p", "--prim", action="store_true", help="use prim", default=False)
    parser.add_argument("-bl", "--backward_blacklist", nargs='+', type=str, help="backward_blacklist")
    parser.add_argument("-show", "--show_ops", action="store_true", default=False)


    args = parser.parse_args()

    return args

if __name__ == "__main__":
    args = parse_args()
    func = func_map[args.operator]
    inputs = inputs_map[args.operator]
    speed_test(args.operator, func, inputs, args.order, args.prim, args.backward_blacklist, show_ops=args.show_ops)
```