### PR TITLE
Add enable_onednn api in AnalysisConfig

### DIFF
--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -995,7 +995,8 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   /// \return bool Whether to use the MKLDNN.
   ///
-  bool mkldnn_enabled() const { return use_mkldnn_; }
+  bool mkldnn_enabled() const { return use_mkldnn_; }  // Deprecated
+  bool onednn_enabled() const { return use_mkldnn_; }
 
   ///
   /// \brief Set the number of cpu math library threads.
@@ -1047,7 +1048,8 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   /// \return bool Whether to use the MKLDNN Int8.
   ///
-  bool mkldnn_int8_enabled() const { return use_mkldnn_int8_; }
+  bool mkldnn_int8_enabled() const { return use_mkldnn_int8_; }  // Deprecated
+  bool onednn_int8_enabled() const { return use_mkldnn_int8_; }
 
   ///
   /// \brief Turn on MKLDNN bfloat16.
@@ -1065,14 +1067,20 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   /// \return bool Whether to disable the MKLDNN Fc passes.
   ///
-  bool mkldnn_fc_passes_disabled() const { return disable_mkldnn_fc_passes_; }
+  bool mkldnn_fc_passes_disabled() const {
+    return disable_mkldnn_fc_passes_;
+  }  // Deprecated
+  bool onednn_fc_passes_disabled() const { return disable_mkldnn_fc_passes_; }
 
   ///
   /// \brief A boolean state telling whether to use the MKLDNN Bfloat16.
   ///
   /// \return bool Whether to use the MKLDNN Bfloat16.
   ///
-  bool mkldnn_bfloat16_enabled() const { return use_mkldnn_bfloat16_; }
+  bool mkldnn_bfloat16_enabled() const {
+    return use_mkldnn_bfloat16_;
+  }  // Deprecated
+  bool onednn_bfloat16_enabled() const { return use_mkldnn_bfloat16_; }
 
   /// \brief Specify the operator type list to use Bfloat16 acceleration.
   ///
@@ -1095,7 +1103,10 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   /// \return bool Whether the MKLDNN quantization is enabled.
   ///
-  bool mkldnn_quantizer_enabled() const { return use_mkldnn_quantizer_; }
+  bool mkldnn_quantizer_enabled() const {
+    return use_mkldnn_quantizer_;
+  }  // Deprecated
+  bool onednn_quantizer_enabled() const { return use_mkldnn_quantizer_; }
 
   ///
   /// \brief Get MKLDNN quantizer config.

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -983,9 +983,12 @@ void BindAnalysisConfig(py::module *m) {
            &AnalysisConfig::SwitchIrDebug,
            py::arg("x") = true,
            py::arg("passes") = std::vector<std::string>())
-      .def("enable_mkldnn", &AnalysisConfig::EnableMKLDNN)
-      .def("disable_mkldnn", &AnalysisConfig::DisableMKLDNN)
-      .def("mkldnn_enabled", &AnalysisConfig::mkldnn_enabled)
+      .def("enable_mkldnn", &AnalysisConfig::EnableMKLDNN)     // Deprecated
+      .def("disable_mkldnn", &AnalysisConfig::DisableMKLDNN)   // Deprecated
+      .def("mkldnn_enabled", &AnalysisConfig::mkldnn_enabled)  // Deprecated
+      .def("enable_onednn", &AnalysisConfig::EnableMKLDNN)
+      .def("disable_onednn", &AnalysisConfig::DisableMKLDNN)
+      .def("onednn_enabled", &AnalysisConfig::mkldnn_enabled)
       .def("enable_cinn", &AnalysisConfig::EnableCINN)
       .def("set_cpu_math_library_num_threads",
            &AnalysisConfig::SetCpuMathLibraryNumThreads)
@@ -993,21 +996,27 @@ void BindAnalysisConfig(py::module *m) {
            &AnalysisConfig::cpu_math_library_num_threads)
       .def("to_native_config", &AnalysisConfig::ToNativeConfig)
       .def("enable_quantizer", &AnalysisConfig::EnableMkldnnQuantizer)
-      .def("enable_mkldnn_bfloat16", &AnalysisConfig::EnableMkldnnBfloat16)
+      .def("enable_mkldnn_bfloat16",
+           &AnalysisConfig::EnableMkldnnBfloat16)  // Deprecated
+      .def("enable_onednn_bfloat16", &AnalysisConfig::EnableMkldnnBfloat16)
 #ifdef PADDLE_WITH_DNNL
       .def("quantizer_config",
            &AnalysisConfig::mkldnn_quantizer_config,
            py::return_value_policy::reference)
-      .def("set_mkldnn_cache_capacity",
+      .def("set_mkldnn_cache_capacity",  // Deprecated
+           &AnalysisConfig::SetMkldnnCacheCapacity,
+           py::arg("capacity") = 0)
+      .def("set_onednn_cache_capacity",
            &AnalysisConfig::SetMkldnnCacheCapacity,
            py::arg("capacity") = 0)
       .def("set_bfloat16_op", &AnalysisConfig::SetBfloat16Op)
-      .def("enable_mkldnn_int8",
+      .def("enable_mkldnn_int8",  // Deprecated
            &AnalysisConfig::EnableMkldnnInt8,
            py::arg("mkldnn_int8_enabled_op_types") =
                std::unordered_set<std::string>({}))
-      .def("mkldnn_int8_enabled", &AnalysisConfig::mkldnn_int8_enabled)
-      .def("disable_mkldnn_fc_passes",
+      .def("mkldnn_int8_enabled",
+           &AnalysisConfig::mkldnn_int8_enabled)  // Deprecated
+      .def("disable_mkldnn_fc_passes",            // Deprecated
            &AnalysisConfig::DisableMkldnnFcPasses,
            R"DOC(
             Disable Mkldnn FC
@@ -1020,11 +1029,33 @@ void BindAnalysisConfig(py::module *m) {
                     >>> from paddle.inference import Config
 
                     >>> config = Config("")
-                    >>> config.enable_mkldnn()
-                    >>> config.disable_mkldnn_fc_passes()
+                    >>> config.enable_onednn()
+                    >>> config.disable_onednn_fc_passes()
+            )DOC")
+      .def("enable_onednn_int8",
+           &AnalysisConfig::EnableMkldnnInt8,
+           py::arg("mkldnn_int8_enabled_op_types") =
+               std::unordered_set<std::string>({}))
+      .def("onednn_int8_enabled", &AnalysisConfig::mkldnn_int8_enabled)
+      .def("disable_onednn_fc_passes",
+           &AnalysisConfig::DisableMkldnnFcPasses,
+           R"DOC(
+            Disable Mkldnn FC
+            Returns:
+                None.
+
+            Examples:
+                .. code-block:: python
+
+                    >>> from paddle.inference import Config
+
+                    >>> config = Config("")
+                    >>> config.enable_onednn()
+                    >>> config.disable_onednn_fc_passes()
             )DOC")
 #endif
-      .def("set_mkldnn_op", &AnalysisConfig::SetMKLDNNOp)
+      .def("set_mkldnn_op", &AnalysisConfig::SetMKLDNNOp)  // Deprecated
+      .def("set_onednn_op", &AnalysisConfig::SetMKLDNNOp)
       .def("set_model_buffer", &AnalysisConfig::SetModelBuffer)
       .def("model_from_memory", &AnalysisConfig::model_from_memory)
       .def("delete_pass",
@@ -1320,26 +1351,41 @@ void BindPaddlePassBuilder(py::module *m) {
   py::class_<PassStrategy, PaddlePassBuilder>(*m, "PassStrategy")
       .def(py::init<const std::vector<std::string> &>())
       .def("enable_cudnn", &PassStrategy::EnableCUDNN)
-      .def("enable_mkldnn", &PassStrategy::EnableMKLDNN)
-      .def("enable_mkldnn_quantizer", &PassStrategy::EnableMkldnnQuantizer)
-      .def("enable_mkldnn_bfloat16", &PassStrategy::EnableMkldnnBfloat16)
+      .def("enable_mkldnn", &PassStrategy::EnableMKLDNN)  // Deprecated
+      .def("enable_mkldnn_quantizer",
+           &PassStrategy::EnableMkldnnQuantizer)  // Deprecated
+      .def("enable_mkldnn_bfloat16",
+           &PassStrategy::EnableMkldnnBfloat16)  // Deprecated
+      .def("enable_onednn", &PassStrategy::EnableMKLDNN)
+      .def("enable_onednn_quantizer", &PassStrategy::EnableMkldnnQuantizer)
+      .def("enable_onednn_bfloat16", &PassStrategy::EnableMkldnnBfloat16)
       .def("use_gpu", &PassStrategy::use_gpu);
 
   py::class_<CpuPassStrategy, PassStrategy>(*m, "CpuPassStrategy")
       .def(py::init<>())
       .def(py::init<const CpuPassStrategy &>())
       .def("enable_cudnn", &CpuPassStrategy::EnableCUDNN)
-      .def("enable_mkldnn", &CpuPassStrategy::EnableMKLDNN)
-      .def("enable_mkldnn_quantizer", &CpuPassStrategy::EnableMkldnnQuantizer)
-      .def("enable_mkldnn_bfloat16", &CpuPassStrategy::EnableMkldnnBfloat16);
+      .def("enable_mkldnn", &CpuPassStrategy::EnableMKLDNN)  // Deprecated
+      .def("enable_mkldnn_quantizer",
+           &CpuPassStrategy::EnableMkldnnQuantizer)  // Deprecated
+      .def("enable_mkldnn_bfloat16",
+           &CpuPassStrategy::EnableMkldnnBfloat16)  // Deprecated
+      .def("enable_onednn", &CpuPassStrategy::EnableMKLDNN)
+      .def("enable_onednn_quantizer", &CpuPassStrategy::EnableMkldnnQuantizer)
+      .def("enable_onednn_bfloat16", &CpuPassStrategy::EnableMkldnnBfloat16);
 
   py::class_<GpuPassStrategy, PassStrategy>(*m, "GpuPassStrategy")
       .def(py::init<>())
       .def(py::init<const GpuPassStrategy &>())
       .def("enable_cudnn", &GpuPassStrategy::EnableCUDNN)
-      .def("enable_mkldnn", &GpuPassStrategy::EnableMKLDNN)
-      .def("enable_mkldnn_quantizer", &GpuPassStrategy::EnableMkldnnQuantizer)
-      .def("enable_mkldnn_bfloat16", &GpuPassStrategy::EnableMkldnnBfloat16);
+      .def("enable_mkldnn", &GpuPassStrategy::EnableMKLDNN)  // Deprecated
+      .def("enable_mkldnn_quantizer",
+           &GpuPassStrategy::EnableMkldnnQuantizer)  // Deprecated
+      .def("enable_mkldnn_bfloat16",
+           &GpuPassStrategy::EnableMkldnnBfloat16)  // Deprecated
+      .def("enable_onednn", &GpuPassStrategy::EnableMKLDNN)
+      .def("enable_onednn_quantizer", &GpuPassStrategy::EnableMkldnnQuantizer)
+      .def("enable_onednn_bfloat16", &GpuPassStrategy::EnableMkldnnBfloat16);
 }
 
 void BindInternalUtils(py::module *m) {

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -238,7 +238,7 @@ class AutoScanTest(unittest.TestCase):
         if use_gpu:
             config.enable_use_gpu(100, 0)
         if not use_mkldnn:
-            config.disable_mkldnn()
+            config.disable_onednn()
         if use_xpu:
             config.enable_xpu()
         if passes is not None:
@@ -335,7 +335,7 @@ class MkldnnAutoScanTest(AutoScanTest):
 
     def inference_config_str(self, config) -> str:
         dic = {}
-        enable_mkldnn = config.mkldnn_enabled()
+        enable_mkldnn = config.onednn_enabled()
         dic["use_mkldnn"] = enable_mkldnn
         enable_gpu = config.use_gpu()
         dic["use_gpu"] = enable_gpu
@@ -571,7 +571,7 @@ class PassAutoScanTest(AutoScanTest):
 
     def inference_config_str(self, config) -> str:
         dic = {}
-        enable_mkldnn = config.mkldnn_enabled()
+        enable_mkldnn = config.onednn_enabled()
         dic["use_mkldnn"] = enable_mkldnn
         enable_gpu = config.use_gpu()
         dic['use_gpu'] = enable_gpu

--- a/test/ir/inference/inference_pass_test.py
+++ b/test/ir/inference/inference_pass_test.py
@@ -142,7 +142,7 @@ class InferencePassTest(unittest.TestCase):
                 self.path + ".pdmodel", self.path + ".pdiparams"
             )
         config.disable_gpu()
-        config.disable_mkldnn()
+        config.disable_onednn()
         config.switch_specify_input_names(True)
         config.switch_ir_optim(True)
         config.switch_use_feed_fetch_ops(False)
@@ -177,9 +177,9 @@ class InferencePassTest(unittest.TestCase):
                     config.enable_tensorrt_varseqlen()
 
         elif use_mkldnn:
-            config.enable_mkldnn()
+            config.enable_onednn()
             if self.enable_mkldnn_bfloat16:
-                config.enable_mkldnn_bfloat16()
+                config.enable_onednn_bfloat16()
         print('config summary:', config.summary())
         return config
 

--- a/test/ir/inference/quant_dequant_test.py
+++ b/test/ir/inference/quant_dequant_test.py
@@ -204,7 +204,7 @@ class QuantDequantTest(unittest.TestCase):
                 self.path + ".pdmodel", self.path + ".pdiparams"
             )
         config.disable_gpu()
-        config.disable_mkldnn()
+        config.disable_onednn()
         config.switch_specify_input_names(True)
         config.switch_ir_optim(True)
         config.switch_use_feed_fetch_ops(False)
@@ -231,9 +231,9 @@ class QuantDequantTest(unittest.TestCase):
                     config.enable_tensorrt_varseqlen()
 
         elif use_mkldnn:
-            config.enable_mkldnn()
+            config.enable_onednn()
             if self.enable_mkldnn_bfloat16:
-                config.enable_mkldnn_bfloat16()
+                config.enable_onednn_bfloat16()
         print('config summary:', config.summary())
         return config
 

--- a/test/ir/inference/test_conv_eltwiseadd_bn_fuse_pass.py
+++ b/test/ir/inference/test_conv_eltwiseadd_bn_fuse_pass.py
@@ -47,7 +47,7 @@ class TestConvEltwiseaddBnFusePass(PassAutoScanTest):
 
         # MKLDNN
         config = self.create_inference_config(use_gpu=False)
-        config.enable_mkldnn()
+        config.enable_onednn()
         yield config, ["conv2d", "elementwise_add"], (1e-4, 1e-5)
 
         # for gpu

--- a/test/ir/inference/test_trt_inference_predictor.py
+++ b/test/ir/inference/test_trt_inference_predictor.py
@@ -98,14 +98,14 @@ class BackendPaddle:
 
         if self.args.enable_mkldnn and not self.args.enable_gpu:
             config.disable_gpu()
-            config.enable_mkldnn()
+            config.enable_onednn()
             if self.args.precision == 'int8':
-                config.enable_mkldnn_int8(
+                config.enable_onednn_int8(
                     {"conv2d", "depthwise_conv2d", "transpose2", "pool2d"}
                 )
         if not self.args.enable_mkldnn and not self.args.enable_gpu:
             config.disable_gpu()
-            # config.enable_mkldnn()
+            # config.enable_onednn()
         if self.args.enable_profile:
             config.enable_profile()
         shape_range_file = os.path.join(

--- a/test/legacy_test/test_attribute_var.py
+++ b/test/legacy_test/test_attribute_var.py
@@ -44,7 +44,7 @@ class UnittestBase(unittest.TestCase):
         config = paddle_infer.Config(
             self.save_path + '.pdmodel', self.save_path + '.pdiparams'
         )
-        config.disable_mkldnn()
+        config.disable_onednn()
         predictor = paddle_infer.create_predictor(config)
         input_names = predictor.get_input_names()
         for i, shape in enumerate(self.shapes):

--- a/test/mkldnn/test_onnx_format_quantization_mobilenetv1.py
+++ b/test/mkldnn/test_onnx_format_quantization_mobilenetv1.py
@@ -208,12 +208,12 @@ class TestPostTrainingQuantization(unittest.TestCase):
         image_shape = [3, 224, 224]
         config = paddle.inference.Config(model_path)
         config.disable_gpu()
-        config.enable_mkldnn()
+        config.enable_onednn()
         config.switch_ir_optim()
         config.set_cpu_math_library_num_threads(1)
         config.disable_glog_info()
         if is_quantized_model:
-            config.enable_mkldnn_int8()
+            config.enable_onednn_int8()
         predictor = paddle.inference.create_predictor(config)
 
         input_names = predictor.get_input_names()

--- a/test/quantization/quant2_int8_lstm_model.py
+++ b/test/quantization/quant2_int8_lstm_model.py
@@ -112,8 +112,8 @@ class TestLstmModelPTQ(unittest.TestCase):
             config.disable_gpu()
             config.switch_use_feed_fetch_ops(True)
             config.switch_ir_optim(True)
-            config.enable_mkldnn()
-            config.disable_mkldnn_fc_passes()  # fc passes caused dnnl error
+            config.enable_onednn()
+            config.disable_onednn_fc_passes()  # fc passes caused dnnl error
             config.pass_builder().insert_pass(5, "fc_lstm_fuse_pass")
             config.set_mkldnn_cache_capacity(mkldnn_cache_capacity)
             if mode == "ptq":
@@ -121,7 +121,7 @@ class TestLstmModelPTQ(unittest.TestCase):
                 config.quantizer_config().set_quant_data(warmup_data)
                 config.quantizer_config().set_quant_batch_size(1)
             elif mode == "qat":
-                config.enable_mkldnn_int8()
+                config.enable_onednn_int8()
 
         return config
 

--- a/test/quantization/quant2_int8_nlp_comparison.py
+++ b/test/quantization/quant2_int8_nlp_comparison.py
@@ -156,9 +156,9 @@ class QuantInt8NLPComparisonTest(unittest.TestCase):
         config.switch_specify_input_names(True)
         config.switch_ir_optim(True)
         config.switch_use_feed_fetch_ops(True)
-        config.enable_mkldnn()
+        config.enable_onednn()
         if target == 'int8':
-            config.enable_mkldnn_int8(self._quantized_ops)
+            config.enable_onednn_int8(self._quantized_ops)
         config.delete_pass(
             "constant_folding_pass"
         )  # same reason as in analyzer_ernie_int8_tester.cc

--- a/test/tokenizer/test_faster_tokenizer_op.py
+++ b/test/tokenizer/test_faster_tokenizer_op.py
@@ -136,7 +136,7 @@ class Predictor:
 
         # fast_tokenizer op only support cpu.
         config.disable_gpu()
-        config.disable_mkldnn()
+        config.disable_onednn()
         config.set_cpu_math_library_num_threads(10)
 
         config.switch_use_feed_fetch_ops(False)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
增加 AnalysisConfig api接口 enable_onednn
用来替换 enable_mkldnn 