### PR TITLE
[AutoParallel] Support dist tensor in item api

### DIFF
--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -184,7 +184,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
                        PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
   py_test_modules(test_dist_tensor_api MODULES test_dist_tensor_api)
   set_tests_properties(test_dist_tensor_api
-                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
+                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 200)
   py_test_modules(test_gpt_with_pir MODULES test_gpt_with_pir)
   set_tests_properties(test_gpt_with_pir PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE"
                                                     TIMEOUT 100)

--- a/test/auto_parallel/semi_auto_parallel_for_item.py
+++ b/test/auto_parallel/semi_auto_parallel_for_item.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from semi_auto_parallel_util import SemiAutoParallelTestBase
+
+import paddle
+import paddle.distributed as dist
+
+
+class TestItemApiForSemiAutoParallel(SemiAutoParallelTestBase):
+    def __init__(self):
+        super().__init__()
+        paddle.seed(self._seed)
+        np.random.seed(self._seed)
+
+    def test_item_api(self):
+        mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
+        a = paddle.rand(shape=[6, 8])
+        b = dist.shard_tensor(a, mesh, [dist.Shard(0)])
+        np.testing.assert_equal(b.item(0, 0), a[0][0].item())
+        np.testing.assert_equal(b.item(3, 5), a[3][5].item())
+
+    def run_test_case(self):
+        if self._backend == "cpu":
+            paddle.set_device("cpu")
+        elif self._backend == "gpu":
+            paddle.set_device("gpu:" + str(dist.get_rank()))
+        else:
+            raise ValueError("Only support cpu or gpu backend.")
+
+        self.test_item_api()
+
+
+if __name__ == '__main__':
+    TestItemApiForSemiAutoParallel().run_test_case()

--- a/test/auto_parallel/semi_auto_parallel_for_reshape.py
+++ b/test/auto_parallel/semi_auto_parallel_for_reshape.py
@@ -55,6 +55,16 @@ class TestReshapeSemiAutoParallel(SemiAutoParallelTestBase):
         assert y.shape == [30, 20, 10]
         assert y._local_shape == [15, 20, 10]
 
+    def test_shape_api_with_reshape(self):
+        mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
+        a = paddle.rand(shape=[4, 6, 8])
+        b = dist.shard_tensor(a, mesh, [dist.Shard(0)])
+
+        dist_shape = paddle.shape(b)
+        b = b.reshape((-1, dist_shape[-1]))
+        assert b.shape == [24, 8]
+        assert b._local_shape == [12, 8]
+
     def run_test_case(self):
         if self._backend == "cpu":
             paddle.set_device("cpu")
@@ -64,6 +74,7 @@ class TestReshapeSemiAutoParallel(SemiAutoParallelTestBase):
             raise ValueError("Only support cpu or gpu backend.")
         self.test_reshape_forward()
         self.test_reshape_infer_shape()
+        self.test_shape_api_with_reshape()
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/test_semi_auto_parallel_basic.py
+++ b/test/auto_parallel/test_semi_auto_parallel_basic.py
@@ -200,6 +200,16 @@ class TestSemiAutoParallelBasic(test_base.CommunicationTestDistBase):
                 user_defined_envs=envs,
             )
 
+    def test_item_api(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "semi_auto_parallel_for_item.py",
+                user_defined_envs=envs,
+            )
+
     def test_squeeze_api(self):
         envs_list = test_base.gen_product_envs_list(
             self._default_envs, self._changeable_envs


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
PCard-73145

让paddle.item支持DistTensor作为输入，如果此时的DistTensor是非replicated状态，就需要进行一次reshard，保证每个rank拿到的item后的结果是正确的。