### PR TITLE
[Dy2St][PIR] Add view op to inplace info

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1360,7 +1360,12 @@ std::map<int, int> GetOpInplaceInfo(const pir::Operation *op) {
       const std::string &inplace_name = yaml_parser.InplaceName(value_name);
       inplace_info[i] = yaml_parser.InputName2Id().at(inplace_name);
     }
+    if (yaml_parser.HasView(value_name)) {
+      const std::string &view_name = yaml_parser.ViewName(value_name);
+      inplace_info[i] = yaml_parser.InputName2Id().at(view_name);
+    }
   }
+
   return inplace_info;
 }
 

--- a/test/dygraph_to_static/test_deal_inplace.py
+++ b/test/dygraph_to_static/test_deal_inplace.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_pir_only,
+)
+
+import paddle
+
+
+def fn_with_inplace_op(inplace_op, x):
+    y = inplace_op(x)
+    z = inplace_op(x)
+    return y + z
+
+
+class TestDealInplace(Dy2StTestBase):
+    def run_test(self, dygraph_fn, *inputs):
+        dygraph_out = dygraph_fn(*inputs)
+        static_fn = paddle.jit.to_static(dygraph_fn)
+        static_out = static_fn(*inputs)
+        np.testing.assert_allclose(dygraph_out.numpy(), static_out.numpy())
+
+    @test_pir_only
+    def test_deal_view(self):
+        bn_layer = paddle.nn.BatchNorm2D(10)
+        x = paddle.to_tensor(np.random.random((2, 10, 3, 3)).astype('float32'))
+        self.run_test(fn_with_inplace_op, bn_layer, x)
+
+    @test_pir_only
+    def test_deal_inplace(self):
+        sigmoid_layer = paddle.nn.Sigmoid()
+        x = paddle.to_tensor(np.random.random((2, 10, 3, 3)).astype('float32'))
+        self.run_test(fn_with_inplace_op, sigmoid_layer, x)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

目前 PIR 下我们 `batch_norm` 组网使用的是 `batch_norm_` 这个 view op（同 inplace），当发生如下组网时候，就会发生错误：

```python
bn = paddle.nn.BatchNorm2D(10)

y = bn(x)
z = bn(x)
```

这里 bn params 中包含被 inplace 操作的参数，也是前反向拆分的中间结果，需要作为前向输出

假设最开始该参数名为 `"param"`，组网简化如下：

```python
param = builtin.parameter("param")

y, param2 = pd_op.batch_norm_(x, param)      # scope 里 "param" 被 rename 为 "param2"
z, param3 = pd_op.batch_norm_(x, param)      # scope 里 "param2" 被 rename 为 "param3"

shadow_output("param2", param2)
shadow_output("param3", param3)
```

因为 `param2` 已经不存在了，就会出问题

我们之前已经有了 inplace 处理逻辑，但缺失对 View 的处理，因此添加了 View 的处理

Pcard-67164