### PR TITLE
[Fix]: histogramdd error on cpu

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4925,12 +4925,7 @@ def histogramdd(
     index_list = paddle.to_tensor(index_list)
     for i in range(D):
         on_edge = reshaped_input[:, i] == edges[i][-1]
-        if paddle.in_dynamic_mode():
-            index_list[i][on_edge] -= 1
-        else:
-            index_list = paddle.static.setitem(
-                index_list, (i, on_edge), index_list[i][on_edge] - 1
-            )
+        index_list[i] = paddle.where(on_edge, index_list[i] - 1, index_list[i])
     index_list = tuple(index_list)
     lut = paddle.arange(
         paddle.to_tensor(hist_shape).prod(),

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4925,7 +4925,15 @@ def histogramdd(
     index_list = paddle.to_tensor(index_list)
     for i in range(D):
         on_edge = reshaped_input[:, i] == edges[i][-1]
-        index_list[i] = paddle.where(on_edge, index_list[i] - 1, index_list[i])
+        if paddle.in_dynamic_mode():
+            index_list[i] = paddle.where(
+                on_edge, index_list[i] - 1, index_list[i]
+            )
+        else:
+            index_list_i = paddle.where(
+                on_edge, index_list[i] - 1, index_list[i]
+            )
+            index_list = paddle.static.setitem(index_list, i, index_list_i)
     index_list = tuple(index_list)
     lut = paddle.arange(
         paddle.to_tensor(hist_shape).prod(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Description
<!-- Describe what you’ve done -->
应该是切片赋值写法不对，cpu nightly版本时，`histogramdd`会出现下面的错误：
![b446669bc9545c42cf664d4102311ee](https://github.com/PaddlePaddle/Paddle/assets/69197635/8e76e069-e40f-41e7-a7ea-1cae6ca88d36)

