### PR TITLE
【Launch】Upgrade ease of launch 

### DIFF
--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -14,6 +14,7 @@
 
 import logging
 import socket
+import time
 
 from paddle.distributed.launch import plugins
 
@@ -220,10 +221,10 @@ class Context:
                         server_socket = socket.socket(
                             socket.AF_INET, socket.SOCK_STREAM
                         )
-                        server_socket.settimeout(30)
+                        server_socket.settimeout(200)
                         try:
                             server_socket.bind((self.node.ip, port))
-                            server_socket.listen(1)
+                            server_socket.listen()
                             connected_addrs = set()
                             connected_clients = []
                             while len(connected_addrs) < len(ip_list) - 1:
@@ -250,7 +251,9 @@ class Context:
                 else:
                     while port < 6779 and not has_connect:
                         has_connect = False
-                        for i in range(5):
+                        # wait server sokcet
+                        time.sleep(2)
+                        for i in range(3):
                             try:
                                 client_socket = socket.socket(
                                     socket.AF_INET, socket.SOCK_STREAM
@@ -262,6 +265,7 @@ class Context:
                                 response = client_socket.recv(1024).decode()
                                 if response == "connect success":
                                     has_connect = True
+                                    client_socket.close()
                                     break
                             except OSError:
                                 print(

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -302,10 +302,10 @@ class Context:
                 if self.envs.get("PADDLE_TRAINERS", None):
                     self._ip = self.envs["PADDLE_TRAINERS"].split(",")[0]
                 else:
-                    raise ValueError("LAUNCH ERROR the master ip error.")
+                    print("LAUNCH ERROR the master ip error.")
             if not self._port:
                 if self.envs.get("PADDLE_PORT", None):
                     self._port = self.envs.get("PADDLE_PORT")
                 else:
-                    raise ValueError("LAUNCH ERROR the master port error.")
+                    print("LAUNCH ERROR the master ip error.")
             self.args.master = f"{self._ip}:{self._port}"

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -59,7 +59,6 @@ class Context:
 
         if self.args.master:
             return False
-
         if len(self.unknown_args) > 0:
             self.logger.warning(
                 f"Compatible mode enable with args {self.unknown_args}"
@@ -165,6 +164,12 @@ class Context:
                     ip_list.append(ip)
         except:
             ip_list = self.args.ips.split(",")
+
+        if ip_list is None:
+            print(
+                "LAUNCH WARNNING ips has been set, but it does not have a value. Please check the launch config"
+            )
+            return
 
         if self.has_set("nnodes"):
             nnodes = int(self.args.nnodes)
@@ -308,4 +313,5 @@ class Context:
                     self._port = self.envs.get("PADDLE_PORT")
                 else:
                     print("LAUNCH ERROR the master ip error.")
-            self.args.master = f"{self._ip}:{self._port}"
+            if self._ip and self._port:
+                self.args.master = f"{self._ip}:{self._port}"

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -105,18 +105,46 @@ class Context:
             "legacy": False,
             "log_level": "INFO",
             "enable_gpu_log": True,
-            "nnodes": "1",
+            "nnodes": "-1",
             "nproc_per_node": None,
+            "log_dir": "log",
+            "run_mode": None,
+            "job_id": "default",
+            "devices": None,
+            "gpus": None,
+            "npus": None,
+            "xpus": None,
+            "ips": None,
+            "auto_parallel_config": None,
+            "auto_tuner_json": None,
+            "servers": "",
+            "trainers": "",
+            "trainer_num": None,
+            "server_num": None,
+            "gloo_port": 6767,
+            "with_gloo": "1",
+            "max_restart": 3,
+            "elastic_level": -1,
+            "elastic_timeout": 30,
+            "host": None,
         }
-        if k in default_values and self.args[k] != default_values[k]:
+
+        if k in default_values and getattr(self.args, k) != default_values[k]:
             return True
+
         return False
 
     def set_env_in_args(self):
         for k, v in env_args_mapping.items():
             attr, attr_type = v
             if k in self.envs:
-                print(
-                    f"LAUNCH WARNING args {attr} will be overridden by env: {k} value: {self.envs[k]}"
-                )
-                setattr(self.args, attr, attr_type(self.envs[k]))
+                if attr in self.args and self.has_set(attr):
+                    continue
+                else:
+                    print(
+                        f"LAUNCH WARNNING args {attr} will be overridden by env: {k} value: {self.envs[k]}"
+                    )
+                    setattr(self.args, attr, attr_type(self.envs[k]))
+        # set nnodes default value
+        if self.args.nnodes == "-1":
+            self.args.nnodes = "1"

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -97,6 +97,21 @@ class Context:
         else:
             return False
 
+    def has_set(self, k):
+        default_values = {
+            "master": None,
+            "rank": -1,
+            "sort_ip": False,
+            "legacy": False,
+            "log_level": "INFO",
+            "enable_gpu_log": True,
+            "nnodes": "1",
+            "nproc_per_node": None,
+        }
+        if k in default_values and self.args[k] != default_values[k]:
+            return True
+        return False
+
     def set_env_in_args(self):
         for k, v in env_args_mapping.items():
             attr, attr_type = v

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -165,6 +165,14 @@ class Context:
         except:
             ip_list = self.args.ips.split(",")
 
+        if len(ip_list) == 1:
+            self.args.master = None
+            self.args.ips = None
+            print(
+                "LAUNCH WARNNING only one node in ips, it will launch in standalone mode.."
+            )
+            return
+
         if self.has_set("nnodes"):
             nnodes = int(self.args.nnodes)
             if nnodes < len(ip_list):

--- a/python/paddle/distributed/launch/context/__init__.py
+++ b/python/paddle/distributed/launch/context/__init__.py
@@ -183,7 +183,7 @@ class Context:
                     f"LAUNCH ERROR the nnodes {nnodes} > len(ip_list)"
                 )
 
-        if self.node.ip not in ip_list:
+        if self.node.ip not in ip_list and self.node.ip != "127.0.0.1":
             raise ValueError(
                 f"LAUNCH ERROR the {self.node.ip} not in ips, please check your config --ips"
             )

--- a/python/paddle/distributed/launch/context/args_envs.py
+++ b/python/paddle/distributed/launch/context/args_envs.py
@@ -99,7 +99,7 @@ def parse_args():
     base_group.add_argument(
         "--nnodes",
         type=str,
-        default="1",
+        default="-1",
         help="the number of nodes, i.e. pod/node number",
     )
 

--- a/python/paddle/distributed/launch/plugins/__init__.py
+++ b/python/paddle/distributed/launch/plugins/__init__.py
@@ -46,18 +46,22 @@ def collective_compatible(ctx):
     if 'PADDLE_TRAINER_ENDPOINTS' in ctx.envs:
         eps = ctx.envs['PADDLE_TRAINER_ENDPOINTS'].split(',')
         hosts = {h.split(':')[0] for h in eps}
-        ctx.args.master = eps[0] if ':' in eps[0] else f'{eps[0]}:6768'
-        ctx.args.nnodes = len(hosts)
-        ctx.logger.info(f'args reset by env PADDLE_TRAINER_ENDPOINTS\n{eps}')
+        if not ctx.has_set("master") and not ctx.has_set("nnodes"):
+            ctx.args.master = eps[0] if ':' in eps[0] else f'{eps[0]}:6768'
+            ctx.args.nnodes = len(hosts)
+            ctx.logger.info(
+                f'args reset by env PADDLE_TRAINER_ENDPOINTS\n{eps}'
+            )
 
     if 'DISTRIBUTED_TRAINER_ENDPOINTS' in ctx.envs:
         eps = ctx.envs['DISTRIBUTED_TRAINER_ENDPOINTS'].split(',')
         hosts = {h.split(':')[0] for h in eps}
-        ctx.args.master = eps[0]
-        ctx.args.nnodes = len(hosts)
-        ctx.logger.info(
-            f'args reset by env DISTRIBUTED_TRAINER_ENDPOINTS\n{eps}'
-        )
+        if not ctx.has_set("master") and not ctx.has_set("nnodes"):
+            ctx.args.master = eps[0]
+            ctx.args.nnodes = len(hosts)
+            ctx.logger.info(
+                f'args  reset by env DISTRIBUTED_TRAINER_ENDPOINTS\n{eps}'
+            )
 
 
 def rewrite_host_ip(ctx):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-81867
This PR upgrades ease of launch module, it primarily addresses two issues.
- The user-provided arguments have the highest priority when launching.
- It introduces the ability to launch with IPS.
 ``` 
# lauch with ip list
mpirun python -m paddle.dsitributed.launch --ips=<ips1,ips2...> train.py
# lauch with hostfile
mpirun python -m paddle.dsitributed.launch --ips=<hostfile> train.py
``` 
hostfile example
```
10.67.224.15
10.67.224.16
10.67.224.17
...
```

When launching without the "master" parameter, the first IP in the IPS list will be used as the master IP, and the port will be automatically detected to form the master:  ips[0]:port.