### PR TITLE
[XPU] fix integer overflow of gm_default_size

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -31,7 +31,7 @@ namespace xpu = baidu::xpu::api;
 namespace phi {
 
 struct XPUContext::Impl {
-  void SetL3Cache(int l3_size = 1024) {
+  void SetL3Cache(int64_t l3_size = 1024) {
     PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(context_->xpu_stream));
     context_->_l3_mgr.set(nullptr, 0, true);  // free origin l3
     void* l3_ptr = nullptr;
@@ -130,7 +130,7 @@ struct XPUContext::Impl {
     }
   }
 
-  void Init(int gm_default_size = 1024, int l3_default_size = 1024) {
+  void Init(int64_t gm_default_size = 1024, int64_t l3_default_size = 1024) {
     owned_ = true;
     backends::xpu::XPUDeviceGuard guard(place_.GetDeviceId());
     LOG_FIRST_N(WARNING, 1)
@@ -222,26 +222,26 @@ struct XPUContext::Impl {
   xpu::BKCLContext_t bkcl_context_{nullptr};
 };
 
-static int get_gm_size(int i) {
-  int default_size = 1024;
+static int64_t get_gm_size(int i) {
+  int64_t default_size = 1024;
   if (std::getenv("XPUAPI_DEFAULT_SIZE") != nullptr) {
-    default_size = atoi(std::getenv("XPUAPI_DEFAULT_SIZE"));
+    default_size = std::atoll(std::getenv("XPUAPI_DEFAULT_SIZE"));
   }
   std::string cur_env = std::string("XPUAPI_DEFAULT_SIZE") + std::to_string(i);
   if (std::getenv(cur_env.c_str()) != nullptr) {
-    default_size = atoi(std::getenv(cur_env.c_str()));
+    default_size = std::atoll(std::getenv(cur_env.c_str()));
   }
   return default_size;
 }
 
-static int get_l3_size(int i) {
-  int default_size = 1024;
+static int64_t get_l3_size(int i) {
+  int64_t default_size = 1024;
   if (std::getenv("XPU_PADDLE_L3_SIZE") != nullptr) {
-    default_size = atoi(std::getenv("XPU_PADDLE_L3_SIZE"));
+    default_size = std::atoll(std::getenv("XPU_PADDLE_L3_SIZE"));
   }
   std::string cur_env = std::string("XPU_PADDLE_L3_SIZE") + std::to_string(i);
   if (std::getenv(cur_env.c_str()) != nullptr) {
-    default_size = atoi(std::getenv(cur_env.c_str()));
+    default_size = std::atoll(std::getenv(cur_env.c_str()));
   }
   return default_size;
 }
@@ -324,7 +324,7 @@ void XPUContext::SetXContext(xpu::Context* context, int i) {
   impls_[i]->SetXContext(context);
 }
 
-void XPUContext::SetL3Cache(int l3_size, int i) {
+void XPUContext::SetL3Cache(int64_t l3_size, int i) {
   impls_[i]->SetL3Cache(l3_size);
 }
 

--- a/paddle/phi/backends/xpu/xpu_context.h
+++ b/paddle/phi/backends/xpu/xpu_context.h
@@ -71,7 +71,7 @@ class XPUContext : public DeviceContext,
   // resource as external, and will not delete any resource when destructing.
   void SetXContext(xpu::Context*, int i = 0);
 
-  void SetL3Cache(int l3_size = 1024, int i = 0);
+  void SetL3Cache(int64_t l3_size = 1024, int i = 0);
 
   void SetXpuVersion(int version);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
fix the integer overflow problem caused by large`XPUAPI_DEFAULT_SIZE`