### PR TITLE
[Prim] Replace assigning nullptr with full-zero Tensor

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -831,8 +831,6 @@ void group_norm_grad(const Tensor& x,
           tmp1.sum(std::vector<int64_t>({0}), scale_ptr->dtype(), false),
           IntArray(std::vector<int64_t>({C})));
       set_output<T>(scale_grad_tmp, scale_grad);
-    } else {
-      scale_grad = nullptr;
     }
   }
 
@@ -841,8 +839,6 @@ void group_norm_grad(const Tensor& x,
       auto bias_grad_tmp =
           sum_y_grad.sum(std::vector<int64_t>({0}), bias_ptr->dtype(), false);
       set_output<T>(bias_grad_tmp, bias_grad);
-    } else {
-      bias_grad = nullptr;
     }
   }
 }
@@ -934,8 +930,6 @@ void layer_norm_grad(const Tensor& x,
         scale_grad_tmp = cast<T>(scale_grad_tmp, scale_ptr->dtype());
       }
       set_output<T>(scale_grad_tmp, scale_grad);
-    } else {
-      scale_grad = nullptr;
     }
   }
 
@@ -949,8 +943,6 @@ void layer_norm_grad(const Tensor& x,
         bias_grad_tmp = cast<T>(bias_grad_tmp, bias_ptr->dtype());
       }
       set_output<T>(bias_grad_tmp, bias_grad);
-    } else {
-      bias_grad = nullptr;
     }
   }
 }

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -214,13 +214,23 @@ void matmul_double_grad(const Tensor& x,
   }
   Tensor dx, dy, ddout_1, ddout_2, ddout;
   if (!grad_x_grad && !grad_y_grad) {
-    x_grad = nullptr;
-    y_grad = nullptr;
-    grad_out_grad = nullptr;
+    if (x_grad) {
+      set_output<T>(full<T>(common::vectorize(x.dims()), 0, x.dtype()), x_grad);
+    }
+    if (y_grad) {
+      set_output<T>(full<T>(common::vectorize(y.dims()), 0, y.dtype()), y_grad);
+    }
+    if (grad_out_grad) {
+      set_output<T>(
+          full<T>(common::vectorize(grad_out.dims()), 0, grad_out.dtype()),
+          grad_out_grad);
+    }
     return;
 
   } else if (!grad_x_grad) {
-    y_grad = nullptr;
+    if (y_grad) {
+      set_output<T>(full<T>(common::vectorize(y.dims()), 0, y.dtype()), y_grad);
+    }
     if (!transpose_x && !transpose_y) {
       if (x_grad) {
         dx = matmul<T>(out_help, yg_help, false, true);
@@ -252,7 +262,9 @@ void matmul_double_grad(const Tensor& x,
     }
 
   } else if (!grad_y_grad) {
-    x_grad = nullptr;
+    if (x_grad) {
+      set_output<T>(full<T>(common::vectorize(x.dims()), 0, x.dtype()), x_grad);
+    }
     if (!transpose_x && !transpose_y) {
       if (y_grad) {
         dy = matmul<T>(xg_help, out_help, true, false);
@@ -573,8 +585,6 @@ void add_triple_grad(const paddle::optional<Tensor>& grad_grad_x,
       } else {
         by_pass<T>(grad_grad_out_grad, grad_grad_y_grad);
       }
-    } else {
-      grad_grad_y_grad = nullptr;
     }
   }
   if (grad_grad_x_grad) {
@@ -595,8 +605,6 @@ void add_triple_grad(const paddle::optional<Tensor>& grad_grad_x,
       } else {
         by_pass<T>(grad_grad_out_grad, grad_grad_x_grad);
       }
-    } else {
-      grad_grad_x_grad = nullptr;
     }
   }
 }
@@ -617,7 +625,9 @@ void subtract_double_grad(const Tensor& y,
     } else if (grad_y_grad) {
       set_output<T>(-grad_y_grad.get(), grad_out_grad);
     } else {
-      grad_out_grad = nullptr;
+      set_output<T>(
+          full<T>(common::vectorize(grad_out.dims()), 0, grad_out.dtype()),
+          grad_out_grad);
     }
   }
 }

--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -214,23 +214,13 @@ void matmul_double_grad(const Tensor& x,
   }
   Tensor dx, dy, ddout_1, ddout_2, ddout;
   if (!grad_x_grad && !grad_y_grad) {
-    if (x_grad) {
-      set_output<T>(full<T>(common::vectorize(x.dims()), 0, x.dtype()), x_grad);
-    }
-    if (y_grad) {
-      set_output<T>(full<T>(common::vectorize(y.dims()), 0, y.dtype()), y_grad);
-    }
-    if (grad_out_grad) {
-      set_output<T>(
-          full<T>(common::vectorize(grad_out.dims()), 0, grad_out.dtype()),
-          grad_out_grad);
-    }
+    x_grad = nullptr;
+    y_grad = nullptr;
+    grad_out_grad = nullptr;
     return;
 
   } else if (!grad_x_grad) {
-    if (y_grad) {
-      set_output<T>(full<T>(common::vectorize(y.dims()), 0, y.dtype()), y_grad);
-    }
+    y_grad = nullptr;
     if (!transpose_x && !transpose_y) {
       if (x_grad) {
         dx = matmul<T>(out_help, yg_help, false, true);
@@ -262,9 +252,7 @@ void matmul_double_grad(const Tensor& x,
     }
 
   } else if (!grad_y_grad) {
-    if (x_grad) {
-      set_output<T>(full<T>(common::vectorize(x.dims()), 0, x.dtype()), x_grad);
-    }
+    x_grad = nullptr;
     if (!transpose_x && !transpose_y) {
       if (y_grad) {
         dy = matmul<T>(xg_help, out_help, true, false);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->
Pcard-75624

Fix code bug in `composite_backward/composite_backward_api.h` and `composite_backward/composite_double_backward_api.h`:

Replace `tensor_ptr = nullptr` with `tensor_ptr = full<T>(...)` for setting pointer to `nullptr` is meaningless in related code when pointers are **pass by value**.