### PR TITLE
[Dy2St] Increase `test_resnet_amp` ut time to 360s

### DIFF
--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -49,7 +49,7 @@ set_tests_properties(test_loop PROPERTIES TIMEOUT 180)
 set_tests_properties(test_mnist_amp PROPERTIES TIMEOUT 240)
 
 if(TEST test_resnet_amp)
-  set_tests_properties(test_resnet_amp PROPERTIES TIMEOUT 240)
+  set_tests_properties(test_resnet_amp PROPERTIES TIMEOUT 360)
 endif()
 
 if(NOT WIN32)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #62835，再次提高 `test_resnet_amp` timeout 到 360s 以避免超时

PCard-66972