### PR TITLE
ConstraintsManager

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/group_merge/substitute_dim_expr_based_on_constraints_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/group_merge/substitute_dim_expr_based_on_constraints_pass.cc
@@ -99,22 +99,6 @@ symbol::ShapeOrDataDimExprs SubstituteShapeOrData(
   return std::visit(lambdas, shape_or_data.variant());
 }
 
-int GetDimExprPriority(const symbol::DimExpr& dim_expr) {
-  return std::visit(
-      symbol::Overloaded{
-          [&](std::int64_t) { return 0; },
-          [&](const std::string&) { return 1; },
-          [&](const symbol::Negative<symbol::DimExpr>&) { return 2; },
-          [&](const symbol::Reciprocal<symbol::DimExpr>&) { return 2; },
-          [&](const symbol::Add<symbol::DimExpr>&) { return 2; },
-          [&](const symbol::Mul<symbol::DimExpr>&) { return 2; },
-          [&](const symbol::Max<symbol::DimExpr>&) { return 2; },
-          [&](const symbol::Min<symbol::DimExpr>&) { return 2; },
-          [&](const symbol::Broadcast<symbol::DimExpr>&) { return 2; },
-      },
-      dim_expr.variant());
-}
-
 std::unordered_map<symbol::DimExpr, symbol::DimExpr> GetDimExprSubstitution(
     pir::ShapeConstraintIRAnalysis* shape_analysis) {
   const std::vector<symbol::DimExprConstraint>& dim_expr_constraints =
@@ -139,7 +123,8 @@ std::unordered_map<symbol::DimExpr, symbol::DimExpr> GetDimExprSubstitution(
     CHECK(!dim_expr_cluster.empty());
     auto dim_expr_root = dim_expr_cluster[0];
     for (const auto& dim_expr : dim_expr_cluster) {
-      if (GetDimExprPriority(dim_expr) < GetDimExprPriority(dim_expr_root)) {
+      if (symbol::GetDimExprPriority(dim_expr) <
+          symbol::GetDimExprPriority(dim_expr_root)) {
         dim_expr_root = dim_expr;
       }
     }

--- a/paddle/common/union_find_set.h
+++ b/paddle/common/union_find_set.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+namespace common {
+
+template <typename T>
+class UnionFindSet {
+ public:
+  T Find(const T& x) {
+    if (parent_.find(x) == parent_.end()) {
+      return x;
+    }
+    if (parent_[x] != x) {
+      parent_[x] = Find(parent_[x]);
+    }
+    return parent_[x];
+  }
+
+  void Union(const T& p, const T& q) {
+    if (parent_.find(p) == parent_.end()) {
+      parent_[p] = p;
+    }
+    if (parent_.find(q) == parent_.end()) {
+      parent_[q] = q;
+    }
+    parent_[Find(q)] = Find(p);
+  }
+
+  std::vector<std::vector<T>> Clusters() {
+    std::unordered_map<T, std::vector<T>> clusters_map;
+    for (auto it = parent_.begin(); it != parent_.end(); it++) {
+      clusters_map[Find(it->first)].emplace_back(it->first);
+    }
+    std::vector<std::vector<T>> clusters;
+    for (auto it = clusters_map.begin(); it != clusters_map.end(); it++) {
+      clusters.emplace_back(it->second);
+    }
+    return clusters;
+  }
+
+  bool IsConnect(const T& p, const T& q) { return Find(p) == Find(q); }
+
+  std::unordered_map<T, T> GetMap() { return parent_; }
+
+ private:
+  std::unordered_map<T, T> parent_;
+};
+
+}  // namespace common

--- a/paddle/common/union_find_set.h
+++ b/paddle/common/union_find_set.h
@@ -22,14 +22,11 @@ namespace common {
 template <typename T>
 class UnionFindSet {
  public:
-  T Find(const T& x) {
+  T Find(const T& x) const {
     if (parent_.find(x) == parent_.end()) {
       return x;
     }
-    if (parent_[x] != x) {
-      parent_[x] = Find(parent_[x]);
-    }
-    return parent_[x];
+    return parent_.at(x);
   }
 
   void Union(const T& p, const T& q) {
@@ -42,7 +39,7 @@ class UnionFindSet {
     parent_[Find(q)] = Find(p);
   }
 
-  std::vector<std::vector<T>> Clusters() {
+  std::vector<std::vector<T>> Clusters() const {
     std::unordered_map<T, std::vector<T>> clusters_map;
     for (auto it = parent_.begin(); it != parent_.end(); it++) {
       clusters_map[Find(it->first)].emplace_back(it->first);
@@ -54,9 +51,9 @@ class UnionFindSet {
     return clusters;
   }
 
-  bool IsConnect(const T& p, const T& q) { return Find(p) == Find(q); }
+  bool IsConnect(const T& p, const T& q) const { return Find(p) == Find(q); }
 
-  std::unordered_map<T, T> GetMap() { return parent_; }
+  std::unordered_map<T, T>* GetMap() { return &parent_; }
 
  private:
   std::unordered_map<T, T> parent_;

--- a/paddle/pir/include/dialect/shape/utils/constraints_manager.h
+++ b/paddle/pir/include/dialect/shape/utils/constraints_manager.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unordered_set>
+
+#include "paddle/common/union_find_set.h"
+#include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
+
+namespace symbol {
+
+class IR_API ConstraintsManager {
+ public:
+  void AddEqCstr(const DimExpr& lhs, const DimExpr& rhs);
+
+  bool IsEqual(const DimExpr& lhs, const DimExpr& rhs);
+
+  void AddGTOneCstr(const DimExpr& dim_expr);
+
+  bool IsGTOne(const DimExpr& dim_expr);
+
+  void AddBCableCstr(const DimExpr& lhs, const DimExpr& rhs);
+
+  void PrintDimExprClusters(std::stringstream& ss);
+
+  using EqualCallbackFunc = std::function<void(const DimExpr&, const DimExpr&)>;
+  void SetEqualCallbackFunc(EqualCallbackFunc equal_callback_func);
+
+ private:
+  void SubstituteInConstraint(const DimExpr& lhs, const DimExpr& rhs);
+
+  std::pair<DimExpr, DimExpr> SimplifyEqualCstr(const DimExpr& lhs,
+                                                const DimExpr& rhs);
+
+ private:
+  EqualCallbackFunc equal_callback_func_ = nullptr;
+
+  using EqualConstraints = common::UnionFindSet<DimExpr>;
+  using GTOneConstraints = std::unordered_set<DimExpr>;
+  using BCableConstraints = std::vector<Broadcastable<DimExpr>>;
+
+  EqualConstraints equals_;
+  GTOneConstraints gtones_;
+  BCableConstraints bcables_;
+};
+
+}  // namespace symbol

--- a/paddle/pir/include/dialect/shape/utils/constraints_manager.h
+++ b/paddle/pir/include/dialect/shape/utils/constraints_manager.h
@@ -25,15 +25,15 @@ class IR_API ConstraintsManager {
  public:
   void AddEqCstr(const DimExpr& lhs, const DimExpr& rhs);
 
-  bool IsEqual(const DimExpr& lhs, const DimExpr& rhs);
+  bool IsEqual(const DimExpr& lhs, const DimExpr& rhs) const;
+
+  std::vector<std::vector<DimExpr>> GetEqualClusters() const;
 
   void AddGTOneCstr(const DimExpr& dim_expr);
 
-  bool IsGTOne(const DimExpr& dim_expr);
+  bool IsGTOne(const DimExpr& dim_expr) const;
 
-  void AddBCableCstr(const DimExpr& lhs, const DimExpr& rhs);
-
-  void PrintDimExprClusters(std::stringstream& ss);
+  void AddBroadcastableCstr(const DimExpr& lhs, const DimExpr& rhs);
 
   using EqualCallbackFunc = std::function<void(const DimExpr&, const DimExpr&)>;
   void SetEqualCallbackFunc(EqualCallbackFunc equal_callback_func);
@@ -41,19 +41,28 @@ class IR_API ConstraintsManager {
  private:
   void SubstituteInConstraint(const DimExpr& lhs, const DimExpr& rhs);
 
-  std::pair<DimExpr, DimExpr> SimplifyEqualCstr(const DimExpr& lhs,
-                                                const DimExpr& rhs);
+  template <typename DoEachT>
+  void EqualConstraintsVisitor(const DoEachT& DoEach);
+
+  template <typename DoEachT>
+  void GTOneConstraintsVisitor(const DoEachT& DoEach);
+
+  template <typename DoEachT>
+  void BroadcastableConstraintsVisitor(const DoEachT& DoEach);
 
  private:
   EqualCallbackFunc equal_callback_func_ = nullptr;
 
   using EqualConstraints = common::UnionFindSet<DimExpr>;
   using GTOneConstraints = std::unordered_set<DimExpr>;
-  using BCableConstraints = std::vector<Broadcastable<DimExpr>>;
+  using BroadcastableConstraints = std::vector<Broadcastable<DimExpr>>;
 
   EqualConstraints equals_;
   GTOneConstraints gtones_;
-  BCableConstraints bcables_;
+  BroadcastableConstraints broadcastables_;
 };
+
+std::ostream& operator<<(std::ostream& os,
+                         const ConstraintsManager& constraints_manager);
 
 }  // namespace symbol

--- a/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
@@ -29,7 +29,13 @@ IR_API DimExpr SubstituteDimExpr(
 
 IR_API int GetDimExprPriority(const DimExpr& dim_expr);
 
-IR_API int CompareDimExprPriority(const DimExpr& lhs, const DimExpr& rhs);
+enum class PriorityComparisonStatus {
+  Superior,  // lhs has a higher priority than rhs
+  Equal,     // lhs and rhs have equal priority
+  Inferior   // lhs has a lower priority than rhs
+};
+IR_API PriorityComparisonStatus CompareDimExprPriority(const DimExpr& lhs,
+                                                       const DimExpr& rhs);
 
 IR_API std::unordered_set<std::string> CollectDimExprSymbols(
     const DimExpr& dim_expr);

--- a/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
@@ -30,9 +30,9 @@ IR_API DimExpr SubstituteDimExpr(
 IR_API int GetDimExprPriority(const DimExpr& dim_expr);
 
 enum class PriorityComparisonStatus {
-  Superior,  // lhs has a higher priority than rhs
-  Equal,     // lhs and rhs have equal priority
-  Inferior   // lhs has a lower priority than rhs
+  HIGHER,  // lhs has a higher priority than rhs
+  EQUAL,   // lhs and rhs have equal priority
+  LOWER    // lhs has a lower priority than rhs
 };
 IR_API PriorityComparisonStatus CompareDimExprPriority(const DimExpr& lhs,
                                                        const DimExpr& rhs);

--- a/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
@@ -27,6 +27,10 @@ IR_API DimExpr SubstituteDimExpr(
     const DimExpr& dim_expr,
     const std::unordered_map<DimExpr, DimExpr>& pattern_to_replacement);
 
+IR_API int GetDimExprPriority(const DimExpr& dim_expr);
+
+IR_API int CompareDimExprPriority(const DimExpr& lhs, const DimExpr& rhs);
+
 IR_API std::unordered_set<std::string> CollectDimExprSymbols(
     const DimExpr& dim_expr);
 

--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -1,0 +1,207 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/pir/include/dialect/shape/utils/constraints_manager.h"
+#include "paddle/pir/include/dialect/shape/utils/dim_expr_builder.h"
+#include "paddle/pir/include/dialect/shape/utils/dim_expr_util.h"
+namespace symbol {
+namespace {
+
+bool CanSubstituteInConstraint(const DimExpr& lhs, const DimExpr& rhs) {
+  int lhs_priority = GetDimExprPriority(lhs);
+  int rhs_priority = GetDimExprPriority(rhs);
+  if (lhs_priority >= 2 || rhs_priority >= 2) {
+    return false;
+  }
+  return true;
+}
+
+bool CanSubstituteInShapeAnalysis(const DimExpr& lhs, const DimExpr& rhs) {
+  int lhs_priority = GetDimExprPriority(lhs);
+  int rhs_priority = GetDimExprPriority(rhs);
+  if (lhs_priority >= 2 && rhs_priority >= 2) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+void ConstraintsManager::AddEqCstr(const DimExpr& lhs, const DimExpr& rhs) {
+  if (lhs == rhs) {
+    return;
+  }
+
+  auto simplify_result = SimplifyEqualCstr(lhs, rhs);
+  if (simplify_result.first != lhs && simplify_result.second != rhs) {
+    AddEqCstr(simplify_result.first, simplify_result.second);
+  } else {
+    equals_.Union(lhs, rhs);
+    VLOG(8) << "AddEqCstr the constraint: " << lhs << " == " << rhs;
+
+    DimExpr origin, subsutituted;
+    if (CompareDimExprPriority(lhs, rhs) > 0) {
+      origin = lhs;
+      subsutituted = rhs;
+    } else {
+      origin = rhs;
+      subsutituted = lhs;
+    }
+    if (CanSubstituteInConstraint(simplify_result.first,
+                                  simplify_result.second)) {
+      SubstituteInConstraint(simplify_result.first, simplify_result.second);
+    }
+    if (equal_callback_func_ &&
+        CanSubstituteInShapeAnalysis(simplify_result.first,
+                                     simplify_result.second)) {
+      equal_callback_func_(simplify_result.first, simplify_result.second);
+    }
+  }
+}
+
+bool ConstraintsManager::IsEqual(const DimExpr& lhs, const DimExpr& rhs) {
+  if (equals_.IsConnect(lhs, rhs)) {
+    return true;
+  }
+  return false;
+}
+
+void ConstraintsManager::PrintDimExprClusters(std::stringstream& ss) {
+  std::vector<std::vector<DimExpr>> equal_clusters = equals_.Clusters();
+  ss << "to print DimExpr equal constraints clusters" << std::endl;
+  for (auto equal_cluster : equal_clusters) {
+    ss << "Equal Clusters {" << std::endl;
+    for (auto dim_expr : equal_cluster) {
+      ss << dim_expr << std::endl;
+    }
+    ss << "}" << std::endl;
+  }
+}
+
+void ConstraintsManager::SetEqualCallbackFunc(
+    EqualCallbackFunc equal_callback_func) {
+  equal_callback_func_ = equal_callback_func;
+}
+
+void ConstraintsManager::SubstituteInConstraint(const DimExpr& origin,
+                                                const DimExpr& substituted) {
+  std::unordered_map<DimExpr, DimExpr> substitution_pattern;
+  substitution_pattern[origin] = substituted;
+
+  auto equals_parents = equals_.GetMap();
+  for (auto it = equals_parents.begin(); it != equals_parents.end();) {
+    DimExpr key = SubstituteDimExpr(it->first, substitution_pattern);
+    DimExpr value = SubstituteDimExpr(it->first, substitution_pattern);
+    if (key != it->first) {
+      it = equals_parents.erase(it);
+      equals_parents[key] = value;
+    } else if (value != it->second) {
+      equals_parents[key] = value;
+      it++;
+    } else {
+      it++;
+    }
+  }
+
+  for (auto it = gtones_.begin(); it != gtones_.end();) {
+    DimExpr substituted_dim_expr = SubstituteDimExpr(*it, substitution_pattern);
+    if (substituted_dim_expr != *it) {
+      it = gtones_.erase(it);
+      gtones_.insert(substituted_dim_expr);
+    } else {
+      it++;
+    }
+  }
+
+  for (auto it = bcables_.begin(); it != bcables_.end(); it++) {
+    DimExpr substituted_lhs =
+        SubstituteDimExpr(it->data->lhs, substitution_pattern);
+    DimExpr substituted_rhs =
+        SubstituteDimExpr(it->data->rhs, substitution_pattern);
+    if (substituted_lhs != it->data->lhs) {
+      it->data->lhs = substituted_lhs;
+    }
+    if (substituted_rhs != it->data->rhs) {
+      it->data->rhs = substituted_rhs;
+    }
+  }
+}
+
+namespace {
+
+std::pair<List<DimExpr>, List<DimExpr>> GetEqualFromAddAndMul(
+    const List<DimExpr>& lhs_list, const List<DimExpr>& rhs_list) {
+  if (lhs_list->size() != rhs_list->size()) {
+    return std::pair(lhs_list, rhs_list);
+  }
+  int diff_count = 0;
+  List<DimExpr> lhs_diffs, rhs_diffs;
+  std::unordered_map<DimExpr, int> lhs_hash;
+  for (const auto& lhs_dim_expr : *lhs_list) {
+    lhs_hash[lhs_dim_expr]++;
+  }
+  for (const auto& rhs_dim_expr : *rhs_list) {
+    if (lhs_hash.count(rhs_dim_expr)) {
+      if (lhs_hash[rhs_dim_expr] >= 1) {
+        lhs_hash[rhs_dim_expr]--;
+        continue;
+      }
+    }
+    rhs_diffs->push_back(rhs_dim_expr);
+  }
+  for (const auto& lhs_dim_expr : *lhs_list) {
+    if (lhs_hash.at(lhs_dim_expr) >= 1) {
+      lhs_hash[lhs_dim_expr]--;
+      lhs_diffs->push_back(lhs_dim_expr);
+    }
+  }
+  return std::pair(lhs_diffs, rhs_diffs);
+}
+
+}  // namespace
+
+std::pair<DimExpr, DimExpr> ConstraintsManager::SimplifyEqualCstr(
+    const DimExpr& lhs, const DimExpr& rhs) {
+  auto DoSimplify = Overloaded{
+      [](const Add<DimExpr>& lhs,
+         const Add<DimExpr>& rhs) -> std::pair<DimExpr, DimExpr> {
+        List<DimExpr> lhs_list = lhs.operands;
+        List<DimExpr> rhs_list = rhs.operands;
+        std::tie(lhs_list, rhs_list) =
+            GetEqualFromAddAndMul(lhs_list, rhs_list);
+        auto lhs_diff =
+            lhs_list->size() == 1 ? lhs_list->at(0) : Add<DimExpr>{lhs_list};
+        auto rhs_diff =
+            rhs_list->size() == 1 ? rhs_list->at(0) : Add<DimExpr>{rhs_list};
+        return std::pair(lhs_diff, rhs_diff);
+      },
+      [](const Mul<DimExpr>& lhs,
+         const Mul<DimExpr>& rhs) -> std::pair<DimExpr, DimExpr> {
+        List<DimExpr> lhs_list = lhs.operands;
+        List<DimExpr> rhs_list = rhs.operands;
+        std::tie(lhs_list, rhs_list) =
+            GetEqualFromAddAndMul(lhs_list, rhs_list);
+        auto lhs_diff =
+            lhs_list->size() == 1 ? lhs_list->at(0) : Mul<DimExpr>{lhs_list};
+        auto rhs_diff =
+            rhs_list->size() == 1 ? rhs_list->at(0) : Mul<DimExpr>{rhs_list};
+        return std::pair(lhs_diff, rhs_diff);
+      },
+      [](const auto& lhs, const auto& rhs) -> std::pair<DimExpr, DimExpr> {
+        return std::make_pair(DimExpr(lhs), DimExpr(rhs));
+      }};
+  return std::visit(DoSimplify, lhs.variant(), rhs.variant());
+}
+
+}  // namespace symbol

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1083,26 +1083,26 @@ IR_API PriorityComparisonStatus CompareDimExprPriority(const DimExpr& lhs,
   int rhs_priority = GetDimExprPriority(rhs);
 
   if (lhs_priority != rhs_priority) {
-    return lhs_priority < rhs_priority ? PriorityComparisonStatus::Superior
-                                       : PriorityComparisonStatus::Inferior;
+    return lhs_priority < rhs_priority ? PriorityComparisonStatus::HIGHER
+                                       : PriorityComparisonStatus::LOWER;
   }
 
   auto CompareForEqualPriority = Overloaded{
       [](const std::string& lhs, const std::string& rhs) {
         if (lhs.size() != rhs.size()) {
-          return lhs.size() < rhs.size() ? PriorityComparisonStatus::Superior
-                                         : PriorityComparisonStatus::Inferior;
+          return lhs.size() < rhs.size() ? PriorityComparisonStatus::HIGHER
+                                         : PriorityComparisonStatus::LOWER;
         }
         int compare_result = lhs.compare(rhs);
         if (compare_result == 0)
-          return PriorityComparisonStatus::Equal;
+          return PriorityComparisonStatus::EQUAL;
         else if (compare_result < 0)
-          return PriorityComparisonStatus::Superior;
+          return PriorityComparisonStatus::HIGHER;
         else
-          return PriorityComparisonStatus::Inferior;
+          return PriorityComparisonStatus::LOWER;
       },
       [](const auto& lhs, const auto& rhs) {
-        return PriorityComparisonStatus::Equal;
+        return PriorityComparisonStatus::EQUAL;
       }};
   return std::visit(CompareForEqualPriority, lhs.variant(), rhs.variant());
 }

--- a/test/cpp/pir/shape_dialect/CMakeLists.txt
+++ b/test/cpp/pir/shape_dialect/CMakeLists.txt
@@ -1,6 +1,7 @@
 paddle_test(symbol_dim_expr_test SRCS symbol_dim_expr_test.cc)
 paddle_test(simplify_dim_expr_test SRCS simplify_dim_expr_test.cc)
 paddle_test(dim_expr_util_test SRCS dim_expr_util_test.cc)
+paddle_test(constraints_manager_test SRCS constraints_manager_test.cc)
 
 if(WITH_CINN)
   paddle_test(shape_analysis_test SRCS shape_analysis_test.cc)

--- a/test/cpp/pir/shape_dialect/constraints_manager_test.cc
+++ b/test/cpp/pir/shape_dialect/constraints_manager_test.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "paddle/pir/include/dialect/shape/utils/constraints_manager.h"
+#include "paddle/pir/include/dialect/shape/utils/dim_expr_builder.h"
+
+namespace symbol::test {
+
+TEST(ConstraintsManager, AddEqCstr) {
+  ConstraintsManager cstr_mgr;
+  DimExprBuilder builder(nullptr);
+
+  // Eq(S1,1) -> S1==1
+  DimExpr int_expr = builder.ConstSize(1);
+  DimExpr sym_expr_1 = builder.Symbol("S1");
+  cstr_mgr.AddEqCstr(int_expr, sym_expr_1);
+  ASSERT_TRUE(cstr_mgr.IsEqual(int_expr, sym_expr_1));
+
+  // Eq(S1,1) and Eq(S0,S1) -> S0==1
+  DimExpr sym_expr_0 = builder.Symbol("S0");
+  cstr_mgr.AddEqCstr(sym_expr_0, sym_expr_1);
+  ASSERT_TRUE(cstr_mgr.IsEqual(int_expr, sym_expr_0));
+
+  // Eq(Add(S1,S3),Add(S2,S3)) -> S1==S2
+  DimExpr sym_expr_2 = builder.Symbol("S2");
+  DimExpr sym_expr_3 = builder.Symbol("S3");
+  DimExpr add_expr_1 = builder.Add(sym_expr_1, sym_expr_3);
+  DimExpr add_expr_0 = builder.Add(sym_expr_2, sym_expr_3);
+  cstr_mgr.AddEqCstr(add_expr_0, add_expr_1);
+  ASSERT_FALSE(cstr_mgr.IsEqual(add_expr_0, add_expr_1));
+  ASSERT_TRUE(cstr_mgr.IsEqual(sym_expr_1, sym_expr_2));
+}
+
+}  // namespace symbol::test

--- a/test/cpp/pir/shape_dialect/constraints_manager_test.cc
+++ b/test/cpp/pir/shape_dialect/constraints_manager_test.cc
@@ -23,25 +23,24 @@ TEST(ConstraintsManager, AddEqCstr) {
   ConstraintsManager cstr_mgr;
   DimExprBuilder builder(nullptr);
 
-  // Eq(S1,1) -> S1==1
-  DimExpr int_expr = builder.ConstSize(1);
-  DimExpr sym_expr_1 = builder.Symbol("S1");
-  cstr_mgr.AddEqCstr(int_expr, sym_expr_1);
-  ASSERT_TRUE(cstr_mgr.IsEqual(int_expr, sym_expr_1));
-
-  // Eq(S1,1) and Eq(S0,S1) -> S0==1
+  // Eq(Mul(S0,S1),Mul(S2,S3))
   DimExpr sym_expr_0 = builder.Symbol("S0");
-  cstr_mgr.AddEqCstr(sym_expr_0, sym_expr_1);
-  ASSERT_TRUE(cstr_mgr.IsEqual(int_expr, sym_expr_0));
-
-  // Eq(Add(S1,S3),Add(S2,S3)) -> S1==S2
+  DimExpr sym_expr_1 = builder.Symbol("S1");
   DimExpr sym_expr_2 = builder.Symbol("S2");
   DimExpr sym_expr_3 = builder.Symbol("S3");
-  DimExpr add_expr_1 = builder.Add(sym_expr_1, sym_expr_3);
-  DimExpr add_expr_0 = builder.Add(sym_expr_2, sym_expr_3);
+  DimExpr mul_expr_0 = builder.Mul(sym_expr_0, sym_expr_1);
+  DimExpr mul_expr_1 = builder.Mul(sym_expr_2, sym_expr_3);
+  cstr_mgr.AddEqCstr(mul_expr_0, mul_expr_1);
+  ASSERT_TRUE(cstr_mgr.IsEqual(mul_expr_0, mul_expr_1));
+
+  // Eq(Add(S0,S1),Add(S0,1))
+  DimExpr int_expr_1 = builder.ConstSize(1);
+  DimExpr add_expr_0 = builder.Add(sym_expr_0, sym_expr_1);
+  DimExpr add_expr_1 = builder.Add(sym_expr_0, int_expr_1);
   cstr_mgr.AddEqCstr(add_expr_0, add_expr_1);
   ASSERT_FALSE(cstr_mgr.IsEqual(add_expr_0, add_expr_1));
-  ASSERT_TRUE(cstr_mgr.IsEqual(sym_expr_1, sym_expr_2));
+  DimExpr mul_expr_2 = builder.Mul(sym_expr_0, int_expr_1);
+  ASSERT_TRUE(cstr_mgr.IsEqual(mul_expr_2, mul_expr_1));
 }
 
 }  // namespace symbol::test

--- a/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
@@ -63,6 +63,32 @@ TEST(DimExprUtil, Calculate) {
   ASSERT_EQ(ret.Get<std::int64_t>(), 1);
 }
 
+TEST(DimExprUtil, GetDimExprPriority) {
+  DimExprBuilder builder(nullptr);
+  int priority_int = GetDimExprPriority(builder.ConstSize(1));
+  ASSERT_EQ(priority_int, 0);
+  int priority_sym = GetDimExprPriority(builder.Symbol("S0"));
+  ASSERT_EQ(priority_sym, 1);
+  int priority_add =
+      GetDimExprPriority(builder.Add(DimExpr("S1"), DimExpr("S2")));
+  ASSERT_EQ(priority_add, 2);
+  int priority_bc =
+      GetDimExprPriority(builder.Broadcast(DimExpr("S3"), DimExpr("S4")));
+  ASSERT_EQ(priority_bc, 2);
+}
+
+TEST(DimExprUtil, CompareDimExprPriority) {
+  DimExprBuilder builder(nullptr);
+  DimExpr sym_expr_0 = builder.Symbol("S0");
+  DimExpr sym_expr_1 = builder.Symbol("S1");
+  DimExpr add_expr = builder.Add(DimExpr("S2"), DimExpr("S3"));
+  DimExpr bc_expr = builder.Broadcast(DimExpr("S4"), DimExpr("S5"));
+  std::cout << "compare:  " << CompareDimExprPriority(sym_expr_0, sym_expr_1);
+  ASSERT_LT(CompareDimExprPriority(sym_expr_0, sym_expr_1), 0);
+  ASSERT_GT(CompareDimExprPriority(add_expr, sym_expr_0), 0);
+  ASSERT_EQ(CompareDimExprPriority(add_expr, bc_expr), 0);
+}
+
 TEST(DimExpr, CollectDimExprSymbol) {
   DimExpr dim_expr = [&]() -> DimExpr {
     DimExprBuilder builder(nullptr);

--- a/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
@@ -83,10 +83,12 @@ TEST(DimExprUtil, CompareDimExprPriority) {
   DimExpr sym_expr_1 = builder.Symbol("S1");
   DimExpr add_expr = builder.Add(DimExpr("S2"), DimExpr("S3"));
   DimExpr bc_expr = builder.Broadcast(DimExpr("S4"), DimExpr("S5"));
-  std::cout << "compare:  " << CompareDimExprPriority(sym_expr_0, sym_expr_1);
-  ASSERT_LT(CompareDimExprPriority(sym_expr_0, sym_expr_1), 0);
-  ASSERT_GT(CompareDimExprPriority(add_expr, sym_expr_0), 0);
-  ASSERT_EQ(CompareDimExprPriority(add_expr, bc_expr), 0);
+  ASSERT_EQ(CompareDimExprPriority(sym_expr_0, sym_expr_1),
+            PriorityComparisonStatus::Superior);
+  ASSERT_EQ(CompareDimExprPriority(add_expr, sym_expr_0),
+            PriorityComparisonStatus::Inferior);
+  ASSERT_EQ(CompareDimExprPriority(add_expr, bc_expr),
+            PriorityComparisonStatus::Equal);
 }
 
 TEST(DimExpr, CollectDimExprSymbol) {

--- a/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
+++ b/test/cpp/pir/shape_dialect/dim_expr_util_test.cc
@@ -84,11 +84,11 @@ TEST(DimExprUtil, CompareDimExprPriority) {
   DimExpr add_expr = builder.Add(DimExpr("S2"), DimExpr("S3"));
   DimExpr bc_expr = builder.Broadcast(DimExpr("S4"), DimExpr("S5"));
   ASSERT_EQ(CompareDimExprPriority(sym_expr_0, sym_expr_1),
-            PriorityComparisonStatus::Superior);
+            PriorityComparisonStatus::HIGHER);
   ASSERT_EQ(CompareDimExprPriority(add_expr, sym_expr_0),
-            PriorityComparisonStatus::Inferior);
+            PriorityComparisonStatus::LOWER);
   ASSERT_EQ(CompareDimExprPriority(add_expr, bc_expr),
-            PriorityComparisonStatus::Equal);
+            PriorityComparisonStatus::EQUAL);
 }
 
 TEST(DimExpr, CollectDimExprSymbol) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996
The previous DimExpr Constraint was relatively simple, so I added constraints “Broadcastable” and ”GTOne“ in this pr，to aid symbolic simplification. And since placing these structures in shape_analysis was semantically unclear, I encapsulated ConstraintsManager to manage these constraints.
Additionally, I have also done some other work on simplifying DimExpr. I adjusted the timing of substitution from SubtituteDimExprBaseOnConstraintsPass to every time adding a constraint. And I add some inference while constraints build.