### PR TITLE
Update unity_build_rule.cmake

### DIFF
--- a/paddle/fluid/operators/amp/unity_build_rule.cmake
+++ b/paddle/fluid/operators/amp/unity_build_rule.cmake
@@ -4,7 +4,3 @@
 # Generally, the combination rules in this file do not need to be modified.
 # If there are some redefined error in compiling with the source file which
 # in combination rule, you can remove the source file from the following rules.
-register_unity_group(cc check_finite_and_unscale_op.cc
-                     update_loss_scaling_op.cc)
-register_unity_group(cu check_finite_and_unscale_op.cu
-                     update_loss_scaling_op.cu)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
unity_build_rule.cmake 中文件不存在

![image](https://github.com/PaddlePaddle/Paddle/assets/4617245/727f36ae-4f5d-4b45-aa14-7bab26f90374)
