### PR TITLE
[Distributed] modify comm data type in eager comm connection

### DIFF
--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -245,7 +245,9 @@ def new_group(ranks=None, backend=None, timeout=_default_timeout):
 
         if int(os.getenv("FLAGS_eager_communication_connection", 0)) == 1:
             paddle.distributed.all_reduce(
-                paddle.zeros([1], dtype=paddle.uint8), group=group, sync_op=True
+                paddle.zeros([1], dtype=paddle.float32),
+                group=group,
+                sync_op=True,
             )
 
         return group

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -1122,7 +1122,9 @@ def init_parallel_env():
 
         if int(os.getenv("FLAGS_eager_communication_connection", 0)) == 1:
             paddle.distributed.all_reduce(
-                paddle.zeros([1], dtype=paddle.uint8), group=group, sync_op=True
+                paddle.zeros([1], dtype=paddle.float32),
+                group=group,
+                sync_op=True,
             )
         return group
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[Pcard-79653]
Modify comm data type when eager comm connection mode is enabled (uint8 --> float32) for better compatibility across various devices.