### PR TITLE
[CINN] Performance Optimization, fix GetGroupTileInfo

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -143,7 +143,6 @@ std::shared_ptr<cinn::ir::GroupTileInfo> OpLowererImpl::GetGroupTileInfo(
     spatial_inner_num = 1;
     reduce_inner_num = 4;
     warp_num = 8;
-
   } else if (reduce_numel == 1) {
     reduce_block = 1;
     if (spatial_is_dynamic) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

修复 GetGroupTileInfo split_factor 未清空的 bug。

该 PR 合入后，当 `shape = [128, 12, 128, 128]` 时，性能指标如下：

#### LayerNorm 超越手工优化 29%：
Phi：320.622us，CINN：`359.411us => 248.445 us`

#### Softmax 持平手工优化:
Phi: 247.695 us，CINN：`370.346us=>248.699 us`