### PR TITLE
[PIR] pir onednn support reshape, flatten, squeeze

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -84,7 +84,7 @@ def OpNameNormalizerInitialization(
                     if k == 'tensor_name' or k == 'tensors_name':
                         op_mutable_attribute_infos[op_name][
                             attribute_name
-                        ].append(v)
+                        ].insert(0, v)
 
         _, legacy_name = insert_new_mappings(op_compat_item["op"])
         legacy_backward_op_names = []

--- a/paddle/fluid/operators/mkldnn/reshape_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/reshape_mkldnn_op.cc
@@ -20,10 +20,8 @@ limitations under the License. */
 namespace {
 enum class ReshapeKernelOpName {
   reshape,
-  reshape2,
   squeeze,
   flatten,
-  flatten2,
 };
 }  // anonymous namespace
 
@@ -105,9 +103,6 @@ class ReshapeMKLDNNKernel : public framework::OpKernel<T> {
         InferShapeSqueezeOp(ctx, x_dims, out_dims);
         break;
       case ReshapeKernelOpName::flatten:
-      case ReshapeKernelOpName::flatten2:
-        InferShapeFlattenOp(ctx, x_dims, out_dims);
-        break;
       default:
         PADDLE_THROW(paddle::platform::errors::OutOfRange(
             "Reshape kernel doesn not support that operator name"));
@@ -317,17 +312,11 @@ class ReshapeGradMKLDNNKernel : public ReshapeMKLDNNKernel<T, op_name> {
       case ReshapeKernelOpName::reshape:
         InferShapeReshapeSqueezeGradOp(ctx, x_dims);
         break;
-      case ReshapeKernelOpName::reshape2:
-        InferShapeReshape2Flatten2GradOp(ctx, x_dims);
-        break;
       case ReshapeKernelOpName::squeeze:
         InferShapeReshapeSqueezeGradOp(ctx, x_dims);
         break;
       case ReshapeKernelOpName::flatten:
         InferShapeFlattenGradOp(ctx, x_dims);
-        break;
-      case ReshapeKernelOpName::flatten2:
-        InferShapeReshape2Flatten2GradOp(ctx, x_dims);
         break;
       default:
         PADDLE_THROW(paddle::platform::errors::OutOfRange(
@@ -340,13 +329,6 @@ class ReshapeGradMKLDNNKernel : public ReshapeMKLDNNKernel<T, op_name> {
       framework::DDim& dx_dims) const {  // NOLINT
     auto* dx = ctx.Output<phi::DenseTensor>(framework::GradVarName("X"));
     dx_dims = dx->dims();
-  }
-
-  void InferShapeReshape2Flatten2GradOp(
-      const framework::ExecutionContext& ctx,
-      framework::DDim& dx_dims) const {  // NOLINT
-    auto xshape_dims = ctx.Input<phi::DenseTensor>("XShape")->dims();
-    dx_dims = common::slice_ddim(xshape_dims, 1, xshape_dims.size());
   }
 
   void InferShapeFlattenGradOp(const framework::ExecutionContext& ctx,
@@ -391,14 +373,6 @@ REGISTER_OP_KERNEL(
                                  ReshapeKernelOpName::reshape>);
 
 REGISTER_OP_KERNEL(
-    reshape2_grad,
-    MKLDNN,
-    phi::CPUPlace,
-    ops::ReshapeGradMKLDNNKernel<float, ReshapeKernelOpName::reshape2>,
-    ops::ReshapeGradMKLDNNKernel<paddle::platform::bfloat16,
-                                 ReshapeKernelOpName::reshape2>);
-
-REGISTER_OP_KERNEL(
     flatten,
     MKLDNN,
     phi::CPUPlace,
@@ -413,19 +387,3 @@ REGISTER_OP_KERNEL(
     ops::ReshapeGradMKLDNNKernel<float, ReshapeKernelOpName::flatten>,
     ops::ReshapeGradMKLDNNKernel<paddle::platform::bfloat16,
                                  ReshapeKernelOpName::flatten>);
-
-REGISTER_OP_KERNEL(
-    flatten2,
-    MKLDNN,
-    phi::CPUPlace,
-    ops::ReshapeMKLDNNKernel<float, ReshapeKernelOpName::flatten2>,
-    ops::ReshapeMKLDNNKernel<paddle::platform::bfloat16,
-                             ReshapeKernelOpName::flatten2>);
-
-REGISTER_OP_KERNEL(
-    flatten2_grad,
-    MKLDNN,
-    phi::CPUPlace,
-    ops::ReshapeGradMKLDNNKernel<float, ReshapeKernelOpName::flatten2>,
-    ops::ReshapeGradMKLDNNKernel<paddle::platform::bfloat16,
-                                 ReshapeKernelOpName::flatten2>);

--- a/paddle/fluid/pir/dialect/operator/ir/ops_onednn_extra.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops_onednn_extra.yaml
@@ -82,13 +82,11 @@
 - op : fc
   extra_args : bool ALL_KERNELS_MUST_COMPUTE_RUNTIME_SHAPE=true, bool use_quantizer=false, str mkldnn_data_type="float32", float scale_in=1.0, float[] scale_weights={1.0f}, float scale_out=1.0, bool force_fp32_output=false
 
-# - op : flatten
+- op : flatten
+  extra_args : str mkldnn_data_type="float32"
 
-# - op : flatten_grad
-
-# - op : flatten2
-
-# - op : flatten2_grad
+- op : flatten_grad
+  extra_args : str mkldnn_data_type="float32"
 
 - op : full
 
@@ -214,13 +212,11 @@
 - op : relu6_grad
   extra_args : float threshold=6.0
 
-# - op : reshape
+- op : reshape
+  extra_args : str mkldnn_data_type="float32", bool use_quantizer=false
 
-# - op : reshape_grad
-
-# - op : reshape_infer
-
-# - op : reshape2_grad
+- op : reshape_grad
+  extra_args : str mkldnn_data_type="float32", bool use_quantizer=false
 
 - op : round
 
@@ -261,11 +257,11 @@
 
 - op : sqrt_grad
 
-# - op : squeeze
+- op : squeeze
+  extra_args : str mkldnn_data_type="float32"
 
-# - op : squeeze_grad
-
-# - op : squeeze_infer
+- op : squeeze_grad
+  extra_args : str mkldnn_data_type="float32"
 
 # - op : stack
 

--- a/paddle/phi/kernels/onednn/flatten_kernel.cc
+++ b/paddle/phi/kernels/onednn/flatten_kernel.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/flatten_kernel.h"
+
+#include "paddle/phi/backends/onednn/onednn_reuse.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void ExecuteFlatten(const Context& dev_ctx,
+                    const DenseTensor& x,
+                    const DDim& x_dims,
+                    const DDim& out_dims,
+                    DenseTensor* out) {
+  auto x_vec_dims = common::vectorize(x_dims);
+
+  funcs::ReorderOneDNNHandler reorder_handler(
+      x_vec_dims,
+      x.dtype(),
+      funcs::ToOneDNNDataType(x.dtype()),
+      dev_ctx.GetEngine());
+
+  auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
+      x.mem_desc(), funcs::to_void_cast(x.data<T>()));
+  out->Resize(x_dims);  // to match x numel, format is changed later
+  // reorder is done into a plain tag to allow usage with blocked formats
+  auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
+      out, funcs::GetPlainOneDNNFormat(x_dims.size()), dev_ctx.GetPlace());
+  auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
+                                                  reorder_src_memory_p);
+  auto& astream = OneDNNContext::tls().get_stream();
+  reorder_p->execute(astream, *reorder_src_memory_p, *reorder_dst_memory_p);
+  astream.wait();
+
+  out->Resize(out_dims);
+
+  auto reshape_dims = out_dims.size() != 0 ? common::vectorize(out_dims)
+                                           : std::vector<int64_t>{1};
+  out->set_mem_desc(reorder_dst_memory_p->get_desc().reshape(reshape_dims));
+}
+
+template <typename T, typename Context>
+void FlattenInferKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        int start_axis,
+                        int stop_axis,
+                        DenseTensor* out) {
+  auto x_dims = x.dims();
+  auto out_dims = out->dims();
+  ExecuteFlatten<T, Context>(dev_ctx, x, x_dims, out_dims, out);
+}
+
+template <typename T, typename Context>
+void FlattenKernel(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   int start_axis,
+                   int stop_axis,
+                   DenseTensor* out,
+                   DenseTensor* xshape UNUSED) {
+  FlattenInferKernel<T, Context>(dev_ctx, x, start_axis, stop_axis, out);
+}
+
+}  // namespace phi
+PD_REGISTER_KERNEL(flatten_infer,
+                   OneDNN,
+                   ONEDNN,
+                   phi::FlattenInferKernel,
+                   float,
+                   phi::dtype::bfloat16) {}
+
+PD_REGISTER_KERNEL(
+    flatten, OneDNN, ONEDNN, phi::FlattenKernel, float, phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/flatten_kernel_grad.cc
+++ b/paddle/phi/kernels/onednn/flatten_kernel_grad.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/flatten_grad_kernel.h"
+
+#include "paddle/phi/backends/onednn/onednn_reuse.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void FlattenGradKernel(const Context& dev_ctx,
+                       const DenseTensor& xshape,
+                       const DenseTensor& out_grad,
+                       DenseTensor* x_grad) {
+  auto out_grad_vec_dims = out_grad.dims().size() != 0
+                               ? common::vectorize(out_grad.dims())
+                               : std::vector<int64_t>{1};
+
+  auto out_grad_type = funcs::ToOneDNNDataType(out_grad.dtype());
+
+  funcs::ReorderOneDNNHandler reorder_handler(
+      out_grad_vec_dims, out_grad.dtype(), out_grad_type, dev_ctx.GetEngine());
+
+  auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
+      out_grad.mem_desc(), funcs::to_void_cast(out_grad.data<T>()));
+  auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
+      x_grad,
+      funcs::GetPlainOneDNNFormat(out_grad_vec_dims.size()),
+      dev_ctx.GetPlace());
+  auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
+                                                  reorder_src_memory_p);
+
+  auto& astream = OneDNNContext::tls().get_stream();
+  reorder_p->execute(astream, *reorder_src_memory_p, *reorder_dst_memory_p);
+  astream.wait();
+
+  auto x_grad_dims = slice_ddim(xshape.dims(), 1, xshape.dims().size());
+  x_grad->Resize(x_grad_dims);
+  reorder_dst_memory_p->get_desc().reshape(common::vectorize(x_grad_dims));
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(flatten_grad,
+                   OneDNN,
+                   ONEDNN,
+                   phi::FlattenGradKernel,
+                   float,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
@@ -18,8 +18,6 @@ template <typename T, typename Context>
 void ReshapeGradKernel(const Context& dev_ctx,
                        const DenseTensor& out_grad,
                        DenseTensor* x_grad) {
-  std::cout << "out_grad.dims() = " << out_grad.dims() << std::endl;
-  std::cout << "x_grad.dims() = " << x_grad->dims() << std::endl;
   auto out_grad_vec_dims = out_grad.dims().size() != 0
                                ? common::vectorize(out_grad.dims())
                                : std::vector<int64_t>{1};

--- a/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/phi/backends/onednn/onednn_reuse.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename Context>
+void ReshapeGradKernel(const Context& dev_ctx,
+                       const DenseTensor& out_grad,
+                       DenseTensor* x_grad) {
+  auto out_grad_vec_dims = out_grad.dims().size() != 0
+                               ? common::vectorize(out_grad.dims())
+                               : std::vector<int64_t>{1};
+
+  auto out_grad_type = funcs::ToOneDNNDataType(out_grad.dtype());
+
+  funcs::ReorderOneDNNHandler reorder_handler(
+      out_grad_vec_dims, out_grad.dtype(), out_grad_type, dev_ctx.GetEngine());
+
+  auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
+      out_grad.mem_desc(), funcs::to_void_cast(out_grad.data<T>()));
+  auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
+      x_grad,
+      funcs::GetPlainOneDNNFormat(out_grad_vec_dims.size()),
+      dev_ctx.GetPlace());
+  auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
+                                                  reorder_src_memory_p);
+
+  auto& astream = OneDNNContext::tls().get_stream();
+  reorder_p->execute(astream, *reorder_src_memory_p, *reorder_dst_memory_p);
+  astream.wait();
+
+  auto x_grad_dims = slice_ddim(xshape.dims(), 1, xshape.dims().size());
+  x_grad->Resize(x_grad_dims);
+  reorder_dst_memory_p->get_desc().reshape(common::vectorize(x_grad_dims));
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(reshape_grad,
+                   OneDNN,
+                   ONEDNN,
+                   phi::ReshapeGradKernel,
+                   float,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
@@ -14,7 +14,7 @@ limitations under the License. */
 
 namespace phi {
 
-template <typename Context>
+template <typename T, typename Context>
 void ReshapeGradKernel(const Context& dev_ctx,
                        const DenseTensor& out_grad,
                        DenseTensor* x_grad) {
@@ -40,9 +40,7 @@ void ReshapeGradKernel(const Context& dev_ctx,
   reorder_p->execute(astream, *reorder_src_memory_p, *reorder_dst_memory_p);
   astream.wait();
 
-  auto x_grad_dims = slice_ddim(xshape.dims(), 1, xshape.dims().size());
-  x_grad->Resize(x_grad_dims);
-  reorder_dst_memory_p->get_desc().reshape(common::vectorize(x_grad_dims));
+  reorder_dst_memory_p->get_desc().reshape(common::vectorize(x_grad->dims()));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
@@ -18,6 +18,8 @@ template <typename T, typename Context>
 void ReshapeGradKernel(const Context& dev_ctx,
                        const DenseTensor& out_grad,
                        DenseTensor* x_grad) {
+  std::cout << "out_grad.dims() = " << out_grad.dims() << std::endl;
+  std::cout << "x_grad.dims() = " << x_grad->dims() << std::endl;
   auto out_grad_vec_dims = out_grad.dims().size() != 0
                                ? common::vectorize(out_grad.dims())
                                : std::vector<int64_t>{1};
@@ -40,7 +42,10 @@ void ReshapeGradKernel(const Context& dev_ctx,
   reorder_p->execute(astream, *reorder_src_memory_p, *reorder_dst_memory_p);
   astream.wait();
 
-  reorder_dst_memory_p->get_desc().reshape(common::vectorize(x_grad->dims()));
+  auto grad_shape = x_grad->dims().size() == 0
+                        ? std::vector<int64_t>{1}
+                        : phi::vectorize<int64_t>(x_grad->dims());
+  reorder_dst_memory_p->get_desc().reshape(grad_shape);
 }
 
 }  // namespace phi

--- a/test/mkldnn/test_flatten_mkldnn_op.py
+++ b/test/mkldnn/test_flatten_mkldnn_op.py
@@ -38,10 +38,17 @@ class TestFlattenOneDNNOp(OpTest):
         self.op_type = "flatten"
 
     def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace())
+        self.check_output_with_place(
+            core.CPUPlace(), check_pir_onednn=(self.op_type == "flatten2")
+        )
 
     def test_check_grad(self):
-        self.check_grad_with_place(core.CPUPlace(), ["X"], "Out")
+        self.check_grad_with_place(
+            core.CPUPlace(),
+            ["X"],
+            "Out",
+            check_pir_onednn=(self.op_type == "flatten2"),
+        )
 
     def init_test_case(self):
         self.in_shape = (3, 2, 2, 10)
@@ -93,7 +100,9 @@ def create_flatten_bf16_test_classes(parent):
 
         def test_check_output(self):
             self.check_output_with_place(
-                core.CPUPlace(), no_check_set=["XShape"]
+                core.CPUPlace(),
+                no_check_set=["XShape"],
+                check_pir_onednn=(self.op_type == "flatten2"),
             )
 
         def test_check_grad(self):
@@ -104,6 +113,7 @@ def create_flatten_bf16_test_classes(parent):
                 "Out",
                 user_defined_grads=[self.dx],
                 user_defined_grad_outputs=[self.dout],
+                check_pir_onednn=(self.op_type == "flatten2"),
             )
 
     cls_name = "{}_{}".format(parent.__name__, "Flatten2_BF16")
@@ -129,7 +139,9 @@ def create_flatten_bf16_test_classes(parent):
             self.dx = np.reshape(self.dout, self.ori_shape)
 
         def test_check_output(self):
-            self.check_output_with_place(core.CPUPlace())
+            self.check_output_with_place(
+                core.CPUPlace(), check_pir_onednn=(self.op_type == "flatten2")
+            )
 
         def test_check_grad(self):
             self.calculate_grads()
@@ -139,6 +151,7 @@ def create_flatten_bf16_test_classes(parent):
                 "Out",
                 user_defined_grads=[self.dx],
                 user_defined_grad_outputs=[convert_float_to_uint16(self.dout)],
+                check_pir_onednn=(self.op_type == "flatten2"),
             )
 
     cls_name = "{}_{}".format(parent.__name__, "Flatten_BF16")

--- a/test/mkldnn/test_reshape_bf16_op.py
+++ b/test/mkldnn/test_reshape_bf16_op.py
@@ -56,7 +56,10 @@ class TestReshapeBf16Op(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(
-            core.CPUPlace(), no_check_set=['XShape'], check_dygraph=False
+            core.CPUPlace(),
+            no_check_set=['XShape'],
+            check_dygraph=False,
+            check_pir_onednn=(self.op_type == "reshape2"),
         )
 
     def test_check_grad(self):
@@ -69,6 +72,7 @@ class TestReshapeBf16Op(OpTest):
             user_defined_grad_outputs=[
                 self.inputs["X"].reshape(self.infered_shape)
             ],
+            check_pir_onednn=(self.op_type == "reshape2"),
         )
 
 

--- a/test/mkldnn/test_reshape_mkldnn_op.py
+++ b/test/mkldnn/test_reshape_mkldnn_op.py
@@ -55,10 +55,19 @@ class TestReshape2OneDNNOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output(no_check_set=['XShape'], check_dygraph=False)
+        self.check_output(
+            no_check_set=['XShape'],
+            check_dygraph=False,
+            check_pir_onednn=(self.op_type == "reshape2"),
+        )
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(
+            ["X"],
+            "Out",
+            check_dygraph=False,
+            check_pir_onednn=(self.op_type == "reshape2"),
+        )
 
 
 class TestReshape2OneDNNOpZeroDim(TestReshape2OneDNNOp):
@@ -212,7 +221,10 @@ def create_reshape_bf16_test_classes(parent):
 
         def test_check_output(self):
             self.check_output_with_place(
-                core.CPUPlace(), no_check_set=["XShape"], check_dygraph=False
+                core.CPUPlace(),
+                no_check_set=["XShape"],
+                check_dygraph=False,
+                check_pir_onednn=(self.op_type == "reshape2"),
             )
 
         def test_check_grad(self):
@@ -224,6 +236,7 @@ def create_reshape_bf16_test_classes(parent):
                 user_defined_grads=[self.dx],
                 user_defined_grad_outputs=[self.dout],
                 check_dygraph=False,
+                check_pir_onednn=(self.op_type == "reshape2"),
             )
 
     cls_name = "{}_{}".format(parent.__name__, "Reshape2_BF16")
@@ -239,7 +252,11 @@ def create_reshape_bf16_test_classes(parent):
             self.outputs = {"Out": self.x.reshape(self.new_shape)}
 
         def test_check_output(self):
-            self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+            self.check_output_with_place(
+                core.CPUPlace(),
+                check_dygraph=False,
+                check_pir_onednn=(self.op_type == "reshape2"),
+            )
 
         def test_check_grad(self):
             self.calculate_grads()
@@ -250,6 +267,7 @@ def create_reshape_bf16_test_classes(parent):
                 user_defined_grads=[self.dx],
                 user_defined_grad_outputs=[convert_float_to_uint16(self.dout)],
                 check_dygraph=False,
+                check_pir_onednn=(self.op_type == "reshape2"),
             )
 
     cls_name = "{}_{}".format(parent.__name__, "Reshape_BF16")

--- a/test/mkldnn/test_squeeze2_mkldnn_op.py
+++ b/test/mkldnn/test_squeeze2_mkldnn_op.py
@@ -55,10 +55,19 @@ class TestSqueeze2OneDNNOp(OpTest):
         self.set_outputs()
 
     def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace(), no_check_set=['XShape'])
+        self.check_output_with_place(
+            core.CPUPlace(),
+            no_check_set=['XShape'],
+            check_pir_onednn=(self.op_type == "squeeze2"),
+        )
 
     def test_check_grad(self):
-        self.check_grad_with_place(core.CPUPlace(), ["X"], "Out")
+        self.check_grad_with_place(
+            core.CPUPlace(),
+            ["X"],
+            "Out",
+            check_pir_onednn=(self.op_type == "squeeze2"),
+        )
 
 
 class TestSqueezeOneDNNOp(TestSqueeze2OneDNNOp):
@@ -158,6 +167,7 @@ def create_squeeze_bf16_test_classes(parent):
                 "Out",
                 user_defined_grads=[self.dx],
                 user_defined_grad_outputs=[self.dout],
+                check_pir_onednn=(self.op_type == "squeeze2"),
             )
 
     cls_name = "{}_{}".format(parent.__name__, "Squeeze2_BF16")
@@ -173,7 +183,9 @@ def create_squeeze_bf16_test_classes(parent):
             self.outputs = {"Out": self.x.reshape(self.new_shape)}
 
         def test_check_output(self):
-            self.check_output_with_place(core.CPUPlace())
+            self.check_output_with_place(
+                core.CPUPlace(), check_pir_onednn=(self.op_type == "squeeze2")
+            )
 
     cls_name = "{}_{}".format(parent.__name__, "Squeeze_BF16")
     TestSqueezeBF16OneDNNOp.__name__ = cls_name


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-67164

pir onednn 支持reshape, flatten, squeeze。将OneDNN的flatten、flatten_grad、reshape_grad迁移到PHI。修改两处问题：
1. 由于reshape涉及0D Tensor，因此set_mem_desc需要做特殊处理。
2. 发现PIR处理op_compat.yaml中shape参数、Shape输入、ShapeTensor输入、ShapeTensorList输入等优先级反了，连同永康做了修复。