### PR TITLE
[CINN] add infer_symbol_shape for yield_store and remove tricky code of yield_store pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -192,6 +192,13 @@ void YieldStoreOp::Build(pir::Builder& builder,
 
 void YieldStoreOp::VerifySig() {}
 
+bool YieldStoreOp::InferSymbolicShape(
+    pir::ShapeConstraintIRAnalysis* shape_analysis) {
+  shape_analysis->SetShapeOrDataForValue(
+      result(0), shape_analysis->GetShapeOrDataForValue(operand_source(0)));
+  return true;
+}
+
 bool ConcatOp::InferSymbolicShape(
     pir::ShapeConstraintIRAnalysis* shape_analysis) {
   VLOG(4) << "Infer symbolic shape for cinn_op.concat";

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -86,7 +86,9 @@ class IR_API FusionOp : public pir::Op<FusionOp> {
 
 // YieldStoreOp represents a store operation for
 // seperate local variable and ouptut
-class IR_API YieldStoreOp : public pir::Op<YieldStoreOp> {
+class IR_API YieldStoreOp
+    : public pir::Op<YieldStoreOp,
+                     paddle::dialect::InferSymbolicShapeInterface> {
  public:
   using Op::Op;
   static const char *name() { return "cinn_op.yield_store"; }
@@ -98,6 +100,8 @@ class IR_API YieldStoreOp : public pir::Op<YieldStoreOp> {
                     pir::Type output_type);
 
   void VerifySig();
+
+  bool InferSymbolicShape(pir::ShapeConstraintIRAnalysis *shape_analysis);
 };
 
 class IR_API ConcatOp


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

1. 为yield_store算子添加InferSymbolicShape实现
2. 删除yield_store相关pass中的特判处理逻辑
