### PR TITLE
[Distributed] support using non-batched comm in pipeline schedule

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -84,7 +84,7 @@ message PpConfig {
     optional bool release_gradients = 6 [ default = false ];
     optional bool overlap_p2p_comm = 7 [default = false];
     optional bool clear_every_step_cache = 8 [default = false];
-    optional bool non_batch_p2p_comm = 9 [default = false];
+    optional bool use_batch_p2p_comm = 9 [default = true];
 }
 
 message DygraphShardingConfig {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -84,6 +84,7 @@ message PpConfig {
     optional bool release_gradients = 6 [ default = false ];
     optional bool overlap_p2p_comm = 7 [default = false];
     optional bool clear_every_step_cache = 8 [default = false];
+    optional bool non_batch_p2p_comm = 9 [default = false];
 }
 
 message DygraphShardingConfig {

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -1265,7 +1265,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 self._p2p_helper.recv_forward(
                     self.is_pipeline_first_stage(),
                     sync_recv=False,
-                    batch_p2p_comm=not self._non_batch_p2p_comm,
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                 )
             )
 
@@ -1334,7 +1334,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                         input_tensor_grad,
                         recv_prev=recv_prev,
                         recv_next=recv_next,
-                        batch_p2p_comm=not self._non_batch_p2p_comm,
+                        batch_p2p_comm=(not self._non_batch_p2p_comm),
                     )
                     # output_tensor_grad is not none if recv_next
                     # append output_tensor_grad no matter none or not
@@ -1345,7 +1345,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     input_tensor = self._p2p_helper.send_forward_recv_forward(
                         output_tensor,
                         recv_prev=recv_prev,
-                        batch_p2p_comm=not self._non_batch_p2p_comm,
+                        batch_p2p_comm=(not self._non_batch_p2p_comm),
                     )
                 # append input_tensor no matter none or not
                 self.input_tensors[next_virtual_pp_rank].append(input_tensor)
@@ -1356,7 +1356,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_forward_recv_forward(
                     output_tensor,
                     recv_prev=recv_prev,
-                    batch_p2p_comm=not self._non_batch_p2p_comm,
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                     overlap_p2p_comm=True,
                 )
                 if (
@@ -1375,7 +1375,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     ) = self._p2p_helper.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
-                        batch_p2p_comm=not self._non_batch_p2p_comm,
+                        batch_p2p_comm=(not self._non_batch_p2p_comm),
                         overlap_p2p_comm=True,
                     )
                     self.output_tensor_grads[self.num_model_chunks - 1].append(
@@ -1466,7 +1466,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_forward_recv_forward(
                     output_tensor,
                     recv_prev=recv_prev,
-                    batch_p2p_comm=not self._non_batch_p2p_comm,
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                     overlap_p2p_comm=True,
                 )
 
@@ -1512,7 +1512,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_backward_recv_backward(
                     input_tensor_grad,
                     recv_next=recv_next,
-                    batch_p2p_comm=not self._non_batch_p2p_comm,
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                     overlap_p2p_comm=True,
                 )
             else:
@@ -1598,7 +1598,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     input_tensor_grad,
                     recv_prev=recv_prev,
                     recv_next=recv_next,
-                    batch_p2p_comm=not self._non_batch_p2p_comm,
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                 )
             # append input_tensor no matter none or not
             self.input_tensors[next_forward_virtual_pp_rank].append(
@@ -1624,7 +1624,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
             if not steady_steps:
                 output_tensor_grad = p2p.recv_backward(
                     self.is_pipeline_last_stage(),
-                    batch_p2p_comm=not self._non_batch_p2p_comm,
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                 )
                 self.output_tensor_grads[self.num_model_chunks - 1].append(
                     output_tensor_grad
@@ -1671,7 +1671,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     self._p2p_helper.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
-                        batch_p2p_comm=not self._non_batch_p2p_comm,
+                        batch_p2p_comm=(not self._non_batch_p2p_comm),
                     )
                 )
 

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -224,7 +224,14 @@ class PipelineParallel(MetaParallelBase):
             "pp_configs"
         ].clear_every_step_cache
 
-        self._batch_p2p_comm = not self._overlap_p2p_comm
+        self._non_batch_p2p_comm = self._strategy.hybrid_configs[
+            "pp_configs"
+        ].non_batch_p2p_comm
+        if not self._non_batch_p2p_comm and self._overlap_p2p_comm:
+            warnings.warn(
+                "non_batch_p2p_comm should be enabled when overlap_p2p_comm is activated, setting non_batch_p2p_comm=True."
+            )
+            self._non_batch_p2p_comm = True
 
         logger.info(
             f"dp_comm_overlap {self._dp_comm_overlap}; \
@@ -490,14 +497,17 @@ class PipelineParallel(MetaParallelBase):
                 logger.info(f"forward step for micro step {step_id}")
                 continue
             input_tensor = self._p2p_helper.recv_forward(
-                self.is_pipeline_first_stage()
+                self.is_pipeline_first_stage(),
+                batch_p2p_comm=(not self._non_batch_p2p_comm),
             )
 
             self._record_stamp("F", step_id, '"B"', self._forward_color)
             output_tensor = self._forward_step(input_tensor, micro_dataset)
             self._record_stamp("F", step_id, '"E"', self._forward_color)
             self._p2p_helper.send_forward(
-                output_tensor, self.is_pipeline_last_stage()
+                output_tensor,
+                self.is_pipeline_last_stage(),
+                batch_p2p_comm=(not self._non_batch_p2p_comm),
             )
 
             input_buffers.append(input_tensor)
@@ -508,7 +518,8 @@ class PipelineParallel(MetaParallelBase):
 
         if steady_steps > 0 and not static_scheduler:
             input_tensor = self._p2p_helper.recv_forward(
-                self.is_pipeline_first_stage()
+                self.is_pipeline_first_stage(),
+                batch_p2p_comm=(not self._non_batch_p2p_comm),
             )
 
         for i in range(steady_steps):
@@ -529,7 +540,9 @@ class PipelineParallel(MetaParallelBase):
             )
 
             output_tensor_grad = self._p2p_helper.send_forward_recv_backward(
-                output_tensor, self.is_pipeline_last_stage()
+                output_tensor,
+                self.is_pipeline_last_stage(),
+                batch_p2p_comm=(not self._non_batch_p2p_comm),
             )
 
             input_buffers.append(input_tensor)
@@ -551,11 +564,15 @@ class PipelineParallel(MetaParallelBase):
             if last_iter:
                 input_tensor = None
                 self._p2p_helper.send_backward(
-                    input_tensor_grad, self.is_pipeline_first_stage()
+                    input_tensor_grad,
+                    self.is_pipeline_first_stage(),
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                 )
             else:
                 input_tensor = self._p2p_helper.send_backward_recv_forward(
-                    input_tensor_grad, self.is_pipeline_first_stage()
+                    input_tensor_grad,
+                    self.is_pipeline_first_stage(),
+                    batch_p2p_comm=(not self._non_batch_p2p_comm),
                 )
 
         for i in range(startup_steps):
@@ -567,7 +584,8 @@ class PipelineParallel(MetaParallelBase):
             output_tensor = output_buffers.pop(0)
 
             output_tensor_grad = self._p2p_helper.recv_backward(
-                self.is_pipeline_last_stage()
+                self.is_pipeline_last_stage(),
+                batch_p2p_comm=(not self._non_batch_p2p_comm),
             )
 
             self._record_stamp(
@@ -580,7 +598,9 @@ class PipelineParallel(MetaParallelBase):
                 "B", steady_steps + i, '"E"', self._backward_color
             )
             self._p2p_helper.send_backward(
-                input_tensor_grad, self.is_pipeline_first_stage()
+                input_tensor_grad,
+                self.is_pipeline_first_stage(),
+                batch_p2p_comm=(not self._non_batch_p2p_comm),
             )
 
         if static_scheduler:
@@ -1245,7 +1265,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 self._p2p_helper.recv_forward(
                     self.is_pipeline_first_stage(),
                     sync_recv=False,
-                    batch_p2p_comm=self._batch_p2p_comm,
+                    batch_p2p_comm=not self._non_batch_p2p_comm,
                 )
             )
 
@@ -1314,7 +1334,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                         input_tensor_grad,
                         recv_prev=recv_prev,
                         recv_next=recv_next,
-                        batch_p2p_comm=self._batch_p2p_comm,
+                        batch_p2p_comm=not self._non_batch_p2p_comm,
                     )
                     # output_tensor_grad is not none if recv_next
                     # append output_tensor_grad no matter none or not
@@ -1325,7 +1345,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     input_tensor = self._p2p_helper.send_forward_recv_forward(
                         output_tensor,
                         recv_prev=recv_prev,
-                        batch_p2p_comm=self._batch_p2p_comm,
+                        batch_p2p_comm=not self._non_batch_p2p_comm,
                     )
                 # append input_tensor no matter none or not
                 self.input_tensors[next_virtual_pp_rank].append(input_tensor)
@@ -1336,7 +1356,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_forward_recv_forward(
                     output_tensor,
                     recv_prev=recv_prev,
-                    batch_p2p_comm=self._batch_p2p_comm,
+                    batch_p2p_comm=not self._non_batch_p2p_comm,
                     overlap_p2p_comm=True,
                 )
                 if (
@@ -1355,7 +1375,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     ) = self._p2p_helper.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
-                        batch_p2p_comm=self._batch_p2p_comm,
+                        batch_p2p_comm=not self._non_batch_p2p_comm,
                         overlap_p2p_comm=True,
                     )
                     self.output_tensor_grads[self.num_model_chunks - 1].append(
@@ -1446,7 +1466,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_forward_recv_forward(
                     output_tensor,
                     recv_prev=recv_prev,
-                    batch_p2p_comm=self._batch_p2p_comm,
+                    batch_p2p_comm=not self._non_batch_p2p_comm,
                     overlap_p2p_comm=True,
                 )
 
@@ -1492,7 +1512,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_backward_recv_backward(
                     input_tensor_grad,
                     recv_next=recv_next,
-                    batch_p2p_comm=self._batch_p2p_comm,
+                    batch_p2p_comm=not self._non_batch_p2p_comm,
                     overlap_p2p_comm=True,
                 )
             else:
@@ -1578,7 +1598,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     input_tensor_grad,
                     recv_prev=recv_prev,
                     recv_next=recv_next,
-                    batch_p2p_comm=self._batch_p2p_comm,
+                    batch_p2p_comm=not self._non_batch_p2p_comm,
                 )
             # append input_tensor no matter none or not
             self.input_tensors[next_forward_virtual_pp_rank].append(
@@ -1604,7 +1624,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
             if not steady_steps:
                 output_tensor_grad = p2p.recv_backward(
                     self.is_pipeline_last_stage(),
-                    batch_p2p_comm=self._batch_p2p_comm,
+                    batch_p2p_comm=not self._non_batch_p2p_comm,
                 )
                 self.output_tensor_grads[self.num_model_chunks - 1].append(
                     output_tensor_grad
@@ -1651,7 +1671,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     self._p2p_helper.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
-                        batch_p2p_comm=self._batch_p2p_comm,
+                        batch_p2p_comm=not self._non_batch_p2p_comm,
                     )
                 )
 

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -224,14 +224,14 @@ class PipelineParallel(MetaParallelBase):
             "pp_configs"
         ].clear_every_step_cache
 
-        self._non_batch_p2p_comm = self._strategy.hybrid_configs[
+        self._use_batch_p2p_comm = self._strategy.hybrid_configs[
             "pp_configs"
-        ].non_batch_p2p_comm
-        if not self._non_batch_p2p_comm and self._overlap_p2p_comm:
+        ].use_batch_p2p_comm
+        if self._use_batch_p2p_comm and self._overlap_p2p_comm:
             warnings.warn(
                 "non_batch_p2p_comm should be enabled when overlap_p2p_comm is activated, setting non_batch_p2p_comm=True."
             )
-            self._non_batch_p2p_comm = True
+            self._use_batch_p2p_comm = False
 
         logger.info(
             f"dp_comm_overlap {self._dp_comm_overlap}; \
@@ -498,7 +498,7 @@ class PipelineParallel(MetaParallelBase):
                 continue
             input_tensor = self._p2p_helper.recv_forward(
                 self.is_pipeline_first_stage(),
-                batch_p2p_comm=(not self._non_batch_p2p_comm),
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
             self._record_stamp("F", step_id, '"B"', self._forward_color)
@@ -507,7 +507,7 @@ class PipelineParallel(MetaParallelBase):
             self._p2p_helper.send_forward(
                 output_tensor,
                 self.is_pipeline_last_stage(),
-                batch_p2p_comm=(not self._non_batch_p2p_comm),
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
             input_buffers.append(input_tensor)
@@ -519,7 +519,7 @@ class PipelineParallel(MetaParallelBase):
         if steady_steps > 0 and not static_scheduler:
             input_tensor = self._p2p_helper.recv_forward(
                 self.is_pipeline_first_stage(),
-                batch_p2p_comm=(not self._non_batch_p2p_comm),
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
         for i in range(steady_steps):
@@ -542,7 +542,7 @@ class PipelineParallel(MetaParallelBase):
             output_tensor_grad = self._p2p_helper.send_forward_recv_backward(
                 output_tensor,
                 self.is_pipeline_last_stage(),
-                batch_p2p_comm=(not self._non_batch_p2p_comm),
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
             input_buffers.append(input_tensor)
@@ -566,13 +566,13 @@ class PipelineParallel(MetaParallelBase):
                 self._p2p_helper.send_backward(
                     input_tensor_grad,
                     self.is_pipeline_first_stage(),
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                 )
             else:
                 input_tensor = self._p2p_helper.send_backward_recv_forward(
                     input_tensor_grad,
                     self.is_pipeline_first_stage(),
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                 )
 
         for i in range(startup_steps):
@@ -585,7 +585,7 @@ class PipelineParallel(MetaParallelBase):
 
             output_tensor_grad = self._p2p_helper.recv_backward(
                 self.is_pipeline_last_stage(),
-                batch_p2p_comm=(not self._non_batch_p2p_comm),
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
             self._record_stamp(
@@ -600,7 +600,7 @@ class PipelineParallel(MetaParallelBase):
             self._p2p_helper.send_backward(
                 input_tensor_grad,
                 self.is_pipeline_first_stage(),
-                batch_p2p_comm=(not self._non_batch_p2p_comm),
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
         if static_scheduler:
@@ -1265,7 +1265,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 self._p2p_helper.recv_forward(
                     self.is_pipeline_first_stage(),
                     sync_recv=False,
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                 )
             )
 
@@ -1334,7 +1334,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                         input_tensor_grad,
                         recv_prev=recv_prev,
                         recv_next=recv_next,
-                        batch_p2p_comm=(not self._non_batch_p2p_comm),
+                        batch_p2p_comm=self._use_batch_p2p_comm,
                     )
                     # output_tensor_grad is not none if recv_next
                     # append output_tensor_grad no matter none or not
@@ -1345,7 +1345,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     input_tensor = self._p2p_helper.send_forward_recv_forward(
                         output_tensor,
                         recv_prev=recv_prev,
-                        batch_p2p_comm=(not self._non_batch_p2p_comm),
+                        batch_p2p_comm=self._use_batch_p2p_comm,
                     )
                 # append input_tensor no matter none or not
                 self.input_tensors[next_virtual_pp_rank].append(input_tensor)
@@ -1356,7 +1356,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_forward_recv_forward(
                     output_tensor,
                     recv_prev=recv_prev,
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                     overlap_p2p_comm=True,
                 )
                 if (
@@ -1375,7 +1375,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     ) = self._p2p_helper.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
-                        batch_p2p_comm=(not self._non_batch_p2p_comm),
+                        batch_p2p_comm=self._use_batch_p2p_comm,
                         overlap_p2p_comm=True,
                     )
                     self.output_tensor_grads[self.num_model_chunks - 1].append(
@@ -1466,7 +1466,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_forward_recv_forward(
                     output_tensor,
                     recv_prev=recv_prev,
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                     overlap_p2p_comm=True,
                 )
 
@@ -1512,7 +1512,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 ) = self._p2p_helper.send_backward_recv_backward(
                     input_tensor_grad,
                     recv_next=recv_next,
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                     overlap_p2p_comm=True,
                 )
             else:
@@ -1598,7 +1598,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     input_tensor_grad,
                     recv_prev=recv_prev,
                     recv_next=recv_next,
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                 )
             # append input_tensor no matter none or not
             self.input_tensors[next_forward_virtual_pp_rank].append(
@@ -1624,7 +1624,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
             if not steady_steps:
                 output_tensor_grad = p2p.recv_backward(
                     self.is_pipeline_last_stage(),
-                    batch_p2p_comm=(not self._non_batch_p2p_comm),
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                 )
                 self.output_tensor_grads[self.num_model_chunks - 1].append(
                     output_tensor_grad
@@ -1671,7 +1671,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     self._p2p_helper.send_backward_recv_backward(
                         input_tensor_grad,
                         recv_next=recv_next,
-                        batch_p2p_comm=(not self._non_batch_p2p_comm),
+                        batch_p2p_comm=self._use_batch_p2p_comm,
                     )
                 )
 
@@ -1835,7 +1835,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
         self.set_virtual_pipeline_rank(0)
         self.input_tensors[0].append(
             self._p2p_helper.recv_forward(
-                self.is_pipeline_first_stage(), sync_recv=False
+                self.is_pipeline_first_stage(),
+                sync_recv=False,
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
         )
 
@@ -1871,7 +1873,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
                     output_tensor = send_recv_buffer_queue.get()
 
             input_tensor = self._p2p_helper.send_forward_recv_forward(
-                output_tensor, recv_prev=recv_prev
+                output_tensor,
+                recv_prev=recv_prev,
+                batch_p2p_comm=self._use_batch_p2p_comm,
             )
             self.input_tensors[next_virtual_pp_rank].append(input_tensor)
 
@@ -1885,7 +1889,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
         if not forward_only:
             self.output_tensor_grads[self.num_model_chunks - 1].append(
                 self._p2p_helper.recv_backward(
-                    self.is_pipeline_last_stage(), sync_recv=False
+                    self.is_pipeline_last_stage(),
+                    sync_recv=False,
+                    batch_p2p_comm=self._use_batch_p2p_comm,
                 )
             )
 
@@ -1920,7 +1926,9 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
 
                 self.output_tensor_grads[next_backward_virtual_pp_rank].append(
                     self._p2p_helper.send_backward_recv_backward(
-                        input_tensor_grad, recv_next=recv_next
+                        input_tensor_grad,
+                        recv_next=recv_next,
+                        batch_p2p_comm=self._use_batch_p2p_comm,
                     )
                 )
 

--- a/test/legacy_test/hybrid_parallel_pp_alexnet.py
+++ b/test/legacy_test/hybrid_parallel_pp_alexnet.py
@@ -176,5 +176,24 @@ class TestDistPPMainGrad(TestDistPPTraining):
         return scheduler, optimizer
 
 
+class TestDistPPTrainingNonBatchedMode(TestDistPPTraining):
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+            "pp_configs": {"non_batch_p2p_comm": True},
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
[Pcard-79653]
Support using non-batched communication in pipeline schedule.
To enable this function, add following param when launching scripts of PaddleNLP:
```
--pipeline_parallel_config "disable_batch_p2p_comm"
```