### PR TITLE
[CINN] Add insert broadcast for some logical ops

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/insert_broadcast_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/insert_broadcast_pass.cc
@@ -112,6 +112,11 @@ class InsertBroadcastPass : public pir::PatternRewritePass {
     ps.Add<InsertBroadcastPattern<paddle::dialect::GreaterThanOp>>(context);
     ps.Add<InsertBroadcastPattern<paddle::dialect::GreaterEqualOp>>(context);
 
+    // logical ops
+    ps.Add<InsertBroadcastPattern<paddle::dialect::LogicalAndOp>>(context);
+    ps.Add<InsertBroadcastPattern<paddle::dialect::LogicalOrOp>>(context);
+    ps.Add<InsertBroadcastPattern<paddle::dialect::LogicalXorOp>>(context);
+
     // bitwise ops
     ps.Add<InsertBroadcastPattern<paddle::dialect::BitwiseOrOp>>(context);
     ps.Add<InsertBroadcastPattern<paddle::dialect::BitwiseXorOp>>(context);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

为 logical 二元算子添加自动插入 broadcast 算子支持。