### PR TITLE
[CINN] Fix bug of cinn pass order

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -214,10 +214,6 @@ int64_t GetOpCount(const ::pir::Operation* op) {
   return count;
 }
 
-int64_t GetFusionOpCount(const ::pir::Program& program) {
-  return GetOpCount<cinn::dialect::FusionOp>(program.module_op());
-}
-
 void ApplyCinnPass(::pir::Program* program,
                    const std::function<std::shared_ptr<pir::PassManager>()>&
                        CreatePassManager) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -23,6 +23,7 @@
 #include "paddle/pir/include/dialect/shape/ir/shape_dialect.h"
 #include "paddle/pir/include/pass/pass_manager.h"
 
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/add_broadcast_to_elementwise_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.h"
@@ -74,6 +75,16 @@ bool HasDynamicShape(const pir::Program& program) {
 }
 }  // namespace
 
+void ApplyPdToCinnPass(
+    ::pir::Program* program,
+    const std::function<std::shared_ptr<::pir::PassManager>()>&
+        CreatePassManager) {
+  std::shared_ptr<pir::PassManager> pass_manager = CreatePassManager();
+  pass_manager->AddPass(cinn::dialect::ir::CreatePdOpToCinnOpPass());
+  pass_manager->AddPass(pir::CreateDeadCodeEliminationPass());
+  pass_manager->Run(program);
+}
+
 void ApplyCinnPreprocessPass(
     ::pir::Program* program,
     const std::function<std::shared_ptr<::pir::PassManager>()>&
@@ -81,16 +92,10 @@ void ApplyCinnPreprocessPass(
   std::shared_ptr<pir::PassManager> pass_manager = CreatePassManager();
   bool has_dynamic_shape = HasDynamicShape(*program);
 
-  pass_manager->AddPass(cinn::dialect::ir::CreateConvert0DTo1DPass());
   if (!has_dynamic_shape && FLAGS_check_infer_symbolic) {
     pass_manager->AddPass(pir::CreateShapeOptimizationPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateCheckInferSymbolicPass());
   }
-  pass_manager->AddPass(cinn::dialect::ir::CreatePdOpToCinnOpPass());
-
-  pass_manager->AddPass(
-      cinn::dialect::ir::CreateAddBroadcastToElementwisePass());
-  pass_manager->AddPass(pir::CreateDeadCodeEliminationPass());
 
   if (has_dynamic_shape) {
     pass_manager->AddPass(cinn::dialect::ir::CreateConvert0DTo1DPass());
@@ -124,6 +129,8 @@ void ApplyGroupOpPass(::pir::Program* program,
                       const std::function<std::shared_ptr<pir::PassManager>()>&
                           CreatePassManager) {
   std::shared_ptr<pir::PassManager> pass_manager = CreatePassManager();
+  pass_manager->AddPass(
+      cinn::dialect::ir::CreateAddBroadcastToElementwisePass());
   if (HasDynamicShape(*program)) {
     pass_manager->AddPass(::pir::CreateShapeOptimizationPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateInsertBroadcastPass());
@@ -188,13 +195,40 @@ void ApplyCinnLowerPass(
   pass_manager->Run(program);
 }
 
+template <typename OP_TYPE>
+int64_t GetOpCount(const ::pir::Operation* op) {
+  int64_t count = 0;
+  for (auto& region : *op) {
+    for (auto& block : region) {
+      for (auto& sub_op : block) {
+        if (sub_op.isa<OP_TYPE>()) {
+          count++;
+          continue;
+        }
+        if (sub_op.num_regions() > 0) {
+          count += GetOpCount<OP_TYPE>(&sub_op);
+        }
+      }
+    }
+  }
+  return count;
+}
+
+int64_t GetFusionOpCount(const ::pir::Program& program) {
+  return GetOpCount<cinn::dialect::FusionOp>(program.module_op());
+}
+
 void ApplyCinnPass(::pir::Program* program,
                    const std::function<std::shared_ptr<pir::PassManager>()>&
                        CreatePassManager) {
+  ApplyPdToCinnPass(program, CreatePassManager);
   ApplyCinnPreprocessPass(program, CreatePassManager);
   ApplyBuildGroupOpPass(program, CreatePassManager);
   ApplyGroupOpPass(program, CreatePassManager);
   ApplyDivideGroupOpToFusionOpPass(program, CreatePassManager);
+  LOG(INFO) << "FusionOp count before lowering : *****[ "
+            << GetOpCount<cinn::dialect::FusionOp>(program->module_op())
+            << " ]*****";
   ApplyCinnLowerPass(program, CreatePassManager);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

由于`pd_to_cinn_pass`是逐层执行，`shape_optimization_pass`是只在module op层级执行一次，两个pass执行顺序的差异会导致控制流子block中的部分算子无法及时通过`shape_optimization_pass`更新符号维度信息，进而导致后续pass出错。
本PR将`pd_to_cinn_pass`单独拆出以避免执行顺序差异而导致的上述问题。