### PR TITLE
[Paddle-TRT] fix remove_padding_recover_padding_pass

### DIFF
--- a/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.cc
+++ b/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.cc
@@ -155,14 +155,19 @@ void FusedTokenPrune::operator()() {
 void ElementWise::operator()() {
   // Create nodes for elementwise.
   auto* elementwise_input = pattern->NewNode(elementwise_input_repr())
-                                ->assert_is_op_input("elementwise_add", "X");
+                                ->assert_is_op_input("elementwise_add", "X")
+                                ->assert_var_not_persistable();
+  auto* elementwise_weight = pattern->NewNode(elementwise_weight_repr())
+                                 ->assert_is_op_input("elementwise_add", "Y")
+                                 ->assert_is_persistable_var();
   auto* elementwise_op =
       pattern->NewNode(elementwise_op_repr())->assert_is_op("elementwise_add");
   auto* elementwise_out = pattern->NewNode(elementwise_out_repr())
                               ->assert_is_op_output("elementwise_add");
 
   // Add links for elementwise op.
-  elementwise_op->LinksFrom({elementwise_input}).LinksTo({elementwise_out});
+  elementwise_op->LinksFrom({elementwise_input, elementwise_weight})
+      .LinksTo({elementwise_out});
 }
 }  // namespace patterns
 

--- a/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.h
+++ b/paddle/fluid/framework/ir/remove_padding_recover_padding_pass.h
@@ -126,6 +126,7 @@ struct ElementWise : public PatternBase {
   void operator()();
 
   PATTERN_DECL_NODE(elementwise_input);
+  PATTERN_DECL_NODE(elementwise_weight);
   PATTERN_DECL_NODE(elementwise_op);
   PATTERN_DECL_NODE(elementwise_out);
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501
fix remove_padding_recover_padding_pass: for elementwise_add