### PR TITLE
[CINN] remove GetBlockOutsideInput in lower pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/broadcast_with_cf.cc
@@ -24,7 +24,6 @@
 using OpLoweringGroup = cinn::hlir::framework::pir::OpLoweringGroup;
 using OpLoweringGroupPtr = std::shared_ptr<OpLoweringGroup>;
 using cinn::dialect::ir::details::CompileGroupAsOpAttribute;
-using cinn::dialect::ir::details::GetBlockOutsideInput;
 
 namespace {
 std::vector<pir::Value> GetOpOuputValues(const pir::Operation* op) {
@@ -274,7 +273,7 @@ void SetLeafBlockByGroupView(
     pir::Block* block,
     std::unordered_map<pir::Block*, OpLoweringGroupPtr>* group_map) {
   pir::IrMapping ir_mapping;
-  auto origin_group_inputs = GetBlockOutsideInput(origin_group->ops());
+  auto origin_group_inputs = origin_group->GetInputOpValues();
   for (auto input : origin_group_inputs) {
     ir_mapping.Add(input, input);
   }

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/collect_sym_expr.cc
@@ -17,7 +17,6 @@
 #include "paddle/pir/include/dialect/shape/utils/dim_expr_util.h"
 
 namespace {
-using cinn::dialect::ir::details::GetBlockOutsideInput;
 using cinn::dialect::ir::details::OpLoweringGroup;
 using cinn::dialect::ir::details::OpLoweringGroupPtr;
 
@@ -38,7 +37,7 @@ bool IsComplicatedDimExpr(const symbol::DimExpr& dim_expr) {
 template <typename DoEachT>
 void VisitEachInputValue(const OpLoweringGroupPtr& group,
                          const DoEachT& DoEach) {
-  for (pir::Value value : GetBlockOutsideInput(group->ops())) {
+  for (pir::Value value : group->GetInputOpValues()) {
     DoEach(value);
   }
 }

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/lower_cinn_fusion_op_pass.cc
@@ -34,7 +34,7 @@ pir::Operation* ProcessDyShapeGroup(
     const OpLoweringGroupPtr& group,
     pir::ShapeConstraintIRAnalysis& shape_analysis,  // NOLINT
     pir::PatternRewriter& rewriter) {                // NOLINT
-  auto group_inputs = GetBlockOutsideInput(group->ops());
+  auto group_inputs = group->GetInputOpValues();
   GroupDimExprInfo group_dim_expr_info = GetGroupDimExprInfo(group);
   const auto& leaves = group_dim_expr_info.all_value_dim_exprs;
   // has multiple branch
@@ -127,7 +127,7 @@ class FusionOpPattern : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
       const OpLoweringGroupPtr& group,
       pir::ShapeConstraintIRAnalysis& shape_analysis,  // NOLINT
       pir::PatternRewriter& rewriter) const {          // NOLINT
-    auto group_inputs = GetBlockOutsideInput(group->ops());
+    auto group_inputs = group->GetInputOpValues();
     // compile group to jit_kernel_op
     std::vector<pir::Type> output_types;
     const auto& group_output_values = group->output_values();

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.cc
@@ -33,29 +33,6 @@ using cinn::hlir::framework::PirCompiler;
 using cinn::hlir::framework::pir::CINNKernelInfo;
 using cinn::hlir::framework::pir::CompatibleInfo;
 
-std::vector<pir::Value> GetBlockOutsideInput(
-    const std::vector<pir::Operation*>& op_list) {
-  std::vector<pir::Value> vec_res;
-  std::unordered_set<::pir::Value> block_inner_output;
-  for (size_t k = 0; k < op_list.size(); ++k) {
-    for (size_t i = 0; i < op_list[k]->num_results(); ++i) {
-      block_inner_output.insert(op_list[k]->result(i));
-    }
-  }
-
-  std::unordered_set<::pir::Value> insert_value;
-  for (size_t k = 0; k < op_list.size(); ++k) {
-    for (size_t i = 0; i < op_list[k]->num_operands(); ++i) {
-      if (!block_inner_output.count(op_list[k]->operand_source(i)) &&
-          !insert_value.count(op_list[k]->operand_source(i))) {
-        vec_res.push_back(op_list[k]->operand_source(i));
-        insert_value.insert(op_list[k]->operand_source(i));
-      }
-    }
-  }
-  return vec_res;
-}
-
 std::unordered_map<OpLoweringGroupPtr,
                    std::unordered_map<std::string, pir::Attribute>>
 CompileGroupAsOpAttribute(const std::vector<OpLoweringGroupPtr>& group_list) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.h
@@ -19,9 +19,6 @@ namespace cinn::dialect::ir::details {
 using OpLoweringGroup = cinn::hlir::framework::pir::OpLoweringGroup;
 using OpLoweringGroupPtr = std::shared_ptr<OpLoweringGroup>;
 
-std::vector<pir::Value> GetBlockOutsideInput(
-    const std::vector<pir::Operation*>& op_list);
-
 std::unordered_map<OpLoweringGroupPtr,
                    std::unordered_map<std::string, pir::Attribute>>
 CompileGroupAsOpAttribute(const std::vector<OpLoweringGroupPtr>& group_list);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Improvements


### Description
`OpLoweringGroup`类实现了获取输入value的接口，不需要在外部重新定义，因此删去相关内容