### PR TITLE
Release/2.6

### DIFF
--- a/paddle/fluid/operators/fused/CMakeLists.txt
+++ b/paddle/fluid/operators/fused/CMakeLists.txt
@@ -70,7 +70,7 @@ if(WITH_GPU OR WITH_ROCM)
     op_library(resnet_unit_op)
   endif()
 
-  if(CUDA_VERSION GREATER_EQUAL 11.6)
+  if((NOT WITH_ROCM) AND (CUDA_VERSION GREATER_EQUAL 11.6))
     op_library(fused_gemm_epilogue_op)
   endif()
 endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1.update zlib to 1.2.11
Compiling paddle with zlib 1.2.8 will cause to sf problem when running with python.tarfile on kylin dtk env. Reference to [https://github.com/PyTables/PyTables/issues/686](url), I update third_party/zlib to 1.2.11. It will not  affect the compilation of paddle, while being able to avoid sf problem.
2.dtk compile problem
On kylin dtk2310 env, this change of cmake will fix fused_gemm_epilogue_op compile error.