### PR TITLE
[Prim] Optimize composite OP silu_grad

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -78,7 +78,7 @@ void silu_grad(const Tensor& x,
       set_output<T>(cast<T>(res, org_dtype), x_grad);
     } else {
       auto sigmoid = 1.0 / (1.0 + exp<T>(-x));
-      auto res = out_grad * sigmoid * (1.0 + x - out);
+      auto res = out_grad * (sigmoid * (1.0 + x * (1.0 - sigmoid)));
       set_output<T>(res, x_grad);
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->
Pcard-75624

Optimize silu_grad


算子名 | 阶数 | 优化前耗时(ms) | 优化后耗时(ms) | 优化前显存(GB) | 优化后显存(GB)
-- | -- | -- | -- | -- | --
silu | 1 | 0.18 | 0.21 | 0.096 | 0.098
silu | 2 | 0.59 | 0.53 | 0.115 | 0.096
silu | 3 | 1.42 | 1.10 | 0.148 | 0.135
