### PR TITLE
new allocator

### DIFF
--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -11,6 +11,7 @@ set(ALLOCATOR_SRCS
     allocator_strategy.cc
     allocator_facade.cc
     auto_growth_best_fit_allocator.cc
+    auto_growth_best_fit_allocator_v2.cc
     virtual_memory_auto_growth_best_fit_allocator.cc
     retry_allocator.cc
     memory_block.cc

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h
@@ -47,7 +47,7 @@ class AutoGrowthBestFitAllocator : public Allocator {
     return FreeIdleChunks();
   }
 
- private:
+ protected:
   uint64_t FreeIdleChunks();
   void Trace() const;
 

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.cc
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.cc
@@ -1,0 +1,165 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include "paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.h"
+
+#include <algorithm>
+#include <mutex>  // NOLINT
+
+#include "paddle/fluid/memory/allocation/aligned_allocator.h"
+#include "paddle/fluid/platform/cuda_device_guard.h"
+#include "paddle/fluid/platform/device/gpu/gpu_info.h"
+#include "paddle/fluid/platform/profiler/event_tracing.h"
+#include "paddle/phi/backends/device_manager.h"
+#include "paddle/phi/core/flags.h"
+
+DECLARE_bool(free_idle_chunk);
+DECLARE_bool(free_when_no_cache_hit);
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+AutoGrowthBestFitAllocatorV2::AutoGrowthBestFitAllocatorV2(
+    const std::shared_ptr<Allocator> &underlying_allocator,
+    size_t alignment,
+    platform::CUDAPlace place,
+    size_t chunk_size,
+    bool allow_free_idle_chunk)
+    : AutoGrowthBestFitAllocator(
+          underlying_allocator, alignment, chunk_size, true),
+      place_(place) {}
+
+phi::Allocation *AutoGrowthBestFitAllocatorV2::AllocateImpl(
+    size_t unaligned_size) {
+  platform::RecordEvent record("AutoGrowthBestFitAllocatorV2::Allocate",
+                               platform::TracerEventType::UserDefined,
+                               9 /*level*/);
+
+  size_t size = AlignedSize(unaligned_size, alignment_);
+
+  VLOG(10) << "Allocate " << unaligned_size << " bytes, aligned to " << size;
+
+  std::lock_guard<SpinLock> guard(spinlock_);
+
+  BlockIt block_it;
+  if (AutoGrowthBestFitAllocatorV2State::GetInstance().IsWarmup()) {
+    auto iter = free_blocks_.lower_bound(std::make_pair(size, nullptr));
+    if (iter != free_blocks_.end() && iter->second->size_ >= unaligned_size &&
+        iter->second->size_ <= size) {
+      block_it = iter->second;
+      free_blocks_.erase(iter);
+      block_it->is_free_ = false;
+      VLOG(10) << "Allocate " << size << " bytes from chunk size "
+               << block_it->size_ << " by strict_matching_state.";
+    } else {
+      size_t actual_avail, actual_total;
+      {
+        platform::CUDADeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_HIP
+        auto result = hipMemGetInfo(&actual_avail, &actual_total);
+#else
+        auto result = cudaMemGetInfo(&actual_avail, &actual_total);
+#endif
+        if (result != gpuSuccess) {
+          actual_avail = 0;
+        }
+      }
+
+      if (actual_avail < size) {
+        FreeIdleChunks();
+      }
+
+      chunks_.emplace_back(static_unique_ptr_cast<Allocation>(
+          underlying_allocator_->Allocate(size)));
+
+      auto *chunk = &(*chunks_.rbegin());
+      size = chunk->allocation_->size();
+      uint8_t *p = reinterpret_cast<uint8_t *>(chunk->allocation_->ptr());
+      auto &blocks = chunk->blocks_;
+      blocks.emplace_back(p, size, false, chunk);
+      block_it = --(blocks.end());
+      VLOG(2) << "Not found and reallocate " << size << "("
+              << static_cast<void *>(p) << ") by strict_matching_state.";
+    }
+  } else {
+    if (is_first_switch_to_regular_) {
+      FreeIdleChunks();
+      is_first_switch_to_regular_ = false;
+    }
+    auto iter = free_blocks_.lower_bound(std::make_pair(size, nullptr));
+
+    if (iter != free_blocks_.end()) {
+      block_it = iter->second;
+      free_blocks_.erase(iter);
+      auto *chunk = block_it->chunk_;
+      size_t remaining_size = block_it->size_ - size;
+      VLOG(10) << "Allocate " << size << " bytes from chunk size "
+               << block_it->size_ << ", remaining " << remaining_size;
+      if (remaining_size == 0) {
+        block_it->is_free_ = false;
+      } else {
+        auto remaining_free_block = chunk->blocks_.insert(
+            block_it, Block(block_it->ptr_, remaining_size, true, chunk));
+        free_blocks_.emplace(std::make_pair(remaining_size, block_it->ptr_),
+                             remaining_free_block);
+        block_it->ptr_ =
+            reinterpret_cast<uint8_t *>(block_it->ptr_) + remaining_size;
+        block_it->size_ = size;
+        block_it->is_free_ = false;
+      }
+    } else {
+      if (FLAGS_free_when_no_cache_hit) {
+        FreeIdleChunks();
+      }
+      size_t realloc_size = std::max(size, chunk_size_);
+
+      try {
+        chunks_.emplace_back(static_unique_ptr_cast<Allocation>(
+            underlying_allocator_->Allocate(realloc_size)));
+      } catch (BadAlloc &ex) {
+        if (FLAGS_free_when_no_cache_hit) throw ex;
+        FreeIdleChunks();
+        chunks_.emplace_back(static_unique_ptr_cast<Allocation>(
+            underlying_allocator_->Allocate(realloc_size)));
+      }
+
+      auto *chunk = &(*chunks_.rbegin());
+      realloc_size = chunk->allocation_->size();
+      uint8_t *p = reinterpret_cast<uint8_t *>(chunk->allocation_->ptr());
+      auto &blocks = chunk->blocks_;
+
+      size_t remaining_size = realloc_size - size;
+      if (remaining_size > 0) {
+        blocks.emplace_back(p, remaining_size, true, chunk);
+        free_blocks_.emplace(std::make_pair(remaining_size, p),
+                             --(blocks.end()));
+      }
+      blocks.emplace_back(p + remaining_size, size, false, chunk);
+      block_it = --(blocks.end());
+      VLOG(2) << "Not found and reallocate " << realloc_size << "("
+              << static_cast<void *>(p) << "), and remaining "
+              << remaining_size;
+    }
+  }
+  ++total_alloc_times_;
+  total_alloc_size_ += size;
+  VLOG(10) << "Alloc " << block_it->size_ << " bytes, ptr = " << block_it->ptr_;
+  return new BlockAllocation(block_it);
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle
+#endif

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.cc
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.cc
@@ -18,6 +18,7 @@
 #include <mutex>  // NOLINT
 
 #include "paddle/fluid/memory/allocation/aligned_allocator.h"
+#include "paddle/fluid/memory/stats.h"
 #include "paddle/fluid/platform/cuda_device_guard.h"
 #include "paddle/fluid/platform/device/gpu/gpu_info.h"
 #include "paddle/fluid/platform/profiler/event_tracing.h"
@@ -26,6 +27,11 @@
 
 DECLARE_bool(free_idle_chunk);
 DECLARE_bool(free_when_no_cache_hit);
+
+PADDLE_DEFINE_EXPORTED_bool(
+    free_idel_when_switch_to_normal,
+    false,
+    "Whether to free idel when switch to normal auto growth.");
 
 namespace paddle {
 namespace memory {
@@ -94,8 +100,9 @@ phi::Allocation *AutoGrowthBestFitAllocatorV2::AllocateImpl(
               << static_cast<void *>(p) << ") by strict_matching_state.";
     }
   } else {
-    if (is_first_switch_to_regular_) {
+    if (is_first_switch_to_regular_ && FLAGS_free_idel_when_switch_to_normal) {
       FreeIdleChunks();
+      DEVICE_MEMORY_STAT_RESET_PEAK(Reserved, place_.device);
       is_first_switch_to_regular_ = false;
     }
     auto iter = free_blocks_.lower_bound(std::make_pair(size, nullptr));

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.h
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.h
@@ -39,10 +39,13 @@ class AutoGrowthBestFitAllocatorV2 : public AutoGrowthBestFitAllocator {
 
  protected:
   phi::Allocation *AllocateImpl(size_t size) override;
+  void FreeImpl(phi::Allocation *allocation) override;
+  void PrintChunks();
 
  private:
   platform::CUDAPlace place_;
   bool is_first_switch_to_regular_{true};
+  bool warmup_done_{false};
 };
 
 class AutoGrowthBestFitAllocatorV2State {
@@ -51,9 +54,14 @@ class AutoGrowthBestFitAllocatorV2State {
 
   ~AutoGrowthBestFitAllocatorV2State() {}
 
-  void SetWarmup(bool warmup) { is_warmup_ = warmup; }
+  void SetWarmup(bool warmup) {
+    is_warmup_ = warmup;
+    warmup_count_++;
+  }
 
   bool IsWarmup() { return is_warmup_; }
+
+  int WarmupCount() { return warmup_count_; }
 
   static AutoGrowthBestFitAllocatorV2State &GetInstance() {
     static AutoGrowthBestFitAllocatorV2State instance;
@@ -62,6 +70,7 @@ class AutoGrowthBestFitAllocatorV2State {
 
  private:
   bool is_warmup_{true};
+  int warmup_count_{0};
 };
 
 }  // namespace allocation

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.h
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator_v2.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <utility>
+
+#include "paddle/fluid/memory/allocation/allocator.h"
+#include "paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h"
+#include "paddle/fluid/memory/allocation/spin_lock.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class AutoGrowthBestFitAllocatorV2 : public AutoGrowthBestFitAllocator {
+ public:
+  AutoGrowthBestFitAllocatorV2(
+      const std::shared_ptr<Allocator> &underlying_allocator,
+      size_t alignment,
+      platform::CUDAPlace place,
+      size_t chunk_size = 0,
+      bool allow_free_idle_chunk = true);
+
+ protected:
+  phi::Allocation *AllocateImpl(size_t size) override;
+
+ private:
+  platform::CUDAPlace place_;
+  bool is_first_switch_to_regular_{true};
+};
+
+class AutoGrowthBestFitAllocatorV2State {
+ public:
+  AutoGrowthBestFitAllocatorV2State() = default;
+
+  ~AutoGrowthBestFitAllocatorV2State() {}
+
+  void SetWarmup(bool warmup) { is_warmup_ = warmup; }
+
+  bool IsWarmup() { return is_warmup_; }
+
+  static AutoGrowthBestFitAllocatorV2State &GetInstance() {
+    static AutoGrowthBestFitAllocatorV2State instance;
+    return instance;
+  }
+
+ private:
+  bool is_warmup_{true};
+};
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle
+#endif

--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -42,6 +42,7 @@ class StatBase {
   virtual int64_t GetCurrentValue() = 0;
   virtual int64_t GetPeakValue() = 0;
   virtual void Update(int64_t) = 0;
+  virtual void ResetPeak() = 0;
 
  private:
   DISABLE_COPY_AND_ASSIGN(StatBase);
@@ -67,6 +68,18 @@ class Stat : public StatBase {
   }
 
   int64_t GetPeakValue() override { return peak_value_; }
+
+  void ResetPeak() override {
+    auto& thread_data_registry =
+        ThreadDataRegistry<ThreadLocalStatType>::GetInstance();
+    ThreadLocalStatType* thread_local_stat =
+        thread_data_registry.GetMutableCurrentThreadData();
+    thread_local_stat->peak = 0;
+
+    int64_t prev_value = peak_value_;
+    while (!peak_value_.compare_exchange_weak(prev_value, 0)) {
+    }
+  }
 
   void Update(int64_t increment) override {
     auto& thread_data_registry =
@@ -170,6 +183,8 @@ void PinnedMemoryStatUpdate(const std::string& stat_type,
   DEVICE_MEMORY_STAT_FUNC(item, id, GetPeakValue)
 #define DEVICE_MEMORY_STAT_UPDATE(item, id, increment) \
   DEVICE_MEMORY_STAT_FUNC(item, id, Update, increment)
+#define DEVICE_MEMORY_STAT_RESET_PEAK(item, id) \
+  DEVICE_MEMORY_STAT_FUNC(item, id, ResetPeak)
 
 #define HOST_MEMORY_STAT_FUNC(item, id, func, ...)                     \
   [&] {                                                                \

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -83,6 +83,7 @@ from paddle.fluid.layers.math_op_patch import monkey_patch_variable
 from .dygraph.base import enable_dygraph, disable_dygraph
 from .dygraph.varbase_patch_methods import monkey_patch_varbase
 from .core import _cuda_synchronize
+from .core import _set_warmup
 from .trainer_desc import (
     TrainerDesc,
     DistMultiTrainer,

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -298,6 +298,7 @@ try:
     from .libpaddle import _set_paddle_lib_path
     from .libpaddle import _create_loaded_parameter
     from .libpaddle import _cuda_synchronize
+    from .libpaddle import _set_warmup
     from .libpaddle import _is_compiled_with_heterps
     from .libpaddle import _promote_types_if_complex_exists
     from .libpaddle import _set_cached_executor_build_strategy

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -1043,6 +1043,8 @@ class Optimizer:
         # FIXME: Need to fix this once we figure out how to handle dependencies
         self._finish_update(target_block, parameters_and_grads)
 
+        paddle.fluid.core._set_warmup(False)
+
         end = len(target_block.ops)
         return target_block._slice_ops(start, end)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what you’ve done -->
Pcard-74613

添加新的显存策略尝试优化显存碎片。
打开方法：export FLAGS_use_auto_growth_v2=1

对外暴露了_set_warmup接口，用于应用标记warmup结束：
1. 目前在optimizer基类中调用了该接口。正常训练1个step则结束warmup
2. 部分模型自定义了optimizer没有使用框架的optimizer，这种情况，模型必须手动调用_set_warmup，否则会出现高频的显存申请释放，这样会影响调度性能，在小batchsize的模型中可能影响模型性能。
3. 如果预测场景需要使用该策略，需要手动调用_set_warmup。

目前CI CE主要通过max_mem_reserved统计显存使用情况。这个策略，由于早期会申请冗余显存块，所以会显得峰值更高。