### PR TITLE
skip normal reset log to avoid mislead user

### DIFF
--- a/paddle/phi/core/distributed/store/tcp_store.cc
+++ b/paddle/phi/core/distributed/store/tcp_store.cc
@@ -241,8 +241,12 @@ void MasterDaemon::ProcessCommands(std::vector<struct pollfd>* p_fds) {
 #else
       _sockets.erase(_sockets.begin() + i - 2);
 #endif
-
-      VLOG(5) << "Meet some exceptions during run:" << ex.what();
+      std::string s(ex.what());
+      if (s.find("TCP connection reset by peer") != std::string::npos) {
+        VLOG(5) << "TCP connection reset by peer";
+      } else {
+        VLOG(5) << "Meet some exceptions during run:" << ex.what();
+      }
     }
   }
 }

--- a/paddle/phi/core/distributed/store/tcp_utils.h
+++ b/paddle/phi/core/distributed/store/tcp_utils.h
@@ -100,12 +100,16 @@ void receive_bytes(SocketType socket, T* buffer, size_t len) {
 
   while (to_recv > 0) {
     auto byte_received = ::recv(socket, ptr, to_recv, 0);
-    PADDLE_ENFORCE_GT(
+    PADDLE_ENFORCE_GE(
         byte_received,
         0,
         phi::errors::InvalidArgument("TCP receive error. Details: %s.",
                                      socket_error().message()));
-
+    if (byte_received == 0) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "TCP connection reset by peer. Details: %s.",
+          socket_error().message()));
+    }
     to_recv -= byte_received;
     ptr += byte_received;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
If recieve bytes is 0, it means the end of tcp connection.
To avoid the following logs when `GLOG_v > 5`
<img width="982" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/6888866/44c5fbf7-4d11-490d-93ec-962fce395987">
Pcard-76459
