### PR TITLE
[CustomDevice] fix ToCDataType

### DIFF
--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -592,13 +592,21 @@ class CustomDevice : public DeviceInterface {
   case in:                     \
     return C_DataType::ret
     switch (data_type) {
-      return_result(phi::DataType::FLOAT64, FLOAT64);
-      return_result(phi::DataType::FLOAT32, FLOAT32);
-      return_result(phi::DataType::FLOAT16, FLOAT16);
-      return_result(phi::DataType::INT64, INT64);
-      return_result(phi::DataType::INT32, INT32);
-      return_result(phi::DataType::INT16, INT16);
+      return_result(phi::DataType::BOOL, BOOL);
+      return_result(phi::DataType::UINT8, UINT8);
+      return_result(phi::DataType::UINT16, UINT16);
+      return_result(phi::DataType::UINT32, UINT32);
+      return_result(phi::DataType::UINT64, UINT64);
       return_result(phi::DataType::INT8, INT8);
+      return_result(phi::DataType::INT16, INT16);
+      return_result(phi::DataType::INT32, INT32);
+      return_result(phi::DataType::INT64, INT64);
+      return_result(phi::DataType::FLOAT16, FLOAT16);
+      return_result(phi::DataType::FLOAT32, FLOAT32);
+      return_result(phi::DataType::FLOAT64, FLOAT64);
+      return_result(phi::DataType::BFLOAT16, BFLOAT16);
+      return_result(phi::DataType::COMPLEX64, COMPLEX64);
+      return_result(phi::DataType::COMPLEX128, COMPLEX128);
       default: {
         PADDLE_THROW(phi::errors::Unavailable(
             "DataType is not supported on %s.", Type()));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/62464 修复该pr引入的bug，删除ToCCLDataType时，遗漏了对ToCDataType增加原ToCCLDataType中支持的BFLOAT16，导致 custom device 的 bfloat16 通信出现问题

