### PR TITLE
[XPU] fix beta1_pow and beta2_pow for AdamW

### DIFF
--- a/paddle/phi/kernels/xpu/adamw_kernel.cc
+++ b/paddle/phi/kernels/xpu/adamw_kernel.cc
@@ -230,9 +230,9 @@ void AdamwDenseKernelKL3(const Context& dev_ctx,
           coeff_,
           lr_ratio_,
           beta1_pow.data<MPDType>(),
-          beta1_pow_out_ptr,
+          nullptr,  // beta1_pow_out_ptr,
           beta2_pow.data<MPDType>(),
-          beta2_pow_out_ptr,
+          nullptr,  // beta2_pow_out_ptr,
           moment1.data<MPDType>(),
           dev_ctx.template Alloc<MPDType>(moment1_out),
           moment2.data<MPDType>(),
@@ -254,9 +254,9 @@ void AdamwDenseKernelKL3(const Context& dev_ctx,
           coeff_,
           lr_ratio_,
           beta1_pow.data<MPDType>(),
-          beta1_pow_out_ptr,
+          nullptr,  // beta1_pow_out_ptr,
           beta2_pow.data<MPDType>(),
-          beta2_pow_out_ptr,
+          nullptr,  // beta2_pow_out_ptr,
           moment1.data<MPDType>(),
           dev_ctx.template Alloc<MPDType>(moment1_out),
           moment2.data<MPDType>(),
@@ -269,6 +269,25 @@ void AdamwDenseKernelKL3(const Context& dev_ctx,
           master_out_data,
           param.numel());
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "adamw");
+    }
+    if (!use_global_beta_pow) {
+      // update beta1_pow and beta2_pow
+      int r = xpu::scale(dev_ctx.x_context(),
+                         beta1_pow.data<MPDType>(),
+                         beta1_pow_out_ptr,
+                         beta1_pow.numel(),
+                         false,
+                         beta1_,
+                         0.0f);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale");
+      r = xpu::scale(dev_ctx.x_context(),
+                     beta2_pow.data<MPDType>(),
+                     beta2_pow_out_ptr,
+                     beta2_pow.numel(),
+                     false,
+                     beta2_,
+                     0.0f);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale");
     }
   }
   return;

--- a/paddle/phi/kernels/xpu/adamw_kernel.cc
+++ b/paddle/phi/kernels/xpu/adamw_kernel.cc
@@ -230,9 +230,9 @@ void AdamwDenseKernelKL3(const Context& dev_ctx,
           coeff_,
           lr_ratio_,
           beta1_pow.data<MPDType>(),
-          beta1_pow_out_ptr,
+          nullptr,  // beta1_pow_out_ptr,
           beta2_pow.data<MPDType>(),
-          beta2_pow_out_ptr,
+          nullptr,  // beta2_pow_out_ptr,
           moment1.data<MPDType>(),
           dev_ctx.template Alloc<MPDType>(moment1_out),
           moment2.data<MPDType>(),
@@ -254,9 +254,9 @@ void AdamwDenseKernelKL3(const Context& dev_ctx,
           coeff_,
           lr_ratio_,
           beta1_pow.data<MPDType>(),
-          beta1_pow_out_ptr,
+          nullptr,  // beta1_pow_out_ptr,
           beta2_pow.data<MPDType>(),
-          beta2_pow_out_ptr,
+          nullptr,  // beta2_pow_out_ptr,
           moment1.data<MPDType>(),
           dev_ctx.template Alloc<MPDType>(moment1_out),
           moment2.data<MPDType>(),
@@ -270,6 +270,23 @@ void AdamwDenseKernelKL3(const Context& dev_ctx,
           param.numel());
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "adamw");
     }
+    // update beta1_pow and beta2_pow
+    int r = xpu::scale(dev_ctx.x_context(),
+                       beta1_pow.data<MPDType>(),
+                       beta1_pow_out_ptr,
+                       beta1_pow.numel(),
+                       false,
+                       beta1_,
+                       0.0f);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale");
+    r = xpu::scale(dev_ctx.x_context(),
+                   beta2_pow.data<MPDType>(),
+                   beta2_pow_out_ptr,
+                   beta2_pow.numel(),
+                   false,
+                   beta2_,
+                   0.0f);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale");
   }
   return;
 }


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Description
之前尝试把“更新`beta1_pow`和更新`beta2_pow`”的逻辑合并到`adamw`的XDNN API调用里面，以减少长度为1的`scale`调用。但是有个潜在的同步问题，在各个core计算速度差距很大的时候，非0号core读到的值可能是0号core更新之后的值。
因此先改回来了，恢复原先的计算逻辑，先调用`adamw`，然后调用两次`scale`。
