### PR TITLE
Fix build error when switching cmake option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,3 @@ paddle/phi/kernels/fusion/cutlass/cutlass_kernels/fpA_intB_gemm/autogen/*
 paddle/phi/kernels/fusion/cutlass/cutlass_kernels/fpA_intB_gemm/autogen_tmp/*
 paddle/fluid/pybind/static_op_function.*
 paddle/fluid/pybind/ops_api.cc
-paddle/fluid/pir/drr/src/*_op_factory_generated.*

--- a/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
@@ -14,6 +14,7 @@
 
 import argparse
 import os
+
 import yaml
 from op_gen import (
     OpCompatParser,
@@ -195,7 +196,7 @@ class OpCreatorCodeGen:
                             params_no_mutable_attr
                         ),
                     )
-    
+
         directory_path = os.path.dirname(cpp_file_path)
         if not os.path.exists(directory_path):
             os.makedirs(directory_path, exist_ok=True)

--- a/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_creator_drr_gen.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import argparse
-
+import os
 import yaml
 from op_gen import (
     OpCompatParser,
@@ -195,6 +195,10 @@ class OpCreatorCodeGen:
                             params_no_mutable_attr
                         ),
                     )
+    
+        directory_path = os.path.dirname(cpp_file_path)
+        if not os.path.exists(directory_path):
+            os.makedirs(directory_path, exist_ok=True)
 
         with open(cpp_file_path, 'w') as f:
             f.write(

--- a/paddle/fluid/pir/drr/CMakeLists.txt
+++ b/paddle/fluid/pir/drr/CMakeLists.txt
@@ -29,7 +29,7 @@ set(op_yaml_files
 )
 
 set(pd_op_creator_file
-    ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/drr/src/pd_op_factory_generated.cc)
+    ${PADDLE_BINARY_DIR}/paddle/fluid/pir/drr/src/pd_op_factory_generated.cc)
 set(pd_op_creator_file_tmp ${pd_op_creator_file}.tmp)
 
 set(pd_dialect_name pd_op)
@@ -62,7 +62,7 @@ if(WITH_CINN AND NOT CINN_ONLY)
       ${PADDLE_SOURCE_DIR}/paddle/cinn/hlir/dialect/operator/ir/ops.yaml)
 
   set(cinn_op_creator_file
-      ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/drr/src/cinn_op_factory_generated.cc
+      ${PADDLE_BINARY_DIR}/paddle/fluid/pir/drr/src/cinn_op_factory_generated.cc
   )
   set(cinn_op_creator_file_tmp ${cinn_op_creator_file}.tmp)
   set(cinn_dialect_name cinn_op)
@@ -96,7 +96,7 @@ if(WITH_MKLDNN)
       ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/dialect/operator/ir/ops_onednn_extra.yaml
   )
   set(onednn_op_creator_file
-      ${PADDLE_SOURCE_DIR}/paddle/fluid/pir/drr/src/onednn_op_factory_generated.cc
+      ${PADDLE_BINARY_DIR}/paddle/fluid/pir/drr/src/onednn_op_factory_generated.cc
   )
   set(onednn_op_creator_file_tmp ${onednn_op_creator_file}.tmp)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

Fix build error when switch cmake from `-DWITH_CINN=ON` to `-DWITH_CINN=OFF` or switch cmake from `-DWITH_MKLDNN=ON` to `-DWITH_MKLDNN=OFF`.
The issue arises when compiling with `DWITH_CINN=ON`, as after compilation, the code is retained directly in the Paddle source directory. And if compiling again with `DWITH_CINN=OFF`, compilation errors occur due to the files generated in the Paddle source directory not being properly cleaned up.
The location of the generated files has been put placed in the /build directory.