### PR TITLE
[HACKATHON 6th][CMake Optimization] use CMAKE_CXX_COMPILER_ID instead CMAKE_COMPILER_IS_XXX etc

### DIFF
--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -39,7 +39,7 @@ elseif(LINUX)
   endif()
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/eigen/TensorRandom.h.patch
        tensor_random_header)
   # See: [Why calling some `git` commands before `patch`?]
@@ -47,19 +47,11 @@ if(CMAKE_COMPILER_IS_GNUCC)
       git checkout -- . && git checkout ${EIGEN_TAG} && patch -Nd
       ${SOURCE_DIR}/unsupported/Eigen/CXX11/src/Tensor <
       ${tensor_random_header})
-  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpfullversion -dumpversion
-                  OUTPUT_VARIABLE GCC_VERSION)
-  string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS ${GCC_VERSION})
-  list(GET GCC_VERSION_COMPONENTS 0 GCC_MAJOR)
-  list(GET GCC_VERSION_COMPONENTS 1 GCC_MINOR)
-  set(GCC_VERSION "${GCC_MAJOR}.${GCC_MINOR}")
-  if(GCC_VERSION GREATER_EQUAL 12.0)
-    file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/eigen/Complex.h.patch
-         complex_header)
-    set(EIGEN_PATCH_COMMAND
-        ${EIGEN_PATCH_COMMAND} && patch -Nd
-        ${SOURCE_DIR}/Eigen/src/Core/arch/SSE/ < ${complex_header})
-  endif()
+  file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/eigen/Complex.h.patch
+       complex_header)
+  set(EIGEN_PATCH_COMMAND
+      ${EIGEN_PATCH_COMMAND} && patch -Nd
+      ${SOURCE_DIR}/Eigen/src/Core/arch/SSE/ < ${complex_header})
 endif()
 
 set(EIGEN_INCLUDE_DIR ${SOURCE_DIR})

--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -42,24 +42,16 @@ if(WITH_GPU)
   endif()
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC)
-  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpfullversion -dumpversion
-                  OUTPUT_VARIABLE GCC_VERSION)
-  string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS ${GCC_VERSION})
-  list(GET GCC_VERSION_COMPONENTS 0 GCC_MAJOR)
-  list(GET GCC_VERSION_COMPONENTS 1 GCC_MINOR)
-  set(GCC_VERSION "${GCC_MAJOR}.${GCC_MINOR}")
-  if(GCC_VERSION GREATER_EQUAL "12.0")
-    file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/device.cc.patch
-         native_dst)
-    file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/types.h.patch
-         types_header)
-    # See: [Why calling some `git` commands before `patch`?]
-    set(GLOO_PATCH_COMMAND
-        git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd
-        ${SOURCE_DIR}/gloo/transport/tcp < ${native_dst} && patch -Nd
-        ${SOURCE_DIR}/gloo/ < ${types_header})
-  endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/device.cc.patch
+       native_dst)
+  file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/types.h.patch
+       types_header)
+  # See: [Why calling some `git` commands before `patch`?]
+  set(GLOO_PATCH_COMMAND
+      git checkout -- . && git checkout ${GLOO_TAG} && patch -Nd
+      ${SOURCE_DIR}/gloo/transport/tcp < ${native_dst} && patch -Nd
+      ${SOURCE_DIR}/gloo/ < ${types_header})
 endif()
 
 file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/gloo/linux.cc.patch

--- a/cmake/simd.cmake
+++ b/cmake/simd.cmake
@@ -4,9 +4,7 @@
 include(CheckCXXSourceRuns)
 include(CheckCXXSourceCompiles)
 
-if(CMAKE_COMPILER_IS_GNUCC
-   OR CMAKE_COMPILER_IS_GNUCXX
-   OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   set(MMX_FLAG "-mmmx")
   set(SSE2_FLAG "-msse2")
   set(SSE3_FLAG "-msse3")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
- [CMAKE_COMPILER_IS_GNUCC](https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILER_IS_GNUCC.html) 和 [CMAKE_COMPILER_IS_GNUCXX](https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILER_IS_GNUCXX.html) 已被标记为 `deprecated`，改用 [CMAKE_CXX_COMPILER_ID](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html)。
- 省略 patch 第三方依赖时对编译器版本的判断
- 添加 Clang/LLVM 支持