### PR TITLE
Revert "fix security (#62626)"

### DIFF
--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -14,7 +14,6 @@
 
 import os
 import platform
-import re
 import site
 import sys
 import warnings
@@ -195,18 +194,8 @@ def run_shell_command(cmd):
         return out.decode('utf-8').strip()
 
 
-def is_valid_filename(filename):
-    pattern = re.compile(r'^[a-zA-Z0-9_.-]+$')
-    if pattern.match(filename):
-        return True
-    else:
-        return False
-
-
 def get_dso_path(core_so, dso_name):
     if core_so and dso_name:
-        assert is_valid_filename(core_so), 'core_so must be a file name.'
-        assert is_valid_filename(dso_name), 'dso_name must be a file name.'
         return run_shell_command(
             f"ldd {core_so}|grep {dso_name}|awk '{{print $3}}'"
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-74613
Reverts PaddlePaddle/Paddle#62683

在 glibc < 2.22 的 linux 机器上，基于 pr_62626, pr_62683 合入后的编包，在执行 “import paddle” 时报错：'Error: Can not preload libgomp.so'

