### PR TITLE
【Hackathon 6th No.26】API improvement for nn.initializer.XavierNormal and nn.initializer.XavierUniform 易用性提升 

### DIFF
--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -561,7 +561,6 @@ class TestXavierInitializer(unittest.TestCase):
         else:
             self.assertEqual(init_op.type, 'gaussian_random')
         self.assertEqual(init_op.attr('seed'), 134)
-        self.assertEqual(init_op.attr('gain'), 0.2)
         return block
 
     def test_xavier_initializer_fp16(self):
@@ -771,7 +770,6 @@ class TestXavierInitializerPir(unittest.TestCase):
                     self.assertAlmostEqual(max, limit, delta=DELTA)
 
                 self.assertEqual(init_op.attrs()['seed'], 134)
-                self.assertEqual(init_op.attrs()['gain'], 0.2)
 
         return main, startup
 

--- a/test/legacy_test/test_initializer.py
+++ b/test/legacy_test/test_initializer.py
@@ -555,7 +555,7 @@ class TestXavierInitializer(unittest.TestCase):
         init_op = block.ops[0]
         if uniform:
             self.assertEqual(init_op.type, 'uniform_random')
-            limit = np.sqrt(6.0 / (12 + 23))
+            limit = 0.2 * np.sqrt(6.0 / (12 + 23))
             self.assertAlmostEqual(init_op.attr('min'), -limit, delta=DELTA)
             self.assertAlmostEqual(init_op.attr('max'), limit, delta=DELTA)
         else:
@@ -760,7 +760,7 @@ class TestXavierInitializerPir(unittest.TestCase):
                 self.assertEqual(len(checked_ops), 1)
                 init_op = checked_ops[0]
                 if uniform:
-                    limit = np.sqrt(6.0 / (12 + 23))
+                    limit = 0.2 * np.sqrt(6.0 / (12 + 23))
                     min = self.get_operand_definition_op_attrs(
                         init_op, "min", "value"
                     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements


### Description
<!-- Describe what you’ve done -->
对 nn.initializer.XavierNormal 和 nn.initializer.XavierUniform 添加参数gain
