### PR TITLE
[pir & auto-parallel] support convert DistParam to pir dist tensor

### DIFF
--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -43,9 +43,21 @@ class ParametersRecorder:
                 type=tensor.type,
                 initializer=non_used_initializer,
             )
+
+            if tensor.placements is not None:  # import for shard tensor api
+                import paddle.distributed as dist
+
+                value = dist.shard_tensor(
+                    value,
+                    tensor.process_mesh,
+                    tensor.placements,
+                    stop_gradient=value.stop_gradient,
+                )
+
             if isinstance(tensor, paddle.Tensor):
                 params.add(tensor)
             mappings[id(tensor)] = value
+
         return mappings[id(tensor)]
 
     def pop(self, program):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
support convert DistParam to pir dist tensor
related #62528
Pcard-76459
```
(%1) = "builtin.parameter" () {is_persistable:[true],parameter_name:"parameter_2",stop_gradient:[false]} : () -> builtin.tensor<16x8xf32>
(%3) = "builtin.parameter" () {is_persistable:[true],parameter_name:"parameter_0",stop_gradient:[false]} : () -> builtin.tensor<16x16xf32>
(%6) = "dist_op.shard_tensor" (%3) {op_dist_attr:error_attribute_type} : (builtin.tensor<16x16xf32>) -> pd_dist.tensor<16x16xf32, mesh: {shape: [2], process_ids: [0,1], dim_names: [x]}, dims_mappings: [-1,0]>
(%7) = "dist_op.shard_tensor" (%1) {op_dist_attr:error_attribute_type} : (builtin.tensor<16x8xf32>) -> pd_dist.tensor<16x8xf32, mesh: {shape: [2], process_ids: [0,1], dim_names: [x]}, dims_mappings: [0,-1]>
(%8) = "pd_op.matmul" (%4, %6) {stop_gradient:[true],transpose_x:false,transpose_y:false} : (pd_dist.tensor<4x16xf32, mesh: {shape: [2], process_ids: [0,1], dim_names: [x]}, dims_mappings: [-1,-1]>, pd_dist.tensor<16x16xf32, mesh: {shape: [2], process_ids: [0,1], dim_names: [x]}, dims_mappings: [-1,0]>) -> builtin.tensor<4x16xf32>
(%11) = "pd_op.matmul" (%10, %7) {stop_gradient:[false],transpose_x:false,transpose_y:false} : (builtin.tensor<4x16xf32>, pd_dist.tensor<16x8xf32, mesh: {shape: [2], process_ids: [0,1], dim_names: [x]}, dims_mappings: [0,-1]>) -> builtin.tensor<4x8xf32>
```