### PR TITLE
[PIR][DynamicShape] Add InferSymbolicShape for builtin.slice Op

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -149,6 +149,27 @@ struct ShadowOutputOpInferSymbolicShapeInterfaceModel
       : InferSymbolicShapeInterface::Concept(InferSymbolicShape) {}
 };
 
+struct SliceOpInferSymbolicShapeInterfaceModel
+    : public InferSymbolicShapeInterface::Concept {
+  static inline bool InferSymbolicShape(
+      pir::Operation* op, pir::ShapeConstraintIRAnalysis* shape_analysis) {
+    // auto input_type = op->operand(0).type().dyn_cast<pir::VectorType>();
+    const auto index =
+        op->attributes().at("index").dyn_cast<pir::Int32Attribute>().data();
+    const auto output_value =
+        (op->operand(0).type().dyn_cast<pir::VectorType>())[index]
+            .dyn_cast<pir::Value>();
+
+    shape_analysis->SetShapeOrDataForValue(
+        op->result(0), shape_analysis->GetShapeOrDataForValue(output_value));
+
+    return true;
+  }
+
+  SliceOpInferSymbolicShapeInterfaceModel()
+      : InferSymbolicShapeInterface::Concept(InferSymbolicShape) {}
+};
+
 struct SplitOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -153,7 +153,6 @@ struct SliceOpInferSymbolicShapeInterfaceModel
     : public InferSymbolicShapeInterface::Concept {
   static inline bool InferSymbolicShape(
       pir::Operation* op, pir::ShapeConstraintIRAnalysis* shape_analysis) {
-    // auto input_type = op->operand(0).type().dyn_cast<pir::VectorType>();
     const auto index =
         op->attributes().at("index").dyn_cast<pir::Int32Attribute>().data();
     const auto output_value =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Add InferSymbolicShape for builtin.slice Op

