### PR TITLE
add flag prim_forward_blacklist

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1470,6 +1470,18 @@ PHI_DEFINE_EXPORTED_bool(prim_check_ops,
                          "Whether to check the decomposed program, to ensure "
                          "that only the primitive operator is present.");
 
+/*
+ * PIR and prim related FLAG
+ * Name: FLAGS_prim_forward_blacklist
+ * Value Range: string, default=""
+ * Example: FLAGS_prim_forward_blacklist="pd_op.relu;pd_op.mean" would block
+ * `relu` and `mean` two ops in decompsition when using CINN
+ */
+PHI_DEFINE_EXPORTED_string(
+    prim_forward_blacklist,
+    "",
+    "It controls the forward blacklist ops to be not decomposed.");
+
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
     defined(PADDLE_WITH_XPU_BKCL)
 /**

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1475,7 +1475,7 @@ PHI_DEFINE_EXPORTED_bool(prim_check_ops,
  * Name: FLAGS_prim_forward_blacklist
  * Value Range: string, default=""
  * Example: FLAGS_prim_forward_blacklist="pd_op.relu;pd_op.mean" would block
- * `relu` and `mean` two ops in decompsition when using CINN
+ * `relu` and `mean` two ops in decompsition
  */
 PHI_DEFINE_EXPORTED_string(
     prim_forward_blacklist,

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1475,12 +1475,12 @@ PHI_DEFINE_EXPORTED_bool(prim_check_ops,
  * Name: FLAGS_prim_forward_blacklist
  * Value Range: string, default=""
  * Example: FLAGS_prim_forward_blacklist="pd_op.relu;pd_op.mean" would block
- * `relu` and `mean` two ops in decompsition
+ * `relu` and `mean` two ops in decompsition.
  */
 PHI_DEFINE_EXPORTED_string(
     prim_forward_blacklist,
     "",
-    "It controls the forward blacklist ops to be not decomposed.");
+    "It controls the forward blacklist ops not to be decomposed.");
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
     defined(PADDLE_WITH_XPU_BKCL)

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1470,13 +1470,9 @@ PHI_DEFINE_EXPORTED_bool(prim_check_ops,
                          "Whether to check the decomposed program, to ensure "
                          "that only the primitive operator is present.");
 
-/*
- * PIR and prim related FLAG
- * Name: FLAGS_prim_forward_blacklist
- * Value Range: string, default=""
- * Example: FLAGS_prim_forward_blacklist="pd_op.relu;pd_op.mean" would block
- * `relu` and `mean` two ops in decompsition.
- */
+// PIR and prim related FLAG
+// Example: FLAGS_prim_forward_blacklist="pd_op.relu;pd_op.mean" would block
+// `relu` and `mean` two ops in decompsition.
 PHI_DEFINE_EXPORTED_string(
     prim_forward_blacklist,
     "",

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -48,12 +48,21 @@ std::unordered_set<std::string> dynamic_shape_blacklist = {"pd_op.squeeze",
 
 namespace {
 std::unordered_set<std::string> StringSplit(const std::string& str) {
-  std::regex reg(";");
-  std::unordered_set<std::string> elems{
-      std::sregex_token_iterator(str.begin(), str.end(), reg, -1),
-      std::sregex_token_iterator()};
-  elems.erase("");
-  return elems;
+  std::istringstream iss(str);
+  std::unordered_set<std::string> tokens;
+  std::string token;
+
+  while (std::getline(iss, token, ';')) {
+    size_t startpos = token.find_first_not_of(" ");
+    size_t endpos = token.find_last_not_of(" ");
+    if ((startpos != std::string::npos) && (endpos != std::string::npos)) {
+      token = token.substr(startpos, endpos - startpos + 1);
+    } else if (startpos != std::string::npos) {
+      token = token.substr(startpos);
+    }
+    tokens.insert(token);
+  }
+  return tokens;
 }
 }  // namespace
 

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -26,7 +26,7 @@
 
 COMMON_DECLARE_bool(prim_skip_dynamic);
 COMMON_DECLARE_bool(prim_check_ops);
-PD_DECLARE_string(prim_forward_blacklist);
+COMMON_DECLARE_string(prim_forward_blacklist);
 
 using paddle::dialect::DenseTensorType;
 using paddle::dialect::SelectedRowsType;

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -49,7 +49,7 @@ std::unordered_set<std::string> dynamic_shape_blacklist = {"pd_op.squeeze",
 namespace {
 std::set<std::string> StringSplit(const std::string& str) {
   std::istringstream iss(str);
-  std::unordered_set<std::string> tokens;
+  std::set<std::string> tokens;
   std::string token;
 
   while (std::getline(iss, token, ';')) {

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -47,7 +47,7 @@ std::unordered_set<std::string> dynamic_shape_blacklist = {"pd_op.squeeze",
                                                            "pd_op.unsqueeze"};
 
 namespace {
-std::unordered_set<std::string> StringSplit(const std::string& str) {
+std::set<std::string> StringSplit(const std::string& str) {
   std::istringstream iss(str);
   std::unordered_set<std::string> tokens;
   std::string token;
@@ -146,8 +146,8 @@ void DecompProgram::check_ops() {
   auto primitives_set = GetPrimitiveOpNames();
   std::set<std::string> undecomposed_set;
   for (const auto& element : decomposed_prog_ops_set_) {
-    auto iter = primitives_set.find(element);
-    if (iter == primitives_set.end()) {
+    if (primitives_set.find(element) == primitives_set.end() &&
+        blacklist_.find(element) == blacklist_.end()) {
       undecomposed_set.insert(element);
     }
   }
@@ -337,9 +337,8 @@ bool DecompProgram::enable_decomp_by_filter(const std::string& op_name) {
     }
   }
   auto from_flag_blacklist = StringSplit(FLAGS_prim_forward_blacklist);
-  if (from_flag_blacklist.size() > 0 &&
-      from_flag_blacklist.find(op_name) != from_flag_blacklist.end())
-    flag = false;
+  if (from_flag_blacklist.size() > 0)
+    blacklist_.insert(from_flag_blacklist.begin(), from_flag_blacklist.end());
   if (blacklist_.size() > 0 && blacklist_.find(op_name) != blacklist_.end())
     flag = false;
   return flag;

--- a/test/prim/pir_prim/test_pir_prim_flags.py
+++ b/test/prim/pir_prim/test_pir_prim_flags.py
@@ -23,7 +23,7 @@ from paddle.decomposition import decomp
 
 
 class TestPrimBlacklistFlags(unittest.TestCase):
-    def not_in_blacklist(self):
+    def not_in_blacklist(self, op_name):
         inputs = np.random.random([2, 3, 4]).astype("float32")
         paddle.enable_static()
         core._set_prim_forward_enabled(True)
@@ -34,24 +34,25 @@ class TestPrimBlacklistFlags(unittest.TestCase):
                 'x', shape=inputs.shape, dtype=str(inputs.dtype)
             )
             y = F.gelu(x)
+            z = F.silu(y)
 
             fwd_ops = [op.name() for op in main_program.global_block().ops]
             # Ensure that tanh in original block
-            self.assertTrue('pd_op.gelu' in fwd_ops)
+            self.assertTrue(op_name in fwd_ops)
 
-            [y] = decomp.decompose(main_program, [y])
+            z = decomp.decompose(main_program, [z])
 
             fwd_ops_new = [op.name() for op in main_program.global_block().ops]
             # Ensure that tanh is splitted into small ops
-            self.assertTrue('pd_op.gelu' not in fwd_ops_new)
+            self.assertTrue(op_name not in fwd_ops_new)
 
         exe = paddle.static.Executor()
         exe.run(startup_program)
-        _ = exe.run(main_program, feed={'x': inputs}, fetch_list=[y])
+        _ = exe.run(main_program, feed={'x': inputs}, fetch_list=[z])
         paddle.disable_static()
         core._set_prim_forward_enabled(False)
 
-    def in_blacklist(self):
+    def in_blacklist(self, op_name):
         inputs = np.random.random([2, 3, 4]).astype("float32")
         paddle.enable_static()
         core._set_prim_forward_enabled(True)
@@ -62,27 +63,33 @@ class TestPrimBlacklistFlags(unittest.TestCase):
                 'x', shape=inputs.shape, dtype=str(inputs.dtype)
             )
             y = F.gelu(x)
+            z = F.silu(y)
 
             fwd_ops = [op.name() for op in main_program.global_block().ops]
             # Ensure that tanh in original block
-            self.assertTrue('pd_op.gelu' in fwd_ops)
+            self.assertTrue(op_name in fwd_ops)
 
-            _ = decomp.decompose(main_program, [y])
+            z = decomp.decompose(main_program, [z])
 
             fwd_ops_new = [op.name() for op in main_program.global_block().ops]
             # Ensure that tanh is splitted into small ops
-            self.assertTrue('pd_op.gelu' in fwd_ops_new)
+            self.assertTrue(op_name in fwd_ops_new)
 
         exe = paddle.static.Executor()
         exe.run(startup_program)
-        _ = exe.run(main_program, feed={'x': inputs}, fetch_list=[y])
+        _ = exe.run(main_program, feed={'x': inputs}, fetch_list=[z])
         paddle.disable_static()
         core._set_prim_forward_enabled(False)
 
     def test_prim_forward_blacklist(self):
-        self.not_in_blacklist()
+        self.not_in_blacklist("pd_op.gelu")
         core._set_prim_forward_blacklist("pd_op.gelu")
-        self.in_blacklist()
+        self.in_blacklist("pd_op.gelu")
+
+    def test_prim_forward_blacklist_flag(self):
+        self.not_in_blacklist("pd_op.silu")
+        paddle.set_flags({"FLAGS_prim_forward_blacklist": "pd_op.silu"})
+        self.in_blacklist("pd_op.silu")
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/prim/pir_prim/test_prim_flags_check_ops.py
+++ b/test/prim/pir_prim/test_prim_flags_check_ops.py
@@ -83,9 +83,6 @@ class TestPrimMode1(unittest.TestCase):
         res = self.base_net("prim")
         for ref, actual in zip(res_ref, res):
             np.testing.assert_allclose(ref, actual, rtol=1e-6)
-        with self.assertRaises(ValueError):
-            core._set_prim_forward_blacklist("pd_op.rsqrt")
-            _ = self.base_net("prim")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
Pcard-66975
Add flags_prim_forward_blacklist in decomp and pir.
```
usage: FLAGS_prim_forward_blacklist="pd_op.relu;pd_op.mean"
``` 