### PR TITLE
[PIR] Adapt scene that TuplePushOp and TuplePopOp are in different sub program

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/tuple_pop_instruction.cc
@@ -28,8 +28,8 @@ TuplePopInstruction::TuplePopInstruction(size_t id,
     : InstructionBase(id, place), op_(op), value_exe_info_(value_exe_info) {
   tuple_pop_op_ = op->dyn_cast<pir::TuplePopOp>();
   VLOG(6) << "construct tuple_pop instruction for: " << tuple_pop_op_->name();
-  auto stack_value = tuple_pop_op_.container();
-  auto var_array = value_exe_info_->GetVarByValue(stack_value);
+  auto outlet_value = tuple_pop_op_.outlet();
+  auto var_array = value_exe_info_->GetVarByValue(outlet_value);
   stack_element_var_array_ = var_array->GetMutable<VariableRefArray>();
 
   std::unordered_map<pir::Value, std::vector<int>> inputs;

--- a/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
+++ b/paddle/fluid/framework/new_executor/instruction/instruction_util.cc
@@ -281,7 +281,9 @@ std::unordered_set<pir::Value> GetInternalInputs(pir::Block* block) {
     }
     if (op.isa<pir::TuplePopOp>()) {
       auto tuple_pop_op = op.dyn_cast<pir::TuplePopOp>();
-      inner_inputs.insert(tuple_pop_op.container());
+      if (tuple_pop_op.has_container()) {
+        inner_inputs.insert(tuple_pop_op.container());
+      }
     }
     for (size_t i = 0; i < op.num_operands(); ++i) {
       inner_inputs.insert(op.operand_source(i));

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -1342,6 +1342,7 @@ void PrintValuesAndVariables(
         GetOriginOutputNames(op_name);
 
     // 1. output string
+    VLOG(10) << "Generate output string ...";
     std::string ret_value_str = "Value   : (";
     std::string ret_variable_str = "Variable: (";
     if (!op.results().empty()) {
@@ -1355,7 +1356,7 @@ void PrintValuesAndVariables(
 
           // get origin name
           std::string origin_name;
-          if (!origin_output_names.empty())
+          if (!origin_output_names.empty() && i < origin_output_names.size())
             origin_name = origin_output_names[i];
           else
             origin_name = var_name;
@@ -1387,10 +1388,12 @@ void PrintValuesAndVariables(
     ret_variable_str += ") = ";
 
     // 2. op name
+    VLOG(10) << "Generate op name ...";
     ret_value_str += op_name;
     ret_variable_str += op_name;
 
     // 3. input string
+    VLOG(10) << "Generate input string ...";
     ret_value_str += "(";
     ret_variable_str += "(";
     if (!op.operands().empty()) {
@@ -1404,7 +1407,7 @@ void PrintValuesAndVariables(
 
           // get origin name
           std::string origin_name;
-          if (!origin_input_names.empty())
+          if (!origin_input_names.empty() && i < origin_input_names.size())
             origin_name = origin_input_names[i];
           else
             origin_name = var_name;

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -45,7 +45,7 @@ INPUT_TYPE_CHECK_TEMPLATE = """
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
   }}
@@ -62,7 +62,7 @@ INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
                           "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
     }}
@@ -93,7 +93,7 @@ OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      IR_ENFORCE(vec_type[i].isa<{standard}>(),
+      IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
                      "Type validation failed for the {index}th output.");
     }}
   }}
@@ -110,7 +110,7 @@ OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
                        "Type validation failed for the {index}th output.");
       }}
     }}

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -45,7 +45,7 @@ INPUT_TYPE_CHECK_TEMPLATE = """
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
+        IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
   }}
@@ -62,7 +62,7 @@ INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
+        IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
                           "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
     }}
@@ -93,7 +93,7 @@ OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
+      IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
                      "Type validation failed for the {index}th output.");
     }}
   }}
@@ -110,7 +110,7 @@ OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
+        IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
                        "Type validation failed for the {index}th output.");
       }}
     }}
@@ -181,6 +181,7 @@ def gen_inputs_type_check_str(
             check_str = INPUT_VECTORTYPE_CHECK_TEMPLATE.format(
                 index=idx + len(op_input_type_list),
                 standard="paddle::dialect::DenseTensorType",
+                allocated_standard="paddle::dialect::AllocatedDenseTensorType",
             )
         inputs_type_check_str += check_str
     return inputs_type_check_str

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -45,9 +45,8 @@ INPUT_TYPE_CHECK_TEMPLATE = """
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE((vec_type[i].isa<{standard}>()
-                        || vec_type[i].isa<{allocated_standard}>()),
-                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
+        PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
+                       paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
       }}
   }}
   else {{
@@ -63,9 +62,8 @@ INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        IR_ENFORCE((vec_type[i].isa<{standard}>()
-                        || vec_type[i].isa<{allocated_standard}>()),
-                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
+        PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
+                          paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
       }}
     }}
     else {{
@@ -95,9 +93,8 @@ OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      IR_ENFORCE((vec_type[i].isa<{standard}>()
-                    || vec_type[i].isa<{allocated_standard}>()),
-                    "Type validation failed for the {index}th output.");
+      PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
+                     paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th output."));
     }}
   }}
   else {{
@@ -113,9 +110,8 @@ OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE((vec_type[i].isa<{standard}>()
-                        || vec_type[i].isa<{allocated_standard}>()),
-                        "Type validation failed for the {index}th output.");
+        PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
+                       paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th output."));
       }}
     }}
     else {{

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -45,8 +45,8 @@ INPUT_TYPE_CHECK_TEMPLATE = """
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
-                       paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
+        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                       "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
   }}
   else {{
@@ -62,8 +62,8 @@ INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
-                          paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type()));
+        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                          "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
     }}
     else {{
@@ -93,8 +93,8 @@ OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
-                     paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th output."));
+      IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                     "Type validation failed for the {index}th output.");
     }}
   }}
   else {{
@@ -110,8 +110,8 @@ OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        PADDLE_ENFORCE_EQ((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()), true,
-                       paddle::platform::errors::InvalidArgument("Type validation failed for the {index}th output."));
+        IR_ENFORCE(vec_type[i].isa<{standard}>(),
+                       "Type validation failed for the {index}th output.");
       }}
     }}
     else {{
@@ -145,11 +145,7 @@ def gen_inputs_type_check_str(
         if is_optional == "true":
             if is_vector:
                 check_str = INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx,
-                    standard=input_type,
-                    allocated_standard=input_type.replace(
-                        "DenseTensorType", "AllocatedDenseTensorType"
-                    ),
+                    index=idx, standard=input_type
                 )
             else:
                 check_str = INPUT_OPTIONAL_TYPE_CHECK_TEMPLATE.format(
@@ -158,11 +154,7 @@ def gen_inputs_type_check_str(
         else:
             if is_vector:
                 check_str = INPUT_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx,
-                    standard=input_type,
-                    allocated_standard=input_type.replace(
-                        "DenseTensorType", "AllocatedDenseTensorType"
-                    ),
+                    index=idx, standard=input_type
                 )
             else:
                 check_str = INPUT_TYPE_CHECK_TEMPLATE.format(
@@ -181,7 +173,6 @@ def gen_inputs_type_check_str(
             check_str = INPUT_VECTORTYPE_CHECK_TEMPLATE.format(
                 index=idx + len(op_input_type_list),
                 standard="paddle::dialect::DenseTensorType",
-                allocated_standard="paddle::dialect::AllocatedDenseTensorType",
             )
         inputs_type_check_str += check_str
     return inputs_type_check_str
@@ -234,11 +225,7 @@ def gen_outputs_type_check_str(op_output_type_list, op_output_optional_list):
         if is_optional == "true":
             if is_vector:
                 check_str = OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx,
-                    standard=output_type,
-                    allocated_standard=output_type.replace(
-                        "DenseTensorType", "AllocatedDenseTensorType"
-                    ),
+                    index=idx, standard=output_type
                 )
             else:
                 check_str = OUTPUT_OPTIONAL_TYPE_CHECK_TEMPLATE.format(
@@ -247,11 +234,7 @@ def gen_outputs_type_check_str(op_output_type_list, op_output_optional_list):
         else:
             if is_vector:
                 check_str = OUTPUT_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx,
-                    standard=output_type,
-                    allocated_standard=output_type.replace(
-                        "DenseTensorType", "AllocatedDenseTensorType"
-                    ),
+                    index=idx, standard=output_type
                 )
             else:
                 check_str = OUTPUT_TYPE_CHECK_TEMPLATE.format(

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -45,8 +45,9 @@ INPUT_TYPE_CHECK_TEMPLATE = """
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
-                       "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
+        IR_ENFORCE((vec_type[i].isa<{standard}>()
+                        || vec_type[i].isa<{allocated_standard}>()),
+                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
   }}
   else {{
@@ -62,8 +63,9 @@ INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
-                          "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
+        IR_ENFORCE((vec_type[i].isa<{standard}>()
+                        || vec_type[i].isa<{allocated_standard}>()),
+                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
     }}
     else {{
@@ -93,8 +95,9 @@ OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
-                     "Type validation failed for the {index}th output.");
+      IR_ENFORCE((vec_type[i].isa<{standard}>()
+                    || vec_type[i].isa<{allocated_standard}>()),
+                    "Type validation failed for the {index}th output.");
     }}
   }}
   else {{
@@ -110,8 +113,9 @@ OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE((vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>()),
-                       "Type validation failed for the {index}th output.");
+        IR_ENFORCE((vec_type[i].isa<{standard}>()
+                        || vec_type[i].isa<{allocated_standard}>()),
+                        "Type validation failed for the {index}th output.");
       }}
     }}
     else {{

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -45,7 +45,7 @@ INPUT_TYPE_CHECK_TEMPLATE = """
 INPUT_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto vec_type = (*this)->operand_source({index}).type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
+        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
                        "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
   }}
@@ -62,7 +62,7 @@ INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto val =  (*this)->operand({index})) {{
     if (auto vec_type = val.type().dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); i++) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
+        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
                           "Type validation failed for the {index}th input, got %s.", (*this)->operand_source({index}).type());
       }}
     }}
@@ -93,7 +93,7 @@ OUTPUT_VECTORTYPE_CHECK_TEMPLATE = """
   auto output_{index}_type = (*this)->result({index}).type();
   if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
     for (size_t i = 0; i < vec_type.size(); i++) {{
-      IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
+      IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
                      "Type validation failed for the {index}th output.");
     }}
   }}
@@ -110,7 +110,7 @@ OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE = """
   if (auto output_{index}_type = (*this)->result({index}).type()) {{
     if (auto vec_type = output_{index}_type.dyn_cast<pir::VectorType>()) {{
       for (size_t i = 0; i < vec_type.size(); ++i) {{
-        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<Allocated{standard}>(),
+        IR_ENFORCE(vec_type[i].isa<{standard}>() || vec_type[i].isa<{allocated_standard}>(),
                        "Type validation failed for the {index}th output.");
       }}
     }}
@@ -145,7 +145,11 @@ def gen_inputs_type_check_str(
         if is_optional == "true":
             if is_vector:
                 check_str = INPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx, standard=input_type
+                    index=idx,
+                    standard=input_type,
+                    allocated_standard=input_type.replace(
+                        "DenseTensorType", "AllocatedDenseTensorType"
+                    ),
                 )
             else:
                 check_str = INPUT_OPTIONAL_TYPE_CHECK_TEMPLATE.format(
@@ -154,7 +158,11 @@ def gen_inputs_type_check_str(
         else:
             if is_vector:
                 check_str = INPUT_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx, standard=input_type
+                    index=idx,
+                    standard=input_type,
+                    allocated_standard=input_type.replace(
+                        "DenseTensorType", "AllocatedDenseTensorType"
+                    ),
                 )
             else:
                 check_str = INPUT_TYPE_CHECK_TEMPLATE.format(
@@ -225,7 +233,11 @@ def gen_outputs_type_check_str(op_output_type_list, op_output_optional_list):
         if is_optional == "true":
             if is_vector:
                 check_str = OUTPUT_OPTIONAL_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx, standard=output_type
+                    index=idx,
+                    standard=output_type,
+                    allocated_standard=output_type.replace(
+                        "DenseTensorType", "AllocatedDenseTensorType"
+                    ),
                 )
             else:
                 check_str = OUTPUT_OPTIONAL_TYPE_CHECK_TEMPLATE.format(
@@ -234,7 +246,11 @@ def gen_outputs_type_check_str(op_output_type_list, op_output_optional_list):
         else:
             if is_vector:
                 check_str = OUTPUT_VECTORTYPE_CHECK_TEMPLATE.format(
-                    index=idx, standard=output_type
+                    index=idx,
+                    standard=output_type,
+                    allocated_standard=output_type.replace(
+                        "DenseTensorType", "AllocatedDenseTensorType"
+                    ),
                 )
             else:
                 check_str = OUTPUT_TYPE_CHECK_TEMPLATE.format(

--- a/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/ops_api_gen.py
@@ -156,6 +156,7 @@ NO_NEED_GEN_STATIC_ONLY_APIS = [
     'seed',
     'send_v2',
     'shadow_feed',
+    'shadow_feed_tensors',
     'shuffle_batch',
     'sparse_momentum',
     'tdm_sampler',

--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -1374,6 +1374,16 @@
     func: shadow_feed
     param: [x]
 
+- op : shadow_feed_tensors
+  args : (Tensor[] x)
+  output : Tensor[](out){x.size()}
+  infer_meta:
+    func: UnchangedVectorInferMeta
+    param: [x]
+  kernel:
+    func: shadow_feed_tensors
+    param: [x]
+
 - op : share_data
   args : (Tensor x)
   output : Tensor(out)

--- a/paddle/fluid/pir/transforms/inplace_pass.cc
+++ b/paddle/fluid/pir/transforms/inplace_pass.cc
@@ -213,6 +213,7 @@ std::unordered_set<pir::Value> GetSkipDeletionValues(const pir::Block& block) {
       skip_dels.insert(op.result(0));
       continue;
     }
+    // TODO(chenxi67) add logic for shadow_feed_tensors op
     if (upper_op_name == "pd_op.fetch" ||
         upper_op_name == "builtin.shadow_output") {
       skip_dels.insert(op.operand_source(0));

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4876,6 +4876,14 @@ void UnchangedArrayInferMeta(const MetaTensor& x, MetaTensor* out) {
   out->set_layout(x.layout());
 }
 
+void UnchangedVectorInferMeta(const std::vector<const MetaTensor*>& xs,
+                              std::vector<MetaTensor*> outs) {
+  for (size_t i = 0; i < xs.size(); ++i) {
+    outs[i]->set_dtype(xs[i]->dtype());
+    outs[i]->set_layout(xs[i]->layout());
+  }
+}
+
 // meta x -> out without change, check if axis in range [-Rank(x), Rank(x)-1]
 void UnchangedInferMetaCheckAxis(const MetaTensor& x,
                                  int axis,

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -753,6 +753,8 @@ void UnchangedExceptLayoutInferMeta(const MetaTensor& x, MetaTensor* out);
 void UnchangedExceptDtypeInferMeta(const MetaTensor& x, MetaTensor* out);
 void UnchangedInferMeta(const MetaTensor& x, MetaTensor* out);
 void UnchangedArrayInferMeta(const MetaTensor& x, MetaTensor* out);
+void UnchangedVectorInferMeta(const std::vector<const MetaTensor*>& xs,
+                              std::vector<MetaTensor*> outs);
 
 // meta x -> out without change, check if axis in range [-Rank(x), Rank(x)-1]
 void UnchangedInferMetaCheckAxis(const MetaTensor& x,

--- a/paddle/phi/kernels/cpu/data_kernel.cc
+++ b/paddle/phi/kernels/cpu/data_kernel.cc
@@ -70,6 +70,23 @@ PD_REGISTER_KERNEL(shadow_feed,
                    phi::complex64,
                    phi::complex128) {}
 
+PD_REGISTER_KERNEL(shadow_feed_tensors,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::ShadowFeedTensorsKernel,
+                   bool,
+                   uint8_t,
+                   float,
+                   int8_t,
+                   int16_t,
+                   int32_t,
+                   int64_t,
+                   double,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
+
 PD_REGISTER_KERNEL(print_kernel,
                    CPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/data_kernel.h
+++ b/paddle/phi/kernels/data_kernel.h
@@ -37,6 +37,11 @@ void ShadowFeedKernel(const Context& ctx,
                       DenseTensor* out);
 
 template <typename T, typename Context>
+void ShadowFeedTensorsKernel(const Context& ctx,
+                             const std::vector<const DenseTensor*>& xs,
+                             std::vector<DenseTensor*> outs);
+
+template <typename T, typename Context>
 void PrintKernel(const Context& ctx,
                  const DenseTensor& x,
                  int first_n,

--- a/paddle/phi/kernels/gpu/data_kernel.cu
+++ b/paddle/phi/kernels/gpu/data_kernel.cu
@@ -35,6 +35,23 @@ PD_REGISTER_KERNEL(shadow_feed,
                    phi::complex64,
                    phi::complex128) {}
 
+PD_REGISTER_KERNEL(shadow_feed_tensors,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::ShadowFeedTensorsKernel,
+                   bool,
+                   uint8_t,
+                   float,
+                   int8_t,
+                   int16_t,
+                   int32_t,
+                   int64_t,
+                   double,
+                   phi::float16,
+                   phi::bfloat16,
+                   phi::complex64,
+                   phi::complex128) {}
+
 PD_REGISTER_KERNEL(print_kernel,
                    GPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -45,16 +45,6 @@ void ShadowFeedTensorsKernel(const Context& ctx,
                              std::vector<DenseTensor*> outs) {
   for (size_t i = 0; i < xs.size(); ++i) {
     ShadowFeedKernel<T, Context>(ctx, *(xs[i]), outs[i]);
-    // if (!xs[i]->initialized()) {
-    //   ctx.template Alloc<T>(outs[i]);
-    //   continue;
-    // }
-    // if (xs[i]->place() == ctx.GetPlace()) {
-    //   outs[i]->ShareDataWith(*(xs[i]));
-    //   outs[i]->set_lod(xs[i]->lod());
-    // } else {
-    //   phi::Copy<Context>(ctx, *(xs[i]), ctx.GetPlace(), true, outs[i]);
-    // }
   }
 }
 

--- a/paddle/phi/kernels/impl/data_impl.h
+++ b/paddle/phi/kernels/impl/data_impl.h
@@ -44,16 +44,17 @@ void ShadowFeedTensorsKernel(const Context& ctx,
                              const std::vector<const DenseTensor*>& xs,
                              std::vector<DenseTensor*> outs) {
   for (size_t i = 0; i < xs.size(); ++i) {
-    if (!xs[i]->initialized()) {
-      ctx.template Alloc<T>(outs[i]);
-      continue;
-    }
-    if (xs[i]->place() == ctx.GetPlace()) {
-      outs[i]->ShareDataWith(*(xs[i]));
-      outs[i]->set_lod(xs[i]->lod());
-    } else {
-      phi::Copy<Context>(ctx, *(xs[i]), ctx.GetPlace(), true, outs[i]);
-    }
+    ShadowFeedKernel<T, Context>(ctx, *(xs[i]), outs[i]);
+    // if (!xs[i]->initialized()) {
+    //   ctx.template Alloc<T>(outs[i]);
+    //   continue;
+    // }
+    // if (xs[i]->place() == ctx.GetPlace()) {
+    //   outs[i]->ShareDataWith(*(xs[i]));
+    //   outs[i]->set_lod(xs[i]->lod());
+    // } else {
+    //   phi::Copy<Context>(ctx, *(xs[i]), ctx.GetPlace(), true, outs[i]);
+    // }
   }
 }
 

--- a/paddle/pir/include/core/value.h
+++ b/paddle/pir/include/core/value.h
@@ -66,7 +66,7 @@ class IR_API Value {
 
   template <typename OpTy>
   OpTy defining_op() const {
-    /// It is safety even if defining_op() return nullptr.
+    /// It is safe even if defining_op() returns nullptr.
     return OpTy::dyn_cast(defining_op());
   }
 

--- a/paddle/pir/include/dialect/control_flow/ir/cf_op.h
+++ b/paddle/pir/include/dialect/control_flow/ir/cf_op.h
@@ -84,6 +84,7 @@ class IR_API TuplePopOp : public Op<TuplePopOp, SideEffectTrait> {
   void VerifySig();
   void VerifyRegion();
 
+  bool has_container() { return outlet().defining_op(); }
   Value container() { return container_interface().container(); }
   Value inlet() { return container_interface().inlet(); }
   Value outlet() { return operand_source(0); }

--- a/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
+++ b/paddle/pir/src/dialect/control_flow/ir/cf_op.cc
@@ -107,19 +107,23 @@ void TuplePopOp::VerifyRegion() {
              "The outlet value of cf.tuple_pop can only be used once.");
 
   // Verify stack validity:
-  auto pop_op = container_interface().tuple_pop_op();
-  IR_ENFORCE(*this == pop_op,
-             "The pop_op of tuple_pop_op must be this tuple_pop_op self.");
+  if (has_container()) {
+    // can be verified only if TuplePopOp and TuplePushOp are in the same
+    // sub_program
+    auto pop_op = container_interface().tuple_pop_op();
+    IR_ENFORCE(*this == pop_op,
+               "The pop_op of tuple_pop_op must be this tuple_pop_op self.");
 
-  auto inlet_size = tuple_push_op().tuple_size();
-  IR_ENFORCE(inlet_size == tuple_size(),
-             "The pop elements size must equal to push elements size.");
-  for (size_t index = 0; index < inlet_size; ++index) {
-    IR_ENFORCE(outlet_element(index).type() == inlet_element(index).type(),
-               "The %d element's push type (%s) isn't equal to pop type (%s)",
-               index,
-               outlet_element(index).type(),
-               inlet_element(index).type());
+    auto inlet_size = tuple_push_op().tuple_size();
+    IR_ENFORCE(inlet_size == tuple_size(),
+               "The pop elements size must equal to push elements size.");
+    for (size_t index = 0; index < inlet_size; ++index) {
+      IR_ENFORCE(outlet_element(index).type() == inlet_element(index).type(),
+                 "The %d element's push type (%s) isn't equal to pop type (%s)",
+                 index,
+                 outlet_element(index).type(),
+                 inlet_element(index).type());
+    }
   }
   VLOG(4) << "End Verifying for TuplePopOp.";
 }

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -564,7 +564,6 @@ class IfElseNet(paddle.nn.Layer):
 
 
 class TestDy2StIfElseBackward(Dy2StTestBase):
-    # TODO(zhangbo): open pir test (IfOp grad execution not yet supported)
     @test_ast_only
     @test_pir_only
     def test_run_backward(self):

--- a/test/dygraph_to_static/test_ifelse.py
+++ b/test/dygraph_to_static/test_ifelse.py
@@ -565,7 +565,8 @@ class IfElseNet(paddle.nn.Layer):
 
 class TestDy2StIfElseBackward(Dy2StTestBase):
     # TODO(zhangbo): open pir test (IfOp grad execution not yet supported)
-    @disable_test_case((ToStaticMode.AST, IrMode.PT))
+    @test_ast_only
+    @test_pir_only
     def test_run_backward(self):
         a = paddle.randn((4, 3), dtype='float32')
         a.stop_gradient = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Pcard-67164
当 if 的前反向计算图（TuplePushOp 和 TuplePopOp）被切分到不同的子图中时，TuplePopOp无法获取对应的container，且由于输出value其实是由TuplePushOp压栈而来，也会丢失这些value的执行期信息。本PR对这一情况进行修复，主要改动如下：

- 在 TuplePopOp 需要获取 container() 的地方增加判断
- 对于TuplePopOp输出无法获取place的情况，仿照DataOp的逻辑，添加shadow_feed_tensors()将执行期place feed进去