### PR TITLE
[Support Inceemental Compile On Windows] Solve Cache Error

### DIFF
--- a/cmake/external/dirent.cmake
+++ b/cmake/external/dirent.cmake
@@ -27,7 +27,9 @@ if((NOT DEFINED DIRENT_NAME) OR (NOT DEFINED DIRENT_URL))
   set(DIRENT_URL
       "${GIT_URL}/tronkko/dirent/archive/refs/tags/1.23.2.tar.gz"
       CACHE STRING "" FORCE)
-  set(DIRENT_CACHE_FILENAME "1.23.2.tar.gz")
+  set(DIRENT_CACHE_FILENAME
+      "1.23.2.tar.gz"
+      CACHE STRING "" FORCE)
 endif()
 
 message(STATUS "DIRENT_NAME: ${DIRENT_NAME}, DIRENT_URL: ${DIRENT_URL}")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Description
Pcard-73263
解决当前Windows平台第二次cmake时（两次cmake命令相同），thirdparty/dirent库文件不存在，导致md5计算错误。
