### PR TITLE
bugfix, add skipIf for multigpu tests

### DIFF
--- a/test/collective/test_communication_api_base.py
+++ b/test/collective/test_communication_api_base.py
@@ -22,9 +22,14 @@ import sys
 import tempfile
 import unittest
 
+import paddle
+
 
 class CommunicationTestDistBase(unittest.TestCase):
     def setUp(self, save_log_dir=None, num_of_devices=2, timeout=120, nnode=1):
+        if num_of_devices > paddle.device.cuda.device_count():
+            self.skipTest("number of GPUs is not enough")
+
         self._python_interp = sys.executable
         self._save_log_dir = save_log_dir
         self._log_dir = tempfile.TemporaryDirectory()

--- a/test/legacy_test/op_test.py
+++ b/test/legacy_test/op_test.py
@@ -3199,6 +3199,13 @@ class OpTest(unittest.TestCase):
                         python_api_info=python_api_info,
                     )
                     runtime_envs = get_subprocess_runtime_envs(place)
+
+                    num_devices = len(
+                        runtime_envs["CUDA_VISIBLE_DEVICES"].split(",")
+                    )
+                    if num_devices > paddle.device.cuda.device_count():
+                        self.skipTest("number of GPUs is not enough")
+
                     start_command = get_subprocess_command(
                         runtime_envs["CUDA_VISIBLE_DEVICES"],
                         generated_grad_test_path,


### PR DESCRIPTION
### PR Category
Others

### PR Types
Bug fixes

### Description
Not all CI/CD machines have 8 GPUs, so this PR adds `skipif` if number of GPUs is not enough
