### PR TITLE
[CINN] Fix build of generate_shape_op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -267,13 +267,12 @@ void GenerateShapeOp::Build(
     const std::vector<pir::Value>& inputs,
     const std::vector<pir::Attribute>& output_dim_exprs,
     const GenerateShapeOp::SymbolBindings& symbol_bindings) {
-  CHECK(!inputs.empty()) << ". output_dim_exprs: " << [&] {
-    std::stringstream ss;
+  if (inputs.empty()) {
+    VLOG(3) << "GenerateShapeOp inputs is empty";
     for (const auto& attr : output_dim_exprs) {
-      ss << attr;
+      CHECK(attr.isa<pir::Int64Attribute>());
     }
-    return ss.str();
-  }();
+  }
   argument.AddInputs(inputs);
   argument.AddAttribute("output_dim_exprs",
                         builder.array_attr(output_dim_exprs));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

`GenerateShapeOp`目前不支持输入Value为空的情况，但在部分场景下输出Value维度信息均为静态int值，此时确实可以没有输入Value。
为保证`GenerateShapeOp`的通用性，本PR修改了`GenerateShapeOp`的Build检查逻辑：允许输入Value为空，但当输入Value为空时必须保证所有输出Value的维度信息均为静态int值。
