### PR TITLE
Fix paddle.mode and paddle.bincount API

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -279,11 +279,14 @@ void BincountInferMeta(const MetaTensor& x,
   }
   out->set_dims(common::make_ddim({-1}));
   if (weights) {
-    out->set_dtype(weights.dtype());
+    if (weights.dtype() == DataType::FLOAT32) {
+      out->set_dtype(DataType::FLOAT32);
+    } else {
+      out->set_dtype(DataType::FLOAT64);
+    }
   } else {
-    out->set_dtype(x.dtype());
+    out->set_dtype(DataType::INT64);
   }
-
   out->share_lod(x);
 }
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -239,7 +239,6 @@ void BCELossInferMeta(const MetaTensor& input,
 
   out->set_dims(input_dims);
   out->set_dtype(input.dtype());
-
   out->share_lod(input);
 }
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -279,11 +279,7 @@ void BincountInferMeta(const MetaTensor& x,
   }
   out->set_dims(common::make_ddim({-1}));
   if (weights) {
-    if (weights.dtype() == DataType::FLOAT32) {
-      out->set_dtype(DataType::FLOAT32);
-    } else {
-      out->set_dtype(DataType::FLOAT64);
-    }
+    out->set_dtype(weights.dtype());
   } else {
     out->set_dtype(DataType::INT64);
   }

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -239,6 +239,7 @@ void BCELossInferMeta(const MetaTensor& input,
 
   out->set_dims(input_dims);
   out->set_dtype(input.dtype());
+
   out->share_lod(input);
 }
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -283,7 +283,7 @@ void BincountInferMeta(const MetaTensor& x,
   } else {
     out->set_dtype(DataType::INT64);
   }
-  
+
   out->share_lod(x);
 }
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -283,6 +283,7 @@ void BincountInferMeta(const MetaTensor& x,
   } else {
     out->set_dtype(DataType::INT64);
   }
+  
   out->share_lod(x);
 }
 

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2537,7 +2537,7 @@ void ModeInferMeta(const MetaTensor& x,
 
   indices->set_dims(dims);
   indices->share_lod(x);
-  indices->set_dtype(x.dtype());
+  indices->set_dtype(DataType::INT64);
 }
 
 void MultinomialInferMeta(const MetaTensor& x,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
paddle.mode和paddle.bincount两个API在静态图模式下组网执行时，出现精度问题。经过分析原因和 [#62801 ](https://github.com/PaddlePaddle/Paddle/pull/62801)所遇到的问题一致，根据kernel中的数据类型进行修复。