### PR TITLE
【pir】modify paddledetection output_grad is none should pass call_vjp

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -439,6 +439,14 @@ def all_stop_gradient_true(block):
     return True
 
 
+def all_output_grad_none(list_of_list):
+    for list_ in list_of_list:
+        for value in list_:
+            if value is not None:
+                return False
+    return True
+
+
 def parent_total_ops(block):
     '''
     when block is sub_block, forward op should include its parent block ops

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -22,6 +22,7 @@ from paddle.autograd.backward_utils import (
     ValueDict,
     ValueSet,
     _as_list,
+    all_output_grad_none,
     all_stop_gradient_true,
     argument_to_value,
     check_type,
@@ -630,7 +631,9 @@ def append_backward_ops(
                     # all(zero_flag) support this op has no contribution for grad
                     # should be delete (prune sub_graph)
                     if (
-                        len(output_grads) == 0 or all(zero_flag)
+                        len(output_grads) == 0
+                        or all(zero_flag)
+                        or all_output_grad_none(output_grads)
                     ) and op.name() not in [
                         "pd_op.while",
                         "pd_op.if",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Description
<!-- Describe what you’ve done -->
pcard-67164

当双输入op的一个输入stop_gradient=True 时会产生一个null_type的梯度，如果这个梯度是下一个反向op的全部output_grad,则需要跳过call_vjp处理。