### PR TITLE
[Inference] Try shrink memory after predictor init

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -502,6 +502,8 @@ bool AnalysisPredictor::Init(
   }
 #endif
 
+  TryShrinkMemory();
+
   inference::DisplayMemoryInfo(place_, "Init predictor");
   return true;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71500
Try shrink memory after predictor init.