### PR TITLE
[PIR][DynamicShape] Fix bug in slice op's InferSymbolicShape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
@@ -16,11 +16,12 @@
 
 namespace paddle::dialect::details {
 
-std::vector<int64_t> VecExpr2Int64(const ExprVec &expr_vec) {
+std::optional<std::vector<int64_t>> VecExpr2Int64(const ExprVec &expr_vec) {
   std::vector<int64_t> int64vec;
   for (auto item : expr_vec) {
-    IR_ENFORCE(item.isa<int64_t>(),
-               "all the elements in expr_vec must be int64_t");
+    if (!item.isa<int64_t>()) {
+      return std::nullopt;
+    }
     int64vec.push_back(item.Get<int64_t>());
   }
   return int64vec;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.cc
@@ -16,6 +16,16 @@
 
 namespace paddle::dialect::details {
 
+std::vector<int64_t> VecExpr2Int64(const ExprVec &expr_vec) {
+  std::vector<int64_t> int64vec;
+  for (auto item : expr_vec) {
+    IR_ENFORCE(item.isa<int64_t>(),
+               "all the elements in expr_vec must be int64_t");
+    int64vec.push_back(item.Get<int64_t>());
+  }
+  return int64vec;
+}
+
 bool ReduceInferDim(pir::Operation *op,
                     pir::ShapeConstraintIRAnalysis *shape_analysis,
                     const std::vector<int64_t> &axis,

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -17,6 +17,12 @@
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/pir/include/dialect/shape/utils/shape_analysis.h"
 
+// To make codes shorter
+using ExprVec = std::vector<symbol::DimExpr>;
+using ShapeOrData = symbol::ShapeOrDataDimExprs;
+using TensorExprs = symbol::TensorShapeOrDataDimExprs;
+using TensorListExprs = symbol::TensorListShapeOrDataDimExprs;
+
 namespace paddle::dialect::details {
 template <typename T>
 struct AttributeTrait;
@@ -59,6 +65,8 @@ std::vector<T> GetVectorAttr(const ::pir::Operation *op,
   }
   return vec_res;
 }
+
+std::vector<int64_t> VecExpr2Int64(const ExprVec &expr_vec);
 
 bool ReduceInferDim(pir::Operation *op,
                     pir::ShapeConstraintIRAnalysis *shape_analysis,

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -66,7 +66,7 @@ std::vector<T> GetVectorAttr(const ::pir::Operation *op,
   return vec_res;
 }
 
-std::vector<int64_t> VecExpr2Int64(const ExprVec &expr_vec);
+std::optional<std::vector<int64_t>> VecExpr2Int64(const ExprVec &expr_vec);
 
 bool ReduceInferDim(pir::Operation *op,
                     pir::ShapeConstraintIRAnalysis *shape_analysis,

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
@@ -19,11 +19,6 @@
 
 namespace paddle::dialect {
 
-// To make codes shorter
-using ShapeOrData = symbol::ShapeOrDataDimExprs;
-using TensorExprs = symbol::TensorShapeOrDataDimExprs;
-using TensorListExprs = symbol::TensorListShapeOrDataDimExprs;
-
 bool DataOpInferSymbolicShape(pir::Operation *op,
                               pir::ShapeConstraintIRAnalysis *shape_analysis) {
   const auto &attributes = op->attributes();
@@ -278,9 +273,96 @@ bool FullIntArrayOpInferSymbolicShape(
   return true;
 }
 
+inline void CheckAndUpdateSliceAttrs(
+    const ExprVec &in_dims,
+    const std::vector<int64_t> &axes,
+    ExprVec *starts_p,
+    ExprVec *ends_p,
+    std::vector<int64_t> *infer_flags = nullptr) {
+  std::vector<int64_t> starts_int = details::VecExpr2Int64(*starts_p);
+  std::vector<int64_t> ends_int = details::VecExpr2Int64(*ends_p);
+  ExprVec &starts = *starts_p;
+  ExprVec &ends = *ends_p;
+  auto IsMaxInt = [](const symbol::DimExpr &expr) {
+    return expr.isa<int64_t>() &&
+           expr.Get<int64_t>() ==
+               static_cast<int64_t>(std::numeric_limits<int>::max());
+  };
+
+  for (size_t i = 0; i < axes.size(); ++i) {
+    int64_t axis = axes[i];
+
+    if (infer_flags != nullptr && (*infer_flags)[i] == -1) {
+      PADDLE_THROW(
+          phi::errors::Unimplemented("SliceOpInferSymbolicShape CAN NOT "
+                                     "deal with -1 in infer_flags now"));
+    }
+
+    // For both start and end can be negtive or positive, we need to handle the
+    // following different arrangements.
+    ends[i] = IsMaxInt(ends[i]) ? in_dims[axis] : ends[i];
+
+    bool both_negative_or_positive = (starts_int[i] >= 0 && ends_int[i] >= 0) ||
+                                     (starts_int[i] <= 0 && ends_int[i] <= 0);
+    bool start_negative_end_positive = starts_int[i] <= 0 && ends_int[i] >= 0;
+    bool start_positive_end_negative = starts_int[i] >= 0 && ends_int[i] <= 0;
+
+    if (both_negative_or_positive) {
+      continue;
+    } else if (start_negative_end_positive) {
+      starts[i] = starts[i] + in_dims[axis];
+    } else if (start_positive_end_negative) {
+      starts[i] = starts[i] - in_dims[axis];
+    } else {
+      LOG(FATAL) << "Dead code";
+    }
+  }
+}
+
+inline ExprVec GetSliceDims(const ExprVec &in_dims,
+                            const std::vector<int64_t> &axes,
+                            const ExprVec &starts,
+                            const ExprVec &ends,
+                            std::vector<int64_t> *infer_flags = nullptr) {
+  ExprVec slice_dims(in_dims);
+
+  for (size_t i = 0; i < axes.size(); ++i) {
+    int64_t axis = axes[i];
+
+    if (infer_flags != nullptr && (*infer_flags)[i] == -1) {
+      PADDLE_THROW(
+          phi::errors::Unimplemented("SliceOpInferSymbolicShape CAN NOT "
+                                     "deal with -1 in infer_flags now"));
+    }
+
+    slice_dims[axis] = ends[i] - starts[i];
+  }
+
+  return slice_dims;
+}
+
+inline ExprVec GetDecreasedDims(const ExprVec &slice_dims,
+                                const std::vector<int64_t> &decrease_axes) {
+  ExprVec decreased_dims(slice_dims);
+  std::vector<uint8_t> decrease_flag(slice_dims.size(), 0);
+  if (decrease_axes.size() > 0) {
+    for (size_t i = 0; i < decrease_axes.size(); ++i) {
+      int64_t axis = decrease_axes[i];
+      decrease_flag[axis] = 1;
+    }
+    ExprVec new_shape;
+    for (int i = 0; i < slice_dims.size(); ++i) {
+      if (decrease_flag[i] == 0) {
+        new_shape.emplace_back(slice_dims[i]);
+      }
+    }
+    decreased_dims = new_shape;
+  }
+  return decreased_dims;
+}
+
 bool SliceOpInferSymbolicShape(pir::Operation *op,
                                pir::ShapeConstraintIRAnalysis *shape_analysis) {
-  // TODO(zhangbopd): Not implemented yet.
   pir::Value operand_source = op->operand_source(0);
   pir::Value operand_starts = op->operand_source(1);
   pir::Value operand_ends = op->operand_source(2);
@@ -293,107 +375,67 @@ bool SliceOpInferSymbolicShape(pir::Operation *op,
   const symbol::ShapeOrDataDimExprs &ends_shape_data =
       shape_analysis->GetShapeOrDataForValue(operand_ends);
 
-  // Currently, we DO NOT support the case that any element in `axes` `starts`
-  // or `ends` is a Symbol.
   const std::vector<int64_t> axes = [&] {
-    const auto &attributes = op->attributes();
-    pir::Attribute attr_axes = attributes.at("axes");
-
-    const auto &axes_vec = attr_axes.dyn_cast<pir::ArrayAttribute>().AsVector();
-    std::vector<int64_t> axes;
+    std::vector<int64_t> axes_vec = details::GetVectorAttr(op, "axes");
     int64_t rank = int64_t(operand_shape_or_data.shape().size());
-    for (auto item : axes_vec) {
-      int64_t axis = item.dyn_cast<pir::Int64Attribute>().data();
-      axes.emplace_back(axis >= 0 ? axis : std::max(int64_t(0), axis + rank));
+    for (size_t i = 0; i < axes_vec.size(); i++) {
+      int64_t axis = axes_vec[i];
+      axes_vec[i] = axis >= 0 ? axis : std::max(int64_t(0), axis + rank);
     }
-    return axes;
+    return axes_vec;
   }();
 
-  const std::vector<int64_t> starts = [&] {
-    std::vector<int64_t> starts;
-    for (auto item : starts_shape_data.data().value()) {
-      IR_ENFORCE(item.isa<int64_t>(),
-                 "Currently, we DO NOT support the case that any element in "
-                 "`starts` is a Symbol.");
-      starts.push_back(item.Get<int64_t>());
+  // Currently, we DO NOT support any element in `starts` is a Symbol.
+  ExprVec starts = starts_shape_data.data().value();
+  ExprVec ends = ends_shape_data.data().value();
+
+  std::vector<int64_t> infer_flags = [op, &axes] {
+    std::vector<int64_t> infer_flags_t =
+        details::GetVectorAttr(op, "infer_flags");
+    if (infer_flags_t.empty()) {
+      infer_flags_t = std::vector<int64_t>(axes.size(), 1);
     }
-    return starts;
+    return infer_flags_t;
   }();
 
-  const std::vector<int64_t> ends = [&] {
-    std::vector<int64_t> ends;
-    for (auto item : ends_shape_data.data().value()) {
-      IR_ENFORCE(item.isa<int64_t>(),
-                 "Currently, we DO NOT support the case that any element in "
-                 "`ends` is a Symbol.");
-      ends.push_back(item.Get<int64_t>());
-    }
-    return ends;
-  }();
+  const std::vector<int64_t> decrease_axis =
+      details::GetVectorAttr(op, "decrease_axis");
+
+  const auto &GetShapeDimExprs = [&]() -> symbol::ShapeOrDataDimExprs {
+    const ExprVec &in_dims = operand_shape_or_data.shape();
+    CheckAndUpdateSliceAttrs(in_dims, axes, &starts, &ends, &infer_flags);
+    ExprVec slice_dims =
+        GetSliceDims(in_dims, axes, starts, ends, &infer_flags);
+    ExprVec out_dims = GetDecreasedDims(slice_dims, decrease_axis);
+
+    return symbol::ShapeOrDataDimExprs{
+        symbol::TensorShapeOrDataDimExprs(out_dims)};
+  };
 
   // When `pd.slice` is operating on a tensor which is produced by a `pd.shape`
   // op, the reseult should be written into data.
   const auto &GetDataDimExprs = [&]() -> symbol::ShapeOrDataDimExprs {
-    const std::vector<symbol::DimExpr> out_data = [&] {
-      std::vector<symbol::DimExpr> out_data;
-      const int64_t start =
-          starts[0] < 0
-              ? starts[0] + operand_shape_or_data.data().value().size()
-              : starts[0];
-      const int64_t end =
-          static_cast<int64_t>(std::numeric_limits<int>::max()) == ends[0]
-              ? operand_shape_or_data.data().value().size()
-              : ends[0];
+    std::vector<symbol::DimExpr> out_data;
+    // Currently, we DO NOT support the case that any element in `axes` `starts`
+    // or `ends` is a Symbol.
+    const auto starts_int = details::VecExpr2Int64(starts);
+    const auto ends_int = details::VecExpr2Int64(ends);
+    const int64_t start =
+        starts_int[0] < 0
+            ? starts_int[0] + operand_shape_or_data.data().value().size()
+            : starts_int[0];
+    const int64_t end =
+        static_cast<int64_t>(std::numeric_limits<int>::max()) == ends_int[0]
+            ? operand_shape_or_data.data().value().size()
+            : ends_int[0];
 
-      for (int64_t i = start; i < end; i++) {
-        out_data.push_back(operand_shape_or_data.data().value()[i]);
-      }
-      return out_data;
-    }();
+    for (int64_t i = start; i < end; i++) {
+      out_data.push_back(operand_shape_or_data.data().value()[i]);
+    }
+
     const std::vector<symbol::DimExpr> shape{std::int64_t(out_data.size())};
     return symbol::ShapeOrDataDimExprs{
         symbol::TensorShapeOrDataDimExprs(shape, out_data)};
-  };
-
-  // Othewise, the reseult should be written into the shape.
-  const auto &GetShapeDimExprs = [&]() -> symbol::ShapeOrDataDimExprs {
-    std::vector<symbol::DimExpr> out_shape = operand_shape_or_data.shape();
-
-    const std::vector<symbol::DimExpr> &dim_expr_starts =
-        starts_shape_data.data().value();
-    const std::vector<symbol::DimExpr> &dim_expr_ends =
-        ends_shape_data.data().value();
-
-    // For both start and end can be negtive or positive, we need to handle the
-    // following different arrangements.
-    auto IsMaxInt = [](const symbol::DimExpr &expr) {
-      return expr.isa<int64_t>() &&
-             expr.Get<int64_t>() ==
-                 static_cast<int64_t>(std::numeric_limits<int>::max());
-    };
-    for (size_t i = 0; i < axes.size(); ++i) {
-      const int64_t axis = axes[i];
-      auto end =
-          IsMaxInt(dim_expr_ends[i]) ? out_shape[axis] : dim_expr_ends[i];
-
-      bool both_negative_or_positive =
-          (starts[i] >= 0 && ends[i] >= 0) || (starts[i] <= 0 && ends[i] <= 0);
-      bool start_negative_end_positive = starts[i] <= 0 && ends[i] >= 0;
-      bool start_positive_end_negative = starts[i] >= 0 && ends[i] <= 0;
-
-      if (both_negative_or_positive) {
-        out_shape[axis] = end - dim_expr_starts[i];
-      } else if (start_negative_end_positive) {
-        out_shape[axis] = end - dim_expr_starts[i] - out_shape[axis];
-      } else if (start_positive_end_negative) {
-        out_shape[axis] = out_shape[axis] - dim_expr_starts[i] + end;
-      } else {
-        LOG(FATAL) << "Dead code";
-      }
-    }
-
-    return symbol::ShapeOrDataDimExprs{
-        symbol::TensorShapeOrDataDimExprs(out_shape)};
   };
 
   symbol::ShapeOrDataDimExprs shape_data =

--- a/test/cpp/pir/shape_dialect/shape_optimization_test.cc
+++ b/test/cpp/pir/shape_dialect/shape_optimization_test.cc
@@ -122,10 +122,10 @@ TEST(shape_optimization, shape_optimization_pass) {
             "Mul(Mul(Mul(Mul(1, S1), 128), 32), 1 / (128))");
   EXPECT_EQ(cast_res.shape()[3], 2);
 
-  EXPECT_EQ(symbol::ToString(relu_res.shape()[0]), "Add(Add(S2, -2), -2)");
-  EXPECT_EQ(symbol::ToString(relu_res.shape()[1]), "Add(Add(S3, -2), -2)");
-  EXPECT_EQ(symbol::ToString(relu_res.shape()[2]), "Add(Add(S4, -2), -2)");
-  EXPECT_EQ(symbol::ToString(relu_res.shape()[3]), "Add(Add(S5, -2), -2)");
+  EXPECT_EQ(symbol::ToString(relu_res.shape()[0]), "Add(-2, -Add(2, -S2))");
+  EXPECT_EQ(symbol::ToString(relu_res.shape()[1]), "Add(-2, -Add(2, -S3))");
+  EXPECT_EQ(symbol::ToString(relu_res.shape()[2]), "Add(-2, -Add(2, -S4))");
+  EXPECT_EQ(symbol::ToString(relu_res.shape()[3]), "Add(-2, -Add(2, -S5))");
 
   EXPECT_EQ(subtract_res.shape()[0], 1);
   EXPECT_EQ(subtract_res.shape()[1], 64);

--- a/test/ir/pir/cinn/symbolic/test_op_infer_sym_shape.py
+++ b/test/ir/pir/cinn/symbolic/test_op_infer_sym_shape.py
@@ -459,5 +459,55 @@ class TestTrilOpInferSymbolicShape(TestBase):
         return True
 
 
+class SliceNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        out = x[:, -1, :]
+
+        return out
+
+
+class TestSliceOpInferSymbolicShape(TestBase):
+    def prepare_data(self):
+        self.cases = [np.random.rand(2, 3, 4)]
+
+        self.expected = [
+            [
+                'shape[S0, S2], data[NULL]',
+            ]
+        ]
+
+    def test_eval_symbolic(self):
+        net = SliceNet()
+
+        for i in range(len(self.cases)):
+            x = self.cases[i]
+            x_spec = InputSpec(
+                shape=[None for index in range(len(x.shape))], dtype='float32'
+            )
+
+            input_spec = [x_spec]
+            net = apply_to_static(net, False, input_spec)
+            net.eval()
+
+            # check the infer result
+            sym_shape_str_list = get_sym_shape_str_for_op(
+                net, input_spec, 'pd_op.slice'
+            )
+            np.testing.assert_equal(
+                len(sym_shape_str_list), len(self.expected[i])
+            )
+            for j in range(len(sym_shape_str_list)):
+                np.testing.assert_equal(
+                    sym_shape_str_list[j].find(self.expected[i][j]),
+                    0,
+                    f'in case i,j = {i},{j}: output shape ({sym_shape_str_list[0]}) is not expected {(self.expected[i][j])}',
+                )
+
+        return True
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/ir/pir/cinn/symbolic/test_op_infer_sym_shape.py
+++ b/test/ir/pir/cinn/symbolic/test_op_infer_sym_shape.py
@@ -465,17 +465,25 @@ class SliceNet(paddle.nn.Layer):
 
     def forward(self, x):
         out = x[:, -1, :]
+        out = x[1:3, 0:2, 2:4]
+
+        axes = [0, 1, 2]
+        starts = [-3, 0, 2]
+        ends = [3, 2, 4]
+        out = paddle.slice(x, axes=axes, starts=starts, ends=ends)
 
         return out
 
 
 class TestSliceOpInferSymbolicShape(TestBase):
     def prepare_data(self):
-        self.cases = [np.random.rand(2, 3, 4)]
+        self.cases = [np.random.rand(4, 5, 6)]
 
         self.expected = [
             [
                 'shape[S0, S2], data[NULL]',
+                'shape[2, 2, 2], data[NULL]',
+                'shape[Add(3, -Add(-3, S0)), 2, 2]',
             ]
         ]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Fix bug in slice op's InferSymbolicShape
