### PR TITLE
[DimExpr] Simplify `Neg<Neg<DimExpr>>` -> `DimExpr`

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/dim_expr_simplify.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_simplify.cc
@@ -82,9 +82,9 @@ struct SimplifyDoubleNeg {
   using dim_expr_type = Negative<DimExpr>;
 
   DimExpr Rewrite(const DimExpr& expr) {
-    const auto& [inner_expr] = *expr.Get<Negative<DimExpr>>();
+    const auto& inner_expr = expr.Get<Negative<DimExpr>>()->data;
     if (inner_expr.Has<Negative<DimExpr>>()) {
-      const auto& [ret_expr] = *inner_expr.Get<Negative<DimExpr>>();
+      const auto& ret_expr = inner_expr.Get<Negative<DimExpr>>()->data;
       return ret_expr;
     } else {
       return expr;

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_simplify.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_simplify.cc
@@ -89,7 +89,6 @@ struct SimplifyDoubleNeg {
     } else {
       return expr;
     }
-    LOG(FATAL) << "Dead code";
   }
 };
 

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -59,6 +59,15 @@ TEST(Simplify, UnitReciprocal) {
   ASSERT_EQ((simplified_dim_expr.Get<std::int64_t>()), 1);
 }
 
+TEST(Simplify, DoubleNegative) {
+  DimExpr inner_expr{Negative<DimExpr>(DimExpr{1})};
+  DimExpr expr{Negative<DimExpr>(inner_expr)};
+
+  DimExpr simplified_dim_expr = SimplifyDimExpr(expr);
+  ASSERT_TRUE((simplified_dim_expr.Has<std::int64_t>()));
+  ASSERT_EQ((simplified_dim_expr.Get<std::int64_t>()), 1);
+}
+
 TEST(Simplify, UnitNegative) {
   DimExpr unit{Negative<DimExpr>{DimExpr{0}}};
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[DimExpr] Simplify `Neg<Neg<DimExpr>>` -> `DimExpr`