### PR TITLE
[DRR][Inference] Fix a drr rewrite bug, Adjust the order of basic pass required by framework in pir inference

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -593,6 +593,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(use_new_executor_);
   CP_MEMBER(use_pir_);
   CP_MEMBER(custom_passes_);
+  CP_MEMBER(custom_pass_only_);
   CP_MEMBER(pm_opt_level_);
 
   if (use_gpu_) {

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -595,6 +595,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(custom_passes_);
   CP_MEMBER(custom_pass_only_);
   CP_MEMBER(pm_opt_level_);
+  CP_MEMBER(ir_debug_passes_);
 
   if (use_gpu_) {
     PADDLE_ENFORCE_EQ(use_xpu_,
@@ -1327,8 +1328,10 @@ NativeConfig AnalysisConfig::ToNativeConfig() const {
   return config;
 }
 
-void AnalysisConfig::SwitchIrDebug(int x) {
+void AnalysisConfig::SwitchIrDebug(int x,
+                                   const std::vector<std::string> &passes) {
   ir_debug_ = x;
+  ir_debug_passes_ = passes;
   Update();
 }
 

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -967,7 +967,7 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   /// \param x whether to debug IR graph analysis phase.
   ///
-  void SwitchIrDebug(int x = true);
+  void SwitchIrDebug(int x = true, const std::vector<std::string>& passes = {});
 
   ///
   /// \brief Turn on MKLDNN.
@@ -1485,6 +1485,7 @@ struct PD_INFER_DECL AnalysisConfig {
   std::vector<std::string> custom_passes_;
   bool custom_pass_only_{false};
   int pm_opt_level_{2};
+  std::vector<std::string> ir_debug_passes_;
 };
 
 }  // namespace paddle

--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -473,7 +473,7 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
   GraphTopo graph_topo_visit(&result_pattern_graph);
   graph_topo_visit.WalkGraphNodesTopoOrder([&](const OpCall& op_call) {
     // set insert point
-    size_t max_input_op_index = 0;
+    size_t max_input_op_index = 0UL;
     pir::Operation* max_index_op = nullptr;
     for (const Tensor* input : op_call.inputs()) {
       if (input->is_none()) {
@@ -483,7 +483,7 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
       if (ir_val) {
         pir::Operation* ir_input_op = ir_val.defining_op();
         if (op_2_temp_program_index.count(ir_input_op) == 0) {
-          max_input_op_index = 0UL;
+          // do nothing
         } else if (max_input_op_index <
                    op_2_temp_program_index.at(ir_input_op)) {
           max_input_op_index = op_2_temp_program_index.at(ir_input_op);

--- a/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/pir/transforms/general/auto_mixed_precision_pass.cc
@@ -62,7 +62,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
 
   bool Initialize(pir::IrContext* context) override {
     PADDLE_ENFORCE_EQ(
-        Has(pir::kPlaceAttr),
+        Has(pir::Pass::kPlaceAttr),
         true,
         phi::errors::InvalidArgument(
             "Pass initialize failed."
@@ -77,7 +77,7 @@ class AutoMixedPrecisionPass : public pir::Pass {
             "required!"
             "Use Set method to set the scope attribute."));
 
-    place_ = Get<phi::Place>(pir::kPlaceAttr);
+    place_ = Get<phi::Place>(pir::Pass::kPlaceAttr);
     precision_mode_ = Get<phi::DataType>("__mixed_precision_mode__");
     context_ = context;
     enable_low_precision_io_ = false;

--- a/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
+++ b/paddle/fluid/pir/transforms/general/constant_folding_pass.cc
@@ -461,30 +461,27 @@ class ConstantFoldingPatternForTrain : public ConstantFoldingPattern {
 
 class ConstantFoldingPass : public pir::Pass {
  public:
-  ConstantFoldingPass()
-      : pir::Pass("constant_folding_pass", 1),
-        place_(phi::CPUPlace{}),
-        scope_(nullptr) {}
+  ConstantFoldingPass() : pir::Pass("constant_folding_pass", 1) {}
 
  private:
   bool Initialize(pir::IrContext* context) override {
     PADDLE_ENFORCE_EQ(
-        Has(pir::kPlaceAttr),
+        Has(pir::Pass::kPlaceAttr),
         true,
         phi::errors::InvalidArgument(
             "Pass initialize failed."
             "When using ConstantFoldingPass, place attribute is required!"
             "Use Set method to set the place attribute."));
     PADDLE_ENFORCE_EQ(
-        Has(pir::kParamScopeAttr),
+        Has(pir::Pass::kParamScopeAttr),
         true,
         phi::errors::InvalidArgument(
             "Pass initialize failed."
             "When using ConstantFoldingPass, scope attribute is required!"
             "Use Set method to set the scope attribute."));
 
-    place_ = Get<phi::Place>(pir::kPlaceAttr);
-    scope_ = &Get<paddle::framework::Scope>(pir::kParamScopeAttr);
+    place_ = Get<phi::Place>(pir::Pass::kPlaceAttr);
+    scope_ = &Get<paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
 
     PADDLE_ENFORCE_NOT_NULL(
         scope_, phi::errors::InvalidArgument("scope can not be nullptr"));
@@ -529,7 +526,7 @@ class ConstantFoldingPass : public pir::Pass {
 
  private:
   size_t suffix_{0};
-  phi::Place place_;
+  phi::Place place_{phi::CPUPlace{}};
   paddle::framework::Scope* scope_{nullptr};
   paddle::framework::interpreter::ExecutionConfig exe_config_{};
   std::vector<std::string> deleted_vars_;

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -981,7 +981,8 @@ void BindAnalysisConfig(py::module *m) {
       .def("lite_engine_enabled", &AnalysisConfig::lite_engine_enabled)
       .def("switch_ir_debug",
            &AnalysisConfig::SwitchIrDebug,
-           py::arg("x") = true)
+           py::arg("x") = true,
+           py::arg("passes") = std::vector<std::string>())
       .def("enable_mkldnn", &AnalysisConfig::EnableMKLDNN)
       .def("disable_mkldnn", &AnalysisConfig::DisableMKLDNN)
       .def("mkldnn_enabled", &AnalysisConfig::mkldnn_enabled)

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1797,7 +1797,9 @@ void BindPassManager(pybind11::module *m) {
       .def("empty", &PassManager::empty)
       .def("clear", &PassManager::clear)
       .def("enable_ir_printing",
-           [](PassManager &self) { self.EnableIRPrinting(); });
+           [](PassManager &self) { self.EnableIRPrinting(); })
+      .def("enable_print_statistics",
+           [](PassManager &self) { self.EnablePrintStatistics(); });
 }
 
 void BindPir(pybind11::module *module) {

--- a/paddle/pir/include/pass/pass.h
+++ b/paddle/pir/include/pass/pass.h
@@ -71,12 +71,12 @@ struct PassInfo {
 
 }  // namespace detail
 
-static const char kParamScopeAttr[] = "__param_scope__";
-static const char kPlaceAttr[] = "__place__";
-
 /// We can access pass only from PassManager.
 class IR_API Pass {
  public:
+  inline static const char kParamScopeAttr[] = "__param_scope__";
+  inline static const char kPlaceAttr[] = "__place__";
+
   explicit Pass(const std::string& name,
                 uint8_t opt_level,
                 const std::vector<std::string>& dependents = {})

--- a/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_attention_fuse_test.cc
@@ -153,8 +153,9 @@ TEST(DrrTest, AttentionFuse) {
   pm.AddPass(pir::CreateMultiHeadMatmulFusePass());
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
-  constant_folding_pass->Set(pir::kPlaceAttr, new phi::Place{phi::GPUPlace{}});
-  constant_folding_pass->Set(pir::kParamScopeAttr,
+  constant_folding_pass->Set(pir::Pass::kPlaceAttr,
+                             new phi::Place{phi::GPUPlace{}});
+  constant_folding_pass->Set(pir::Pass::kParamScopeAttr,
                              new paddle::framework::Scope{});
   pm.AddPass(std::move(constant_folding_pass));
   pm.AddPass(pir::CreateDeadCodeEliminationPass());

--- a/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
+++ b/test/cpp/pir/pattern_rewrite/pattern_rewrite_test.cc
@@ -406,8 +406,8 @@ TEST(pattern_rewrite, Patterns) {
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
   phi::Place place = phi::CPUPlace();
-  constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place);
-  constant_folding_pass->Set(pir::kParamScopeAttr,
+  constant_folding_pass->SetNotOwned(pir::Pass::kPlaceAttr, &place);
+  constant_folding_pass->Set(pir::Pass::kParamScopeAttr,
                              new paddle::framework::Scope());
   pm.AddPass(std::move(constant_folding_pass));
   pm.AddPass(pir::CreateDeadCodeEliminationPass());
@@ -484,8 +484,8 @@ TEST(constant_folding, ConstantFolding) {
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
   phi::Place place = phi::CPUPlace();
-  constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place);
-  constant_folding_pass->SetNotOwned(pir::kParamScopeAttr, &scope);
+  constant_folding_pass->SetNotOwned(pir::Pass::kPlaceAttr, &place);
+  constant_folding_pass->SetNotOwned(pir::Pass::kParamScopeAttr, &scope);
   pm.AddPass(std::move(constant_folding_pass));
   pm.AddPass(pir::CreateDeadCodeEliminationPass());
   pm.EnableIRPrinting();
@@ -507,8 +507,8 @@ TEST(constant_folding, ConstantFolding_Train) {
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
   phi::Place place = phi::CPUPlace();
-  constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place);
-  constant_folding_pass->SetNotOwned(pir::kParamScopeAttr, &scope);
+  constant_folding_pass->SetNotOwned(pir::Pass::kPlaceAttr, &place);
+  constant_folding_pass->SetNotOwned(pir::Pass::kParamScopeAttr, &scope);
   constant_folding_pass->Set("train_mode", new bool(true));
 
   pm.AddPass(std::move(constant_folding_pass));
@@ -576,8 +576,8 @@ TEST(constant_folding, ConstantFolding_Combine) {
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
   phi::Place place = phi::CPUPlace();
-  constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place);
-  constant_folding_pass->Set(pir::kParamScopeAttr,
+  constant_folding_pass->SetNotOwned(pir::Pass::kPlaceAttr, &place);
+  constant_folding_pass->Set(pir::Pass::kParamScopeAttr,
                              new paddle::framework::Scope());
   pm.AddPass(std::move(constant_folding_pass));
   pm.AddPass(pir::CreateDeadCodeEliminationPass());
@@ -617,8 +617,8 @@ TEST(constant_folding, ConstantFolding_MultiOutput) {
   std::unique_ptr<pir::Pass> constant_folding_pass =
       pir::CreateConstantFoldingPass();
   phi::Place place = phi::CPUPlace();
-  constant_folding_pass->SetNotOwned(pir::kPlaceAttr, &place);
-  constant_folding_pass->Set(pir::kParamScopeAttr,
+  constant_folding_pass->SetNotOwned(pir::Pass::kPlaceAttr, &place);
+  constant_folding_pass->Set(pir::Pass::kParamScopeAttr,
                              new paddle::framework::Scope());
   pm.AddPass(std::move(constant_folding_pass));
   pm.AddPass(pir::CreateDeadCodeEliminationPass());

--- a/test/ir/pir/fused_pass/onednn/pass_test.py
+++ b/test/ir/pir/fused_pass/onednn/pass_test.py
@@ -38,6 +38,7 @@ class PassTest(unittest.TestCase):
 
         pm = pir.PassManager(opt_level=4)
         pm.enable_ir_printing()
+        pm.enable_print_statistics()
         for pass_name in self.pass_list:
             pm.add_pass(pass_name)
         pm.run(program)

--- a/test/ir/pir/fused_pass/onednn/pass_test.py
+++ b/test/ir/pir/fused_pass/onednn/pass_test.py
@@ -37,6 +37,7 @@ class PassTest(unittest.TestCase):
             self.pass_list = [self.pass_list]
 
         pm = pir.PassManager(opt_level=4)
+        pm.enable_ir_printing()
         for pass_name in self.pass_list:
             pm.add_pass(pass_name)
         pm.run(program)

--- a/test/ir/pir/fused_pass/pass_test.py
+++ b/test/ir/pir/fused_pass/pass_test.py
@@ -38,6 +38,7 @@ class PassTest(unittest.TestCase):
 
         pm = pir.PassManager(opt_level=4)
         pm.enable_ir_printing()
+        pm.enable_print_statistics()
         for pass_name in self.pass_list:
             pm.add_pass(pass_name)
         pm.run(program)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-71500
- Fix a drr rewrite bug
- Adjust the order of basic pass required by framework in pir inference