### PR TITLE
fix  KthvalueInferMeta

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2202,7 +2202,7 @@ void KthvalueInferMeta(const MetaTensor& x,
   out->set_dtype(x.dtype());
   indices->set_dims(dims);
   indices->share_lod(x);
-  indices->set_dtype(x.dtype());
+  indices->set_dtype(DataType::INT64);
 }
 
 void LogicalNotInferMeta(const MetaTensor& x, MetaTensor* out) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
#### 问题描述
下述动转静代码执行时
```Python
#!/bin/env python
# -*- coding: utf-8 -*-
# encoding=utf-8 vi:ts=4:sw=4:expandtab:ft=python
"""

"""

import numpy as np
import paddle

paddle.seed(33)
np.random.seed(33)

def compare(result, expect, delta=1e-10, rtol=1e-10):
    """
    比较函数
    :param result: 输入值
    :param expect: 输出值
    :param delta: 误差值
    :param rtol: 相对误差
    :return:
    """
    if isinstance(expect, paddle.Tensor) or isinstance(expect, np.ndarray):
        if isinstance(result, paddle.Tensor):
            result = result.numpy()
        if isinstance(expect, paddle.Tensor):
            expect = expect.numpy()
        res = np.allclose(result, expect, atol=delta, rtol=rtol, equal_nan=True)
        # 出错打印错误数据
        # if res is False:
        #     diff = abs(result - expect)
        #     logging.error("expect is: {}".format(expect))
        #     logging.error("result is: {}".format(result))
        #     logging.error("Output has diff! max diff: {}".format(np.amax(diff)))
        # if result.dtype != expect.dtype:
        #     logging.error(
        #         "Different output data types! res type is: {}, and expect type is: {}".format(
        #             result.dtype, expect.dtype
        #         )
        #     )
        assert res
        assert result.shape == expect.shape
        assert result.dtype == expect.dtype
    elif isinstance(expect, list) or isinstance(expect, tuple):
        for i, element in enumerate(expect):
            if isinstance(result, (np.generic, np.ndarray)) or isinstance(result, paddle.Tensor):
                if i > 0:
                    break
                compare(result, expect[i], delta, rtol)

            else:
                compare(result[i], expect[i], delta, rtol)
    elif isinstance(expect, (bool, int, float)):
        assert expect == result
    else:
        raise Exception("expect is unknown data struction in compare_tool!!!")

def randtool(dtype, low, high, shape):
    """
    np random tools
    """
    if dtype == "int":
        return np.random.randint(low, high, shape)

    elif dtype == "float":
        return low + (high - low) * np.random.random(shape)

def naive_func(a, in_params, func):
    """用于动转静的方法"""
    layer = eval(func)(**a, **in_params)
    return layer

func = "paddle.kthvalue"

in_tensor = {
    "x": paddle.to_tensor(randtool("float", -1, 1, shape=[5, 3, 4, 4]), dtype="float32"),
}

in_params = {
    "k": 3,
    "axis": 0,
}

paddle.seed(33)
obj = naive_func
dy_out = obj(in_tensor, in_params, func)

paddle.seed(33)
jit_obj = paddle.jit.to_static(obj)
st_out = jit_obj(in_tensor, in_params, func)
print("dy_out is: ", dy_out)
print("st_out is: ", st_out)

paddle.jit.save(jit_obj, path="kthvalue")
print("jit.save is successfully !!!")

paddle.seed(33)
jit = paddle.jit.load("kthvalue")
print("jit.load is successfully !!!")

paddle.seed(33)
inputs_key = sorted(in_tensor.keys())
inputs_value = []
for k in inputs_key:
    inputs_value.append(in_tensor[k])
# print('inputs_value is: ', inputs_value)
res = jit(*inputs_value)
print('jit.load res: ', res)

compare(dy_out, res, delta=1e-5, rtol=1e-6)
```
会遇到`indices`输出全为0的问题
```
jit.load res:  [Tensor(shape=[3, 4, 4], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [[[-0.07591926, -0.26354831, -0.17811839, -0.47940060],
         [ 0.60465443, -0.14411892, -0.11287902,  0.21788037],
         [ 0.56884265, -0.02682375,  0.06054568, -0.08810953],
         [ 0.46526086, -0.21340129, -0.29790798, -0.20623052]],

        [[-0.36299756, -0.06327001,  0.66013783,  0.06157992],
         [ 0.56318831,  0.28023970,  0.13557813,  0.00581930],
         [ 0.37604561, -0.56533492, -0.14192767,  0.02036260],
         [ 0.19907297,  0.44599527, -0.13094325,  0.02038879]],

        [[ 0.05510214, -0.33704653, -0.09510893, -0.41952190],
         [ 0.37856624, -0.42806000, -0.37419304, -0.17315947],
         [-0.27487597,  0.12684217,  0.42080349, -0.70518380],
         [-0.05522427,  0.13258798,  0.21601824,  0.56292760]]]), Tensor(shape=[3, 4, 4], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [[[0.00000000, 0.        , 0.00000000, 0.        ],
         [0.        , 0.        , 0.        , 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ]],

        [[0.00000000, 0.        , 0.        , 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ]],

        [[0.00000000, 0.        , 0.00000000, 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ],
         [0.00000000, 0.        , 0.00000000, 0.        ]]])]
```
静态图如下：
```
{
    (%0) = "data(phi_kernel)" () {dtype:(pd_op.DataType)bool,is_persistable:[false],kernel_key:<backend:GPU|layout:Undefined(AnyLayout)|dtype:float32>,kernel_name:"data",name:"_jst.0.a.0",op_name:"pd_op.data",place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[],stop_gradient:[false]} : () -> gpu_tensor<5x3x4x4xf32>
    (%1, %2) = "kthvalue(phi_kernel)" (%0) {axis:(Int32)0,is_persistable:[false,false],k:(Int32)3,keepdim:false,kernel_key:<backend:GPU|layout:NCHW|dtype:float32>,kernel_name:"kthvalue",op_name:"pd_op.kthvalue",stop_gradient:[false,false]} : (gpu_tensor<5x3x4x4xf32>) -> gpu_tensor<3x4x4xf32>, gpu_tensor<3x4x4xf32>
    (%3) = "full(phi_kernel)" () {dtype:(pd_op.DataType)float32,kernel_key:<backend:CPU|layout:Undefined(AnyLayout)|dtype:float32>,kernel_name:"full",op_name:"pd_op.full",place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)1} : () -> cpu_tensor<1xf32>
    (%4) = "scale_(phi_kernel)" (%1, %3) {bias:(Float)0,bias_after_scale:true,is_inplace:true,is_persistable:[false],kernel_key:<backend:GPU|layout:NCHW|dtype:float32>,kernel_name:"scale",op_name:"pd_op.scale_",stop_gradient:[false]} : (gpu_tensor<3x4x4xf32>, cpu_tensor<1xf32>) -> gpu_tensor<3x4x4xf32>
    (%5) = "full(phi_kernel)" () {dtype:(pd_op.DataType)float32,kernel_key:<backend:CPU|layout:Undefined(AnyLayout)|dtype:float32>,kernel_name:"full",op_name:"pd_op.full",place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)1} : () -> cpu_tensor<1xf32>
    (%6) = "scale_(phi_kernel)" (%2, %5) {bias:(Float)0,bias_after_scale:true,is_inplace:true,is_persistable:[false],kernel_key:<backend:GPU|layout:NCHW|dtype:float32>,kernel_name:"scale",op_name:"pd_op.scale_",stop_gradient:[false]} : (gpu_tensor<3x4x4xf32>, cpu_tensor<1xf32>) -> gpu_tensor<3x4x4xf32>
    () = "builtin.shadow_output" (%4) {output_name:"translated_layer/scale_0.tmp_0"} : (gpu_tensor<3x4x4xf32>) -> 
    () = "builtin.shadow_output" (%6) {output_name:"translated_layer/scale_1.tmp_0"} : (gpu_tensor<3x4x4xf32>) -> 
}
```
将`kthvalue`算子中的Value(%2)和`scale_`算子中的Value(%2)分别打印输出
- kthvalue
```
3 2 0 0 1 4 2 2 2 0 4 4 1 1 3 1 2 1 3 4 4 4 3 4 4 3 1 2 0 0 1 1 0 0 1 4 1 1 4 3 0 3 0 3 0 1 2 3
```
- scale_
```
4.2039e-45 0 2.8026e-45 0 0 0 0 0 1.4013e-45 0 5.60519e-45 0 2.8026e-45 0 2.8026e-45 0 2.8026e-45 0 0 0 5.60519e-45 0 5.60519e-45 0 1.4013e-45 0 1.4013e-45 0 4.2039e-45 0 1.4013e-45 0 2.8026e-45 0 1.4013e-45 0 4.2039e-45 0 5.60519e-45 0 5.60519e-45 0 5.60519e-45 0 4.2039e-45 0 5.60519e-45 0
```
猜测是数据类型错误导致的。
在`paddle/phi/kernels/gpu/kthvalue_kernel.cu`中`indices`的数据类型为
```C++
  int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
```
定位到`InferMeta`的问题。
```C++
  indices->set_dims(dims);
  indices->share_lod(x);
  indices->set_dtype(x.dtype());
}
```