### PR TITLE
[SOT][3.12] Fix that `frame` in eval custom code was not released in `tstate` - step 2

### DIFF
--- a/paddle/fluid/pybind/cpython_internals.c
+++ b/paddle/fluid/pybind/cpython_internals.c
@@ -109,7 +109,7 @@ static void Internal_clear_thread_frame(PyThreadState *tstate,
          tstate->datastack_top);
   tstate->c_recursion_remaining--;
   assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
-  Internal_PyFrame_Clear(frame);  // see _PyFrame_ClearExceptCode
+  Internal_PyFrame_ClearExceptCode(frame);
   Py_DECREF(frame->f_code);
   tstate->c_recursion_remaining++;
   Internal_PyThreadState_PopFrame(tstate, frame);
@@ -125,7 +125,7 @@ static void Internal_clear_gen_frame(PyThreadState *tstate,
   gen->gi_exc_state.previous_item = NULL;
   tstate->c_recursion_remaining--;
   assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
-  Internal_PyFrame_Clear(frame);  // see _PyFrame_ClearExceptCode
+  Internal_PyFrame_ClearExceptCode(frame);
   tstate->c_recursion_remaining++;
   frame->previous = NULL;
 }
@@ -584,7 +584,11 @@ static void Internal_take_ownership(PyFrameObject *f,
 }
 
 // Call on 3.11 _PyFrame_Clear is called on 3.12+ _PyFrame_ClearExceptCode
+#if PY_VERSION_HEX >= 0x030c0000
+void Internal_PyFrame_ClearExceptCode(_PyInterpreterFrame *frame) {
+#else
 void Internal_PyFrame_Clear(_PyInterpreterFrame *frame) {
+#endif
   /* It is the responsibility of the owning generator/coroutine
    * to have cleared the enclosing generator, if any. */
   assert(frame->owner != FRAME_OWNED_BY_GENERATOR ||

--- a/paddle/fluid/pybind/cpython_internals.h
+++ b/paddle/fluid/pybind/cpython_internals.h
@@ -43,6 +43,7 @@ void Internal_PyEvalFrameClearAndPop(PyThreadState *tstate,
                                      _PyInterpreterFrame *frame);
 _PyInterpreterFrame *Internal_PyThreadState_PushFrame(PyThreadState *tstate,
                                                       size_t size);
+void Internal_PyFrame_ClearExceptCode(_PyInterpreterFrame *frame);
 #endif
 
 #endif

--- a/paddle/fluid/pybind/eval_frame.c
+++ b/paddle/fluid/pybind/eval_frame.c
@@ -366,6 +366,9 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
     PyObject *result = PyObject_CallObject(callback, args);
     Py_DECREF(args);
     if (result == NULL) {
+#if PY_VERSION_HEX >= 0x030C0000
+      Internal_PyEvalFrameClearAndPop(tstate, frame);
+#endif
       return NULL;
     }
     code = PyObject_GetAttrString(result, "code");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

#### 背景:

我们在 #61703 修改了对 `frame` 的管理，但是并没有考虑到 `PyObject_CallObject` 是 error 的情况, 反应到代码上就是 `PyObject_CallObject` 的结果为 `NULL`。

具体表现就是，当有`assertRaises` 检查和 `try` 运行失败的时候，会导致`frame`没能正常释放

#### TODO: 

在支持的同时发现了另一个问题，是由 log 导致的

复现方式:
```bash
export SOT_LOG_LEVEL=9 COST_MODEL=False MIN_GRAPH_SIZE=0 STRICT_MODE=True FLAGS_cudnn_deterministic=False

python test/sot/test_simulate_initialize.py TestInit.test_created_layer_reconstruct
```
`SOT_LOG_LEVEL` 设置为 3 以上即可, 目前定位是在`python/paddle/jit/sot/opcode_translator/eval_frame_callback.py`的`print_locals`函数

#### 相关链接:
* #61703
* #61174
* #61173
