### PR TITLE
[AutoParallel] extract split matmul_grad_op to pass_utils

### DIFF
--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -19,7 +19,7 @@ from ..auto_parallel.static.utils import (
     get_logger,
 )
 from .pass_base import PassBase, register_pass
-from .pass_utils import _split_matmul_grad_to_matmul
+from .pass_utils import split_matmul_grad_to_matmul
 
 logger = get_logger(logging.INFO)
 
@@ -113,7 +113,7 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
                 continue
 
             # matmul_grad_op => matmul_v2 + reshape + reshape + matmul_v2 + reshape
-            _split_matmul_grad_to_matmul(
+            split_matmul_grad_to_matmul(
                 block, matmul_grad_id, self.dist_context, self.op_namescope
             )
 

--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -94,7 +94,7 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
             matmul_grad_op = ops[matmul_grad_id]
             allreduce_op = ops[allreduce_id]
 
-            # NOTE(Sonder): When there are ops between matmul_grad and allreduce, we should check whether the
+            # NOTE(Sonder): When there are ops between matmul_grad and allreduce, we should check whether
             # these ops rely on the output of the intermediate ops. If so, we should not split the matmul_grad.
             # Otherwise, the output of the intermediate ops will get wrong results.
             skip_overlapping = False

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -29,6 +29,9 @@ from paddle.distributed.auto_parallel.static.utils import (
     use_new_executor,
 )
 from paddle.distributed.fleet.meta_optimizers.common import OpRole
+from paddle.distributed.auto_parallel.static.utils import (
+    naive_set_dist_op_attr_for_program_by_mesh_and_mapping
+)
 
 __not_shape_var_type__ = [
     core.VarDesc.VarType.READER,
@@ -785,3 +788,178 @@ def _add_event_dependency(recorder_op, waiter_op):
     if recorder_op.dist_attr.event_to_record not in waiter_wait_list:
         waiter_wait_list.append(recorder_op.dist_attr.event_to_record)
         waiter_op.dist_attr.events_to_wait = waiter_wait_list
+
+
+def _insert_reshape_op(block, index, x, shape, op_role, op_namescope="/", out=None, dist_context=None):
+    var_x = block.var(x[0])
+    if dist_context:
+        x_dist_attr = dist_context.get_tensor_dist_attr_for_program(var_x)
+
+    if out is None:
+        out = block.create_var(
+            name=f"{x[0]}@reshape.out",
+            dtype=var_x.dtype,
+            persistable=False,
+        )
+        if dist_context:
+            dist_context.set_tensor_dist_attr_for_program(out, x_dist_attr)
+
+    x_shape = block.create_var(
+        name=f"{x[0]}@reshape.xshape", dtype=var_x.dtype
+    )
+    if dist_context:
+        dist_context.set_tensor_dist_attr_for_program(x_shape, x_dist_attr)
+
+    reshape_op = block._insert_op_without_sync(
+        index=index,
+        type="reshape2",
+        inputs={"X": x},
+        outputs={"Out": out, "XShape": x_shape},
+        attrs={
+            "shape": shape,
+            "op_role": op_role,
+            'op_namescope': op_namescope,
+        },
+    )
+    if dist_context:
+        naive_set_dist_op_attr_for_program_by_mesh_and_mapping(
+            reshape_op,
+            process_mesh=x_dist_attr.process_mesh,
+            ref_mapping=x_dist_attr.dims_mapping,
+            ctx=dist_context,
+            chunk_id=x_dist_attr.chunk_id,
+        )
+
+    return out
+
+
+def _split_matmul_grad_to_matmul(
+    block, matmul_grad_id, op_namescope="/", dist_context=None
+):
+    ops = block.ops
+    matmul_grad_op = ops[matmul_grad_id]
+    
+    tran_x = matmul_grad_op.attr("trans_x")
+    assert (
+        not tran_x
+    ), f"matmul_grad(id={matmul_grad_id}) with tran_x == True is not supported for spliting matmul_grad to matmul"
+    tran_y = matmul_grad_op.attr("trans_y")
+    assert (
+        not tran_y
+    ), f"matmul_grad(id={matmul_grad_id}) with tran_y == True is not supported for spliting matmul_grad to matmul"
+    
+    x = matmul_grad_op.input("X")
+    y = matmul_grad_op.input("Y")
+    out_grad = matmul_grad_op.input("Out@GRAD")
+    x_grad = matmul_grad_op.output("X@GRAD")
+    y_grad = matmul_grad_op.output("Y@GRAD")
+    op_role = matmul_grad_op.attr("op_role")
+    
+    # NOTE(Ruibiao): Required OP scheduling order: matmul(dOut, Y^T) -> c_allreduce_sum(dX) -> matmul(X^T, dOut).
+    # c_allreduce_sum(dX) and matmul(X^T, dOut) cannot be swapped. Otherwise, after buffer_shared_inplace_pass
+    # adding share_buffer OP before c_allreduce_sum, c_allreduce_sum will synchronous with comp-stream, and then
+    # the matmul op before it cannot be overlapped.
+    var_x = block.var(x[0])
+    var_out_grad = block.var(out_grad[0])
+    var_y_grad = block.var(y_grad[0])
+    
+    x_dims = var_x.shape
+    out_grad_dims = var_out_grad.shape
+    y_grad_dims = var_y_grad.shape
+    
+    assert len(x_dims) == len(
+        out_grad_dims
+    ), f"The rank of x must be equal to that of out_grad, but got x rank = {len(x_dims)} and out_grad rank = {len(out_grad_dims)}."
+    if len(x_dims) > 2:
+        assert (
+            x_dims[0:2] == out_grad_dims[0:2]
+        ), f"The first two dimensions of x must be equal to that of out_grad, but got x_dims:{x_dims} and out_grad_dims:{out_grad_dims}."
+    new_x_dims = [x_dims[0] * x_dims[1]] + list(x_dims[2:])
+    new_out_grad_dims = [
+        out_grad_dims[0] * out_grad_dims[1]
+    ] + list(out_grad_dims[2:])
+    
+    # NOTE(Ruibiao): Why insert reshape op here?
+    # When the rank of input matrix is 3, MatmulGradKernel use reshape to fold the first two dimensions of x and out_grad (see FoldInitDims in matmul_grad_kernel_impl.h), and then calls blas.Matmul to calculate y_grad.
+    # If we directly append matmul op to calculate y_grad without FoldInitDims, blas.BatchedGEMM is actually called in MatmulKernel, which has a larger cost than using blas.Matmul after dimension folding.
+    # Therefore, we imitate MatmulGradKernel here by inserting reshape op before matmul.
+    new_x = _insert_reshape_op(
+        block, 
+        matmul_grad_id + 1, 
+        x, 
+        new_x_dims, 
+        op_role,
+        op_namescope=op_namescope,
+        dist_context=dist_context
+    )
+    new_out_grad = _insert_reshape_op(
+        block, 
+        matmul_grad_id + 2, 
+        out_grad, 
+        new_out_grad_dims, 
+        op_role,
+        op_namescope=op_namescope,
+        dist_context=dist_context
+    )
+    new_y_grad = block.create_var(
+        name=f"{y_grad[0]}@reshape.out",
+        dtype=var_y_grad.dtype,
+        persistable=False,
+    )
+    
+    if dist_context:
+        dist_context.set_tensor_dist_attr_for_program(
+            new_y_grad,
+            dist_context.get_tensor_dist_attr_for_program(var_y_grad),
+        )
+    
+    if dist_context:
+        matmul_grad_dist_attr = (
+            dist_context.get_op_dist_attr_for_program(matmul_grad_op)
+        )
+
+    matmul_op = block._insert_op_without_sync(
+        index=matmul_grad_id + 3,
+        type="matmul_v2",
+        inputs={"X": new_x, "Y": new_out_grad},
+        outputs={"Out": new_y_grad},
+        attrs={
+            "trans_x": True,
+            "trans_y": False,
+            "op_role": op_role,
+            'op_namescope': op_namescope,
+        },
+    )
+    if dist_context:
+        dist_context.set_op_dist_attr_for_program(
+            matmul_op, matmul_grad_dist_attr
+        )
+    _insert_reshape_op(
+        block,
+        matmul_grad_id + 4,
+        [new_y_grad.name],
+        y_grad_dims,
+        op_role,
+        y_grad,
+        op_namescope=op_namescope,
+        dist_context=dist_context
+    )
+    
+    matmul_op = block._insert_op_without_sync(
+        index=matmul_grad_id + 1,
+        type="matmul_v2",
+        inputs={"X": out_grad, "Y": y},
+        outputs={"Out": x_grad},
+        attrs={
+            "trans_x": False,
+            "trans_y": True,
+            "op_role": op_role,
+            'op_namescope': op_namescope,
+        },
+    )
+    if dist_context:
+        dist_context.set_op_dist_attr_for_program(
+            matmul_op, matmul_grad_dist_attr
+        )
+
+    block._remove_op(matmul_grad_id, sync=False)

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -934,8 +934,8 @@ def _split_matmul_grad_to_matmul(
         [new_y_grad.name],
         y_grad_dims,
         op_role,
-        y_grad,
         dist_context=dist_context,
+        out=y_grad,
         op_namescope=op_namescope,
     )
 

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -26,12 +26,10 @@ from paddle.distributed.auto_parallel.static.utils import (
     is_backward_op,
     is_forward_op,
     is_optimize_op,
+    naive_set_dist_op_attr_for_program_by_mesh_and_mapping,
     use_new_executor,
 )
 from paddle.distributed.fleet.meta_optimizers.common import OpRole
-from paddle.distributed.auto_parallel.static.utils import (
-    naive_set_dist_op_attr_for_program_by_mesh_and_mapping
-)
 
 __not_shape_var_type__ = [
     core.VarDesc.VarType.READER,
@@ -790,7 +788,16 @@ def _add_event_dependency(recorder_op, waiter_op):
         waiter_op.dist_attr.events_to_wait = waiter_wait_list
 
 
-def _insert_reshape_op(block, index, x, shape, op_role, op_namescope="/", out=None, dist_context=None):
+def _insert_reshape_op(
+    block,
+    index,
+    x,
+    shape,
+    op_role,
+    out=None,
+    op_namescope="/",
+    dist_context=None,
+):
     var_x = block.var(x[0])
     if dist_context:
         x_dist_attr = dist_context.get_tensor_dist_attr_for_program(var_x)
@@ -804,9 +811,7 @@ def _insert_reshape_op(block, index, x, shape, op_role, op_namescope="/", out=No
         if dist_context:
             dist_context.set_tensor_dist_attr_for_program(out, x_dist_attr)
 
-    x_shape = block.create_var(
-        name=f"{x[0]}@reshape.xshape", dtype=var_x.dtype
-    )
+    x_shape = block.create_var(name=f"{x[0]}@reshape.xshape", dtype=var_x.dtype)
     if dist_context:
         dist_context.set_tensor_dist_attr_for_program(x_shape, x_dist_attr)
 
@@ -838,7 +843,7 @@ def _split_matmul_grad_to_matmul(
 ):
     ops = block.ops
     matmul_grad_op = ops[matmul_grad_id]
-    
+
     tran_x = matmul_grad_op.attr("trans_x")
     assert (
         not tran_x
@@ -847,14 +852,14 @@ def _split_matmul_grad_to_matmul(
     assert (
         not tran_y
     ), f"matmul_grad(id={matmul_grad_id}) with tran_y == True is not supported for spliting matmul_grad to matmul"
-    
+
     x = matmul_grad_op.input("X")
     y = matmul_grad_op.input("Y")
     out_grad = matmul_grad_op.input("Out@GRAD")
     x_grad = matmul_grad_op.output("X@GRAD")
     y_grad = matmul_grad_op.output("Y@GRAD")
     op_role = matmul_grad_op.attr("op_role")
-    
+
     # NOTE(Ruibiao): Required OP scheduling order: matmul(dOut, Y^T) -> c_allreduce_sum(dX) -> matmul(X^T, dOut).
     # c_allreduce_sum(dX) and matmul(X^T, dOut) cannot be swapped. Otherwise, after buffer_shared_inplace_pass
     # adding share_buffer OP before c_allreduce_sum, c_allreduce_sum will synchronous with comp-stream, and then
@@ -862,11 +867,11 @@ def _split_matmul_grad_to_matmul(
     var_x = block.var(x[0])
     var_out_grad = block.var(out_grad[0])
     var_y_grad = block.var(y_grad[0])
-    
+
     x_dims = var_x.shape
     out_grad_dims = var_out_grad.shape
     y_grad_dims = var_y_grad.shape
-    
+
     assert len(x_dims) == len(
         out_grad_dims
     ), f"The rank of x must be equal to that of out_grad, but got x rank = {len(x_dims)} and out_grad rank = {len(out_grad_dims)}."
@@ -875,47 +880,47 @@ def _split_matmul_grad_to_matmul(
             x_dims[0:2] == out_grad_dims[0:2]
         ), f"The first two dimensions of x must be equal to that of out_grad, but got x_dims:{x_dims} and out_grad_dims:{out_grad_dims}."
     new_x_dims = [x_dims[0] * x_dims[1]] + list(x_dims[2:])
-    new_out_grad_dims = [
-        out_grad_dims[0] * out_grad_dims[1]
-    ] + list(out_grad_dims[2:])
-    
+    new_out_grad_dims = [out_grad_dims[0] * out_grad_dims[1]] + list(
+        out_grad_dims[2:]
+    )
+
     # NOTE(Ruibiao): Why insert reshape op here?
     # When the rank of input matrix is 3, MatmulGradKernel use reshape to fold the first two dimensions of x and out_grad (see FoldInitDims in matmul_grad_kernel_impl.h), and then calls blas.Matmul to calculate y_grad.
     # If we directly append matmul op to calculate y_grad without FoldInitDims, blas.BatchedGEMM is actually called in MatmulKernel, which has a larger cost than using blas.Matmul after dimension folding.
     # Therefore, we imitate MatmulGradKernel here by inserting reshape op before matmul.
     new_x = _insert_reshape_op(
-        block, 
-        matmul_grad_id + 1, 
-        x, 
-        new_x_dims, 
+        block,
+        matmul_grad_id + 1,
+        x,
+        new_x_dims,
         op_role,
         op_namescope=op_namescope,
-        dist_context=dist_context
+        dist_context=dist_context,
     )
     new_out_grad = _insert_reshape_op(
-        block, 
-        matmul_grad_id + 2, 
-        out_grad, 
-        new_out_grad_dims, 
+        block,
+        matmul_grad_id + 2,
+        out_grad,
+        new_out_grad_dims,
         op_role,
         op_namescope=op_namescope,
-        dist_context=dist_context
+        dist_context=dist_context,
     )
     new_y_grad = block.create_var(
         name=f"{y_grad[0]}@reshape.out",
         dtype=var_y_grad.dtype,
         persistable=False,
     )
-    
+
     if dist_context:
         dist_context.set_tensor_dist_attr_for_program(
             new_y_grad,
             dist_context.get_tensor_dist_attr_for_program(var_y_grad),
         )
-    
+
     if dist_context:
-        matmul_grad_dist_attr = (
-            dist_context.get_op_dist_attr_for_program(matmul_grad_op)
+        matmul_grad_dist_attr = dist_context.get_op_dist_attr_for_program(
+            matmul_grad_op
         )
 
     matmul_op = block._insert_op_without_sync(
@@ -942,9 +947,9 @@ def _split_matmul_grad_to_matmul(
         op_role,
         y_grad,
         op_namescope=op_namescope,
-        dist_context=dist_context
+        dist_context=dist_context,
     )
-    
+
     matmul_op = block._insert_op_without_sync(
         index=matmul_grad_id + 1,
         type="matmul_v2",

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -835,7 +835,7 @@ def _insert_reshape_op(
     return out
 
 
-def _split_matmul_grad_to_matmul(
+def split_matmul_grad_to_matmul(
     block, matmul_grad_id, dist_context, op_namescope="/"
 ):
     ops = block.ops

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -823,7 +823,7 @@ def _insert_reshape_op(
             'op_namescope': op_namescope,
         },
     )
-    
+
     naive_set_dist_op_attr_for_program_by_mesh_and_mapping(
         reshape_op,
         process_mesh=x_dist_attr.process_mesh,
@@ -927,9 +927,7 @@ def _split_matmul_grad_to_matmul(
         },
     )
 
-    dist_context.set_op_dist_attr_for_program(
-        matmul_op, matmul_grad_dist_attr
-    )
+    dist_context.set_op_dist_attr_for_program(matmul_op, matmul_grad_dist_attr)
     _insert_reshape_op(
         block,
         matmul_grad_id + 4,
@@ -954,8 +952,6 @@ def _split_matmul_grad_to_matmul(
         },
     )
 
-    dist_context.set_op_dist_attr_for_program(
-        matmul_op, matmul_grad_dist_attr
-    )
+    dist_context.set_op_dist_attr_for_program(matmul_op, matmul_grad_dist_attr)
 
     block._remove_op(matmul_grad_id, sync=False)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

将 allreduce_matmul_grad_overlapping 中拆分 matmul_grad_op 的操作提取到 pass_utils 当中

相关 Issue:
- https://github.com/PaddlePaddle/Paddle/issues/62666
