### PR TITLE
support pir apply optimizer in distributed scenario.

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -102,6 +102,10 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
     for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.operand_dist_attr(i);
       os << ",operand(" + std::to_string(i) + "):{";
+      if (!dist_attr) {
+        os << "null}";
+        continue;
+      }
       if (dist_attr.process_mesh_attr() != op_dist_attr.process_mesh_attr()) {
         os << "mesh_shape:[" +
                   phi::distributed::auto_parallel::str_join(
@@ -132,6 +136,10 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
     for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.result_dist_attr(i);
       os << ",result(" + std::to_string(i) + "):{";
+      if (!dist_attr) {
+        os << "null}";
+        continue;
+      }
       if (dist_attr.process_mesh_attr() != op_dist_attr.process_mesh_attr()) {
         os << "mesh_shape:[" +
                   phi::distributed::auto_parallel::str_join(

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
@@ -14,26 +14,51 @@
 
 #include "paddle/fluid/pir/dialect/distributed/ir/dist_tools.h"
 #include "paddle/common/enforce.h"
+#include "paddle/pir/include/core/operation.h"
 
 namespace paddle {
 namespace dialect {
 
-bool HasDistInput(const std::vector<pir::Value>& inputs) {
+bool HasDistInput(const std::vector<pir::Value>& inputs,
+                  ProcessMeshAttribute* p_mesh_attr) {
   for (auto value : inputs) {
-    if (value.type().isa<DistDenseTensorType>()) {
+    if (auto dist_type = value.type().dyn_cast<DistTypeInterface>()) {
+      if (p_mesh_attr) {
+        *p_mesh_attr = dist_type.process_mesh_attr();
+      }
       return true;
     }
   }
   return false;
 }
 
-bool AllInputAreDist(const std::vector<pir::Value>& inputs) {
+void CvtAllInputsToDist(const std::vector<pir::Value>& inputs,
+                        ProcessMeshAttribute mesh_attr) {
   for (auto value : inputs) {
-    if (!value.type().isa<DistDenseTensorType>()) {
-      return false;
+    if (auto type = value.type()) {
+      if (type.isa<DistTypeInterface>()) continue;
+      auto dense_type = type.dyn_cast<pir::DenseTensorType>();
+      if (!dense_type) {
+        PADDLE_THROW(common::errors::Unimplemented(
+            "Currently only support convert dense_tensor_type to dist type."));
+      }
+      auto ctx = pir::IrContext::Instance();
+      auto dist_type = DistDenseTensorType::get(ctx, dense_type, mesh_attr);
+      value.set_type(dist_type);
+      if (auto define_op = value.defining_op()) {
+        if (define_op->num_operands() != 0u || define_op->num_results() != 1u) {
+          PADDLE_THROW(common::errors::InvalidArgument(
+              "Currently only allowed add dist attribue for leaf nodes "
+              "operation. The current op is %s",
+              define_op->name()));
+        }
+        define_op->set_attribute(
+            kAttrOpDistAttr,
+            OperationDistAttribute::get(
+                ctx, mesh_attr, {dist_type.tensor_dist_attr()}, {}));
+      }
     }
   }
-  return true;
 }
 
 phi::distributed::DistMetaTensor CvtToDistMetaTensor(DistDenseTensorType type) {
@@ -48,6 +73,7 @@ phi::distributed::DistMetaTensor CvtToDistMetaTensor(DistDenseTensorType type) {
 TensorDistAttribute CvtToPirDistAttr(
     const phi::distributed::ArgDistAttr& dist_attr) {
   auto& attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr, dist_attr);
+  if (attr.process_mesh().empty()) return nullptr;
   return TensorDistAttribute::get(pir::IrContext::Instance(),
                                   attr.process_mesh(),
                                   attr.dims_mapping(),

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
@@ -61,7 +61,7 @@ void CvtAllInputsToDist(const std::vector<pir::Value>& inputs,
         define_op->set_attribute(
             kAttrOpDistAttr,
             OperationDistAttribute::get(
-                ctx, mesh_attr, {dist_type.tensor_dist_attr()}, {}));
+                ctx, mesh_attr, {}, {dist_type.tensor_dist_attr()}));
       }
     }
   }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
@@ -46,10 +46,16 @@ void CvtAllInputsToDist(const std::vector<pir::Value>& inputs,
       auto dist_type = DistDenseTensorType::get(ctx, dense_type, mesh_attr);
       value.set_type(dist_type);
       if (auto define_op = value.defining_op()) {
-        if (define_op->num_operands() != 0u || define_op->num_results() != 1u) {
+        if (define_op->num_operands() != 0u) {
           PADDLE_THROW(common::errors::InvalidArgument(
               "Currently only allowed add dist attribue for leaf nodes "
               "operation. The current op is %s",
+              define_op->name()));
+        }
+        if (define_op->num_results() != 1u) {
+          PADDLE_THROW(common::errors::InvalidArgument(
+              "Currently only allowed add dist attribue for operation with "
+              "single output. The current op is %s",
               define_op->name()));
         }
         define_op->set_attribute(

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.h
@@ -21,8 +21,12 @@
 namespace paddle {
 namespace dialect {
 
-bool HasDistInput(const std::vector<pir::Value>& inputs);
-bool AllInputAreDist(const std::vector<pir::Value>& inputs);
+bool HasDistInput(const std::vector<pir::Value>& inputs,
+                  ProcessMeshAttribute* p_mesh_attr = nullptr);
+
+void CvtAllInputsToDist(const std::vector<pir::Value>& inputs,
+                        ProcessMeshAttribute mesh_attr);
+
 phi::distributed::DistMetaTensor CvtToDistMetaTensor(DistDenseTensorType type);
 TensorDistAttribute CvtToPirDistAttr(
     const phi::distributed::ArgDistAttr& dist_attr);

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_type.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_type.h
@@ -68,6 +68,7 @@ class DistDenseTensorType
   static DistDenseTensorType get(pir::IrContext* ctx,
                                  pir::DenseTensorType dense_tensor_type,
                                  TensorDistAttribute tensor_dist_attr) {
+    if (!dense_tensor_type) return nullptr;
     auto local_ddim =
         InferLocalDDim(dense_tensor_type.dims(), tensor_dist_attr);
     return get(ctx, dense_tensor_type, tensor_dist_attr, local_ddim);

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -639,18 +639,20 @@ class Engine:
             mix_fw_program
         )
         # Step 1.2: pir backward
-        if mode != "predict" and self._loss:
+        if mode == "train" and self._loss and self._optimizer:
             loss = dist_program.get_output_value_by_name(self._loss_names[0])
             if loss.initialized():
-                paddle.autograd.ir_backward.append_backward(loss)
+                with static.program_guard(dist_program):
+                    params_grads = paddle.autograd.ir_backward.append_backward(
+                        loss
+                    )
+                    self._optimizer._apply_optimize(
+                        loss, startup_program=None, params_grads=params_grads
+                    )
             else:
                 self._logger.info(
                     "loss value is not found, skip append backward."
                 )
-        # TODO(winter-wang) Step 1.3:  adapot opt.minimize() for pir-auto-parallel
-        # with program_guard(dist_program):
-        #     ptimizer_ops = self._optimizer.apply_gradients(params_grads)
-
         # Part 2: Parallelism search
         # NOTE make all parallelis search logic work as Pass,
         # and all the Pass in this Part should be optional to allow consistence in dynamic and static mode.

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -772,7 +772,7 @@ class Optimizer:
     def _create_param_lr(self, param_and_grad):
         # create learning rate tensor for every parameter
         param = param_and_grad[0]
-        if hasattr(param, 'optimize_attr'):
+        if hasattr(param, 'optimize_attr') and param.optimize_attr is not None:
             param_lr = param.optimize_attr['learning_rate']
             if isinstance(param_lr, (Variable, paddle.pir.Value)):
                 return param_lr

--- a/test/auto_parallel/pir/test_to_static_pir_program.py
+++ b/test/auto_parallel/pir/test_to_static_pir_program.py
@@ -130,15 +130,26 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
 
         relu_idx = 0
         matmul_idx = 0
+        data_idx = 0
         matmul_grad_idx = 0
+        sgd_idx = 0
         ops = main_program.global_block().ops
-        self.assertEqual(ops[-1].name(), "pd_op.matmul_grad")
-        self.assertEqual(ops[-2].name(), "pd_op.relu_grad")
-        self.assertEqual(ops[-3].name(), "pd_op.matmul_grad")
-        self.assertEqual(ops[-4].name(), "pd_op.relu_grad")
-        self.assertEqual(ops[-5].name(), "pd_op.subtract_grad")
-        self.assertEqual(ops[-6].name(), "pd_op.square_grad")
-        self.assertEqual(ops[-7].name(), "pd_op.mean_grad")
+
+        backward_op_list = [
+            "pd_op.sgd_",
+            "pd_op.sgd_",
+            "pd_op.matmul_grad",
+            "pd_op.relu_grad",
+            "pd_op.matmul_grad",
+            "pd_op.relu_grad",
+            "pd_op.subtract_grad",
+            "pd_op.square_grad",
+            "pd_op.mean_grad",
+        ]
+        index = -1
+        for op_name in backward_op_list:
+            self.assertEqual(ops[index].name(), op_name)
+            index = index - 1
 
         for op in ops:
             # skip shadow_output
@@ -155,8 +166,10 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
             )
 
             if op.name() == 'pd_op.data':
-                self.assertEqual(tensor.dist_attr().dims_mapping, [-1, -1])
-                self.assertEqual(tensor.dist_attr().partial_dims, set())
+                if data_idx != 0:
+                    self.assertEqual(tensor.dist_attr().dims_mapping, [-1, -1])
+                    self.assertEqual(tensor.dist_attr().partial_dims, set())
+                data_idx += 1
             elif op.name() == 'builtin.parameter':
                 self.assertTrue(tensor.is_dense_tensor_type())
                 self.assertTrue(tensor.is_dist_dense_tensor_type())
@@ -218,6 +231,20 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
                         tensor._local_shape, [BATCH_SIZE, IMAGE_SIZE // 2]
                     )
                 matmul_grad_idx += 1
+            if op.name() == 'pd_op.sgd_':
+                if sgd_idx == 0:
+                    self.assertEqual(tensor.dist_attr().dims_mapping, [0, -1])
+                    self.assertEqual(tensor.dist_attr().partial_dims, set())
+                    self.assertEqual(
+                        tensor._local_shape, [IMAGE_SIZE // 2, CLASS_NUM]
+                    )
+                elif sgd_idx == 1:
+                    self.assertEqual(tensor.dist_attr().dims_mapping, [-1, 0])
+                    self.assertEqual(tensor.dist_attr().partial_dims, set())
+                    self.assertEqual(
+                        tensor._local_shape, [IMAGE_SIZE, IMAGE_SIZE // 2]
+                    )
+                sgd_idx += 1
 
         # dist_model.train()
         # for batch_id, (image, label) in enumerate(dist_loader()):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->
- op build支持混合了分布式tensor和单机tensor的输入，此时会将单机tensor扩展为dims_mapping为-1的分布式tensor。
  - 本pr合入后，InferMeta逻辑修改如下：
    ```cxx  
    // MatmulOp::InferMeta函数实现，包含了分布式InferSpmd逻辑
    std::vector<pir::Type> MatmulOp::InferMeta(const std::vector<pir::Value>& input_values, pir::AttributeMap& attributes) {
      // 其它单机代码省略
      // 该部分为分布式专属逻辑
      ProcessMeshAttribute op_mesh;
      if(HasDistInput(input_values, &op_mesh)) {
        CvtAllInputsToDist(input_values, op_mesh);
        auto ctx = pir::IrContext::Instance();
        std::vector<TensorDistAttribute> operand_dist_attrs, result_dist_attrs;
        auto dist_meta_x = CvtToDistMetaTensor(x_.type().dyn_cast<DistDenseTensorType>());
        auto dist_meta_y = CvtToDistMetaTensor(y_.type().dyn_cast<DistDenseTensorType>());
        auto spmd_info = InferSpmd(dist_meta_x, dist_meta_y, transpose_x, transpose_y);
        for(auto& arg_dist : spmd_info.first) {
            operand_dist_attrs.push_back(CvtToPirDistAttr(arg_dist));
        }
    
        auto dist_attr_out = CvtToPirDistAttr(spmd_info.second[0]);
        result_dist_attrs.push_back(dist_attr_out);
        argument_outputs.push_back(DistDenseTensorType::get(ctx, out_type.dyn_cast<pir::DenseTensorType>(), dist_attr_out));
        attributes[kAttrOpDistAttr] = OperationDistAttribute::get(
            ctx,
            op_mesh,
            operand_dist_attrs,
            result_dist_attrs
        );
        return argument_outputs;
      }
      //其它单机代码省略
    }
    ```
- optimizer适配分布式场景。
  - 在本pr中的test_to_static_pir_program单测中，组网得到的program经append_backward & apply optimizer以后，相比于PR #62897 中只append_backward的program, 新增了一个用于获取learning_rate的data_op， 以及两个用于更新梯度的sgd_算子。新的 program如下
     ```cxx
    {
         (%0) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"learning_rate_1",op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[]}},persistable:[true],place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[],stop_gradient:[true]} : () -> pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>
         (%1) = "builtin.parameter" () {is_distributed:[false],is_parameter:[true],need_clip:[true],op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},result(0):{dims_maping:[0,-1]}},parameter_name:"parameter_1",persistable:[true],stop_gradient:[false],trainable:[true]} : () -> pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>
         (%2) = "builtin.parameter" () {is_distributed:[false],is_parameter:[true],need_clip:[true],op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},result(0):{dims_maping:[-1,0]}},parameter_name:"parameter_0",persistable:[true],stop_gradient:[false],trainable:[true]} : () -> pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>
         (%3) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"input0",op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},result(0):{dims_maping:[-1,-1]}},place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[4,16],stop_gradient:[true]} : () -> pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%4) = "pd_op.data" () {dtype:(pd_op.DataType)float32,name:"label0",op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},result(0):{dims_maping:[-1,-1]}},place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[4,8],stop_gradient:[true]} : () -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%5) = "pd_op.relu" (%3) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]}},stop_gradient:[true]} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%6) = "pd_op.matmul" (%5, %2) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[-1,0]},result(0):{dims_maping:[-1,0]}},stop_gradient:[false],transpose_x:false,transpose_y:false} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>) -> pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>
         (%7) = "pd_op.relu" (%6) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,0]},result(0):{dims_maping:[-1,0]}},stop_gradient:[false]} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>) -> pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>
         (%8) = "pd_op.matmul" (%7, %1) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,0]},operand(1):{dims_maping:[0,-1]},result(0):{dims_maping:[-1,-1],partial(0,SUM)}},stop_gradient:[false],transpose_x:false,transpose_y:false} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1], partial(0,SUM)>
         (%9) = "pd_op.relu" (%8) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]}},stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1], partial(0,SUM)>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%10) = "pd_op.subtract" (%9, %4) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]}},stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%11) = "pd_op.square" (%10) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]}},stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%12) = "pd_op.mean" (%11) {axis:(pd_op.IntArray)[],keepdim:false,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},result(0):{dims_maping:[]}},stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>
         () = "builtin.shadow_output" (%12) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[]}},output_name:"loss_0"} : (pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>) -> 
         (%13) = "pd_op.full" () {dtype:(pd_op.DataType)float32,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1]}},place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)1} : () -> pd_dist.tensor<1xf32, mesh_shape:[2],dims_mappings:[-1]>
         (%14) = "pd_op.full_like" (%12, %13) {dtype:(pd_op.DataType)float32,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[]},result(0):{dims_maping:[]}},place:(pd_op.Place)Place(undefined:0),stop_gradient:[false]} : (pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>, pd_dist.tensor<1xf32, mesh_shape:[2],dims_mappings:[-1]>) -> pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>
         (%15) = "pd_op.mean_grad" (%11, %14) {axis:(pd_op.IntArray)[],keepdim:false,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[]},result(0):{dims_maping:[-1,-1]}},reduce_all:false,stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%16) = "pd_op.square_grad" (%10, %15) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]}},stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%17, %18) = "pd_op.subtract_grad" (%9, %4, %16) {axis:(Int32)-1,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[-1,-1]},operand(2):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]},result(1):{dims_maping:[-1,-1]}},stop_gradient:[false,false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, <<NULL TYPE>>
         (%19) = "pd_op.relu_grad" (%9, %17) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,-1]}},stop_gradient:[false]} : (pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>
         (%20, %21) = "pd_op.matmul_grad" (%7, %1, %19) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,0]},operand(1):{dims_maping:[0,-1]},operand(2):{dims_maping:[-1,-1]},result(0):{dims_maping:[-1,0]},result(1):{dims_maping:[0,-1]}},stop_gradient:[false,false],transpose_x:false,transpose_y:false} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>, pd_dist.tensor<4x8xf32, mesh_shape:[2],dims_mappings:[-1,-1]>) -> pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>
         (%22) = "pd_op.relu_grad" (%7, %20) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,0]},operand(1):{dims_maping:[-1,0]},result(0):{dims_maping:[-1,0]}},stop_gradient:[false]} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>) -> pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>
         (%23, %24) = "pd_op.matmul_grad" (%5, %2, %22) {op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,-1]},operand(1):{dims_maping:[-1,0]},operand(2):{dims_maping:[-1,0]},result(0):{dims_maping:[-1,-1],partial(0,SUM)},result(1):{dims_maping:[-1,0]}},stop_gradient:[false,false],transpose_x:false,transpose_y:false} : (pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,-1]>, pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, pd_dist.tensor<4x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>) -> <<NULL TYPE>>, pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>
         (%25, %26) = "pd_op.sgd_" (%1, %0, %21, <<NULL VALUE>>) {multi_precision:false,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[0,-1]},operand(1):{dims_maping:[]},operand(2):{dims_maping:[0,-1]},operand(3):{null},result(0):{dims_maping:[0,-1]},result(1):{null}},stop_gradient:[false,false]} : (pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>, pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>, pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>, <<NULL TYPE>>) -> pd_dist.tensor<16x8xf32, mesh_shape:[2],dims_mappings:[0,-1]>, <<NULL TYPE>>
         (%27, %28) = "pd_op.sgd_" (%2, %0, %24, <<NULL VALUE>>) {multi_precision:false,op_dist_attr:{mesh:{shape:[2],process_ids:[0,1]},operand(0):{dims_maping:[-1,0]},operand(1):{dims_maping:[]},operand(2):{dims_maping:[-1,0]},operand(3):{null},result(0):{dims_maping:[-1,0]},result(1):{null}},stop_gradient:[false,false]} : (pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, pd_dist.tensor<f32, mesh_shape:[2],dims_mappings:[]>, pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, <<NULL TYPE>>) -> pd_dist.tensor<16x16xf32, mesh_shape:[2],dims_mappings:[-1,0]>, <<NULL TYPE>>
     }
     ```
