### PR TITLE
fix nanmedian cpu kernel crash 易用性提升

### DIFF
--- a/paddle/phi/kernels/cpu/nanmedian_kernel.cc
+++ b/paddle/phi/kernels/cpu/nanmedian_kernel.cc
@@ -103,8 +103,12 @@ void CalcMedianFunc(const Context& dev_ctx,
         offset = i * sort_k;
         int64_t pos = offset + sort_k - 1;
         o_ptr[i] = sort_out_ptr[pos];
-        m_ptr[2 * i] = sort_indices_ptr[pos];
-        m_ptr[2 * i + 1] = sort_indices_ptr[pos];
+        if (mode == "avg") {
+          m_ptr[2 * i] = sort_indices_ptr[pos];
+          m_ptr[2 * i + 1] = sort_indices_ptr[pos];
+        } else {
+          m_ptr[i] = sort_indices_ptr[pos];
+        }
       }
     } else {
       for (i = 0; i < pre_dim; i++) {

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -586,6 +586,19 @@ class TestNanmedianModeMean(unittest.TestCase):
         self.assertEqual(x.grad.shape, [])
         np.testing.assert_allclose(x.grad, np.array(0.0))
 
+    def test_dygraph_cpu(self):
+        paddle.disable_static(place=paddle.CPUPlace())
+        with paddle.base.dygraph.guard():
+            data = np.array(
+                [[1.4907, 1.0593, 1.5696], [1.4907, 1.0593, 1.5696]]
+            )
+            out = paddle.nanmedian(
+                paddle.to_tensor(data), axis=1, keepdim=False
+            )
+        np_res = np.nanmedian(data, axis=1)
+        np.testing.assert_allclose(np_res, out, rtol=1e-05, equal_nan=True)
+        paddle.enable_static()
+
 
 class TestNanmedianFP16Op(OpTest):
     def setUp(self):

--- a/test/legacy_test/test_nanmedian.py
+++ b/test/legacy_test/test_nanmedian.py
@@ -344,6 +344,22 @@ class TestNanmedianModeMin(unittest.TestCase):
         self.assertEqual(x.grad.shape, [])
         np.testing.assert_allclose(x.grad, np.array(0.0))
 
+    def test_dygraph_cpu(self):
+        paddle.disable_static(place=paddle.CPUPlace())
+        with paddle.base.dygraph.guard():
+            data = np.array(
+                [[1.4907, 1.0593, 1.5696], [1.4907, 1.0593, 1.5696]]
+            )
+            out, index = paddle.nanmedian(
+                paddle.to_tensor(data), axis=1, keepdim=False, mode='min'
+            )
+        np_res = np_nanmedain_axis(data, axis=1)
+        np.testing.assert_allclose(np_res, out, rtol=1e-05, equal_nan=True)
+        np.testing.assert_allclose(
+            np.array([0, 0]), index, rtol=1e-05, equal_nan=True
+        )
+        paddle.enable_static()
+
 
 class TestNanmedianModeMean(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/PaConvert/pull/382#discussion_r1549097768
‘min’ 模式下 index 分配的内存空间大小等于output的空间大小，‘avg’ 模式下 index 分配的内存空间大小等于output的空间大小的 2 倍。由于之前修改 cpu kernel 时漏改了一处计算 index 的地方，造成了底层的崩溃。
