### PR TITLE
Fixed build error in cpu version

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -185,7 +185,7 @@ void CinnJitInstruction::Run() {
   fn_ptr_impl_->Run(tensor_args_, static_cast<void*>(stream));
 #else
   VLOG(0) << "Not Supported: cinn jit instruction currently does not "
-                      "support non-CUDA kernel";
+             "support non-CUDA kernel";
 #endif
 }
 

--- a/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/cinn_jit_instruction.cc
@@ -184,7 +184,7 @@ void CinnJitInstruction::Run() {
   // 2. exexute kernel
   fn_ptr_impl_->Run(tensor_args_, static_cast<void*>(stream));
 #else
-  VLOG(phi::FATAL) << "Not Supported: cinn jit instruction currently does not "
+  VLOG(0) << "Not Supported: cinn jit instruction currently does not "
                       "support non-CUDA kernel";
 #endif
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Before this commit, when we use `cmake .. -DPY_VERSION=3.10 -DWITH_GPU=OFF -DWITH_TESTING=ON -DWITH_CINN=ON` to build, we got build error.
After this commit, we can build successfully.