### PR TITLE
【CINN】Replace pow_0.5 with sqrt

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -459,6 +459,11 @@ class ElementwisePowOpPattern
           rewriter.Build<paddle::dialect::RsqrtOp>(op->operand_source(0));
       rewriter.ReplaceAllUsesWith(op.result(0), rsqrt.result(0));
       rewriter.EraseOp(op);
+    } else if (factor == 0.5) {
+      auto sqrt =
+          rewriter.Build<paddle::dialect::SqrtOp>(op->operand_source(0));
+      rewriter.ReplaceAllUsesWith(op.result(0), sqrt.result(0));
+      rewriter.EraseOp(op);
     }
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
pcard-81637

replace pow(x, 0.5) with sqrt(x). Throught the experiment of layernorm backward, the performance could be improved about 14%.
<img width="567" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/18052330/63d831d8-454b-49bd-81d7-5c0b742eec01">
