### PR TITLE
[Dy2St][2.6] Disable `test_sentiment` on release/2.6

### DIFF
--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -9,6 +9,8 @@ set(GC_ENVS FLAGS_eager_delete_tensor_gb=0.0)
 
 list(REMOVE_ITEM TEST_OPS test_lac)
 list(REMOVE_ITEM TEST_OPS test_grad) # disable test_grad on release/2.6
+list(REMOVE_ITEM TEST_OPS test_sentiment
+)# disable test_sentiment on release/2.6
 # NOTE(Aurelius84): In case of Windows CI, if open ON_INFER, RWLOCK of Scope
 # will be removed and will cause some random failed in multi-thread.
 if(WITH_PYTHON)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

2.6 分支禁用掉 `test_sentiment` 以确保 CI 不会受到影响

- #60131

Pcard-67164