### PR TITLE
[HACKATHON 6th][CMake Optimization] use new cmake policy CMP0135 for third party dependences

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -15,6 +15,11 @@
 include(ExternalProject)
 # Create a target named "third_party", which can compile external dependencies on all platform(windows/linux/mac)
 
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 set(THIRD_PARTY_PATH
     "${CMAKE_BINARY_DIR}/third_party"
     CACHE STRING


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
CMake 在 3.24 版本后新增 [CMP0135](https://cmake.org/cmake/help/latest/policy/CMP0135.html)，当 [ExternalProject_Add()](https://cmake.org/cmake/help/latest/module/ExternalProject.html#command:externalproject_add) 没有指定 `DOWNLOAD_EXTRACT_TIMESTAMP` 选项，且没有指定 CMP0135 的时候，默认选择 `OLD` Behavior，即将解压的第三方源码的文件时间设置为压缩包内的文件时间，并输出警告。

本 PR 使 CMake 使用 CMP0135 的 `New` Behavior，即将解压的第三方源码的文件时间设置为解压该文件的时间，避免在 CMake 构建时显示一大堆警告。