### PR TITLE
[CINN] Upgrade EliminateCommonGlobalMemoryRead

### DIFF
--- a/paddle/cinn/optim/eliminate_common_global_memory_read.cc
+++ b/paddle/cinn/optim/eliminate_common_global_memory_read.cc
@@ -109,9 +109,22 @@ struct GlobalTensorInfoCollector : public ir::IRMutator<Expr*> {
       return true;
     };
 
+    auto IndiceContainsLoad =
+        [&](const IndicesAndExtent& indice_and_extent) -> bool {
+      for (const auto& index : indice_and_extent.indices) {
+        std::set<Expr> load_tensors = ir::ir_utils::CollectLoadTensors(
+            index, /*teller=*/[&](const Expr*) -> bool { return true; });
+        if (load_tensors.size() > 0) {
+          return true;
+        }
+      }
+      return false;
+    };
+
     auto IsGlobalTensorNeedEliminate =
         [&](const std::vector<IndicesAndExtent>& indice_and_extent) -> bool {
       if (indice_and_extent.size() <= 1) return false;
+      if (IndiceContainsLoad(indice_and_extent[0])) return false;
       return AllIndiceAndExtentEqual(indice_and_extent);
     };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

ROPE 子图存在 gather 算子，导致出现形如 `var_1_local[(4ll * (var_3[0ll] & 2047))]` 的下标表达式。该表达式在做局部变量分析时，局部变量会声明成如下格式： `float var_local_buffer [ min((4ll + (4ll * var_3[0])), 8192ll) ];` 实际上，无法动态分配这样的内存。
本 PR 对 EliminateCommonGlobalMemoryRead 加上了限制：不处理包含 Load 的下标表达式。

The ROPE subgraph has gatherer operator, resulting in subscript expressions in the form of `var_1_local [(4ll * (var_3 [0ll]&2047)]`. When performing local variable analysis, this expression will declare the local variable in the following format:  `float var_local_buffer [min ((4ll+(4ll * var3 [0])), 8192ll)]`. It is not possible to dynamically allocate such memory.
This PR restricts EliminateCommonGlobalMemoryRead: it does not handle index expressions containing Load.