### PR TITLE
[Prim] Optimize composite OP silu_double_grad

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -441,13 +441,15 @@ void silu_double_grad(const Tensor& x,
                       Tensor* grad_x,
                       Tensor* grad_out_grad) {
   auto sigmoid = 1 / (1 + exp<T>(-x));
-  auto ddx_mul_tt = grad_x_grad * (x - out + 1);
+  auto tmp = 1 + x - out;
+  auto ddx_mul_sigmoid = grad_x_grad * sigmoid;
   if (grad_out_grad) {
-    set_output<T>(ddx_mul_tt * sigmoid, grad_out_grad);
+    set_output<T>(ddx_mul_sigmoid * tmp, grad_out_grad);
   }
   if (grad_x) {
     auto sigmoid_g = sigmoid * (1 - sigmoid);
-    set_output<T>(ddx_mul_tt * sigmoid_g, grad_x);
+    set_output<T>(ddx_mul_sigmoid * out_grad * (1 - sigmoid) * (tmp - out + 1),
+                  grad_x);
   }
 }
 

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -441,15 +441,16 @@ void silu_double_grad(const Tensor& x,
                       Tensor* grad_x,
                       Tensor* grad_out_grad) {
   auto sigmoid = 1 / (1 + exp<T>(-x));
-  auto tmp = 1 + x - out;
-  auto ddx_mul_sigmoid = grad_x_grad * sigmoid;
+  auto tmp1 = 1 - sigmoid;
+  auto tmp2 = 1 + tmp1 * x;
+  auto grad_x_grad_mul_sigmoid = grad_x_grad * sigmoid;
   if (grad_out_grad) {
-    set_output<T>(ddx_mul_sigmoid * tmp, grad_out_grad);
+    auto ddout = grad_x_grad_mul_sigmoid * tmp2;
+    set_output<T>(ddout, grad_out_grad);
   }
   if (grad_x) {
-    auto sigmoid_g = sigmoid * (1 - sigmoid);
-    set_output<T>(ddx_mul_sigmoid * out_grad * (1 - sigmoid) * (tmp - out + 1),
-                  grad_x);
+    auto dx = grad_x_grad_mul_sigmoid * out_grad * (1 + (tmp2 - out)) * tmp1;
+    set_output<T>(dx, grad_x);
   }
 }
 

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -441,15 +441,13 @@ void silu_double_grad(const Tensor& x,
                       Tensor* grad_x,
                       Tensor* grad_out_grad) {
   auto sigmoid = 1 / (1 + exp<T>(-x));
-  auto tmp1 = 1 - sigmoid;
-  auto tmp2 = 1 + tmp1 * x;
+  auto ddx_mul_tt = grad_x_grad * (x - out + 1);
   if (grad_out_grad) {
-    auto ddout = grad_x_grad * sigmoid * tmp2;
-    set_output<T>(ddout, grad_out_grad);
+    set_output<T>(ddx_mul_tt * sigmoid, grad_out_grad);
   }
   if (grad_x) {
-    auto dx = sigmoid * grad_x_grad * out_grad * (1 + (tmp2 - out)) * tmp1;
-    set_output<T>(dx, grad_x);
+    auto sigmoid_g = sigmoid * (1 - sigmoid);
+    set_output<T>(ddx_mul_tt * sigmoid_g, grad_x);
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->
Pcard-75624

Optimize composite OP `silu_double_grad` code via precomputing common item：`x_grad_grad * sigmoid(x)`