### PR TITLE
[XPU] add useless pad op when padding all zero to identity_op pass;

### DIFF
--- a/paddle/fluid/framework/ir/identity_op_clean_pass.cc
+++ b/paddle/fluid/framework/ir/identity_op_clean_pass.cc
@@ -78,6 +78,21 @@ FindUselessOpPattern::FindUselessOpPattern(PDPattern* pattern,
               return in_name == out_name;
             } else if (op_type == "concat") {
               return x->Op()->Input("X").size() == 1;
+            } else if (op_type == "pad3d") {
+              if (x->Op()->HasAttr("paddings", true)) {
+                if (x->Op()->GetAttrType("paddings", true) ==
+                    proto::AttrType::INT) {
+                  return x->Op()->GetAttrIfExists<int>("paddings") == 0;
+                } else if (x->Op()->GetAttrType("paddings", true) ==
+                           proto::AttrType::INTS) {
+                  const auto ints =
+                      x->Op()->GetAttrIfExists<std::vector<int>>("paddings");
+                  for (const auto x : ints) {
+                    if (x) return false;
+                  }
+                  return true;
+                }
+              }
             }
             // you can add more cases here.
             return false;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
删除无效的pad3d op, 如果padding参数都是0, 是一个无效op