### PR TITLE
[SOT][3.12] Compat for `COMPARE_OP` arg

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1171,7 +1171,12 @@ class OpcodeExecutorBase:
         push_n=1
     )  # call instance, in, not in may call TensorVariable.get_py_value, which raise BreakGraphError
     def COMPARE_OP(self, instr: Instruction):
-        op = dis.cmp_op[instr.arg]
+        cmp_op_index = instr.arg
+        if sys.version_info >= (3, 12):
+            # Python 3.12 use lower 4 bits to store the inline cache `jump mask`
+            # see https://github.com/python/cpython/pull/100924
+            cmp_op_index >>= 4
+        op = dis.cmp_op[cmp_op_index]
         right, left = self.stack.pop(), self.stack.pop()
         self.stack.push(
             BuiltinVariable(

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -1037,6 +1037,8 @@ class PyCodeGen:
         only generator operator instruction, do nothing for
         operands.
         """
+        if sys.version_info >= (3, 12):
+            cmp_op <<= 4
         self._add_instr("COMPARE_OP", cmp_op)
 
     def _add_instr(self, *args, **kwargs):

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,19 +1,15 @@
-./test_09_f_string.py
 ./test_10_build_unpack.py
 ./test_11_jumps.py
 ./test_12_for_loop.py
 ./test_14_operators.py
 ./test_15_slice.py
 ./test_17_paddle_layer.py
-./test_20_string.py
 ./test_21_global.py
 ./test_analysis_inputs.py
-./test_binary_operator_tracker.py
 ./test_break_graph.py
 ./test_builtin_map.py
 ./test_builtin_range.py
 ./test_builtin_zip.py
-./test_dup_top.py
 ./test_enumerate.py
 ./test_guard_user_defined_fn.py
 ./test_inplace_api.py
@@ -30,5 +26,4 @@
 ./test_specialization.py
 ./test_str_format.py
 ./test_tensor_dtype_in_guard.py
-./test_dtype.py
 ./test_builtin_bool.py

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -14,7 +14,6 @@
 ./test_guard_user_defined_fn.py
 ./test_inplace_api.py
 ./test_min_graph_size.py
-./test_numpy_var_if.py
 ./test_output_restoration.py
 ./test_side_effects.py
 ./test_simulate_initialize.py
@@ -25,5 +24,4 @@
 ./test_sot_resnet50_backward.py
 ./test_specialization.py
 ./test_str_format.py
-./test_tensor_dtype_in_guard.py
 ./test_builtin_bool.py


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

对 Python3.12 中 `COMPARE_OP` oparg 进行适配，3.12 中会使用 `instr.arg >> 4`，低 4 bit 会用来作为 inline cache jump mask 使用（python/cpython#100924）

- #61174
- #61173

PCard-66972