### PR TITLE
[PIR][DynamicShape] Add InferSymbolicShape interface for cinn.broadcast op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -7,6 +7,7 @@
   kernel :
     func : expand
     param : [x, broadcast_axes]
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : isclose
   args : (Tensor x, Tensor y, float rtol=1e-5, float atol=1e-8,  bool equal_nan=false)

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.cc
@@ -1570,6 +1570,21 @@ bool ReshapeOpInferSymbolicShape(
   return true;
 }
 
+bool BroadcastOpInferSymbolicShape(
+    pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  const std::vector<int> shape = GetVectorAttr<int>(op, "out_shape");
+
+  std::vector<symbol::DimExpr> out_dims;
+  for (int dim : shape) {
+    out_dims.emplace_back(static_cast<std::int64_t>(dim));
+  }
+  symbol::ShapeOrDataDimExprs shape_data{
+      symbol::TensorShapeOrDataDimExprs(out_dims)};
+  shape_analysis->SetShapeOrDataForValue(op->result(0), shape_data);
+
+  return true;
+}
+
 }  // namespace cinn::dialect
 
 IR_DEFINE_EXPLICIT_TYPE_ID(paddle::dialect::InferSymbolicShapeInterface)

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape.h
@@ -304,6 +304,8 @@ bool ReduceSumOpInferSymbolicShape(
     pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis);
 bool ReshapeOpInferSymbolicShape(
     pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis);
+bool BroadcastOpInferSymbolicShape(
+    pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis);
 
 }  // namespace cinn::dialect
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Add InferSymbolicShape interface for cinn.broadcast op
