### PR TITLE
fix auto backward bug

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -444,6 +444,14 @@ def all_stop_gradient_true(block):
     return True
 
 
+def all_input_stop_gradient_true(list_of_list):
+    for list_ in list_of_list:
+        for stop_gradient in list_:
+            if stop_gradient is False:
+                return False
+    return True
+
+
 def all_output_grad_none(list_of_list):
     for list_ in list_of_list:
         for value in list_:

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -643,9 +643,6 @@ def append_backward_ops(
                         len(output_grads) == 0
                         or all(zero_flag)
                         or all_output_grad_none(output_grads)
-                        or all_input_stop_gradient_true(
-                            input_grad_stopgradients
-                        )
                     ) and op.name() not in [
                         "pd_op.while",
                         "pd_op.if",
@@ -653,6 +650,14 @@ def append_backward_ops(
                     ]:
                         continue
 
+                    if all_input_stop_gradient_true(
+                        input_grad_stopgradients
+                    ) and op.name() not in [
+                        "pd_op.array_read",
+                        "pd_op.array_write_",
+                        "pd_op.increment_",
+                    ]:
+                        continue
                     if op.name() == "pd_op.if":
                         origin_inputs = get_real_op_inputs(op)
                         for sub_block in op.blocks():

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -22,6 +22,7 @@ from paddle.autograd.backward_utils import (
     ValueDict,
     ValueSet,
     _as_list,
+    all_input_stop_gradient_true,
     all_output_grad_none,
     all_stop_gradient_true,
     argument_to_value,
@@ -642,6 +643,9 @@ def append_backward_ops(
                         len(output_grads) == 0
                         or all(zero_flag)
                         or all_output_grad_none(output_grads)
+                        or all_input_stop_gradient_true(
+                            input_grad_stopgradients
+                        )
                     ) and op.name() not in [
                         "pd_op.while",
                         "pd_op.if",

--- a/test/auto_parallel/pir/test_to_static_pir_program.py
+++ b/test/auto_parallel/pir/test_to_static_pir_program.py
@@ -139,8 +139,6 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
         backward_op_list = [
             "pd_op.sgd_",
             "pd_op.sgd_",
-            "pd_op.relu_grad",
-            "pd_op.c_allreduce_sum_",
             "pd_op.matmul_grad",
             "pd_op.relu_grad",
             "pd_op.matmul_grad",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes
### Description
<!-- Describe what you’ve done -->
- fix the bug in pir auto backward.
  while the stop_gradient of all inputs is true, we should skip calling the vjp interface.
