### PR TITLE
[DimExpr] Move dim_expr_util_test to CI-Coverage

### DIFF
--- a/test/cpp/pir/shape_dialect/CMakeLists.txt
+++ b/test/cpp/pir/shape_dialect/CMakeLists.txt
@@ -1,5 +1,6 @@
 paddle_test(symbol_dim_expr_test SRCS symbol_dim_expr_test.cc)
 paddle_test(simplify_dim_expr_test SRCS simplify_dim_expr_test.cc)
+paddle_test(dim_expr_util_test SRCS dim_expr_util_test.cc)
 
 if(WITH_CINN)
   paddle_test(shape_analysis_test SRCS shape_analysis_test.cc)
@@ -16,9 +17,6 @@ if(WITH_CINN)
   set_tests_properties(
     infer_symbolic_shape_test PROPERTIES ENVIRONMENT
                                          "FLAGS_enable_pir_in_executor=true")
-
-  paddle_test(dim_expr_util_test SRCS dim_expr_util_test.cc)
-  set_tests_properties(dim_expr_util_test PROPERTIES LABELS "RUN_TYPE=CINN")
 endif()
 
 if(WITH_ONNXRUNTIME AND WIN32)

--- a/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
@@ -63,7 +63,7 @@ TEST(DimExpr, CollectDimExprSymbol) {
   std::unordered_set<std::string> symbols = CollectDimExprSymbols(dim_expr);
   std::unordered_set<std::string> expected = {
       "S0", "S1", "S2", "S3", "S4", "S5"};
-  ASSERT_EQ(symbols.size(), 6);
+  ASSERT_EQ(symbols.size(), 6UL);
   for (const auto& symbol : symbols) {
     ASSERT_TRUE(expected.find(symbol) != expected.end());
   }

--- a/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
@@ -63,9 +63,9 @@ TEST(DimExpr, CollectDimExprSymbol) {
   std::unordered_set<std::string> symbols = CollectDimExprSymbols(dim_expr);
   std::unordered_set<std::string> expected = {
       "S0", "S1", "S2", "S3", "S4", "S5"};
-  EXPECT_EQ(symbols.size(), 6);
+  ASSERT_EQ(symbols.size(), 6);
   for (const auto& symbol : symbols) {
-    EXPECT_TRUE(expected.find(symbol) != expected.end());
+    ASSERT_TRUE(expected.find(symbol) != expected.end());
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

[DimExpr] Move dim_expr_util_test to CI-Coverage

dim_expr_util 作为基础的功能函数，已经从 CINN 移到 pir 下。相应的，将 DimExpr 单测从 CI-CINN 移至 CI-Coverage，从而监控代码覆盖率