### PR TITLE
Update docs of _register_backward_hook

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1986,7 +1986,7 @@ This hook will be called every time the gradient of current Tensor has been full
 
 There are two differences with `_register_grad_hook`:
 1. This backward hook will be executed after the gradient accumulation completed across batches,
-  but the hook registered by `_register_grad_hook` will be executed the gradient accumulation
+  but the hook registered by `_register_grad_hook` will be executed before the gradient accumulation
   completed in current batch.
 2. This backward hook function should have the following signature:
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Docs

### Description
修改 `_register_backward_hook` 的文档。`_register_grad_hook` 所注册的 hook 函数的执行时机是在执行梯度聚合「前」。原文档的缺少了介词 `before`

Pcard-81345