### PR TITLE
Revert add rotary_emb_base for fused_rotary_position_embedding

### DIFF
--- a/paddle/phi/api/yaml/fused_backward.yaml
+++ b/paddle/phi/api/yaml/fused_backward.yaml
@@ -17,8 +17,8 @@
   support_dygraph_mode : true
 
 - backward_op : fused_rotary_position_embedding_grad
-  forward: fused_rotary_position_embedding (Tensor q, Tensor k, Tensor v, float rotary_emb_base = 10000.0) -> Tensor(out_q), Tensor(out_k), Tensor(out_v)
-  args : (Tensor out_q_grad, Tensor out_k_grad,Tensor out_v_grad, float rotary_emb_base = 10000.0)
+  forward: fused_rotary_position_embedding (Tensor q, Tensor k, Tensor v) -> Tensor(out_q), Tensor(out_k), Tensor(out_v)
+  args : (Tensor out_q_grad, Tensor out_k_grad,Tensor out_v_grad)
   output : Tensor(q_grad), Tensor(k_grad), Tensor(v_grad)
   optional : out_k_grad, out_v_grad, k_grad, v_grad
   infer_meta :

--- a/paddle/phi/api/yaml/fused_ops.yaml
+++ b/paddle/phi/api/yaml/fused_ops.yaml
@@ -66,7 +66,7 @@
   optional : cache_kv, pre_caches, rotary_pos_emb, time_step, seq_lengths, src_mask
 
 - op : fused_rotary_position_embedding
-  args : (Tensor q, Tensor k, Tensor v, float rotary_emb_base = 10000.0)
+  args : (Tensor q, Tensor k, Tensor v)
   output : Tensor(out_q), Tensor(out_k), Tensor(out_v)
   infer_meta :
     func : FusedRopeInferMeta

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -1207,7 +1207,6 @@ void IndexAddGradInferMeta(const MetaTensor& index,
 void FusedRopeGradInferMeta(const MetaTensor& dout_q,
                             const MetaTensor& dout_k,
                             const MetaTensor& dout_v,
-                            const float rotary_emb_base,
                             MetaTensor* dq,
                             MetaTensor* dk,
                             MetaTensor* dv) {

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -194,7 +194,6 @@ void FusedDropoutAddGradInferMeta(const MetaTensor& seed_offset,
 void FusedRopeGradInferMeta(const MetaTensor& dout_q,
                             const MetaTensor& dout_k,
                             const MetaTensor& dout_v,
-                            const float rotary_emb_base,
                             MetaTensor* dq,
                             MetaTensor* dk,
                             MetaTensor* dv);

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -3231,7 +3231,6 @@ void FusedAdamInferMeta(
 void FusedRopeInferMeta(const MetaTensor& q,
                         const MetaTensor& k,
                         const MetaTensor& v,
-                        const float rotary_emb_base,
                         MetaTensor* out_q,
                         MetaTensor* out_k,
                         MetaTensor* out_v) {

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -609,7 +609,6 @@ void MoeInferMeta(const MetaTensor& x,
 void FusedRopeInferMeta(const MetaTensor& q,
                         const MetaTensor& k,
                         const MetaTensor& v,
-                        const float rotary_emb_base,
                         MetaTensor* out_q,
                         MetaTensor* out_k,
                         MetaTensor* out_v);

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_grad_kernel.cu
@@ -26,7 +26,6 @@ __global__ void VectorizedFusedRopeGradKernel(phi::Array<const T*, 3> ins_data,
                                               int64_t seq_len,
                                               int64_t num_heads,
                                               int64_t head_dim,
-                                              const float rotary_emb_base,
                                               phi::Array<T*, 3> outs_data,
                                               int num_inputs,
                                               MPType div_c) {
@@ -52,8 +51,8 @@ __global__ void VectorizedFusedRopeGradKernel(phi::Array<const T*, 3> ins_data,
       int64_t pos_seq = index_wc / (num_heads * head_dim);
       MPType idx = static_cast<MPType>((index_wc % head_dim) / 2 * 2.0);
       MPType indicses =
-          static_cast<MPType>(1) / pow(static_cast<MPType>(rotary_emb_base),
-                                       idx * static_cast<MPType>(div_c));
+          static_cast<MPType>(1) /
+          pow(static_cast<MPType>(10000), idx * static_cast<MPType>(div_c));
       MPType value = pos_seq * indicses;
       sin_value[nx] = sin(value);
       cos_value[nx] = cos(value);
@@ -88,7 +87,6 @@ void FusedRopeGradKernel(const Context& dev_ctx,
                          const DenseTensor& dout_q,
                          const paddle::optional<DenseTensor>& dout_k,
                          const paddle::optional<DenseTensor>& dout_v,
-                         const float rotary_emb_base,
                          DenseTensor* dq,
                          DenseTensor* dk,
                          DenseTensor* dv) {
@@ -144,7 +142,6 @@ void FusedRopeGradKernel(const Context& dev_ctx,
                                    seq_len,
                                    num_heads,
                                    head_dim,
-                                   rotary_emb_base,
                                    outs_data,
                                    num_inputs,
                                    div_c);

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
@@ -27,7 +27,6 @@ __global__ void VectorizedFusedRopeKernel(phi::Array<const T*, 3> ins_data,
                                           int64_t seq_len,
                                           int64_t num_heads,
                                           int64_t head_dim,
-                                          const float rotary_emb_base,
                                           phi::Array<T*, 3> outs_data,
                                           int num_inputs,
                                           MPType div_c) {
@@ -53,8 +52,8 @@ __global__ void VectorizedFusedRopeKernel(phi::Array<const T*, 3> ins_data,
       int64_t pos_seq = index_wc / (num_heads * head_dim);
       MPType idx = static_cast<MPType>((index_wc % head_dim) / 2 * 2.0);
       MPType indicses =
-          static_cast<MPType>(1) / pow(static_cast<MPType>(rotary_emb_base),
-                                       idx * static_cast<MPType>(div_c));
+          static_cast<MPType>(1) /
+          pow(static_cast<MPType>(10000), idx * static_cast<MPType>(div_c));
       MPType value = pos_seq * indicses;
       sin_value[nx] = sin(value);
       cos_value[nx] = cos(value);
@@ -93,7 +92,6 @@ void FusedRopeKernel(const Context& dev_ctx,
                      const DenseTensor& q,
                      const paddle::optional<DenseTensor>& k,
                      const paddle::optional<DenseTensor>& v,
-                     const float rotary_emb_base,
                      DenseTensor* out_q,
                      DenseTensor* out_k,
                      DenseTensor* out_v) {
@@ -149,7 +147,6 @@ void FusedRopeKernel(const Context& dev_ctx,
                                    seq_len,
                                    num_heads,
                                    head_dim,
-                                   rotary_emb_base,
                                    outs_data,
                                    num_inputs,
                                    div_c);

--- a/python/paddle/incubate/nn/functional/fused_rotary_position_embedding.py
+++ b/python/paddle/incubate/nn/functional/fused_rotary_position_embedding.py
@@ -17,7 +17,7 @@ from paddle import _C_ops
 from paddle.framework import in_dynamic_mode
 
 
-def fused_rotary_position_embedding(q, k=None, v=None, rotary_emb_base=10000.0):
+def fused_rotary_position_embedding(q, k=None, v=None):
     r"""
     Fused rotary position embedding.
 
@@ -46,10 +46,7 @@ def fused_rotary_position_embedding(q, k=None, v=None, rotary_emb_base=10000.0):
             out_q, out_k, out_v = fused_rotary_position_embedding(q, k, v)
     """
     if in_dynamic_mode():
-        assert isinstance(
-            rotary_emb_base, float
-        ), f"type of rotary_emb_base must be float, but got {type(rotary_emb_base)}"
-        return _C_ops.fused_rotary_position_embedding(q, k, v, rotary_emb_base)
+        return _C_ops.fused_rotary_position_embedding(q, k, v)
 
     raise RuntimeError(
         "This feature is currently supported only in dynamic mode and with CUDAPlace."

--- a/test/legacy_test/test_fused_rotary_position_embedding.py
+++ b/test/legacy_test/test_fused_rotary_position_embedding.py
@@ -41,15 +41,13 @@ def mult_qkv(value, cos_tensor, sin_tensor):
     return query
 
 
-def paddle_fused_rotary_position_embedding(
-    init_q, init_k, init_v, rotary_emb_base=10000.0
-):
+def paddle_fused_rotary_position_embedding(init_q, init_k, init_v):
     q, k, v = deal_qkv(init_q, init_k, init_v)
 
     pos_seq = paddle.arange(0, q.shape[2], 1, dtype="float32")
     indices = paddle.arange(0, q.shape[3], 2, dtype="float32")
 
-    indices = 1 / rotary_emb_base ** (indices / q.shape[3])
+    indices = 1 / 10000 ** (indices / q.shape[3])
     sinusoid_inp = pos_seq.unsqueeze(1) * indices.unsqueeze(0)
 
     sin_sin = np.empty((q.shape[2] * q.shape[3]), dtype=np.float32)
@@ -94,7 +92,6 @@ class TestFusedRotaryPositionEmbedding(unittest.TestCase):
         self.dtype = 'float32'
         self.training = True
         self.seed = 1203
-        self.rotary_emb_base = 10000.0
 
     def get_paddle_tensor(self):
         tmp = paddle.randn(self.shape, self.dtype)
@@ -109,9 +106,7 @@ class TestFusedRotaryPositionEmbedding(unittest.TestCase):
         tensor_q = self.get_paddle_tensor()
         tensor_k = self.get_paddle_tensor()
         tensor_v = self.get_paddle_tensor()
-        out_q, out_k, out_v = rope_function(
-            tensor_q, tensor_k, tensor_v, rotary_emb_base=self.rotary_emb_base
-        )
+        out_q, out_k, out_v = rope_function(tensor_q, tensor_k, tensor_v)
 
         fw.append(out_q)
         fw.append(out_k)
@@ -151,30 +146,6 @@ class TestFusedRotaryPositionEmbedding(unittest.TestCase):
                 name="q", shape=self.shape, dtype=self.dtype
             )
             fused_rotary_position_embedding(static_q, static_q, static_q)
-        paddle.disable_static()
-
-
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not compiled with CUDA ",
-)
-class TestFusedRotaryPositionEmbeddingRotaryEmbBase(
-    TestFusedRotaryPositionEmbedding
-):
-    def setUp(self):
-        self.shape = [1, 16, 1, 16]
-        self.dtype = 'float32'
-        self.training = True
-        self.seed = 1203
-        self.rotary_emb_base = 500000.0
-
-    def test_error(self):
-        paddle.enable_static()
-        with self.assertRaises(RuntimeError):
-            static_q = paddle.static.data(
-                name="q", shape=self.shape, dtype=self.dtype
-            )
-            fused_rotary_position_embedding(static_q, static_q, static_q, 10000)
         paddle.disable_static()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->

Revert "add rotary_emb_base for fused_rotary_position_embedding (#62328)"

This reverts commit 8c347e25a54703c940e13a9d712571bad930d3d3.