### PR TITLE
[PIR] Speedup `some_in_set` in append backward

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -272,30 +272,7 @@ def _as_list(x):
 
 
 def some_in_set(value_list, value_set):
-    # def operand2value(values):
-    #     value_set = ValueSet()
-    #     for item in values:
-    #         if isinstance(item, pir.OpOperand):
-    #             value_set.add(item.source())
-    #         else:
-    #             value_set.add(item)
-    #     return value_set
-    for value in value_list:
-        assert isinstance(value, (pir.Value, type(None)))
-
-    for value in value_set:
-        assert isinstance(value, (pir.Value, type(None)))
-
-    def to_value(value):
-        if isinstance(value, pir.Value):
-            return value
-        elif isinstance(value, pir.OpOperand):
-            return value.source()
-        else:
-            raise ValueError(f'Unsupported type {type(value)}')
-
-    # if operand2value(value_list) & operand2value(value_set):
-    return any(to_value(v) in value_set for v in value_list)
+    return any(v in value_set for v in value_list)
 
 
 def is_control_flow(op):

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -281,10 +281,10 @@ def some_in_set(value_list, value_set):
     #             value_set.add(item)
     #     return value_set
     for value in value_list:
-        assert isinstance(value, pir.Value)
+        assert isinstance(value, (pir.Value, type(None)))
 
     for value in value_set:
-        assert isinstance(value, pir.Value)
+        assert isinstance(value, (pir.Value, type(None)))
 
     def to_value(value):
         if isinstance(value, pir.Value):
@@ -295,10 +295,7 @@ def some_in_set(value_list, value_set):
             raise ValueError(f'Unsupported type {type(value)}')
 
     # if operand2value(value_list) & operand2value(value_set):
-    if any(to_value(v) in value_set for v in value_list):
-        return True
-    else:
-        return False
+    return any(to_value(v) in value_set for v in value_list)
 
 
 def is_control_flow(op):

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -272,16 +272,30 @@ def _as_list(x):
 
 
 def some_in_set(value_list, value_set):
-    def operand2value(values):
-        value_set = ValueSet()
-        for item in values:
-            if isinstance(item, pir.OpOperand):
-                value_set.add(item.source())
-            else:
-                value_set.add(item)
-        return value_set
+    # def operand2value(values):
+    #     value_set = ValueSet()
+    #     for item in values:
+    #         if isinstance(item, pir.OpOperand):
+    #             value_set.add(item.source())
+    #         else:
+    #             value_set.add(item)
+    #     return value_set
+    for value in value_list:
+        assert isinstance(value, pir.Value)
 
-    if operand2value(value_list) & operand2value(value_set):
+    for value in value_set:
+        assert isinstance(value, pir.Value)
+
+    def to_value(value):
+        if isinstance(value, pir.Value):
+            return value
+        elif isinstance(value, pir.OpOperand):
+            return value.source()
+        else:
+            raise ValueError(f'Unsupported type {type(value)}')
+
+    # if operand2value(value_list) & operand2value(value_set):
+    if any(to_value(v) in value_set for v in value_list):
         return True
     else:
         return False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

加速 grad API 中 `some_in_set` 实现，以加速动转静添加反向，修改后测试模型添加反向时间从 17s 降低到 2s

经过 CI 测试，`some_in_set(value_list, value_set)` 中，`value_list` 只包含 Value，`value_set` 包含 Value 和 None，因此无需 `Operand -> Value` 的转换

Pcard-67164