### PR TITLE
[Prim] Use by_pass instead of set_output when directly set input arg to output arg

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -702,9 +702,9 @@ void add_double_grad(const Tensor& y,
     if (grad_x_grad && grad_y_grad) {
       set_output<T>(grad_x_grad.get() + grad_y_grad.get(), grad_out_grad);
     } else if (grad_x_grad) {
-      set_output<T>(grad_x_grad.get(), grad_out_grad);
+      by_pass<T>(grad_x_grad.get(), grad_out_grad);
     } else if (grad_y_grad) {
-      set_output<T>(grad_y_grad.get(), grad_out_grad);
+      by_pass<T>(grad_y_grad.get(), grad_out_grad);
     } else {
       set_output<T>(full<T>(common::vectorize(grad_out.dims()), 0.0, y.dtype()),
                     grad_out_grad);
@@ -773,9 +773,9 @@ void subtract_double_grad(const Tensor& y,
     if (grad_x_grad && grad_y_grad) {
       set_output<T>(grad_x_grad.get() - grad_y_grad.get(), grad_out_grad);
     } else if (grad_x_grad) {
-      set_output<T>(grad_x_grad.get(), grad_out_grad);
+      by_pass<T>(grad_x_grad.get(), grad_out_grad);
     } else if (grad_y_grad) {
-      set_output<T>(-grad_y_grad.get(), grad_out_grad);
+      by_pass<T>(-grad_y_grad.get(), grad_out_grad);
     } else {
       set_output<T>(
           full<T>(common::vectorize(grad_out.dims()), 0, grad_out.dtype()),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Use `by_pass` instead of `set_output`