### PR TITLE
[PIR] Add group_norm_silu_xpu_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -121,7 +121,6 @@
 #include "paddle/fluid/pir/transforms/passes.h"
 #include "paddle/fluid/pir/transforms/pd_op_to_kernel_pass.h"
 #include "paddle/fluid/pir/transforms/shape_optimization_pass.h"
-#include "paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.h"
 #include "paddle/pir/include/pass/pass_manager.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -121,6 +121,7 @@
 #include "paddle/fluid/pir/transforms/passes.h"
 #include "paddle/fluid/pir/transforms/pd_op_to_kernel_pass.h"
 #include "paddle/fluid/pir/transforms/shape_optimization_pass.h"
+#include "paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.h"
 #include "paddle/pir/include/pass/pass_manager.h"
 #include "paddle/pir/include/pass/pass_registry.h"
 

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -618,7 +618,8 @@ const std::vector<std::string> kPirXpuPasses{// Functional pass
                                              "map_op_to_another_pass",
                                              "identity_op_clean_pass",
                                              // Operator fusion pass
-                                             "add_layernorm_xpu_fuse_pass"};
+                                             "add_layernorm_xpu_fuse_pass",
+                                             "group_norm_silu_xpu_fuse_pass"};
 
 const std::vector<std::string> kPirMkldnnPasses{
     "conv2d_bias_fuse_pass",

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -52,4 +52,5 @@ USE_PIR_PASS(conv_elementwise_add_onednn_fuse_pass);
 
 #ifdef PADDLE_WITH_XPU
 USE_PIR_PASS(add_layernorm_xpu_fuse_pass);
+USE_PIR_PASS(group_norm_silu_xpu_fuse_pass);
 #endif

--- a/paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.cc
@@ -64,17 +64,6 @@ class GroupNormSiluPattern : public paddle::drr::DrrPatternBase {
               {&pat.Tensor("Y"), &pat.Tensor("Mean"), &pat.Tensor("Variance")});
     silu({&pat.Tensor("Y")}, {&pat.Tensor("Out")});
 
-    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
-      std::vector<int64_t> x_shape =
-          pir::GetShapeFromValue(match_ctx.Tensor("X"));
-      std::vector<int64_t> y_shape =
-          pir::GetShapeFromValue(match_ctx.Tensor("Y"));
-      if (x_shape.size() == y_shape.size()) {
-        return true;
-      }
-      return false;
-    });
-
     paddle::drr::ResultPattern res = pat.ResultPattern();
 
     const auto &group_norm_silu_xpu = res.Op(

--- a/paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+class GroupNormSiluPattern : public paddle::drr::DrrPatternBase {
+ public:
+  std::string name() const override { return "GroupNormSiluPattern"; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+    const auto &groupnorm = pat.Op(
+        paddle::dialect::GroupNormOp::name(),
+        {{"epsilon", pat.Attr("epsilon")}, {"groups", pat.Attr("groups")}});
+
+    const auto &silu = pat.Op(paddle::dialect::SiluOp::name());
+
+    groupnorm({&pat.Tensor("X"), &pat.Tensor("Bias"), &pat.Tensor("Scale")},
+              {&pat.Tensor("Y"), &pat.Tensor("Mean"), &pat.Tensor("Variance")});
+    silu({&pat.Tensor("Y")}, {&pat.Tensor("Out")});
+
+    pat.RequireNativeCall([&](const paddle::drr::MatchContext &match_ctx) {
+      std::vector<int64_t> x_shape =
+          pir::GetShapeFromValue(match_ctx.Tensor("X"));
+      std::vector<int64_t> y_shape =
+          pir::GetShapeFromValue(match_ctx.Tensor("Y"));
+      if (x_shape.size() == y_shape.size()) {
+        return true;
+      }
+      return false;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &group_norm_silu_xpu = res.Op(
+        paddle::dialect::GroupNormSiluXpuOp::name(),
+        {{{"epsilon", pat.Attr("epsilon")}, {"groups", pat.Attr("groups")}}});
+    group_norm_silu_xpu(
+        {&res.Tensor("x"), &res.Tensor("bias"), &res.Tensor("scale")},
+        {&res.Tensor("out")});
+  }
+};
+
+class GroupNormSiluXpuFusePass : public pir::PatternRewritePass {
+ public:
+  GroupNormSiluXpuFusePass()
+      : pir::PatternRewritePass("group_norm_silu_xpu_fuse_pass", 2) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add(paddle::drr::Create<GroupNormSiluPattern>(context));
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+std::unique_ptr<Pass> CreateGroupNormSiluXpuFusePass() {
+  return std::make_unique<GroupNormSiluXpuFusePass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(group_norm_silu_xpu_fuse_pass, GroupNormSiluXpuFusePass);

--- a/paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/xpu/group_norm_silu_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateGroupNormSiluXpuFusePass();
+
+}  // namespace pir

--- a/test/ir/pir/fused_pass/xpu/test_group_norm_silu_xpu_fuse_pass.py
+++ b/test/ir/pir/fused_pass/xpu/test_group_norm_silu_xpu_fuse_pass.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+from paddle.base import core
+
+paddle.enable_static()
+
+
+class TestGroupNormSiluXpuFusePattern(PassTest):
+    r"""
+                      X
+              Scale   |   Bias
+                   \  |  /
+                  group norm
+                   /  |  \
+                  /   |   \
+            variance  |   mean
+                      |
+                     silu
+                      |
+                    output
+    """
+
+    def is_program_valid(self, program):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                channels = 128
+                groups = 32
+                x = paddle.static.data(
+                    name='X', shape=[1, channels, 64, 64], dtype='float32'
+                )
+
+                group_norm = paddle.nn.GroupNorm(groups, channels)
+                silu = paddle.nn.Silu()
+
+                group_norm_out = group_norm(x)
+                out = silu(group_norm_out)
+                out = paddle.assign(out)
+                self.pass_list = ['group_norm_silu_xpu_fuse_pass']
+                self.feeds = {
+                    "X": np.random.random((1, channels, 64, 64)).astype(
+                        "float32"
+                    ),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "pd_op.group_norm": 0,
+                    "pd_op.silu": 0,
+                    "pd_op.group_norm_silu_xpu": 1,
+                }
+                return [main_prog, start_prog]
+
+    def setUp(self):
+        if core.is_compiled_with_xpu():
+            self.places.append(paddle.XPUPlace(0))
+        self.skip_accuracy_verification = True
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
New features


### Description
新增融合算子group_norm_silu_xpu_fuse_pass的pir实现，将group_norm和silu进行了融合。在xpu平台上，经过实测，性能提升了约10%。
