### PR TITLE
【Hackathon 6th No.29】为 paddle.nn.functional.max_unpool1d / max_unpool2d / max_unpool3d/paddle.nn.functional.kl_div 进行功能增强

### DIFF
--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -1265,8 +1265,8 @@
     func : inverse_grad
 
 - backward_op : kldiv_loss_grad
-  forward : kldiv_loss(Tensor x, Tensor label, str reduction="mean") -> Tensor(out)
-  args : (Tensor x, Tensor label, Tensor out_grad, str reduction)
+  forward : kldiv_loss(Tensor x, Tensor label, str reduction="mean", bool log_target = false) -> Tensor(out)
+  args : (Tensor x, Tensor label, Tensor out_grad, str reduction, bool log_target)
   output : Tensor(x_grad)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -1534,7 +1534,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : kldiv_loss
-  args : (Tensor x, Tensor label, str reduction = "mean")
+  args : (Tensor x, Tensor label, str reduction = "mean", bool log_target = false)
   output : Tensor(out)
   infer_meta :
     func : KLDivInferMeta

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -98,6 +98,7 @@ void AllValueCompareInferMeta(const MetaTensor& x,
 void KLDivInferMeta(const MetaTensor& x,
                     const MetaTensor& label,
                     const std::string& reduction,
+                    bool log_target,
                     MetaTensor* out,
                     MetaConfig config) {
   auto dim_x = x.dims();

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -42,6 +42,7 @@ void AllValueCompareInferMeta(const MetaTensor& x,
 void KLDivInferMeta(const MetaTensor& x,
                     const MetaTensor& label,
                     const std::string& reduction,
+                    bool log_target,
                     MetaTensor* out,
                     MetaConfig config = MetaConfig());
 

--- a/paddle/phi/kernels/cpu/unpool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/unpool_grad_kernel.cc
@@ -130,8 +130,18 @@ void Unpool3dGradKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    unpool_grad, CPU, ALL_LAYOUT, phi::UnpoolGradKernel, float, double) {}
+PD_REGISTER_KERNEL(unpool_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::UnpoolGradKernel,
+                   float,
+                   double,
+                   int64_t) {}
 
-PD_REGISTER_KERNEL(
-    unpool3d_grad, CPU, ALL_LAYOUT, phi::Unpool3dGradKernel, float, double) {}
+PD_REGISTER_KERNEL(unpool3d_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::Unpool3dGradKernel,
+                   float,
+                   double,
+                   int64_t) {}

--- a/paddle/phi/kernels/cpu/unpool_kernel.cc
+++ b/paddle/phi/kernels/cpu/unpool_kernel.cc
@@ -126,7 +126,8 @@ void Unpool3dKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(unpool, CPU, ALL_LAYOUT, phi::UnpoolKernel, float, double) {}
+PD_REGISTER_KERNEL(
+    unpool, CPU, ALL_LAYOUT, phi::UnpoolKernel, float, double, int64_t) {}
 
 PD_REGISTER_KERNEL(
-    unpool3d, CPU, ALL_LAYOUT, phi::Unpool3dKernel, float, double) {}
+    unpool3d, CPU, ALL_LAYOUT, phi::Unpool3dKernel, float, double, int64_t) {}

--- a/paddle/phi/kernels/gpu/unpool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/unpool_grad_kernel.cu
@@ -188,8 +188,18 @@ void Unpool3dGradKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    unpool_grad, GPU, ALL_LAYOUT, phi::UnpoolGradKernel, float, double) {}
+PD_REGISTER_KERNEL(unpool_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::UnpoolGradKernel,
+                   float,
+                   double,
+                   int64_t) {}
 
-PD_REGISTER_KERNEL(
-    unpool3d_grad, GPU, ALL_LAYOUT, phi::Unpool3dGradKernel, float, double) {}
+PD_REGISTER_KERNEL(unpool3d_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::Unpool3dGradKernel,
+                   float,
+                   double,
+                   int64_t) {}

--- a/paddle/phi/kernels/gpu/unpool_kernel.cu
+++ b/paddle/phi/kernels/gpu/unpool_kernel.cu
@@ -173,7 +173,13 @@ void Unpool3dKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    unpool, GPU, ALL_LAYOUT, phi::UnpoolKernel, int, float, double) {}
+    unpool, GPU, ALL_LAYOUT, phi::UnpoolKernel, int, float, double, int64_t) {}
 
-PD_REGISTER_KERNEL(
-    unpool3d, GPU, ALL_LAYOUT, phi::Unpool3dKernel, int, float, double) {}
+PD_REGISTER_KERNEL(unpool3d,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::Unpool3dKernel,
+                   int,
+                   float,
+                   double,
+                   int64_t) {}

--- a/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
@@ -23,7 +23,7 @@ namespace phi {
 using Array1 = Eigen::DSizes<int64_t, 1>;
 template <typename T>
 struct KLDivLossBackward {
-  HOSTDEVICE bool LogTarget = false;
+  bool LogTarget = false;
 
   HOSTDEVICE KLDivLossBackward(bool _log_target) : LogTarget(_log_target) {}
 

--- a/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_grad_kernel_impl.h
@@ -23,13 +23,19 @@ namespace phi {
 using Array1 = Eigen::DSizes<int64_t, 1>;
 template <typename T>
 struct KLDivLossBackward {
-  HOSTDEVICE KLDivLossBackward() {}
+  HOSTDEVICE bool LogTarget = false;
+
+  HOSTDEVICE KLDivLossBackward(bool _log_target) : LogTarget(_log_target) {}
 
   HOSTDEVICE T operator()(const T& target, const T& grad) const {
-    if (target <= 0) {
-      return 0;
+    if (LogTarget) {
+      return static_cast<T>(-1.) * std::exp(target) * grad;
     } else {
-      return static_cast<T>(-1.) * grad;
+      if (target <= 0) {
+        return 0;
+      } else {
+        return static_cast<T>(-1.) * target * grad;
+      }
     }
   }
 };
@@ -40,6 +46,7 @@ void KLDivLossGradKernel(const Context& dev_ctx,
                          const DenseTensor& label,
                          const DenseTensor& d_out,
                          const std::string& reduction,
+                         bool log_target,
                          DenseTensor* d_x) {
   auto& place = *dev_ctx.eigen_device();
   auto* target = &label;
@@ -58,9 +65,9 @@ void KLDivLossGradKernel(const Context& dev_ctx,
   auto loss_grad_t = phi::EigenVector<T>::Flatten(*loss_grad);
 
   auto loss_grad_expand = loss_grad_t.broadcast(Array1(expand));
-  auto grad_t = target_t * loss_grad_expand;
+  auto grad_t = loss_grad_expand;
   input_grad_t.device(place) =
-      target_t.binaryExpr(grad_t, KLDivLossBackward<T>());
+      target_t.binaryExpr(grad_t, KLDivLossBackward<T>(log_target));
 
   if ("mean" == reduction) {
     input_grad_t.device(place) = input_grad_t / static_cast<T>(numel);

--- a/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
@@ -24,21 +24,29 @@ namespace phi {
 using Array1 = Eigen::DSizes<int64_t, 1>;
 template <typename T>
 struct KLDivLossForward {
-  HOSTDEVICE KLDivLossForward() {}
+  HOSTDEVICE bool LogTarget = false;
+
+  HOSTDEVICE KLDivLossForward(bool _log_target) : LogTarget(_log_target) {}
 
   HOSTDEVICE T operator()(const T& target, const T& input) const {
-    if (target <= 0) {
-      return 0;
+    if (LogTarget) {
+      return std::exp(target) * (target - input);
     } else {
-      return target * (std::log(target) - input);
+      if (target <= 0) {
+        return 0;
+      } else {
+        return target * (std::log(target) - input);
+      }
     }
   }
 };
+
 template <typename T, typename Context>
 void KLDivLossKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const DenseTensor& label,
                      const std::string& reduction,
+                     bool log_target,
                      DenseTensor* out) {
   auto& place = *(dev_ctx.eigen_device());
   auto* input = &x;
@@ -51,7 +59,7 @@ void KLDivLossKernel(const Context& dev_ctx,
   auto input_t = phi::EigenVector<T>::Flatten(*input);
   auto target_t = phi::EigenVector<T>::Flatten(*target);
   auto loss_t = phi::EigenVector<T>::Flatten(*loss);
-  auto output = target_t.binaryExpr(input_t, KLDivLossForward<T>());
+  auto output = target_t.binaryExpr(input_t, KLDivLossForward<T>(log_target));
   if ("none" == reduction) {
     loss_t.device(place) = output;
   } else if ("batchmean" == reduction) {

--- a/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
+++ b/paddle/phi/kernels/impl/kldiv_loss_kernel_impl.h
@@ -24,7 +24,7 @@ namespace phi {
 using Array1 = Eigen::DSizes<int64_t, 1>;
 template <typename T>
 struct KLDivLossForward {
-  HOSTDEVICE bool LogTarget = false;
+  bool LogTarget = false;
 
   HOSTDEVICE KLDivLossForward(bool _log_target) : LogTarget(_log_target) {}
 

--- a/paddle/phi/kernels/kldiv_loss_grad_kernel.h
+++ b/paddle/phi/kernels/kldiv_loss_grad_kernel.h
@@ -24,5 +24,6 @@ void KLDivLossGradKernel(const Context& dev_ctx,
                          const DenseTensor& label,
                          const DenseTensor& d_out,
                          const std::string& reduction,
+                         bool log_target,
                          DenseTensor* d_x);
 }  // namespace phi

--- a/paddle/phi/kernels/kldiv_loss_kernel.h
+++ b/paddle/phi/kernels/kldiv_loss_kernel.h
@@ -26,5 +26,6 @@ void KLDivLossKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const DenseTensor& label,
                      const std::string& reduction,
+                     bool log_target,
                      DenseTensor* out);
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/kldiv_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/kldiv_loss_grad_kernel.cc
@@ -25,6 +25,7 @@ void KLDivLossGradKernel(const Context& dev_ctx,
                          const DenseTensor& label,
                          const DenseTensor& d_out,
                          const std::string& reduction,
+                         bool log_target,
                          DenseTensor* d_x) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(d_x);

--- a/paddle/phi/kernels/xpu/kldiv_loss_kernel.cc
+++ b/paddle/phi/kernels/xpu/kldiv_loss_kernel.cc
@@ -24,6 +24,7 @@ void KLDivLossKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const DenseTensor& label,
                      const std::string& reduction,
+                     bool log_target,
                      DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   dev_ctx.template Alloc<T>(out);

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1618,7 +1618,7 @@ def poisson_nll_loss(
     return loss_out
 
 
-def kl_div(input, label, reduction='mean', name=None):
+def kl_div(input, label, reduction='mean', log_target=False, name=None):
     r"""
     Calculate the Kullback-Leibler divergence loss
     between Input(X) and Input(Target). Notes that Input(X) is the
@@ -1626,7 +1626,13 @@ def kl_div(input, label, reduction='mean', name=None):
 
     KL divergence loss is calculated as follows:
 
+    If `log_target` is False:
+
     $$l(x, y) = y * (\log(y) - x)$$
+
+    If `log_target` is True:
+
+    $$l(x, y) = \exp(y) * (y - x)$$
 
     Here :math:`x` is input and :math:`y` is label.
 
@@ -1649,6 +1655,7 @@ def kl_div(input, label, reduction='mean', name=None):
             if `reduction` is ``'sum'``, the reduced sum loss is returned;
             if `reduction` is ``'none'``, no reduction will be applied.
             Default is ``'mean'``.
+        log_target (bool, optional): Indicate whether `label` is passed in log space. Default is False.
         name(str, optional): Name for the operation (optional, default is None). For more information,
             please refer to :ref:`api_guide_Name`.
 
@@ -1703,7 +1710,7 @@ def kl_div(input, label, reduction='mean', name=None):
         label = paddle.cast(label, 'float64')
 
     if in_dynamic_or_pir_mode():
-        out = _C_ops.kldiv_loss(input, label, 'none')
+        out = _C_ops.kldiv_loss(input, label, 'none', log_target)
         if reduction == 'mean':
             out = paddle.mean(out)
         elif reduction == 'sum':
@@ -1729,7 +1736,7 @@ def kl_div(input, label, reduction='mean', name=None):
             type='kldiv_loss',
             inputs={'X': input, 'Target': label},
             outputs={'Loss': loss},
-            attrs={'reduction': 'none'},
+            attrs={'reduction': 'none', 'log_target': log_target},
         )
 
         if reduction == 'mean':

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1709,8 +1709,16 @@ def kl_div(input, label, reduction='mean', log_target=False, name=None):
     ):
         label = paddle.cast(label, 'float64')
 
+    compiled_with_xpu = paddle.is_compiled_with_xpu()
+    if compiled_with_xpu:
+        if log_target:
+            label = paddle.exp(label)
+
     if in_dynamic_or_pir_mode():
-        out = _C_ops.kldiv_loss(input, label, 'none', log_target)
+        if compiled_with_xpu:
+            out = _C_ops.kldiv_loss(input, label, 'none')
+        else:
+            out = _C_ops.kldiv_loss(input, label, 'none', log_target)
         if reduction == 'mean':
             out = paddle.mean(out)
         elif reduction == 'sum':
@@ -1732,11 +1740,15 @@ def kl_div(input, label, reduction='mean', log_target=False, name=None):
         base.data_feeder.check_type(reduction, 'reduction', str, 'kl_div')
 
         loss = helper.create_variable_for_type_inference(dtype=input.dtype)
+        if compiled_with_xpu:
+            attrs = {'reduction': 'none'}
+        else:
+            attrs = {'reduction': 'none', 'log_target': log_target}
         helper.append_op(
             type='kldiv_loss',
             inputs={'X': input, 'Target': label},
             outputs={'Loss': loss},
-            attrs={'reduction': 'none', 'log_target': log_target},
+            attrs=attrs,
         )
 
         if reduction == 'mean':

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1709,16 +1709,12 @@ def kl_div(input, label, reduction='mean', log_target=False, name=None):
     ):
         label = paddle.cast(label, 'float64')
 
-    compiled_with_xpu = paddle.is_compiled_with_xpu()
-    if compiled_with_xpu:
+    if paddle.is_compiled_with_xpu():
         if log_target:
             label = paddle.exp(label)
 
     if in_dynamic_or_pir_mode():
-        if compiled_with_xpu:
-            out = _C_ops.kldiv_loss(input, label, 'none')
-        else:
-            out = _C_ops.kldiv_loss(input, label, 'none', log_target)
+        out = _C_ops.kldiv_loss(input, label, 'none', log_target)
         if reduction == 'mean':
             out = paddle.mean(out)
         elif reduction == 'sum':
@@ -1740,15 +1736,11 @@ def kl_div(input, label, reduction='mean', log_target=False, name=None):
         base.data_feeder.check_type(reduction, 'reduction', str, 'kl_div')
 
         loss = helper.create_variable_for_type_inference(dtype=input.dtype)
-        if compiled_with_xpu:
-            attrs = {'reduction': 'none'}
-        else:
-            attrs = {'reduction': 'none', 'log_target': log_target}
         helper.append_op(
             type='kldiv_loss',
             inputs={'X': input, 'Target': label},
             outputs={'Loss': loss},
-            attrs=attrs,
+            attrs={'reduction': 'none', 'log_target': log_target},
         )
 
         if reduction == 'mean':

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -763,7 +763,7 @@ def max_unpool1d(
         x (Tensor): The input tensor of unpooling operator which is a 3-D tensor with
                           shape [N, C, L]. The format of input tensor is `"NCL"`,
                           where `N` is batch size, `C` is the number of channels, `L` is
-                          the length of the feature. The data type is float32 or float64.
+                          the length of the feature. The data type is float32, float64 or int64.
         indices (Tensor): The indices given out by maxpooling1d which is a 3-D tensor with
                           shape [N, C, L]. The format of input tensor is `"NCL"` ,
                           where `N` is batch size, `C` is the number of channels, `L` is
@@ -821,6 +821,8 @@ def max_unpool1d(
     # use 2d to implenment 1d should expand padding in advance.
     padding = _expand_low_nd_padding(padding)
 
+    if output_size is not None:
+        output_size = output_size[:2] + [1] + output_size[2:]
     output_size = _unpool_output_size(
         x, kernel_size, stride, padding, output_size
     )
@@ -871,7 +873,7 @@ def max_unpool2d(
                           shape [N, C, H, W]. The format of input tensor is `"NCHW"`,
                           where `N` is batch size, `C` is the number of channels,
                           `H` is the height of the feature, and `W` is the width of the
-                          feature. The data type if float32 or float64.
+                          feature. The data type if  float32, float64 or int64.
         indices (Tensor): The indices given out by maxpooling2d which is a 4-D tensor with
                           shape [N, C, H, W]. The format of input tensor is `"NCHW"` ,
                           where `N` is batch size, `C` is the number of channels,
@@ -1019,7 +1021,7 @@ def max_unpool3d(
                           shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"`,
                           where `N` is batch size, `C` is the number of channels, `D` is
                           the depth of the feature, `H` is the height of the feature,
-                          and `W` is the width of the feature. The data type is float32 or float64.
+                          and `W` is the width of the feature. The data type is float32, float64 or int64.
         indices (Tensor): The indices given out by maxpooling3d which is a 5-D tensor with
                           shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` ,
                           where `N` is batch size, `C` is the number of channels, `D` is

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1034,7 +1034,13 @@ class KLDivLoss(Layer):
 
     KL divergence loss is calculated as follows:
 
+    If `log_target` is False:
+
     $$l(x, y) = y * (\log(y) - x)$$
+
+    If `log_target` is True:
+
+    $$l(x, y) = \exp(y) * (y - x)$$
 
     Here :math:`x` is input and :math:`y` is label.
 
@@ -1054,6 +1060,7 @@ class KLDivLoss(Layer):
             if `reduction` is ``'sum'``, the reduced sum loss is returned;
             if `reduction` is ``'none'``, no reduction will be applied.
             Default is ``'mean'``.
+        log_target (bool, optional): Indicate whether `label` is passed in log space. Default is False.
 
     Shape:
 
@@ -1099,12 +1106,13 @@ class KLDivLoss(Layer):
 
     """
 
-    def __init__(self, reduction='mean'):
+    def __init__(self, reduction='mean', log_target=False):
         super().__init__()
         self.reduction = reduction
+        self.log_target = log_target
 
     def forward(self, input, label):
-        out = F.kl_div(input, label, self.reduction)
+        out = F.kl_div(input, label, self.reduction, self.log_target)
         return out
 
 

--- a/test/legacy_test/test_kldiv_loss_op.py
+++ b/test/legacy_test/test_kldiv_loss_op.py
@@ -108,7 +108,7 @@ class TestKLDivLossDygraph(unittest.TestCase):
         gt_loss = kldiv_loss(x, target, reduction, log_target)
 
         with paddle.base.dygraph.guard():
-            kldiv_criterion = paddle.nn.KLDivLoss(reduction)
+            kldiv_criterion = paddle.nn.KLDivLoss(reduction, log_target)
             pred_loss = kldiv_criterion(
                 paddle.to_tensor(x), paddle.to_tensor(target)
             )

--- a/test/legacy_test/test_kldiv_loss_op.py
+++ b/test/legacy_test/test_kldiv_loss_op.py
@@ -21,9 +21,12 @@ from paddle.nn.functional import kl_div
 from paddle.pir_utils import test_with_pir_api
 
 
-def kldiv_loss(x, target, reduction):
-    output = target * (np.log(target) - x)
-    loss = np.where(target >= 0, output, np.zeros_like(x))
+def kldiv_loss(x, target, reduction, log_target=False):
+    if log_target:
+        loss = np.exp(target) * (target - x)
+    else:
+        output = target * (np.log(target) - x)
+        loss = np.where(target >= 0, output, np.zeros_like(x))
 
     if reduction == "batchmean":
         if len(x.shape) > 0:
@@ -46,13 +49,16 @@ class TestKLDivLossOp(OpTest):
         x = np.random.uniform(-10, 10, self.x_shape).astype('float64')
         target = np.random.uniform(-10, 10, self.x_shape).astype('float64')
 
-        self.attrs = {"reduction": self.reduction}
+        self.attrs = {
+            "reduction": self.reduction,
+            "log_target": self.log_target,
+        }
 
         self.inputs = {
             'X': x,
             'Target': target,
         }
-        loss = kldiv_loss(x, target, self.reduction)
+        loss = kldiv_loss(x, target, self.reduction, self.log_target)
         self.outputs = {'Loss': loss.astype('float64')}
 
     def test_check_output(self):
@@ -64,31 +70,42 @@ class TestKLDivLossOp(OpTest):
     def initTestCase(self):
         self.x_shape = (4, 5, 5)
         self.reduction = 'batchmean'
+        self.log_target = False
 
 
 class TestKLDivLossOp2(TestKLDivLossOp):
     def initTestCase(self):
         self.x_shape = (3, 2, 7, 7)
         self.reduction = 'none'
+        self.log_target = False
 
 
 class TestKLDivLossOp3(TestKLDivLossOp):
     def initTestCase(self):
         self.x_shape = (2, 3, 5, 7, 9)
         self.reduction = 'mean'
+        self.log_target = False
 
 
 class TestKLDivLossOp4(TestKLDivLossOp):
     def initTestCase(self):
         self.x_shape = (5, 20)
         self.reduction = 'sum'
+        self.log_target = False
+
+
+class TestKLDivLossOp5(TestKLDivLossOp):
+    def initTestCase(self):
+        self.x_shape = (5, 20)
+        self.reduction = 'sum'
+        self.log_target = True
 
 
 class TestKLDivLossDygraph(unittest.TestCase):
-    def run_kl_loss(self, reduction, shape=(5, 20)):
+    def run_kl_loss(self, reduction, shape=(5, 20), log_target=False):
         x = np.random.uniform(-10, 10, shape).astype('float64')
         target = np.random.uniform(-10, 10, shape).astype('float64')
-        gt_loss = kldiv_loss(x, target, reduction)
+        gt_loss = kldiv_loss(x, target, reduction, log_target)
 
         with paddle.base.dygraph.guard():
             kldiv_criterion = paddle.nn.KLDivLoss(reduction)
@@ -112,6 +129,9 @@ class TestKLDivLossDygraph(unittest.TestCase):
     def test_kl_loss_none(self):
         self.run_kl_loss('none')
 
+    def test_kl_loss_mean_logtarget(self):
+        self.run_kl_loss('mean', log_target=True)
+
     @test_with_pir_api
     def test_kl_loss_static_api(self):
         with paddle_static_guard():
@@ -121,6 +141,7 @@ class TestKLDivLossDygraph(unittest.TestCase):
             paddle.nn.functional.kl_div(input, label)
             paddle.nn.functional.kl_div(input, label, 'sum')
             paddle.nn.functional.kl_div(input, label, 'batchmean')
+            paddle.nn.functional.kl_div(input, label, 'batchmean', True)
 
 
 class TestKLDivLossTypePromotion(unittest.TestCase):

--- a/test/legacy_test/test_unpool1d_op.py
+++ b/test/legacy_test/test_unpool1d_op.py
@@ -135,6 +135,35 @@ class TestUnpool1DOpAPI_dygraph3(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestUnpool1DOpAPI_dygraph4(unittest.TestCase):
+    def test_case(self):
+        places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
+            paddle.disable_static()
+            input_data = np.arange(3 * 16).reshape([1, 3, 16]).astype("int64")
+            input_x = paddle.to_tensor(input_data)
+            output, indices = F.max_pool1d(
+                input_x, kernel_size=2, stride=2, return_mask=True
+            )
+            output_unpool = F.max_unpool1d(
+                output,
+                indices,
+                kernel_size=2,
+                stride=2,
+                output_size=input_x.shape,
+            )
+            expected_output_unpool = unpool1dmax_forward_naive(
+                output.numpy(), indices.numpy(), [2], [2], [0], [16]
+            )
+            np.testing.assert_allclose(
+                output_unpool.numpy(), expected_output_unpool, rtol=1e-05
+            )
+
+        paddle.enable_static()
+
+
 class TestUnpool1DOpAPI_static(unittest.TestCase):
     @test_with_pir_api
     def test_case(self):

--- a/test/legacy_test/test_unpool1d_op.py
+++ b/test/legacy_test/test_unpool1d_op.py
@@ -142,13 +142,13 @@ class TestUnpool1DOpAPI_dygraph4(unittest.TestCase):
             places.append(paddle.CUDAPlace(0))
         for place in places:
             paddle.disable_static()
-            input_data = np.arange(3 * 16).reshape([1, 3, 16]).astype("int64")
+            input_data = np.arange(3 * 16).reshape([1, 3, 16]).astype("float32")
             input_x = paddle.to_tensor(input_data)
             output, indices = F.max_pool1d(
                 input_x, kernel_size=2, stride=2, return_mask=True
             )
             output_unpool = F.max_unpool1d(
-                output,
+                output.astype("int64"),
                 indices,
                 kernel_size=2,
                 stride=2,

--- a/test/legacy_test/test_unpool3d_op.py
+++ b/test/legacy_test/test_unpool3d_op.py
@@ -373,6 +373,44 @@ class TestUnpool3DOpAPI_dygraph3(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestUnpool3DOpAPI_dygraph4(unittest.TestCase):
+    def test_case(self):
+        places = [paddle.CPUPlace()]
+        if paddle.base.core.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
+            paddle.disable_static()
+            input_data = (
+                np.arange(3 * 4 * 4 * 6)
+                .reshape([1, 3, 4, 4, 6])
+                .astype("int64")
+            )
+            input_x = paddle.to_tensor(input_data)
+            output, indices = F.max_pool3d(
+                input_x, kernel_size=2, stride=2, return_mask=True
+            )
+            output_unpool = F.max_unpool3d(
+                output,
+                indices,
+                kernel_size=2,
+                stride=2,
+                output_size=input_x.shape,
+            )
+            expected_output_unpool = unpool3dmax_forward_naive(
+                output.numpy(),
+                indices.numpy(),
+                [2, 2, 2],
+                [2, 2, 2],
+                [0, 0, 0],
+                [4, 4, 6],
+            )
+            np.testing.assert_allclose(
+                output_unpool.numpy(), expected_output_unpool, rtol=1e-05
+            )
+
+        paddle.enable_static()
+
+
 class TestUnpool3DOpAPI_static(unittest.TestCase):
     @test_with_pir_api
     def test_case(self):

--- a/test/legacy_test/test_unpool3d_op.py
+++ b/test/legacy_test/test_unpool3d_op.py
@@ -383,14 +383,14 @@ class TestUnpool3DOpAPI_dygraph4(unittest.TestCase):
             input_data = (
                 np.arange(3 * 4 * 4 * 6)
                 .reshape([1, 3, 4, 4, 6])
-                .astype("int64")
+                .astype("float32")
             )
             input_x = paddle.to_tensor(input_data)
             output, indices = F.max_pool3d(
                 input_x, kernel_size=2, stride=2, return_mask=True
             )
             output_unpool = F.max_unpool3d(
-                output,
+                output.astype("int64"),
                 indices,
                 kernel_size=2,
                 stride=2,

--- a/test/legacy_test/test_unpool_op.py
+++ b/test/legacy_test/test_unpool_op.py
@@ -425,13 +425,13 @@ class TestUnpoolOpAPI_dy4(unittest.TestCase):
                         ]
                     ]
                 ]
-            ).astype("int64")
+            ).astype("float32")
             input_x = paddle.to_tensor(input_data)
             output, indices = F.max_pool2d(
                 input_x, kernel_size=2, stride=2, return_mask=True
             )
             out_pp = F.max_unpool2d(
-                output,
+                output.astype("int64"),
                 indices,
                 kernel_size=2,
                 stride=None,

--- a/test/legacy_test/test_unpool_op.py
+++ b/test/legacy_test/test_unpool_op.py
@@ -400,6 +400,51 @@ class TestUnpoolOpAPI_dy3(unittest.TestCase):
             np.testing.assert_allclose(out_pp.numpy(), expect_res, rtol=1e-05)
 
 
+class TestUnpoolOpAPI_dy4(unittest.TestCase):
+    def test_case(self):
+        import numpy as np
+
+        import paddle
+        import paddle.nn.functional as F
+        from paddle import base
+        from paddle.base import core
+
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+        else:
+            place = core.CPUPlace()
+        with base.dygraph.guard(place):
+            input_data = np.array(
+                [
+                    [
+                        [
+                            [1, 2, 3, 4, 5],
+                            [6, 7, 8, 9, 10],
+                            [11, 12, 13, 14, 15],
+                            [16, 17, 18, 19, 20],
+                        ]
+                    ]
+                ]
+            ).astype("int64")
+            input_x = paddle.to_tensor(input_data)
+            output, indices = F.max_pool2d(
+                input_x, kernel_size=2, stride=2, return_mask=True
+            )
+            out_pp = F.max_unpool2d(
+                output,
+                indices,
+                kernel_size=2,
+                stride=None,
+                output_size=input_x.shape,
+            )
+            output_np = output.numpy()
+            indices_np = indices.numpy()
+            expect_res = unpool2dmax_forward_naive(
+                output_np, indices_np, [2, 2], [2, 2], [0, 0], [4, 5]
+            ).astype("float64")
+            np.testing.assert_allclose(out_pp.numpy(), expect_res, rtol=1e-05)
+
+
 class TestUnpoolOpAPI_st(unittest.TestCase):
     @test_with_pir_api
     def test_case(self):


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Description
1. paddle.nn.functional.max_unpool1d / max_unpool2d / max_unpool3d 增加支持 int64 输入
2. paddle.nn.functional.max_unpool1d / max_unpool2d / max_unpool3d 的 output_size 参数的判断有 bug，输入正确的 output_size 会报错：
这个目前按 x -> out, indices = pool(x, ...) -> unpool(out, indices, ..., output_size=x.shape) 这样来检验的话有问题的是paddle.nn.functional.max_unpool1d，output_size 参数处理之前少加了一维，是否还存在其他问题？

3. paddle.nn.functional.kl_div 增加参数 log_target
