### PR TITLE
[PIR] open `test_linspace`、`test_slice` test for `test_zero_dim_no_backward_api`

### DIFF
--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -381,7 +381,6 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
 
-    @test_with_pir_api
     def test_standard_normal(self):
         out1 = paddle.standard_normal([])
         out2 = paddle.standard_normal(self.shape)

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -266,6 +266,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
             paddle.full([], 4, 'int32'),
         ]
 
+    @test_with_pir_api
     def test_slice(self):
         starts = [paddle.full([], 1, 'int32'), paddle.full([], 1, 'int32')]
         ends = [paddle.full([], 3, 'int32'), paddle.full([], 3, 'int32')]
@@ -288,6 +289,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         )[0]
         self.assertEqual(res.shape, (5, 2, 2))
 
+    @test_with_pir_api
     def test_linspace(self):
         start = paddle.full([], 1.0)
         stop = paddle.full([], 5.0)
@@ -379,6 +381,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
 
+    @test_with_pir_api
     def test_standard_normal(self):
         out1 = paddle.standard_normal([])
         out2 = paddle.standard_normal(self.shape)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

打开`test_linspace`、`test_slice` 单测

相关链接:
* #62652