### PR TITLE
[Pim] Use add_grad composite as default

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -70,7 +70,7 @@ black_ops_list = [
 prim_white_list = [
     "matmul_double_grad",
     "subtract_double_grad",
-    "add_triple_grad",
+    "add_grad",
     "silu_double_grad",
     "tanh_triple_grad",
     "minimum_double_grad",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance 

### Description
<!-- Describe what you’ve done -->
Pcard-75624

Add `add_grad` to prim white list as default grad function, because `add_grad` is much faster than `add_triple_grad` and `add_double_grad` in high-order derivative case as mostly only `set_output` called in `add_grad`.