### PR TITLE
Dynamically bind dtype 

### DIFF
--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -35,12 +35,14 @@ limitations under the License. */
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
+COMMON_DECLARE_bool(enable_pir_api);
+
 namespace paddle {
 namespace pybind {
 
 extern PyTypeObject* p_tensor_type;
 
-PyDoc_STRVAR(tensor_name__doc__,  // NOLINT
+PyDoc_STRVAR(tensor_name__doc__,  // NOLINT  // NOLINT
              R"DOC(name
 
 Tensor's name.
@@ -847,25 +849,47 @@ Examples:
 )DOC");
 PyObject* tensor_properties_get_dtype(TensorObject* self, void* closure) {
   EAGER_TRY
-  if (!self->tensor.defined()) {
-    // be same to old dygraph
-    return ToPyObject(framework::proto::VarType::FP32);
-  }
-  if (egr::IsVariableCompatTensor(self->tensor)) {
-    auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
-        self->tensor.impl().get());
-    if (var_tensor->IsType<paddle::framework::Vocab>()) {
-      return ToPyObject(framework::proto::VarType::RAW);
-    } else if (var_tensor->IsType<paddle::framework::Strings>()) {
-      return ToPyObject(framework::proto::VarType::STRING);
+  if (FLAGS_enable_pir_api) {
+    if (!self->tensor.defined()) {
+      // be same to old dygraph
+      return ToPyObject(phi::DataType::FLOAT32);
+    }
+    if (egr::IsVariableCompatTensor(self->tensor)) {
+      auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
+          self->tensor.impl().get());
+      if (var_tensor->IsType<paddle::framework::Vocab>()) {
+        return ToPyObject(phi::DataType::UNDEFINED);
+      } else if (var_tensor->IsType<paddle::framework::Strings>()) {
+        return ToPyObject(phi::DataType::PSTRING);
+      } else {
+        PADDLE_THROW(paddle::platform::errors::Unavailable(
+            "VariableCompatTensor only support get shape from Vocab or "
+            "Strings."));
+      }
     } else {
-      PADDLE_THROW(paddle::platform::errors::Unavailable(
-          "VariableCompatTensor only support get shape from Vocab or "
-          "Strings."));
+      return ToPyObject(self->tensor.type());
     }
   } else {
-    return ToPyObject(
-        paddle::framework::TransToProtoVarType(self->tensor.type()));
+    if (!self->tensor.defined()) {
+      // be same to old dygraph
+      return ToPyObject(framework::proto::VarType::FP32);
+    }
+    if (egr::IsVariableCompatTensor(self->tensor)) {
+      auto* var_tensor = static_cast<const egr::VariableCompatTensor*>(
+          self->tensor.impl().get());
+      if (var_tensor->IsType<paddle::framework::Vocab>()) {
+        return ToPyObject(framework::proto::VarType::RAW);
+      } else if (var_tensor->IsType<paddle::framework::Strings>()) {
+        return ToPyObject(framework::proto::VarType::STRING);
+      } else {
+        PADDLE_THROW(paddle::platform::errors::Unavailable(
+            "VariableCompatTensor only support get shape from Vocab or "
+            "Strings."));
+      }
+    } else {
+      return ToPyObject(
+          paddle::framework::TransToProtoVarType(self->tensor.type()));
+    }
   }
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -42,7 +42,7 @@ namespace pybind {
 
 extern PyTypeObject* p_tensor_type;
 
-PyDoc_STRVAR(tensor_name__doc__,  // NOLINT  // NOLINT
+PyDoc_STRVAR(tensor_name__doc__,  // NOLINT
              R"DOC(name
 
 Tensor's name.

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -2416,9 +2416,11 @@ paddle::DataType CastPyArg2DataType(PyObject* obj,
   if (obj == Py_None) {
     return phi::DataType::UNDEFINED;
   }
-
-  framework::proto::VarType::Type type = CastPyArg2ProtoType(obj, arg_pos);
-  return framework::TransToPhiDataType(type);
+  if (PyObject_TypeCheck(obj, g_vartype_pytype)) {
+    framework::proto::VarType::Type type = CastPyArg2ProtoType(obj, arg_pos);
+    return framework::TransToPhiDataType(type);
+  }
+  return CastPyArg2DataTypeDirectly(obj, op_type, arg_pos);
 }
 
 paddle::Tensor PyTensorHook::operator()(const paddle::Tensor& var) {

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1077,6 +1077,12 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
   return obj.ptr();
 }
 
+PyObject* ToPyObject(const phi::DataType& dtype) {
+  auto obj = ::pybind11::cast(dtype);
+  obj.inc_ref();
+  return obj.ptr();
+}
+
 PyObject* ToPyObject(const pir::Value& value) {
   auto obj = ::pybind11::cast(value);
   obj.inc_ref();

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -148,6 +148,7 @@ PyObject* ToPyObject(const phi::distributed::Placements& value);
 PyObject* ToPyObject(const phi::SelectedRows* value);
 PyObject* ToPyObject(const paddle::framework::proto::VarType::Type& dtype);
 PyObject* ToPyObject(const paddle::framework::proto::VarType& type);
+PyObject* ToPyObject(const phi::DataType& type);
 PyObject* ToPyObject(const void* value);
 PyObject* ToPyObject(const std::unordered_map<int, int>& value);
 PyObject* ToPyObject(

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -64,6 +64,7 @@ class OpAttrTypeMap {
 };
 
 extern PyTypeObject* g_vartype_pytype;
+extern PyTypeObject* g_data_type_pytype;
 extern PyTypeObject* g_blockdesc_pytype;
 extern PyTypeObject* p_tensor_type;
 
@@ -72,6 +73,7 @@ bool PyObject_CheckBool(PyObject** obj) { return PyBool_Check(*obj); }
 bool PyObject_CheckLongOrToLong(PyObject** obj) {
   if ((PyLong_Check(*obj) && !PyBool_Check(*obj)) ||
       PyObject_TypeCheck(*obj, g_vartype_pytype) ||        // NOLINT
+      PyObject_TypeCheck(*obj, g_data_type_pytype) ||      // NOLINT
       (PyObject_TypeCheck(*obj, p_tensor_type) &&          // NOLINT
        (((TensorObject*)(*obj))->tensor.numel() == 1))) {  // NOLINT
     return true;

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -87,7 +87,7 @@ def monkey_patch_math_tensor():
                 >>> print("new tensor's dtype is: {}".format(new_tensor.dtype))
                 new tensor's dtype is: paddle.float32
         """
-        if not isinstance(dtype, core.VarDesc.VarType):
+        if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
             dtype = convert_np_dtype_to_dtype_(dtype)
         return _C_ops.cast(self, dtype)
 

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -25,6 +25,7 @@ from paddle.base.data_feeder import (
     _PADDLE_DTYPE_2_NUMPY_DTYPE,
     convert_uint16_to_float,
 )
+from paddle.base.framework import paddle_type_to_proto_type
 from paddle.profiler.utils import in_profiler_mode
 from paddle.utils import deprecated
 
@@ -219,10 +220,14 @@ def monkey_patch_tensor():
             else:
                 dtype = convert_np_dtype_to_dtype_(value.dtype)
 
+            self_dtype = self.dtype
+            if isinstance(self_dtype, core.DataType):
+                self_dtype = paddle_type_to_proto_type[self_dtype]
+
             assert (
-                self.dtype == dtype
+                self_dtype == dtype
             ), "Variable dtype not match, Variable [ {} ] need tensor with dtype {}  but load tensor with dtype {}".format(
-                self.name, self.dtype, dtype
+                self.name, self_dtype, dtype
             )
 
             # NOTE(wuweilong): self could be Tensor, the subsequent behavior are defined in different files

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1262,7 +1262,7 @@ def convert_np_dtype_to_dtype_(np_dtype):
         core.VarDesc.VarType / core.DataType : The data type in Paddle.
 
     """
-    if use_pir_api():
+    if in_pir_mode():
         return pir.core.convert_np_dtype_to_dtype_(np_dtype)
 
     # Convert the data type string to numpy data type.

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -7590,6 +7590,9 @@ class EagerParamBase(core.eager.Tensor):
                 )
 
         if dtype is not None:
+            # TODO: Remove this conversion after the we use DataType in Tensor constructor
+            if isinstance(dtype, core.DataType):
+                dtype = paddle_type_to_proto_type[dtype]
             if not isinstance(dtype, core.VarDesc.VarType):
                 dtype = convert_np_dtype_to_dtype_(dtype)
 

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1350,13 +1350,15 @@ def _create_tensor(
     **kwargs,
 ):
     if dtype is not None:
+        if not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
+            dtype = convert_np_dtype_to_dtype_(dtype)
         if isinstance(dtype, core.DataType):
             dtype = paddle_type_to_proto_type[dtype]
-        elif not isinstance(dtype, core.VarDesc.VarType):
-            dtype = convert_np_dtype_to_dtype_(dtype)
+    else:
+        dtype = core.VarDesc.VarType.FP32
 
     eager_tensor = core.eager.Tensor(
-        dtype if dtype else core.VarDesc.VarType.FP32,
+        dtype,
         list(shape) if shape else [],
         name,
         type if type else core.VarDesc.VarType.LOD_TENSOR,

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1350,7 +1350,9 @@ def _create_tensor(
     **kwargs,
 ):
     if dtype is not None:
-        if not isinstance(dtype, core.VarDesc.VarType):
+        if isinstance(dtype, core.DataType):
+            dtype = paddle_type_to_proto_type[dtype]
+        elif not isinstance(dtype, core.VarDesc.VarType):
             dtype = convert_np_dtype_to_dtype_(dtype)
 
     eager_tensor = core.eager.Tensor(

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1262,7 +1262,7 @@ def convert_np_dtype_to_dtype_(np_dtype):
         core.VarDesc.VarType / core.DataType : The data type in Paddle.
 
     """
-    if in_pir_mode():
+    if use_pir_api():
         return pir.core.convert_np_dtype_to_dtype_(np_dtype)
 
     # Convert the data type string to numpy data type.

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import paddle
+
 from ..base import framework
 from ..base.core import (
     DataType,
@@ -57,6 +59,22 @@ def bind_vartype():
 
     bool = VarDesc.VarType.BOOL
 
+    paddle.dtype = dtype
+    paddle.uint8 = uint8
+    paddle.int8 = int8
+    paddle.int16 = int16
+    paddle.int32 = int32
+    paddle.int64 = int64
+
+    paddle.float32 = float32
+    paddle.float64 = float64
+    paddle.float16 = float16
+    paddle.bfloat16 = bfloat16
+
+    paddle.complex64 = complex64
+    paddle.complex128 = complex128
+    paddle.bool = bool
+
 
 def bind_datatype():
     global dtype
@@ -92,6 +110,22 @@ def bind_datatype():
     complex128 = DataType.COMPLEX128
 
     bool = DataType.BOOL
+
+    paddle.dtype = dtype
+    paddle.uint8 = uint8
+    paddle.int8 = int8
+    paddle.int16 = int16
+    paddle.int32 = int32
+    paddle.int64 = int64
+
+    paddle.float32 = float32
+    paddle.float64 = float64
+    paddle.float16 = float16
+    paddle.bfloat16 = bfloat16
+
+    paddle.complex64 = complex64
+    paddle.complex128 = complex128
+    paddle.bool = bool
 
 
 enable_pir_api = framework.get_flags("FLAGS_enable_pir_api")[

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -14,6 +14,8 @@
 
 from ..base import framework
 from ..base.core import (
+    DataType,
+    VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
 )
@@ -21,8 +23,6 @@ from ..base.data_feeder import _NUMPY_DTYPE_2_PADDLE_DTYPE
 
 
 def bind_vartype():
-    from ..base.core import VarDesc
-
     global dtype
     global uint8
     global int8
@@ -59,8 +59,6 @@ def bind_vartype():
 
 
 def bind_datatype():
-    from ..base.core import DataType
-
     global dtype
     global uint8
     global int8

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -12,32 +12,98 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..base import framework
 from ..base.core import (
-    VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
 )
 from ..base.data_feeder import _NUMPY_DTYPE_2_PADDLE_DTYPE
 
-dtype = VarDesc.VarType
-dtype.__qualname__ = "dtype"
-dtype.__module__ = "paddle"
 
-uint8 = VarDesc.VarType.UINT8
-int8 = VarDesc.VarType.INT8
-int16 = VarDesc.VarType.INT16
-int32 = VarDesc.VarType.INT32
-int64 = VarDesc.VarType.INT64
+def bind_vartype():
+    from ..base.core import VarDesc
 
-float32 = VarDesc.VarType.FP32
-float64 = VarDesc.VarType.FP64
-float16 = VarDesc.VarType.FP16
-bfloat16 = VarDesc.VarType.BF16
+    global dtype
+    global uint8
+    global int8
+    global int16
+    global int32
+    global int64
+    global float32
+    global float64
+    global float16
+    global bfloat16
+    global complex64
+    global complex128
+    global bool
 
-complex64 = VarDesc.VarType.COMPLEX64
-complex128 = VarDesc.VarType.COMPLEX128
+    dtype = VarDesc.VarType
+    dtype.__qualname__ = "dtype"
+    dtype.__module__ = "paddle"
 
-bool = VarDesc.VarType.BOOL
+    uint8 = VarDesc.VarType.UINT8
+    int8 = VarDesc.VarType.INT8
+    int16 = VarDesc.VarType.INT16
+    int32 = VarDesc.VarType.INT32
+    int64 = VarDesc.VarType.INT64
+
+    float32 = VarDesc.VarType.FP32
+    float64 = VarDesc.VarType.FP64
+    float16 = VarDesc.VarType.FP16
+    bfloat16 = VarDesc.VarType.BF16
+
+    complex64 = VarDesc.VarType.COMPLEX64
+    complex128 = VarDesc.VarType.COMPLEX128
+
+    bool = VarDesc.VarType.BOOL
+
+
+def bind_datatype():
+    from ..base.core import DataType
+
+    global dtype
+    global uint8
+    global int8
+    global int16
+    global int32
+    global int64
+    global float32
+    global float64
+    global float16
+    global bfloat16
+    global complex64
+    global complex128
+    global bool
+
+    dtype = DataType
+    dtype.__qualname__ = "dtype"
+    dtype.__module__ = "paddle"
+
+    uint8 = DataType.UINT8
+    int8 = DataType.INT8
+    int16 = DataType.INT16
+    int32 = DataType.INT32
+    int64 = DataType.INT64
+
+    float32 = DataType.FLOAT32
+    float64 = DataType.FLOAT64
+    float16 = DataType.FLOAT16
+    bfloat16 = DataType.BFLOAT16
+
+    complex64 = DataType.COMPLEX64
+    complex128 = DataType.COMPLEX128
+
+    bool = DataType.BOOL
+
+
+enable_pir_api = framework.get_flags("FLAGS_enable_pir_api")[
+    "FLAGS_enable_pir_api"
+]
+
+if enable_pir_api:
+    bind_datatype()
+else:
+    bind_vartype()
 
 
 def iinfo(dtype):
@@ -130,9 +196,7 @@ def finfo(dtype):
     """
     import paddle
 
-    if paddle.base.framework.in_pir_mode() and isinstance(
-        dtype, paddle.pir.core.DataType
-    ):
+    if isinstance(dtype, paddle.pir.core.DataType):
         dtype = paddle.base.framework.paddle_type_to_proto_type[dtype]
     elif dtype in _NUMPY_DTYPE_2_PADDLE_DTYPE:
         dtype = _NUMPY_DTYPE_2_PADDLE_DTYPE[dtype]

--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -14,6 +14,7 @@
 
 import paddle
 from paddle.autograd.backward_utils import ValueDict
+from paddle.framework import core
 
 from ..dy2static.program_translator import _program_hash, synchronized
 
@@ -37,8 +38,11 @@ class ParametersRecorder:
         mappings = self.tensor2value[key]
         if id(tensor) not in mappings:
             non_used_initializer = paddle.nn.initializer.Constant(0.0)
+            dtype = tensor.dtype
+            if isinstance(dtype, core.VarDesc.VarType):
+                vartype_to_datatype[dtype]
             value = create_parameter(
-                dtype=vartype_to_datatype[tensor.dtype],
+                dtype=dtype,
                 shape=tensor.shape,
                 type=tensor.type,
                 initializer=non_used_initializer,

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -16,7 +16,6 @@ from functools import cached_property
 
 import paddle
 from paddle.amp.auto_cast import amp_state
-from paddle.base import framework
 from paddle.base.data_feeder import convert_dtype
 from paddle.base.unique_name import (
     UniqueNameGenerator,
@@ -44,12 +43,16 @@ class MetaInfo:
         # We always use float32 in simulation if AMP is enabled.
         if isinstance(tensor, paddle.pir.Value):
             name = "Value@NoName"
-            persistable = tensor.persistable
-            dtype = framework.paddle_type_to_proto_type[tensor.dtype]
-        else:
+        else:  # For Tensor or Variable
             name = tensor.name
-            persistable = tensor.persistable
-            dtype = tensor.dtype
+        persistable = tensor.persistable
+        dtype = tensor.dtype
+        expected_dtype_class = (
+            paddle.core.DataType
+            if paddle.framework.use_pir_api()
+            else paddle.core.VarDesc.VarType
+        )
+        assert isinstance(dtype, expected_dtype_class)
         current_amp_state = amp_state()
         if (
             dtype == paddle.float16

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -40,7 +40,6 @@ class MetaInfo:
 
     @staticmethod
     def from_tensor(tensor):
-        # We always use float32 in simulation if AMP is enabled.
         if isinstance(tensor, paddle.pir.Value):
             name = "Value@NoName"
         else:  # For Tensor or Variable
@@ -53,6 +52,8 @@ class MetaInfo:
             else paddle.core.VarDesc.VarType
         )
         assert isinstance(dtype, expected_dtype_class)
+
+        # We always use float32 in simulation if AMP is enabled.
         current_amp_state = amp_state()
         if (
             dtype == paddle.float16

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -288,7 +288,7 @@ class TensorDtypeVariable(DataVariable):
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
         if isinstance(
-            value, (paddle.base.core.VarDesc.VarType, paddle.core.DataType)
+            value, (paddle.core.VarDesc.VarType, paddle.core.DataType)
         ):
             return TensorDtypeVariable(value, graph, tracker)
 
@@ -394,7 +394,7 @@ class TensorVariable(VariableBase):
     @property
     def main_info(self) -> dict[str, Any]:
         dtype = self.meta.dtype
-        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+        if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         return {
             "shape": self.meta.shape,
@@ -488,21 +488,21 @@ class TensorVariable(VariableBase):
 
     def is_complex(self):
         dtype = self.meta.dtype
-        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+        if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_cp_dtype = dtype in CP_DTYPE_ABBRS
         return ConstantVariable(is_cp_dtype, self.graph, DummyTracker([self]))
 
     def is_integer(self):
         dtype = self.meta.dtype
-        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+        if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_int_dtype = dtype in INT_DTYPE_ABBRS
         return ConstantVariable(is_int_dtype, self.graph, DummyTracker([self]))
 
     def is_floating_point(self):
         dtype = self.meta.dtype
-        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+        if isinstance(dtype, paddle.core.VarDesc.VarType):
             dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_fp_dtype = dtype in FP_DTYPE_ABBRS
         return ConstantVariable(is_fp_dtype, self.graph, DummyTracker([self]))

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -287,7 +287,9 @@ class TensorDtypeVariable(DataVariable):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, paddle.dtype):
+        if isinstance(
+            value, (paddle.base.core.VarDesc.VarType, paddle.core.DataType)
+        ):
             return TensorDtypeVariable(value, graph, tracker)
 
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 import paddle
+from paddle.base.framework import paddle_type_to_proto_type
 from paddle.framework import use_pir_api
 from paddle.pir.core import vartype_to_datatype
 
@@ -410,9 +411,14 @@ class TensorVariable(VariableBase):
 
     @property
     def main_info(self) -> dict[str, Any]:
+        from paddle.framework import core
+
+        dtype = self.meta.dtype
+        if isinstance(dtype, core.DataType):
+            dtype = paddle_type_to_proto_type[dtype]
         return {
             "shape": self.meta.shape,
-            "dtype": DTYPE_ABBRS[self.meta.dtype],
+            "dtype": DTYPE_ABBRS[dtype],
             "stop_gradient": self.meta.stop_gradient,
             "var_name": self.var_name,
         }

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 import paddle
-from paddle.base.framework import paddle_type_to_proto_type
 from paddle.framework import core
 
 from ....infer_meta import MetaInfo
@@ -61,30 +60,30 @@ if TYPE_CHECKING:
 
 
 FP_DTYPE_ABBRS = {
-    paddle.bfloat16: "bfloat16",
-    paddle.float64: "float64",
-    paddle.float32: "float32",
-    paddle.float16: "float16",
+    core.DataType.BFLOAT16: "bfloat16",
+    core.DataType.FLOAT64: "float64",
+    core.DataType.FLOAT32: "float32",
+    core.DataType.FLOAT16: "float16",
 }
 
 CP_DTYPE_ABBRS = {
-    paddle.complex64: "complex64",
-    paddle.complex128: "complex128",
+    core.DataType.COMPLEX64: "complex64",
+    core.DataType.COMPLEX128: "complex128",
 }
 
 INT_DTYPE_ABBRS = {
-    paddle.int8: "int8",
-    paddle.int16: "int16",
-    paddle.int32: "int32",
-    paddle.int64: "int64",
-    paddle.uint8: "uint8",
+    core.DataType.INT8: "int8",
+    core.DataType.INT16: "int16",
+    core.DataType.INT32: "int32",
+    core.DataType.INT64: "int64",
+    core.DataType.UINT8: "uint8",
 }
 
 DTYPE_ABBRS = {
     **FP_DTYPE_ABBRS,
     **CP_DTYPE_ABBRS,
     **INT_DTYPE_ABBRS,
-    paddle.bool: "bool",
+    core.DataType.BOOL: "bool",
 }
 
 
@@ -393,8 +392,8 @@ class TensorVariable(VariableBase):
     @property
     def main_info(self) -> dict[str, Any]:
         dtype = self.meta.dtype
-        if isinstance(dtype, core.DataType):
-            dtype = paddle_type_to_proto_type[dtype]
+        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+            dtype = paddle.pir.core.vartype_to_datatype[dtype]
         return {
             "shape": self.meta.shape,
             "dtype": DTYPE_ABBRS[dtype],
@@ -487,16 +486,22 @@ class TensorVariable(VariableBase):
 
     def is_complex(self):
         dtype = self.meta.dtype
+        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+            dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_cp_dtype = dtype in CP_DTYPE_ABBRS
         return ConstantVariable(is_cp_dtype, self.graph, DummyTracker([self]))
 
     def is_integer(self):
         dtype = self.meta.dtype
+        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+            dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_int_dtype = dtype in INT_DTYPE_ABBRS
         return ConstantVariable(is_int_dtype, self.graph, DummyTracker([self]))
 
     def is_floating_point(self):
         dtype = self.meta.dtype
+        if isinstance(dtype, paddle.base.core.VarDesc.VarType):
+            dtype = paddle.pir.core.vartype_to_datatype[dtype]
         is_fp_dtype = dtype in FP_DTYPE_ABBRS
         return ConstantVariable(is_fp_dtype, self.graph, DummyTracker([self]))
 

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -708,11 +708,11 @@ class ClipGradByGlobalNorm(ClipGradBase):
                 )
 
             if (
-                sum_square.dtype == core.VarDesc.VarType.FP16
-                or sum_square.dtype == core.VarDesc.VarType.BF16
+                sum_square.dtype == paddle.float16
+                or sum_square.dtype == paddle.bfloat16
             ):
                 sum_square_list_fp16.append(sum_square)
-            elif sum_square.dtype == core.VarDesc.VarType.FP32:
+            elif sum_square.dtype == paddle.float32:
                 sum_square_list_fp32.append(sum_square)
             else:
                 sum_square_list.append(sum_square)

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -1555,6 +1555,11 @@ class RNNBase(LayerList):
             )
             if in_dynamic_mode():
                 with paddle.no_grad():
+                    dtype = params[0].dtype
+                    if isinstance(dtype, core.DataType):
+                        dtype = paddle.base.framework.paddle_type_to_proto_type[
+                            dtype
+                        ]
                     _legacy_C_ops.coalesce_tensor(
                         self._all_weights,
                         self._all_weights,
@@ -1564,7 +1569,7 @@ class RNNBase(LayerList):
                         "use_align",
                         False,
                         "dtype",
-                        params[0].dtype,
+                        dtype,
                     )
                     return
             # for static-graph, append coalesce_tensor into startup program

--- a/python/paddle/pir_utils.py
+++ b/python/paddle/pir_utils.py
@@ -16,6 +16,7 @@
 from functools import wraps
 
 import paddle
+from paddle.framework.dtype import bind_datatype, bind_vartype
 
 
 class IrGuard:
@@ -49,11 +50,13 @@ class IrGuard:
             paddle.enable_static()
         paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
         paddle.base.framework.global_var._use_pir_api_ = True
+        bind_datatype()
         self._switch_to_pir()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         paddle.framework.set_flags({"FLAGS_enable_pir_api": False})
         paddle.base.framework.global_var._use_pir_api_ = False
+        bind_vartype()
         self._switch_to_old_ir()
         if self.in_dygraph_outside:
             paddle.disable_static()

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -215,7 +215,10 @@ class InputSpec:
         # convert dtype into united representation
         if dtype is not None:
             if isinstance(dtype, (np.dtype, str)):
-                dtype = convert_np_dtype_to_dtype_(dtype)
+                if paddle.framework.use_pir_api():
+                    dtype = paddle.pir.core.convert_np_dtype_to_dtype_(dtype)
+                else:
+                    dtype = convert_np_dtype_to_dtype_(dtype)
 
         self.dtype = dtype
         self.name = name

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -215,10 +215,7 @@ class InputSpec:
         # convert dtype into united representation
         if dtype is not None:
             if isinstance(dtype, (np.dtype, str)):
-                if paddle.framework.use_pir_api():
-                    dtype = paddle.pir.core.convert_np_dtype_to_dtype_(dtype)
-                else:
-                    dtype = convert_np_dtype_to_dtype_(dtype)
+                dtype = convert_np_dtype_to_dtype_(dtype)
 
         self.dtype = dtype
         self.name = name

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -23,6 +23,7 @@ from paddle.framework import (
     in_dynamic_mode,
     in_dynamic_or_pir_mode,
     in_pir_mode,
+    use_pir_api,
 )
 
 from ..base.data_feeder import (
@@ -1100,9 +1101,9 @@ def randint(low=0, high=None, shape=[1], dtype=None, name=None):
         low = 0
     if dtype is None:
         dtype = core.VarDesc.VarType.INT64
-        if in_pir_mode():
+        if use_pir_api():
             dtype = DataType.INT64
-    elif not isinstance(dtype, core.VarDesc.VarType):
+    elif not isinstance(dtype, (core.VarDesc.VarType, core.DataType)):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_mode():

--- a/test/dygraph_to_static/test_declarative.py
+++ b/test/dygraph_to_static/test_declarative.py
@@ -249,7 +249,7 @@ class TestDifferentInputSpecCacheProgram(Dy2StTestBase):
 
         foo = paddle.jit.to_static(foo_func)
 
-        # [16, 10] + [10] (varbase)
+        # [16, 10] + [10] (Tensor)
         out_1 = foo(paddle.to_tensor(x_data), paddle.to_tensor(y_data))
         np.testing.assert_allclose(x_data + y_data, out_1.numpy(), rtol=1e-05)
         self.assertTrue(len(foo.program_cache) == 1)

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -116,6 +116,7 @@ class TestStdAPI_alias(unittest.TestCase):
 
 class TestStdError(unittest.TestCase):
     def test_error(self):
+        paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', [2, 3, 4], 'int32')
             self.assertRaises(TypeError, paddle.std, x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

目前框架内有两套dtype的表示，一套是老静态图的VarType，一套是PIR下的DataType。动态图在c++端底层的dtype都是DataType，但是之前应该是为了兼容，所以动态图python的dtype也还是VarType类型。

这个pr主要是想修改python端的paddle.dtype，在PIR下paddle.dtype返回的是DataType类型；在老静态图下返回的是VarType类型。

<p align="center">
  <img src="https://github.com/PaddlePaddle/Paddle/assets/38436475/d6bf5746-d202-420a-a5c7-531676622421" alt="dtype drawio" width="500px"/>
</p>

通过将动态图切分成 PIR 和非 PIR 模式，以确保在任何一种情况下 dtype 都是动静统一的，以免添加众多繁杂的转换、特殊处理逻辑，在不久的将来，左侧的 `not use_pir_api` 场景就可以完全废弃掉了

> [!IMPORTANT]
>
> 本 PR 主要影响是在开启 `FLAGS_enable_pir_api=True` 场景下动态图的行为（含动转静），当然，CI 上目前没有这种测试（除动转静单测，动转静单测整体还是跑在动态图下，因此会测到部分动态图相关逻辑），因此测试可能是不全面的，这就需要未来去逐渐针对适配升级，不过当前 PR 已经手动在部分 Seg、Detection 模型上测试开启 `FLAGS_enable_pir_api=True` 通过，更多的场景可能需要在合入后联动「SOT+PIR」模型测试一同测试和修复（就目前经验而言，这类问题修复非常快）

参考 https://github.com/PaddlePaddle/Paddle/pull/62146