### PR TITLE
[WIP][Fix] Fix divide_double_grad when computing grad(grad(z, y), y)

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
@@ -190,15 +190,15 @@
 
 - backward_op : divide_double_grad
   forward : divide_grad (Tensor x, Tensor y, Tensor out, Tensor grad_out, int axis = -1) -> Tensor(grad_x), Tensor(grad_y)
-  args : (Tensor y, Tensor out, Tensor grad_x, Tensor grad_x_grad, Tensor grad_y_grad, int axis = -1)
-  output : Tensor(y_grad), Tensor(out_grad), Tensor(grad_out_grad)
+  args : (Tensor x, Tensor y, Tensor out, Tensor grad_x, Tensor grad_out, Tensor grad_x_grad, Tensor grad_y_grad, int axis = -1)
+  output : Tensor(x_grad), Tensor(y_grad), Tensor(grad_out_grad)
   infer_meta :
     func : GeneralTernaryGradInferMeta
-    param : [y, grad_x, grad_x]
+    param : [x, y, out]
   kernel :
     func : divide_double_grad
     data_type : out
-  optional : grad_x_grad, grad_y_grad
+  optional : grad_x_grad, grad_y_grad, grad_x
   inplace : (grad_x_grad -> grad_out_grad)
 
 - backward_op : divide_grad

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -175,15 +175,15 @@
 
 - backward_op : divide_double_grad
   forward : divide_grad (Tensor x, Tensor y, Tensor out, Tensor grad_out, int axis = -1) -> Tensor(grad_x), Tensor(grad_y)
-  args : (Tensor y, Tensor out, Tensor grad_x, Tensor grad_x_grad, Tensor grad_y_grad, int axis = -1)
-  output : Tensor(y_grad), Tensor(out_grad), Tensor(grad_out_grad)
+  args : (Tensor x, Tensor y, Tensor out, Tensor grad_x, Tensor grad_out, Tensor grad_x_grad, Tensor grad_y_grad, int axis = -1)
+  output : Tensor(x_grad), Tensor(y_grad), Tensor(grad_out_grad)
   infer_meta :
     func : GeneralTernaryGradInferMeta
-    param : [y, grad_x, grad_x]
+    param : [x, y, out]
   kernel :
     func : divide_double_grad
     data_type : out
-  optional : grad_x_grad, grad_y_grad
+  optional : grad_x_grad, grad_y_grad, grad_x
   inplace : (grad_x_grad -> grad_out_grad)
 
 - backward_op : divide_grad

--- a/paddle/phi/kernels/elementwise_divide_grad_kernel.h
+++ b/paddle/phi/kernels/elementwise_divide_grad_kernel.h
@@ -31,14 +31,16 @@ void DivideGradKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void DivideDoubleGradKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
                             const DenseTensor& y,
                             const DenseTensor& out,
-                            const DenseTensor& dx,
+                            const paddle::optional<DenseTensor>& grad_x,
+                            const DenseTensor& grad_out,
                             const paddle::optional<DenseTensor>& ddx,
                             const paddle::optional<DenseTensor>& ddy,
                             int axis,
+                            DenseTensor* dx,
                             DenseTensor* dy,
-                            DenseTensor* dout,
                             DenseTensor* ddout);
 
 }  // namespace phi

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -120,7 +120,8 @@ void SubtractDoubleGradImpl(const Context& dev_ctx,
 template <typename T>
 struct DivGradDX {
   HOSTDEVICE T operator()(T x UNUSED, T y, T out UNUSED, T dout) const {
-    return dout / y;
+    // return dout / y;
+    return dout;
   }
 };
 
@@ -158,28 +159,35 @@ struct DivGradDY<phi::dtype::complex<T>> {
 template <typename T>
 struct DivDoubleDY {
   HOSTDEVICE T operator()(T x, T y, T out, T dout) const {
-    return y * out * dout - x * dout;
+    return static_cast<T>(2) * y * out * dout - x * dout;
   }
+};
+
+template <typename T>
+struct DivGradDX_OLD {
+  HOSTDEVICE T operator()(T x, T y, T out, T dout) const { return dout / y; }
 };
 
 template <typename T, typename Context>
 void DivideDoubleGradKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
                             const DenseTensor& y,
                             const DenseTensor& out,
-                            const DenseTensor& dx,
+                            const paddle::optional<DenseTensor>& grad_x,
+                            const DenseTensor& grad_out,
                             const paddle::optional<DenseTensor>& ddx,
                             const paddle::optional<DenseTensor>& ddy,
                             int axis,
+                            DenseTensor* dx,
                             DenseTensor* dy,
-                            DenseTensor* dout,
                             DenseTensor* ddout) {
+  if (dx) {
+    dx->Resize(x.dims());
+    dev_ctx.template Alloc<T>(dx);
+  }
   if (dy) {
     dy->Resize(y.dims());
     dev_ctx.template Alloc<T>(dy);
-  }
-  if (dout) {
-    dout->Resize(out.dims());
-    dev_ctx.template Alloc<T>(dout);
   }
   if (ddout) {
     ddout->Resize(out.dims());
@@ -189,21 +197,36 @@ void DivideDoubleGradKernel(const Context& dev_ctx,
   // ddY_safe == null ? 0 : ddY
   DenseTensor ddX_safe, ddY_safe;
   phi::funcs::GetDoubleGradSafeTensor<Context, T>(
-      dev_ctx, dx, ddx.get_ptr(), &ddX_safe);
+      dev_ctx, out, ddx.get_ptr(), &ddX_safe);
   phi::funcs::GetDoubleGradSafeTensor<Context, T>(
       dev_ctx, y, ddy.get_ptr(), &ddY_safe);
 
+  // dX = -grad_x * ddY / Y
+  // dY = Out * grad_x * ddY / Y - grad_x * ddX / Y
   // ddOut = ddX / Y - Out * ddY / Y = (ddX - Out * ddY) / Y
-  // dY = Out * dX * ddY / Y - dX * ddX / Y
-  // dOut = - dX * ddY
   // To save memory, (1) dout can be used as 'tmp' tensor, (2) ddout can
   // inplace ddx
-  DenseTensor tmp;
-  if (dout) {
-    tmp = *dout;
+  DenseTensor tmp;  // grad_x can be reused in computation of dx and dy for the
+                    // common item: dout/y
+  if (grad_x.get_ptr()) {
+    // if grad_x exist, reuse it as tmp
+    tmp = grad_x.get();
   } else {
+    // manually compute grad_x = dout / y
     tmp.Resize(out.dims());
     dev_ctx.template Alloc<T>(&tmp);
+    phi::funcs::
+        ElemwiseGradCompute<Context, T, DivGradDX_OLD<T>, DivDoubleDY<T>>(
+            dev_ctx,
+            grad_out,  // x, useless here, just for placeholder
+            y,         // y
+            out,       // out, useless here, just for placeholder
+            grad_out,  // dout
+            axis,
+            &tmp,                // dx
+            nullptr,             // dy
+            DivGradDX_OLD<T>(),  // dx=dout/y
+            DivDoubleDY<T>());   // useless here, just for placeholder
   }
   if (dy) {
     // dX_div_Y = dX / Y;
@@ -212,26 +235,37 @@ void DivideDoubleGradKernel(const Context& dev_ctx,
                                       T,
                                       funcs::DivideFunctor<T>,
                                       funcs::InverseDivideFunctor<T>>(
-        dev_ctx, dx, y, &dX_div_Y, axis);
-
+        dev_ctx, tmp, y, &dX_div_Y, axis);  // compute dout/y^2 into dX_div_Y
     // NOTE(dengkaipeng): in the following ElemwiseGradCompute, for the
     // first output tensor is nullptr, the branch to calculate first
     // output tensor will not be activated, DivGradDx function will not
     // be called and can be ignored, the first branch has little effect
     // on running speed.
 
-    // dY = Out * dX * ddY / Y - dX * ddX / Y
+    // dY = 2 * Out * dX * ddY / Y - dX * ddX / Y
     phi::funcs::ElemwiseGradCompute<Context, T, DivGradDX<T>, DivDoubleDY<T>>(
         dev_ctx,
-        ddX_safe,
-        ddY_safe,
-        out,
-        dX_div_Y,
+        ddX_safe,  // x
+        ddY_safe,  // y
+        out,       // out
+        dX_div_Y,  // dout
         axis,
-        nullptr,
-        dy,
-        DivGradDX<T>(),
-        DivDoubleDY<T>());
+        nullptr,            // dx
+        dy,                 // dy
+        DivGradDX<T>(),     // useless here, just for placeholder
+        DivDoubleDY<T>());  // 2 * ddy * out * grad_x / y - ddx * grad_x / y
+  }
+
+  if (dx) {
+    // dx = - grad_x * ddY / y
+    funcs::DefaultElementwiseOperator<Context,
+                                      T,
+                                      funcs::MultiplyFunctor<T>,
+                                      funcs::InverseMultiplyFunctor<T>>(
+        dev_ctx, tmp, ddY_safe, dx, axis);  // dx=z_g*y_g_g/y^2
+    auto& place = *dev_ctx.eigen_device();
+    auto dx_result = phi::EigenVector<T>::Flatten(*dx);
+    dx_result.device(place) = static_cast<T>(-1) * dx_result;
   }
 
   if (ddout) {
@@ -240,31 +274,20 @@ void DivideDoubleGradKernel(const Context& dev_ctx,
                                       T,
                                       funcs::MultiplyFunctor<T>,
                                       funcs::InverseMultiplyFunctor<T>>(
-        dev_ctx, out, ddY_safe, &tmp, axis);
+        dev_ctx, out, ddY_safe, &tmp, axis);  // tmp = z*y_g_g
     funcs::DefaultElementwiseOperator<Context,
                                       T,
                                       funcs::SubtractFunctor<T>,
                                       funcs::InverseSubtractFunctor<T>>(
-        dev_ctx, ddX_safe, tmp, &tmp, axis);
+        dev_ctx, ddX_safe, tmp, &tmp, axis);  // tmp = x_g_g - z*y_g_g
     funcs::DefaultElementwiseOperator<Context,
                                       T,
                                       funcs::DivideFunctor<T>,
                                       funcs::InverseDivideFunctor<T>>(
-        dev_ctx, tmp, y, ddout, axis);
-  }
-
-  if (dout) {
-    // dOut = - dX * ddY
-    funcs::DefaultElementwiseOperator<Context,
-                                      T,
-                                      funcs::MultiplyFunctor<T>,
-                                      funcs::InverseMultiplyFunctor<T>>(
-        dev_ctx, dx, ddY_safe, dout, axis);
-    auto& place = *dev_ctx.eigen_device();
-    auto dout_result = phi::EigenVector<T>::Flatten(*dout);
-    dout_result.device(place) = static_cast<T>(-1) * dout_result;
+        dev_ctx, tmp, y, ddout, axis);  // ddout = (x_g_g - z*y_g_g)/y
   }
 }
+
 template <typename T, typename Context>
 void ElementwiseFMaxGradKernel(const Context& dev_ctx,
                                const DenseTensor& x,

--- a/test/cpp/fluid/elementwise/test_elementwise_div_grad_grad.cc
+++ b/test/cpp/fluid/elementwise/test_elementwise_div_grad_grad.cc
@@ -60,8 +60,8 @@ class TestElementwiseDivGradGradWithoutDout
     std::vector<T> dy(numel);
     std::vector<T> ddout(numel);
     for (size_t i = 0; i < numel; ++i) {
-      // dY(Y@GRAD) = Out * dX * ddY / Y - dX * ddX / Y
-      dy[i] = (feed_datas_["DX"][i] / feed_datas_["Y"][i]) *
+      // dY(Y@GRAD) = 2 * Out * dX * ddY / Y - dX * ddX / Y
+      dy[i] = (2 * feed_datas_["DX"][i] / feed_datas_["Y"][i]) *
               (feed_datas_["Out"][i] * feed_datas_["DDY"][i] -
                feed_datas_["DDX"][i]);
       // ddOut = ddX / Y - Out * ddY / Y = (ddX - Out * ddY) / Y

--- a/test/cpp/fluid/elementwise/test_elementwise_div_grad_grad.cc
+++ b/test/cpp/fluid/elementwise/test_elementwise_div_grad_grad.cc
@@ -46,11 +46,12 @@ class TestElementwiseDivGradGradWithoutDout
  public:
   TestElementwiseDivGradGradWithoutDout(const platform::Place &place,
                                         const framework::DDim &dims)
-      : TestElementwiseOpGradGrad<T>("elementwise_div_grad_grad",
-                                     place,
-                                     dims,
-                                     {"Y", "Out", "DDX", "DDY", "DX"},
-                                     {"Y@GRAD", "DDOut"}) {}
+      : TestElementwiseOpGradGrad<T>(
+            "elementwise_div_grad_grad",
+            place,
+            dims,
+            {"X", "Y", "Out", "DX", "DOut", "DDX", "DDY"},
+            {"X@GRAD", "Y@GRAD", "DDOut"}) {}
 
   using TestElementwiseOpGradGrad<T>::feed_datas_;
   using TestElementwiseOpGradGrad<T>::expected_outs_;
@@ -76,12 +77,16 @@ class TestElementwiseDivGradGradWithoutDout
   std::unique_ptr<framework::OperatorBase> CreateTestOp() override {
     auto op = framework::OpRegistry::CreateOp(
         this->op_type_,
-        {{"Y", {"Y"}},
-         {"Out", {"Out"}},
-         {"DDX", {"DDX"}},
-         {"DDY", {"DDY"}},
-         {"DX", {"DX"}}},
-        {{"Y@GRAD", {"Y@GRAD"}}, {"DDOut", {"DDOut"}}},
+        {
+            {"X", {"X"}},
+            {"Y", {"Y"}},
+            {"Out", {"Out"}},
+            {"DX", {"DX"}},
+            {"DOut", {"DOut"}},
+            {"DDX", {"DDX"}},
+            {"DDY", {"DDY"}},
+        },
+        {{"X@GRAD", {"X@GRAD"}}, {"Y@GRAD", {"Y@GRAD"}}, {"DDOut", {"DDOut"}}},
         {{"use_mkldnn", false}, {"axis", 0}});
     return op;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->
Pcard-75624

Normalize and fix code of `divide_double_grad` kernel, as error occurs when computing `y_grad_grad` and correct computation code of `dy` in UT file `test/cpp/fluid/elementwise/test_elementwise_div_grad_grad.cc`

Divide 1-order and 2-order computation graph and equation is depicted below

![image](https://github.com/PaddlePaddle/Paddle/assets/23737287/233fd42c-e423-465f-8746-a6f44f6842fa)


test code(atol=rtol=1e-6)

``` py
import paddle
import numpy as np
import torch

def test_div_double_grad_same_shape():
    x_data = np.random.rand(1024, 512).astype("float32") + 1.0
    y_data = np.random.rand(1024, 512).astype("float32") + 1.0

    # paddle below
    x_p = paddle.to_tensor(x_data)
    y_p = paddle.to_tensor(y_data)
    x_p.stop_gradient = False
    y_p.stop_gradient = False

    z_p = x_p / y_p

    z_x_p = paddle.grad(z_p, x_p, create_graph=True)[0]
    z_y_p = paddle.grad(z_p, y_p, create_graph=True)[0]

    z_y_y_p = paddle.grad(z_y_p, y_p)[0]
    z_x_y_p = paddle.grad(z_x_p, y_p)[0]
    # z_y_x_p = paddle.grad(z_y_p, x_p)[0]

    # torch below
    x_t = torch.from_numpy(x_data).cuda()
    y_t = torch.from_numpy(y_data).cuda()
    x_t.requires_grad = True
    y_t.requires_grad = True

    z_t = x_t / y_t

    z_x_t = torch.autograd.grad(z_t.sum(), x_t, create_graph=True)[0]
    z_y_t = torch.autograd.grad(z_t.sum(), y_t, create_graph=True)[0]

    z_y_y_t = torch.autograd.grad(z_y_t.sum(), y_t)[0]
    z_x_y_t = torch.autograd.grad(z_x_t.sum(), y_t)[0]
    # z_y_x_t = torch.autograd.grad(z_y_t.sum(), x_t)[0]

    np.testing.assert_allclose(z_p.numpy(), z_t.detach().cpu().numpy(), 1e-6, 1e-6)

    np.testing.assert_allclose(z_x_p.numpy(), z_x_t.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(z_y_p.numpy(), z_y_t.detach().cpu().numpy(), 1e-6, 1e-6)

    np.testing.assert_allclose(z_x_y_p.numpy(), z_x_y_t.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(z_y_y_p.numpy(), z_y_y_t.detach().cpu().numpy(), 1e-6, 1e-6)
    # np.testing.assert_allclose(z_y_x_p.numpy(), z_y_x_t.detach().cpu().numpy(), 1e-6, 1e-6)


def test_div_double_grad_broadcast_x():
    x_data = np.random.rand(1024, 1).astype("float32") + 1.0
    y_data = np.random.rand(1024, 512).astype("float32") + 1.0

    # paddle below
    x_p = paddle.to_tensor(x_data)
    y_p = paddle.to_tensor(y_data)
    x_p.stop_gradient = False
    y_p.stop_gradient = False

    z_p = x_p / y_p

    z_x_p = paddle.grad(z_p, x_p, create_graph=True)[0]
    z_y_p = paddle.grad(z_p, y_p, create_graph=True)[0]

    z_y_y_p = paddle.grad(z_y_p, y_p)[0]
    z_x_y_p = paddle.grad(z_x_p, y_p)[0]
    # z_y_x_p = paddle.grad(z_y_p, x_p)[0]

    # torch below
    x_t = torch.from_numpy(x_data).cuda()
    y_t = torch.from_numpy(y_data).cuda()
    x_t.requires_grad = True
    y_t.requires_grad = True

    z_t = x_t / y_t

    z_x_t = torch.autograd.grad(z_t.sum(), x_t, create_graph=True)[0]
    z_y_t = torch.autograd.grad(z_t.sum(), y_t, create_graph=True)[0]

    z_y_y_t = torch.autograd.grad(z_y_t.sum(), y_t)[0]
    z_x_y_t = torch.autograd.grad(z_x_t.sum(), y_t)[0]
    # z_y_x_t = torch.autograd.grad(z_y_t.sum(), x_t)[0]

    np.testing.assert_allclose(z_p.numpy(), z_t.detach().cpu().numpy(), 1e-6, 1e-6)

    np.testing.assert_allclose(z_x_p.numpy(), z_x_t.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(z_y_p.numpy(), z_y_t.detach().cpu().numpy(), 1e-6, 1e-6)

    np.testing.assert_allclose(z_x_y_p.numpy(), z_x_y_t.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(z_y_y_p.numpy(), z_y_y_t.detach().cpu().numpy(), 1e-6, 1e-6)
    # np.testing.assert_allclose(z_y_x_p.numpy(), z_y_x_t.detach().cpu().numpy(), 1e-6, 1e-6)


def test_div_double_grad_broadcast_y():
    x_data = np.random.rand(1024, 512).astype("float32") + 1.0
    y_data = np.random.rand(1024, 1).astype("float32") + 1.0

    # paddle below
    x_p = paddle.to_tensor(x_data)
    y_p = paddle.to_tensor(y_data)
    x_p.stop_gradient = False
    y_p.stop_gradient = False

    z_p = x_p / y_p

    z_x_p = paddle.grad(z_p, x_p, create_graph=True)[0]
    z_y_p = paddle.grad(z_p, y_p, create_graph=True)[0]

    z_y_y_p = paddle.grad(z_y_p, y_p)[0]
    z_x_y_p = paddle.grad(z_x_p, y_p)[0]
    # z_y_x_p = paddle.grad(z_y_p, x_p)[0]

    # torch below
    x_t = torch.from_numpy(x_data).cuda()
    y_t = torch.from_numpy(y_data).cuda()
    x_t.requires_grad = True
    y_t.requires_grad = True

    z_t = x_t / y_t

    z_x_t = torch.autograd.grad(z_t.sum(), x_t, create_graph=True)[0]
    z_y_t = torch.autograd.grad(z_t.sum(), y_t, create_graph=True)[0]

    z_y_y_t = torch.autograd.grad(z_y_t.sum(), y_t)[0]
    z_x_y_t = torch.autograd.grad(z_x_t.sum(), y_t)[0]
    # z_y_x_t = torch.autograd.grad(z_y_t.sum(), x_t)[0]

    np.testing.assert_allclose(z_p.numpy(), z_t.detach().cpu().numpy(), 1e-6, 1e-6)

    np.testing.assert_allclose(z_x_p.numpy(), z_x_t.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(z_y_p.numpy(), z_y_t.detach().cpu().numpy(), 1e-6, 1e-6)

    np.testing.assert_allclose(z_x_y_p.numpy(), z_x_y_t.detach().cpu().numpy(), 1e-6, 1e-6)
    np.testing.assert_allclose(z_y_y_p.numpy(), z_y_y_t.detach().cpu().numpy(), 1e-6, 1e-6)
    # np.testing.assert_allclose(z_y_x_p.numpy(), z_y_x_t.detach().cpu().numpy(), 1e-6, 1e-6)


if __name__ == "__main__":
    test_div_double_grad_same_shape()
    test_div_double_grad_broadcast_x()
    test_div_double_grad_broadcast_y()
```