### PR TITLE
[PIR]Fix Bugs and adapt Custom op unittest

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.cc
@@ -280,7 +280,6 @@ void CustomKernelInstruction::BuildCustomContext(
               out_name));
       VLOG(3) << "Custom Operator: BuildContext - inplace optional outputs : "
               << out_name << " is None.";
-      cache_out_ptrs_.emplace_back(nullptr);
       custom_kernel_ctx_.EmplaceBackOutput(std::move(paddle::Tensor()));
 
       VLOG(8) << "ctx->EmplaceBackOutput : an optional output";

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -617,9 +617,9 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
             pir_op_name,
             fwd_outputs_name.size(),
             out_grads.size()));
-
     bool is_double_grad_op =
-        (bwd_pir_op_name.find("_grad_grad") != pir_op_name.npos) ? true : false;
+        (bwd_pir_op_name.find("_grad_grad") != bwd_pir_op_name.npos) ? true
+                                                                     : false;
     pir::IrContext* ctx = pir::IrContext::Instance();
     pir::OpInfo pir_info = ctx->GetRegisteredOpInfo(bwd_pir_op_name);
     pir::OperationArgument argument(pir_info);
@@ -671,7 +671,6 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
             grad_op_input_name));
       }
     };
-
     // Construct custom grad op inputs
     int input_index = 0;
     int vec_input_index = 0;
@@ -689,32 +688,43 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
         // grad op input is in out_grads
         input_values = out_grads[input_location.second];
       }
-
-      if (input_values.size() > 1) {
+      if (paddle::framework::detail::IsDuplicableVar(bwd_input_name)) {
         std::vector<std::vector<int64_t>> tmp_input_shapes;
         std::vector<phi::DataType> tmp_input_dtypes;
+        pir::Value input_value;
         vec_input_name2id_map[bwd_input_name] = vec_input_index;
         vec_input_index++;
-        for (auto& input_value : input_values) {
-          paddle::dialect::DenseTensorType input_tensor =
-              input_value.type().dyn_cast<paddle::dialect::DenseTensorType>();
-          tmp_input_shapes.push_back(phi::vectorize(input_tensor.dims()));
-          tmp_input_dtypes.push_back(
-              paddle::dialect::TransToPhiDataType(input_tensor.dtype()));
+        bool is_optional =
+            (input_values.size() == 1 && input_values[0].impl() == nullptr);
+        if (!is_optional) {
+          for (auto& input_value : input_values) {
+            paddle::dialect::DenseTensorType input_tensor =
+                input_value.type().dyn_cast<paddle::dialect::DenseTensorType>();
+            tmp_input_shapes.push_back(phi::vectorize(input_tensor.dims()));
+            tmp_input_dtypes.push_back(
+                paddle::dialect::TransToPhiDataType(input_tensor.dtype()));
+          }
+          input_value = paddle::dialect::builtin_combine(input_values);
         }
         vec_input_shapes.push_back(tmp_input_shapes);
         vec_input_dtypes.push_back(tmp_input_dtypes);
-        auto input_value = paddle::dialect::builtin_combine(input_values);
         argument_inputs.push_back(input_value);
       } else {
+        std::vector<int64_t> tmp_input_shape;
+        phi::DataType tmp_input_dtype = DataType::UNDEFINED;
         input_name2id_map[bwd_input_name] = input_index;
         input_index++;
         pir::Value input_value = input_values[0];  // NOLINT
-        paddle::dialect::DenseTensorType input_tensor =
-            input_value.type().dyn_cast<paddle::dialect::DenseTensorType>();
-        input_shapes.push_back(phi::vectorize(input_tensor.dims()));
-        input_dtypes.push_back(
-            paddle::dialect::TransToPhiDataType(input_tensor.dtype()));
+        if (input_value.impl() != nullptr) {
+          paddle::dialect::DenseTensorType input_tensor =
+              input_value.type().dyn_cast<paddle::dialect::DenseTensorType>();
+          tmp_input_shape = phi::vectorize(input_tensor.dims());
+          tmp_input_dtype =
+              paddle::dialect::TransToPhiDataType(input_tensor.dtype());
+        }
+        input_shapes.push_back(tmp_input_shape);
+        input_dtypes.push_back(tmp_input_dtype);
+
         argument_inputs.push_back(input_value);
       }
     }
@@ -729,7 +739,6 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
       custom_attrs.push_back(paddle::dialect::TransAttrToAny(fwd_op_attr));
       argument.AddAttribute(fwd_attr_name, fwd_op_attr);
     }
-
     // Run Compile InferMeta
     std::vector<std::vector<int64_t>> output_shapes =
         paddle::framework::RunInferShape(infershape_func,
@@ -752,18 +761,23 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     std::unordered_map<std::string, size_t> output_name2value_num;
     for (size_t i = 0; i < bwd_outputs_name.size(); ++i) {
       const auto& bwd_output_name = bwd_outputs_name.at(i);
+      const auto& bwd_input =
+          paddle::framework::detail::NoGrad(bwd_output_name, is_double_grad_op);
+
       if (paddle::framework::detail::IsDuplicableVar(bwd_output_name)) {
-        const auto& bwd_input = paddle::framework::detail::NoGrad(
-            bwd_output_name, is_double_grad_op);
         auto index = vec_input_name2id_map[bwd_input];
-        auto& input_shapes = vec_input_shapes[index];
-        output_name2value_num[bwd_output_name] = input_shapes.size();
-        all_values_num += input_shapes.size();
+        auto& vec_input_shape = vec_input_shapes[index];
+        output_name2value_num[bwd_output_name] = vec_input_shape.size();
       } else {
-        output_name2value_num[bwd_output_name] = 1;
-        all_values_num++;
+        auto index = input_name2id_map[bwd_input];
+        // input_shapes[index] is dim of tensor, if the dim doesn't have
+        // element, it must be a optional tensor that is None in custom operator
+        output_name2value_num[bwd_output_name] =
+            input_shapes[index].size() == 0 ? 0 : 1;
       }
+      all_values_num += output_name2value_num[bwd_output_name];
     }
+
     PADDLE_ENFORCE_EQ(
         output_shapes.size(),
         all_values_num,
@@ -785,13 +799,25 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
             "Tensors' dtype",
             all_values_num,
             output_dtypes.size()));
-
     // Construct custom grad op outputs
     size_t value_index = 0;
     for (size_t i = 0; i < bwd_outputs_name.size(); ++i) {
       const auto& bwd_output_name = bwd_outputs_name.at(i);
+      auto value_num = output_name2value_num[bwd_output_name];
+      if (value_num == 0) {
+        // Optional value condition
+        if (paddle::framework::detail::IsDuplicableVar(bwd_output_name)) {
+          std::vector<pir::Type> out_types;
+          pir::Type out_vector_type =
+              pir::VectorType::get(pir::IrContext::Instance(), out_types);
+          argument_outputs.push_back(out_vector_type);
+        } else {
+          pir::Type out_type;
+          argument_outputs.push_back(out_type);
+        }
+        continue;
+      }
       if (paddle::framework::detail::IsDuplicableVar(bwd_output_name)) {
-        auto value_num = output_name2value_num[bwd_output_name];
         std::vector<pir::Type> out_types;
         for (size_t j = 0; j < value_num; ++j) {
           auto ddims = phi::make_ddim(output_shapes[value_index]);
@@ -827,6 +853,7 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
       }
     }
     argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+
     // Build Operation
     std::vector<pir::Value> op_results;
     pir::Operation* bwd_op =
@@ -839,6 +866,42 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
     for (size_t i = 0; i < stop_gradients.size(); ++i) {
       res[i].resize(stop_gradients[i].size());
     }
+
+    auto GetInputGradientIndex = [&](const std::string& bwd_output_name,
+                                     bool is_double_grad_op) -> size_t {
+      /*
+        This function is used to get the index of input that need calculate
+        gradient in forward op. For example: forward inputs : TensorA, TensorB,
+        TensorC, TensorD backward outputs: TensorC@Grad, TensorA@Grad So, we
+        only need to calculate gradient of TensorA and TensorC and store them in
+        res; In this example, the res size is 2, and the first element of res
+        should store TensorA@Grad, and the second element of res should store
+        TensorC@Grad.
+
+        So, This function will return 1 if we pass TensorC@Grad and return 0 if
+        we pass TensorA@Grad.
+      */
+      size_t gradient_vec_index = 0;
+      const auto& fwd_input =
+          paddle::framework::detail::NoGrad(bwd_output_name, is_double_grad_op);
+      auto fwd_inputs_name_iter =
+          std::find(fwd_inputs_name.begin(), fwd_inputs_name.end(), fwd_input);
+      size_t input_index =
+          std::distance(fwd_inputs_name.begin(), fwd_inputs_name_iter);
+      for (size_t i = 0; i < input_index; ++i) {
+        for (size_t j = 0; j < bwd_outputs_name.size(); j++) {
+          const auto& fwd_input_name_tmp = paddle::framework::detail::NoGrad(
+              bwd_outputs_name[j], is_double_grad_op);
+          if (fwd_input_name_tmp == fwd_inputs_name[i]) {
+            // find forward input that need calculate gradient
+            gradient_vec_index++;
+            break;
+          }
+        }
+      }
+      return gradient_vec_index;
+    };
+
     // Build result and apply stop gradients
     for (size_t i = 0; i < bwd_outputs_name.size(); ++i) {
       const auto& bwd_output_name = bwd_outputs_name.at(i);
@@ -855,16 +918,20 @@ struct CustomOpVjpInterfaceModel : public VjpInterface::Concept {
                 "forward input that need calculate gradients.",
                 pir_op_name,
                 bwd_output_name));
-        int index =
-            std::distance(fwd_inputs_name.begin(), fwd_inputs_name_iter);
-        auto split_op =
-            ApiBuilder::Instance().GetBuilder()->Build<pir::SplitOp>(
-                bwd_op->result(i));
-        res[index] = split_op.outputs();
+        int index = GetInputGradientIndex(bwd_output_name, is_double_grad_op);
+        if (bwd_op->result(i).type().dyn_cast<pir::VectorType>().size() != 0) {
+          auto split_op =
+              ApiBuilder::Instance().GetBuilder()->Build<pir::SplitOp>(
+                  bwd_op->result(i));
+          res[index] = split_op.outputs();
+        } else {
+          // optional output condition
+          pir::Value empty_value;
+          res[index][0] = empty_value;
+        }
       } else {
         if (fwd_inputs_name_iter != fwd_inputs_name.end()) {
-          int index =
-              std::distance(fwd_inputs_name.begin(), fwd_inputs_name_iter);
+          int index = GetInputGradientIndex(bwd_output_name, is_double_grad_op);
           res[index][0] = bwd_op->result(i);
         } else {
           // Situation that has only one input and only one output. If not meet

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -153,50 +153,48 @@ static std::function<T(const pir::Attribute& attr)> GetAttrCast(
       kAttrCastMap = {
           {AttrType::BOOL,
            [](const pir::Attribute& attr) {
-             return VariantType{attr.dyn_cast<pir::BoolAttribute>().data()};
+             return T{attr.dyn_cast<pir::BoolAttribute>().data()};
            }},
           {AttrType::FLOAT,
            [](const pir::Attribute& attr) {
-             return VariantType{attr.dyn_cast<pir::FloatAttribute>().data()};
+             return T{attr.dyn_cast<pir::FloatAttribute>().data()};
            }},
           {AttrType::DOUBLE,
            [](const pir::Attribute& attr) {
-             return VariantType{attr.dyn_cast<pir::DoubleAttribute>().data()};
+             return T{attr.dyn_cast<pir::DoubleAttribute>().data()};
            }},
           {AttrType::INT32,
            [](const pir::Attribute& attr) {
-             return VariantType{attr.dyn_cast<pir::Int32Attribute>().data()};
+             return T{attr.dyn_cast<pir::Int32Attribute>().data()};
            }},
           {AttrType::INT64,
            [](const pir::Attribute& attr) {
-             return VariantType{attr.dyn_cast<pir::Int64Attribute>().data()};
+             return T{attr.dyn_cast<pir::Int64Attribute>().data()};
            }},
           {AttrType::INT_ARRAY,
            [](const pir::Attribute& attr) {
-             return VariantType{
-                 attr.dyn_cast<paddle::dialect::IntArrayAttribute>()
-                     .data()
-                     .GetData()};
+             return T{attr.dyn_cast<paddle::dialect::IntArrayAttribute>()
+                          .data()
+                          .GetData()};
            }},
           {AttrType::STRING,
            [](const pir::Attribute& attr) {
-             return VariantType{attr.dyn_cast<pir::StrAttribute>().AsString()};
+             return T{attr.dyn_cast<pir::StrAttribute>().AsString()};
            }},
           {AttrType::DATA_TYPE,
            [](const pir::Attribute& attr) {
-             return VariantType{
+             return T{
                  attr.dyn_cast<paddle::dialect::DataTypeAttribute>().data()};
            }},
           {AttrType::PLACE,
            [](const pir::Attribute& attr) {
-             return VariantType{
-                 attr.dyn_cast<paddle::dialect::PlaceAttribute>().data()};
+             return T{attr.dyn_cast<paddle::dialect::PlaceAttribute>().data()};
            }},
           {AttrType::ARRAY,
            [](const pir::Attribute& attr) {
              auto attr_vec = attr.dyn_cast<pir::ArrayAttribute>().AsVector();
              if (attr_vec.empty()) {
-               return VariantType{std::vector<int>()};
+               return T{std::vector<int>()};
              }
              AttrType element_type = GetAttributeType(attr_vec[0]);
 
@@ -207,61 +205,51 @@ static std::function<T(const pir::Attribute& attr)> GetAttrCast(
                  vec_bools.push_back(
                      vec_element.dyn_cast<pir::BoolAttribute>().data());
                }
-               AttrType element_type = GetAttributeType(attr_vec[0]);
-
-               if (element_type == AttrType::BOOL) {
-                 std::vector<bool> vec_bools;
-                 vec_bools.reserve(attr_vec.size());
-                 for (auto vec_element : attr_vec) {
-                   vec_bools.push_back(
-                       vec_element.dyn_cast<pir::BoolAttribute>().data());
-                 }
-                 return T{vec_bools};
-               } else if (element_type == AttrType::INT32) {
-                 std::vector<int> vec_int32;
-                 vec_int32.reserve(attr_vec.size());
-                 for (auto vec_element : attr_vec) {
-                   vec_int32.push_back(
-                       vec_element.dyn_cast<pir::Int32Attribute>().data());
-                 }
-                 return T{vec_int32};
-               } else if (element_type == AttrType::INT64) {
-                 std::vector<int64_t> vec_int64;
-                 vec_int64.reserve(attr_vec.size());
-                 for (auto vec_element : attr_vec) {
-                   vec_int64.push_back(
-                       vec_element.dyn_cast<pir::Int64Attribute>().data());
-                 }
-                 return T{vec_int64};
-               } else if (element_type == AttrType::FLOAT) {
-                 std::vector<float> vec_float;
-                 vec_float.reserve(attr_vec.size());
-                 for (auto vec_element : attr_vec) {
-                   vec_float.push_back(
-                       vec_element.dyn_cast<pir::FloatAttribute>().data());
-                 }
-                 return T{vec_float};
-               } else if (element_type == AttrType::DOUBLE) {
-                 std::vector<double> vec_double;
-                 vec_double.reserve(attr_vec.size());
-                 for (auto vec_element : attr_vec) {
-                   vec_double.push_back(
-                       vec_element.dyn_cast<pir::DoubleAttribute>().data());
-                 }
-                 return T{vec_double};
-               } else if (element_type == AttrType::STRING) {
-                 std::vector<std::string> vec_string;
-                 vec_string.reserve(attr_vec.size());
-                 for (auto vec_element : attr_vec) {
-                   vec_string.push_back(
-                       vec_element.dyn_cast<pir::StrAttribute>().AsString());
-                 }
-                 return T{vec_string};
-               } else {
-                 PADDLE_THROW(phi::errors::Unimplemented(
-                     "Unsupported ir Attribute type when casting it into "
-                     "vector."));
+               return T{vec_bools};
+             } else if (element_type == AttrType::INT32) {
+               std::vector<int> vec_int32;
+               vec_int32.reserve(attr_vec.size());
+               for (auto vec_element : attr_vec) {
+                 vec_int32.push_back(
+                     vec_element.dyn_cast<pir::Int32Attribute>().data());
                }
+               return T{vec_int32};
+             } else if (element_type == AttrType::INT64) {
+               std::vector<int64_t> vec_int64;
+               vec_int64.reserve(attr_vec.size());
+               for (auto vec_element : attr_vec) {
+                 vec_int64.push_back(
+                     vec_element.dyn_cast<pir::Int64Attribute>().data());
+               }
+               return T{vec_int64};
+             } else if (element_type == AttrType::FLOAT) {
+               std::vector<float> vec_float;
+               vec_float.reserve(attr_vec.size());
+               for (auto vec_element : attr_vec) {
+                 vec_float.push_back(
+                     vec_element.dyn_cast<pir::FloatAttribute>().data());
+               }
+               return T{vec_float};
+             } else if (element_type == AttrType::DOUBLE) {
+               std::vector<double> vec_double;
+               vec_double.reserve(attr_vec.size());
+               for (auto vec_element : attr_vec) {
+                 vec_double.push_back(
+                     vec_element.dyn_cast<pir::DoubleAttribute>().data());
+               }
+               return T{vec_double};
+             } else if (element_type == AttrType::STRING) {
+               std::vector<std::string> vec_string;
+               vec_string.reserve(attr_vec.size());
+               for (auto vec_element : attr_vec) {
+                 vec_string.push_back(
+                     vec_element.dyn_cast<pir::StrAttribute>().AsString());
+               }
+               return T{vec_string};
+             } else {
+               PADDLE_THROW(phi::errors::Unimplemented(
+                   "Unsupported ir Attribute type when casting it into "
+                   "vector."));
              }
            }},
       };

--- a/paddle/fluid/pir/dialect/operator/utils/utils.cc
+++ b/paddle/fluid/pir/dialect/operator/utils/utils.cc
@@ -146,123 +146,136 @@ static inline AttrType GetAttributeType(const pir::Attribute& attr) {
   }
 }
 
-static std::unordered_map<
-    AttrType,
-    std::function<VariantType(const pir::Attribute& attr)>>
-    kAttrCastMap = {
-        {AttrType::BOOL,
-         [](const pir::Attribute& attr) {
-           return VariantType{attr.dyn_cast<pir::BoolAttribute>().data()};
-         }},
-        {AttrType::FLOAT,
-         [](const pir::Attribute& attr) {
-           return VariantType{attr.dyn_cast<pir::FloatAttribute>().data()};
-         }},
-        {AttrType::DOUBLE,
-         [](const pir::Attribute& attr) {
-           return VariantType{attr.dyn_cast<pir::DoubleAttribute>().data()};
-         }},
-        {AttrType::INT32,
-         [](const pir::Attribute& attr) {
-           return VariantType{attr.dyn_cast<pir::Int32Attribute>().data()};
-         }},
-        {AttrType::INT64,
-         [](const pir::Attribute& attr) {
-           return VariantType{attr.dyn_cast<pir::Int64Attribute>().data()};
-         }},
-        {AttrType::INT_ARRAY,
-         [](const pir::Attribute& attr) {
-           return VariantType{
-               attr.dyn_cast<paddle::dialect::IntArrayAttribute>()
-                   .data()
-                   .GetData()};
-         }},
-        {AttrType::STRING,
-         [](const pir::Attribute& attr) {
-           return VariantType{attr.dyn_cast<pir::StrAttribute>().AsString()};
-         }},
-        {AttrType::DATA_TYPE,
-         [](const pir::Attribute& attr) {
-           return VariantType{
-               attr.dyn_cast<paddle::dialect::DataTypeAttribute>().data()};
-         }},
-        {AttrType::PLACE,
-         [](const pir::Attribute& attr) {
-           return VariantType{
-               attr.dyn_cast<paddle::dialect::PlaceAttribute>().data()};
-         }},
-        {AttrType::ARRAY,
-         [](const pir::Attribute& attr) {
-           auto attr_vec = attr.dyn_cast<pir::ArrayAttribute>().AsVector();
-           if (attr_vec.empty()) {
-             return VariantType{std::vector<int>()};
-           }
-           AttrType element_type = GetAttributeType(attr_vec[0]);
+template <typename T>
+static std::function<T(const pir::Attribute& attr)> GetAttrCast(
+    AttrType attr_type) {
+  std::unordered_map<AttrType, std::function<T(const pir::Attribute& attr)>>
+      kAttrCastMap = {
+          {AttrType::BOOL,
+           [](const pir::Attribute& attr) {
+             return VariantType{attr.dyn_cast<pir::BoolAttribute>().data()};
+           }},
+          {AttrType::FLOAT,
+           [](const pir::Attribute& attr) {
+             return VariantType{attr.dyn_cast<pir::FloatAttribute>().data()};
+           }},
+          {AttrType::DOUBLE,
+           [](const pir::Attribute& attr) {
+             return VariantType{attr.dyn_cast<pir::DoubleAttribute>().data()};
+           }},
+          {AttrType::INT32,
+           [](const pir::Attribute& attr) {
+             return VariantType{attr.dyn_cast<pir::Int32Attribute>().data()};
+           }},
+          {AttrType::INT64,
+           [](const pir::Attribute& attr) {
+             return VariantType{attr.dyn_cast<pir::Int64Attribute>().data()};
+           }},
+          {AttrType::INT_ARRAY,
+           [](const pir::Attribute& attr) {
+             return VariantType{
+                 attr.dyn_cast<paddle::dialect::IntArrayAttribute>()
+                     .data()
+                     .GetData()};
+           }},
+          {AttrType::STRING,
+           [](const pir::Attribute& attr) {
+             return VariantType{attr.dyn_cast<pir::StrAttribute>().AsString()};
+           }},
+          {AttrType::DATA_TYPE,
+           [](const pir::Attribute& attr) {
+             return VariantType{
+                 attr.dyn_cast<paddle::dialect::DataTypeAttribute>().data()};
+           }},
+          {AttrType::PLACE,
+           [](const pir::Attribute& attr) {
+             return VariantType{
+                 attr.dyn_cast<paddle::dialect::PlaceAttribute>().data()};
+           }},
+          {AttrType::ARRAY,
+           [](const pir::Attribute& attr) {
+             auto attr_vec = attr.dyn_cast<pir::ArrayAttribute>().AsVector();
+             if (attr_vec.empty()) {
+               return VariantType{std::vector<int>()};
+             }
+             AttrType element_type = GetAttributeType(attr_vec[0]);
 
-           if (element_type == AttrType::BOOL) {
-             std::vector<bool> vec_bools;
-             vec_bools.reserve(attr_vec.size());
-             for (auto vec_element : attr_vec) {
-               vec_bools.push_back(
-                   vec_element.dyn_cast<pir::BoolAttribute>().data());
+             if (element_type == AttrType::BOOL) {
+               std::vector<bool> vec_bools;
+               vec_bools.reserve(attr_vec.size());
+               for (auto vec_element : attr_vec) {
+                 vec_bools.push_back(
+                     vec_element.dyn_cast<pir::BoolAttribute>().data());
+               }
+               AttrType element_type = GetAttributeType(attr_vec[0]);
+
+               if (element_type == AttrType::BOOL) {
+                 std::vector<bool> vec_bools;
+                 vec_bools.reserve(attr_vec.size());
+                 for (auto vec_element : attr_vec) {
+                   vec_bools.push_back(
+                       vec_element.dyn_cast<pir::BoolAttribute>().data());
+                 }
+                 return T{vec_bools};
+               } else if (element_type == AttrType::INT32) {
+                 std::vector<int> vec_int32;
+                 vec_int32.reserve(attr_vec.size());
+                 for (auto vec_element : attr_vec) {
+                   vec_int32.push_back(
+                       vec_element.dyn_cast<pir::Int32Attribute>().data());
+                 }
+                 return T{vec_int32};
+               } else if (element_type == AttrType::INT64) {
+                 std::vector<int64_t> vec_int64;
+                 vec_int64.reserve(attr_vec.size());
+                 for (auto vec_element : attr_vec) {
+                   vec_int64.push_back(
+                       vec_element.dyn_cast<pir::Int64Attribute>().data());
+                 }
+                 return T{vec_int64};
+               } else if (element_type == AttrType::FLOAT) {
+                 std::vector<float> vec_float;
+                 vec_float.reserve(attr_vec.size());
+                 for (auto vec_element : attr_vec) {
+                   vec_float.push_back(
+                       vec_element.dyn_cast<pir::FloatAttribute>().data());
+                 }
+                 return T{vec_float};
+               } else if (element_type == AttrType::DOUBLE) {
+                 std::vector<double> vec_double;
+                 vec_double.reserve(attr_vec.size());
+                 for (auto vec_element : attr_vec) {
+                   vec_double.push_back(
+                       vec_element.dyn_cast<pir::DoubleAttribute>().data());
+                 }
+                 return T{vec_double};
+               } else if (element_type == AttrType::STRING) {
+                 std::vector<std::string> vec_string;
+                 vec_string.reserve(attr_vec.size());
+                 for (auto vec_element : attr_vec) {
+                   vec_string.push_back(
+                       vec_element.dyn_cast<pir::StrAttribute>().AsString());
+                 }
+                 return T{vec_string};
+               } else {
+                 PADDLE_THROW(phi::errors::Unimplemented(
+                     "Unsupported ir Attribute type when casting it into "
+                     "vector."));
+               }
              }
-             return VariantType{vec_bools};
-           } else if (element_type == AttrType::INT32) {
-             std::vector<int> vec_int32;
-             vec_int32.reserve(attr_vec.size());
-             for (auto vec_element : attr_vec) {
-               vec_int32.push_back(
-                   vec_element.dyn_cast<pir::Int32Attribute>().data());
-             }
-             return VariantType{vec_int32};
-           } else if (element_type == AttrType::INT64) {
-             std::vector<int64_t> vec_int64;
-             vec_int64.reserve(attr_vec.size());
-             for (auto vec_element : attr_vec) {
-               vec_int64.push_back(
-                   vec_element.dyn_cast<pir::Int64Attribute>().data());
-             }
-             return VariantType{vec_int64};
-           } else if (element_type == AttrType::FLOAT) {
-             std::vector<float> vec_float;
-             vec_float.reserve(attr_vec.size());
-             for (auto vec_element : attr_vec) {
-               vec_float.push_back(
-                   vec_element.dyn_cast<pir::FloatAttribute>().data());
-             }
-             return VariantType{vec_float};
-           } else if (element_type == AttrType::DOUBLE) {
-             std::vector<double> vec_double;
-             vec_double.reserve(attr_vec.size());
-             for (auto vec_element : attr_vec) {
-               vec_double.push_back(
-                   vec_element.dyn_cast<pir::DoubleAttribute>().data());
-             }
-             return VariantType{vec_double};
-           } else if (element_type == AttrType::STRING) {
-             std::vector<std::string> vec_string;
-             vec_string.reserve(attr_vec.size());
-             for (auto vec_element : attr_vec) {
-               vec_string.push_back(
-                   vec_element.dyn_cast<pir::StrAttribute>().AsString());
-             }
-             return VariantType{vec_string};
-           } else {
-             PADDLE_THROW(phi::errors::Unimplemented(
-                 "Unsupported ir Attribute type when casting it into "
-                 "vector."));
-           }
-         }},
-};
+           }},
+      };
+  return kAttrCastMap[attr_type];
+}
 
 VariantType GetAttributeData(const pir::Attribute& attr) {
   AttrType attr_type = GetAttributeType(attr);
-  return kAttrCastMap[attr_type](attr);
+  return GetAttrCast<VariantType>(attr_type)(attr);
 }
 
 paddle::any TransAttrToAny(const pir::Attribute& attr) {
   AttrType attr_type = GetAttributeType(attr);
-  return kAttrCastMap[attr_type](attr);
+  return GetAttrCast<paddle::any>(attr_type)(attr);
 }
 
 bool IsLegacyOp(const std::string& name) { return LegacyOpList.count(name); }
@@ -480,6 +493,5 @@ std::vector<int64_t> ParseValueShape(const pir::Value& shape,
   }
   return vec_shape;
 }
-
 }  // namespace dialect
 }  // namespace paddle

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -536,13 +536,17 @@ static PyObject *static_api_run_custom_op(PyObject *self,
       VLOG(7) << "Add un-initialized tensor "
                  "because the optional input is None";
       if (paddle::framework::detail::IsDuplicableVar(input)) {
-        vec_input_shapes.emplace_back();
-        vec_input_dtypes.emplace_back();
+        std::vector<std::vector<int64_t>> vec_input_shape;
+        std::vector<DataType> vec_input_dtype;
+        vec_input_shapes.emplace_back(vec_input_shape);
+        vec_input_dtypes.emplace_back(vec_input_dtype);
         vec_input_name2id_map[inputs[i]] = vec_input_index;
         vec_input_index++;
       } else {
-        input_shapes.emplace_back();
-        input_dtypes.emplace_back();
+        std::vector<int64_t> input_shape;
+        DataType input_dtype = DataType::UNDEFINED;
+        input_shapes.emplace_back(input_shape);
+        input_dtypes.emplace_back(input_dtype);
         input_name2id_map[inputs[i]] = input_index;
         input_index++;
       }
@@ -565,8 +569,10 @@ static PyObject *static_api_run_custom_op(PyObject *self,
       }
       vec_input_shapes.push_back(tmp_input_shapes);
       vec_input_dtypes.push_back(tmp_input_dtypes);
-      auto input_value = paddle::dialect::stack(input_values, /*axis*/ 0);
-      argument_inputs.push_back(input_value);
+      auto combine_op = paddle::dialect::ApiBuilder::Instance()
+                            .GetBuilder()
+                            ->Build<pir::CombineOp>(input_values);
+      argument_inputs.push_back(combine_op.out());
     } else {
       input_name2id_map[inputs[i]] = input_index;
       input_index++;
@@ -717,13 +723,20 @@ static PyObject *static_api_run_custom_op(PyObject *self,
               "`SetInplaceMap` in your output when registry custom operator."));
       const auto &input = inplace_reverse_map.at(output);
       auto index = vec_input_name2id_map[input];
-      auto &input_shapes = vec_input_shapes[index];
-      output_name2value_num[output] = input_shapes.size();
-      all_values_num += input_shapes.size();
+      auto &vec_input_shape = vec_input_shapes[index];
+      output_name2value_num[output] = vec_input_shape.size();
     } else {
-      output_name2value_num[output] = 1;
-      all_values_num++;
+      if (inplace_reverse_map.find(output) != inplace_reverse_map.end()) {
+        const auto &input = inplace_reverse_map.at(output);
+        auto index = input_name2id_map[input];
+        // input_shapes[index] is dim of tensor, if the dim doesn't have
+        // element, it must be a optional tensor that is None in custom operator
+        output_name2value_num[output] = input_shapes[index].size() == 0 ? 0 : 1;
+      } else {
+        output_name2value_num[output]++;
+      }
     }
+    all_values_num += output_name2value_num[output];
   }
 
   PADDLE_ENFORCE_EQ(
@@ -751,8 +764,21 @@ static PyObject *static_api_run_custom_op(PyObject *self,
   size_t value_index = 0;
   for (size_t i = 0; i < outputs.size(); ++i) {
     const auto &output = outputs.at(i);
+    auto value_num = output_name2value_num[output];
+    if (value_num == 0) {
+      // Optional value condition
+      if (paddle::framework::detail::IsDuplicableVar(output)) {
+        std::vector<pir::Type> out_types;
+        pir::Type out_vector_type =
+            pir::VectorType::get(pir::IrContext::Instance(), out_types);
+        argument_outputs.push_back(out_vector_type);
+      } else {
+        pir::Type out_type;
+        argument_outputs.push_back(out_type);
+      }
+      continue;
+    }
     if (paddle::framework::detail::IsDuplicableVar(output)) {
-      auto value_num = output_name2value_num[output];
       std::vector<pir::Type> out_types;
       for (size_t j = 0; j < value_num; ++j) {
         auto ddims = phi::make_ddim(output_shapes[value_index]);

--- a/test/custom_op/test_custom_concat.py
+++ b/test/custom_op/test_custom_concat.py
@@ -20,6 +20,7 @@ from utils import extra_cc_args, extra_nvcc_args, paddle_includes
 
 import paddle
 from paddle import static
+from paddle.pir_utils import test_with_pir_api
 from paddle.utils.cpp_extension import get_build_directory, load
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 
@@ -94,10 +95,19 @@ def concat_static(func, dtype, np_inputs, axis_v, with_attr=False):
                     "x2": np_inputs[1].astype(dtype),
                     "axis": axis,
                 }
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                fetch_list = [
+                    out,
+                    ops[-1].result(0),  # x1_grad
+                    ops[-1].result(1),
+                ]  # x2_grad
+            else:
+                fetch_list = [out.name, x1.name + "@GRAD", x2.name + "@GRAD"]
             out_v, x1_grad_v, x2_grad_v = exe.run(
                 static.default_main_program(),
                 feed=feed_dict,
-                fetch_list=[out.name, x1.name + "@GRAD", x2.name + "@GRAD"],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return out_v, x1_grad_v, x2_grad_v
@@ -133,6 +143,7 @@ class TestCustomConcatDynamicAxisJit(unittest.TestCase):
                 for x_grad, pd_x_grad in zip(grad_inputs, pd_grad_inputs):
                     self.check_output(x_grad, pd_x_grad, "x_grad")
 
+    @test_with_pir_api
     def test_static(self):
         for dtype in self.dtypes:
             for axis in self.axises:
@@ -165,6 +176,7 @@ class TestCustomConcatDynamicAxisJit(unittest.TestCase):
                 for x_grad, pd_x_grad in zip(grad_inputs, pd_grad_inputs):
                     self.check_output(x_grad, pd_x_grad, "x_grad")
 
+    @test_with_pir_api
     def test_static_with_attr(self):
         for dtype in self.dtypes:
             for axis in self.axises:

--- a/test/custom_op/test_custom_conj.py
+++ b/test/custom_op/test_custom_conj.py
@@ -20,6 +20,7 @@ from utils import check_output, extra_cc_args, extra_nvcc_args, paddle_includes
 
 import paddle
 from paddle import static
+from paddle.pir_utils import test_with_pir_api
 from paddle.utils.cpp_extension import get_build_directory, load
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 
@@ -83,10 +84,16 @@ def conj_static(func, shape, dtype, np_input):
             exe = static.Executor()
             exe.run(static.default_startup_program())
 
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                fetch_list = [out, ops[-1].result(0)]
+            else:
+                fetch_list = [out.name, x.name + "@GRAD"]
+
             out_v, x_grad_v = exe.run(
                 static.default_main_program(),
                 feed={"x": np_input},
-                fetch_list=[out.name, x.name + "@GRAD"],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return out_v, x_grad_v
@@ -106,6 +113,7 @@ class TestCustomConjJit(unittest.TestCase):
             check_output(out, pd_out, "out")
             check_output(x_grad, pd_x_grad, "x's grad")
 
+    @test_with_pir_api
     def test_static(self):
         for dtype in self.dtypes:
             np_input = np.random.random(self.shape).astype(dtype)

--- a/test/custom_op/test_custom_inplace.py
+++ b/test/custom_op/test_custom_inplace.py
@@ -26,6 +26,7 @@ from utils import (
 
 import paddle
 from paddle import static
+from paddle.pir_utils import test_with_pir_api
 from paddle.utils.cpp_extension import get_build_directory, load
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 
@@ -76,19 +77,31 @@ def inplace_static_add(func, device, dtype, np_x, np_y):
             exe = static.Executor()
             exe.run(static.default_startup_program())
 
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                fetch_list = [
+                    x,
+                    out,
+                    ops[-1].result(0),
+                    ops[-1].result(1),
+                    ops[-2].result(0),
+                ]
+            else:
+                fetch_list = [
+                    x.name,
+                    out.name,
+                    x.name + "@GRAD",
+                    y.name + "@GRAD",
+                    out.name + "@GRAD",
+                ]
+
             x_v, out_v, x_grad_v, y_grad_v, out_grad_v = exe.run(
                 static.default_main_program(),
                 feed={
                     "x": np_x.astype(dtype),
                     "y": np_y.astype(dtype),
                 },
-                fetch_list=[
-                    x.name,
-                    out.name,
-                    x.name + "@GRAD",
-                    y.name + "@GRAD",
-                    out.name + "@GRAD",
-                ],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return x_v, out_v, x_grad_v, y_grad_v, out_grad_v
@@ -142,6 +155,39 @@ def inplace_static_add_vector(custom_func, device, dtype, np_inputs, np_y):
             exe = static.Executor()
             exe.run(static.default_startup_program())
 
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                if custom_func:
+                    fetch_list = [
+                        out[0],
+                        out[1],
+                        ops[-1].result(0),  # x1_grad
+                        ops[-1].result(1),  # x2_grad
+                        ops[-2].result(1),  # y_grad
+                        ops[-5].result(0),  # out0_grad
+                        ops[-5].result(1),
+                    ]  # out1_grad
+                else:
+                    fetch_list = [
+                        out[0],
+                        out[1],
+                        ops[-4].result(0),  # x1_grad
+                        ops[-3].result(0),  # x2_grad
+                        ops[-1].result(0),  # y_grad
+                        ops[-5].result(0),  # out0_grad
+                        ops[-5].result(1),
+                    ]  # out1_grad
+            else:
+                fetch_list = [
+                    out[0].name,
+                    out[1].name,
+                    x1.name + "@GRAD",
+                    x2.name + "@GRAD",
+                    y.name + "@GRAD",
+                    out[0].name + "@GRAD",
+                    out[1].name + "@GRAD",
+                ]
+
             (
                 out0_v,
                 out1_v,
@@ -157,15 +203,7 @@ def inplace_static_add_vector(custom_func, device, dtype, np_inputs, np_y):
                     "x2": np_inputs[1].astype(dtype),
                     "y": np_y.astype(dtype),
                 },
-                fetch_list=[
-                    out[0].name,
-                    out[1].name,
-                    x1.name + "@GRAD",
-                    x2.name + "@GRAD",
-                    y.name + "@GRAD",
-                    out[0].name + "@GRAD",
-                    out[1].name + "@GRAD",
-                ],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return (
@@ -216,6 +254,24 @@ def inplace_static_relu_net(func, device, dtype, np_x, np_y, np_z):
             exe = static.Executor()
             exe.run(static.default_startup_program())
 
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                fetch_list = [
+                    x,
+                    y,
+                    out,
+                    ops[-1].result(0),  # x_grad
+                    ops[-1].result(1),
+                ]  # y_grad
+            else:
+                fetch_list = [
+                    x.name,
+                    y.name,
+                    out.name,
+                    x.name + "@GRAD",
+                    y.name + "@GRAD",
+                ]
+
             x_v, y_v, out_v, x_grad_v, y_grad_v = exe.run(
                 static.default_main_program(),
                 feed={
@@ -223,13 +279,7 @@ def inplace_static_relu_net(func, device, dtype, np_x, np_y, np_z):
                     "y": np_y.astype(dtype),
                     "z": np_z.astype(dtype),
                 },
-                fetch_list=[
-                    x.name,
-                    y.name,
-                    out.name,
-                    x.name + "@GRAD",
-                    y.name + "@GRAD",
-                ],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return x_v, y_v, out_v, x_grad_v, y_grad_v
@@ -284,6 +334,49 @@ def static_multi_inplace(custom_func, device, dtype, np_x, np_y, np_a, np_b):
             mean_out = paddle.mean(paddle.add(out_xy, out_ab))
             static.append_backward(mean_out)
 
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                if custom_func:
+                    fetch_list = [
+                        x,
+                        out_xy,
+                        ops[-1].result(0),  # x_grad
+                        ops[-1].result(1),  # y_grad
+                        ops[-2].result(0),  # out_xy_grad
+                        a,
+                        out_ab,
+                        ops[-1].result(2),  # a_grad
+                        ops[-1].result(3),  # b_grad
+                        ops[-2].result(1),
+                    ]  # out_ab_grad
+                else:
+                    fetch_list = [
+                        x,
+                        out_xy,
+                        ops[-2].result(0),  # x_grad
+                        ops[-2].result(1),  # y_grad
+                        ops[-3].result(0),  # out_xy_grad
+                        a,
+                        out_ab,
+                        ops[-1].result(0),  # a_grad
+                        ops[-1].result(1),  # b_grad
+                        ops[-3].result(1),
+                    ]  # out_ab_grad
+
+            else:
+                fetch_list = [
+                    x.name,
+                    out_xy.name,
+                    x.name + "@GRAD",
+                    y.name + "@GRAD",
+                    out_xy.name + "@GRAD",
+                    a.name,
+                    out_ab.name,
+                    a.name + "@GRAD",
+                    b.name + "@GRAD",
+                    out_ab.name + "@GRAD",
+                ]
+
             exe = static.Executor()
             exe.run(static.default_startup_program())
 
@@ -306,18 +399,7 @@ def static_multi_inplace(custom_func, device, dtype, np_x, np_y, np_a, np_b):
                     "a": np_a.astype(dtype),
                     "b": np_b.astype(dtype),
                 },
-                fetch_list=[
-                    x.name,
-                    out_xy.name,
-                    x.name + "@GRAD",
-                    y.name + "@GRAD",
-                    out_xy.name + "@GRAD",
-                    a.name,
-                    out_ab.name,
-                    a.name + "@GRAD",
-                    b.name + "@GRAD",
-                    out_ab.name + "@GRAD",
-                ],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return (
@@ -348,6 +430,7 @@ class TestCustomInplaceJit(unittest.TestCase):
             np.random.random((3, 2)).astype("float32"),
         ]
 
+    @test_with_pir_api
     def test_static_add(self):
         for device in self.devices:
             for dtype in self.dtypes:
@@ -426,6 +509,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                 check_output(custom_x_grad, pd_x_grad, "x_grad")
                 check_output(custom_y_grad, pd_y_grad, "y_grad")
 
+    @test_with_pir_api
     def test_static_add_vector(self):
         for device in self.devices:
             for dtype in self.dtypes:
@@ -498,6 +582,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                 check_output(custom_x_grad, pd_x_grad, "x_grad")
                 check_output(custom_y_grad, pd_y_grad, "y_grad")
 
+    @test_with_pir_api
     def test_static_relu_net(self):
         for device in self.devices:
             for dtype in self.dtypes:
@@ -573,6 +658,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                 check_output(custom_x_grad, pd_x_grad, "x_grad")
                 check_output(custom_y_grad, pd_y_grad, "y_grad")
 
+    @test_with_pir_api
     def test_static_multi_inplace(self):
         for device in self.devices:
             for dtype in self.dtypes:

--- a/test/custom_op/test_custom_linear.py
+++ b/test/custom_op/test_custom_linear.py
@@ -21,6 +21,7 @@ from utils import check_output, extra_cc_args, extra_nvcc_args, paddle_includes
 import paddle
 import paddle.nn.functional as F
 from paddle import static
+from paddle.pir_utils import test_with_pir_api
 from paddle.utils.cpp_extension import get_build_directory, load
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 
@@ -71,6 +72,30 @@ def linear_static(func, device, dtype, np_x, np_weight, np_bias):
             exe = static.Executor()
             exe.run(static.default_startup_program())
 
+            if paddle.framework.in_pir_mode():
+                ops = static.default_main_program().global_block().ops
+                if func.__name__ == "custom_linear":
+                    fetch_list = [
+                        out,
+                        ops[-1].result(0),  # x_grad
+                        ops[-1].result(1),  # weight_grad
+                        ops[-1].result(2),
+                    ]  # bias_grad
+                else:
+                    fetch_list = [
+                        out,
+                        ops[-1].result(0),  # x_grad
+                        ops[-1].result(1),  # weight_grad
+                        ops[-2].result(1),
+                    ]  # bias_grad
+            else:
+                fetch_list = [
+                    out.name,
+                    x.name + "@GRAD",
+                    weight.name + "@GRAD",
+                    bias.name + "@GRAD",
+                ]
+
             out_v, x_grad_v, weight_grad_v, bias_grad_v = exe.run(
                 static.default_main_program(),
                 feed={
@@ -78,12 +103,7 @@ def linear_static(func, device, dtype, np_x, np_weight, np_bias):
                     "weight": np_weight.astype(dtype),
                     "bias": np_bias.astype(dtype),
                 },
-                fetch_list=[
-                    out.name,
-                    x.name + "@GRAD",
-                    weight.name + "@GRAD",
-                    bias.name + "@GRAD",
-                ],
+                fetch_list=fetch_list,
             )
     paddle.disable_static()
     return out_v, x_grad_v, weight_grad_v, bias_grad_v
@@ -99,6 +119,7 @@ class TestCustomLinearJit(unittest.TestCase):
         self.np_weight = np.full([2, 4], fill_value=0.5, dtype="float32")
         self.np_bias = np.ones([4], dtype="float32")
 
+    @test_with_pir_api
     def test_static(self):
         for device in self.devices:
             for dtype in self.dtypes:

--- a/test/custom_op/test_custom_raw_op_kernel_op.py
+++ b/test/custom_op/test_custom_raw_op_kernel_op.py
@@ -22,7 +22,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.pir_utils import test_with_pir_api
 
 MODULE_NAME = "custom_raw_op_kernel_op_lib"
 
@@ -72,7 +71,6 @@ class TestCustomRawReluOp(unittest.TestCase):
         self.assertIsNotNone(custom_raw_relu_op)
         return custom_raw_relu_op(x)
 
-    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         shape = [2, 3]

--- a/test/custom_op/test_custom_raw_op_kernel_op.py
+++ b/test/custom_op/test_custom_raw_op_kernel_op.py
@@ -22,6 +22,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.pir_utils import test_with_pir_api
 
 MODULE_NAME = "custom_raw_op_kernel_op_lib"
 
@@ -71,6 +72,7 @@ class TestCustomRawReluOp(unittest.TestCase):
         self.assertIsNotNone(custom_raw_relu_op)
         return custom_raw_relu_op(x)
 
+    @test_with_pir_api
     def test_static(self):
         paddle.enable_static()
         shape = [2, 3]

--- a/test/custom_op/test_custom_tensor_operator.py
+++ b/test/custom_op/test_custom_tensor_operator.py
@@ -25,6 +25,7 @@ from utils import (
 
 import paddle
 from paddle import static
+from paddle.pir_utils import test_with_pir_api
 from paddle.utils.cpp_extension import get_build_directory, load
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 
@@ -34,6 +35,14 @@ file = f'{get_build_directory()}\\custom_tensor_operator\\custom_tensor_operator
 if os.name == 'nt' and os.path.isfile(file):
     cmd = f'del {file}'
     run_cmd(cmd, True)
+
+custom_module = load(
+    name='custom_tensor_operator',
+    sources=['custom_tensor_operator.cc'],
+    extra_include_paths=paddle_includes,  # add for Coverage CI
+    extra_cxx_cflags=extra_cc_args,  # test for cc flags
+    verbose=True,
+)
 
 
 def test_custom_add_dynamic(func, device, dtype, np_x, use_func=True):
@@ -74,7 +83,7 @@ def test_custom_add_static(func, device, dtype, np_x, use_func=True):
             out_v = exe.run(
                 static.default_main_program(),
                 feed={'X': np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()
@@ -119,7 +128,7 @@ def test_custom_subtract_static(func, device, dtype, np_x, use_func=True):
             out_v = exe.run(
                 static.default_main_program(),
                 feed={'X': np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()
@@ -164,7 +173,7 @@ def test_custom_multiply_static(func, device, dtype, np_x, use_func=True):
             out_v = exe.run(
                 static.default_main_program(),
                 feed={'X': np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()
@@ -208,7 +217,7 @@ def test_custom_divide_static(func, device, dtype, np_x, use_func=True):
             out_v = exe.run(
                 static.default_main_program(),
                 feed={'X': np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()
@@ -217,40 +226,49 @@ def test_custom_divide_static(func, device, dtype, np_x, use_func=True):
 
 class TestJITLoad(unittest.TestCase):
     def setUp(self):
-        self.custom_module = load(
-            name='custom_tensor_operator',
-            sources=['custom_tensor_operator.cc'],
-            extra_include_paths=paddle_includes,  # add for Coverage CI
-            extra_cxx_cflags=extra_cc_args,  # test for cc flags
-            verbose=True,
-        )
+        self.custom_module = custom_module
         self.devices = ['cpu']
         self.dtypes = ['float32', 'float64']
         if paddle.is_compiled_with_cuda():
             self.devices.append('gpu')
             self.dtypes.append('float16')
 
-    def test_all(self):
+    def test_dynamic(self):
         self.add = self.custom_module.custom_add
         self.subtract = self.custom_module.custom_subtract
         self.multiply = self.custom_module.custom_multiply
         self.divide = self.custom_module.custom_divide
-        self._test_static()
         self._test_dynamic()
         self.add = self.custom_module.custom_scalar_add
         self.subtract = self.custom_module.custom_scalar_subtract
         self.multiply = self.custom_module.custom_scalar_multiply
         self.divide = self.custom_module.custom_scalar_divide
-        self._test_static()
         self._test_dynamic()
         self.add = self.custom_module.custom_left_scalar_add
         self.subtract = self.custom_module.custom_left_scalar_subtract
         self.multiply = self.custom_module.custom_left_scalar_multiply
         self.divide = self.custom_module.custom_left_scalar_divide
-        self._test_static()
         self._test_dynamic()
         self._test_logical_operants()
         self._test_compare_operants()
+
+    @test_with_pir_api
+    def test_static(self):
+        self.add = self.custom_module.custom_add
+        self.subtract = self.custom_module.custom_subtract
+        self.multiply = self.custom_module.custom_multiply
+        self.divide = self.custom_module.custom_divide
+        self._test_static()
+        self.add = self.custom_module.custom_scalar_add
+        self.subtract = self.custom_module.custom_scalar_subtract
+        self.multiply = self.custom_module.custom_scalar_multiply
+        self.divide = self.custom_module.custom_scalar_divide
+        self._test_static()
+        self.add = self.custom_module.custom_left_scalar_add
+        self.subtract = self.custom_module.custom_left_scalar_subtract
+        self.multiply = self.custom_module.custom_left_scalar_multiply
+        self.divide = self.custom_module.custom_left_scalar_divide
+        self._test_static()
 
     def _test_static(self):
         for device in self.devices:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164
适配框架内可适配的自定义算子的单测，涉及到保存加载相关的单测未适配
主要解决了如下问题：

- 优化前反向带有optional输入输出的infershape/inferdtype逻辑，支持optional + vec，optional + inplace等特殊组合模式处理
- 支持前反向optional + vec输入输出场景的Operation构建
- 优化前反向带有inplace输入输出的infershape/inferdtype逻辑，支持inplace + 自定义infershape/inferdtype混合场景下推断输出的shape和dtype
- 优化Vjp函数梯度结果保存逻辑，支持无需计算输入梯度场景
- 重构工具函数GetAttributeData，支持通过模板参数来选择返回variant类型或者any类型
- 修复高阶反向场景判断bug
- 修复PaddleNLP模型中，inplace自定义算子infershape错误修改Input维度问题