### PR TITLE
[Dy2St][PIR] Clear out and middles after share into scope

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -1020,8 +1020,8 @@ inline void PirRunProgramGradAPI(
     const std::vector<paddle::Tensor> &x,
     const std::vector<paddle::Tensor> &params,
     const std::vector<paddle::Tensor> &out_grad,
-    const std::vector<paddle::Tensor> &middles,
-    const std::vector<paddle::Tensor> &out,
+    std::vector<paddle::Tensor> &middles,                       // NOLINT
+    std::vector<paddle::Tensor> &out,                           // NOLINT
     const std::vector<paddle::framework::Scope *> &step_scope,  // NOLINT
     const paddle::framework::AttributeMap &attrs,
     std::vector<paddle::Tensor *> &x_grad,       // NOLINT
@@ -1079,6 +1079,9 @@ inline void PirRunProgramGradAPI(
       backward_global_block, out, forward_output_values, global_inner_scope);
   details::ShareTensorsIntoScopeByValue(
       backward_global_block, params, parameter_values, global_inner_scope);
+
+  out.clear();
+  middles.clear();
 
   auto &interpretercore_info_cache =
       paddle::framework::InterpreterCoreInfoCache::Instance();

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -1080,6 +1080,7 @@ inline void PirRunProgramGradAPI(
   details::ShareTensorsIntoScopeByValue(
       backward_global_block, params, parameter_values, global_inner_scope);
 
+  // Clear out and middles to avoid hold memory until backward finish.
   out.clear();
   middles.clear();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

反向 share 到 scope 后马上清掉 `middles` 和 `out` 以免 hold 住全部前向中间变量和输出，这样整个反向结束才能释放这部分显存，导致峰值显存过高发生 OOM

Pcard-67164