### PR TITLE
Revert "[Scalar] Replace add_ad_func, subtract_ad_func with scale_ad_func when meeting scalar op Tensor"

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/onednn/onednn_instruction.cc
@@ -94,8 +94,6 @@ static phi::Attribute ConvertPirAttribute2RuntimeAttribute(
     phi::DataType dtype =
         attr.dyn_cast<paddle::dialect::DataTypeAttribute>().data();
     return dtype;
-  } else if (attr_type_name == "paddle::dialect::ScalarAttribute") {
-    return attr.dyn_cast<dialect::ScalarAttribute>().data();
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
         "ConvertPirAttribute2RuntimeAttribute not support [%s] ",

--- a/paddle/fluid/operators/generator/generate_op.py
+++ b/paddle/fluid/operators/generator/generate_op.py
@@ -125,8 +125,7 @@ def process_scalar(op_item, scalar_configs):
                         '"' + attr_item['default_value'] + '"'
                     )
                 if attr_item['is_support_tensor'] is False:
-                    if 'tensor_name' in scalar_config:
-                        attr_item['tensor_name'] = scalar_config['tensor_name']
+                    attr_item['tensor_name'] = scalar_config['tensor_name']
 
 
 def process_int_array(op_item, int_array_configs):

--- a/paddle/fluid/prim/api/auto_code_generated/tensor_operants_gen.py
+++ b/paddle/fluid/prim/api/auto_code_generated/tensor_operants_gen.py
@@ -95,11 +95,11 @@ namespace paddle {
 namespace prim {
 
 Tensor EagerTensorOperants::add(const Tensor& x, const Scalar& y) {
-  return ::scale_ad_func(x, 1.0f, y, true);
+  return ::add_ad_func(x, ::full_like_ad_func(x, y));
 }
 
 Tensor EagerTensorOperants::subtract(const Tensor& x, const Scalar& y) {
-  return ::scale_ad_func(x, 1.0f, -y, true);
+  return ::subtract_ad_func(x, ::full_like_ad_func(x, y));
 }
 
 Tensor EagerTensorOperants::multiply(const Tensor& x, const Scalar& y) {
@@ -111,11 +111,11 @@ Tensor EagerTensorOperants::divide(const Tensor& x, const Scalar& y) {
 }
 
 Tensor EagerTensorOperants::add(const Scalar& x, const Tensor& y) {
-  return ::scale_ad_func(y, 1.0f, x, true);
+  return ::add_ad_func(::full_like_ad_func(y, x), y);
 }
 
 Tensor EagerTensorOperants::subtract(const Scalar& x, const Tensor& y) {
-  return ::scale_ad_func(y, -1.0f, x, true);
+  return ::subtract_ad_func(::full_like_ad_func(y, x), y);
 }
 
 Tensor EagerTensorOperants::multiply(const Scalar& x, const Tensor& y) {

--- a/paddle/phi/README.md
+++ b/paddle/phi/README.md
@@ -206,7 +206,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  DenseTensor* out);
 ```
@@ -354,7 +354,7 @@ Tensor mean(const Tensor& x);
 
 Tensor scale(const Tensor& x,
              const Scalar& scale,
-             const Scalar& bias,
+             float bias,
              bool bias_after_scale);
 ```
 

--- a/paddle/phi/api/include/tensor.h
+++ b/paddle/phi/api/include/tensor.h
@@ -715,7 +715,7 @@ class PADDLE_API Tensor final {
   Tensor maximum(const Tensor& y) const;
   Tensor minimum(const Tensor& y) const;
   Tensor scale(const Scalar& scale = 1.0,
-               const Scalar& bias = 0.0,
+               float bias = 0.0,
                bool bias_after_scale = true) const;
   Tensor sum(const IntArray& axis = {},
              DataType dtype = DataType::UNDEFINED,

--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -2002,7 +2002,7 @@
   inplace : (out_grad -> x_grad)
 
 - backward_op : scale_grad
-  forward : scale (Tensor x, Scalar scale, Scalar bias, bool bias_after_scale) -> Tensor(out)
+  forward : scale (Tensor x, Scalar scale, float bias, bool bias_after_scale) -> Tensor(out)
   args : (Tensor out_grad, Scalar scale=1.0)
   output : Tensor(x_grad)
   invoke : scale(out_grad, scale, 0.0f, true)

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2894,9 +2894,6 @@
     scale :
       data_type : float
       tensor_name : ScaleTensor
-    bias :
-      data_type : float
-      support_tensor : false
   extra :
     attrs : [bool use_mkldnn = false]
 

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2419,7 +2419,7 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : scale
-  args : (Tensor x, Scalar scale=1.0, Scalar bias=0.0, bool bias_after_scale=true)
+  args : (Tensor x, Scalar scale=1.0, float bias=0.0, bool bias_after_scale=true)
   output : Tensor(out)
   infer_meta :
     func : UnchangedInferMeta

--- a/paddle/phi/common/scalar.h
+++ b/paddle/phi/common/scalar.h
@@ -226,44 +226,6 @@ class ScalarBase {
     return !operator==(other);
   }
 
-  ScalarBase operator-() const {
-    DataType data_type = this->dtype();
-    switch (data_type) {
-      case DataType::BOOL:
-        return ScalarBase(-(this->data_.b));
-      case DataType::INT8:
-        return ScalarBase(-(this->data_.i8));
-      case DataType::UINT8:
-        return ScalarBase(-(this->data_.ui8));
-      case DataType::INT16:
-        return ScalarBase(-(this->data_.i16));
-      case DataType::UINT16:
-        return ScalarBase(-(this->data_.ui16));
-      case DataType::INT32:
-        return ScalarBase(-(this->data_.i32));
-      case DataType::UINT32:
-        return ScalarBase(-(this->data_.ui32));
-      case DataType::INT64:
-        return ScalarBase(-(this->data_.i64));
-      case DataType::UINT64:
-        return ScalarBase(-(this->data_.ui64));
-      case DataType::FLOAT16:
-        return ScalarBase(-(this->data_.f16));
-      case DataType::BFLOAT16:
-        return ScalarBase(-(this->data_.bf16));
-      case DataType::FLOAT32:
-        return ScalarBase(-(this->data_.f32));
-      case DataType::FLOAT64:
-        return ScalarBase(-(this->data_.f64));
-      case DataType::COMPLEX64:
-        return ScalarBase(-(this->data_.c64));
-      case DataType::COMPLEX128:
-        return ScalarBase(-(this->data_.c128));
-      default:
-        PD_THROW("Invalid tensor data type `", dtype_, "`.");
-    }
-  }
-
   std::string ToRawString() const {
     std::stringstream ss;
     switch (dtype_) {

--- a/paddle/phi/infermeta/spmd_rules/scale.cc
+++ b/paddle/phi/infermeta/spmd_rules/scale.cc
@@ -16,7 +16,7 @@ namespace phi {
 namespace distributed {
 SpmdInfo ScaleInferSpmd(const DistMetaTensor& x,
                         const Scalar& scale,
-                        const Scalar& bias,
+                        float bias,
                         bool bias_after_scale) {
   return ElementwiseUnaryInferSpmd(x);
 }

--- a/paddle/phi/infermeta/spmd_rules/scale.h
+++ b/paddle/phi/infermeta/spmd_rules/scale.h
@@ -24,7 +24,7 @@ namespace phi {
 namespace distributed {
 SpmdInfo ScaleInferSpmd(const DistMetaTensor& x,
                         const Scalar& scale,
-                        const Scalar& bias,
+                        float bias,
                         bool bias_after_scale);
 }
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/scale_kernel.cc
+++ b/paddle/phi/kernels/cpu/scale_kernel.cc
@@ -29,7 +29,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  DenseTensor* out) {
   // calc
@@ -44,7 +44,12 @@ void ScaleKernel(const Context& dev_ctx,
     return;
   }
   phi::funcs::EigenScale<std::decay_t<decltype(dev)>, T>::Eval(
-      dev, eigen_out, eigen_x, scale.to<T>(), bias.to<T>(), bias_after_scale);
+      dev,
+      eigen_out,
+      eigen_x,
+      scale.to<T>(),
+      static_cast<T>(bias),
+      bias_after_scale);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/scale_kernel.cu
+++ b/paddle/phi/kernels/gpu/scale_kernel.cu
@@ -45,7 +45,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  DenseTensor* out) {
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
@@ -61,7 +61,8 @@ void ScaleKernel(const Context& dev_ctx,
       dev_ctx,
       inputs,
       &outputs,
-      ScaleFunctor<T, MT>(scale.to<MT>(), bias.to<MT>(), bias_after_scale));
+      ScaleFunctor<T, MT>(
+          scale.to<MT>(), static_cast<MT>(bias), bias_after_scale));
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/onednn/scale_kernel.cc
+++ b/paddle/phi/kernels/onednn/scale_kernel.cc
@@ -23,11 +23,11 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  DenseTensor* out) {
   float alpha = scale.to<float>();
-  float beta = bias_after_scale ? bias.to<float>() : bias.to<float>() * alpha;
+  float beta = bias_after_scale ? bias : bias * alpha;
 
   funcs::ActivationOneDNNHandler<T> handler(dnnl::algorithm::eltwise_linear,
                                             alpha,

--- a/paddle/phi/kernels/scale_kernel.h
+++ b/paddle/phi/kernels/scale_kernel.h
@@ -24,7 +24,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  DenseTensor* out);
 
@@ -32,7 +32,7 @@ template <typename T, typename Context>
 DenseTensor Scale(const Context& dev_ctx,
                   const DenseTensor& x,
                   const Scalar& scale,
-                  const Scalar& bias,
+                  float bias,
                   bool bias_after_scale) {
   DenseTensor dense_out;
   MetaTensor meta_out(&dense_out);

--- a/paddle/phi/kernels/selected_rows/scale_kernel.cc
+++ b/paddle/phi/kernels/selected_rows/scale_kernel.cc
@@ -26,7 +26,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const SelectedRows& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  SelectedRows* out) {
   if (x.value().Holder() != out->value().Holder() ||

--- a/paddle/phi/kernels/selected_rows/scale_kernel.h
+++ b/paddle/phi/kernels/selected_rows/scale_kernel.h
@@ -24,7 +24,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const SelectedRows& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  SelectedRows* out);
 

--- a/paddle/phi/kernels/xpu/scale_kernel.cc
+++ b/paddle/phi/kernels/xpu/scale_kernel.cc
@@ -23,7 +23,7 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const DenseTensor& x,
                  const Scalar& scale,
-                 const Scalar& bias,
+                 float bias,
                  bool bias_after_scale,
                  DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
@@ -45,7 +45,7 @@ void ScaleKernel(const Context& dev_ctx,
                      x.numel(),
                      bias_after_scale,
                      scale.to<float>(),
-                     bias.to<float>());
+                     bias);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale");
 }
 

--- a/test/autograd/test_transform.py
+++ b/test/autograd/test_transform.py
@@ -21,8 +21,6 @@ paddle.enable_static()
 
 
 class TestAutoGradTransformForAdd(unittest.TestCase):
-    # This UT is deprecated for 'prim2org' mechanism has been already deprecated
-    # so this UT will be skipped as method 'test_run' was renamed to '_test_run'
     def setUp(self):
         self.main_program = paddle.static.Program()
         self.startup_program = paddle.static.Program()
@@ -140,7 +138,7 @@ class TestAutoGradTransformForAdd(unittest.TestCase):
             'elementwise_mul',
         ]
 
-    def _test_run(self):
+    def test_run(self):
         # Must using with program_guard(), otherwise prim ops will append other block
         with paddle.static.program_guard(
             self.main_program, self.startup_program

--- a/test/cpp/phi/api/scale_api.h
+++ b/test/cpp/phi/api/scale_api.h
@@ -32,7 +32,7 @@ namespace experimental {
 
 Tensor scale_kernel_context(const Tensor& x,
                             const Scalar& scale,
-                            const Scalar& bias,
+                            float bias,
                             bool bias_after_scale) {
   Backend kernel_backend = Backend::UNDEFINED;
   DataLayout kernel_layout = DataLayout::UNDEFINED;
@@ -70,7 +70,7 @@ Tensor scale_kernel_context(const Tensor& x,
   auto dense_x = std::dynamic_pointer_cast<phi::DenseTensor>(x.impl());
   kernel_context.EmplaceBackInput(dense_x.get());
 
-  kernel_context.EmplaceBackAttr(scale);
+  kernel_context.EmplaceBackAttr(phi::Scalar(scale));
   kernel_context.EmplaceBackAttr(bias);
   kernel_context.EmplaceBackAttr(bias_after_scale);
 
@@ -90,48 +90,48 @@ static void ScaleCPU(DataType kernel_dtype,
                      const phi::CPUContext& dev_ctx,
                      const phi::DenseTensor& x,
                      const Scalar& scale,
-                     const Scalar& bias,
+                     float bias,
                      bool bias_after_scale,
                      phi::DenseTensor* dense_out) {
   switch (kernel_dtype) {
     case phi::DataType::FLOAT64: {
       phi::ScaleKernel<double>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::FLOAT32: {
       phi::ScaleKernel<float>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::BFLOAT16: {
       phi::ScaleKernel<phi::dtype::bfloat16>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT64: {
       phi::ScaleKernel<int64_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT32: {
       phi::ScaleKernel<int32_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT16: {
       phi::ScaleKernel<int16_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT8: {
       phi::ScaleKernel<int8_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::UINT8: {
       phi::ScaleKernel<uint8_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     default: {
@@ -149,48 +149,48 @@ static void ScaleGPU(DataType kernel_dtype,
                      const phi::GPUContext& dev_ctx,
                      const phi::DenseTensor& x,
                      const Scalar& scale,
-                     const Scalar& bias,
+                     float bias,
                      bool bias_after_scale,
                      phi::DenseTensor* dense_out) {
   switch (kernel_dtype) {
     case phi::DataType::FLOAT64: {
       phi::ScaleKernel<double>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::FLOAT32: {
       phi::ScaleKernel<float>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::FLOAT16: {
       phi::ScaleKernel<phi::dtype::float16>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT64: {
       phi::ScaleKernel<int64_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT32: {
       phi::ScaleKernel<int32_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT16: {
       phi::ScaleKernel<int16_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::INT8: {
       phi::ScaleKernel<int8_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     case phi::DataType::UINT8: {
       phi::ScaleKernel<uint8_t>(
-          dev_ctx, x, scale, bias, bias_after_scale, dense_out);
+          dev_ctx, x, phi::Scalar(scale), bias, bias_after_scale, dense_out);
       break;
     }
     default: {
@@ -207,7 +207,7 @@ static void ScaleGPU(DataType kernel_dtype,
 
 Tensor scale_switch_case(const Tensor& x,
                          const Scalar& scale,
-                         const Scalar& bias,
+                         float bias,
                          bool bias_after_scale) {
   Backend kernel_backend = Backend::UNDEFINED;
   DataLayout kernel_layout = DataLayout::UNDEFINED;


### PR DESCRIPTION
> [!IMPORTANT]
> PR https://github.com/PaddlePaddle/Paddle/pull/62598 might **cause error in NPU** device as `bias` argument of `scale` kernel  is not adapted to `Scalar` type.

Reverts PaddlePaddle/Paddle#62598

Related fix PR
- https://github.com/PaddlePaddle/PaddleCustomDevice/pull/1073
- https://github.com/PaddlePaddle/PaddleCustomDevice/pull/1056
