### PR TITLE
[SOT][3.12] Fix SOT analysis used names in Python 3.12

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -43,6 +43,7 @@ class State:
 def is_read_opcode(opname):
     if opname in [
         "LOAD_FAST",
+        "LOAD_FAST_CHECK",
         "LOAD_DEREF",
         "LOAD_NAME",
         "LOAD_GLOBAL",
@@ -76,7 +77,7 @@ def analysis_used_names(
     instructions: list[Instruction],
     current_instr_idx: int,
     stop_instr_idx: int | None = None,
-) -> OrderedSet[str]:
+) -> tuple[OrderedSet[str], OrderedSet[str]]:
     """
     Analyze the inputs of the instructions from current_instr_idx to stop_instr_idx.
 
@@ -87,13 +88,11 @@ def analysis_used_names(
             If None, the analysis will stop at the end of the instructions.
 
     Returns:
-        set[str]: The analysis result.
+        State: The analysis result.
     """
     root_state = State(OrderedSet(), OrderedSet(), OrderedSet())
 
-    def fork(
-        state: State, start: int, jump: bool, jump_target: int
-    ) -> OrderedSet[str]:
+    def fork(state: State, start: int, jump: bool, jump_target: int) -> State:
         new_start = start + 1 if not jump else jump_target
         new_state = State(
             OrderedSet(state.reads),
@@ -102,7 +101,7 @@ def analysis_used_names(
         )
         return walk(new_state, new_start)
 
-    def walk(state: State, start: int) -> OrderedSet[str]:
+    def walk(state: State, start: int) -> State:
         end = len(instructions) if stop_instr_idx is None else stop_instr_idx
         for i in range(start, end):
             if i in state.visited:

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,7 +1,6 @@
 ./test_11_jumps.py
 ./test_12_for_loop.py
 ./test_21_global.py
-./test_analysis_inputs.py
 ./test_break_graph.py
 ./test_builtin_zip.py
 ./test_guard_user_defined_fn.py

--- a/test/sot/test_analysis_inputs.py
+++ b/test/sot/test_analysis_inputs.py
@@ -144,7 +144,11 @@ def case8(x):
     return x
 
 
-case9_offset = -9 if sys.version_info >= (3, 11) else -7
+# NOTE(SigureMo): The offset should be between index of CALL instruction of assert_inputs_equals
+# and the index of the CALL instruction of breakgraph_api
+case9_offset = -7
+case9_offset = -9 if sys.version_info >= (3, 11) else case9_offset
+case9_offset = -6 if sys.version_info >= (3, 12) else case9_offset
 
 
 def case9(x):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

在 SOT `analysis_used_names` 中添加 `LOAD_FAST_CHECK`，确保 read/write 分析无误

修改 case9 中的常量 offset

- #61174
- #61173

PCard-66972