### PR TITLE
fix recompute in static_auto

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -518,7 +518,8 @@ def recompute(function, *args, **kwargs):
         )
 
         # Remove it when static_auto_recompute supports use_reentrant.
-        kwargs.pop('use_reentrant')
+        if 'use_reentrant' in kwargs:
+            kwargs.pop('use_reentrant')
 
         return static_auto_recompute(function)(*args, **kwargs)
 

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -517,9 +517,12 @@ def recompute(function, *args, **kwargs):
             recompute as static_auto_recompute,
         )
 
-        # Remove it when static_auto_recompute supports use_reentrant.
+        # Remove it when static_auto_recompute supports use_reentrant and preserve_rng_state.
         if 'use_reentrant' in kwargs:
             kwargs.pop('use_reentrant')
+
+        if 'preserve_rng_state' in kwargs:
+            kwargs.pop('preserve_rng_state')
 
         return static_auto_recompute(function)(*args, **kwargs)
 

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -517,6 +517,9 @@ def recompute(function, *args, **kwargs):
             recompute as static_auto_recompute,
         )
 
+        # Remove it when static_auto_recompute supports use_reentrant.
+        kwargs.pop('use_reentrant')
+
         return static_auto_recompute(function)(*args, **kwargs)
 
     # Hack to mix *args with **kwargs in a python 2.7-compliant way


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Remove the use_reentrant parameter when using static_auto_recompute.