### PR TITLE
[CINN] Fix bug of 0d to 1d

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/convert_0d_to_1d_pass.cc
@@ -37,9 +37,10 @@ class FullOpPattern : public pir::OpRewritePattern<paddle::dialect::FullOp> {
 
   bool Match(paddle::dialect::FullOp op) const override {
     return op.attribute("shape")
-               .dyn_cast<paddle::dialect::IntArrayAttribute>()
-               .data()
-               .size() == 0;
+                   .dyn_cast<paddle::dialect::IntArrayAttribute>()
+                   .data()
+                   .size() == 0 &&
+           op.out().type().dyn_cast<pir::DenseTensorType>().dims().size() == 0;
   }
 
   void Rewrite(paddle::dialect::FullOp op,

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -928,7 +928,7 @@ std::vector<ir::Expr> OpLowererImpl::LowerOps(
       StrategyFunctionSymbolic strategy = strategy_map[cinn_op];
       CHECK(static_cast<bool>(strategy))
           << " cinn_op_name: " << cinn_op_name
-          << "has no CINNStrategySymbolic registered.";
+          << " has no CINNStrategySymbolic registered.";
       op_impl = OpStrategy::SelectImpl(strategy(node_attrs,
                                                 op_func_arg_tensors,
                                                 out_types,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

while控制流场景下，对FullOp的trick处理导致0D转1D的Pass处理存在Bug，本PR加强了0D转1D Pass中对Full算子的检查逻辑，修复while控制流中出现的Bug.