### PR TITLE
[PIR inference]update add_rms_norm pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1250,8 +1250,14 @@ struct PD_INFER_DECL AnalysisConfig {
                           bool custom_pass_only = false);
 
   ///
-  /// \brief Set passmanager opt level.Pass level lower than
+  /// \brief Set passmanager opt level. Pass level lower than
   /// opt level which will be added to passmanager
+  /// \param opt_level PassManager Level, Optional values is 0,1,2,3,4.
+  /// If 0, only contain the basic pass.
+  /// If 1, constant fold, cse, memory optimize, etc.
+  /// If 2, the fusion logical pass.
+  /// If 3, layout, etc.
+  /// If 4, add the radical optimization, maybe affect precision, etc.
   ///
   void SetOptimizationLevel(int opt_level);
 

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1250,14 +1250,16 @@ struct PD_INFER_DECL AnalysisConfig {
                           bool custom_pass_only = false);
 
   ///
-  /// \brief Set passmanager opt level. Pass level lower than
-  /// opt level which will be added to passmanager
-  /// \param opt_level PassManager Level, Optional values is 0,1,2,3,4.
-  /// If 0, only contain the basic pass.
-  /// If 1, constant fold, cse, memory optimize, etc.
-  /// If 2, the fusion logical pass.
-  /// If 3, layout, etc.
-  /// If 4, add the radical optimization, maybe affect precision, etc.
+  /// \brief Set pir Optimization level.
+  /// \param opt_level The optimization level
+  /// The optimization Level in range [0,4], Default 2.
+  /// Higher optimization level allows the predictor to apply more passes.
+  /// If 0, Only basic pass support.
+  /// If 1, Additional support for functional pass.
+  /// If 2, Additional support the fusion logical pass,maybe affect precision
+  /// and speed.
+  /// If 3, support layout pass, etc.
+  /// If 4, add the radicaloptimization, maybe affect precision, etc.
   ///
   void SetOptimizationLevel(int opt_level);
 

--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -324,7 +324,11 @@ bool DrrRewritePattern::MatchFromOutputToInput(
     }
     return false;
   };
-
+  // Check whether Drr Tensor and IR Value is None.
+  const auto& IsNoneTensorAndValue = [&](const Tensor* drr_input_tensor,
+                                         pir::Value ir_value) {
+    return drr_input_tensor->is_none() && ir_value == nullptr;
+  };
   // Step 1: Initialize DRR matched queue.
   bool matched = true;
   size_t step = 0;
@@ -348,7 +352,14 @@ bool DrrRewritePattern::MatchFromOutputToInput(
     auto ir_input_values = ir_node->operands_source();
     for (size_t i = 0; i < drr_input_tensors.size(); ++i) {
       if (drr_input_tensors[i]->is_none()) {
-        continue;
+        if (IsNoneTensorAndValue(drr_input_tensors[i], ir_input_values[i])) {
+          continue;
+        } else {
+          VLOG(8)
+              << " drr_input_tensors is None,but ir_input_values is different!";
+          matched = false;
+          break;
+        }
       }
       if (HasVisitedOperands(drr_input_tensors[i], ir_input_values[i])) {
         matched = false;

--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -325,8 +325,8 @@ bool DrrRewritePattern::MatchFromOutputToInput(
     return false;
   };
   // Check whether Drr Tensor and IR Value is None.
-  const auto& IsNoneTensorAndValue = [&](const Tensor* drr_input_tensor,
-                                         pir::Value ir_value) {
+  const auto& IsNoneTensorAndValue = [](const Tensor* drr_input_tensor,
+                                        pir::Value ir_value) {
     return drr_input_tensor->is_none() && ir_value == nullptr;
   };
   // Step 1: Initialize DRR matched queue.
@@ -355,8 +355,9 @@ bool DrrRewritePattern::MatchFromOutputToInput(
         if (IsNoneTensorAndValue(drr_input_tensors[i], ir_input_values[i])) {
           continue;
         } else {
-          VLOG(8)
-              << " drr_input_tensors is None,but ir_input_values is different!";
+          VLOG(8) << drr_node->name() << "Match failed:drr_input[" << i
+                  << "] !=  pir_intput[" << i << "] , drr_input_tensor[" << i
+                  << "] is None.";
           matched = false;
           break;
         }

--- a/paddle/fluid/pir/transforms/gpu/add_norm_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/add_norm_fuse_pass.cc
@@ -140,12 +140,12 @@ class RmsNormFusePattern : public paddle::drr::DrrPatternBase {
 
 class AddRmsNormFusePattern : public paddle::drr::DrrPatternBase {
  private:
-  const bool extart_add_;
+  const bool extra_add_;
 
  public:
-  explicit AddRmsNormFusePattern(bool extart_add) : extart_add_(extart_add) {}
+  explicit AddRmsNormFusePattern(bool extra_add) : extra_add_(extra_add) {}
 
-  uint32_t benefit() const override { return extart_add_ ? 2 : 1; }
+  uint32_t benefit() const override { return extra_add_ ? 2 : 1; }
 
   std::string name() const override { return "AddRmsNormFusePattern"; }
 
@@ -173,7 +173,7 @@ class AddRmsNormFusePattern : public paddle::drr::DrrPatternBase {
                   &pat.Tensor("inv_var_0")});
     // TODO(bukejiyu) :DRR support matching placeholder op,
     // the following needs to be deleted
-    if (extart_add_) {
+    if (extra_add_) {
       const auto &add1 = pat.Op(paddle::dialect::AddOp::name());
       pat.Tensor("add_out1") =
           add1(pat.Tensor("add_out"), pat.Tensor("any_tensor"));
@@ -206,12 +206,12 @@ class AddRmsNormFusePattern : public paddle::drr::DrrPatternBase {
 
 class AddLayerNormFusePattern : public paddle::drr::DrrPatternBase {
  private:
-  const bool extart_add_;
+  const bool extra_add_;
 
  public:
-  explicit AddLayerNormFusePattern(bool extart_add) : extart_add_(extart_add) {}
+  explicit AddLayerNormFusePattern(bool extra_add) : extra_add_(extra_add) {}
 
-  uint32_t benefit() const override { return extart_add_ ? 2 : 1; }
+  uint32_t benefit() const override { return extra_add_ ? 2 : 1; }
   std::string name() const override { return "AddLayerNormFusePattern"; }
 
   void operator()(paddle::drr::DrrPatternContext *ctx) const override {
@@ -228,7 +228,7 @@ class AddLayerNormFusePattern : public paddle::drr::DrrPatternBase {
                 &pat.Tensor("variance_out_0")});
     // TODO(bukejiyu) :DRR support matching placeholder op,
     // the following needs to be deleted
-    if (extart_add_) {
+    if (extra_add_) {
       const auto &add1 = pat.Op(paddle::dialect::AddOp::name());
       pat.Tensor("add_out1") =
           add1(pat.Tensor("add_out"), pat.Tensor("any_tensor"));
@@ -272,19 +272,19 @@ class AddNormFusePass : public pir::PatternRewritePass {
     //                                mul --->rms_norm
     // w-----------------------------
     bool is_half_weight = true;
-    bool extart_add = true;
+    bool extra_add = true;
     ps.Add(paddle::drr::Create<RmsNormFusePattern>(context, !is_half_weight));
     ps.Add(paddle::drr::Create<RmsNormFusePattern>(context, is_half_weight));
     // x--------
     //           add-rms_norm ---> rms_norm
     // residual-
-    ps.Add(paddle::drr::Create<AddRmsNormFusePattern>(context, !extart_add));
-    ps.Add(paddle::drr::Create<AddRmsNormFusePattern>(context, extart_add));
+    ps.Add(paddle::drr::Create<AddRmsNormFusePattern>(context, !extra_add));
+    ps.Add(paddle::drr::Create<AddRmsNormFusePattern>(context, extra_add));
     // x--------
     //           add-layer_norm ----> fused_bias_residual_layernorm
     // residual-
-    ps.Add(paddle::drr::Create<AddLayerNormFusePattern>(context, !extart_add));
-    ps.Add(paddle::drr::Create<AddLayerNormFusePattern>(context, extart_add));
+    ps.Add(paddle::drr::Create<AddLayerNormFusePattern>(context, !extra_add));
+    ps.Add(paddle::drr::Create<AddLayerNormFusePattern>(context, extra_add));
     return ps;
   }
 };

--- a/test/ir/pir/fused_pass/CMakeLists.txt
+++ b/test/ir/pir/fused_pass/CMakeLists.txt
@@ -19,6 +19,7 @@ foreach(target ${TEST_INTERP_CASES})
 endforeach()
 
 set_tests_properties(test_pir_multihead_matmul_fuse_pass PROPERTIES TIMEOUT 100)
+set_tests_properties(test_add_norm_fuse_pass PROPERTIES TIMEOUT 300)
 if(WITH_CUTLASS)
   set_tests_properties(test_fused_weight_only_linear_pass PROPERTIES TIMEOUT
                                                                      300)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference


### PR Types
Others


### Description
Pcard-71500
1.增加input tensor 是none时的匹配限制，当drr inputtensor是none时，irvalue中对应的值也需要是none
2.更新 add_rms_norm pass 使其匹配更多的情况
3.增加 SetOptimizationLevel 接口注释