### PR TITLE
Update tensor.cc

### DIFF
--- a/paddle/phi/api/include/tensor.h
+++ b/paddle/phi/api/include/tensor.h
@@ -106,26 +106,6 @@ class PADDLE_API Tensor final {
   explicit Tensor(std::shared_ptr<phi::TensorBase> tensor_impl);
 
   /**
-   * @brief Construct a new Tensor object on the target place.
-   *
-   * This is a deprecated method and may be removed in the future!!!
-   *
-   * @param place
-   */
-  explicit Tensor(const Place& place);
-
-  /**
-   * @brief Construct a new Tensor object on the target place
-   * with specified shape.
-   *
-   * This is a deprecated method and may be removed in the future!!!
-   *
-   * @param place
-   * @param shape
-   */
-  Tensor(const Place& place, const std::vector<int64_t>& shape);
-
-  /**
    * @brief Construct a new Tensor object by a TensorBase pointer and name
    *
    * @param tensor_impl

--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -60,40 +60,6 @@ Tensor::Tensor(std::shared_ptr<phi::TensorBase> tensor_impl,
       phi::errors::InvalidArgument("TensorImpl with nullptr is not supported"));
 }
 
-Tensor::Tensor(const Place &place) {
-  LOG_FIRST_N(WARNING, 1)
-      << "The Tensor(place) constructor is deprecated since version "
-         "2.3, and will be removed in version 2.4! Please use "
-         "`paddle::empty/full` method to create a new "
-         "Tensor instead. "
-         "Reason: A legal tensor cannot be constructed only based on "
-         "the `place`, and datatype, shape, layout, etc. is also "
-         "required.";
-  DefaultAllocator alloc(place);
-  impl_ = std::make_shared<phi::DenseTensor>(
-      &alloc,
-      phi::DenseTensorMeta(phi::DataType::FLOAT32,
-                           common::make_ddim({}),
-                           phi::DataLayout::NCHW));
-}
-
-Tensor::Tensor(const Place &place, const std::vector<int64_t> &shape) {
-  LOG_FIRST_N(WARNING, 1)
-      << "The Tensor(place, shape) constructor is deprecated since "
-         "version 2.3, and will be removed in version 2.4! Please use "
-         "`paddle::empty/full` method to create a new "
-         "Tensor instead. "
-         "Reason: A legal tensor cannot be constructed only based on "
-         "the `place` and `shape`, and datatype, layout, etc. is also "
-         "required.";
-  DefaultAllocator alloc(place);
-  impl_ = std::make_shared<phi::DenseTensor>(
-      &alloc,
-      phi::DenseTensorMeta(phi::DataType::FLOAT32,
-                           common::make_ddim({shape}),
-                           phi::DataLayout::NCHW));
-}
-
 Tensor::Tensor(std::shared_ptr<phi::TensorBase> tensor_impl,
                const std::string &name)
     : impl_(std::move(tensor_impl)), name_(name) {}

--- a/test/cpp/phi/api/test_phi_tensor.cc
+++ b/test/cpp/phi/api/test_phi_tensor.cc
@@ -238,11 +238,6 @@ void TestDataInterface() {
   CHECK(const_tensor_ptr != nullptr);
 }
 
-void TestJudgeTensorType() {
-  Tensor test_tensor(phi::CPUPlace(), {1, 1});
-  CHECK(test_tensor.is_dense_tensor() == true);
-}
-
 TEST(PhiTensor, All) {
   VLOG(2) << "TestCopy";
   GroupTestCopy();
@@ -260,8 +255,6 @@ TEST(PhiTensor, All) {
   TestInitialized();
   VLOG(2) << "TestDataInterface";
   TestDataInterface();
-  VLOG(2) << "TestJudgeTensorType";
-  TestJudgeTensorType();
 }
 
 }  // namespace tests


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
The interface introduction content is to explain that the need to remove
```
"The Tensor(place, shape) constructor is deprecated since "
         "version 2.3, and will be removed in version 2.4! Please use "
         "`paddle::empty/full` method to create a new "
         "Tensor instead. "
```