### PR TITLE
[Paddle Inference] Lower trt_convert_yolo_box test time cost.

### DIFF
--- a/test/ir/inference/test_trt_convert_yolo_box.py
+++ b/test/ir/inference/test_trt_convert_yolo_box.py
@@ -56,13 +56,13 @@ class TrtConvertYoloBoxTest(TrtLayerAutoScanTest):
             iou_aware,
             iou_aware_factor,
         ) in product(
-            [1, 4],
-            [80, 30],
+            [1],
+            [80],
             [[10, 13, 16, 30, 33, 23]],
-            [32, 16],
-            [0.01, 0.02],
+            [32],
+            [0.01],
             [True, False],
-            [1.0, 0.9],
+            [1.0],
             [False, True],
             [0.5],
         ):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Lower trt_convert_yolo_box test time cost.
Pcard-71502