### PR TITLE
[common] fix #63106 Incorrect segmentation

### DIFF
--- a/paddle/common/enforce.cc
+++ b/paddle/common/enforce.cc
@@ -64,7 +64,8 @@ int GetCallStackLevel() { return FLAGS_call_stack_level; }
 std::string SimplifyErrorTypeFormat(const std::string& str) {
   std::ostringstream sout;
   size_t type_end_pos = str.find(':', 0);
-  if (str.substr(type_end_pos - 5, 6) == "Error:") {
+  if (type_end_pos != str.npos && type_end_pos >= 5 &&
+      str.substr(type_end_pos - 5, 6) == "Error:") {
     // Remove "Error:", add "()"
     // Examples:
     //    InvalidArgumentError: xxx -> (InvalidArgument) xxx

--- a/paddle/common/enforce.cc
+++ b/paddle/common/enforce.cc
@@ -64,10 +64,10 @@ int GetCallStackLevel() { return FLAGS_call_stack_level; }
 std::string SimplifyErrorTypeFormat(const std::string& str) {
   std::ostringstream sout;
   size_t type_end_pos = str.find(':', 0);
-  if (str.substr(type_end_pos - 5, type_end_pos) == "Error:") {
+  if (str.substr(type_end_pos - 5, 6) == "Error:") {
     // Remove "Error:", add "()"
     // Examples:
-    //    InvalidArgumentError: xxx -> (InvalidArgument): xxx
+    //    InvalidArgumentError: xxx -> (InvalidArgument) xxx
     sout << "(" << str.substr(0, type_end_pos - 5) << ")"
          << str.substr(type_end_pos + 1);
   } else {

--- a/test/legacy_test/test_cpp_error_msg.py
+++ b/test/legacy_test/test_cpp_error_msg.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+class TestCppErrorMsg(unittest.TestCase):
+    def test_invalid_argument(self):
+        with self.assertRaises(ValueError) as em:
+            input_value = paddle.to_tensor([1, 2, 3, 4, 5])
+            paddle.bincount(input_value, minlength=-1)
+        # InvalidArgumentError: xxx -> (InvalidArgument) xxx
+        self.assertEqual(
+            str(em.exception).startswith("(InvalidArgument)"), True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_cpp_error_msg.py
+++ b/test/legacy_test/test_cpp_error_msg.py
@@ -22,6 +22,7 @@ class TestCppErrorMsg(unittest.TestCase):
         with self.assertRaises(ValueError) as em:
             input_value = paddle.to_tensor([1, 2, 3, 4, 5])
             paddle.bincount(input_value, minlength=-1)
+        print(em.exception)
         # InvalidArgumentError: xxx -> (InvalidArgument) xxx
         self.assertEqual(
             str(em.exception).startswith("(InvalidArgument)"), True

--- a/test/legacy_test/test_cpp_error_msg.py
+++ b/test/legacy_test/test_cpp_error_msg.py
@@ -18,11 +18,13 @@ import paddle
 
 
 class TestCppErrorMsg(unittest.TestCase):
+    def setUp(self) -> None:
+        paddle.base.set_flags({'FLAGS_call_stack_level': 1})
+
     def test_invalid_argument(self):
         with self.assertRaises(ValueError) as em:
             input_value = paddle.to_tensor([1, 2, 3, 4, 5])
             paddle.bincount(input_value, minlength=-1)
-        print(em.exception)
         # InvalidArgumentError: xxx -> (InvalidArgument) xxx
         self.assertEqual(
             str(em.exception).startswith("(InvalidArgument)"), True


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修正 #63106 中的分割错误，并添加单测

```bash
 ValueError: InvalidArgumentError: The minlength should be greater than or equal to 0.But received minlength is -1
```

修正后
```bash
ValueError: (InvalidArgument) The minlength should be greater than or equal to 0.But received minlength is -1
```
