### PR TITLE
[AutoTuner] Add custom search dim

### DIFF
--- a/python/paddle/distributed/auto_tuner/tuner.py
+++ b/python/paddle/distributed/auto_tuner/tuner.py
@@ -138,6 +138,10 @@ class AutoTuner:
             for rr in self.tuner_cfg["refined_recompute"]:
                 keys_to_compare.append(rr)
 
+        if self.tuner_cfg.get("custom_search_dim", None):
+            for key in self.tuner_cfg["custom_search_dim"]:
+                keys_to_compare.append(key)
+
         for cfg in self.resume_cfgs:
             ret_is_same = True
             for key in keys_to_compare:

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -649,6 +649,12 @@ def launch():
                     dir_name += str(cur_cfg[key])
                     log_dir = log_dir + "_" + dir_name
 
+            if "custom_search_dim" in tuner_cfg:
+                for key in tuner_cfg["custom_search_dim"]:
+                    dir_name = "".join(i.capitalize() for i in key.split("_"))
+                    dir_name += str(cur_cfg[key])
+                    log_dir = log_dir + "_" + dir_name
+
             ctx.args.log_dir = os.path.join(
                 os.path.dirname(ctx.args.auto_tuner_json), log_dir
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
PCard-81541
Add custom dimension search functionality to the autotuner.
When prune is set to true, the autotuner will execute in the order of the values. Once a runnable option is encountered, the subsequent values will not be searched.
![image](https://github.com/PaddlePaddle/Paddle/assets/10421743/4a932956-42b5-406d-b723-71d814e0cf0f)

