### PR TITLE
[Prim][PIR] support rsqrt op backward in prim pir

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -460,6 +460,15 @@ void sqrt_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
 }
 
 template <typename T>
+void rsqrt_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
+  if (x_grad) {
+    // This calculation is important for resnet.
+    auto x_grad_tmp = -0.5 * out * out * out * out_grad;
+    set_output<T>(x_grad_tmp, x_grad);
+  }
+}
+
+template <typename T>
 void floor_grad(const Tensor& out_grad, Tensor* x_grad) {
   if (x_grad) {
     auto zero_tensor =

--- a/paddle/fluid/primitive/codegen/gen.py
+++ b/paddle/fluid/primitive/codegen/gen.py
@@ -63,6 +63,7 @@ UNARY_PRIM_VJP_OPS = [
     'exp_grad',
     'floor_grad',
     'log_grad',
+    'rsqrt_grad',
     'sin_grad',
     'cos_grad',
     'tanh_grad',

--- a/paddle/fluid/primitive/rule/vjp/details.h
+++ b/paddle/fluid/primitive/rule/vjp/details.h
@@ -722,6 +722,15 @@ void sqrt_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
 }
 
 template <typename T>
+void rsqrt_grad(const Tensor& out, const Tensor& out_grad, Tensor* x_grad) {
+  if (x_grad) {
+    // This calculation is important for resnet.
+    auto x_grad_tmp = -0.5 * out * out * out * out_grad;
+    set_output<T>(x_grad_tmp, x_grad);
+  }
+}
+
+template <typename T>
 void silu_grad(const Tensor& x,
                const Tensor& out,
                const Tensor& out_grad,

--- a/paddle/phi/api/yaml/backward.yaml
+++ b/paddle/phi/api/yaml/backward.yaml
@@ -2010,6 +2010,7 @@
     spmd_rule : ElementwiseUnaryGradInferSpmd
   kernel :
     func : rsqrt_grad
+  composite : rsqrt_grad(out, out_grad, x_grad)
   backward : rsqrt_double_grad
   inplace : (out_grad -> x_grad)
 

--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -657,22 +657,6 @@ def unsqueeze_composite(x, axis):
     return [out, None]
 
 
-# @REGISTER_COMPOSITE('rsqrt')
-# def rsqrt_composite(x):
-#     """define composite rule of op rsqrt."""
-#     # rsqrt(x) = x^(-0.5)
-#     is_amp = False
-#     from paddle.base.data_feeder import convert_dtype
-
-#     dtype = convert_dtype(x.dtype)
-#     if dtype in ["float16", "uint16"]:
-#         is_amp = True
-#         x = cast(x, "float32")
-#     y = full(x.shape if len(x.shape) == 0 else [1], -0.5, x.dtype)
-#     res = pow(x, y)
-#     return res if not is_amp else cast(res, dtype)
-
-
 @REGISTER_COMPOSITE('group_norm')
 def group_norm_composite(x, scale, bias, epsilon, groups, data_layout):
     """

--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -657,20 +657,20 @@ def unsqueeze_composite(x, axis):
     return [out, None]
 
 
-@REGISTER_COMPOSITE('rsqrt')
-def rsqrt_composite(x):
-    """define composite rule of op rsqrt."""
-    # rsqrt(x) = x^(-0.5)
-    is_amp = False
-    from paddle.base.data_feeder import convert_dtype
+# @REGISTER_COMPOSITE('rsqrt')
+# def rsqrt_composite(x):
+#     """define composite rule of op rsqrt."""
+#     # rsqrt(x) = x^(-0.5)
+#     is_amp = False
+#     from paddle.base.data_feeder import convert_dtype
 
-    dtype = convert_dtype(x.dtype)
-    if dtype in ["float16", "uint16"]:
-        is_amp = True
-        x = cast(x, "float32")
-    y = full(x.shape if len(x.shape) == 0 else [1], -0.5, x.dtype)
-    res = pow(x, y)
-    return res if not is_amp else cast(res, dtype)
+#     dtype = convert_dtype(x.dtype)
+#     if dtype in ["float16", "uint16"]:
+#         is_amp = True
+#         x = cast(x, "float32")
+#     y = full(x.shape if len(x.shape) == 0 else [1], -0.5, x.dtype)
+#     res = pow(x, y)
+#     return res if not is_amp else cast(res, dtype)
 
 
 @REGISTER_COMPOSITE('group_norm')

--- a/test/legacy_test/test_activation_op.py
+++ b/test/legacy_test/test_activation_op.py
@@ -1863,6 +1863,7 @@ class TestRsqrt(TestActivation):
         self.op_type = "rsqrt"
         self.python_api = paddle.rsqrt
         self.public_python_api = paddle.rsqrt
+        self.prim_op_type = "prim"
         self.init_dtype()
         self.init_shape()
         self.if_enable_cinn()
@@ -1894,7 +1895,9 @@ class TestRsqrt(TestActivation):
             ['X'],
             'Out',
             max_relative_error=0.0005,
+            check_prim=True,
             check_pir=True,
+            check_prim_pir=True,
             check_pir_onednn=self.check_pir_onednn,
         )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others

### PR Types
Others


### Description
support rsqrt op backward in prim pir
