### PR TITLE
[PIR] Adaptation of `TestNoBackwardAPIStatic.test_unique*`

### DIFF
--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -487,6 +487,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, (4,))
         self.assertEqual(res[0][2], 1)
 
+    @test_with_pir_api
     def test_unique_consecutive(self):
         x = paddle.rand([])
         y, inverse, counts = paddle.unique_consecutive(
@@ -494,14 +495,15 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[y, inverse, counts])
-        self.assertEqual(y, x)
-        self.assertEqual(inverse, 0)
-        self.assertEqual(counts, 1)
-        self.assertEqual(res[0].shape, (1,))
+        res = self.exe.run(prog, fetch_list=[x, y, inverse, counts])
+        self.assertEqual(res[0], res[1])
+        self.assertEqual(res[2], 0)
+        self.assertEqual(res[3], 1)
         self.assertEqual(res[1].shape, (1,))
         self.assertEqual(res[2].shape, (1,))
+        self.assertEqual(res[3].shape, (1,))
 
+    @test_with_pir_api
     def test_unique(self):
         x = paddle.rand([])
         y, index, inverse, counts = paddle.unique(
@@ -509,15 +511,15 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[y, index, inverse, counts])
-        self.assertEqual(y, x)
-        self.assertEqual(index, 0)
-        self.assertEqual(inverse, 0)
-        self.assertEqual(counts, 1)
-        self.assertEqual(res[0].shape, (1,))
+        res = self.exe.run(prog, fetch_list=[x, y, index, inverse, counts])
+        self.assertEqual(res[0], res[1])
+        self.assertEqual(res[2], 0)
+        self.assertEqual(res[3], 0)
+        self.assertEqual(res[4], 1)
         self.assertEqual(res[1].shape, (1,))
         self.assertEqual(res[2].shape, (1,))
         self.assertEqual(res[3].shape, (1,))
+        self.assertEqual(res[4].shape, (1,))
 
     @test_with_pir_api
     def test_static_matrix_rank(self):

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -494,7 +494,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
             x, return_inverse=True, return_counts=True
         )
 
-        prog = paddle.static.default_main_program()
+        prog = paddle.static.program_guard()
         x_res, y_res, inverse_res, counts_res = self.exe.run(
             prog, fetch_list=[x, y, inverse, counts]
         )
@@ -512,7 +512,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
             x, return_index=True, return_inverse=True, return_counts=True
         )
 
-        prog = paddle.static.default_main_program()
+        prog = paddle.static.program_guard()
         x_res, y_res, index_res, inverse_res, counts_res = self.exe.run(
             prog, fetch_list=[x, y, index, inverse, counts]
         )

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -495,13 +495,15 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, y, inverse, counts])
-        self.assertEqual(res[0], res[1])
-        self.assertEqual(res[2], 0)
-        self.assertEqual(res[3], 1)
-        self.assertEqual(res[1].shape, (1,))
-        self.assertEqual(res[2].shape, (1,))
-        self.assertEqual(res[3].shape, (1,))
+        x_res, y_res, inverse_res, counts_res = self.exe.run(
+            prog, fetch_list=[x, y, inverse, counts]
+        )
+        self.assertEqual(x_res, y_res)
+        self.assertEqual(inverse_res, 0)
+        self.assertEqual(counts_res, 1)
+        self.assertEqual(y_res.shape, (1,))
+        self.assertEqual(inverse_res.shape, (1,))
+        self.assertEqual(counts_res.shape, (1,))
 
     @test_with_pir_api
     def test_unique(self):
@@ -511,15 +513,17 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[x, y, index, inverse, counts])
-        self.assertEqual(res[0], res[1])
-        self.assertEqual(res[2], 0)
-        self.assertEqual(res[3], 0)
-        self.assertEqual(res[4], 1)
-        self.assertEqual(res[1].shape, (1,))
-        self.assertEqual(res[2].shape, (1,))
-        self.assertEqual(res[3].shape, (1,))
-        self.assertEqual(res[4].shape, (1,))
+        x_res, y_res, index_res, inverse_res, counts_res = self.exe.run(
+            prog, fetch_list=[x, y, index, inverse, counts]
+        )
+        self.assertEqual(x_res, y_res)
+        self.assertEqual(index_res, 0)
+        self.assertEqual(inverse_res, 0)
+        self.assertEqual(counts_res, 1)
+        self.assertEqual(y_res.shape, (1,))
+        self.assertEqual(index_res.shape, (1,))
+        self.assertEqual(inverse_res.shape, (1,))
+        self.assertEqual(counts_res.shape, (1,))
 
     @test_with_pir_api
     def test_static_matrix_rank(self):

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -489,41 +489,56 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
 
     @test_with_pir_api
     def test_unique_consecutive(self):
-        x = paddle.rand([])
-        y, inverse, counts = paddle.unique_consecutive(
-            x, return_inverse=True, return_counts=True
-        )
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            x = paddle.rand([])
+            y, inverse, counts = paddle.unique_consecutive(
+                x, return_inverse=True, return_counts=True
+            )
 
-        prog = paddle.static.program_guard()
-        x_res, y_res, inverse_res, counts_res = self.exe.run(
-            prog, fetch_list=[x, y, inverse, counts]
-        )
-        self.assertEqual(x_res, y_res)
-        self.assertEqual(inverse_res, 0)
-        self.assertEqual(counts_res, 1)
-        self.assertEqual(y_res.shape, (1,))
-        self.assertEqual(inverse_res.shape, (1,))
-        self.assertEqual(counts_res.shape, (1,))
+            (
+                x_res,
+                y_res,
+                inverse_res,
+                counts_res,
+            ) = paddle.static.Executor().run(
+                main_program, fetch_list=[x, y, inverse, counts]
+            )
+            self.assertEqual(x_res, y_res)
+            self.assertEqual(inverse_res, 0)
+            self.assertEqual(counts_res, 1)
+            self.assertEqual(y_res.shape, (1,))
+            self.assertEqual(inverse_res.shape, (1,))
+            self.assertEqual(counts_res.shape, (1,))
 
     @test_with_pir_api
     def test_unique(self):
-        x = paddle.rand([])
-        y, index, inverse, counts = paddle.unique(
-            x, return_index=True, return_inverse=True, return_counts=True
-        )
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            x = paddle.rand([])
+            y, index, inverse, counts = paddle.unique(
+                x, return_index=True, return_inverse=True, return_counts=True
+            )
 
-        prog = paddle.static.program_guard()
-        x_res, y_res, index_res, inverse_res, counts_res = self.exe.run(
-            prog, fetch_list=[x, y, index, inverse, counts]
-        )
-        self.assertEqual(x_res, y_res)
-        self.assertEqual(index_res, 0)
-        self.assertEqual(inverse_res, 0)
-        self.assertEqual(counts_res, 1)
-        self.assertEqual(y_res.shape, (1,))
-        self.assertEqual(index_res.shape, (1,))
-        self.assertEqual(inverse_res.shape, (1,))
-        self.assertEqual(counts_res.shape, (1,))
+            (
+                x_res,
+                y_res,
+                index_res,
+                inverse_res,
+                counts_res,
+            ) = paddle.static.Executor().run(
+                main_program, fetch_list=[x, y, index, inverse, counts]
+            )
+            self.assertEqual(x_res, y_res)
+            self.assertEqual(index_res, 0)
+            self.assertEqual(inverse_res, 0)
+            self.assertEqual(counts_res, 1)
+            self.assertEqual(y_res.shape, (1,))
+            self.assertEqual(index_res.shape, (1,))
+            self.assertEqual(inverse_res.shape, (1,))
+            self.assertEqual(counts_res.shape, (1,))
 
     @test_with_pir_api
     def test_static_matrix_rank(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

适配 `test/legacy_test/test_zero_dim_no_backward_api.py` 下的 `TestNoBackwardAPIStatic.test_unique_consecutive`和`TestNoBackwardAPIStatic.test_unique`，改为测试执行后的结果

我们在这里不能直接使用 `Value` 进行比较，一个是`unique_consecutive`，一个是`uniform`

相关链接:
* #62652
* #60902