### PR TITLE
[PIR] support wrap_type_interface.

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_type.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_type.cc
@@ -26,8 +26,8 @@ TensorDistAttribute DistDenseTensorType::tensor_dist_attr() const {
   return storage()->tensor_dist_attr;
 }
 
-const common::DDim& DistDenseTensorType::global_ddim() const {
-  return storage()->global_ddim;
+const common::DDim& DistDenseTensorType::local_ddim() const {
+  return storage()->local_ddim;
 }
 
 DistDenseTensorType DistDenseTensorType::get(

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_type.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_type.h
@@ -24,17 +24,21 @@ namespace dialect {
 class DistDenseTensorTypeStorage;
 
 class DistDenseTensorType
-    : public pir::Type::
-          TypeBase<DistDenseTensorType, pir::Type, DistDenseTensorTypeStorage> {
+    : public pir::Type::TypeBase<DistDenseTensorType,
+                                 pir::Type,
+                                 DistDenseTensorTypeStorage,
+                                 pir::WrapTypeInterface> {
  public:
   using Base::Base;
 
   pir::DenseTensorType dense_tensor_type() const;
   TensorDistAttribute tensor_dist_attr() const;
-  const common::DDim& global_ddim() const;
-  const common::DDim& local_ddim() const { return dense_tensor_type().dims(); }
+  const common::DDim& global_ddim() const { return dense_tensor_type().dims(); }
+  const common::DDim& local_ddim() const;
   Type dtype() const { return dense_tensor_type().dtype(); }
   DataLayout data_layout() const { return dense_tensor_type().data_layout(); }
+
+  Type prim_type() { return dense_tensor_type(); }
 
   ProcessMeshAttribute process_mesh_attr() const {
     return tensor_dist_attr().process_mesh_attr();
@@ -52,7 +56,7 @@ class DistDenseTensorType
   static DistDenseTensorType get(pir::IrContext* ctx,
                                  pir::DenseTensorType dense_tensor_type,
                                  TensorDistAttribute tensor_dist_attr,
-                                 const common::DDim& global_ddim);
+                                 const common::DDim& local_ddim);
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/ir/type_storage.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/type_storage.h
@@ -33,10 +33,10 @@ struct DistDenseTensorTypeStorage : public pir::TypeStorage {
 
   DistDenseTensorTypeStorage(pir::DenseTensorType dense_tensor_type,
                              TensorDistAttribute tensor_dist_attr,
-                             const common::DDim& global_ddim)
+                             const common::DDim& local_ddim)
       : dense_tensor_type(dense_tensor_type),
         tensor_dist_attr(tensor_dist_attr),
-        global_ddim(global_ddim) {}
+        local_ddim(local_ddim) {}
 
   ///
   /// \brief Each derived TypeStorage must define a Construct method, which
@@ -53,10 +53,10 @@ struct DistDenseTensorTypeStorage : public pir::TypeStorage {
   static std::size_t HashValue(const ParamKey& key) {
     auto dense_tensor_type_hash = std::hash<pir::Type>()(std::get<0>(key));
     auto tensor_dist_attr_hash = std::hash<pir::Attribute>()(std::get<1>(key));
-    auto global_ddim_hash = std::hash<common::DDim>()(std::get<2>(key));
+    auto local_ddim_hash = std::hash<common::DDim>()(std::get<2>(key));
     auto value = pir::detail::hash_combine(dense_tensor_type_hash,
                                            tensor_dist_attr_hash);
-    return pir::detail::hash_combine(value, global_ddim_hash);
+    return pir::detail::hash_combine(value, local_ddim_hash);
   }
 
   ///
@@ -65,16 +65,16 @@ struct DistDenseTensorTypeStorage : public pir::TypeStorage {
   bool operator==(const ParamKey& key) const {
     return dense_tensor_type == std::get<0>(key) &&
            tensor_dist_attr == std::get<1>(key) &&
-           global_ddim == std::get<2>(key);
+           local_ddim == std::get<2>(key);
   }
 
   ///
   /// \brief DistDenseTensorTypeStorage include three parameters:
-  /// dense_tensor_type, tensor_dist_attr and global_ddim;
+  /// dense_tensor_type, tensor_dist_attr and local_ddim;
   ///
   pir::DenseTensorType dense_tensor_type;
   TensorDistAttribute tensor_dist_attr;
-  common::DDim global_ddim;
+  common::DDim local_ddim;
 };
 
 }  // namespace dialect

--- a/paddle/pir/include/core/builtin_type.h
+++ b/paddle/pir/include/core/builtin_type.h
@@ -66,6 +66,15 @@ class IR_API DenseTensorType : public Type::TypeBase<DenseTensorType,
   DataLayout data_layout() const;
   const LoD &lod() const;
   size_t offset() const;
+
+  ///
+  /// \brief Implementation of 'classof' that compares the type id of
+  /// the provided value with the concrete type id.
+  ///
+  static bool classof(Type type);
+
+  static DenseTensorType dyn_cast_impl(Type type);
+
   static DenseTensorType get(IrContext *ctx,
                              Type dtype,
                              const Dim &dims,

--- a/paddle/pir/include/core/builtin_type_interfaces.h
+++ b/paddle/pir/include/core/builtin_type_interfaces.h
@@ -137,6 +137,31 @@ class IR_API ShapedTypeInterface
   Concept *impl_;
 };
 
+class IR_API WrapTypeInterface : public TypeInterfaceBase<WrapTypeInterface> {
+ public:
+  struct Concept {
+    /// Defined these methods with the interface.
+    explicit Concept(Type (*prim_type)(Type)) : prim_type(prim_type) {}
+    Type (*prim_type)(Type);
+  };
+
+  template <class ConcreteType>
+  struct Model : public Concept {
+    static Type prim_type(Type type) {
+      return pir::cast<ConcreteType>(type).prim_type();
+    }
+    Model() : Concept(prim_type) {}
+  };
+
+  WrapTypeInterface(Type type, Concept *impl)
+      : TypeInterfaceBase<WrapTypeInterface>(type), impl_(impl) {}
+
+  Type prim_type() { return impl_->prim_type(*this); }
+
+ private:
+  Concept *impl_;
+};
 }  // namespace pir
 
 IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::ShapedTypeInterface)
+IR_EXPORT_DECLARE_EXPLICIT_TYPE_ID(pir::WrapTypeInterface)

--- a/paddle/pir/include/core/storage_manager_support.h
+++ b/paddle/pir/include/core/storage_manager_support.h
@@ -90,7 +90,7 @@ class StorageHelperBase : public BaseT {
   ///
   template <typename T>
   static bool classof(T val) {
-    return val.type_id() == type_id();
+    return val && val.type_id() == type_id();
   }
 
   ///

--- a/paddle/pir/src/core/builtin_type.cc
+++ b/paddle/pir/src/core/builtin_type.cc
@@ -30,6 +30,25 @@ const DenseTensorType::LoD& DenseTensorType::lod() const {
 }
 
 size_t DenseTensorType::offset() const { return storage()->offset_; }
+bool DenseTensorType::classof(Type type) {
+  if (type) {
+    if (type.type_id() == type_id()) return true;
+    if (auto wrap_type = type.dyn_cast<WrapTypeInterface>()) {
+      return classof(wrap_type.prim_type());
+    }
+  }
+  return false;
+}
+DenseTensorType DenseTensorType::dyn_cast_impl(Type type) {
+  if (type) {
+    if (type.type_id() == type_id()) return DenseTensorType(type.storage());
+    if (auto wrap_type = type.dyn_cast<WrapTypeInterface>()) {
+      return dyn_cast_impl(wrap_type.prim_type());
+    }
+  }
+  return nullptr;
+}
+
 }  // namespace pir
 
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::UInt8Type)

--- a/paddle/pir/src/core/builtin_type_interfaces.cc
+++ b/paddle/pir/src/core/builtin_type_interfaces.cc
@@ -27,3 +27,4 @@ pir::DDim ShapedTypeInterface::GetShape() const {
 
 }  // namespace pir
 IR_DEFINE_EXPLICIT_TYPE_ID(pir::ShapedTypeInterface)
+IR_DEFINE_EXPLICIT_TYPE_ID(pir::WrapTypeInterface)

--- a/test/cpp/pir/distributed/dist_dialect_test.cc
+++ b/test/cpp/pir/distributed/dist_dialect_test.cc
@@ -128,6 +128,40 @@ TEST(dist_dense_tensor_type_test, base) {
   EXPECT_EQ(dist_densor_type.local_ddim(), dims);
 }
 
+TEST(dist_dense_tensor_type_test, warp_type_interface) {
+  pir::IrContext* ctx = pir::IrContext::Instance();
+  ctx->GetOrRegisterDialect<DistDialect>();
+  ctx->GetOrRegisterDialect<OperatorDialect>();
+  std::vector<int64_t> mesh_shape = {2, 3};
+  std::vector<int64_t> process_ids = {0, 1, 2, 3, 4, 5};
+  std::vector<std::string> dim_names = {"x", "y"};
+  phi::distributed::ProcessMesh process_mesh(
+      mesh_shape, process_ids, dim_names);
+  auto mesh_attr = ProcessMeshAttribute::get(ctx, process_mesh);
+
+  std::vector<int64_t> dims_mapping = {0, -1};
+  paddle::flat_hash_map<int64_t, phi::ReduceType> partial_status{
+      {1, phi::ReduceType::kRedSum}};
+  // construct a TensorDistAttribute.
+  auto tensor_dist_attr =
+      TensorDistAttribute::get(ctx, mesh_attr, dims_mapping, partial_status);
+
+  pir::Type fp32_dtype = pir::Float32Type::get(ctx);
+  common::DDim dims = {2, 2};
+  common::DataLayout data_layout = common::DataLayout::NCHW;
+  pir::LoD lod = {{0, 1, 2}};
+  size_t offset = 0;
+  pir::DenseTensorType dense_tensor_type = pir::DenseTensorType::get(
+      ctx, fp32_dtype, dims, data_layout, lod, offset);
+
+  pir::Type dist_densor_type =
+      DistDenseTensorType::get(ctx, dense_tensor_type, tensor_dist_attr, dims);
+
+  EXPECT_TRUE(dist_densor_type.isa<pir::DenseTensorType>());
+  EXPECT_EQ(dist_densor_type.dyn_cast<pir::DenseTensorType>(),
+            dense_tensor_type);
+}
+
 TEST(operation_dist_attr_test, base) {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<DistDialect>();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
1. 新增 WarpTypeInterface。表示该类型是某种其它类型对象的封装，同时可以通过Type prim_type() 接口来获取到被封装的对象。 
2. 给DistDenseTensorType附加WarpTypeInterface接口，表示封装了一个DenseTensorType对象。
单测如下：
```cxx
  pir::Type dist_densor_type = DistDenseTensorType::get(ctx, dense_tensor_type, tensor_dist_attr, dims);
  EXPECT_TRUE(dist_densor_type.isa<pir::DenseTensorType>());
  EXPECT_EQ(dist_densor_type.dyn_cast<pir::DenseTensorType>(), dense_tensor_type);
```



### Other
Pcard-67164
