### PR TITLE
[CINN] Fix bug of fuse shape ops to generate_shape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_shape_ops_into_generate_shape_op_pass.cc
@@ -26,6 +26,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/transforms/transform_general_functions.h"
 #include "paddle/pir/include/core/builtin_dialect.h"
 #include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
 #include "paddle/pir/include/dialect/shape/utils/shape_analysis.h"
@@ -57,8 +58,8 @@ std::vector<pir::Value> FindSourceDenseTensorOfDimTensor(
         // find input dimension tensor;
         pir::Operation* owner = value.defining_op();
         if (owner == nullptr) return;
-        for (int i = 0; i < owner->num_operands(); ++i) {
-          Visit(owner->operand_source(i));
+        for (auto input_value : pir::GetUsedExternalValue(*owner)) {
+          Visit(input_value);
         }
       };
   const auto& IsDimTensorOrListDimExpr = symbol::Overloaded{


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复 `generate_shape_op` 在处理输入Value的defining op为`GroupOp`等无operands参数算子时的逻辑Bug.