### PR TITLE
[CINN] Provide performance monitor subgraph

### DIFF
--- a/test/ir/pir/cinn/test_cinn_rms_norm.py
+++ b/test/ir/pir/cinn/test_cinn_rms_norm.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import utils
+
+import paddle
+
+
+class CINNRMSNormSubGraph(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.variance_epsilon = 1e-6
+        self.reduce_num = 4096
+
+    def forward(self, hidden_states, weight):
+        variance = hidden_states.pow(2).sum(-1, keepdim=True) / self.reduce_num
+        hidden_states = (
+            paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
+        )
+        return hidden_states * weight
+
+
+class PaddleRMSNormSubGraph(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.variance_epsilon = 1e-6
+
+    def forward(self, hidden_states, weight):
+        return paddle.incubate.nn.functional.fused_rms_norm(
+            x=hidden_states,
+            norm_weight=weight,
+            norm_bias=None,
+            epsilon=self.variance_epsilon,
+            begin_norm_axis=2,
+        )
+
+
+class TestRMSNormSubGraph(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.shape = [1, 13, 4096]
+        self.x = paddle.uniform(self.shape, dtype="float32", min=-0.5, max=0.5)
+        self.x.stop_gradient = False
+        self.weight = paddle.ones(shape=[self.shape[-1]], dtype="float32")
+        self.weight.stop_gradient = False
+
+    def train(self, use_cinn):
+        if use_cinn:
+            net = CINNRMSNormSubGraph()
+        else:
+            net = PaddleRMSNormSubGraph()
+        net.eval()
+        net = utils.apply_to_static(net, use_cinn)
+        for i in range(10000):
+            out = net(self.x, self.weight)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+
+        dy_out = self.train(use_cinn=False)
+        np.testing.assert_allclose(
+            cinn_out.numpy(), dy_out.numpy(), atol=1e-6, rtol=1e-6
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/pir/cinn/test_cinn_rope.py
+++ b/test/ir/pir/cinn/test_cinn_rope.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+import utils
+
+import paddle
+from paddle import nn
+
+
+class CINNRopeSubgraph(nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, q, k, cos, sin, position_ids):
+        cos = cos.squeeze(axis=[0, 2])  # [seq_len, dim]
+        sin = sin.squeeze(axis=[0, 2])  # [seq_len, dim]
+
+        cos = cos[position_ids].unsqueeze(2)  # [bs, seq_len, 1, dim]
+        sin = sin[position_ids].unsqueeze(2)  # [bs, seq_len, 1, dim]
+        q_embed = (q * cos) + (self.rotate_half(q) * sin)
+        k_embed = (k * cos) + (self.rotate_half(k) * sin)
+        return q_embed, k_embed
+
+    def rotate_half(self, x):
+        """Rotates half the hidden dims of the input."""
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return paddle.concat([-x2, x1], axis=-1)  # shape is the same as x
+
+
+class PaddleRopeSubGraph(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, q, k, cos, sin, position_ids):
+        (
+            out_q,
+            out_k,
+            _,
+        ) = paddle.incubate.nn.functional.fused_rotary_position_embedding(
+            q, k, None, sin, cos, position_ids, use_neox_rotary_style=False
+        )
+        return out_q, out_k
+
+
+class TestRopeSubGraph(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.q = paddle.randn([13, 2048, 32, 128], dtype="float32")
+        self.q.stop_gradient = False
+
+        self.k = paddle.randn([13, 2048, 32, 128], dtype="float32")
+        self.k.stop_gradient = False
+
+        self.cos = paddle.randn([1, 2048, 1, 128], dtype="float32")
+        self.cos.stop_gradient = False
+
+        self.sin = paddle.randn([1, 2048, 1, 128], dtype="float32")
+        self.sin.stop_gradient = False
+
+        self.position_ids = paddle.randint(
+            high=2048, shape=[13, 2048], dtype="int64"
+        )
+        # self.position_ids = paddle.arange(end=2048, dtype="int64").unsqueeze(0)
+        self.position_ids.stop_gradient = False
+
+    def eval(self, use_cinn):
+        if use_cinn:
+            net = CINNRopeSubgraph()
+        else:
+            net = PaddleRopeSubGraph()
+        net.eval()
+        net = utils.apply_to_static(net, use_cinn)
+        for i in range(10000):
+            out = net(self.q, self.k, self.cos, self.sin, self.position_ids)
+        return out
+
+    def test_eval(self):
+        cinn_outs = self.eval(use_cinn=True)
+        dy_outs = self.eval(use_cinn=False)
+
+        for cinn_out, dy_out in zip(cinn_outs, dy_outs):
+            np.testing.assert_allclose(
+                cinn_out.numpy(), dy_out.numpy(), atol=1e-6
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

Execute FLAGS:

`FLAGS_pir_apply_shape_optimization_pass=0 FLAGS_enable_pir_api=1 FLAGS_prim_enable_dynamic=true FLAGS_prim_all=true FLAGS_cinn_new_group_scheduler=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_bucket_compile=True FLAGS_cinn_compile_with_nvrtc=True FLAGS_nvrtc_compile_to_cubin=True FLAGS_support_reduce_stride_read=1`