### PR TITLE
【AutoParallel】Add `data_type` for add op in PIR

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/ops.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops.yaml
@@ -22,6 +22,7 @@
     spmd_rule : ElementwiseBinaryInferSpmd
   kernel :
     func : add
+    data_type: x
   inplace : (x -> out)
   backward : add_grad
   data_transform :

--- a/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
@@ -27,6 +27,7 @@
     spmd_rule : ElementwiseBinaryGradInferSpmd
   kernel :
     func : add_grad
+    data_type: out
   no_need_buffer : x, y
   composite : add_grad(x, y, out_grad, axis, x_grad, y_grad)
   backward : add_double_grad

--- a/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
+++ b/paddle/fluid/pir/dialect/operator/ir/ops_backward.yaml
@@ -27,7 +27,7 @@
     spmd_rule : ElementwiseBinaryGradInferSpmd
   kernel :
     func : add_grad
-    data_type: out
+    data_type: out_grad
   no_need_buffer : x, y
   composite : add_grad(x, y, out_grad, axis, x_grad, y_grad)
   backward : add_double_grad


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Use the dtype of `X` of `elementwise_add` to get the `dtype` of  the`kernel`.