### PR TITLE
[Dy2St][PIR] Fix `convert_attr` for Tensor

### DIFF
--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -66,7 +66,11 @@ def convert_attr(x, attr):
     # Value and Tensor are unified. So we don't need to transform
     # the size attr into a method call. The AttributeJstTransformer and
     # convert_attr can be safely removed.
-    if isinstance(x, Variable) and attr == "size":
+    if (
+        isinstance(x, Variable)
+        and not isinstance(x, paddle.Tensor)
+        and attr == "size"
+    ):
         return x.size()
     else:
         return getattr(x, attr)

--- a/python/paddle/jit/dy2static/transformers/transform.py
+++ b/python/paddle/jit/dy2static/transformers/transform.py
@@ -19,6 +19,8 @@
 
 import os
 
+from paddle.framework import use_pir_api
+
 from .. import logging_utils
 from ..utils import ast_to_source_code
 from .assert_transformer import AssertTransformer
@@ -102,13 +104,17 @@ class DygraphToStaticAst(BaseTransformer):
             LogicalTransformer,  # logical and/or/not
             CreateVariableTransformer,  # create undefined var for if / while / for
             LoopTransformer,  # for/while -> while_op
-            IfElseTransformer,  # if/else -> cond_op
+            IfElseTransformer,  # if/else -> if_op
             AssertTransformer,  # assert statement
             CallTransformer,  # transform call recursively
             CastTransformer,  # type casting statement
             DecoratorTransformer,  # transform decorators to function call
             NameloadJstTransformer,
         ]
+
+        if use_pir_api():
+            # It's unnecessary in PIR mode
+            transformers.remove(AttributeJstTransformer)
 
         apply_optimization(transformers)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 `convert_attr` 传入 Tensor 的情况

PIR 下不需要 `AttributeJstTransformer`，因此直接删掉～

PCard-66972