### PR TITLE
【pir】Optimize backward of delete unused tuple_push and tuple_pop

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -403,7 +403,13 @@ def remove_op(block, op, state):
                 raise ValueError(
                     'input_grad in [%s] is value which need to sum ', op.name()
                 )
-
+def while_prune_check(while_tuple_ops):
+    if len(while_tuple_ops) != 0:
+        for opresult in while_tuple_ops[0].results():
+            if not opresult.use_empty():
+                return False
+        return True
+    return False
 
 def remove_useless_full_like_ops(block, ops, state):
     '''

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -403,6 +403,8 @@ def remove_op(block, op, state):
                 raise ValueError(
                     'input_grad in [%s] is value which need to sum ', op.name()
                 )
+
+
 def while_prune_check(while_tuple_ops):
     if len(while_tuple_ops) != 0:
         for opresult in while_tuple_ops[0].results():
@@ -410,6 +412,7 @@ def while_prune_check(while_tuple_ops):
                 return False
         return True
     return False
+
 
 def remove_useless_full_like_ops(block, ops, state):
     '''

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -34,6 +34,7 @@ from paddle.autograd.backward_utils import (
     is_control_flow,
     is_inplace_net,
     parent_total_ops,
+    while_prune_check,
     remove_op,
     remove_useless_full_like_ops,
     return_map_value,
@@ -597,6 +598,7 @@ def append_backward_ops(
         if op.name() != "builtin.combine" and op.name() != "builtin.split":
             clear_effective_forward_ops.append(op)
     with bwd_block:
+        while_tuple_ops = []
         for op in clear_effective_forward_ops:
             if paddle.framework.core.has_vjp(op):
                 # prepare output_grad
@@ -611,6 +613,7 @@ def append_backward_ops(
                 ) = make_input_with_input_stopgradient(op)
 
                 if op.name() == "cf.tuple_push":
+                    stackop = op.operand_source(0).get_defining_op()                    
                     with dynamic_shape_prim_vjp_guard(op, inputs):
                         copy_out = paddle.framework.core.call_vjp(
                             op,
@@ -621,6 +624,9 @@ def append_backward_ops(
                         )
 
                     pop_op = bwd_block.ops[-1]
+                    while_tuple_ops.append(pop_op)
+                    while_tuple_ops.append(op)
+                    while_tuple_ops.append(stackop)
                     bwd_ops = [pop_op]
                     for output, copy_output in zip(inputs[1:], copy_out[1:]):
                         control_flow_value_to_copyvalue_map[
@@ -818,6 +824,14 @@ def append_backward_ops(
                     state.op_to_opgrad[op] = []
 
         if fwd_block != bwd_block:
+
+            if while_prune_check(while_tuple_ops):
+                print(paddle.pir.core.default_main_program())
+                breakpoint()
+                remove_op(bwd_block, while_tuple_ops[0], state)
+                while_tuple_ops[1].get_parent_block().remove_op(while_tuple_ops[1])
+                while_tuple_ops[2].get_parent_block().remove_op(while_tuple_ops[2])
+
             append_yield(
                 bwd_block,
                 base_op,

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -34,13 +34,13 @@ from paddle.autograd.backward_utils import (
     is_control_flow,
     is_inplace_net,
     parent_total_ops,
-    while_prune_check,
     remove_op,
     remove_useless_full_like_ops,
     return_map_value,
     return_map_value_list,
     some_in_set,
     update_no_grad_set_by_stopgradient,
+    while_prune_check,
 )
 from paddle.base.libpaddle.pir import (
     build_pipe_for_block,
@@ -613,7 +613,7 @@ def append_backward_ops(
                 ) = make_input_with_input_stopgradient(op)
 
                 if op.name() == "cf.tuple_push":
-                    stackop = op.operand_source(0).get_defining_op()                    
+                    stackop = op.operand_source(0).get_defining_op()
                     with dynamic_shape_prim_vjp_guard(op, inputs):
                         copy_out = paddle.framework.core.call_vjp(
                             op,
@@ -824,13 +824,14 @@ def append_backward_ops(
                     state.op_to_opgrad[op] = []
 
         if fwd_block != bwd_block:
-
             if while_prune_check(while_tuple_ops):
-                print(paddle.pir.core.default_main_program())
-                breakpoint()
                 remove_op(bwd_block, while_tuple_ops[0], state)
-                while_tuple_ops[1].get_parent_block().remove_op(while_tuple_ops[1])
-                while_tuple_ops[2].get_parent_block().remove_op(while_tuple_ops[2])
+                while_tuple_ops[1].get_parent_block().remove_op(
+                    while_tuple_ops[1]
+                )
+                while_tuple_ops[2].get_parent_block().remove_op(
+                    while_tuple_ops[2]
+                )
 
             append_yield(
                 bwd_block,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Description
<!-- Describe what you’ve done -->
pcard-67164

优化backward 逻辑，while反向没有使用到前向block的变量时将会删除tuple_push 相关OP