### PR TITLE
[Prim] Use sqrt instead of rsqrt for pnorm decomposition

### DIFF
--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -155,8 +155,7 @@ Tensor p_norm_decomp(const Tensor& x,
     res = sum<T>(res, {axis}, x_tmp.dtype(), keepdim);
   } else if (porder == 2.0) {
     // 2-norm
-    auto one = full<T>(empty_shape, 1, x_tmp.dtype());
-    res = one / rsqrt<T>(sum<T>(x_tmp * x_tmp, {axis}, x_tmp.dtype(), keepdim));
+    res = sqrt<T>(sum<T>(x_tmp * x_tmp, {axis}, x_tmp.dtype(), keepdim));
   } else if (porder == INFINITY) {
     // +INF-norm
     res = abs<T>(x_tmp);

--- a/paddle/fluid/primitive/primitive.yaml
+++ b/paddle/fluid/primitive/primitive.yaml
@@ -3,6 +3,7 @@
 - multiply
 - divide
 - elementwise_pow
+- sqrt
 - rsqrt
 - sin
 - sinh


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
Add `sqrt` to primitive operators and replace `1/rsqrt` with `sqrt` for `p_norm_decomp`