### PR TITLE
[Dygraph]  Fix `EagerReducer::MarkVarReady()` 's lank of HasGrad() branch

### DIFF
--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -846,8 +846,8 @@ void EagerReducer::MarkVarReady(const size_t var_index,
         }
 
         group_tensor
-            .ShareDataWith(*(
-                std::dynamic_pointer_cast<phi::DenseTensor>(grad_tensor.impl())))
+            .ShareDataWith(*(std::dynamic_pointer_cast<phi::DenseTensor>(
+                grad_tensor.impl())))
             .Resize({grad_tensor.numel()});
       } else {
         VLOG(3) << "Tensor[" << tensors_[var_index].name()

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -846,19 +846,16 @@ void EagerReducer::MarkVarReady(const size_t var_index,
         }
 
         group_tensor
-            .ShareDataWith(*(
-                std::dynamic_pointer_cast<phi::DenseTensor>(grad_tensor.impl())))
+            .ShareDataWith(*(std::dynamic_pointer_cast<phi::DenseTensor>(
+                grad_tensor.impl())))
             .Resize({grad_tensor.numel()});
       } else {
         VLOG(3) << "Tensor[" << tensors_[var_index].name()
                 << "] doesn't have grad";
-        if (!group_tensor.initialized()) {
-          group_tensor.Resize({static_cast<int64_t>(length)});
-          group_tensor.mutable_data(inner_place_, group.dtype_);
-        }
         auto *dev_ctx =
             platform::DeviceContextPool::Instance().Get(inner_place_);
         group_tensor.Resize({static_cast<int64_t>(length)});
+        dev_ctx->Alloc(&group_tensor, group.dtype_);
         phi::funcs::set_constant(*dev_ctx, &group_tensor, 0.0f);
       }
     } else {

--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -831,23 +831,36 @@ void EagerReducer::MarkVarReady(const size_t var_index,
     auto &group_tensor = group.dense_tensors_[inside_group_index];
     const auto length = group.length_[inside_group_index];
     if (is_used_var) {
-      auto *autograd_meta = tensors_[var_index].get_autograd_meta();
-      paddle::Tensor grad_tensor =
-          static_cast<egr::AutogradMeta *>(autograd_meta)->Grad();
-      if (grad_tensor.is_dense_tensor()) {
-        const auto &tensor_impl = grad_tensor.impl();
-        auto dense_tensor =
-            std::dynamic_pointer_cast<phi::DenseTensor>(tensor_impl);
-        if (!dense_tensor->meta().is_contiguous()) {
-          grad_tensor.set_impl(std::make_shared<phi::DenseTensor>(std::move(
-              paddle::experimental::Trans2Contiguous(*dense_tensor))));
+      if (HasGrad(var_index)) {
+        auto *autograd_meta = tensors_[var_index].get_autograd_meta();
+        paddle::Tensor grad_tensor =
+            static_cast<egr::AutogradMeta *>(autograd_meta)->Grad();
+        if (grad_tensor.is_dense_tensor()) {
+          const auto &tensor_impl = grad_tensor.impl();
+          auto dense_tensor =
+              std::dynamic_pointer_cast<phi::DenseTensor>(tensor_impl);
+          if (!dense_tensor->meta().is_contiguous()) {
+            grad_tensor.set_impl(std::make_shared<phi::DenseTensor>(std::move(
+                paddle::experimental::Trans2Contiguous(*dense_tensor))));
+          }
         }
-      }
 
-      group_tensor
-          .ShareDataWith(*(
-              std::dynamic_pointer_cast<phi::DenseTensor>(grad_tensor.impl())))
-          .Resize({grad_tensor.numel()});
+        group_tensor
+            .ShareDataWith(*(
+                std::dynamic_pointer_cast<phi::DenseTensor>(grad_tensor.impl())))
+            .Resize({grad_tensor.numel()});
+      } else {
+        VLOG(3) << "Tensor[" << tensors_[var_index].name()
+                << "] doesn't have grad";
+        if (!group_tensor.initialized()) {
+          group_tensor.Resize({static_cast<int64_t>(length)});
+          group_tensor.mutable_data(inner_place_, group.dtype_);
+        }
+        auto *dev_ctx =
+            platform::DeviceContextPool::Instance().Get(inner_place_);
+        group_tensor.Resize({static_cast<int64_t>(length)});
+        phi::funcs::set_constant(*dev_ctx, &group_tensor, 0.0f);
+      }
     } else {
       // TODO(shenliang03): maybe save the memory by avoiding tensor
       // construction


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Pcard-67164

EagrReducer的MarkVarReady函数缺少HasGrad()分支判断，相应的GradVar如果没有被initialized，会在该函数内报出segmentation fault
问题来源：PaddleDetection部分模型的多卡运行