### PR TITLE
delete use_calib mode property

### DIFF
--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -269,7 +269,6 @@ struct Argument {
   DECL_ARGUMENT_FIELD(tensorrt_use_static_engine,
                       TensorRtUseStaticEngine,
                       bool);
-  DECL_ARGUMENT_FIELD(tensorrt_use_calib_mode, TensorRtUseCalibMode, bool);
   DECL_ARGUMENT_FIELD(tensorrt_use_cuda_graph, TensorRtUseCudaGraph, bool);
   DECL_ARGUMENT_FIELD(tensorrt_use_varseqlen, TensorRtUseOSS, bool);
   DECL_ARGUMENT_FIELD(tensorrt_with_interleaved, TensorRtWithInterleaved, bool);

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -188,8 +188,6 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set("program",
                 new framework::ProgramDesc *(&argument->main_program()));
       pass->Set("predictor_id", new int(argument->predictor_id()));
-      bool use_calib_mode = argument->tensorrt_use_calib_mode();
-      pass->Set("use_calib_mode", new bool(use_calib_mode));
       pass->Set("trt_precision_mode", new int(trt_precision_mode));
       pass->Set("context_memory_sharing",
                 new bool(argument->trt_engine_memory_sharing()));
@@ -199,8 +197,8 @@ void IRPassManager::CreatePasses(Argument *argument,
       bool inspector_serialize = argument->tensorrt_inspector_serialize();
       bool model_from_memory = argument->model_from_memory();
       std::string optim_cache_dir = argument->optim_cache_dir();
-      bool int8_valid = !(model_from_memory && optim_cache_dir.empty() &&
-                          enable_int8 && use_calib_mode);
+      bool int8_valid =
+          !(model_from_memory && optim_cache_dir.empty() && enable_int8);
       PADDLE_ENFORCE_EQ(
           int8_valid,
           true,

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -471,7 +471,6 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(trt_use_dla_);
   CP_MEMBER(trt_dla_core_);
   CP_MEMBER(trt_use_static_engine_);
-  CP_MEMBER(trt_use_calib_mode_);
   CP_MEMBER(trt_use_cuda_graph_);
   CP_MEMBER(trt_use_varseqlen_);
   CP_MEMBER(trt_with_interleaved_);
@@ -752,7 +751,6 @@ void AnalysisConfig::EnableTensorRtEngine(int64_t workspace_size,
                                           int min_subgraph_size,
                                           Precision precision_mode,
                                           bool use_static,
-                                          bool use_calib_mode,
                                           bool use_cuda_graph) {
 #ifdef PADDLE_WITH_TENSORRT
   if (!use_gpu()) {
@@ -766,7 +764,6 @@ void AnalysisConfig::EnableTensorRtEngine(int64_t workspace_size,
   tensorrt_min_subgraph_size_ = min_subgraph_size;
   tensorrt_precision_mode_ = precision_mode;
   trt_use_static_engine_ = use_static;
-  trt_use_calib_mode_ = use_calib_mode;
   trt_use_cuda_graph_ = use_cuda_graph;
   if (use_cuda_graph) {
     LOG_FIRST_N(INFO, 1) << "You have enabled Trt Cuda Graph, you must ensure "
@@ -1424,8 +1421,6 @@ std::string AnalysisConfig::Summary() {
                     std::to_string(tensorrt_min_subgraph_size_)});
       os.InsertRow({"tensorrt_use_static_engine",
                     trt_use_static_engine_ ? "true" : "false"});
-      os.InsertRow(
-          {"tensorrt_use_calib_mode", trt_use_calib_mode_ ? "true" : "false"});
       os.InsertRow(
           {"tensorrt_use_cuda_graph", trt_use_cuda_graph_ ? "true" : "false"});
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1785,7 +1785,6 @@ void AnalysisPredictor::PrepareArgument() {
     argument_->SetTensorRtUseDLA(config_.trt_use_dla_);
     argument_->SetTensorRtDLACore(config_.trt_dla_core_);
     argument_->SetTensorRtUseStaticEngine(config_.trt_use_static_engine_);
-    argument_->SetTensorRtUseCalibMode(config_.trt_use_calib_mode_);
     argument_->SetTensorRtUseCudaGraph(config_.trt_use_cuda_graph_);
     argument_->SetCloseTrtPluginFp16(config_.disable_trt_plugin_fp16_);
     argument_->SetTensorRtShapeRangeInfoPath(config_.shape_range_info_path());

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -665,8 +665,6 @@ struct PD_INFER_DECL AnalysisConfig {
   /// engine.
   /// \param precision The precision used in TensorRT.
   /// \param use_static Serialize optimization information to disk for reusing.
-  /// \param use_calib_mode Use TRT int8 calibration(post training
-  /// quantization).
   /// \param use_cuda_graph Use CudaGraph to reduce the time consumption of
   /// enqueue. Note that this option can only be enabled when your input is
   /// constant (including the batch dimension).
@@ -677,7 +675,6 @@ struct PD_INFER_DECL AnalysisConfig {
                             int min_subgraph_size = 3,
                             Precision precision = Precision::kFloat32,
                             bool use_static = false,
-                            bool use_calib_mode = true,
                             bool use_cuda_graph = false);
   ///
   /// \brief A boolean state telling whether the TensorRT engine is used.
@@ -1300,7 +1297,6 @@ struct PD_INFER_DECL AnalysisConfig {
   int tensorrt_min_subgraph_size_{3};
   Precision tensorrt_precision_mode_{Precision::kFloat32};
   bool trt_use_static_engine_{false};
-  bool trt_use_calib_mode_{true};
   bool trt_use_cuda_graph_{false};
   bool trt_use_varseqlen_{false};
   bool trt_with_interleaved_{false};

--- a/paddle/fluid/inference/capi/paddle_c_api.h
+++ b/paddle/fluid/inference/capi/paddle_c_api.h
@@ -218,8 +218,7 @@ PADDLE_CAPI_EXPORT extern void PD_EnableTensorRtEngine(
     int max_batch_size,
     int min_subgraph_size,
     Precision precision,
-    bool use_static,
-    bool use_calib_mode);
+    bool use_static);
 
 PADDLE_CAPI_EXPORT extern bool PD_TensorrtEngineEnabled(
     const PD_AnalysisConfig* config);

--- a/paddle/fluid/inference/capi/pd_config.cc
+++ b/paddle/fluid/inference/capi/pd_config.cc
@@ -247,8 +247,7 @@ void PD_EnableTensorRtEngine(PD_AnalysisConfig* config,
                              int max_batch_size,
                              int min_subgraph_size,
                              Precision precision,
-                             bool use_static,
-                             bool use_calib_mode) {
+                             bool use_static) {
   PADDLE_ENFORCE_NOT_NULL(
       config,
       paddle::platform::errors::InvalidArgument(
@@ -257,8 +256,7 @@ void PD_EnableTensorRtEngine(PD_AnalysisConfig* config,
                                       max_batch_size,
                                       min_subgraph_size,
                                       paddle::ConvertToACPrecision(precision),
-                                      use_static,
-                                      use_calib_mode);
+                                      use_static);
 }
 
 bool PD_TensorrtEngineEnabled(const PD_AnalysisConfig* config) {

--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -239,15 +239,13 @@ void PD_ConfigEnableTensorRtEngine(__pd_keep PD_Config* pd_config,
                                    int32_t max_batch_size,
                                    int32_t min_subgraph_size,
                                    PD_PrecisionType precision,
-                                   PD_Bool use_static,
-                                   PD_Bool use_calib_mode) {
+                                   PD_Bool use_static) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->EnableTensorRtEngine(workspace_size,
                                max_batch_size,
                                min_subgraph_size,
                                ConvertToCxxPrecisionType(precision),
-                               use_static,
-                               use_calib_mode);
+                               use_static);
 }
 PD_Bool PD_ConfigTensorRtEngineEnabled(__pd_keep PD_Config* pd_config) {
   CHECK_AND_CONVERT_PD_CONFIG;

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -336,8 +336,6 @@ PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigIrOptim(
 /// \param[in] precision The precision used in TensorRT.
 /// \param[in] use_static Serialize optimization information to disk for
 /// reusing.
-/// \param[in] use_calib_mode Use TRT int8 calibration(post training
-/// quantization).
 ///
 PADDLE_CAPI_EXPORT extern void PD_ConfigEnableTensorRtEngine(
     __pd_keep PD_Config* pd_config,
@@ -345,8 +343,7 @@ PADDLE_CAPI_EXPORT extern void PD_ConfigEnableTensorRtEngine(
     int32_t max_batch_size,
     int32_t min_subgraph_size,
     PD_PrecisionType precision,
-    PD_Bool use_static,
-    PD_Bool use_calib_mode);
+    PD_Bool use_static);
 ///
 /// \brief A boolean state telling whether the TensorRT engine is used.
 ///

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -162,7 +162,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
   std::unique_ptr<TRTInt8Calibrator> calibrator_;
   bool enable_int8_;
   bool enable_fp16_;
-  bool use_calib_mode_;
   std::string calibration_data_;
   std::string engine_key_;
   std::string calibration_engine_key_;
@@ -188,7 +187,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
     device_id_ = Attr<int>("gpu_device_id");
     enable_int8_ = Attr<bool>("enable_int8");
     enable_fp16_ = Attr<bool>("enable_fp16");
-    use_calib_mode_ = Attr<bool>("use_calib_mode");
     calibration_data_ = Attr<std::string>("calibration_data");
     engine_key_ = Attr<std::string>("engine_key");
     calibration_engine_key_ = Attr<std::string>("calibration_engine_key");
@@ -211,8 +209,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
     }
     // calibration_mode is true represents we need to
     // generate the calibration table data.
-    calibration_mode_ =
-        (enable_int8_ && calibration_data_.empty() && use_calib_mode_);
+    calibration_mode_ = (enable_int8_ && calibration_data_.empty());
 
     VLOG(4) << "calibration_mode: " << calibration_mode_;
     if (enable_int8_ && !calibration_data_.empty()) {

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -897,7 +897,6 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("min_subgraph_size") = 3,
            py::arg("precision_mode") = AnalysisConfig::Precision::kFloat32,
            py::arg("use_static") = false,
-           py::arg("use_calib_mode") = true,
            py::arg("use_cuda_graph") = false)
       .def("enable_tensorrt_memory_optim",
            &AnalysisConfig::EnableTensorRTMemoryOptim,

--- a/r/README.md
+++ b/r/README.md
@@ -62,8 +62,7 @@ config$enable_tensorrt_engine(workspace_size,
                               max_batch_size,
                               min_subgraph_size,
                               paddle$AnalysisConfig$Precision$FLOAT32,
-                              use_static,
-                              use_calib_mode
+                              use_static
                               ) # use TensorRT
 config$enable_mkldnn() # use MKLDNN
 config$delete_pass(pass_name) # delete IR pass

--- a/r/README_cn.md
+++ b/r/README_cn.md
@@ -59,8 +59,7 @@ config$enable_tensorrt_engine(workspace_size,
                               max_batch_size,
                               min_subgraph_size,
                               paddle$AnalysisConfig$Precision$Float32,
-                              use_static,
-                              use_calib_mode
+                              use_static
                               ) # 开启TensorRT
 config$enable_mkldnn() # 开启MKLDNN
 config$disable_glog_info() # 禁用预测中的glog日志

--- a/test/cpp/fluid/tensorrt/tensorrt_engine_op_test.cc
+++ b/test/cpp/fluid/tensorrt/tensorrt_engine_op_test.cc
@@ -131,7 +131,6 @@ void DynamicShapeTest(bool allow_build_at_runtime) {
   engine_op_desc.SetAttr("calibration_data", std::string(""));
   engine_op_desc.SetAttr("enable_int8", static_cast<bool>(false));
   engine_op_desc.SetAttr("enable_fp16", static_cast<bool>(false));
-  engine_op_desc.SetAttr("use_calib_mode", static_cast<bool>(false));
   engine_op_desc.SetAttr("output_name_mapping",
                          std::vector<std::string>({"z0"}));
   engine_op_desc.SetAttr("origin_output_rank", std::vector<int>({2}));
@@ -281,7 +280,6 @@ void Execute(int batch_size, int input_dim, int output_dim, int nlayers = 1) {
   engine_op_desc.SetAttr("calibration_data", std::string(""));
   engine_op_desc.SetAttr("enable_int8", static_cast<bool>(false));
   engine_op_desc.SetAttr("enable_fp16", static_cast<bool>(false));
-  engine_op_desc.SetAttr("use_calib_mode", static_cast<bool>(false));
   engine_op_desc.SetAttr("output_name_mapping",
                          std::vector<std::string>({"z3"}));
   engine_op_desc.SetAttr("origin_output_rank", std::vector<int>({2}));

--- a/test/cpp/inference/api/analyzer_capi_exp_gpu_tester.cc
+++ b/test/cpp/inference/api/analyzer_capi_exp_gpu_tester.cc
@@ -59,7 +59,7 @@ TEST(PD_Config, gpu_interface) {
   EXPECT_TRUE(cudnn);
 
   PD_ConfigEnableTensorRtEngine(
-      config, 1 << 20, 1, 3, PD_PRECISION_INT8, FALSE, TRUE);
+      config, 1 << 20, 1, 3, PD_PRECISION_INT8, FALSE);
   bool trt_enable = PD_ConfigTensorRtEngineEnabled(config);
   EXPECT_TRUE(trt_enable);
 
@@ -140,7 +140,7 @@ TEST(PD_Config, use_gpu) {
   EXPECT_TRUE(ir_optim);
 
   PD_ConfigEnableTensorRtEngine(
-      config, 1 << 20, 1, 3, PD_PRECISION_FLOAT32, FALSE, FALSE);
+      config, 1 << 20, 1, 3, PD_PRECISION_FLOAT32, FALSE);
   bool trt_enable = PD_ConfigTensorRtEngineEnabled(config);
   EXPECT_TRUE(trt_enable);
   PD_ConfigEnableMemoryOptim(config, true);
@@ -160,7 +160,7 @@ TEST(PD_Config, trt_int8) {
   PD_Config* config = PD_ConfigCreate();
   PD_ConfigEnableUseGpu(config, 100, 0, 0);
   PD_ConfigEnableTensorRtEngine(
-      config, 1 << 20, 1, 3, PD_PRECISION_INT8, FALSE, TRUE);
+      config, 1 << 20, 1, 3, PD_PRECISION_INT8, FALSE);
   bool trt_enable = PD_ConfigTensorRtEngineEnabled(config);
   EXPECT_TRUE(trt_enable);
   PD_ConfigDestroy(config);
@@ -171,7 +171,7 @@ TEST(PD_Config, trt_fp16) {
   PD_Config* config = PD_ConfigCreate();
   PD_ConfigEnableUseGpu(config, 100, 0, 0);
   PD_ConfigEnableTensorRtEngine(
-      config, 1 << 20, 1, 3, PD_PRECISION_HALF, FALSE, FALSE);
+      config, 1 << 20, 1, 3, PD_PRECISION_HALF, FALSE);
   bool trt_enable = PD_ConfigTensorRtEngineEnabled(config);
   EXPECT_TRUE(trt_enable);
   PD_Predictor* predictor = PD_PredictorCreate(config);

--- a/test/cpp/inference/api/trt_mobilenet_test.cc
+++ b/test/cpp/inference/api/trt_mobilenet_test.cc
@@ -50,7 +50,7 @@ TEST(PredictorPool, use_trt_cuda_graph) {
   config.EnableUseGpu(100, 0);
   config.SetModel(model_dir);
   config.EnableTensorRtEngine(
-      1 << 20, 1, 3, PrecisionType::kFloat32, false, false, true);
+      1 << 20, 1, 3, PrecisionType::kFloat32, false, false);
   config.Exp_DisableTensorRtOPs({"fc"});
   config.EnableTensorRtDLA(0);
   services::PredictorPool pred_pool(config, 1);

--- a/test/custom_op/test_inference_gap_setup.py
+++ b/test/custom_op/test_inference_gap_setup.py
@@ -102,7 +102,6 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             min_subgraph_size=0,
             precision_mode=paddle.inference.PrecisionType.Float32,
             use_static=True,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {"x": [32, 3, 7, 7]},

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -613,14 +613,12 @@ class TrtLayerAutoScanTest(AutoScanTest):
             min_subgraph_size,
             precision,
             use_static,
-            use_calib_mode,
         ):
             self.workspace_size = workspace_size
             self.max_batch_size = max_batch_size
             self.min_subgraph_size = min_subgraph_size
             self.precision = precision
             self.use_static = use_static
-            self.use_calib_mode = use_calib_mode
 
     class DynamicShapeParam:
         """
@@ -647,7 +645,6 @@ class TrtLayerAutoScanTest(AutoScanTest):
             min_subgraph_size=0,
             precision=paddle_infer.PrecisionType.Float32,
             use_static=True,
-            use_calib_mode=False,
         )
         self.dynamic_shape = self.DynamicShapeParam({}, {}, {}, False)
         self.num_percent_cases = float(
@@ -670,7 +667,6 @@ class TrtLayerAutoScanTest(AutoScanTest):
                 min_subgraph_size=self.trt_param.min_subgraph_size,
                 precision_mode=self.trt_param.precision,
                 use_static=self.trt_param.use_static,
-                use_calib_mode=self.trt_param.use_calib_mode,
             )
             if self.dynamic_shape.min_input_shape and (
                 self.dynamic_shape.min_input_shape.keys()

--- a/test/ir/inference/inference_pass_test.py
+++ b/test/ir/inference/inference_pass_test.py
@@ -155,7 +155,6 @@ class InferencePassTest(unittest.TestCase):
                     self.trt_parameters.min_subgraph_size,
                     self.trt_parameters.precision,
                     self.trt_parameters.use_static,
-                    self.trt_parameters.use_calib_mode,
                 )
                 if self.trt_parameters.use_inspector:
                     config.enable_tensorrt_inspector(
@@ -316,7 +315,6 @@ class InferencePassTest(unittest.TestCase):
             min_subgraph_size,
             precision,
             use_static,
-            use_calib_mode,
             use_inspector=False,
             inspector_serialize=False,
         ):
@@ -325,7 +323,6 @@ class InferencePassTest(unittest.TestCase):
             self.min_subgraph_size = min_subgraph_size
             self.precision = precision
             self.use_static = use_static
-            self.use_calib_mode = use_calib_mode
             self.use_inspector = use_inspector
             self.inspector_serialize = inspector_serialize
 

--- a/test/ir/inference/quant_dequant_test.py
+++ b/test/ir/inference/quant_dequant_test.py
@@ -217,7 +217,6 @@ class QuantDequantTest(unittest.TestCase):
                     self.trt_parameters.min_subgraph_size,
                     self.trt_parameters.precision,
                     self.trt_parameters.use_static,
-                    self.trt_parameters.use_calib_mode,
                 )
 
                 if self.dynamic_shape_params:
@@ -423,14 +422,12 @@ class QuantDequantTest(unittest.TestCase):
             min_subgraph_size,
             precision,
             use_static,
-            use_calib_mode,
         ):
             self.workspace_size = workspace_size
             self.max_batch_size = max_batch_size
             self.min_subgraph_size = min_subgraph_size
             self.precision = precision
             self.use_static = use_static
-            self.use_calib_mode = use_calib_mode
 
     class DynamicShapeParam:
         '''

--- a/test/ir/inference/test_adaptive_pool2d_convert_global_pass_autoscan.py
+++ b/test/ir/inference/test_adaptive_pool2d_convert_global_pass_autoscan.py
@@ -87,7 +87,6 @@ class TestAdaptivePool2dConvertGlobalPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, ['pool2d'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_conv_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_bn_fuse_pass.py
@@ -175,7 +175,6 @@ class TestConvBnFusePass(PassAutoScanTest):
                 min_subgraph_size=1,
                 precision_mode=paddle_infer.PrecisionType.Float32,
                 use_static=False,
-                use_calib_mode=False,
             )
             yield config, ['fused_conv2d_add_act'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_conv_elementwise_add_fuse_pass.py
+++ b/test/ir/inference/test_conv_elementwise_add_fuse_pass.py
@@ -134,7 +134,6 @@ class TestConvEltwiseAddFusePass(PassAutoScanTest):
             min_subgraph_size=1,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, ['fused_conv2d_add_act'], (1e-4, 1e-4)
 

--- a/test/ir/inference/test_delete_c_identity_op_pass.py
+++ b/test/ir/inference/test_delete_c_identity_op_pass.py
@@ -30,7 +30,6 @@ class TestDeleteCIdentityPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, ['relu'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_element_groupnorm_act_fuse_pass.py
+++ b/test/ir/inference/test_element_groupnorm_act_fuse_pass.py
@@ -43,7 +43,6 @@ class TestElementGNActPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_forbid_dynamic_op_api.py
+++ b/test/ir/inference/test_forbid_dynamic_op_api.py
@@ -102,7 +102,6 @@ class TestTRTOptimizationLevel(unittest.TestCase):
             min_subgraph_size=3,
             precision_mode=PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.enable_memory_optim()
         config.exp_disable_tensorrt_dynamic_shape_ops(True)

--- a/test/ir/inference/test_groupnorm_act_pass_fuse_pass.py
+++ b/test/ir/inference/test_groupnorm_act_pass_fuse_pass.py
@@ -42,7 +42,6 @@ class TestElementGNActPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_layernorm_shift_partition_pass.py
+++ b/test/ir/inference/test_layernorm_shift_partition_pass.py
@@ -50,7 +50,6 @@ class TestLayernormShiftPartitionPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -73,7 +72,6 @@ class TestLayernormShiftPartitionPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -290,7 +288,6 @@ class TestLayernormShiftPartition2Pass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -313,7 +310,6 @@ class TestLayernormShiftPartition2Pass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_map_matmul_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_to_mul_pass.py
@@ -46,8 +46,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         #     workspace_size=10240,
         #     min_subgraph_size=0,
         #     precision_mode=paddle_infer.PrecisionType.Float32,
-        #     use_static=False,
-        #     use_calib_mode=False)
+        #     use_static=False)
         # yield config, ["mul", ], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):

--- a/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_matmul_pass.py
@@ -46,8 +46,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         #     workspace_size=10240,
         #     min_subgraph_size=0,
         #     precision_mode=paddle_infer.PrecisionType.Float32,
-        #     use_static=False,
-        #     use_calib_mode=False)
+        #     use_static=False)
         # yield config, ["matmul", ], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):

--- a/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
+++ b/test/ir/inference/test_map_matmul_v2_to_mul_pass.py
@@ -46,8 +46,7 @@ class TestMapMatmulToMulPass(PassAutoScanTest):
         #     workspace_size=10240,
         #     min_subgraph_size=0,
         #     precision_mode=paddle_infer.PrecisionType.Float32,
-        #     use_static=False,
-        #     use_calib_mode=False)
+        #     use_static=False)
         # yield config, ["mul", ], (1e-5, 1e-5)
 
     def add_ignore_pass_case(self):

--- a/test/ir/inference/test_merge_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_merge_layernorm_fuse_pass.py
@@ -49,7 +49,6 @@ class TestMergeLayernormFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {"input_data": [1, 196, 96]},
@@ -65,7 +64,6 @@ class TestMergeLayernormFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {"input_data": [1, 196, 96]},

--- a/test/ir/inference/test_multihead_matmul_roformer_fuse_pass.py
+++ b/test/ir/inference/test_multihead_matmul_roformer_fuse_pass.py
@@ -32,7 +32,6 @@ class TestMultiheadMatmulRoformerFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_preln_groupnorm_act_fuse_pass.py
+++ b/test/ir/inference/test_preln_groupnorm_act_fuse_pass.py
@@ -43,7 +43,6 @@ class TestElementGNActPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -189,7 +188,6 @@ class TestElementGNNoActPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_preln_layernorm_x_fuse_pass.py
+++ b/test/ir/inference/test_preln_layernorm_x_fuse_pass.py
@@ -43,7 +43,6 @@ class TestLayernormShiftPartitionPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -69,7 +68,6 @@ class TestLayernormShiftPartitionPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_reverse_roll_fuse_pass.py
+++ b/test/ir/inference/test_reverse_roll_fuse_pass.py
@@ -50,7 +50,6 @@ class ReverseRollPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -74,7 +73,6 @@ class ReverseRollPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -240,7 +238,6 @@ class ReverseRoll2Pass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -264,7 +261,6 @@ class ReverseRoll2Pass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_save_optimized_model_pass.py
+++ b/test/ir/inference/test_save_optimized_model_pass.py
@@ -119,7 +119,6 @@ class TestSaveOptimizedModelPassWithTRT(
                 min_subgraph_size=3,
                 precision_mode=PrecisionType.Half,
                 use_static=True,
-                use_calib_mode=False,
             )
             config.set_trt_dynamic_shape_info(
                 {"x": [1, 3, 224, 224], "flatten_0.tmp_0": [1, 9216]},
@@ -147,7 +146,6 @@ class TestSaveOptimizedModelPassWithTRT(
                 min_subgraph_size=3,
                 precision_mode=PrecisionType.Half,
                 use_static=True,
-                use_calib_mode=False,
             )
             config.enable_memory_optim()
             config.switch_ir_optim(False)

--- a/test/ir/inference/test_shuffle_channel_detect_pass.py
+++ b/test/ir/inference/test_shuffle_channel_detect_pass.py
@@ -102,7 +102,6 @@ class TestShuffleChannelDetectPass(PassAutoScanTest):
             min_subgraph_size=1,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, ['shuffle_channel'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_simplify_with_basic_ops_pass_autoscan.py
+++ b/test/ir/inference/test_simplify_with_basic_ops_pass_autoscan.py
@@ -80,7 +80,6 @@ class TestSimplifyWithBasicOpsPassUpscale(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, ['relu'], (1e-5, 1e-5)
 
@@ -149,7 +148,6 @@ class TestSimplifyWithBasicOpsPassDowngrade(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, ['scale', 'relu'], (1e-5, 1e-5)
 

--- a/test/ir/inference/test_skip_merge_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_skip_merge_layernorm_fuse_pass.py
@@ -43,7 +43,6 @@ class TestMergeLayernormFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {"input0_data": [1, 196, 96], "input1_data": [1, 196, 96]},
@@ -59,7 +58,6 @@ class TestMergeLayernormFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {"input0_data": [1, 196, 96], "input1_data": [1, 196, 96]},

--- a/test/ir/inference/test_split_layernorm_to_math_ops_pass.py
+++ b/test/ir/inference/test_split_layernorm_to_math_ops_pass.py
@@ -33,7 +33,6 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -66,7 +65,6 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {
@@ -98,7 +96,6 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, [
             'reduce_mean',
@@ -119,7 +116,6 @@ class TestSplitLayernormToMathOpsPass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         yield config, [
             'reduce_mean',

--- a/test/ir/inference/test_trt_c_allreduce_infer_script.py
+++ b/test/ir/inference/test_trt_c_allreduce_infer_script.py
@@ -95,7 +95,6 @@ def run(op_type, precision):
             if precision == "fp16"
             else PrecisionType.Int8,
             use_static=False,
-            use_calib_mode=False,
         )
         config.set_trt_dynamic_shape_info(
             {"data": [3, 4]}, {"data": [3, 4]}, {"data": [3, 4]}

--- a/test/ir/inference/test_trt_convert_multiclass_nms.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms.py
@@ -40,7 +40,6 @@ class TrtConvertMulticlassNMSTest(TrtLayerAutoScanTest):
                 min_subgraph_size=self.trt_param.min_subgraph_size,
                 precision_mode=self.trt_param.precision,
                 use_static=self.trt_param.use_static,
-                use_calib_mode=self.trt_param.use_calib_mode,
             )
             if (
                 len(self.dynamic_shape.min_input_shape) != 0

--- a/test/ir/inference/test_trt_convert_multiclass_nms3.py
+++ b/test/ir/inference/test_trt_convert_multiclass_nms3.py
@@ -40,7 +40,6 @@ class TrtConvertMulticlassNMS3Test(TrtLayerAutoScanTest):
                 min_subgraph_size=self.trt_param.min_subgraph_size,
                 precision_mode=self.trt_param.precision,
                 use_static=self.trt_param.use_static,
-                use_calib_mode=self.trt_param.use_calib_mode,
             )
             if (
                 len(self.dynamic_shape.min_input_shape) != 0

--- a/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
+++ b/test/ir/inference/test_trt_emb_eltwise_layernorm_fuse_pass.py
@@ -204,7 +204,6 @@ class TestEmbeddingEltwiseLayerNormFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         if program_config.ops[0].type == 'lookup_table':
             config.set_trt_dynamic_shape_info(
@@ -466,7 +465,6 @@ class TestEmbeddingEltwiseLayerNormFusePassNoBroadcast(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         if program_config.ops[0].type == 'lookup_table':
             config.set_trt_dynamic_shape_info(

--- a/test/ir/inference/test_trt_exp_tensorrt_subgraph.py
+++ b/test/ir/inference/test_trt_exp_tensorrt_subgraph.py
@@ -40,7 +40,6 @@ class TrtConvertSetValue(TrtLayerAutoScanTest):
                 min_subgraph_size=self.trt_param.min_subgraph_size,
                 precision_mode=self.trt_param.precision,
                 use_static=self.trt_param.use_static,
-                use_calib_mode=self.trt_param.use_calib_mode,
             )
             if self.dynamic_shape.min_input_shape and (
                 self.dynamic_shape.min_input_shape.keys()

--- a/test/ir/inference/test_trt_explicit_quantization.py
+++ b/test/ir/inference/test_trt_explicit_quantization.py
@@ -46,7 +46,6 @@ class TestExplicitQuantizationLayer:
             min_subgraph_size=0,
             precision_mode=precision_mode,
             use_static=False,
-            use_calib_mode=False,
         )
         if precision_mode == PrecisionType.Int8:
             config.enable_tensorrt_explicit_quantization()

--- a/test/ir/inference/test_trt_explicit_quantization_model.py
+++ b/test/ir/inference/test_trt_explicit_quantization_model.py
@@ -135,7 +135,6 @@ class TestExplicitQuantizationModel:
             min_subgraph_size=3,
             precision_mode=precision_mode,
             use_static=False,
-            use_calib_mode=False,
         )
         if trt_int8:
             config.enable_tensorrt_explicit_quantization()

--- a/test/ir/inference/test_trt_inference_fp16_io.py
+++ b/test/ir/inference/test_trt_inference_fp16_io.py
@@ -104,7 +104,6 @@ class TestEnableLowPrecisionIOWithTRTAllGraph(
             min_subgraph_size=3,
             precision_mode=PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.enable_tensorrt_memory_optim(True, 1)
         config.enable_tuned_tensorrt_dynamic_shape()
@@ -130,7 +129,6 @@ class TestEnableLowPrecisionIOWithTRTSubGraph(
             min_subgraph_size=3,
             precision_mode=PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.enable_tensorrt_memory_optim(True, 1)
         config.enable_tuned_tensorrt_dynamic_shape()

--- a/test/ir/inference/test_trt_inference_predictor.py
+++ b/test/ir/inference/test_trt_inference_predictor.py
@@ -131,8 +131,7 @@ class BackendPaddle:
                     precision_mode=precision_mode,
                     max_batch_size=max_batch_size,
                     min_subgraph_size=self.args.subgraph_size,
-                    use_static=False,
-                    use_calib_mode=False
+                    use_static=False
                     if self.args.precision == 'int8'
                     else False,
                 )

--- a/test/ir/inference/test_trt_ops_fp16_mix_precision.py
+++ b/test/ir/inference/test_trt_ops_fp16_mix_precision.py
@@ -103,7 +103,6 @@ class TestTRTOptimizationLevel(unittest.TestCase):
             min_subgraph_size=3,
             precision_mode=PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
 
         config.exp_specify_tensorrt_subgraph_precision(

--- a/test/ir/inference/test_trt_optimization_level.py
+++ b/test/ir/inference/test_trt_optimization_level.py
@@ -102,7 +102,6 @@ class TestTRTOptimizationLevel(unittest.TestCase):
             min_subgraph_size=3,
             precision_mode=PrecisionType.Half,
             use_static=False,
-            use_calib_mode=False,
         )
         config.enable_memory_optim()
         config.disable_glog_info()

--- a/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
+++ b/test/ir/inference/test_trt_remove_amp_strategy_op_pass.py
@@ -99,7 +99,6 @@ class TestRemoveStrategyOpBase:
                 min_subgraph_size=0,
                 precision_mode=self.precision_mode,
                 use_static=False,
-                use_calib_mode=False,
             )
             config.set_trt_dynamic_shape_info(*self.dynamic_shape_info)
         predictor = create_predictor(config)

--- a/test/ir/inference/test_trt_support_nhwc_pass.py
+++ b/test/ir/inference/test_trt_support_nhwc_pass.py
@@ -121,7 +121,6 @@ class TRTNHWCConvertTest(unittest.TestCase):
             min_subgraph_size=3,
             precision_mode=self.precision_mode,
             use_static=False,
-            use_calib_mode=False,
         )
         predictor = inference.create_predictor(config)
         return predictor

--- a/test/ir/inference/test_trt_tuned_dynamic_shape.py
+++ b/test/ir/inference/test_trt_tuned_dynamic_shape.py
@@ -66,7 +66,6 @@ class TRTTunedDynamicShapeTest(unittest.TestCase):
                 min_subgraph_size=0,
                 precision_mode=paddle.inference.PrecisionType.Float32,
                 use_static=True,
-                use_calib_mode=False,
             )
             config.enable_tuned_tensorrt_dynamic_shape(
                 'shape_range.pbtxt', True

--- a/test/ir/inference/test_trt_while_op.py
+++ b/test/ir/inference/test_trt_while_op.py
@@ -139,7 +139,6 @@ class TestWhileOP(unittest.TestCase):
             min_subgraph_size=0,
             precision_mode=paddle.inference.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False,
         )
         config_trt.set_trt_dynamic_shape_info(
             {

--- a/test/ir/inference/test_use_optimized_model_api.py
+++ b/test/ir/inference/test_use_optimized_model_api.py
@@ -88,7 +88,6 @@ class UseOptimizedModel(InferencePassTest):
             min_subgraph_size=1,
             precision_mode=paddle.inference.PrecisionType.Float32,
             use_static=True,
-            use_calib_mode=False,
         )
         config.enable_tuned_tensorrt_dynamic_shape()
         config.exp_disable_tensorrt_ops(["elementwise_add"])

--- a/tools/cinn/paddle_benchmark/paddle_test_benchmark.py
+++ b/tools/cinn/paddle_benchmark/paddle_test_benchmark.py
@@ -75,7 +75,6 @@ def set_config(args):
         min_subgraph_size=3,
         precision_mode=paddle_infer.PrecisionType.Float32,
         use_static=False,
-        use_calib_mode=False,
     )
     config.enable_memory_optim()
     config.gpu_device_id()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-71501
删除了use_calib_mode属性，之前是这样
```
config.enable_tensorrt_engine(
                workspace_size=1024,
                max_batch_size=1,
                min_subgraph_size=0,
                precision_mode=paddle.inference.PrecisionType.Float32,
                use_static=True,
                use_calib_mode=False,
            )
```
现在是这样
```
config.enable_tensorrt_engine(
                workspace_size=1024,
                max_batch_size=1,
                min_subgraph_size=0,
                precision_mode=paddle.inference.PrecisionType.Float32,
                use_static=True,
)
```