### PR TITLE
[Support Incremental Compile On Windows] Support Auto Trigger Cmake When Yaml Change

### DIFF
--- a/paddle/phi/api/CMakeLists.txt
+++ b/paddle/phi/api/CMakeLists.txt
@@ -1,2 +1,9 @@
 add_subdirectory(profiler)
 add_subdirectory(lib)
+if(WIN32)
+  file(GLOB YAML_FILE "${CMAKE_CURRENT_SOURCE_DIR}/yaml/*.yaml")
+  set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY CMAKE_CONFIGURE_DEPENDS ${YAML_FILE})
+endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation


### PR Types
Improvements


### Description
Win32平台增量编译自动触发支持更多场景，当yaml文件改动时重新触发cmake，保证增量编译构建的正确性。