### PR TITLE
add op info

### DIFF
--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -273,6 +273,7 @@ void IrPrinter::PrintOpResult(Operation* op) {
       [this](Value v) { this->PrintValue(v); },
       [this]() { this->os << ", "; });
   os << ")";
+  os << "(op_id: op_" << op->id() << ")";
 }
 
 void IrPrinter::PrintAttributeMap(Operation* op) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
Pcard-66975
add op id to op info in printer.
before:
    (%15) = "pd_op.feed" () {col:(Int32)4,is_persistable:[false],name:"top_p",stop_gradient:[false]} : () -> builtin.tensor<1xf32>
after:
    (%15)(op_id: op_19) = "pd_op.feed" () {col:(Int32)4,is_persistable:[false],name:"top_p",stop_gradient:[false]} : () -> builtin.tensor<1xf32>
