### PR TITLE
Fix typo (`Arraow` -> `Arrow`)

### DIFF
--- a/paddle/pir/src/core/parser/lexer.cc
+++ b/paddle/pir/src/core/parser/lexer.cc
@@ -18,7 +18,7 @@ Token Lexer::ConsumeToken() {
   SkipWhitespace();
   if (auto token = LexIdentifier()) {
     return *token;
-  } else if (auto token = LexNumberOrArraow()) {
+  } else if (auto token = LexNumberOrArrow()) {
     return *token;
   } else if (auto token = LexEndTagOrNullVal()) {
     return *token;
@@ -84,7 +84,7 @@ std::unique_ptr<Token> Lexer::LexIdentifier() {
   return token;
 }
 
-std::unique_ptr<Token> Lexer::LexNumberOrArraow() {
+std::unique_ptr<Token> Lexer::LexNumberOrArrow() {
   if (!isdigit(is.peek()) && is.peek() != '-') {
     return nullptr;
   }
@@ -94,7 +94,7 @@ std::unique_ptr<Token> Lexer::LexNumberOrArraow() {
 
   if (token_digit[0] == '-' && is.peek() == '>') {
     GetChar();
-    std::unique_ptr<Token> arrow_token(new Token{"->", ARRAOW});
+    std::unique_ptr<Token> arrow_token(new Token{"->", ARROW});
     return arrow_token;
   }
   while (isdigit(is.peek())) {

--- a/paddle/pir/src/core/parser/lexer.h
+++ b/paddle/pir/src/core/parser/lexer.h
@@ -30,7 +30,7 @@ class Lexer {
   Token ConsumeToken();
   Token PeekToken();
   std::unique_ptr<Token> LexIdentifier();
-  std::unique_ptr<Token> LexNumberOrArraow();
+  std::unique_ptr<Token> LexNumberOrArrow();
   std::unique_ptr<Token> LexEndTagOrNullVal();
   std::unique_ptr<Token> LexValueId();
   std::unique_ptr<Token> LexEOF();

--- a/paddle/pir/src/core/parser/token.h
+++ b/paddle/pir/src/core/parser/token.h
@@ -23,7 +23,7 @@ enum Token_type {
   ENDTAG = 3,
   VALUEID = 4,
   STRING = 5,
-  ARRAOW = 6,
+  ARROW = 6,
   NULL_ = 7,
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Fix typo (`Arraow` -> `Arrow`)