### PR TITLE
[PIR] Adaptation of `test_zero_dim_no_backward_api`, extract init data

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -915,7 +915,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None, name=None):
             elif isinstance(shape, paddle.pir.Value):
                 pass
             else:
-                TypeError("Shape only supports OpResult, or list, or tuple.")
+                TypeError("Shape only supports Value, or list, or tuple.")
 
         if out is None:
             out = _C_ops.full(shape, value, dtype, place)

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -915,7 +915,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None, name=None):
             elif isinstance(shape, paddle.pir.Value):
                 pass
             else:
-                TypeError("Shape only supports Value, or list, or tuple.")
+                TypeError("Shape only supports OpResult, or list, or tuple.")
 
         if out is None:
             out = _C_ops.full(shape, value, dtype, place)

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -260,6 +260,9 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
     def setUp(self):
         paddle.enable_static()
         self.exe = paddle.static.Executor()
+        self.shape = []
+
+    def init_data(self):
         self.shape = [
             paddle.full([], 2, 'int32'),
             paddle.full([], 3, 'int32'),
@@ -312,6 +315,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         np.testing.assert_array_equal(res, [1.0, 2.0, 3.0, 4.0, 5.0])
 
     def test_normal(self):
+        self.init_data()
         mean = paddle.full([], 0.0)
         std = paddle.full([], 0.0)
         out1 = paddle.normal(mean, std)
@@ -325,25 +329,35 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         self.assertEqual(res[1].shape, ())
         self.assertEqual(res[2].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_rand(self):
-        out1 = paddle.rand([])
-        out2 = paddle.rand(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.rand([])
+            out2 = paddle.rand(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_randn(self):
-        out1 = paddle.randn([])
-        out2 = paddle.randn(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.randn([])
+            out2 = paddle.randn(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, (2, 3, 4))
 
     @test_with_pir_api
     def test_randint(self):
@@ -381,76 +395,106 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
 
+    @test_with_pir_api
     def test_standard_normal(self):
-        out1 = paddle.standard_normal([])
-        out2 = paddle.standard_normal(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.standard_normal([])
+            out2 = paddle.standard_normal(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_uniform(self):
-        out1 = paddle.uniform([])
-        out2 = paddle.uniform(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.uniform([])
+            out2 = paddle.uniform(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_empty_and_empty_like(self):
-        out1 = paddle.empty([])
-        out2 = paddle.empty_like(out1)
-        out3 = paddle.empty(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.empty([])
+            out2 = paddle.empty_like(out1)
+            out3 = paddle.empty(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2, out3]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2, out3]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, ())
+            self.assertEqual(res[2].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_full_and_full_like(self):
-        out1 = paddle.full([], 0.5)
-        out2 = paddle.full_like(out1, 0.5)
-        out3 = paddle.full(self.shape, 0.5)
-        out4 = paddle.full(self.shape, paddle.full([], 0.5))
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.full([], 0.5)
+            out2 = paddle.full_like(out1, 0.5)
+            out3 = paddle.full(self.shape, 0.5)
+            out4 = paddle.full(self.shape, paddle.full([], 0.5))
 
-        res = self.exe.run(
-            paddle.static.default_main_program(),
-            fetch_list=[out1, out2, out3, out4],
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, (2, 3, 4))
-        self.assertEqual(res[3].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program,
+                fetch_list=[out1, out2, out3, out4],
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, ())
+            self.assertEqual(res[2].shape, (2, 3, 4))
+            self.assertEqual(res[3].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_ones_and_ones_like(self):
-        out1 = paddle.ones([])
-        out2 = paddle.ones_like(out1)
-        out3 = paddle.ones(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.ones([])
+            out2 = paddle.ones_like(out1)
+            out3 = paddle.ones(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2, out3]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2, out3]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, ())
+            self.assertEqual(res[2].shape, (2, 3, 4))
 
+    @test_with_pir_api
     def test_zeros_and_zeros_like(self):
-        out1 = paddle.zeros([])
-        out2 = paddle.zeros_like(out1)
-        out3 = paddle.zeros(self.shape)
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            self.init_data()
+            out1 = paddle.zeros([])
+            out2 = paddle.zeros_like(out1)
+            out3 = paddle.zeros(self.shape)
 
-        res = self.exe.run(
-            paddle.static.default_main_program(), fetch_list=[out1, out2, out3]
-        )
-        self.assertEqual(res[0].shape, ())
-        self.assertEqual(res[1].shape, ())
-        self.assertEqual(res[2].shape, (2, 3, 4))
+            res = paddle.static.Executor().run(
+                main_program, fetch_list=[out1, out2, out3]
+            )
+            self.assertEqual(res[0].shape, ())
+            self.assertEqual(res[1].shape, ())
+            self.assertEqual(res[2].shape, (2, 3, 4))
 
     @test_with_pir_api
     def test_embedding(self):

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -260,10 +260,9 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
     def setUp(self):
         paddle.enable_static()
         self.exe = paddle.static.Executor()
-        self.shape = []
 
-    def init_data(self):
-        self.shape = [
+    def create_dynamic_shape(self):
+        return [
             paddle.full([], 2, 'int32'),
             paddle.full([], 3, 'int32'),
             paddle.full([], 4, 'int32'),
@@ -315,12 +314,11 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         np.testing.assert_array_equal(res, [1.0, 2.0, 3.0, 4.0, 5.0])
 
     def test_normal(self):
-        self.init_data()
         mean = paddle.full([], 0.0)
         std = paddle.full([], 0.0)
         out1 = paddle.normal(mean, std)
         out2 = paddle.normal(0.0, 1.0, [])
-        out3 = paddle.normal(0.0, 1.0, self.shape)
+        out3 = paddle.normal(0.0, 1.0, self.create_dynamic_shape())
 
         res = self.exe.run(
             paddle.static.default_main_program(), fetch_list=[out1, out2, out3]
@@ -334,9 +332,8 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.rand([])
-            out2 = paddle.rand(self.shape)
+            out2 = paddle.rand(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2]
@@ -349,9 +346,8 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.randn([])
-            out2 = paddle.randn(self.shape)
+            out2 = paddle.randn(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2]
@@ -400,9 +396,8 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.standard_normal([])
-            out2 = paddle.standard_normal(self.shape)
+            out2 = paddle.standard_normal(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2]
@@ -415,9 +410,8 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.uniform([])
-            out2 = paddle.uniform(self.shape)
+            out2 = paddle.uniform(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2]
@@ -430,10 +424,9 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.empty([])
             out2 = paddle.empty_like(out1)
-            out3 = paddle.empty(self.shape)
+            out3 = paddle.empty(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2, out3]
@@ -447,11 +440,12 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.full([], 0.5)
             out2 = paddle.full_like(out1, 0.5)
-            out3 = paddle.full(self.shape, 0.5)
-            out4 = paddle.full(self.shape, paddle.full([], 0.5))
+            out3 = paddle.full(self.create_dynamic_shape(), 0.5)
+            out4 = paddle.full(
+                self.create_dynamic_shape(), paddle.full([], 0.5)
+            )
 
             res = paddle.static.Executor().run(
                 main_program,
@@ -467,10 +461,9 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.ones([])
             out2 = paddle.ones_like(out1)
-            out3 = paddle.ones(self.shape)
+            out3 = paddle.ones(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2, out3]
@@ -484,10 +477,9 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         main_program = paddle.static.Program()
         startup_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            self.init_data()
             out1 = paddle.zeros([])
             out2 = paddle.zeros_like(out1)
-            out3 = paddle.zeros(self.shape)
+            out3 = paddle.zeros(self.create_dynamic_shape())
 
             res = paddle.static.Executor().run(
                 main_program, fetch_list=[out1, out2, out3]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
我们不应该在`setUp`中加载任何数据，因为在这时还没确定是哪种 IR 模式运行

相关链接:
* #62652