### PR TITLE
Implement the composition of abs_double_grad

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -34,6 +34,18 @@ using IntArray = paddle::experimental::IntArrayBase<paddle::Tensor>;
 //  differentiation
 
 template <typename T>
+void abs_double_grad(const Tensor& x,
+                     const Tensor& grad_x_grad,
+                     Tensor* grad_out_grad) {
+  // abs grad grad : ddout = ddx * sign(x)
+
+  if (grad_out_grad) {
+    auto sign_tmp = sign<T>(x);
+    set_output<T>(grad_x_grad * sign_tmp, grad_out_grad);
+  }
+}
+
+template <typename T>
 void tanh_double_grad(const Tensor& out,
                       const Tensor& grad_out,
                       const Tensor& grad_x_grad,

--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -13,6 +13,7 @@
   kernel :
     func : abs_double_grad
     data_type : grad_x_grad
+  composite : abs_double_grad(x, grad_x_grad, grad_out_grad)
 
 - backward_op : abs_grad
   forward : abs (Tensor x) -> Tensor(out)

--- a/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
@@ -41,6 +41,7 @@ class TestAbsDoubleGradComp(unittest.TestCase):
         def actual(primal):
             paddle.disable_static()
             core.set_prim_eager_enabled(True)
+            core._set_prim_backward_blacklist("abs_grad")
             x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
             x.stop_gradient = False
             y = paddle.tanh(paddle.abs(x))

--- a/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ class TestAbsDoubleGradComp(unittest.TestCase):
         if cls.cotangent is not None:
             cls.cotangent = cls.cotangent.astype(cls.dtype)
 
-    def test_pow_grad_comp_dygraph(self):
+    def test_abs_double_grad_comp_dygraph(self):
         def actual(primal):
             paddle.disable_static()
             core.set_prim_eager_enabled(True)

--- a/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import numpy as np
+import parameterized as param
+
+import paddle
+from paddle.base import core
+
+sys.path.append('../../../../legacy_test/')
+
+
+@param.parameterized_class(
+    ('primal', 'cotangent', 'dtype'),
+    [
+        (np.random.rand(10, 10), np.random.rand(10, 10), np.float32),
+    ],
+)
+class TestAbsDoubleGradComp(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.primal = cls.primal.astype(cls.dtype)
+        if cls.cotangent is not None:
+            cls.cotangent = cls.cotangent.astype(cls.dtype)
+
+    def test_pow_grad_comp_dygraph(self):
+        def actual(primal):
+            paddle.disable_static()
+            core.set_prim_eager_enabled(True)
+            x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
+            x.stop_gradient = False
+            y = paddle.tanh(paddle.abs(x))
+            x_cotangent = paddle.grad(
+                y, x, create_graph=True, retain_graph=True
+            )
+            return x_cotangent[0]
+
+        def desired(primal):
+            paddle.disable_static()
+            core.set_prim_eager_enabled(False)
+            x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
+            x.stop_gradient = False
+            y = paddle.tanh(paddle.abs(x))
+            x_cotangent = paddle.grad(
+                y, x, create_graph=True, retain_graph=True
+            )
+            return x_cotangent[0]
+
+        np.testing.assert_allclose(
+            actual=actual(self.primal),
+            desired=desired(self.primal),
+            rtol=1e-6,
+            atol=0,
+        )
+        core.set_prim_eager_enabled(False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_abs_double_grad.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
 import numpy as np
@@ -20,8 +19,6 @@ import parameterized as param
 
 import paddle
 from paddle.base import core
-
-sys.path.append('../../../../legacy_test/')
 
 
 @param.parameterized_class(
@@ -45,10 +42,9 @@ class TestAbsDoubleGradComp(unittest.TestCase):
             x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
             x.stop_gradient = False
             y = paddle.tanh(paddle.abs(x))
-            x_cotangent = paddle.grad(
-                y, x, create_graph=True, retain_graph=True
-            )
-            return x_cotangent[0]
+            dx = paddle.grad(y, x, create_graph=True, retain_graph=True)
+            ddx = paddle.grad(dx, x, create_graph=True, retain_graph=True)
+            return ddx[0]
 
         def desired(primal):
             paddle.disable_static()
@@ -56,10 +52,9 @@ class TestAbsDoubleGradComp(unittest.TestCase):
             x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
             x.stop_gradient = False
             y = paddle.tanh(paddle.abs(x))
-            x_cotangent = paddle.grad(
-                y, x, create_graph=True, retain_graph=True
-            )
-            return x_cotangent[0]
+            dx = paddle.grad(y, x, create_graph=True, retain_graph=True)
+            ddx = paddle.grad(dx, x, create_graph=False, retain_graph=False)
+            return ddx[0]
 
         np.testing.assert_allclose(
             actual=actual(self.primal),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
实现abs二阶微分的组合实现，测试代码为：
```python
import paddle
import numpy as np

def test_abs_double_grad():
    paddle.framework.core.set_prim_eager_enabled(False)
    shape = [1024, 512]
    x = paddle.to_tensor(np.random.randn(*shape), dtype="float32")
    x.stop_gradient=False
    y_fused_res = paddle.tanh(paddle.abs(x))
    dx = paddle.grad(y_fused_res, x, create_graph=True, retain_graph=False)[0]
    ddx_fused_res = paddle.grad(dx, x, create_graph=False, retain_graph=False)[0]
    paddle.framework.core.set_prim_eager_enabled(True)
    paddle.framework.core._set_prim_backward_blacklist("abs_grad")
    y_composite_res = paddle.tanh(paddle.abs(x))
    dx = paddle.grad(y_composite_res, x, create_graph=True, retain_graph=False)[0]
    ddx_composite_res = paddle.grad(dx, x, create_graph=False, retain_graph=False)[0]
    np.testing.assert_allclose(ddx_fused_res.numpy(), ddx_composite_res.numpy(), 1e-6, 1e-6)
```
@HydrogenSulfate 