### PR TITLE
【AutoParallel】Fix fused_rope spmd in static graph mode

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/operators/dist_fused_rope.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_fused_rope.py
@@ -101,6 +101,7 @@ class DistributedFusedRope(DistributedOperatorImplContainer):
 
         use_neox_rotary_style = op_desc.attr("use_neox_rotary_style")
         time_major = op_desc.attr("time_major")
+        rotary_emb_base = op_desc.attr("rotary_emb_base")
 
         # step2: infer spmd
         rule = get_phi_spmd_rule("fused_rotary_position_embedding")
@@ -114,6 +115,7 @@ class DistributedFusedRope(DistributedOperatorImplContainer):
             position_ids_spec,
             use_neox_rotary_style,
             time_major,
+            rotary_emb_base,
         )
         bw_results = rule.infer_backward(
             q_spec,
@@ -127,6 +129,7 @@ class DistributedFusedRope(DistributedOperatorImplContainer):
             out_v_spec,
             use_neox_rotary_style,
             time_major,
+            rotary_emb_base,
         )
 
         # remove optional args in spmd results


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Fix fused_rope spmd in static graph mode. The origin code may lead to core dump.