### PR TITLE
Introduce PipelineParallelMicroStepCallback for Custom Hooks in Pipeline Parallelism

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/__init__.py
+++ b/python/paddle/distributed/fleet/meta_parallel/__init__.py
@@ -26,6 +26,7 @@ from .parallel_layers import (  # noqa: F401
 )
 from .pipeline_parallel import (  # noqa: F401
     PipelineParallel,
+    PipelineParallelMicroStepLocations,
     PipelineParallelWithInterleave,
     PipelineParallelWithInterleaveFthenB,
 )

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -16,6 +16,8 @@ import sys
 import time
 import warnings
 from collections import defaultdict
+from enum import Enum
+from typing import Callable, Dict, List
 
 import paddle
 from paddle import framework
@@ -144,6 +146,61 @@ class FakeMicroDataset:
             "batch_size = %d, micro_batch_size = %d, accumulate_steps = %d."
             % (batch_size, self._micro_batch_size, self._acc_steps)
         )
+
+
+# Enum for specifying the pipeline parallel micro-step locations.
+class PipelineParallelMicroStepLocations(Enum):
+    FORWARD_BEGIN = 'forward_begin'
+    FORWARD_END = 'forward_end'
+    BACKWARD_BEGIN = 'backward_begin'
+    BACKWARD_END = 'backward_end'
+
+
+# A callback class for managing hooks at different stages of a pipeline parallel process.
+class PipelineParallelMicroStepCallback:
+    def __init__(self):
+        # Initializes a dictionary to store hooks for each micro-step location.
+        self.hooks: Dict[PipelineParallelMicroStepLocations, List[Callable]] = {
+            PipelineParallelMicroStepLocations.FORWARD_BEGIN: [],
+            PipelineParallelMicroStepLocations.FORWARD_END: [],
+            PipelineParallelMicroStepLocations.BACKWARD_BEGIN: [],
+            PipelineParallelMicroStepLocations.BACKWARD_END: [],
+        }
+
+    def register_hook(
+        self, location: PipelineParallelMicroStepLocations, hook: Callable
+    ):
+        """
+        Registers a hook function to be called at a specified pipeline parallel micro-step location.
+
+        Args:
+            location (PipelineParallelMicroStepLocations): The micro-step location where the hook should be registered.
+            hook (Callable): The hook function to be registered. The function should accept the following optional keyword arguments:
+                - input_tensor (paddle.Tensor): The input tensor to the current micro-step.
+                - output_tensor (paddle.Tensor): The output tensor from the current micro-step.
+                - input_tensor_grad (paddle.Tensor): The gradient of the input tensor.
+                - output_tensor_grad (paddle.Tensor): The gradient of the output tensor.
+                - step_id (paddle.Tensor): An identifier for the current step in the pipeline.
+
+        Raises:
+            AssertionError: If the specified location is not a valid micro-step location.
+        """
+        assert (
+            location in self.hooks
+        ), f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+        self.hooks[location].append(hook)
+
+    def on_location(
+        self, location: PipelineParallelMicroStepLocations, **kwargs
+    ):
+        """
+        Triggers all registered hooks at a specified pipeline parallel micro-step location.
+        """
+        assert (
+            location in self.hooks
+        ), f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+        for hook in self.hooks[location]:
+            hook(**kwargs)
 
 
 class PipelineParallel(MetaParallelBase):
@@ -300,6 +357,8 @@ class PipelineParallel(MetaParallelBase):
 
         self._compute_loss = True
 
+        self.callbacks = PipelineParallelMicroStepCallback()
+
         logger.info(
             f"Pipeline Info -- num_stages: {self.num_stages}, stage_id: {self.stage_id}"
         )
@@ -324,6 +383,11 @@ class PipelineParallel(MetaParallelBase):
             self.register_allreduce_overlap_hook(
                 self._layers, self.dp_group, self.accumulate_steps, True
             )
+
+    def register_hook(
+        self, location: PipelineParallelMicroStepLocations, hook: Callable
+    ):
+        self.callbacks.register_hook(location, hook)
 
     def is_pipeline_first_stage(self, ignore_virtual=False):
         if not ignore_virtual:
@@ -504,7 +568,9 @@ class PipelineParallel(MetaParallelBase):
             )
 
             self._record_stamp("F", step_id, '"B"', self._forward_color)
-            output_tensor = self._forward_step(input_tensor, micro_dataset)
+            output_tensor = self._forward_step(
+                input_tensor, micro_dataset, step_id=step_id
+            )
             self._record_stamp("F", step_id, '"E"', self._forward_color)
             self._p2p_helper.send_forward(
                 output_tensor,
@@ -536,7 +602,9 @@ class PipelineParallel(MetaParallelBase):
             self._record_stamp(
                 "F", startup_steps + i, '"B"', self._forward_color
             )
-            output_tensor = self._forward_step(input_tensor, micro_dataset)
+            output_tensor = self._forward_step(
+                input_tensor, micro_dataset, step_id=startup_steps + i
+            )
             self._record_stamp(
                 "F", startup_steps + i, '"E"', self._forward_color
             )
@@ -559,7 +627,7 @@ class PipelineParallel(MetaParallelBase):
 
             self._record_stamp("B", i, '"B"', self._backward_color)
             input_tensor_grad = self._backward_step(
-                input_tensor, output_tensor, output_tensor_grad
+                input_tensor, output_tensor, output_tensor_grad, step_id=i
             )
             self._record_stamp("B", i, '"E"', self._backward_color)
 
@@ -594,7 +662,10 @@ class PipelineParallel(MetaParallelBase):
                 "B", steady_steps + i, '"B"', self._backward_color
             )
             input_tensor_grad = self._backward_step(
-                input_tensor, output_tensor, output_tensor_grad
+                input_tensor,
+                output_tensor,
+                output_tensor_grad,
+                step_id=steady_steps + i,
             )
             self._record_stamp(
                 "B", steady_steps + i, '"E"', self._backward_color
@@ -786,7 +857,9 @@ class PipelineParallel(MetaParallelBase):
 
         return self.train_loss
 
-    def _forward_step(self, input_tensor, micro_dataset, chunk_id=None):
+    def _forward_step(
+        self, input_tensor, micro_dataset, chunk_id=None, step_id=None
+    ):
         if self._enable_timer:
             self.timers("forward_step").start()
         if self.is_pipeline_first_stage():
@@ -795,7 +868,18 @@ class PipelineParallel(MetaParallelBase):
 
         assert chunk_id is None or isinstance(chunk_id, int)
 
+        self.callbacks.on_location(
+            PipelineParallelMicroStepLocations.FORWARD_BEGIN,
+            input_tensor=input_tensor,
+            step_id=step_id,
+        )
         output_tensor = self._layers.forward(input_tensor, chunk_id=chunk_id)
+        self.callbacks.on_location(
+            PipelineParallelMicroStepLocations.FORWARD_END,
+            input_tensor=input_tensor,
+            output_tensor=output_tensor,
+            step_id=step_id,
+        )
 
         if self.is_pipeline_last_stage():
             # train calculate loss for train
@@ -840,10 +924,19 @@ class PipelineParallel(MetaParallelBase):
             return backward_loss_tensor
         return output_tensor
 
-    def _backward_step(self, input_tensor, output_tensor, output_tensor_grad):
+    def _backward_step(
+        self, input_tensor, output_tensor, output_tensor_grad, step_id=None
+    ):
         if self._enable_timer:
             self.timers("backward_step").start()
         with paddle.amp.auto_cast(enable=False):
+            self.callbacks.on_location(
+                PipelineParallelMicroStepLocations.BACKWARD_BEGIN,
+                input_tensor=input_tensor,
+                output_tensor=output_tensor,
+                output_tensor_grad=output_tensor_grad,
+                step_id=step_id,
+            )
             if self.is_pipeline_last_stage():
                 assert output_tensor_grad is None
                 if self.scaler:
@@ -874,6 +967,14 @@ class PipelineParallel(MetaParallelBase):
                     input_tensor_grad = input_tensor.grad
             if self._enable_timer:
                 self.timers("backward_step").stop()
+            self.callbacks.on_location(
+                PipelineParallelMicroStepLocations.BACKWARD_END,
+                input_tensor=input_tensor,
+                output_tensor=output_tensor,
+                input_tensor_grad=input_tensor_grad,
+                output_tensor_grad=output_tensor_grad,
+                step_id=step_id,
+            )
             return input_tensor_grad
 
     def _check_micro_batch_data_valid(self, micro_batch_data):
@@ -1109,7 +1210,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
         )
         input_tensor = self.input_tensors[virtual_pp_rank][-1]
         output_tensor = self._forward_step(
-            input_tensor, micro_dataset, virtual_pp_rank
+            input_tensor, micro_dataset, virtual_pp_rank, step_id=micro_step
         )
         self.output_tensors[virtual_pp_rank].append(output_tensor)
 
@@ -1173,9 +1274,8 @@ class PipelineParallelWithInterleave(PipelineParallel):
         output_tensor = self.output_tensors[virtual_pp_rank].pop(0)
         output_tensor_grad = self.output_tensor_grads[virtual_pp_rank].pop(0)
         input_tensor_grad = self._backward_step(
-            input_tensor, output_tensor, output_tensor_grad
+            input_tensor, output_tensor, output_tensor_grad, step_id=micro_step
         )
-
         self._overlap_comm_grads()
 
         return input_tensor_grad


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
APIs

### Description

This PR introduces `PipelineParallelMicroStepCallback` in PaddlePaddle, allowing enhanced management of hooks within pipeline parallel processes. Unlike existing `register_forward_post_hook` and `register_forward_pre_hook` methods for `nn.Layer`, this feature facilitates registering callbacks at specific pipeline stages, such as `forward_begin`, `forward_end`, `backward_begin`, and `backward_end`. This is particularly relevant for `PipelineParallel` where layers are divided into multiple chunks. The addition aims to support a variety of tasks including logging, monitoring, and dynamic parameter adjustments during pipeline execution. I am proposing this feature to align with PaddlePaddle's design principles and address the specific needs of pipeline parallelism. Feedback on the API's design and functionality would be greatly appreciated to ensure this enhancement meets community standards and expectations.