### PR TITLE
[PIR] Adaptation of `TestSundryAPIStatic.test_static_data`

### DIFF
--- a/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
@@ -373,9 +373,7 @@ class TestSundryAPIStatic(unittest.TestCase):
             feed={
                 "x1": np.array(1.0, dtype='float32'),
             },
-            fetch_list=[
-                x1,
-            ],
+            fetch_list=[x1],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], np.array(1.0))
@@ -390,9 +388,7 @@ class TestSundryAPIStatic(unittest.TestCase):
                 "x2": 100.5,
                 "x3": 200.5,
             },
-            fetch_list=[
-                y,
-            ],
+            fetch_list=[y],
         )
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[0], 301.0)

--- a/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
+++ b/test/legacy_test/test_zero_dim_sundry_static_api_part3.py
@@ -363,6 +363,7 @@ class TestSundryAPIStatic(unittest.TestCase):
         res = self.exe.run(prog, feed={"x": x_tensor}, fetch_list=[out])
         self.assertEqual(res[0].shape, (3, 4, 2))
 
+    @test_with_pir_api
     @prog_scope()
     def test_static_data(self):
         x1 = paddle.static.data(name="x1", shape=[])
@@ -373,7 +374,7 @@ class TestSundryAPIStatic(unittest.TestCase):
                 "x1": np.array(1.0, dtype='float32'),
             },
             fetch_list=[
-                x1.name,
+                x1,
             ],
         )
         self.assertEqual(res[0].shape, ())
@@ -390,7 +391,7 @@ class TestSundryAPIStatic(unittest.TestCase):
                 "x3": 200.5,
             },
             fetch_list=[
-                y.name,
+                y,
             ],
         )
         self.assertEqual(res[0].shape, ())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->

修复`TestSundryAPIStatic.test_static_data`单测, PIR 下已经明确不使用`name`作为`fetch_list`

相关链接:
* #62652