### PR TITLE
【PIR OpTest Fix No.22】 fix test_elementwise_sub_op

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -3260,11 +3260,13 @@
     strided_slice_grad : GetStridedSliceGradExpectedKernelType
 
 - op : subtract (elementwise_sub)
-  backward : subtract_grad (elementwise_sub_grad)
+  backward : subtract_grad (elementwise_sub_grad), subtract_double_grad (elementwise_sub_grad_grad)
   inputs :
     {x : X, y: Y}
   outputs :
-    out : Out
+    {out : Out}
+  attrs :
+    {scale_x : Scale_x, scale_y : Scale_y, scale_out : Scale_out}
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32",
              bool use_quantizer = false, float Scale_x = 1.0f, float Scale_y = 1.0f, float Scale_out = 1.0f]

--- a/test/legacy_test/test_elementwise_sub_op.py
+++ b/test/legacy_test/test_elementwise_sub_op.py
@@ -879,10 +879,10 @@ class TestComplexElementwiseSubOp(OpTest):
 
 class TestRealComplexElementwiseSubOp(TestComplexElementwiseSubOp):
     def init_input_output(self):
-        self.x = np.random.random(self.shape).astype(self.dtype)
-        self.y = np.random.random(self.shape).astype(
+        self.x = np.random.random(self.shape).astype(
             self.dtype
         ) + 1j * np.random.random(self.shape).astype(self.dtype)
+        self.y = np.random.random(self.shape).astype(self.dtype)
         self.out = self.x - self.y
 
     def if_enable_cinn(self):

--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -91,6 +91,7 @@ test_elementwise_min_op
 test_elementwise_mod_op
 test_elementwise_mul_op
 test_elementwise_pow_op
+test_elementwise_sub_op
 test_empty_op
 test_erf_op
 test_erfinv_op


### PR DESCRIPTION
### PR Category
 Others

### PR Types
Others

### Description

PIR Op单测修复
修复单测 `test_elementwise_sub_op`
修复后打开`FLAGS_enable_pir_in_executor`单测是否通过：是

报错函数：
```c++
template <typename T>
T* DenseTensor::data() {
  T* ret = static_cast<T*>(data());
  PADDLE_ENFORCE_EQ(
      dtype(),
      phi::CppTypeToDataType<T>::Type(),
      phi::errors::InvalidArgument(
          "The type of data we are trying to retrieve (%s) does not match the "
          "type of data (%s) currently contained in the container.",
          phi::CppTypeToDataType<T>::Type(),
          dtype()));
  return ret;
}
```

报错信息：
![1711255588324](https://github.com/PaddlePaddle/Paddle/assets/81598289/9ea08966-46b1-4a4a-8dd3-e7a1a76467b0)
这里的错误为type not match错误，错误发生在处理输出类型为complex128时的，但比较奇怪的点有以下几点：
- 打印前后计算图对比发现前后类型命名一致，选择的都是element_sub_grad kernel
- elementwise_sub_op和elementwise_add_op等一系列elementwise_op在ops.yaml和backward.yaml已有定义好的前向反向op，且使用的是相同的正向反向infermeta，但add在complex未出现错误，sub出现错误。
- 直接注释掉报错的PADDLE_ENFORCE_EQ后再次进行测试，发现单侧完全可以通过

疑问：
- 此处代码应该是想对原始data进行转换，将原本的data强转为对应的c++格式，问题出现在该tensor的期望形式和要强转到的c++形式不一样，但因为这个函数名字比较大众，所以我实在找不到是在哪里调的这个函数，想请教一下paddle是否有打印c++完整错误栈的方式，或者说这个强制转换可能会发生在哪里，然后我再继续调一下这个函数。
