### PR TITLE
cinn(test): fix if op

### DIFF
--- a/test/ir/pir/cinn/symbolic/test_if_st.py
+++ b/test/ir/pir/cinn/symbolic/test_if_st.py
@@ -38,7 +38,7 @@ class IfSubgraph(nn.Layer):
     def forward(self, x):
         if x.shape[-1] > 1:
             x = self.exp_sub(x)
-        x = paddle.nn.ReLU(x)
+        x = paddle.nn.functional.relu(x)
         return x
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-78120
The nn.ReLU api does not work in dynamic to static, resulting in the error shown below, not ReLU op in pir program
<img width="1186" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/13588285/c0476ce6-af58-41c7-bcad-a497f7bb78fc">

