### PR TITLE
[CINN Performance] Add CreateSingleOpFallbackToPhiPass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -36,6 +36,7 @@
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/divide_group_op_to_fusion_op_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/move_generate_shape_ops_to_prologue_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/simplify_dim_expr_pass.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/substitute_dim_expr_based_on_constraints_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/insert_broadcast_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/lower_cinn_fusion_op_pass.h"
@@ -176,6 +177,7 @@ void ApplyCinnLowerPass(
     pass_manager->AddPass(std::move(pass.value()));
   }
 
+  pass_manager->AddPass(cinn::dialect::ir::CreateSingleOpFallbackToPhiPass());
   if (has_dynamic_shape && !force_static_shape) {
     pass_manager->AddPass(
         cinn::dialect::ir::CreateLowerCinnDyShapeFusionOpPass());

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/divide_group_op_to_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/divide_group_op_to_fusion_op_pass.cc
@@ -216,5 +216,3 @@ std::unique_ptr<::pir::Pass> CreateDivideGroupOpToFusionOpPass() {
 }  // namespace ir
 }  // namespace dialect
 }  // namespace cinn
-
-// REGISTER_IR_PASS(cinn_group_lowering, DivideGroupOpToFusionOpPass);

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.cc
@@ -1,0 +1,147 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.h"
+
+#include "build/paddle/cinn/hlir/dialect/operator/ir/cinn_op.h"
+#include "build/paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
+#include "paddle/cinn/hlir/dialect/runtime/ir/runtime_dialect.h"
+#include "paddle/fluid/pir/dialect/kernel/ir/kernel_dialect.h"
+#include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+namespace {
+
+class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
+ public:
+  explicit FusionOpPattern(::pir::IrContext* context)
+      : pir::OpRewritePattern<cinn::dialect::FusionOp>(context) {}
+
+  bool MatchAndRewrite(cinn::dialect::FusionOp fusion_op,
+                       pir::PatternRewriter& rewriter) const override {
+    // Fallback only when FusionOp has two operators inside: AnySingleOp +
+    // cf.yield
+    if (fusion_op.GetOperators().size() > 2) {
+      return false;
+    }
+    CHECK_EQ(fusion_op.GetOperators().size(), 2);
+    CHECK(fusion_op.GetOperators()[1]->isa<::pir::YieldOp>());
+
+    auto* program = fusion_op->GetParentProgram();
+    auto& shape_analysis = pir::ShapeAnalysisManager::Instance().Get(
+        fusion_op->GetParentProgram());
+    pir::Operation* paddle_op =
+        FallBackOp(fusion_op.GetOperators()[0], rewriter);
+
+    for (size_t i = 0; i < fusion_op.num_results(); ++i) {
+      rewriter.ReplaceAllUsesWith(fusion_op.result(i), paddle_op->result(i));
+      if (shape_analysis.HasShapeOrDataForValue(fusion_op.result(i))) {
+        shape_analysis.SetShapeOrDataForValue(
+            paddle_op->result(i),
+            shape_analysis.GetShapeOrDataForValue(fusion_op.result(i)));
+      } else {
+        LOG(WARNING) << "No shape_data for "
+                     << fusion_op.result(i).defining_op()->name() << "_result_"
+                     << i << ", this may cause error in dynamic shape";
+      }
+    }
+
+    rewriter.EraseOp(fusion_op);
+    return true;
+  }
+
+ private:
+  typedef pir::Operation* (FusionOpPattern::*CinnOpHandler)(
+      pir::Operation*, pir::PatternRewriter&) const;
+
+  pir::Operation* ReshapeOpPattern(
+      pir::Operation* op,
+      pir::PatternRewriter& rewriter) const {  // NOLINT
+    auto reshape_op = op->dyn_cast<cinn::dialect::ReshapeOp>();
+    CHECK(reshape_op);
+
+    const std::vector<int64_t> vec_out_shape = [&]() {
+      auto out_shape_attr = reshape_op.attribute("shape")
+                                .dyn_cast<pir::ArrayAttribute>()
+                                .AsVector();
+      CHECK_GT(out_shape_attr.size(), 0);
+
+      std::vector<int64_t> ret;
+      std::transform(
+          out_shape_attr.begin(),
+          out_shape_attr.end(),
+          std::back_inserter(ret),
+          [](const auto& attr) {
+            return attr.template dyn_cast<::pir::Int32Attribute>().data();
+          });
+      return ret;
+    }();
+
+    auto paddle_reshape = rewriter.Build<paddle::dialect::ReshapeOp>(
+        reshape_op->operand_source(0), vec_out_shape);
+    return paddle_reshape;
+  }
+
+  const std::unordered_map<std::string, CinnOpHandler>& op_handler_map() const {
+    static std::unordered_map<std::string, CinnOpHandler> handler_map = {
+        {cinn::dialect::ReshapeOp::name(), &FusionOpPattern::ReshapeOpPattern},
+    };
+    return handler_map;
+  }
+
+  pir::Operation* FallBackOp(pir::Operation* op,
+                             pir::PatternRewriter& rewriter) const {  // NOLINT
+    auto it = op_handler_map().find(op->name());
+    if (it == op_handler_map().end()) {
+      LOG(FATAL) << "No fallback handler for op: " << op->name();
+    }
+    return (this->*(it->second))(op, rewriter);
+  }
+};
+
+class SingleOpFallbackToPhiPass : public pir::PatternRewritePass {
+ public:
+  SingleOpFallbackToPhiPass()
+      : pir::PatternRewritePass("single_op_fallback_to_phi", 1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    context->GetOrRegisterDialect<cinn::dialect::RuntimeDialect>();
+    context->GetOrRegisterDialect<cinn::dialect::OperatorDialect>();
+    context->GetOrRegisterDialect<paddle::dialect::KernelDialect>();
+
+    pir::RewritePatternSet ps(context);
+    ps.Add<FusionOpPattern>(context);
+
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation* op) const override {
+    return op->num_regions() > 0;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<::pir::Pass> CreateSingleOpFallbackToPhiPass() {
+  return std::make_unique<SingleOpFallbackToPhiPass>();
+}
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/single_op_fallback_to_phi.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/pass/pass.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+std::unique_ptr<::pir::Pass> CreateSingleOpFallbackToPhiPass();
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/test/ir/pir/cinn/symbolic/test_single_op_fallback_to_phi.py
+++ b/test/ir/pir/cinn/symbolic/test_single_op_fallback_to_phi.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import unittest
+from os.path import dirname
+
+import numpy as np
+
+import paddle
+from paddle.static import InputSpec
+
+sys.path.append(dirname(dirname(__file__)))
+from utils import apply_to_static
+
+
+class MatmulReshapeMatmulNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    # (64, 96) * (96, 32) -> (64, 32)
+    # (64, 32) -> reshape -> (16, 128)
+    # (16, 128) * (128, 16) -> (16, 16)
+    def forward(self, x, y, z):
+        out = paddle.matmul(x, y)
+        out = paddle.reshape(out, [16, -1])
+        out = paddle.matmul(out, z)
+        return out
+
+
+class TestSingleOpFallbackToPhi(unittest.TestCase):
+    """
+    Test Pir API + @to_static + CINN.
+    """
+
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x = paddle.randn([64, 96], dtype="float32")
+        self.x.stop_gradient = False
+        self.y = paddle.randn([96, 32], dtype="float32")
+        self.y.stop_gradient = False
+        self.z = paddle.randn([128, 16], dtype="float32")
+        self.z.stop_gradient = False
+
+    def eval(self, use_cinn):
+        paddle.seed(2022)
+        net = MatmulReshapeMatmulNet()
+        if use_cinn:
+            net = apply_to_static(net, use_cinn)
+        net.eval()
+        out = net(self.x, self.y, self.z)
+        return out
+
+    def test_eval(self):
+        cinn_out = self.eval(use_cinn=True)
+        dy_out = self.eval(use_cinn=False)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+
+
+class TestSingleOpFallbackToPhiDynamic(TestSingleOpFallbackToPhi):
+    def eval(self, use_cinn):
+        paddle.seed(2022)
+        net = MatmulReshapeMatmulNet()
+        if use_cinn:
+            input_spec = [
+                InputSpec(shape=[None, None], dtype="float32"),
+                InputSpec(shape=[None, None], dtype="float32"),
+                InputSpec(shape=[None, None], dtype="float32"),
+            ]
+            net = apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = net(self.x, self.y, self.z)
+        return out
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what you’ve done -->
pcard-76996

当 FusionOp 内只有单个 ReshapeOp 时，该 kernel fallback 到 paddle::ReshapeOp 执行，从而利用 paddle reshape 的 inplace 机制，节省 kernel 执行开销

When there is only a single ReshapeOp in FusionOp, the kernel fallsback to paddle::ReshapeOp for execution, thus utilizing the inplace mechanism of paddle reshape to save kernel execution overhead.