### PR TITLE
Dynamically bind dtype

### DIFF
--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -35,12 +35,14 @@ limitations under the License. */
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
+COMMON_DECLARE_bool(enable_pir_api);
+
 namespace paddle {
 namespace pybind {
 
 extern PyTypeObject* p_tensor_type;
 
-PyDoc_STRVAR(tensor_name__doc__,  // NOLINT
+PyDoc_STRVAR(tensor_name__doc__,  // NOLINT  // NOLINT
              R"DOC(name
 
 Tensor's name.
@@ -847,25 +849,47 @@ Examples:
 )DOC");
 PyObject* tensor_properties_get_dtype(TensorObject* self, void* closure) {
   EAGER_TRY
-  if (!self->tensor.defined()) {
-    // be same to old dygraph
-    return ToPyObject(framework::proto::VarType::FP32);
-  }
-  if (egr::IsVariableCompatTensor(self->tensor)) {
-    auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
-        self->tensor.impl().get());
-    if (var_tensor->IsType<paddle::framework::Vocab>()) {
-      return ToPyObject(framework::proto::VarType::RAW);
-    } else if (var_tensor->IsType<paddle::framework::Strings>()) {
-      return ToPyObject(framework::proto::VarType::STRING);
+  if (FLAGS_enable_pir_api) {
+    if (!self->tensor.defined()) {
+      // be same to old dygraph
+      return ToPyObject(phi::DataType::FLOAT32);
+    }
+    if (egr::IsVariableCompatTensor(self->tensor)) {
+      auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
+          self->tensor.impl().get());
+      if (var_tensor->IsType<paddle::framework::Vocab>()) {
+        return ToPyObject(phi::DataType::UNDEFINED);
+      } else if (var_tensor->IsType<paddle::framework::Strings>()) {
+        return ToPyObject(phi::DataType::PSTRING);
+      } else {
+        PADDLE_THROW(paddle::platform::errors::Unavailable(
+            "VariableCompatTensor only support get shape from Vocab or "
+            "Strings."));
+      }
     } else {
-      PADDLE_THROW(paddle::platform::errors::Unavailable(
-          "VariableCompatTensor only support get shape from Vocab or "
-          "Strings."));
+      return ToPyObject(self->tensor.type());
     }
   } else {
-    return ToPyObject(
-        paddle::framework::TransToProtoVarType(self->tensor.type()));
+    if (!self->tensor.defined()) {
+      // be same to old dygraph
+      return ToPyObject(framework::proto::VarType::FP32);
+    }
+    if (egr::IsVariableCompatTensor(self->tensor)) {
+      auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
+          self->tensor.impl().get());
+      if (var_tensor->IsType<paddle::framework::Vocab>()) {
+        return ToPyObject(framework::proto::VarType::RAW);
+      } else if (var_tensor->IsType<paddle::framework::Strings>()) {
+        return ToPyObject(framework::proto::VarType::STRING);
+      } else {
+        PADDLE_THROW(paddle::platform::errors::Unavailable(
+            "VariableCompatTensor only support get shape from Vocab or "
+            "Strings."));
+      }
+    } else {
+      return ToPyObject(
+          paddle::framework::TransToProtoVarType(self->tensor.type()));
+    }
   }
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -42,7 +42,7 @@ namespace pybind {
 
 extern PyTypeObject* p_tensor_type;
 
-PyDoc_STRVAR(tensor_name__doc__,  // NOLINT  // NOLINT
+PyDoc_STRVAR(tensor_name__doc__,  // NOLINT
              R"DOC(name
 
 Tensor's name.

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1077,6 +1077,12 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
   return obj.ptr();
 }
 
+PyObject* ToPyObject(const phi::DataType& dtype) {
+  auto obj = ::pybind11::cast(dtype);
+  obj.inc_ref();
+  return obj.ptr();
+}
+
 PyObject* ToPyObject(const pir::Value& value) {
   auto obj = ::pybind11::cast(value);
   obj.inc_ref();

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -148,6 +148,7 @@ PyObject* ToPyObject(const phi::distributed::Placements& value);
 PyObject* ToPyObject(const phi::SelectedRows* value);
 PyObject* ToPyObject(const paddle::framework::proto::VarType::Type& dtype);
 PyObject* ToPyObject(const paddle::framework::proto::VarType& type);
+PyObject* ToPyObject(const phi::DataType& type);
 PyObject* ToPyObject(const void* value);
 PyObject* ToPyObject(const std::unordered_map<int, int>& value);
 PyObject* ToPyObject(

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -14,6 +14,8 @@
 
 from ..base import framework
 from ..base.core import (
+    DataType,
+    VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
 )
@@ -21,8 +23,6 @@ from ..base.data_feeder import _NUMPY_DTYPE_2_PADDLE_DTYPE
 
 
 def bind_vartype():
-    from ..base.core import VarDesc
-
     global dtype
     global uint8
     global int8
@@ -59,8 +59,6 @@ def bind_vartype():
 
 
 def bind_datatype():
-    from ..base.core import DataType
-
     global dtype
     global uint8
     global int8

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -12,32 +12,98 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..base import framework
 from ..base.core import (
-    VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
 )
 from ..base.data_feeder import _NUMPY_DTYPE_2_PADDLE_DTYPE
 
-dtype = VarDesc.VarType
-dtype.__qualname__ = "dtype"
-dtype.__module__ = "paddle"
 
-uint8 = VarDesc.VarType.UINT8
-int8 = VarDesc.VarType.INT8
-int16 = VarDesc.VarType.INT16
-int32 = VarDesc.VarType.INT32
-int64 = VarDesc.VarType.INT64
+def bind_vartype():
+    from ..base.core import VarDesc
 
-float32 = VarDesc.VarType.FP32
-float64 = VarDesc.VarType.FP64
-float16 = VarDesc.VarType.FP16
-bfloat16 = VarDesc.VarType.BF16
+    global dtype
+    global uint8
+    global int8
+    global int16
+    global int32
+    global int64
+    global float32
+    global float64
+    global float16
+    global bfloat16
+    global complex64
+    global complex128
+    global bool
 
-complex64 = VarDesc.VarType.COMPLEX64
-complex128 = VarDesc.VarType.COMPLEX128
+    dtype = VarDesc.VarType
+    dtype.__qualname__ = "dtype"
+    dtype.__module__ = "paddle"
 
-bool = VarDesc.VarType.BOOL
+    uint8 = VarDesc.VarType.UINT8
+    int8 = VarDesc.VarType.INT8
+    int16 = VarDesc.VarType.INT16
+    int32 = VarDesc.VarType.INT32
+    int64 = VarDesc.VarType.INT64
+
+    float32 = VarDesc.VarType.FP32
+    float64 = VarDesc.VarType.FP64
+    float16 = VarDesc.VarType.FP16
+    bfloat16 = VarDesc.VarType.BF16
+
+    complex64 = VarDesc.VarType.COMPLEX64
+    complex128 = VarDesc.VarType.COMPLEX128
+
+    bool = VarDesc.VarType.BOOL
+
+
+def bind_datatype():
+    from ..base.core import DataType
+
+    global dtype
+    global uint8
+    global int8
+    global int16
+    global int32
+    global int64
+    global float32
+    global float64
+    global float16
+    global bfloat16
+    global complex64
+    global complex128
+    global bool
+
+    dtype = DataType
+    dtype.__qualname__ = "dtype"
+    dtype.__module__ = "paddle"
+
+    uint8 = DataType.UINT8
+    int8 = DataType.INT8
+    int16 = DataType.INT16
+    int32 = DataType.INT32
+    int64 = DataType.INT64
+
+    float32 = DataType.FLOAT32
+    float64 = DataType.FLOAT64
+    float16 = DataType.FLOAT16
+    bfloat16 = DataType.BFLOAT16
+
+    complex64 = DataType.COMPLEX64
+    complex128 = DataType.COMPLEX128
+
+    bool = DataType.BOOL
+
+
+enable_pir_api = framework.get_flags("FLAGS_enable_pir_api")[
+    "FLAGS_enable_pir_api"
+]
+
+if enable_pir_api:
+    bind_datatype()
+else:
+    bind_vartype()
 
 
 def iinfo(dtype):
@@ -130,9 +196,7 @@ def finfo(dtype):
     """
     import paddle
 
-    if paddle.base.framework.in_pir_mode() and isinstance(
-        dtype, paddle.pir.core.DataType
-    ):
+    if isinstance(dtype, paddle.pir.core.DataType):
         dtype = paddle.base.framework.paddle_type_to_proto_type[dtype]
     elif dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
         dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]

--- a/python/paddle/pir_utils.py
+++ b/python/paddle/pir_utils.py
@@ -16,6 +16,7 @@
 from functools import wraps
 
 import paddle
+from paddle.framework.dtype import bind_datatype, bind_vartype
 
 
 class IrGuard:
@@ -49,11 +50,13 @@ class IrGuard:
             paddle.enable_static()
         paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
         paddle.base.framework.global_var._use_pir_api_ = True
+        bind_datatype()
         self._switch_to_pir()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         paddle.framework.set_flags({"FLAGS_enable_pir_api": False})
         paddle.base.framework.global_var._use_pir_api_ = False
+        bind_vartype()
         self._switch_to_old_ir()
         if self.in_dygraph_outside:
             paddle.disable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
目前框架内有两套dtype的表示，一套是老静态图的VarType，一套是PIR下的DataType。动态图在c++端底层的dtype都是DataType，但是之前应该是为了兼容，所以动态图python的dtype也还是VarType类型。

这个pr主要是想修改python端的paddle.dtype，在PIR下paddle.dtype返回的是DataType类型；在老静态图下返回的是VarType类型。
参考 https://github.com/PaddlePaddle/Paddle/pull/62146