### PR TITLE
[SOT][3.12] fix codegen out of range about generating `LOAD_ATTR` in Python 3.12

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -742,13 +742,13 @@ class PyCodeGen:
             idx = self.cell_free_storage.index(name)
         return self.add_instr("LOAD_DEREF", arg=idx, argval=name)
 
-    def gen_load_attr(self, name: str, push_null=False):
+    def gen_load_attr(self, name: str, is_method=False):
         if name not in self._code_options["co_names"]:
             self._code_options["co_names"].append(name)
         idx = self._code_options["co_names"].index(name)
         if sys.version_info >= (3, 12):
             idx <<= 1
-            if push_null:
+            if is_method:
                 idx |= 1
         return self.add_instr("LOAD_ATTR", arg=idx, argval=name)
 
@@ -765,10 +765,13 @@ class PyCodeGen:
         return self.add_instr("DELETE_ATTR", arg=idx, argval=name)
 
     def gen_load_method(self, name: str):
-        if name not in self._code_options["co_names"]:
-            self._code_options["co_names"].append(name)
-        idx = self._code_options["co_names"].index(name)
-        return self.add_instr("LOAD_METHOD", arg=idx, argval=name)
+        if sys.version_info >= (3, 12):
+            self.gen_load_attr(name, True)
+        else:
+            if name not in self._code_options["co_names"]:
+                self._code_options["co_names"].append(name)
+            idx = self._code_options["co_names"].index(name)
+            return self.add_instr("LOAD_METHOD", arg=idx, argval=name)
 
     def gen_delete_global(self, name: str):
         if name not in self._code_options["co_names"]:

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -766,12 +766,11 @@ class PyCodeGen:
 
     def gen_load_method(self, name: str):
         if sys.version_info >= (3, 12):
-            self.gen_load_attr(name, True)
-        else:
-            if name not in self._code_options["co_names"]:
-                self._code_options["co_names"].append(name)
-            idx = self._code_options["co_names"].index(name)
-            return self.add_instr("LOAD_METHOD", arg=idx, argval=name)
+            return self.gen_load_attr(name, True)
+        if name not in self._code_options["co_names"]:
+            self._code_options["co_names"].append(name)
+        idx = self._code_options["co_names"].index(name)
+        return self.add_instr("LOAD_METHOD", arg=idx, argval=name)
 
     def gen_delete_global(self, name: str):
         if name not in self._code_options["co_names"]:

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -742,12 +742,14 @@ class PyCodeGen:
             idx = self.cell_free_storage.index(name)
         return self.add_instr("LOAD_DEREF", arg=idx, argval=name)
 
-    def gen_load_attr(self, name: str):
+    def gen_load_attr(self, name: str, push_null=False):
         if name not in self._code_options["co_names"]:
             self._code_options["co_names"].append(name)
         idx = self._code_options["co_names"].index(name)
         if sys.version_info >= (3, 12):
             idx <<= 1
+            if push_null:
+                idx |= 1
         return self.add_instr("LOAD_ATTR", arg=idx, argval=name)
 
     def gen_store_attr(self, name: str):

--- a/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from .mutable_data import MutableData
@@ -124,18 +123,12 @@ class DictSideEffectRestorer(SideEffectRestorer):
         # Reference to the original dict.
         # load old_dict.update and new_dict to stack.
         self.var.reconstruct(codegen)
-        if sys.version_info >= (3, 12):
-            codegen.gen_load_attr("update", True)
-        else:
-            codegen.gen_load_method("update")
+        codegen.gen_load_method("update")
         # Generate dict by each key-value pair.
         self.var.reconstruct(codegen, use_tracker=False)
         # load old_dict.clear to stack.
         self.var.reconstruct(codegen)
-        if sys.version_info >= (3, 12):
-            codegen.gen_load_attr("clear", True)
-        else:
-            codegen.gen_load_method("clear")
+        codegen.gen_load_method("clear")
 
     def post_gen(self, codegen: PyCodeGen):
         # Call methods to apply side effects.

--- a/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/side_effects.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from .mutable_data import MutableData
@@ -123,12 +124,18 @@ class DictSideEffectRestorer(SideEffectRestorer):
         # Reference to the original dict.
         # load old_dict.update and new_dict to stack.
         self.var.reconstruct(codegen)
-        codegen.gen_load_method("update")
+        if sys.version_info >= (3, 12):
+            codegen.gen_load_attr("update", True)
+        else:
+            codegen.gen_load_method("update")
         # Generate dict by each key-value pair.
         self.var.reconstruct(codegen, use_tracker=False)
         # load old_dict.clear to stack.
         self.var.reconstruct(codegen)
-        codegen.gen_load_method("clear")
+        if sys.version_info >= (3, 12):
+            codegen.gen_load_attr("clear", True)
+        else:
+            codegen.gen_load_method("clear")
 
     def post_gen(self, codegen: PyCodeGen):
         # Call methods to apply side effects.

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,6 +1,5 @@
 ./test_11_jumps.py
 ./test_12_for_loop.py
-./test_21_global.py
 ./test_break_graph.py
 ./test_builtin_zip.py
 ./test_guard_user_defined_fn.py


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Description
python 3.12中，test_21_global.py单测codegen超出范围报错：`ValueError: bytes must be in range(0, 256)`，
排查发现是因为side_effect文件的dict默认调用gen_load_method，对应的[opcode是262](https://github.com/python/cpython/blob/418e72041349dccdd2bf6ad58643fec3314b1691/Lib/opcode.py#L273) 所以出错；3.12中dict.update/clear函数调用不会生成`LOAD_METHOD`字节码，所以改成生成`LOAD_ATTR`，而dict的update/clear方法需要生成`LOAD_ATTR`额外push NULL；

TODO: test_inplace_api.py存在类似codegen问题和`POP_JUMP_FORWARD_IF_FALSE`不支持生成问题
- #61174
- #61173