### PR TITLE
[SOT][3.12] Filter out duplicate store vars

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -27,6 +27,8 @@ from typing import Any, Callable
 
 import opcode
 
+from paddle.jit.utils import OrderedSet
+
 from ...profiler import EventGuard, event_register
 from ...psdb import NO_BREAKGRAPH_CODES
 from ...utils import (
@@ -1748,7 +1750,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
             end_idx: instruction index where simulation get break.
             stack: current stack
         """
-        store_vars = list(stack)
+        store_vars = list(OrderedSet(stack))
         store_var_info = {var.id: None for var in stack}
 
         for name in restore_names:

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,4 +1,3 @@
-./test_11_jumps.py
 ./test_side_effects.py
 ./test_sot_resnet.py
 ./test_sot_resnet50_backward.py

--- a/test/sot/skip_files_py312
+++ b/test/sot/skip_files_py312
@@ -1,3 +1,0 @@
-./test_side_effects.py
-./test_sot_resnet.py
-./test_sot_resnet50_backward.py

--- a/test/sot/test_01_basic.py
+++ b/test/sot/test_01_basic.py
@@ -24,7 +24,7 @@ def foo(x: int, y: paddle.Tensor):
     return x + y
 
 
-class TestExecutor(TestCaseBase):
+class TestBasic(TestCaseBase):
     def test_simple(self):
         self.assert_results(foo, 1, paddle.to_tensor(2))
 

--- a/test/sot/test_08_rot.py
+++ b/test/sot/test_08_rot.py
@@ -74,7 +74,7 @@ def rot_four_return_d(
     return d + 1
 
 
-class TestExecutor(TestCaseBase):
+class TestRot(TestCaseBase):
     def test_simple(self):
         a = paddle.to_tensor(1)
         b = paddle.to_tensor(2)

--- a/test/sot/test_10_build_unpack.py
+++ b/test/sot/test_10_build_unpack.py
@@ -75,7 +75,7 @@ def build_map_unpack_with_call(
     return z["a"] + 1
 
 
-class TestExecutor(TestCaseBase):
+class TestBuildUnpack(TestCaseBase):
     def test_simple(self):
         a = paddle.to_tensor(1)
         b = paddle.to_tensor(2)

--- a/test/sot/test_11_jumps.py
+++ b/test/sot/test_11_jumps.py
@@ -81,7 +81,7 @@ true_tensor = paddle.to_tensor(True)
 false_tensor = paddle.to_tensor(False)
 
 
-class TestExecutor(TestCaseBase):
+class TestJump(TestCaseBase):
     def test_simple(self):
         self.assert_results(jump_absolute, 5, a)
 

--- a/test/sot/test_13_make_function.py
+++ b/test/sot/test_13_make_function.py
@@ -30,7 +30,7 @@ def make_fn(x: paddle.Tensor):
     return fn(1) + fn(2, c=5) + x
 
 
-class TestExecutor(TestCaseBase):
+class TestMakeFunction(TestCaseBase):
     def test_simple(self):
         self.assert_results(make_fn, paddle.to_tensor(1))
 

--- a/test/sot/test_14_operators.py
+++ b/test/sot/test_14_operators.py
@@ -285,7 +285,7 @@ def operator_pos(y: int):
     return operator.pos(+y)
 
 
-class TestExecutor(TestCaseBase):
+class TestOperators(TestCaseBase):
     def test_simple(self):
         a = paddle.to_tensor(1)
         b = paddle.to_tensor(True)

--- a/test/sot/test_19_closure.py
+++ b/test/sot/test_19_closure.py
@@ -170,7 +170,7 @@ def create_closure():
     return closure
 
 
-class TestExecutor(TestCaseBase):
+class TestClosure(TestCaseBase):
     def test_closure(self):
         self.assert_results(foo, 1, paddle.to_tensor(2))
         self.assert_results(foo2, paddle.to_tensor(2))
@@ -187,7 +187,7 @@ class TestExecutor(TestCaseBase):
             )
 
 
-class TestExecutor2(TestCaseBase):
+class TestClosure2(TestCaseBase):
     def test_closure(self):
         self.assert_results(foo7)
 
@@ -210,7 +210,7 @@ def test_slice_in_for_loop(x, iter_num=3):
     return out
 
 
-class TestExecutor3(TestCaseBase):
+class TestClosure3(TestCaseBase):
     def test_closure(self):
         tx = paddle.to_tensor([1.0, 2.0, 3.0])
         # need side effect of list.
@@ -237,7 +237,7 @@ def non_local_test(t: paddle.Tensor):
     return t
 
 
-class TestExecutor4(TestCaseBase):
+class TestClosure4(TestCaseBase):
     def test_closure(self):
         tx = paddle.to_tensor([1.0])
         self.assert_results(non_local_test, tx)

--- a/test/sot/test_20_string.py
+++ b/test/sot/test_20_string.py
@@ -65,7 +65,7 @@ def str_endswith():
     return (a1, a2, a3, a4, a5, a6, a7)
 
 
-class TestExecutor(TestCaseBase):
+class TestString(TestCaseBase):
     def test_string_format(self):
         self.assert_results(string_format, paddle.to_tensor(1))
 

--- a/test/sot/test_break_graph.py
+++ b/test/sot/test_break_graph.py
@@ -44,7 +44,7 @@ def multi_output(x: paddle.Tensor):
         return 2 * m
 
 
-class TestExecutor(TestCaseBase):
+class TestBreakgraph(TestCaseBase):
     def test_simple(self):
         x = paddle.to_tensor(2)
         self.assert_results(multi_output, x)

--- a/test/sot/test_builtin_range.py
+++ b/test/sot/test_builtin_range.py
@@ -67,7 +67,7 @@ def test_range_10(stop: int, tensor: paddle.Tensor):
     return tensor
 
 
-class TestExecutor(TestCaseBase):
+class TestRange(TestCaseBase):
     def test_cases(self):
         start = 3
         stop = 10

--- a/test/sot/test_builtin_zip.py
+++ b/test/sot/test_builtin_zip.py
@@ -76,7 +76,7 @@ def test_zip_8(iter_1, iter_2):
     return sum
 
 
-class TestExecutor(TestCaseBase):
+class TestZip(TestCaseBase):
     def test_simple_cases(self):
         x = 8
         y = 5

--- a/test/sot/test_call_object.py
+++ b/test/sot/test_call_object.py
@@ -67,7 +67,7 @@ def foo_5(b, x):
     return b.self_call(x, "multi")
 
 
-class TestExecutor(TestCaseBase):
+class TestCallObject(TestCaseBase):
     def test_simple(self):
         c = B(13)
         c.a.multi = patched2

--- a/test/sot/test_delete_fast.py
+++ b/test/sot/test_delete_fast.py
@@ -28,7 +28,7 @@ def test_delete_fast(a):
     return a
 
 
-class TestExecutor(TestCaseBase):
+class TestDeleteFast(TestCaseBase):
     def test_simple(self):
         a = paddle.to_tensor(1)
         self.assert_results(test_delete_fast, a)

--- a/test/sot/test_enumerate.py
+++ b/test/sot/test_enumerate.py
@@ -85,7 +85,7 @@ def test_enumerate_10(layer_list, x):
     return sum
 
 
-class TestExecutor(TestCaseBase):
+class TestEnumerate(TestCaseBase):
     def test_cases(self):
         x = 8
         y = 5

--- a/test/sot/test_execution_base.py
+++ b/test/sot/test_execution_base.py
@@ -33,7 +33,7 @@ def simple(x):
     return ret
 
 
-class TestExecutor(TestCaseBase):
+class TestExecutionBase(TestCaseBase):
     def test_simple(self):
         x = paddle.to_tensor([1.0])
         y = paddle.to_tensor([2.0])

--- a/test/sot/test_inplace_api.py
+++ b/test/sot/test_inplace_api.py
@@ -86,7 +86,7 @@ def inplace_case_2(x):
     return x
 
 
-class TestExecutor(TestCaseBase):
+class TestInplaceApi(TestCaseBase):
     def test_case(self):
         self.assert_results(inplace_case_0, paddle.randn((1, 4)))
         self.assert_results(inplace_case_1, [paddle.randn((1, 4))])

--- a/test/sot/test_segment_linear.py
+++ b/test/sot/test_segment_linear.py
@@ -56,7 +56,7 @@ class SimpleNet(nn.Layer):
         return logits
 
 
-class TestExecutor(TestCaseBase):
+class TestSegmentLinear(TestCaseBase):
     @strict_mode_guard(False)
     def test_simple(self):
         x = paddle.randn((1, 8, 8))

--- a/test/sot/test_str_format.py
+++ b/test/sot/test_str_format.py
@@ -28,7 +28,7 @@ def find_spec(self, fullname, path, target=None):
     return method()
 
 
-class TestStrFormat(TestCaseBase):
+class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(find_spec, "self", "fullname", "path", None)
 

--- a/test/sot/test_str_format.py
+++ b/test/sot/test_str_format.py
@@ -28,7 +28,7 @@ def find_spec(self, fullname, path, target=None):
     return method()
 
 
-class TestExecutor(TestCaseBase):
+class TestStrFormat(TestCaseBase):
     def test_simple(self):
         self.assert_results(find_spec, "self", "fullname", "path", None)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

过滤掉 `store_vars` 里重复的 var，同一个 var 只需要 store 一次，在 3.12 JUMP 打断时候，会有两个相同的 var 在栈上，就会导致 store 两次，第二次 store 时候就挂了

并修改单测名 `TestExecutor`，剩余两个下个 PR 再说（超过 20 个文件了）

- #61174
- #61173

Pcard-67164