### PR TITLE
Fix a bug in ConcatOpInferSymbolicShape

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -38,8 +38,16 @@ bool ConcatOpInferSymbolicShape(
                      .to<int64_t>();
   size_t rank = shape_data_list[0].shape().size();
   axis = axis >= 0 ? axis : std::max(int64_t(0), int64_t(axis + rank));
+  bool has_value = true;
 
-  if (shape_data_list[0].data().has_value()) {
+  for (auto &shape_data : shape_data_list) {
+    if (!shape_data.data().has_value()) {
+      has_value = false;
+      break;
+    }
+  }
+
+  if (has_value) {
     if (rank == 1) {
       ExprVec data = details::GetExprVecFromData(
           shape_analysis->GetShapeOrDataForValue(operand_source));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
cinn 子图 54 报错 `bad option access`。
定位到是 concate shape 推导的问题：某些时候 shape_data_list 中的数据，前几个 has_value() 为 true，后几个 has_value() 为 false，不能仅通过第一个判断整体 has_value() 是否为 true。