### PR TITLE
[Support Inceemental Compile On Windows] Support Auto Trigger Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,10 @@ endif()
 if(WIN32)
   option(MSVC_STATIC_CRT "use static C Runtime library by default" ON)
   message("Build static library of PHI")
-  set(CMAKE_SUPPRESS_REGENERATION ON)
+  # (Note xuxinyi04): If CMAKE_SUPPRESS_REGENERATION is OFF, which is default, then CMake adds a
+  # special target on which all other targets depend that checks the build system and optionally
+  # re-runs CMake to regenerate the build system when the target specification source changes.
+  set(CMAKE_SUPPRESS_REGENERATION OFF)
   set(CMAKE_STATIC_LIBRARY_PREFIX lib)
   set(WITH_SHARED_PHI
       OFF

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -375,6 +375,8 @@ set CUDA_TOOLKIT_ROOT_DIR=%CUDA_TOOLKIT_ROOT_DIR:\=/%
 
 rem install ninja if GENERATOR is Ninja
 if %GENERATOR% == "Ninja" (
+    rem Set the default generator for cmake to Ninja 
+    setx CMAKE_GENERATOR Ninja
     pip install ninja
     if %errorlevel% NEQ 0 (
         echo pip install ninja failed!


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Description
Pcard-73263
解决当前Windows平台的cmake自动触发问题。5年前的 https://github.com/PaddlePaddle/Paddle/pull/15654 设置 CMAKE_SUPPRESS_REGENERATION 为 ON，从而避免MSbuild构建过程中的重复检查、编译warnnings和额外生成目标的问题。但后续该标志也用于控制是否生成一特殊目标，该目标用于检测是否需要重新生成本地构建文件，因此PR15654导致windows平台的构建文件中RERUN_CMAKE规则永远不会被自动触发。此外设置用户环境变量CMAKE_GENRERATOR=Ninja，解决ninja作为生成器时，自动触发cmake过程中的cmake Loop问题。
