### PR TITLE
[Dy2St][PIR] Replace output with inplace source

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -267,7 +267,7 @@ static void ShareTensorsFromScopeByValue(
   for (size_t i = 0; i < tensors.size(); ++i) {
     auto name = names[i];
     auto &value = values[i];
-    VLOG(2) << "share " << name << " from scope";
+    VLOG(4) << "Share Tensor From Scope: " << name;
 
     if (value.impl() == nullptr) {
       // skip stop_gradient.

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -263,10 +263,18 @@ static void ShareTensorsFromScopeByValue(
     const std::vector<::pir::Value> &values,
     paddle::framework::Scope *scope) {
   auto names = GetNameFromValue(block, values, false);
+  auto input_names = GetNameFromValue(block, values, true);
   for (size_t i = 0; i < tensors.size(); ++i) {
-    auto &name = names[i];
+    auto name = names[i];
+    auto input_name = input_names[i];
     auto &value = values[i];
+    if (name == paddle::framework::kFakeVarName) {
+      name = input_name;
+    }
     VLOG(2) << "share " << name << " from scope";
+    VLOG(0) << "share " << name << " from scope";
+    // VLOG(0) << "defining op is " << value.defining_op()->name();
+
     if (value.impl() == nullptr) {
       // skip stop_gradient.
       continue;
@@ -422,6 +430,7 @@ inline void PirRunProgramAPI(
     bool require_any_grad,
     const paddle::framework::AttributeMap &attrs,
     const int64_t &place_hash_key) {
+  VLOG(0) << "[RunProgramOp] Forward start";
   VLOG(2) << "RunProgramOpKernel Compute";
   // In the original run_program OP, the default value of the is_test
   // attribute is false, we should check if there is is_test parameter
@@ -564,6 +573,21 @@ inline void PirRunProgramAPI(
     // Step 2. update scope for cache interpretercore
     details::ShareTensorsIntoScopeByValue(
         forward_global_block, x, input_values, global_inner_scope);
+    // auto names = details::GetNameFromValue(forward_global_block,
+    // param_values, true); std::vector<std::string> names_re; for (auto name :
+    // names) {
+    //   if (name == "parameter_52") {
+    //     names_re.push_back("output_3776");
+    //   }
+    //   else if (name == "parameter_53") {
+    //     names_re.push_back("output_3777");
+    //   }
+    //   else {
+    //     names_re.push_back(name);
+    //   }
+    // }
+    // details::ShareTensorsIntoScopeWithName(params, names_re,
+    // global_inner_scope);
     details::ShareTensorsIntoScopeByValue(
         forward_global_block, params, param_values, global_inner_scope);
     // TODO(xiongkun): new ir how to build scope.
@@ -588,8 +612,10 @@ inline void PirRunProgramAPI(
     paddle::platform::RecordEvent record_event(
         "fetch_and_gc", paddle::platform::TracerEventType::UserDefined, 1);
     // Get Output, and Middle Outputs
+    VLOG(0) << "Start to share output from scope";
     details::ShareTensorsFromScopeByValue(
         forward_global_block, out, output_values, global_inner_scope);
+    VLOG(0) << "Start to share middles from scope";
     details::ShareTensorsFromScopeByValue(
         forward_global_block, middles, middle_values, global_inner_scope);
 
@@ -1019,6 +1045,7 @@ inline void PirRunProgramGradAPI(
     std::vector<paddle::Tensor *> &x_grad,       // NOLINT
     std::vector<paddle::Tensor *> &params_grad,  // NOLINT
     const int64_t &place_hash_key) {
+  VLOG(0) << "[RunProgramOp] Backward start";
   // if all output vars are set to stop_gradient, grad op no need to executed
   if (x_grad.empty() && params_grad.empty()) return;
   auto *out_scope_vec = &step_scope;

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -91,39 +91,45 @@ static bool IsVariableRefArray(const Tensor &tensor) {
 
 static auto GetNameFromValue(const ::pir::Block *block,
                              const std::vector<::pir::Value> &values,
-                             bool is_input) {
+                             bool allow_input,
+                             bool allow_output) {
+  PADDLE_ENFORCE_EQ(
+      allow_input || allow_output,
+      true,
+      paddle::platform::errors::InvalidArgument(
+          "GetNameFromValue should allow input or output at least one."));
   // we use name here, later value is used directly.
   std::unordered_map<::pir::Value, std::string> value2name;
-  if (is_input) {
+  if (allow_input) {
     for (auto &kwarg : block->kwargs()) {
       value2name[kwarg.second] = kwarg.first;
     }
   }
   for (auto &op : *block) {
     std::string name;
-    if (is_input && op.name() == "pd_op.data") {
+    if (allow_input && op.name() == "pd_op.data") {
       name =
           op.attributes().at("name").dyn_cast<pir::StrAttribute>().AsString();
       value2name[op.results()[0].Value::impl()] = name;
-    } else if (!is_input && op.name() == "builtin.set_parameter") {
+    } else if (allow_output && op.name() == "builtin.set_parameter") {
       name = op.attributes()
                  .at("parameter_name")
                  .dyn_cast<pir::StrAttribute>()
                  .AsString();
       value2name[op.operand(0).source()] = name;
-    } else if (!is_input && op.name() == "builtin.shadow_output") {
+    } else if (allow_output && op.name() == "builtin.shadow_output") {
       name = op.attributes()
                  .at("output_name")
                  .dyn_cast<pir::StrAttribute>()
                  .AsString();
       value2name[op.operand(0).source()] = name;
-    } else if (is_input && op.name() == "builtin.parameter") {
+    } else if (allow_input && op.name() == "builtin.parameter") {
       name = op.attributes()
                  .at("parameter_name")
                  .dyn_cast<pir::StrAttribute>()
                  .AsString();
       value2name[op.result(0).Value::impl()] = name;
-    } else if (is_input && op.name() == "builtin.constant") {
+    } else if (allow_input && op.name() == "builtin.constant") {
       if (op.isa<pir::ConstantTensorOp>()) {
         name = op.dyn_cast<pir::ConstantTensorOp>().tensor_name();
         value2name[op.result(0).Value::impl()] = name;
@@ -248,12 +254,7 @@ static void ShareTensorsIntoScopeByValue(
     const std::vector<Tensor> &tensors,
     const std::vector<::pir::Value> &values,
     paddle::framework::Scope *scope) {
-  auto names = GetNameFromValue(block, values, true);
-  if (VLOG_IS_ON(4)) {
-    for (auto &s : names) {
-      VLOG(4) << "ShareTensorIntoScopeByValue name: " << s;
-    }
-  }
+  auto names = GetNameFromValue(block, values, true, false);
   ShareTensorsIntoScopeWithName(tensors, names, scope);
 }
 
@@ -262,18 +263,11 @@ static void ShareTensorsFromScopeByValue(
     const std::vector<Tensor *> &tensors,
     const std::vector<::pir::Value> &values,
     paddle::framework::Scope *scope) {
-  auto names = GetNameFromValue(block, values, false);
-  auto input_names = GetNameFromValue(block, values, true);
+  auto names = GetNameFromValue(block, values, true, true);
   for (size_t i = 0; i < tensors.size(); ++i) {
     auto name = names[i];
-    auto input_name = input_names[i];
     auto &value = values[i];
-    if (name == paddle::framework::kFakeVarName) {
-      name = input_name;
-    }
     VLOG(2) << "share " << name << " from scope";
-    VLOG(0) << "share " << name << " from scope";
-    // VLOG(0) << "defining op is " << value.defining_op()->name();
 
     if (value.impl() == nullptr) {
       // skip stop_gradient.
@@ -533,20 +527,20 @@ inline void PirRunProgramAPI(
     // *backward_program);
 
     // update interpretercore skip_gc_var
-    auto skip_names =
-        details::GetNameFromValue(forward_global_block, middle_values, false);
+    auto skip_names = details::GetNameFromValue(
+        forward_global_block, middle_values, false, true);
     auto skip_names_set =
         std::set<std::string>(skip_names.begin(), skip_names.end());
     auto no_need_buffer_values = PADDLE_GET_CONST(std::vector<::pir::Value>,
                                                   attrs.at("no_need_buffers"));
     auto no_need_buffer_names = details::GetNameFromValue(
-        forward_global_block, no_need_buffer_values, false);
+        forward_global_block, no_need_buffer_values, false, true);
     for (auto &name : no_need_buffer_names) {
       VLOG(4) << "Find no need buffer vars with name:" << name;
       skip_names_set.erase(name);
     }
-    skip_names =
-        details::GetNameFromValue(forward_global_block, output_values, false);
+    skip_names = details::GetNameFromValue(
+        forward_global_block, output_values, false, true);
     skip_names_set.insert(skip_names.begin(), skip_names.end());
     details::print_collection(skip_names_set);
     interpreter_core->SetSkipGcVars(skip_names_set);
@@ -1154,11 +1148,11 @@ inline void PirRunProgramGradAPI(
 
     // get all eager gc vars
     std::set<std::string> skip_eager_delete_vars;
-    auto skip_names =
-        details::GetNameFromValue(backward_global_block, x_grad_values, false);
+    auto skip_names = details::GetNameFromValue(
+        backward_global_block, x_grad_values, false, true);
     skip_eager_delete_vars.insert(skip_names.begin(), skip_names.end());
-    skip_names =
-        details::GetNameFromValue(backward_global_block, p_grad_values, false);
+    skip_names = details::GetNameFromValue(
+        backward_global_block, p_grad_values, false, true);
     skip_eager_delete_vars.insert(skip_names.begin(), skip_names.end());
     interpreter_core->SetSkipGcVars(skip_eager_delete_vars);
     cache.UpdateSkipEagerDeleteVars(program_id,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#### 问题描述

SOT/AST+PIR 模型暴露问题，伪码描述如下：

```python
def fn(x):
   mean1 = builtin.parameter("parameter_1")
   y, mean2 = pd_op.batch_norm_(x, mean1, ...)
   return y
```

对于这个 Program 来说，动转静前向输入包含原输入 `x` 和 parameter `mean1`，前向输出包含原输出 `y` 和反向所需的中间变量 `mean2`，问题就出在这个 `mean1` 和 `mean2` 是 inplace 的（实际上是 view 的，但 PIR 下是一样的）

由于 `mean1` 和 `mean2` 是 inplace 的，所以他们对应同一个 Variable，`mean2` 作为输出我们会添加 `shadow_output` 来确保能够取出来，但由于 `mean2` 实际上就是 `mean1`，它已经有作为输入的 `parameter_1` 这个名字了，实际上是不需要通过 `shadow_output` 来重命名的。**而且，如果进行重命名，在第一个 step 我们在 share 到 scope 时需要使用 `parameter_1` 这个名字来 share，而第二个 step 因为已经 rename 成另一个名字了，这就会导致 share 失败。**

#### 解决方案

归根结底，问题出在一个输入 Value 经过若干 inplace 操作得到一个输出 Value，此时这个输出 Value 不应该添加 `shadow_output`，而是应该直接替换为输入 Value。为了达成这一点，我们需要在前反向拆分时，对 Program 中所有 inplace 链进行分析，比如下图：

<p align="center">
  <img src="https://github.com/PaddlePaddle/Paddle/assets/38436475/cde1090f-c4a5-4f6e-81c2-a90f87bbd138" alt="inplace-chain drawio" width="500px" />
</p>

这里仅标识出了 inplace Value，忽略非 inplace Value，并且按照时序拉直，比如这里的链路 A 中的 A1 作为输入，A4 作为输出，那么 A4 不应该添加 `shadow_output`。

具体替换结果如下图所示：

<p align="center">
  <img src="https://github.com/PaddlePaddle/Paddle/assets/38436475/20e31750-fe72-436e-8e2a-7ab0a18b845e" alt="split-and-inplace drawio" width="500px" />
</p>

但是这里为什么不直接将 A4 从中间变量中删掉呢？因为考虑到动转静前向的输出侧并不仅仅包含中间变量，还包含原前向的输出，针对中间变量尚且可以删掉，但如果针对输出的话就不太好删掉了，因此我们对中间变量和输出变量采用相同的操作，就是替换为 inplace 的输入侧源 Value。

如果考虑前反向全部情况，根据下图动转静前反向的输入输出关系，实际上我们需要处理如下几种情况：

<p align="center">
  <img src="https://github.com/PaddlePaddle/Paddle/assets/38436475/84293c5c-6201-4e40-a4ed-b8cd64b09854" alt="split-program drawio" width="500px" />
</p>

```
前向：

x | param -> outputs
x | param -> middles

反向：

x | param | middles | outputs | out_grads -> x_grads
x | param | middles | outputs | out_grads -> param_grads
```

但是由于前向输入 `x` 是用 `data` op 创建的，data op 在经过 lower 到 kernel pass 后会跟随一个 `shadow_feed` op，而 `shadow_feed` op 不是 inplace 的，会创建一个 inner var，也就是说前向输入 `x` 永远不会出现上述的同时作为输入和输出的问题，因为在一开始就有一个非 inplace 的操作，因此我们不需要处理前向输入，只需要处理 parameter。

类似地，反向全部输入都是通过 block kwarg 创建的，而 kwarg 也会在 lower 后跟随一个 `shadow_feed`，因此整个反向都不会出现上述问题，也就是说反向不需要处理。

因此需要处理的只有：

```
前向：

param -> outputs
param -> middles
```

但由于最开始是考虑这种情况的，即便将来 `data`/`kwarg` 后不插 `shadow_feed` 也能很容易实现。（因为目前看反向会有过多 `shadow_feed`，非常影响性能，也许之后这个 `shadow_feed` 会被删掉也说不定）

> [!NOTE]
>
> 虽然问题清楚了，但仍然没能找到一个简单的复现样例，因此没有添加单测，关于 inplace 的单测在 #62300 已经添加过了，但不能复现，本 PR 在模型上验证通过