### PR TITLE
[CodeStyle] Add ruff format config to keep compatibility to ruff format user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ exclude = [
 line-length = 80
 target-version = "py38"
 
+[tool.ruff.format]
+# Prevent change to double quotes by some users use ruff format
+quote-style = "preserve"
+
 [tool.ruff.lint]
 select = [
     # Pycodestyle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

添加 Ruff format 配置项 `quote-style = "preserve"`，即 black 的 `skip-string-normalization = true`，以确保即便是 ruff 用户也不会修改掉引号

> [!NOTE]
>
> 我们现在还没有迁移到 Ruff formatter，我们仍在使用 black 作为格式化工具，本 PR 只是确保 Ruff formatter 用户在格式化后不会造成大量引号变动

PCard-66972