### PR TITLE
[CINN] Add symbol info when print group

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -55,7 +55,7 @@ std::shared_ptr<OpLoweringGroup> OpLoweringGroup::Clone(
 }
 
 std::ostream& operator<<(std::ostream& os, const OpLoweringGroup& group) {
-  auto PrintSymbolDim = [&](const ::pir::Operation& op) {
+  auto PrintSymbolDims = [&](const ::pir::Operation& op) {
     if (group.value_to_shape_or_data_exprs_.empty()) return;
     os << " {";
     for (uint32_t i = 0; i < op.num_operands(); ++i) {
@@ -73,7 +73,7 @@ std::ostream& operator<<(std::ostream& os, const OpLoweringGroup& group) {
   os << "Group " << group.group_id() << " :\n";
   for (auto* op : group.ops()) {
     printer.PrintOperation(op);
-    PrintSymbolDim(*op);
+    PrintSymbolDims(*op);
     os << "\n";
   }
   return os;

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -60,12 +60,16 @@ std::ostream& operator<<(std::ostream& os, const OpLoweringGroup& group) {
     os << " {";
     for (uint32_t i = 0; i < op.num_operands(); ++i) {
       if (i > 0) os << ",";
-      os << "<" << group.GetShapeOrDataExprs(op.operand_source(i)) << ">";
+      if (group.HasShapeOrDataExprs(op.operand_source(i))) {
+        os << "<" << group.GetShapeOrDataExprs(op.operand_source(i)) << ">";
+      }
     }
     os << "} -> {";
     for (uint32_t i = 0; i < op.num_results(); ++i) {
       if (i > 0) os << ",";
-      os << "<" << group.GetShapeOrDataExprs(op.result(i)) << ">";
+      if (group.HasShapeOrDataExprs(op.result(i))) {
+        os << "<" << group.GetShapeOrDataExprs(op.result(i)) << ">";
+      }
     }
     os << "}";
   };

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -55,10 +55,25 @@ std::shared_ptr<OpLoweringGroup> OpLoweringGroup::Clone(
 }
 
 std::ostream& operator<<(std::ostream& os, const OpLoweringGroup& group) {
+  auto PrintSymbolDim = [&](const ::pir::Operation& op) {
+    if (group.value_to_shape_or_data_exprs_.empty()) return;
+    os << " {";
+    for (uint32_t i = 0; i < op.num_operands(); ++i) {
+      if (i > 0) os << ",";
+      os << "<" << group.GetShapeOrDataExprs(op.operand_source(i)) << ">";
+    }
+    os << "} -> {";
+    for (uint32_t i = 0; i < op.num_results(); ++i) {
+      if (i > 0) os << ",";
+      os << "<" << group.GetShapeOrDataExprs(op.result(i)) << ">";
+    }
+    os << "}";
+  };
   ::pir::IrPrinter printer(os);
   os << "Group " << group.group_id() << " :\n";
   for (auto* op : group.ops()) {
     printer.PrintOperation(op);
+    PrintSymbolDim(*op);
     os << "\n";
   }
   return os;

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.h
@@ -279,6 +279,8 @@ class OpLoweringGroup {
                                          ::pir::IrMapping* ir_mapping) const;
 
  private:
+  friend std::ostream& operator<<(std::ostream&, const OpLoweringGroup&);
+
   // group id, consisted of op's id.
   std::string group_id_{common::UniqName("group_")};
   // op in this group

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -980,14 +980,14 @@ class SubstituteDimExprHelper final {
     return SubstituteVariadic(dim_expr);
   }
 
-  template <typename T>
-  std::optional<DimExpr> SubstituteVariadic(const T& dim_expr) {
+  template <template <typename> class OpT>
+  std::optional<DimExpr> SubstituteVariadic(const OpT<DimExpr>& dim_expr) {
     auto opt_result = SubstituteEntireExpr(dim_expr);
 
     if (opt_result.has_value()) {
-      if (opt_result->template isa<T>()) {
-        auto new_result =
-            SubstituteSubOperands(opt_result->template dyn_cast<T>());
+      if (opt_result->template isa<OpT<DimExpr>>()) {
+        auto new_result = SubstituteSubOperands(
+            opt_result->template dyn_cast<OpT<DimExpr>>());
         if (new_result.has_value()) {
           return new_result;
         }
@@ -998,8 +998,8 @@ class SubstituteDimExprHelper final {
     }
   }
 
-  template <typename T>
-  std::optional<DimExpr> SubstituteEntireExpr(const T& dim_expr) {
+  template <template <typename> class OpT>
+  std::optional<DimExpr> SubstituteEntireExpr(const OpT<DimExpr>& dim_expr) {
     const auto& operands = *(dim_expr.operands);
     List<DimExpr> substituted_operands{};
     size_t replace_cnt = 0;
@@ -1011,15 +1011,15 @@ class SubstituteDimExprHelper final {
                                           : operand);
     }
     if (replace_cnt == 0) return std::nullopt;
-    return SimplifyDimExpr(T{substituted_operands});
+    return SimplifyDimExpr(OpT<DimExpr>{substituted_operands});
   }
 
-  template <typename T>
-  std::optional<DimExpr> SubstituteSubOperands(const T& dim_expr) {
+  template <template <typename> class OpT>
+  std::optional<DimExpr> SubstituteSubOperands(const OpT<DimExpr>& dim_expr) {
     const std::unordered_set<DimExpr> operands_set{dim_expr.operands->begin(),
                                                    dim_expr.operands->end()};
 
-    auto CanReplaceSubOperands = [&operands_set](const T& dim_expr) {
+    auto CanReplaceSubOperands = [&operands_set](const OpT<DimExpr>& dim_expr) {
       for (const auto& operand : *dim_expr.operands) {
         if (operands_set.find(operand) == operands_set.end()) return false;
       }
@@ -1027,8 +1027,8 @@ class SubstituteDimExprHelper final {
     };
 
     for (const auto& kv : pattern_to_replacement_) {
-      if (!kv.first.isa<T>()) continue;
-      const auto& dim_expr_pattern = kv.first.dyn_cast<T>();
+      if (!kv.first.isa<OpT<DimExpr>>()) continue;
+      const auto& dim_expr_pattern = kv.first.dyn_cast<OpT<DimExpr>>();
       if (!CanReplaceSubOperands(dim_expr_pattern)) continue;
 
       List<DimExpr> ret_operands{kv.second};
@@ -1039,7 +1039,7 @@ class SubstituteDimExprHelper final {
           ret_operands->push_back(operand);
         }
       }
-      return SimplifyDimExpr(T{ret_operands});
+      return SimplifyDimExpr(OpT<DimExpr>{ret_operands});
     }
 
     return std::nullopt;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

在打印`OpLoweringGroup`时增加op输入输出value的符号维度信息。打印示例如下：
```
(%0) = "cinn_op.slice" (%1) {axes:[(Int64)1],decrease_axis:[],ends:[(Int64)2147483647],infer_flags:[(Int64)1],starts:[(Int64)-1],stop_gradient:[false],sym_shape_str:"shape[S0, 1], data[NULL]"} : (builtin.tensor<-1x-1xi64>) -> builtin.tensor<-1x-1xi64> {<shape[S0, S1], data[NULL]>} -> {<shape[S0, 1], data[NULL]>}
(%2) = "cinn_op.scale" (%0) {bias:(Float)1,bias_after_scale:true,scale:(Float)1,stop_gradient:[false],sym_shape_str:"shape[S0, 1], data[NULL]"} : (builtin.tensor<-1x-1xi64>) -> builtin.tensor<-1x-1xi64> {<shape[S0, 1], data[NULL]>} -> {<shape[S0, 1], data[NULL]>}
(%3) = "cinn_op.concat" (%1, %2) {axis:(Int32)1,stop_gradient:[false],sym_shape_str:"shape[S0, Add(S1, 1)], data[NULL]"} : (builtin.tensor<-1x-1xi64>, builtin.tensor<-1x-1xi64>) -> builtin.tensor<-1x-1xi64> {<shape[S0, S1], data[NULL]>,<shape[S0, 1], data[NULL]>} -> {<shape[S0, Add(S1, 1)], data[NULL]>} 
```