### PR TITLE
Fix paddle_gtest_main_new dependency

### DIFF
--- a/paddle/testing/CMakeLists.txt
+++ b/paddle/testing/CMakeLists.txt
@@ -20,10 +20,26 @@ if(WITH_TESTING)
     SRCS paddle_gtest_main.cc
     DEPS ${paddle_gtest_main_deps})
 
-  cc_library(
-    paddle_gtest_main_new
-    SRCS paddle_gtest_main.cc
-    DEPS gtest xxhash framework_proto eigen3 dlpack)
+  if(LINUX)
+    cc_library(
+      paddle_gtest_main_new
+      SRCS paddle_gtest_main.cc
+      DEPS gtest
+           xxhash
+           framework_proto
+           eigen3
+           dlpack
+           common
+           init
+           allocator
+           phi_utils)
+  else()
+    cc_library(
+      paddle_gtest_main_new
+      SRCS paddle_gtest_main.cc
+      DEPS gtest xxhash framework_proto eigen3 dlpack)
+  endif()
+
   if(WITH_MKLDNN)
     add_dependencies(paddle_gtest_main_new mkldnn)
   endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Ubuntu 22.04.2 Linux环境下
修改开启WITH_TESTING时，paddle_gtest_main_new少链接库错误
![image](https://github.com/PaddlePaddle/Paddle/assets/4617245/c3a987ea-a366-490c-b2f7-b536945747f3)