### PR TITLE
[cherry-pick 2.6] Fix bug of put_along_axis/take_along_axis

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -1760,8 +1760,8 @@
   optional : boxes_num
 
 - backward_op : put_along_axis_grad
-  forward : put_along_axis (Tensor arr, Tensor indices, Tensor values, int axis, str reduce = "assign") -> Tensor(out)
-  args : (Tensor arr, Tensor indices, Tensor out_grad, int axis, str reduce)
+  forward : put_along_axis (Tensor arr, Tensor indices, Tensor values, int axis, str reduce = "assign", bool include_self = true) -> Tensor(out)
+  args : (Tensor arr, Tensor indices, Tensor values, Tensor out, Tensor out_grad, int axis, str reduce, bool include_self)
   output : Tensor(arr_grad), Tensor(values_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2432,7 +2432,7 @@
   outputs :
     out : Result
   attrs :
-    {axis : Axis, reduce : Reduce}
+    {axis : Axis, reduce : Reduce, include_self: Include_self}
 
 - op : pylayer
   backward : pylayer_grad

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2032,7 +2032,7 @@
   backward : psroi_pool_grad
 
 - op : put_along_axis
-  args : (Tensor arr, Tensor indices, Tensor values, int axis, str reduce = "assign")
+  args : (Tensor arr, Tensor indices, Tensor values, int axis, str reduce = "assign", bool include_self = true)
   output : Tensor(out)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/backends/gpu/gpu_primitives.h
+++ b/paddle/phi/backends/gpu/gpu_primitives.h
@@ -395,6 +395,182 @@ CUDA_ATOMIC_WRAPPER(Add, complex<double>) {
                          CudaAtomicAdd(imag, val.imag));
 }
 
+// For atomicMul.
+CUDA_ATOMIC_WRAPPER(Mul, int) {
+  int res = *address, old = res;  // NOLINT
+  do {
+    old = res;
+    res = atomicCAS(address,     // NOLINT
+                    old,         // NOLINT
+                    val * old);  // NOLINT
+  } while (old != res);
+  return res;
+}
+
+CUDA_ATOMIC_WRAPPER(Mul, unsigned int) {
+  unsigned int res = *address, old = res;  // NOLINT
+  do {
+    old = res;
+    res = atomicCAS(address,     // NOLINT
+                    old,         // NOLINT
+                    val * old);  // NOLINT
+  } while (old != res);
+  return res;
+}
+// CUDA API uses unsigned long long int, we cannot use uint64_t here.
+// It because unsigned long long int is not necessarily uint64_t
+CUDA_ATOMIC_WRAPPER(Mul, unsigned long long int) {  // NOLINT
+  unsigned long long int old = *address, assumed;   // NOLINT
+
+  do {
+    assumed = old;
+    old = atomicCAS(address, assumed, val * assumed);
+  } while (assumed != old);
+  return old;
+}
+
+CUDA_ATOMIC_WRAPPER(Mul, int64_t) {
+  // Here, we check long long int must be int64_t.
+  static_assert(sizeof(int64_t) == sizeof(long long int),  // NOLINT
+                "long long should be int64");
+  long long int res = *address, old = res;  // NOLINT
+  do {
+    old = res;
+    res = (long long int)atomicCAS(                                  // NOLINT
+        (unsigned long long int *)address,                           // NOLINT
+        (unsigned long long int)old,                                 // NOLINT
+        (unsigned long long int)val * (unsigned long long int)old);  // NOLINT
+  } while (old != res);
+  return res;
+}
+
+CUDA_ATOMIC_WRAPPER(Mul, float) {
+  int *const address_as_i = reinterpret_cast<int *>(address);
+  int old = *address_as_i, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(
+        address_as_i, assumed, __float_as_int(val * __int_as_float(assumed)));
+  } while (assumed != old);
+
+  return __int_as_float(old);
+}
+
+CUDA_ATOMIC_WRAPPER(Mul, double) {
+  unsigned long long int *const address_as_ull =            // NOLINT
+      reinterpret_cast<unsigned long long int *>(address);  // NOLINT
+  unsigned long long int old = *address_as_ull, assumed;    // NOLINT
+
+  do {
+    assumed = old;
+
+    old = atomicCAS(address_as_ull,
+                    assumed,
+                    __double_as_longlong(val * __longlong_as_double(assumed)));
+  } while (assumed != old);
+
+  return __longlong_as_double(old);
+}
+
+#ifdef PADDLE_CUDA_FP16
+inline static __device__ uint32_t mul_to_low_half(uint32_t val, float x) {
+  phi::dtype::float16 low_half;
+  // The float16 in lower 16bits
+  low_half.x = static_cast<uint16_t>(val & 0xFFFFu);
+  low_half = static_cast<phi::dtype::float16>(static_cast<float>(low_half) * x);
+  return (val & 0xFFFF0000u) | low_half.x;
+}
+
+inline static __device__ uint32_t mul_to_high_half(uint32_t val, float x) {
+  phi::dtype::float16 high_half;
+  // The float16 in higher 16bits
+  high_half.x = static_cast<uint16_t>(val >> 16);
+  high_half =
+      static_cast<phi::dtype::float16>(static_cast<float>(high_half) * x);
+  return (val & 0xFFFFu) | (static_cast<uint32_t>(high_half.x) << 16);
+}
+
+CUDA_ATOMIC_WRAPPER(Mul, phi::dtype::float16) {
+  if (*address >= val) {
+    return *address;
+  }
+  uint32_t *address_as_ui = reinterpret_cast<uint32_t *>(
+      reinterpret_cast<char *>(address) -
+      (reinterpret_cast<uintptr_t>(address) & 0x02));
+  float val_f = static_cast<float>(val);
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  if (((uintptr_t)address & 0x02) == 0) {
+    // The float16 value stay at lower 16 bits of the address.
+    do {
+      assumed = old;
+      old = atomicCAS(address_as_ui, assumed, mul_to_low_half(assumed, val_f));
+    } while (old != assumed);
+    phi::dtype::float16 ret;
+    ret.x = old & 0xFFFFu;
+    return ret;
+  } else {
+    // The float16 value stay at higher 16 bits of the address.
+    do {
+      assumed = old;
+      old = atomicCAS(address_as_ui, assumed, mul_to_high_half(assumed, val_f));
+    } while (old != assumed);
+    phi::dtype::float16 ret;
+    ret.x = old >> 16;
+    return ret;
+  }
+}
+#endif
+
+inline static __device__ uint32_t bf16_mul_to_low_half(uint32_t val, float x) {
+  phi::dtype::bfloat16 low_half;
+  // The bfloat16 in lower 16bits
+  low_half.x = static_cast<uint16_t>(val & 0xFFFFu);
+  low_half =
+      static_cast<phi::dtype::bfloat16>(static_cast<float>(low_half) * x);
+  return (val & 0xFFFF0000u) | low_half.x;
+}
+
+inline static __device__ uint32_t bf16_mul_to_high_half(uint32_t val, float x) {
+  phi::dtype::bfloat16 high_half;
+  // The bfloat16 in higher 16bits
+  high_half.x = static_cast<uint16_t>(val >> 16);
+  high_half =
+      static_cast<phi::dtype::bfloat16>(static_cast<float>(high_half) * x);
+  return (val & 0xFFFFu) | (static_cast<uint32_t>(high_half.x) << 16);
+}
+
+CUDA_ATOMIC_WRAPPER(Mul, phi::dtype::bfloat16) {
+  uint32_t *address_as_ui = reinterpret_cast<uint32_t *>(
+      reinterpret_cast<char *>(address) -
+      (reinterpret_cast<uintptr_t>(address) & 0x02));
+  float val_f = static_cast<float>(val);
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  if (((uintptr_t)address & 0x02) == 0) {
+    // The bfloat16 value stay at lower 16 bits of the address.
+    do {
+      assumed = old;
+      old = atomicCAS(
+          address_as_ui, assumed, bf16_mul_to_low_half(assumed, val_f));
+    } while (old != assumed);
+    phi::dtype::bfloat16 ret;
+    ret.x = old & 0xFFFFu;
+    return ret;
+  } else {
+    // The bfloat16 value stay at higher 16 bits of the address.
+    do {
+      assumed = old;
+      old = atomicCAS(
+          address_as_ui, assumed, bf16_mul_to_high_half(assumed, val_f));
+    } while (old != assumed);
+    phi::dtype::bfloat16 ret;
+    ret.x = old >> 16;
+    return ret;
+  }
+}
+
 // For atomicMax
 USE_CUDA_ATOMIC(Max, int);
 USE_CUDA_ATOMIC(Max, unsigned int);

--- a/paddle/phi/kernels/cpu/cum_maxmin_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_maxmin_grad_kernel.cc
@@ -38,10 +38,10 @@ void CummaxGradKernel(const Context& dev_ctx,
   }
   if (dtype == DataType::INT32) {
     phi::funcs::cpu_scatter_add_kernel<T, int32_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   } else if (dtype == DataType::INT64) {
     phi::funcs::cpu_scatter_add_kernel<T, int64_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   }
 }
 
@@ -61,10 +61,10 @@ void CumminGradKernel(const Context& dev_ctx,
   }
   if (dtype == DataType::INT32) {
     phi::funcs::cpu_scatter_add_kernel<T, int32_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   } else if (dtype == DataType::INT64) {
     phi::funcs::cpu_scatter_add_kernel<T, int64_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   }
 }
 

--- a/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
@@ -25,11 +25,14 @@ namespace phi {
 
 template <typename T, typename Context>
 void PutAlongAxisGradKernel(const Context& dev_ctx,
-                            const DenseTensor& x UNUSED,
+                            const DenseTensor& x,
                             const DenseTensor& index,
+                            const DenseTensor& value,
+                            const DenseTensor& out,
                             const DenseTensor& out_grad,
                             int axis,
-                            const std::string& reduce UNUSED,
+                            const std::string& reduce,
+                            bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad) {
   PADDLE_ENFORCE_EQ(
@@ -40,31 +43,135 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
   const auto& index_type = index.dtype();
   if (x_grad) {
     phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
-    if (index_type == DataType::INT32) {
-      phi::funcs::cpu_scatter_input_grad_kernel<T, int32_t>(
-          // Here passing an unused argument out_grad, because it's
-          // convenient to instantiate a bunch of template function with the
-          // same arguments list.
-          out_grad,
-          axis,
-          index,
-          *x_grad,
-          dev_ctx);
-    } else {
-      phi::funcs::cpu_scatter_input_grad_kernel<T, int64_t>(
-          out_grad, axis, index, *x_grad, dev_ctx);
+    if (include_self == false || reduce == "assign") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::cpu_scatter_input_grad_kernel<T, int32_t>(
+            // Here passing an unused argument out_grad, because it's
+            // convenient to instantiate a bunch of template function with the
+            // same arguments list.
+            out_grad,
+            axis,
+            index,
+            *x_grad,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::cpu_scatter_input_grad_kernel<T, int64_t>(
+            out_grad, axis, index, *x_grad, include_self, dev_ctx);
+      }
+    } else if (reduce == "multiply" || reduce == "mul" || reduce == "amin" ||
+               reduce == "amax") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::cpu_scatter_mul_min_max_input_grad_kernel<T, int32_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *x_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::cpu_scatter_mul_min_max_input_grad_kernel<T, int64_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *x_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      }
+    } else if (reduce == "mean") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::cpu_scatter_mean_input_grad_kernel<T, int32_t>(
+            // Here passing an unused argument out_grad, because it's
+            // convenient to instantiate a bunch of template function with the
+            // same arguments list.
+            out_grad,
+            axis,
+            index,
+            *x_grad,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::cpu_scatter_mean_input_grad_kernel<T, int64_t>(
+            out_grad, axis, index, *x_grad, include_self, dev_ctx);
+      }
     }
   }
 
   if (value_grad) {
     value_grad->Resize(index.dims());
     dev_ctx.template Alloc<T>(value_grad);
-    if (index_type == DataType::INT32) {
-      phi::funcs::cpu_scatter_value_grad_kernel<T, int32_t>(
-          out_grad, axis, index, *value_grad, dev_ctx);
-    } else {
-      phi::funcs::cpu_scatter_value_grad_kernel<T, int64_t>(
-          out_grad, axis, index, *value_grad, dev_ctx);
+    auto* grad_data = value_grad->data<T>();
+    int64_t grad_size = value_grad->numel();
+    memset(grad_data, 0, sizeof(T) * grad_size);
+    if (reduce == "assign") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::cpu_scatter_value_grad_kernel<T, int32_t>(
+            out_grad, axis, index, *value_grad, include_self, dev_ctx);
+      } else if (index_type == DataType::INT64) {
+        phi::funcs::cpu_scatter_value_grad_kernel<T, int64_t>(
+            out_grad, axis, index, *value_grad, include_self, dev_ctx);
+      }
+    } else if (reduce == "add" || reduce == "mean") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::cpu_scatter_add_mean_value_grad_kernel<T, int32_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::cpu_scatter_add_mean_value_grad_kernel<T, int64_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      }
+    } else if (reduce == "mul" || reduce == "multiply" || reduce == "amin" ||
+               reduce == "amax") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::cpu_scatter_mul_min_max_value_grad_kernel<T, int32_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::cpu_scatter_mul_min_max_value_grad_kernel<T, int64_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      }
     }
   }
 }

--- a/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
@@ -30,6 +30,7 @@ void PutAlongAxisKernel(const Context& dev_ctx,
                         const DenseTensor& value,
                         int axis,
                         const std::string& reduce,
+                        bool include_self,
                         DenseTensor* out) {
   PADDLE_ENFORCE_EQ(
       dev_ctx.GetPlace().GetType() == phi::AllocationType::CPU,
@@ -41,31 +42,56 @@ void PutAlongAxisKernel(const Context& dev_ctx,
   if (reduce == "add") {
     if (index_type == DataType::INT32) {
       phi::funcs::cpu_scatter_add_kernel<T, int32_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     } else if (index_type == DataType::INT64) {
       phi::funcs::cpu_scatter_add_kernel<T, int64_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     }
   } else if (reduce == "multiply" || reduce == "mul") {
     if (index_type == DataType::INT32) {
       phi::funcs::cpu_scatter_mul_kernel<T, int32_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     } else if (index_type == DataType::INT64) {
       phi::funcs::cpu_scatter_mul_kernel<T, int64_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     }
   } else if (reduce == "assign") {
     if (index_type == DataType::INT32) {
       phi::funcs::cpu_scatter_assign_kernel<T, int32_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     } else if (index_type == DataType::INT64) {
       phi::funcs::cpu_scatter_assign_kernel<T, int64_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
+    }
+  } else if (reduce == "mean") {
+    if (index_type == DataType::INT32) {
+      phi::funcs::cpu_scatter_mean_kernel<T, int32_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    } else if (index_type == DataType::INT64) {
+      phi::funcs::cpu_scatter_mean_kernel<T, int64_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    }
+  } else if (reduce == "amax") {
+    if (index_type == DataType::INT32) {
+      phi::funcs::cpu_scatter_max_kernel<T, int32_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    } else if (index_type == DataType::INT64) {
+      phi::funcs::cpu_scatter_max_kernel<T, int64_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    }
+  } else if (reduce == "amin") {
+    if (index_type == DataType::INT32) {
+      phi::funcs::cpu_scatter_min_kernel<T, int32_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    } else if (index_type == DataType::INT64) {
+      phi::funcs::cpu_scatter_min_kernel<T, int64_t>(
+          *out, axis, index, value, include_self, dev_ctx);
     }
   } else {
     PADDLE_THROW(errors::InvalidArgument(
         "can not support reduce: '%s' for scatter kernel, only "
-        "support reduce op: 'add', 'assign', 'mul' and 'multiply', the "
+        "support reduce op: 'add', 'assign', 'mul', 'mean', 'amin', 'amax' and "
+        "'multiply', the "
         "default reduce "
         "op is 'assign' ",
         reduce));

--- a/paddle/phi/kernels/cpu/take_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/take_along_axis_grad_kernel.cc
@@ -50,10 +50,11 @@ void TakeAlongAxisGradKernel(const Context& dev_ctx,
         axis,
         index,
         out_grad,
+        true,
         dev_ctx);  // the gradient of gather is scatter
   } else if (index_type == phi::DataType::INT64) {
     phi::funcs::cpu_scatter_add_kernel<T, int64_t>(
-        *x_grad, axis, index, out_grad, dev_ctx);
+        *x_grad, axis, index, out_grad, true, dev_ctx);
   }
 }
 

--- a/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/take_along_axis_kernel.cc
@@ -38,9 +38,11 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
 
   const auto& index_type = index.dtype();
   if (index_type == DataType::INT32) {
-    phi::funcs::cpu_gather_kernel<T, int32_t>(x, axis, index, *out, dev_ctx);
+    phi::funcs::cpu_gather_kernel<T, int32_t>(
+        x, axis, index, *out, true, dev_ctx);
   } else if (index_type == DataType::INT64) {
-    phi::funcs::cpu_gather_kernel<T, int64_t>(x, axis, index, *out, dev_ctx);
+    phi::funcs::cpu_gather_kernel<T, int64_t>(
+        x, axis, index, *out, true, dev_ctx);
   }
 }
 

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -48,6 +48,24 @@ class ReduceMultiply {
 };
 static ReduceMultiply reduce_mul;
 
+class ReduceMax {
+ public:
+  template <typename tensor_t>
+  void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    *self_data = *src_data > *self_data ? *src_data : *self_data;
+  }
+};
+static ReduceMax reduce_max;
+
+class ReduceMin {
+ public:
+  template <typename tensor_t>
+  void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    *self_data = *src_data < *self_data ? *src_data : *self_data;
+  }
+};
+static ReduceMin reduce_min;
+
 template <typename tensor_t,
           typename index_t = int64_t,
           bool is_scatter_like = true>
@@ -55,10 +73,11 @@ struct cpu_gather_scatter_functor {
   template <typename func_t>
   void operator()(phi::DenseTensor self,
                   int dim,
-                  const phi::DenseTensor& index UNUSED,
+                  const phi::DenseTensor& index,
                   const phi::DenseTensor& src,
-                  const std::string& method_name UNUSED,
+                  const std::string& method_name,
                   const func_t& reduce_op,
+                  bool include_self,
                   const phi::DeviceContext& ctx UNUSED) {
     if (index.numel() == 0) {
       return;
@@ -96,6 +115,7 @@ struct cpu_gather_scatter_functor {
       outer_dim_size_src *= src_dims[i];
     }
     int64_t index_idx = 0;
+    std::vector<int> nums_of_elements(self.numel(), 0);
     // N layer loop squeezed into 3 layers loop
     for (int64_t i = 0; i < inner_dim_size; i++) {
       for (int64_t j = 0; j < select_dim_size; j++) {
@@ -132,9 +152,28 @@ struct cpu_gather_scatter_functor {
             replace_index_src = k + index * outer_dim_size_src +
                                 i * outer_dim_size_src * src_select_dim_size;
           }
-          reduce_op((tensor_t*)(self_data + replace_index_self),  // NOLINT
-                    (tensor_t*)(src_data + replace_index_src));   // NOLINT
+          if (include_self == false &&
+              nums_of_elements[replace_index_self] == 0) {
+            self_data[replace_index_self] = src_data[replace_index_src];
+          } else {
+            reduce_op((tensor_t*)(self_data + replace_index_self),  // NOLINT
+                      (tensor_t*)(src_data + replace_index_src));   // NOLINT
+          }
+          nums_of_elements[replace_index_self] += 1;
           index_idx++;
+        }
+      }
+    }
+    if (method_name == "scatter_mean_cpu") {
+      for (int i = 0; i < self_size; i++) {
+        if (nums_of_elements[i]) {
+          if (include_self) {
+            self_data[i] =
+                self_data[i] / static_cast<tensor_t>(nums_of_elements[i] + 1);
+          } else {
+            self_data[i] =
+                self_data[i] / static_cast<tensor_t>(nums_of_elements[i]);
+          }
         }
       }
     }
@@ -146,11 +185,18 @@ void cpu_gather_kernel(phi::DenseTensor self,
                        int dim,
                        const phi::DenseTensor& index,
                        phi::DenseTensor result,
+                       bool include_self,
                        const phi::DeviceContext& ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/false>()(
-      result, dim, index, self, "gather_out_cpu", tensor_assign, ctx);
+                             /*is_scatter_like=*/false>()(result,
+                                                          dim,
+                                                          index,
+                                                          self,
+                                                          "gather_out_cpu",
+                                                          tensor_assign,
+                                                          include_self,
+                                                          ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -158,11 +204,18 @@ void cpu_scatter_assign_kernel(phi::DenseTensor self,
                                int dim,
                                const phi::DenseTensor& index,
                                phi::DenseTensor src,
+                               bool include_self,
                                const phi::DeviceContext& ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(
-      self, dim, index, src, "scatter_assign_cpu", tensor_assign, ctx);
+                             /*is_scatter_like=*/true>()(self,
+                                                         dim,
+                                                         index,
+                                                         src,
+                                                         "scatter_assign_cpu",
+                                                         tensor_assign,
+                                                         include_self,
+                                                         ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -170,11 +223,12 @@ void cpu_scatter_add_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
                              /*is_scatter_like=*/true>()(
-      self, dim, index, src, "scatter_add_cpu", reduce_add, ctx);
+      self, dim, index, src, "scatter_add_cpu", reduce_add, include_self, ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -182,11 +236,51 @@ void cpu_scatter_mul_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx) {
   cpu_gather_scatter_functor<tensor_t,
                              index_t,
                              /*is_scatter_like=*/true>()(
-      self, dim, index, src, "scatter_mul_cpu", reduce_mul, ctx);
+      self, dim, index, src, "scatter_mul_cpu", reduce_mul, include_self, ctx);
+}
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mean_kernel(phi::DenseTensor self,
+                             int dim,
+                             const phi::DenseTensor& index,
+                             phi::DenseTensor src,
+                             bool include_self,
+                             const phi::DeviceContext& ctx) {
+  cpu_gather_scatter_functor<tensor_t,
+                             index_t,
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "scatter_mean_cpu", reduce_add, include_self, ctx);
+}
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_max_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx) {
+  cpu_gather_scatter_functor<tensor_t,
+                             index_t,
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "scatter_max_cpu", reduce_max, include_self, ctx);
+}
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_min_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx) {
+  cpu_gather_scatter_functor<tensor_t,
+                             index_t,
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "scatter_min_cpu", reduce_min, include_self, ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -194,6 +288,7 @@ void cpu_scatter_input_grad_kernel(phi::DenseTensor self UNUSED,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self UNUSED,
                                    const phi::DeviceContext& ctx UNUSED) {
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
@@ -230,10 +325,134 @@ void cpu_scatter_input_grad_kernel(phi::DenseTensor self UNUSED,
 }
 
 template <typename tensor_t, typename index_t>
+void cpu_scatter_mul_min_max_input_grad_kernel(phi::DenseTensor self UNUSED,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self UNUSED,
+                                               const phi::DeviceContext& ctx) {
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+  auto* out_data = out.data<tensor_t>();
+  auto* x_data = x.data<tensor_t>();
+  auto* value_data = value.data<tensor_t>();
+
+  int64_t grad_size = grad.numel();
+  auto index_dims = index.dims();
+  auto grad_dims = grad.dims();
+  auto value_dims = value.dims();
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t outer_dim_size_value = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  int64_t value_select_dim_size = value_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+    outer_dim_size_value *= value_dims[i];
+  }
+
+  int64_t index_idx = 0;
+  std::vector<int> num_elements(grad_size, 0);
+  for (int64_t i = 0; i < inner_dim_size; i++) {
+    for (int64_t j = 0; j < select_dim_size; j++) {
+      for (int64_t k = 0; k < outer_dim_size; k++) {
+        int64_t index = index_data[index_idx];
+        int64_t replace_index_grad =
+            k + index * outer_dim_size_grad +
+            i * outer_dim_size_grad * grad_select_dim_size;
+        if ((reduce == "multiply" || reduce == "mul") &&
+            num_elements[replace_index_grad] == 0) {
+          grad_data[replace_index_grad] = static_cast<tensor_t>(
+              grad_data[replace_index_grad] * out_data[replace_index_grad] /
+              x_data[replace_index_grad]);
+          num_elements[replace_index_grad] += 1;
+        } else if (reduce == "amin" || reduce == "amax") {
+          if (out_data[replace_index_grad] != x_data[replace_index_grad]) {
+            grad_data[replace_index_grad] = 0;
+          } else {
+            int64_t replace_index_value =
+                k + j * outer_dim_size_value +
+                i * outer_dim_size_value * value_select_dim_size;
+            if (out_data[replace_index_grad] == value_data[replace_index_value])
+              num_elements[replace_index_grad] += 1;
+          }
+        }
+        index_idx++;
+      }
+    }
+  }
+  if (reduce == "amin" || reduce == "amax") {
+    for (int64_t i = 0; i < grad_size; i++) {
+      grad_data[i] = grad_data[i] / static_cast<tensor_t>(num_elements[i] + 1);
+    }
+  }
+}
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mean_input_grad_kernel(phi::DenseTensor self UNUSED,
+                                        int dim,
+                                        const phi::DenseTensor& index,
+                                        phi::DenseTensor grad,
+                                        bool include_self UNUSED,
+                                        const phi::DeviceContext& ctx UNUSED) {
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+
+  auto index_dims = index.dims();
+  auto grad_dims = grad.dims();
+
+  int64_t grad_size = grad.numel();
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_data = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_data *= grad_dims[i];
+  }
+
+  int64_t index_idx = 0;
+  std::vector<int> num_elements(grad_size, 0);
+  for (int64_t i = 0; i < inner_dim_size; i++) {
+    for (int64_t j = 0; j < select_dim_size; j++) {
+      for (int64_t k = 0; k < outer_dim_size; k++) {
+        int64_t index = index_data[index_idx];
+        int64_t replace_index = k + index * outer_dim_size_data +
+                                i * outer_dim_size_data * grad_select_dim_size;
+        num_elements[replace_index] += 1;
+        index_idx++;
+      }
+    }
+  }
+  for (int64_t i = 0; i < grad_size; i++)
+    if (num_elements[i])
+      grad_data[i] = grad_data[i] / static_cast<tensor_t>(num_elements[i] + 1);
+}
+
+template <typename tensor_t, typename index_t>
 void cpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self UNUSED,
                                    const phi::DeviceContext& ctx UNUSED) {
   auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
@@ -244,12 +463,7 @@ void cpu_scatter_value_grad_kernel(phi::DenseTensor self,
   auto grad_dims = grad.dims();
 
   int64_t self_size = self.numel();
-  int64_t grad_size = grad.numel();
-  bool* is_self_grad_used = new bool[self_size];
-
-  for (int i = 0; i < self_size; i++) {
-    is_self_grad_used[i] = false;
-  }
+  std::vector<bool> is_self_grad_used(self_size, false);
 
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
@@ -268,9 +482,6 @@ void cpu_scatter_value_grad_kernel(phi::DenseTensor self,
     outer_dim_size_grad *= grad_dims[i];
   }
   int64_t index_idx = index.numel() - 1;
-  for (int i = 0; i < grad_size; i++) {
-    grad_data[i] = static_cast<tensor_t>(0);
-  }
   for (int64_t i = inner_dim_size - 1; i >= 0; i--) {
     for (int64_t j = select_dim_size - 1; j >= 0; j--) {
       for (int64_t k = outer_dim_size - 1; k >= 0; k--) {
@@ -289,15 +500,210 @@ void cpu_scatter_value_grad_kernel(phi::DenseTensor self,
       }
     }
   }
-  delete[] is_self_grad_used;
 }
 
-Instantiate_Template_Function(cpu_gather_kernel)
-    Instantiate_Template_Function(cpu_scatter_assign_kernel)
-        Instantiate_Template_Function(cpu_scatter_add_kernel)
-            Instantiate_Template_Function(cpu_scatter_mul_kernel)
-                Instantiate_Template_Function(cpu_scatter_input_grad_kernel)
-                    Instantiate_Template_Function(cpu_scatter_value_grad_kernel)
+template <typename tensor_t, typename index_t>
+void cpu_scatter_add_mean_value_grad_kernel(
+    phi::DenseTensor self,
+    int dim,
+    const phi::DenseTensor& index,
+    const phi::DenseTensor& out UNUSED,
+    const phi::DenseTensor& x UNUSED,
+    const phi::DenseTensor& value UNUSED,
+    phi::DenseTensor grad,
+    const std::string& reduce,
+    bool include_self,
+    const phi::DeviceContext& ctx UNUSED) {
+  auto* self_data = self.data<tensor_t>();
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+
+  auto index_dims = index.dims();
+  auto self_dims = self.dims();
+  auto grad_dims = grad.dims();
+
+  int64_t self_size = self.numel();
+  int64_t grad_size = grad.numel();
+  std::vector<int> num_elements;
+  if (reduce == "mean") {
+    for (int i = 0; i < self_size; i++) {
+      if (include_self)
+        num_elements.push_back(1);
+      else
+        num_elements.push_back(0);
+    }
+  }
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_self = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t self_select_dim_size = self_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_self *= self_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+  }
+  for (int i = 0; i < grad_size; i++) {
+    grad_data[i] = static_cast<tensor_t>(0);
+  }
+  int64_t index_idx = index.numel() - 1;
+  if (reduce == "mean") {
+    for (int64_t i = inner_dim_size - 1; i >= 0; i--) {
+      for (int64_t j = select_dim_size - 1; j >= 0; j--) {
+        for (int64_t k = outer_dim_size - 1; k >= 0; k--) {
+          int64_t index = index_data[index_idx];
+          int64_t replace_index_self =
+              k + index * outer_dim_size_self +
+              i * outer_dim_size_self * self_select_dim_size;
+          num_elements[replace_index_self] += 1;
+          index_idx--;
+        }
+      }
+    }
+    index_idx = index.numel() - 1;
+  }
+  for (int64_t i = inner_dim_size - 1; i >= 0; i--) {
+    for (int64_t j = select_dim_size - 1; j >= 0; j--) {
+      for (int64_t k = outer_dim_size - 1; k >= 0; k--) {
+        int64_t index = index_data[index_idx];
+        int64_t replace_index_self =
+            k + index * outer_dim_size_self +
+            i * outer_dim_size_self * self_select_dim_size;
+        int64_t replace_index_grad =
+            k + j * outer_dim_size_grad +
+            i * outer_dim_size_grad * grad_select_dim_size;
+        if (reduce == "add")
+          grad_data[replace_index_grad] = self_data[replace_index_self];
+        else if (reduce == "mean")
+          grad_data[replace_index_grad] =
+              self_data[replace_index_self] /
+              static_cast<tensor_t>(num_elements[replace_index_self]);
+        index_idx--;
+      }
+    }
+  }
+}
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mul_min_max_value_grad_kernel(phi::DenseTensor self,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self,
+                                               const phi::DeviceContext& ctx) {
+  auto* self_data = self.data<tensor_t>();
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+  auto* out_data = out.data<tensor_t>();
+  auto* x_data = x.data<tensor_t>();
+  auto* value_data = value.data<tensor_t>();
+
+  auto index_dims = index.dims();
+  auto self_dims = self.dims();
+  auto grad_dims = grad.dims();
+
+  int64_t self_size = self.numel();
+  std::vector<int> num_elements;
+  if (reduce == "amin" || reduce == "amax") {
+    for (int i = 0; i < self_size; i++) {
+      num_elements.push_back(0);
+    }
+  }
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_self = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t self_select_dim_size = self_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_self *= self_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+  }
+  int64_t index_idx = 0;
+  for (int64_t i = 0; i < inner_dim_size; i++) {
+    for (int64_t j = 0; j < select_dim_size; j++) {
+      for (int64_t k = 0; k < outer_dim_size; k++) {
+        int64_t index = index_data[index_idx];
+        int64_t replace_index_self =
+            k + index * outer_dim_size_self +
+            i * outer_dim_size_self * self_select_dim_size;
+        int64_t replace_index_grad =
+            k + j * outer_dim_size_grad +
+            i * outer_dim_size_grad * grad_select_dim_size;
+        if ((reduce == "amin" || reduce == "amax") &&
+            out_data[replace_index_self] == value_data[replace_index_grad]) {
+          num_elements[replace_index_self] += 1;
+        } else if (reduce == "mul" || reduce == "multiply") {
+          grad_data[replace_index_grad] =
+              self_data[replace_index_self] *
+              (out_data[replace_index_self] / value_data[replace_index_grad]);
+        }
+        index_idx++;
+      }
+    }
+  }
+  if (reduce == "amin" || reduce == "amax") {
+    index_idx = 0;
+    for (int64_t i = 0; i < inner_dim_size; i++) {
+      for (int64_t j = 0; j < select_dim_size; j++) {
+        for (int64_t k = 0; k < outer_dim_size; k++) {
+          int64_t index = index_data[index_idx];
+          int64_t replace_index_self =
+              k + index * outer_dim_size_self +
+              i * outer_dim_size_self * self_select_dim_size;
+          int64_t replace_index_grad =
+              k + j * outer_dim_size_grad +
+              i * outer_dim_size_grad * grad_select_dim_size;
+          if (out_data[replace_index_self] == value_data[replace_index_grad]) {
+            if (out_data[replace_index_self] == x_data[replace_index_self])
+              grad_data[replace_index_grad] =
+                  self_data[replace_index_self] /
+                  static_cast<tensor_t>(num_elements[replace_index_self] + 1);
+            else
+              grad_data[replace_index_grad] =
+                  self_data[replace_index_self] /
+                  static_cast<tensor_t>(num_elements[replace_index_self]);
+          }
+          index_idx++;
+        }
+      }
+    }
+  }
+}
+
+Instantiate_Template_Function(cpu_gather_kernel)                  // NOLINT
+    Instantiate_Template_Function(cpu_scatter_assign_kernel)      // NOLINT
+    Instantiate_Template_Function(cpu_scatter_add_kernel)         // NOLINT
+    Instantiate_Template_Function(cpu_scatter_mul_kernel)         // NOLINT
+    Instantiate_Template_Function(cpu_scatter_mean_kernel)        // NOLINT
+    Instantiate_Template_Function(cpu_scatter_max_kernel)         // NOLINT
+    Instantiate_Template_Function(cpu_scatter_min_kernel)         // NOLINT
+    Instantiate_Template_Function(cpu_scatter_input_grad_kernel)  // NOLINT
+    Instantiate_Template_Function(cpu_scatter_value_grad_kernel)  // NOLINT
+    Instantiate_Template_Function_With_Out(
+        cpu_scatter_mul_min_max_input_grad_kernel)                     // NOLINT
+    Instantiate_Template_Function(cpu_scatter_mean_input_grad_kernel)  // NOLINT
+    Instantiate_Template_Function_With_Out(
+        cpu_scatter_add_mean_value_grad_kernel)  // NOLINT
+    Instantiate_Template_Function_With_Out(
+        cpu_scatter_mul_min_max_value_grad_kernel)  // NOLINT
 
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -46,13 +46,51 @@ static ReduceAdd reduce_add;
 
 class ReduceMul {
  public:
-  template <typename tensor_t>
+  template <
+      typename tensor_t,
+      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    phi::CudaAtomicMul(self_data, *src_data);
+  }
+  template <typename tensor_t,
+            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
   __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
     *self_data *= *src_data;
-    // TODO(huangxu96) platform::CudaAtomicMul(*self_data, *src_data);
   }
 };
 static ReduceMul reduce_mul;
+
+class ReduceMax {
+ public:
+  template <
+      typename tensor_t,
+      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    phi::CudaAtomicMax(self_data, *src_data);
+  }
+  template <typename tensor_t,
+            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    *self_data = *src_data > *self_data ? *src_data : *self_data;
+  }
+};
+static ReduceMax reduce_max;
+
+class ReduceMin {
+ public:
+  template <
+      typename tensor_t,
+      std::enable_if_t<!std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    phi::CudaAtomicMin(self_data, *src_data);
+  }
+  template <typename tensor_t,
+            std::enable_if_t<std::is_same<tensor_t, uint8_t>::value>* = nullptr>
+  __device__ void operator()(tensor_t* self_data, tensor_t* src_data) const {
+    *self_data = *src_data < *self_data ? *src_data : *self_data;
+  }
+};
+static ReduceMin reduce_min;
 
 template <typename tensor_t,
           typename index_t,
@@ -143,9 +181,19 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
                                        int64_t outer_dim_size_src,
                                        int64_t numel,
                                        int64_t numel_data,
+                                       bool include_self,
                                        const func_t& reduce_op) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   if (tid >= numel) return;
+  extern __shared__ int shared_mem[];
+  if (include_self == false) {
+    if (tid == 0) {
+      for (int i = 0; i < numel_data; i++) {
+        shared_mem[i] = numel + 1;  // thread_ids
+      }
+    }
+    __syncthreads();
+  }
   int64_t i, j, k;  // The i, j, k here is the index of the 3 layers loop
                     // squeezed from the N layers loop.
   /* tid = i * select_dim_size * outer_dim_size + j * outer_dim_size + k */
@@ -182,9 +230,105 @@ __global__ void GatherScatterGPUKernel(tensor_t* self_data,
     replace_index_src = k + index * outer_dim_size_src +
                         i * outer_dim_size_src * src_select_dim_size;
   }
+  bool is_op_done = false;
+  if (include_self == false) {
+    phi::CudaAtomicMin(shared_mem + replace_index_self, tid);
+    __syncthreads();
+    if (tid == shared_mem[replace_index_self]) {
+      self_data[replace_index_self] = src_data[replace_index_src];
+      is_op_done = true;
+    }
+    __syncthreads();
+  }
+  if (!is_op_done)
+    reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
+              static_cast<tensor_t*>(src_data + replace_index_src));
+}
 
+template <typename tensor_t,
+          typename index_t,
+          typename func_t,
+          bool is_scatter_like = true>
+__global__ void ScatterMeanGPUKernel(tensor_t* self_data,
+                                     int dim,
+                                     const index_t* index_data,
+                                     tensor_t* src_data,
+                                     int select_dim_size,
+                                     int self_select_dim_size,
+                                     int src_select_dim_size,
+                                     int64_t outer_dim_size,
+                                     int64_t outer_dim_size_self,
+                                     int64_t outer_dim_size_src,
+                                     int64_t numel,
+                                     int64_t numel_data,
+                                     bool include_self,
+                                     const func_t& reduce_op) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  extern __shared__ int shared_mem[];
+
+  if (tid == 0) {
+    for (int i = 0; i < numel_data; i++) {
+      shared_mem[i] = 0;  // thread_id
+      if (include_self)
+        shared_mem[numel_data + i] = 1;  // reduce size
+      else
+        shared_mem[numel_data + i] = 0;
+    }
+  }
+  __syncthreads();
+  int64_t i, j, k;  // The i, j, k here is the index of the 3 layers loop
+                    // squeezed from the N layers loop.
+  /* tid = i * select_dim_size * outer_dim_size + j * outer_dim_size + k */
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  /*
+    gather computation formula:
+
+    self[i][j][k] = src[index[i][j][k]][j][k]  # if dim == 0
+    self[i][j][k] = src[i][index[i][j][k]][k]  # if dim == 1
+    self[i][j][k] = src[i][j][index[i][j][k]]  # if dim == 2
+
+    scatter computation formula:
+
+    self[index[i][j][k]][j][k] = src[i][j][k]  # if dim == 0
+    self[i][index[i][j][k]][k] = src[i][j][k]  # if dim == 1
+    self[i][j][index[i][j][k]] = src[i][j][k]  # if dim == 2
+
+  */
+  // index matrix has different shape with self matrix or src matrix.
+  int64_t replace_index_self, replace_index_src;
+  if (is_scatter_like) {
+    replace_index_self = k + index * outer_dim_size_self +
+                         i * outer_dim_size_self * self_select_dim_size;
+
+    replace_index_src = k + j * outer_dim_size_src +
+                        i * outer_dim_size_src * src_select_dim_size;
+  } else {
+    replace_index_self = tid;
+
+    replace_index_src = k + index * outer_dim_size_src +
+                        i * outer_dim_size_src * src_select_dim_size;
+  }
+  if (include_self == false) {
+    self_data[replace_index_self] = 0;
+    __syncthreads();
+  }
   reduce_op(static_cast<tensor_t*>(self_data + replace_index_self),
             static_cast<tensor_t*>(src_data + replace_index_src));
+
+  phi::CudaAtomicMax(shared_mem + replace_index_self, tid);
+  phi::CudaAtomicAdd(shared_mem + numel_data + replace_index_self, 1);
+  __syncthreads();
+
+  if (tid == shared_mem[replace_index_self]) {
+    self_data[replace_index_self] =
+        self_data[replace_index_self] /
+        static_cast<tensor_t>(shared_mem[replace_index_self + numel_data]);
+  }
 }
 
 template <typename tensor_t,
@@ -198,6 +342,7 @@ struct gpu_gather_scatter_functor {
                   phi::DenseTensor src,
                   const std::string& method_name,
                   const func_t& reduce_op,
+                  bool include_self,
                   const phi::DeviceContext& ctx) {
     if (index.numel() == 0) {
       return;
@@ -235,8 +380,7 @@ struct gpu_gather_scatter_functor {
     int64_t grid = (n + block - 1) / block;
     auto stream = reinterpret_cast<const phi::GPUContext&>(ctx).stream();
     if (method_name == "scatter_assign_gpu") {
-      int shared_mem_size =
-          is_scatter_like ? sizeof(int) * self_size : sizeof(int) * index_size;
+      int shared_mem_size = sizeof(int) * self_size;
       ScatterAssignGPUKernel<tensor_t, index_t, func_t, is_scatter_like>
           <<<grid, block, shared_mem_size, stream>>>(self_data,
                                                      dim,
@@ -251,21 +395,41 @@ struct gpu_gather_scatter_functor {
                                                      index_size,
                                                      self_size,
                                                      reduce_op);
+    } else if (method_name == "scatter_mean_gpu") {
+      int shared_mem_size = sizeof(int) * self_size * 2;
+      ScatterMeanGPUKernel<tensor_t, index_t, func_t, is_scatter_like>
+          <<<grid, block, shared_mem_size, stream>>>(self_data,
+                                                     dim,
+                                                     index_data,
+                                                     src_data,
+                                                     select_dim_size,
+                                                     self_select_dim_size,
+                                                     src_select_dim_size,
+                                                     outer_dim_size,
+                                                     outer_dim_size_self,
+                                                     outer_dim_size_src,
+                                                     index_size,
+                                                     self_size,
+                                                     include_self,
+                                                     reduce_op);
     } else {
+      int shared_mem_size = 0;
+      if (include_self == false) shared_mem_size = sizeof(int) * self_size;
       GatherScatterGPUKernel<tensor_t, index_t, func_t, is_scatter_like>
-          <<<grid, block, 0, stream>>>(self_data,
-                                       dim,
-                                       index_data,
-                                       src_data,
-                                       select_dim_size,
-                                       self_select_dim_size,
-                                       src_select_dim_size,
-                                       outer_dim_size,
-                                       outer_dim_size_self,
-                                       outer_dim_size_src,
-                                       index_size,
-                                       self_size,
-                                       reduce_op);
+          <<<grid, block, shared_mem_size, stream>>>(self_data,
+                                                     dim,
+                                                     index_data,
+                                                     src_data,
+                                                     select_dim_size,
+                                                     self_select_dim_size,
+                                                     src_select_dim_size,
+                                                     outer_dim_size,
+                                                     outer_dim_size_self,
+                                                     outer_dim_size_src,
+                                                     index_size,
+                                                     self_size,
+                                                     include_self,
+                                                     reduce_op);
     }
   }
 };  // struct gpu_gather_scatter_functor
@@ -275,11 +439,18 @@ void gpu_gather_kernel(phi::DenseTensor self,
                        int dim,
                        const phi::DenseTensor& index,
                        phi::DenseTensor result,
+                       bool include_self,
                        const phi::DeviceContext& ctx) {
   gpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/false>()(
-      result, dim, index, self, "gather_out_gpu", tensor_assign, ctx);
+                             /*is_scatter_like=*/false>()(result,
+                                                          dim,
+                                                          index,
+                                                          self,
+                                                          "gather_out_gpu",
+                                                          tensor_assign,
+                                                          include_self,
+                                                          ctx);
   return;
 }
 
@@ -288,11 +459,18 @@ void gpu_scatter_assign_kernel(phi::DenseTensor self,
                                int dim,
                                const phi::DenseTensor& index,
                                phi::DenseTensor src,
+                               bool include_self,
                                const phi::DeviceContext& ctx) {
   gpu_gather_scatter_functor<tensor_t,
                              index_t,
-                             /*is_scatter_like=*/true>()(
-      self, dim, index, src, "scatter_assign_gpu", tensor_assign, ctx);
+                             /*is_scatter_like=*/true>()(self,
+                                                         dim,
+                                                         index,
+                                                         src,
+                                                         "scatter_assign_gpu",
+                                                         tensor_assign,
+                                                         include_self,
+                                                         ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -300,11 +478,12 @@ void gpu_scatter_add_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx) {
   gpu_gather_scatter_functor<tensor_t,
                              index_t,
                              /*is_scatter_like=*/true>()(
-      self, dim, index, src, "scatter_add_gpu", reduce_add, ctx);
+      self, dim, index, src, "scatter_add_gpu", reduce_add, include_self, ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -312,11 +491,51 @@ void gpu_scatter_mul_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx) {
   gpu_gather_scatter_functor<tensor_t,
                              index_t,
                              /*is_scatter_like=*/true>()(
-      self, dim, index, src, "scatter_mul_gpu", reduce_mul, ctx);
+      self, dim, index, src, "scatter_mul_gpu", reduce_mul, include_self, ctx);
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mean_kernel(phi::DenseTensor self,
+                             int dim,
+                             const phi::DenseTensor& index,
+                             phi::DenseTensor src,
+                             bool include_self,
+                             const phi::DeviceContext& ctx) {
+  gpu_gather_scatter_functor<tensor_t,
+                             index_t,
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "scatter_mean_gpu", reduce_add, include_self, ctx);
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_max_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx) {
+  gpu_gather_scatter_functor<tensor_t,
+                             index_t,
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "scatter_max_gpu", reduce_max, include_self, ctx);
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_min_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx) {
+  gpu_gather_scatter_functor<tensor_t,
+                             index_t,
+                             /*is_scatter_like=*/true>()(
+      self, dim, index, src, "scatter_min_gpu", reduce_min, include_self, ctx);
 }
 
 template <typename tensor_t, typename index_t>
@@ -347,6 +566,7 @@ void gpu_scatter_input_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self UNUSED,
                                    const phi::DeviceContext& ctx) {
   auto* index_data = index.data<index_t>();
   auto* grad_data = grad.data<tensor_t>();
@@ -388,6 +608,259 @@ void gpu_scatter_input_grad_kernel(phi::DenseTensor self,
 }
 
 template <typename tensor_t, typename index_t>
+__global__ void ScatterMulInputGradGPUKernel(tensor_t* grad_data,
+                                             int dim,
+                                             const index_t* index_data,
+                                             const tensor_t* out_data,
+                                             const tensor_t* x_data,
+                                             int select_dim_size,
+                                             int grad_select_dim_size,
+                                             int64_t outer_dim_size,
+                                             int64_t outer_dim_size_grad,
+                                             int64_t numel,
+                                             int64_t numel_grad) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  extern __shared__ int thread_ids[];
+  if (tid == 0) {
+    for (int i = 0; i < numel_grad; i++) {
+      thread_ids[i] = 0;
+    }
+  }
+  __syncthreads();
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index = k + index * outer_dim_size_grad +
+                          i * outer_dim_size_grad * grad_select_dim_size;
+  atomicMax(thread_ids + replace_index, tid);
+  __syncthreads();
+  if (tid == thread_ids[replace_index]) {
+    grad_data[replace_index] = grad_data[replace_index] *
+                               out_data[replace_index] / x_data[replace_index];
+  }
+}
+
+template <typename tensor_t, typename index_t>
+__global__ void ScatterMinMaxInputGradGPUKernel(tensor_t* grad_data,
+                                                int dim,
+                                                const index_t* index_data,
+                                                const tensor_t* out_data,
+                                                const tensor_t* x_data,
+                                                const tensor_t* value_data,
+                                                const tensor_t* self_data,
+                                                int select_dim_size,
+                                                int grad_select_dim_size,
+                                                int value_select_dim_size,
+                                                int64_t outer_dim_size,
+                                                int64_t outer_dim_size_grad,
+                                                int64_t outer_dim_size_value,
+                                                int64_t numel,
+                                                int64_t numel_grad,
+                                                const std::string& reduce) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  extern __shared__ int shared_mem[];
+
+  if (tid == 0) {
+    for (int i = 0; i < numel_grad; i++) {
+      shared_mem[i] = 1;  // number of elements
+    }
+  }
+  __syncthreads();
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index = k + index * outer_dim_size_grad +
+                          i * outer_dim_size_grad * grad_select_dim_size;
+  int64_t replace_index_value =
+      k + j * outer_dim_size_value +
+      i * outer_dim_size_value * value_select_dim_size;
+  if (value_data[replace_index_value] == out_data[replace_index])
+    phi::CudaAtomicAdd(shared_mem + replace_index, 1);
+  __syncthreads();
+  if (out_data[replace_index] != x_data[replace_index]) {
+    grad_data[replace_index] = 0;
+  } else {
+    grad_data[replace_index] = self_data[replace_index] /
+                               static_cast<tensor_t>(shared_mem[replace_index]);
+  }
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mul_min_max_input_grad_kernel(phi::DenseTensor self,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value
+                                                   UNUSED,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self UNUSED,
+                                               const phi::DeviceContext& ctx) {
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+  auto* out_data = out.data<tensor_t>();
+  auto* x_data = x.data<tensor_t>();
+  auto* value_data = value.data<tensor_t>();
+  auto* self_data = self.data<tensor_t>();
+
+  int64_t grad_size = grad.numel();
+  int64_t index_size = index.numel();
+  auto index_dims = index.dims();
+  auto grad_dims = grad.dims();
+  auto x_dims = x.dims();
+  auto value_dims = value.dims();
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t outer_dim_size_value = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  int64_t value_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+    outer_dim_size_value *= value_dims[i];
+  }
+  int block = 512;
+  int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
+  int64_t grid = (n + block - 1) / block;
+  auto stream = reinterpret_cast<const phi::GPUContext&>(ctx).stream();
+  if (reduce == "mul" || reduce == "multiply") {
+    int shared_mem_size = sizeof(int) * grad_size;
+    ScatterMulInputGradGPUKernel<tensor_t, index_t>
+        <<<grid, block, shared_mem_size, stream>>>(grad_data,
+                                                   dim,
+                                                   index_data,
+                                                   out_data,
+                                                   x_data,
+                                                   select_dim_size,
+                                                   grad_select_dim_size,
+                                                   outer_dim_size,
+                                                   outer_dim_size_grad,
+                                                   index_size,
+                                                   grad_size);
+  } else if (reduce == "amin" || reduce == "amax") {
+    int shared_mem_size = sizeof(int) * grad_size;
+    ScatterMinMaxInputGradGPUKernel<tensor_t, index_t>
+        <<<grid, block, shared_mem_size, stream>>>(grad_data,
+                                                   dim,
+                                                   index_data,
+                                                   out_data,
+                                                   x_data,
+                                                   value_data,
+                                                   self_data,
+                                                   select_dim_size,
+                                                   grad_select_dim_size,
+                                                   value_select_dim_size,
+                                                   outer_dim_size,
+                                                   outer_dim_size_grad,
+                                                   outer_dim_size_value,
+                                                   index_size,
+                                                   grad_size,
+                                                   reduce);
+  }
+}
+
+template <typename tensor_t, typename index_t>
+__global__ void ScatterMeanInputGradGPUKernel(tensor_t* grad_data,
+                                              int dim,
+                                              const index_t* index_data,
+                                              int select_dim_size,
+                                              int grad_select_dim_size,
+                                              int64_t outer_dim_size,
+                                              int64_t outer_dim_size_grad,
+                                              int64_t numel,
+                                              int64_t numel_grad) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  extern __shared__ int shared_mem[];
+  if (tid == 0) {
+    for (int i = 0; i < numel_grad; i++) {
+      shared_mem[i] = 0;               // thread_ids
+      shared_mem[numel_grad + i] = 1;  // number of elements
+    }
+  }
+  __syncthreads();
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index = k + index * outer_dim_size_grad +
+                          i * outer_dim_size_grad * grad_select_dim_size;
+  atomicMax(shared_mem + replace_index, tid);
+  phi::CudaAtomicAdd(shared_mem + numel_grad + replace_index, 1);
+  __syncthreads();
+  if (tid == shared_mem[replace_index]) {
+    grad_data[replace_index] =
+        grad_data[replace_index] /
+        static_cast<tensor_t>(shared_mem[numel_grad + replace_index]);
+  }
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mean_input_grad_kernel(phi::DenseTensor self,
+                                        int dim,
+                                        const phi::DenseTensor& index,
+                                        phi::DenseTensor grad,
+                                        bool include_self UNUSED,
+                                        const phi::DeviceContext& ctx) {
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+
+  auto index_dims = index.dims();
+  auto grad_dims = grad.dims();
+
+  int64_t grad_size = grad.numel();
+  int64_t index_size = index.numel();
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+  }
+
+  int block = 512;
+  int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
+  int64_t grid = (n + block - 1) / block;
+  auto stream = reinterpret_cast<const phi::GPUContext&>(ctx).stream();
+  int shared_mem_size = sizeof(int) * grad_size * 2;
+  ScatterMeanInputGradGPUKernel<tensor_t, index_t>
+      <<<grid, block, shared_mem_size, stream>>>(grad_data,
+                                                 dim,
+                                                 index_data,
+                                                 select_dim_size,
+                                                 grad_select_dim_size,
+                                                 outer_dim_size,
+                                                 outer_dim_size_grad,
+                                                 index_size,
+                                                 grad_size);
+}
+
+template <typename tensor_t, typename index_t>
 __global__ void ScatterValueGradGPUKernel(tensor_t* grad_data,
                                           int dim,
                                           const tensor_t* self_data,
@@ -418,7 +891,6 @@ __global__ void ScatterValueGradGPUKernel(tensor_t* grad_data,
   index_t index = index_data[tid];
   int64_t replace_index_self = k + index * outer_dim_size_self +
                                i * outer_dim_size_self * self_select_dim_size;
-
   atomicMax(thread_ids + replace_index_self, tid);
   __syncthreads();
 
@@ -433,6 +905,7 @@ void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self UNUSED,
                                    const phi::DeviceContext& ctx) {
   auto* self_data = self.data<tensor_t>();
   auto* index_data = index.data<index_t>();
@@ -480,11 +953,334 @@ void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                                  index_size,
                                                  self_size);
 }
-Instantiate_Template_Function(gpu_gather_kernel)
-    Instantiate_Template_Function(gpu_scatter_assign_kernel)
-        Instantiate_Template_Function(gpu_scatter_add_kernel)
-            Instantiate_Template_Function(gpu_scatter_mul_kernel)
-                Instantiate_Template_Function(gpu_scatter_input_grad_kernel)
-                    Instantiate_Template_Function(gpu_scatter_value_grad_kernel)
+
+template <typename tensor_t, typename index_t>
+__global__ void ScatterMeanValueGradGPUKernel(tensor_t* grad_data,
+                                              int dim,
+                                              const tensor_t* self_data,
+                                              const index_t* index_data,
+                                              int select_dim_size,
+                                              int self_select_dim_size,
+                                              int grad_select_dim_size,
+                                              int64_t outer_dim_size,
+                                              int64_t outer_dim_size_self,
+                                              int64_t outer_dim_size_grad,
+                                              int64_t numel,
+                                              int64_t numel_self,
+                                              bool include_self) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  extern __shared__ int shared_mem[];
+
+  if (tid == 0) {
+    for (int i = 0; i < numel_self; i++) {
+      if (include_self)
+        shared_mem[i] = 1;  // number of elements
+      else
+        shared_mem[i] = 0;
+    }
+  }
+  __syncthreads();
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index_self = k + index * outer_dim_size_self +
+                               i * outer_dim_size_self * self_select_dim_size;
+
+  phi::CudaAtomicAdd(shared_mem + replace_index_self, 1);
+  __syncthreads();
+
+  int64_t replace_index_grad = k + j * outer_dim_size_grad +
+                               i * outer_dim_size_grad * grad_select_dim_size;
+  grad_data[replace_index_grad] =
+      self_data[replace_index_self] /
+      static_cast<tensor_t>(shared_mem[replace_index_self]);
+}
+
+template <typename tensor_t, typename index_t>
+__global__ void ScatterAddValueGradGPUKernel(tensor_t* grad_data,
+                                             int dim,
+                                             const tensor_t* self_data,
+                                             const index_t* index_data,
+                                             int select_dim_size,
+                                             int self_select_dim_size,
+                                             int grad_select_dim_size,
+                                             int64_t outer_dim_size,
+                                             int64_t outer_dim_size_self,
+                                             int64_t outer_dim_size_grad,
+                                             int64_t numel) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index_self = k + index * outer_dim_size_self +
+                               i * outer_dim_size_self * self_select_dim_size;
+  int64_t replace_index_grad = k + j * outer_dim_size_grad +
+                               i * outer_dim_size_grad * grad_select_dim_size;
+  grad_data[replace_index_grad] = self_data[replace_index_self];
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_add_mean_value_grad_kernel(
+    phi::DenseTensor self,
+    int dim,
+    const phi::DenseTensor& index,
+    const phi::DenseTensor& out UNUSED,
+    const phi::DenseTensor& x UNUSED,
+    const phi::DenseTensor& value UNUSED,
+    phi::DenseTensor grad,
+    const std::string& reduce,
+    bool include_self,
+    const phi::DeviceContext& ctx UNUSED) {
+  auto* self_data = self.data<tensor_t>();
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+
+  auto index_dims = index.dims();
+  auto self_dims = self.dims();
+  auto grad_dims = grad.dims();
+
+  int64_t self_size = self.numel();
+  int64_t grad_size = grad.numel();
+  int64_t index_size = index.numel();
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_self = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t self_select_dim_size = self_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_self *= self_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+  }
+  int block = 512;
+  int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
+  int64_t grid = (n + block - 1) / block;
+  auto stream = reinterpret_cast<const phi::GPUContext&>(ctx).stream();
+  if (reduce == "mean") {
+    int shared_mem_size = sizeof(int) * self_size;
+    ScatterMeanValueGradGPUKernel<tensor_t, index_t>
+        <<<grid, block, shared_mem_size, stream>>>(grad_data,
+                                                   dim,
+                                                   self_data,
+                                                   index_data,
+                                                   select_dim_size,
+                                                   self_select_dim_size,
+                                                   grad_select_dim_size,
+                                                   outer_dim_size,
+                                                   outer_dim_size_self,
+                                                   outer_dim_size_grad,
+                                                   index_size,
+                                                   self_size,
+                                                   include_self);
+  } else if (reduce == "add") {
+    ScatterAddValueGradGPUKernel<tensor_t, index_t>
+        <<<grid, block, 0, stream>>>(grad_data,
+                                     dim,
+                                     self_data,
+                                     index_data,
+                                     select_dim_size,
+                                     self_select_dim_size,
+                                     grad_select_dim_size,
+                                     outer_dim_size,
+                                     outer_dim_size_self,
+                                     outer_dim_size_grad,
+                                     index_size);
+  }
+}
+
+template <typename tensor_t, typename index_t>
+__global__ void ScatterMulValueGradGPUKernel(tensor_t* grad_data,
+                                             int dim,
+                                             const index_t* index_data,
+                                             const tensor_t* self_data,
+                                             const tensor_t* value_data,
+                                             const tensor_t* out_data,
+                                             int select_dim_size,
+                                             int self_select_dim_size,
+                                             int grad_select_dim_size,
+                                             int64_t outer_dim_size,
+                                             int64_t outer_dim_size_self,
+                                             int64_t outer_dim_size_grad,
+                                             int64_t numel) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index_self = k + index * outer_dim_size_self +
+                               i * outer_dim_size_self * self_select_dim_size;
+  int64_t replace_index_grad = k + j * outer_dim_size_grad +
+                               i * outer_dim_size_grad * grad_select_dim_size;
+  grad_data[replace_index_grad] =
+      self_data[replace_index_self] *
+      (out_data[replace_index_self] / value_data[replace_index_grad]);
+}
+
+template <typename tensor_t, typename index_t>
+__global__ void ScatterMinMaxValueGradGPUKernel(tensor_t* grad_data,
+                                                int dim,
+                                                const index_t* index_data,
+                                                const tensor_t* self_data,
+                                                const tensor_t* value_data,
+                                                const tensor_t* out_data,
+                                                const tensor_t* x_data,
+                                                int select_dim_size,
+                                                int self_select_dim_size,
+                                                int grad_select_dim_size,
+                                                int64_t outer_dim_size,
+                                                int64_t outer_dim_size_self,
+                                                int64_t outer_dim_size_grad,
+                                                int64_t numel,
+                                                int64_t numel_self,
+                                                bool include_self) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid >= numel) return;
+  extern __shared__ int shared_mem[];
+  int64_t i, j, k;
+  i = tid / (select_dim_size * outer_dim_size);
+  int64_t remind = tid % (select_dim_size * outer_dim_size);
+  j = remind / outer_dim_size;
+  k = remind % outer_dim_size;
+  index_t index = index_data[tid];
+  int64_t replace_index_self = k + index * outer_dim_size_self +
+                               i * outer_dim_size_self * self_select_dim_size;
+  int64_t replace_index_grad = k + j * outer_dim_size_grad +
+                               i * outer_dim_size_grad * grad_select_dim_size;
+  if (tid == 0) {
+    for (int i = 0; i < numel_self; i++) {
+      if (include_self &&
+          x_data[replace_index_self] == out_data[replace_index_self])
+        shared_mem[i] = 1;
+      else
+        shared_mem[i] = 0;  // number of elements
+    }
+  }
+  __syncthreads();
+  grad_data[replace_index_grad] = 0;
+  if (value_data[replace_index_grad] == out_data[replace_index_self])
+    phi::CudaAtomicAdd(shared_mem + replace_index_self, 1);
+  __syncthreads();
+  if (value_data[replace_index_grad] == out_data[replace_index_self])
+    grad_data[replace_index_grad] =
+        self_data[replace_index_self] /
+        static_cast<tensor_t>(shared_mem[replace_index_self]);
+}
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mul_min_max_value_grad_kernel(phi::DenseTensor self,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self,
+                                               const phi::DeviceContext& ctx) {
+  auto* self_data = self.data<tensor_t>();
+  auto* index_data = index.data<index_t>();
+  auto* grad_data = grad.data<tensor_t>();
+  auto* out_data = out.data<tensor_t>();
+  auto* x_data = x.data<tensor_t>();
+  auto* value_data = value.data<tensor_t>();
+
+  auto index_dims = index.dims();
+  auto self_dims = self.dims();
+  auto grad_dims = grad.dims();
+
+  int64_t self_size = self.numel();
+  int64_t index_size = index.numel();
+
+  int64_t inner_dim_size = 1;
+  int64_t outer_dim_size = 1;
+  int64_t outer_dim_size_self = 1;
+  int64_t outer_dim_size_grad = 1;
+  int64_t select_dim_size = index_dims[dim];
+  int64_t self_select_dim_size = self_dims[dim];
+  int64_t grad_select_dim_size = grad_dims[dim];
+  for (int i = 0; i < dim; ++i) {
+    inner_dim_size *= index_dims[i];
+  }
+
+  for (int i = dim + 1; i < index_dims.size(); i++) {
+    outer_dim_size *= index_dims[i];
+    outer_dim_size_self *= self_dims[i];
+    outer_dim_size_grad *= grad_dims[i];
+  }
+  int block = 512;
+  int64_t n = inner_dim_size * select_dim_size * outer_dim_size;
+  int64_t grid = (n + block - 1) / block;
+  auto stream = reinterpret_cast<const phi::GPUContext&>(ctx).stream();
+  if (reduce == "mul" || reduce == "multiply") {
+    ScatterMulValueGradGPUKernel<tensor_t, index_t>
+        <<<grid, block, 0, stream>>>(grad_data,
+                                     dim,
+                                     index_data,
+                                     self_data,
+                                     value_data,
+                                     out_data,
+                                     select_dim_size,
+                                     self_select_dim_size,
+                                     grad_select_dim_size,
+                                     outer_dim_size,
+                                     outer_dim_size_self,
+                                     outer_dim_size_grad,
+                                     index_size);
+  } else if (reduce == "amin" || reduce == "amax") {
+    int shared_mem_size = sizeof(int) * self_size;
+    ScatterMinMaxValueGradGPUKernel<tensor_t, index_t>
+        <<<grid, block, shared_mem_size, stream>>>(grad_data,
+                                                   dim,
+                                                   index_data,
+                                                   self_data,
+                                                   value_data,
+                                                   out_data,
+                                                   x_data,
+                                                   select_dim_size,
+                                                   self_select_dim_size,
+                                                   grad_select_dim_size,
+                                                   outer_dim_size,
+                                                   outer_dim_size_self,
+                                                   outer_dim_size_grad,
+                                                   index_size,
+                                                   self_size,
+                                                   include_self);
+  }
+}
+
+Instantiate_Template_Function(gpu_gather_kernel)                  // NOLINT
+    Instantiate_Template_Function(gpu_scatter_assign_kernel)      // NOLINT
+    Instantiate_Template_Function(gpu_scatter_add_kernel)         // NOLINT
+    Instantiate_Template_Function(gpu_scatter_mul_kernel)         // NOLINT
+    Instantiate_Template_Function(gpu_scatter_min_kernel)         // NOLINT
+    Instantiate_Template_Function(gpu_scatter_max_kernel)         // NOLINT
+    Instantiate_Template_Function(gpu_scatter_mean_kernel)        // NOLINT
+    Instantiate_Template_Function(gpu_scatter_input_grad_kernel)  // NOLINT
+    Instantiate_Template_Function(gpu_scatter_value_grad_kernel)  // NOLINT
+    Instantiate_Template_Function_With_Out(
+        gpu_scatter_mul_min_max_input_grad_kernel)                     // NOLINT
+    Instantiate_Template_Function(gpu_scatter_mean_input_grad_kernel)  // NOLINT
+    Instantiate_Template_Function_With_Out(
+        gpu_scatter_add_mean_value_grad_kernel)  // NOLINT
+    Instantiate_Template_Function_With_Out(
+        gpu_scatter_mul_min_max_value_grad_kernel)  // NOLINT
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.h
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.h
@@ -36,11 +36,46 @@ namespace funcs {
                                     int dim,                           \
                                     const phi::DenseTensor& index,     \
                                     phi::DenseTensor result,           \
+                                    bool include_self,                 \
                                     const phi::DeviceContext& ctx);    \
   template void func<tensor_t, int64_t>(phi::DenseTensor input,        \
                                         int dim,                       \
                                         const phi::DenseTensor& index, \
                                         phi::DenseTensor result,       \
+                                        bool include_self,             \
+                                        const phi::DeviceContext& ctx);
+
+#define Instantiate_Template_Function_With_Out(func)                        \
+  Instantiate_Template_Function_index_t_With_Out(func, int)                 \
+      Instantiate_Template_Function_index_t_With_Out(func, float)           \
+          Instantiate_Template_Function_index_t_With_Out(func, double)      \
+              Instantiate_Template_Function_index_t_With_Out(func, int64_t) \
+                  Instantiate_Template_Function_index_t_With_Out(           \
+                      func, phi::dtype::float16)                            \
+                      Instantiate_Template_Function_index_t_With_Out(       \
+                          func, phi::dtype::bfloat16)                       \
+                          Instantiate_Template_Function_index_t_With_Out(   \
+                              func, unsigned char)
+#define Instantiate_Template_Function_index_t_With_Out(func, tensor_t) \
+  template void func<tensor_t, int>(phi::DenseTensor input,            \
+                                    int dim,                           \
+                                    const phi::DenseTensor& index,     \
+                                    const phi::DenseTensor& out,       \
+                                    const phi::DenseTensor& self,      \
+                                    const phi::DenseTensor& value,     \
+                                    phi::DenseTensor result,           \
+                                    const std::string& reduce,         \
+                                    bool include_self,                 \
+                                    const phi::DeviceContext& ctx);    \
+  template void func<tensor_t, int64_t>(phi::DenseTensor input,        \
+                                        int dim,                       \
+                                        const phi::DenseTensor& index, \
+                                        const phi::DenseTensor& out,   \
+                                        const phi::DenseTensor& self,  \
+                                        const phi::DenseTensor& value, \
+                                        phi::DenseTensor result,       \
+                                        const std::string& reduce,     \
+                                        bool include_self,             \
                                         const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -48,6 +83,7 @@ void cpu_gather_kernel(phi::DenseTensor self,
                        int dim,
                        const phi::DenseTensor& index,
                        phi::DenseTensor result,
+                       bool include_self,
                        const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -55,6 +91,7 @@ void cpu_scatter_assign_kernel(phi::DenseTensor self,
                                int dim,
                                const phi::DenseTensor& index,
                                phi::DenseTensor src,
+                               bool include_self,
                                const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -62,6 +99,7 @@ void cpu_scatter_add_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -69,6 +107,31 @@ void cpu_scatter_mul_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mean_kernel(phi::DenseTensor self,
+                             int dim,
+                             const phi::DenseTensor& index,
+                             phi::DenseTensor src,
+                             bool include_self,
+                             const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_max_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_min_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -76,20 +139,67 @@ void cpu_scatter_input_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self,
                                    const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mul_min_max_input_grad_kernel(phi::DenseTensor self,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self,
+                                               const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mean_input_grad_kernel(phi::DenseTensor self,
+                                        int dim,
+                                        const phi::DenseTensor& index,
+                                        phi::DenseTensor grad,
+                                        bool include_self,
+                                        const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
 void cpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self,
                                    const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_add_mean_value_grad_kernel(phi::DenseTensor self,
+                                            int dim,
+                                            const phi::DenseTensor& index,
+                                            const phi::DenseTensor& out,
+                                            const phi::DenseTensor& x,
+                                            const phi::DenseTensor& value,
+                                            phi::DenseTensor grad,
+                                            const std::string& reduce,
+                                            bool include_self,
+                                            const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void cpu_scatter_mul_min_max_value_grad_kernel(phi::DenseTensor self,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self,
+                                               const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
 void gpu_gather_kernel(phi::DenseTensor self,
                        int dim,
                        const phi::DenseTensor& index,
                        phi::DenseTensor result,
+                       bool include_self,
                        const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -97,6 +207,7 @@ void gpu_scatter_assign_kernel(phi::DenseTensor self,
                                int dim,
                                const phi::DenseTensor& index,
                                phi::DenseTensor src,
+                               bool include_self,
                                const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -104,6 +215,7 @@ void gpu_scatter_add_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -111,6 +223,31 @@ void gpu_scatter_mul_kernel(phi::DenseTensor self,
                             int dim,
                             const phi::DenseTensor& index,
                             phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mean_kernel(phi::DenseTensor self,
+                             int dim,
+                             const phi::DenseTensor& index,
+                             phi::DenseTensor src,
+                             bool include_self,
+                             const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_max_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
+                            const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_min_kernel(phi::DenseTensor self,
+                            int dim,
+                            const phi::DenseTensor& index,
+                            phi::DenseTensor src,
+                            bool include_self,
                             const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
@@ -118,14 +255,60 @@ void gpu_scatter_input_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self,
                                    const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mul_min_max_input_grad_kernel(phi::DenseTensor self UNUSED,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self,
+                                               const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mean_input_grad_kernel(phi::DenseTensor self,
+                                        int dim,
+                                        const phi::DenseTensor& index,
+                                        phi::DenseTensor grad,
+                                        bool include_self,
+                                        const phi::DeviceContext& ctx);
 
 template <typename tensor_t, typename index_t>
 void gpu_scatter_value_grad_kernel(phi::DenseTensor self,
                                    int dim,
                                    const phi::DenseTensor& index,
                                    phi::DenseTensor grad,
+                                   bool include_self,
                                    const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_add_mean_value_grad_kernel(phi::DenseTensor self,
+                                            int dim,
+                                            const phi::DenseTensor& index,
+                                            const phi::DenseTensor& out,
+                                            const phi::DenseTensor& x,
+                                            const phi::DenseTensor& value,
+                                            phi::DenseTensor grad,
+                                            const std::string& reduce,
+                                            bool include_self,
+                                            const phi::DeviceContext& ctx);
+
+template <typename tensor_t, typename index_t>
+void gpu_scatter_mul_min_max_value_grad_kernel(phi::DenseTensor self,
+                                               int dim,
+                                               const phi::DenseTensor& index,
+                                               const phi::DenseTensor& out,
+                                               const phi::DenseTensor& x,
+                                               const phi::DenseTensor& value,
+                                               phi::DenseTensor grad,
+                                               const std::string& reduce,
+                                               bool include_self,
+                                               const phi::DeviceContext& ctx);
 
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
@@ -39,10 +39,10 @@ void CummaxGradKernel(const Context& dev_ctx,
 
   if (dtype == DataType::INT32) {
     phi::funcs::gpu_scatter_add_kernel<T, int32_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   } else if (dtype == DataType::INT64) {
     phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   }
 }
 
@@ -63,10 +63,10 @@ void CumminGradKernel(const Context& dev_ctx,
 
   if (dtype == DataType::INT32) {
     phi::funcs::gpu_scatter_add_kernel<T, int32_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   } else if (dtype == DataType::INT64) {
     phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
-        *x_grad, axis, indices, out_grad, dev_ctx);
+        *x_grad, axis, indices, out_grad, true, dev_ctx);
   }
 }
 

--- a/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
@@ -27,9 +27,12 @@ template <typename T, typename Context>
 void PutAlongAxisGradKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             const DenseTensor& index,
+                            const DenseTensor& value,
+                            const DenseTensor& out,
                             const DenseTensor& out_grad,
                             int axis,
                             const std::string& reduce,
+                            bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad) {
   PADDLE_ENFORCE_EQ(dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU,
@@ -40,23 +43,118 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
   const auto& index_type = index.dtype();
   if (x_grad) {
     phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
-    if (index_type == DataType::INT32) {
-      phi::funcs::gpu_scatter_input_grad_kernel<T, int32_t>(
-          out_grad, axis, index, *x_grad, dev_ctx);
-    } else {
-      phi::funcs::gpu_scatter_input_grad_kernel<T, int64_t>(
-          out_grad, axis, index, *x_grad, dev_ctx);
+    if (!include_self || reduce == "assign") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::gpu_scatter_input_grad_kernel<T, int32_t>(
+            out_grad, axis, index, *x_grad, include_self, dev_ctx);
+      } else {
+        phi::funcs::gpu_scatter_input_grad_kernel<T, int64_t>(
+            out_grad, axis, index, *x_grad, include_self, dev_ctx);
+      }
+    } else if (reduce == "multiply" || reduce == "mul" || reduce == "amin" ||
+               reduce == "amax") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::gpu_scatter_mul_min_max_input_grad_kernel<T, int32_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *x_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::gpu_scatter_mul_min_max_input_grad_kernel<T, int64_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *x_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      }
+    } else if (reduce == "mean") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::gpu_scatter_mean_input_grad_kernel<T, int32_t>(
+            out_grad, axis, index, *x_grad, include_self, dev_ctx);
+      } else {
+        phi::funcs::gpu_scatter_mean_input_grad_kernel<T, int64_t>(
+            out_grad, axis, index, *x_grad, include_self, dev_ctx);
+      }
     }
   }
   if (value_grad) {
     value_grad->Resize(index.dims());
     dev_ctx.template Alloc<T>(value_grad);
-    if (index_type == DataType::INT32) {
-      phi::funcs::gpu_scatter_value_grad_kernel<T, int32_t>(
-          out_grad, axis, index, *value_grad, dev_ctx);
-    } else {
-      phi::funcs::gpu_scatter_value_grad_kernel<T, int64_t>(
-          out_grad, axis, index, *value_grad, dev_ctx);
+    auto* grad_data = value_grad->data<T>();
+    int64_t grad_size = value_grad->numel();
+    cudaMemset(grad_data, 0, sizeof(T) * grad_size);
+    if (reduce == "assign") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::gpu_scatter_value_grad_kernel<T, int32_t>(
+            out_grad, axis, index, *value_grad, include_self, dev_ctx);
+      } else if (index_type == DataType::INT64) {
+        phi::funcs::gpu_scatter_value_grad_kernel<T, int64_t>(
+            out_grad, axis, index, *value_grad, include_self, dev_ctx);
+      }
+    } else if (reduce == "add" || reduce == "mean") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::gpu_scatter_add_mean_value_grad_kernel<T, int32_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::gpu_scatter_add_mean_value_grad_kernel<T, int64_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      }
+    } else if (reduce == "mul" || reduce == "multiply" || reduce == "amin" ||
+               reduce == "amax") {
+      if (index_type == DataType::INT32) {
+        phi::funcs::gpu_scatter_mul_min_max_value_grad_kernel<T, int32_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      } else {
+        phi::funcs::gpu_scatter_mul_min_max_value_grad_kernel<T, int64_t>(
+            out_grad,
+            axis,
+            index,
+            out,
+            x,
+            value,
+            *value_grad,
+            reduce,
+            include_self,
+            dev_ctx);
+      }
     }
   }
 }

--- a/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
@@ -30,6 +30,7 @@ void PutAlongAxisKernel(const Context& dev_ctx,
                         const DenseTensor& value,
                         int axis,
                         const std::string& reduce,
+                        bool include_self,
                         DenseTensor* out) {
   PADDLE_ENFORCE_EQ(dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU,
                     true,
@@ -42,31 +43,56 @@ void PutAlongAxisKernel(const Context& dev_ctx,
   if (reduce == "add") {
     if (index_type == DataType::INT32) {
       phi::funcs::gpu_scatter_add_kernel<T, int32_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     } else if (index_type == DataType::INT64) {
       phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     }
   } else if (reduce == "multiply" || reduce == "mul") {
     if (index_type == DataType::INT32) {
       phi::funcs::gpu_scatter_mul_kernel<T, int32_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     } else if (index_type == DataType::INT64) {
       phi::funcs::gpu_scatter_mul_kernel<T, int64_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     }
   } else if (reduce == "assign") {
     if (index_type == DataType::INT32) {
       phi::funcs::gpu_scatter_assign_kernel<T, int32_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
     } else if (index_type == DataType::INT64) {
       phi::funcs::gpu_scatter_assign_kernel<T, int64_t>(
-          *out, axis, index, value, dev_ctx);
+          *out, axis, index, value, include_self, dev_ctx);
+    }
+  } else if (reduce == "mean") {
+    if (index_type == DataType::INT32) {
+      phi::funcs::gpu_scatter_mean_kernel<T, int32_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    } else if (index_type == DataType::INT64) {
+      phi::funcs::gpu_scatter_mean_kernel<T, int64_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    }
+  } else if (reduce == "amax") {
+    if (index_type == DataType::INT32) {
+      phi::funcs::gpu_scatter_max_kernel<T, int32_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    } else if (index_type == DataType::INT64) {
+      phi::funcs::gpu_scatter_max_kernel<T, int64_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    }
+  } else if (reduce == "amin") {
+    if (index_type == DataType::INT32) {
+      phi::funcs::gpu_scatter_min_kernel<T, int32_t>(
+          *out, axis, index, value, include_self, dev_ctx);
+    } else if (index_type == DataType::INT64) {
+      phi::funcs::gpu_scatter_min_kernel<T, int64_t>(
+          *out, axis, index, value, include_self, dev_ctx);
     }
   } else {
     PADDLE_THROW(errors::InvalidArgument(
         "can not support reduce: '%s' for scatter kernel, only "
-        "support reduce op: 'add', 'assign', 'mul' and 'multiply', the "
+        "support reduce op: 'add', 'assign', 'mul', 'mean', 'amin', 'amax' and "
+        "'multiply', the "
         "default reduce op is 'assign' ",
         reduce));
     return;

--- a/paddle/phi/kernels/gpu/take_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_grad_kernel.cu
@@ -46,10 +46,11 @@ void TakeAlongAxisGradKernel(const Context& dev_ctx,
         axis,
         index,
         out_grad,
+        true,
         dev_ctx);  // the gradient of gather is scatter
   } else if (index_type == DataType::INT64) {
     phi::funcs::gpu_scatter_add_kernel<T, int64_t>(
-        *x_grad, axis, index, out_grad, dev_ctx);
+        *x_grad, axis, index, out_grad, true, dev_ctx);
   } else {
     PADDLE_THROW(
         phi::errors::InvalidArgument("The data type of input index is expected "

--- a/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/take_along_axis_kernel.cu
@@ -33,9 +33,11 @@ void TakeAlongAxisKernel(const Context& dev_ctx,
 
   const auto& index_type = index.dtype();
   if (index_type == DataType::INT32) {
-    phi::funcs::gpu_gather_kernel<T, int32_t>(x, axis, index, *out, dev_ctx);
+    phi::funcs::gpu_gather_kernel<T, int32_t>(
+        x, axis, index, *out, true, dev_ctx);
   } else if (index_type == DataType::INT64) {
-    phi::funcs::gpu_gather_kernel<T, int64_t>(x, axis, index, *out, dev_ctx);
+    phi::funcs::gpu_gather_kernel<T, int64_t>(
+        x, axis, index, *out, true, dev_ctx);
   } else {
     PADDLE_THROW(
         phi::errors::InvalidArgument("The data type of input index is expected "

--- a/paddle/phi/kernels/put_along_axis_grad_kernel.h
+++ b/paddle/phi/kernels/put_along_axis_grad_kernel.h
@@ -24,9 +24,12 @@ template <typename T, typename Context>
 void PutAlongAxisGradKernel(const Context& dev_ctx,
                             const DenseTensor& x,
                             const DenseTensor& index,
+                            const DenseTensor& value,
+                            const DenseTensor& out,
                             const DenseTensor& out_grad,
                             int axis,
                             const std::string& reduce,
+                            bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad);
 

--- a/paddle/phi/kernels/put_along_axis_kernel.h
+++ b/paddle/phi/kernels/put_along_axis_kernel.h
@@ -27,6 +27,7 @@ void PutAlongAxisKernel(const Context& dev_ctx,
                         const DenseTensor& value,
                         int axis,
                         const std::string& reduce,
+                        bool include_self,
                         DenseTensor* out);
 
 }  // namespace phi

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5308,11 +5308,12 @@ def put_along_axis(
     Args:
         arr (Tensor) : The Destination Tensor. Supported data types are float32 and float64.
         indices (Tensor) : Indices to put along each 1d slice of arr. This must match the dimension of arr,
-            and need to broadcast against arr. Supported data type are int and int64.
+            and need to broadcast against arr if broadcast is 'True'. Supported data type are int and int64.
+        values (Tensor) : The value element(s) to put. The data types should be same as arr.
         axis (int) : The axis to put 1d slices along.
-        reduce (str, optional): The reduce operation, default is 'assign', support 'add', 'assign', 'mul' and 'multiply'.
-        include_self (bool, optional): whether to reduce with the elements of arr. (Only support True now)
-        broadcast (bool, optional): whether to broadcast indices.
+        reduce (str, optional): The reduce operation, default is 'assign', support 'add', 'assign', 'mul', 'multiply', "mean", "amin" and "amax".
+        include_self (bool, optional): whether to reduce with the elements of arr, default is 'True'.
+        broadcast (bool, optional): whether to broadcast indices, default is 'True'.
 
     Returns:
         Tensor, The indexed element, same dtype with arr
@@ -5332,9 +5333,45 @@ def put_along_axis(
             [[99, 99, 99],
              [60, 40, 50]])
 
+            >>> index = paddle.zeros((2,2)).astype("int32")
+            >>> value=paddle.to_tensor([[1,2],[3,4]]).astype(x.dtype)
+            >>> result = paddle.put_along_axis(x, index, value, 0, "add", True, False)
+            >>> print(result)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[14, 36, 20],
+             [60, 40, 50]])
+
+            >>> result = paddle.put_along_axis(x, index, value, 0, "mul", True, False)
+            >>> print(result)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[30 , 240, 20 ],
+             [60 , 40 , 50 ]])
+
+            >>> result = paddle.put_along_axis(x, index, value, 0, "mean", True, False)
+            >>> print(result)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[4 , 12, 20],
+             [60, 40, 50]])
+
+            >>> result = paddle.put_along_axis(x, index, value, 0, "amin", True, False)
+            >>> print(result)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[1 , 2 , 20],
+             [60, 40, 50]])
+
+            >>> result = paddle.put_along_axis(x, index, value, 0, "amax", True, False)
+            >>> print(result)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[10, 30, 20],
+             [60, 40, 50]])
+
+            >>> result = paddle.put_along_axis(x, index, value, 0, "add", False, False)
+            >>> print(result)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[4 , 6 , 20],
+             [60, 40, 50]])
+
     """
-    if not include_self:
-        raise ValueError("`include_self` is only support True now.")
     if len(arr.shape) != len(indices.shape):
         raise ValueError(
             "`indices` and `arr` must have the same number of dimensions!"
@@ -5381,7 +5418,15 @@ def put_along_axis(
                 )
             )
     if in_dynamic_or_pir_mode():
-        return _C_ops.put_along_axis(arr, indices, values, axis, reduce)
+        if convert_dtype(indices.dtype) not in ['int32', 'int64']:
+            raise TypeError(
+                "The data type of indices should be one of ['int32', 'int64'], but got {}".format(
+                    str(convert_dtype(indices.dtype))
+                )
+            )
+        return _C_ops.put_along_axis(
+            arr, indices, values, axis, reduce, include_self
+        )
     else:
         check_variable_and_dtype(
             arr,
@@ -5400,20 +5445,27 @@ def put_along_axis(
         check_variable_and_dtype(
             indices, 'index', ['int32', 'int64'], 'put_along_axis'
         )
+        check_type(include_self, 'include_self', bool, 'put_along_axis')
         helper = LayerHelper('put_along_axis', **locals())
         dtype = helper.input_dtype()
         result = helper.create_variable_for_type_inference(dtype)
         helper.append_op(
             type="put_along_axis",
             inputs={"Input": arr, "Index": indices, "Value": values},
-            attrs={"Axis": axis, "Reduce": reduce},
+            attrs={
+                "Axis": axis,
+                "Reduce": reduce,
+                "Include_self": include_self,
+            },
             outputs={"Result": result},
         )
         return result
 
 
 @inplace_apis_in_dygraph_only
-def put_along_axis_(arr, indices, values, axis, reduce='assign'):
+def put_along_axis_(
+    arr, indices, values, axis, reduce='assign', include_self=True
+):
     r"""
     Inplace version of ``put_along_axis`` API, the output Tensor will be inplaced with input ``arr``.
     Please refer to :ref:`api_paddle_put_along_axis`.
@@ -5432,7 +5484,9 @@ def put_along_axis_(arr, indices, values, axis, reduce='assign'):
     if broadcast_shape:
         indices = paddle.broadcast_to(indices, broadcast_shape)
     values = paddle.broadcast_to(values, indices.shape)
-    return _C_ops.put_along_axis_(arr, indices, values, axis, reduce)
+    return _C_ops.put_along_axis_(
+        arr, indices, values, axis, reduce, include_self
+    )
 
 
 def index_add(x, index, axis, value, name=None):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -120,6 +120,470 @@ class TestPutAlongAxisOpCase2(TestPutAlongAxisOp):
         self.axis_type = "int64"
 
 
+class TestPutAlongAxisOpMul(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "mul"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] *= self.value[
+                        i, j, k
+                    ]
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': True,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMulNotIncludeSelf(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "mul"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        self.nums = np.zeros_like(self.target)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    if self.nums[i, self.index[i, j, k], k] == 0:
+                        self.target[i, self.index[i, j, k], k] = self.value[
+                            i, j, k
+                        ]
+                    else:
+                        self.target[i, self.index[i, j, k], k] *= self.value[
+                            i, j, k
+                        ]
+                    self.nums[i, self.index[i, j, k], k] += 1
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': False,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpAdd(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "add"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] += self.value[
+                        i, j, k
+                    ]
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': True,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = np.random.randint(1, 100, (5, 5, 5)).astype(
+            self.value_type
+        )
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpAddNotIncludeSelf(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "add"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        self.nums = np.zeros_like(self.target)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    if self.nums[i, self.index[i, j, k], k] == 0:
+                        self.target[i, self.index[i, j, k], k] = self.value[
+                            i, j, k
+                        ]
+                    else:
+                        self.target[i, self.index[i, j, k], k] += self.value[
+                            i, j, k
+                        ]
+                    self.nums[i, self.index[i, j, k], k] += 1
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': False,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMean(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "mean"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        self.nums = np.ones_like(self.target)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] += self.value[
+                        i, j, k
+                    ]
+                    self.nums[i, self.index[i, j, k], k] += 1
+        for i in range(10):
+            for j in range(10):
+                for k in range(10):
+                    self.target[i, j, k] /= self.nums[i, j, k]
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': True,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMeanNotIncludeSelf(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "mean"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        self.nums = np.zeros_like(self.target)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    if self.nums[i, self.index[i, j, k], k] == 0:
+                        self.target[i, self.index[i, j, k], k] = self.value[
+                            i, j, k
+                        ]
+                    else:
+                        self.target[i, self.index[i, j, k], k] += self.value[
+                            i, j, k
+                        ]
+                    self.nums[i, self.index[i, j, k], k] += 1
+        for i in range(10):
+            for j in range(10):
+                for k in range(10):
+                    if self.nums[i, j, k] > 0:
+                        self.target[i, j, k] = (
+                            self.target[i, j, k] / self.nums[i, j, k]
+                        )
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': False,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMin(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "amin"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] = (
+                        self.value[i, j, k]
+                        if self.value[i, j, k]
+                        < self.target[i, self.index[i, j, k], k]
+                        else self.target[i, self.index[i, j, k], k]
+                    )
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'include_self': True,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = (
+            np.arange(1, 126).reshape((5, 5, 5)).astype(self.value_type)
+        )
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMinNotIncludeSelf(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "amin"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] = self.value[i, j, k]
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] = (
+                        self.value[i, j, k]
+                        if self.value[i, j, k]
+                        < self.target[i, self.index[i, j, k], k]
+                        else self.target[i, self.index[i, j, k], k]
+                    )
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': False,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = (
+            np.arange(1, 126).reshape((5, 5, 5)).astype(self.value_type)
+        )
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMax(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "amax"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] = (
+                        self.value[i, j, k]
+                        if self.value[i, j, k]
+                        > self.target[i, self.index[i, j, k], k]
+                        else self.target[i, self.index[i, j, k], k]
+                    )
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'include_self': True,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = (
+            np.arange(1, 126).reshape((5, 5, 5)).astype(self.value_type)
+        )
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
+class TestPutAlongAxisOpMaxNotIncludeSelf(TestPutAlongAxisOp):
+    def setUp(self):
+        self.init_data()
+        self.reduce_op = "amax"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] = self.value[i, j, k]
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] = (
+                        self.value[i, j, k]
+                        if self.value[i, j, k]
+                        > self.target[i, self.index[i, j, k], k]
+                        else self.target[i, self.index[i, j, k], k]
+                    )
+        self.inputs = {
+            'Input': self.xnp,
+            'Index': self.index,
+            'Value': self.value,
+        }
+        self.attrs = {
+            'Axis': self.axis,
+            'Reduce': self.reduce_op,
+            'Include_self': False,
+            'broadcast': False,
+        }
+        self.outputs = {'Result': self.target}
+
+    def init_data(self):
+        self.dtype = 'float64'
+        self.x_type = "float64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float64"
+        self.value = (
+            np.arange(1, 126).reshape((5, 5, 5)).astype(self.value_type)
+        )
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+
+
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
@@ -468,13 +932,262 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
         except Exception as error:
             self.assertIsInstance(error, RuntimeError)
 
-        # use includ_self=False
-        try:
+    def test_index_type_error(self):
+        tensorx = paddle.to_tensor([[1, 2, 3], [4, 5, 6]]).astype("float32")
+        indices = paddle.to_tensor([[1]]).astype("float32")
+        values = paddle.to_tensor([[2]])
+        with self.assertRaises(TypeError):
             res = paddle.put_along_axis(
-                tensorx, indices, 1.0, 0, 'assign', False
+                tensorx, indices, values, 0, 'mul', True, False
             )
-        except Exception as error:
-            self.assertIsInstance(error, ValueError)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestPutAlongAxisAPIMulFloat32(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = 'float32'
+        self.x_type = "float32"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float32"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.random.randint(0, 5, (5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] *= self.value[
+                        i, j, k
+                    ]
+
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.xnp)
+            index_tensor = paddle.to_tensor(self.index)
+            value_tensor = paddle.to_tensor(self.value)
+            out = paddle.put_along_axis(
+                x_tensor,
+                index_tensor,
+                value_tensor,
+                self.axis,
+                "mul",
+                True,
+                False,
+            )
+            out_ref = self.target
+            np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+
+        run(paddle.CUDAPlace(0))
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestPutAlongAxisAPIMulBF16(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = 'float32'
+        self.x_type = "float32"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "float32"
+        self.value = np.random.randint(1, 3, (3, 3, 3)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.random.randint(0, 3, (3, 3, 3)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.random(self.x_shape).astype(self.x_type)
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    self.target[i, self.index[i, j, k], k] *= self.value[
+                        i, j, k
+                    ]
+        self.xnp = convert_float_to_uint16(self.xnp)
+        self.value = convert_float_to_uint16(self.value)
+        self.target = convert_float_to_uint16(self.target)
+
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.xnp)
+            index_tensor = paddle.to_tensor(self.index)
+            value_tensor = paddle.to_tensor(self.value)
+            out = paddle.put_along_axis(
+                x_tensor,
+                index_tensor,
+                value_tensor,
+                self.axis,
+                "mul",
+                True,
+                False,
+            )
+            out_ref = self.target
+            np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+
+        run(paddle.CUDAPlace(0))
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestPutAlongAxisAPIMulInt32(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = 'int32'
+        self.x_type = "int32"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "int32"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int32"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] *= self.value[
+                        i, j, k
+                    ]
+
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.xnp)
+            index_tensor = paddle.to_tensor(self.index)
+            value_tensor = paddle.to_tensor(self.value)
+            out = paddle.put_along_axis(
+                x_tensor,
+                index_tensor,
+                value_tensor,
+                self.axis,
+                "mul",
+                True,
+                False,
+            )
+            out_ref = self.target
+            np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+
+        run(paddle.CUDAPlace(0))
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestPutAlongAxisAPIMulInt64(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = 'int64'
+        self.x_type = "int64"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "int64"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] *= self.value[
+                        i, j, k
+                    ]
+
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.xnp)
+            index_tensor = paddle.to_tensor(self.index)
+            value_tensor = paddle.to_tensor(self.value)
+            out = paddle.put_along_axis(
+                x_tensor,
+                index_tensor,
+                value_tensor,
+                self.axis,
+                "mul",
+                True,
+                False,
+            )
+            out_ref = self.target
+            np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+
+        run(paddle.CUDAPlace(0))
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestPutAlongAxisAPIMulUint8(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.dtype = 'uint8'
+        self.x_type = "uint8"
+        self.x_shape = (10, 10, 10)
+        self.value_type = "uint8"
+        self.value = np.random.randint(1, 5, (5, 5, 5)).astype(self.value_type)
+        self.index_type = "int64"
+        self.index = np.zeros((5, 5, 5)).astype(self.index_type)
+        self.axis = 1
+        self.axis_type = "int64"
+        self.op_type = "put_along_axis"
+        self.python_api = paddle.tensor.put_along_axis
+        self.xnp = np.random.randint(1, 5, self.x_shape).astype(self.x_type)
+        # numpy put_along_axis is an inplace operation.
+        self.target = copy.deepcopy(self.xnp)
+        for i in range(5):
+            for j in range(5):
+                for k in range(5):
+                    self.target[i, self.index[i, j, k], k] *= self.value[
+                        i, j, k
+                    ]
+
+    def test_api_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_tensor = paddle.to_tensor(self.xnp)
+            index_tensor = paddle.to_tensor(self.index)
+            value_tensor = paddle.to_tensor(self.value)
+            out = paddle.put_along_axis(
+                x_tensor,
+                index_tensor,
+                value_tensor,
+                self.axis,
+                "mul",
+                True,
+                False,
+            )
+            out_ref = self.target
+            np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.001)
+
+        run(paddle.CUDAPlace(0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what you’ve done -->

card-80850

**优化与增强put_along_axis/take_along_axis的系列工作**：

https://github.com/PaddlePaddle/Paddle/pull/59163 是第一个PR，最早在23.12.4合入，已随版进入到`v2.6.0`发版，但该PR造成了一些Bug，在后续多个PR里进行了修复，并未进入到2.6分支。根据用户的要求，将后续这些修复工作也都cherry-pick到`v2.6.1`中，PR彼此前后依赖：
- https://github.com/PaddlePaddle/Paddle/pull/59674
- https://github.com/PaddlePaddle/Paddle/pull/60551
- https://github.com/PaddlePaddle/Paddle/pull/60618
- https://github.com/PaddlePaddle/Paddle/pull/60934