### PR TITLE
[Dy2St] Remove duplicate implementation of `compare_legacy_with_pt` in `dygraph_to_static_utils`

### DIFF
--- a/test/dygraph_to_static/dygraph_to_static_utils.py
+++ b/test/dygraph_to_static/dygraph_to_static_utils.py
@@ -97,7 +97,6 @@ DISABLED_TO_STATIC_TEST_FILES = {
 DISABLED_IR_TEST_FILES = {
     IrMode.LEGACY_IR: [],
     IrMode.PT: [
-        "test_save_inference_model",
         "test_tensor_hook",
     ],
     IrMode.PIR: [],
@@ -428,7 +427,6 @@ def import_legacy_test_utils():
 legacy_test_utils = import_legacy_test_utils()
 dygraph_guard = legacy_test_utils.dygraph_guard
 static_guard = legacy_test_utils.static_guard
-compare_legacy_with_pt = legacy_test_utils.compare_legacy_with_pt
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

`compare_legacy_with_pt` 已经移动到 `legacy_test/utils`，清理原处于动转静 utils 重复的 `compare_legacy_with_pt`，这是动转静历史遗留的装饰器，如非必要，已经不再推荐在动转静单测内使用

PCard-66972