### PR TITLE
[DCU CI]fix PR-CI-DCU compile bug

### DIFF
--- a/paddle/fluid/pir/dialect/CMakeLists.txt
+++ b/paddle/fluid/pir/dialect/CMakeLists.txt
@@ -264,6 +264,9 @@ file(GLOB_RECURSE dist_dialect_srcs
 set(op_dialect_srcs ${op_dialect_srcs} ${dist_dialect_srcs})
 # endif()
 set(op_dialect_deps phi common pir type_info string_helper)
+if(WITH_ROCM)
+  set(op_dialect_deps ${op_dialect_deps} global_utils)
+endif()
 
 cc_library(
   op_dialect

--- a/test/cpp/auto_parallel/CMakeLists.txt
+++ b/test/cpp/auto_parallel/CMakeLists.txt
@@ -14,20 +14,22 @@ if(WITH_DISTRIBUTE)
     SRCS dist_tensor_test.cc
     DEPS phi common)
 
-  paddle_test(spmd_rule_test SRCS spmd_rule_test.cc DEPS spmd_rule_test_util)
+  paddle_test(spmd_rule_test SRCS spmd_rule_test.cc DEPS spmd_rule_test_util
+              phi)
 
   paddle_test(softmax_grad_spmd_rule_test SRCS softmax_grad_spmd_rule_test.cc
-              DEPS spmd_rule_test_util)
+              DEPS spmd_rule_test_util phi)
 
   paddle_test(tile_spmd_rule_test SRCS tile_spmd_rule_test.cc DEPS
-              spmd_rule_test_util)
+              spmd_rule_test_util phi)
 
   paddle_test(
     fused_linear_param_grad_add_spmd_rule_test SRCS
-    fused_linear_param_grad_add_spmd_rule_test.cc DEPS spmd_rule_test_util)
+    fused_linear_param_grad_add_spmd_rule_test.cc DEPS spmd_rule_test_util phi)
 
-  paddle_test(cross_entropy_softmax_spmd_rule_test SRCS
-              cross_entropy_softmax_spmd_rule_test.cc DEPS spmd_rule_test_util)
+  paddle_test(
+    cross_entropy_softmax_spmd_rule_test SRCS
+    cross_entropy_softmax_spmd_rule_test.cc DEPS spmd_rule_test_util phi)
 
   paddle_test(expand_as_spmd_rule_test SRCS expand_as_spmd_rule_test.cc DEPS
               spmd_rule_test_util phi)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
修复PR-CI-DCU编译bug，部分单测在link的时候找不到phi里的符号，是因为在海光dcu流水线只有为with_shared_phi=on的时候才去link 动态库phi，但是with_shared_phi为off时候就没有link，故找不到phi里的符号

Pcard-67174