### PR TITLE
[Inference] Fix absolute paths bug in tensorrt_engine op

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -506,8 +506,8 @@ std::string TensorRtSubgraphPass::CreateTensorRTOp(
                                            &max_shape_tensor,
                                            &optim_shape_tensor);
     } else {
-      shape_range_info_path =
-          Get<std::string>("model_opt_cache_dir") + "shape_range_info.pbtxt";
+      shape_range_info_path = Get<std::string>("model_opt_cache_dir") + "/" +
+                              "shape_range_info.pbtxt";
       if (open(shape_range_info_path.c_str(), O_RDONLY) != -1) {
         VLOG(1) << "trt dynamic_shape deserialize from "
                 << shape_range_info_path;

--- a/paddle/fluid/inference/analysis/passes/save_optimized_model_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/save_optimized_model_pass.cc
@@ -74,7 +74,7 @@ void SaveOptimizedModelPass::SaveOptimizedModel(Argument* argument) {
       }
     }
 
-    std::string save_params_path = path + ".pdiparams";
+    std::string save_params_path = path + "/" + "_optimized.pdiparams";
     std::vector<std::string> save_var_list(save_var_set.begin(),
                                            save_var_set.end());
     std::sort(save_var_list.begin(), save_var_list.end());
@@ -105,7 +105,7 @@ void SaveOptimizedModelPass::SaveOptimizedModel(Argument* argument) {
         }
       }
     }
-    std::string save_model_path = path + ".pdmodel";
+    std::string save_model_path = path + "/" + "_optimized.pdmodel";
     auto str = optimized_program_desc.Proto()->SerializeAsString();
     std::ofstream file(save_model_path.c_str(), std::ios::binary);
     file.write(str.c_str(), str.size());  // NOLINT

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -620,8 +620,14 @@ void AnalysisPredictor::ClearExtraParams() {
         op_desc->SetAttr("model_opt_cache_dir", model_opt_cache_dir);
       }
       if (op_desc->HasAttr("shape_range_info_path")) {
-        op_desc->SetAttr("shape_range_info_path",
-                         config_.shape_range_info_path_);
+        if (config_.shape_range_info_path_.empty()) {
+          op_desc->SetAttr(
+              "shape_range_info_path",
+              model_opt_cache_dir + "/" + "shape_range_info.pbtxt");
+        } else {
+          op_desc->SetAttr("shape_range_info_path",
+                           config_.shape_range_info_path_);
+        }
       }
     }
   }

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -424,8 +424,10 @@ bool AnalysisPredictor::Init(
   // Use Optimized model to inference
   if (config_.use_optimized_model_) {
     std::string optimized_model_path = GetOptimizedModelPath();
-    std::string optimized_model = optimized_model_path + ".pdmodel";
-    std::string optimized_params = optimized_model_path + ".pdiparams";
+    std::string optimized_model =
+        optimized_model_path + "/" + "_optimized.pdmodel";
+    std::string optimized_params =
+        optimized_model_path + "/" + "_optimized.pdiparams";
     if (FileExists(optimized_model) && FileExists(optimized_params)) {
       config_.SetModel(optimized_model, optimized_params);
       LOG(INFO) << "Load Optimized model from " << optimized_model_path;
@@ -434,6 +436,8 @@ bool AnalysisPredictor::Init(
           << "The optimized model is not found, fallback to original model. "
              "EnableSaveOptimModel will be turned on and the optimized model "
              "can be available next time.";
+      // UseOptimizedModel supports only the default path of shape_range_info
+      config_.shape_range_info_path_ = "";
       config_.EnableSaveOptimModel(true);
       config_.UseOptimizedModel(false);
     }
@@ -596,7 +600,7 @@ std::string AnalysisPredictor::GetOptimizedModelPath() {
             ? config_.model_dir()
             : inference::analysis::GetDirRoot(config_.prog_file());
   }
-  return model_opt_cache_dir + "/" + "_optimized";
+  return model_opt_cache_dir;
 }
 
 void AnalysisPredictor::ClearExtraParams() {
@@ -608,6 +612,16 @@ void AnalysisPredictor::ClearExtraParams() {
                                          op_desc->GetAttr("parameters"));
       trt_repetitive_params.insert(
           trt_repetitive_params.end(), trt_params.begin(), trt_params.end());
+      // TODO(ming1753): This is a trick solution to the problem of possible
+      // absolute paths in the model_opt_cache_dir and shape_range_info_path
+      // attributes in tensorrt_engine op. Expect the issue to be completely
+      // resolved in PIR.
+      auto model_opt_cache_dir_from_model = PADDLE_GET_CONST(
+          std::string, op_desc->GetAttr("model_opt_cache_dir"));
+      auto model_opt_cache_dir = GetOptimizedModelPath();
+      op_desc->SetAttr("model_opt_cache_dir", model_opt_cache_dir);
+      op_desc->SetAttr("shape_range_info_path",
+                       model_opt_cache_dir + "/" + "shape_range_info.pbtxt");
     }
   }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -436,8 +436,6 @@ bool AnalysisPredictor::Init(
           << "The optimized model is not found, fallback to original model. "
              "EnableSaveOptimModel will be turned on and the optimized model "
              "can be available next time.";
-      // UseOptimizedModel supports only the default path of shape_range_info
-      config_.shape_range_info_path_ = "";
       config_.EnableSaveOptimModel(true);
       config_.UseOptimizedModel(false);
     }
@@ -612,16 +610,19 @@ void AnalysisPredictor::ClearExtraParams() {
                                          op_desc->GetAttr("parameters"));
       trt_repetitive_params.insert(
           trt_repetitive_params.end(), trt_params.begin(), trt_params.end());
-      // TODO(ming1753): This is a trick solution to the problem of possible
+      // NOTE(ming1753): This is a trick solution to the problem of possible
       // absolute paths in the model_opt_cache_dir and shape_range_info_path
-      // attributes in tensorrt_engine op. Expect the issue to be completely
-      // resolved in PIR.
+      // attributes in tensorrt_engine op.
       auto model_opt_cache_dir_from_model = PADDLE_GET_CONST(
           std::string, op_desc->GetAttr("model_opt_cache_dir"));
       auto model_opt_cache_dir = GetOptimizedModelPath();
-      op_desc->SetAttr("model_opt_cache_dir", model_opt_cache_dir);
-      op_desc->SetAttr("shape_range_info_path",
-                       model_opt_cache_dir + "/" + "shape_range_info.pbtxt");
+      if (op_desc->HasAttr("model_opt_cache_dir")) {
+        op_desc->SetAttr("model_opt_cache_dir", model_opt_cache_dir);
+      }
+      if (op_desc->HasAttr("shape_range_info_path")) {
+        op_desc->SetAttr("shape_range_info_path",
+                         config_.shape_range_info_path_);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501

关联PR https://github.com/PaddlePaddle/Paddle/pull/61598

save_optimized_model_pass保存的模型中的tensorrt_engine算子有以下问题：
model_opt_cache_dir和shape_range_info_path将路径保存为op属性，因此就必须要求生成cache的路径和实际使用相同。该PR修复这个问题，可以在实际使用时重新设置cache路径。