### PR TITLE
[SOT][3.12] Support `BINARY_SLICE` and `STORE_SLICE` opcode in Python 3.12

### DIFF
--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -2,7 +2,6 @@
 ./test_11_jumps.py
 ./test_12_for_loop.py
 ./test_14_operators.py
-./test_15_slice.py
 ./test_21_global.py
 ./test_analysis_inputs.py
 ./test_break_graph.py


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
python 3.12 支持 `BINARY_SLICE` and  `STORE_SLICE`

- #61173
- #61174