### PR TITLE
delete io in __all__

### DIFF
--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import atexit  # noqa: F401
-from . import io
 from .spawn import spawn
 from .launch.main import launch
 from .parallel import (  # noqa: F401
@@ -113,7 +112,6 @@ from .checkpoint.save_state_dict import save_state_dict
 from .checkpoint.load_state_dict import load_state_dict
 
 __all__ = [
-    "io",
     "spawn",
     "launch",
     "scatter",

--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import atexit  # noqa: F401
+from . import io  # noqa: F401
 from .spawn import spawn
 from .launch.main import launch
 from .parallel import (  # noqa: F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Description
<!-- Describe what you’ve done -->
删除 `paddle/distributed/__init__.py` 里的 `__all__ `里的 “io”，因为 doc-preview CI 检查会通过 \_\_all\_\_ 来遍历文档，io 是一个模块而不是API，导致检查时报错。而且删除 “io” 应该是没啥影响的。