### PR TITLE
[Auto Parallel] Move reduce to opt stage

### DIFF
--- a/python/paddle/distributed/auto_parallel/constants.py
+++ b/python/paddle/distributed/auto_parallel/constants.py
@@ -104,6 +104,9 @@ GRADIENT_MERGE = "gradient_merge"
 set_field_default_config(GRADIENT_MERGE, "enable", False)
 set_field_default_config(GRADIENT_MERGE, "k_steps", 1)
 set_field_default_config(GRADIENT_MERGE, "avg", True)
+set_field_default_config(
+    GRADIENT_MERGE, "dp_gradient_sync_after_accumulate", False
+)
 
 #########################################
 # pipeline configuration

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -416,8 +416,12 @@ class Parallelizer:
             )
             dp_pass.apply([main_program], [startup_program], self._pass_context)
 
-        if self._strategy.dp_gradient_sync_after_accumulate:
+        dp_gradient_sync_after_accumulate = (
+            self._strategy.gradient_merge.dp_gradient_sync_after_accumulate
+        )
+        if dp_gradient_sync_after_accumulate:
             global_params_grads = params_grads
+
         if self._strategy.sharding.enable:
             config = copy.deepcopy(self._strategy.sharding.to_dict())
             config["dist_context"] = self._dist_context
@@ -487,7 +491,7 @@ class Parallelizer:
         if self.is_train and self._strategy.gradient_merge.enable:
             config = copy.deepcopy(self._strategy.gradient_merge.to_dict())
             config["dist_context"] = self._dist_context
-            if self._strategy.dp_gradient_sync_after_accumulate:
+            if dp_gradient_sync_after_accumulate:
                 config["params_grads"] = global_params_grads
             else:
                 config["params_grads"] = params_grads

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -416,6 +416,7 @@ class Parallelizer:
             )
             dp_pass.apply([main_program], [startup_program], self._pass_context)
 
+        global_params_grads = params_grads
         if self._strategy.sharding.enable:
             config = copy.deepcopy(self._strategy.sharding.to_dict())
             config["dist_context"] = self._dist_context
@@ -485,7 +486,7 @@ class Parallelizer:
         if self.is_train and self._strategy.gradient_merge.enable:
             config = copy.deepcopy(self._strategy.gradient_merge.to_dict())
             config["dist_context"] = self._dist_context
-            config["params_grads"] = params_grads
+            config["params_grads"] = global_params_grads
             auto_parallel_gradient_merge_pass = new_pass(
                 "auto_parallel_gradient_merge_pass", config
             )

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -493,7 +493,6 @@ class Parallelizer:
             auto_parallel_gradient_merge_pass.apply(
                 [main_program], [startup_program], self._pass_context
             )
-        self._logger.info(main_program)
 
         if self._strategy.pipeline.enable and not use_new_executor():
             config = copy.deepcopy(self._strategy.pipeline.to_dict())

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -493,6 +493,7 @@ class Parallelizer:
             auto_parallel_gradient_merge_pass.apply(
                 [main_program], [startup_program], self._pass_context
             )
+        print(main_program)
 
         if self._strategy.pipeline.enable and not use_new_executor():
             config = copy.deepcopy(self._strategy.pipeline.to_dict())

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -493,7 +493,7 @@ class Parallelizer:
             auto_parallel_gradient_merge_pass.apply(
                 [main_program], [startup_program], self._pass_context
             )
-        print(main_program)
+        self._logger.info(main_program)
 
         if self._strategy.pipeline.enable and not use_new_executor():
             config = copy.deepcopy(self._strategy.pipeline.to_dict())

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -275,6 +275,7 @@ def _move_reduce_to_optimizer_ops_block(main_program, optimize_ops_block):
                 len(removed_op_idx)
             )
             new_op_desc.copy_from(op.desc)
+            new_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
             removed_op_idx.append(idx)
 
             if op.type == "c_allreduce_sum":
@@ -285,6 +286,7 @@ def _move_reduce_to_optimizer_ops_block(main_program, optimize_ops_block):
                             len(removed_op_idx)
                         )
                         new_op_desc.copy_from(main_block.ops[scale_index].desc)
+                        new_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
                         removed_op_idx.append(scale_index)
                         break
                     scale_index += 1

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -274,6 +274,9 @@ def _move_reduce_to_optimizer_ops_block(
     for idx, op in list(enumerate(main_block.ops)):
         if is_data_parallel_reduce_op(op):
             op_input_names = op.desc.input_arg_names()
+            # NOTE(sonder): When "@RENAME@" is in the input name, it means that the op has been renamed.
+            # Such types input names are caused by shared parameter policy.
+            # Gradient merge should accumulate the gradient of ops without renaming.
             if "@RENAME" in op_input_names[0]:
                 continue
 

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -273,6 +273,8 @@ def _move_reduce_to_optimizer_ops_block(
     for idx, op in list(enumerate(main_block.ops)):
         if is_data_parallel_reduce_op(op):
             op_input_names = op.desc.input_arg_names()
+            if "@RENAME" in op_input_names[0]:
+                continue
 
             reduce_op_desc = optimize_ops_block.desc._insert_op(
                 len(removed_op_idx)

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -279,7 +279,7 @@ def _move_reduce_to_optimizer_ops_block(
             )
             reduce_op_desc.copy_from(op.desc)
             reduce_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
-            reduce_op_desc.append(idx)
+            removed_op_idx.append(idx)
 
             if op_input_names[0] in params_grads_name:
                 elementadd_op = main_block.ops[idx + 1]

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -283,15 +283,6 @@ def _move_reduce_to_optimizer_ops_block(
             reduce_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
             removed_op_idx.append(idx)
 
-            if op_input_names[0] in params_grads_name:
-                elementadd_op = main_block.ops[idx + 1]
-                elementadd_op_desc = optimize_ops_block.desc._insert_op(
-                    len(removed_op_idx)
-                )
-                elementadd_op_desc.copy_from(elementadd_op.desc)
-                elementadd_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
-                removed_op_idx.append(idx + 1)
-
     for idx in removed_op_idx[::-1]:
         main_block._remove_op(idx, sync=False)
 

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -18,6 +18,7 @@ import paddle
 from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
 from paddle.distributed.auto_parallel.static.operators.common import (
     is_data_parallel_reduce_op,
+    is_data_parallel_scale_op,
 )
 from paddle.distributed.auto_parallel.static.process_group import (
     get_world_process_group,
@@ -282,6 +283,21 @@ def _move_reduce_to_optimizer_ops_block(
             reduce_op_desc.copy_from(op.desc)
             reduce_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
             removed_op_idx.append(idx)
+
+            if op.type in ["c_allreduce_sum", "c_reduce_sum"]:
+                scale_index = idx + 1
+                while scale_index < len(main_block.ops):
+                    if is_data_parallel_scale_op(main_block.ops[scale_index]):
+                        scale_op_desc = optimize_ops_block.desc._insert_op(
+                            len(removed_op_idx)
+                        )
+                        scale_op_desc.copy_from(
+                            main_block.ops[scale_index].desc
+                        )
+                        scale_op_desc._set_attr(OP_ROLE_KEY, OpRole.Optimize)
+                        removed_op_idx.append(scale_index)
+                        break
+                    scale_index += 1
 
     for idx in removed_op_idx[::-1]:
         main_block._remove_op(idx, sync=False)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
静态图下开启sharding后，每个micro batch 反向阶段都会进行 allreduce, 但是反向阶段做通信的操作性能比较差

sharding 的这个 pass 在做通信的时候会插入一下reduce去做通信，现在将reduce移动到opt阶段

```
没有gm:  reduce(grad) -> opt(grad)
有gm: reduce(grad) -> grad_megred=add(grad) -> opt(grad_megred)         
优化后: grad_megred=add(grad) -> reduce(grad_megred) -> opt(grad_megred)
                                insert role=opt
```


依赖环境：

- PaddleNLP develop llama 模型 （hidden_layer 修改为 4）
- 4 卡 1080 Ti 服务器

经过测试，llama 模型的loss和pr修改前可以对齐

测试 Case:

- 使用 c_reduce_sum 通过测试，llama 模型 loss 可以对齐 ✅
- 使用 c_reduce_avg 通过测试，llama 模型 loss 可以对齐 ✅

