### PR TITLE
[CINN] Fix bug of substituting dim expr for group

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.cc
@@ -575,7 +575,7 @@ std::vector<pir::Value> GetMinimalInputs(
       [&](pir::Value input_tensor,
           const std::vector<symbol::DimExpr>& dim_exprs) {
         for (const auto& dim_expr : dim_exprs) {
-          if (dim_expr.isa<int64_t>()) continue;
+          if (!dim_expr.isa<std::string>()) continue;
           if (handled_dim_exprs.insert(dim_expr).second) {
             first_occurred_input_tensors.insert(input_tensor);
           }

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -116,7 +116,6 @@ void ApplyBuildGroupOpPass(
 
   pass_manager->AddPass(pir::CreateBuildCinnPass());
   if (has_dynamic_shape) {
-    pass_manager->AddPass(pir::CreateShapeOptimizationPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateInsertBroadcastPass());
   }
   pass_manager->Run(program);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

**问题描述：**
目前Group的输入Value维度符号为复合符号（如 S0+S1）时，会自动替换为新的简单符号表示（如S10）。但当输入Value的维度符号既有S0,S1 同时也有Broadcast(S0, S1)，此时如果将Broadcast(S0, S1)替换为新符号的话会丢失掉与S0,S1的广播约束信息，对于此类情况Broadcast(S0, S1)是不需要替换为新符号的。

**修复方案：**
本PR中增加了对输入Value维度替换复合符号的过滤处理，当一个复合符号的所有基础符号都能在其他输入Value的维度符号中找到时，将不会对这样的复合符号进行替换。
