### PR TITLE
cinn(test): fix test_while_st

### DIFF
--- a/test/ir/pir/cinn/symbolic/test_while_dy.py
+++ b/test/ir/pir/cinn/symbolic/test_while_dy.py
@@ -33,10 +33,11 @@ class WhileExpSub(nn.Layer):
 
     def forward(self, x):
         loop_count = 0
-        while x.sum() > 0 and loop_count < 1:
+        while loop_count < 1:
             y = paddle.exp(x)
             x = y - x
             loop_count += 1
+        return x
 
 
 class TestWhile(unittest.TestCase):

--- a/test/ir/pir/cinn/symbolic/test_while_st.py
+++ b/test/ir/pir/cinn/symbolic/test_while_st.py
@@ -33,10 +33,12 @@ class WhileExpSub(nn.Layer):
 
     def forward(self, x):
         loop_count = 0
-        while x.sum() > 0 and loop_count < 1:
+        while loop_count < 1:
             y = paddle.exp(x)
             x = y - x
             loop_count += 1
+
+        return x
 
 
 class TestWhile(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-78120

CINN not support 0D Tensor, like x.sum().
Remove 0D operator in testcase.