### PR TITLE
Add some empty cmakelist.txt to avoid paddle_test No.35-37 upcoming conflicts

### DIFF
--- a/test/cpp/fluid/CMakeLists.txt
+++ b/test/cpp/fluid/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(memory)
 add_subdirectory(benchmark)
 add_subdirectory(framework)
+add_subdirectory(platform)
 
 if(WITH_CINN)
   add_subdirectory(cinn)

--- a/test/cpp/fluid/platform/CMakeLists.txt
+++ b/test/cpp/fluid/platform/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(device)
+add_subdirectory(profiler)

--- a/test/cpp/fluid/platform/device/CMakeLists.txt
+++ b/test/cpp/fluid/platform/device/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(custom)

--- a/test/cpp/fluid/platform/device/custom/CMakeLists.txt
+++ b/test/cpp/fluid/platform/device/custom/CMakeLists.txt
@@ -1,1 +1,1 @@
-# (Liyulingyue) create an empty cmake file to avoid conflict
+# Note(Liyulingyue): create an empty cmake file to avoid conflict

--- a/test/cpp/fluid/platform/device/custom/CMakeLists.txt
+++ b/test/cpp/fluid/platform/device/custom/CMakeLists.txt
@@ -1,0 +1,1 @@
+# (Liyulingyue) create an empty cmake file to avoid conflict

--- a/test/cpp/fluid/platform/profiler/CMakeLists.txt
+++ b/test/cpp/fluid/platform/profiler/CMakeLists.txt
@@ -1,1 +1,1 @@
-# (Liyulingyue) create an empty cmake file to avoid conflict
+# Note(Liyulingyue): create an empty cmake file to avoid conflict

--- a/test/cpp/fluid/platform/profiler/CMakeLists.txt
+++ b/test/cpp/fluid/platform/profiler/CMakeLists.txt
@@ -1,0 +1,1 @@
+# (Liyulingyue) create an empty cmake file to avoid conflict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
In https://github.com/PaddlePaddle/Paddle/issues/60793, No35-37 need move test file from fluid/platform/.. into test/cpp/fluid/.... To avoid conflict, I create some empty cmakelist.txt

相关链接:
* #62034
* #62035
* #62036