### PR TITLE
[CINN]disable infer shape in static shape

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -110,7 +110,6 @@ class CinnJitInstruction::FnPtrImpl {
     for (int i = 0; i < output_tensor_size; ++i) {
       DDim dim(output_tensor_shapes[i],
                kernel_args[input_tensor_size + i]->dims().size());
-      std::cerr << "ddim !!!!!!!!!!! " << i << "\t" << dim << std::endl;
       kernel_args[input_tensor_size + i]->Resize(dim);
       free(output_tensor_shapes[i]);
     }
@@ -164,8 +163,6 @@ CinnJitInstruction::CinnJitInstruction(
         result.type().dyn_cast<paddle::dialect::AllocatedDenseTensorType>();
     tensor->set_type(
         paddle::dialect::TransToPhiDataType(alloc_tensor_type.dtype()));
-    std::cerr << "dd  dd " << i << "\t" << alloc_tensor_type.dims()
-              << std::endl;
     for (size_t j = 0; j < alloc_tensor_type.dims().size(); ++j) {
       if (alloc_tensor_type.dims()[j] < 0) {
         need_update_shape = true;

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -110,6 +110,7 @@ class CinnJitInstruction::FnPtrImpl {
     for (int i = 0; i < output_tensor_size; ++i) {
       DDim dim(output_tensor_shapes[i],
                kernel_args[input_tensor_size + i]->dims().size());
+      std::cerr << "ddim !!!!!!!!!!! " << i << "\t" << dim << std::endl;
       kernel_args[input_tensor_size + i]->Resize(dim);
       free(output_tensor_shapes[i]);
     }
@@ -163,6 +164,14 @@ CinnJitInstruction::CinnJitInstruction(
         result.type().dyn_cast<paddle::dialect::AllocatedDenseTensorType>();
     tensor->set_type(
         paddle::dialect::TransToPhiDataType(alloc_tensor_type.dtype()));
+    std::cerr << "dd  dd " << i << "\t" << alloc_tensor_type.dims()
+              << std::endl;
+    for (size_t j = 0; j < alloc_tensor_type.dims().size(); ++j) {
+      if (alloc_tensor_type.dims()[j] < 0) {
+        need_update_shape = true;
+        continue;
+      }
+    }
     tensor->Resize(alloc_tensor_type.dims());
   }
 }
@@ -173,7 +182,7 @@ void CinnJitInstruction::Run() {
 
   auto stream = gpu_ctx->stream();
 
-  if (FLAGS_cinn_bucket_compile) {
+  if (FLAGS_cinn_bucket_compile && need_update_shape) {
     fn_ptr_impl_->InferShape(
         tensor_args_, input_tensor_size, output_tensor_size);
   }

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.h
@@ -52,6 +52,7 @@ class CinnJitInstruction : public InstructionBase {
   int32_t input_tensor_size;
   int32_t output_tensor_size;
 
+  bool need_update_shape{false};
   std::vector<phi::DenseTensor*> tensor_args_;
 
   ::pir::Operation* op_{nullptr};  // not owned


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

在后续的动静shape的merge结构中， infer shape的推导存在一些的问题，暂时禁用静态shape场景下更新输出的shape（也无需更新shape）