### PR TITLE
[PHI kernels] add tf32 fc quantization mode; fix pool3d, conv3d test failure

### DIFF
--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -54,8 +54,10 @@ XPUFCCalcType FCCalcType() {
     return XPUFCCalcType::FC_FLOAT;
   } else if (std::getenv("XPU_PADDLE_FC_INT32_WITH_LL") != nullptr) {
     return XPUFCCalcType::FC_INT32_WITH_LL;
-  } else if (std::is_same<phi::dtype::bfloat16, T>::value ||
-             std::is_same<XPUTypeBF16, T>::value) {
+  } else if ((std::is_same<phi::dtype::bfloat16, T>::value ||
+              std::is_same<XPUTypeBF16, T>::value) ||
+             (std::is_same<float, T>::value &&
+              std::getenv("XPU_PADDLE_FC_TF32") != nullptr)) {
     return XPUFCCalcType::FC_TF32;
   }
   return XPUFCCalcType::FC_INT16;


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
Add tf32 fc quantization mode; fix pool3d, conv3d test failure.

to activate tf32 quantization for float input data type:export XPU_PADDLE_FC_TF32=1
