### PR TITLE
[Dy2St][PIR] Enable PIR ut `test_container`

### DIFF
--- a/test/dygraph_to_static/test_container.py
+++ b/test/dygraph_to_static/test_container.py
@@ -17,7 +17,10 @@ import tempfile
 import unittest
 
 import numpy as np
-from dygraph_to_static_utils import Dy2StTestBase
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_legacy_and_pt_and_pir,
+)
 
 import paddle
 from paddle.framework import use_pir_api
@@ -73,7 +76,6 @@ class NestSequentialNet(paddle.nn.Layer):
 
 class TestSequential(Dy2StTestBase):
     def setUp(self):
-        paddle.set_device('cpu')
         self.seed = 2021
         self.temp_dir = tempfile.TemporaryDirectory()
         self._init_config()
@@ -110,8 +112,8 @@ class TestSequential(Dy2StTestBase):
 
         return out
 
+    @test_legacy_and_pt_and_pir
     def test_train(self):
-        paddle.jit.set_code_level(100)
         dy_out = self._run(to_static=False)
         st_out = self._run(to_static=True)
         np.testing.assert_allclose(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

更新 `test/dygraph_to_static/test_container.py`，移除 `paddle.set_device('cpu')`，在 PIR 模式下我们使用的 IrGuard 里调用的 `enable_static` 会消除掉前面设置的 device，进而导致 CUDA 700 错误，我们不需要固定在 CPU 跑，因此直接移除

- #60131

Pcard-67164