### PR TITLE
[CustomDevice] Turn off stride for customdevice

### DIFF
--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -28,9 +28,15 @@
 #include "paddle/phi/core/compat/op_utils.h"
 #include "paddle/utils/string/string_helper.h"
 
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+PHI_DEFINE_EXPORTED_bool(use_stride_kernel,
+                         false,
+                         "Whether to use stride kernel if op support stride.");
+#else
 PHI_DEFINE_EXPORTED_bool(use_stride_kernel,
                          true,
                          "Whether to use stride kernel if op support stride.");
+#endif
 
 COMMON_DECLARE_int32(low_precision_op_list);
 COMMON_DECLARE_bool(enable_api_kernel_fallback);

--- a/test/indexing/test_getitem.py
+++ b/test/indexing/test_getitem.py
@@ -22,6 +22,8 @@ from paddle.base import core
 from paddle.base.variable_index import _getitem_static
 from paddle.pir_utils import test_with_pir_api
 
+paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+
 
 class TestGetitemInDygraph(unittest.TestCase):
     def setUp(self):

--- a/test/indexing/test_setitem.py
+++ b/test/indexing/test_setitem.py
@@ -22,6 +22,8 @@ from paddle.base import core
 from paddle.base.variable_index import _setitem_static
 from paddle.pir_utils import test_with_pir_api
 
+paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+
 
 class TestSetitemInDygraph(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -19,6 +19,8 @@ import numpy as np
 import paddle
 from paddle import base
 
+paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+
 
 class TestAsStrided(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_index_select_strided.py
+++ b/test/legacy_test/test_index_select_strided.py
@@ -19,6 +19,8 @@ import numpy as np
 import paddle
 from paddle import base
 
+paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+
 
 class TestIndexSelectStrided(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -19,6 +19,8 @@ import numpy as np
 
 import paddle
 
+paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+
 
 class TestInplace(unittest.TestCase):
     def test_forward_version(self):

--- a/test/legacy_test/test_tensor_unfold.py
+++ b/test/legacy_test/test_tensor_unfold.py
@@ -19,6 +19,8 @@ import numpy as np
 import paddle
 from paddle import base
 
+paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+
 
 class TestTensorUnfold(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
因为 CustomDevice 上的 contiguous 和 strided_copy 算子尚未得到优化，开启 stride 后会导致训练速度变慢，故 CustomDevice 暂时关闭 stride kernel，待优化完毕后重新打开。