### PR TITLE
[Distributed] support pre alloc memory function in distributed env

### DIFF
--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -33,6 +33,8 @@ from .utils.log_util import logger, set_log_level
 
 __all__ = []
 
+g_pre_alloc_memory = int(os.environ.get("FLAGS_pre_alloc_memory", 0))
+
 
 def apply_ir_passes(main_program, startup_program, config):
     build_strategy = config._user_defined_strategy.build_strategy._copy()
@@ -361,7 +363,17 @@ class Fleet:
                 cg.set_comm_group(
                     'model', mp_rank, mp_degree, mp_ring_id, mp_group_ranks
                 )
+        self.maybe_pre_alloc_device_memory()
         return self
+
+    def maybe_pre_alloc_device_memory(self):
+        if g_pre_alloc_memory > 0:
+            logger.warning(
+                f'To avoid creating memory shards, pre-allocating a tensor whose memory capacity is {g_pre_alloc_memory} GB and then release it.'
+            )
+            memory_size = int((g_pre_alloc_memory * 1024 * 1024 * 1024) // 4)
+            x = paddle.empty([memory_size], dtype=paddle.float32)
+            del x
 
     # test allreduce perf
     def allreduce_perf(

--- a/test/collective/fleet/hybrid_parallel_mp_model_with_sequence_parallel.py
+++ b/test/collective/fleet/hybrid_parallel_mp_model_with_sequence_parallel.py
@@ -216,7 +216,7 @@ class TestDistSPSyncTraining(unittest.TestCase):
                 "sync_moment": False,
             },
         }
-        os.environ["FLAGS_pre_alloc_memory"] = 10
+        os.environ["FLAGS_pre_alloc_memory"] = "1"
         fleet.init(is_collective=True, strategy=strategy)
 
     def build_model_optimizer_train(

--- a/test/collective/fleet/hybrid_parallel_mp_model_with_sequence_parallel.py
+++ b/test/collective/fleet/hybrid_parallel_mp_model_with_sequence_parallel.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import random
 import unittest
 
@@ -216,7 +215,6 @@ class TestDistSPSyncTraining(unittest.TestCase):
                 "sync_moment": False,
             },
         }
-        os.environ["FLAGS_pre_alloc_memory"] = "1"
         fleet.init(is_collective=True, strategy=strategy)
 
     def build_model_optimizer_train(

--- a/test/collective/fleet/hybrid_parallel_mp_model_with_sequence_parallel.py
+++ b/test/collective/fleet/hybrid_parallel_mp_model_with_sequence_parallel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import random
 import unittest
 
@@ -215,6 +216,7 @@ class TestDistSPSyncTraining(unittest.TestCase):
                 "sync_moment": False,
             },
         }
+        os.environ["FLAGS_pre_alloc_memory"] = 10
         fleet.init(is_collective=True, strategy=strategy)
 
     def build_model_optimizer_train(

--- a/test/legacy_test/test_parallel_dygraph_dataparallel.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel.py
@@ -128,6 +128,8 @@ def start_local_trainers(
         }
 
         proc_env["FLAGS_allocator_strategy"] = allocator_strategy
+        proc_env["FLAGS_pre_alloc_memory"] = "1"
+
         if allocator_strategy == "auto_growth":
             proc_env["FLAGS_fraction_of_gpu_memory_to_use"] = "0.1"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[Pcard-79653]
Support pre alloc memory function in distributed env to avoid memory shards.
* usage: alloc memory size of 40GB on each cards before training and then release them.
```
export FLAGS_pre_alloc_memory=40
python -m paddle.distributed.launch run_pretrain.py
```