### PR TITLE
Fix enable_host_event_recorder_hook declare

### DIFF
--- a/paddle/fluid/framework/new_executor/program_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/program_interpreter.cc
@@ -41,7 +41,7 @@
 COMMON_DECLARE_bool(dynamic_static_unified_comm);
 #endif
 
-COMMON_DECLARE_bool(enable_host_event_recorder_hook);
+PHI_DECLARE_bool(enable_host_event_recorder_hook);
 PD_DECLARE_bool(log_memory_stats);
 COMMON_DECLARE_string(static_runtime_data_save_path);
 COMMON_DECLARE_bool(save_static_runtime_data);

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -65,7 +65,7 @@ PD_DECLARE_bool(benchmark);
 COMMON_DECLARE_bool(check_nan_inf);
 PD_DECLARE_bool(enable_unused_var_check);
 COMMON_DECLARE_bool(run_kp_kernel);
-COMMON_DECLARE_bool(enable_host_event_recorder_hook);
+PHI_DECLARE_bool(enable_host_event_recorder_hook);
 
 namespace paddle {
 namespace framework {

--- a/paddle/phi/api/profiler/device_tracer.cc
+++ b/paddle/phi/api/profiler/device_tracer.cc
@@ -25,7 +25,7 @@ limitations under the License. */
 #include "paddle/common/flags.h"
 #include "paddle/phi/core/enforce.h"
 
-PD_DECLARE_bool(enable_host_event_recorder_hook);
+PHI_DECLARE_bool(enable_host_event_recorder_hook);
 
 namespace phi {
 

--- a/paddle/phi/api/profiler/profiler.h
+++ b/paddle/phi/api/profiler/profiler.h
@@ -28,7 +28,7 @@ limitations under the License. */
 #include "paddle/phi/api/profiler/event_tracing.h"
 #include "paddle/phi/api/profiler/supplement_tracing.h"
 
-COMMON_DECLARE_bool(enable_host_event_recorder_hook);
+PHI_DECLARE_bool(enable_host_event_recorder_hook);
 
 namespace phi {
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
修改 enable_host_event_recorder_hook 声明 PHI_DECLARE_bool

paddle/phi/api/profiler/profiler.cc 中使用的是PHI_前缀 PHI_DEFINE_bool

![image](https://github.com/PaddlePaddle/Paddle/assets/4617245/7fca5c15-c4bf-44bf-9e79-8c19328c9b20)

如果前缀不同，开启WITH_GFLAGS时有错误