### PR TITLE
Fix Warning about  LIBCMT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,8 @@ if(WIN32)
         "${${flag_var}} /ignore:4049 /ignore:4217 /ignore:4006 /ignore:4221")
     if(MSVC_STATIC_CRT)
       set(${flag_var} "${${flag_var}} /NODEFAULTLIB:MSVCRT.LIB")
+    else()
+      set(${flag_var} "${${flag_var}} /NODEFAULTLIB:LIBCMT.LIB")
     endif()
   endforeach()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Pcard-73263
消除pr-ci-windows流水线存在207次链接警告。warning info:LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library
