### PR TITLE
Removing 'repeat_interleave_with_tensor_index' from 'op_compat.yaml'

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2636,15 +2636,6 @@
   attrs :
     {repeats : Repeats, axis : dim}
 
-- op : repeat_interleave_with_tensor_index
-  backward : repeat_interleave_with_tensor_index_grad
-  inputs :
-    {x : X, repeats: RepeatTensor}
-  outputs:
-    out : Out
-  attrs:
-    axis : dim
-
 - op : requantize
   inputs :
     input : Input


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
removing repeat_interleave_with_tensor_index from op_compat.yaml