### PR TITLE
[PIR][oneDNN] Add scale_matmul_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -626,6 +626,7 @@ const std::vector<std::string> kPirMkldnnPasses{
     "conv2d_transpose_bias_fuse_pass",
     "conv3d_bias_fuse_pass",
     "batch_norm_act_fuse_pass",
+    "scale_matmul_fuse_pass",
     "reshape_transpose_matmul_fuse_pass",
     "matmul_transpose_reshape_fuse_pass",
     "matmul_elementwise_add_fuse_pass",

--- a/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_elementwise_add_fuse_pass.cc
@@ -59,16 +59,6 @@ class MatmulElementwiseAddFusePattern : public paddle::drr::DrrPatternBase {
         as_x_ ? add(pat.Tensor("Out"), pat.Tensor("residual"))
               : add(pat.Tensor("residual"), pat.Tensor("Out"));
 
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::set<bool> bool_sets = {true, false};
-      auto result_x = match_ctx.Attr<bool>("transpose_x");
-      auto result_y = match_ctx.Attr<bool>("transpose_y");
-      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
-        return false;
-      }
-      return true;
-    });
-
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
     const auto &fused_matmul =
@@ -156,16 +146,6 @@ class FusedMatmulElementwiseAddFusePattern
     pat.Tensor("add_out") =
         as_x_ ? add(pat.Tensor("Out"), pat.Tensor("residual"))
               : add(pat.Tensor("residual"), pat.Tensor("Out"));
-
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::set<bool> bool_sets = {true, false};
-      auto result_x = match_ctx.Attr<bool>("transpose_x");
-      auto result_y = match_ctx.Attr<bool>("transpose_y");
-      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
-        return false;
-      }
-      return true;
-    });
 
     pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
       auto none_tensor = match_ctx.Tensor("none");

--- a/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/matmul_transpose_reshape_fuse_pass.cc
@@ -63,16 +63,6 @@ class MatmulTransposeReshapeFusePattern : public paddle::drr::DrrPatternBase {
             {&pat.Tensor("reshape_out"), &pat.Tensor("Xshape")});
 
     pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::set<bool> bool_sets = {true, false};
-      auto result_x = match_ctx.Attr<bool>("transpose_x");
-      auto result_y = match_ctx.Attr<bool>("transpose_y");
-      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
-        return false;
-      }
-      return true;
-    });
-
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
       auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
       auto perm = match_ctx.Attr<std::vector<int>>("perm");
       const std::vector<int> supported_axis{0, 2, 1, 3};
@@ -249,7 +239,6 @@ class MatmulTransposeReshapeFusePass : public pir::PatternRewritePass {
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
     pir::RewritePatternSet ps(context);
-    std::vector<bool> bool_set = {false, true};
     int benefit_idx = 1;
     ps.Add(paddle::drr::Create<MatmulTransposeReshapeFusePattern>(
         context,

--- a/paddle/fluid/pir/transforms/onednn/reshape_transpose_matmul_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/reshape_transpose_matmul_fuse_pass.cc
@@ -72,16 +72,6 @@ class ReshapeTransposeMatmulFusePattern : public paddle::drr::DrrPatternBase {
     }
 
     pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::set<bool> bool_sets = {true, false};
-      auto result_x = match_ctx.Attr<bool>("transpose_x");
-      auto result_y = match_ctx.Attr<bool>("transpose_y");
-      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
-        return false;
-      }
-      return true;
-    });
-
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
       auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");
       auto perm = match_ctx.Attr<std::vector<int>>("perm");
       if (shape.size() < 2 || shape.size() > 4) return false;
@@ -218,16 +208,6 @@ class ReshapeTransposeFusedMatmulFusePattern
               &pat.Tensor("residual")},
              {&pat.Tensor("Out")});
     }
-
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::set<bool> bool_sets = {true, false};
-      auto result_x = match_ctx.Attr<bool>("transpose_x");
-      auto result_y = match_ctx.Attr<bool>("transpose_y");
-      if (bool_sets.count(result_x) == 0 || bool_sets.count(result_y) == 0) {
-        return false;
-      }
-      return true;
-    });
 
     pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
       auto shape = match_ctx.Attr<std::vector<int64_t>>("int_array");

--- a/paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.cc
@@ -1,0 +1,296 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/onednn_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+class ScaleMatmulFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  std::string matmul_name_;
+  std::string fused_matmul_name_;
+  uint32_t benefit_;
+  bool as_x_;  // decide if the output of scale is for input_x of matmul
+
+ public:
+  ScaleMatmulFusePattern(const std::string &matmul_name,
+                         const std::string &fused_matmul_name,
+                         uint32_t benefit,
+                         bool as_x)
+      : matmul_name_(matmul_name),
+        fused_matmul_name_(fused_matmul_name),
+        benefit_(benefit),
+        as_x_(as_x) {}
+
+  std::string name() const override { return "ScaleMatmulFusePattern"; }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &full = pat.Op(paddle::dialect::FullOp::name(),
+                              {{"value", pat.Attr("scale_")}});
+    pat.Tensor("scale") = full();
+
+    const auto &scale =
+        pat.Op(paddle::dialect::ScaleOp::name(),
+               {{"bias", pat.Attr("bias")},
+                {"bias_after_scale", pat.Attr("bias_after_scale")}});
+    scale({&pat.Tensor("scale_in"), &pat.Tensor("scale")},
+          {&pat.Tensor("scale_out")});
+
+    const auto &matmul = pat.Op(matmul_name_,
+                                {{"transpose_x", pat.Attr("transpose_x")},
+                                 {"transpose_y", pat.Attr("transpose_y")}});
+    if (as_x_) {
+      matmul({&pat.Tensor("scale_out"), &pat.Tensor("other")},
+             {&pat.Tensor("Out")});
+    } else {
+      matmul({&pat.Tensor("other"), &pat.Tensor("scale_out")},
+             {&pat.Tensor("Out")});
+    }
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      auto scale = match_ctx.Attr<float>("scale_");
+      auto bias = match_ctx.Attr<float>("bias");
+      // conditions align with fluid pass
+      if (bias != 0.0f) return false;
+      if (scale <= 0.0f) return false;
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"trans_x", pat.Attr("transpose_x")},
+        {"trans_y", pat.Attr("transpose_y")},
+        {"fuse_activation", res.StrAttr("")},
+        {"fuse_alpha", res.Float32Attr(0.0f)},
+        {"fuse_beta", res.Float32Attr(0.0f)},
+        {"fused_reshape_x", res.VectorInt32Attr({})},
+        {"fused_transpose_x", res.VectorInt32Attr({})},
+        {"fused_reshape_y", res.VectorInt32Attr({})},
+        {"fused_transpose_y", res.VectorInt32Attr({})},
+        {"fused_output_scale", res.Float32Attr(1.0f)},
+        {"fused_reshape_out", res.VectorInt32Attr({})},
+        {"fused_transpose_out", res.VectorInt32Attr({})},
+        {"mkldnn_data_type", res.StrAttr("float32")},
+        {"scale_x", res.Float32Attr(1.0f)},
+        {"scale_y", res.Float32Attr(1.0f)},
+        {"scale_in_eltwise", res.Float32Attr(0.0f)},
+        {"scale_out", res.Float32Attr(1.0f)},
+        {"force_fp32_output", res.BoolAttr(false)}};
+
+    const auto &matmul_alpha_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
+          auto scale = match_ctx.Attr<float>("scale_");
+          return scale;
+        });
+
+    fused_attrs.emplace("matmul_alpha", matmul_alpha_attr);
+
+    const auto &fused_matmul = res.Op(fused_matmul_name_, fused_attrs);
+
+    if (as_x_) {
+      fused_matmul({&res.Tensor("scale_in"),
+                    &res.Tensor("other"),
+                    &res.InputNoneTensor()},
+                   {&res.Tensor("Out")});
+    } else {
+      fused_matmul({&res.Tensor("other"),
+                    &res.Tensor("scale_in"),
+                    &res.InputNoneTensor()},
+                   {&res.Tensor("Out")});
+    }
+  }
+};
+
+class ScaleFusedMatmulFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  std::string matmul_name_;
+  std::string fused_matmul_name_;
+  uint32_t benefit_;
+  bool as_x_;  // decide if the output of transpose is for input_x of matmul
+
+ public:
+  ScaleFusedMatmulFusePattern(const std::string &matmul_name,
+                              const std::string &fused_matmul_name,
+                              uint32_t benefit,
+                              bool as_x)
+      : matmul_name_(matmul_name),
+        fused_matmul_name_(fused_matmul_name),
+        benefit_(benefit),
+        as_x_(as_x) {}
+
+  std::string name() const override { return "ScaleFusedMatmulFusePattern"; }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &full = pat.Op(paddle::dialect::FullOp::name(),
+                              {{"value", pat.Attr("scale_")}});
+    pat.Tensor("scale") = full();
+
+    const auto &scale =
+        pat.Op(paddle::dialect::ScaleOp::name(),
+               {{"bias", pat.Attr("bias")},
+                {"bias_after_scale", pat.Attr("bias_after_scale")}});
+    scale({&pat.Tensor("scale_in"), &pat.Tensor("scale")},
+          {&pat.Tensor("scale_out")});
+
+    const auto &matmul =
+        pat.Op(matmul_name_,
+               {{"trans_x", pat.Attr("transpose_x")},
+                {"trans_y", pat.Attr("transpose_y")},
+                {"matmul_alpha", pat.Attr("matmul_alpha")},
+                {"fuse_activation", pat.Attr("fuse_activation")},
+                {"fuse_alpha", pat.Attr("fuse_alpha")},
+                {"fuse_beta", pat.Attr("fuse_beta")},
+                {"fused_output_scale", pat.Attr("fused_output_scale")},
+                {"fused_reshape_x", pat.Attr("fused_reshape_x")},
+                {"fused_transpose_x", pat.Attr("fused_transpose_x")},
+                {"fused_reshape_y", pat.Attr("fused_reshape_y")},
+                {"fused_transpose_y", pat.Attr("fused_transpose_y")},
+                {"fused_reshape_out", pat.Attr("fused_reshape_out")},
+                {"fused_transpose_out", pat.Attr("fused_transpose_out")},
+                {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+                {"scale_x", pat.Attr("scale_x")},
+                {"scale_y", pat.Attr("scale_y")},
+                {"scale_in_eltwise", pat.Attr("scale_in_eltwise")},
+                {"scale_out", pat.Attr("scale_out")},
+                {"force_fp32_output", pat.Attr("force_fp32_output")}});
+    if (as_x_) {
+      matmul({&pat.Tensor("scale_out"),
+              &pat.Tensor("other"),
+              &pat.Tensor("residual")},
+             {&pat.Tensor("Out")});
+    } else {
+      matmul({&pat.Tensor("other"),
+              &pat.Tensor("scale_out"),
+              &pat.Tensor("residual")},
+             {&pat.Tensor("Out")});
+    }
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      auto matmul_alpha = match_ctx.Attr<float>("matmul_alpha");
+      auto scale = match_ctx.Attr<float>("scale_");
+      auto bias = match_ctx.Attr<float>("bias");
+      // conditions align with fluid pass
+      if (matmul_alpha == 0.0f) return false;
+      if (bias != 0.0f) return false;
+      if (scale <= 0.0f) return false;
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"trans_x", pat.Attr("transpose_x")},
+        {"trans_y", pat.Attr("transpose_y")},
+        {"fuse_activation", pat.Attr("fuse_activation")},
+        {"fuse_alpha", pat.Attr("fuse_alpha")},
+        {"fuse_beta", pat.Attr("fuse_beta")},
+        {"fused_reshape_x", pat.Attr("fused_reshape_x")},
+        {"fused_transpose_x", pat.Attr("fused_transpose_x")},
+        {"fused_reshape_y", pat.Attr("fused_reshape_y")},
+        {"fused_transpose_y", pat.Attr("fused_transpose_y")},
+        {"fused_output_scale", pat.Attr("fused_output_scale")},
+        {"fused_reshape_out", pat.Attr("fused_reshape_out")},
+        {"fused_transpose_out", pat.Attr("fused_transpose_out")},
+        {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+        {"scale_x", pat.Attr("scale_x")},
+        {"scale_y", pat.Attr("scale_y")},
+        {"scale_in_eltwise", pat.Attr("scale_in_eltwise")},
+        {"scale_out", pat.Attr("scale_out")},
+        {"force_fp32_output", pat.Attr("force_fp32_output")}};
+
+    const auto &matmul_alpha_attr = res.ComputeAttr(
+        [](const paddle::drr::MatchContext &match_ctx) -> float {
+          auto scale = match_ctx.Attr<float>("scale_");
+          auto matmul_alpha = match_ctx.Attr<float>("matmul_alpha");
+          return scale * matmul_alpha;
+        });
+
+    fused_attrs.emplace("matmul_alpha", matmul_alpha_attr);
+
+    const auto &fused_matmul = res.Op(fused_matmul_name_, fused_attrs);
+
+    if (as_x_) {
+      fused_matmul({&res.Tensor("scale_in"),
+                    &res.Tensor("other"),
+                    &res.Tensor("residual")},
+                   {&res.Tensor("Out")});
+    } else {
+      fused_matmul({&res.Tensor("other"),
+                    &res.Tensor("scale_in"),
+                    &res.Tensor("residual")},
+                   {&res.Tensor("Out")});
+    }
+  }
+};
+
+class ScaleMatmulFusePass : public pir::PatternRewritePass {
+ public:
+  ScaleMatmulFusePass()
+      : pir::PatternRewritePass("reshape_transpose_matmul_fuse_pass", 3) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    std::vector<bool> bool_set = {false, true};
+    int benefit_idx = 5;
+    for (auto as_x : bool_set) {
+      ps.Add(paddle::drr::Create<ScaleMatmulFusePattern>(
+          context,
+          paddle::dialect::MatmulOp::name(),
+          paddle::onednn::dialect::FusedMatmulOp::name(),
+          benefit_idx,
+          as_x));
+      benefit_idx--;
+    }
+
+    for (auto as_x : bool_set) {
+      ps.Add(paddle::drr::Create<ScaleFusedMatmulFusePattern>(
+          context,
+          paddle::onednn::dialect::FusedMatmulOp::name(),
+          paddle::onednn::dialect::FusedMatmulOp::name(),
+          benefit_idx,
+          as_x));
+      benefit_idx--;
+    }
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateScaleMatmulFusePass() {
+  // pd_op.reshape + pd_op.transpose + pd_op.matmul -> onednn_op.fused_matmul
+  // pd_op.reshape + pd_op.transpose + pd_op.fused_matmul ->
+  // onednn_op.fused_matmul
+  return std::make_unique<ScaleMatmulFusePass>();
+}
+}  // namespace pir
+
+REGISTER_IR_PASS(scale_matmul_fuse_pass, ScaleMatmulFusePass);

--- a/paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/scale_matmul_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateScaleMatmulFusePass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -46,6 +46,7 @@ USE_PIR_PASS(batch_norm_act_fuse_pass);
 USE_PIR_PASS(conv2d_bias_fuse_pass);
 USE_PIR_PASS(conv2d_transpose_bias_fuse_pass);
 USE_PIR_PASS(conv3d_bias_fuse_pass);
+USE_PIR_PASS(scale_matmul_fuse_pass);
 USE_PIR_PASS(reshape_transpose_matmul_fuse_pass);
 USE_PIR_PASS(matmul_transpose_reshape_fuse_pass);
 USE_PIR_PASS(matmul_elementwise_add_fuse_pass);

--- a/test/ir/pir/fused_pass/onednn/test_scale_matmul_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_scale_matmul_fuse_pass.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+
+paddle.enable_static()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestReshapeTranspoeMatmulFusePatternCase1(PassTest):
+    r'''
+      x
+      |
+    scale      y
+       \      /
+        matmul
+          |
+      matmul_out
+    '''
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[2, 2, 3, 4], dtype='float32'
+                )
+                y = paddle.static.data(
+                    name='y', shape=[2, 2, 4, 3], dtype='float32'
+                )
+
+                scale_out = paddle.scale(x, scale=0.5)
+                matmul_out = paddle.matmul(scale_out, y)
+                matmul_out = paddle.assign(matmul_out)
+                self.pass_list = ['scale_matmul_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((2, 2, 3, 4)).astype("float32"),
+                    "y": np.random.random((2, 2, 4, 3)).astype("float32"),
+                }
+                self.fetch_list = [matmul_out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.scale": 0,
+                    "pd_op.matmul": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+@unittest.skipIf(
+    not paddle.base.core.is_compiled_with_mkldnn(),
+    "Test case only for OneDNN pass.",
+)
+class TestReshapeTranspoeMatmulFusePatternCase2(PassTest):
+    r'''
+            y
+            |
+    x     scale
+     \      /
+      matmul
+        |
+    matmul_out
+    '''
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[5, 5, 5, 5], dtype='float32'
+                )
+                y = paddle.static.data(
+                    name='y', shape=[5, 5, 5, 5], dtype='float32'
+                )
+
+                scale_out = paddle.scale(y, scale=0.3)
+                matmul_out = paddle.matmul(x, scale_out)
+                matmul_out = paddle.assign(matmul_out)
+                self.pass_list = ['scale_matmul_fuse_pass']
+                self.feeds = {
+                    "x": np.random.random((5, 5, 5, 5)).astype("float32"),
+                    "y": np.random.random((5, 5, 5, 5)).astype("float32"),
+                }
+                self.fetch_list = [matmul_out]
+                self.valid_op_map = {
+                    "onednn_op.fused_matmul": 1,
+                    "pd_op.scale": 0,
+                    "pd_op.matmul": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/ir/pir/fused_pass/onednn/test_scale_matmul_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_scale_matmul_fuse_pass.py
@@ -22,10 +22,6 @@ import paddle
 paddle.enable_static()
 
 
-@unittest.skipIf(
-    not paddle.base.core.is_compiled_with_mkldnn(),
-    "Test case only for OneDNN pass.",
-)
 class TestReshapeTranspoeMatmulFusePatternCase1(PassTest):
     r'''
       x
@@ -78,10 +74,6 @@ class TestReshapeTranspoeMatmulFusePatternCase1(PassTest):
         self.check_pass_correct()
 
 
-@unittest.skipIf(
-    not paddle.base.core.is_compiled_with_mkldnn(),
-    "Test case only for OneDNN pass.",
-)
 class TestReshapeTranspoeMatmulFusePatternCase2(PassTest):
     r'''
             y


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Based on new pass mechanism, here we add pass "scale_matmul_fuse_pass" for PIR.

The new pass is same as "scale_matmul_fuse_pass" in "/paddle/fluid/framework/ir/onednn/scale_matmul_fuse_pass.cc"