### PR TITLE
delete parameter op from drr pass's source pattern

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 
 #include "glog/logging.h"
 #include "paddle/common/flags.h"
@@ -917,6 +918,11 @@ void AnalysisConfig::Update() {
   auto &&info = SerializeInfoCache();
   if (info == serialized_info_cache_) return;
 
+  std::unordered_set<std::string> deleted_passes;
+  if (pass_builder_) {
+    deleted_passes = pass_builder_->GetAllDeletedPasses();
+  }
+
   // Transfer pass_builder and copy the existing compatible passes.
   if (!pass_builder_ || ((use_gpu() ^ pass_builder_->use_gpu())) ||
       ((use_xpu() ^ pass_builder_->use_xpu())) ||
@@ -1129,7 +1135,7 @@ void AnalysisConfig::Update() {
         "but did not have the option -DWITH_CUSTOM_DEVICE compiled."));
 #endif
   }
-  for (auto &delete_pass : pass_builder()->GetAllDeletedPasses()) {
+  for (const auto &delete_pass : deleted_passes) {
     pass_builder_->DeletePass(delete_pass);
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71500

- delete parameter op in drr pass's source pattern.
- fix delete_pass function not working.

我们不建议在source pattern里定义parameter op，这样可能会造成create  result pattern里op时，被创建出来的op被放置在了顶层block且位于parameter op前面（匹配到的pattern是在sub block里），这是不合理的IR。