### PR TITLE
【AutoParallel】Fix type_promote of 'elementwise_add'

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8212,7 +8212,10 @@ def add_cast_for_type_promotion(op, block, idx, var_name, out_dtype):
     op.desc._rename_input(var_name.name, out_var.name)
 
 
-def can_skip_promote(op):
+def can_skip_promote(op, device):
+    # Only GPU elementwise_add kernel supports the pattern "float + half".
+    if device != 'GPU':
+        return False
     if op.type != "elementwise_add":
         return False
     input_x_dtype = op.block._find_var_recursive(op.input('X')[0]).dtype
@@ -8226,6 +8229,12 @@ def can_skip_promote(op):
 
 
 def process_type_promotion(program):
+    # Get _current_expected_place place
+    device = None
+    if core.is_compiled_with_cuda() and isinstance(
+        _current_expected_place(), core.CUDAPlace
+    ):
+        device = 'GPU'
     org_program = program
     if program is None:
         program = default_main_program()
@@ -8247,7 +8256,7 @@ def process_type_promotion(program):
                 op.type, None
             )
             # type promotion only support some dyadic api
-            if need_transed_var_names is None or can_skip_promote(op):
+            if need_transed_var_names is None or can_skip_promote(op, device):
                 idx += 1
                 continue
 

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8213,7 +8213,7 @@ def add_cast_for_type_promotion(op, block, idx, var_name, out_dtype):
 
 
 def can_skip_promote(op):
-    if op.type != "elementwis_add":
+    if op.type != "elementwise_add":
         return False
     input_names = op.input_arg_names
     input_x_dtype = op.block._var_recursive(input_names[0]).dtype

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8215,13 +8215,13 @@ def add_cast_for_type_promotion(op, block, idx, var_name, out_dtype):
 def can_skip_promote(op):
     if op.type != "elementwise_add":
         return False
-    input_names = op.input_arg_names
-    input_x_dtype = op.block._var_recursive(input_names[0]).dtype
-    input_y_dtype = op.block._var_recursive(input_names[1]).dtype
+    input_x_dtype = op.block._find_var_recursive(op.input('X')[0]).dtype
+    input_y_dtype = op.block._find_var_recursive(op.input('Y')[0]).dtype
     if input_x_dtype == paddle.float32 and (
         input_y_dtype in [paddle.float16, paddle.bfloat16]
     ):
         return True
+
     return False
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76459
There is no need to do data type promotion for `elementwise_add` in the case "float + half".