### PR TITLE
[CINN Unittest] Add unittest for complex symbol shape

### DIFF
--- a/test/ir/pir/cinn/symbolic/test_complex_symbol_subgraph.py
+++ b/test/ir/pir/cinn/symbolic/test_complex_symbol_subgraph.py
@@ -36,10 +36,10 @@ class ComplexSymbolSubgraph(nn.Layer):
             self.hidden_size, self.intermediate_size, bias_attr=False
         )
 
-    def forward(self, x):
-        y = paddle.concat([x, x, x], 1)
-        z = self.linear(y)
-        return paddle.exp(z) - z
+    def forward(self, a, b):
+        c = paddle.concat([a, a, b], 1)
+        d = self.linear(c)
+        return paddle.exp(d) - d
 
 
 class TestComplexSymbolSubgraph(unittest.TestCase):
@@ -61,10 +61,11 @@ class TestComplexSymbolSubgraph(unittest.TestCase):
         net = ComplexSymbolSubgraph()
         input_spec = [
             InputSpec(shape=[1, None, 768], dtype='float32'),
+            InputSpec(shape=[1, None, 768], dtype='float32'),
         ]
         net = utils.apply_to_static(net, use_cinn, input_spec)
         net.eval()
-        out = net(self.hidden_states)
+        out = net(self.hidden_states, self.hidden_states)
         if use_cinn:
             self.check_jit_kernel_info(net.forward)
         return out

--- a/test/ir/pir/cinn/symbolic/test_complex_symbol_subgraph.py
+++ b/test/ir/pir/cinn/symbolic/test_complex_symbol_subgraph.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from os.path import dirname
+
+import numpy as np
+
+import paddle
+from paddle import nn
+from paddle.static import InputSpec
+
+sys.path.append(dirname(dirname(__file__)))
+
+import utils
+
+
+class ComplexSymbolSubgraph(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.hidden_size = 768
+        self.intermediate_size = 1008
+        self.linear = nn.Linear(
+            self.hidden_size, self.intermediate_size, bias_attr=False
+        )
+
+    def forward(self, x):
+        y = paddle.concat([x, x, x], 1)
+        z = self.linear(y)
+        return paddle.exp(z) - z
+
+
+class TestComplexSymbolSubgraph(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.shape = [1, 2048, 768]
+        self.hidden_states = paddle.randn(self.shape, dtype="float32")
+        self.hidden_states.stop_gradient = False
+
+    def check_jit_kernel_info(self, static_fn):
+        utils.check_jit_kernel_number(static_fn, 2)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 2})
+
+    def eval(self, use_cinn):
+        paddle.seed(2024)
+        net = ComplexSymbolSubgraph()
+        input_spec = [
+            InputSpec(shape=[1, None, 768], dtype='float32'),
+        ]
+        net = utils.apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = net(self.hidden_states)
+        if use_cinn:
+            self.check_jit_kernel_info(net.forward)
+        return out
+
+    def test_eval(self):
+        dy_out = self.eval(use_cinn=False)
+        if utils.unittest_use_cinn():
+            cinn_out = self.eval(use_cinn=True)
+            np.testing.assert_allclose(
+                cinn_out.numpy(), dy_out.numpy(), atol=1e-6, rtol=1e-6
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

验证编译器在S0+S1作为Group输入维度符号场景下的正确性。

单测执行命令：`FLAGS_pd_unittest_use_cinn=1 ctest -R test_complex_symbol_subgraph -V`

```
{
    (%0) = "builtin.parameter" () {is_persistable:[true],parameter_name:"parameter_1",stop_gradient:[false],sym_shape_str:"shape[768, 1008], data[NULL]"} : () -> pd_op.tensor<768x1008xf32>
    (%1) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"a",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1,-1,768],stop_gradient:[false],sym_shape_str:"shape[1, S0, 768], data[NULL]"} : () -> pd_op.tensor<1x-1x768xf32>
    (%2) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"b",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1,-1,768],stop_gradient:[false],sym_shape_str:"shape[1, S1, 768], data[NULL]"} : () -> pd_op.tensor<1x-1x768xf32>
    (%3) = cinn_op.fusion () -> pd_op.tensor<1x-3x768xf32> {
    (%4) = "cinn_op.concat" (%1, %1, %2) {axis:(Int32)1,stop_gradient:[false],sym_shape_str:"shape[1, Add(Add(S0, S0), S1), 768], data[NULL]"} : (pd_op.tensor<1x-1x768xf32>, pd_op.tensor<1x-1x768xf32>, pd_op.tensor<1x-1x768xf32>) -> pd_op.tensor<1x-3x768xf32>
    () = "cf.yield" (%4) {} : (pd_op.tensor<1x-3x768xf32>) ->  
 }
    (%5) = "pd_op.matmul" (%3, %0) {stop_gradient:[false],sym_shape_str:"shape[1, Add(Add(S0, S0), S1), 1008], data[NULL]",transpose_x:false,transpose_y:false} : (pd_op.tensor<1x-3x768xf32>, pd_op.tensor<768x1008xf32>) -> pd_op.tensor<1x-1x1008xf32>
    (%6) = cinn_op.fusion () -> pd_op.tensor<1x-1x1008xf32> {
    (%7) = "pd_op.exp" (%5) {stop_gradient:[false],sym_shape_str:"shape[1, Add(Add(S0, S0), S1), 1008], data[NULL]"} : (pd_op.tensor<1x-1x1008xf32>) -> pd_op.tensor<1x-1x1008xf32>
    (%8) = "pd_op.subtract" (%7, %5) {stop_gradient:[false],sym_shape_str:"shape[1, Add(Add(S0, S0), S1), 1008], data[NULL]"} : (pd_op.tensor<1x-1x1008xf32>, pd_op.tensor<1x-1x1008xf32>) -> pd_op.tensor<1x-1x1008xf32>
    () = "cf.yield" (%8) {} : (pd_op.tensor<1x-1x1008xf32>) ->  
 }
    () = "builtin.shadow_output" (%6) {output_name:"output_0",sym_shape_str:"shape[1, Add(Add(S0, S0), S1), 1008], data[NULL]"} : (pd_op.tensor<1x-1x1008xf32>) -> 
}
```

当前错误：
```
627: F0222 09:53:56.076833 24212 nvrtc_util.cc:152] Check failed: compile_res == NVRTC_SUCCESS (6 vs. 0) default_program(19): error: identifier "S1" is undefined
627: 
627: default_program(19): error: identifier "S0" is undefined
627: 
627: default_program(29): error: identifier "S1" is undefined
627: 
627: default_program(29): error: identifier "S0" is undefined
627: 
627: 4 errors detected in the compilation of "default_program".
627: 
627: 
627: The code is:
627: #include <cstdint>
627: 
627: #define CINN_WITH_CUDA
627: #include "bfloat16.h"
627: #include "float16.h"
627: using cinn::common::bfloat16;
627: using cinn::common::float16;
627: using cinn::common::half4;
627: using cinn::common::half8;
627: using cinn::common::float8;
627: 
627: #include "cinn_cuda_runtime_source.cuh"
627: 
627: extern "C" {
627: 
627: __global__
627: void __launch_bounds__(32) fn_exp_subtract__COND__FPA__FPA__FPA__FPA__FPA_2016llMULS0_BPA_ADD_FPA_1008llMULS1_BPA__BPA_GE1_BPA_AND_FPA__FPA__FPA_2016llMULS0_BPA_ADD_FPA_1008llMULS1_BPA__BPA_LT1024_BPA__BPA_AND_FPA__FPA_1GE1_BPA_AND_FPA_1LT256_BPA__BPA__BPA___kernel(const float* __restrict__ var, float* __restrict__ var_1)
627: {
627:   if (((int)blockIdx.x < (((1008ll * S1) / 32) + (1ll + (63ll * S0))))) {
627:     if (((int)threadIdx.x < 32)) {
627:       if ((((32 * (int)blockIdx.x) + (int)threadIdx.x) < ((2016ll * S0) + (1008ll * S1)))) {
627:         var_1[((((32ll * (int)blockIdx.x) + (int)threadIdx.x) % 1008ll) + (1008ll * ((((32ll * (int)blockIdx.x) + (int)threadIdx.x) / 1008ll) % ((2ll * S0) + S1))))] = (cinn_nvgpu_exp_fp32(var[((((32ll * (int)blockIdx.x) + (int)threadIdx.x) % 1008ll) + (1008ll * ((((32ll * (int)blockIdx.x) + (int)threadIdx.x) / 1008ll) % ((2ll * S0) + S1))))]) - var[((((32ll * (int)blockIdx.x) + (int)threadIdx.x) % 1008ll) + (1008ll * ((((32ll * (int)blockIdx.x) + (int)threadIdx.x) / 1008ll) % ((2ll * S0) + S1))))]);
627:       };
627:     };
627:   };
627: }__global__
627: void __launch_bounds__(32) fn_exp_subtract__COND__FPA__FPA__FPA__FPA__FPA_2016llMULS0_BPA_ADD_FPA_1008llMULS1_BPA__BPA_GE1024_BPA_AND_FPA__FPA__FPA_2016llMULS0_BPA_ADD_FPA_1008llMULS1_BPA__BPA_LT2147483647_BPA__BPA_AND_FPA__FPA_1GE1_BPA_AND_FPA_1LT256_BPA__BPA__BPA___kernel(const float* __restrict__ var, float* __restrict__ var_1)
627: {
627:   if (((int)blockIdx.x < (((1008ll * S1) / 32) + (1ll + (63ll * S0))))) {
627:     if (((int)threadIdx.x < 32)) {
627:       if ((((32 * (int)blockIdx.x) + (int)threadIdx.x) < ((2016ll * S0) + (1008ll * S1)))) {
627:         var_1[((((32ll * (int)blockIdx.x) + (int)threadIdx.x) % 1008ll) + (1008ll * ((((32ll * (int)blockIdx.x) + (int)threadIdx.x) / 1008ll) % ((2ll * S0) + S1))))] = (cinn_nvgpu_exp_fp32(var[((((32ll * (int)blockIdx.x) + (int)threadIdx.x) % 1008ll) + (1008ll * ((((32ll * (int)blockIdx.x) + (int)threadIdx.x) / 1008ll) % ((2ll * S0) + S1))))]) - var[((((32ll * (int)blockIdx.x) + (int)threadIdx.x) % 1008ll) + (1008ll * ((((32ll * (int)blockIdx.x) + (int)threadIdx.x) / 1008ll) % ((2ll * S0) + S1))))]);
627:       };
627:     };
627:   };
627: }
627: 
627: }
627: *** Check failure stack trace: ***
627:     @     0x7f2d7bd0d10d  google::LogMessage::Fail()
627:     @     0x7f2d7bd0f3bd  google::LogMessage::SendToLog()
627:     @     0x7f2d7bd0cbfd  google::LogMessage::Flush()
627:     @     0x7f2d7bd0feb9  google::LogMessageFatal::~LogMessageFatal()
627:     @     0x7f2db192eace  cinn::backends::nvrtc::Compiler::CompileCudaSource()
627:     @     0x7f2db1931752  cinn::backends::nvrtc::Compiler::operator()()
627:     @     0x7f2db192940c  cinn::backends::Compiler::CompileCudaModule()
627:     @     0x7f2db192a14d  cinn::backends::Compiler::Build()
627:     @     0x7f2db1a30ef3  cinn::hlir::framework::CompilationTask::CodegenAndJit()
627:     @     0x7f2d7f8d030f  _ZNSt17_Function_handlerIFviEZN4cinn4hlir9framework11PirCompiler16BuildCUDAJITInfoERKSt6vectorISt10shared_ptrINS3_3pir5GroupEESaIS9_EEEUliE_E9_M_invokeERKSt9_Any_dataOi
627:     @     0x7f2db17526f9  _ZNSt17_Function_handlerIFSt10unique_ptrINSt13__future_base12_Result_baseENS2_8_DeleterEEvENS1_12_Task_setterIS0_INS1_7_ResultIiEES3_EZNS1_11_Task_stateIZN4cinn5utils12parallel_runERKSt8functionIFviEEONSC_13JobDispatcherEiEUliE_SaIiEFiiEE6_M_runEOiEUlvE_iEEE9_M_invokeERKSt9_Any_data
627:     @     0x7f2db1751e7f  std::__future_base::_State_baseV2::_M_do_set()
627:     @     0x7f2dd2a8d907  __pthread_once_slow
627:     @     0x7f2db175247a  std::thread::_State_impl<>::_M_run()
627:     @     0x7f2dc9a73ecf  execute_native_thread_routine
627:     @     0x7f2dd2a856db  start_thread
627:     @     0x7f2dd2dbe61f  clone
627:     @              (nil)  (unknown)
```