### PR TITLE
Test dtype

### DIFF
--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -35,6 +35,8 @@ limitations under the License. */
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
+COMMON_DECLARE_bool(enable_pir_api);
+
 namespace paddle {
 namespace pybind {
 
@@ -847,24 +849,48 @@ Examples:
 )DOC");
 PyObject* tensor_properties_get_dtype(TensorObject* self, void* closure) {
   EAGER_TRY
-  if (!self->tensor.defined()) {
-    // be same to old dygraph
-    return ToPyObject(phi::DataType::FLOAT32);
-  }
-  if (egr::IsVariableCompatTensor(self->tensor)) {
-    auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
-        self->tensor.impl().get());
-    if (var_tensor->IsType<paddle::framework::Vocab>()) {
-      return ToPyObject(phi::DataType::UNDEFINED);
-    } else if (var_tensor->IsType<paddle::framework::Strings>()) {
-      return ToPyObject(phi::DataType::PSTRING);
+
+  if (FLAGS_enable_pir_api) {
+    if (!self->tensor.defined()) {
+      // be same to old dygraph
+      return ToPyObject(phi::DataType::FLOAT32);
+    }
+    if (egr::IsVariableCompatTensor(self->tensor)) {
+      auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
+          self->tensor.impl().get());
+      if (var_tensor->IsType<paddle::framework::Vocab>()) {
+        return ToPyObject(phi::DataType::UNDEFINED);
+      } else if (var_tensor->IsType<paddle::framework::Strings>()) {
+        return ToPyObject(phi::DataType::PSTRING);
+      } else {
+        PADDLE_THROW(paddle::platform::errors::Unavailable(
+            "VariableCompatTensor only support get shape from Vocab or "
+            "Strings."));
+      }
     } else {
-      PADDLE_THROW(paddle::platform::errors::Unavailable(
-          "VariableCompatTensor only support get shape from Vocab or "
-          "Strings."));
+      return ToPyObject(self->tensor.type());
     }
   } else {
-    return ToPyObject(self->tensor.type());
+    if (!self->tensor.defined()) {
+      // be same to old dygraph
+      return ToPyObject(framework::proto::VarType::FP32);
+    }
+    if (egr::IsVariableCompatTensor(self->tensor)) {
+      auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
+          self->tensor.impl().get());
+      if (var_tensor->IsType<paddle::framework::Vocab>()) {
+        return ToPyObject(framework::proto::VarType::RAW);
+      } else if (var_tensor->IsType<paddle::framework::Strings>()) {
+        return ToPyObject(framework::proto::VarType::STRING);
+      } else {
+        PADDLE_THROW(paddle::platform::errors::Unavailable(
+            "VariableCompatTensor only support get shape from Vocab or "
+            "Strings."));
+      }
+    } else {
+      return ToPyObject(
+          paddle::framework::TransToProtoVarType(self->tensor.type()));
+    }
   }
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -849,23 +849,22 @@ PyObject* tensor_properties_get_dtype(TensorObject* self, void* closure) {
   EAGER_TRY
   if (!self->tensor.defined()) {
     // be same to old dygraph
-    return ToPyObject(framework::proto::VarType::FP32);
+    return ToPyObject(phi::DataType::FLOAT32);
   }
   if (egr::IsVariableCompatTensor(self->tensor)) {
     auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
         self->tensor.impl().get());
     if (var_tensor->IsType<paddle::framework::Vocab>()) {
-      return ToPyObject(framework::proto::VarType::RAW);
+      return ToPyObject(phi::DataType::UNDEFINED);
     } else if (var_tensor->IsType<paddle::framework::Strings>()) {
-      return ToPyObject(framework::proto::VarType::STRING);
+      return ToPyObject(phi::DataType::PSTRING);
     } else {
       PADDLE_THROW(paddle::platform::errors::Unavailable(
           "VariableCompatTensor only support get shape from Vocab or "
           "Strings."));
     }
   } else {
-    return ToPyObject(
-        paddle::framework::TransToProtoVarType(self->tensor.type()));
+    return ToPyObject(self->tensor.type());
   }
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1070,8 +1070,8 @@ PyObject* ToPyObject(const paddle::framework::proto::VarType& type) {
   return obj.ptr();
 }
 
-PyObject* ToPyObject(const phi::DataType& type) {
-  auto obj = ::pybind11::cast(type);
+PyObject* ToPyObject(const phi::DataType& dtype) {
+  auto obj = ::pybind11::cast(dtype);
   obj.inc_ref();
   return obj.ptr();
 }

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1070,6 +1070,12 @@ PyObject* ToPyObject(const paddle::framework::proto::VarType& type) {
   return obj.ptr();
 }
 
+PyObject* ToPyObject(const phi::DataType& type) {
+  auto obj = ::pybind11::cast(type);
+  obj.inc_ref();
+  return obj.ptr();
+}
+
 PyObject* ToPyObject(const phi::DenseTensor* value) {
   auto obj = ::pybind11::cast(value, py::return_value_policy::reference);
   obj.inc_ref();

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -148,6 +148,7 @@ PyObject* ToPyObject(const phi::distributed::Placements& value);
 PyObject* ToPyObject(const phi::SelectedRows* value);
 PyObject* ToPyObject(const paddle::framework::proto::VarType::Type& dtype);
 PyObject* ToPyObject(const paddle::framework::proto::VarType& type);
+PyObject* ToPyObject(const phi::DataType& type);
 PyObject* ToPyObject(const void* value);
 PyObject* ToPyObject(const std::unordered_map<int, int>& value);
 PyObject* ToPyObject(

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -2212,7 +2212,7 @@ class Variable(metaclass=VariableMetaClass):
                 >>> print("Dtype of current Var is: {}".format(new_variable.dtype))
                 Dtype of current Var is: paddle.float32
         """
-        return pir.core.vartype_to_datatype[self.desc.dtype()]
+        return self.desc.dtype()
 
     @property
     def lod_level(self):

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -2212,7 +2212,7 @@ class Variable(metaclass=VariableMetaClass):
                 >>> print("Dtype of current Var is: {}".format(new_variable.dtype))
                 Dtype of current Var is: paddle.float32
         """
-        return self.desc.dtype()
+        return pir.core.vartype_to_datatype[self.desc.dtype()]
 
     @property
     def lod_level(self):

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -130,9 +130,7 @@ def finfo(dtype):
     """
     import paddle
 
-    if paddle.base.framework.in_pir_mode() and isinstance(
-        dtype, paddle.pir.core.DataType
-    ):
+    if isinstance(dtype, paddle.pir.core.DataType):
         dtype = paddle.base.framework.paddle_type_to_proto_type[dtype]
     elif dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
         dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -12,32 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..base import core
 from ..base.core import (
-    VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
 )
 from ..base.data_feeder import _NUMPY_DTYPE_2_PADDLE_DTYPE
 
-dtype = VarDesc.VarType
+dtype = core.DataType
 dtype.__qualname__ = "dtype"
 dtype.__module__ = "paddle"
 
-uint8 = VarDesc.VarType.UINT8
-int8 = VarDesc.VarType.INT8
-int16 = VarDesc.VarType.INT16
-int32 = VarDesc.VarType.INT32
-int64 = VarDesc.VarType.INT64
+uint8 = core.DataType.UINT8
+int8 = core.DataType.INT8
+int16 = core.DataType.INT16
+int32 = core.DataType.INT32
+int64 = core.DataType.INT64
 
-float32 = VarDesc.VarType.FP32
-float64 = VarDesc.VarType.FP64
-float16 = VarDesc.VarType.FP16
-bfloat16 = VarDesc.VarType.BF16
+float32 = core.DataType.FLOAT32
+float64 = core.DataType.FLOAT64
+float16 = core.DataType.FLOAT16
+bfloat16 = core.DataType.BFLOAT16
 
-complex64 = VarDesc.VarType.COMPLEX64
-complex128 = VarDesc.VarType.COMPLEX128
+complex64 = core.DataType.COMPLEX64
+complex128 = core.DataType.COMPLEX128
 
-bool = VarDesc.VarType.BOOL
+bool = core.DataType.BOOL
 
 
 def iinfo(dtype):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

目前框架内有两套dtype的表示，一套是老静态图的VarType，一套是PIR下的DataType。动态图在c++端底层的dtype都是DataType，但是之前应该是为了兼容，所以动态图python的dtype也还是VarType类型。

这个pr主要是想修改python端的paddle.dtype，在PIR下paddle.dtype返回的是DataType类型；在老静态图下返回的是VarType类型。
