### PR TITLE
Update op_utils.h

### DIFF
--- a/paddle/phi/core/compat/op_utils.h
+++ b/paddle/phi/core/compat/op_utils.h
@@ -29,11 +29,6 @@ namespace phi {
 
 const static std::string deprecated_kernel_name = "deprecated";  // NOLINT
 
-const std::unordered_set<std::string> standard_kernel_suffixs({
-    "sr",  // SelectedRows kernel
-    "raw"  // fallback kernel of original fluid op
-});
-
 /**
  * Some fluid ops are no longer used under the corresponding official API
  * system of 2.0. These names need to correspond to the official API names


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
standard_kernel_suffixs is not used.