### PR TITLE
[PIR][oneDNN] Add matmul_transpose_reshape_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -625,6 +625,7 @@ const std::vector<std::string> kPirMkldnnPasses{
     "conv3d_bias_fuse_pass",
     "batch_norm_act_fuse_pass",
     "reshape_transpose_matmul_fuse_pass",
+    "matmul_transpose_reshape_fuse_pass",
     "matmul_elementwise_add_fuse_pass",
     "matmul_activation_fuse_pass",
     "conv_elementwise_add_mkldnn_fuse_pass"};

--- a/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
@@ -185,16 +185,6 @@ class FusedMatmulTransposeReshapeFusePattern
             {&pat.Tensor("reshape_out"), &pat.Tensor("Xshape")});
 
     pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::set<bool> bool_sets = {true, false};
-      auto result_x = match_ctx.Attr<bool>("transpose_x");
-      auto result_y = match_ctx.Attr<bool>("transpose_y");
-      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
-        return false;
-      }
-      return true;
-    });
-
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
       auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
       auto perm = match_ctx.Attr<std::vector<int>>("perm");
       const std::vector<int> supported_axis{0, 2, 1, 3};

--- a/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
@@ -1,0 +1,292 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/onednn_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+class MatmulTransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  std::string matmul_name_;
+  std::string fused_matmul_name_;
+  uint32_t benefit_;
+
+ public:
+  MatmulTransposeReshapeFusePattern(const std::string &matmul_name,
+                                    const std::string &fused_matmul_name,
+                                    uint32_t benefit)
+      : matmul_name_(matmul_name),
+        fused_matmul_name_(fused_matmul_name),
+        benefit_(benefit) {}
+
+  std::string name() const override {
+    return "MatmulTransposeReshapeFusePattern";
+  }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &matmul = pat.Op(matmul_name_,
+                                {{"transpose_x", pat.Attr("transpose_x")},
+                                 {"transpose_y", pat.Attr("transpose_y")}});
+    matmul({&pat.Tensor("X"), &pat.Tensor("Y")}, {&pat.Tensor("Out")});
+
+    const auto &transpose = pat.Op(paddle::dialect::TransposeOp::name(),
+                                   {{"perm", pat.Attr("perm")}});
+    pat.Tensor("transpose_out") = transpose(pat.Tensor("Out"));
+
+    const auto &full_int_array = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                        {{"value", pat.Attr("int_array")}});
+    pat.Tensor("shape") = full_int_array();
+
+    const auto &reshape = pat.Op(paddle::dialect::ReshapeOp::name());
+    reshape({&pat.Tensor("transpose_out"), &pat.Tensor("shape")},
+            {&pat.Tensor("reshape_out"), &pat.Tensor("Xshape")});
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      std::set<bool> bool_sets = {true, false};
+      auto result_x = match_ctx.Attr<bool>("transpose_x");
+      auto result_y = match_ctx.Attr<bool>("transpose_y");
+      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
+        return false;
+      }
+      return true;
+    });
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
+      auto perm = match_ctx.Attr<std::vector<int>>("perm");
+      const std::vector<int> supported_axis{0, 2, 1, 3};
+      if (perm != supported_axis) return false;
+      if (shape.size() != 3) return false;
+      if (std::count(shape.begin(), shape.end(), -1) > 1) return false;
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"trans_x", pat.Attr("transpose_x")},
+        {"trans_y", pat.Attr("transpose_y")},
+        {"matmul_alpha", res.Float32Attr(1.0f)},
+        {"fuse_activation", res.StrAttr("")},
+        {"fuse_alpha", res.Float32Attr(0.0f)},
+        {"fuse_beta", res.Float32Attr(0.0f)},
+        {"fused_output_scale", res.Float32Attr(1.0f)},
+        {"fused_reshape_x", res.VectorInt32Attr({})},
+        {"fused_transpose_x", res.VectorInt32Attr({})},
+        {"fused_reshape_y", res.VectorInt32Attr({})},
+        {"fused_transpose_y", res.VectorInt32Attr({})},
+        {"mkldnn_data_type", res.StrAttr("float32")},
+        {"scale_x", res.Float32Attr(1.0f)},
+        {"scale_y", res.Float32Attr(1.0f)},
+        {"scale_in_eltwise", res.Float32Attr(0.0f)},
+        {"scale_out", res.Float32Attr(1.0f)},
+        {"force_fp32_output", res.BoolAttr(false)}};
+
+    const auto &fused_reshape_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int> {
+          std::vector<int> int_array_value;
+          auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
+          for (auto i : shape) {
+            int_array_value.emplace_back(static_cast<int>(i));
+          }
+          return int_array_value;
+        });
+
+    fused_attrs.emplace("fused_reshape_out", fused_reshape_attr);
+    fused_attrs.emplace("fused_transpose_out", pat.Attr("perm"));
+
+    const auto &fused_matmul = res.Op(fused_matmul_name_, fused_attrs);
+
+    fused_matmul({&res.Tensor("X"), &res.Tensor("Y"), &res.InputNoneTensor()},
+                 {&res.Tensor("reshape_out")});
+  }
+};
+
+class FusedMatmulTransposeReshapeFusePattern
+    : public paddle::drr::DrrPatternBase {
+ private:
+  std::string matmul_name_;
+  std::string fused_matmul_name_;
+  uint32_t benefit_;
+
+ public:
+  FusedMatmulTransposeReshapeFusePattern(const std::string &matmul_name,
+                                         const std::string &fused_matmul_name,
+                                         uint32_t benefit)
+      : matmul_name_(matmul_name),
+        fused_matmul_name_(fused_matmul_name),
+        benefit_(benefit) {}
+
+  std::string name() const override {
+    return "FusedMatmulTransposeReshapeFusePattern";
+  }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &matmul =
+        pat.Op(matmul_name_,
+               {{"trans_x", pat.Attr("transpose_x")},
+                {"trans_y", pat.Attr("transpose_y")},
+                {"matmul_alpha", pat.Attr("matmul_alpha")},
+                {"fuse_activation", pat.Attr("fuse_activation")},
+                {"fuse_alpha", pat.Attr("fuse_alpha")},
+                {"fuse_beta", pat.Attr("fuse_beta")},
+                {"fused_output_scale", pat.Attr("fused_output_scale")},
+                {"fused_reshape_x", pat.Attr("fused_reshape_x")},
+                {"fused_transpose_x", pat.Attr("fused_transpose_x")},
+                {"fused_reshape_y", pat.Attr("fused_reshape_y")},
+                {"fused_transpose_y", pat.Attr("fused_transpose_y")},
+                {"fused_reshape_out", pat.Attr("fused_reshape_out")},
+                {"fused_transpose_out", pat.Attr("fused_transpose_out")},
+                {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+                {"scale_x", pat.Attr("scale_x")},
+                {"scale_y", pat.Attr("scale_y")},
+                {"scale_in_eltwise", pat.Attr("scale_in_eltwise")},
+                {"scale_out", pat.Attr("scale_out")},
+                {"force_fp32_output", pat.Attr("force_fp32_output")}});
+
+    matmul({&pat.Tensor("X"), &pat.Tensor("Y"), &pat.Tensor("residual")},
+           {&pat.Tensor("Out")});
+
+    const auto &transpose = pat.Op(paddle::dialect::TransposeOp::name(),
+                                   {{"perm", pat.Attr("perm")}});
+    pat.Tensor("transpose_out") = transpose(pat.Tensor("Out"));
+
+    const auto &full_int_array = pat.Op(paddle::dialect::FullIntArrayOp::name(),
+                                        {{"value", pat.Attr("int_array")}});
+    pat.Tensor("shape") = full_int_array();
+
+    const auto &reshape = pat.Op(paddle::dialect::ReshapeOp::name());
+    reshape({&pat.Tensor("transpose_out"), &pat.Tensor("shape")},
+            {&pat.Tensor("reshape_out"), &pat.Tensor("Xshape")});
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      std::set<bool> bool_sets = {true, false};
+      auto result_x = match_ctx.Attr<bool>("transpose_x");
+      auto result_y = match_ctx.Attr<bool>("transpose_y");
+      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
+        return false;
+      }
+      return true;
+    });
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
+      auto perm = match_ctx.Attr<std::vector<int>>("perm");
+      const std::vector<int> supported_axis{0, 2, 1, 3};
+      if (perm != supported_axis) return false;
+      if (shape.size() != 3) return false;
+      if (std::count(shape.begin(), shape.end(), -1) > 1) return false;
+
+      return true;
+    });
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      if (!(match_ctx.Attr<std::vector<int>>("fused_reshape_out").empty()))
+        return false;
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"trans_x", pat.Attr("transpose_x")},
+        {"trans_y", pat.Attr("transpose_y")},
+        {"matmul_alpha", pat.Attr("matmul_alpha")},
+        {"fuse_activation", pat.Attr("fuse_activation")},
+        {"fuse_alpha", pat.Attr("fuse_alpha")},
+        {"fuse_beta", pat.Attr("fuse_beta")},
+        {"fused_output_scale", pat.Attr("fused_output_scale")},
+        {"fused_reshape_x", pat.Attr("fused_reshape_x")},
+        {"fused_transpose_x", pat.Attr("fused_transpose_x")},
+        {"fused_reshape_y", pat.Attr("fused_reshape_y")},
+        {"fused_transpose_y", pat.Attr("fused_transpose_y")},
+        {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+        {"scale_x", pat.Attr("scale_x")},
+        {"scale_y", pat.Attr("scale_y")},
+        {"scale_in_eltwise", pat.Attr("scale_in_eltwise")},
+        {"scale_out", pat.Attr("scale_out")},
+        {"force_fp32_output", pat.Attr("force_fp32_output")}};
+
+    const auto &fused_reshape_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> std::vector<int> {
+          std::vector<int> int_array_value;
+          auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
+          for (auto i : shape) {
+            int_array_value.emplace_back(static_cast<int>(i));
+          }
+          return int_array_value;
+        });
+
+    fused_attrs.emplace("fused_reshape_out", fused_reshape_attr);
+    fused_attrs.emplace("fused_transpose_out", pat.Attr("perm"));
+
+    const auto &fused_matmul = res.Op(fused_matmul_name_, fused_attrs);
+
+    fused_matmul({&res.Tensor("X"), &res.Tensor("Y"), &res.Tensor("residual")},
+                 {&res.Tensor("reshape_out")});
+  }
+};
+
+class MatmulTransposeReshapeFusePass : public pir::PatternRewritePass {
+ public:
+  MatmulTransposeReshapeFusePass()
+      : pir::PatternRewritePass("matmul_transpose_reshape_fuse_pass", 3) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    std::vector<bool> bool_set = {false, true};
+    int benefit_idx = 1;
+    ps.Add(paddle::drr::Create<MatmulTransposeReshapeFusePattern>(
+        context,
+        paddle::dialect::MatmulOp::name(),
+        paddle::onednn::dialect::FusedMatmulOp::name(),
+        benefit_idx++));
+
+    ps.Add(paddle::drr::Create<FusedMatmulTransposeReshapeFusePattern>(
+        context,
+        paddle::onednn::dialect::FusedMatmulOp::name(),
+        paddle::onednn::dialect::FusedMatmulOp::name(),
+        benefit_idx++));
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateMatmulTransposeReshapeFusePass() {
+  // pd_op.matmul + pd_op.transpose + pd_op.reshape -> onednn_op.fused_matmul
+  // pd_op.fused_matmul + pd_op.transpose + pd_op.reshape ->
+  // onednn_op.fused_matmul
+  return std::make_unique<MatmulTransposeReshapeFusePass>();
+}
+}  // namespace pir
+
+REGISTER_IR_PASS(matmul_transpose_reshape_fuse_pass,
+                 MatmulTransposeReshapeFusePass);

--- a/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateMatmulTransposeReshapeFusePass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -45,6 +45,7 @@ USE_PIR_PASS(conv2d_bias_fuse_pass);
 USE_PIR_PASS(conv2d_transpose_bias_fuse_pass);
 USE_PIR_PASS(conv3d_bias_fuse_pass);
 USE_PIR_PASS(reshape_transpose_matmul_fuse_pass);
+USE_PIR_PASS(matmul_transpose_reshape_fuse_pass);
 USE_PIR_PASS(matmul_elementwise_add_fuse_pass);
 USE_PIR_PASS(matmul_activation_fuse_pass);
 USE_PIR_PASS(conv_elementwise_add_mkldnn_fuse_pass);

--- a/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
@@ -22,10 +22,6 @@ import paddle
 paddle.enable_static()
 
 
-@unittest.skipIf(
-    not paddle.base.core.is_compiled_with_mkldnn(),
-    "Test case only for OneDNN pass.",
-)
 class TestMatmulTransposeReshapeFusePattern(PassTest):
     r'''
     x       y
@@ -84,10 +80,6 @@ class TestMatmulTransposeReshapeFusePattern(PassTest):
         self.check_pass_correct()
 
 
-@unittest.skipIf(
-    not paddle.base.core.is_compiled_with_mkldnn(),
-    "Test case only for OneDNN pass.",
-)
 class TestMatmulTransposeReshapeAddFusePattern(PassTest):
     r'''
     x       y

--- a/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
@@ -117,14 +117,14 @@ class TestMatmulTransposeReshapeAddFusePattern(PassTest):
                 y = paddle.static.data(
                     name='y', shape=[5, 5, 5, 5], dtype='float32'
                 )
-                bias = paddle.static.create_parameter(
-                    name="bias", shape=[1], dtype='float32'
+                residual = paddle.static.create_parameter(
+                    name="residual", shape=[1], dtype='float32'
                 )
 
                 matmul_out = paddle.matmul(x, y)
                 transpose_out = paddle.transpose(matmul_out, perm=[0, 2, 1, 3])
                 reshape_out = paddle.reshape(transpose_out, [0, 0, 25])
-                out = paddle.add(reshape_out, bias)
+                out = paddle.add(reshape_out, residual)
                 out = paddle.assign(out)
                 self.pass_list = [
                     'matmul_transpose_reshape_fuse_pass',
@@ -133,7 +133,7 @@ class TestMatmulTransposeReshapeAddFusePattern(PassTest):
                 self.feeds = {
                     "x": np.random.random((5, 5, 5, 5)).astype("float32"),
                     "y": np.random.random((5, 5, 5, 5)).astype("float32"),
-                    "bias": np.random.random(1).astype("float32"),
+                    "residual": np.random.random(1).astype("float32"),
                 }
                 self.fetch_list = [out]
                 self.valid_op_map = {

--- a/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
@@ -82,7 +82,11 @@ class TestMatmulTransposeReshapeFusePattern(PassTest):
 
 class TestMatmulTransposeReshapeAddFusePattern(PassTest):
     r'''
-    x       y
+           y
+           |
+        reshape
+           |
+    x  transpose
      \     /
       matmul
         |
@@ -113,12 +117,15 @@ class TestMatmulTransposeReshapeAddFusePattern(PassTest):
                     name="residual", shape=[1], dtype='float32'
                 )
 
-                matmul_out = paddle.matmul(x, y)
+                reshape_out = paddle.reshape(y, [0, 0, 0, 0])
+                transpose_out = paddle.transpose(reshape_out, perm=[0, 2, 3, 1])
+                matmul_out = paddle.matmul(x, transpose_out)
                 transpose_out = paddle.transpose(matmul_out, perm=[0, 2, 1, 3])
                 reshape_out = paddle.reshape(transpose_out, [0, 0, 25])
                 out = paddle.add(reshape_out, residual)
                 out = paddle.assign(out)
                 self.pass_list = [
+                    'reshape_transpose_matmul_fuse_pass',
                     'matmul_transpose_reshape_fuse_pass',
                     'matmul_elementwise_add_fuse_pass',
                 ]

--- a/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
 import numpy as np
-
-sys.path.append("../")
 from pass_test import PassTest
 
 import paddle
@@ -29,7 +26,19 @@ paddle.enable_static()
     not paddle.base.core.is_compiled_with_mkldnn(),
     "Test case only for OneDNN pass.",
 )
-class TestReshapeTranspoeMatmulFusePatternCase1(PassTest):
+class TestMatmulTransposeReshapeFusePattern(PassTest):
+    r'''
+    x       y
+     \     /
+      matmul
+        |
+    transpose
+        |
+     reshape
+        |
+       out
+    '''
+
     def is_program_valid(self, program=None):
         return True
 
@@ -80,6 +89,20 @@ class TestReshapeTranspoeMatmulFusePatternCase1(PassTest):
     "Test case only for OneDNN pass.",
 )
 class TestMatmulTransposeReshapeAddFusePattern(PassTest):
+    r'''
+    x       y
+     \     /
+      matmul
+        |
+    transpose
+        |
+     reshape  residual
+         \   /
+          add
+           |
+          out
+    '''
+
     def is_program_valid(self, program=None):
         return True
 

--- a/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_matmul_transpose_reshape_fuse_pass.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import numpy as np
+
+sys.path.append("../")
+from pass_test import PassTest
+
+import paddle
+
+paddle.enable_static()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestReshapeTranspoeMatmulFusePatternCase1(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[8, 12, 128, 128], dtype='float32'
+                )
+                y = paddle.static.data(
+                    name='y', shape=[8, 12, 128, 64], dtype='float32'
+                )
+
+                matmul_out = paddle.matmul(x, y)
+                transpose_out = paddle.transpose(matmul_out, perm=[0, 2, 1, 3])
+                reshape_out = paddle.reshape(
+                    transpose_out, shape=[0, 0, 12 * 64]
+                )
+                reshape_out = paddle.assign(reshape_out)
+                self.pass_list = ['matmul_transpose_reshape_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((8, 12, 128, 128)).astype("float32"),
+                    "y": np.random.random((8, 12, 128, 64)).astype("float32"),
+                }
+                self.fetch_list = [reshape_out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.matmul": 0,
+                    "pd_op.reshape": 0,
+                    "pd_op.transpose": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestMatmulTransposeReshapeAddFusePattern(PassTest):
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                bias = paddle.static.create_parameter(
+                    name="bias", shape=[1], dtype='float32'
+                )
+
+                matmul_out = paddle.matmul(x, y)
+                transpose_out = paddle.transpose(matmul_out, perm=[0, 2, 1, 3])
+                reshape_out = paddle.reshape(transpose_out, [0, 0, 25])
+                out = paddle.add(reshape_out, bias)
+                out = paddle.assign(out)
+                self.pass_list = [
+                    'matmul_transpose_reshape_fuse_pass',
+                    'matmul_elementwise_add_fuse_pass',
+                ]
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "bias": np.random.random(1).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.reshape": 0,
+                    "pd_op.transpose": 0,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features


### Description
<!-- Describe what you’ve done -->
Based on new pass mechanism, here we add pass "matmul_transpose_reshape_fuse_pass" for PIR.

The new pass is same as "matmul_transpose_reshape_mkldnn_fuse_pass" in "/paddle/fluid/framework/ir/mkldnn/matmul_transpose_reshapel_mkldnn_fuse_pass.cc"
