### PR TITLE
add inference api:exp_disable_tensorrt_dynamic_shape_ops

### DIFF
--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -251,6 +251,7 @@ struct Argument {
                       TRTExcludeVarNames,
                       std::vector<std::string>);
   DECL_ARGUMENT_FIELD(trt_forbid_dynamic_op, TRTForbidDynamicOp, bool);
+
   DECL_ARGUMENT_FIELD(tensorrt_disabled_ops,
                       TensorRtDisabledOPs,
                       std::vector<std::string>);

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -250,6 +250,7 @@ struct Argument {
   DECL_ARGUMENT_FIELD(trt_exclude_var_names,
                       TRTExcludeVarNames,
                       std::vector<std::string>);
+  DECL_ARGUMENT_FIELD(trt_forbid_dynamic_op, TRTForbidDynamicOp, bool);
   DECL_ARGUMENT_FIELD(tensorrt_disabled_ops,
                       TensorRtDisabledOPs,
                       std::vector<std::string>);

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -173,6 +173,8 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set(
           "trt_exclude_var_names",
           new std::vector<std::string>(argument->trt_exclude_var_names()));
+      pass->Set("forbid_dynamic_op",
+                new bool(argument->trt_forbid_dynamic_op()));
       pass->Set("program",
                 new framework::ProgramDesc *(&argument->main_program()));
       pass->Set("predictor_id", new int(argument->predictor_id()));

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -175,6 +175,7 @@ void IRPassManager::CreatePasses(Argument *argument,
           new std::vector<std::string>(argument->trt_exclude_var_names()));
       pass->Set("forbid_dynamic_op",
                 new bool(argument->trt_forbid_dynamic_op()));
+
       pass->Set("program",
                 new framework::ProgramDesc *(&argument->main_program()));
       pass->Set("predictor_id", new int(argument->predictor_id()));

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -160,6 +160,7 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
              trt_disabled_ops.end(),
              node->Op()->Type()) != trt_disabled_ops.end()) {
       VLOG(3) << node->Op()->Type().c_str()
+
               << " is diabled by config in TensorRT";
       return false;
     }

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -153,6 +153,7 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
   auto trt_disabled_ops = Get<std::vector<std::string>>("trt_disabled_ops");
   auto with_dynamic_shape = Get<bool>("with_dynamic_shape");
   auto use_explicit_quantization = Get<bool>("use_explicit_quantization");
+  auto forbid_dynamic_op = Get<bool>("forbid_dynamic_op");
   auto teller = [&](const framework::ir::Node *node) {
     if (!node->IsOp() || !node->Op()) return false;
     if (find(trt_disabled_ops.begin(),
@@ -172,8 +173,11 @@ void analysis::TensorRtSubgraphPass::ApplyImpl(
         }
       }
     }
-    bool is_ok = tensorrt::OpTeller::Global().Tell(
-        node, no_calib_int8, with_dynamic_shape, use_explicit_quantization);
+    bool is_ok = tensorrt::OpTeller::Global().Tell(node,
+                                                   no_calib_int8,
+                                                   with_dynamic_shape,
+                                                   forbid_dynamic_op,
+                                                   use_explicit_quantization);
     if (!is_ok)
       VLOG(3) << node->Op()->Type().c_str() << " op is not in TensorRT";
     return is_ok;

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -781,7 +781,8 @@ void AnalysisConfig::MarkTrtEngineOutputs(
   trt_output_tensor_names_ = output_tensor_names;
 }
 
-void AnalysisConfig::Exp_DisableDynamicTensorRTOPs(bool trt_forbid_dynamic_op) {
+void AnalysisConfig::Exp_DisableTensorRTDynamicShapeOPs(
+    bool trt_forbid_dynamic_op) {
   trt_forbid_dynamic_op_ = trt_forbid_dynamic_op;
 }
 

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -462,6 +462,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(tensorrt_min_subgraph_size_);
   CP_MEMBER(tensorrt_precision_mode_);
   CP_MEMBER(trt_mark_output_);
+  CP_MEMBER(trt_forbid_dynamic_op_)
   CP_MEMBER(trt_output_tensor_names_);
   CP_MEMBER(trt_disabled_ops_);
   CP_MEMBER(trt_use_dla_);
@@ -778,6 +779,10 @@ void AnalysisConfig::MarkTrtEngineOutputs(
     const std::vector<std::string> &output_tensor_names) {
   trt_mark_output_ = true;
   trt_output_tensor_names_ = output_tensor_names;
+}
+
+void AnalysisConfig::Exp_DisableDynamicTensorRTOPs(bool trt_forbid_dynamic_op) {
+  trt_forbid_dynamic_op_ = trt_forbid_dynamic_op;
 }
 
 void AnalysisConfig::EnableTensorRTMemoryOptim(bool engine_memory_sharing,
@@ -1128,6 +1133,7 @@ std::string AnalysisConfig::SerializeInfoCache() {
   ss << tensorrt_max_batchsize_;
   ss << tensorrt_min_subgraph_size_;
   ss << trt_mark_output_;
+  ss << trt_forbid_dynamic_op_;
 
   ss << use_dlnne_;
   ss << dlnne_min_subgraph_size_;
@@ -1415,6 +1421,8 @@ std::string AnalysisConfig::Summary() {
       os.InsertRow({"trt_engine_memory_sharing",
                     trt_engine_memory_sharing_ ? "true" : "false"});
       os.InsertRow({"trt_mark_output", trt_mark_output_ ? "true" : "false"});
+      os.InsertRow(
+          {"trt_forbid_dynamic_op", trt_forbid_dynamic_op_ ? "true" : "false"});
 #endif
     }
   }

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1757,6 +1757,7 @@ void AnalysisPredictor::PrepareArgument() {
     argument_->SetTRTOutputTensorNames(config_.trt_output_tensor_names_);
     argument_->SetTensorRtDisabledOPs(config_.trt_disabled_ops_);
     argument_->SetTRTExcludeVarNames(config_.trt_exclude_var_names_);
+    argument_->SetTRTForbidDynamicOp(config_.trt_forbid_dynamic_op_);
     argument_->SetTensorRtUseDLA(config_.trt_use_dla_);
     argument_->SetTensorRtDLACore(config_.trt_dla_core_);
     argument_->SetTensorRtUseStaticEngine(config_.trt_use_static_engine_);

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1758,6 +1758,7 @@ void AnalysisPredictor::PrepareArgument() {
     argument_->SetTensorRtDisabledOPs(config_.trt_disabled_ops_);
     argument_->SetTRTExcludeVarNames(config_.trt_exclude_var_names_);
     argument_->SetTRTForbidDynamicOp(config_.trt_forbid_dynamic_op_);
+
     argument_->SetTensorRtUseDLA(config_.trt_use_dla_);
     argument_->SetTensorRtDLACore(config_.trt_dla_core_);
     argument_->SetTensorRtUseStaticEngine(config_.trt_use_static_engine_);

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -813,6 +813,8 @@ struct PD_INFER_DECL AnalysisConfig {
   void Exp_DisableTensorRtSubgraph(
       const std::vector<std::string>& var_name_not_trt);
 
+  void Exp_DisableDynamicTensorRTOPs(bool trt_forbid_dynamic_op);
+
   ///
   /// \brief Replace some TensorRT plugins to TensorRT OSS(
   /// https://github.com/NVIDIA/TensorRT), with which some models's inference
@@ -1271,6 +1273,7 @@ struct PD_INFER_DECL AnalysisConfig {
   bool trt_use_varseqlen_{false};
   bool trt_with_interleaved_{false};
   bool trt_mark_output_{false};
+  bool trt_forbid_dynamic_op_{false};
   std::vector<std::string> trt_output_tensor_names_{};
   std::vector<std::string> trt_exclude_var_names_{};
   std::string tensorrt_transformer_posid_{""};

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -813,7 +813,7 @@ struct PD_INFER_DECL AnalysisConfig {
   void Exp_DisableTensorRtSubgraph(
       const std::vector<std::string>& var_name_not_trt);
 
-  void Exp_DisableDynamicTensorRTOPs(bool trt_forbid_dynamic_op);
+  void Exp_DisableTensorRTDynamicShapeOPs(bool trt_forbid_dynamic_op);
 
   ///
   /// \brief Replace some TensorRT plugins to TensorRT OSS(

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1274,6 +1274,7 @@ struct PD_INFER_DECL AnalysisConfig {
   bool trt_with_interleaved_{false};
   bool trt_mark_output_{false};
   bool trt_forbid_dynamic_op_{false};
+
   std::vector<std::string> trt_output_tensor_names_{};
   std::vector<std::string> trt_exclude_var_names_{};
   std::string tensorrt_transformer_posid_{""};

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -3353,6 +3353,18 @@ struct CustomPluginTeller : public Teller {
     const std::string op_type = desc.Type();
     std::string expect_plugin_name;
 
+    std::unordered_set<std::string> control_set = {"conditional_block",
+                                                   "while"};
+    std::unordered_set<std::string> feed_fetch_set = {"feed", "fetch"};
+    if (control_set.find(op_type) != control_set.end()) {
+      return false;
+    }
+
+    if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
+      return false;
+    }
+
+
     if (forbid_dynamic_op_enter_into_trt) {
       LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
       auto* block = desc.Block();
@@ -3412,6 +3424,17 @@ struct CustomGenericPluginTeller : public Teller {
                   bool forbid_dynamic_op_enter_into_trt = false,
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
+
+    std::unordered_set<std::string> control_set = {"conditional_block",
+                                                   "while"};
+    std::unordered_set<std::string> feed_fetch_set = {"feed", "fetch"};
+    if (control_set.find(op_type) != control_set.end()) {
+      return false;
+    }
+
+    if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
+      return false;
+    }
 
     if (forbid_dynamic_op_enter_into_trt) {
       LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -34,7 +34,8 @@ namespace paddle {
 namespace inference {
 namespace tensorrt {
 
-bool checkForDynamicShapes(const framework::OpDesc& desc) {
+// 检查是否是动态shape,如果是动态shape,则返回false,否则返回true
+bool HasOnlyStaticShapes(const framework::OpDesc& desc) {
   VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
   auto* block = desc.Block();
   auto inputs = desc.Inputs();
@@ -138,9 +139,8 @@ struct SimpleOpTypeSetTeller : public Teller {
     if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
       return false;
     }
-    if (forbid_dynamic_op_enter_into_trt) {
-      bool is_dynamic = checkForDynamicShapes(desc);
-      return is_dynamic;
+    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+      return false;
     }
 
     // do not support the op which is labeled the `skip_quant`
@@ -3252,9 +3252,8 @@ struct GenericPluginTeller : public Teller {
       return false;
     }
 
-    if (forbid_dynamic_op_enter_into_trt) {
-      bool is_dynamic = checkForDynamicShapes(desc);
-      return is_dynamic;
+    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+      return false;
     }
     // only consider dynamic_shape mode
     if (!with_dynamic_shape) {
@@ -3340,9 +3339,8 @@ struct CustomPluginTeller : public Teller {
       return false;
     }
 
-    if (forbid_dynamic_op_enter_into_trt) {
-      bool is_dynamic = checkForDynamicShapes(desc);
-      return is_dynamic;
+    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+      return false;
     }
 
     if (with_dynamic_shape) {
@@ -3382,9 +3380,8 @@ struct CustomGenericPluginTeller : public Teller {
       return false;
     }
 
-    if (forbid_dynamic_op_enter_into_trt) {
-      bool is_dynamic = checkForDynamicShapes(desc);
-      return is_dynamic;
+    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+      return false;
     }
 
     auto& op_meta_info_map = OpMetaInfoMap::Instance();

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -34,8 +34,8 @@ namespace paddle {
 namespace inference {
 namespace tensorrt {
 
-// 检查是否是动态shape,如果是动态shape,则返回false,否则返回true
-bool HasOnlyStaticShapes(const framework::OpDesc& desc) {
+// 检查是否是动态shape,如果是动态shape,则返回true,否则返回false
+bool IsDynamicShapeOp(const framework::OpDesc& desc) {
   VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
   auto* block = desc.Block();
   auto inputs = desc.Inputs();
@@ -46,7 +46,7 @@ bool HasOnlyStaticShapes(const framework::OpDesc& desc) {
         const auto shape = var_desc->GetShape();
         for (auto ele : shape) {
           if (ele < 0) {
-            return false;
+            return true;
           }
         }
       }
@@ -61,7 +61,7 @@ bool HasOnlyStaticShapes(const framework::OpDesc& desc) {
         const auto shape = var_desc->GetShape();
         for (auto ele : shape) {
           if (ele < 0) {
-            return false;
+            return true;
           }
         }
       }
@@ -139,7 +139,7 @@ struct SimpleOpTypeSetTeller : public Teller {
     if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
       return false;
     }
-    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
       return false;
     }
 
@@ -3252,7 +3252,7 @@ struct GenericPluginTeller : public Teller {
       return false;
     }
 
-    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
       return false;
     }
     // only consider dynamic_shape mode
@@ -3339,7 +3339,7 @@ struct CustomPluginTeller : public Teller {
       return false;
     }
 
-    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
       return false;
     }
 
@@ -3380,7 +3380,7 @@ struct CustomGenericPluginTeller : public Teller {
       return false;
     }
 
-    if (forbid_dynamic_op_enter_into_trt && !(HasOnlyStaticShapes(desc))) {
+    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
       return false;
     }
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -105,7 +105,7 @@ struct SimpleOpTypeSetTeller : public Teller {
     }
 
     if (forbid_dynamic_op_enter_into_trt) {
-      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
       auto* block = desc.Block();
       auto inputs = desc.Inputs();
       for (auto iter : inputs) {
@@ -3248,7 +3248,7 @@ struct GenericPluginTeller : public Teller {
     }
 
     if (forbid_dynamic_op_enter_into_trt) {
-      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
       auto* block = desc.Block();
       auto inputs = desc.Inputs();
       for (auto iter : inputs) {
@@ -3364,9 +3364,8 @@ struct CustomPluginTeller : public Teller {
       return false;
     }
 
-
     if (forbid_dynamic_op_enter_into_trt) {
-      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
       auto* block = desc.Block();
       auto inputs = desc.Inputs();
       for (auto iter : inputs) {
@@ -3437,7 +3436,7 @@ struct CustomGenericPluginTeller : public Teller {
     }
 
     if (forbid_dynamic_op_enter_into_trt) {
-      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
       auto* block = desc.Block();
       auto inputs = desc.Inputs();
       for (auto iter : inputs) {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -3241,20 +3241,6 @@ struct GenericPluginTeller : public Teller {
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
 
-    std::unordered_set<std::string> control_set = {"conditional_block",
-                                                   "while"};
-    std::unordered_set<std::string> feed_fetch_set = {"feed", "fetch"};
-    if (control_set.find(op_type) != control_set.end()) {
-      return false;
-    }
-
-    if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
-      return false;
-    }
-
-    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
-      return false;
-    }
     // only consider dynamic_shape mode
     if (!with_dynamic_shape) {
       return false;
@@ -3312,6 +3298,9 @@ struct GenericPluginTeller : public Teller {
         VLOG(3) << op_type << " has no DynamicMetaFn.";
         return false;
       }
+      if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
+        return false;
+      }
       return true;
     }
   }
@@ -3328,21 +3317,6 @@ struct CustomPluginTeller : public Teller {
     const std::string op_type = desc.Type();
     std::string expect_plugin_name;
 
-    std::unordered_set<std::string> control_set = {"conditional_block",
-                                                   "while"};
-    std::unordered_set<std::string> feed_fetch_set = {"feed", "fetch"};
-    if (control_set.find(op_type) != control_set.end()) {
-      return false;
-    }
-
-    if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
-      return false;
-    }
-
-    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
-      return false;
-    }
-
     if (with_dynamic_shape) {
       expect_plugin_name = op_type + "_paddle_trt_dynamic_plugin";
     } else {
@@ -3357,6 +3331,9 @@ struct CustomPluginTeller : public Teller {
         return true;
     }
     return false;
+    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
+      return false;
+    }
   }
 };
 
@@ -3368,21 +3345,6 @@ struct CustomGenericPluginTeller : public Teller {
                   bool forbid_dynamic_op_enter_into_trt = false,
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
-
-    std::unordered_set<std::string> control_set = {"conditional_block",
-                                                   "while"};
-    std::unordered_set<std::string> feed_fetch_set = {"feed", "fetch"};
-    if (control_set.find(op_type) != control_set.end()) {
-      return false;
-    }
-
-    if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
-      return false;
-    }
-
-    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
-      return false;
-    }
 
     auto& op_meta_info_map = OpMetaInfoMap::Instance();
     const auto& meta_info_map = op_meta_info_map.GetMap();
@@ -3408,6 +3370,9 @@ struct CustomGenericPluginTeller : public Teller {
     }
     VLOG(3) << op_type << " has no meta info";
     return false;
+    if (forbid_dynamic_op_enter_into_trt && IsDynamicShapeOp(desc)) {
+      return false;
+    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -89,6 +89,7 @@ struct SimpleOpTypeSetTeller : public Teller {
   bool operator()(const framework::OpDesc& desc,
                   bool use_no_calib_int8 = false,
                   bool with_dynamic_shape = false,
+                  bool forbid_dynamic_op_enter_into_trt = false,
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
 
@@ -101,6 +102,40 @@ struct SimpleOpTypeSetTeller : public Teller {
 
     if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
       return false;
+    }
+
+    if (forbid_dynamic_op_enter_into_trt) {
+      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      auto* block = desc.Block();
+      auto inputs = desc.Inputs();
+      for (auto iter : inputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+
+      auto outputs = desc.Outputs();
+      for (auto iter : outputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
     }
 
     // do not support the op which is labeled the `skip_quant`
@@ -3197,8 +3232,54 @@ struct GenericPluginTeller : public Teller {
   bool operator()(const framework::OpDesc& desc,
                   bool use_no_calib_int8 = false,
                   bool with_dynamic_shape = false,
+                  bool forbid_dynamic_op_enter_into_trt = false,
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
+
+    std::unordered_set<std::string> control_set = {"conditional_block",
+                                                   "while"};
+    std::unordered_set<std::string> feed_fetch_set = {"feed", "fetch"};
+    if (control_set.find(op_type) != control_set.end()) {
+      return false;
+    }
+
+    if (feed_fetch_set.find(op_type) != feed_fetch_set.end()) {
+      return false;
+    }
+
+    if (forbid_dynamic_op_enter_into_trt) {
+      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      auto* block = desc.Block();
+      auto inputs = desc.Inputs();
+      for (auto iter : inputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+
+      auto outputs = desc.Outputs();
+      for (auto iter : outputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+    }
     // only consider dynamic_shape mode
     if (!with_dynamic_shape) {
       return false;
@@ -3267,9 +3348,44 @@ struct CustomPluginTeller : public Teller {
   bool operator()(const framework::OpDesc& desc,
                   bool use_no_calib_int8 = false,
                   bool with_dynamic_shape = false,
+                  bool forbid_dynamic_op_enter_into_trt = false,
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
     std::string expect_plugin_name;
+
+    if (forbid_dynamic_op_enter_into_trt) {
+      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      auto* block = desc.Block();
+      auto inputs = desc.Inputs();
+      for (auto iter : inputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+
+      auto outputs = desc.Outputs();
+      for (auto iter : outputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+    }
 
     if (with_dynamic_shape) {
       expect_plugin_name = op_type + "_paddle_trt_dynamic_plugin";
@@ -3293,8 +3409,44 @@ struct CustomGenericPluginTeller : public Teller {
   bool operator()(const framework::OpDesc& desc,
                   bool use_no_calib_int8 = false,
                   bool with_dynamic_shape = false,
+                  bool forbid_dynamic_op_enter_into_trt = false,
                   bool use_explicit_quantization = false) override {
     const std::string op_type = desc.Type();
+
+    if (forbid_dynamic_op_enter_into_trt) {
+      LOG(INFO) << "forbid_dynamic_op_enter_into_trt is open";
+      auto* block = desc.Block();
+      auto inputs = desc.Inputs();
+      for (auto iter : inputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+
+      auto outputs = desc.Outputs();
+      for (auto iter : outputs) {
+        for (auto var_name : iter.second) {
+          if (block) {
+            auto* var_desc = block->FindVar(var_name);
+            const auto shape = var_desc->GetShape();
+            for (auto ele : shape) {
+              if (ele < 0) {
+                return false;
+              }
+            }
+          }
+        }
+      }
+    }
+
     auto& op_meta_info_map = OpMetaInfoMap::Instance();
     const auto& meta_info_map = op_meta_info_map.GetMap();
     if (meta_info_map.count(op_type) > 0) {
@@ -3325,9 +3477,11 @@ struct CustomGenericPluginTeller : public Teller {
 bool OpTeller::Tell(const framework::ir::Node* node,
                     bool use_no_calib_int8,
                     bool with_dynamic_shape,
+                    bool forbid_dynamic_op_enter_into_trt,
                     bool use_explicit_quantization) {
   const std::string op_type = node->Op()->Type();
   const framework::OpDesc desc = *node->Op();
+
   // do not support the op which is labeled the `skip_quant`
   if ((desc.HasAttr("namescope") &&
        PADDLE_GET_CONST(std::string, desc.GetAttr("op_namescope")) ==
@@ -3338,6 +3492,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
   if ((*default_teller)(desc,
                         use_no_calib_int8,
                         with_dynamic_shape,
+                        forbid_dynamic_op_enter_into_trt,
                         use_explicit_quantization)) {
     SetOpConverterType(node->Op(), OpConverterType::Default);
     return true;
@@ -3346,6 +3501,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
   if ((*generic_plugin_teller)(desc,
                                use_no_calib_int8,
                                with_dynamic_shape,
+                               forbid_dynamic_op_enter_into_trt,
                                use_explicit_quantization)) {
     SetOpConverterType(node->Op(), OpConverterType::GenericPluginCreater);
     return true;
@@ -3354,6 +3510,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
   if ((*custom_plugin_teller)(desc,
                               use_no_calib_int8,
                               with_dynamic_shape,
+                              forbid_dynamic_op_enter_into_trt,
                               use_explicit_quantization)) {
     SetOpConverterType(node->Op(), OpConverterType::CustomPluginCreater);
     return true;
@@ -3362,6 +3519,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
   if ((*custom_generic_plugin_teller)(desc,
                                       use_no_calib_int8,
                                       with_dynamic_shape,
+                                      forbid_dynamic_op_enter_into_trt,
                                       use_explicit_quantization)) {
     SetOpConverterType(node->Op(), OpConverterType::CustomGenericPluginCreater);
     return true;

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -34,7 +34,8 @@ namespace paddle {
 namespace inference {
 namespace tensorrt {
 
-// 检查是否是动态shape,如果是动态shape,则返回true,否则返回false
+// Check if it is a dynamic shape. If it is a dynamic shape, return true;
+// otherwise, return false
 bool IsDynamicShapeOp(const framework::OpDesc& desc) {
   VLOG(3) << "forbid_dynamic_op_enter_into_trt is open";
   auto* block = desc.Block();

--- a/paddle/fluid/inference/tensorrt/op_teller.h
+++ b/paddle/fluid/inference/tensorrt/op_teller.h
@@ -41,6 +41,7 @@ struct Teller {
   virtual bool operator()(const framework::OpDesc& desc,
                           bool use_no_calib_int8 = false,
                           bool with_dynamic_shape = false,
+                          bool forbid_dynamic_op_enter_into_trt = false,
                           bool use_explicit_quantization = false) = 0;
 
   virtual ~Teller() = default;
@@ -77,6 +78,7 @@ class OpTeller {
   bool Tell(const framework::ir::Node* node,
             bool use_no_calib_int8 = false,
             bool with_dynamic_shape = false,
+            bool forbid_dynamic_op_enter_into_trt = false,
             bool use_explicit_quantization = false);
 
   std::unique_ptr<Teller>& GetDefaultTeller() { return tellers_.at(0); }

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -934,6 +934,8 @@ void BindAnalysisConfig(py::module *m) {
       .def("exp_disable_tensorrt_ops", &AnalysisConfig::Exp_DisableTensorRtOPs)
       .def("exp_disable_tensorrt_subgraph",
            &AnalysisConfig::Exp_DisableTensorRtSubgraph)
+      .def("exp_disable_dynamic_tensorrt_ops",
+           &AnalysisConfig::Exp_DisableDynamicTensorRTOPs)
       .def("enable_tensorrt_dla",
            &AnalysisConfig::EnableTensorRtDLA,
            py::arg("dla_core") = 0)

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -935,8 +935,8 @@ void BindAnalysisConfig(py::module *m) {
       .def("exp_disable_tensorrt_ops", &AnalysisConfig::Exp_DisableTensorRtOPs)
       .def("exp_disable_tensorrt_subgraph",
            &AnalysisConfig::Exp_DisableTensorRtSubgraph)
-      .def("exp_disable_dynamic_tensorrt_ops",
-           &AnalysisConfig::Exp_DisableDynamicTensorRTOPs)
+      .def("exp_disable_tensorrt_dynamic_shape_ops",
+           &AnalysisConfig::Exp_DisableTensorRTDynamicShapeOPs)
       .def("enable_tensorrt_dla",
            &AnalysisConfig::EnableTensorRtDLA,
            py::arg("dla_core") = 0)

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -926,6 +926,7 @@ void BindAnalysisConfig(py::module *m) {
       .def("enable_tuned_tensorrt_dynamic_shape",
            &AnalysisConfig::EnableTunedTensorRtDynamicShape,
            py::arg("shape_range_info_path") = "",
+
            py::arg("allow_build_at_runtime") = true)
       .def("tuned_tensorrt_dynamic_shape",
            &AnalysisConfig::tuned_tensorrt_dynamic_shape)

--- a/test/ir/inference/test_forbid_dynamic_op_api.py
+++ b/test/ir/inference/test_forbid_dynamic_op_api.py
@@ -95,7 +95,6 @@ class TestTRTOptimizationLevel(unittest.TestCase):
         config = Config(
             self.model_prefix + '.pdmodel', self.model_prefix + '.pdiparams'
         )
-        config.switch_ir_debug(True)
         config.enable_use_gpu(256, 0, PrecisionType.Half)
         config.enable_tensorrt_engine(
             workspace_size=1 << 30,
@@ -107,7 +106,7 @@ class TestTRTOptimizationLevel(unittest.TestCase):
         )
         config.enable_memory_optim()
         config.exp_disable_dynamic_tensorrt_ops(True)
-        # config.disable_glog_info()
+        config.disable_glog_info()
         config.set_tensorrt_optimization_level(0)
         self.assertEqual(config.tensorrt_optimization_level(), 0)
         predictor = create_predictor(config)

--- a/test/ir/inference/test_forbid_dynamic_op_api.py
+++ b/test/ir/inference/test_forbid_dynamic_op_api.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle import nn, static
+from paddle.inference import Config, PrecisionType, create_predictor
+
+paddle.enable_static()
+
+
+class SimpleNet(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2D(
+            in_channels=4,
+            out_channels=4,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+        )
+        self.relu1 = nn.ReLU()
+        self.conv2 = nn.Conv2D(
+            in_channels=4,
+            out_channels=2,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+        )
+        self.relu2 = nn.ReLU()
+        self.conv3 = nn.Conv2D(
+            in_channels=2,
+            out_channels=1,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+        )
+        self.relu3 = nn.ReLU()
+        self.flatten = nn.Flatten()
+        self.fc = nn.Linear(729, 10)
+        self.softmax = nn.Softmax()
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.relu1(x)
+        x = self.conv2(x)
+        x = self.relu2(x)
+        x = self.conv3(x)
+        x = self.relu3(x)
+        x = self.flatten(x)
+        x = self.fc(x)
+        x = self.softmax(x)
+        return x
+
+
+class TestTRTOptimizationLevel(unittest.TestCase):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.temp_dir.name, 'optimization_level', '')
+        self.model_prefix = self.path + 'infer_model'
+
+    def tearDown(self):
+        shutil.rmtree(self.path)
+
+    def build_model(self):
+        image = static.data(
+            name='img', shape=[None, 4, 224, 224], dtype='float32'
+        )
+        predict = SimpleNet()(image)
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
+        paddle.static.save_inference_model(
+            self.model_prefix, [image], [predict], exe
+        )
+
+    def init_predictor(self):
+        config = Config(
+            self.model_prefix + '.pdmodel', self.model_prefix + '.pdiparams'
+        )
+        config.switch_ir_debug(True)
+        config.enable_use_gpu(256, 0, PrecisionType.Half)
+        config.enable_tensorrt_engine(
+            workspace_size=1 << 30,
+            max_batch_size=1,
+            min_subgraph_size=3,
+            precision_mode=PrecisionType.Half,
+            use_static=False,
+            use_calib_mode=False,
+        )
+        config.enable_memory_optim()
+        config.exp_disable_dynamic_tensorrt_ops(True)
+        # config.disable_glog_info()
+        config.set_tensorrt_optimization_level(0)
+        self.assertEqual(config.tensorrt_optimization_level(), 0)
+        predictor = create_predictor(config)
+        return predictor
+
+    def infer(self, predictor, img):
+        input_names = predictor.get_input_names()
+        for i, name in enumerate(input_names):
+            input_tensor = predictor.get_input_handle(name)
+            input_tensor.reshape(img[i].shape)
+            input_tensor.copy_from_cpu(img[i].copy())
+        predictor.run()
+        results = []
+        output_names = predictor.get_output_names()
+        for i, name in enumerate(output_names):
+            output_tensor = predictor.get_output_handle(name)
+            output_data = output_tensor.copy_to_cpu()
+            results.append(output_data)
+        return results
+
+    def test_optimization_level(self):
+        self.build_model()
+        predictor = self.init_predictor()
+        img = np.ones((1, 4, 224, 224), dtype=np.float32)
+        results = self.infer(predictor, img=[img])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/inference/test_forbid_dynamic_op_api.py
+++ b/test/ir/inference/test_forbid_dynamic_op_api.py
@@ -105,7 +105,7 @@ class TestTRTOptimizationLevel(unittest.TestCase):
             use_calib_mode=False,
         )
         config.enable_memory_optim()
-        config.exp_disable_dynamic_tensorrt_ops(True)
+        config.exp_disable_tensorrt_dynamic_shape_ops(True)
         config.disable_glog_info()
         config.set_tensorrt_optimization_level(0)
         self.assertEqual(config.tensorrt_optimization_level(), 0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501
推理新增dynamic_shape op禁止使用trt推理，使用原生gpu推理。
此处的dynamic shape op指的是，运行的时候shape会改变的Op，这些Op被禁止进入TRT。
<img width="259" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/39205361/20d894df-a44d-4999-9ac2-9b885b4b7618">
如上图，tensorrt_engine的输入为dynamic_shape，使用
```
config.exp_disable_tensorrt_dynamic_shape_ops(True)
```
<img width="447" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/39205361/a3058033-d165-40a3-817c-71c3825d62f8">

如图所示，使用原生gpu推理
