### PR TITLE
[DRR] drr match bug fix

### DIFF
--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -298,8 +298,20 @@ bool DrrRewritePattern::MatchFromOutputToInput(
     source_pattern_match_ctx->BindIrOperation(drr_node, ir_node);
     // binding input_tensor of current_op
     for (size_t i = 0; i < drr_input_tensors.size(); ++i) {
-      source_pattern_match_ctx->BindIrValue(drr_input_tensors[i]->name(),
-                                            ir_node->operand(i).source());
+      if (source_pattern_match_ctx->tensor_map().count(
+              drr_input_tensors[i]->name()) != 0 &&
+          ir_node->operand(i).source() !=
+              source_pattern_match_ctx->tensor_map().at(
+                  drr_input_tensors[i]->name())) {
+        matched = false;
+        VLOG(8) << " tensor_map key[" << drr_input_tensors[i]->name()
+                << "] already exists,but value is different!";
+        break;
+      } else {
+        source_pattern_match_ctx->BindIrValue(drr_input_tensors[i]->name(),
+                                              ir_node->operand(i).source());
+      }
+
       if (ir_node->operand_source(i).isa<pir::BlockArgument>()) {
         matched = false;
         VLOG(8) << drr_node->name()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
修复以下bug：

以下 ir可以匹配上 drr pattern：
drr source pattern（不同起始op的input是相同的tensor1）：
tensor1->op1 tensor1 ->op2 ....剩余op均相同

ir（ir中 不同起始op的input tensor1、tensor2）:
tensor1->op1 tensor2->op2 ...剩余op均相同

Pcard-71500