### PR TITLE
[SOT] Skip load store pass if `DUP` in opcode

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
@@ -90,7 +90,7 @@ def find_related_local_opcodes(instrs, code_options):
             if len(stack) > 0 and stack[-1] is not None:
                 opcode_pairs.append((stack[-1], instr))
             stack.pop()
-        elif "ROT" in instr.opname:
+        elif "ROT" in instr.opname or "DUP" in instr.opname:
             return []
         else:
             try:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

load store pass 中跳过包含 `DUP` 的情况

比如目前代码 pass 前后 diff 如下

```diff
             -1 LOAD_FAST                         (resume_26_stack_0)                     
-            -1 LOAD_FAST                         (resume_26_stack_1)                     
             22 DUP_TOP                                                                   
             24 STORE_FAST                    4   (kernel_size)                           
-            26 STORE_FAST                    5   (stride)                                

 221         28 LOAD_GLOBAL                   3   (F)                                     
             30 LOAD_ATTR                     4   (avg_pool2d)                            
             32 LOAD_FAST                     2   (xi)                                    
             34 LOAD_FAST                     4   (kernel_size)                           
-            36 LOAD_FAST                     5   (stride)                                
+            36 LOAD_FAST                         (resume_26_stack_1)    
             38 LOAD_CONST                    4   (('kernel_size', 'stride'))             
             40 CALL_FUNCTION_KW              3   (3)                                     
             42 STORE_FAST                    2   (xi)                                    

```

原来代码里 `DUP_TOP` 的是 `resume_26_stack_1`，pass 后 `DUP_TOP` 的就是 `resume_26_stack_0` 了

Pcard-67164
