### PR TITLE
API improvement for paddle.nonzero 易用性提升

### DIFF
--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -403,7 +403,7 @@ def nonzero(x, as_tuple=False):
     of `input`. Given a n-Dimensional `input` tensor with shape [x_1, x_2, ..., x_n], If
     as_tuple is False, we can get a output tensor with shape [z, n], where `z` is the
     number of all non-zero elements in the `input` tensor. If as_tuple is True, we can get
-    a 1-D tensor tuple of length `n`, and the shape of each 1-D tensor is [z, 1].
+    a 1-D tensor tuple of length `n`, and the shape of each 1-D tensor is [z].
 
     Args:
         x (Tensor): The input tensor variable.
@@ -433,13 +433,9 @@ def nonzero(x, as_tuple=False):
             >>> for out in out_z1_tuple:
             ...     print(out)
             Tensor(shape=[3, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [[0],
-             [1],
-             [2]])
+            [0, 1, 2])
             Tensor(shape=[3, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [[0],
-             [1],
-             [2]])
+            [0, 1, 2])
 
             >>> out_z2 = paddle.nonzero(x2)
             >>> print(out_z2)
@@ -451,8 +447,7 @@ def nonzero(x, as_tuple=False):
             >>> for out in out_z2_tuple:
             ...     print(out)
             Tensor(shape=[2, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [[1],
-             [3]])
+            [1, 3])
 
     """
     list_out = []
@@ -491,11 +486,13 @@ def nonzero(x, as_tuple=False):
     if not as_tuple:
         return outs
     elif rank == 1:
-        return (outs,)
+        return (outs.reshape([-1]),)
     else:
         for i in range(rank):
             list_out.append(
-                paddle.slice(outs, axes=[1], starts=[i], ends=[i + 1])
+                paddle.slice(outs, axes=[1], starts=[i], ends=[i + 1]).reshape(
+                    [-1]
+                )
             )
         return tuple(list_out)
 

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -432,9 +432,9 @@ def nonzero(x, as_tuple=False):
             >>> out_z1_tuple = paddle.nonzero(x1, as_tuple=True)
             >>> for out in out_z1_tuple:
             ...     print(out)
-            Tensor(shape=[3, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 1, 2])
-            Tensor(shape=[3, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 1, 2])
 
             >>> out_z2 = paddle.nonzero(x2)
@@ -446,7 +446,7 @@ def nonzero(x, as_tuple=False):
             >>> out_z2_tuple = paddle.nonzero(x2, as_tuple=True)
             >>> for out in out_z2_tuple:
             ...     print(out)
-            Tensor(shape=[2, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[2], dtype=int64, place=Place(cpu), stop_gradient=True,
             [1, 3])
 
     """
@@ -666,9 +666,8 @@ def where(condition, x=None, y=None, name=None):
 
             >>> out = paddle.where(x>1)
             >>> print(out)
-            (Tensor(shape=[2, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [[2],
-             [3]]),)
+            (Tensor(shape=[2], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [2, 3]),)
     """
     if np.isscalar(x):
         x = paddle.full([1], x, np.array([x]).dtype.name)

--- a/test/legacy_test/test_nonzero_api.py
+++ b/test/legacy_test/test_nonzero_api.py
@@ -37,7 +37,8 @@ class TestNonZeroAPI(unittest.TestCase):
             y = paddle.nonzero(x, as_tuple=True)
             self.assertEqual(type(y), tuple)
             self.assertEqual(len(y), 2)
-            z = paddle.concat(list(y), axis=1)
+            index_list = [index.reshape([-1, 1]) for index in y]
+            z = paddle.concat(index_list, axis=1)
             exe = base.Executor(base.CPUPlace())
 
             (res,) = exe.run(
@@ -53,7 +54,8 @@ class TestNonZeroAPI(unittest.TestCase):
             y = paddle.nonzero(x, as_tuple=True)
             self.assertEqual(type(y), tuple)
             self.assertEqual(len(y), 1)
-            z = paddle.concat(list(y), axis=1)
+            index_list = [index.reshape([-1, 1]) for index in y]
+            z = paddle.concat(index_list, axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': data}, fetch_list=[z.name], return_numpy=False

--- a/test/legacy_test/test_where_op.py
+++ b/test/legacy_test/test_where_op.py
@@ -760,7 +760,8 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = paddle.where(x)
             self.assertEqual(type(y), tuple)
             self.assertEqual(len(y), 2)
-            z = paddle.concat(list(y), axis=1)
+            index_list = [index.reshape([-1, 1]) for index in y]
+            z = paddle.concat(index_list, axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': data}, fetch_list=[z.name], return_numpy=False
@@ -774,7 +775,8 @@ class TestWhereDygraphAPI(unittest.TestCase):
             y = paddle.where(x)
             self.assertEqual(type(y), tuple)
             self.assertEqual(len(y), 1)
-            z = paddle.concat(list(y), axis=1)
+            index_list = [index.reshape([-1, 1]) for index in y]
+            z = paddle.concat(index_list, axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
                 feed={'x': data}, fetch_list=[z.name], return_numpy=False


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Description
需解决的问题：`paddle.nonzero` 指定 `as_tuple=True` 时行为与 pytorch 不一致，假设 N 为非0个数，C 为维度个数，将 [N, C] 作为 tuple 返回时，应返回 C 个 [N] 。但目前返回 C 个 [N, 1]，多了一维。
