### PR TITLE
Fix unity_build_rule.cmake files

### DIFF
--- a/paddle/fluid/operators/amp/unity_build_rule.cmake
+++ b/paddle/fluid/operators/amp/unity_build_rule.cmake
@@ -4,7 +4,3 @@
 # Generally, the combination rules in this file do not need to be modified.
 # If there are some redefined error in compiling with the source file which
 # in combination rule, you can remove the source file from the following rules.
-register_unity_group(cc check_finite_and_unscale_op.cc
-                     update_loss_scaling_op.cc)
-register_unity_group(cu check_finite_and_unscale_op.cu
-                     update_loss_scaling_op.cu)

--- a/paddle/fluid/operators/controlflow/unity_build_rule.cmake
+++ b/paddle/fluid/operators/controlflow/unity_build_rule.cmake
@@ -6,15 +6,11 @@
 # in combination rule, you can remove the source file from the following rules.
 register_unity_group(
   cc
-  compare_all_op.cc
-  compare_op.cc
   conditional_block_infer_op.cc
   feed_op.cc
   fetch_op.cc
   fetch_v2_op.cc
   get_places_op.cc
-  logical_op.cc
-  bitwise_op.cc
   tensor_array_read_write_op.cc
   while_op.cc)
 register_unity_group(cu logical_op.cu bitwise_op.cu compare_op.cu

--- a/paddle/fluid/operators/fused/unity_build_rule.cmake
+++ b/paddle/fluid/operators/fused/unity_build_rule.cmake
@@ -10,11 +10,7 @@ register_unity_group(
   fused_embedding_fc_lstm_op.cc
   fused_embedding_seq_pool_op.cc
   fusion_lstm_op.cc
-  fusion_repeated_fc_relu_op.cc
-  fusion_seqconv_eltadd_relu_op.cc
-  fusion_seqexpand_concat_fc_op.cc
   fusion_seqpool_concat_op.cc
-  fusion_squared_mat_sub_op.cc
   multi_gru_op.cc
   mkldnn/multi_gru_mkldnn_op.cc
   fusion_seqpool_cvm_concat_op.cc)

--- a/paddle/fluid/operators/metrics/unity_build_rule.cmake
+++ b/paddle/fluid/operators/metrics/unity_build_rule.cmake
@@ -4,5 +4,4 @@
 # Generally, the combination rules in this file do not need to be modified.
 # If there are some redefined error in compiling with the source file which
 # in combination rule, you can remove the source file from the following rules.
-register_unity_group(cc accuracy_op.cc auc_op.cc precision_recall_op.cc)
-register_unity_group(cu accuracy_op.cu auc_op.cu)
+register_unity_group(cc precision_recall_op.cc)

--- a/paddle/fluid/operators/prim_ops/unity_build_rule.cmake
+++ b/paddle/fluid/operators/prim_ops/unity_build_rule.cmake
@@ -2,7 +2,6 @@ register_unity_group(
   cc
   reshape_p_op.cc
   broadcast_p_op.cc
-  reduce_p_op.cc
   transpose_p_op.cc
   split_p_op.cc
   concat_p_op.cc

--- a/paddle/fluid/operators/reduce_ops/unity_build_rule.cmake
+++ b/paddle/fluid/operators/reduce_ops/unity_build_rule.cmake
@@ -4,8 +4,7 @@
 # Generally, the combination rules in this file do not need to be modified.
 # If there are some redefined error in compiling with the source file which
 # in combination rule, you can remove the source file from the following rules.
-register_unity_group(cc reduce_all_op.cc reduce_any_op.cc)
-register_unity_group(cu reduce_all_op.cu reduce_any_op.cu)
+
 # The following groups are to make better use of `/MP` which MSVC's parallel
 # compilation instruction when compiling in Unity Build.
 register_unity_group(cu frobenius_norm_op.cu)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
文件不存在，取消unity_build_rule.cmake中文件配置

![image](https://github.com/PaddlePaddle/Paddle/assets/4617245/727f36ae-4f5d-4b45-aa14-7bab26f90374)