### PR TITLE
[PIR][oneDNN] Add matmul_elementwise_add_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -82,6 +82,7 @@
 #include "paddle/fluid/inference/api/mkldnn_quantizer.h"
 #include "paddle/fluid/pir/transforms/onednn/batch_norm_act_fuse_pass.h"
 #include "paddle/fluid/pir/transforms/onednn/conv_bias_fuse_pass.h"
+#include "paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.h"
 #endif
 
 #ifdef PADDLE_WITH_ONNXRUNTIME
@@ -1001,6 +1002,7 @@ bool AnalysisPredictor::PrepareExecutor() {
         mkldnn_pm.AddPass(::pir::CreateConv2dTransposeBiasFusePass());
         mkldnn_pm.AddPass(::pir::CreateConv3dBiasFusePass());
         mkldnn_pm.AddPass(::pir::CreateBatchNormActFusePass());
+        mkldnn_pm.AddPass(::pir::CreateMatmulElementwiseAddFusePass());
 
         auto constant_folding_pass = ::pir::CreateConstantFoldingPass();
         constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place_);

--- a/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
@@ -27,7 +27,7 @@ class MatmulElementwiseAddFusePattern : public paddle::drr::DrrPatternBase {
   std::string matmul_name_;
   std::string fused_matmul_name_;
   uint32_t benefit_;
-  bool as_x_;
+  bool as_x_;  // Decide input direction of add
 
  public:
   MatmulElementwiseAddFusePattern(const std::string &matmul_name,
@@ -106,8 +106,8 @@ class FusedMatmulElementwiseAddFusePattern
   std::string matmul_name_;
   std::string fused_matmul_name_;
   uint32_t benefit_;
-  bool as_x_;
-  bool as_x2_;
+  bool as_x_;   // Decide input direction of 1st add
+  bool as_x2_;  // Decide input direction of 2nd add
 
  public:
   FusedMatmulElementwiseAddFusePattern(const std::string &matmul_name,

--- a/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/onednn_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+class MatmulElementwiseAddFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  std::string matmul_name_;
+  std::string fused_matmul_name_;
+
+ public:
+  MatmulElementwiseAddFusePattern(const std::string &matmul_name,
+                                  const std::string &fused_matmul_name)
+      : matmul_name_(matmul_name), fused_matmul_name_(fused_matmul_name) {}
+
+  std::string name() const override {
+    return "MatmulElementwiseAddFusePattern";
+  }
+
+  uint32_t benefit() const override { return 2; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &matmul = pat.Op(matmul_name_,
+                                {{"transpose_x", pat.Attr("transpose_x")},
+                                 {"transpose_y", pat.Attr("transpose_y")}});
+
+    const auto &add = pat.Op(paddle::dialect::AddOp::name());
+    matmul({&pat.Tensor("X"), &pat.Tensor("Y")}, {&pat.Tensor("Out")});
+
+    pat.Tensor("add_out") = add(pat.Tensor("Out"), pat.Tensor("residual"));
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      std::set<bool> bool_sets = {true, false};
+      auto result_x = match_ctx.Attr<bool>("transpose_x");
+      auto result_y = match_ctx.Attr<bool>("transpose_y");
+      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
+        return false;
+      }
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &fused_matmul =
+        res.Op(fused_matmul_name_,
+               {{
+                   {"trans_x", pat.Attr("transpose_x")},
+                   {"trans_y", pat.Attr("transpose_y")},
+                   {"matmul_alpha", res.Float32Attr(1.0f)},
+                   {"fuse_activation", res.StrAttr("")},
+                   {"fuse_alpha", res.Float32Attr(0.0f)},
+                   {"fuse_beta", res.Float32Attr(0.0f)},
+                   {"fused_output_scale", res.Float32Attr(1.0f)},
+                   {"fused_reshape_x", res.VectorInt32Attr({})},
+                   {"fused_transpose_x", res.VectorInt32Attr({})},
+                   {"fused_reshape_y", res.VectorInt32Attr({})},
+                   {"fused_transpose_y", res.VectorInt32Attr({})},
+                   {"fused_reshape_out", res.VectorInt32Attr({})},
+                   {"fused_transpose_out", res.VectorInt32Attr({})},
+                   {"mkldnn_data_type", res.StrAttr("float32")},
+                   {"scale_x", res.Float32Attr(1.0f)},
+                   {"scale_y", res.Float32Attr(1.0f)},
+                   {"scale_in_eltwise", res.Float32Attr(0.0f)},
+                   {"scale_out", res.Float32Attr(1.0f)},
+                   {"force_fp32_output", res.BoolAttr(false)},
+               }});
+
+    fused_matmul({&res.Tensor("X"), &res.Tensor("Y"), &res.Tensor("residual")},
+                 {&res.Tensor("add_out")});
+  }
+};
+
+class MatmulElementwiseAddFusePass : public pir::PatternRewritePass {
+ public:
+  MatmulElementwiseAddFusePass()
+      : pir::PatternRewritePass("matmul_elementwise_add_fuse_pass", 2) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add(paddle::drr::Create<MatmulElementwiseAddFusePattern>(
+        context,
+        paddle::dialect::MatmulOp::name(),
+        paddle::onednn::dialect::FusedMatmulOp::name()));
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateMatmulElementwiseAddFusePass() {
+  // pd_op.batch_norm + pd_op.relu -> onednn_op.batch_norm
+  return std::make_unique<MatmulElementwiseAddFusePass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(matmul_elementwise_add_fuse_pass,
+                 MatmulElementwiseAddFusePass);

--- a/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
@@ -193,7 +193,7 @@ class FusedMatmulElementwiseAddFusePattern
 class MatmulElementwiseAddFusePass : public pir::PatternRewritePass {
  public:
   MatmulElementwiseAddFusePass()
-      : pir::PatternRewritePass("matmul_elementwise_add_fuse_pass", 2) {}
+      : pir::PatternRewritePass("matmul_elementwise_add_fuse_pass", 3) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);

--- a/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateMatmulElementwiseAddFusePass();
+
+}  // namespace pir

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -96,6 +96,7 @@
 
 #ifdef PADDLE_WITH_DNNL
 #include "paddle/fluid/pir/transforms/onednn/batch_norm_act_fuse_pass.h"
+#include "paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.h"
 #endif
 
 namespace py = pybind11;
@@ -152,6 +153,7 @@ USE_PIR_PASS(fused_dot_product_attention_pass);
 
 #ifdef PADDLE_WITH_DNNL
 USE_PIR_PASS(batch_norm_act_fuse_pass);
+USE_PIR_PASS(matmul_elementwise_add_fuse_pass);
 #endif
 
 COMMON_DECLARE_bool(print_ir);

--- a/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
@@ -27,13 +27,14 @@ paddle.enable_static()
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePattern(PassTest):
-    r'''x     y
-    \   /
-    matmul  resdual(parameter)
-       \   /
-        add
-         |
-        out
+    r'''
+    x     y
+     \   /
+     matmul  resdual(parameter)
+        \   /
+         add
+          |
+         out
     '''
 
     def is_program_valid(self, program=None):
@@ -85,13 +86,14 @@ class TestMatmulAddFusePattern(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePatternCase2(PassTest):
-    r'''x     y
-    \   /
-    matmul  resdual(data)
-       \   /
-        add
-         |
-        out
+    r'''
+    x     y
+     \   /
+     matmul  resdual(data)
+        \   /
+         add
+          |
+         out
     '''
 
     def is_program_valid(self, program=None):
@@ -143,7 +145,8 @@ class TestMatmulAddFusePatternCase2(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePatternCase3(PassTest):
-    r'''x     y
+    r'''
+                       x     y
                         \   /
     resdual(parameter)  matmul
                     \   /
@@ -201,7 +204,8 @@ class TestMatmulAddFusePatternCase3(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePatternCase4(PassTest):
-    r'''x     y
+    r'''
+                   x     y
                     \   /
     resdual(data)  matmul
                 \   /
@@ -259,7 +263,8 @@ class TestMatmulAddFusePatternCase4(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestFusedMatmulAddFusePattern(PassTest):
-    r'''x     y
+    r'''
+                   x     y
                     \   /
     resdual(data)  matmul
                 \   /

--- a/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+
+paddle.enable_static()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestConv2dAddFusePass(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias = paddle.static.create_parameter(
+                    name="bias", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, x)
+                out = paddle.add(matmul_out, bias)
+                out = paddle.assign(out)
+                self.pass_list = ['matmul_elementwise_add_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
@@ -27,6 +27,15 @@ paddle.enable_static()
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePattern(PassTest):
+    r'''x     y
+    \   /
+    matmul  resdual(parameter)
+       \   /
+        add
+         |
+        out
+    '''
+
     def is_program_valid(self, program=None):
         return True
 
@@ -38,16 +47,20 @@ class TestMatmulAddFusePattern(PassTest):
                 x = paddle.static.data(
                     name='x', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias = paddle.static.create_parameter(
-                    name="bias", shape=[1], dtype='float32'
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                matmul_out = paddle.matmul(x, x)
-                out = paddle.add(matmul_out, bias)
+                residual = paddle.static.create_parameter(
+                    name="residual", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, y)
+                out = paddle.add(matmul_out, residual)
                 out = paddle.assign(out)
                 self.pass_list = ['matmul_elementwise_add_fuse_pass']
                 self.feeds = {
                     "x": np.random.random((5, 5, 5, 5)).astype("float32"),
-                    "bias": np.random.random(1).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "residual": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out]
                 self.valid_op_map = {
@@ -72,6 +85,15 @@ class TestMatmulAddFusePattern(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePatternCase2(PassTest):
+    r'''x     y
+    \   /
+    matmul  resdual(data)
+       \   /
+        add
+         |
+        out
+    '''
+
     def is_program_valid(self, program=None):
         return True
 
@@ -83,16 +105,20 @@ class TestMatmulAddFusePatternCase2(PassTest):
                 x = paddle.static.data(
                     name='x', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias = paddle.static.data(
-                    name="bias", shape=[1], dtype='float32'
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                matmul_out = paddle.matmul(x, x)
-                out = paddle.add(matmul_out, bias)
+                residual = paddle.static.data(
+                    name="residual", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, y)
+                out = paddle.add(matmul_out, residual)
                 out = paddle.assign(out)
                 self.pass_list = ['matmul_elementwise_add_fuse_pass']
                 self.feeds = {
                     "x": np.random.random((5, 5, 5, 5)).astype("float32"),
-                    "bias": np.random.random(1).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "residual": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out]
                 self.valid_op_map = {
@@ -117,6 +143,15 @@ class TestMatmulAddFusePatternCase2(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePatternCase3(PassTest):
+    r'''x     y
+                        \   /
+    resdual(parameter)  matmul
+                    \   /
+                     add
+                      |
+                     out
+    '''
+
     def is_program_valid(self, program=None):
         return True
 
@@ -128,16 +163,20 @@ class TestMatmulAddFusePatternCase3(PassTest):
                 x = paddle.static.data(
                     name='x', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias = paddle.static.create_parameter(
-                    name="bias", shape=[1], dtype='float32'
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                matmul_out = paddle.matmul(x, x)
-                out = paddle.add(bias, matmul_out)
+                residual = paddle.static.create_parameter(
+                    name="residual", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, y)
+                out = paddle.add(residual, matmul_out)
                 out = paddle.assign(out)
                 self.pass_list = ['matmul_elementwise_add_fuse_pass']
                 self.feeds = {
                     "x": np.random.random((5, 5, 5, 5)).astype("float32"),
-                    "bias": np.random.random(1).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "residual": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out]
                 self.valid_op_map = {
@@ -162,6 +201,15 @@ class TestMatmulAddFusePatternCase3(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulAddFusePatternCase4(PassTest):
+    r'''x     y
+                    \   /
+    resdual(data)  matmul
+                \   /
+                 add
+                  |
+                 out
+    '''
+
     def is_program_valid(self, program=None):
         return True
 
@@ -173,16 +221,20 @@ class TestMatmulAddFusePatternCase4(PassTest):
                 x = paddle.static.data(
                     name='x', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias = paddle.static.data(
-                    name="bias", shape=[1], dtype='float32'
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                matmul_out = paddle.matmul(x, x)
-                out = paddle.add(bias, matmul_out)
+                residual = paddle.static.data(
+                    name="residual", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, y)
+                out = paddle.add(residual, matmul_out)
                 out = paddle.assign(out)
                 self.pass_list = ['matmul_elementwise_add_fuse_pass']
                 self.feeds = {
                     "x": np.random.random((5, 5, 5, 5)).astype("float32"),
-                    "bias": np.random.random(1).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "residual": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out]
                 self.valid_op_map = {
@@ -207,6 +259,19 @@ class TestMatmulAddFusePatternCase4(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestFusedMatmulAddFusePattern(PassTest):
+    r'''x     y
+                    \   /
+    resdual(data)  matmul
+                \   /
+                 add
+                  |
+                 out  residual2(data)
+                  \   /
+                   add
+                    |
+                 out_end
+    '''
+
     def is_program_valid(self, program=None):
         return True
 
@@ -218,17 +283,25 @@ class TestFusedMatmulAddFusePattern(PassTest):
                 x = paddle.static.data(
                     name='x', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias = paddle.static.data(
-                    name="bias", shape=[1], dtype='float32'
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                matmul_out = paddle.matmul(x, x)
-                out = paddle.add(bias, matmul_out)
-                out_end = paddle.add(out, bias)
+                residual = paddle.static.data(
+                    name="residual", shape=[1], dtype='float32'
+                )
+                residual2 = paddle.static.data(
+                    name="residual2", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, y)
+                out = paddle.add(residual, matmul_out)
+                out_end = paddle.add(out, residual2)
                 out_end = paddle.assign(out_end)
                 self.pass_list = ['matmul_elementwise_add_fuse_pass']
                 self.feeds = {
                     "x": np.random.random((5, 5, 5, 5)).astype("float32"),
-                    "bias": np.random.random(1).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "residual": np.random.random(1).astype("float32"),
+                    "residual2": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out_end]
                 self.valid_op_map = {

--- a/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_elementwise_add_fuse_pass.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
 
 import numpy as np
+
+sys.path.append("../")
 from pass_test import PassTest
 
 import paddle
@@ -26,7 +29,7 @@ paddle.enable_static()
     not paddle.base.core.is_compiled_with_mkldnn(),
     "Test case only for OneDNN pass.",
 )
-class TestConv2dAddFusePass(PassTest):
+class TestMatmulAddFusePass(PassTest):
     def is_program_valid(self, program=None):
         return True
 
@@ -43,6 +46,141 @@ class TestConv2dAddFusePass(PassTest):
                 )
                 matmul_out = paddle.matmul(x, x)
                 out = paddle.add(matmul_out, bias)
+                out = paddle.assign(out)
+                self.pass_list = ['matmul_elementwise_add_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestMatmulAddFusePassCase2(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias = paddle.static.data(
+                    name="bias", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, x)
+                out = paddle.add(matmul_out, bias)
+                out = paddle.assign(out)
+                self.pass_list = ['matmul_elementwise_add_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestMatmulAddFusePassCase3(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias = paddle.static.create_parameter(
+                    name="bias", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, x)
+                out = paddle.add(bias, matmul_out)
+                out = paddle.assign(out)
+                self.pass_list = ['matmul_elementwise_add_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestMatmulAddFusePassCase4(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias = paddle.static.data(
+                    name="bias", shape=[1], dtype='float32'
+                )
+                matmul_out = paddle.matmul(x, x)
+                out = paddle.add(bias, matmul_out)
                 out = paddle.assign(out)
                 self.pass_list = ['matmul_elementwise_add_fuse_pass']
                 self.feeds = {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Based on new pass mechanism, here we add pass "matmul_elementwise_add_fuse_pass" for PIR.

The new pass is same as "matmul_elementwise_add_mkldnn_fuse_pass" in "/paddle/fluid/framework/ir/mkldnn/matmul_elementwise_add_mkldnn_fuse_pass.cc"
