### PR TITLE
[PIR] Filter out attribute `op_callstack` when print program

### DIFF
--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "paddle/fluid/framework/op_proto_maker.h"
 #include "paddle/pir/include/core/block.h"
 #include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/builtin_type.h"
@@ -279,6 +280,11 @@ void IrPrinter::PrintAttributeMap(Operation* op) {
   AttributeMap attributes = op->attributes();
   std::map<std::string, Attribute, std::less<>> order_attributes(
       attributes.begin(), attributes.end());
+
+  // Filter out the callstack attribute
+  order_attributes.erase(
+      paddle::framework::OpProtoAndCheckerMaker::OpCreationCallstackAttrName());
+
   os << " {";
 
   pir::detail::PrintInterleave(

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -17,7 +17,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "paddle/fluid/framework/op_proto_maker.h"
 #include "paddle/pir/include/core/block.h"
 #include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/builtin_type.h"
@@ -282,8 +281,7 @@ void IrPrinter::PrintAttributeMap(Operation* op) {
       attributes.begin(), attributes.end());
 
   // Filter out the callstack attribute
-  order_attributes.erase(
-      paddle::framework::OpProtoAndCheckerMaker::OpCreationCallstackAttrName());
+  order_attributes.erase("op_callstack");
 
   os << " {";
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

#62139 引入了 `op_callstack` 属性，print 时跳过该属性以保持 program 的简洁，之后可能会有类似 PrintOptions 的机制，但目前先特判实现～

Pcard-67164