### PR TITLE
[SOT][3.12] Support `END_FOR` opcode by skiping `END_FOR` in `FOR_ITER` in Python 3.12

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -2100,6 +2100,8 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
             self._inline_call_for_loop(iterator, instr)
             self._lasti = self.indexof(instr.jump_to)
+            next_instr = self._instructions[self._lasti]
+            self._lasti += int(next_instr.opname == 'END_FOR')
         except BreakGraphError as e:
             log(3, f"[BreakGraph] FOR_ITER sim for loop failed for: {e}\n")
             if backup_iter_idx:

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -3,14 +3,10 @@
 ./test_12_for_loop.py
 ./test_14_operators.py
 ./test_15_slice.py
-./test_17_paddle_layer.py
 ./test_21_global.py
 ./test_analysis_inputs.py
 ./test_break_graph.py
-./test_builtin_map.py
-./test_builtin_range.py
 ./test_builtin_zip.py
-./test_enumerate.py
 ./test_guard_user_defined_fn.py
 ./test_inplace_api.py
 ./test_min_graph_size.py


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
python 3.12 支持 `END_FOR`：通过在 `FOR_ITER` 跳过 `END_FOR` [(Python/bytecodes.c#L2314)](https://github.com/python/cpython/blob/2ea2d25cc67e268975d471a367478fbe48880743/Python/bytecodes.c#L2314)

- #61173
- #61174