### PR TITLE
[PIR] Delete special processing logic variables for data op in the PIR execution system BuildScope

### DIFF
--- a/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
+++ b/paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.cc
@@ -480,18 +480,9 @@ void HandleForSpecialOp(pir::Operation* op,
         auto shape = op->attribute<dialect::IntArrayAttribute>("shape");
         auto dim = phi::make_ddim(shape.data().GetData());
         auto dtype = op->attribute<dialect::DataTypeAttribute>("dtype");
-        auto place = op->attribute<dialect::PlaceAttribute>("place").data();
-        if (place.GetType() == phi::AllocationType::UNDEFINED) {
-          place = phi::CPUPlace();
-        }
         if (!common::contain_unknown_dim(dim)) {
           phi::DenseTensorMeta meta(dtype.data(), dim);
           t->set_meta(meta);
-          auto* dev_ctx = platform::DeviceContextPool::Instance().Get(place);
-          dev_ctx->Alloc(t, dtype.data());
-          VLOG(10) << "[Alloc var]: "
-                   << op->attribute<pir::StrAttribute>("name") << " "
-                   << t->initialized();
         }
       }
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Delete special processing logic variables for data op in the PIR execution system BuildScope.
Pcard-67164