### PR TITLE
[cmake] support MacOS arm liblapack

### DIFF
--- a/cmake/external/lapack.cmake
+++ b/cmake/external/lapack.cmake
@@ -48,19 +48,34 @@ elseif(WIN32)
   set(GFORTRAN_LIB "${LAPACK_LIB_DIR}/libgfortran-3.dll")
   set(BLAS_LIB "${LAPACK_LIB_DIR}/libblas.dll")
   set(LAPACK_LIB "${LAPACK_LIB_DIR}/liblapack.dll")
-else()
-  set(LAPACK_FILE
-      "lapack_mac_v3.10.0.20210628.tar.gz"
-      CACHE STRING "" FORCE)
-  set(LAPACK_URL
-      "https://paddlepaddledeps.bj.bcebos.com/${LAPACK_FILE}"
-      CACHE STRING "" FORCE)
-  set(LAPACK_URL_MD5 427aecf8dee8523de3566ca8e47944d7)
-  set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.0.dylib")
-  set(GNU_RT_LIB_2 "${LAPACK_LIB_DIR}/libgcc_s.1.dylib")
-  set(GFORTRAN_LIB "${LAPACK_LIB_DIR}/libgfortran.5.dylib")
-  set(BLAS_LIB "${LAPACK_LIB_DIR}/libblas.3.dylib")
-  set(LAPACK_LIB "${LAPACK_LIB_DIR}/liblapack.3.dylib")
+else() # MacOS
+  if(APPLE AND WITH_ARM)
+    set(LAPACK_FILE
+        "lapack_mac_arm64_v0.3.26.tar.gz"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL
+        "https://github.com/PaddlePaddle/Paddle/files/14790239/${LAPACK_FILE}"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL_MD5 3f6412105ae2b7465e5ee90c8673e6d4)
+    set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.0.dylib")
+    set(GNU_RT_LIB_2 "${LAPACK_LIB_DIR}/libgcc_s.1.dylib")
+    set(GFORTRAN_LIB "${LAPACK_LIB_DIR}/libgfortran.5.dylib")
+    set(BLAS_LIB "${LAPACK_LIB_DIR}/libblas.dylib")
+    set(LAPACK_LIB "${LAPACK_LIB_DIR}/liblapack.dylib")
+  else()
+    set(LAPACK_FILE
+        "lapack_mac_v3.10.0.20210628.tar.gz"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL
+        "https://paddlepaddledeps.bj.bcebos.com/${LAPACK_FILE}"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL_MD5 427aecf8dee8523de3566ca8e47944d7)
+    set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.0.dylib")
+    set(GNU_RT_LIB_2 "${LAPACK_LIB_DIR}/libgcc_s.1.dylib")
+    set(GFORTRAN_LIB "${LAPACK_LIB_DIR}/libgfortran.5.dylib")
+    set(BLAS_LIB "${LAPACK_LIB_DIR}/libblas.3.dylib")
+    set(LAPACK_LIB "${LAPACK_LIB_DIR}/liblapack.3.dylib")
+  endif()
 endif()
 
 function(download_lapack)

--- a/cmake/external/lapack.cmake
+++ b/cmake/external/lapack.cmake
@@ -54,7 +54,7 @@ else() # MacOS
         "lapack_mac_arm64_v0.3.26.tar.gz"
         CACHE STRING "" FORCE)
     set(LAPACK_URL
-        "https://github.com/PaddlePaddle/Paddle/files/14790239/${LAPACK_FILE}"
+        "https://github.com/PaddlePaddle/Paddle/files/14791051/${LAPACK_FILE}"
         CACHE STRING "" FORCE)
     set(LAPACK_URL_MD5 3f6412105ae2b7465e5ee90c8673e6d4)
     set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.0.dylib")

--- a/cmake/external/lapack.cmake
+++ b/cmake/external/lapack.cmake
@@ -54,7 +54,7 @@ else() # MacOS
         "lapack_mac_arm64_v0.3.26.tar.gz"
         CACHE STRING "" FORCE)
     set(LAPACK_URL
-        "https://github.com/PaddlePaddle/Paddle/files/14791051/${LAPACK_FILE}"
+        "https://paddlepaddledeps.bj.bcebos.com/${LAPACK_FILE}"
         CACHE STRING "" FORCE)
     set(LAPACK_URL_MD5 3f6412105ae2b7465e5ee90c8673e6d4)
     set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.0.dylib")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 #62958 中的TODO，支持 MacOS M 系列的`lapack`库

编译后所需的动态库: [lapack_mac_arm64_v0.3.26.tar.gz](https://github.com/PaddlePaddle/Paddle/files/14791051/lapack_mac_arm64_v0.3.26.tar.gz)


运行`python test/legacy_test/test_zero_dim_sundry_static_api_part4.py TestSundryAPIStatic.test_linalg_cond`具体报错如下:
```bash
    PreconditionNotMetError: The third-party dynamic library (liblapack.3.dylib) that Paddle depends on is not configured correctly. (error code is dlopen(/usr/local/cuda/lib/liblapack.3.dylib, 0x0005): tried: '/usr/local/cuda/lib/liblapack.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/cuda/lib/liblapack.3.dylib' (no such file), '/usr/local/cuda/lib/liblapack.3.dylib' (no such file))
      Suggestions:
      1. Check if the third-party dynamic library (e.g. CUDA, CUDNN) is installed correctly and its version is matched with paddlepaddle you installed.
      2. Configure third-party dynamic library environment variables as follows:
      - Linux: set LD_LIBRARY_PATH by `export LD_LIBRARY_PATH=...`
      - Windows: set PATH by `set PATH=XXX;%PATH%`
      - Mac: set  DYLD_LIBRARY_PATH by `export DYLD_LIBRARY_PATH=...` [Note: After Mac OS 10.11, using the DYLD_LIBRARY_PATH is impossible unless System Integrity Protection (SIP) is disabled.] (at /Users/gouzi/Documents/git/Paddle/paddle/phi/backends/dynload/dynamic_loader.cc:275)
      [operator < pd_kernel.phi_kernel > error]
```
