### PR TITLE
[Dy2St] Fix missing Tensor name when trans to contiguous

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -1153,7 +1153,7 @@ class DygraphFunctionGeneratorBase(FunctionGeneratorBase):
             for name, (ttype, pos) in forward_inputs_position_map.items():
                 if name in need_pre_contiguous_set:
                     pre_contiguous_list.append(
-                        f"{indent}const auto& {name}_tmp = (require_any_grad && {name}.is_dense_tensor() && !std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())->meta().is_contiguous()) ? paddle::Tensor(std::make_shared<phi::DenseTensor>(paddle::experimental::Trans2Contiguous(*(std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())))), {name}.mutable_autograd_meta()) : {name};"
+                        f"{indent}const auto& {name}_tmp = (require_any_grad && {name}.is_dense_tensor() && !std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())->meta().is_contiguous()) ? paddle::Tensor(std::make_shared<phi::DenseTensor>(paddle::experimental::Trans2Contiguous(*(std::dynamic_pointer_cast<phi::DenseTensor>({name}.impl())))), {name}.mutable_autograd_meta(), {name}.name()) : {name};"
                     )
                     self.inputs_call_list_tmp[pos] = (
                         self.inputs_call_list_tmp[pos] + '_tmp'

--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -124,7 +124,8 @@ static std::vector<paddle::Tensor> Trans2ContiguousTensors(
           std::make_shared<phi::DenseTensor>(
               paddle::experimental::Trans2Contiguous(
                   *(std::dynamic_pointer_cast<phi::DenseTensor>(t.impl())))),
-          t.mutable_autograd_meta());
+          t.mutable_autograd_meta(),
+          t.name());
     } else {
       res.emplace_back(t);
     }

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -201,8 +201,8 @@ static void ShareTensorsIntoScopeWithName(
     const std::vector<std::string> &tensor_names,
     paddle::framework::Scope *scope) {
   for (size_t i = 0; i < tensors.size(); ++i) {
-    VLOG(4) << "Share Tensor Into Scope: " << i;
     auto name = tensor_names[i];
+    VLOG(4) << "Share Tensor Into Scope: " << name;
     if (name == paddle::framework::kFakeVarName ||
         name == paddle::framework::kEmptyVarName) {
       continue;
@@ -235,6 +235,7 @@ static void ShareTensorsIntoScope(const std::vector<Tensor> &tensors,
       [&](const std::vector<Tensor> &tensors) {
         std::vector<std::string> names;
         for (auto &t : tensors) {
+          VLOG(0) << "Tensor name is: " << t.name();
           names.push_back(t.name());
         }
         return names;
@@ -622,6 +623,9 @@ inline void RunProgramAPI(
     bool require_any_grad,
     const paddle::framework::AttributeMap &attrs,
     const int64_t &place_hash_key) {
+  for (auto p : params) {
+    VLOG(0) << "param name: " << p.name();
+  }
   VLOG(2) << "RunProgramOpKernel Compute";
   // In the original run_program OP, the default value of the is_test
   // attribute is false, we should check if there is is_test parameter

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -235,7 +235,6 @@ static void ShareTensorsIntoScope(const std::vector<Tensor> &tensors,
       [&](const std::vector<Tensor> &tensors) {
         std::vector<std::string> names;
         for (auto &t : tensors) {
-          VLOG(0) << "Tensor name is: " << t.name();
           names.push_back(t.name());
         }
         return names;
@@ -623,9 +622,6 @@ inline void RunProgramAPI(
     bool require_any_grad,
     const paddle::framework::AttributeMap &attrs,
     const int64_t &place_hash_key) {
-  for (auto p : params) {
-    VLOG(0) << "param name: " << p.name();
-  }
   VLOG(2) << "RunProgramOpKernel Compute";
   // In the original run_program OP, the default value of the is_test
   // attribute is false, we should check if there is is_test parameter

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1831,7 +1831,8 @@ static PyObject* tensor__setitem_dygraph(TensorObject* self,
                             paddle::experimental::Trans2Contiguous(
                                 *(std::dynamic_pointer_cast<phi::DenseTensor>(
                                     transback_sub_tensor.impl())))),
-                        transback_sub_tensor.mutable_autograd_meta())
+                        transback_sub_tensor.mutable_autograd_meta(),
+                        transback_sub_tensor.name())
                   : transback_sub_tensor;
 
           grad_node = std::shared_ptr<SetValueWithTensorGradNode>(

--- a/paddle/phi/api/include/tensor.h
+++ b/paddle/phi/api/include/tensor.h
@@ -142,14 +142,16 @@ class PADDLE_API Tensor final {
   explicit Tensor(const std::string& name) : name_(name) {}
 
   /**
-   * @brief Construct a new Tensor object by a TensorBase pointer and
-   * autograd_meta
+   * @brief Construct a new Tensor object by a TensorBase pointer, autograd meta
+   * and name
    *
    * @param tensor_impl
    * @param autograd_meta
+   * @param name
    */
   Tensor(std::shared_ptr<phi::TensorBase> tensor_impl,
-         std::shared_ptr<AbstractAutogradMeta> autograd_meta);
+         std::shared_ptr<AbstractAutogradMeta> autograd_meta,
+         const std::string& name);
 
   /* Part 2: Dimension, DataType and DataLayout methods */
 

--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -53,8 +53,11 @@ Tensor::Tensor(std::shared_ptr<phi::TensorBase> tensor_impl)
 }
 
 Tensor::Tensor(std::shared_ptr<phi::TensorBase> tensor_impl,
-               std::shared_ptr<AbstractAutogradMeta> autograd_meta)
-    : impl_(std::move(tensor_impl)), autograd_meta_(std::move(autograd_meta)) {
+               std::shared_ptr<AbstractAutogradMeta> autograd_meta,
+               const std::string &name)
+    : impl_(std::move(tensor_impl)),
+      autograd_meta_(std::move(autograd_meta)),
+      name_(name) {
   PADDLE_ENFORCE_NOT_NULL(
       impl_,
       phi::errors::InvalidArgument("TensorImpl with nullptr is not supported"));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 `Trans2ContiguousTensors` 后 name 缺失导致 share 到 scope 里的 Variable 名字为空，进而导致后续执行阶段找不到 Variable 而挂掉的问题

PCard-66972