### PR TITLE
[PIR] empty support pir

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2119,8 +2119,22 @@ def empty(shape, dtype=None, name=None):
         if in_dynamic_mode():
             shape = paddle.utils.convert_shape_to_list(shape)
         else:
-            if isinstance(dtype, core.VarDesc.VarType):
-                dtype = paddle.pir.core.vartype_to_datatype[dtype]
+            check_dtype(
+                dtype,
+                'dtype',
+                [
+                    'bool',
+                    'float16',
+                    'float32',
+                    'float64',
+                    'int32',
+                    'int64',
+                    'complex64',
+                    'complex128',
+                ],
+                'empty',
+            )
+
             paddle.utils.check_shape(shape)
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2116,7 +2116,22 @@ def empty(shape, dtype=None, name=None):
     dtype = convert_dtype(dtype)
 
     if in_dynamic_or_pir_mode():
-        shape = paddle.utils.convert_shape_to_list(shape)
+        if in_dynamic_mode():
+            shape = paddle.utils.convert_shape_to_list(shape)
+        else:
+            if isinstance(dtype, core.VarDesc.VarType):
+                dtype = paddle.pir.core.vartype_to_datatype[dtype]
+            paddle.utils.check_shape(shape)
+            if isinstance(shape, (list, tuple)):
+                if paddle.utils._contain_var(shape):
+                    shape = paddle.utils.get_int_tensor_list(
+                        shape, _current_expected_place()
+                    )
+            elif isinstance(shape, paddle.pir.Value):
+                pass
+            else:
+                raise TypeError("Shape only supports Value, or list, or tuple.")
+
         out = _C_ops.empty(
             shape, convert_np_dtype_to_dtype_(dtype), _current_expected_place()
         )

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2136,6 +2136,7 @@ def empty(shape, dtype=None, name=None):
                     'float16',
                     'float32',
                     'float64',
+                    'uint16',
                     'int32',
                     'int64',
                     'complex64',
@@ -2145,6 +2146,8 @@ def empty(shape, dtype=None, name=None):
             )
 
             paddle.utils.check_shape(shape)
+            if isinstance(shape, np.ndarray):
+                shape = shape.tolist()
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):
                     shape = paddle.utils.get_int_tensor_list(

--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_nullary_op.py
+++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_nullary_op.py
@@ -110,7 +110,7 @@ class EmptyOpInferSymbolicShapeTest(TestBase):
     def test_eval_symbolic(self):
         net = EmptyNet()
 
-        x_spec = InputSpec(shape=[None, None, None], dtype='float32')
+        x_spec = InputSpec(shape=[None, None, None], dtype='int32')
         input_spec = [x_spec]
         net = apply_to_static(net, False, input_spec)
         net.eval()

--- a/test/legacy_test/test_empty_op.py
+++ b/test/legacy_test/test_empty_op.py
@@ -20,7 +20,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 from paddle import base
 from paddle.base import core
-from paddle.base.framework import convert_np_dtype_to_dtype_
+from paddle.base.framework import convert_np_dtype_to_proto_type
 
 
 # Situation 1: Attr(shape) is a list(without tensor)
@@ -59,7 +59,7 @@ class TestEmptyOp(OpTest):
     def init_config(self):
         shape = [500, 3]
         dtype = 'float32'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
         self.inputs = {}
         self.outputs = {'Out': np.zeros(shape).astype(dtype)}
@@ -69,7 +69,7 @@ class TestEmptyOp2(TestEmptyOp):
     def init_config(self):
         shape = [500, 3]
         dtype = 'float64'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
         self.inputs = {}
         self.outputs = {'Out': np.zeros(shape).astype(dtype)}
@@ -79,7 +79,7 @@ class TestEmptyOp3(TestEmptyOp):
     def init_config(self):
         shape = [500, 3]
         dtype = 'int32'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
         self.inputs = {}
         self.outputs = {'Out': np.zeros(shape).astype(dtype)}
@@ -89,7 +89,7 @@ class TestEmptyOp4(TestEmptyOp):
     def init_config(self):
         shape = [500, 3]
         dtype = 'int64'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
         self.inputs = {}
         self.outputs = {'Out': np.zeros(shape).astype(dtype)}
@@ -99,7 +99,7 @@ class TestEmptyOp5(TestEmptyOp):
     def init_config(self):
         shape = [500, 3]
         dtype = 'bool'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
         self.inputs = {}
         self.outputs = {'Out': np.zeros(shape).astype(dtype)}
@@ -115,7 +115,7 @@ class TestEmptyOp_ShapeTensor(OpTest):
     def init_config(self):
         self.shape = [500, 3]
         dtype = 'float32'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
         self.attrs = {'dtype': dtype_inner}
         self.inputs = {"ShapeTensor": np.array(self.shape).astype("int32")}
         self.outputs = {'Out': np.zeros(self.shape).astype(dtype)}
@@ -159,7 +159,7 @@ class TestEmptyOp_ShapeTensorList(OpTest):
         self.infer_shape = [-1, 92]
 
         dtype = 'float32'
-        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(dtype)
 
         shape_tensor_list = []
         for index, ele in enumerate(self.shape):
@@ -241,6 +241,7 @@ class TestEmptyAPI(unittest.TestCase):
         paddle.enable_static()
 
     def test_static_graph(self):
+        paddle.enable_static()
         dtype = 'float64'
 
         positive_2_int32 = paddle.tensor.fill_constant([1], "int32", 3)
@@ -287,7 +288,7 @@ class TestEmptyFP16Op(TestEmptyOp):
     def init_config(self):
         shape = [500, 3]
         self.dtype = np.float16
-        dtype_inner = convert_np_dtype_to_dtype_(self.dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(self.dtype)
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
         self.inputs = {}
         self.outputs = {'Out': np.zeros(shape).astype(self.dtype)}
@@ -305,7 +306,7 @@ class TestEmptyBF16Op(OpTest):
         self.__class__.op_type = self.op_type
         self.python_api = paddle.empty
         shape = np.array([200, 3]).astype('int32')
-        dtype_inner = convert_np_dtype_to_dtype_(self.dtype)
+        dtype_inner = convert_np_dtype_to_proto_type(self.dtype)
         output = np.zeros(shape).astype(self.dtype)
         self.inputs = {}
         self.attrs = {'shape': shape, 'dtype': dtype_inner}
@@ -328,6 +329,7 @@ class TestEmptyBF16Op(OpTest):
 class TestEmptyError(unittest.TestCase):
     def test_attr(self):
         def test_dtype():
+            paddle.enable_static()
             shape = [200, 3]
             dtype = 'uint8'
             result = paddle.empty(shape=shape, dtype=dtype)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
empty支持PIR，同时修改empty的op单测，确保在默认打开PIR后也能跑通。