### PR TITLE
Fix ShapeOrDate "operater==" access array out of bounds

### DIFF
--- a/paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h
@@ -60,7 +60,7 @@ class ShapeOrData {
   bool operator==(const ShapeOrData<T>& other) const {
     if (data_.has_value() && !other.data_.has_value()) return false;
     if (!data_.has_value() && other.data_.has_value()) return false;
-    if (shape_.size() != shape_.size()) return false;
+    if (shape_.size() != other.shape_.size()) return false;
 
     if (data_.has_value() && other.data_.has_value()) {
       if (data_.value().size() != other.data_.value().size()) return false;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996
This pr is to fix the Segmentation fault in insert_broadcast_pass when run forward unittest.
This problem is due to the ShapeOrDate "operater==" access array out of bounds.