### PR TITLE
[CINN] Optimize implement of substituting dim expr for broadcast

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -977,7 +977,50 @@ class SubstituteDimExprHelper final {
   }
 
   std::optional<DimExpr> SubstituteImpl(const Broadcast<DimExpr>& dim_expr) {
-    return SubstituteVariadic(dim_expr);
+    auto opt_result = SubstituteVariadic(dim_expr);
+    if (opt_result.has_value() && !opt_result->isa<Broadcast<DimExpr>>())
+      return opt_result;
+
+    const std::unordered_set<DimExpr> operands_set = [&] {
+      std::unordered_set<DimExpr> operands_set;
+      if (opt_result.has_value()) {
+        auto new_bc_expr = opt_result->dyn_cast<Broadcast<DimExpr>>();
+        operands_set.insert(new_bc_expr.operands->begin(),
+                            new_bc_expr.operands->end());
+      } else {
+        operands_set.insert(dim_expr.operands->begin(),
+                            dim_expr.operands->end());
+      }
+      return operands_set;
+    }();
+
+    auto CanReplaceSubOperands =
+        [&operands_set](const Broadcast<DimExpr>& dim_expr) {
+          for (const auto& operand : *dim_expr.operands) {
+            if (operands_set.find(operand) == operands_set.end()) return false;
+          }
+          return true;
+        };
+
+    for (const auto& kv : pattern_to_replacement_) {
+      const auto& dim_expr_pattern = kv.first;
+      if (!dim_expr_pattern.isa<Broadcast<DimExpr>>()) continue;
+      auto bc_dim_expr_pattern =
+          dim_expr_pattern.dyn_cast<Broadcast<DimExpr>>();
+      if (!CanReplaceSubOperands(bc_dim_expr_pattern)) continue;
+
+      List<DimExpr> ret_operands{kv.second};
+      for (const auto& operand : operands_set) {
+        if (std::find(bc_dim_expr_pattern.operands->begin(),
+                      bc_dim_expr_pattern.operands->end(),
+                      operand) == bc_dim_expr_pattern.operands->end()) {
+          ret_operands->push_back(operand);
+        }
+      }
+      return SimplifyDimExpr(Broadcast<DimExpr>{ret_operands});
+    }
+
+    return opt_result;
   }
 
   template <typename T>
@@ -993,7 +1036,7 @@ class SubstituteDimExprHelper final {
                                           : operand);
     }
     if (replace_cnt == 0) return std::nullopt;
-    return T{substituted_operands};
+    return SimplifyDimExpr(T{substituted_operands});
   }
 
   std::unordered_map<DimExpr, DimExpr> pattern_to_replacement_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164

升级DimExpr替换模块接口，支持将形如 `Broadcast(S0, S4, S27)` 之类的符号做 `Broadcast(S0, S4) --> S4`方式的局部替换，替换结果为`Broadcast(S4, S27)`。