### PR TITLE
[Dy2St][PIR] Allow define a local variable in single branch

### DIFF
--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -589,7 +589,6 @@ def ifelse_temp_local_var(x):
     else:
         tmp = x + 2
         y = tmp * 2
-    # return tmp + 1
     return y
 
 

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -24,6 +24,7 @@ from dygraph_to_static_utils import (
     test_ast_only,
     test_legacy_and_pt_and_pir,
     test_legacy_only,
+    test_pir_only,
 )
 from ifelse_simple_func import (
     NetWithControlFlowIf,
@@ -580,6 +581,56 @@ class TestDy2StIfElseBackward(Dy2StTestBase):
         np.testing.assert_allclose(
             (b + net.param).numpy(), out.numpy(), rtol=1e-05
         )
+
+
+def ifelse_temp_local_var(x):
+    if x:
+        y = x + 1
+    else:
+        tmp = x + 2
+        y = tmp * 2
+    # return tmp + 1
+    return y
+
+
+def ifelse_use_undefined_var(x):
+    if x:
+        y = x + 1
+    else:
+        tmp = x + 2
+        y = tmp * 2
+    return tmp + 1
+
+
+class TestIfElseMaybeUnbound(Dy2StTestBase):
+    @test_legacy_and_pt_and_pir
+    def test_maybe_unbound(self):
+        truethy = paddle.to_tensor(1)
+        falsy = paddle.to_tensor(0)
+
+        dygraph_out = ifelse_temp_local_var(truethy)
+        static_fn = paddle.jit.to_static(ifelse_temp_local_var)
+        static_out = static_fn(truethy)
+        np.testing.assert_allclose(dygraph_out.numpy(), static_out.numpy())
+
+        dygraph_out = ifelse_temp_local_var(falsy)
+        static_fn = paddle.jit.to_static(ifelse_temp_local_var)
+        static_out = static_fn(falsy)
+        np.testing.assert_allclose(dygraph_out.numpy(), static_out.numpy())
+
+    @test_ast_only
+    @test_pir_only
+    def test_use_undefined_var(self):
+        truethy = paddle.to_tensor(1)
+        falsy = paddle.to_tensor(0)
+
+        static_fn = paddle.jit.to_static(ifelse_use_undefined_var)
+        with self.assertRaises(TypeError):
+            static_fn(truethy)
+
+        static_fn = paddle.jit.to_static(ifelse_use_undefined_var)
+        with self.assertRaises(TypeError):
+            static_fn(falsy)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

允许 PIR 动转静控制流在其中某一个分支定义局部变量，比如

```python
def foo(x):
    if x:
        tmp = x + 1
        y = tmp * 2
    else:
        y = x + 2
    return y
```

此种情况 tmp 虽然是输出，但后续没有用到，可以直接将其作为 UndefinedVar，如果用户后续用到了（即便走了 true branch），也会在组网阶段直接挂掉，因为这种用法本来就是有风险的

PCard-66972