### PR TITLE
[CINN] Support Op which numel is less than 32 into cinn

### DIFF
--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -323,7 +323,7 @@ bool IsTempDenySpecialOp(const ::pir::Operation& op) {
   if (op.name() == "cinn_op.generate_shape") {
     return false;
   }
-  return IsShapeComputeOp(op) || IsSmallNumelOp(op);
+  return IsShapeComputeOp(op);
 }
 
 // Mainly used for pd_to_cinn_pass and reused in IsSupportInCinn function.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing


### Description
<!-- Describe what you’ve done -->
Pcard-67164

之前由于CINN后端对于元素个数小于32时的场景处理不完备添加了临时方案将元素个数小于32的算子拦截在CINN之外，当前CINN后端逐渐完备，故放开对于元素个数小于32的算子拦截。