### PR TITLE
Symbolic shape inference support for pd_op.split and builtin.split

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
@@ -1188,7 +1188,7 @@ bool SplitOpInferSymbolicShape(pir::Operation *op,
 
   // sections
   const std::vector<symbol::DimExpr> &sections_sym = [&] {
-    auto sections_shape_or_data =
+    const auto &sections_shape_or_data =
         shape_analysis->GetShapeOrDataForValue(op->operand_source(1));
     std::vector<symbol::DimExpr> sections_sym;
     if (sections_shape_or_data.data().has_value()) {
@@ -1243,7 +1243,7 @@ bool SplitOpInferSymbolicShape(pir::Operation *op,
       return shape_data_list;
     }
     for (uint32_t idx = 0; idx < sections_sym.size(); idx++) {
-      const auto section_sym = sections_sym[idx];
+      const auto &section_sym = sections_sym[idx];
       output_dims_sym[axis] = IsNotMinusOne(section_sym)
                                   ? section_sym
                                   : x_dims_sym[axis] - sum_exclude_minus_one;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
@@ -1170,9 +1170,11 @@ bool SplitOpInferSymbolicShape(pir::Operation *op,
   // input
   const auto &x_shape_or_data =
       shape_analysis->GetShapeOrDataForValue(op->operand_source(0));
-  IR_ENFORCE(!x_shape_or_data.data().has_value(),
-             "Currently InferSymbolicShape of SplitOp only support "
-             "input without value.");
+  PADDLE_ENFORCE_EQ(x_shape_or_data.data().has_value(),
+                    false,
+                    phi::errors::InvalidArgument(
+                        "InferSymbolicShape of SplitOp only support input with "
+                        "value now."));
   const auto &x_dims_sym = x_shape_or_data.shape();
 
   // axis

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
@@ -1169,7 +1169,7 @@ bool SplitOpInferSymbolicShape(pir::Operation *op,
                                pir::ShapeConstraintIRAnalysis *shape_analysis) {
   VLOG(0) << "InferSymbolicShape of pd_op.split!";
   // x
-  auto x_shape_or_data =
+  const auto& x_shape_or_data =
       shape_analysis->GetShapeOrDataForValue(op->operand_source(0));
   IR_ENFORCE(!x_shape_or_data.data().has_value(),
              "Currently InferSymbolicShape of SplitOp only support "

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/paddle_op_infer_sym.cc
@@ -1553,6 +1553,8 @@ bool RepeatInterleaveOpInferSymbolicShape(
 }
 bool SplitWithNumOpInferSymbolicShape(
     pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  PADDLE_THROW(phi::errors::Unimplemented(
+      op->name() + " 's InferSymbolicShape interface is NOT implemented now."));
   return true;
 }
 bool TrilIndicesOpInferSymbolicShape(

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -168,9 +168,10 @@ struct SplitOpInferSymbolicShapeInterfaceModel
             .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
 
     for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
-      IR_ENFORCE(!shape_data_list[rst_idx].data().has_value(),
-                 "Currently InferSymbolicShape of SplitOp only support "
-                 "input without value.");
+      PADDLE_ENFORCE_EQ(shape_data_list[rst_idx].data().has_value(),
+                        false,
+                        "Currently InferSymbolicShape of SplitOp only support "
+                        "input without value.");
       shape_analysis->SetShapeOrDataForValue(
           op->result(rst_idx),
           symbol::ShapeOrDataDimExprs{shape_data_list[rst_idx]});

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -159,6 +159,103 @@ struct ShadowOutputOpInferSymbolicShapeInterfaceModel
       : InferSymbolicShapeInterface::Concept(InferSymbolicShape) {}
 };
 
+struct SplitOpInferSymbolicShapeInterfaceModel
+    : public InferSymbolicShapeInterface::Concept {
+  static inline bool InferSymbolicShape(
+      pir::Operation* op, pir::ShapeConstraintIRAnalysis* shape_analysis) {
+    VLOG(0) << "InferSymbolicShape of SplitOp!";
+    // x
+    IR_ENFORCE(!op->operand_source(0).data().has_value(),
+               "Currently InferSymbolicShape of SplitOp only support "
+               "input without value.");
+    auto x_shape_or_data =
+        shape_analysis->GetShapeOrDataForValue(op->operand_source(0));
+    std::vector<symbol::DimExpr> x_dims_sym = x_shape_or_data.shape();
+
+    // axis
+    CHECK(op->operand_source(2).defining_op()->isa<paddle::dialect::FullOp>());
+
+    int64_t axis = op->operand_source(2)
+                       .defining_op<paddle::dialect::FullOp>()
+                       .attributes()
+                       .at("value")
+                       .dyn_cast<paddle::dialect::ScalarAttribute>()
+                       .data()
+                       .to<int64_t>();
+
+    // sections or num
+    if (op->operand_source(1).defining_op()->isa<paddle::dialect::FullOp>()) {
+      // num
+      VLOG(0) << "Num!";
+      int64_t num = op->operand_source(1)
+                        .defining_op<paddle::dialect::FullOp>()
+                        .attributes()
+                        .at("value")
+                        .dyn_cast<paddle::dialect::ScalarAttribute>()
+                        .data()
+                        .to<int64_t>();
+      x_dims_sym[axis] = x_dims_sym[axis] / num;
+
+      // all the result have the same shape
+      for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
+        shape_analysis->SetShapeOrDataForValue(
+            op->result(rst_idx),
+            symbol::ShapeOrDataDimExprs{
+                symbol::TensorShapeOrDataDimExprs(x_dims_sym)});
+      }
+    } else {
+      // sections
+      VLOG(0) << "Sections!";
+      auto sections_shape_or_data =
+          shape_analysis->GetShapeOrDataForValue(op->operand_source(1));
+      std::vector<symbol::DimExpr> sections_sym;
+      if (sections_shape_or_data.data().has_value()) {
+        sections_sym = sections_shape_or_data.data().value();
+      } else {
+        sections_sym = sections_shape_or_data.shape();
+      }
+
+      const auto& GetSum = [&](const auto& dim_exprs, const auto& Filter) {
+        symbol::DimExpr sum{1};
+        for (const auto& dim_expr : dim_exprs) {
+          if (Filter(dim_expr)) {
+            sum = sum + dim_expr;
+          }
+        }
+        return product;
+      };
+
+      const auto& IsNotMinusOne = [&](const symbol::DimExpr& dim_expr) {
+        if (dim_expr.isa<int64_t>()) {
+          return dim_expr.dyn_cast<int64_t>() != static_cast<int64_t>(-1);
+        }
+        return true;
+      };
+
+      const auto& sum_exclude_minus_one =
+          GetSum(operand_shape_or_data.data().value(), IsNotMinusOne);
+
+      symbol::DimExpr x_ori_dim_on_axis = x_dims_sym[axis];
+
+      for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
+        auto section_sym = sections_sym[rst_idx];
+        x_dims_sym[axis] = IsNotMinusOne(section_sym)
+                               ? section_sym
+                               : x_ori_dim_on_axis - sum_exclude_minus_one;
+
+        shape_analysis->SetShapeOrDataForValue(
+            op->result(rst_idx),
+            symbol::ShapeOrDataDimExprs{
+                symbol::TensorShapeOrDataDimExprs(x_dims_sym)});
+      }
+    }
+    return true;
+  }
+
+  SplitOpInferSymbolicShapeInterfaceModel()
+      : InferSymbolicShapeInterface::Concept(InferSymbolicShape) {}
+};
+
 struct YieldOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(
@@ -195,6 +292,11 @@ OperatorDialect::OperatorDialect(pir::IrContext* ctx)
       std::move(pir::InterfaceValue::Get<
                 InferSymbolicShapeInterface,
                 ShadowOutputOpInferSymbolicShapeInterfaceModel>()));
+
+  info = ctx->GetRegisteredOpInfo(pir::SplitOp::name());
+  info.AttachInterface(std::move(
+      pir::InterfaceValue::Get<InferSymbolicShapeInterface,
+                               SplitOpInferSymbolicShapeInterfaceModel>()));
 
   info = ctx->GetRegisteredOpInfo(pir::YieldOp::name());
   info.AttachInterface(std::move(

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -167,7 +167,7 @@ struct SplitOpInferSymbolicShapeInterfaceModel
     VLOG(0) << "num_operands: " << op->num_operands();
     VLOG(0) << "op: " << op;
     // x
-    auto x_shape_or_data =
+    const auto& x_shape_or_data =
         shape_analysis->GetShapeOrDataForValue(op->operand_source(0));
     IR_ENFORCE(!x_shape_or_data.data().has_value(),
                "Currently InferSymbolicShape of SplitOp only support "

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -172,7 +172,7 @@ struct SplitOpInferSymbolicShapeInterfaceModel
     IR_ENFORCE(!x_shape_or_data.data().has_value(),
                "Currently InferSymbolicShape of SplitOp only support "
                "input without value.");
-    std::vector<symbol::DimExpr> x_dims_sym = x_shape_or_data.shape();
+    const auto& x_dims_sym = x_shape_or_data.shape();
 
     // axis
     CHECK(op->operand_source(2).defining_op()->isa<paddle::dialect::FullOp>());

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -163,93 +163,17 @@ struct SplitOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(
       pir::Operation* op, pir::ShapeConstraintIRAnalysis* shape_analysis) {
-    VLOG(0) << "InferSymbolicShape of builtin.split!";
-    VLOG(0) << "num_operands: " << op->num_operands();
-    VLOG(0) << "op: " << op;
-    // x
-    const auto& x_shape_or_data =
-        shape_analysis->GetShapeOrDataForValue(op->operand_source(0));
-    IR_ENFORCE(!x_shape_or_data.data().has_value(),
-               "Currently InferSymbolicShape of SplitOp only support "
-               "input without value.");
-    const auto& x_dims_sym = x_shape_or_data.shape();
+    const auto& shape_data_list =
+        shape_analysis->GetShapeOrDataForValue(op->operand_source(0))
+            .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
 
-    // axis
-    CHECK(op->operand_source(2).defining_op()->isa<paddle::dialect::FullOp>());
-
-    int64_t axis = op->operand_source(2)
-                       .defining_op<paddle::dialect::FullOp>()
-                       .attributes()
-                       .at("value")
-                       .dyn_cast<paddle::dialect::ScalarAttribute>()
-                       .data()
-                       .to<int64_t>();
-
-    // sections or num
-    if (op->operand_source(1).defining_op()->isa<paddle::dialect::FullOp>()) {
-      // num
-      VLOG(0) << "Num!";
-      int64_t num = op->operand_source(1)
-                        .defining_op<paddle::dialect::FullOp>()
-                        .attributes()
-                        .at("value")
-                        .dyn_cast<paddle::dialect::ScalarAttribute>()
-                        .data()
-                        .to<int64_t>();
-      x_dims_sym[axis] = x_dims_sym[axis] / num;
-
-      // all the result have the same shape
-      for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
-        shape_analysis->SetShapeOrDataForValue(
-            op->result(rst_idx),
-            symbol::ShapeOrDataDimExprs{
-                symbol::TensorShapeOrDataDimExprs(x_dims_sym)});
-      }
-    } else {
-      // sections
-      VLOG(0) << "Sections!";
-      auto sections_shape_or_data =
-          shape_analysis->GetShapeOrDataForValue(op->operand_source(1));
-      std::vector<symbol::DimExpr> sections_sym;
-      if (sections_shape_or_data.data().has_value()) {
-        sections_sym = sections_shape_or_data.data().value();
-      } else {
-        sections_sym = sections_shape_or_data.shape();
-      }
-
-      const auto& GetSum = [&](const auto& dim_exprs, const auto& Filter) {
-        symbol::DimExpr sum{1};
-        for (const auto& dim_expr : dim_exprs) {
-          if (Filter(dim_expr)) {
-            sum = sum + dim_expr;
-          }
-        }
-        return sum;
-      };
-
-      const auto& IsNotMinusOne = [&](const symbol::DimExpr& dim_expr) {
-        if (dim_expr.isa<int64_t>()) {
-          return dim_expr.dyn_cast<int64_t>() != static_cast<int64_t>(-1);
-        }
-        return true;
-      };
-
-      const auto& sum_exclude_minus_one =
-          GetSum(sections_shape_or_data.data().value(), IsNotMinusOne);
-
-      symbol::DimExpr x_ori_dim_on_axis = x_dims_sym[axis];
-
-      for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
-        auto section_sym = sections_sym[rst_idx];
-        x_dims_sym[axis] = IsNotMinusOne(section_sym)
-                               ? section_sym
-                               : x_ori_dim_on_axis - sum_exclude_minus_one;
-
-        shape_analysis->SetShapeOrDataForValue(
-            op->result(rst_idx),
-            symbol::ShapeOrDataDimExprs{
-                symbol::TensorShapeOrDataDimExprs(x_dims_sym)});
-      }
+    for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
+      IR_ENFORCE(!shape_data_list[rst_idx].data().has_value(),
+                 "Currently InferSymbolicShape of SplitOp only support "
+                 "input without value.");
+      shape_analysis->SetShapeOrDataForValue(
+          op->result(rst_idx),
+          symbol::ShapeOrDataDimExprs{shape_data_list[rst_idx]});
     }
     return true;
   }

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -168,10 +168,12 @@ struct SplitOpInferSymbolicShapeInterfaceModel
             .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
 
     for (uint32_t rst_idx = 0; rst_idx < op->num_results(); rst_idx++) {
-      PADDLE_ENFORCE_EQ(shape_data_list[rst_idx].data().has_value(),
-                        false,
-                        "Currently InferSymbolicShape of SplitOp only support "
-                        "input without value.");
+      PADDLE_ENFORCE_EQ(
+          shape_data_list[rst_idx].data().has_value(),
+          false,
+          paddle::platform::errors::InvalidArgument(
+              "Currently InferSymbolicShape of SplitOp only support "
+              "input without value."));
       shape_analysis->SetShapeOrDataForValue(
           op->result(rst_idx),
           symbol::ShapeOrDataDimExprs{shape_data_list[rst_idx]});

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -1078,6 +1078,7 @@
   kernel :
     func : split
   backward : split_grad
+  interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : split_with_num
   args : (Tensor x, int num, Scalar(int) axis)

--- a/test/ir/pir/cinn/symbolic/test_op_infer_sym_shape.py
+++ b/test/ir/pir/cinn/symbolic/test_op_infer_sym_shape.py
@@ -541,7 +541,6 @@ class TestSplitOpInferSymbolicShape(TestBase):
     def prepare_data(self):
         self.cases = [np.random.rand(4, 6, 5)]
 
-        # FIXME: not the expected yet, just a placeholder
         self.expected = [
             [
                 'shape[S0, S1, S2], data[NULL]',

--- a/test/ir/pir/cinn/symbolic/test_unary_op_infer_sym_shape.py
+++ b/test/ir/pir/cinn/symbolic/test_unary_op_infer_sym_shape.py
@@ -102,7 +102,7 @@ class TestArgMaxMinOpInferSymbolicShape(TestBase):
                 np.testing.assert_equal(
                     sym_shape_str_list[j].find(self.expected[i][j]),
                     0,
-                    f'in case i,j = {i},{j}: output shape ({sym_shape_str_list[0]}) is not expected {(self.expected[i][j])}',
+                    f'in case i,j = {i},{j}: output shape ({sym_shape_str_list[j]}) is not expected {(self.expected[i][j])}',
                 )
 
         return True


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
Add Infer Symbolic Shape for pd_op.split and builtin.split