### PR TITLE
[PIR] add paddle fatal mechanism.

### DIFF
--- a/paddle/common/enforce.cc
+++ b/paddle/common/enforce.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/common/enforce.h"
 #include <array>
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
@@ -48,13 +49,19 @@ std::string SimplifyDemangleStr(std::string str) {
   }
   return str;
 }
+
+std::atomic_bool paddle_fatal_skip{false};
+
 }  // namespace
 
 namespace common {
 namespace enforce {
-TEST_API int GetCallStackLevel() { return FLAGS_call_stack_level; }
+void SkipPaddleFatal(bool skip) { paddle_fatal_skip.store(skip); }
+bool IsPaddleFatalSkip() { return paddle_fatal_skip.load(); }
 
-TEST_API std::string SimplifyErrorTypeFormat(const std::string& str) {
+int GetCallStackLevel() { return FLAGS_call_stack_level; }
+
+std::string SimplifyErrorTypeFormat(const std::string& str) {
   std::ostringstream sout;
   size_t type_end_pos = str.find(':', 0);
   if (type_end_pos == std::string::npos) {

--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -134,6 +134,7 @@ void ThrowWarnInternal(const std::string& message);
 #define PADDLE_THROW(...)                                         \
   do {                                                            \
     HANDLE_THE_ERROR                                              \
+    ::common::enforce::SkipPaddleFatal();                         \
     throw ::common::enforce::EnforceNotMet(                       \
         ::common::ErrorSummary(__VA_ARGS__), __FILE__, __LINE__); \
     END_HANDLE_THE_ERROR                                          \

--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -134,7 +134,6 @@ void ThrowWarnInternal(const std::string& message);
 #define PADDLE_THROW(...)                                         \
   do {                                                            \
     HANDLE_THE_ERROR                                              \
-    ::common::enforce::SkipPaddleFatal();                         \
     throw ::common::enforce::EnforceNotMet(                       \
         ::common::ErrorSummary(__VA_ARGS__), __FILE__, __LINE__); \
     END_HANDLE_THE_ERROR                                          \

--- a/paddle/pir/include/core/op_info.h
+++ b/paddle/pir/include/core/op_info.h
@@ -32,7 +32,7 @@ typedef void (*VerifyPtr)(Operation *op);
 
 class IR_API OpInfo {
  public:
-  OpInfo() = default;
+  OpInfo(std::nullptr_t ptr = nullptr){};  // NOLINT
 
   OpInfo(const OpInfo &other) = default;
 

--- a/paddle/pir/include/core/value.h
+++ b/paddle/pir/include/core/value.h
@@ -32,7 +32,7 @@ class ValueImpl;
 ///
 class IR_API Value {
  public:
-  Value() = default;
+  Value(std::nullptr_t ptr = nullptr){};  // NOLINT
 
   Value(detail::ValueImpl *impl) : impl_(impl) {}  // NOLINT
 

--- a/paddle/pir/src/core/block.cc
+++ b/paddle/pir/src/core/block.cc
@@ -24,7 +24,10 @@
 namespace pir {
 Block::~Block() {
   if (!use_empty()) {
-    LOG(FATAL) << "Destroyed a block that is still in use.";
+    auto parent_op = GetParentOp();
+    PADDLE_FATAL(
+        "Destroyed a block that is still in use.. The parent op is : %s",
+        parent_op ? parent_op->name() : std::string("nullptr"));
   }
   ClearOps();
   ClearKwargs();

--- a/paddle/pir/src/core/block_argument.cc
+++ b/paddle/pir/src/core/block_argument.cc
@@ -75,7 +75,17 @@ class BlockArgumentImpl : public ValueImpl {
 
 BlockArgumentImpl::~BlockArgumentImpl() {
   if (!use_empty()) {
-    LOG(FATAL) << "Destroyed a block argument that is still in use.";
+    if (is_kwarg_) {
+      PADDLE_FATAL(
+          "Destroyed a keyword block argument that is still in use. The key is "
+          ": %s",
+          keyword_);
+    } else {
+      PADDLE_FATAL(
+          "Destroyed a position block argument that is still in use. The index "
+          "is : %u",
+          index_);
+    }
   }
 }
 

--- a/paddle/pir/src/core/op_result_impl.h
+++ b/paddle/pir/src/core/op_result_impl.h
@@ -60,12 +60,7 @@ class OpResultImpl : public ValueImpl {
 ///
 class OpInlineResultImpl : public OpResultImpl {
  public:
-  OpInlineResultImpl(Type type, uint32_t result_index)
-      : OpResultImpl(type, result_index) {
-    if (result_index > MAX_INLINE_RESULT_IDX) {
-      throw("Inline result index should not exceed MaxInlineResultIndex(5)");
-    }
-  }
+  OpInlineResultImpl(Type type, uint32_t result_index);
 
   static bool classof(const ValueImpl &value) {
     return value.kind() < OUTLINE_RESULT_IDX;

--- a/paddle/pir/src/core/op_result_impl.h
+++ b/paddle/pir/src/core/op_result_impl.h
@@ -42,7 +42,7 @@ class OpResultImpl : public ValueImpl {
   ///
   uint32_t index() const;
 
-  ~OpResultImpl();
+  TEST_API ~OpResultImpl();
 
   ///
   /// \brief attribute related public interfaces
@@ -60,7 +60,7 @@ class OpResultImpl : public ValueImpl {
 ///
 class OpInlineResultImpl : public OpResultImpl {
  public:
-  OpInlineResultImpl(Type type, uint32_t result_index);
+  TEST_API OpInlineResultImpl(Type type, uint32_t result_index);
 
   static bool classof(const ValueImpl &value) {
     return value.kind() < OUTLINE_RESULT_IDX;

--- a/paddle/pir/src/core/operation.cc
+++ b/paddle/pir/src/core/operation.cc
@@ -372,9 +372,13 @@ void Operation::Verify() {
 }
 
 int32_t Operation::ComputeOpResultOffset(uint32_t index) const {
-  if (index >= num_results_) {
-    LOG(FATAL) << "index exceeds OP op result range.";
-  }
+  PADDLE_ENFORCE_LT(
+      index,
+      num_results_,
+      common::errors::PreconditionNotMet(
+          "The op result index [%u] must less than results size[%u].",
+          index,
+          num_results_));
   if (index < OUTLINE_RESULT_IDX) {
     return -static_cast<int32_t>((index + 1u) * sizeof(OpInlineResultImpl));
   }
@@ -384,9 +388,13 @@ int32_t Operation::ComputeOpResultOffset(uint32_t index) const {
 }
 
 int32_t Operation::ComputeOpOperandOffset(uint32_t index) const {
-  if (index >= num_operands_) {
-    LOG(FATAL) << "index exceeds OP op operand range.";
-  }
+  PADDLE_ENFORCE_LT(
+      index,
+      num_operands_,
+      common::errors::PreconditionNotMet(
+          "The op operand index [%u] must less than operands size[%u].",
+          index,
+          num_operands_));
   return static_cast<int32_t>(index * sizeof(OpOperandImpl) +
                               sizeof(Operation));
 }

--- a/paddle/pir/src/core/value_impl.cc
+++ b/paddle/pir/src/core/value_impl.cc
@@ -14,6 +14,7 @@
 
 #include <glog/logging.h>
 
+#include "paddle/common/enforce.h"
 #include "paddle/pir/src/core/value_impl.h"
 
 namespace {
@@ -50,10 +51,12 @@ std::string ValueImpl::PrintUdChain() {
   return result.str();
 }
 ValueImpl::ValueImpl(Type type, uint32_t kind) : id_(GenerateId()) {
-  if (kind > BLOCK_ARG_IDX) {
-    LOG(FATAL) << "The kind of value_impl(" << kind
-               << "), is bigger than BLOCK_ARG_IDX(7)";
-  }
+  PADDLE_ENFORCE_LE(
+      kind,
+      BLOCK_ARG_IDX,
+      common::errors::PreconditionNotMet(
+          "The kind of value_impl[%u] must not bigger than BLOCK_ARG_IDX(7)",
+          kind));
   type_ = type;
   first_use_offseted_by_kind_ = reinterpret_cast<OpOperandImpl *>(
       reinterpret_cast<uintptr_t>(nullptr) + kind);

--- a/test/cpp/pir/core/CMakeLists.txt
+++ b/test/cpp/pir/core/CMakeLists.txt
@@ -8,6 +8,7 @@ paddle_test(ir_program_test SRCS ir_program_test.cc)
 paddle_test(ir_infershape_test SRCS ir_infershape_test.cc)
 paddle_test(scalar_attribute_test SRCS scalar_attribute_test.cc)
 paddle_test(ir_printer_test SRCS ir_printer_test.cc DEPS test_dialect)
+paddle_test(paddle_fatal_test SRCS paddle_fatal_test.cc)
 
 file(
   DOWNLOAD https://paddle-ci.gz.bcebos.com/ir_translator_test/resnet50_main.prog

--- a/test/cpp/pir/core/block_argument_test.cc
+++ b/test/cpp/pir/core/block_argument_test.cc
@@ -103,3 +103,22 @@ TEST(block_argument_test, kwargs) {
   EXPECT_EQ(block->kwargs_size(), 4u);
   EXPECT_EQ(value.type(), builder.bool_type());
 }
+
+TEST(block_argument_test, fatal) {
+  auto block = new pir::Block();
+  auto arg = block->AddArg(nullptr);
+  auto op = pir::Operation::Create({arg}, {}, {}, nullptr);
+  EXPECT_DEATH(delete block,
+               "Destroyed a position block argument that is still in use.*");
+  auto kwarg = block->AddKwarg("a", nullptr);
+  arg.ReplaceAllUsesWith(kwarg);
+  block->ClearArgs();
+  EXPECT_DEATH(delete block,
+               "Destroyed a keyword block argument that is still in use.*");
+
+  op->Destroy();
+  op = pir::Operation::Create({}, {}, {}, nullptr, 0, {block});
+  EXPECT_DEATH(delete block, "Destroyed a block that is still in use.*");
+  op->Destroy();
+  delete block;
+}

--- a/test/cpp/pir/core/ir_value_test.cc
+++ b/test/cpp/pir/core/ir_value_test.cc
@@ -21,6 +21,7 @@
 #include "paddle/pir/include/core/ir_context.h"
 #include "paddle/pir/include/core/operation.h"
 #include "paddle/pir/include/dialect/shape/utils/shape_analysis.h"
+#include "paddle/pir/src/core/op_result_impl.h"
 
 // This unittest is used to test the construction interfaces of value class and
 // operation. The constructed test scenario is: a = OP1(); b = OP2(); c = OP3(a,
@@ -50,7 +51,7 @@ TEST(value_test, value_test) {
       op1_inputs,
       test::CreateAttributeMap({"op1_name"}, {"op1_attr"}),
       op1_output_types,
-      pir::OpInfo());
+      nullptr);
   op1->Print(std::cout);
   pir::Value a = op1->result(0);
   EXPECT_TRUE(a.use_empty());
@@ -61,7 +62,7 @@ TEST(value_test, value_test) {
       op2_inputs,
       test::CreateAttributeMap({"op2_name"}, {"op2_attr"}),
       op2_output_types,
-      pir::OpInfo());
+      nullptr);
   op2->Print(std::cout);
   pir::Value b = op2->result(0);
   EXPECT_TRUE(b.use_empty());
@@ -72,7 +73,7 @@ TEST(value_test, value_test) {
       op3_inputs,
       test::CreateAttributeMap({"op3_name"}, {"op3_attr"}),
       op3_output_types,
-      pir::OpInfo());
+      nullptr);
 
   EXPECT_TRUE(op1->result(0).HasOneUse());
   EXPECT_TRUE(op2->result(0).HasOneUse());
@@ -88,7 +89,7 @@ TEST(value_test, value_test) {
       op4_inputs,
       test::CreateAttributeMap({"op4_name"}, {"op4_attr"}),
       op4_output_types,
-      pir::OpInfo());
+      nullptr);
   op4->Print(std::cout);
 
   // Test 1:
@@ -134,4 +135,22 @@ TEST(value_test, value_test) {
   op2->Destroy();
   VLOG(0) << op1->result(0).PrintUdChain() << std::endl;
   op1->Destroy();
+}
+
+TEST(op_result_test, exception) {
+  EXPECT_THROW(
+      pir::detail::OpInlineResultImpl(nullptr, MAX_INLINE_RESULT_IDX + 1),
+      common::enforce::EnforceNotMet);
+  pir::IrContext *ctx = pir::IrContext::Instance();
+  auto op = pir::Operation::Create(
+      {}, {{"test", pir::Int32Attribute::get(ctx, 1)}}, {nullptr}, nullptr);
+  auto result = op->result(0);
+  auto op2 = pir::Operation::Create({result}, {}, {}, nullptr);
+  EXPECT_DEATH(op->Destroy(), "Destroyed a op_result that is still in use.*");
+  EXPECT_THROW(result.set_attribute("test", nullptr),
+               common::enforce::EnforceNotMet);
+  EXPECT_THROW(op->result(1), common::enforce::EnforceNotMet);
+  EXPECT_THROW(op->operand(1), common::enforce::EnforceNotMet);
+  op2->Destroy();
+  op->Destroy();
 }

--- a/test/cpp/pir/core/paddle_fatal_test.cc
+++ b/test/cpp/pir/core/paddle_fatal_test.cc
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "paddle/common/enforce.h"
+#include "paddle/phi/core/enforce.h"
+
+class FatalClass {
+ public:
+  FatalClass() {}
+  ~FatalClass() { PADDLE_FATAL("fatal occured in deconstructor!"); }
+};
+
+void throw_exception_in_func() {
+  FatalClass test_case;
+  PADDLE_THROW(::common::errors::External("throw excption in func"));
+}
+
+void terminate_in_func() { FatalClass test_case; }
+
+TEST(paddle_fatal_test, base) {
+  EXPECT_FALSE(::common::enforce::IsPaddleFatalSkip());
+  EXPECT_DEATH(terminate_in_func(), "fatal occured in deconstructor!.*");
+  EXPECT_THROW(throw_exception_in_func(), common::enforce::EnforceNotMet);
+  EXPECT_TRUE(::common::enforce::IsPaddleFatalSkip());
+  // skip fatal.
+  terminate_in_func();
+  // unskip paddle fatal.
+  ::common::enforce::SkipPaddleFatal(false);
+  EXPECT_DEATH(terminate_in_func(), "fatal occured in deconstructor!.*");
+}

--- a/test/cpp/pir/core/paddle_fatal_test.cc
+++ b/test/cpp/pir/core/paddle_fatal_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@ TEST(paddle_fatal_test, base) {
   EXPECT_FALSE(::common::enforce::IsPaddleFatalSkip());
   EXPECT_DEATH(terminate_in_func(), "fatal occured in deconstructor!.*");
   EXPECT_THROW(throw_exception_in_func(), common::enforce::EnforceNotMet);
-  EXPECT_TRUE(::common::enforce::IsPaddleFatalSkip());
+  EXPECT_FALSE(::common::enforce::IsPaddleFatalSkip());
+  ::common::enforce::SkipPaddleFatal(true);
   // skip fatal.
   terminate_in_func();
   // unskip paddle fatal.
   ::common::enforce::SkipPaddleFatal(false);
-  EXPECT_DEATH(terminate_in_func(), "fatal occured in deconstructor!.*");
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

- 新增paddle fatal 机制。
    - 全局维护唯一的布尔变量：paddle_fatal_skip, 初始化为false。
    - 当 paddle_fatal_skip 变量为true时, PADDLE_FATAL不起任何作用，等价于空语句。
    - 当 paddle_fatal_skip 变量为false时,PADDLE_FATAL会在打印相关信息后，调用std::abort()终止程序。
    - 新增数据结构PaddleFatalGuard, 该数据结构在构造函数中记录当前paddle_fatal_skip的值，并将paddle_fatal_skip设为true, 析构函数中将paddle_fatal_skip恢复为原值。
    - 在common::enforce:::EnforceNotMet和pir::IrNotMetException的异常中增加PaddleFatalGuard成员变量。 目前paddle代码中的PADDLE_ENFORCE_*和IR_ENFORCE中抛出的就是这两者异常，这意味着当程序在某处通过ADDLE_ENFORCE_*或者IR_ENFORCE判定失败，抛出异常，当异常对象沿着调用栈展开时，会跳过析构函数中的PADDLE_FATAL, 保证了上层调用者不用担心异常信息丢失，可以正确捕获到相应的异常。
- 将PIR库中用到的析构函数中的LOG((FATAL)替换为PADDLE_FATAL。
- 将PIR库中析构函数之外位置的LOG((FATAL)替换为PADDLE_ENFORCE_*。

### Other
Pcard-67164