### PR TITLE
[common][PIR] fix `SimplifyErrorTypeFormat` formatting error

### DIFF
--- a/paddle/common/enforce.cc
+++ b/paddle/common/enforce.cc
@@ -64,12 +64,15 @@ int GetCallStackLevel() { return FLAGS_call_stack_level; }
 std::string SimplifyErrorTypeFormat(const std::string& str) {
   std::ostringstream sout;
   size_t type_end_pos = str.find(':', 0);
-  if (type_end_pos == std::string::npos) {
-    sout << str;
-  } else {
-    // Remove "Error:", add "()""
+  if (str.substr(type_end_pos - 5, type_end_pos) == "Error:") {
+    // Remove "Error:", add "()"
+    // Examples:
+    //    InvalidArgumentError: xxx -> (InvalidArgument): xxx
     sout << "(" << str.substr(0, type_end_pos - 5) << ")"
          << str.substr(type_end_pos + 1);
+  } else {
+    // type_end_pos == std::string::npos
+    sout << str;
   }
   return sout.str();
 }

--- a/paddle/pir/src/core/op_result_impl.cc
+++ b/paddle/pir/src/core/op_result_impl.cc
@@ -32,7 +32,7 @@ uint32_t OpResultImpl::index() const {
 OpResultImpl::~OpResultImpl() {
   if (!use_empty()) {
     PADDLE_FATAL(
-        "Destroyed a op_result that is still in use. The owner op type is : %s",
+        "Destroyed a op_result that is still in use. The owner op type is: %s",
         owner()->name());
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复错误的 error 提示格式化

示例:

修复前
```bash
(Destroyed a op_result that is still in use. The owner op typ) builtin.parameter (at /Users/gouzi/Documents/git/Paddle/paddle/pir/src/core/op_result_impl.cc:36)
```
修复后
```bash
Destroyed a op_result that is still in use. The owner op type is: builtin.parameter (at /Users/gouzi/Documents/git/Paddle/paddle/pir/src/core/op_result_impl.cc:36)
```
