### PR TITLE
[Autotuner]get max_mem in all node

### DIFF
--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -964,6 +964,32 @@ def launch():
             if tuner_cfg['metric_cfg']['name'] not in cur_cfg:
                 cur_cfg[tuner_cfg['metric_cfg']['name']] = None
 
+            path = f"auto_tuner/mem/{job_id}/{ip}"
+            if nnodes > 1:
+                while not client.put(
+                    path, str(cur_cfg["max_mem_usage"]).encode('latin-1')
+                ):
+                    time.sleep(1)
+                result = list(client.get_prefix(f"auto_tuner/mem/{job_id}"))
+                size = len(result)
+                while size != nnodes:
+                    time.sleep(1)
+                    result = list(
+                        client.get_prefix(f"auto_tuner/mem/{job_id}/")
+                    )
+                    size = len(result)
+                mem_allnodes = [i[0].decode() for i in result]
+
+                for mem in mem_allnodes:
+                    if mem is None:
+                        continue
+                    if mem == "OOM":
+                        cur_cfg["max_mem_usage"] = mem
+                        break
+                    cur_cfg["max_mem_usage"] = max(
+                        int(mem), int(cur_cfg["max_mem_usage"])
+                    )
+
             # if need accurate peak memory
             if os.environ.get("FLAGS_log_memory_stats", False):
                 max_peak_memory = None


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-81863
Modify the max_mem_usage field recorded by the autotuner to represent the global maximum max_mem_usage in a multi-node scenario.