### PR TITLE
[Distributed] fix sharding on custom devices

### DIFF
--- a/python/paddle/distributed/communication/reduce.py
+++ b/python/paddle/distributed/communication/reduce.py
@@ -123,7 +123,7 @@ def reduce(tensor, dst, op=ReduceOp.SUM, group=None, sync_op=True):
             >>> # [[1, 2, 3], [1, 2, 3]] (2 GPUs, out for rank 1)
     """
     # AVG is only supported when nccl >= 2.10
-    if op == ReduceOp.AVG and paddle.base.core.nccl_version() < 21000:
+    if op == ReduceOp.AVG and (not is_avg_reduce_op_supported()):
         group = (
             paddle.distributed.collective._get_global_group()
             if group is None
@@ -201,3 +201,10 @@ def reduce(tensor, dst, op=ReduceOp.SUM, group=None, sync_op=True):
         )
     else:
         raise ValueError(f"Unknown parameter: {op}.")
+
+
+def is_avg_reduce_op_supported():
+    if paddle.is_compiled_with_cuda():
+        return paddle.base.core.nccl_version() >= 21000
+    else:
+        return False

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -23,7 +23,10 @@ from paddle import framework
 from paddle.base.dygraph import base as imperative_base
 from paddle.base.framework import EagerParamBase
 from paddle.distributed import fleet
-from paddle.distributed.communication.reduce import ReduceOp
+from paddle.distributed.communication.reduce import (
+    ReduceOp,
+    is_avg_reduce_op_supported,
+)
 
 from ...utils.log_util import logger
 from ...utils.tensor_fusion_helper import (
@@ -101,11 +104,10 @@ class DygraphShardingOptimizer:
         self.use_reduce_avg = strategy.hybrid_configs[
             'sharding_configs'
         ].use_reduce_avg
-        if self.use_reduce_avg and paddle.base.core.nccl_version() < 21000:
+        if self.use_reduce_avg and (not is_avg_reduce_op_supported()):
             self.use_reduce_avg = False
             warnings.warn(
-                "nccl reduce_avg requires nccl>=2.10.0, but current version is %s"
-                % paddle.base.core.nccl_version()
+                "nccl reduce_avg requires paddle compiled with cuda and nccl>=2.10.0, please check compilation setups."
             )
 
         pp_overlap = strategy.hybrid_configs['pp_configs'].sharding_comm_overlap


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[Pcard-79653]
nccl_version() is not callable when paddle is compiled without cuda, thus causes sharding mode broken on devices other than gpu.
This PR fix this problem.