### PR TITLE
【AutoParallel】Enable amp strategy in `dist.to_static`

### DIFF
--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1470,6 +1470,7 @@ class DistModel:
                 "fused_dropout_add_pass"
             )
 
+        inner_strategy.amp = copy.deepcopy(strategy.amp)
         inner_strategy.sharding = copy.deepcopy(strategy.sharding)
         inner_strategy.gradient_merge = copy.deepcopy(strategy.gradient_merge)
         inner_strategy.pipeline = copy.deepcopy(strategy.pipeline)

--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -400,6 +400,9 @@ class ProgramHelper:
                 # The parameter is not in this rank.
                 if not scope_var:
                     continue
+                # The parameter do not need to transform
+                if param.dtype in [paddle.float16, paddle.bfloat16]:
+                    continue
                 assert (
                     scope_var and scope_tensor._is_initialized()
                 ), f"Parameter: {param.name} is not put into global_scope or not initialized."

--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import inspect
 import logging
 from collections import defaultdict
+
+import numpy as np
 
 import paddle
 from paddle.jit import not_to_static, to_static
@@ -27,6 +30,7 @@ from paddle.nn import Layer
 from paddle.static import Parameter, global_scope, program_guard
 from paddle.static.amp.fp16_utils import (
     DEFAULT_AMP_OPTIONS,
+    _convert_float_to_bfloat16,
     prepare_op_amp_options,
 )
 
@@ -384,6 +388,44 @@ class ProgramHelper:
             elif param.is_dist():
                 dense_tensor = global_scope().var(param.name).get_tensor()
                 dense_tensor._share_data_with(param.get_tensor().get_tensor())
+
+        # transform the parameter in eager mode for amp.
+        amp_stragety = dist_context.strategy.amp
+        amp_config = copy.deepcopy(amp_stragety.to_dict())
+        if amp_stragety.enable and amp_config["level"] in ["o2", "o3"]:
+            for param in self.concrete_program.parameters:
+                amp_dtype = amp_config["dtype"]
+                scope_var = global_scope().find_var(param.name)
+                scope_tensor = global_scope().var(param.name).get_tensor()
+                # The parameter is not in this rank.
+                if not scope_var:
+                    continue
+                assert (
+                    scope_var and scope_tensor._is_initialized()
+                ), f"Parameter: {param.name} is not put into global_scope or not initialized."
+                var = main_program.global_block().vars[param.name]
+                var_dist_attr = dist_context.get_tensor_dist_attr_for_program(
+                    var
+                )
+                dist_attr = {
+                    "dims_mapping": var_dist_attr.dims_mapping,
+                    "process_shape": var_dist_attr.process_mesh.shape,
+                    "process_group": var_dist_attr.process_mesh.process_ids,
+                }
+                if amp_dtype == "float16":
+                    sliced_param = Converter.slice_with_dist_attr(
+                        np.float16(param.numpy()), dist_attr
+                    )
+                    scope_tensor.set(sliced_param, place)
+                elif amp_dtype == "bfloat16":
+                    sliced_param = Converter.slice_with_dist_attr(
+                        _convert_float_to_bfloat16(place, param.numpy()),
+                        dist_attr,
+                    )
+                    scope_tensor.set(
+                        sliced_param,
+                        place,
+                    )
 
         world_group = get_world_process_group()
         if (

--- a/python/paddle/distributed/auto_parallel/static/helper.py
+++ b/python/paddle/distributed/auto_parallel/static/helper.py
@@ -416,15 +416,23 @@ class ProgramHelper:
                     "process_group": var_dist_attr.process_mesh.process_ids,
                 }
                 if amp_dtype == "float16":
-                    sliced_param = Converter.slice_with_dist_attr(
-                        np.float16(param.numpy()), dist_attr
-                    )
+                    if param.is_dist():
+                        sliced_param = np.float16(param._local_value().numpy())
+                    else:
+                        sliced_param = Converter.slice_with_dist_attr(
+                            np.float16(param.numpy()), dist_attr
+                        )
                     scope_tensor.set(sliced_param, place)
                 elif amp_dtype == "bfloat16":
-                    sliced_param = Converter.slice_with_dist_attr(
-                        _convert_float_to_bfloat16(place, param.numpy()),
-                        dist_attr,
-                    )
+                    if param.is_dist():
+                        sliced_param = _convert_float_to_bfloat16(
+                            place, param._local_value().numpy()
+                        )
+                    else:
+                        sliced_param = Converter.slice_with_dist_attr(
+                            _convert_float_to_bfloat16(place, param.numpy()),
+                            dist_attr,
+                        )
                     scope_tensor.set(
                         sliced_param,
                         place,

--- a/python/paddle/distributed/passes/auto_parallel_fp16.py
+++ b/python/paddle/distributed/passes/auto_parallel_fp16.py
@@ -308,10 +308,25 @@ class FP16State:
             if op.type == "cast":
                 in_name = op.input('X')[0]
                 out_name = op.output('Out')[0]
-                in_var = block._find_var_recursive(in_name)
-                out_var = block._find_var_recursive(out_name)
-                op._set_attr("in_dtype", in_var.dtype)
-                op._set_attr("out_dtype", out_var.dtype)
+                if "@GRAD" in in_name:
+                    in_var_fw = block._find_var_recursive(
+                        in_name[: in_name.find("@")]
+                    )
+                    out_var_fw = block._find_var_recursive(
+                        out_name[: out_name.find("@")]
+                    )
+                    op._set_attr('in_dtype', in_var_fw.dtype)
+                    op._set_attr('out_dtype', out_var_fw.dtype)
+
+                    in_var = block._find_var_recursive(in_name)
+                    out_var = block._find_var_recursive(out_name)
+                    in_var.desc.set_dtype(in_var_fw.dtype)
+                    out_var.desc.set_dtype(out_var_fw.dtype)
+                else:
+                    in_var = block._find_var_recursive(in_name)
+                    out_var = block._find_var_recursive(out_name)
+                    op._set_attr("in_dtype", in_var.dtype)
+                    op._set_attr("out_dtype", out_var.dtype)
 
     def resolute_tensor_dtype(self, block):
         for op in block.ops:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-76459
1. Pass the amp strategy in `dist.to_static`  for `static graph` to using amp strategy in semi-autoparallelism.
2. Support initializing model with `dtype==float32`, and use amp strategy in scenarios where `to_static` is enabled
3. Fix the bug in the `auto_parallel_fp16` pass when the model using `cast` operator from `float32` to `half`