### PR TITLE
[Dy2St] Move `TypeHintTransformer` ahead of `IfElseTransformer`

### DIFF
--- a/python/paddle/jit/dy2static/transformers/transform.py
+++ b/python/paddle/jit/dy2static/transformers/transform.py
@@ -92,7 +92,7 @@ class DygraphToStaticAst(BaseTransformer):
         self.visit(node)
 
         transformers = [
-            TypeHintTransformer,  # remove all typehint in gast.Name
+            TypeHintTransformer,  # remove all typehint
             RegisterHookTransformer,
             EarlyReturnTransformer,
             AttributeJstTransformer,  # Tensor.size -> Tensor.size(), it's unnecessary in PIR mode

--- a/python/paddle/jit/dy2static/transformers/transform.py
+++ b/python/paddle/jit/dy2static/transformers/transform.py
@@ -92,6 +92,7 @@ class DygraphToStaticAst(BaseTransformer):
         self.visit(node)
 
         transformers = [
+            TypeHintTransformer,  # remove all typehint in gast.Name
             RegisterHookTransformer,
             EarlyReturnTransformer,
             AttributeJstTransformer,  # Tensor.size -> Tensor.size(), it's unnecessary in PIR mode
@@ -107,7 +108,6 @@ class DygraphToStaticAst(BaseTransformer):
             CastTransformer,  # type casting statement
             DecoratorTransformer,  # transform decorators to function call
             NameloadJstTransformer,
-            TypeHintTransformer,  # remove all typehint in gast.Name
         ]
 
         apply_optimization(transformers)

--- a/python/paddle/jit/dy2static/transformers/typehint_transformer.py
+++ b/python/paddle/jit/dy2static/transformers/typehint_transformer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from paddle.utils import gast
+
 from .base import BaseTransformer
 
 __all__ = []
@@ -39,3 +41,9 @@ class TypeHintTransformer(BaseTransformer):
         node.annotation = None
         self.generic_visit(node)
         return node
+
+    def visit_AnnAssign(self, node):
+        if node.value is None:
+            return None
+        assign_node = gast.Assign(targets=[node.target], value=node.value)
+        return assign_node

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -23,9 +23,6 @@ from dygraph_to_static_utils import (
 
 import paddle
 
-SEED = 2020
-np.random.seed(SEED)
-
 
 class A:
     pass

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from typing import List
 
 import numpy as np
 from dygraph_to_static_utils import (
@@ -35,13 +36,25 @@ def function(x: A) -> A:
     return 2 * x
 
 
-class TestTypeHint(Dy2StTestBase):
+def fn_annotation_assign_with_value(x: paddle.Tensor):
+    if x:
+        y: List["paddle.Tensor"] = [x + 1]
+    else:
+        y: List["paddle.Tensor"] = [x - 1]
+    return y
+
+
+def fn_annotation_assign_without_value(x: paddle.Tensor):
+    if x:
+        y: List["paddle.Tensor"]
+        y = [x + 1]
+    else:
+        y = [x - 1]
+    return y
+
+
+class TestTypeHints(Dy2StTestBase):
     def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
         self.x = np.zeros(shape=(1), dtype=np.int32)
         self._init_dyfunc()
 
@@ -70,8 +83,28 @@ class TestTypeHint(Dy2StTestBase):
     def test_ast_to_func(self):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
-        print(static_numpy, dygraph_numpy)
         np.testing.assert_allclose(dygraph_numpy, static_numpy, rtol=1e-05)
+
+
+class TestAnnAssign(Dy2StTestBase):
+    def assert_fn_dygraph_and_static_unified(self, dygraph_fn, x):
+        static_fn = paddle.jit.to_static(fn_annotation_assign_with_value)
+        dygraph_fn = dygraph_fn
+        static_res = static_fn(x)
+        dygraph_res = dygraph_fn(x)
+        np.testing.assert_allclose(dygraph_res, static_res, rtol=1e-05)
+
+    @test_legacy_and_pt_and_pir
+    def test_ann_assign_with_value(self):
+        self.assert_fn_dygraph_and_static_unified(
+            fn_annotation_assign_with_value, paddle.to_tensor(1)
+        )
+
+    @test_legacy_and_pt_and_pir
+    def test_ann_assign_without_value(self):
+        self.assert_fn_dygraph_and_static_unified(
+            fn_annotation_assign_without_value, paddle.to_tensor(1)
+        )
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_typehint.py
+++ b/test/dygraph_to_static/test_typehint.py
@@ -85,7 +85,7 @@ class TestTypeHints(Dy2StTestBase):
 
 class TestAnnAssign(Dy2StTestBase):
     def assert_fn_dygraph_and_static_unified(self, dygraph_fn, x):
-        static_fn = paddle.jit.to_static(fn_annotation_assign_with_value)
+        static_fn = paddle.jit.to_static(dygraph_fn)
         dygraph_fn = dygraph_fn
         static_res = static_fn(x)
         dygraph_res = dygraph_fn(x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复 AST 动转静 IfElseTransformer 转写后将含类型注释的变量变为 nonlocal 变量而导致 SyntaxError 的问题，问题源自 https://github.com/PaddlePaddle/PaddleScience/pull/815#issue-2199045572

cc @HydrogenSulfate

比如

```python
paddle-py310 ❯ TRANSLATOR_VERBOSITY=1 TRANSLATOR_CODE_LEVEL=16 python test.py
Fri Mar 22 06:32:15 Dynamic-to-Static INFO: (Level 1) Source code: 
@paddle.jit.to_static(full_graph=True)
def foo(x: paddle.Tensor):
    if x:
        y: List['paddle.Tensor'] = x + 1
    else:
        y: List['paddle.Tensor'] = x - 1
    return y
Fri Mar 22 06:32:15 Dynamic-to-Static INFO: After the level 16 ast transformer: 'TypeHintTransformer', the transformed code:
def foo(x):
    y = _jst.UndefinedVar('y')
    __return_0 = False
    __return_value_0 = None

    def get_args_0():
        nonlocal y
        return (_jst.Ld(y),)

    def set_args_0(__args):
        nonlocal y
        (y,) = _jst.Ld(__args)

    def true_fn_0():
        nonlocal y
        y: _jst.Ld(_jst.Ld(List)['paddle.Tensor']) = _jst.Ld(x) + 1
        return

    def false_fn_0():
        nonlocal y
        y: _jst.Ld(_jst.Ld(List)['paddle.Tensor']) = _jst.Ld(x) - 1
        return
    _jst.IfElse(_jst.Ld(x), _jst.Ld(true_fn_0), _jst.Ld(false_fn_0), _jst.Ld(get_args_0), _jst.Ld(set_args_0), ('y',), push_pop_names=None)
    __return_value_0 = _jst.Ld(y)
    return _jst.Ld(__return_value_0)
Fri Mar 22 06:32:15 Dynamic-to-Static WARNING: Please file an issue at 'https://github.com/PaddlePaddle/Paddle/issues' if you can't handle this <class 'SyntaxError'> yourself.
Traceback (most recent call last):
  File "/workspace/Paddle/test.py", line 39, in <module>
    foo(paddle.to_tensor(1))
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 502, in __call__
    return self._perform_call(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 825, in _perform_call
    raise e
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 794, in _perform_call
    _, partial_program_layer = self.get_concrete_program(
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 876, in get_concrete_program
    concrete_program, partial_program_layer = self._program_cache[
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 1685, in __getitem__
    self._caches[item_id] = self._build_once(item)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 1610, in _build_once
    concrete_program = ConcreteProgram.from_func_spec(
  File "/home/nyakku/mambaforge/envs/paddle-py310/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/workspace/Paddle/build/python/paddle/base/wrapped_decorator.py", line 26, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/base/dygraph/base.py", line 66, in __impl__
    return func(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 1292, in from_func_spec
    static_func = convert_to_static(dygraph_function)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 188, in convert_to_static
    static_func = _FUNCTION_CACHE.convert_with_cache(function)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 113, in convert_with_cache
    static_func = self._convert(func)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/program_translator.py", line 153, in _convert
    static_func, file_name = ast_to_func(root, func)
  File "/workspace/Paddle/build/python/paddle/jit/dy2static/utils.py", line 320, in ast_to_func
    loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/nyakku/.cache/paddle/to_static_tmp/27002/foom17kuuup.py", line 24
    y: _jst.Ld(_jst.Ld(List)['paddle.Tensor']) = _jst.Ld(x) + 1
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: annotated name 'y' can't be nonlocal
```

原来 `y` 转写后变成了 nonlocal 变量，而 nonlocal 变量是不允许加类型注释的

因此将 `TypeHintTransformer` 从最后一个移到最前面，并添加了 `AnnAssign` 的处理（同样是删除 annotation，变成普通的 `Assgin` node）

PCard-66972