### PR TITLE
[Prim][PIR] group_norm decomp rule supports rank 3,4,5 and NHWC

### DIFF
--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -839,14 +839,19 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
     const float epsilon,
     const int groups,
     const std::string& data_format) {
-  if (data_format != "NCHW") {
-    // TODO(chengyanfu): support NHWC data format
-    PADDLE_THROW(phi::errors::Unimplemented("Only support NCHW format."));
+  std::vector<int64_t> c_axis;
+  if (data_format == "NCHW") {
+    c_axis = {1};
+  } else if (data_format == "NHWC") {
+    c_axis = {-1};
+  } else {
+    PADDLE_THROW(
+        phi::errors::Unimplemented("Only support NCHW and NHWC format."));
   }
   size_t rank = x.shape().size();
-  if (rank != 3 && rank != 4) {
-    PADDLE_THROW(
-        phi::errors::Unimplemented("Only support NCHW format in rank 3 or 4."));
+  if (rank < 3 || rank > 5) {
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "Only support NCHW and NHWC format in rank {3, 4, 5}."));
   }
 
   auto org_dtype = x.dtype();
@@ -856,21 +861,17 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
   if (need_cast) {
     x_cast = cast<T>(x, DataType::FLOAT32);
   }
-  if (rank == 3) {
-    x_cast = unsqueeze<T>(x_cast, {-1});
-  }
   Tensor x_dim_t;
   Tensor out, mean_, var_;
   if (has_dynamic_shape(x_cast.shape())) {
     x_dim_t = shape<T>(x_cast);
-    std::vector<int64_t> one_axis(1, 1);
     Tensor x_shape = get_slice<T>(x_dim_t, 0) * groups;
     Tensor dim_1 = full<T>({1}, -1, x_dim_t.type());
     x_shape = concat<T>({x_shape, dim_1});
     x_cast = backend::reshape<T>(x_cast, x_shape);
-    mean_ = mean_decomp<T>(x_cast, one_axis, true);
+    mean_ = mean_decomp<T>(x_cast, c_axis, true);
     Tensor var_tmp_ =
-        mean_decomp<T>(x_cast * x_cast, one_axis, true) - mean_ * mean_;
+        mean_decomp<T>(x_cast * x_cast, c_axis, true) - mean_ * mean_;
     var_ = maximum<T>(
         var_tmp_,
         backend::full_with_tensor<T>(shape<T>(var_tmp_), 0, var_tmp_.dtype()));
@@ -880,23 +881,32 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
     out = backend::reshape<T>(res, x_dim_t);
   } else {
     auto x_dim = x_cast.shape();
-    std::vector<int64_t> one_axis(1, 1);
 
     std::vector<int64_t> x_shape{x_dim[0] * groups, -1};
     x_cast = reshape<T>(x_cast, x_shape);
-    mean_ = mean_decomp<T>(x_cast, one_axis, true);
+    mean_ = mean_decomp<T>(x_cast, c_axis, true);
     auto var_tmp_ =
-        mean_decomp<T>(x_cast * x_cast, one_axis, true) - mean_ * mean_;
+        mean_decomp<T>(x_cast * x_cast, c_axis, true) - mean_ * mean_;
     var_ = maximum<T>(var_tmp_, full<T>(var_tmp_.shape(), 0, var_tmp_.dtype()));
     auto var_inv = rsqrt<T>(var_ + full<T>(empty_shape, epsilon, var_.dtype()));
     auto res = (x_cast - mean_) * var_inv;
     out = reshape<T>(res, x_dim);
   }
 
-  std::vector<int64_t> slice_bias_shape{-1, 1, 1};
+  std::vector<int64_t> slice_bias_shape;
+  if (data_format == "NCHW") {
+    slice_bias_shape = {-1};
+    for (size_t i = 0; i < rank - 2; i++) {
+      slice_bias_shape.push_back(1);
+    }
+  }
   Tensor scale_cast;
   if (scale) {
-    scale_cast = reshape<T>(scale.get(), slice_bias_shape);
+    if (data_format == "NCHW") {
+      scale_cast = reshape<T>(scale.get(), slice_bias_shape);
+    } else {
+      scale_cast = scale.get();
+    }
     if (need_cast) {
       scale_cast = cast<T>(scale_cast, DataType::FLOAT32);
     }
@@ -904,7 +914,11 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
   }
   Tensor bias_cast;
   if (bias) {
-    bias_cast = reshape<T>(bias.get(), slice_bias_shape);
+    if (data_format == "NCHW") {
+      bias_cast = reshape<T>(bias.get(), slice_bias_shape);
+    } else {
+      bias_cast = bias.get();
+    }
     if (need_cast) {
       bias_cast = cast<T>(bias_cast, DataType::FLOAT32);
     }
@@ -924,9 +938,6 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
   }
   if (need_cast) {
     out = cast<T>(out, org_dtype);
-  }
-  if (rank == 3) {
-    out = squeeze<T>(out, {-1});
   }
 
   return std::make_tuple(out, mean_out, var_out);

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -28,10 +28,6 @@ static std::vector<int64_t> empty_shape;
 
 template <typename T>
 static Tensor get_slice(const Tensor& x, int64_t idx) {
-  if (idx < 0) {
-    VLOG(0) << "idx <0 **************** ";
-    idx = idx + x.shape().size() - 1;
-  }
   return slice<T>(x, {0}, {idx}, {idx + 1}, {1}, {});
 }
 

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -899,7 +899,7 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
     if (data_format == "NCHW") {
       x_cast = reshape<T>(x_cast, {x_dim[0] * groups, -1});
     } else {
-      int c_div_g = x_dim[-1] / groups;
+      int c_div_g = x_dim[rank - 1] / groups;
       x_cast = reshape<T>(x_cast, {x_dim[0], -1, groups, c_div_g});
     }
     mean_ = mean_decomp<T>(x_cast, c_axis, true);
@@ -935,7 +935,6 @@ std::tuple<Tensor, Tensor, Tensor> group_norm_decomp(
     } else {
       bias_cast = bias.get();
     }
-
     if (need_cast) {
       bias_cast = cast<T>(bias_cast, DataType::FLOAT32);
     }

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -122,7 +122,7 @@ class TestGroupNormOp(OpTest):
         inplace_atol = 0
         place = core.CPUPlace()
 
-        check_prim_output = True if self.data_format == "NCHW" else False
+        check_prim_output = True
         self.check_output_with_place(
             place, atol=atol, check_pir=True, check_prim_pir=check_prim_output
         )
@@ -216,7 +216,7 @@ class TestGroupNormFP16OP(TestGroupNormOp):
         atol = 1e-3
         inplace_atol = 1e-3
 
-        check_prim_output = True if self.data_format == "NCHW" else False
+        check_prim_output = True
         place = core.CUDAPlace(0)
         # group_norm uses AtomicAdd on CUDAPlace, which do not ensure
         # computation order when multiple threads write the same address. So the
@@ -295,7 +295,7 @@ class TestGroupNormBF16Op(OpTest):
         atol = 1e-2
         inplace_atol = 1e-2
 
-        check_prim_output = True if self.data_format == "NCHW" else False
+        check_prim_output = True
         place = core.CUDAPlace(0)
         # group_norm uses AtomicAdd on CUDAPlace, which do not ensure
         # computation order when multiple threads write the same address. So the

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -118,6 +118,8 @@ class TestGroupNormOp(OpTest):
         self.attrs['data_layout'] = self.data_format
 
     def test_check_output(self):
+        self.fw_comp_atol = 1e-13
+        self.fw_comp_rtol = 1e-13
         atol = 0
         inplace_atol = 0
         place = core.CPUPlace()
@@ -128,8 +130,6 @@ class TestGroupNormOp(OpTest):
         )
 
         if core.is_compiled_with_cuda():
-            self.fw_comp_atol = 1e-13
-            self.fw_comp_rtol = 1e-13
             place = core.CUDAPlace(0)
             # group_norm uses AtomicAdd on CUDAPlace, which do not ensure
             # computation order when multiple threads write the same address. So the

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -121,6 +121,17 @@ def group_norm_net4(x):
     return group_norm(x)
 
 
+def group_norm_net5(x):
+    group_norm = paddle.nn.GroupNorm(
+        num_channels=x.shape[-1],
+        num_groups=32,
+        weight_attr=False,
+        bias_attr=False,
+        data_format='NHWC',
+    )
+    return group_norm(x)
+
+
 def layer_norm_net1(x):
     return paddle.nn.functional.layer_norm(x, x.shape[1:])
 
@@ -441,6 +452,19 @@ class TestPrimGroupNorm4(unittest.TestCase):
         self.init_x_shape = [None, 640, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net4
+        self.necessary_ops = "pd_op.group_norm"
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimGroupNorm5(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [50, 10, 20, 640]
+        self.init_x_shape = [None, None, None, 640]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"
         self.enable_cinn = False
         self.tol = 1e-6

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -471,8 +471,8 @@ class TestPrimGroupNorm5(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 10, 20, 16, 128]
-        self.init_x_shape = [8, 10, 20, 16, 128]
+        self.x_shape = [8, 12, 20, 16, 128]
+        self.init_x_shape = [8, 12, 20, 16, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -92,44 +92,54 @@ def swiglu_net2(x):
     return paddle.incubate.nn.functional.swiglu(x)
 
 
+group_norm1 = paddle.nn.GroupNorm(num_channels=640, num_groups=32)
+
+
 def group_norm_net1(x):
-    group_norm = paddle.nn.GroupNorm(num_channels=x.shape[1], num_groups=32)
-    return group_norm(x)
+    return group_norm1(x)
+
+
+group_norm2 = paddle.nn.GroupNorm(
+    num_channels=640, num_groups=32, weight_attr=False
+)
 
 
 def group_norm_net2(x):
-    group_norm = paddle.nn.GroupNorm(
-        num_channels=x.shape[1], num_groups=32, weight_attr=False
-    )
-    return group_norm(x)
+    return group_norm2(x)
+
+
+group_norm3 = paddle.nn.GroupNorm(
+    num_channels=640, num_groups=32, bias_attr=False
+)
 
 
 def group_norm_net3(x):
-    group_norm = paddle.nn.GroupNorm(
-        num_channels=x.shape[1], num_groups=32, bias_attr=False
-    )
-    return group_norm(x)
+    return group_norm3(x)
+
+
+group_norm4 = paddle.nn.GroupNorm(
+    num_channels=640,
+    num_groups=32,
+    weight_attr=False,
+    bias_attr=False,
+)
 
 
 def group_norm_net4(x):
-    group_norm = paddle.nn.GroupNorm(
-        num_channels=x.shape[1],
-        num_groups=32,
-        weight_attr=False,
-        bias_attr=False,
-    )
-    return group_norm(x)
+    return group_norm4(x)
+
+
+group_norm5 = paddle.nn.GroupNorm(
+    num_channels=640,
+    num_groups=32,
+    weight_attr=False,
+    bias_attr=False,
+    data_format='NHWC',
+)
 
 
 def group_norm_net5(x):
-    group_norm = paddle.nn.GroupNorm(
-        num_channels=x.shape[-1],
-        num_groups=32,
-        weight_attr=False,
-        bias_attr=False,
-        data_format='NHWC',
-    )
-    return group_norm(x)
+    return group_norm5(x)
 
 
 def layer_norm_net1(x):
@@ -405,7 +415,7 @@ class TestPrimFlatten2(TestPrimBase):
         self.tol = 1e-6
 
 
-class TestPrimGroupNorm1(unittest.TestCase):
+class TestPrimGroupNorm1(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
@@ -418,7 +428,7 @@ class TestPrimGroupNorm1(unittest.TestCase):
         self.tol = 1e-6
 
 
-class TestPrimGroupNorm2(unittest.TestCase):
+class TestPrimGroupNorm2(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
@@ -431,7 +441,7 @@ class TestPrimGroupNorm2(unittest.TestCase):
         self.tol = 1e-6
 
 
-class TestPrimGroupNorm3(unittest.TestCase):
+class TestPrimGroupNorm3(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
@@ -444,11 +454,11 @@ class TestPrimGroupNorm3(unittest.TestCase):
         self.tol = 1e-6
 
 
-class TestPrimGroupNorm4(unittest.TestCase):
+class TestPrimGroupNorm4(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 640, 10, 20]
+        self.x_shape = [8, 640, 10, 20]
         self.init_x_shape = [None, 640, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net4
@@ -457,17 +467,43 @@ class TestPrimGroupNorm4(unittest.TestCase):
         self.tol = 1e-6
 
 
-class TestPrimGroupNorm5(unittest.TestCase):
+class TestPrimGroupNorm5(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 10, 20, 640]
+        self.x_shape = [8, 10, 20, 16, 640]
+        self.init_x_shape = [8, 10, 20, 16, 640]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = group_norm_net5
+        self.necessary_ops = "pd_op.group_norm"
+        self.enable_cinn = False
+        self.tol = 5e-6
+
+
+class TestPrimGroupNorm6(TestPrimBase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [8, 10, 20, 16, 640]
+        self.init_x_shape = [None, None, None, None, 640]
+        self.x = np.random.random(self.x_shape).astype(self.dtype)
+        self.net = group_norm_net5
+        self.necessary_ops = "pd_op.group_norm"
+        self.enable_cinn = False
+        self.tol = 5e-6
+
+
+class TestPrimGroupNorm7(TestPrimBase):
+    def setUp(self):
+        np.random.seed(2023)
+        self.dtype = "float32"
+        self.x_shape = [8, 10, 20, 640]
         self.init_x_shape = [None, None, None, 640]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"
         self.enable_cinn = False
-        self.tol = 1e-6
+        self.tol = 5e-6
 
 
 if __name__ == "__main__":

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -419,7 +419,7 @@ class TestPrimGroupNorm1(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 128, 10, 20]
+        self.x_shape = [8, 128, 10, 20]
         self.init_x_shape = [None, 128, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net1
@@ -432,7 +432,7 @@ class TestPrimGroupNorm2(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 128, 10, 20]
+        self.x_shape = [8, 128, 10, 20]
         self.init_x_shape = [None, 128, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net2
@@ -471,8 +471,8 @@ class TestPrimGroupNorm5(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 12, 20, 16, 128]
-        self.init_x_shape = [8, 12, 20, 16, 128]
+        self.x_shape = [8, 6, 8, 4, 128]
+        self.init_x_shape = [8, 6, 8, 4, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"
@@ -484,7 +484,7 @@ class TestPrimGroupNorm6(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 10, 20, 16, 128]
+        self.x_shape = [8, 6, 8, 4, 128]
         self.init_x_shape = [None, None, None, None, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
@@ -497,7 +497,7 @@ class TestPrimGroupNorm7(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 10, 20, 128]
+        self.x_shape = [8, 10, 8, 128]
         self.init_x_shape = [None, None, None, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -92,7 +92,7 @@ def swiglu_net2(x):
     return paddle.incubate.nn.functional.swiglu(x)
 
 
-group_norm1 = paddle.nn.GroupNorm(num_channels=640, num_groups=32)
+group_norm1 = paddle.nn.GroupNorm(num_channels=128, num_groups=32)
 
 
 def group_norm_net1(x):
@@ -100,7 +100,7 @@ def group_norm_net1(x):
 
 
 group_norm2 = paddle.nn.GroupNorm(
-    num_channels=640, num_groups=32, weight_attr=False
+    num_channels=128, num_groups=32, weight_attr=False
 )
 
 
@@ -109,7 +109,7 @@ def group_norm_net2(x):
 
 
 group_norm3 = paddle.nn.GroupNorm(
-    num_channels=640, num_groups=32, bias_attr=False
+    num_channels=128, num_groups=32, bias_attr=False
 )
 
 
@@ -118,7 +118,7 @@ def group_norm_net3(x):
 
 
 group_norm4 = paddle.nn.GroupNorm(
-    num_channels=640,
+    num_channels=128,
     num_groups=32,
     weight_attr=False,
     bias_attr=False,
@@ -130,7 +130,7 @@ def group_norm_net4(x):
 
 
 group_norm5 = paddle.nn.GroupNorm(
-    num_channels=640,
+    num_channels=128,
     num_groups=32,
     weight_attr=False,
     bias_attr=False,
@@ -419,60 +419,60 @@ class TestPrimGroupNorm1(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 640, 10, 20]
-        self.init_x_shape = [None, 640, None, None]
+        self.x_shape = [50, 128, 10, 20]
+        self.init_x_shape = [None, 128, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net1
         self.necessary_ops = "pd_op.group_norm"
         self.enable_cinn = False
-        self.tol = 1e-6
+        self.tol = 5e-6
 
 
 class TestPrimGroupNorm2(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 640, 10, 20]
-        self.init_x_shape = [None, 640, None, None]
+        self.x_shape = [50, 128, 10, 20]
+        self.init_x_shape = [None, 128, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net2
         self.necessary_ops = "pd_op.group_norm"
         self.enable_cinn = False
-        self.tol = 1e-6
+        self.tol = 5e-6
 
 
 class TestPrimGroupNorm3(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [50, 640, 10]
-        self.init_x_shape = [None, 640, None]
+        self.x_shape = [50, 128, 10]
+        self.init_x_shape = [None, 128, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net3
         self.necessary_ops = "pd_op.group_norm"
         self.enable_cinn = False
-        self.tol = 1e-6
+        self.tol = 5e-6
 
 
 class TestPrimGroupNorm4(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 640, 10, 20]
-        self.init_x_shape = [None, 640, None, None]
+        self.x_shape = [8, 128, 10, 20]
+        self.init_x_shape = [None, 128, None, None]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net4
         self.necessary_ops = "pd_op.group_norm"
         self.enable_cinn = False
-        self.tol = 1e-6
+        self.tol = 5e-6
 
 
 class TestPrimGroupNorm5(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 10, 20, 16, 640]
-        self.init_x_shape = [8, 10, 20, 16, 640]
+        self.x_shape = [8, 10, 20, 16, 128]
+        self.init_x_shape = [8, 10, 20, 16, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"
@@ -484,8 +484,8 @@ class TestPrimGroupNorm6(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 10, 20, 16, 640]
-        self.init_x_shape = [None, None, None, None, 640]
+        self.x_shape = [8, 10, 20, 16, 128]
+        self.init_x_shape = [None, None, None, None, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"
@@ -497,8 +497,8 @@ class TestPrimGroupNorm7(TestPrimBase):
     def setUp(self):
         np.random.seed(2023)
         self.dtype = "float32"
-        self.x_shape = [8, 10, 20, 640]
-        self.init_x_shape = [None, None, None, 640]
+        self.x_shape = [8, 10, 20, 128]
+        self.init_x_shape = [None, None, None, 128]
         self.x = np.random.random(self.x_shape).astype(self.dtype)
         self.net = group_norm_net5
         self.necessary_ops = "pd_op.group_norm"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-66975
Op group_norm decomp rule supports rank 3,4,5 and NHWC.
