### PR TITLE
Implement the composition of sin_double_grad

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -38,7 +38,6 @@ ops_to_fill_zero_for_empty_grads = {
     "tanh_grad",
     "tanh_double_grad",
     "tanh_triple_grad",
-    "sin_double_grad",
     "sin_triple_grad",
     "cos_double_grad",
     "cos_triple_grad",

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -55,19 +55,14 @@ void tanh_double_grad(const Tensor& out,
 
 template <typename T>
 void sin_double_grad(const Tensor& x,
-                     const paddle::optional<Tensor>& grad_out,
+                     const Tensor& grad_out,
                      const Tensor& grad_x_grad,
                      Tensor* x_grad,
                      Tensor* grad_out_grad) {
   // sin grad grad : ddout = cosx * ddx, dx = -dy * sinx * ddx
   if (x_grad) {
-    if (grad_out) {
-      auto x_grad_tmp = -(grad_out.get() * sin<T>(x) * grad_x_grad);
-      set_output<T>(x_grad_tmp, x_grad);
-    } else {
-      auto x_grad_tmp = full<T>(common::vectorize(x.dims()), 0.0, x.dtype());
-      set_output<T>(x_grad_tmp, x_grad);
-    }
+    auto x_grad_tmp = -(grad_out * sin<T>(x) * grad_x_grad);
+    set_output<T>(x_grad_tmp, x_grad);
   }
 
   if (grad_out_grad) {

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -54,6 +54,29 @@ void tanh_double_grad(const Tensor& out,
 }
 
 template <typename T>
+void sin_double_grad(const Tensor& x,
+                     const paddle::optional<Tensor>& grad_out,
+                     const Tensor& grad_x_grad,
+                     Tensor* x_grad,
+                     Tensor* grad_out_grad) {
+  // sin grad grad : ddout = cosx * ddx, dx = -dy * sinx * ddx
+  if (x_grad) {
+    if (grad_out) {
+      auto x_grad_tmp = -(grad_out.get() * sin<T>(x) * grad_x_grad);
+      set_output<T>(x_grad_tmp, x_grad);
+    } else {
+      auto x_grad_tmp = full<T>(common::vectorize(x.dims()), 0.0, x.dtype());
+      set_output<T>(x_grad_tmp, x_grad);
+    }
+  }
+
+  if (grad_out_grad) {
+    auto grad_out_grad_tmp = cos<T>(x) * grad_x_grad;
+    set_output<T>(grad_out_grad_tmp, grad_out_grad);
+  }
+}
+
+template <typename T>
 void tanh_triple_grad(const Tensor& out,
                       const Tensor& grad_out_forward,
                       const Tensor& grad_x_grad_forward,

--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -2169,6 +2169,7 @@
   optional: grad_out
   backward : sin_triple_grad
   inplace : (grad_x_grad -> grad_out_grad)
+  composite : sin_double_grad(x, grad_out, grad_x_grad, x_grad, grad_out_grad)
 
 - backward_op : sin_grad
   forward : sin (Tensor x) -> Tensor(out)

--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -2166,7 +2166,6 @@
     param : [x, x]
   kernel :
     func : sin_double_grad
-  optional: grad_out
   backward : sin_triple_grad
   inplace : (grad_x_grad -> grad_out_grad)
   composite : sin_double_grad(x, grad_out, grad_x_grad, x_grad, grad_out_grad)

--- a/paddle/phi/kernels/activation_grad_kernel.h
+++ b/paddle/phi/kernels/activation_grad_kernel.h
@@ -89,7 +89,7 @@ void ReluDoubleGradKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void SinDoubleGradKernel(const Context& dev_ctx,
                          const DenseTensor& x,
-                         const paddle::optional<DenseTensor>& dout,
+                         const DenseTensor& dout,
                          const DenseTensor& ddx,
                          DenseTensor* dx,
                          DenseTensor* ddout);

--- a/paddle/phi/kernels/impl/activation_grad_impl.h
+++ b/paddle/phi/kernels/impl/activation_grad_impl.h
@@ -669,7 +669,7 @@ void SquareDoubleGradKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void SinDoubleGradKernel(const Context& dev_ctx,
                          const DenseTensor& x,
-                         const paddle::optional<DenseTensor>& dout,
+                         const DenseTensor& dout,
                          const DenseTensor& ddx,
                          DenseTensor* dx,
                          DenseTensor* ddout) {
@@ -680,7 +680,7 @@ void SinDoubleGradKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(ddout);
   }
   phi::funcs::SinDoubleGradFunctor<T> functor;
-  functor(dev_ctx, &x, dout.get_ptr(), &ddx, dx, ddout);
+  functor(dev_ctx, &x, &dout, &ddx, dx, ddout);
 }
 
 template <typename T, typename Context>

--- a/test/prim/prim/vjp/eager/test_comp_eager_sin_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_sin_double_grad.py
@@ -41,14 +41,13 @@ class TestSinDoubleGradComp(unittest.TestCase):
         def actual(primal):
             paddle.disable_static()
             core.set_prim_eager_enabled(True)
-            core._set_prim_backward_blacklist("cos_grad")
+            core._set_prim_backward_blacklist("sin_grad")
             x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
             x.stop_gradient = False
             y = paddle.sin(x)
-            x_cotangent = paddle.grad(
-                y, x, create_graph=True, retain_graph=True
-            )
-            return x_cotangent[0]
+            dx = paddle.grad(y, x, create_graph=True, retain_graph=True)
+            ddx = paddle.grad(dx, x, create_graph=True, retain_graph=True)
+            return ddx[0]
 
         def desired(primal):
             paddle.disable_static()
@@ -56,10 +55,9 @@ class TestSinDoubleGradComp(unittest.TestCase):
             x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
             x.stop_gradient = False
             y = paddle.sin(x)
-            x_cotangent = paddle.grad(
-                y, x, create_graph=True, retain_graph=True
-            )
-            return x_cotangent[0]
+            dx = paddle.grad(y, x, create_graph=True, retain_graph=True)
+            ddx = paddle.grad(dx, x, create_graph=True, retain_graph=True)
+            return ddx[0]
 
         np.testing.assert_allclose(
             actual=actual(self.primal),

--- a/test/prim/prim/vjp/eager/test_comp_eager_sin_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_sin_double_grad.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import numpy as np
+import parameterized as param
+
+import paddle
+from paddle.base import core
+
+sys.path.append('../../../../legacy_test/')
+
+
+@param.parameterized_class(
+    ('primal', 'cotangent', 'dtype'),
+    [
+        (np.random.rand(10, 10), np.random.rand(10, 10), np.float32),
+    ],
+)
+class TestSinDoubleGradComp(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.primal = cls.primal.astype(cls.dtype)
+        if cls.cotangent is not None:
+            cls.cotangent = cls.cotangent.astype(cls.dtype)
+
+    def test_sin_double_grad_comp_dygraph(self):
+        def actual(primal):
+            paddle.disable_static()
+            core.set_prim_eager_enabled(True)
+            core._set_prim_backward_blacklist("cos_grad")
+            x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
+            x.stop_gradient = False
+            y = paddle.sin(x)
+            x_cotangent = paddle.grad(
+                y, x, create_graph=True, retain_graph=True
+            )
+            return x_cotangent[0]
+
+        def desired(primal):
+            paddle.disable_static()
+            core.set_prim_eager_enabled(False)
+            x = paddle.to_tensor(primal, dtype='float32', stop_gradient=False)
+            x.stop_gradient = False
+            y = paddle.sin(x)
+            x_cotangent = paddle.grad(
+                y, x, create_graph=True, retain_graph=True
+            )
+            return x_cotangent[0]
+
+        np.testing.assert_allclose(
+            actual=actual(self.primal),
+            desired=desired(self.primal),
+            rtol=1e-6,
+            atol=0,
+        )
+        core.set_prim_eager_enabled(False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/prim/prim/vjp/eager/test_comp_eager_sin_double_grad.py
+++ b/test/prim/prim/vjp/eager/test_comp_eager_sin_double_grad.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
 import numpy as np
@@ -20,8 +19,6 @@ import parameterized as param
 
 import paddle
 from paddle.base import core
-
-sys.path.append('../../../../legacy_test/')
 
 
 @param.parameterized_class(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
实现sin的二阶微分组合，测试代码为：
```python
import paddle
import numpy as np

def test_sin_double_grad():
    paddle.framework.core.set_prim_eager_enabled(False)
    shape = [1024, 512]
    x = paddle.to_tensor(np.random.randn(*shape), dtype="float32")
    x.stop_gradient=False
    y_fused_res = paddle.sin(x)
    dx = paddle.grad(y_fused_res, x, create_graph=True, retain_graph=False)[0]
    ddx_fused_res = paddle.grad(dx, x, create_graph=False, retain_graph=False)[0]
    paddle.framework.core.set_prim_eager_enabled(True)
    paddle.framework.core._set_prim_backward_blacklist("sin_grad")
    y_composite_res = paddle.sin(x)
    dx = paddle.grad(y_composite_res, x, create_graph=True, retain_graph=False)[0]
    ddx_composite_res = paddle.grad(dx, x, create_graph=False, retain_graph=False)[0]
    np.testing.assert_allclose(ddx_fused_res.numpy(), ddx_composite_res.numpy(), 1e-6, 1e-6)

```
@HydrogenSulfate 