### PR TITLE
Fix DEFIN_NOT definite_not

### DIFF
--- a/paddle/fluid/framework/op_compatible_info.cc
+++ b/paddle/fluid/framework/op_compatible_info.cc
@@ -68,42 +68,48 @@ inline bool CompareVersion(const std::string& str_first,
 }
 
 void OpCompatibleMap::InitOpCompatibleMap() {
-  op_compatible_map_["sequence_pad"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["sequence_unpad"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+  op_compatible_map_["sequence_pad"] = {"1.6.0",
+                                        OpCompatibleType::definite_not};
+  op_compatible_map_["sequence_unpad"] = {"1.6.0",
+                                          OpCompatibleType::definite_not};
 
   op_compatible_map_["coalesce_tensor"] = {"1.6.0",
-                                           OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["crop_tensor"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+                                           OpCompatibleType::definite_not};
+  op_compatible_map_["crop_tensor"] = {"1.6.0", OpCompatibleType::definite_not};
   op_compatible_map_["deformable_conv"] = {"1.6.0",
-                                           OpCompatibleType::DEFIN_NOT};
+                                           OpCompatibleType::definite_not};
   op_compatible_map_["deformable_conv_v1"] = {"1.6.0",
-                                              OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["dpsgd"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["eye"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["fill_any_like"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["hard_swish"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["gather_nd"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["instance_norm"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+                                              OpCompatibleType::definite_not};
+  op_compatible_map_["dpsgd"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["eye"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["fill_any_like"] = {"1.6.0",
+                                         OpCompatibleType::definite_not};
+  op_compatible_map_["hard_swish"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["gather_nd"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["instance_norm"] = {"1.6.0",
+                                         OpCompatibleType::definite_not};
   op_compatible_map_["lookup_table_v2"] = {"1.6.0",
-                                           OpCompatibleType::DEFIN_NOT};
+                                           OpCompatibleType::definite_not};
   op_compatible_map_["match_matrix_tensor"] = {"1.6.0",
-                                               OpCompatibleType::DEFIN_NOT};
+                                               OpCompatibleType::definite_not};
   op_compatible_map_["multiclass_nms2"] = {"1.6.0",
-                                           OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["one_hot_v2"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+                                           OpCompatibleType::definite_not};
+  op_compatible_map_["one_hot_v2"] = {"1.6.0", OpCompatibleType::definite_not};
   op_compatible_map_["pull_box_sparse"] = {"1.6.0",
-                                           OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["scatter_nd_add"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["shard_index"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["size"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["strided_slice"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+                                           OpCompatibleType::definite_not};
+  op_compatible_map_["scatter_nd_add"] = {"1.6.0",
+                                          OpCompatibleType::definite_not};
+  op_compatible_map_["shard_index"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["size"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["strided_slice"] = {"1.6.0",
+                                         OpCompatibleType::definite_not};
   op_compatible_map_["trilinear_interp"] = {"1.6.0",
-                                            OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["unfold"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["unique"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+                                            OpCompatibleType::definite_not};
+  op_compatible_map_["unfold"] = {"1.6.0", OpCompatibleType::definite_not};
+  op_compatible_map_["unique"] = {"1.6.0", OpCompatibleType::definite_not};
   op_compatible_map_["unique_with_counts"] = {"1.6.0",
-                                              OpCompatibleType::DEFIN_NOT};
-  op_compatible_map_["var_conv_2d"] = {"1.6.0", OpCompatibleType::DEFIN_NOT};
+                                              OpCompatibleType::definite_not};
+  op_compatible_map_["var_conv_2d"] = {"1.6.0", OpCompatibleType::definite_not};
 
   op_compatible_map_["reshape2"] = {"1.6.0", OpCompatibleType::possible};
   op_compatible_map_["slice"] = {"1.6.0", OpCompatibleType::possible};
@@ -156,7 +162,7 @@ CompatibleInfo OpCompatibleMap::GetOpCompatibleInfo(std::string op_name) const {
   if (it != op_compatible_map_.end()) {
     return it->second;
   } else {
-    return {default_required_version_, OpCompatibleType::DEFIN_NOT};
+    return {default_required_version_, OpCompatibleType::definite_not};
   }
 }
 
@@ -174,7 +180,7 @@ OpCompatibleType OpCompatibleMap::IsRequireMiniVersion(
     if (CompareVersion(str_current_version, default_required_version_)) {
       return OpCompatibleType::compatible;
     } else {
-      return OpCompatibleType::DEFIN_NOT;
+      return OpCompatibleType::definite_not;
     }
   }
 }

--- a/paddle/fluid/framework/op_compatible_info.h
+++ b/paddle/fluid/framework/op_compatible_info.h
@@ -28,7 +28,7 @@ class OpCompatibleMap;
 
 enum class OpCompatibleType {
   compatible = 0,       //   support previous version
-  DEFIN_NOT = 1,        //   definitely can't support previous version
+  definite_not = 1,     //   definitely can't support previous version
   possible = 2,         //   possible can support previous version, not sure
   bug_fix = 3,          //   bug fix, can't support previous version
   precision_change = 4  //   precision change, may cause difference

--- a/test/cpp/fluid/framework/op_compatible_info_test.cc
+++ b/test/cpp/fluid/framework/op_compatible_info_test.cc
@@ -37,7 +37,7 @@ TEST(test_op_compatible_info, test_op_compatible) {
             std::string());
 
   auto comp_1 = comp_map.IsRequireMiniVersion("sequence_pad", "1.5.0");
-  ASSERT_EQ(comp_1, OpCompatibleType::DEFIN_NOT);
+  ASSERT_EQ(comp_1, OpCompatibleType::definite_not);
   auto comp_2 = comp_map.IsRequireMiniVersion("sequence_pad", "1.6.0");
   ASSERT_EQ(comp_2, OpCompatibleType::compatible);
   auto comp_3 = comp_map.IsRequireMiniVersion("sequence_pad", "1.6.1");
@@ -45,14 +45,14 @@ TEST(test_op_compatible_info, test_op_compatible) {
   auto comp_6 = comp_map.IsRequireMiniVersion("sequence_pad", "1.7.0");
   ASSERT_EQ(comp_6, OpCompatibleType::compatible);
   auto comp_7 = comp_map.IsRequireMiniVersion("sequence_pad", "0.7.0");
-  ASSERT_EQ(comp_7, OpCompatibleType::DEFIN_NOT);
+  ASSERT_EQ(comp_7, OpCompatibleType::definite_not);
   auto comp_8 = comp_map.IsRequireMiniVersion("sequence_pad", "2.0.0");
   ASSERT_EQ(comp_8, OpCompatibleType::compatible);
 
   ASSERT_EQ(comp_map.IsRequireMiniVersion("unkop", "2.0.0"),
             OpCompatibleType::compatible);
   ASSERT_EQ(comp_map.IsRequireMiniVersion("unkop", "0.7.0"),
-            OpCompatibleType::DEFIN_NOT);
+            OpCompatibleType::definite_not);
 
   ASSERT_EQ(comp_map.IsRequireMiniVersion("slice", "0.7.0"),
             OpCompatibleType::possible);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
DEFIN_NOT 容易认为是 DEFINE_NOT，修改definite_not
OpCompatibleType 其他项为小写，改为小写一致