### PR TITLE
Fix typos(`RreplenishLayerAndOutput` -> `ReplenishLayerAndOutput`)

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/activation_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/activation_op.cc
@@ -112,7 +112,7 @@ class ActivationOpConverter : public OpConverter {
 
     auto output_name = op_desc.Output("Out")[0];
 
-    RreplenishLayerAndOutput(layer, op_type_, {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, op_type_, {output_name}, test_mode);
   }
 
  protected:

--- a/paddle/fluid/inference/tensorrt/convert/affine_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/affine_channel_op.cc
@@ -72,7 +72,7 @@ class AffineChannelOpConverter : public OpConverter {
                                       power_weights.get(),
                                       channel_axis);
 
-    RreplenishLayerAndOutput(layer, "affine_channel", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "affine_channel", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/anchor_generator_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/anchor_generator_op.cc
@@ -80,7 +80,7 @@ class AnchorGeneratorOpConverter : public OpConverter {
                                         anchor_generator_inputs.size(),
                                         *anchor_generator_plugin);
 
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         anchor_generator_layer, "anchor_generator", output_names, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/arg_max_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/arg_max_op.cc
@@ -42,10 +42,10 @@ class ArgMaxOpConverter : public OpConverter {
     auto output_name = op_desc.Output("Out")[0];
     bool keepdims = PADDLE_GET_CONST(bool, op_desc.GetAttr("keepdims"));
     if (keepdims) {
-      RreplenishLayerAndOutput(topk_layer,
-                               "arg_max",
-                               {output_name + "_value", output_name},
-                               test_mode);
+      ReplenishLayerAndOutput(topk_layer,
+                              "arg_max",
+                              {output_name + "_value", output_name},
+                              test_mode);
     } else {
       auto squeeze_layer =
           TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *topk_layer->getOutput(1));
@@ -55,7 +55,7 @@ class ArgMaxOpConverter : public OpConverter {
         dims.d[i] = dims.d[i + 1];
       }
       squeeze_layer->setReshapeDimensions(dims);
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           squeeze_layer, "arg_max", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/arg_min_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/arg_min_op.cc
@@ -42,10 +42,10 @@ class ArgMinOpConverter : public OpConverter {
     auto output_name = op_desc.Output("Out")[0];
     bool keepdims = PADDLE_GET_CONST(bool, op_desc.GetAttr("keepdims"));
     if (keepdims) {
-      RreplenishLayerAndOutput(topk_layer,
-                               "arg_min",
-                               {output_name + "_value", output_name},
-                               test_mode);
+      ReplenishLayerAndOutput(topk_layer,
+                              "arg_min",
+                              {output_name + "_value", output_name},
+                              test_mode);
     } else {
       auto squeeze_layer =
           TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *topk_layer->getOutput(1));
@@ -55,7 +55,7 @@ class ArgMinOpConverter : public OpConverter {
         dims.d[i] = dims.d[i + 1];
       }
       squeeze_layer->setReshapeDimensions(dims);
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           squeeze_layer, "arg_min", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/assign_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/assign_op.cc
@@ -28,7 +28,7 @@ class AssignOpConverter : public OpConverter {
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
     auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Identity, *input);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "assign", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "assign", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/batch_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/batch_norm_op.cc
@@ -170,10 +170,10 @@ class BatchNormOpConverter : public OpConverter {
       squeeze_layer =
           TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *(layer->getOutput(0)));
       squeeze_layer->setReshapeDimensions(squeeze_shape);
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           squeeze_layer, "batchnorm_add_scale", {output_name}, test_mode);
     } else {
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           layer, "batchnorm_add_scale", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/bilinear_interp_v2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bilinear_interp_v2_op.cc
@@ -148,7 +148,7 @@ class BilinearInterpolateV2OpConverter : public OpConverter {
       layer->setScales(scales.data(), scales.size());
     }
 
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "bilinear_interp_v2", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/bitwise_and_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bitwise_and_op.cc
@@ -49,7 +49,7 @@ class BitwiseAndConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "bitwise_and", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "bitwise_and", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/bitwise_not_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bitwise_not_op.cc
@@ -69,7 +69,7 @@ class BitwiseNotConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "bitwise_not", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "bitwise_not", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/bitwise_or_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bitwise_or_op.cc
@@ -49,7 +49,7 @@ class BitwiseOrConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "bitwise_or", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "bitwise_or", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/bmm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/bmm_op.cc
@@ -38,7 +38,7 @@ class BMMOpConverter : public OpConverter {
                                  *input2,
                                  nvinfer1::MatrixOperation::kNONE);
 
-    RreplenishLayerAndOutput(layer, "bmm", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "bmm", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/c_allreduce_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/c_allreduce_op.cc
@@ -84,7 +84,7 @@ class CAllReduceOpConverter : public OpConverter {
 #endif
     auto output_name = op_desc.Output("Out")[0];
 
-    RreplenishLayerAndOutput(layer, name, {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, name, {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/cast_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/cast_op.cc
@@ -57,7 +57,7 @@ class CastOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "cast", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "cast", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/celu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/celu_op.cc
@@ -78,7 +78,7 @@ class CeluOpConverter : public OpConverter {
                                  nvinfer1::ElementWiseOperation::kSUM);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "celu", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "celu", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/clip_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/clip_op.cc
@@ -39,7 +39,7 @@ class ClipOpConverter : public OpConverter {
     layer->setBeta(max);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "clip", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "clip", {output_name}, test_mode);
 #else
     PADDLE_THROW(
         platform::errors::Fatal("clip TRT converter is only supported on TRT "

--- a/paddle/fluid/inference/tensorrt/convert/concat_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/concat_op.cc
@@ -49,7 +49,7 @@ class ConcatOpConverter : public OpConverter {
         engine_, Concatenation, itensors.data(), itensors.size());
     layer->setAxis(axis);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "concat", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "concat", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/cross_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/cross_multihead_matmul_op.cc
@@ -265,7 +265,7 @@ class CrossMultiheadMatMulOpConverter : public OpConverter {
         ("shuffle_last_multihead_matmul(Output: " + output_name + ")").c_str());
     // return
     layer = reshape_after_mha_layer;
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "cross_multihead_matmul", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/cumsum_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/cumsum_op.cc
@@ -45,7 +45,7 @@ class CumsumOpConverter : public OpConverter {
         cumsum_dim.d[0] = 1;
       }
       layer->setReshapeDimensions(cumsum_dim);
-      RreplenishLayerAndOutput(layer, "cumsum", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "cumsum", {output_name}, test_mode);
     } else {
       int axis = 0;
       if (op_desc.HasAttr("axis")) {
@@ -161,7 +161,7 @@ class CumsumOpConverter : public OpConverter {
       nvinfer1::ILoopOutputLayer* loopOut =
           loop->addLoopOutput(*curSum->getOutput(0), reverseFlag, axis);
       loopOut->setInput(1, *tripLimit);
-      RreplenishLayerAndOutput(loopOut, "cumsum", {output_name}, test_mode);
+      ReplenishLayerAndOutput(loopOut, "cumsum", {output_name}, test_mode);
     }
 #else
     VLOG(3) << "Cumsum is not supported when TensorRT < 7.2.2";

--- a/paddle/fluid/inference/tensorrt/convert/deformable_conv_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/deformable_conv_op.cc
@@ -105,7 +105,7 @@ class DeformableConvOpConverter : public OpConverter {
       std::vector<std::string> output_names;
       output_names.push_back(op_desc.Output("Output").front());
 
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           deformable_conv_layer, "deformable_conv", output_names, test_mode);
     } else {
       auto* deformable_conv_plugin = new plugin::DeformableConvPluginDynamic(
@@ -133,7 +133,7 @@ class DeformableConvOpConverter : public OpConverter {
       std::vector<std::string> output_names;
       output_names.push_back(op_desc.Output("Output").front());
 
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           deformable_conv_layer, "deformable_conv", output_names, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/dequantize_linear_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/dequantize_linear_op.cc
@@ -49,7 +49,7 @@ class DequantizeLinearOpConverter : public OpConverter {
       layer->setAxis(axis);
     }
     auto output_name = op_desc.Output("Y")[0];
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "dequantize_linear", {output_name}, test_model);
 #else
     PADDLE_THROW(

--- a/paddle/fluid/inference/tensorrt/convert/dropout_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/dropout_op.cc
@@ -43,7 +43,7 @@ class DropoutOpConverter : public OpConverter {
         downgrade_in_infer == "upscale_in_train") {
       auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input1);
       auto output_name = op_desc.Output("Out")[0];
-      RreplenishLayerAndOutput(layer, "dropout", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "dropout", {output_name}, test_mode);
       return;
     }
 
@@ -75,7 +75,7 @@ class DropoutOpConverter : public OpConverter {
                         std::move(weight_tensor));
     auto output_name = op_desc.Output("Out")[0];
 
-    RreplenishLayerAndOutput(layer, "dropout", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "dropout", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/einsum_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/einsum_op.cc
@@ -39,7 +39,7 @@ class EinsumOpConverter : public OpConverter {
         engine_, Einsum, input_tensors.data(), input_num, equation.c_str());
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "einsum", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "einsum", {output_name}, test_mode);
 #else
     VLOG(3) << "Einsum is not supported when TensorRT < 8.2.0";
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -162,7 +162,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
                                          *(less_layer->getOutput(0)),
                                          *(equal_layer->getOutput(0)),
                                          nvinfer1::ElementWiseOperation::kOR);
-      RreplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
     } else if (op_type_ == "greater_equal") {
       auto* greater_layer =
           TRT_ENGINE_ADD_LAYER(engine_,
@@ -181,7 +181,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
                                          *(greater_layer->getOutput(0)),
                                          *(equal_layer->getOutput(0)),
                                          nvinfer1::ElementWiseOperation::kOR);
-      RreplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
     } else if (op_type_ == "mod") {
       auto* div_layer =
           TRT_ENGINE_ADD_LAYER(engine_,
@@ -203,7 +203,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
                                          *(mul_layer->getOutput(0)),
                                          nvinfer1::ElementWiseOperation::kSUB);
       SupportFP32MixPrecision(output_name, op_desc.Type(), layer);
-      RreplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
     } else {
       auto op_pair = ops.find(op_type_);
       PADDLE_ENFORCE_NE(
@@ -217,7 +217,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
       auto* layer = TRT_ENGINE_ADD_LAYER(
           engine_, ElementWise, *X, *reshape_y_tensor, op_pair->second);
       SupportFP32MixPrecision(output_name, op_desc.Type(), layer);
-      RreplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
     }
   }
 
@@ -350,7 +350,7 @@ class PowOpConverter : public OpConverter {
     auto* layer = TRT_ENGINE_ADD_LAYER(
         engine_, ElementWise, *X, *Y, nvinfer1::ElementWiseOperation::kPOW);
     SupportFP32MixPrecision(output_name, op_desc.Type(), layer);
-    RreplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "elementwise", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/elementwiseadd_transpose_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwiseadd_transpose_op.cc
@@ -40,10 +40,10 @@ class ElementwiseaddTransposeOpConverter : public OpConverter {
           engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
       std::vector<std::string> output_names;
       output_names.emplace_back(op_desc.Output("Out").front());
-      RreplenishLayerAndOutput(elementwise_layer,
-                               "fuse_elementwiseadd_transpose",
-                               output_names,
-                               test_mode);
+      ReplenishLayerAndOutput(elementwise_layer,
+                              "fuse_elementwiseadd_transpose",
+                              output_names,
+                              test_mode);
     }
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc
@@ -171,12 +171,12 @@ class EmbEltwiseLayerNormOpConverter : public OpConverter {
       } else {
         layer = plugin_layer;
         auto output_name = op_desc.Output("Out")[0];
-        RreplenishLayerAndOutput(layer,
-                                 "ManyEmbLayerNormVarlenPluginDynamicV1",
-                                 {output_name,
-                                  std::string("qkv_plugin_mask"),
-                                  std::string("max_seqlen_tensor")},
-                                 test_mode);
+        ReplenishLayerAndOutput(layer,
+                                "ManyEmbLayerNormVarlenPluginDynamicV1",
+                                {output_name,
+                                 std::string("qkv_plugin_mask"),
+                                 std::string("max_seqlen_tensor")},
+                                test_mode);
       }
     } else {
       for (int i = 0; i < input_num; i++) {
@@ -247,7 +247,7 @@ class EmbEltwiseLayerNormOpConverter : public OpConverter {
       }
       layer = plugin_layer;
       auto output_name = op_desc.Output("Out")[0];
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           layer, "ManyEmbLayerNormPluginDynamicV1", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/equal_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/equal_op.cc
@@ -68,7 +68,7 @@ class EqualOpConverter : public OpConverter {
 
     layer = TRT_ENGINE_ADD_LAYER(
         engine_, ElementWise, *X, *Y, nvinfer1::ElementWiseOperation::kEQUAL);
-    RreplenishLayerAndOutput(layer, "equal", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "equal", {output_name}, test_mode);
   }
 };
 
@@ -125,7 +125,7 @@ class NotEqualOpConverter : public OpConverter {
     layer = TRT_ENGINE_ADD_LAYER(
         engine_, Unary, *layer->getOutput(0), nvinfer1::UnaryOperation::kNOT);
 
-    RreplenishLayerAndOutput(layer, "not_equal", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "not_equal", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/expand_v2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/expand_v2_op.cc
@@ -113,7 +113,7 @@ class ExpandOpConverter : public OpConverter {
     layer->setInput(2, *sizes_tensor);
     layer->setInput(3, *strides_tensor);
 
-    RreplenishLayerAndOutput(layer, op_type_, {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, op_type_, {output_name}, test_mode);
   }
 
  protected:

--- a/paddle/fluid/inference/tensorrt/convert/fill_any_like_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_any_like_op.cc
@@ -77,7 +77,7 @@ class FillAnyLikeOpConverter : public OpConverter {
     layer->setInput(2, *sizes_tensor);
     layer->setInput(3, *strides_tensor);
 
-    RreplenishLayerAndOutput(layer, "fill_any_like", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "fill_any_like", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/fill_constant_batch_size_like_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_constant_batch_size_like_op.cc
@@ -76,7 +76,7 @@ class FillConstantBatchSizeLikeOpConverter : public OpConverter {
     layer->setInput(1, *Add1DConstantLayer(value_vec, name + "alpha", true));
     layer->setInput(2, *Add1DConstantLayer(beta_vec, name + "beta", false));
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "fill_constant_batch_size_like", {output_name}, test_mode);
 #endif
   }

--- a/paddle/fluid/inference/tensorrt/convert/fill_constant_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_constant_op.cc
@@ -120,7 +120,7 @@ class FillConstantOpConverter : public OpConverter {
           TRT_ENGINE_ADD_LAYER(engine_, Constant, trt_in_shape, weight.get());
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "fill_constant", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "fill_constant", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/flash_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flash_multihead_matmul_op.cc
@@ -239,7 +239,7 @@ class FlashMultiheadMatMulOpConverter : public OpConverter {
     reshape_after_mha_layer->setName(
         ("shuffle_last_multihead_matmul(Output: " + output_name + ")").c_str());
     layer = reshape_after_mha_layer;
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "flash_multihead_matmul", {output_name}, test_mode);
   }
 
@@ -444,7 +444,7 @@ class FlashMultiheadMatMulOpConverter : public OpConverter {
          ")")
             .c_str());
     std::vector<std::string> output_names = {output_name};
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         reshape_after_attention_layer, op_desc.Type(), output_names, test_mode);
   }
 

--- a/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
@@ -169,7 +169,7 @@ class FlattenContiguousRangeOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "flatten_contiguous_range", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
@@ -88,7 +88,7 @@ class FlattenOpConverter : public OpConverter {
       layer->setInput(1, *(concat_layer->getOutput(0)));
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "flatten", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "flatten", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/flip_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flip_op.cc
@@ -72,7 +72,7 @@ class FlipOpConverter : public OpConverter {
 
     auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Identity, *input);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "flip", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "flip", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/gather_nd_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gather_nd_op.cc
@@ -36,7 +36,7 @@ class GatherNdOpConverter : public OpConverter {
     auto layer = TRT_ENGINE_ADD_LAYER(
         engine_, GatherV2, *input, *index, nvinfer1::GatherMode::kND);
     layer->setNbElementWiseDims(0);
-    RreplenishLayerAndOutput(layer, "gather_nd", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "gather_nd", {output_name}, test_mode);
 #else
     VLOG(4) << "convert a paddle gather_nd op to tensorrt gather_nd plugin";
 

--- a/paddle/fluid/inference/tensorrt/convert/gather_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gather_op.cc
@@ -54,7 +54,7 @@ class GatherOpConverter : public OpConverter {
         engine_, Gather, *input_tensor, *reshape_layer->getOutput(0), axis);
     layer->setNbElementWiseDims(0);
 
-    RreplenishLayerAndOutput(layer, "gather", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "gather", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
@@ -236,7 +236,7 @@ class GeluOpConverter : public OpConverter {
 #endif  // if IS_TRT_VERSION_GE(7000)
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "gelu", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "gelu", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
+++ b/paddle/fluid/inference/tensorrt/convert/generic_and_custom_plugin_creater.cc
@@ -165,7 +165,7 @@ class CustomPluginCreater : public OpConverter {
         output_names.push_back(arg_name);
     }
 
-    RreplenishLayerAndOutput(layer, op_desc.Type(), output_names, test_mode);
+    ReplenishLayerAndOutput(layer, op_desc.Type(), output_names, test_mode);
   }
 };
 
@@ -248,7 +248,7 @@ class GenericPluginCreater : public OpConverter {
         new plugin::GenericPlugin(op, in_out_info, with_fp16);
     layer = engine_->AddDynamicPlugin(inputs.data(), inputs.size(), plugin);
 
-    RreplenishLayerAndOutput(layer, op_desc.Type(), output_names, test_mode);
+    ReplenishLayerAndOutput(layer, op_desc.Type(), output_names, test_mode);
   }
 };
 
@@ -334,7 +334,7 @@ class CustomGenericPluginCreater : public OpConverter {
         inputs.data(), inputs.size(), (plugin::DynamicPluginTensorRT *)plugin);
     CHECK(layer);
 
-    RreplenishLayerAndOutput(layer, op_desc.Type(), outputs, test_mode);
+    ReplenishLayerAndOutput(layer, op_desc.Type(), outputs, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/grid_sampler_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/grid_sampler_op.cc
@@ -66,7 +66,7 @@ class GridSamplerOpConverter : public OpConverter {
     layer->setSampleMode(sampleMode);
     layer->setAlignCorners(align_corners);
 
-    RreplenishLayerAndOutput(layer, "grid_sampler", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "grid_sampler", {output_name}, test_mode);
 #else
     VLOG(3) << "grid_sampler is not supported when TensorRT < 8.5.1";
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/group_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/group_norm_op.cc
@@ -81,7 +81,7 @@ class GroupNormOpConverter : public OpConverter {
       nvinfer1::ILayer* groupnorm_layer =
           engine_->AddDynamicPlugin(&input_itensor, 1, plugin);
       auto output_name = op_desc.Output("Y")[0];
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           groupnorm_layer, "group_norm", {output_name}, test_mode);
     } else {
       int gn_num = input_itensor->getDimensions().d[0] * groups;
@@ -100,7 +100,7 @@ class GroupNormOpConverter : public OpConverter {
       nvinfer1::ILayer* groupnorm_layer =
           engine_->AddPlugin(&input_itensor, 1, plugin);
       auto output_name = op_desc.Output("Y")[0];
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           groupnorm_layer, "group_norm", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/hard_sigmoid_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/hard_sigmoid_op.cc
@@ -40,7 +40,7 @@ class HardSigmoidOpConverter : public OpConverter {
     layer->setBeta(offset);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "hard_sigmoid", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "hard_sigmoid", {output_name}, test_mode);
 #else
     PADDLE_THROW(platform::errors::Fatal(
         "Hard sigmoid TRT converter is only supported on TRT 5 or higher. "

--- a/paddle/fluid/inference/tensorrt/convert/hard_swish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/hard_swish_op.cc
@@ -85,7 +85,7 @@ class HardSwishOpConverter : public OpConverter {
                                    nvinfer1::ElementWiseOperation::kDIV);
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "hard_swish", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "hard_swish", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/index_select_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/index_select_op.cc
@@ -64,7 +64,7 @@ class IndexSelectConverter : public OpConverter {
         engine_, Gather, *input_tensor, *reshape_layer->getOutput(0), axis);
     layer->setNbElementWiseDims(0);
 
-    RreplenishLayerAndOutput(layer, "index_select", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "index_select", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
@@ -73,7 +73,7 @@ class InstanceNormOpConverter : public OpConverter {
         instance_norm_inputs.data(), instance_norm_inputs.size(), *plugin);
 
     auto output_name = op_desc.Output("Y")[0];
-    RreplenishLayerAndOutput(layer, "instance_norm", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "instance_norm", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
@@ -70,7 +70,7 @@ class LayerNormOpConverter : public OpConverter {
       auto layer = TRT_ENGINE_ADD_LAYER(
           engine_, Normalization, *X, *Scale_reshape, *Bias_reshape, axisMask);
       layer->setEpsilon(eps);
-      RreplenishLayerAndOutput(layer, "layer_norm", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "layer_norm", {output_name}, test_mode);
 #endif
 #if IS_TRT_VERSION_LT(8600)
       // For dynamic shape & trt<8.6,
@@ -113,7 +113,7 @@ class LayerNormOpConverter : public OpConverter {
               variance_shape,
               with_fp16);
       layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           layernorm_layer, "layer_norm", {output_name}, test_mode);
 #endif
     } else {
@@ -160,7 +160,7 @@ class LayerNormOpConverter : public OpConverter {
           with_fp16);
       auto* layernorm_layer = engine_->AddPlugin(
           &X, 1, reinterpret_cast<plugin::PluginTensorRT*>(plugin));
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           layernorm_layer, "layer_norm", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/layernorm_shift_partition_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layernorm_shift_partition_op.cc
@@ -96,7 +96,7 @@ class LayerNormShiftPartitionOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Y").front();
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layernorm_layer, "layernorm_shift_partition", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/leaky_relu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/leaky_relu_op.cc
@@ -116,7 +116,7 @@ class LeakyReluOpConverter : public OpConverter {
     engine_->SetWeights(alpha_name, std::move(alpha_tensor));
 #endif
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         output_layer, "leaky_relu", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/logsigmoid_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/logsigmoid_op.cc
@@ -54,7 +54,7 @@ class LogSigmoidOpConverter : public OpConverter {
                                  *(sigmoid->getOutput(0)),
                                  nvinfer1::UnaryOperation::kLOG);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "logsigmoid", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "logsigmoid", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/lookup_table_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/lookup_table_op.cc
@@ -47,7 +47,7 @@ class LookupTableOpConverter : public OpConverter {
 
     auto* gather_layer = TRT_ENGINE_ADD_LAYER(
         engine_, Gather, *w_tensor, *reshape_layer->getOutput(0), 0);
-    RreplenishLayerAndOutput(gather_layer, "gather", {out_name}, test_mode);
+    ReplenishLayerAndOutput(gather_layer, "gather", {out_name}, test_mode);
   }
 };
 
@@ -68,7 +68,7 @@ class LookupTableV2OpConverter : public OpConverter {
 
     auto* gather_layer =
         TRT_ENGINE_ADD_LAYER(engine_, Gather, *w_tensor, *ids_tensor, 0);
-    RreplenishLayerAndOutput(gather_layer, "gather", {out_name}, test_mode);
+    ReplenishLayerAndOutput(gather_layer, "gather", {out_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/matrix_multiply_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matrix_multiply_op.cc
@@ -261,7 +261,7 @@ class MatrixMultiplyOpConverter : public OpConverter {
                                    nvinfer1::ElementWiseOperation::kPROD);
       SupportFP32MixPrecision(output_name, op_desc.Type(), layer);
     }
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "matrix_multiply_op", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/merge_layernorm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/merge_layernorm_op.cc
@@ -76,7 +76,7 @@ class MergeLayernormOpConverter : public OpConverter {
           "mode."));
     }
     auto output_name = op_desc.Output("Y").front();
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         merge_layernorm_layer, "merge_layernorm", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/mish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/mish_op.cc
@@ -54,7 +54,7 @@ class MishOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "mish", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "mish", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/multiclass_nms3_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multiclass_nms3_op.cc
@@ -163,11 +163,11 @@ class MultiClassNMS3OpConverter : public OpConverter {
         nvinfer1::Weights{
             nvinfer1::DataType::kINT32, static_cast<void*>(index.data()), 1});
 
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         batch_nms_layer, "multiclass_nms3", {rois_num_name}, test_mode);
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         nms_concat_layer, "multiclass_nms3", {output_name}, test_mode);
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         constant_layer, "multiclass_nms3", {index_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/multiclass_nms_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multiclass_nms_op.cc
@@ -151,7 +151,7 @@ class MultiClassNMSOpConverter : public OpConverter {
     int axis_index = engine_->with_dynamic_shape() ? 1 : 0;
     nms_concat_layer->setAxis(axis_index + 1);
 
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         nms_concat_layer, "multiclass_nms", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multihead_matmul_op.cc
@@ -253,7 +253,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
               max_seqlen_tensor);  // max_seqlen, eval_placeholder_3
           auto plugin_layer = engine_->network()->addPluginV2(
               plugin_inputs.data(), plugin_inputs.size(), *plugin);
-          RreplenishLayerAndOutput(
+          ReplenishLayerAndOutput(
               plugin_layer, "multihead_matmul", {output_name}, test_mode);
         } else {
           auto* reshape_before_matrix =
@@ -757,7 +757,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
 
           // return
           layer = reshape_after_mha_layer;
-          RreplenishLayerAndOutput(
+          ReplenishLayerAndOutput(
               layer, "multihead_matmul", {output_name}, test_mode);
         } else {
           PADDLE_ENFORCE_EQ(
@@ -867,7 +867,7 @@ class MultiheadMatMulOpConverter : public OpConverter {
               new plugin::QkvToContextPluginDynamic(
                   hidden_in, head_number, head_size, scale, with_fp16);
           layer = engine_->AddDynamicPlugin(plugin_inputs.data(), 2, plugin);
-          RreplenishLayerAndOutput(
+          ReplenishLayerAndOutput(
               layer, "multihead_matmul", {output_name}, test_mode);
         }
       }

--- a/paddle/fluid/inference/tensorrt/convert/multihead_matmul_roformer_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/multihead_matmul_roformer_op.cc
@@ -193,7 +193,7 @@ class MultiheadMatMulRoformerOpConverter : public OpConverter {
           "You can use the config.SetTRTDynamicShapeInfo(...) interface to set "
           "the shape information to run the dynamic shape mode."));
     }
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "multihead_matmul_roformer", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_op.cc
@@ -91,7 +91,7 @@ class NearestInterpolateOpConverter : public OpConverter {
     }
     layer->setScales(scales.data(), scales.size());
 
-    RreplenishLayerAndOutput(layer, "nearest_interp", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "nearest_interp", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
@@ -124,7 +124,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
       layer->setScales(scales.data(), scales.size());
     }
 
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "nearest_interp_v2", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/one_hot_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/one_hot_op.cc
@@ -79,7 +79,7 @@ class OneHotOpConverter : public OpConverter {
         engine_, OneHot, *indices_tensor, *values_tensor, *depth_tensor, -1);
 
     auto output_name = op_desc.Output("Out").front();
-    RreplenishLayerAndOutput(layer, "one_hot", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "one_hot", {output_name}, test_mode);
 #else
     VLOG(3) << "one_hot is not supported when TensorRT < 8.5.1";
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/op_converter.h
+++ b/paddle/fluid/inference/tensorrt/convert/op_converter.h
@@ -760,7 +760,7 @@ class OpConverter {
     return Add1DConstantLayer(input_data, weight_name, scalar);
   }
 
-  void RreplenishLayerAndOutput(
+  void ReplenishLayerAndOutput(
       nvinfer1::ILayer* layer,
       const std::string& layer_type,
       const std::vector<std::string>& output_tensor_names,

--- a/paddle/fluid/inference/tensorrt/convert/pad3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pad3d_op.cc
@@ -168,7 +168,7 @@ class Pad3dOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(slice_layer, "pad3d", {output_name}, test_mode);
+    ReplenishLayerAndOutput(slice_layer, "pad3d", {output_name}, test_mode);
 
 #else
     VLOG(3) << "pad3d is not supported when TensorRT < 8.2";

--- a/paddle/fluid/inference/tensorrt/convert/pad_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pad_op.cc
@@ -50,7 +50,7 @@ class PadOpConverter : public OpConverter {
                             platform::errors::External(
                                 "add padding layer to tensorrt engine error"));
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "pad", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "pad", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
@@ -370,7 +370,7 @@ class Pool2dOpConverter : public OpConverter {
       layer = pool_layer;
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "pool2d", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "pool2d", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
@@ -224,7 +224,7 @@ class Pool3dOpConverter : public OpConverter {
       layer = pool_layer;
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "pool3d", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "pool3d", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/preln_groupnorm_act_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_groupnorm_act_op.cc
@@ -74,7 +74,7 @@ class PrelnGroupnormActOpConverter : public OpConverter {
       std::vector<std::string> output_names;
       output_names.emplace_back(op_desc.Output("Out_0").front());
       output_names.emplace_back(op_desc.Output("Out_1").front());
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           groupnorm_layer, "preln_groupnorm_act", output_names, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/preln_layernorm_shift_partition_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_layernorm_shift_partition_op.cc
@@ -76,10 +76,10 @@ class PrelnLayerNormShiftPartitionOpConverter : public OpConverter {
     std::vector<std::string> output_names;
     output_names.emplace_back(op_desc.Output("Out_0").front());
     output_names.emplace_back(op_desc.Output("Out_1").front());
-    RreplenishLayerAndOutput(layernorm_layer,
-                             "preln_layernorm_shift_partition",
-                             output_names,
-                             test_mode);
+    ReplenishLayerAndOutput(layernorm_layer,
+                            "preln_layernorm_shift_partition",
+                            output_names,
+                            test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/preln_residual_bias.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_residual_bias.cc
@@ -100,7 +100,7 @@ class PrelnResidualBiasOpConverter : public OpConverter {
     std::vector<std::string> output_names;
     output_names.push_back(op_desc.Output("Y")[0]);
     output_names.push_back(op_desc.Output("BiasDropoutResidualOut")[0]);
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "preln_residual_bias", output_names, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/preln_skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/preln_skip_layernorm.cc
@@ -100,7 +100,7 @@ class PrelnSkipLayerNormOpConverter : public OpConverter {
     std::vector<std::string> output_names;
     output_names.push_back(op_desc.Output("Out_0")[0]);
     output_names.push_back(op_desc.Output("Out_1")[0]);
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "preln_skip_layernorm", {output_names}, test_mode);
 #else
     PADDLE_THROW(platform::errors::Fatal(

--- a/paddle/fluid/inference/tensorrt/convert/prelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/prelu_op.cc
@@ -120,7 +120,7 @@ class PReluOpConverter : public OpConverter {
         engine_, ParametricReLU, *input, *real_alpha_tensor);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "prelu", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "prelu", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/prompt_tuning_emb_eltwise_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/prompt_tuning_emb_eltwise_layernorm.cc
@@ -159,14 +159,14 @@ class PromptTuningEmbEltwiseLayerNormOpConverter : public OpConverter {
     engine_->DeleteITensor("pos_id", engine_->GetITensor("pos_id"));
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(plugin_layer,
-                             "PromptTuningEmbLayerNormVarlenPluginDynamicV1",
-                             {output_name,
-                              std::string("qkv_plugin_mask"),
-                              std::string("max_seqlen_tensor"),
-                              std::string("mask_id"),
-                              std::string("pos_id")},
-                             test_mode);
+    ReplenishLayerAndOutput(plugin_layer,
+                            "PromptTuningEmbLayerNormVarlenPluginDynamicV1",
+                            {output_name,
+                             std::string("qkv_plugin_mask"),
+                             std::string("max_seqlen_tensor"),
+                             std::string("mask_id"),
+                             std::string("pos_id")},
+                            test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/qk_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/qk_multihead_matmul_op.cc
@@ -289,7 +289,7 @@ class QkMultiheadMatMulOpConverter : public OpConverter {
         ("shuffle_last_multihead_matmul(Output: " + output_name + ")").c_str());
     nvinfer1::ILayer* layer = nullptr;
     layer = reshape_after_mha_layer;
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "qk_multihead_matmul", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/quantize_linear_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/quantize_linear_op.cc
@@ -50,7 +50,7 @@ class QuantizeLinearOpConverter : public OpConverter {
       layer->setAxis(axis);
     }
     auto output_name = op_desc.Output("Y")[0];
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "quantize_linear", {output_name}, test_model);
 #else
     PADDLE_THROW(

--- a/paddle/fluid/inference/tensorrt/convert/range_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/range_op.cc
@@ -59,7 +59,7 @@ class RangeOpConverter : public OpConverter {
     layer->setInput(1, *start1);
     layer->setInput(2, *step);
 
-    RreplenishLayerAndOutput(layer, "range", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "range", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/recover_padding_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/recover_padding_op.cc
@@ -66,8 +66,7 @@ class RecoverPadding : public OpConverter {
     plugin::RecoverPaddingPlugin* plugin = new plugin::RecoverPaddingPlugin();
     nvinfer1::ILayer* layer =
         engine_->AddDynamicPlugin(plugin_inputs.data(), input_num, plugin);
-    RreplenishLayerAndOutput(
-        layer, "recover_padding", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "recover_padding", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/reduce_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reduce_op.cc
@@ -94,7 +94,7 @@ class ReduceOpConverter : public OpConverter {
     auto output_name = op_desc.Output("Out")[0];
     // Ensure that the output type and input type are consistent.
     layer->getOutput(0)->setType(layer->getInput(0)->getType());
-    RreplenishLayerAndOutput(layer, op_type, {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, op_type, {output_name}, test_mode);
   }
 
  protected:
@@ -216,7 +216,7 @@ class ReduceAnyOpConverter : public ReduceOpConverter {
     // Ensure that the output type and input type are consistent.
     layer->getOutput(0)->setType(cast_layer->getInput(0)->getType());
 
-    RreplenishLayerAndOutput(layer, op_type, {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, op_type, {output_name}, test_mode);
   };
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/reshape_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reshape_op.cc
@@ -73,7 +73,7 @@ class ReshapeOpConverter : public OpConverter {
             "reshape2 op into "
             "Paddle-TRT."));
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "reshape", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "reshape", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/reverse_roll_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reverse_roll_op.cc
@@ -68,7 +68,7 @@ class ReverseRollOpConverter : public OpConverter {
           "ReverseROll TRT Plugin should run in dynamic shape."));
     }
     auto output_name = op_desc.Output("Out").front();
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         reverse_roll_layer, "reverse_roll", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/rnn_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/rnn_op.cc
@@ -303,7 +303,7 @@ class RnnNativeOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(finally_layer, "rnn", {output_name}, test_mode);
+    ReplenishLayerAndOutput(finally_layer, "rnn", {output_name}, test_mode);
     // free
     if (is_bidirec) {
       for (auto& weight_bias : weight_bias_vec) delete[] weight_bias;

--- a/paddle/fluid/inference/tensorrt/convert/roi_align_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/roi_align_op.cc
@@ -65,7 +65,7 @@ class RoiAlignOpConverter : public OpConverter {
     layer = roi_align_layer;
 
     std::vector<std::string> output_names{output_name};
-    RreplenishLayerAndOutput(layer, "roi_align", output_names, test_mode);
+    ReplenishLayerAndOutput(layer, "roi_align", output_names, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/roll_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/roll_op.cc
@@ -87,7 +87,7 @@ class RollOpConverter : public OpConverter {
       }
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "roll", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "roll", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/scale_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/scale_op.cc
@@ -218,7 +218,7 @@ class ScaleOpConverter : public OpConverter {
             ("Scale: Shuffle_reshape (Output: " + out_name + ")").c_str());
       }
     }
-    RreplenishLayerAndOutput(layer, "scale", {out_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "scale", {out_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/set_value_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/set_value_op.cc
@@ -249,7 +249,7 @@ class SetValueConverter : public OpConverter {
 
       layer->setAxis(axes);
 
-      RreplenishLayerAndOutput(layer, "set_value", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "set_value", {output_name}, test_mode);
     } else {
       PADDLE_THROW(platform::errors::Fatal(
           "static shape mode not supported in set value yet"));

--- a/paddle/fluid/inference/tensorrt/convert/shape_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shape_op.cc
@@ -30,7 +30,7 @@ class ShapeOpConverter : public OpConverter {
     auto* input = engine_->GetITensor(op_desc.Input("Input")[0]);
     nvinfer1::ILayer* layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "shape", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "shape", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/share_data_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/share_data_op.cc
@@ -28,7 +28,7 @@ class ShareDataOpConverter : public OpConverter {
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
     auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Identity, *input);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "share_data", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "share_data", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
@@ -60,7 +60,7 @@ class ShuffleChannelOpConverter : public OpConverter {
       auto* output_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
       output_layer->setInput(1, *input_shape_tensor);
 
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           output_layer, "shuffle_channel", {output_name}, test_mode);
     }
 #endif
@@ -79,7 +79,7 @@ class ShuffleChannelOpConverter : public OpConverter {
       nvinfer1::Dims3 reshape_dim2(c, h, w);
       reshape_layer->setReshapeDimensions(reshape_dim2);
 
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           reshape_layer, "shuffle_channel", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/silu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/silu_op.cc
@@ -56,7 +56,7 @@ class SiluOpConverter : public OpConverter {
                                  nvinfer1::ElementWiseOperation::kPROD);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "silu", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "silu", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/size_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/size_op.cc
@@ -39,7 +39,7 @@ class SizeOpConverter : public OpConverter {
                                        reduce_dim,
                                        false);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "size", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "size", {output_name}, test_mode);
   }
 };
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/convert/skip_groupnorm_act_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_groupnorm_act_op.cc
@@ -70,7 +70,7 @@ class SkipGroupnormActOpConverter : public OpConverter {
       nvinfer1::ILayer* groupnorm_layer =
           engine_->AddDynamicPlugin(inputs.data(), 2, plugin);
       auto output_name = op_desc.Output("Out")[0];
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           groupnorm_layer, "skip_groupnorm_act", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -257,7 +257,7 @@ class SkipLayerNormOpConverter : public OpConverter {
         layer = plugin_layer;
       }
     }
-    RreplenishLayerAndOutput(layer, "skip_layernorm", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "skip_layernorm", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/skip_merge_layernorm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_merge_layernorm_op.cc
@@ -80,10 +80,10 @@ class SkipMergeLayernormOpConverter : public OpConverter {
           "mode."));
     }
     auto output_name = op_desc.Output("Out").front();
-    RreplenishLayerAndOutput(skip_merge_layernorm_layer,
-                             "skip_merge_layernorm",
-                             {output_name},
-                             test_mode);
+    ReplenishLayerAndOutput(skip_merge_layernorm_layer,
+                            "skip_merge_layernorm",
+                            {output_name},
+                            test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/slice_op.cc
@@ -217,7 +217,7 @@ class SliceOpConverter : public OpConverter {
         layer = static_cast<nvinfer1::ILayer*>(reshape_layer);
       }
     }
-    RreplenishLayerAndOutput(layer, "slice", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "slice", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/softmax_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/softmax_op.cc
@@ -92,10 +92,10 @@ class SoftMaxOpConverter : public OpConverter {
           TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *layer->getOutput(0));
       reshaped_layer->setReshapeDimensions(
           engine_->GetITensor(op_desc.Input("X")[0])->getDimensions());
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           reshaped_layer, "reshape_softmax_reshape", {output_name}, test_mode);
     } else {
-      RreplenishLayerAndOutput(layer, "softmax", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "softmax", {output_name}, test_mode);
     }
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/sparse_fc_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/sparse_fc_op.cc
@@ -203,15 +203,15 @@ class SparseFcOpConverter : public OpConverter {
                                    Activation,
                                    *(fc_layer_int8->getOutput(0)),
                                    nvinfer1::ActivationType::kRELU);
-          RreplenishLayerAndOutput(relu_layer_int8,
-                                   "relu_after_ernie_fc_int8",
-                                   {output_name},
-                                   test_mode);
+          ReplenishLayerAndOutput(relu_layer_int8,
+                                  "relu_after_ernie_fc_int8",
+                                  {output_name},
+                                  test_mode);
         } else {
-          RreplenishLayerAndOutput(fc_layer_int8,
-                                   "ernie_fc_op_int8: Convolution",
-                                   {output_name},
-                                   test_mode);
+          ReplenishLayerAndOutput(fc_layer_int8,
+                                  "ernie_fc_op_int8: Convolution",
+                                  {output_name},
+                                  test_mode);
         }
       } else {
         // add fc layer
@@ -225,12 +225,12 @@ class SparseFcOpConverter : public OpConverter {
                                    Activation,
                                    *(fc_layer_float->getOutput(0)),
                                    nvinfer1::ActivationType::kRELU);
-          RreplenishLayerAndOutput(relu_layer_float,
-                                   "relu_after_ernie_fc_float",
-                                   {output_name},
-                                   test_mode);
+          ReplenishLayerAndOutput(relu_layer_float,
+                                  "relu_after_ernie_fc_float",
+                                  {output_name},
+                                  test_mode);
         } else {
-          RreplenishLayerAndOutput(
+          ReplenishLayerAndOutput(
               fc_layer_float, "ernie_fc_op_float", {output_name}, test_mode);
         }
       }
@@ -264,10 +264,10 @@ class SparseFcOpConverter : public OpConverter {
         auto* fc_after_reshape_int8 = reshape_after_fc(
             fc_layer_int8->getOutput(0), x_dim, x_num_col_dims);
 
-        RreplenishLayerAndOutput(fc_after_reshape_int8,
-                                 "sparse_fc_op_int8_reshape_after_fc: Shuffle",
-                                 {output_name},
-                                 test_mode);
+        ReplenishLayerAndOutput(fc_after_reshape_int8,
+                                "sparse_fc_op_int8_reshape_after_fc: Shuffle",
+                                {output_name},
+                                test_mode);
       } else {
         plugin::SpmmPluginDynamic* plugin = new_spmm_plugin(
             weight,
@@ -285,10 +285,10 @@ class SparseFcOpConverter : public OpConverter {
         auto* fc_after_reshape_float = reshape_after_fc(
             fc_layer_float->getOutput(0), x_dim, x_num_col_dims);
 
-        RreplenishLayerAndOutput(fc_after_reshape_float,
-                                 "shuffle_after_sparse_fc",
-                                 {output_name},
-                                 test_mode);
+        ReplenishLayerAndOutput(fc_after_reshape_float,
+                                "shuffle_after_sparse_fc",
+                                {output_name},
+                                test_mode);
       }
     };
 

--- a/paddle/fluid/inference/tensorrt/convert/sparse_multihead_matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/sparse_multihead_matmul_op.cc
@@ -431,7 +431,7 @@ class SparseMultiheadMatMulOpConverter : public OpConverter {
           "You can use the config.SetTRTDynamicShapeInfo(...) interface to set "
           "the shape information to run the dynamic shape mode."));
     }
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         layer, "multihead_matmul", {output_name}, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/split_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/split_op.cc
@@ -127,7 +127,7 @@ class SplitOpConverter : public OpConverter {
         layer->setInput(3, *stride_tensor);
 
         auto output_name = op_desc.Output("Out")[i];
-        RreplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
+        ReplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
       }
     } else {
       auto chw_input_dims = input->getDimensions();
@@ -151,7 +151,7 @@ class SplitOpConverter : public OpConverter {
                                      trt_size_dims,
                                      trt_step_dims);
         auto output_name = op_desc.Output("Out")[i];
-        RreplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
+        ReplenishLayerAndOutput(layer, "split", {output_name}, test_mode);
       }
     }
 #else
@@ -172,7 +172,7 @@ class SplitOpConverter : public OpConverter {
     for (int i = 0; i < output_num; i++) {
       output_names.push_back(op_desc.Output("Out")[i]);
     }
-    RreplenishLayerAndOutput(layer, "split", output_names, test_mode);
+    ReplenishLayerAndOutput(layer, "split", output_names, test_mode);
 #endif
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/square_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/square_op.cc
@@ -36,7 +36,7 @@ class SquareOpConverter : public OpConverter {
                                        nvinfer1::ElementWiseOperation::kPROD);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "square", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "square", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/squeeze2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/squeeze2_op.cc
@@ -85,7 +85,7 @@ class Squeeze2OpConverter : public OpConverter {
     } else {
       layer->setReshapeDimensions(trt_out_dims);
     }
-    RreplenishLayerAndOutput(layer, "squeeze2", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "squeeze2", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/stack_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/stack_op.cc
@@ -76,7 +76,7 @@ class StackOpConverter : public OpConverter {
         engine_, Concatenation, inputs.data(), inputs.size());
     layer->setAxis(axis);
 
-    RreplenishLayerAndOutput(layer, "stack", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "stack", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/strided_slice_op.cc
@@ -180,7 +180,7 @@ class StridedSliceOpConverter : public OpConverter {
         layer = static_cast<nvinfer1::ILayer*>(reshape_layer);
       }
     }
-    RreplenishLayerAndOutput(layer, "strided_slice", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "strided_slice", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/sum_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/sum_op.cc
@@ -43,7 +43,7 @@ class SumOpConverter : public OpConverter {
       }
     }
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "sum", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "sum", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/swish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/swish_op.cc
@@ -74,7 +74,7 @@ class SwishOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "swish", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "swish", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/take_along_axis_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/take_along_axis_op.cc
@@ -49,8 +49,7 @@ class TakeAlongAxisOpConverter : public OpConverter {
                                       nvinfer1::GatherMode::kELEMENT);
     layer->setGatherAxis(axis);
 
-    RreplenishLayerAndOutput(
-        layer, "take_along_axis", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "take_along_axis", {output_name}, test_mode);
 #endif
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/tanhshrink_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/tanhshrink_op.cc
@@ -55,7 +55,7 @@ class TanhshrinkOpConverter : public OpConverter {
                                  *(tanh->getOutput(0)),
                                  nvinfer1::ElementWiseOperation::kSUB);
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "tanh_shrink", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "tanh_shrink", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/temporal_shift_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/temporal_shift_op.cc
@@ -205,10 +205,10 @@ class TemporalShiftOpConverter : public OpConverter {
           TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *reshape_layer3->getOutput(0));
       nvinfer1::Permutation permute_order{0, 2, 3, 1};
       transpose_layer2->setFirstTranspose(permute_order);
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           transpose_layer2, "temporal_shift", {output_name}, test_mode);
     } else {
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           reshape_layer3, "temporal_shift", {output_name}, test_mode);
     }
 #else

--- a/paddle/fluid/inference/tensorrt/convert/tile_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/tile_op.cc
@@ -91,7 +91,7 @@ class TileOpConverter : public OpConverter {
       layer->setInput(2, *output_shape_tensor);
       layer->setInput(3, *stride_tensor);
       layer->setMode(nvinfer1::SliceMode::kWRAP);
-      RreplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
 
     } else {
       std::vector<int> repeat_times =
@@ -122,7 +122,7 @@ class TileOpConverter : public OpConverter {
       auto layer = TRT_ENGINE_ADD_LAYER(
           engine_, Slice, *input, input_shape, output_dim, output_stride);
       layer->setMode(nvinfer1::SliceMode::kWRAP);
-      RreplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
+      ReplenishLayerAndOutput(layer, "tile", {output_name}, test_mode);
     }
 
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/trans_layernorm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/trans_layernorm_op.cc
@@ -77,10 +77,10 @@ class TransLayerNormOpConverter : public OpConverter {
 
     auto output_layernorm_name = op_desc.Output("Out_layernorm").front();
     auto output_reshape_name = op_desc.Output("Out_reshape").front();
-    RreplenishLayerAndOutput(layernorm_layer,
-                             "trans_layernorm",
-                             {output_layernorm_name, output_reshape_name},
-                             test_mode);
+    ReplenishLayerAndOutput(layernorm_layer,
+                            "trans_layernorm",
+                            {output_layernorm_name, output_reshape_name},
+                            test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/transformer_input_convert_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/transformer_input_convert_op.cc
@@ -51,10 +51,10 @@ class TransformerInputConvert : public OpConverter {
     nvinfer1::ILayer* layer =
         engine_->AddDynamicPlugin(&input, input_num, plugin);
 
-    RreplenishLayerAndOutput(layer,
-                             "transformer_input_convert",
-                             {pos_id_name, max_seqlen_name},
-                             test_mode);
+    ReplenishLayerAndOutput(layer,
+                            "transformer_input_convert",
+                            {pos_id_name, max_seqlen_name},
+                            test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/transpose_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/transpose_op.cc
@@ -44,7 +44,7 @@ class TransposeOpConverter : public OpConverter {
     layer->setFirstTranspose(perm);
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, "transpose", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "transpose", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/unary_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/unary_op.cc
@@ -70,7 +70,7 @@ class UnaryOpConverter : public OpConverter {
     }
 
     auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(layer, op_type_, {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, op_type_, {output_name}, test_mode);
   }
 
  protected:

--- a/paddle/fluid/inference/tensorrt/convert/unbind_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/unbind_op.cc
@@ -74,7 +74,7 @@ class UnbindOpConverter : public OpConverter {
       auto inputReshaped =
           TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *inputSliced_out);
       inputReshaped->setInput(1, *newDims_tensor);
-      RreplenishLayerAndOutput(
+      ReplenishLayerAndOutput(
           inputReshaped, "unbind", {output_name}, test_mode);
     }
   }

--- a/paddle/fluid/inference/tensorrt/convert/unsqueeze2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/unsqueeze2_op.cc
@@ -90,7 +90,7 @@ class Unsqueeze2OpConverter : public OpConverter {
     } else {
       layer->setReshapeDimensions(trt_out_dims);
     }
-    RreplenishLayerAndOutput(layer, "unsqueeze2", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "unsqueeze2", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/where_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/where_op.cc
@@ -41,7 +41,7 @@ class WhereOpConverter : public OpConverter {
     auto layer = TRT_ENGINE_ADD_LAYER(
         engine_, Select, *condition_tensor, *input_x_tensor, *input_y_tensor);
 
-    RreplenishLayerAndOutput(layer, "where", {output_name}, test_mode);
+    ReplenishLayerAndOutput(layer, "where", {output_name}, test_mode);
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/yolo_box_head_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/yolo_box_head_op.cc
@@ -45,7 +45,7 @@ class YoloBoxHeadOpConverter : public OpConverter {
         yolo_box_inputs.data(), yolo_box_inputs.size(), *yolo_box_plugin);
     std::vector<std::string> output_names;
     output_names.push_back(op_desc.Output("Out").front());
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         yolo_box_head_layer, "yolo_box_head", output_names, test_mode);
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/yolo_box_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/yolo_box_op.cc
@@ -75,7 +75,7 @@ class YoloBoxOpConverter : public OpConverter {
     output_names.push_back(op_desc.Output("Boxes").front());
     output_names.push_back(op_desc.Output("Scores").front());
 
-    RreplenishLayerAndOutput(
+    ReplenishLayerAndOutput(
         yolo_box_layer, "yolo_box", output_names, test_mode);
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Fix RreplenishLayerAndOutput ReplenishLayerAndOutput