### PR TITLE
[Prim] Use scale instead of mathematical operators for reducing launched kernel 

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -73,12 +73,13 @@ void silu_grad(const Tensor& x,
       auto x_cast = cast<T>(x, phi::DataType::FLOAT32);
       auto out_cast = cast<T>(out, phi::DataType::FLOAT32);
       auto out_grad_cast = cast<T>(out_grad, phi::DataType::FLOAT32);
-      auto sigmoid = 1.0 / (1.0 + exp<T>(-x_cast));
-      auto res = out_grad_cast * sigmoid * (1.0 + x_cast - out_cast);
+      auto sigmoid = 1.0 / scale<T>(exp<T>(scale<T>(x_cast, -1.0)), 1.0, 1.0);
+      auto res =
+          out_grad_cast * sigmoid * (scale<T>(x_cast - out_cast, 1.0, 1.0));
       set_output<T>(cast<T>(res, org_dtype), x_grad);
     } else {
-      auto sigmoid = 1.0 / (1.0 + exp<T>(-x));
-      auto res = out_grad * sigmoid * (1.0 + x - out);
+      auto sigmoid = 1.0 / scale<T>(exp<T>(scale<T>(x, -1.0)), 1.0, 1.0);
+      auto res = out_grad * sigmoid * scale<T>(x - out, 1.0, 1.0);
       set_output<T>(res, x_grad);
     }
   }
@@ -180,7 +181,7 @@ void gather_grad(const Tensor& x,
 template <typename T>
 void tanh_grad(const Tensor& out, const Tensor& grad_out, Tensor* grad_x) {
   if (!grad_x) return;
-  auto grad_x_tmp = grad_out * (1 - out * out);
+  auto grad_x_tmp = grad_out * scale<T>(out * out, -1.0, 1.0);
   set_output<T>(grad_x_tmp, grad_x);
 }
 
@@ -416,7 +417,7 @@ void elementwise_pow_grad(const Tensor& x,
   }  // indicate we will compute dy
   if (dx) {
     // dx = y * x^(y-1)
-    auto tmp_z = y - 1.0;
+    auto tmp_z = scale<T>(y, 1.0, -1.0);
     auto x_pow_z = elementwise_pow<T>(x, tmp_z);
     auto dx_res = y * x_pow_z * out_grad;
     if (y.dims() != x.dims()) {
@@ -611,7 +612,7 @@ void exp_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
 template <typename T>
 void sigmoid_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
-    set_output<T>(out_grad * (out * (1 - out)), x_grad);
+    set_output<T>(out_grad * (out * scale<T>(out, -1.0, 1.0)), x_grad);
   }
 }
 

--- a/test/cpp/prim/test_static_prim.cc
+++ b/test/cpp/prim/test_static_prim.cc
@@ -182,7 +182,7 @@ TEST(StaticPrim, TanhBackwardComposite) {
                                        target_block,
                                        grad_sub_block));
   ASSERT_EQ(target_block->AllOps().size(), static_cast<std::size_t>(1));
-  ASSERT_EQ(grad_ops.size(), static_cast<std::size_t>(4));
+  ASSERT_EQ(grad_ops.size(), static_cast<std::size_t>(3));
   ASSERT_EQ(target_block->AllOps()[0]->Type(), "tanh");
   ASSERT_EQ(target_block->AllOps()[0]->Inputs().at("X").size(),
             static_cast<std::size_t>(1));

--- a/test/cpp/prim/test_static_prim.cc
+++ b/test/cpp/prim/test_static_prim.cc
@@ -198,27 +198,19 @@ TEST(StaticPrim, TanhBackwardComposite) {
   ASSERT_EQ(grad_ops[0]->Inputs().at("Y")[0], "b");
   ASSERT_EQ(grad_ops[0]->Inputs().at("X")[0], "b");
 
-  ASSERT_EQ(grad_ops[1]->Type(), "fill_constant");
+  ASSERT_EQ(grad_ops[1]->Type(), "scale");
   ASSERT_EQ(PADDLE_GET_CONST(int, grad_ops[1]->GetAttr("dtype")),
             static_cast<int>(5));  // ProtoDataType::FP32
   ASSERT_EQ(grad_ops[1]->Outputs().at("Out").size(),
             static_cast<std::size_t>(1));
 
-  ASSERT_EQ(grad_ops[2]->Type(), "elementwise_sub");
+  ASSERT_EQ(grad_ops[2]->Type(), "elementwise_mul");
   ASSERT_EQ(grad_ops[2]->Inputs().at("X").size(), static_cast<std::size_t>(1));
   ASSERT_EQ(grad_ops[2]->Inputs().at("Y").size(), static_cast<std::size_t>(1));
-  ASSERT_EQ(grad_ops[2]->Inputs().at("X")[0],
+  ASSERT_EQ(grad_ops[2]->Inputs().at("Y")[0],
             grad_ops[1]->Outputs().at("Out")[0]);
+  ASSERT_EQ(grad_ops[2]->Inputs().at("X")[0], "b@GRAD");
   ASSERT_EQ(grad_ops[2]->Outputs().at("Out").size(),
-            static_cast<std::size_t>(1));
-
-  ASSERT_EQ(grad_ops[3]->Type(), "elementwise_mul");
-  ASSERT_EQ(grad_ops[3]->Inputs().at("X").size(), static_cast<std::size_t>(1));
-  ASSERT_EQ(grad_ops[3]->Inputs().at("Y").size(), static_cast<std::size_t>(1));
-  ASSERT_EQ(grad_ops[3]->Inputs().at("Y")[0],
-            grad_ops[2]->Outputs().at("Out")[0]);
-  ASSERT_EQ(grad_ops[3]->Inputs().at("X")[0], "b@GRAD");
-  ASSERT_EQ(grad_ops[3]->Outputs().at("Out").size(),
             static_cast<std::size_t>(1));
 }
 

--- a/test/prim/test_comp_get_grad_op_desc_prim_enabled.py
+++ b/test/prim/test_comp_get_grad_op_desc_prim_enabled.py
@@ -43,8 +43,7 @@ from paddle.base import core, framework
             (),
             (
                 'elementwise_mul',
-                'fill_constant',
-                'elementwise_sub',
+                'scale',
                 'elementwise_mul',
             ),
         ),

--- a/test/prim/test_comp_skip_op_set.py
+++ b/test/prim/test_comp_skip_op_set.py
@@ -29,8 +29,7 @@ class TestGetGradOpDescPrimEnabled(unittest.TestCase):
         self.desired_ops = 'tanh_grad'
         self.desired_ops_no_skip = (
             'elementwise_mul',
-            'fill_constant',
-            'elementwise_sub',
+            'scale',
             'elementwise_mul',
         )
         paddle.enable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->

Pcard-75624

Use `scale` instead of combination of operator `*` and `+` when meeting $\alpha \times Tensor + \beta$, so that `full_like` kernel launching can be reduced during computation.