### PR TITLE
fix review comment in PR62659

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_all_func_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_all_func_gen.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from op_infer_spmd_func_gen import gen_op_infer_spmd_func
-from op_infermeta_gen import gen_op_infermeta_func
+from op_infermeta_func_gen import gen_op_infermeta_func
 from op_member_access_func_gen import gen_op_member_access_func
 from op_vjp_interface_func_gen import gen_op_vjp_interface_func
 

--- a/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_build_gen.py
@@ -386,7 +386,7 @@ def GenBuildAttributes(
                 op_attribute_type=op_non_mutable_attribute_type_list[idx],
                 attr=op_non_mutable_attribute_name_list[idx],
             )
-        attr_str += """  argument.AddAttribute("{attr_name}", attr_{attr_name});\n  argument_attributes.insert({{"{attr_name}", attr_{attr_name}}});\n""".format(
+        attr_str += """  argument_attributes.insert({{"{attr_name}", attr_{attr_name}}});\n""".format(
             attr_name=op_non_mutable_attribute_name_list[idx]
         )
 
@@ -748,6 +748,7 @@ def GenBuildOutputs(
                     type=op_output_type_list[idx], name=output_name
                 )
 
+    build_output_str += "  argument.AddAttributes(argument_attributes);\n"
     build_output_str += "  argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());\n"
     # NOTE(Aurelius84): PassStopGradients must be placed after argument.AddOutputs.
     build_output_str += "  ::pir::PassStopGradientsDefaultly(argument);\n"
@@ -831,7 +832,8 @@ def gen_build_func_str(
     )
 
     build_outputs_str = """
-  std::vector<pir::Type> argument_outputs = {op_name}::InferMeta(argument_inputs, argument_attributes);
+  std::vector<pir::Type> argument_outputs = {op_name}::InferMeta(argument_inputs, &argument_attributes);
+  argument.AddAttributes(argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);""".format(
         op_name=op_class_name

--- a/paddle/fluid/pir/dialect/op_generator/op_infermeta_func_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_infermeta_func_gen.py
@@ -19,8 +19,8 @@ from op_build_gen import (
 from utils import to_pascal_case
 
 OP_INFERMETA_DECL_STRING = (
-    "  static void InferMeta( phi::InferMetaContext *infer_meta );\n"
-    "  static std::vector<pir::Type> InferMeta( const std::vector<pir::Value>& input_values, pir::AttributeMap& attributes );"
+    "  static void InferMeta(phi::InferMetaContext *infer_meta );\n"
+    "  static std::vector<pir::Type> InferMeta( const std::vector<pir::Value>& input_values, pir::AttributeMap* p_attributes );"
 )
 
 OP_INFERMETA_IMPL_TEMPLATE_1 = """
@@ -31,7 +31,10 @@ void {op_name}::InferMeta( phi::InferMetaContext *infer_meta ) {{
 """
 
 OP_INFERMETA_IMPL_TEMPLATE_2 = """
-std::vector<pir::Type> {op_name}::InferMeta(const std::vector<pir::Value>& input_values, pir::AttributeMap& attributes) {{
+std::vector<pir::Type> {op_name}::InferMeta(const std::vector<pir::Value>& input_values, pir::AttributeMap* p_attributes) {{
+  PADDLE_ENFORCE_NOT_NULL(
+        p_attributes, common::errors::Fatal("AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto& attributes = *p_attributes; (void)attributes;
 {infermeta_inputs}
 {get_attributes_str}
 {infermeta_outputs}
@@ -40,7 +43,7 @@ std::vector<pir::Type> {op_name}::InferMeta(const std::vector<pir::Value>& input
 """
 
 OP_INFERMETA_IMPL_TEMPLATE_2_BY_INVOKE = """
-std::vector<pir::Type> {op_name}::InferMeta(const std::vector<pir::Value>& input_values, pir::AttributeMap& attributes) {{
+std::vector<pir::Type> {op_name}::InferMeta(const std::vector<pir::Value>& input_values, pir::AttributeMap* attributes) {{
   return {invoke_class}::InferMeta(input_values, attributes);
 }}
 """
@@ -613,7 +616,11 @@ def GenDistBranch(args, op_info):
         return ""
     TEMPLATE = """
   // Auto Parallel condition
-  if(!input_values.empty() && AllInputAreDist(input_values)) {{
+  if(HasDistInput(input_values)) {{
+    if(!AllInputAreDist(input_values)) {{
+        PADDLE_THROW(common::errors::Unimplemented(
+            "Mixed inputs with DenseTensor and DistDenseTensor are not supported yet."));
+    }}
     ProcessMeshAttribute op_mesh = input_values[0].type().dyn_cast<DistDenseTensorType>().process_mesh_attr();
     std::vector<TensorDistAttribute> operand_dist_attrs, result_dist_attrs;"""
     dist_branch_str = TEMPLATE.format()

--- a/paddle/fluid/pir/dialect/operator/interface/infermeta.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infermeta.h
@@ -25,12 +25,12 @@ class InferMetaInterface : public pir::OpInterfaceBase<InferMetaInterface> {
   struct Concept {
     explicit Concept(void (*infer_meta)(phi::InferMetaContext *),
                      std::vector<pir::Type> (*infer_meta_by_value)(
-                         const std::vector<pir::Value> &, pir::AttributeMap &))
+                         const std::vector<pir::Value> &, pir::AttributeMap *))
         : infer_meta_(infer_meta), infer_meta_by_value_(infer_meta_by_value) {}
 
     void (*infer_meta_)(phi::InferMetaContext *);
     std::vector<pir::Type> (*infer_meta_by_value_)(
-        const std::vector<pir::Value> &, pir::AttributeMap &);  // NOLINT
+        const std::vector<pir::Value> &, pir::AttributeMap *);
   };
 
   template <class ConcreteOp>
@@ -40,8 +40,8 @@ class InferMetaInterface : public pir::OpInterfaceBase<InferMetaInterface> {
     }
     static inline std::vector<pir::Type> InferMetaByValue(
         const std::vector<pir::Value> &input_values,
-        pir::AttributeMap &attributes) {  // NOLINT
-      return ConcreteOp::InferMeta(input_values, attributes);
+        pir::AttributeMap *p_attributes) {
+      return ConcreteOp::InferMeta(input_values, p_attributes);
     }
     Model() : Concept(InferMeta, InferMetaByValue) {}
   };
@@ -55,8 +55,8 @@ class InferMetaInterface : public pir::OpInterfaceBase<InferMetaInterface> {
   }
 
   std::vector<pir::Type> InferMeta(const std::vector<pir::Value> &input_values,
-                                   pir::AttributeMap &attributes) {  // NOLINT
-    return impl_->infer_meta_by_value_(input_values, attributes);
+                                   pir::AttributeMap *p_attributes) {
+    return impl_->infer_meta_by_value_(input_values, p_attributes);
   }
 
  private:

--- a/paddle/fluid/pir/dialect/operator/ir/manual_onednn_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_onednn_op.cc
@@ -113,7 +113,7 @@ void ExpandOp::Build(pir::Builder& builder,
   argument_attributes.insert({"mkldnn_data_type", attr_mkldnn_data_type});
 
   std::vector<pir::Type> argument_outputs =
-      ExpandOp::InferMeta(argument_inputs, argument_attributes);
+      ExpandOp::InferMeta(argument_inputs, &argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -156,7 +156,7 @@ void ExpandOp::Build(pir::Builder& builder,
   argument_attributes.insert({"mkldnn_data_type", attr_mkldnn_data_type});
 
   std::vector<pir::Type> argument_outputs =
-      ExpandOp::InferMeta(argument_inputs, argument_attributes);
+      ExpandOp::InferMeta(argument_inputs, &argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -180,7 +180,7 @@ void ExpandOp::Build(pir::Builder& builder,
   argument_attributes.insert({"mkldnn_data_type", attr_mkldnn_data_type});
 
   std::vector<pir::Type> argument_outputs =
-      ExpandOp::InferMeta(argument_inputs, argument_attributes);
+      ExpandOp::InferMeta(argument_inputs, &argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -243,7 +243,11 @@ void ExpandOp::InferMeta(phi::InferMetaContext* infer_meta) {
 
 std::vector<pir::Type> ExpandOp::InferMeta(
     const std::vector<pir::Value>& input_values,
-    pir::AttributeMap& attributes) {  // NOLINT
+    pir::AttributeMap* p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
              input_values.size());

--- a/paddle/fluid/pir/dialect/operator/ir/manual_onednn_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_onednn_op.h
@@ -84,7 +84,7 @@ class ExpandOp : public pir::Op<ExpandOp,
   static void InferMeta(phi::InferMetaContext* infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value>& input_values,
-      pir::AttributeMap& attributes);  // NOLINT
+      pir::AttributeMap* p_attributes);  // NOLINT
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -133,7 +133,7 @@ void AddNOp::Build(pir::Builder &builder,             // NOLINT
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      AddNOp::InferMeta(argument_inputs, argument_attributes);
+      AddNOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -146,7 +146,7 @@ void AddNOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> AddNOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta AddNOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -229,7 +229,7 @@ void AddN_Op::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      AddN_Op::InferMeta(argument_inputs, argument_attributes);
+      AddN_Op::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
@@ -292,7 +292,7 @@ void AddN_Op::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> AddN_Op::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta AddN_Op";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -428,9 +428,10 @@ void AddNArrayOp::Build(pir::Builder &builder,             // NOLINT
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      AddNArrayOp::InferMeta(argument_inputs, argument_attributes);
+      AddNArrayOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
+  argument.AddAttributes(argument_attributes);
   ::pir::PassStopGradientsDefaultly(argument);
 }
 
@@ -441,7 +442,7 @@ void AddNArrayOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> AddNArrayOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta AddNArrayOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -583,7 +584,7 @@ void FusedGemmEpilogueOp::Build(pir::Builder &builder,
   argument.AddAttribute("activation", attr_activation);
   argument_attributes.insert({"activation", attr_activation});
   std::vector<pir::Type> argument_outputs =
-      FusedGemmEpilogueOp::InferMeta(argument_inputs, argument_attributes);
+      FusedGemmEpilogueOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
@@ -662,7 +663,12 @@ void FusedGemmEpilogueOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> FusedGemmEpilogueOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta FusedGemmEpilogueOp";
   IR_ENFORCE(input_values.size() == 3,
              "Num of inputs is expected to be 3 but got %d.",
@@ -893,7 +899,7 @@ void FusedGemmEpilogueGradOp::Build(pir::Builder &builder,
   argument.AddAttribute("activation_grad", attr_activation_grad);
   argument_attributes.insert({"activation_grad", attr_activation_grad});
   std::vector<pir::Type> argument_outputs =
-      FusedGemmEpilogueGradOp::InferMeta(argument_inputs, argument_attributes);
+      FusedGemmEpilogueGradOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
@@ -907,7 +913,12 @@ void FusedGemmEpilogueGradOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> FusedGemmEpilogueGradOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   IR_ENFORCE(input_values.size() == 4,
              "Num of inputs is expected to be 4 but got %d.",
              input_values.size());
@@ -1120,7 +1131,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      SplitGradOp::InferMeta(argument_inputs, argument_attributes);
+      SplitGradOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -1139,7 +1150,7 @@ void SplitGradOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      SplitGradOp::InferMeta(argument_inputs, argument_attributes);
+      SplitGradOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -1204,7 +1215,7 @@ void SplitGradOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> SplitGradOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta SplitGradOp";
 
   IR_ENFORCE(input_values.size() == 2,
@@ -1297,7 +1308,7 @@ void CreateArrayOp::Build(pir::Builder &builder,
   argument.AddAttribute("dtype", attr_dtype);
   argument_attributes.insert({"dtype", attr_dtype});
   std::vector<pir::Type> argument_outputs =
-      CreateArrayOp::InferMeta(argument_inputs, argument_attributes);
+      CreateArrayOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -1343,7 +1354,12 @@ void CreateArrayOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> CreateArrayOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta CreateArrayOp";
 
   PADDLE_ENFORCE(
@@ -1415,7 +1431,7 @@ void CreateArrayLikeOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddAttribute("val", attr_val);
   argument_attributes.insert({"val", attr_val});
   std::vector<pir::Type> argument_outputs =
-      CreateArrayLikeOp::InferMeta(argument_inputs, argument_attributes);
+      CreateArrayLikeOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -1461,7 +1477,7 @@ void CreateArrayLikeOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> CreateArrayLikeOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta CreateArrayLikeOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -1534,7 +1550,7 @@ void ArrayLengthOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ArrayLengthOp::InferMeta(argument_inputs, argument_attributes);
+      ArrayLengthOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
 }
@@ -1582,7 +1598,7 @@ void ArrayLengthOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ArrayLengthOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta ArrayLengthOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -1666,7 +1682,7 @@ void ArrayReadOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ArrayReadOp::InferMeta(argument_inputs, argument_attributes);
+      ArrayReadOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -1683,7 +1699,7 @@ void ArrayReadOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ArrayReadOp::InferMeta(argument_inputs, argument_attributes);
+      ArrayReadOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -1738,7 +1754,7 @@ void ArrayReadOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ArrayReadOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta ArrayLengthOp";
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
@@ -1838,7 +1854,7 @@ void ArrayWrite_Op::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ArrayWrite_Op::InferMeta(argument_inputs, argument_attributes);
+      ArrayWrite_Op::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   constexpr char kStopGradientAttrName[] = "stop_gradient";
@@ -1906,7 +1922,7 @@ void ArrayWrite_Op::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ArrayWrite_Op::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta ArrayWrite_Op";
   IR_ENFORCE(input_values.size() == 3,
              "Num of inputs is expected to be 3 but got %d.",
@@ -2037,7 +2053,7 @@ void ArrayToTensorOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddAttribute("use_stack", attr_use_stack);
   argument_attributes.insert({"use_stack", attr_use_stack});
   std::vector<pir::Type> argument_outputs =
-      ArrayToTensorOp::InferMeta(argument_inputs, argument_attributes);
+      ArrayToTensorOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -2098,7 +2114,12 @@ void ArrayToTensorOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ArrayToTensorOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta ArrayToTensorOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -2224,7 +2245,7 @@ void TensorToArrayOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddAttribute("use_stack", attr_use_stack);
   argument_attributes.insert({"use_stack", attr_use_stack});
   std::vector<pir::Type> argument_outputs =
-      TensorToArrayOp::InferMeta(argument_inputs, argument_attributes);
+      TensorToArrayOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -2287,7 +2308,12 @@ void TensorToArrayOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> TensorToArrayOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta TensorToArrayOp";
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
@@ -2487,7 +2513,7 @@ void SliceArrayOp::Build(pir::Builder &builder,             // NOLINT
   pir::AttributeMap argument_attributes = {};
   VLOG(4) << "Builder construction outputs";
   std::vector<pir::Type> argument_outputs =
-      SliceArrayOp::InferMeta(argument_inputs, argument_attributes);
+      SliceArrayOp::InferMeta(argument_inputs, &argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2499,7 +2525,7 @@ void SliceArrayOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> SliceArrayOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta SliceArrayOp";
   IR_ENFORCE(input_values.size() == 3,
              "Num of inputs is expected to be 3 but got %d.",
@@ -2637,7 +2663,7 @@ void SliceArrayDenseOp::Build(pir::Builder &builder,             // NOLINT
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      SliceArrayDenseOp::InferMeta(argument_inputs, argument_attributes);
+      SliceArrayDenseOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -2650,7 +2676,7 @@ void SliceArrayDenseOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> SliceArrayDenseOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta SliceArrayDenseOp";
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
@@ -2735,7 +2761,7 @@ void AssignArrayOp::Build(pir::Builder &builder,
 
   VLOG(4) << "Builder construction outputs";
   std::vector<pir::Type> argument_outputs =
-      AssignArrayOp::InferMeta(argument_inputs, argument_attributes);
+      AssignArrayOp::InferMeta(argument_inputs, &argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
 }
@@ -2789,7 +2815,7 @@ phi::DataType AssignArrayOp::GetKernelTypeForVar(
 
 std::vector<pir::Type> AssignArrayOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta AssignArrayOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -2890,7 +2916,7 @@ void AssignArray_Op::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> AssignArray_Op::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta AssignArray_Op";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -2984,7 +3010,7 @@ void ExpandOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ExpandOp::InferMeta(argument_inputs, argument_attributes);
+      ExpandOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3017,7 +3043,7 @@ void ExpandOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ExpandOp::InferMeta(argument_inputs, argument_attributes);
+      ExpandOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3036,7 +3062,7 @@ void ExpandOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ExpandOp::InferMeta(argument_inputs, argument_attributes);
+      ExpandOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3156,7 +3182,7 @@ void ExpandOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ExpandOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta ExpandOp";
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
@@ -3303,7 +3329,7 @@ void IncrementOp::Build(pir::Builder &builder,
   argument.AddAttribute("value", attr_value);
   argument_attributes.insert({"value", attr_value});
   std::vector<pir::Type> argument_outputs =
-      IncrementOp::InferMeta(argument_inputs, argument_attributes);
+      IncrementOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3330,7 +3356,7 @@ void IncrementOp::Build(pir::Builder &builder,
   argument.AddAttribute("value", attr_value);
   argument_attributes.insert({"value", attr_value});
   std::vector<pir::Type> argument_outputs =
-      IncrementOp::InferMeta(argument_inputs, argument_attributes);
+      IncrementOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3378,7 +3404,12 @@ void IncrementOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> IncrementOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta IncrementOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -3483,7 +3514,7 @@ void Increment_Op::Build(pir::Builder &builder,
   argument.AddAttribute("value", attr_value);
   argument_attributes.insert({"value", attr_value});
   std::vector<pir::Type> argument_outputs =
-      Increment_Op::InferMeta(argument_inputs, argument_attributes);
+      Increment_Op::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3510,7 +3541,7 @@ void Increment_Op::Build(pir::Builder &builder,
   argument.AddAttribute("value", attr_value);
   argument_attributes.insert({"value", attr_value});
   std::vector<pir::Type> argument_outputs =
-      Increment_Op::InferMeta(argument_inputs, argument_attributes);
+      Increment_Op::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3559,7 +3590,12 @@ void Increment_Op::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> Increment_Op::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta Increment_Op";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
@@ -3664,7 +3700,7 @@ void AssignOut_Op::Build(pir::Builder &builder,
   pir::AttributeMap argument_attributes = {};
 
   std::vector<pir::Type> argument_outputs =
-      AssignOut_Op::InferMeta(argument_inputs, argument_attributes);
+      AssignOut_Op::InferMeta(argument_inputs, &argument_attributes);
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   constexpr char kStopGradientAttrName[] = "stop_gradient";
   auto stop_gradient0 =
@@ -3719,7 +3755,7 @@ void AssignOut_Op::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> AssignOut_Op::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
              input_values.size());
@@ -3785,7 +3821,7 @@ void ShapeBroadcastOp::Build(pir::Builder &builder,
   VLOG(4) << "Builder construction attributes";
   pir::AttributeMap argument_attributes = {};
   std::vector<pir::Type> argument_outputs =
-      ShapeBroadcastOp::InferMeta(argument_inputs, argument_attributes);
+      ShapeBroadcastOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -3798,7 +3834,7 @@ void ShapeBroadcastOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ShapeBroadcastOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   VLOG(4) << "Start infermeta ShapeBroadcastOp";
   IR_ENFORCE(input_values.size() == 2,
              "Num of inputs is expected to be 2 but got %d.",
@@ -4008,7 +4044,7 @@ void MemcpyD2hMultiIoOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> MemcpyD2hMultiIoOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",
              input_values.size());
@@ -4142,7 +4178,7 @@ void ArrayPopOp::Build(pir::Builder &builder,             // NOLINT
   argument.AddAttribute("index", attr_index);
   argument_attributes.insert({"index", attr_index});
   std::vector<pir::Type> argument_outputs =
-      ArrayPopOp::InferMeta(argument_inputs, argument_attributes);
+      ArrayPopOp::InferMeta(argument_inputs, &argument_attributes);
 
   argument.AddOutputs(argument_outputs.begin(), argument_outputs.end());
   ::pir::PassStopGradientsDefaultly(argument);
@@ -4155,7 +4191,12 @@ void ArrayPopOp::InferMeta(phi::InferMetaContext *infer_meta) {
 
 std::vector<pir::Type> ArrayPopOp::InferMeta(
     const std::vector<pir::Value> &input_values,
-    pir::AttributeMap &attributes) {  // NOLINT
+    pir::AttributeMap *p_attributes) {
+  PADDLE_ENFORCE_NOT_NULL(
+      p_attributes,
+      common::errors::Fatal(
+          "AttrtibueMap pointer in InferMeta function is nullptr."));
+  auto &attributes = *p_attributes;
   VLOG(4) << "Start infermeta ArrayPopOp";
   IR_ENFORCE(input_values.size() == 1,
              "Num of inputs is expected to be 1 but got %d.",

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -55,7 +55,7 @@ class AddNOp : public pir::Op<AddNOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
@@ -87,7 +87,7 @@ class AddN_Op : public pir::Op<AddN_Op,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class AddNArrayOp : public pir::Op<AddNArrayOp,
@@ -110,7 +110,7 @@ class AddNArrayOp : public pir::Op<AddNArrayOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class FusedGemmEpilogueOp
@@ -140,7 +140,7 @@ class FusedGemmEpilogueOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class FusedGemmEpilogueGradOp
@@ -173,7 +173,7 @@ class FusedGemmEpilogueGradOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
@@ -199,7 +199,7 @@ class SplitGradOp : public pir::Op<SplitGradOp, OpYamlInfoInterface> {
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class CreateArrayOp
@@ -218,7 +218,7 @@ class CreateArrayOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class CreateArrayLikeOp : public pir::Op<CreateArrayLikeOp,
@@ -240,7 +240,7 @@ class CreateArrayLikeOp : public pir::Op<CreateArrayLikeOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class ArrayLengthOp
@@ -260,7 +260,7 @@ class ArrayLengthOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class ArrayReadOp : public pir::Op<ArrayReadOp,
@@ -288,7 +288,7 @@ class ArrayReadOp : public pir::Op<ArrayReadOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -321,7 +321,7 @@ class ArrayWrite_Op : public pir::Op<ArrayWrite_Op,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -352,7 +352,7 @@ class ArrayToTensorOp : public pir::Op<ArrayToTensorOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -382,7 +382,7 @@ class TensorToArrayOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class SliceArrayOp
@@ -416,7 +416,7 @@ class SliceArrayOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class SliceArrayDenseOp
@@ -448,7 +448,7 @@ class SliceArrayDenseOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class AssignArrayOp
@@ -479,7 +479,7 @@ class AssignArrayOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class AssignArray_Op
@@ -507,7 +507,7 @@ class AssignArray_Op
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class ExpandOp : public pir::Op<ExpandOp,
@@ -551,7 +551,7 @@ class ExpandOp : public pir::Op<ExpandOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -597,7 +597,7 @@ class IncrementOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -644,7 +644,7 @@ class Increment_Op
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -686,7 +686,7 @@ class AssignOut_Op
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,
@@ -729,7 +729,7 @@ class MemcpyD2hMultiIoOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 class IR_API ShapeBroadcastOp
@@ -755,7 +755,7 @@ class IR_API ShapeBroadcastOp
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 
   bool InferSymbolicShape(pir::ShapeConstraintIRAnalysis *shape_analysis);
 };
@@ -790,7 +790,7 @@ class ArrayPopOp : public pir::Op<ArrayPopOp,
   static void InferMeta(phi::InferMetaContext *infer_meta);
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
-      pir::AttributeMap &attributes);  // NOLINT
+      pir::AttributeMap *p_attributes);
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -92,15 +92,15 @@ pir::Type ConvertOpTypeToKernelType(pir::IrContext* ctx,
 static const std::vector<pir::Type> InferMetaByValue(
     pir::Operation* op,
     const std::vector<pir::Value>& input_values,
-    pir::AttributeMap& attribute_map) {  // NOLINT
+    pir::AttributeMap* p_attribute_map) {  // NOLINT
   pir::OpInfo op_info =
       pir::IrContext::Instance()->GetRegisteredOpInfo(op->name());
   auto infer_meta_interface =
       op_info.GetInterfaceImpl<paddle::dialect::InferMetaInterface>();
   std::vector<pir::Type> output_types;
   if (infer_meta_interface) {
-    output_types =
-        infer_meta_interface->infer_meta_by_value_(input_values, attribute_map);
+    output_types = infer_meta_interface->infer_meta_by_value_(input_values,
+                                                              p_attribute_map);
   }
   return output_types;
 }
@@ -2095,7 +2095,7 @@ std::vector<pir::Type> BuildOutputs(
       input_values.emplace_back(op_item->operand(i).source());
     }
     std::vector<pir::Type> output_types =
-        InferMetaByValue(op_item, input_values, attribute_map);
+        InferMetaByValue(op_item, input_values, &attribute_map);
 
     if (output_types.size() != 0) {
       PADDLE_ENFORCE_EQ(
@@ -2129,7 +2129,7 @@ std::vector<pir::Type> BuildOutputs(
                           &op_output_types);
     }
   } else {
-    auto base_types = InferMetaByValue(op_item, new_vec_inputs, attribute_map);
+    auto base_types = InferMetaByValue(op_item, new_vec_inputs, &attribute_map);
     PADDLE_ENFORCE_EQ(base_types.size(),
                       op_item->num_results(),
                       phi::errors::PreconditionNotMet(

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -5,4 +5,10 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
   py_test_modules(test_ir_dist_attr MODULES test_ir_dist_attr ENVS
                   FLAGS_enable_pir_api=1)
   py_test_modules(test_static_pir_program MODULES test_static_pir_program)
+  py_test_modules(test_pir_elementwise_spmd MODULES test_elementwise_spmd_rule
+                  ENVS FLAGS_enable_pir_api=1)
+  py_test_modules(test_pir_relu_spmd MODULES test_relu_spmd_rule ENVS
+                  FLAGS_enable_pir_api=1)
+  py_test_modules(test_pir_mse_spmd MODULES test_mse_spmd_rule ENVS
+                  FLAGS_enable_pir_api=1)
 endif()

--- a/test/auto_parallel/pir/test_elementwise_spmd_rule.py
+++ b/test/auto_parallel/pir/test_elementwise_spmd_rule.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.distributed as dist
+
+paddle.enable_static()
+
+
+class TestElementwiseSpmdRule(unittest.TestCase):
+    def test_build_replicated_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            y = paddle.static.data(name='y', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Replicate()])
+            dist_y = dist.shard_tensor(y, mesh, [dist.Replicate()])
+            dist_out = dist_x + dist_y
+        # element_wise out
+        self.assertEqual(dist_out.shape, [64, 36])
+        self.assertEqual(dist_out._local_shape, [64, 36])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [-1, -1])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(len(dist_out.dist_attr().partial_dims), 0)
+
+    def test_build_col_parallel_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            y = paddle.static.data(name='y', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Replicate()])
+            dist_y = dist.shard_tensor(y, mesh, [dist.Shard(1)])
+            dist_out = dist_x + dist_y
+
+        # element_wise out
+        self.assertEqual(dist_out.shape, [64, 36])
+        self.assertEqual(dist_out._local_shape, [64, 18])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [-1, 0])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(len(dist_out.dist_attr().partial_dims), 0)
+
+    def test_build_row_parallel_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            y = paddle.static.data(name='y', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Shard(1)])
+            dist_y = dist.shard_tensor(y, mesh, [dist.Shard(0)])
+            dist_out = dist_x + dist_y
+
+        # element_wise out
+        self.assertEqual(dist_out.shape, [64, 36])
+        self.assertEqual(dist_out._local_shape, [64, 18])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [-1, 0])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(dist_out.dist_attr().partial_dims, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/pir/test_mse_spmd_rule.py
+++ b/test/auto_parallel/pir/test_mse_spmd_rule.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.distributed as dist
+
+paddle.enable_static()
+
+
+class TestMseSpmdRule(unittest.TestCase):
+    def test_build_replicated_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            y = paddle.static.data(name='y', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Replicate()])
+            dist_y = dist.shard_tensor(y, mesh, [dist.Replicate()])
+            dist_out = paddle.nn.loss.MSELoss()(dist_x, dist_y)
+        # mse out
+        self.assertEqual(dist_out.shape, [])
+        self.assertEqual(dist_out._local_shape, [])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(len(dist_out.dist_attr().partial_dims), 0)
+
+    def test_build_col_parallel_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            y = paddle.static.data(name='y', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Replicate()])
+            dist_y = dist.shard_tensor(y, mesh, [dist.Shard(1)])
+            dist_out = paddle.nn.loss.MSELoss()(dist_x, dist_y)
+
+        # mse out
+        self.assertEqual(dist_out.shape, [])
+        self.assertEqual(dist_out._local_shape, [])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(len(dist_out.dist_attr().partial_dims), 1)
+
+    def test_build_row_parallel_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            y = paddle.static.data(name='y', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Shard(1)])
+            dist_y = dist.shard_tensor(y, mesh, [dist.Shard(0)])
+            dist_out = paddle.nn.loss.MSELoss()(dist_x, dist_y)
+
+        # mse out
+        self.assertEqual(dist_out.shape, [])
+        self.assertEqual(dist_out._local_shape, [])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(dist_out.dist_attr().partial_dims, {0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/pir/test_relu_spmd_rule.py
+++ b/test/auto_parallel/pir/test_relu_spmd_rule.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.distributed as dist
+
+paddle.enable_static()
+
+
+class TestReluSpmdRule(unittest.TestCase):
+    def test_build_replicated_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Replicate()])
+            dist_out = paddle.nn.functional.relu(dist_x)
+        # relu out
+        self.assertEqual(dist_out.shape, [64, 36])
+        self.assertEqual(dist_out._local_shape, [64, 36])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [-1, -1])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(len(dist_out.dist_attr().partial_dims), 0)
+
+    def test_build_col_parallel_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Shard(0)])
+            dist_out = paddle.nn.functional.relu(dist_x)
+
+        # relu out
+        self.assertEqual(dist_out.shape, [64, 36])
+        self.assertEqual(dist_out._local_shape, [32, 36])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [0, -1])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(len(dist_out.dist_attr().partial_dims), 0)
+
+    def test_build_row_parallel_program(self):
+        main_program = paddle.base.Program()
+        with paddle.base.program_guard(main_program):
+            mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+            x = paddle.static.data(name='x', shape=[64, 36])
+            dist_x = dist.shard_tensor(x, mesh, [dist.Shard(1)])
+            dist_out = paddle.nn.functional.relu(dist_x)
+
+        # relu out
+        self.assertEqual(dist_out.shape, [64, 36])
+        self.assertEqual(dist_out._local_shape, [64, 18])
+        self.assertEqual(dist_out.dist_attr().dims_mapping, [-1, 0])
+        self.assertTrue(
+            isinstance(
+                dist_out.dist_attr().process_mesh,
+                paddle.base.libpaddle.ProcessMesh,
+            )
+        )
+        self.assertEqual(dist_out.dist_attr().process_mesh.shape, [2])
+        self.assertEqual(dist_out.dist_attr().process_mesh.process_ids, [0, 1])
+        self.assertEqual(dist_out.dist_attr().partial_dims, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cpp/pir/core/ir_infershape_test.cc
+++ b/test/cpp/pir/core/ir_infershape_test.cc
@@ -53,8 +53,7 @@ class OperationTest
     fn(infer_meta);
   }
   static std::vector<pir::Type> InferMeta(
-      const std::vector<pir::Value> &input_values,
-      const pir::AttributeMap &attributes) {
+      const std::vector<pir::Value> &input_values, pir::AttributeMap *) {
     VLOG(4) << "Start infermeta OperationTest";
     std::vector<pir::Type> argument_outputs;
     return argument_outputs;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->
完善上个PR #62659 中的review意见。
- 修复类似relu等op的infersomd中计算出的分布式属性未被插入op中的bug。
- 将InferMeta的函数参数由 AttributeMap& attributes 调整为AttribtueAmp* p_attributes .
- 补充elementwise_add、relu、mse的op级别分布式单测。
- 在出现混合输入的时候，由回退单机逻辑调整为抛异常。
```cxx  
  // MatmulOp::InferMeta函数实现，包含了分布式InferSpmd逻辑
  std::vector<pir::Type> MatmulOp::InferMeta(const std::vector<pir::Value>& input_values, pir::AttributeMap& attributes) {
    // 其它单机代码省略
    // 该部分为修改后的分布式InferSpmd逻辑，仅在分布式条件下会生成该部分代码，当混合输入时，会抛异常
    if(HasDistInput(input_values)) {
      if(!AllInputAreDist(input_values)) {
          PADDLE_THROW(common::errors::Unimplemented(
              "Current not supported mixed distributed inputs."));
      }
      ProcessMeshAttribute op_mesh = input_values[0].type().dyn_cast<DistDenseTensorType>().process_mesh_attr();
      std::vector<TensorDistAttribute> operand_dist_attrs, result_dist_attrs;
      auto dist_meta_x = CvtToDistMetaTensor(x_.type().dyn_cast<DistDenseTensorType>());
      auto dist_meta_y = CvtToDistMetaTensor(y_.type().dyn_cast<DistDenseTensorType>());
      auto spmd_info = InferSpmd(dist_meta_x, dist_meta_y, transpose_x, transpose_y);
      for(auto& arg_dist : spmd_info.first) {
          operand_dist_attrs.push_back(CvtToPirDistAttr(arg_dist));
      }

      auto dist_attr_out = CvtToPirDistAttr(spmd_info.second[0]);
      result_dist_attrs.push_back(dist_attr_out);
      argument_outputs.push_back(DistDenseTensorType::get(pir::IrContext::Instance(), out_type.dyn_cast<pir::DenseTensorType>(), dist_attr_out));

      attributes[kAttrOpDistAttr] = OperationDistAttribute::get(
          pir::IrContext::Instance(),
          op_mesh,
          operand_dist_attrs,
          result_dist_attrs
      );
      return argument_outputs;
    } 
    //其它单机代码省略
```
### Other
Pcard-67164
