### PR TITLE
Fix fused_rope dist op by adding time_major attr

### DIFF
--- a/paddle/phi/infermeta/spmd_rules/fused_rope.h
+++ b/paddle/phi/infermeta/spmd_rules/fused_rope.h
@@ -29,8 +29,8 @@ SpmdInfo FusedRopeInferSpmd(const DistMetaTensor& q,
                             const DistMetaTensor& sin,
                             const DistMetaTensor& cos,
                             const DistMetaTensor& position_ids,
-                            bool use_neox_rotary_style,
-                            bool time_major);
+                            bool use_neox_rotary_style = true,
+                            bool time_major = false);
 
 SpmdInfo FusedRopeInferSpmdReverse(const DistMetaTensor& q,
                                    const DistMetaTensor& k,
@@ -41,8 +41,8 @@ SpmdInfo FusedRopeInferSpmdReverse(const DistMetaTensor& q,
                                    const DistMetaTensor& out_q,
                                    const DistMetaTensor& out_k,
                                    const DistMetaTensor& out_v,
-                                   bool use_neox_rotary_style,
-                                   bool time_major);
+                                   bool use_neox_rotary_style = true,
+                                   bool time_major = false);
 
 SpmdInfo FusedRopeGradInferSpmd(const DistMetaTensor& sin,
                                 const DistMetaTensor& cos,
@@ -50,8 +50,8 @@ SpmdInfo FusedRopeGradInferSpmd(const DistMetaTensor& sin,
                                 const DistMetaTensor& out_q_grad,
                                 const DistMetaTensor& out_k_grad,
                                 const DistMetaTensor& out_v_grad,
-                                bool use_neox_rotary_style,
-                                bool time_major);
+                                bool use_neox_rotary_style = true,
+                                bool time_major = false);
 
 }  // namespace distributed
 }  // namespace phi

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_fused_rope.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_fused_rope.py
@@ -100,6 +100,7 @@ class DistributedFusedRope(DistributedOperatorImplContainer):
         )
 
         use_neox_rotary_style = op_desc.attr("use_neox_rotary_style")
+        time_major = op_desc.attr("time_major")
 
         # step2: infer spmd
         rule = get_phi_spmd_rule("fused_rotary_position_embedding")
@@ -112,6 +113,7 @@ class DistributedFusedRope(DistributedOperatorImplContainer):
             cos_spec,
             position_ids_spec,
             use_neox_rotary_style,
+            time_major,
         )
         bw_results = rule.infer_backward(
             q_spec,
@@ -124,6 +126,7 @@ class DistributedFusedRope(DistributedOperatorImplContainer):
             out_k_spec,
             out_v_spec,
             use_neox_rotary_style,
+            time_major,
         )
 
         # remove optional args in spmd results


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
之前的 pr : https://github.com/PaddlePaddle/Paddle/pull/61417 为 fused_rope 新增了 `time_major` 属性。
1. 本 pr 针对静半场景，为 fused_rope dist op 的 spmd 规则推导传入 `time_major` 属性，否则在静半场景下会报错：

<img width="1385" alt="10cf12359046ebffbc5f759746a6ca88" src="https://github.com/PaddlePaddle/Paddle/assets/61354321/d1902685-1c30-48c4-aecd-aeaab077ed44">

2. 为 fused_rope 的 spmd 推导函数里的属性入参添加默认值，默认值与 fused_rotary_position_embedding python api 一致

Pcard-76459
