### PR TITLE
[Fused Kernel Update] Ensure resnet_basic_block works properly when L3 memory of XPU is limited.

### DIFF
--- a/paddle/fluid/operators/fused/resnet_basic_block_op_xpu.cc
+++ b/paddle/fluid/operators/fused/resnet_basic_block_op_xpu.cc
@@ -386,7 +386,7 @@ class ResNetBasicBlockXPUKernel : public framework::OpKernel<T> {
 
       XPUType* conv3_input_l3_data = nullptr;
       XPUType* conv3_filter_l3_data =
-          RAII_GUARD.alloc_l3<XPUType>(attr.conv3_filter_numel);
+          RAII_GUARD.alloc_l3_or_gm<XPUType>(attr.conv3_filter_numel);
 
       if (attr.find_max) {
         r = xpu::findmax_copy_fusion(dev_ctx.x_context(),
@@ -490,7 +490,7 @@ class ResNetBasicBlockXPUKernel : public framework::OpKernel<T> {
     // 2. conv1
     XPUType* conv1_input_l3_data = nullptr;
     XPUType* conv1_filter_l3_data =
-        RAII_GUARD.alloc_l3<XPUType>(attr.conv1_filter_numel);
+        RAII_GUARD.alloc_l3_or_gm<XPUType>(attr.conv1_filter_numel);
     if (attr.find_max) {
       r = xpu::findmax_copy_fusion(dev_ctx.x_context(),
                                    x_data,
@@ -589,7 +589,7 @@ class ResNetBasicBlockXPUKernel : public framework::OpKernel<T> {
     // 4. conv2
     XPUType* conv2_input_l3_data = nullptr;
     XPUType* conv2_filter_l3_data =
-        RAII_GUARD.alloc_l3<XPUType>(attr.conv2_filter_numel);
+        RAII_GUARD.alloc_l3_or_gm<XPUType>(attr.conv2_filter_numel);
     if (attr.find_max) {
       phi::DenseTensor* max_input2 = ctx.Output<phi::DenseTensor>("MaxInput2");
       phi::DenseTensor* max_filter2 =

--- a/test/xpu/test_fused_resnet_basic_block_op_xpu.py
+++ b/test/xpu/test_fused_resnet_basic_block_op_xpu.py
@@ -18,16 +18,16 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    create_test_class,
     get_xpu_op_support_types,
 )
 from op_test import OpTest
 
 import paddle
 from paddle import base, nn
+from paddle.base import core
 from paddle.base.framework import default_main_program
 from paddle.incubate.xpu.resnet_block import ResNetBasicBlock
-
-paddle.enable_static()
 
 
 class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
@@ -37,7 +37,6 @@ class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
 
     class TestResNetBasicBlockOp(OpTest):
         def setUp(self):
-            paddle.disable_static()
             self.dtype = self.in_type
             self.place = paddle.XPUPlace(0)
             self.__class__.op_type = "resnet_basic_block"
@@ -65,8 +64,6 @@ class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
             self.has_shortcut = False
 
         def Base(self):
-            paddle.disable_static()
-
             conv1_weight = base.ParamAttr(
                 initializer=paddle.nn.initializer.XavierNormal(),
                 learning_rate=0.001,
@@ -165,8 +162,6 @@ class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
             return result, tensor_src.grad
 
         def FusedResNetBasicBlock(self):
-            paddle.disable_static()
-
             fused_conv1_weight = base.ParamAttr(
                 initializer=paddle.nn.initializer.XavierNormal(),
                 learning_rate=0.001,
@@ -300,13 +295,13 @@ class XPUTestResNetBasicBlockOp(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('resnet_basic_block')
-# for stype in support_types:
-#    create_test_class(
-#        globals(),
-#        XPUTestResNetBasicBlockOp,
-#        stype,
-#        ignore_device_version=[core.XPUVersion.XPU1],
-#    )
+for stype in support_types:
+    create_test_class(
+        globals(),
+        XPUTestResNetBasicBlockOp,
+        stype,
+        ignore_device_version=[core.XPUVersion.XPU1],
+    )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
Ensure resnet_basic_block works properly when L3 memory of XPU is limited.
