### PR TITLE
Add 'index' parameter for ProcessMesh.get_mesh_with_dim

### DIFF
--- a/python/paddle/distributed/auto_parallel/process_mesh.py
+++ b/python/paddle/distributed/auto_parallel/process_mesh.py
@@ -239,7 +239,7 @@ class ProcessMesh(core.ProcessMesh):
         assert dim_name in self._dim_names
         return self._shape[self._dim_names.index(dim_name)]
 
-    def get_mesh_with_dim(self, dim_name):
+    def get_mesh_with_dim(self, dim_name, index=None):
         assert (
             dim_name in self._dim_names
         ), f'{dim_name} is not a valid dim name.'
@@ -251,6 +251,9 @@ class ProcessMesh(core.ProcessMesh):
             dim for dim in self._dim_names if dim != dim_name
         ]
         new_mesh = self._mesh.transpose(new_order)
+
+        if index is not None:
+            return ProcessMesh(new_mesh[index], new_dim_names[1:])
         return ProcessMesh(new_mesh, new_dim_names)
 
     def __enter__(self):

--- a/test/auto_parallel/test_interface.py
+++ b/test/auto_parallel/test_interface.py
@@ -269,7 +269,8 @@ class TestAutoParallelAPI(unittest.TestCase):
             first_pp_mesh.process_ids, list(arr.transpose([1, 0, 2]).flatten())
         )
 
-        pp_stage_0_mesh = first_pp_mesh[0]
+        pp_stage_0_mesh = auto.get_mesh().get_mesh_with_dim("pp", 0)
+        self.assertEqual(pp_stage_0_mesh, first_pp_mesh[0])
         self.assertEqual(pp_stage_0_mesh.shape, [2, 4])
         self.assertEqual(
             pp_stage_0_mesh.process_ids, [0, 1, 2, 3, 16, 17, 18, 19]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-76459
升级自动并行`ProcessMesh.get_mesh_with_dim`接口，新增`index`参数支持直接获取指定维度index下标索引的mesh。缺省为`None`，表示获取该维度下所有mesh，等价于index=[:]。

**【相关背景】**
自动并行随机性控制依赖mesh的全局自增id构造随机种子。对于需要获取特定维度mesh的场景，若该维度不在第一维，之前的接口写法需要先构造一个指定维度在第一维的中间状态mesh，然后再通过`[]`索引特定的下标mesh；若获取的维度在第一维，则不需要有实际的转置操作，不会多出一个mesh，这导致两种情况下全局自增id不同（相差1），因而生成的随机种子也不同。
在用户侧，表现出的现象是相同模型上两种逻辑等价的mesh操作，却运算出了不同的loss结果，这种现象不符合常识，令人困惑，对用户体验有影响。
这个问题在自动并行Llama模型上被发现。PR https://github.com/PaddlePaddle/PaddleNLP/pull/8011 对Llama模型调整了mesh拓扑顺序，将`[dp, pp]`调整为`[pp, dp]`，通信拓扑顺序改变，只是影响了逻辑上的process_mesh与物理卡之间的映射关系，但却由于mesh全局自增id的偏移触发了模型运行结果改变。

**相关代码：** https://github.com/PaddlePaddle/PaddleNLP/blob/develop/paddlenlp/transformers/llama/modeling_auto.py#L78

**修改之前：**
```python
mesh = mesh.get_mesh_with_dim("pp")[pp_idx] 
```
`get_mesh_with_dim`先将pp转置到第一维（`[dp, pp, mp]`->`[pp, dp, mp]`）,产生中间mesh: `[pp, dp, mp] `，然后再对中间mesh取pp_idx索引，得到实际需要的mesh：`[dp, mp]`。调整后拓扑顺序是pp在前的情况下，这个中间mesh本身就存在，不会影响自增id。

**修改之后：**
```python
mesh = mesh.get_mesh_with_dim("pp", pp_idx) 
```
`get_mesh_with_dim`直接构造实际需要的mesh:`[dp, mp]`，不产生中间结果。


**【one more thing】**
对这种写法的改变，只是一种临时解决方案，并未从根本上解决问题。要彻底避免类似问题，本质上应该让自动并行生成的随机种子对mesh的“逻辑改变”不敏感，但由于自动并行process_mesh在设计上的灵活性，许多逻辑概念允许用户任意改变（如转置mesh、重排process_id、重命名dims等），要改造需要对整个随机种子生成算法进行重新设计和实现，工作量较大。
