### PR TITLE
【CINN】Modify gpu resource allocation config

### DIFF
--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -81,7 +81,7 @@ BuildPureStaticShapeConfig(
           /* spatial_inner_num = */ 1,
           /* reduce_method = */ BlockReduceMethod()};
       return {{bucket_info, tile_config}};
-    } else {
+    } else if (base_info->reduce_numel <= 2048) {
       BucketInfo bucket_info{/* sp_lower_bound = */ 1,
                              /* sp_upper_bound = */ 1,
                              /* rb_lower_bound = */ 257,
@@ -89,6 +89,17 @@ BuildPureStaticShapeConfig(
       ScheduleConfig::TileConfig tile_config{
           /* warp_num = */ 8,
           /* tree_reduce_num = */ 256,
+          /* spatial_inner_num = */ 1,
+          /* reduce_method = */ BlockReduceMethod()};
+      return {{bucket_info, tile_config}};
+    } else {
+      BucketInfo bucket_info{/* sp_lower_bound = */ 1,
+                             /* sp_upper_bound = */ 1,
+                             /* rb_lower_bound = */ 257,
+                             /* rb_upper_bound = */ kMaxNumel};
+      ScheduleConfig::TileConfig tile_config{
+          /* warp_num = */ 32,
+          /* tree_reduce_num = */ 1024,
           /* spatial_inner_num = */ 1,
           /* reduce_method = */ BlockReduceMethod()};
       return {{bucket_info, tile_config}};
@@ -147,7 +158,7 @@ BuildPureStaticShapeConfig(
         /* reduce_method = */ BlockReduceMethod()};
     return {{bucket_info, tile_config}};
   } else {
-    int64_t warp_num = 8;
+    int64_t warp_num = 32;
     int64_t spatial_inner_num = 1;
     int64_t tree_reduce_num = warp_num * 32;
     BucketInfo bucket_info{/* sp_lower_bound = */ 1,
@@ -279,7 +290,7 @@ BuildStaticReduceConfig(
         /* reduce_method = */ BlockReduceMethod()};
     return {{bucket_info, tile_config}};
   } else {
-    int64_t warp_num = 8;
+    int64_t warp_num = 32;
     int64_t spatial_inner_num = 1;
     int64_t tree_reduce_num = warp_num * 32;
     BucketInfo bucket_info{/* sp_lower_bound = */ 1,

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -95,7 +95,7 @@ BuildPureStaticShapeConfig(
     } else {
       BucketInfo bucket_info{/* sp_lower_bound = */ 1,
                              /* sp_upper_bound = */ 1,
-                             /* rb_lower_bound = */ 257,
+                             /* rb_lower_bound = */ 2049,
                              /* rb_upper_bound = */ kMaxNumel};
       ScheduleConfig::TileConfig tile_config{
           /* warp_num = */ 32,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done --> 
pcard-82036
Modify gpu resource allocation config to enable softmax with shape [1, 32000] use 1024 threadIdx.x