### PR TITLE
[PIR+CINN]Fix remove_unchanged_reshape_pass maybe chanage CombineOp input's Type

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/refresh_combine_pattern.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/refresh_combine_pattern.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "paddle/pir/include/core/builtin_op.h"
+#include "paddle/pir/include/pattern_rewrite/pattern_match.h"
+
+class RefreshCombineOpPattern
+    : public ::pir::OpRewritePattern<::pir::CombineOp> {
+ public:
+  using ::pir::OpRewritePattern<::pir::CombineOp>::OpRewritePattern;
+  bool MatchAndRewrite(pir::CombineOp op,
+                       pir::PatternRewriter& rewriter) const override {
+    auto new_combine_op = rewriter.Build<::pir::CombineOp>(op.inputs());
+    rewriter.ReplaceAllUsesWith(op.result(0), new_combine_op.result(0));
+    rewriter.EraseOp(op);
+    return true;
+  }
+};

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
@@ -70,6 +70,7 @@ bool RemoveOp(pir::Operation* op, pir::PatternRewriter* rewriter) {
     rewriter->EraseOp(op);
     return true;
   }
+
   return false;
 }
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
@@ -70,7 +70,6 @@ bool RemoveOp(pir::Operation* op, pir::PatternRewriter* rewriter) {
     rewriter->EraseOp(op);
     return true;
   }
-
   return false;
 }
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
@@ -19,6 +19,7 @@
 #include "paddle/cinn/hlir/dialect/operator/transforms/refresh_combine_pattern.h"
 #include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/common/ddim.h"
+#include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
@@ -33,39 +34,39 @@
 namespace cinn {
 namespace dialect {
 namespace ir {
+using paddle::dialect::details::GetExprVecFromShape;
 
 bool RemoveOp(pir::Operation* op, pir::PatternRewriter* rewriter) {
+  const auto& IsDynamicShape = [](const pir::Value& value) -> bool {
+    return value.type().dyn_cast<pir::ShapedTypeInterface>().IsDynamicShape();
+  };
+  const auto& GetDims = [](const pir::Value& value) {
+    return value.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
+  };
+
+  pir::Value input = op->operand_source(0);
+  pir::Value output = op->result(0);
   const auto& IsSameShape = [&]() -> bool {
-    if (op->operand_source(0)
-            .type()
-            .dyn_cast<pir::ShapedTypeInterface>()
-            .IsDynamicShape() ||
-        op->result(0)
-            .type()
-            .dyn_cast<pir::ShapedTypeInterface>()
-            .IsDynamicShape()) {
-      pir::ShapeConstraintIRAnalysis& shape_analysis =
+    const bool has_dynamic_shape =
+        IsDynamicShape(input) || IsDynamicShape(output);
+    if (has_dynamic_shape) {
+      auto& shape_analysis =
           pir::ShapeAnalysisManager::Instance().Get(op->GetParentProgram());
-      if (shape_analysis.HasShapeOrDataForValue(op->operand_source(0)) &&
-          shape_analysis.HasShapeOrDataForValue(op->result(0))) {
-        return shape_analysis.GetShapeOrDataForValue(op->operand_source(0))
-                   .shape() ==
-               shape_analysis.GetShapeOrDataForValue(op->result(0)).shape();
+      if (shape_analysis.HasShapeOrDataForValue(input) &&
+          shape_analysis.HasShapeOrDataForValue(output)) {
+        auto input_sym_shape =
+            GetExprVecFromShape(shape_analysis.GetShapeOrDataForValue(input));
+        auto output_sym_shape =
+            GetExprVecFromShape(shape_analysis.GetShapeOrDataForValue(output));
+        return input_sym_shape == output_sym_shape;
       }
       return false;
     }
-
-    return (op->operand_source(0)
-                .type()
-                .dyn_cast<paddle::dialect::DenseTensorType>()
-                .dims()) == (op->result(0)
-                                 .type()
-                                 .dyn_cast<paddle::dialect::DenseTensorType>()
-                                 .dims());
+    return GetDims(input) == GetDims(output);
   };
 
   if (IsSameShape()) {
-    rewriter->ReplaceAllUsesWith(op->result(0), op->operand_source(0));
+    rewriter->ReplaceAllUsesWith(output, input);
     rewriter->EraseOp(op);
     return true;
   }

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
@@ -40,7 +40,7 @@ bool RemoveOp(pir::Operation* op, pir::PatternRewriter* rewriter) {
   const auto& IsDynamicShape = [](const pir::Value& value) -> bool {
     return value.type().dyn_cast<pir::ShapedTypeInterface>().IsDynamicShape();
   };
-  const auto& GetDims = [](const pir::Value& value) {
+  const auto& GetDims = [](const pir::Value& value) -> decltype(auto) {
     return value.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
   };
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/remove_unchanged_reshape_pass.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/cinn/hlir/dialect/operator/ir/cinn_op.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/op_with_group_merge_util.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/refresh_combine_pattern.h"
 #include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/common/ddim.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
@@ -114,6 +115,7 @@ class RemoveUnchangedReshapePass : public pir::PatternRewritePass {
     ps.Add<RemoveUnchangedReshapePattern<cinn::dialect::ReshapeOp>>(context);
     ps.Add<RemoveUnchangedReshapePattern<paddle::dialect::ReshapeOp>>(context);
     ps.Add<MergeReshapePattern>(context);
+    ps.Add<RefreshCombineOpPattern>(context);
 
     return ps;
   }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_utils.h
@@ -91,6 +91,25 @@ inline ExprVec GetExprVecFromData(const ShapeOrData &shapeordata) {
   }
 }
 
+inline ExprVec GetExprVecFromShape(const ShapeOrData &shapeordata) {
+  const auto GetShapeExprsFromList = [&]() {
+    ExprVec result;
+    TensorListExprs list =
+        shapeordata.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
+    for (size_t i = 0; i < list.size(); i++) {
+      for (auto expr : list[i].data().value()) {
+        result.emplace_back(expr);
+      }
+    }
+    return result;
+  };
+  if (shapeordata.isa<TensorListExprs>()) {
+    return GetShapeExprsFromList();
+  } else {
+    return shapeordata.shape();
+  }
+}
+
 std::optional<std::vector<int64_t>> VecExpr2Int64(const ExprVec &expr_vec);
 
 ExprVec VecInt642Expr(const std::vector<int64_t> &int_vec);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-67164 

修复了remove_unchanged_reshape_pass 在删除reshape op后可能导致后续 CombineOp的输入与输出Type不一致，故此处重建CombineOp自动矫正