### PR TITLE
【PIR OpTest Fix No.29】 fix test_coalesce_tensor_op

### DIFF
--- a/test/white_list/pir_op_test_white_list
+++ b/test/white_list/pir_op_test_white_list
@@ -42,6 +42,7 @@ test_class_center_sample_op
 test_clip_by_norm_op
 test_clip_mkldnn_op
 test_clip_op
+test_coalesce_tensor_op
 test_compare_op
 test_compare_reduce_op
 test_complex_abs


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

PIR Op单测修复
修复单测 `test_coalesce_tensor_op`
修复后打开`FLAGS_enable_pir_in_executor`单测是否通过：是
未修改就能通过单侧，只做了补充到白名单中