### PR TITLE
[PIR] pir onednn support add_n

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -1345,7 +1345,7 @@ def AutoCodeGen(op_info_items, all_op_info_items, namespaces, dialect_name):
             if len(op_traits) > 0:
                 op_traits_str = "," + ",".join(op_traits)
 
-            if op_name in PD_MANUAL_OP_LIST:
+            if op_name in PD_MANUAL_OP_LIST and dialect_name != "onednn_op":
                 continue
             if op_kernel_map is None:
                 func_list = [None]

--- a/paddle/fluid/pir/dialect/operator/ir/ops_onednn_extra.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops_onednn_extra.yaml
@@ -15,7 +15,8 @@
 
 - op : abs_grad
 
-# - op : add_n
+- op : add_n_with_kernel
+  extra_args : str mkldnn_data_type="float32"
 
 - op : batch_norm
   extra_args : bool fuse_with_relu=false

--- a/test/mkldnn/test_sum_bf16_mkldnn_op.py
+++ b/test/mkldnn/test_sum_bf16_mkldnn_op.py
@@ -48,7 +48,7 @@ class TestSumBF16MKLDNN(TestSumOp):
         self.attrs = {'use_mkldnn': self.use_mkldnn}
 
     def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace())
+        self.check_output_with_place(core.CPUPlace(), check_pir_onednn=True)
 
     def test_check_grad(self):
         pass

--- a/test/mkldnn/test_sum_mkldnn_op.py
+++ b/test/mkldnn/test_sum_mkldnn_op.py
@@ -39,11 +39,13 @@ class TestSumMKLDNN(TestSumOp):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_dygraph=False, check_pir_onednn=True)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_grad(['x0'], 'Out', check_dygraph=False)
+        self.check_grad(
+            ['x0'], 'Out', check_dygraph=False, check_pir_onednn=True
+        )
 
 
 class TestMKLDNNSumInplaceOp(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-67164

pir onednn 支持add_n。

经过本PR调研，目前add_n“故事”比较多，在这里做记录：
1. add_n在PHI里，以及动态图前向里，由于不支持vector of Tensor作为Input，所有手写了add_n_impl的手写PHI C++ API。和add_n_ad_func。
2. add_n反向是由`scale_ad_func(out_grad, phi::Scalar(1.0), 0.0, true)`实现的。因此：
  - 动态图反向手写了add_n_node
  - PIR中手写了AddNOp，主要是Vjp需要手写。
3. PIR中，add_n前向不需要手写，PIR有能力直接调用add_n，传入vector of Tensor。因此在`paddle/fluid/pir/dialect/operator/ir/ops.yaml`中重新加了add_n_with_kernel的配置。之所以加_with_kernel是为了和PHI的add_n名字冲突。
4. 在PIR支持SelectedRows时，由于add_n在Verify时需要支持SelectedRows，代码生成不能支持。所以又手写了AddNWithKernelOp。
5. 由于PIR-OneDNN的add_n不涉及反向Vjp，也不涉及SelectedRows，因此不需要手写，所以直接靠op_gen.py生成即可。