### PR TITLE
【Hackathon 6th No. 27】为 paddle.io.RandomSampler/random_split /Layer.clear_gradients 进行功能增强 -part

### DIFF
--- a/python/paddle/io/dataloader/dataset.py
+++ b/python/paddle/io/dataloader/dataset.py
@@ -489,7 +489,7 @@ def random_split(dataset, lengths, generator=None):
 
     Args:
         dataset (Dataset): Dataset to be split
-        lengths (sequence): lengths of splits to be produced
+        lengths (sequence): lengths or fractions of splits to be produced
         generator (Generator, optional): Generator used for the random permutation. Default is None then the DefaultGenerator is used in manual_seed().
 
     Returns:

--- a/python/paddle/io/dataloader/dataset.py
+++ b/python/paddle/io/dataloader/dataset.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import bisect
+import math
+import warnings
 from typing import Iterable
 
 import paddle
@@ -522,6 +524,28 @@ def random_split(dataset, lengths, generator=None):
             5 3
             6 8
     """
+    if math.isclose(sum(lengths), 1) and sum(lengths) <= 1:
+        subset_lengths = []
+        for i, frac in enumerate(lengths):
+            if frac < 0 or frac > 1:
+                raise ValueError(
+                    f"Fraction at index {i} is not between 0 and 1"
+                )
+            n_items_in_split = int(math.floor(len(dataset) * frac))
+            subset_lengths.append(n_items_in_split)
+        remainder = len(dataset) - sum(subset_lengths)
+
+        for i in range(remainder):
+            idx_to_add_at = i % len(subset_lengths)
+            subset_lengths[idx_to_add_at] += 1
+        lengths = subset_lengths
+        for i, length in enumerate(lengths):
+            if length == 0:
+                warnings.warn(
+                    f"Length of split at index {i} is 0. "
+                    f"This might result in an empty dataset."
+                )
+
     # Cannot verify that dataset is Sized
     if sum(lengths) != len(dataset):  # type: ignore
         raise ValueError(

--- a/python/paddle/io/dataloader/sampler.py
+++ b/python/paddle/io/dataloader/sampler.py
@@ -215,10 +215,10 @@ class RandomSampler(Sampler):
                 f"replacement={self.replacement}"
             )
 
-        if not self.replacement and self._num_samples > len(self.data_source):
+        if not self.replacement and self.num_samples > len(self.data_source):
             raise ValueError(
                 "num_samples should be smaller than or equal to length of data_source when replacement is False, "
-                f"but got num_samples: {self._num_samples} > data_source: {len(self.data_source)}"
+                f"but got num_samples: {self.num_samples} > data_source: {len(self.data_source)}"
             )
 
         if not isinstance(self.num_samples, int) or self.num_samples <= 0:

--- a/python/paddle/io/dataloader/sampler.py
+++ b/python/paddle/io/dataloader/sampler.py
@@ -215,6 +215,12 @@ class RandomSampler(Sampler):
                 f"replacement={self.replacement}"
             )
 
+        if not self.replacement and self._num_samples > len(self.data_source):
+            raise ValueError(
+                "num_samples should be smaller than or equal to length of data_source when replacement is False, "
+                f"but got num_samples: {self._num_samples} > data_source: {len(self.data_source)}"
+            )
+
         if not isinstance(self.num_samples, int) or self.num_samples <= 0:
             raise ValueError(
                 "num_samples should be a positive integer, "
@@ -243,13 +249,8 @@ class RandomSampler(Sampler):
                 ).tolist():
                     yield index
             else:
-                for _ in range(self.num_samples // n):
-                    for index in np.random.choice(
-                        np.arange(n), n, replace=False
-                    ).tolist():
-                        yield index
                 for index in np.random.choice(
-                    np.arange(n), self.num_samples % n, replace=False
+                    np.arange(n), self.num_samples, replace=False
                 ).tolist():
                     yield index
 

--- a/python/paddle/io/dataloader/sampler.py
+++ b/python/paddle/io/dataloader/sampler.py
@@ -160,11 +160,7 @@ class RandomSampler(Sampler):
                 object which implemented :code:`__len__` to get indices as the range of :code:`dataset` length. Default None.
         replacement(bool, optional): If False, sample the whole dataset, If True,
                 set :attr:`num_samples` for how many samples to draw. Default False.
-        num_samples(int, optional): Set sample number to draw. If :attr:`replacement`
-                is True, it will take samples according to the number you set. If
-                :attr:`replacement` is False, then it will yield randonly permutated
-                indices of the whohle dataset for :code:`num_samples//len(data_source)`
-                times and then yield indices without replacement for :code:`num_samples % len(data_source)` times. Default None.
+        num_samples(int, optional): set sample number to draw. Default None.
         generator(Generator, optional): specify a generator to sample the :code:`data_source`. Default None, disabled.
 
     Returns:

--- a/python/paddle/io/dataloader/sampler.py
+++ b/python/paddle/io/dataloader/sampler.py
@@ -160,7 +160,7 @@ class RandomSampler(Sampler):
                 object which implemented :code:`__len__` to get indices as the range of :code:`dataset` length. Default None.
         replacement(bool, optional): If False, sample the whole dataset, If True,
                 set :attr:`num_samples` for how many samples to draw. Default False.
-        num_samples(int, optional): set sample number to draw. Default None.
+        num_samples(int, optional): set sample number to draw. Default None, which is set to the length of `data_source`.
         generator(Generator, optional): specify a generator to sample the :code:`data_source`. Default None, disabled.
 
     Returns:

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -1349,9 +1349,13 @@ class Layer:
                 name = layer_prefix + ('.' if layer_prefix else '') + key
                 yield name, buffer
 
-    def clear_gradients(self):
+    def clear_gradients(self, set_to_zero=True):
         """
         Clear the gradients of all parameters for this layer.
+
+        Args:
+            set_to_zero (bool, optional): Whether to set the trainable parameters'
+                gradients to zero or None. Default is True.
 
         Returns:
             None
@@ -1375,7 +1379,7 @@ class Layer:
         """
         for p in self.parameters():
             if p.trainable:
-                p.clear_gradient()
+                p.clear_gradient(set_to_zero)
 
     def _build_once(self, *args, **kwargs):
         pass

--- a/test/legacy_test/test_batch_sampler.py
+++ b/test/legacy_test/test_batch_sampler.py
@@ -87,6 +87,16 @@ class TestRandomSampler(unittest.TestCase):
             rets.append(i)
             assert i >= 0 and i < 100
 
+    def test_with_num_samples_and_without_replacement(self):
+        dataset = RandomDataset(100, 10)
+        sampler = RandomSampler(dataset, num_samples=150, replacement=False)
+        assert len(sampler) == 150
+
+        rets = []
+        for i in iter(sampler):
+            rets.append(i)
+            assert i >= 0 and i < 100
+
     def test_with_generator(self):
         dataset = RandomDataset(100, 10)
         generator = iter(range(0, 60))

--- a/test/legacy_test/test_batch_sampler.py
+++ b/test/legacy_test/test_batch_sampler.py
@@ -89,8 +89,8 @@ class TestRandomSampler(unittest.TestCase):
 
     def test_with_num_samples_and_without_replacement(self):
         dataset = RandomDataset(100, 10)
-        sampler = RandomSampler(dataset, num_samples=150, replacement=False)
-        assert len(sampler) == 150
+        sampler = RandomSampler(dataset, num_samples=80, replacement=False)
+        assert len(sampler) == 80
 
         rets = []
         for i in iter(sampler):
@@ -120,6 +120,10 @@ class TestRandomSampler(unittest.TestCase):
         for i in iter(sampler):
             rets.append(i)
         assert tuple(sorted(rets)) == tuple(range(0, 50))
+
+    def test_with_num_samples_error(self):
+        dataset = RandomDataset(100, 10)
+        self.assertRaises(ValueError, RandomSampler, dataset, False, 120)
 
 
 class TestSubsetRandomSampler(unittest.TestCase):

--- a/test/legacy_test/test_dataloader_dataset.py
+++ b/test/legacy_test/test_dataloader_dataset.py
@@ -89,5 +89,34 @@ class TestDatasetWithDiffOutputPlace(unittest.TestCase):
                     break
 
 
+class TestRandomSplitApi(unittest.TestCase):
+    def test_main(self):
+        paddle.seed(1)
+
+        dataset1, dataset2, dataset3 = paddle.io.random_split(
+            range(5), [0.3, 0.0, 0.7]
+        )
+
+        self.assertTrue(len(dataset1) == 2)
+        self.assertTrue(len(dataset2) == 0)
+        self.assertTrue(len(dataset3) == 3)
+
+        elements_list = list(range(5))
+
+        for _, val in enumerate(dataset1):
+            elements_list.remove(val)
+
+        for _, val in enumerate(dataset3):
+            elements_list.remove(val)
+
+        self.assertTrue(len(elements_list) == 0)
+
+    def test_errors(self):
+        paddle.seed(1)
+        self.assertRaises(
+            ValueError, paddle.io.random_split, range(5), [-0.2, 1.2]
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -2465,6 +2465,28 @@ class TestExcludedLayersSupportBool(unittest.TestCase):
             self.assertTrue(model._linear.weight.dtype == paddle.float32)
 
 
+class TestLayerClearGradientSetToZero(unittest.TestCase):
+    def test_layer_clear_gradient_set_to_zero_true(self):
+        with base.dygraph.guard():
+            net = MyLayer()
+            inputs = paddle.randn([10, 1])
+            outputs = net(inputs)
+            outputs.backward()
+            net.clear_gradients()
+            self.assertTrue(
+                net._linear.weight.grad.numpy() == np.array([[0.0]])
+            )
+
+    def test_layer_clear_gradient_set_to_zero_false(self):
+        with base.dygraph.guard():
+            net = MyLayer()
+            inputs = paddle.randn([10, 1])
+            outputs = net(inputs)
+            outputs.backward()
+            net.clear_gradients(set_to_zero=False)
+            self.assertTrue(net._linear.weight.grad is None)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_multiprocess_dataloader_dataset.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dataset.py
@@ -133,36 +133,26 @@ class TestRandomSplitApi(unittest.TestCase):
 
         self.assertTrue(len(elements_list) == 0)
 
-
-class TestRandomSplitApi2(unittest.TestCase):
-    def run_main(self, places):
+    def test_fraction(self):
         paddle.seed(1)
-        place = paddle.CPUPlace()
-        with base.dygraph.guard(place):
-            dataset1, dataset2, dataset3 = paddle.io.random_split(
-                range(5), [0.3, 0.0, 0.7]
-            )
 
-            self.assertTrue(len(dataset1) == 2)
-            self.assertTrue(len(dataset2) == 0)
-            self.assertTrue(len(dataset3) == 3)
+        dataset1, dataset2, dataset3 = paddle.io.random_split(
+            range(5), [0.3, 0.0, 0.7]
+        )
 
-            elements_list = list(range(5))
+        self.assertTrue(len(dataset1) == 2)
+        self.assertTrue(len(dataset2) == 0)
+        self.assertTrue(len(dataset3) == 3)
 
-            for _, val in enumerate(dataset1):
-                elements_list.remove(val)
+        elements_list = list(range(5))
 
-            for _, val in enumerate(dataset3):
-                elements_list.remove(val)
+        for _, val in enumerate(dataset1):
+            elements_list.remove(val)
 
-            self.assertTrue(len(elements_list) == 0)
+        for _, val in enumerate(dataset3):
+            elements_list.remove(val)
 
-    def test_main(self):
-        places = [paddle.CPUPlace()]
-        if paddle.is_compiled_with_cuda():
-            places.append(paddle.CUDAPlace(0))
-        for p in places:
-            self.run_main(places=p)
+        self.assertTrue(len(elements_list) == 0)
 
 
 class TestRandomSplitError(unittest.TestCase):

--- a/test/legacy_test/test_multiprocess_dataloader_dataset.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dataset.py
@@ -134,6 +134,26 @@ class TestRandomSplitApi(unittest.TestCase):
         self.assertTrue(len(elements_list) == 0)
 
 
+class TestRandomSplitApi2(unittest.TestCase):
+    def test_main(self):
+        paddle.seed(1)
+
+        dataset1, dataset2 = paddle.io.random_split(range(5), [0.3, 0.0, 0.7])
+
+        self.assertTrue(len(dataset1) == 2)
+        self.assertTrue(len(dataset2) == 3)
+
+        elements_list = list(range(5))
+
+        for _, val in enumerate(dataset1):
+            elements_list.remove(val)
+
+        for _, val in enumerate(dataset2):
+            elements_list.remove(val)
+
+        self.assertTrue(len(elements_list) == 0)
+
+
 class TestRandomSplitError(unittest.TestCase):
     def test_errors(self):
         paddle.seed(1)
@@ -141,6 +161,9 @@ class TestRandomSplitError(unittest.TestCase):
         self.assertRaises(ValueError, paddle.io.random_split, range(5), [3, 8])
         self.assertRaises(ValueError, paddle.io.random_split, range(5), [8])
         self.assertRaises(ValueError, paddle.io.random_split, range(5), [])
+        self.assertRaises(
+            ValueError, paddle.io.random_split, range(5), [-0.2, 1.2]
+        )
 
 
 class TestSubsetDataset(unittest.TestCase):

--- a/test/legacy_test/test_multiprocess_dataloader_dataset.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dataset.py
@@ -138,17 +138,20 @@ class TestRandomSplitApi2(unittest.TestCase):
     def test_main(self):
         paddle.seed(1)
 
-        dataset1, dataset2 = paddle.io.random_split(range(5), [0.3, 0.0, 0.7])
+        dataset1, dataset2, dataset3 = paddle.io.random_split(
+            range(5), [0.3, 0.0, 0.7]
+        )
 
         self.assertTrue(len(dataset1) == 2)
-        self.assertTrue(len(dataset2) == 3)
+        self.assertTrue(len(dataset2) == 0)
+        self.assertTrue(len(dataset3) == 3)
 
         elements_list = list(range(5))
 
         for _, val in enumerate(dataset1):
             elements_list.remove(val)
 
-        for _, val in enumerate(dataset2):
+        for _, val in enumerate(dataset3):
             elements_list.remove(val)
 
         self.assertTrue(len(elements_list) == 0)

--- a/test/legacy_test/test_multiprocess_dataloader_dataset.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dataset.py
@@ -135,26 +135,34 @@ class TestRandomSplitApi(unittest.TestCase):
 
 
 class TestRandomSplitApi2(unittest.TestCase):
-    def test_main(self):
+    def run_main(self, places):
         paddle.seed(1)
+        place = paddle.CPUPlace()
+        with base.dygraph.guard(place):
+            dataset1, dataset2, dataset3 = paddle.io.random_split(
+                range(5), [0.3, 0.0, 0.7]
+            )
 
-        dataset1, dataset2, dataset3 = paddle.io.random_split(
-            range(5), [0.3, 0.0, 0.7]
-        )
+            self.assertTrue(len(dataset1) == 2)
+            self.assertTrue(len(dataset2) == 0)
+            self.assertTrue(len(dataset3) == 3)
 
-        self.assertTrue(len(dataset1) == 2)
-        self.assertTrue(len(dataset2) == 0)
-        self.assertTrue(len(dataset3) == 3)
+            elements_list = list(range(5))
 
-        elements_list = list(range(5))
+            for _, val in enumerate(dataset1):
+                elements_list.remove(val)
 
-        for _, val in enumerate(dataset1):
-            elements_list.remove(val)
+            for _, val in enumerate(dataset3):
+                elements_list.remove(val)
 
-        for _, val in enumerate(dataset3):
-            elements_list.remove(val)
+            self.assertTrue(len(elements_list) == 0)
 
-        self.assertTrue(len(elements_list) == 0)
+    def test_main(self):
+        places = [paddle.CPUPlace()]
+        if paddle.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for p in places:
+            self.run_main(places=p)
 
 
 class TestRandomSplitError(unittest.TestCase):

--- a/test/legacy_test/test_multiprocess_dataloader_dataset.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dataset.py
@@ -133,27 +133,6 @@ class TestRandomSplitApi(unittest.TestCase):
 
         self.assertTrue(len(elements_list) == 0)
 
-    def test_fraction(self):
-        paddle.seed(1)
-
-        dataset1, dataset2, dataset3 = paddle.io.random_split(
-            range(5), [0.3, 0.0, 0.7]
-        )
-
-        self.assertTrue(len(dataset1) == 2)
-        self.assertTrue(len(dataset2) == 0)
-        self.assertTrue(len(dataset3) == 3)
-
-        elements_list = list(range(5))
-
-        for _, val in enumerate(dataset1):
-            elements_list.remove(val)
-
-        for _, val in enumerate(dataset3):
-            elements_list.remove(val)
-
-        self.assertTrue(len(elements_list) == 0)
-
 
 class TestRandomSplitError(unittest.TestCase):
     def test_errors(self):
@@ -162,9 +141,6 @@ class TestRandomSplitError(unittest.TestCase):
         self.assertRaises(ValueError, paddle.io.random_split, range(5), [3, 8])
         self.assertRaises(ValueError, paddle.io.random_split, range(5), [8])
         self.assertRaises(ValueError, paddle.io.random_split, range(5), [])
-        self.assertRaises(
-            ValueError, paddle.io.random_split, range(5), [-0.2, 1.2]
-        )
 
 
 class TestSubsetDataset(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1. paddle.io.RandomSampler 当参数 replacement = False 时，改为允许指定 num_samples，改法参考 pytorch：https://github.com/pytorch/pytorch/blob/main/torch/utils/data/sampler.py#L165
2. paddle.io.random_split 的 lengths 参数增加支持比例划分方式。
3. paddle.nn.Layer.clear_gradients 增加 set_to_zero 参数。
