### PR TITLE
API improvement paddle.nanmedian 易用性提升

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -1647,8 +1647,8 @@
     func : mv_grad
 
 - backward_op : nanmedian_grad
-  forward : nanmedian (Tensor x, IntArray axis, bool keepdim) -> Tensor(out), Tensor(medians)
-  args : (Tensor x, Tensor medians, Tensor out_grad, IntArray axis, bool keepdim)
+  forward : nanmedian (Tensor x, IntArray axis, bool keepdim, str mode) -> Tensor(out), Tensor(medians)
+  args : (Tensor x, Tensor medians, Tensor out_grad, IntArray axis, bool keepdim, str mode)
   output : Tensor(x_grad)
   infer_meta :
     func : NanmedianGradInferMeta

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2033,13 +2033,12 @@
   backward : mv_grad
 
 - op : nanmedian
-  args : (Tensor x, IntArray axis = {}, bool keepdim = true)
+  args : (Tensor x, IntArray axis = {}, bool keepdim = true, str mode="avg")
   output : Tensor(out), Tensor(medians)
   infer_meta :
     func : NanmedianInferMeta
   kernel :
     func : nanmedian
-  intermediate : medians
   backward : nanmedian_grad
 
 - op : nearest_interp

--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -843,6 +843,7 @@ void NanmedianGradInferMeta(const MetaTensor& x,
                             const MetaTensor& out_grad,
                             const IntArray& axes,
                             bool keep_dim,
+                            const std::string& mode,
                             MetaTensor* x_grad) {
   auto x_dims = x.dims();
   x_grad->set_dims(x_dims);

--- a/paddle/phi/infermeta/backward.h
+++ b/paddle/phi/infermeta/backward.h
@@ -370,6 +370,7 @@ void NanmedianGradInferMeta(const MetaTensor& x,
                             const MetaTensor& out_grad,
                             const IntArray& axes,
                             bool keep_dim,
+                            const std::string& mode,
                             MetaTensor* x_grad);
 
 void NceGradInferMeta(const MetaTensor& input,

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2567,6 +2567,7 @@ void MultinomialInferMeta(const MetaTensor& x,
 void NanmedianInferMeta(const MetaTensor& x,
                         const IntArray& axes,
                         bool keep_dim,
+                        const std::string& mode,
                         MetaTensor* out,
                         MetaTensor* median_index) {
   std::vector<int64_t> axis_list = axes.GetData();

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2573,9 +2573,6 @@ void NanmedianInferMeta(const MetaTensor& x,
   std::vector<int64_t> axis_list = axes.GetData();
   auto x_dim = x.dims();
   int64_t x_rank = x_dim.size();
-  out->set_dtype(x.dtype());
-  median_index->set_dtype(DataType::INT64);
-  median_index->set_dims(common::make_ddim({x.numel() * 2}));
 
   std::vector<int32_t> out_dim;
   if (axis_list.empty()) {
@@ -2630,8 +2627,13 @@ void NanmedianInferMeta(const MetaTensor& x,
       }
     }
   }
+  out->set_dtype(x.dtype());
+  out->set_dims(make_ddim(out_dim));
 
-  out->set_dims(common::make_ddim(out_dim));
+  auto median_dim = out_dim;
+  median_dim.push_back(2);
+  median_index->set_dtype(DataType::INT64);
+  median_index->set_dims(make_ddim(median_dim));
 }
 
 void NMSInferMeta(const MetaTensor& x, float threshold, MetaTensor* out) {

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2631,7 +2631,9 @@ void NanmedianInferMeta(const MetaTensor& x,
   out->set_dims(make_ddim(out_dim));
 
   auto median_dim = out_dim;
-  median_dim.push_back(2);
+  if (mode == "avg") {
+    median_dim.push_back(2);
+  }
   median_index->set_dtype(DataType::INT64);
   median_index->set_dims(make_ddim(median_dim));
 }

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -392,6 +392,7 @@ void MultinomialInferMeta(const MetaTensor& x,
 void NanmedianInferMeta(const MetaTensor& x,
                         const IntArray& axes,
                         bool keep_dim,
+                        const std::string& mode,
                         MetaTensor* out,
                         MetaTensor* median_index);
 

--- a/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
@@ -21,26 +21,12 @@
 
 namespace phi {
 
-template <typename T, typename Context>
-void CalcMedianGradKernel(const Context& dev_ctx,
-                          const DenseTensor& x,
-                          const DenseTensor& median_index,
-                          const DenseTensor& out_grad,
-                          DenseTensor* x_grad) {
-  T* dx_data = dev_ctx.template Alloc<T>(x_grad);
-  if (!dx_data) return;
-
-  phi::funcs::SetConstant<Context, T> set_zero;
-  set_zero(dev_ctx, x_grad, static_cast<T>(0));
-
-  const int64_t* m_data = median_index.data<int64_t>();
-  const T* dout_data = out_grad.data<T>();
-  int64_t numel = x.numel();
-  auto x_dim = x.dims();
-  int64_t rank = x_dim.size();
-  int64_t stride = x_dim[static_cast<int>(rank - 1)];
-  int64_t pre_dim = numel / stride;
-
+template <typename T>
+void CalcMedianMeanGrad(int64_t pre_dim,
+                        int64_t stride,
+                        const int64_t* m_data,
+                        T* dx_data,
+                        const T* dout_data) {
   int64_t i = 0;
   int64_t offset = 0;
   for (i = 0; i < pre_dim; i++) {
@@ -57,6 +43,50 @@ void CalcMedianGradKernel(const Context& dev_ctx,
   }
 }
 
+template <typename T>
+void CalcMedianMinGrad(int64_t pre_dim,
+                       int64_t stride,
+                       const int64_t* m_data,
+                       T* dx_data,
+                       const T* dout_data) {
+  int64_t i = 0;
+  int64_t offset = 0;
+  for (i = 0; i < pre_dim; i++) {
+    if (m_data[2 * i] >= 0) {
+      dx_data[offset + m_data[2 * i]] = dout_data[i];
+    }
+    offset += stride;
+  }
+}
+
+template <typename T, typename Context>
+void CalcMedianGradKernel(const Context& dev_ctx,
+                          const DenseTensor& x,
+                          const DenseTensor& median_index,
+                          const DenseTensor& out_grad,
+                          const std::string& mode,
+                          DenseTensor* x_grad) {
+  T* dx_data = dev_ctx.template Alloc<T>(x_grad);
+  if (!dx_data) return;
+
+  phi::funcs::SetConstant<Context, T> set_zero;
+  set_zero(dev_ctx, x_grad, static_cast<T>(0));
+
+  const int64_t* m_data = median_index.data<int64_t>();
+  const T* dout_data = out_grad.data<T>();
+  int64_t numel = x.numel();
+  auto x_dim = x.dims();
+  int64_t rank = x_dim.size();
+  int64_t stride = x_dim[static_cast<int>(rank - 1)];
+  int64_t pre_dim = numel / stride;
+
+  if (mode == "avg") {
+    CalcMedianMeanGrad(pre_dim, stride, m_data, dx_data, dout_data);
+  } else {
+    CalcMedianMinGrad(pre_dim, stride, m_data, dx_data, dout_data);
+  }
+}
+
 template <typename T, typename Context>
 void NanmedianGradKernel(const Context& dev_ctx,
                          const DenseTensor& x,
@@ -64,6 +94,7 @@ void NanmedianGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& axes,
                          bool keepdim UNUSED,
+                         const std::string& mode,
                          DenseTensor* x_grad) {
   DenseTensor tmp_x;
   auto rank = x.dims().size();
@@ -71,14 +102,14 @@ void NanmedianGradKernel(const Context& dev_ctx,
     tmp_x = x;
     tmp_x.Resize({x.numel()});
     CalcMedianGradKernel<T, Context>(
-        dev_ctx, tmp_x, median_index, out_grad, x_grad);
+        dev_ctx, tmp_x, median_index, out_grad, mode, x_grad);
   } else {
     funcs::PreprocessMedianKernel<T, Context>(dev_ctx, x, axes, &tmp_x);
 
     DenseTensor tmp_x_grad;
     tmp_x_grad.Resize(x_grad->dims());
     CalcMedianGradKernel<T, Context>(
-        dev_ctx, tmp_x, median_index, out_grad, &tmp_x_grad);
+        dev_ctx, tmp_x, median_index, out_grad, mode, &tmp_x_grad);
 
     dev_ctx.template Alloc<T>(x_grad);
     funcs::PostprocessMedianGradKernel<T, Context>(

--- a/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_grad_kernel.cc
@@ -52,8 +52,8 @@ void CalcMedianMinGrad(int64_t pre_dim,
   int64_t i = 0;
   int64_t offset = 0;
   for (i = 0; i < pre_dim; i++) {
-    if (m_data[2 * i] >= 0) {
-      dx_data[offset + m_data[2 * i]] = dout_data[i];
+    if (m_data[i] >= 0) {
+      dx_data[offset + m_data[i]] = dout_data[i];
     }
     offset += stride;
   }

--- a/paddle/phi/kernels/cpu/nanmedian_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_kernel.cc
@@ -30,7 +30,8 @@ void CalcMedianFunc(const Context& dev_ctx,
                     int64_t stride,
                     int64_t pre_dim,
                     T* o_ptr,
-                    int64_t* m_ptr) {
+                    int64_t* m_ptr,
+                    const std::string& mode) {
   DenseTensor sort_out;
   DenseTensor sort_indices;
   auto sort_dim = x.dims();
@@ -51,12 +52,12 @@ void CalcMedianFunc(const Context& dev_ctx,
   int64_t offset = 0;
   int64_t i = 0;
   bool is_ori_odd = stride & 1;
-  if (ignore_nan) {
+  if (ignore_nan) {  // ignore_nan - has nan value; sort_k = max_valid_num
     for (i = 0; i < pre_dim; i++) {
       offset = i * sort_k;
       if (nan_counts[i] == stride) {
         m_ptr[i * 2] = -1;
-        m_ptr[i * 2 + 1] = -1;
+        m_ptr[i * 2 + 1] = -1;  // index is -1
         o_ptr[i] = sort_out_ptr[offset];
       } else {
         int64_t nan_k = nan_counts[i] > 0
@@ -69,17 +70,27 @@ void CalcMedianFunc(const Context& dev_ctx,
           m_ptr[2 * i + 1] = sort_indices_ptr[pos];
           o_ptr[i] = sort_out_ptr[pos];
         } else {
-          m_ptr[2 * i] =
-              row_pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
-          m_ptr[2 * i + 1] = sort_indices_ptr[pos];
+          // nan_k is even
           T m_val_left =
               row_pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
           T m_val_right = sort_out_ptr[pos];
-          o_ptr[i] = (m_val_left + m_val_right) / div_factor;
+          if (mode == "avg") {
+            m_ptr[2 * i] =
+                row_pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
+            m_ptr[2 * i + 1] = sort_indices_ptr[pos];
+            o_ptr[i] = (m_val_left + m_val_right) / div_factor;
+          } else {
+            // mode == "min": output median value should be the left val since
+            // the sort_out is in ascending order
+            m_ptr[2 * i] =
+                row_pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
+            m_ptr[2 * i + 1] = m_ptr[2 * i];
+            o_ptr[i] = m_val_left;
+          }
         }
       }
     }
-  } else {
+  } else {  // not ignore_nan - no nan value; sort_k = stride/2 + 1
     if (is_ori_odd) {
       for (i = 0; i < pre_dim; i++) {
         offset = i * sort_k;
@@ -92,12 +103,21 @@ void CalcMedianFunc(const Context& dev_ctx,
       for (i = 0; i < pre_dim; i++) {
         offset = i * sort_k;
         int64_t pos = offset + sort_k - 1;
-        m_ptr[2 * i] =
-            sort_k > 1 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
-        m_ptr[2 * i + 1] = sort_indices_ptr[pos];
         T m_val_left = sort_k > 1 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
         T m_val_right = sort_out_ptr[pos];
-        o_ptr[i] = (m_val_left + m_val_right) / div_factor;
+        if (mode == "avg") {
+          m_ptr[2 * i] =
+              sort_k > 1 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
+          m_ptr[2 * i + 1] = sort_indices_ptr[pos];
+          o_ptr[i] = (m_val_left + m_val_right) / div_factor;
+        } else {
+          // mode == "min": output median value should be the left val since the
+          // sort_out is in ascending order
+          m_ptr[2 * i] =
+              sort_k > 1 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
+          m_ptr[2 * i + 1] = m_ptr[2 * i];
+          o_ptr[i] = m_val_left;
+        }
       }
     }
   }
@@ -106,6 +126,7 @@ void CalcMedianFunc(const Context& dev_ctx,
 template <typename T, typename Context>
 void ProcessMedianKernel(const Context& dev_ctx,
                          const DenseTensor& x,
+                         const std::string& mode,
                          DenseTensor* out,
                          DenseTensor* median_index) {
   const T* x_data = x.data<T>();
@@ -155,7 +176,7 @@ void ProcessMedianKernel(const Context& dev_ctx,
       for (i = 0; i < pre_dim; i++) {
         out_data[i] = std::numeric_limits<T>::quiet_NaN();
         m_data[2 * i] = -1;
-        m_data[2 * i + 1] = -1;
+        m_data[2 * i + 1] = -1;  // indices are all -1
       }
       return;
     }
@@ -171,7 +192,8 @@ void ProcessMedianKernel(const Context& dev_ctx,
                              stride,
                              pre_dim,
                              out_data,
-                             m_data);
+                             m_data,
+                             mode);
 }
 
 template <typename T, typename Context>
@@ -179,18 +201,23 @@ void NanmedianKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const IntArray& axes,
                      bool keepdim UNUSED,
+                     const std::string& mode,
                      DenseTensor* out,
                      DenseTensor* median_index) {
   DenseTensor tmp_x;
   auto rank = x.dims().size();
   if ((axes.size() == 0) || rank <= 1) {
     tmp_x = x;
-    tmp_x.Resize({x.numel()});
+    tmp_x.Resize({x.numel()});  // flatten
   } else {
-    funcs::PreprocessMedianKernel<T, Context>(dev_ctx, x, axes, &tmp_x);
+    funcs::PreprocessMedianKernel<T, Context>(
+        dev_ctx,
+        x,
+        axes,
+        &tmp_x);  // resize to 2D so as to compute median on last axis
   }
 
-  ProcessMedianKernel<T, Context>(dev_ctx, tmp_x, out, median_index);
+  ProcessMedianKernel<T, Context>(dev_ctx, tmp_x, mode, out, median_index);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
@@ -37,9 +37,6 @@ __global__ void KernelNanmedianMeanGrad(const int64_t* medians_ptr,
                                         int64_t pre_dim) {
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t offset = index * stride;
-    printf("index: %d\n", index);
-    printf("medians_ptr[2 * index]: %d\n", medians_ptr[2 * index]);
-    printf("medians_ptr[2 * index+1]: %d\n", medians_ptr[2 * index + 1]);
 
     if (medians_ptr[2 * index] >= 0) {
       if (medians_ptr[2 * index] == medians_ptr[2 * index + 1]) {
@@ -62,8 +59,6 @@ __global__ void KernelNanmedianMinGrad(const int64_t* medians_ptr,
                                        int64_t pre_dim) {
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t offset = index * stride;
-    printf("index: %d\n", index);
-    printf("medians_ptr[index]: %d\n", medians_ptr[index]);
 
     if (medians_ptr[index] >= 0) {
       dx_data[offset + medians_ptr[index]] = out_grad_ptr[index];
@@ -83,7 +78,7 @@ void CalcMedianGradKernel(const Context& dev_ctx,
 
   phi::funcs::SetConstant<Context, T> set_zero;
   set_zero(dev_ctx, x_grad, static_cast<T>(0));
-  VLOG(0) << "x_grad->dims():  " << x_grad->dims();
+  // VLOG(0) << "x_grad->dims():  " << x_grad->dims();
 
   auto stream = dev_ctx.stream();
   const T* x_data = x.data<T>();

--- a/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
@@ -63,11 +63,10 @@ __global__ void KernelNanmedianMinGrad(const int64_t* medians_ptr,
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t offset = index * stride;
     printf("index: %d\n", index);
-    printf("medians_ptr[2 * index]: %d\n", medians_ptr[2 * index]);
-    printf("medians_ptr[2 * index+1]: %d\n", medians_ptr[2 * index + 1]);
+    printf("medians_ptr[index]: %d\n", medians_ptr[index]);
 
-    if (medians_ptr[2 * index] >= 0) {
-      dx_data[offset + medians_ptr[2 * index]] = out_grad_ptr[index];
+    if (medians_ptr[index] >= 0) {
+      dx_data[offset + medians_ptr[index]] = out_grad_ptr[index];
     }
   }
 }

--- a/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_grad_kernel.cu
@@ -30,12 +30,11 @@ inline int GET_BLOCKS(const int N) {
 }
 
 template <typename T>
-__global__ void KernelNanmedianGrad(const T* x_data,
-                                    const int64_t* medians_ptr,
-                                    const T* out_grad_ptr,
-                                    T* dx_data,
-                                    int64_t stride,
-                                    int64_t pre_dim) {
+__global__ void KernelNanmedianMeanGrad(const int64_t* medians_ptr,
+                                        const T* out_grad_ptr,
+                                        T* dx_data,
+                                        int64_t stride,
+                                        int64_t pre_dim) {
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t offset = index * stride;
     printf("index: %d\n", index);
@@ -55,11 +54,30 @@ __global__ void KernelNanmedianGrad(const T* x_data,
   }
 }
 
+template <typename T>
+__global__ void KernelNanmedianMinGrad(const int64_t* medians_ptr,
+                                       const T* out_grad_ptr,
+                                       T* dx_data,
+                                       int64_t stride,
+                                       int64_t pre_dim) {
+  CUDA_KERNEL_LOOP(index, pre_dim) {
+    int64_t offset = index * stride;
+    printf("index: %d\n", index);
+    printf("medians_ptr[2 * index]: %d\n", medians_ptr[2 * index]);
+    printf("medians_ptr[2 * index+1]: %d\n", medians_ptr[2 * index + 1]);
+
+    if (medians_ptr[2 * index] >= 0) {
+      dx_data[offset + medians_ptr[2 * index]] = out_grad_ptr[index];
+    }
+  }
+}
+
 template <typename T, typename Context>
 void CalcMedianGradKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const DenseTensor& median_index,
                           const DenseTensor& out_grad,
+                          const std::string& mode,
                           DenseTensor* x_grad) {
   T* dx_data = dev_ctx.template Alloc<T>(x_grad);
   if (!dx_data) return;
@@ -79,9 +97,15 @@ void CalcMedianGradKernel(const Context& dev_ctx,
   int64_t stride = x_dim[x_rank - 1];
   int64_t pre_dim = numel / stride;
 
-  KernelNanmedianGrad<T>
-      <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
-          x_data, m_data, out_grad_ptr, dx_data, stride, pre_dim);
+  if (mode == "avg") {
+    KernelNanmedianMeanGrad<T>
+        <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+            m_data, out_grad_ptr, dx_data, stride, pre_dim);
+  } else {  // mode == "min"
+    KernelNanmedianMinGrad<T>
+        <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+            m_data, out_grad_ptr, dx_data, stride, pre_dim);
+  }
 }
 
 template <typename T, typename Context>
@@ -91,6 +115,7 @@ void NanmedianGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& axes,
                          bool keepdim UNUSED,
+                         const std::string& mode,
                          DenseTensor* x_grad) {
   DenseTensor tmp_x;
   auto rank = x.dims().size();
@@ -98,14 +123,14 @@ void NanmedianGradKernel(const Context& dev_ctx,
     tmp_x = x;
     tmp_x.Resize({x.numel()});
     CalcMedianGradKernel<T, Context>(
-        dev_ctx, tmp_x, median_index, out_grad, x_grad);
+        dev_ctx, tmp_x, median_index, out_grad, mode, x_grad);
   } else {
     funcs::PreprocessMedianKernel<T, Context>(dev_ctx, x, axes, &tmp_x);
 
     DenseTensor tmp_x_grad;
     tmp_x_grad.Resize(x_grad->dims());
     CalcMedianGradKernel<T, Context>(
-        dev_ctx, tmp_x, median_index, out_grad, &tmp_x_grad);
+        dev_ctx, tmp_x, median_index, out_grad, mode, &tmp_x_grad);
 
     dev_ctx.template Alloc<T>(x_grad);
     funcs::PostprocessMedianGradKernel<T, Context>(

--- a/paddle/phi/kernels/gpu/nanmedian_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_kernel.cu
@@ -168,7 +168,8 @@ __global__ void CalcNanmedianMinKernel(const T* sort_out_ptr,
                                        const bool is_odd,
                                        const int64_t pre_dim,
                                        const int64_t max_valid_num,
-                                       const int64_t stride const T nan_val) {
+                                       const int64_t stride,
+                                       const T nan_val) {
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t pos = static_cast<int64_t>(index * max_valid_num);
     int64_t nan_cnt = nan_counts[index];

--- a/paddle/phi/kernels/gpu/nanmedian_kernel.cu
+++ b/paddle/phi/kernels/gpu/nanmedian_kernel.cu
@@ -69,14 +69,14 @@ __global__ void KernelNanCounts(const T* input,
 }
 
 template <typename T>
-__global__ void CalcMedianKernel(const T* sort_out_ptr,
-                                 const int64_t* sort_indices_ptr,
-                                 int64_t* median_val,
-                                 T* output,
-                                 T div_factor,
-                                 const bool is_odd,
-                                 const int64_t pre_dim,
-                                 const int64_t stride) {
+__global__ void CalcMedianMeanKernel(const T* sort_out_ptr,
+                                     const int64_t* sort_indices_ptr,
+                                     int64_t* median_val,
+                                     T* output,
+                                     T div_factor,
+                                     const bool is_odd,
+                                     const int64_t pre_dim,
+                                     const int64_t stride) {
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t pos = static_cast<int64_t>((index + 1) * stride) - 1;
     if (is_odd) {
@@ -84,28 +84,52 @@ __global__ void CalcMedianKernel(const T* sort_out_ptr,
       median_val[index * 2 + 1] = sort_indices_ptr[pos];
       output[index] = sort_out_ptr[pos];
     } else {
+      T median_val_left = pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
+      T median_val_right = sort_out_ptr[pos];
       median_val[index * 2] =
           pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
       median_val[index * 2 + 1] = sort_indices_ptr[pos];
-      T median_val_left = pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
-      T median_val_right = sort_out_ptr[pos];
       output[index] = (median_val_left + median_val_right) / div_factor;
     }
   }
 }
 
 template <typename T>
-__global__ void CalcNanmedianKernel(const T* sort_out_ptr,
+__global__ void CalcMedianMinKernel(const T* sort_out_ptr,
                                     const int64_t* sort_indices_ptr,
-                                    int64_t* nan_counts,
                                     int64_t* median_val,
                                     T* output,
                                     const bool is_odd,
                                     const int64_t pre_dim,
-                                    const int64_t max_valid_num,
-                                    const int64_t stride,
-                                    const T div_factor,
-                                    const T nan_val) {
+                                    const int64_t stride) {
+  CUDA_KERNEL_LOOP(index, pre_dim) {
+    int64_t pos = static_cast<int64_t>((index + 1) * stride) - 1;
+    if (is_odd) {
+      median_val[index * 2] = sort_indices_ptr[pos];
+      median_val[index * 2 + 1] = sort_indices_ptr[pos];
+      output[index] = sort_out_ptr[pos];
+    } else {
+      T median_val_left = pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
+      median_val[index * 2] =
+          pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
+      median_val[index * 2 + 1] = median_val[index * 2];
+      output[index] = median_val_left;
+    }
+  }
+}
+
+template <typename T>
+__global__ void CalcNanmedianMeanKernel(const T* sort_out_ptr,
+                                        const int64_t* sort_indices_ptr,
+                                        int64_t* nan_counts,
+                                        int64_t* median_val,
+                                        T* output,
+                                        const bool is_odd,
+                                        const int64_t pre_dim,
+                                        const int64_t max_valid_num,
+                                        const int64_t stride,
+                                        const T div_factor,
+                                        const T nan_val) {
   CUDA_KERNEL_LOOP(index, pre_dim) {
     int64_t pos = static_cast<int64_t>(index * max_valid_num);
     int64_t nan_cnt = nan_counts[index];
@@ -124,12 +148,50 @@ __global__ void CalcNanmedianKernel(const T* sort_out_ptr,
         median_val[index * 2 + 1] = sort_indices_ptr[pos];
         output[index] = sort_out_ptr[pos];
       } else {
+        T median_val_left = pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
+        T median_val_right = sort_out_ptr[pos];
         median_val[index * 2] =
             pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
         median_val[index * 2 + 1] = sort_indices_ptr[pos];
-        T median_val_left = pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
-        T median_val_right = sort_out_ptr[pos];
         output[index] = (median_val_left + median_val_right) / div_factor;
+      }
+    }
+  }
+}
+
+template <typename T>
+__global__ void CalcNanmedianMinKernel(const T* sort_out_ptr,
+                                       const int64_t* sort_indices_ptr,
+                                       int64_t* nan_counts,
+                                       int64_t* median_val,
+                                       T* output,
+                                       const bool is_odd,
+                                       const int64_t pre_dim,
+                                       const int64_t max_valid_num,
+                                       const int64_t stride const T nan_val) {
+  CUDA_KERNEL_LOOP(index, pre_dim) {
+    int64_t pos = static_cast<int64_t>(index * max_valid_num);
+    int64_t nan_cnt = nan_counts[index];
+    if (nan_cnt == stride) {
+      median_val[index * 2] = -1;
+      median_val[index * 2 + 1] = -1;
+      output[index] = nan_val;
+    } else {
+      int64_t nan_k =
+          nan_cnt > 0 ? static_cast<int64_t>(stride - nan_cnt) : max_valid_num;
+      int64_t row_pos = static_cast<int64_t>(nan_k >> 1);
+      pos += row_pos;
+
+      if (nan_k & 1) {
+        median_val[index * 2] = sort_indices_ptr[pos];
+        median_val[index * 2 + 1] = sort_indices_ptr[pos];
+        output[index] = sort_out_ptr[pos];
+      } else {
+        T median_val_left = pos > 0 ? sort_out_ptr[pos - 1] : sort_out_ptr[pos];
+        median_val[index * 2] =
+            pos > 0 ? sort_indices_ptr[pos - 1] : sort_indices_ptr[pos];
+        median_val[index * 2 + 1] = median_val[index * 2];
+        output[index] = median_val_left;
       }
     }
   }
@@ -138,6 +200,7 @@ __global__ void CalcNanmedianKernel(const T* sort_out_ptr,
 template <typename T, typename Context>
 void ProcessMedianKernel(const Context& dev_ctx,
                          const DenseTensor& x,
+                         const std::string& mode,
                          DenseTensor* out,
                          DenseTensor* median_index) {
   auto stream = dev_ctx.stream();
@@ -231,30 +294,57 @@ void ProcessMedianKernel(const Context& dev_ctx,
   T div_factor = static_cast<T>(2.0);
   T nan_val = std::numeric_limits<T>::quiet_NaN();
   if (ignore_nan) {
-    CalcNanmedianKernel<T>
-        <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
-            sort_out_ptr,
-            sort_indices_ptr,
-            nan_counts_ptr,
-            m_data,
-            out_data,
-            is_ori_odd,
-            pre_dim,
-            max_valid_num,
-            stride,
-            div_factor,
-            nan_val);
+    if (mode == "avg") {
+      CalcNanmedianMeanKernel<T>
+          <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+              sort_out_ptr,
+              sort_indices_ptr,
+              nan_counts_ptr,
+              m_data,
+              out_data,
+              is_ori_odd,
+              pre_dim,
+              max_valid_num,
+              stride,
+              div_factor,
+              nan_val);
+    } else {  // mode == "min"
+      CalcNanmedianMinKernel<T>
+          <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+              sort_out_ptr,
+              sort_indices_ptr,
+              nan_counts_ptr,
+              m_data,
+              out_data,
+              is_ori_odd,
+              pre_dim,
+              max_valid_num,
+              stride,
+              nan_val);
+    }
   } else {
-    CalcMedianKernel<T>
-        <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
-            sort_out_ptr,
-            sort_indices_ptr,
-            m_data,
-            out_data,
-            div_factor,
-            is_ori_odd,
-            pre_dim,
-            sort_k);
+    if (mode == "avg") {
+      CalcMedianMeanKernel<T>
+          <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+              sort_out_ptr,
+              sort_indices_ptr,
+              m_data,
+              out_data,
+              div_factor,
+              is_ori_odd,
+              pre_dim,
+              sort_k);
+    } else {  // mode == "min"
+      CalcMedianMinKernel<T>
+          <<<GET_BLOCKS(pre_dim), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+              sort_out_ptr,
+              sort_indices_ptr,
+              m_data,
+              out_data,
+              is_ori_odd,
+              pre_dim,
+              sort_k);
+    }
   }
 }
 
@@ -263,6 +353,7 @@ void NanmedianKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const IntArray& axes,
                      bool keepdim,
+                     const std::string& mode,
                      DenseTensor* out,
                      DenseTensor* median_index) {
   DenseTensor tmp_x;
@@ -274,7 +365,7 @@ void NanmedianKernel(const Context& dev_ctx,
     funcs::PreprocessMedianKernel<T, Context>(dev_ctx, x, axes, &tmp_x);
   }
 
-  ProcessMedianKernel<T, Context>(dev_ctx, tmp_x, out, median_index);
+  ProcessMedianKernel<T, Context>(dev_ctx, tmp_x, mode, out, median_index);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/nanmedian_grad_kernel.h
+++ b/paddle/phi/kernels/nanmedian_grad_kernel.h
@@ -26,5 +26,6 @@ void NanmedianGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const IntArray& axes,
                          bool keep_dim,
+                         const std::string& mode,
                          DenseTensor* x_grad);
 }  // namespace phi

--- a/paddle/phi/kernels/nanmedian_kernel.h
+++ b/paddle/phi/kernels/nanmedian_kernel.h
@@ -24,6 +24,7 @@ void NanmedianKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const IntArray& axes,
                      bool keep_dim,
+                     const std::string& mode,
                      DenseTensor* out,
                      DenseTensor* medians);
 }  // namespace phi

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -295,12 +295,9 @@ def nanmedian(x, axis=None, keepdim=False, mode='avg', name=None):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        Tensor or tuple of Tensor.
-        If ``mode`` == 'avg', the result will be the tensor of nanmedian values;
-        If ``mode`` == 'min' and ``axis`` is not int (None or list or tuple), the result will
-            be the tensor of nanmedian values;
-        If ``mode`` == 'min' and ``axis`` is int, the result will be a tuple of two tensors
-            containing nanmedian values and their indices.
+        Tensor or tuple of Tensor. If ``mode`` == 'min' and ``axis`` is int, the result
+        will be a tuple of two tensors (nanmedian value and nanmedian index). Otherwise,
+        only nanmedian value will be returned.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -289,22 +289,22 @@ def nanmedian(x, axis=None, keepdim=False, mode='avg', name=None):
             dimensions(it is of size 1 in this case). Otherwise, the shape of
             the output Tensor is squeezed in ``axis`` . Default is False.
         mode (str, optional): Whether to use mean or min operation to calculate
-            the median values when the input tensor has an even number of elements
-            in the dimension ``axis``. Support 'avg' and 'min'. Default is 'avg'.
+            the nanmedian values when the input tensor has an even number of non-NaN elements
+            along the dimension ``axis``. Support 'avg' and 'min'. Default is 'avg'.
         name (str, optional): Name for the operation (optional, default is None).
             For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        ((Tensor, Tensor), optional)
-        If ``mode`` == 'avg', the result will be the tensor of median values;
-        If ``mode`` == 'min' and ``axis`` is None or tuple, the result will be the tensor of median values;
-        If ``mode`` == 'min' and ``axis`` is not None, the result will be a tuple of two tensors
-        containing median values and their indices.
+        Tensor or tuple of Tensor.
+        If ``mode`` == 'avg', the result will be the tensor of nanmedian values;
+        If ``mode`` == 'min' and ``axis`` is not int (None or list or tuple), the result will
+            be the tensor of nanmedian values;
+        If ``mode`` == 'min' and ``axis`` is int, the result will be a tuple of two tensors
+            containing nanmedian values and their indices.
 
-        When ``mode`` == 'avg', if data type of ``x`` is float64, data type of median values will be float64,
-        otherwise data type of median values will be float32.
-        When ``mode`` == 'min', the data type of median values will be the same as ``x``. The data type of
-        indices will be int64.
+        When ``mode`` == 'avg', the output dtype is the same as `x`.
+        When ``mode`` == 'min', the data type of nanmedian values will be the same as ``x``.
+            If indices are retured, the data type will be int64.
 
     Examples:
         .. code-block:: python
@@ -328,20 +328,24 @@ def nanmedian(x, axis=None, keepdim=False, mode='avg', name=None):
             >>> print(y4.numpy())
             2.0
 
-            >>> y5, y5_index = x.nanmedian(0, mode='min')
+            >>> y5 = x.nanmedian(mode='min')
             >>> print(y5.numpy())
+            2.0
+
+            >>> y6, y6_index = x.nanmedian(0, mode='min')
+            >>> print(y6.numpy())
             [0. 1. 2.]
-            >>> print(y5_index.numpy())
+            >>> print(y6_index.numpy())
             [1 1 1]
 
-            >>> y6, y6_index = x.nanmedian(1, mode='min')
-            >>> print(y6.numpy())
+            >>> y7, y7_index = x.nanmedian(1, mode='min')
+            >>> print(y7.numpy())
             [2. 1.]
-            >>> print(y6_index.numpy())
+            >>> print(y7_index.numpy())
             [1 1]
 
-            >>> y7 = x.nanmedian((0,1), mode='min')
-            >>> print(y7.numpy())
+            >>> y8 = x.nanmedian((0,1), mode='min')
+            >>> print(y8.numpy())
             2.0
     """
     if not isinstance(x, (Variable, paddle.pir.Value)):
@@ -384,7 +388,7 @@ def nanmedian(x, axis=None, keepdim=False, mode='avg', name=None):
         )
         indices.stop_gradient = True
     if mode == 'min' and need_index:
-        return out, indices[..., 0]
+        return out, indices
     else:
         return out
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -302,10 +302,7 @@ def nanmedian(x, axis=None, keepdim=False, mode='avg', name=None):
         If ``mode`` == 'min' and ``axis`` is int, the result will be a tuple of two tensors
             containing nanmedian values and their indices.
 
-        When ``mode`` == 'avg', the output dtype is the same as `x`.
-        When ``mode`` == 'min', the data type of nanmedian values will be the same as ``x``.
-            If indices are retured, the data type will be int64.
-
+        The data type of nanmedian values is the same as ``x``.
     Examples:
         .. code-block:: python
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -302,7 +302,6 @@ def nanmedian(x, axis=None, keepdim=False, mode='avg', name=None):
         If ``mode`` == 'min' and ``axis`` is int, the result will be a tuple of two tensors
             containing nanmedian values and their indices.
 
-        The data type of nanmedian values is the same as ``x``.
     Examples:
         .. code-block:: python
 

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import unittest
 
 import numpy as np
@@ -24,7 +25,89 @@ from paddle.pir_utils import test_with_pir_api
 np.random.seed(102)
 
 
-class TestNanmedian(unittest.TestCase):
+def np_nanmedain(data):
+    data_flat = data.flatten()
+    data_cnt = len(data_flat)
+    nan_cnt = np.isnan(data).sum()
+
+    data_flat[np.isnan(data_flat)] = np.inf
+    data_sort = np.sort(data_flat)
+    data_sort[np.isinf(data_sort)] = np.nan
+
+    valid_num = data_cnt - nan_cnt
+
+    if valid_num % 2:
+        is_odd = False
+    else:
+        is_odd = True
+
+    i = int(valid_num / 2)
+    if is_odd:
+        np_res = min(data_sort[i - 1], data_sort[i])
+    else:
+        np_res = data_sort[i]
+    return np_res
+
+
+def np_nanmedain_axis(data, axis=None):
+    data = copy.deepcopy(data)
+
+    if axis is None:
+        return np_nanmedain(data)
+
+    if isinstance(axis, list):
+        axis = axis
+    elif isinstance(axis, set):
+        axis = list(axis)
+    else:
+        axis = [axis]
+
+    axis = [a + len(data.shape) if a < 0 else a for a in axis]
+
+    trans_shape = []
+    reshape = []
+    for i in range(len(data.shape)):
+        if i not in axis:
+            trans_shape.append(i)
+            reshape.append(data.shape[i])
+    last_shape = 1
+    for i in range(len(data.shape)):
+        if i in axis:
+            trans_shape.append(i)
+            last_shape *= data.shape[i]
+    reshape.append(last_shape)
+
+    data_flat = np.transpose(data, trans_shape)
+
+    data_flat = np.reshape(data_flat, (-1, reshape[-1]))
+
+    data_cnt = data_flat.shape[-1]
+    nan_cnt = np.isnan(data_flat).sum(-1)
+
+    data_flat[np.isnan(data_flat)] = np.inf
+    data_sort = np.sort(data_flat, axis=-1)
+    data_sort[np.isinf(data_sort)] = np.nan
+
+    valid_num = data_cnt - nan_cnt
+    is_odd = valid_num % 2
+
+    np_res = np.zeros(len(is_odd), dtype=data.dtype)
+    for j in range(len(is_odd)):
+        if valid_num[j] == 0:
+            np_res[j] = np.nan
+            continue
+
+        i = int(valid_num[j] / 2)
+        if is_odd[j]:
+            np_res[j] = data_sort[j, i]
+        else:
+            np_res[j] = min(data_sort[j, i - 1], data_sort[j, i])
+
+    np_res = np.reshape(np_res, reshape[:-1])
+    return np_res
+
+
+class TestNanmedianModeMin(unittest.TestCase):
     def setUp(self):
         single_axis_shape = 120
         multi_axis_shape = (2, 3, 4, 5)
@@ -47,20 +130,18 @@ class TestNanmedian(unittest.TestCase):
         self.fake_data["single_axis_partial_nan"] = single_partial_nan
         self.fake_data["multi_axis_partial_nan"] = multi_partial_nan
 
-        row_data = np.random.uniform(-1, 1, multi_axis_shape).astype(np.float32)
+        row_data = np.random.uniform(-10, 10, multi_axis_shape)
         row_data[:, :, :, 0] = np.nan
         row_data[:, :, :2, 1] = np.nan
         row_data[:, :, 2:, 2] = np.nan
-        self.fake_data["row_nan_even"] = row_data
+        self.fake_data["row_nan_even"] = row_data.astype(np.float32)
         self.fake_data["row_nan_float64"] = row_data.astype(np.float64)
-        self.fake_data["row_nan_int64"] = row_data.astype(np.int64)
-        self.fake_data["row_nan_int32"] = row_data.astype(np.int32)
 
-        col_data = np.random.uniform(-1, 1, multi_axis_shape).astype(np.float32)
-        col_data[:, :, 0, :] = np.nan
+        col_data = np.random.uniform(-10, 10, multi_axis_shape)
+        col_data[:, :, 0, :] = float('nan')
         col_data[:, :, 1, :3] = np.nan
         col_data[:, :, 2, 3:] = np.nan
-        self.fake_data["col_nan_odd"] = col_data
+        self.fake_data["col_nan_odd"] = col_data.astype(np.float32)
 
         self.place = (
             paddle.CUDAPlace(0)
@@ -84,15 +165,17 @@ class TestNanmedian(unittest.TestCase):
     def test_api_static(self):
         data = self.fake_data["col_nan_odd"]
         paddle.enable_static()
-        np_res = np.nanmedian(data, keepdims=True)
+        np_res = np_nanmedain(data)
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', data.shape)
-            out1 = paddle.nanmedian(x, keepdim=True)
-            out2 = paddle.tensor.nanmedian(x, keepdim=True)
-            out3 = paddle.tensor.stat.nanmedian(x, keepdim=True)
+            out1 = paddle.nanmedian(x, keepdim=False, mode='min')
+            out2 = paddle.tensor.nanmedian(x, keepdim=False, mode='min')
+            out3 = paddle.tensor.stat.nanmedian(x, keepdim=False, mode='min')
             axis = np.arange(len(data.shape)).tolist()
-            out4 = paddle.nanmedian(x, axis=axis, keepdim=True)
-            out5 = paddle.nanmedian(x, axis=tuple(axis), keepdim=True)
+            out4, _ = paddle.nanmedian(x, axis=axis, keepdim=False, mode='min')
+            out5, _ = paddle.nanmedian(
+                x, axis=tuple(axis), keepdim=False, mode='min'
+            )
             exe = paddle.static.Executor(self.place)
             res = exe.run(
                 feed={'X': data}, fetch_list=[out1, out2, out3, out4, out5]
@@ -114,7 +197,7 @@ class TestNanmedian(unittest.TestCase):
                 axis = set(axis)
             return axis
 
-        def test_data_case(data):
+        def test_data_case(data, name):
             for keep_dim in [False, True]:
                 if np.isnan(data).all() and keep_dim:
                     np_ver = np.version.version.split('.')
@@ -124,13 +207,251 @@ class TestNanmedian(unittest.TestCase):
                         )
                         continue
 
-                np_res = np.nanmedian(data, keepdims=keep_dim)
+                np_res = np_nanmedain(data)
+                pd_res = paddle.nanmedian(
+                    paddle.to_tensor(data), keepdim=keep_dim, mode='min'
+                )
+                np.testing.assert_allclose(
+                    np_res, pd_res.item(), rtol=1e-05, equal_nan=True
+                )
+
+        def test_axis_case(data, axis):
+            if axis is not None:
+                pd_res, _ = paddle.nanmedian(
+                    paddle.to_tensor(data), axis=axis, keepdim=False, mode='min'
+                )
+            else:
+                pd_res = paddle.nanmedian(
+                    paddle.to_tensor(data), axis=axis, keepdim=False, mode='min'
+                )
+            axis = clean_axis_numpy(axis, len(data.shape))
+            np_res = np_nanmedain_axis(data, axis)
+            np.testing.assert_allclose(
+                np_res, pd_res.numpy(), rtol=1e-05, equal_nan=True
+            )
+
+        for name, data in self.fake_data.items():
+            test_data_case(data, name)
+
+        for axis in self.axis_candiate_list:
+            test_axis_case(self.fake_data["row_nan_even"], axis)
+            test_axis_case(self.fake_data["col_nan_odd"], axis)
+
+        paddle.enable_static()
+
+    def test_errors(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data("X", [10, 12])
+
+            def test_dtype():
+                x2 = paddle.static.data('X2', [10, 12], 'bool')
+                paddle.nanmedian(x2, mode='min')
+
+            def test_empty_axis():
+                paddle.nanmedian(x, axis=[], keepdim=True, mode='min')
+
+            def test_axis_not_in_range():
+                paddle.nanmedian(x, axis=3, keepdim=True, mode='min')
+
+            def test_duplicated_axis():
+                paddle.nanmedian(x, axis=[1, -1], keepdim=True, mode='min')
+
+            self.assertRaises(TypeError, test_dtype)
+            self.assertRaises(ValueError, test_empty_axis)
+            self.assertRaises(ValueError, test_axis_not_in_range)
+            self.assertRaises(ValueError, test_duplicated_axis)
+
+    def test_dygraph(self):
+        paddle.disable_static(place=self.place)
+        with paddle.base.dygraph.guard():
+            data = self.fake_data["col_nan_odd"]
+            out = paddle.nanmedian(
+                paddle.to_tensor(data), keepdim=False, mode='min'
+            )
+        np_res = np_nanmedain(data)
+        np.testing.assert_allclose(np_res, out, rtol=1e-05, equal_nan=True)
+        paddle.enable_static()
+
+    def test_check_grad(self):
+        paddle.disable_static(place=self.place)
+        shape = (4, 5)
+        x_np = np.arange(np.prod(shape)).reshape(shape).astype(np.float64)
+        x_np[0, :] = np.nan
+        x_np[1, :3] = np.nan
+        x_np[2, 3:] = np.nan
+
+        x_tensor = paddle.to_tensor(x_np, stop_gradient=False)
+        y = paddle.nanmedian(x_tensor, keepdim=True, mode='min')
+        dx = paddle.grad(y, x_tensor)[0].numpy()
+
+        np_grad = np.zeros(shape)
+        np_grad[2, 2] = 1.0
+        np.testing.assert_allclose(np_grad, dx, rtol=1e-05, equal_nan=True)
+
+    def test_check_grad_axis(self):
+        paddle.disable_static(place=self.place)
+        shape = (4, 5)
+        x_np = np.random.uniform(-1, 1, shape).astype(np.float64)
+        x_np[0, :] = np.nan
+        x_np[1, :3] = np.nan
+        x_np[2, 3:] = np.nan
+        x_np_sorted = np.sort(x_np)
+        nan_counts = np.count_nonzero(np.isnan(x_np).astype(np.int32), axis=1)
+        np_grad = np.zeros(shape)
+        for i in range(shape[0]):
+            valid_cnts = shape[1] - nan_counts[i]
+            if valid_cnts == 0:
+                continue
+
+            mid = int(valid_cnts / 2)
+            targets = []
+            is_odd = valid_cnts % 2
+            if not is_odd and mid > 0:
+                min_val = min(x_np_sorted[i, mid - 1], x_np_sorted[i, mid])
+                targets.append(min_val)
+            else:
+                targets.append(x_np_sorted[i, mid])
+
+            for j in range(shape[1]):
+                if x_np[i, j] in targets:
+                    np_grad[i, j] = 1 if is_odd else 1
+
+        x_tensor = paddle.to_tensor(x_np, stop_gradient=False)
+        y, _ = paddle.nanmedian(x_tensor, axis=1, mode='min')
+        dx = paddle.grad(y, x_tensor)[0].numpy()
+        np.testing.assert_allclose(np_grad, dx, rtol=1e-05, equal_nan=True)
+
+    def test_mode_min_index(self):
+        paddle.disable_static(place=self.place)
+        x = paddle.arange(2 * 100).reshape((2, 100)).astype(paddle.float32)
+        out, index = paddle.median(x, axis=1, mode='min')
+        np.testing.assert_allclose(out.numpy(), [49.0, 149.0])
+        np.testing.assert_equal(index.numpy(), [49, 49])
+
+    def test_check_grad_0d(self):
+        paddle.disable_static(place=self.place)
+        x = paddle.rand([])
+        x.stop_gradient = False
+        y = paddle.nanmedian(x, mode='min')
+        y.backward()
+        self.assertEqual(x.grad.shape, [])
+        np.testing.assert_allclose(x.grad, np.array(1.0))
+
+        x = paddle.to_tensor(float('nan'), stop_gradient=False)
+        y = paddle.nanmedian(x, mode='min')
+        y.backward()
+        self.assertEqual(x.grad.shape, [])
+        np.testing.assert_allclose(x.grad, np.array(0.0))
+
+
+class TestNanmedianModeMean(unittest.TestCase):
+    def setUp(self):
+        single_axis_shape = 120
+        multi_axis_shape = (2, 3, 4, 5)
+
+        self.fake_data = {
+            "single_axis_normal": np.random.uniform(
+                -1, 1, single_axis_shape
+            ).astype(np.float32),
+            "multi_axis_normal": np.random.uniform(
+                -1, 1, multi_axis_shape
+            ).astype(np.float32),
+            "single_axis_all_nan": np.full(single_axis_shape, np.nan),
+            "multi_axis_all_nan": np.full(multi_axis_shape, np.nan),
+        }
+
+        single_partial_nan = self.fake_data["single_axis_normal"].copy()
+        single_partial_nan[single_partial_nan > 0] = np.nan
+        multi_partial_nan = self.fake_data["multi_axis_normal"].copy()
+        multi_partial_nan[multi_partial_nan > 0] = np.nan
+        self.fake_data["single_axis_partial_nan"] = single_partial_nan
+        self.fake_data["multi_axis_partial_nan"] = multi_partial_nan
+
+        row_data = np.random.uniform(-10, 10, multi_axis_shape)
+        row_data[:, :, :, 0] = np.nan
+        row_data[:, :, :2, 1] = np.nan
+        row_data[:, :, 2:, 2] = np.nan
+        self.fake_data["row_nan_even"] = row_data.astype(np.float32)
+        self.fake_data["row_nan_float64"] = row_data.astype(np.float64)
+        # self.fake_data["row_nan_int64"] = row_data.astype(np.int64)
+        # self.fake_data["row_nan_int32"] = row_data.astype(np.int32)
+
+        col_data = np.random.uniform(-10, 10, multi_axis_shape)
+        col_data[:, :, 0, :] = float('nan')
+        col_data[:, :, 1, :3] = np.nan
+        col_data[:, :, 2, 3:] = np.nan
+        self.fake_data["col_nan_odd"] = col_data.astype(np.float32)
+
+        self.place = (
+            paddle.CUDAPlace(0)
+            if core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+        self.axis_candiate_list = [
+            None,
+            0,
+            2,
+            -1,
+            -2,
+            (1, 2),
+            [0, -1],
+            [0, 1, 3],
+            (1, 2, 3),
+            [0, 2, 1, 3],
+        ]
+
+    @test_with_pir_api
+    def test_api_static(self):
+        data = self.fake_data["col_nan_odd"]
+        paddle.enable_static()
+        np_res = np.nanmedian(data)
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data('X', data.shape)
+            out1 = paddle.nanmedian(x, keepdim=False)
+            out2 = paddle.tensor.nanmedian(x, keepdim=False)
+            out3 = paddle.tensor.stat.nanmedian(x, keepdim=False)
+            axis = np.arange(len(data.shape)).tolist()
+            out4 = paddle.nanmedian(x, axis=axis, keepdim=False)
+            out5 = paddle.nanmedian(x, axis=tuple(axis), keepdim=False)
+            exe = paddle.static.Executor(self.place)
+            res = exe.run(
+                feed={'X': data}, fetch_list=[out1, out2, out3, out4, out5]
+            )
+
+        for out in res:
+            np.testing.assert_allclose(np_res, out, rtol=1e-05, equal_nan=True)
+
+    def test_api_dygraph(self):
+        paddle.disable_static(self.place)
+
+        def clean_axis_numpy(axis, shape_len):
+            if isinstance(axis, tuple):
+                axis = list(axis)
+            if isinstance(axis, list):
+                for k in range(len(axis)):
+                    if axis[k] < 0:
+                        axis[k] += shape_len
+                axis = set(axis)
+            return axis
+
+        def test_data_case(data, name):
+            for keep_dim in [False, True]:
+                if np.isnan(data).all() and keep_dim:
+                    np_ver = np.version.version.split('.')
+                    if int(np_ver[0]) < 1 or int(np_ver[1]) <= 20:
+                        print(
+                            "This numpy version does not support all nan elements when keepdim is True"
+                        )
+                        continue
+
+                np_res = np.nanmedian(data)
                 pd_res = paddle.nanmedian(
                     paddle.to_tensor(data), keepdim=keep_dim
                 )
-                assert np_res.shape == pd_res.numpy().shape
+
                 np.testing.assert_allclose(
-                    np_res, pd_res.numpy(), rtol=1e-05, equal_nan=True
+                    np_res, pd_res.item(), rtol=1e-05, equal_nan=True
                 )
 
         def test_axis_case(data, axis):
@@ -138,13 +459,13 @@ class TestNanmedian(unittest.TestCase):
                 paddle.to_tensor(data), axis=axis, keepdim=False
             )
             axis = clean_axis_numpy(axis, len(data.shape))
-            np_res = np.nanmedian(data, axis=axis, keepdims=False)
+            np_res = np.nanmedian(data, axis)
             np.testing.assert_allclose(
                 np_res, pd_res.numpy(), rtol=1e-05, equal_nan=True
             )
 
         for name, data in self.fake_data.items():
-            test_data_case(data)
+            test_data_case(data, name)
 
         for axis in self.axis_candiate_list:
             test_axis_case(self.fake_data["row_nan_even"], axis)
@@ -170,24 +491,28 @@ class TestNanmedian(unittest.TestCase):
             def test_duplicated_axis():
                 paddle.nanmedian(x, axis=[1, -1], keepdim=True)
 
+            def test_mode():
+                paddle.nanmedian(x, mode='max')
+
             self.assertRaises(TypeError, test_dtype)
             self.assertRaises(ValueError, test_empty_axis)
             self.assertRaises(ValueError, test_axis_not_in_range)
             self.assertRaises(ValueError, test_duplicated_axis)
+            self.assertRaises(ValueError, test_mode)
 
     def test_dygraph(self):
         paddle.disable_static(place=self.place)
         with paddle.base.dygraph.guard():
             data = self.fake_data["col_nan_odd"]
-            out = paddle.nanmedian(paddle.to_tensor(data), keepdim=True)
-        np_res = np.nanmedian(data, keepdims=True)
+            out = paddle.nanmedian(paddle.to_tensor(data), keepdim=False)
+        np_res = np.nanmedian(data)
         np.testing.assert_allclose(np_res, out, rtol=1e-05, equal_nan=True)
         paddle.enable_static()
 
     def test_check_grad(self):
         paddle.disable_static(place=self.place)
         shape = (4, 5)
-        x_np = np.random.uniform(-1, 1, shape).astype(np.float64)
+        x_np = np.arange(np.prod(shape)).reshape(shape).astype(np.float64)
         x_np[0, :] = np.nan
         x_np[1, :3] = np.nan
         x_np[2, 3:] = np.nan
@@ -197,8 +522,8 @@ class TestNanmedian(unittest.TestCase):
         dx = paddle.grad(y, x_tensor)[0].numpy()
 
         np_grad = np.zeros(shape)
-        np_grad[1, 3] = 0.5
-        np_grad[3, 2] = 0.5
+        np_grad[2, 2] = 0.5
+        np_grad[3, 0] = 0.5
         np.testing.assert_allclose(np_grad, dx, rtol=1e-05, equal_nan=True)
 
     def test_check_grad_axis(self):
@@ -255,8 +580,9 @@ class TestNanmedianFP16Op(OpTest):
         self.python_out_sig = ["Out"]
         X = np.random.random((100, 100)).astype('float16')
         Out = np.nanmedian(X)
+        indices = np.zeros_like(Out, dtype='int64')
         self.inputs = {'X': X}
-        self.outputs = {'Out': Out}
+        self.outputs = {'Out': Out, 'MedianIndex': indices}
 
     def test_check_output(self):
         self.check_output(check_pir=True)
@@ -279,8 +605,12 @@ class TestNanmedianBF16Op(OpTest):
         self.python_out_sig = ["Out"]
         X = np.random.random((100, 100)).astype('float32')
         Out = np.nanmedian(X)
+        indices = np.zeros_like(Out, dtype='int64')
         self.inputs = {'X': convert_float_to_uint16(X)}
-        self.outputs = {'Out': convert_float_to_uint16(Out)}
+        self.outputs = {
+            'Out': convert_float_to_uint16(Out),
+            'MedianIndex': indices,
+        }
 
     def test_check_output(self):
         place = core.CUDAPlace(0)

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -325,7 +325,7 @@ class TestNanmedianModeMin(unittest.TestCase):
     def test_mode_min_index(self):
         paddle.disable_static(place=self.place)
         x = paddle.arange(2 * 100).reshape((2, 100)).astype(paddle.float32)
-        out, index = paddle.median(x, axis=1, mode='min')
+        out, index = paddle.nanmedian(x, axis=1, mode='min')
         np.testing.assert_allclose(out.numpy(), [49.0, 149.0])
         np.testing.assert_equal(index.numpy(), [49, 49])
 

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -172,8 +172,8 @@ class TestNanmedianModeMin(unittest.TestCase):
             out2 = paddle.tensor.nanmedian(x, keepdim=False, mode='min')
             out3 = paddle.tensor.stat.nanmedian(x, keepdim=False, mode='min')
             axis = np.arange(len(data.shape)).tolist()
-            out4, _ = paddle.nanmedian(x, axis=axis, keepdim=False, mode='min')
-            out5, _ = paddle.nanmedian(
+            out4 = paddle.nanmedian(x, axis=axis, keepdim=False, mode='min')
+            out5 = paddle.nanmedian(
                 x, axis=tuple(axis), keepdim=False, mode='min'
             )
             exe = paddle.static.Executor(self.place)
@@ -216,7 +216,7 @@ class TestNanmedianModeMin(unittest.TestCase):
                 )
 
         def test_axis_case(data, axis):
-            if axis is not None:
+            if (axis is not None) and (not isinstance(axis, (list, tuple))):
                 pd_res, _ = paddle.nanmedian(
                     paddle.to_tensor(data), axis=axis, keepdim=False, mode='min'
                 )


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Description
- 增加参数 `mode` ：默认值 'avg' ，另外可取 'min' 。当所需要计算的 tensor 在 `axis` 轴上有偶数个元素时， 'avg' 表示计算结果为中间两个数的算术平均值；'min' 则为二者的最小值。
- 返回值：当  `mode = 'min'` 且 `axis` 不为 None 或 tuple 时，返回值为 (median_values, median_indices) ；其他情况下返回值为 median_values 的 tensor 。

  参考
  - https://github.com/PaddlePaddle/Paddle/pull/55285
