### PR TITLE
[Opt] Use scale with bias of type float to save full_like op

### DIFF
--- a/paddle/fluid/prim/api/auto_code_generated/tensor_operants_gen.py
+++ b/paddle/fluid/prim/api/auto_code_generated/tensor_operants_gen.py
@@ -95,11 +95,11 @@ namespace paddle {
 namespace prim {
 
 Tensor EagerTensorOperants::add(const Tensor& x, const Scalar& y) {
-  return ::add_ad_func(x, ::full_like_ad_func(x, y));
+  return ::scale_ad_func(x, 1.0f, y.to<float>(), true);
 }
 
 Tensor EagerTensorOperants::subtract(const Tensor& x, const Scalar& y) {
-  return ::subtract_ad_func(x, ::full_like_ad_func(x, y));
+  return ::scale_ad_func(x, 1.0f, -(y.to<float>()), true);
 }
 
 Tensor EagerTensorOperants::multiply(const Tensor& x, const Scalar& y) {
@@ -111,11 +111,11 @@ Tensor EagerTensorOperants::divide(const Tensor& x, const Scalar& y) {
 }
 
 Tensor EagerTensorOperants::add(const Scalar& x, const Tensor& y) {
-  return ::add_ad_func(::full_like_ad_func(y, x), y);
+  return ::scale_ad_func(y, 1.0f, x.to<float>(), true);
 }
 
 Tensor EagerTensorOperants::subtract(const Scalar& x, const Tensor& y) {
-  return ::subtract_ad_func(::full_like_ad_func(y, x), y);
+  return ::scale_ad_func(y, -1.0f, x.to<float>(), true);
 }
 
 Tensor EagerTensorOperants::multiply(const Scalar& x, const Tensor& y) {
@@ -131,7 +131,7 @@ Tensor EagerTensorOperants::pow(const Tensor& x, const Tensor& y) {
 }
 
 Tensor EagerTensorOperants::pow(const Tensor& x, const Scalar& y) {
-  return ::elementwise_pow_ad_func(x, ::full_like_ad_func(x, y));
+  return ::pow_ad_func(x, y);
 }
 
 """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->

Pcard-75624

Same as #62598, but use float conversion instead of upgrading bias type of `scale` op from float to scalar, for this behavior may be incompatible with inference model.
