### PR TITLE
[DistDialect] Add static dist program adaptation logic

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -105,11 +105,14 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
     // }
     for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.operand_dist_attr(i);
-      os << ",operand(" + std::to_string(i) + "):{mesh_shape:[" +
-                phi::distributed::auto_parallel::str_join(
-                    dist_attr.process_mesh_attr().shape()) +
-                "]";
-      os << ",dims_maping:[" +
+      os << ",operand(" + std::to_string(i) + "):{";
+      if (dist_attr.process_mesh_attr() != op_dist_attr.process_mesh_attr()) {
+        os << "mesh_shape:[" +
+                  phi::distributed::auto_parallel::str_join(
+                      dist_attr.process_mesh_attr().shape()) +
+                  "],";
+      }
+      os << "dims_maping:[" +
                 phi::distributed::auto_parallel::str_join(
                     dist_attr.dims_mapping()) +
                 "]";
@@ -138,11 +141,14 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
     // }
     for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.result_dist_attr(i);
-      os << ",result(" + std::to_string(i) + "):{mesh_shape:[" +
-                phi::distributed::auto_parallel::str_join(
-                    dist_attr.process_mesh_attr().shape()) +
-                "]";
-      os << ",dims_maping:[" +
+      os << ",result(" + std::to_string(i) + "):{";
+      if (dist_attr.process_mesh_attr() != op_dist_attr.process_mesh_attr()) {
+        os << "mesh_shape:[" +
+                  phi::distributed::auto_parallel::str_join(
+                      dist_attr.process_mesh_attr().shape()) +
+                  "],";
+      }
+      os << "dims_maping:[" +
                 phi::distributed::auto_parallel::str_join(
                     dist_attr.dims_mapping()) +
                 "]";

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -80,6 +80,10 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
       os << ", "
          << phi::distributed::auto_parallel::str_join(partial_status_strs);
     }
+  } else if (auto op_dist_attr = attr.dyn_cast<OperationDistAttribute>()) {
+    os << "mesh: " << op_dist_attr.process_mesh_attr().process_mesh();
+    os << ", num_operand_dist_attrs: " << op_dist_attr.num_operand_dist_attrs();
+    os << ", num_result_dist_attrs: " << op_dist_attr.num_result_dist_attrs();
   } else {
     os << "error_attribute_type";
   }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -100,9 +100,6 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
                   op_dist_attr.process_mesh_attr().process_ids()) +
               "]";
     auto num_operand_dist_attrs = op_dist_attr.num_operand_dist_attrs();
-    // if (num_operand_dist_attrs > 0) {
-    //   os << ",operands_dist_attrs:{";
-    // }
     for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.operand_dist_attr(i);
       os << ",operand(" + std::to_string(i) + "):{";
@@ -132,13 +129,7 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
         os << "}";
       }
     }
-    // if (num_operand_dist_attrs > 0) {
-    //   os << "}";
-    // }
     auto num_result_dist_attrs = op_dist_attr.num_result_dist_attrs();
-    // if (num_result_dist_attrs > 0) {
-    //   os << ",result_dist_attrs:{";
-    // }
     for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.result_dist_attr(i);
       os << ",result(" + std::to_string(i) + "):{";
@@ -168,9 +159,6 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
         os << "}";
       }
     }
-    // if (num_result_dist_attrs > 0) {
-    //   os << "}";
-    // }
   } else {
     os << "error_attribute_type";
   }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -82,8 +82,58 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
     }
   } else if (auto op_dist_attr = attr.dyn_cast<OperationDistAttribute>()) {
     os << "mesh: " << op_dist_attr.process_mesh_attr().process_mesh();
-    os << ", num_operand_dist_attrs: " << op_dist_attr.num_operand_dist_attrs();
-    os << ", num_result_dist_attrs: " << op_dist_attr.num_result_dist_attrs();
+    auto num_operand_dist_attrs = op_dist_attr.num_operand_dist_attrs();
+    for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
+      auto dist_attr = op_dist_attr.operand_dist_attr(i);
+      os << "{operand(" << i << ") mesh shape: ["
+         << phi::distributed::auto_parallel::str_join(
+                dist_attr.process_mesh_attr().shape())
+         << "]";
+      os << ", dims_maping: [" +
+                phi::distributed::auto_parallel::str_join(
+                    tensor_dist_attr.dims_mapping()) +
+                "]";
+      if (tensor_dist_attr.partial_status().size() > 0) {
+        std::vector<std::string> partial_status_strs;
+        for (auto &itr : tensor_dist_attr.partial_status()) {
+          std::string s = "partial(" + std::to_string(itr.first) + "," +
+                          phi::ReduceTypeStrings[static_cast<int>(itr.second)] +
+                          ")";
+          partial_status_strs.emplace_back(s);
+        }
+        os << ", "
+           << phi::distributed::auto_parallel::str_join(partial_status_strs)
+           << "}";
+      } else {
+        os << "}";
+      }
+    }
+    auto num_result_dist_attrs = op_dist_attr.num_result_dist_attrs();
+    for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
+      auto dist_attr = op_dist_attr.result_dist_attr(i);
+      os << ", {result(" << i << ") mesh shape: ["
+         << phi::distributed::auto_parallel::str_join(
+                dist_attr.process_mesh_attr().shape())
+         << "]";
+      os << ", dims_maping: [" +
+                phi::distributed::auto_parallel::str_join(
+                    tensor_dist_attr.dims_mapping()) +
+                "]";
+      if (tensor_dist_attr.partial_status().size() > 0) {
+        std::vector<std::string> partial_status_strs;
+        for (auto &itr : tensor_dist_attr.partial_status()) {
+          std::string s = "partial(" + std::to_string(itr.first) + "," +
+                          phi::ReduceTypeStrings[static_cast<int>(itr.second)] +
+                          ")";
+          partial_status_strs.emplace_back(s);
+        }
+        os << ", "
+           << phi::distributed::auto_parallel::str_join(partial_status_strs)
+           << "}";
+      } else {
+        os << "}";
+      }
+    }
   } else {
     os << "error_attribute_type";
   }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -81,21 +81,24 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
          << phi::distributed::auto_parallel::str_join(partial_status_strs);
     }
   } else if (auto op_dist_attr = attr.dyn_cast<OperationDistAttribute>()) {
-    os << "mesh: " << op_dist_attr.process_mesh_attr().process_mesh();
+    os << " {mesh: " << op_dist_attr.process_mesh_attr().process_mesh();
     auto num_operand_dist_attrs = op_dist_attr.num_operand_dist_attrs();
+    if (num_operand_dist_attrs > 0) {
+      os << ", operands_dist_attrs: {";
+    }
     for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.operand_dist_attr(i);
-      os << "{operand(" << i << ") mesh shape: ["
+      os << "operand(" << i << "): {mesh shape: ["
          << phi::distributed::auto_parallel::str_join(
                 dist_attr.process_mesh_attr().shape())
          << "]";
       os << ", dims_maping: [" +
                 phi::distributed::auto_parallel::str_join(
-                    tensor_dist_attr.dims_mapping()) +
+                    dist_attr.dims_mapping()) +
                 "]";
-      if (tensor_dist_attr.partial_status().size() > 0) {
+      if (dist_attr.partial_status().size() > 0) {
         std::vector<std::string> partial_status_strs;
-        for (auto &itr : tensor_dist_attr.partial_status()) {
+        for (auto &itr : dist_attr.partial_status()) {
           std::string s = "partial(" + std::to_string(itr.first) + "," +
                           phi::ReduceTypeStrings[static_cast<int>(itr.second)] +
                           ")";
@@ -108,20 +111,26 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
         os << "}";
       }
     }
+    if (num_operand_dist_attrs > 0) {
+      os << "}";
+    }
     auto num_result_dist_attrs = op_dist_attr.num_result_dist_attrs();
+    if (num_result_dist_attrs > 0) {
+      os << ", result_dist_attrs: {";
+    }
     for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.result_dist_attr(i);
-      os << ", {result(" << i << ") mesh shape: ["
+      os << "result(" << i << "): {mesh shape: ["
          << phi::distributed::auto_parallel::str_join(
                 dist_attr.process_mesh_attr().shape())
          << "]";
       os << ", dims_maping: [" +
                 phi::distributed::auto_parallel::str_join(
-                    tensor_dist_attr.dims_mapping()) +
+                    dist_attr.dims_mapping()) +
                 "]";
-      if (tensor_dist_attr.partial_status().size() > 0) {
+      if (dist_attr.partial_status().size() > 0) {
         std::vector<std::string> partial_status_strs;
-        for (auto &itr : tensor_dist_attr.partial_status()) {
+        for (auto &itr : dist_attr.partial_status()) {
           std::string s = "partial(" + std::to_string(itr.first) + "," +
                           phi::ReduceTypeStrings[static_cast<int>(itr.second)] +
                           ")";
@@ -133,6 +142,9 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
       } else {
         os << "}";
       }
+    }
+    if (num_result_dist_attrs > 0) {
+      os << "}";
     }
   } else {
     os << "error_attribute_type";

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -61,11 +61,21 @@ void DistDialect::PrintType(pir::Type type, std::ostream &os) const {
 
 void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
   if (auto process_mesh_attr = attr.dyn_cast<ProcessMeshAttribute>()) {
-    os << "mesh: " << process_mesh_attr.process_mesh();
+    os << "mesh_shape:[" +
+              phi::distributed::auto_parallel::str_join(
+                  process_mesh_attr.shape()) +
+              "]";
+    os << ",process_ids:[" +
+              phi::distributed::auto_parallel::str_join(
+                  process_mesh_attr.process_ids()) +
+              "]";
   } else if (auto tensor_dist_attr = attr.dyn_cast<TensorDistAttribute>()) {
     // Todo: Design the tensor dist attr print format.
-    os << "mesh: " << tensor_dist_attr.process_mesh_attr().process_mesh();
-    os << ", dims_mappings: [" +
+    os << "mesh_shape:[" +
+              phi::distributed::auto_parallel::str_join(
+                  tensor_dist_attr.process_mesh_attr().shape()) +
+              "]";
+    os << ",dims_mappings:[" +
               phi::distributed::auto_parallel::str_join(
                   tensor_dist_attr.dims_mapping()) +
               "]";
@@ -81,18 +91,25 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
          << phi::distributed::auto_parallel::str_join(partial_status_strs);
     }
   } else if (auto op_dist_attr = attr.dyn_cast<OperationDistAttribute>()) {
-    os << " {mesh: " << op_dist_attr.process_mesh_attr().process_mesh();
+    os << "mesh_shape:[" +
+              phi::distributed::auto_parallel::str_join(
+                  op_dist_attr.process_mesh_attr().shape()) +
+              "]";
+    os << ",process_ids:[" +
+              phi::distributed::auto_parallel::str_join(
+                  op_dist_attr.process_mesh_attr().process_ids()) +
+              "]";
     auto num_operand_dist_attrs = op_dist_attr.num_operand_dist_attrs();
-    if (num_operand_dist_attrs > 0) {
-      os << ", operands_dist_attrs: {";
-    }
+    // if (num_operand_dist_attrs > 0) {
+    //   os << ",operands_dist_attrs:{";
+    // }
     for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.operand_dist_attr(i);
-      os << "operand(" << i << "): {mesh shape: ["
-         << phi::distributed::auto_parallel::str_join(
-                dist_attr.process_mesh_attr().shape())
-         << "]";
-      os << ", dims_maping: [" +
+      os << ",operand(" + std::to_string(i) + "):{mesh_shape:[" +
+                phi::distributed::auto_parallel::str_join(
+                    dist_attr.process_mesh_attr().shape()) +
+                "]";
+      os << ",dims_maping:[" +
                 phi::distributed::auto_parallel::str_join(
                     dist_attr.dims_mapping()) +
                 "]";
@@ -104,27 +121,28 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
                           ")";
           partial_status_strs.emplace_back(s);
         }
-        os << ", "
-           << phi::distributed::auto_parallel::str_join(partial_status_strs)
-           << "}";
+        os << "," +
+                  phi::distributed::auto_parallel::str_join(
+                      partial_status_strs) +
+                  "}";
       } else {
         os << "}";
       }
     }
-    if (num_operand_dist_attrs > 0) {
-      os << "}";
-    }
+    // if (num_operand_dist_attrs > 0) {
+    //   os << "}";
+    // }
     auto num_result_dist_attrs = op_dist_attr.num_result_dist_attrs();
-    if (num_result_dist_attrs > 0) {
-      os << ", result_dist_attrs: {";
-    }
+    // if (num_result_dist_attrs > 0) {
+    //   os << ",result_dist_attrs:{";
+    // }
     for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.result_dist_attr(i);
-      os << "result(" << i << "): {mesh shape: ["
-         << phi::distributed::auto_parallel::str_join(
-                dist_attr.process_mesh_attr().shape())
-         << "]";
-      os << ", dims_maping: [" +
+      os << ",result(" + std::to_string(i) + "):{mesh_shape:[" +
+                phi::distributed::auto_parallel::str_join(
+                    dist_attr.process_mesh_attr().shape()) +
+                "]";
+      os << ",dims_maping:[" +
                 phi::distributed::auto_parallel::str_join(
                     dist_attr.dims_mapping()) +
                 "]";
@@ -136,16 +154,17 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
                           ")";
           partial_status_strs.emplace_back(s);
         }
-        os << ", "
-           << phi::distributed::auto_parallel::str_join(partial_status_strs)
-           << "}";
+        os << "," +
+                  phi::distributed::auto_parallel::str_join(
+                      partial_status_strs) +
+                  "}";
       } else {
         os << "}";
       }
     }
-    if (num_result_dist_attrs > 0) {
-      os << "}";
-    }
+    // if (num_result_dist_attrs > 0) {
+    //   os << "}";
+    // }
   } else {
     os << "error_attribute_type";
   }

--- a/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.cc
@@ -80,7 +80,7 @@ void ProcessBlock(pir::Block* block) {
       shard_result_value.ReplaceAllUsesWith(shard_operand_value);
       VLOG(0) << "here5";
       // OperationDistAttribute op_dist_attr =
-      //     op_item->attribute(kAttrOpDistAttrs)
+      //     op_item->attribute(kAttrOpDistAttr)
       //         .dyn_cast<OperationDistAttribute>();
       // VLOG(0) << "here6";
       // VLOG(0) << "here6.1";
@@ -92,7 +92,7 @@ void ProcessBlock(pir::Block* block) {
       //                                 op_dist_attr.result_dist_attrs());
       VLOG(0) << "here7";
       shard_operand_define_op->set_attribute(
-          kAttrOpDistAttrs, op_item->attribute(kAttrOpDistAttrs));
+          kAttrOpDistAttr, op_item->attribute(kAttrOpDistAttr));
       VLOG(0) << "here8";
       deleted_ops.push_back(op_item);
     }
@@ -120,7 +120,7 @@ void VerifyBlock(pir::Block* block) {
                       phi::errors::PreconditionNotMet(
                           "Block still contain shard_tensor_op."));
 
-    if (op_item && !op_item->HasAttribute(kAttrOpDistAttrs)) {
+    if (op_item && !op_item->HasAttribute(kAttrOpDistAttr)) {
       PADDLE_THROW(platform::errors::PreconditionNotMet(
           "The op [%s] does not hase OperatorDistAttr after Mix2Dist Pass.",
           op_item->name()));

--- a/paddle/fluid/pir/dialect/op_generator/op_infermeta_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_infermeta_gen.py
@@ -667,7 +667,7 @@ def GenDistBranch(args, op_info):
 """
             dist_branch_str += TEMPLATE.format(idx=idx, name=output_name)
     TEMPLATE = """
-    attributes[kAttrOpDistAttrs] = OperationDistAttribute::get(
+    attributes[kAttrOpDistAttr] = OperationDistAttribute::get(
         pir::IrContext::Instance(),
         op_mesh,
         operand_dist_attrs,

--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -37,10 +37,10 @@ void BindOperationDistAttribute(py::module *m) {
              print_stream << self;
              return print_stream.str();
            })
-      .def("process_mesh",
-           [](OperationDistAttribute &self) {
-             return self.process_mesh_attr().process_mesh();
-           })
+      .def_property_readonly("process_mesh",
+                             [](OperationDistAttribute &self) {
+                               return self.process_mesh_attr().process_mesh();
+                             })
       .def("num_operand_dist_attrs",
            &OperationDistAttribute::num_operand_dist_attrs)
       .def("operand_dist_attrs", &OperationDistAttribute::operand_dist_attrs)
@@ -60,13 +60,19 @@ void BindTensorDistAttribute(py::module *m) {
              print_stream << self;
              return print_stream.str();
            })
-      .def("process_mesh",
-           [](TensorDistAttribute &self) {
-             return self.process_mesh_attr().process_mesh();
-           })
-      .def("dims_mapping", &TensorDistAttribute::dims_mapping)
-      .def("partial_status", &TensorDistAttribute::partial_status)
-      .def("partial_dims", &TensorDistAttribute::partial_dims);
+      .def_property_readonly("process_mesh",
+                             [](TensorDistAttribute &self) {
+                               return self.process_mesh_attr().process_mesh();
+                             })
+      .def_property_readonly(
+          "dims_mapping",
+          [](TensorDistAttribute &self) { return self.dims_mapping(); })
+      .def_property_readonly(
+          "partial_status",
+          [](TensorDistAttribute &self) { return self.partial_status(); })
+      .def_property_readonly("partial_dims", [](TensorDistAttribute &self) {
+        return self.partial_dims();
+      });
 }
 
 void BindDistOpsAPI(pybind11::module *module) {

--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -55,7 +55,7 @@ void BindTensorDistAttribute(py::module *m) {
   py::class_<TensorDistAttribute> dist_attr(*m, "TensorDistAttribute");
   dist_attr
       .def("__str__",
-           [](OperationDistAttribute &self) {
+           [](TensorDistAttribute &self) {
              std::ostringstream print_stream;
              print_stream << self;
              return print_stream.str();

--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -15,14 +15,59 @@
 #include <Python.h>
 #include "pybind11/stl.h"
 
+#include "paddle/fluid/pir/dialect/distributed/ir/dist_attribute.h"
 #include "paddle/fluid/pybind/dist_api.h"
 #include "paddle/fluid/pybind/dist_static_op_function.h"
 #include "paddle/phi/core/enforce.h"
 
 namespace py = pybind11;
 
+using paddle::dialect::OperationDistAttribute;
+using paddle::dialect::TensorDistAttribute;
+
 namespace paddle {
 namespace pybind {
+
+void BindOperationDistAttribute(py::module *m) {
+  py::class_<OperationDistAttribute> dist_attr(*m, "OperationDistAttribute");
+  dist_attr
+      .def("__str__",
+           [](OperationDistAttribute &self) {
+             std::ostringstream print_stream;
+             print_stream << self;
+             return print_stream.str();
+           })
+      .def("process_mesh",
+           [](OperationDistAttribute &self) {
+             return self.process_mesh_attr().process_mesh();
+           })
+      .def("num_operand_dist_attrs",
+           &OperationDistAttribute::num_operand_dist_attrs)
+      .def("operand_dist_attrs", &OperationDistAttribute::operand_dist_attrs)
+      .def("operand_dist_attr", &OperationDistAttribute::operand_dist_attr)
+      .def("num_result_dist_attrs",
+           &OperationDistAttribute::num_result_dist_attrs)
+      .def("result_dist_attrs", &OperationDistAttribute::result_dist_attrs)
+      .def("result_dist_attr", &OperationDistAttribute::result_dist_attr);
+}
+
+void BindTensorDistAttribute(py::module *m) {
+  py::class_<TensorDistAttribute> dist_attr(*m, "TensorDistAttribute");
+  dist_attr
+      .def("__str__",
+           [](OperationDistAttribute &self) {
+             std::ostringstream print_stream;
+             print_stream << self;
+             return print_stream.str();
+           })
+      .def("process_mesh",
+           [](TensorDistAttribute &self) {
+             return self.process_mesh_attr().process_mesh();
+           })
+      .def("dims_mapping", &TensorDistAttribute::dims_mapping)
+      .def("partial_status", &TensorDistAttribute::partial_status)
+      .def("partial_dims", &TensorDistAttribute::partial_dims);
+}
 
 void BindDistOpsAPI(pybind11::module *module) {
   {
@@ -37,6 +82,8 @@ void BindDistOpsAPI(pybind11::module *module) {
 
 void BindDistApi(pybind11::module *module) {
   auto ir_module = module->def_submodule("pir");
+  BindOperationDistAttribute(&ir_module);
+  BindTensorDistAttribute(&ir_module);
   auto ops_modules = ir_module.def_submodule("ops");
   BindDistOpsAPI(&ops_modules);
 }

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -697,17 +697,15 @@ void BindOperation(py::module *m) {
                     OpCreationCallstackAttrName(),
                 pir::ArrayAttribute::get(pir::IrContext::Instance(),
                                          op_callstack_infos));
-          });
-#ifdef PADDLE_WITH_DISTRIBUTE
-  op.def("dist_attr", [](Operation &self) {
-    if (self.HasAttribute(kAttrOpDistAttr)) {
-      return self.attribute<OperationDistAttribute>(kAttrOpDistAttr);
-    } else {
-      PADDLE_THROW(
-          phi::errors::InvalidArgument("dist_attr is only for dist op."));
-    }
-  });
-#endif
+          })
+      .def("dist_attr", [](Operation &self) {
+        if (self.HasAttribute(kAttrOpDistAttr)) {
+          return self.attribute<OperationDistAttribute>(kAttrOpDistAttr);
+        } else {
+          PADDLE_THROW(
+              phi::errors::InvalidArgument("dist_attr is only for dist op."));
+        }
+      });
   py::class_<Operation::BlockContainer> block_container(
       *m, "Operation_BlockContainer", R"DOC(
     The Operation_BlockContainer only use to walk all blocks in the operation.
@@ -974,16 +972,14 @@ void BindValue(py::module *m) {
                  BoolAttribute::get(pir::IrContext::Instance(), true));
              return out;
            })
-      .def("__repr__", &Value2String);
-#ifdef PADDLE_WITH_DISTRIBUTE
-  value.def("dist_attr", [](Value &self) {
-    if (!self.type().isa<DistDenseTensorType>()) {
-      PADDLE_THROW(phi::errors::InvalidArgument(
-          "_local_shape is only for distdense tensor."));
-    }
-    return self.type().dyn_cast<DistDenseTensorType>().tensor_dist_attr();
-  });
-#endif
+      .def("__repr__", &Value2String)
+      .def("dist_attr", [](Value &self) {
+        if (!self.type().isa<DistDenseTensorType>()) {
+          PADDLE_THROW(phi::errors::InvalidArgument(
+              "_local_shape is only for distdense tensor."));
+        }
+        return self.type().dyn_cast<DistDenseTensorType>().tensor_dist_attr();
+      });
 }
 
 void BindOpOperand(py::module *m) {

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -976,7 +976,7 @@ void BindValue(py::module *m) {
       .def("dist_attr", [](Value &self) {
         if (!self.type().isa<DistDenseTensorType>()) {
           PADDLE_THROW(phi::errors::InvalidArgument(
-              "_local_shape is only for distdense tensor."));
+              "dist_attr is only for distdense tensor."));
         }
         return self.type().dyn_cast<DistDenseTensorType>().tensor_dist_attr();
       });

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -97,6 +97,10 @@
 #include "paddle/fluid/pir/transforms/onednn/batch_norm_act_fuse_pass.h"
 #endif
 
+#ifdef PADDLE_WITH_DISTRIBUTE
+#include "paddle/fluid/pybind/dist_static_op_function.h"
+#endif
+
 namespace py = pybind11;
 using paddle::dialect::ApiBuilder;
 using paddle::dialect::DenseTensorArrayType;
@@ -1828,6 +1832,19 @@ void BindPassManager(pybind11::module *m) {
            [](PassManager &self) { self.EnableIRPrinting(); });
 }
 
+#ifdef PADDLE_WITH_DISTRIBUTE
+void BindDistOpsAPI(pybind11::module *module) {
+  {
+    if (PyModule_AddFunctions(module->ptr(), DistOpsAPI) < 0) {
+      {
+        PADDLE_THROW(
+            phi::errors::Fatal("Add C++ DistOpsAPI to core.ops failed!"));
+      }
+    }
+  }
+}
+#endif
+
 void BindPir(pybind11::module *module) {
   auto ir_module = module->def_submodule("pir");
   BindProgram(&ir_module);
@@ -1846,6 +1863,9 @@ void BindPir(pybind11::module *module) {
   BindControlFlowApi(&ir_module);
   auto ops_modules = ir_module.def_submodule("ops");
   BindOpsAPI(&ops_modules);
+#ifdef PADDLE_WITH_DISTRIBUTE
+  BindDistOpsAPI(&ops_modules);
+#endif
   BindIrParser(&ir_module);
 }
 

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -535,7 +535,8 @@ void BindOperation(py::module *m) {
                // SymbolAttribute is only used in PIR, no need to pass to Python
                if (pair.second.isa<pir::shape::SymbolAttribute>()) continue;
                if (pair.first == kAttrOpDistAttr) {
-                 attrs_dict[pair.first.c_str()] = pair.second;
+                 attrs_dict[pair.first.c_str()] =
+                     pair.second.dyn_cast<OperationDistAttribute>();
                } else {
                  attrs_dict[pair.first.c_str()] =
                      paddle::dialect::GetAttributeData(pair.second);

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1055,31 +1055,6 @@ void BindAttribute(py::module *m) {
     print_stream << self;
     return print_stream.str();
   });
-#ifdef PADDLE_WITH_DISTRIBUTE
-  ir_attr
-      .def_property_readonly(
-          "process_mesh",
-          [](Attribute &self) {
-            if (self.isa<TensorDistAttribute>()) {
-              return self.dyn_cast<TensorDistAttribute>()
-                  .process_mesh_attr()
-                  .process_mesh();
-            } else {
-              PADDLE_THROW(phi::errors::InvalidArgument(
-                  "process_mesh is only for OperationDistAttribute and "
-                  "TensorDistAttribute."));
-            }
-          })
-      .def_property_readonly("dims_mapping", [](Attribute &self) {
-        if (self.isa<TensorDistAttribute>()) {
-          return self.dyn_cast<TensorDistAttribute>().dims_mapping();
-        } else {
-          PADDLE_THROW(phi::errors::InvalidArgument(
-              "process_mesh is only for OperationDistAttribute and "
-              "TensorDistAttribute."));
-        }
-      });
-#endif
 }
 
 struct PyInsertionPoint {

--- a/paddle/pir/include/core/attribute.h
+++ b/paddle/pir/include/core/attribute.h
@@ -20,7 +20,7 @@
 
 constexpr char kAttrStopGradients[] = "stop_gradient";
 constexpr char kAttrIsPersistable[] = "is_persistable";
-constexpr char kAttrOpDistAttrs[] = "op_dist_attrs";
+constexpr char kAttrOpDistAttr[] = "op_dist_attr";
 
 namespace pir {
 class AttributeStorage;

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -4,4 +4,6 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
                        PROPERTIES ENVIRONMENT "FLAGS_enable_pir_api=1")
   py_test_modules(test_ir_dist_attr MODULES test_ir_dist_attr ENVS
                   FLAGS_enable_pir_api=1)
+  py_test_modules(test_static_pir_program MODULES test_static_pir_program)
+>>>>>>> mv test_ir_dist_attr.py to auto_parallel dir
 endif()

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -5,5 +5,4 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
   py_test_modules(test_ir_dist_attr MODULES test_ir_dist_attr ENVS
                   FLAGS_enable_pir_api=1)
   py_test_modules(test_static_pir_program MODULES test_static_pir_program)
->>>>>>> mv test_ir_dist_attr.py to auto_parallel dir
 endif()

--- a/test/auto_parallel/pir/test_ir_dist_attr.py
+++ b/test/auto_parallel/pir/test_ir_dist_attr.py
@@ -109,13 +109,16 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(
             dist_out._local_shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
         )
-        self.assertTrue(dist_out.dims_mapping == [-1, -1, -1])
+        self.assertTrue(dist_out.dist_attr().dims_mapping == [-1, -1, -1])
         self.assertTrue(
-            isinstance(dist_out.process_mesh, paddle.base.libpaddle.ProcessMesh)
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
         )
-        self.assertTrue(dist_out.process_mesh.shape == [2])
-        self.assertTrue(dist_out.process_mesh.process_ids == [0, 1])
-        self.assertTrue(len(dist_out.partial_dims) == 0)
+        self.assertTrue(dist_out.dist_attr().process_mesh.shape == [2])
+        self.assertTrue(dist_out.dist_attr().process_mesh.process_ids == [0, 1])
+        self.assertTrue(len(dist_out.dist_attr().partial_dims) == 0)
 
     def test_build_col_parallel_program(self):
         with paddle.pir_utils.IrGuard():
@@ -151,18 +154,20 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(dist_w0.dist_attr().dims_mapping == [-1, 0])
         # matmul out
         self.assertTrue(dist_out.shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE])
-        print(f'--dist_out: {dist_out.is_dist_dense_tensor_type()}')
         self.assertTrue(
             dist_out._local_shape
             == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE // MP_SIZE]
         )
-        self.assertTrue(dist_out.dims_mapping == [-1, -1, 0])
+        self.assertTrue(dist_out.dist_attr().dims_mapping == [-1, -1, 0])
         self.assertTrue(
-            isinstance(dist_out.process_mesh, paddle.base.libpaddle.ProcessMesh)
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
         )
-        self.assertTrue(dist_out.process_mesh.shape == [2])
-        self.assertTrue(dist_out.process_mesh.process_ids == [0, 1])
-        self.assertTrue(len(dist_out.partial_dims) == 0)
+        self.assertTrue(dist_out.dist_attr().process_mesh.shape == [2])
+        self.assertTrue(dist_out.dist_attr().process_mesh.process_ids == [0, 1])
+        self.assertTrue(len(dist_out.dist_attr().partial_dims) == 0)
 
     def test_build_row_parallel_program(self):
         with paddle.pir_utils.IrGuard():
@@ -205,13 +210,16 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(
             dist_out._local_shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
         )
-        self.assertTrue(dist_out.dims_mapping == [-1, -1, -1])
+        self.assertTrue(dist_out.dist_attr().dims_mapping == [-1, -1, -1])
         self.assertTrue(
-            isinstance(dist_out.process_mesh, paddle.base.libpaddle.ProcessMesh)
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
         )
-        self.assertTrue(dist_out.process_mesh.shape == [2])
-        self.assertTrue(dist_out.process_mesh.process_ids == [0, 1])
-        self.assertTrue(dist_out.partial_dims == {0})
+        self.assertTrue(dist_out.dist_attr().process_mesh.shape == [2])
+        self.assertTrue(dist_out.dist_attr().process_mesh.process_ids == [0, 1])
+        self.assertTrue(dist_out.dist_attr().partial_dims == {0})
 
     def test_build_with_shard_tensor(self):
         with paddle.pir_utils.IrGuard():

--- a/test/auto_parallel/pir/test_ir_dist_attr.py
+++ b/test/auto_parallel/pir/test_ir_dist_attr.py
@@ -46,11 +46,9 @@ class TestBuildFakeProgram(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     tmp = input._local_shape
                 with self.assertRaises(ValueError):
-                    tmp = input.dist_attr().dims_mapping
+                    tmp = input.dist_attr()
                 with self.assertRaises(ValueError):
-                    tmp = w0.dist_attr().process_mesh
-                with self.assertRaises(ValueError):
-                    tmp = w0.dist_attr().partial_dims
+                    tmp = w0.dist_attr()
 
                 dist_input = dtensor_from_local(input, mesh, [dist.Replicate()])
                 dist_w0 = dtensor_from_local(w0, mesh, [dist.Replicate()])

--- a/test/auto_parallel/pir/test_ir_dist_attr.py
+++ b/test/auto_parallel/pir/test_ir_dist_attr.py
@@ -151,6 +151,7 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(dist_w0.dist_attr().dims_mapping == [-1, 0])
         # matmul out
         self.assertTrue(dist_out.shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE])
+        print(f'--dist_out: {dist_out.is_dist_dense_tensor_type()}')
         self.assertTrue(
             dist_out._local_shape
             == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE // MP_SIZE]

--- a/test/auto_parallel/pir/test_ir_dist_attr.py
+++ b/test/auto_parallel/pir/test_ir_dist_attr.py
@@ -46,11 +46,11 @@ class TestBuildFakeProgram(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     tmp = input._local_shape
                 with self.assertRaises(ValueError):
-                    tmp = input.dims_mapping
+                    tmp = input.dist_attr().dims_mapping
                 with self.assertRaises(ValueError):
-                    tmp = w0.process_mesh
+                    tmp = w0.dist_attr().process_mesh
                 with self.assertRaises(ValueError):
-                    tmp = w0.partial_dims
+                    tmp = w0.dist_attr().partial_dims
 
                 dist_input = dtensor_from_local(input, mesh, [dist.Replicate()])
                 dist_w0 = dtensor_from_local(w0, mesh, [dist.Replicate()])
@@ -83,22 +83,28 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(w0.shape == [HIDDEN_SIZE, HIDDEN_SIZE])
         self.assertTrue(dist_input.shape == dist_input._local_shape)
         self.assertTrue(w0.shape == w0._local_shape)
-        self.assertTrue(dist_input.dims_mapping == [-1, -1, -1])
+        self.assertTrue(dist_input.dist_attr().dims_mapping == [-1, -1, -1])
         self.assertTrue(
             isinstance(
-                dist_input.process_mesh, paddle.base.libpaddle.ProcessMesh
+                dist_input.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
             )
         )
-        self.assertTrue(dist_input.process_mesh.shape == [2])
-        self.assertTrue(dist_input.process_mesh.process_ids == [0, 1])
-        self.assertTrue(len(dist_input.partial_dims) == 0)
-        self.assertTrue(dist_w0.dims_mapping == [-1, -1])
+        self.assertTrue(dist_input.dist_attr().process_mesh.shape == [2])
         self.assertTrue(
-            isinstance(dist_w0.process_mesh, paddle.base.libpaddle.ProcessMesh)
+            dist_input.dist_attr().process_mesh.process_ids == [0, 1]
         )
-        self.assertTrue(dist_w0.process_mesh.shape == [2])
-        self.assertTrue(dist_w0.process_mesh.process_ids == [0, 1])
-        self.assertTrue(len(dist_w0.partial_dims) == 0)
+        self.assertTrue(len(dist_input.dist_attr().partial_dims) == 0)
+        self.assertTrue(dist_w0.dist_attr().dims_mapping == [-1, -1])
+        self.assertTrue(
+            isinstance(
+                dist_w0.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertTrue(dist_w0.dist_attr().process_mesh.shape == [2])
+        self.assertTrue(dist_w0.dist_attr().process_mesh.process_ids == [0, 1])
+        self.assertTrue(len(dist_w0.dist_attr().partial_dims) == 0)
 
         # matmul out
         self.assertTrue(dist_out.shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE])
@@ -143,8 +149,8 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(
             w0._local_shape == [HIDDEN_SIZE, HIDDEN_SIZE // MP_SIZE]
         )
-        self.assertTrue(dist_input.dims_mapping == [-1, -1, -1])
-        self.assertTrue(dist_w0.dims_mapping == [-1, 0])
+        self.assertTrue(dist_input.dist_attr().dims_mapping == [-1, -1, -1])
+        self.assertTrue(dist_w0.dist_attr().dims_mapping == [-1, 0])
         # matmul out
         self.assertTrue(dist_out.shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE])
         self.assertTrue(
@@ -193,8 +199,8 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertTrue(
             w0._local_shape == [HIDDEN_SIZE // MP_SIZE, HIDDEN_SIZE]
         )
-        self.assertTrue(dist_input.dims_mapping == [-1, -1, 0])
-        self.assertTrue(dist_w0.dims_mapping == [0, -1])
+        self.assertTrue(dist_input.dist_attr().dims_mapping == [-1, -1, 0])
+        self.assertTrue(dist_w0.dist_attr().dims_mapping == [0, -1])
         # matmul out
         self.assertTrue(dist_out.shape == [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE])
         self.assertTrue(

--- a/test/auto_parallel/pir/test_static_pir_program.py
+++ b/test/auto_parallel/pir/test_static_pir_program.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.distributed as dist
+
+BATCH_SIZE = 2
+SEQ_LEN = 4
+HIDDEN_SIZE = 8
+MP_SIZE = 2
+
+
+class TestBuildFakeProgram(unittest.TestCase):
+    def test_build_with_shard_tensor(self):
+        paddle.enable_static()
+        with paddle.pir_utils.IrGuard():
+            main_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program):
+                mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+                input = paddle.static.data(
+                    name='input',
+                    shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE],
+                )
+                w0 = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[HIDDEN_SIZE, HIDDEN_SIZE],
+                    name="w0",
+                    initializer=paddle.nn.initializer.Uniform(),
+                )
+                w1 = paddle.create_parameter(
+                    dtype="float32",
+                    shape=[HIDDEN_SIZE, HIDDEN_SIZE],
+                    name="w1",
+                    initializer=paddle.nn.initializer.Uniform(),
+                )
+                self.assertTrue(input.is_dense_tensor_type())
+                self.assertTrue(w0.is_dense_tensor_type())
+
+                dist_input = dist.shard_tensor(input, mesh, [dist.Replicate()])
+                dist_w0 = dist.shard_tensor(w0, mesh, [dist.Shard(0)])
+                dist_w1 = dist.shard_tensor(w1, mesh, [dist.Shard(1)])
+
+        print(f'main_program: {main_program}')
+        self.assertTrue(main_program.num_ops() == 6)
+
+        self.assertFalse(input.use_empty())
+        self.assertFalse(w0.use_empty())
+        self.assertFalse(w1.use_empty())
+
+        self.assertTrue(dist_input.use_empty())
+        self.assertTrue(dist_w0.use_empty())
+        self.assertTrue(dist_w1.use_empty())
+
+        self.assertTrue(w0.is_dense_tensor_type())
+        self.assertTrue(w1.is_dense_tensor_type())
+        self.assertTrue(input.is_dense_tensor_type())
+
+        # check dist type
+        self.assertTrue(dist_input.is_dist_dense_tensor_type())
+        self.assertTrue(dist_w0.is_dist_dense_tensor_type())
+        self.assertTrue(dist_w1.is_dist_dense_tensor_type())
+
+        # check global shape
+        self.assertEqual(dist_input.shape, [BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE])
+        self.assertEqual(dist_w0.shape, [HIDDEN_SIZE, HIDDEN_SIZE])
+        self.assertEqual(dist_w1.shape, [HIDDEN_SIZE, HIDDEN_SIZE])
+        # check local shape
+        self.assertTrue(
+            dist_input._local_shape == dist_input.shape
+        )  # replicated, local = global
+        self.assertTrue(
+            dist_w0._local_shape == [HIDDEN_SIZE // MP_SIZE, HIDDEN_SIZE]
+        )  # sharded, local != global, sharded by mesh size
+        self.assertTrue(
+            dist_w1._local_shape == [HIDDEN_SIZE, HIDDEN_SIZE // MP_SIZE]
+        )  # sharded, local != global, sharded by mesh size
+
+        # check op dist_attr
+        self.assertFalse(input.get_defining_op().has_attr("op_dist_attr"))
+        self.assertFalse(w0.get_defining_op().has_attr("op_dist_attr"))
+        self.assertFalse(w1.get_defining_op().has_attr("op_dist_attr"))
+
+        dist_input_op_dist_attr = dist_input.get_defining_op().dist_attr()
+        attrs_op_dist_attr = (
+            dist_input.get_defing_op().attrs().get("op_dist_attr")
+        )
+        # #check attrs
+        self.assertEqual(dist_input_op_dist_attr, attrs_op_dist_attr)
+
+        self.assertEqual(dist_input_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_input_op_dist_attr.num_operand_dist_attrs(), 0)
+        self.assertEqual(dist_input_op_dist_attr.num_result_dist_attrs(), 1)
+
+        dist_w0_op_dist_attr = dist_w0.get_defining_op().dist_attr()
+        self.assertEqual(dist_w0_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_w0_op_dist_attr.num_operand_dist_attrs(), 0)
+        self.assertEqual(dist_w0_op_dist_attr.num_result_dist_attrs(), 1)
+
+        dist_w1_op_dist_attr = dist_w1.get_defining_op().dist_attr()
+        self.assertEqual(dist_w1_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_w1_op_dist_attr.num_operand_dist_attrs(), 0)
+        self.assertEqual(dist_w1_op_dist_attr.num_result_dist_attrs(), 1)
+
+        # check op result dist_attr
+        self.assertEqual(
+            dist_input_op_dist_attr.result_dist_attr(0).process_mesh(), mesh
+        )
+        self.assertEqual(
+            dist_input_op_dist_attr.result_dist_attr(0).dims_mapping,
+            [-1, -1, -1],
+        )
+
+        self.assertEqual(
+            dist_w0_op_dist_attr.result_dist_attr(0).process_mesh, mesh
+        )
+        self.assertEqual(
+            dist_w0_op_dist_attr.result_dist_attr(0).dims_mapping, [0, -1]
+        )
+
+        self.assertEqual(
+            dist_w1_op_dist_attr.result_dist_attr(0).process_mesh, mesh
+        )
+        self.assertEqual(
+            dist_w1_op_dist_attr.result_dist_attr(0).dims_mapping, [-1, 0]
+        )
+
+        # check value dist_attr
+        dist_input_dist_attr = dist_input.dist_attr()
+        self.assertEqual(
+            dist_input_op_dist_attr.result_dist_attr(0), dist_input_dist_attr
+        )
+        self.assertEqual(dist_input_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_input_dist_attr.dims_mapping, [-1, -1, -1])
+
+        dist_w0_dist_attr = dist_w0.dist_attr()
+        self.assertEqual(
+            dist_w0_op_dist_attr.result_dist_attr(0), dist_w0_dist_attr
+        )
+        self.assertEqual(dist_w0_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_w0_dist_attr.dims_mapping, [0, -1])
+
+        dist_w1_dist_attr = dist_w1.dist_attr()
+        self.assertEqual(
+            dist_w1_op_dist_attr.result_dist_attr(0), dist_w1_dist_attr
+        )
+        self.assertEqual(dist_w1_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_w1_dist_attr.dims_mapping, [-1, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/pir/test_static_pir_program.py
+++ b/test/auto_parallel/pir/test_static_pir_program.py
@@ -93,8 +93,6 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertFalse(w1.get_defining_op().has_attr("op_dist_attr"))
 
         dist_input_op_dist_attr = dist_input.get_defining_op().dist_attr()
-        print(f'op_dist_attr: {dist_input_op_dist_attr}')
-        print(f'tensor_dist_attr: {dist_input.dist_attr()}')
         # #check attrs
 
         self.assertEqual(dist_input_op_dist_attr.process_mesh, mesh)

--- a/test/auto_parallel/pir/test_static_pir_program.py
+++ b/test/auto_parallel/pir/test_static_pir_program.py
@@ -93,6 +93,8 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertFalse(w1.get_defining_op().has_attr("op_dist_attr"))
 
         dist_input_op_dist_attr = dist_input.get_defining_op().dist_attr()
+        print(f'op_dist_attr: {dist_input_op_dist_attr}')
+        print(f'tensor_dist_attr: {dist_input.dist_attr()}')
         # #check attrs
 
         self.assertEqual(dist_input_op_dist_attr.process_mesh, mesh)

--- a/test/auto_parallel/pir/test_static_pir_program.py
+++ b/test/auto_parallel/pir/test_static_pir_program.py
@@ -95,57 +95,57 @@ class TestBuildFakeProgram(unittest.TestCase):
         dist_input_op_dist_attr = dist_input.get_defining_op().dist_attr()
         # #check attrs
 
-        self.assertEqual(dist_input_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_input_op_dist_attr.process_mesh, mesh)
         self.assertEqual(dist_input_op_dist_attr.num_operand_dist_attrs(), 0)
         self.assertEqual(dist_input_op_dist_attr.num_result_dist_attrs(), 1)
 
         dist_w0_op_dist_attr = dist_w0.get_defining_op().dist_attr()
-        self.assertEqual(dist_w0_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_w0_op_dist_attr.process_mesh, mesh)
         self.assertEqual(dist_w0_op_dist_attr.num_operand_dist_attrs(), 0)
         self.assertEqual(dist_w0_op_dist_attr.num_result_dist_attrs(), 1)
 
         dist_w1_op_dist_attr = dist_w1.get_defining_op().dist_attr()
-        self.assertEqual(dist_w1_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(dist_w1_op_dist_attr.process_mesh, mesh)
         self.assertEqual(dist_w1_op_dist_attr.num_operand_dist_attrs(), 0)
         self.assertEqual(dist_w1_op_dist_attr.num_result_dist_attrs(), 1)
 
         attrs_op_dist_attr = (
             dist_input.get_defining_op().attrs().get("op_dist_attr")
         )
-        self.assertEqual(attrs_op_dist_attr.process_mesh(), mesh)
+        self.assertEqual(attrs_op_dist_attr.process_mesh, mesh)
 
         # check op result dist_attr
         self.assertEqual(
-            dist_input_op_dist_attr.result_dist_attr(0).process_mesh(), mesh
+            dist_input_op_dist_attr.result_dist_attr(0).process_mesh, mesh
         )
         self.assertEqual(
-            dist_input_op_dist_attr.result_dist_attr(0).dims_mapping(),
+            dist_input_op_dist_attr.result_dist_attr(0).dims_mapping,
             [-1, -1, -1],
         )
 
         self.assertEqual(
-            dist_w0_op_dist_attr.result_dist_attr(0).process_mesh(), mesh
+            dist_w0_op_dist_attr.result_dist_attr(0).process_mesh, mesh
         )
         self.assertEqual(
-            dist_w0_op_dist_attr.result_dist_attr(0).dims_mapping(), [0, -1]
+            dist_w0_op_dist_attr.result_dist_attr(0).dims_mapping, [0, -1]
         )
 
         self.assertEqual(
-            dist_w1_op_dist_attr.result_dist_attr(0).process_mesh(), mesh
+            dist_w1_op_dist_attr.result_dist_attr(0).process_mesh, mesh
         )
         self.assertEqual(
-            dist_w1_op_dist_attr.result_dist_attr(0).dims_mapping(), [-1, 0]
+            dist_w1_op_dist_attr.result_dist_attr(0).dims_mapping, [-1, 0]
         )
 
         # check value dist_attr
-        self.assertEqual(dist_input.dist_attr().process_mesh(), mesh)
-        self.assertEqual(dist_input.dist_attr().dims_mapping(), [-1, -1, -1])
+        self.assertEqual(dist_input.dist_attr().process_mesh, mesh)
+        self.assertEqual(dist_input.dist_attr().dims_mapping, [-1, -1, -1])
 
-        self.assertEqual(dist_w0.dist_attr().process_mesh(), mesh)
-        self.assertEqual(dist_w0.dist_attr().dims_mapping(), [0, -1])
+        self.assertEqual(dist_w0.dist_attr().process_mesh, mesh)
+        self.assertEqual(dist_w0.dist_attr().dims_mapping, [0, -1])
 
-        self.assertEqual(dist_w1.dist_attr().process_mesh(), mesh)
-        self.assertEqual(dist_w1.dist_attr().dims_mapping(), [-1, 0])
+        self.assertEqual(dist_w1.dist_attr().process_mesh, mesh)
+        self.assertEqual(dist_w1.dist_attr().dims_mapping, [-1, 0])
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/pir/test_to_static_pir_program.py
+++ b/test/auto_parallel/pir/test_to_static_pir_program.py
@@ -100,10 +100,12 @@ class TestToStaticPirProgramEval(unittest.TestCase):
             tensor = op.result(0)
             if op.name() == 'pd_op.data':
                 self.assertTrue(tensor.is_dist_dense_tensor_type())
-                self.assertEqual(tensor.process_mesh.shape, [2])
-                self.assertEqual(tensor.process_mesh.process_ids, [0, 1])
-                self.assertEqual(tensor.dims_mapping, [-1, -1])
-                self.assertEqual(tensor.partial_dims, set())
+                self.assertEqual(tensor.dist_attr().process_mesh.shape, [2])
+                self.assertEqual(
+                    tensor.dist_attr().process_mesh.process_ids, [0, 1]
+                )
+                self.assertEqual(tensor.dist_attr().dims_mapping, [-1, -1])
+                self.assertEqual(tensor.dist_attr().partial_dims, set())
             elif op.name() == "builtin.parameter":
                 pass  # TODO check
 
@@ -128,10 +130,12 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
             tensor = op.result(0)
             if op.name() == 'pd_op.data':
                 self.assertTrue(tensor.is_dist_dense_tensor_type())
-                self.assertEqual(tensor.process_mesh.shape, [2])
-                self.assertEqual(tensor.process_mesh.process_ids, [0, 1])
-                self.assertEqual(tensor.dims_mapping, [-1, -1])
-                self.assertEqual(tensor.partial_dims, set())
+                self.assertEqual(tensor.dist_attr().process_mesh.shape, [2])
+                self.assertEqual(
+                    tensor.dist_attr().process_mesh.process_ids, [0, 1]
+                )
+                self.assertEqual(tensor.dist_attr().dims_mapping, [-1, -1])
+                self.assertEqual(tensor.dist_attr().partial_dims, set())
             elif op.name() == 'builtin.parameter':
                 self.assertTrue(tensor.is_dense_tensor_type())
                 self.assertFalse(tensor.is_dist_dense_tensor_type())
@@ -141,13 +145,19 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
                 if use_op.name() == 'dist_op.shard_tensor':
                     tensor = use_op.result(0)
                     self.assertTrue(tensor.is_dist_dense_tensor_type())
-                    self.assertEqual(tensor.process_mesh.shape, [2])
-                    self.assertEqual(tensor.process_mesh.process_ids, [0, 1])
+                    self.assertEqual(tensor.dist_attr().process_mesh.shape, [2])
+                    self.assertEqual(
+                        tensor.dist_attr().process_mesh.process_ids, [0, 1]
+                    )
                     if tensor.shape == [IMAGE_SIZE, IMAGE_SIZE]:
-                        self.assertEqual(tensor.dims_mapping, [-1, 0])
+                        self.assertEqual(
+                            tensor.dist_attr().dims_mapping, [-1, 0]
+                        )
                     elif tensor.shape == [IMAGE_SIZE, CLASS_NUM]:
-                        self.assertEqual(tensor.dims_mapping, [0, -1])
-                    self.assertEqual(tensor.partial_dims, set())
+                        self.assertEqual(
+                            tensor.dist_attr().dims_mapping, [0, -1]
+                        )
+                    self.assertEqual(tensor.dist_attr().partial_dims, set())
 
         # dist_model.train()
         # for batch_id, (image, label) in enumerate(dist_loader()):

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -66,6 +66,7 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         'offset',
         'pin_memory',
         'placements',
+        'process_mesh',
         'reconstruct_from_',
         'register_hook',
         'retain_grads',
@@ -105,8 +106,7 @@ STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         'set_type',
         'use_empty',
         'is_dist_dense_tensor_type',
-        'dims_mapping',  # TODO Unify as Placement
-        'partial_dims',  # TODO Unify as Placement
+        'dist_attr',
         'value_assign',
         'replace_grad_users_with',
     ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

1. 增加dist program组网适配逻辑，完善attribute相关的pybind接口
2. 增加OperationDistAttribute打印格式: 如果op的operand和result的dist_attr与op的mesh一致，则dist_attr的mesh不打印

```shell
{
    (%0) = "builtin.parameter" () {is_persistable:[true],parameter_name:"w1",stop_gradient:[false]} : () -> builtin.tensor<8x8xf32>
    (%1) = "builtin.parameter" () {is_persistable:[true],parameter_name:"w0",stop_gradient:[false]} : () -> builtin.tensor<8x8xf32>
    (%2) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"input",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[2,4,8],stop_gradient:[true]} : () -> builtin.tensor<2x4x8xf32>
    (%3) = "dist_op.shard_tensor" (%2) {op_dist_attr:mesh_shape:[2],process_ids:[0,1],result(0):{dims_maping:[-1,-1,-1]}} : (builtin.tensor<2x4x8xf32>) -> pd_dist.tensor<2x4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1,-1]>
    (%4) = "dist_op.shard_tensor" (%1) {op_dist_attr:mesh_shape:[2],process_ids:[0,1],result(0):{dims_maping:[0,-1]}} : (builtin.tensor<8x8xf32>) -> pd_dist.tensor<8x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>
    (%5) = "dist_op.shard_tensor" (%0) {op_dist_attr:mesh_shape:[2],process_ids:[0,1],result(0):{dims_maping:[-1,0]}} : (builtin.tensor<8x8xf32>) -> pd_dist.tensor<8x8xf32, mesh_shape:[2],dims_mappings:[-1,0]>
}
``` 