### PR TITLE
[HACKATHON 6th] Fix clang-12 support

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -167,6 +167,7 @@ if(NOT WIN32)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(COMMON_FLAGS
         ${COMMON_FLAGS}
+        -Wno-error=unknown-warning-option # For some unknown warning options in lower version clang
         -Wno-error=unused-private-field
         -Wno-error=unused-const-variable
         -Wno-error=deprecated-copy-with-user-provided-copy # For three/five/zeros rule, clang

--- a/paddle/fluid/framework/ir/generate_pass_tester.cc
+++ b/paddle/fluid/framework/ir/generate_pass_tester.cc
@@ -32,8 +32,7 @@ REGISTER_GENERATE_PASS(generate_fc_fuse) {
       }
     };
     // replace
-    SUBGRAPH_(replace) = [subgraph = &replace, with_relu](
-                             VAR_(x), VAR_(y), VAR_(z)) {
+    SUBGRAPH_(replace) = [subgraph = &replace](VAR_(x), VAR_(y), VAR_(z)) {
       auto& fc = OP_(fc)({{"Input", x}, {"W", y}, {"Bias", z}});
       return fc.Out("Out");
     };

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass_tester.cc
@@ -120,8 +120,9 @@ ProgramDesc BuildConvRequantProgramDesc(bool use_mkldnn,
                                         float scale_out,
                                         float scale_in) {
   ProgramDesc prog;
-  for (auto& v : std::initializer_list<std::string>(
-           {"a", "w1", "b1", "d", "e", "f", "w2", "b2", "i"})) {
+  const std::vector<std::string> values = {
+      "a", "w1", "b1", "d", "e", "f", "w2", "b2", "i"};
+  for (auto& v : values) {
     auto* var = prog.MutableBlock(0)->Var(v);
     if (v.find("w") == 0 || v.find("b") == 0) {
       var->SetPersistable(true);
@@ -240,7 +241,7 @@ ProgramDesc BuildOpRequantProgramDesc(bool use_mkldnn,
         {"h"},
         use_mkldnn,
         {matmul_scale, requant_scale3});
-  SetOp(&prog, "concat", "Concat", {"c", "f", "h"}, {"g"}, {use_mkldnn});
+  SetOp(&prog, "concat", "Concat", {"c", "f", "h"}, {"g"}, use_mkldnn);
 
   return prog;
 }
@@ -683,7 +684,7 @@ ProgramDesc BuildRequantOpProgramDesc(bool use_mkldnn,
         {"h"},
         use_mkldnn,
         {op_scale_in, op_scale_out});
-  SetOp(&prog, "concat", "Concat", {"b", "e", "h"}, {"i"}, {use_mkldnn});
+  SetOp(&prog, "concat", "Concat", {"b", "e", "h"}, {"i"}, use_mkldnn);
 
   return prog;
 }

--- a/paddle/fluid/framework/ir/mkldnn/params_quantization_mkldnn_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/params_quantization_mkldnn_pass_tester.cc
@@ -39,8 +39,8 @@ struct Data {
   const std::vector<float>& getData() const { return data; }
 
  private:
-  const std::vector<int64_t> shape;
-  const std::vector<float> data;
+  const std::vector<int64_t> shape{};
+  const std::vector<float> data{};
 };
 
 struct TestScope {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -934,16 +934,14 @@ bool AnalysisPredictor::PrepareExecutor() {
                                  config_.pm_opt_level_);
       if (!config_.custom_passes_.empty()) {
         for (const auto &custom_pass : config_.custom_passes_) {
-          pass_pm.AddPass(
-              std::move(pir::PassRegistry::Instance().Get(custom_pass)));
+          pass_pm.AddPass(pir::PassRegistry::Instance().Get(custom_pass));
         }
       }
       if (config_.use_gpu()) {
         // gpu
         if (!config_.custom_pass_only_) {
           for (const auto &gpu_pass : kPirGpuPasses) {
-            pass_pm.AddPass(
-                std::move(pir::PassRegistry::Instance().Get(gpu_pass)));
+            pass_pm.AddPass(pir::PassRegistry::Instance().Get(gpu_pass));
           }
         }
 
@@ -963,8 +961,7 @@ bool AnalysisPredictor::PrepareExecutor() {
         // mkldnn
         if (!config_.custom_pass_only_) {
           for (const auto &mkldnn_pass : kPirMkldnnPasses) {
-            pass_pm.AddPass(
-                std::move(pir::PassRegistry::Instance().Get(mkldnn_pass)));
+            pass_pm.AddPass(pir::PassRegistry::Instance().Get(mkldnn_pass));
           }
         }
 #endif
@@ -972,8 +969,7 @@ bool AnalysisPredictor::PrepareExecutor() {
         // cpu
         if (!config_.custom_pass_only_) {
           for (const auto &cpu_pass : kPirCpuPasses) {
-            pass_pm.AddPass(
-                std::move(pir::PassRegistry::Instance().Get(cpu_pass)));
+            pass_pm.AddPass(pir::PassRegistry::Instance().Get(cpu_pass));
           }
         }
       }

--- a/paddle/fluid/inference/api/details/zero_copy_tensor_test.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor_test.cc
@@ -57,9 +57,10 @@ std::unique_ptr<Tensor> CreateTensor(paddle_infer::PlaceType place,
 
 template <typename T>
 struct RandomGenerator {
-  RandomGenerator(double min = (std::numeric_limits<T>::min)(),
-                  double max = (std::numeric_limits<T>::max)())
-      : dist_{static_cast<double>(min), static_cast<double>(max)} {}
+  RandomGenerator(
+      double min = static_cast<double>((std::numeric_limits<T>::min)()),
+      double max = static_cast<double>((std::numeric_limits<T>::max)()))
+      : dist_{min, max} {}
   T operator()() { return static_cast<T>(dist_(random_engine_)); }
 
  private:

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -487,7 +487,7 @@ bool ReshapeOpInferSymbolicShape(
 
   shape_analysis->SetShapeOrDataForValue(op->result(0), shape_data);
 
-  const auto &x_shape = [&] {
+  const auto UNUSED &x_shape = [&] {
     std::vector<symbol::DimExpr> x_shape{symbol::DimExpr(0)};
     const auto &original_shape =
         shape_analysis->GetShapeOrDataForValue(op->operand_source(0)).shape();
@@ -840,7 +840,7 @@ bool TransposeOpInferSymbolicShape(
 
   int x_rank = x_dims.size();
 
-  const std::vector<int32_t> formatted_axis = [op, x_rank, &perm] {
+  const std::vector<int32_t> formatted_axis = [x_rank, &perm] {
     std::vector<int32_t> out(perm.size(), 0);
     std::transform(perm.begin(),
                    perm.end(),

--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -243,9 +243,9 @@ OperatorDialect::OperatorDialect(pir::IrContext* ctx)
                        ShadowOutputOpInferSymbolicShapeInterfaceModel>());
 
   info = ctx->GetRegisteredOpInfo(pir::SplitOp::name());
-  info.AttachInterface(std::move(
+  info.AttachInterface(
       pir::InterfaceValue::Get<InferSymbolicShapeInterface,
-                               SplitOpInferSymbolicShapeInterfaceModel>()));
+                               SplitOpInferSymbolicShapeInterfaceModel>());
 
   info = ctx->GetRegisteredOpInfo(pir::YieldOp::name());
   info.AttachInterface(

--- a/test/cpp/fluid/framework/new_executor/workqueue_test.cc
+++ b/test/cpp/fluid/framework/new_executor/workqueue_test.cc
@@ -61,7 +61,7 @@ TEST(WorkQueue, TestSingleThreadedWorkQueue) {
   // AddTask
   EXPECT_EQ(finished.load(), false);
   EXPECT_EQ(counter.load(), 0u);
-  work_queue->AddTask([&counter, &finished, kLoopNum]() {
+  work_queue->AddTask([&counter, &finished]() {
     for (unsigned i = 0; i < kLoopNum; ++i) {
       ++counter;
     }
@@ -111,7 +111,7 @@ TEST(WorkQueue, TestMultiThreadedWorkQueue) {
   EXPECT_EQ(finished.load(), false);
   EXPECT_EQ(counter.load(), 0u);
   for (unsigned i = 0; i < kExternalLoopNum; ++i) {
-    work_queue->AddTask([&counter, &finished, kLoopNum]() {
+    work_queue->AddTask([&counter, &finished]() {
       for (unsigned i = 0; i < kLoopNum; ++i) {
         ++counter;
       }
@@ -147,7 +147,6 @@ TEST(WorkQueue, TestWorkQueueGroup) {
   using paddle::framework::EventsWaiter;
   using paddle::framework::WorkQueueGroup;
   using paddle::framework::WorkQueueOptions;
-  std::atomic<bool> finished{false};
   std::atomic<unsigned> counter{0};
   constexpr unsigned kExternalLoopNum = 100;
   constexpr unsigned kLoopNum = 1000000;
@@ -175,13 +174,13 @@ TEST(WorkQueue, TestWorkQueueGroup) {
   // AddTask
   EXPECT_EQ(counter.load(), 0u);
   for (unsigned i = 0; i < kExternalLoopNum; ++i) {
-    queue_group->AddTask(1, [&counter, &finished, kLoopNum]() {
+    queue_group->AddTask(1, [&counter]() {
       for (unsigned i = 0; i < kLoopNum; ++i) {
         ++counter;
       }
     });
   }
-  queue_group->AddTask(0, [&counter, &finished, kLoopNum]() {
+  queue_group->AddTask(0, [&counter]() {
     for (unsigned i = 0; i < kLoopNum; ++i) {
       ++counter;
     }

--- a/test/cpp/fluid/framework/new_executor/workqueue_test.cc
+++ b/test/cpp/fluid/framework/new_executor/workqueue_test.cc
@@ -61,7 +61,7 @@ TEST(WorkQueue, TestSingleThreadedWorkQueue) {
   // AddTask
   EXPECT_EQ(finished.load(), false);
   EXPECT_EQ(counter.load(), 0u);
-  work_queue->AddTask([&counter, &finished]() {
+  work_queue->AddTask([=, &counter, &finished]() {
     for (unsigned i = 0; i < kLoopNum; ++i) {
       ++counter;
     }
@@ -111,7 +111,7 @@ TEST(WorkQueue, TestMultiThreadedWorkQueue) {
   EXPECT_EQ(finished.load(), false);
   EXPECT_EQ(counter.load(), 0u);
   for (unsigned i = 0; i < kExternalLoopNum; ++i) {
-    work_queue->AddTask([&counter, &finished]() {
+    work_queue->AddTask([=, &counter, &finished]() {
       for (unsigned i = 0; i < kLoopNum; ++i) {
         ++counter;
       }
@@ -174,13 +174,13 @@ TEST(WorkQueue, TestWorkQueueGroup) {
   // AddTask
   EXPECT_EQ(counter.load(), 0u);
   for (unsigned i = 0; i < kExternalLoopNum; ++i) {
-    queue_group->AddTask(1, [&counter]() {
+    queue_group->AddTask(1, [=, &counter]() {
       for (unsigned i = 0; i < kLoopNum; ++i) {
         ++counter;
       }
     });
   }
-  queue_group->AddTask(0, [&counter]() {
+  queue_group->AddTask(0, [=, &counter]() {
     for (unsigned i = 0; i < kLoopNum; ++i) {
       ++counter;
     }

--- a/test/cpp/inference/api/analyzer_bert_tester.cc
+++ b/test/cpp/inference/api/analyzer_bert_tester.cc
@@ -120,7 +120,7 @@ TEST(Analyzer_bert, transfer_scope_cache) {
   std::string line;
 
   for (int i = 0; i < threads_num; i++) {
-    threads.emplace_back([&, i]() {
+    threads.emplace_back([&]() {
       std::getline(fin, line);
       input = ParseInputStreamToVector(line);
       predictor->Run(input, &output, FLAGS_batch_size);

--- a/test/cpp/inference/api/analyzer_mmp_tester.cc
+++ b/test/cpp/inference/api/analyzer_mmp_tester.cc
@@ -79,8 +79,7 @@ void compare(bool use_mkldnn = false) {
   output->copy_to_cpu(xx_output.data());
 
   // Initialize xx model's predictor to trigger oneDNN cache clearing
-  predictor_xx =
-      std::move(InitializePredictor(FLAGS_infer_model2, data, use_mkldnn));
+  predictor_xx = InitializePredictor(FLAGS_infer_model2, data, use_mkldnn);
 
   // Run sequence of models
   predictor_1->ZeroCopyRun();

--- a/test/cpp/inference/api/lite_mul_model_test.cc
+++ b/test/cpp/inference/api/lite_mul_model_test.cc
@@ -32,7 +32,7 @@ int test_predictor(const AnalysisConfig& config_in,
   std::unique_ptr<PaddlePredictor> predictor;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    predictor = std::move(CreatePaddlePredictor(config));
+    predictor = CreatePaddlePredictor(config);
   }
   if (barrier) {
     barrier->Wait();
@@ -75,7 +75,7 @@ int test_predictor_zero_copy(const AnalysisConfig& config_in,
   std::unique_ptr<PaddlePredictor> predictor;
   {
     std::unique_lock<std::mutex> lock(mutex);
-    predictor = std::move(CreatePaddlePredictor(config));
+    predictor = CreatePaddlePredictor(config);
   }
   if (barrier) {
     barrier->Wait();

--- a/test/cpp/inference/api/mkldnn_quantizer_tester.cc
+++ b/test/cpp/inference/api/mkldnn_quantizer_tester.cc
@@ -27,7 +27,7 @@ class MkldnnQuantizerTest : public testing::Test {
  public:
   MkldnnQuantizerTest() {
     AnalysisConfig config(FLAGS_dirname);
-    predictor = std::move(CreatePaddlePredictor(config));
+    predictor = CreatePaddlePredictor(config);
     auto* predictor_p = static_cast<AnalysisPredictor*>(predictor.get());
 
     auto qconfig = new MkldnnQuantizerConfig();

--- a/test/cpp/new_executor/standalone_executor_test.cc
+++ b/test/cpp/new_executor/standalone_executor_test.cc
@@ -126,17 +126,18 @@ ProgramDesc GetLmMainProgram() {
   auto& global_block = main_prog.Block(0);
   int64_t batch_size = 20;
 
-  auto& op1 = global_block.AllOps()[1];
+  const auto allOps = global_block.AllOps();
+  auto& op1 = allOps[1];
   auto shape1 = PADDLE_GET_CONST(std::vector<int64_t>, op1->GetAttr("shape"));
   shape1[0] = batch_size * 20;
   op1->SetAttr("shape", shape1);
 
-  auto& op2 = global_block.AllOps()[2];
+  auto& op2 = allOps[2];
   auto shape2 = PADDLE_GET_CONST(std::vector<int64_t>, op2->GetAttr("shape"));
   shape2[0] = batch_size;
   op2->SetAttr("shape", shape2);
 
-  auto& op3 = global_block.AllOps()[3];
+  auto& op3 = allOps[3];
   auto shape3 = PADDLE_GET_CONST(std::vector<int64_t>, op3->GetAttr("shape"));
   shape3[0] = batch_size;
   op3->SetAttr("shape", shape3);

--- a/test/cpp/pir/core/ir_parser_test.cc
+++ b/test/cpp/pir/core/ir_parser_test.cc
@@ -118,7 +118,6 @@ TestTask* ParserTest::GetTestTask() {
 bool ParserTest::ConsumeTestTask(TestTask* test_task, pir::IrContext* ctx) {
   std::string test_info = test_task->test_info;
   TestType test_type = test_task->test_type;
-  std::unique_ptr<pir::IrPrinter> printer;
   std::unique_ptr<pir::IrParser> parser;
   std::stringstream is(test_info);
   parser.reset(new pir::IrParser(ctx, is));

--- a/test/cpp/prim/test_static_prim.cc
+++ b/test/cpp/prim/test_static_prim.cc
@@ -174,13 +174,13 @@ TEST(StaticPrim, TanhBackwardComposite) {
       static_cast<prim::DescTensor*>(out_grad.impl().get())->get_ptr();
   target_block->RenameVar(out_grad_desc->Name(), "b@GRAD");
   std::vector<std::unique_ptr<framework::OpDesc>> grad_ops =
-      std::move(framework::OpInfoMap::Instance()
-                    .Get(forward_opdesc->Type())
-                    .CompGradOpMaker()(*forward_opdesc,
-                                       std::unordered_set<std::string>(),
-                                       &grad_to_var,
-                                       target_block,
-                                       grad_sub_block));
+      framework::OpInfoMap::Instance()
+          .Get(forward_opdesc->Type())
+          .CompGradOpMaker()(*forward_opdesc,
+                             std::unordered_set<std::string>(),
+                             &grad_to_var,
+                             target_block,
+                             grad_sub_block);
   ASSERT_EQ(target_block->AllOps().size(), static_cast<std::size_t>(1));
   ASSERT_EQ(grad_ops.size(), static_cast<std::size_t>(4));
   ASSERT_EQ(target_block->AllOps()[0]->Type(), "tanh");


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
本 PR 是 “支持 Clang 编译 Paddle” 的收尾工作之一，修复了一些遗留的问题，现已支持 Clang-12 以上版本的编译。

后续的工作包括：
- 当使用 Clang 编译时，为 CUDA 程序指定 Host Compiler 为 Clang
- 当使用 Clang 编译时，将所有第三方依赖库的编译器也指定为 Clang
- 集成额外的链接器支持（如 lld 可以大幅降低链接时的内存占用和链接时间）
