### PR TITLE
[eager][utils] fix `GRAD_SLOT_META_TEMPLATE` fmt error

### DIFF
--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -717,8 +717,8 @@ std::string EagerUtils::GradNodeStr(const egr::GradNodeBase& node) {
       in_slot_str +=
           paddle::string::Sprintf(SLOT_INFO_TEMPLATE, i, sg_str, edges_str);
     }
-    std::string in_meta_str =
-        paddle::string::Sprintf(GRAD_SLOT_META_TEMPLATE, in_slot_str);
+    std::string in_meta_str = paddle::string::Sprintf(
+        GRAD_SLOT_META_TEMPLATE, in_metas.size(), in_slot_str);
     return paddle::string::Sprintf(
         GRAD_NODE_TEMPLATE, out_meta_str, in_meta_str);
   } else if (VLOG_IS_ON(5)) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
 User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 `GLOG_v>=6`  下格式化输出的错误

在 log_v 6 下 `const char* GRAD_SLOT_META_TEMPLATE = " {SlotSize: [%d]: %s} ";` 需要传大小和内容，而修复前只传了内容

```bash
I0409 13:34:50.035048 3900504768 eager_op_function.cc:28054] Running Eager Final State API: arange
I0409 13:34:50.035063 3900504768 eager_op_function.cc:28056] args count: 2
I0409 13:34:50.035090 3900504768 dygraph_functions.cc:56816] Running AD API: arange
I0409 13:34:50.035135 3900504768 dygraph_functions.cc:56840]  No Type Promotion for arange_ad_func api.
I0409 13:34:50.035171 3900504768 dygraph_functions.cc:56862] Running C++ API: arange
Assertion failed: (0 && "tinyformat: Too many conversion specifiers in format string"), function formatImpl, file tinyformat.h, line 816.
[1]    12681 abort      python test/dygraph_to_static/test_no_gradient.py
```
修复后
```bash
I0409 14:24:41.228745 3900504768 eager_op_function.cc:28054] Running Eager Final State API: arange
I0409 14:24:41.228746 3900504768 eager_op_function.cc:28056] args count: 2
I0409 14:24:41.228751 3900504768 dygraph_functions.cc:56816] Running AD API: arange
I0409 14:24:41.228753 3900504768 dygraph_functions.cc:56840]  No Type Promotion for arange_ad_func api.
I0409 14:24:41.228755 3900504768 dygraph_functions.cc:56862] Running C++ API: arange
I0409 14:24:41.228794 3900504768 dygraph_functions.cc:56879] { Input: [
( start , [{Name: None, Initialized: 1, Ptr: 0x12f4864d8,TensorInfo: [ Type: DenseTensor, Dtype: int32, Place: Place(cpu), Shape: 1, DistAttr: Unknown ], ADInfo:[ Grad: [ {Name: None, Initialized: 0, Ptr: 0x0,TensorInfo: [ Unknown ], ADInfo:[ None ]} ],  GradNode: [ BackwardOutMeta: [  {SlotSize: [1]: SlotID: 0, StopGradients: 0, , Edges[ { NULL Edge } ]}  ], BackwardInMeta: [  {SlotSize: [1]: SlotID: 0, StopGradients: 0, , Edges[ { NULL Edge } ]}  ] ], StopGradient: [ 1 ] ]}]),
( end , [{Name: None, Initialized: 1, Ptr: 0x12f4fcf68,TensorInfo: [ Type: DenseTensor, Dtype: int32, Place: Place(cpu), Shape: 1, DistAttr: Unknown ], ADInfo:[ Grad: [ {Name: None, Initialized: 0, Ptr: 0x0,TensorInfo: [ Unknown ], ADInfo:[ None ]} ],  GradNode: [ BackwardOutMeta: [  {SlotSize: [1]: SlotID: 0, StopGradients: 0, , Edges[ { NULL Edge } ]}  ], BackwardInMeta: [  {SlotSize: [1]: SlotID: 0, StopGradients: 0, , Edges[ { NULL Edge } ]}  ] ], StopGradient: [ 1 ] ]}]),
( step , [{Name: None, Initialized: 1, Ptr: 0x12f4dca28,TensorInfo: [ Type: DenseTensor, Dtype: int32, Place: Place(cpu), Shape: 1, DistAttr: Unknown ], ADInfo:[ Grad: [ {Name: None, Initialized: 0, Ptr: 0x0,TensorInfo: [ Unknown ], ADInfo:[ None ]} ],  GradNode: [ BackwardOutMeta: [  {SlotSize: [1]: SlotID: 0, StopGradients: 0, , Edges[ { NULL Edge } ]}  ], BackwardInMeta: [  {SlotSize: [1]: SlotID: 0, StopGradients: 0, , Edges[ { NULL Edge } ]}  ] ], StopGradient: [ 1 ] ]}]), ]}
```
