### PR TITLE
[Prim] Optimize composite tanh_triple_grad

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -98,63 +98,88 @@ void tanh_triple_grad(const Tensor& out,
                       Tensor* out_grad,
                       Tensor* grad_out_forward_grad,
                       Tensor* grad_x_grad_forward_grad) {
-  if (out_grad) {
-    if (grad_out_grad_grad) {
-      if (grad_out_new_grad) {
-        auto out_grad_tmp =
-            (-2 * out * grad_x_grad_forward * grad_out_grad_grad.get()) -
-            (2 * grad_out_forward * grad_x_grad_forward *
-             grad_out_new_grad.get());
-        set_output<T>(out_grad_tmp, out_grad);
-      } else {
-        auto out_grad_tmp =
-            -2 * out * grad_x_grad_forward * grad_out_grad_grad.get();
-        set_output<T>(out_grad_tmp, out_grad);
-      }
-    } else {
-      if (grad_out_new_grad) {
-        auto out_grad_tmp = -(2 * grad_out_forward * grad_x_grad_forward *
-                              grad_out_new_grad.get());
-        set_output<T>(out_grad_tmp, out_grad);
-      } else {
-        auto out_grad_tmp = 0 * out;
-        set_output<T>(out_grad_tmp, out_grad);
-      }
+  /*
+  dy = -2 * dy * ddx * ddy - 2 * y * ddx * dddy
+  ddy = -2 * y * ddx * ddy
+  dddx = -2 * y * dy * ddy + (1 - y^2) * dddy
+  */
+  if (grad_out_new_grad && grad_out_grad_grad) {
+    Tensor neg_2_out;
+    if (grad_out_forward_grad || grad_x_grad_forward_grad) {
+      neg_2_out = scale<T>(out, -2.0);
     }
-  }
-
-  if (grad_out_forward_grad) {
-    if (grad_out_new_grad) {
+    if (out_grad) {
+      auto out_grad_tmp = (scale<T>(grad_x_grad_forward, -2.0) *
+                           (grad_out_forward * grad_out_new_grad.get() +
+                            out * grad_out_grad_grad.get()));
+      set_output<T>(out_grad_tmp, out_grad);
+    }
+    if (grad_out_forward_grad) {
       auto grad_out_forward_grad_tmp =
-          -2 * out * grad_x_grad_forward * grad_out_new_grad.get();
-      set_output<T>(grad_out_forward_grad_tmp, grad_out_forward_grad);
-    } else {
-      auto grad_out_forward_grad_tmp = 0 * out;
+          (neg_2_out * grad_x_grad_forward * grad_out_new_grad.get());
       set_output<T>(grad_out_forward_grad_tmp, grad_out_forward_grad);
     }
-  }
-
-  if (grad_x_grad_forward_grad) {
-    if (grad_out_grad_grad) {
-      if (grad_out_new_grad) {
-        auto grad_x_grad_forward_grad_tmp =
-            (1 - (out * out)) * grad_out_grad_grad.get() -
-            2 * out * grad_out_forward * grad_out_new_grad.get();
-        set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
-      } else {
-        auto grad_x_grad_forward_grad_tmp =
-            (1 - (out * out)) * grad_out_grad_grad.get();
-        set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
-      }
-    } else {
-      if (grad_out_new_grad) {
-        auto grad_x_grad_forward_grad_tmp =
-            -(2 * out * grad_out_forward * grad_out_new_grad.get());
-        set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
-      } else {
-        auto grad_x_grad_forward_grad_tmp = 0 * grad_x_grad_forward;
-        set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
-      }
+    if (grad_x_grad_forward_grad) {
+      auto grad_x_grad_forward_grad_tmp =
+          (scale<T>(out * out, -1.0, 1.0) * grad_out_grad_grad.get() +
+           neg_2_out * grad_out_forward * grad_out_new_grad.get());
+      set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
+    }
+  } else if (grad_out_new_grad) {
+    // regard grad_out_grad_grad is zero
+    Tensor neg_2_out;
+    if (grad_out_forward_grad || grad_x_grad_forward_grad) {
+      neg_2_out = scale<T>(out, -2.0);
+    }
+    if (out_grad) {
+      auto out_grad_tmp = (scale<T>(grad_x_grad_forward, -2.0) *
+                           (grad_out_forward * grad_out_new_grad.get()));
+      set_output<T>(out_grad_tmp, out_grad);
+    }
+    if (grad_out_forward_grad) {
+      auto grad_out_forward_grad_tmp =
+          (neg_2_out * grad_x_grad_forward * grad_out_new_grad.get());
+      set_output<T>(grad_out_forward_grad_tmp, grad_out_forward_grad);
+    }
+    if (grad_x_grad_forward_grad) {
+      auto grad_x_grad_forward_grad_tmp =
+          (neg_2_out * grad_out_forward * grad_out_new_grad.get());
+      set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
+    }
+  } else if (grad_out_grad_grad) {
+    // regard grad_out_new_grad is zero
+    if (out_grad) {
+      auto out_grad_tmp = (scale<T>(grad_x_grad_forward, -2.0) *
+                           (out * grad_out_grad_grad.get()));
+      set_output<T>(out_grad_tmp, out_grad);
+    }
+    if (grad_out_forward_grad) {
+      auto grad_out_forward_grad_tmp =
+          full<T>(common::vectorize(out.dims()), 0, out.dtype());
+      set_output<T>(grad_out_forward_grad_tmp, grad_out_forward_grad);
+    }
+    if (grad_x_grad_forward_grad) {
+      auto grad_x_grad_forward_grad_tmp =
+          (scale<T>(out * out, -1.0, 1.0) * grad_out_grad_grad.get());
+      set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
+    }
+  } else {
+    if (out_grad) {
+      auto out_grad_tmp =
+          full<T>(common::vectorize(out.dims()), 0, out.dtype());
+      set_output<T>(out_grad_tmp, out_grad);
+    }
+    if (grad_out_forward_grad) {
+      auto grad_out_forward_grad_tmp =
+          full<T>(common::vectorize(out.dims()), 0, out.dtype());
+      set_output<T>(grad_out_forward_grad_tmp, grad_out_forward_grad);
+    }
+    if (grad_x_grad_forward_grad) {
+      auto grad_x_grad_forward_grad_tmp =
+          full<T>(common::vectorize(grad_x_grad_forward.dims()),
+                  0,
+                  grad_x_grad_forward.dtype());
+      set_output<T>(grad_x_grad_forward_grad_tmp, grad_x_grad_forward_grad);
     }
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Description
<!-- Describe what you’ve done -->

Pcard-75624

Optimize composite OP `tanh_triple_grad` via multiplexing variables to reduce duplicated computation.

| before | after |
|:--: | :--: |
| number prim op calls(17): ![image](https://github.com/PaddlePaddle/Paddle/assets/23737287/9fead16c-8b55-472b-b785-f8841462e36b)| number prim op calls(13):  ![image](https://github.com/PaddlePaddle/Paddle/assets/23737287/87687e77-8e7b-4892-a2d0-d1314fd2f211) |
| Avg. 366 us(over 48 `tanh_triple_grad`) | Avg. 302 us (over 48 `tanh_triple_grad`)|












































































