### PR TITLE
[clang-tidy]  fix about 31、32、34、41、45

### DIFF
--- a/paddle/fluid/framework/io/crypto/aes_cipher.cc
+++ b/paddle/fluid/framework/io/crypto/aes_cipher.cc
@@ -65,7 +65,7 @@ std::string AESCipher::EncryptInternal(const std::string& plaintext,
   std::string ciphertext;
   m_filter->Attach(new CryptoPP::StringSink(ciphertext));
   CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
-  CryptoPP::StringSource(plaintext, true, filter_redirector);
+  CryptoPP::StringSource ss(plaintext, true, filter_redirector);
   if (need_iv) {
     return iv_ + ciphertext;
   }
@@ -96,7 +96,7 @@ std::string AESCipher::DecryptInternal(const std::string& ciphertext,
   std::string plaintext;
   m_filter->Attach(new CryptoPP::StringSink(plaintext));
   CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
-  CryptoPP::StringSource(
+  CryptoPP::StringSource ss(
       ciphertext.substr(ciphertext_beg), true, filter_redirector);
 
   return plaintext;
@@ -124,7 +124,7 @@ std::string AESCipher::AuthenticatedEncryptInternal(
   std::string ciphertext;
   m_filter->Attach(new CryptoPP::StringSink(ciphertext));
   CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
-  CryptoPP::StringSource(plaintext, true, filter_redirector);
+  CryptoPP::StringSource ss(plaintext, true, filter_redirector);
   if (need_iv) {
     ciphertext = iv_.append(ciphertext);
   }
@@ -155,7 +155,7 @@ std::string AESCipher::AuthenticatedDecryptInternal(
   std::string plaintext;
   m_filter->Attach(new CryptoPP::StringSink(plaintext));
   CryptoPP::Redirector* filter_redirector = new CryptoPP::Redirector(*m_filter);
-  CryptoPP::StringSource(
+  CryptoPP::StringSource ss(
       ciphertext.substr(ciphertext_beg), true, filter_redirector);
   PADDLE_ENFORCE_EQ(
       m_filter->GetLastResult(),

--- a/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
@@ -298,7 +298,7 @@ void *Alloc<platform::CUDAPlace>(const platform::CUDAPlace &place,
   auto *buddy_allocator = GetGPUBuddyAllocator(place.device);
   auto *ptr = buddy_allocator->Alloc(size);
   if (ptr == nullptr) {
-    platform::CUDADeviceGuard(place.device);
+    platform::CUDADeviceGuard guard(place.device);
     size_t avail, total;
     platform::GpuMemoryUsage(&avail, &total);
     PADDLE_THROW(platform::errors::ResourceExhausted(

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -594,7 +594,7 @@ TEST(enforce, cannot_to_string_type) {
 }
 
 TEST(GET_DATA_SAFELY_MACRO, SUCCESS) {
-  int* a = new int(10);
+  int* a = new int(10);  // NOLINT
   GET_DATA_SAFELY(a, "Input", "X", "dummy");
 }
 

--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -53,7 +53,7 @@ DenseTensor::DenseTensor(const std::shared_ptr<phi::Allocation>& holder,
                          const DenseTensorMeta& meta)
     : meta_(meta), holder_(holder) {}
 
-DenseTensor::DenseTensor(const DenseTensor& other) {
+DenseTensor::DenseTensor(const DenseTensor& other) {  // NOLINT
   this->meta_ = other.meta();
   holder_ = other.holder_;
   storage_properties_ =

--- a/paddle/phi/core/sparse_coo_tensor.cc
+++ b/paddle/phi/core/sparse_coo_tensor.cc
@@ -51,7 +51,7 @@ SparseCooTensor::SparseCooTensor(DenseTensor&& non_zero_indices,
   meta_.dtype = non_zero_elements.dtype();
 }
 
-SparseCooTensor::SparseCooTensor(const SparseCooTensor& other) {
+SparseCooTensor::SparseCooTensor(const SparseCooTensor& other) {  // NOLINT
   this->non_zero_indices_ = other.non_zero_indices_;
   this->non_zero_elements_ = other.non_zero_elements_;
   this->coalesced_ = other.coalesced_;

--- a/paddle/phi/core/sparse_csr_tensor.cc
+++ b/paddle/phi/core/sparse_csr_tensor.cc
@@ -66,7 +66,7 @@ SparseCsrTensor::SparseCsrTensor(const DenseTensor& non_zero_crows,
   meta_.dtype = non_zero_elements.dtype();
 }
 
-SparseCsrTensor::SparseCsrTensor(const SparseCsrTensor& other) {
+SparseCsrTensor::SparseCsrTensor(const SparseCsrTensor& other) {  // NOLINT
   this->non_zero_crows_ = other.non_zero_crows_;
   this->non_zero_cols_ = other.non_zero_cols_;
   this->non_zero_elements_ = other.non_zero_elements_;

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -37,7 +37,7 @@ StringTensor::StringTensor(const std::shared_ptr<phi::Allocation>& holder,
                            const StringTensorMeta& meta)
     : meta_(meta), holder_(holder) {}
 
-StringTensor::StringTensor(const StringTensor& other) {
+StringTensor::StringTensor(const StringTensor& other) {  // NOLINT
   this->meta_ = other.meta();
   holder_ = other.holder_;
 }

--- a/paddle/phi/core/utils/intrusive_ref_counter.h
+++ b/paddle/phi/core/utils/intrusive_ref_counter.h
@@ -57,7 +57,7 @@ inline void intrusive_ptr_release(
     const intrusive_ref_counter<DerivedT>* p) noexcept {
   if (p->ref_.load(std::memory_order_acquire) == 0 ||
       p->ref_.fetch_sub(1) == 0) {
-    delete static_cast<const DerivedT*>(p);
+    delete static_cast<const DerivedT*>(p);  // NOLINT
   }
 }
 

--- a/paddle/phi/infermeta/spmd_rules/unsqueeze.cc
+++ b/paddle/phi/infermeta/spmd_rules/unsqueeze.cc
@@ -74,7 +74,7 @@ std::vector<std::shared_ptr<DimTrans>> MakeUnsqueezeDimTransReverse(
   ret.resize(x_ndim);
   fill(ret.begin(), ret.end(), std::make_shared<Singleton>());
 
-  for (int64_t i = 0, j = 0; i < out_ndim; i++) {
+  for (int64_t i = 0, j = 0; i < out_ndim; i++) {  // NOLINT
     auto it = find(axis.begin(), axis.end(), i);
 
     if (it == axis.end()) {

--- a/paddle/pir/src/core/builtin_type_interfaces.cc
+++ b/paddle/pir/src/core/builtin_type_interfaces.cc
@@ -18,11 +18,11 @@
 namespace pir {
 
 Type ShapedTypeInterface::GetElementType() const {
-  return impl_->get_element_type(*this);
+  return impl_->get_element_type(*this);  // NOLINT
 }
 
 pir::DDim ShapedTypeInterface::GetShape() const {
-  return impl_->get_shape(*this);
+  return impl_->get_shape(*this);  // NOLINT
 }
 
 }  // namespace pir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
* https://github.com/PaddlePaddle/Paddle/issues/54073
45 	clang-analyzer-cplusplus.NewDelete
41 	cppcoreguidelines-slicing
34  	bugprone-copy-constructor-init
32 	bugprone-unused-raii
31 	clang-analyzer-cplusplus.NewDeleteLeaks
