### PR TITLE
Fix copy *.h on paddle/pir dir introduced from PR#61863

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -876,7 +876,7 @@ headers = (
     # init headers
     list(find_files('init_phi.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/platform')) +  # phi init headers
     # init headers
-    list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/pir/include')) +  # pir init headers
+    list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/pir/include', recursive=True)) +  # pir init headers
     # init headers
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/pir/drr/include')) +  # drr init headers
     # init headers


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71500
Fix bug from https://github.com/PaddlePaddle/Paddle/pull/61863