### PR TITLE
fix rocksdb compile error on gcc84

### DIFF
--- a/cmake/external/rocksdb.cmake
+++ b/cmake/external/rocksdb.cmake
@@ -14,8 +14,6 @@
 
 include(ExternalProject)
 
-# find_package(jemalloc REQUIRED)
-
 set(ROCKSDB_SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/rocksdb)
 set(ROCKSDB_TAG 6.19.fb)
 
@@ -32,28 +30,10 @@ set(ROCKSDB_INCLUDE_DIR
 set(ROCKSDB_LIBRARIES
     "${ROCKSDB_INSTALL_DIR}/lib/librocksdb.a"
     CACHE FILEPATH "rocksdb library." FORCE)
-set(ROCKSDB_COMMON_FLAGS
-    "-g -pipe -O2 -W -Wall -Wno-unused-parameter -fPIC -fno-builtin-memcmp -fno-omit-frame-pointer"
-)
-set(ROCKSDB_FLAGS
-    "-DNDEBUG -DROCKSDB_JEMALLOC -DJEMALLOC_NO_DEMANGLE -DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX -DOS_LINUX -DROCKSDB_FALLOCATE_PRESENT -DHAVE_PCLMUL -DZLIB -DROCKSDB_MALLOC_USABLE_SIZE -DROCKSDB_PTHREAD_ADAPTIVE_MUTEX -DROCKSDB_BACKTRACE -DROCKSDB_SUPPORT_THREAD_LOCAL -DROCKSDB_USE_RTTI -DROCKSDB_SCHED_GETCPU_PRESENT -DROCKSDB_RANGESYNC_PRESENT -DROCKSDB_AUXV_GETAUXVAL_PRESENT"
-)
-set(ROCKSDB_CMAKE_CXX_FLAGS
-    "${ROCKSDB_COMMON_FLAGS} -DROCKSDB_LIBAIO_PRESENT ${ROCKSDB_FLAGS} -fPIC -I${JEMALLOC_INCLUDE_DIR}"
-)
-if(NOT WITH_ARM)
-  set(ROCKSDB_FLAGS "${ROCKSDB_FLAGS} -DHAVE_SSE42")
-  set(ROCKSDB_CMAKE_CXX_FLAGS
-      "${ROCKSDB_CMAKE_CXX_FLAGS} -msse -msse4.2 -mpclmul")
-endif()
-set(ROCKSDB_CMAKE_C_FLAGS
-    "${ROCKSDB_COMMON_FLAGS} ${ROCKSDB_FLAGS} -DROCKSDB_LIBAIO_PRESENT -fPIC -I${JEMALLOC_INCLUDE_DIR}"
-)
-include_directories(${ROCKSDB_INCLUDE_DIR})
 
-set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} -pthread")
-
-set(ROCKSDB_CMAKE_SHARED_LINKER_FLAGS "-ldl -lrt -lz")
+set(ROCKSDB_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -DROCKSDB_LIBAIO_PRESENT -I${JEMALLOC_INCLUDE_DIR}")
+set(ROCKSDB_SHARED_LINKER_FLAGS "-Wl,--no-as-needed -ldl")
 
 if(WITH_ARM)
   file(TO_NATIVE_PATH ${PADDLE_SOURCE_DIR}/patches/rocksdb/libaio.h.patch
@@ -62,6 +42,7 @@ if(WITH_ARM)
       git checkout -- . && git checkout ${ROCKSDB_TAG} && patch -Nd
       ${PADDLE_SOURCE_DIR}/third_party/rocksdb/env/ < ${native_src})
 endif()
+
 ExternalProject_Add(
   extern_rocksdb
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -76,25 +57,23 @@ ExternalProject_Add(
              -DWITH_GFLAGS=OFF
              -DWITH_TESTS=OFF
              -DWITH_JEMALLOC=ON
-             -DWITH_BENCHMARK_TOOLS=OFF
-             -DFAIL_ON_WARNINGS=OFF # For Clang compatibility
              -DJeMalloc_LIBRARIES=${JEMALLOC_LIBRARIES}
              -DJeMalloc_INCLUDE_DIRS=${JEMALLOC_INCLUDE_DIR}
-             -DCMAKE_CXX_FLAGS=${ROCKSDB_CMAKE_CXX_FLAGS}
-             -DCMAKE_C_FLAGS=${ROCKSDB_CMAKE_C_FLAGS}
-             -DCMAKE_SHARED_LINKER_FLAGS=${ROCKSDB_CMAKE_SHARED_LINKER_FLAGS}
-  INSTALL_COMMAND
-    mkdir -p ${ROCKSDB_INSTALL_DIR}/lib/ && cp
-    ${ROCKSDB_PREFIX_DIR}/src/extern_rocksdb-build/librocksdb.a
-    ${ROCKSDB_LIBRARIES} && cp -r ${ROCKSDB_SOURCE_DIR}/include
-    ${ROCKSDB_INSTALL_DIR}/
+             -DWITH_BENCHMARK_TOOLS=OFF
+             -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+             -DCMAKE_CXX_FLAGS=${ROCKSDB_CXX_FLAGS}
+             -DCMAKE_SHARED_LINKER_FLAGS=${ROCKSDB_SHARED_LINKER_FLAGS}
+  CMAKE_CACHE_ARGS
+    -DCMAKE_INSTALL_PREFIX:PATH=${ROCKSDB_INSTALL_DIR}
+    -DCMAKE_INSTALL_LIBDIR:PATH=${ROCKSDB_INSTALL_DIR}/lib
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+    -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
   BUILD_BYPRODUCTS ${ROCKSDB_LIBRARIES})
+add_dependencies(extern_rocksdb snappy extern_jemalloc)
 
 add_library(rocksdb STATIC IMPORTED GLOBAL)
-
-add_dependencies(extern_rocksdb snappy)
-add_dependencies(extern_rocksdb extern_jemalloc)
 set_property(TARGET rocksdb PROPERTY IMPORTED_LOCATION ${ROCKSDB_LIBRARIES})
+include_directories(${ROCKSDB_INCLUDE_DIR})
 add_dependencies(rocksdb extern_rocksdb)
 
 list(APPEND external_project_dependencies rocksdb)

--- a/test/cpp/auto_parallel/CMakeLists.txt
+++ b/test/cpp/auto_parallel/CMakeLists.txt
@@ -8,7 +8,10 @@ cc_test(
   DEPS proto_desc)
 
 if(WITH_DISTRIBUTE)
-  cc_library(spmd_rule_test_util SRCS spmd_rule_test_util.cc)
+  cc_library(
+    spmd_rule_test_util
+    SRCS spmd_rule_test_util.cc
+    DEPS gtest)
   cc_test(
     dist_tensor_test
     SRCS dist_tensor_test.cc


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix rocksdb compile error on high gcc versions, gcc84 clang15 etc.
Pcard-77889

