### PR TITLE
[Bug Fix] Fix multiple definition of cinn_runtime_display_debug_info

### DIFF
--- a/paddle/cinn/common/context.cc
+++ b/paddle/cinn/common/context.cc
@@ -78,7 +78,4 @@ std::string NameGenerator::New(const std::string& name_hint) {
 
 }  // namespace common
 
-PD_DEFINE_bool(cinn_runtime_display_debug_info,
-               false,
-               "Whether to display debug information in runtime");
 }  // namespace cinn

--- a/paddle/cinn/common/context.h
+++ b/paddle/cinn/common/context.h
@@ -28,8 +28,6 @@
 
 namespace cinn {
 
-PD_DECLARE_bool(cinn_runtime_display_debug_info);
-
 namespace ir {
 class Expr;
 }  // namespace ir

--- a/paddle/cinn/ir/lowered_func.cc
+++ b/paddle/cinn/ir/lowered_func.cc
@@ -30,6 +30,8 @@
 #include "paddle/cinn/runtime/intrinsic.h"
 #include "paddle/cinn/utils/string.h"
 
+PD_DECLARE_bool(cinn_runtime_display_debug_info);
+
 namespace cinn {
 namespace ir {
 

--- a/paddle/cinn/lang/lower_impl.cc
+++ b/paddle/cinn/lang/lower_impl.cc
@@ -30,6 +30,8 @@
 #include "paddle/cinn/optim/transform_polyfor_to_for.h"
 #include "paddle/cinn/poly/stage.h"
 
+PD_DECLARE_bool(cinn_runtime_display_debug_info);
+
 namespace cinn {
 namespace lang {
 namespace detail {

--- a/paddle/cinn/runtime/flags.cc
+++ b/paddle/cinn/runtime/flags.cc
@@ -199,6 +199,10 @@ PD_DEFINE_string(cinn_pass_visualize_dir,
                  "Specify the directory path of pass visualize file of graph, "
                  "which is used for debug.");
 
+PD_DEFINE_bool(cinn_runtime_display_debug_info,
+               false,
+               "Whether to display debug information in runtime");
+
 PD_DEFINE_bool(enable_auto_tuner,
                BoolFromEnv("FLAGS_enable_auto_tuner", false),
                "Whether enable auto tuner.");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

CINN 中的全局变量 `cinn_runtime_display_debug_info` 定义在了某个特定的 cc 文件内，本 PR 将该变量移到 flags.cc 文件内，统一管理