### PR TITLE
[SOT][PIR] Adapt SOT call stack in PIR mode

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -656,18 +656,20 @@ void BindOperation(py::module *m) {
             pir::Attribute op_callstack = self.attribute<pir::Attribute>(
                 paddle::framework::OpProtoAndCheckerMaker::
                     OpCreationCallstackAttrName());
-            PADDLE_ENFORCE(
-                op_callstack.isa<pir::ArrayAttribute>(),
-                "The callstack of operation `%s` should be an array attribute.",
-                self.name());
+            PADDLE_ENFORCE(op_callstack.isa<pir::ArrayAttribute>(),
+                           phi::errors::PreconditionNotMet(
+                               "The callstack of operation `%s` should be an "
+                               "array attribute.",
+                               self.name()));
             auto op_callstack_array_attr =
                 op_callstack.dyn_cast<pir::ArrayAttribute>();
             for (size_t i = 0; i < op_callstack_array_attr.size(); ++i) {
               PADDLE_ENFORCE(
                   op_callstack_array_attr.at(i).isa<pir::StrAttribute>(),
-                  "The callstack info of operation `%s` should be array of "
-                  "string attribute.",
-                  self.name());
+                  phi::errors::PreconditionNotMet(
+                      "The callstack info of operation `%s` should be array of "
+                      "string attribute.",
+                      self.name()));
               callstack_list.append(op_callstack_array_attr.at(i)
                                         .dyn_cast<pir::StrAttribute>()
                                         .AsString());

--- a/python/paddle/jit/sot/symbolic/interpreter.py
+++ b/python/paddle/jit/sot/symbolic/interpreter.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 import paddle
 from paddle.utils import to_sequence
 
-from ..utils import InnerError, map_if, map_if_extend
+from ..utils import InnerError, log_do, map_if, map_if_extend
 from .statement_ir import SIRRuntimeCache, Symbol
 
 if TYPE_CHECKING:
@@ -51,16 +51,17 @@ def replace_symbol(
 
 
 def _append_opstack_between(start, end, stack):
-    # NOTE(xiongkun): we don't sync for speed. careful!!
-    # [start, end)
-    if paddle.base.framework.use_pir_api():
-        return
+    # The range is [start, end)
     from paddle.framework import core
 
     op_maker = core.op_proto_and_checker_maker
     callstack_attr_name = op_maker.kOpCreationCallstackAttrName()
     for op in for_each_ops_between(start, end):
-        op._set_attr(callstack_attr_name, stack)
+        if paddle.framework.use_pir_api():
+            op.callstack = stack
+        else:
+            # NOTE(xiongkun): we don't sync for speed. careful!!
+            op._set_attr(callstack_attr_name, stack)
 
 
 def for_each_ops_between(start, end):
@@ -121,8 +122,11 @@ class Interpreter:
             if len(to_sequence(outs)) != len(to_sequence(stmt.outputs)):
                 raise InnerError("Number output mismatch, some error happen.")
 
-            _append_opstack_between(
-                before_stmt_opnum, opnum_in_program() + 1, stmt.stmt_stack
+            log_do(
+                3,
+                lambda: _append_opstack_between(
+                    before_stmt_opnum, opnum_in_program() + 1, stmt.stmt_stack
+                ),
             )
 
             map_if(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

op callstack 的 SOT 适配，使用模拟 callstack 替换原始组网 callstack，仅 log_level >= 3 生效

Pcard-67164