### PR TITLE
reopen test_fused_gemm_epilogue_pass

### DIFF
--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -44,8 +44,6 @@ const std::unordered_set<std::string> LegacyOpList = {
     FtrlOp::name(),
     FusedElemwiseAddActivationOp::name(),
     FusedElemwiseAddActivationGradOp::name(),
-    FusedGemmEpilogueOp::name(),
-    FusedGemmEpilogueGradOp::name(),
     DpsgdOp::name(),
     SendV2Op::name(),
     RecvV2Op::name(),

--- a/test/ir/pir/fused_pass/CMakeLists.txt
+++ b/test/ir/pir/fused_pass/CMakeLists.txt
@@ -8,10 +8,6 @@ if(NOT WITH_CUTLASS)
   list(REMOVE_ITEM TEST_INTERP_CASES ${CUTLASS_TEST_CASES})
 endif()
 
-if(WITH_COVERAGE)
-  list(REMOVE_ITEM TEST_INTERP_CASES test_fused_gemm_epilogue_pass)
-endif()
-
 foreach(target ${TEST_INTERP_CASES})
   py_test_modules(${target} MODULES ${target})
 endforeach()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-76459
reopen test_fused_gemm_epilogue_pass

FusedGemmEpilogueOp is not a legacy op, since it has phi kernel.