### PR TITLE
[SOT][3.12] Support `POP_JUMP_IF_NONE` and `POP_JUMP_IF_NOT_NONE` opcode in Python 3.12 

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1396,11 +1396,13 @@ class OpcodeExecutorBase:
 
     POP_JUMP_FORWARD_IF_NONE = pop_jump_if_op_wrapper([operator_is_none])
     POP_JUMP_BACKWARD_IF_NONE = POP_JUMP_FORWARD_IF_NONE
+    POP_JUMP_IF_NONE = POP_JUMP_FORWARD_IF_NONE
 
     POP_JUMP_FORWARD_IF_NOT_NONE = pop_jump_if_op_wrapper(
         [operator_is_not_none]
     )
     POP_JUMP_BACKWARD_IF_NOT_NONE = POP_JUMP_FORWARD_IF_NOT_NONE
+    POP_JUMP_IF_NOT_NONE = POP_JUMP_IF_TRUE
 
     @call_break_graph_decorator(push_n=lambda arg: arg)
     def UNPACK_SEQUENCE(self, instr: Instruction):

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1402,7 +1402,7 @@ class OpcodeExecutorBase:
         [operator_is_not_none]
     )
     POP_JUMP_BACKWARD_IF_NOT_NONE = POP_JUMP_FORWARD_IF_NOT_NONE
-    POP_JUMP_IF_NOT_NONE = POP_JUMP_IF_TRUE
+    POP_JUMP_IF_NOT_NONE = POP_JUMP_FORWARD_IF_NOT_NONE
 
     @call_break_graph_decorator(push_n=lambda arg: arg)
     def UNPACK_SEQUENCE(self, instr: Instruction):

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,3 +1,4 @@
+./test_11_jumps.py
 ./test_12_for_loop.py
 ./test_21_global.py
 ./test_builtin_zip.py

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,6 +1,5 @@
 ./test_12_for_loop.py
 ./test_21_global.py
-./test_analysis_inputs.py
 ./test_builtin_zip.py
 ./test_inplace_api.py
 ./test_min_graph_size.py

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,4 +1,3 @@
-./test_11_jumps.py
 ./test_12_for_loop.py
 ./test_21_global.py
 ./test_analysis_inputs.py

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -2,9 +2,7 @@
 ./test_12_for_loop.py
 ./test_21_global.py
 ./test_analysis_inputs.py
-./test_break_graph.py
 ./test_builtin_zip.py
-./test_guard_user_defined_fn.py
 ./test_inplace_api.py
 ./test_min_graph_size.py
 ./test_side_effects.py


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
python 3.12 支持 `POP_JUMP_IF_NONE` and `POP_JUMP_IF_NOT_NONE`
test_11_jumps.py单测里面还涉及到“opcode: `LOAD_FAST_CHECK` is not supported.“等其他报错，暂不处理
- #61174
- #61173