### PR TITLE
bugfix paddle_gtest_main_new build

### DIFF
--- a/paddle/testing/CMakeLists.txt
+++ b/paddle/testing/CMakeLists.txt
@@ -23,7 +23,14 @@ if(WITH_TESTING)
   cc_library(
     paddle_gtest_main_new
     SRCS paddle_gtest_main.cc
-    DEPS gtest xxhash framework_proto eigen3 dlpack)
+    DEPS phi
+         init
+         phi_utils
+         gtest
+         xxhash
+         framework_proto
+         eigen3
+         dlpack)
   if(WITH_MKLDNN)
     add_dependencies(paddle_gtest_main_new mkldnn)
   endif()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
This PR solves https://github.com/PaddlePaddle/Paddle/issues/61311. The paddle_gtest_main.cc calls paddle::memory, paddle::flags and paddle::framework, so libpaddle_gtest_main_new.a should link to libphi.a, libinit.a and libphi_utils.a. Otherwise, it triggers compile error:
```
#29 4078.0 : && /usr/local/bin/ccache /usr/bin/c++ -march=sandybridge -mtune=broadwell -Wno-error=switch -Wno-error=uninitialized -Wno-error=deprecated-declarations -Wno-deprecated-declarations -std=c++17 -m64 -fPIC -fno-omit-frame-pointer -pipe -ffunction-sections -fdata-sections -Werror -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-error=array-bounds -Wno-error=ignored-attributes -Wno-error=int-in-bool-context -Wimplicit-fallthrough=0 -Wno-sign-compare -Wno-non-virtual-dtor -Wno-ignored-qualifiers -Wno-ignored-attributes -Wno-parentheses -mavx -O3 -DNDEBUG  test/cpp/phi/core/CMakeFiles/test_c_tcp_store.dir/test_tcp_store.cc.o -o test/cpp/phi/core/test_c_tcp_store -L/usr/lib/x86_64-linux-gnu/libnvinfer.so   -L/opt/paddle/paddle/build/paddle/fluid/pybind   -L/opt/paddle/paddle/build/paddle/phi -Wl,-rpath,/usr/lib/x86_64-linux-gnu/libnvinfer.so:/opt/paddle/paddle/build/paddle/fluid/pybind:/opt/paddle/paddle/build/paddle/phi:/opt/paddle/paddle/build/paddle/common  third_party/install/glog/lib/libglog.a  -lpaddle  paddle/testing/libpaddle_gtest_main_new.a  -lphi  /usr/lib/x86_64-linux-gnu/libpython3.10.so  paddle/phi/libphi.so  paddle/common/libcommon.so  paddle/phi/api/profiler/libphi_profiler_proto.a  paddle/phi/core/distributed/auto_parallel/libauto_parallel_proto.a  paddle/utils/libpaddle_flags.a  libcblas.a  third_party/install/openblas/lib/libopenblas.a  third_party/install/utf8proc/lib/libutf8proc.a  paddle/phi/core/libexternal_error_proto.a  third_party/install/gloo/lib/libgloo.a  third_party/install/dgc/lib/libdgc.a  third_party/install/xxhash/lib/libxxhash.a  third_party/install/gtest/lib/libgtest.a  paddle/fluid/framework/libframework_proto.a  third_party/install/glog/lib/libglog.a  third_party/install/protobuf/lib/libprotobuf.a -pthread -ldl -lrt -lz -lssl -lcrypto -pthread -Wl,--no-as-needed -ldl -lrt -lz && :
#29 4078.0 /usr/bin/ld: paddle/testing/libpaddle_gtest_main_new.a(paddle_gtest_main.cc.o): in function `main':
#29 4078.0 paddle_gtest_main.cc:(.text.startup.main+0x31): undefined reference to `paddle::memory::allocation::UseAllocatorStrategyGFlag()'
#29 4078.0 /usr/bin/ld: paddle_gtest_main.cc:(.text.startup.main+0x5e1): undefined reference to `paddle_flags::FLAGS_enable_gpu_memory_usage_log'
#29 4078.0 /usr/bin/ld: paddle_gtest_main.cc:(.text.startup.main+0x623): undefined reference to `paddle::framework::InitMemoryMethod()'
#29 4078.0 /usr/bin/ld: paddle_gtest_main.cc:(.text.startup.main+0x628): undefined reference to `paddle::framework::InitDevices()'
#29 4078.0 /usr/bin/ld: paddle_gtest_main.cc:(.text.startup.main+0x62d): undefined reference to `paddle::framework::InitDefaultKernelSignatureMap()'
#29 4078.0 collect2: error: ld returned 1 exit status
```
