### PR TITLE
cinn(backend): fix reduce without last dim precision bug

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -214,6 +214,7 @@ std::shared_ptr<cinn::ir::GroupTileInfo> OpLowererImpl::GetGroupTileInfo(
 
   if (reduce_block > 1 && reduce_block <= 256) {
     group_tile_info->reduce_method = ir::WarpReduceMethod();
+    reduce_inner_num = std::ceil(group_tile_info->reduce_block * 1.0 / 32);
   }
 
   for (auto op : group->ops) {

--- a/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
@@ -238,6 +238,9 @@ void TileFirstGeneralTactic::SplitReduceInner(ir::IRSchedule* sch,
           std::ceil(context_->group_tile_info->reduce_numel * 1.0 /
                     context_->group_tile_info->reduce_inner_num));
       split_factors.emplace_back(context_->group_tile_info->reduce_inner_num);
+    } else if (IsWarpReduce(context_->group_tile_info)) {
+      split_factors.emplace_back(32);
+      split_factors.emplace_back(context_->group_tile_info->reduce_inner_num);
     } else {
       split_factors.emplace_back(
           std::ceil(context_->group_tile_info->reduce_block * 1.0 /

--- a/paddle/cinn/ir/schedule/ir_schedule_util.cc
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.cc
@@ -272,19 +272,12 @@ std::vector<int> ValidateFactors(const std::vector<int>& factors,
     }
     return validated_factors;
   } else {
-    if (product > total_extent) {
-      std::ostringstream os;
-      os << "In Split, the factors' product[" << product
-         << "] should be not larger than or equal "
-            "to original loop's extent["
-         << total_extent << "]!" << std::endl;
-      throw IRScheduleErrorHandler(primitive, os.str(), module_expr);
-    }
     int minus_one_candidate = static_cast<int>(
         ceil(static_cast<double>(total_extent) / static_cast<double>(product)));
     for (int i = 0; i < validated_factors.size(); ++i) {
       if (validated_factors[i] == -1) {
         validated_factors[i] = minus_one_candidate;
+        break;
       }
     }
     return validated_factors;

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_0.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_0.py
@@ -39,14 +39,22 @@ class LayerCase(paddle.nn.Layer):
 
     def forward(
         self,
-        var_0,  # (shape: [22, 64, 56, 56], dtype: paddle.float32, stop_gradient: False)
-        var_1,  # (shape: [22, 64, 56, 56], dtype: paddle.float32, stop_gradient: False)
-        var_2,  # (shape: [22, 128, 28, 28], dtype: paddle.float32, stop_gradient: False)
-        var_3,  # (shape: [22, 128, 28, 28], dtype: paddle.float32, stop_gradient: False)
-        var_4,  # (shape: [22, 256, 14, 14], dtype: paddle.float32, stop_gradient: False)
-        var_5,  # (shape: [22, 256, 14, 14], dtype: paddle.float32, stop_gradient: False)
-        var_6,  # (shape: [22, 512, 7, 7], dtype: paddle.float32, stop_gradient: False)
-        var_7,  # (shape: [22, 512, 7, 7], dtype: paddle.float32, stop_gradient: False)
+        # (shape: [22, 64, 56, 56], dtype: paddle.float32, stop_gradient: False)
+        var_0,
+        # (shape: [22, 64, 56, 56], dtype: paddle.float32, stop_gradient: False)
+        var_1,
+        # (shape: [22, 128, 28, 28], dtype: paddle.float32, stop_gradient: False)
+        var_2,
+        # (shape: [22, 128, 28, 28], dtype: paddle.float32, stop_gradient: False)
+        var_3,
+        # (shape: [22, 256, 14, 14], dtype: paddle.float32, stop_gradient: False)
+        var_4,
+        # (shape: [22, 256, 14, 14], dtype: paddle.float32, stop_gradient: False)
+        var_5,
+        # (shape: [22, 512, 7, 7], dtype: paddle.float32, stop_gradient: False)
+        var_6,
+        # (shape: [22, 512, 7, 7], dtype: paddle.float32, stop_gradient: False)
+        var_7,
     ):
         var_40 = paddle.tensor.manipulation.stack(
             [
@@ -108,5 +116,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-6)
 
 
-# if __name__ == '__main__':
-#     unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_32.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_32.py
@@ -28,7 +28,8 @@ class LayerCase(paddle.nn.Layer):
 
     def forward(
         self,
-        var_0,  # (shape: [22, 1024, 1, 1], dtype: paddle.float32, stop_gradient: True)
+        # (shape: [22, 1024, 1, 1], dtype: paddle.float32, stop_gradient: True)
+        var_0,
     ):
         var_1 = paddle.tensor.manipulation.reshape(
             x=var_0, shape=[22, 1, 2, 512]
@@ -74,5 +75,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-8)
 
 
-# if __name__ == '__main__':
-#     unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_33.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_33.py
@@ -36,8 +36,10 @@ class LayerCase(paddle.nn.Layer):
 
     def forward(
         self,
-        var_0,  # (shape: [10, 64, 14, 14], dtype: paddle.float32, stop_gradient: False)
-        var_1,  # (shape: [10, 256, 14, 14], dtype: paddle.float32, stop_gradient: False)
+        # (shape: [10, 64, 14, 14], dtype: paddle.float32, stop_gradient: False)
+        var_0,
+        # (shape: [10, 256, 14, 14], dtype: paddle.float32, stop_gradient: False)
+        var_1,
     ):
         var_2 = paddle.nn.functional.conv._conv_nd(
             var_0,
@@ -98,5 +100,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-5)
 
 
-# if __name__ == '__main__':
-#     unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/pir/cinn/sub_graphs/test_sub_graph_5.py
+++ b/test/ir/pir/cinn/sub_graphs/test_sub_graph_5.py
@@ -28,7 +28,8 @@ class LayerCase(paddle.nn.Layer):
 
     def forward(
         self,
-        var_0,  # (shape: [22, 16, 384], dtype: paddle.float32, stop_gradient: False)
+        # (shape: [22, 16, 384], dtype: paddle.float32, stop_gradient: False)
+        var_0,
     ):
         var_1 = var_0.mean(1)
         var_2 = paddle.tensor.manipulation.reshape(var_1, [-1, 384])
@@ -67,5 +68,5 @@ class TestLayer(unittest.TestCase):
             np.testing.assert_allclose(st.numpy(), cinn.numpy(), atol=1e-6)
 
 
-# if __name__ == '__main__':
-#     unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/test/prim/pir_prim/CMakeLists.txt
+++ b/test/prim/pir_prim/CMakeLists.txt
@@ -38,6 +38,7 @@ if(WITH_CINN)
       ${target}
       ENVS
       GLOG_v=1
+      FLAGS_group_schedule_tiling_first=true
       FLAGS_prim_check_ops=true
       FLAGS_enable_pir_api=true
       FLAGS_prim_enable_dynamic=true

--- a/test/prim/pir_prim/test_prim_rms_norm_st_shape.py
+++ b/test/prim/pir_prim/test_prim_rms_norm_st_shape.py
@@ -14,7 +14,11 @@
 
 import unittest
 
+import numpy as np
+
 import paddle
+from paddle.framework import core
+from paddle.static import InputSpec
 
 
 def apply_to_static(net, use_cinn, input_spec=None):
@@ -42,61 +46,61 @@ def rms_norm2(hidden_states, weight):
     return hidden_states * weight
 
 
-# class TestPrimMode1(unittest.TestCase):
-#     def setUp(self):
-#         np.random.seed(2023)
-#         self.shape_x = [1, 300, 4096]
-#         self.shape_y = [4096]
-#         self.x = np.random.random(self.shape_x).astype("float32")
-#         self.y = np.random.random(self.shape_y).astype("float32")
-#         self.net = rms_norm1
-#         self.enable_cinn = True
+class TestPrimMode1(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.shape_x = [1, 300, 4096]
+        self.shape_y = [4096]
+        self.x = np.random.random(self.shape_x).astype("float32")
+        self.y = np.random.random(self.shape_y).astype("float32")
+        self.net = rms_norm1
+        self.enable_cinn = True
 
-#     def base_net(self, flag=None):
-#         x = paddle.to_tensor(self.x)
-#         y = paddle.to_tensor(self.y)
-#         if flag == "prim":
-#             core._set_prim_all_enabled(True)
-#             fn = apply_to_static(
-#                 self.net,
-#                 use_cinn=self.enable_cinn,
-#                 input_spec=[
-#                     InputSpec(shape=[1, 300, 4096], dtype='float32'),
-#                     InputSpec(shape=[4096], dtype='float32'),
-#                 ],
-#             )
-#             fn.eval()
-#         else:
-#             fn = self.net
-#         res = fn(x, y)
+    def base_net(self, flag=None):
+        x = paddle.to_tensor(self.x)
+        y = paddle.to_tensor(self.y)
+        if flag == "prim":
+            core._set_prim_all_enabled(True)
+            fn = apply_to_static(
+                self.net,
+                use_cinn=self.enable_cinn,
+                input_spec=[
+                    InputSpec(shape=[1, 300, 4096], dtype='float32'),
+                    InputSpec(shape=[4096], dtype='float32'),
+                ],
+            )
+            fn.eval()
+        else:
+            fn = self.net
+        res = fn(x, y)
 
-#         if flag == "prim":
-#             ops = [
-#                 op.name()
-#                 for op in fn.program_cache.last()[-1][-1]
-#                 .infer_program.program.global_block()
-#                 .ops
-#             ]
-#             assert "pd_op.mean" not in ops
-#             core._set_prim_all_enabled(False)
-#         return res
+        if flag == "prim":
+            ops = [
+                op.name()
+                for op in fn.program_cache.last()[-1][-1]
+                .infer_program.program.global_block()
+                .ops
+            ]
+            assert "pd_op.mean" not in ops
+            core._set_prim_all_enabled(False)
+        return res
 
-#     def test_prim_all_dynamic(self):
-#         res_ref = self.base_net()
-#         res = self.base_net("prim")
-#         for ref, actual in zip(res_ref, res):
-#             np.testing.assert_allclose(ref, actual, rtol=1e-6)
+    def test_prim_all_dynamic(self):
+        res_ref = self.base_net()
+        res = self.base_net("prim")
+        for ref, actual in zip(res_ref, res):
+            np.testing.assert_allclose(ref, actual, rtol=1e-6)
 
 
-# class TestPrimMode2(TestPrimMode1):
-#     def setUp(self):
-#         np.random.seed(2023)
-#         self.shape_x = [1, 300, 4096]
-#         self.shape_y = [4096]
-#         self.x = np.random.random(self.shape_x).astype("float32")
-#         self.y = np.random.random(self.shape_y).astype("float32")
-#         self.net = rms_norm2
-#         self.enable_cinn = True
+class TestPrimMode2(TestPrimMode1):
+    def setUp(self):
+        np.random.seed(2023)
+        self.shape_x = [1, 300, 4096]
+        self.shape_y = [4096]
+        self.x = np.random.random(self.shape_x).astype("float32")
+        self.y = np.random.random(self.shape_y).astype("float32")
+        self.net = rms_norm2
+        self.enable_cinn = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-
1. 动态shape场景，split原语支持extent<split_factor。
2. TileFirst采用WarpReduce策略时，限定blockDim.x为32。
