### PR TITLE
[Don't merge][SOT][PIR] fix `Not support builtin function __bool__ with args: Args(ObjectVariable)` for test_slice

### DIFF
--- a/test/dygraph_to_static/test_slice.py
+++ b/test/dygraph_to_static/test_slice.py
@@ -27,6 +27,7 @@ from dygraph_to_static_utils import (
 
 import paddle
 from paddle.framework import use_pir_api
+from paddle.jit.sot.utils import strict_mode_guard
 from paddle.static import InputSpec
 
 SEED = 2020
@@ -156,6 +157,7 @@ class TestSliceInIf(TestSliceBase):
         self.dygraph_func = test_slice_in_if
 
     @test_legacy_and_pt_and_pir
+    @strict_mode_guard(False)
     def test_transformed_static_result(self):
         self.init_dygraph_func()
         static_res = self.run_static_mode()

--- a/test/dygraph_to_static/test_slice.py
+++ b/test/dygraph_to_static/test_slice.py
@@ -328,4 +328,5 @@ class TestSliceZeroShapeTensor(Dy2StTestBase):
 
 
 if __name__ == '__main__':
+    breakpoint()
     unittest.main()

--- a/test/dygraph_to_static/test_slice.py
+++ b/test/dygraph_to_static/test_slice.py
@@ -159,6 +159,7 @@ class TestSliceInIf(TestSliceBase):
     @test_legacy_and_pt_and_pir
     @strict_mode_guard(False)
     def test_transformed_static_result(self):
+        breakpoint()
         self.init_dygraph_func()
         static_res = self.run_static_mode()
         dygraph_res = self.run_dygraph_mode()
@@ -328,5 +329,4 @@ class TestSliceZeroShapeTensor(Dy2StTestBase):
 
 
 if __name__ == '__main__':
-    breakpoint()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

允许 Fallback `__bool__ with args: Args(ObjectVariable)` 的情况