### PR TITLE
[PIR] pir onednn elemetwise datalayout trans

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.h
@@ -75,6 +75,8 @@ class OneDNNPhiKernelInstruction : public InstructionBase {
   std::map<std::string, phi::Attribute> ctx_attr_{};
   std::map<std::string, std::vector<std::string>> inputs_{};
   std::map<std::string, std::vector<std::string>> outputs_{};
+  std::string kernel_name_;
+  phi::KernelKey kernel_key_;
 };
 }  // namespace framework
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-67164

PIR OneDNN中对DataLayout Transfer有特殊处理逻辑，通过ops_onednn_extra.yaml中标记data_format_tensors，在Instruction中做处理。但elementwise的处理逻辑，无法通过yaml配置表达，因此只能将特殊逻辑写入Instruction中。