### PR TITLE
fix reduce_avg for comm_overlap=false

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -297,9 +297,13 @@ class DygraphShardingOptimizer:
                     ), "param.grad should be None when using main_grad"
                     g_var = param.main_grad
                 if g_var is not None:
-                    reduce_op = (
-                        ReduceOp.AVG if self.use_reduce_avg else ReduceOp.SUM
-                    )
+                    reduce_op = ReduceOp.AVG
+                    if not self.use_reduce_avg:
+                        sharding_nrank = (
+                            hcg.get_sharding_parallel_group().nranks
+                        )
+                        g_var.scale_(1.0 / sharding_nrank)
+                        reduce_op = ReduceOp.SUM
                     param_rank = self._param2rank[param.name]
                     paddle.distributed.reduce(
                         g_var,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Description
<!-- Describe what you’ve done --> fix reduce_avg for comm_overlap=false

Pcard-70426

#62147 中支持reduce_avg时误删了 comm_overlap=false场景下对梯度的scale
