### PR TITLE
API improvement for paddle.median 易用性提升

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -374,7 +374,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        ((Tensor, Tensor), optional)
+        Tensor or tuple of Tensor.
         If ``mode`` == 'avg', the result will be the tensor of median values;
         If ``mode`` == 'min' and ``axis`` is None, the result will be the tensor of median values;
         If ``mode`` == 'min' and ``axis`` is not None, the result will be a tuple of two tensors

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -368,16 +368,16 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             dimensions(it is of size 1 in this case). Otherwise, the shape of
             the output Tensor is squeezed in ``axis`` . Default is False.
         mode (str, optional): Whether to use mean or min operation to calculate
-            the median value when the input tensor has an even number of elements
+            the median values when the input tensor has an even number of elements
             in the dimension ``axis``. Support 'avg' and 'min'.
         name (str, optional): Name for the operation (optional, default is None).
             For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
         ((Tensor, Tensor), optional), results of median along ``axis`` of ``x``. If ``mode`` is
-        'min' and axis is not None, the result will be a tuple containing a tensor of median value and a tensor
+        'min' and axis is not None, the result will be a tuple containing a tensor of median values and a tensor
         of its indices. The data type of the indices will be int64. Otherwise the result will be the tensor of
-        median value. If data type of ``x`` is float64, data type of median value will be float64, otherwise
+        median values. If data type of ``x`` is float64, data type of median values will be float64, otherwise
         data type will be float32.
 
     Examples:
@@ -514,14 +514,8 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             out_tensor = out_tensor.squeeze(axis)
 
     if mode == 'min' and inp_axis is not None:
-        if is_flatten:
-            if keepdim:
-                out_idx = out_idx.reshape([1] * dims)
-            else:
-                out_idx = out_idx.reshape([])
-        else:
-            if not keepdim:
-                out_idx = out_idx.squeeze(axis)
+        if not keepdim:
+            out_idx = out_idx.squeeze(axis)
         return out_tensor, out_idx
     return out_tensor
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -415,7 +415,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             >>> y5 = paddle.median(x, mode='min')
             >>> print(y5)
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
-            5.5)
+            5.)
 
             >>> median_value, median_indices = paddle.median(x, axis=1, mode='min')
             >>> print(median_value)

--- a/test/legacy_test/test_median.py
+++ b/test/legacy_test/test_median.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import unittest
 
 import numpy as np
@@ -22,7 +23,84 @@ from paddle.pir_utils import test_with_pir_api
 DELTA = 1e-6
 
 
-class TestMedian(unittest.TestCase):
+def np_medain_min(data, keepdims=False):
+    shape = data.shape
+    data_flat = data.flatten()
+    data_cnt = len(data_flat)
+
+    data_flat[np.isnan(data_flat)] = np.inf
+    data_sort = np.sort(data_flat)
+    data_sort[np.isinf(data_sort)] = np.nan
+
+    if data_cnt % 2:
+        is_odd = False
+    else:
+        is_odd = True
+
+    i = int(data_cnt / 2)
+    if is_odd:
+        np_res = min(data_sort[i - 1], data_sort[i])
+    else:
+        np_res = data_sort[i]
+    if keepdims:
+        new_shape = [1] * len(shape)
+        return np_res.reshape(new_shape)
+    else:
+        return np_res
+
+
+def np_medain_min_axis(data, axis=None, keepdims=False):
+    data = copy.deepcopy(data)
+    if axis is None:
+        return np_medain_min(data, keepdims)
+
+    axis = axis + len(data.shape) if axis < 0 else axis
+    trans_shape = []
+    reshape = []
+    for i in range(len(data.shape)):
+        if i != axis:
+            trans_shape.append(i)
+            reshape.append(data.shape[i])
+    trans_shape.append(axis)
+    last_shape = data.shape[axis]
+    reshape.append(last_shape)
+
+    data_flat = np.transpose(data, trans_shape)
+
+    data_flat = np.reshape(data_flat, (-1, reshape[-1]))
+
+    data_cnt = np.full(
+        shape=data_flat.shape[:-1], fill_value=data_flat.shape[-1]
+    )
+
+    data_flat[np.isnan(data_flat)] = np.inf
+    data_sort = np.sort(data_flat, axis=-1)
+    data_sort[np.isinf(data_sort)] = np.nan
+
+    is_odd = data_cnt % 2
+
+    np_res = np.zeros(len(is_odd), dtype=data.dtype)
+
+    for j in range(len(is_odd)):
+        if data_cnt[j] == 0:
+            np_res[j] = np.nan
+            continue
+
+        i = int(data_cnt[j] / 2)
+        if is_odd[j]:
+            np_res[j] = data_sort[j, i]
+        else:
+            np_res[j] = min(data_sort[j, i - 1], data_sort[j, i])
+
+    if keepdims:
+        shape = list(data.shape)
+        shape[axis] = 1
+        return np.reshape(np_res, shape)
+    else:
+        return np.reshape(np_res, reshape[:-1])
+
+
+class TestMedianAvg(unittest.TestCase):
     def check_numpy_res(self, np1, np2):
         self.assertEqual(np1.shape, np2.shape)
         mismatch = np.sum((np1 - np2) * (np1 - np2))
@@ -83,7 +161,79 @@ class TestMedian(unittest.TestCase):
         x = paddle.arange(12).reshape([3, 4])
         self.assertRaises(ValueError, paddle.median, x, 1.0)
         self.assertRaises(ValueError, paddle.median, x, 2)
+        self.assertRaises(ValueError, paddle.median, x, 2, False, 'max')
         self.assertRaises(ValueError, paddle.median, paddle.to_tensor([]))
+
+
+class TestMedianMin(unittest.TestCase):
+    def check_numpy_res(self, np1, np2):
+        self.assertEqual(np1.shape, np2.shape)
+        mismatch = np.sum((np1 - np2) * (np1 - np2))
+        self.assertAlmostEqual(mismatch, 0, DELTA)
+
+    def static_single_test_median(self, lis_test):
+        paddle.enable_static()
+        x, axis, keepdims = lis_test
+        res_np = np_medain_min_axis(x, axis=axis, keepdims=keepdims)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        exe = paddle.static.Executor()
+        with paddle.static.program_guard(main_program, startup_program):
+            x_in = paddle.static.data(shape=x.shape, dtype=x.dtype, name='x')
+            y = paddle.median(x_in, axis, keepdims, mode='min')
+            [res_pd, _] = exe.run(feed={'x': x}, fetch_list=[y])
+            self.check_numpy_res(res_pd, res_np)
+        paddle.disable_static()
+
+    def dygraph_single_test_median(self, lis_test):
+        x, axis, keepdims = lis_test
+        res_np = np_medain_min_axis(x, axis=axis, keepdims=keepdims)
+        res_pd, _ = paddle.median(
+            paddle.to_tensor(x), axis, keepdims, mode='min'
+        )
+        self.check_numpy_res(res_pd.numpy(False), res_np)
+
+    @test_with_pir_api
+    def test_median_static(self):
+        h = 3
+        w = 4
+        l = 2
+        x = np.arange(h * w * l).reshape([h, w, l]).astype("float32")
+        lis_tests = [
+            [x, axis, keepdims]
+            for axis in [-1, 0, 1, 2]
+            for keepdims in [False, True]
+        ]
+        for lis_test in lis_tests:
+            self.static_single_test_median(lis_test)
+
+    def test_median_dygraph(self):
+        paddle.disable_static()
+        h = 3
+        w = 4
+        l = 2
+        x = np.arange(h * w * l).reshape([h, w, l]).astype("float32")
+        lis_tests = [
+            [x, axis, keepdims]
+            for axis in [-1, 0, 1, 2]
+            for keepdims in [False, True]
+        ]
+        for lis_test in lis_tests:
+            self.dygraph_single_test_median(lis_test)
+
+    def test_index_even_case(self):
+        paddle.disable_static()
+        x = paddle.arange(2 * 100).reshape((2, 100)).astype(paddle.float32)
+        out, index = paddle.median(x, axis=1, mode='min')
+        np.testing.assert_allclose(out.numpy(), [49.0, 149.0])
+        np.testing.assert_equal(index.numpy(), [49, 49])
+
+    def test_index_odd_case(self):
+        paddle.disable_static()
+        x = paddle.arange(30).reshape((3, 10)).astype(paddle.float32)
+        out, index = paddle.median(x, axis=1, mode='min')
+        np.testing.assert_allclose(out.numpy(), [4.0, 14.0, 24.0])
+        np.testing.assert_equal(index.numpy(), [4, 4, 4])
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_median.py
+++ b/test/legacy_test/test_median.py
@@ -166,11 +166,6 @@ class TestMedianAvg(unittest.TestCase):
 
 
 class TestMedianMin(unittest.TestCase):
-    def check_numpy_res(self, np1, np2):
-        self.assertEqual(np1.shape, np2.shape)
-        mismatch = np.sum((np1 - np2) * (np1 - np2))
-        self.assertAlmostEqual(mismatch, 0, DELTA)
-
     def static_single_test_median(self, lis_test):
         paddle.enable_static()
         x, axis, keepdims = lis_test
@@ -182,7 +177,7 @@ class TestMedianMin(unittest.TestCase):
             x_in = paddle.static.data(shape=x.shape, dtype=x.dtype, name='x')
             y = paddle.median(x_in, axis, keepdims, mode='min')
             [res_pd, _] = exe.run(feed={'x': x}, fetch_list=[y])
-            self.check_numpy_res(res_pd, res_np)
+            np.testing.assert_allclose(res_pd, res_np)
         paddle.disable_static()
 
     def dygraph_single_test_median(self, lis_test):
@@ -191,7 +186,7 @@ class TestMedianMin(unittest.TestCase):
         res_pd, _ = paddle.median(
             paddle.to_tensor(x), axis, keepdims, mode='min'
         )
-        self.check_numpy_res(res_pd.numpy(False), res_np)
+        np.testing.assert_allclose(res_pd.numpy(False), res_np)
 
     @test_with_pir_api
     def test_median_static(self):


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Description
- 增加参数 `mode` ：默认值 'avg' ，另外可取 'min' 。当所需要计算的 tensor 在 `axis` 轴上有偶数个元素时， 'avg' 表示计算结果为中间两个数的算术平均值；'min' 则为二者的最小值。
- 返回值：当  `mode = 'min'` 且 `axis` 不为 None 时，返回值为 (median_values, median_indices) ；其他情况下返回值为 median_values 的 tensor 。
