### PR TITLE
[PIR] fix `test_zero_dim_binary_api` UT

### DIFF
--- a/test/legacy_test/test_zero_dim_binary_api.py
+++ b/test/legacy_test/test_zero_dim_binary_api.py
@@ -22,6 +22,8 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.framework import use_pir_api
+from paddle.pir_utils import test_with_pir_api
 
 binary_api_list = [
     {'func': paddle.add, 'cls_method': '__add__'},
@@ -215,11 +217,12 @@ class TestBinaryAPI(unittest.TestCase):
 
         paddle.enable_static()
 
-    def test_static_binary(self):
+    @test_with_pir_api
+    def test_static_binary_0D_0D(self):
         paddle.enable_static()
         for api in binary_api_list:
             main_prog = paddle.static.Program()
-            block = main_prog.global_block()
+            exe = paddle.static.Executor()
             with paddle.static.program_guard(
                 main_prog, paddle.static.Program()
             ):
@@ -231,25 +234,40 @@ class TestBinaryAPI(unittest.TestCase):
                 if isinstance(api, dict):
                     out = api['func'](x, y)
                     out_cls = getattr(
-                        paddle.static.Variable, api['cls_method']
+                        paddle.pir.Value if use_pir_api() else paddle.static.Variable, api['cls_method']
                     )(x, y)
                     self.assertEqual(out.shape, out_cls.shape)
                 else:
                     out = api(x, y)
-                paddle.static.append_backward(out)
+                paddle.static.append_backward(out,parameter_list=[x,y])
 
-                self.assertEqual(x.shape, ())
-                self.assertEqual(y.shape, ())
-                self.assertEqual(out.shape, ())
-                if block.has_var(x.grad_name):
-                    out_grad = block.var(out.grad_name)
-                    x_grad = block.var(x.grad_name)
-                    y_grad = block.var(y.grad_name)
+                if use_pir_api():
+                    self.assertEqual(x.shape, [])
+                    self.assertEqual(y.shape, [])
+                    self.assertEqual(out.shape, [])
+                else:
+                    self.assertEqual(x.shape, ())
+                    self.assertEqual(y.shape, ())
+                    self.assertEqual(out.shape, ())
 
-                    self.assertEqual(x_grad.shape, ())
-                    self.assertEqual(y_grad.shape, ())
-                    self.assertEqual(out_grad.shape, ())
+                # 1) Test Program
+                res = exe.run(main_prog, fetch_list=[out,x,y])
+                assert res is not None
+                assert len(res) == 3
+                for item in res:
+                    self.assertEqual(item.shape, ())
+        paddle.disable_static()
 
+    @test_with_pir_api
+    def test_static_binary_0D_ND(self):
+        paddle.enable_static()
+        for api in binary_api_list:
+            main_prog = paddle.static.Program()
+            exe = paddle.static.Executor()
+            block = main_prog.global_block()
+            with paddle.static.program_guard(
+                main_prog, paddle.static.Program()
+            ):
                 # 2) x is 0D, y is ND
                 x = paddle.rand([])
                 y = paddle.rand([2, 3, 4])
@@ -258,25 +276,54 @@ class TestBinaryAPI(unittest.TestCase):
                 if isinstance(api, dict):
                     out = api['func'](x, y)
                     out_cls = getattr(
-                        paddle.static.Variable, api['cls_method']
+                        paddle.pir.Value if use_pir_api() else paddle.static.Variable, api['cls_method']
                     )(x, y)
                     self.assertEqual(out.shape, out_cls.shape)
                 else:
                     out = api(x, y)
                 paddle.static.append_backward(out)
 
-                self.assertEqual(x.shape, ())
-                self.assertEqual(y.shape, (2, 3, 4))
-                self.assertEqual(out.shape, (2, 3, 4))
-                if block.has_var(x.grad_name):
-                    out_grad = block.var(out.grad_name)
-                    x_grad = block.var(x.grad_name)
-                    y_grad = block.var(y.grad_name)
+                if use_pir_api():
+                    self.assertEqual(x.shape, [])
+                    self.assertEqual(y.shape, [2, 3, 4])
+                    self.assertEqual(out.shape, [2, 3, 4])
+                else:
+                    self.assertEqual(x.shape, ())
+                    self.assertEqual(y.shape, (2, 3, 4))
+                    self.assertEqual(out.shape, (2, 3, 4))
 
-                    self.assertEqual(x_grad.shape, ())
-                    self.assertEqual(y_grad.shape, (2, 3, 4))
-                    self.assertEqual(out_grad.shape, (2, 3, 4))
+                if api == paddle.kron and not use_pir_api():
+                    self.assertEqual(x.shape, ())
+                    self.assertEqual(y.shape, (2, 3, 4))
+                    self.assertEqual(out.shape, (2, 3, 4))
+                    if block.has_var(x.grad_name):
+                        out_grad = block.var(out.grad_name)
+                        x_grad = block.var(x.grad_name)
+                        y_grad = block.var(y.grad_name)
+                    continue
 
+                # 2) Test Program
+                res = exe.run(main_prog, fetch_list=[out,x,y])
+                assert res is not None
+                assert len(res) == 3
+                out_grad = res[0]
+                x_grad = res[1]
+                y_grad = res[2]
+                self.assertEqual(out_grad.shape, (2, 3, 4))
+                self.assertEqual(x_grad.shape, ())
+                self.assertEqual(y_grad.shape, (2, 3, 4))
+        paddle.disable_static()
+
+    @test_with_pir_api
+    def test_static_binary_ND_0D(self):
+        paddle.enable_static()
+        for api in binary_api_list:
+            main_prog = paddle.static.Program()
+            exe = paddle.static.Executor()
+            block = main_prog.global_block()
+            with paddle.static.program_guard(
+                main_prog, paddle.static.Program()
+            ):
                 # 3) x is ND, y is 0d
                 x = paddle.rand([2, 3, 4])
                 y = paddle.rand([])
@@ -285,44 +332,81 @@ class TestBinaryAPI(unittest.TestCase):
                 if isinstance(api, dict):
                     out = api['func'](x, y)
                     out_cls = getattr(
-                        paddle.static.Variable, api['cls_method']
+                        paddle.pir.Value if use_pir_api() else paddle.static.Variable, api['cls_method']
                     )(x, y)
                     self.assertEqual(out.shape, out_cls.shape)
                 else:
                     out = api(x, y)
                 paddle.static.append_backward(out)
 
-                self.assertEqual(x.shape, (2, 3, 4))
-                self.assertEqual(y.shape, ())
-                self.assertEqual(out.shape, (2, 3, 4))
-                if block.has_var(x.grad_name):
-                    out_grad = block.var(out.grad_name)
-                    x_grad = block.var(x.grad_name)
-                    y_grad = block.var(y.grad_name)
+                if use_pir_api():
+                    self.assertEqual(x.shape, [2, 3, 4])
+                    self.assertEqual(y.shape, [])
+                    self.assertEqual(out.shape, [2, 3, 4])
+                else:
+                    self.assertEqual(x.shape, (2, 3, 4))
+                    self.assertEqual(y.shape, ())
+                    self.assertEqual(out.shape, (2, 3, 4))
 
-                    self.assertEqual(x_grad.shape, (2, 3, 4))
-                    self.assertEqual(y_grad.shape, ())
-                    self.assertEqual(out_grad.shape, (2, 3, 4))
+                if api == paddle.kron and not use_pir_api():
+                    self.assertEqual(x.shape, (2, 3, 4))
+                    self.assertEqual(y.shape, ())
+                    self.assertEqual(out.shape, (2, 3, 4))
+                    if block.has_var(x.grad_name):
+                        out_grad = block.var(out.grad_name)
+                        x_grad = block.var(x.grad_name)
+                        y_grad = block.var(y.grad_name)
+                    continue
 
+                # 3) Test Program
+                res = exe.run(main_prog, fetch_list=[out,x,y])
+                assert res is not None
+                assert len(res) == 3
+                out_grad = res[0]
+                x_grad = res[1]
+                y_grad = res[2]
+                self.assertEqual(out_grad.shape, (2, 3, 4))
+                self.assertEqual(y_grad.shape, ())
+                self.assertEqual(x_grad.shape, (2, 3, 4))
+        paddle.disable_static()
+
+    @test_with_pir_api
+    def test_static_binary_0D_scalar(self):
+        paddle.enable_static()
+        for api in binary_api_list:
+            main_prog = paddle.static.Program()
+            exe = paddle.static.Executor()
+            with paddle.static.program_guard(
+                main_prog, paddle.static.Program()
+            ):
                 # 4) x is 0D , y is scalar
                 x = paddle.rand([])
                 x.stop_gradient = False
                 y = 0.5
                 if isinstance(api, dict):
-                    out = getattr(paddle.static.Variable, api['cls_method'])(
+                    out = getattr(paddle.pir.Value if use_pir_api() else paddle.static.Variable, api['cls_method'])(
                         x, y
                     )
                     paddle.static.append_backward(out)
 
-                    self.assertEqual(x.shape, ())
-                    self.assertEqual(out.shape, ())
-                    if block.has_var(x.grad_name):
-                        out_grad = block.var(out.grad_name)
-                        x_grad = block.var(x.grad_name)
+                    if use_pir_api():
+                        self.assertEqual(x.shape, [])
+                        self.assertEqual(out.shape, [])
+                    else:
+                        self.assertEqual(x.shape, ())
+                        self.assertEqual(out.shape, ())
 
-                        self.assertEqual(out_grad.shape, ())
-                        self.assertEqual(x_grad.shape, ())
+                    # 4) Test Program
+                    res = exe.run(main_prog, fetch_list=[out,x])
+                    assert res is not None
+                    assert len(res) == 2
+                    for item in res:
+                        self.assertEqual(item.shape, ())
+        paddle.disable_static()
 
+    @test_with_pir_api
+    def test_static_binary_int_api(self):
+        paddle.enable_static()
         for api in binary_int_api_list:
             main_prog = paddle.static.Program()
             with paddle.static.program_guard(
@@ -332,19 +416,28 @@ class TestBinaryAPI(unittest.TestCase):
                 x = paddle.randint(-10, 10, [])
                 y = paddle.randint(-10, 10, [])
                 out = api(x, y)
-                self.assertEqual(out.shape, ())
+                if use_pir_api():
+                    self.assertEqual(out.shape, [])
+                else:
+                    self.assertEqual(out.shape, ())
 
                 # 2) x is ND , y is 0D
                 x = paddle.randint(-10, 10, [3, 5])
                 y = paddle.randint(-10, 10, [])
                 out = api(x, y)
-                self.assertEqual(out.shape, (3, 5))
+                if use_pir_api():
+                    self.assertEqual(out.shape, [3, 5])
+                else:
+                    self.assertEqual(out.shape, (3, 5))
 
                 # 3) x is 0D , y is ND
                 x = paddle.randint(-10, 10, [])
                 y = paddle.randint(-10, 10, [3, 5])
                 out = api(x, y)
-                self.assertEqual(out.shape, (3, 5))
+                if use_pir_api():
+                    self.assertEqual(out.shape, [3, 5])
+                else:
+                    self.assertEqual(out.shape, (3, 5))
 
         paddle.disable_static()
 

--- a/test/legacy_test/test_zero_dim_binary_api.py
+++ b/test/legacy_test/test_zero_dim_binary_api.py
@@ -248,11 +248,7 @@ class TestBinaryAPI(unittest.TestCase):
                     self.assertEqual(out.shape, out_cls.shape)
                 else:
                     out = api(x, y)
-                (
-                    (x, x_grad),
-                    (_, y_grad),
-                    (_, out_grad),
-                ) = paddle.static.append_backward(
+                grad_list = paddle.static.append_backward(
                     out, parameter_list=[x, y, out]
                 )
 
@@ -260,10 +256,13 @@ class TestBinaryAPI(unittest.TestCase):
                 self.assertShapeEqual(y, [])
                 self.assertShapeEqual(out, [])
 
-                if x is None:
-                    self.assertShapeEqual(x_grad, [])
-                    self.assertShapeEqual(y_grad, [])
-                    self.assertShapeEqual(out_grad, [])
+                if len(grad_list) != 0 and grad_list[0][1] is not None:
+                    # x_grad
+                    self.assertShapeEqual(grad_list[0][1], [])
+                    # y_grad
+                    self.assertShapeEqual(grad_list[1][1], [])
+                    # out_grad
+                    self.assertShapeEqual(grad_list[2][1], [])
 
         paddle.disable_static()
 
@@ -300,8 +299,11 @@ class TestBinaryAPI(unittest.TestCase):
                 self.assertShapeEqual(out, [2, 3, 4])
 
                 if len(grad_list) != 0 and grad_list[0][1] is not None:
+                    # x_grad
                     self.assertShapeEqual(grad_list[0][1], [])
+                    # y_grad
                     self.assertShapeEqual(grad_list[1][1], [2, 3, 4])
+                    # out_grad
                     self.assertShapeEqual(grad_list[2][1], [2, 3, 4])
         paddle.disable_static()
 
@@ -329,11 +331,7 @@ class TestBinaryAPI(unittest.TestCase):
                     self.assertEqual(out.shape, out_cls.shape)
                 else:
                     out = api(x, y)
-                (
-                    (x, x_grad),
-                    (_, y_grad),
-                    (_, out_grad),
-                ) = paddle.static.append_backward(
+                grad_list = paddle.static.append_backward(
                     out, parameter_list=[x, y, out]
                 )
 
@@ -341,10 +339,13 @@ class TestBinaryAPI(unittest.TestCase):
                 self.assertShapeEqual(y, [])
                 self.assertShapeEqual(out, [2, 3, 4])
 
-                if x is None:
-                    self.assertShapeEqual(x_grad, [2, 3, 4])
-                    self.assertShapeEqual(y_grad, [])
-                    self.assertShapeEqual(out_grad, [2, 3, 4])
+                if len(grad_list) != 0 and grad_list[0][1] is not None:
+                    # x_grad
+                    self.assertShapeEqual(grad_list[0][1], [2, 3, 4])
+                    # y_grad
+                    self.assertShapeEqual(grad_list[1][1], [])
+                    # out_grad
+                    self.assertShapeEqual(grad_list[2][1], [2, 3, 4])
         paddle.disable_static()
 
     @test_with_pir_api
@@ -366,16 +367,17 @@ class TestBinaryAPI(unittest.TestCase):
                         else paddle.static.Variable,
                         api['cls_method'],
                     )(x, y)
-                    (x, x_grad), (_, out_grad) = paddle.static.append_backward(
+                    grad_list = paddle.static.append_backward(
                         out, parameter_list=[x, out]
                     )
-
                     self.assertShapeEqual(x, [])
                     self.assertShapeEqual(out, [])
 
-                    if x is None:
-                        self.assertShapeEqual(x_grad, [])
-                        self.assertShapeEqual(out_grad, [])
+                    if len(grad_list) != 0 and grad_list[0][1] is not None:
+                        # x_grad
+                        self.assertShapeEqual(grad_list[0][1], [])
+                        # out_grad
+                        self.assertShapeEqual(grad_list[1][1], [])
         paddle.disable_static()
 
     @test_with_pir_api
@@ -390,19 +392,19 @@ class TestBinaryAPI(unittest.TestCase):
                 x = paddle.randint(-10, 10, [])
                 y = paddle.randint(-10, 10, [])
                 out = api(x, y)
-                self.assertShapeEqual(out.shape, [])
+                self.assertShapeEqual(out, [])
 
                 # 2) x is ND , y is 0D
                 x = paddle.randint(-10, 10, [3, 5])
                 y = paddle.randint(-10, 10, [])
                 out = api(x, y)
-                self.assertShapeEqual(out.shape, [3, 5])
+                self.assertShapeEqual(out, [3, 5])
 
                 # 3) x is 0D , y is ND
                 x = paddle.randint(-10, 10, [])
                 y = paddle.randint(-10, 10, [3, 5])
                 out = api(x, y)
-                self.assertShapeEqual(out.shape, [3, 5])
+                self.assertShapeEqual(out, [3, 5])
 
         paddle.disable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

* 适配 `test_with_pir_api`
* 拆分为`0D_0D`、`0D_ND`、`ND_0D`、`0D_scalar` 四种

相关单测:
* #62652