### PR TITLE
fix gpu_info cuda112_macro error which cause compile error on cuda < 11.2

### DIFF
--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -370,8 +370,12 @@ class RecordedGpuMallocHelper {
 #ifdef PADDLE_WITH_TESTING
     gpu_ptrs.erase(ptr);
 #endif
-  }
 
+#else
+    PADDLE_THROW(phi::errors::Unavailable(
+        "FreeAsync is not supported in this version of CUDA."));
+#endif
+  }
   void *GetBasePtr(void *ptr) {
 #ifdef PADDLE_WITH_TESTING
     auto it = gpu_ptrs.upper_bound(ptr);
@@ -384,11 +388,6 @@ class RecordedGpuMallocHelper {
         "The RecordedGpuMallocHelper::GetBasePtr is only implemented with "
         "testing, should not use for release."));
     return nullptr;
-#endif
-
-#else
-    PADDLE_THROW(phi::errors::Unavailable(
-        "FreeAsync is not supported in this version of CUDA."));
 #endif
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
pr #62264  will  cause make compile error on cuda < 11.2, see issue: https://github.com/PaddlePaddle/Paddle/issues/62066

Pcard-81347