### PR TITLE
【pir】modify x -> x backward , modify remove op 

### DIFF
--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -908,9 +908,11 @@ def calc_gradient_helper(outputs, inputs, grad_outputs, no_grad_set):
     # update no_grad_set if some value stop_gradient=True
     update_no_grad_set_by_stopgradient(block, no_grad_set)
     with block:
-        grad_outputs, complete_outputs, backward_ops = prepare_grad_outputs(
-            grad_outputs, outputs, state
-        )
+        (
+            complete_grad_outputs,
+            complete_outputs,
+            backward_ops,
+        ) = prepare_grad_outputs(grad_outputs, outputs, state)
 
     inputs_set = ValueSet(inputs)
     stop_gradient_false_outputs = []
@@ -964,12 +966,11 @@ def calc_gradient_helper(outputs, inputs, grad_outputs, no_grad_set):
                 remove_useless_full_like_ops(sub_block, sub_block.ops, state)
 
     for bwd_op in inverse_sort_op(remove_ops):
-        if bwd_op.result(0) in ValueSet(grad_outputs):
+        if bwd_op.result(0) in ValueSet(complete_grad_outputs):
             continue
         if bwd_op.result(0).use_empty():
             remove_op(block, bwd_op, state)
     state.turn_map()
-
     input_grad_map = state.value_to_valuegrad
 
     return input_grad_map

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -150,7 +150,10 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
         # fwd : op1 -> op2 -> op3 -> output
         # bwd : op1G <- op2G <- op3G <- outputG <- full_likeop/feedop
         if grad is None:
-            append_full_like(1.0, output, output, state, backward_ops)
+            grad_value = append_full_like(
+                1.0, output, output, state, backward_ops
+            )
+            grad_outputs[i] = grad_value
         else:
             if output.shape != grad.shape:
                 raise ValueError(
@@ -194,7 +197,7 @@ def prepare_grad_outputs(grad_outputs, outputs, state):
 
                     complete_outputs.append(opresult)
 
-    return complete_outputs, backward_ops
+    return grad_outputs, complete_outputs, backward_ops
 
 
 def prune_ops(total_ops, inputs_set, outputs_set, no_grad_set):
@@ -905,7 +908,7 @@ def calc_gradient_helper(outputs, inputs, grad_outputs, no_grad_set):
     # update no_grad_set if some value stop_gradient=True
     update_no_grad_set_by_stopgradient(block, no_grad_set)
     with block:
-        complete_outputs, backward_ops = prepare_grad_outputs(
+        grad_outputs, complete_outputs, backward_ops = prepare_grad_outputs(
             grad_outputs, outputs, state
         )
 

--- a/test/ir/pir/test_ir_backward.py
+++ b/test/ir/pir/test_ir_backward.py
@@ -145,9 +145,7 @@ def get_ir_program_1():
     )
     with paddle.static.program_guard(main_program, start_program):
         x_s = paddle.static.data('x', [4, 4], x.dtype)
-        y_s = paddle.static.data('y', [4, 4], x.dtype)
         x_s.stop_gradient = False
-        y_s.stop_gradient = False
 
         k_s = paddle.tanh(x_s)
         z_x = paddle.tanh(x_s)

--- a/test/ir/pir/test_ir_backward.py
+++ b/test/ir/pir/test_ir_backward.py
@@ -104,7 +104,7 @@ class TesBackward_1(unittest.TestCase):
             out = paddle.mean(tanh_out)
             input_grad = grad(out, input, no_grad_vars=[input])
             self.assertEqual(
-                pir_program.global_block().ops[-1].name(), "pd_op.mean"
+                pir_program.global_block().ops[-3].name(), "pd_op.mean"
             )
 
     def test_split(self):
@@ -192,7 +192,6 @@ class TesBackward_2(unittest.TestCase):
             out = paddle.concat([add_out, add_out])
             input_grad = grad(out, input_x)
         ops_name = [
-            "pd_op.data",
             "pd_op.data",
             "pd_op.tanh",
             "pd_op.tanh",

--- a/test/legacy_test/test_zero_dim_sundry_static_api_part2.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part2.py
@@ -242,10 +242,11 @@ class TestSundryAPIStatic(unittest.TestCase):
         x.stop_gradient = False
         out = paddle.increment(x, 1.0)
         grad_list = paddle.static.append_backward(out, parameter_list=[x, out])
-
         prog = paddle.static.default_main_program()
         if paddle.framework.in_pir_mode():
-            grad_list = [_grad for _param, _grad in grad_list if _grad]
+            grad_list = [
+                _grad for _param, _grad in grad_list if _grad is not None
+            ]
             res = self.exe.run(prog, fetch_list=[x, out] + grad_list)
             self.assertEqual(res[0].shape, ())
             self.assertEqual(res[1].shape, ())

--- a/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
@@ -343,7 +343,9 @@ class TestSundryAPIStatic(unittest.TestCase):
         prog = paddle.static.default_main_program()
         if paddle.framework.in_pir_mode():
             res = self.exe.run(
-                prog, feed={}, fetch_list=[out, grad_list[0], grad_list[1]]
+                prog,
+                feed={},
+                fetch_list=[out, grad_list[0][1], grad_list[1][1]],
             )
         else:
             res = self.exe.run(

--- a/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
@@ -332,6 +332,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         self.assertEqual(res[2].shape, ())
         self.assertEqual(res[3].shape, ())
 
+    @test_with_pir_api
     @prog_scope()
     def test_t(self):
         x = paddle.full([], 2.0)
@@ -340,9 +341,14 @@ class TestSundryAPIStatic(unittest.TestCase):
         grad_list = paddle.static.append_backward(out, parameter_list=[out, x])
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(
-            prog, feed={}, fetch_list=[out, out.grad_name, x.grad_name]
-        )
+        if paddle.framework.in_pir_mode():
+            res = self.exe.run(
+                prog, feed={}, fetch_list=[out, grad_list[0], grad_list[1]]
+            )
+        else:
+            res = self.exe.run(
+                prog, feed={}, fetch_list=[out, out.grad_name, x.grad_name]
+            )
 
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Description
<!-- Describe what you’ve done -->
pcard-67164

当只有full_like创建的梯度时，默认会剪枝。导致返回值是输入的相关样例拿不到梯度