### PR TITLE
add vjp interface for reshard op.

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/dist_api.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_api.cc
@@ -45,23 +45,20 @@ pir::Value shard_tensor(const pir::Value& x,
   return shard_tensor_op.out();
 }
 
-pir::Value reshard(const pir::Value& x,
-                   const phi::distributed::ProcessMesh& process_mesh,
-                   const std::vector<int64_t>& dims_mapping) {
+pir::Value reshard(
+    const pir::Value& x,
+    const phi::distributed::ProcessMesh& process_mesh,
+    const std::vector<int64_t>& dims_mapping,
+    const flat_hash_map<int64_t, phi::ReduceType>& partial_status) {
   pir::IrContext* ctx = pir::IrContext::Instance();
-  // TODO(ywt01) get partial_status by func parameter
-  paddle::flat_hash_map<int64_t, phi::ReduceType> partial_status;
   TensorDistAttribute tensor_dist_attr =
       TensorDistAttribute::get(ctx, process_mesh, dims_mapping, partial_status);
-
-  auto reshard_op = ApiBuilder::Instance().GetBuilder()->Build<ReShardOp>(
-      x, tensor_dist_attr);
-  return reshard_op.result(0);
+  return reshard(x, tensor_dist_attr);
 }
 
 pir::Value reshard(const pir::Value& x,
                    const TensorDistAttribute& tensor_dist_attr) {
-  auto reshard_op = ApiBuilder::Instance().GetBuilder()->Build<ReShardOp>(
+  auto reshard_op = ApiBuilder::Instance().GetBuilder()->Build<ReshardOp>(
       x, tensor_dist_attr);
   return reshard_op.result(0);
 }

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_api.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_api.h
@@ -29,9 +29,11 @@ pir::Value shard_tensor(const pir::Value& x,
                         const phi::distributed::ProcessMesh& process_mesh,
                         const std::vector<int64_t>& dims_mapping);
 
-pir::Value reshard(const pir::Value& x,
-                   const phi::distributed::ProcessMesh& process_mesh,
-                   const std::vector<int64_t>& dims_mapping);
+pir::Value reshard(
+    const pir::Value& x,
+    const phi::distributed::ProcessMesh& process_mesh,
+    const std::vector<int64_t>& dims_mapping,
+    const flat_hash_map<int64_t, phi::ReduceType>& partial_status = {});
 
 pir::Value reshard(const pir::Value& x,
                    const TensorDistAttribute& tensor_dist_attr);

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -35,7 +35,7 @@ void DistDialect::initialize() {
                      TensorDistAttribute,
                      OperationDistAttribute>();
   RegisterTypes<DistDenseTensorType>();
-  RegisterOps<ShardTensorOp, ReShardOp>();
+  RegisterOps<ShardTensorOp, ReshardOp>();
 }
 
 void DistDialect::PrintType(pir::Type type, std::ostream &os) const {

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_op.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_op.h
@@ -15,6 +15,8 @@
 #pragma once
 #include <vector>
 
+#include "paddle/fluid/pir/dialect/operator/interface/op_yaml_info.h"
+#include "paddle/fluid/pir/dialect/operator/interface/vjp.h"
 #include "paddle/pir/include/core/builder.h"
 #include "paddle/pir/include/core/builtin_type.h"
 #include "paddle/pir/include/core/op_base.h"
@@ -39,7 +41,7 @@ class ShardTensorOp : public pir::Op<ShardTensorOp> {
   void VerifySig();
 };
 
-class ReShardOp : public pir::Op<ReShardOp> {
+class ReshardOp : public pir::Op<ReshardOp, VjpInterface, OpYamlInfoInterface> {
  public:
   using Op::Op;
   static const char* name() { return "dist_op.reshard"; }
@@ -49,10 +51,19 @@ class ReShardOp : public pir::Op<ReShardOp> {
                              pir::OperationArgument& argument,  // NOLINT
                              pir::Value input,
                              TensorDistAttribute tensor_dist_attr);
+
+  static OpInfoTuple GetOpInfo();
+  static std::vector<std::vector<pir::Value>> Vjp(
+      pir::Operation* op,
+      const std::vector<std::vector<pir::Value>>& inputs_,
+      const std::vector<std::vector<pir::Value>>& outputs,
+      const std::vector<std::vector<pir::Value>>& out_grads,
+      const std::vector<std::vector<bool>>& stop_gradients);
+
   void VerifySig();
 };
 }  // namespace dialect
 }  // namespace paddle
 
 IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::ShardTensorOp)
-IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::ReShardOp)
+IR_DECLARE_EXPLICIT_TYPE_ID(paddle::dialect::ReshardOp)

--- a/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_util.h
+++ b/paddle/fluid/pir/dialect/operator/utils/op_yaml_info_util.h
@@ -98,8 +98,9 @@ struct OpRunTimeInfo {
   std::vector<std::string> skip_transform_inputs;
   pir::AttributeMap extra_args_default_value;
   std::vector<std::string> data_format_tensors;
-  bool is_onednn_only;
-  bool dynamic_fallback;
+  bool is_onednn_only = false;
+  bool dynamic_fallback = false;
+  OpRunTimeInfo() = default;
 
   OpRunTimeInfo(const std::string& infer_meta_func,
                 const std::vector<std::string>& infer_meta_param,

--- a/paddle/fluid/pybind/dist_static_op_function.h
+++ b/paddle/fluid/pybind/dist_static_op_function.h
@@ -18,6 +18,7 @@
 #include "paddle/fluid/pir/dialect/operator/ir/api_builder.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/fluid/pybind/exception.h"
+#include "paddle/fluid/pybind/pir.h"
 #include "paddle/phi/core/enforce.h"
 
 namespace paddle {
@@ -66,12 +67,29 @@ static PyObject *static_api_reshard(PyObject *self,
     PyObject *process_mesh_obj = PyTuple_GET_ITEM(args, 1);
     auto process_mesh = CastPyArg2ProcessMesh(process_mesh_obj, 1);
 
-    PyObject *dims_mapping_obj = PyTuple_GET_ITEM(args, 2);
-    auto dims_mapping = CastPyArg2VectorOfInt64(dims_mapping_obj, 2);
+    PyObject *placements_obj = PyTuple_GET_ITEM(args, 2);
+    auto placements = CastPyArg2VectorOfPlacement(placements_obj, 2);
 
-    PyObject *placements_obj = PyTuple_GET_ITEM(args, 3);
-    auto placements = CastPyArg2VectorOfPlacement(placements_obj, 3);
-
+    int64_t ndim = GetValueDims(input).size();
+    std::vector<int64_t> dim_map(ndim, -1);
+    for (size_t i = 0; i < placements.size(); i++) {
+      auto &placement = placements[i];
+      if (placement->is_shard()) {
+        auto shard_dim =
+            dynamic_cast<const phi::distributed::Shard &>(*placement).get_dim();
+        PADDLE_ENFORCE_EQ(
+            dim_map[shard_dim],
+            -1,
+            common::errors::InvalidArgument(
+                "Tensor dim %lld is already sharded on mesh dim %lld,"
+                " DistTensor operator implementation does not support things "
+                "like hybrid"
+                " sharding strategies yet (i.e. [Shard(0), Shard(0)])",
+                shard_dim,
+                dim_map[shard_dim]));
+        dim_map[shard_dim] = i;
+      }
+    }
     paddle::flat_hash_map<int64_t, phi::ReduceType> partial_status;
     for (size_t i = 0; i < placements.size(); ++i) {
       auto &p = placements[i];
@@ -83,8 +101,8 @@ static PyObject *static_api_reshard(PyObject *self,
     }
 
     // Call ir static api
-    auto static_api_out = paddle::dialect::reshard(
-        input, process_mesh, dims_mapping, partial_status);
+    auto static_api_out =
+        paddle::dialect::reshard(input, process_mesh, dim_map, partial_status);
 
     return ToPyObject(static_api_out);
   } catch (...) {

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -35,7 +35,6 @@ from paddle.distributed.auto_parallel.interface import (
     shard_tensor as shard_tensor_static,
 )
 from paddle.distributed.auto_parallel.placement_type import (
-    to_dim_map,
     to_placements,
 )
 from paddle.distributed.auto_parallel.static.completion import (
@@ -393,8 +392,7 @@ def reshard(dist_tensor, mesh, placements):
 
         return paddle.base.core.reshard(dist_tensor, dist_attr)
     elif in_pir_mode():
-        dim_map = to_dim_map(placements, dist_tensor.ndim)
-        return paddle._pir_ops.reshard(dist_tensor, mesh, dim_map, placements)
+        return paddle._pir_ops.reshard(dist_tensor, mesh, placements)
     else:
         assert isinstance(
             dist_tensor, Variable

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -28,12 +28,16 @@ from paddle.base.framework import (
     EagerParamBase,
     Variable,
     default_main_program,
+    in_pir_mode,
 )
 from paddle.distributed.auto_parallel import Engine, strategy as auto_strategy
 from paddle.distributed.auto_parallel.interface import (
     shard_tensor as shard_tensor_static,
 )
-from paddle.distributed.auto_parallel.placement_type import to_placements
+from paddle.distributed.auto_parallel.placement_type import (
+    to_dim_map,
+    to_placements,
+)
 from paddle.distributed.auto_parallel.static.completion import (
     mark_as_sharding_propagation_skip_op,
 )
@@ -388,6 +392,9 @@ def reshard(dist_tensor, mesh, placements):
             dist_attr._set_partial_dims(partial_dims)
 
         return paddle.base.core.reshard(dist_tensor, dist_attr)
+    elif in_pir_mode():
+        dim_map = to_dim_map(placements, dist_tensor.ndim)
+        return paddle._pir_ops.reshard(dist_tensor, mesh, dim_map, placements)
     else:
         assert isinstance(
             dist_tensor, Variable

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -392,7 +392,7 @@ def reshard(dist_tensor, mesh, placements):
 
         return paddle.base.core.reshard(dist_tensor, dist_attr)
     elif in_pir_mode():
-        return paddle._pir_ops.reshard(dist_tensor, mesh, placements)
+        return paddle._C_ops.reshard(dist_tensor, mesh, placements)
     else:
         assert isinstance(
             dist_tensor, Variable

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -712,6 +712,7 @@ class Engine:
         # TODO(zhiqiu): fit the processes below for pir
         if self._in_pir_mode:
             self._parallel_pir(mode)
+            self._has_prepared[mode] = True
             return
         # Do the planning process
         self._plan(mode)

--- a/test/auto_parallel/pir/CMakeLists.txt
+++ b/test/auto_parallel/pir/CMakeLists.txt
@@ -12,6 +12,7 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
   py_test_modules(test_pir_mse_spmd MODULES test_mse_spmd_rule ENVS
                   FLAGS_enable_pir_api=1)
   py_test_modules(test_mlp MODULES test_mlp ENVS FLAGS_enable_pir_api=1)
+  py_test_modules(test_reshard MODULES test_reshard ENVS FLAGS_enable_pir_api=1)
   set_tests_properties(test_mlp PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT
                                            60)
 endif()

--- a/test/auto_parallel/pir/test_reshard.py
+++ b/test/auto_parallel/pir/test_reshard.py
@@ -23,7 +23,7 @@ from paddle import nn
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[0]))
 from test_to_static_pir_program import (
     BATCH_SIZE,
-    IMAGE_SIZE,
+    CLASS_NUM,
     DemoNet,
     create_data_loader,
 )
@@ -77,7 +77,7 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
                     )
                     self.assertEqual(
                         self.fwd_input._local_shape,
-                        [BATCH_SIZE, IMAGE_SIZE // 2],
+                        [BATCH_SIZE, CLASS_NUM],
                     )
                     self.fwd_output = op.result(0)
                     self.assertEqual(
@@ -88,7 +88,7 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
                     )
                     self.assertEqual(
                         self.fwd_output._local_shape,
-                        [BATCH_SIZE / 2, IMAGE_SIZE // 2],
+                        [BATCH_SIZE / 2, CLASS_NUM],
                     )
                 elif index == 1:
                     # backward reshard op

--- a/test/auto_parallel/pir/test_reshard.py
+++ b/test/auto_parallel/pir/test_reshard.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import sys
+import unittest
+
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[0]))
+from test_to_static_pir_program import (
+    BATCH_SIZE,
+    IMAGE_SIZE,
+    DemoNet,
+    create_data_loader,
+)
+
+
+class ReshardDemoNet(DemoNet):
+    def __init__(self, mesh, shard=True):
+        super().__init__(mesh, shard=True)
+
+    def forward(self, x):
+        out = DemoNet.forward(self, x)
+        out = dist.reshard(out, self._mesh, [dist.Shard(0)])
+        return out
+
+
+class TestToStaticPirProgramTrain(unittest.TestCase):
+    def test_to_static_program(self):
+        mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
+        layer = ReshardDemoNet(mesh)
+        opt = paddle.optimizer.SGD(
+            learning_rate=0.1, parameters=layer.parameters()
+        )
+        loss_fn = nn.MSELoss()
+        loader = create_data_loader()
+        dist_loader = dist.shard_dataloader(loader, meshes=[mesh])
+        dist_model = dist.to_static(layer, dist_loader, loss_fn, opt)
+        engine = dist_model._engine
+        engine._build("train")
+        dist_program = engine._fwd_main_progs["train"]
+        dist_program = paddle.base.libpaddle.pir.apply_mix2dist_pass(
+            dist_program
+        )
+        loss = dist_program.get_output_value_by_name(engine._loss_names[0])
+        with paddle.static.program_guard(dist_program):
+            params_grads = paddle.autograd.ir_backward.append_backward(loss)
+            engine._optimizer._apply_optimize(
+                loss, startup_program=None, params_grads=params_grads
+            )
+
+        index = 0
+        for op in dist_program.global_block().ops:
+            if op.name() == 'dist_op.reshard':
+                if index == 0:
+                    # forward reshard op
+                    self.fwd_input = op.operand_source(0)
+                    self.assertEqual(
+                        self.fwd_input.dist_attr().dims_mapping, [-1, -1]
+                    )
+                    self.assertEqual(
+                        self.fwd_input.dist_attr().partial_dims, set()
+                    )
+                    self.assertEqual(
+                        self.fwd_input._local_shape,
+                        [BATCH_SIZE, IMAGE_SIZE // 2],
+                    )
+                    self.fwd_output = op.result(0)
+                    self.assertEqual(
+                        self.fwd_output.dist_attr().dims_mapping, [0, -1]
+                    )
+                    self.assertEqual(
+                        self.fwd_output.dist_attr().partial_dims, set()
+                    )
+                    self.assertEqual(
+                        self.fwd_output._local_shape,
+                        [BATCH_SIZE / 2, IMAGE_SIZE // 2],
+                    )
+                elif index == 1:
+                    # backward reshard op
+                    self.assertEqual(op.result(0).type(), self.fwd_input.type())
+                index += 1
+        self.assertEqual(index, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/cpp/pir/distributed/dist_dialect_test.cc
+++ b/test/cpp/pir/distributed/dist_dialect_test.cc
@@ -345,8 +345,8 @@ TEST(shard_tensor_op_replicate_test, base) {
   auto dst_mesh_attr = ProcessMeshAttribute::get(ctx, dst_process_mesh);
   auto dst_tensor_dist_attr = TensorDistAttribute::get(
       ctx, dst_mesh_attr, dst_dims_mapping, partial_status);
-  paddle::dialect::ReShardOp reshard_op =
-      builder.Build<paddle::dialect::ReShardOp>(shard_op.out(),
+  paddle::dialect::ReshardOp reshard_op =
+      builder.Build<paddle::dialect::ReshardOp>(shard_op.out(),
                                                 dst_tensor_dist_attr);
 
   EXPECT_TRUE(reshard_op.result(0).type().isa<DistDenseTensorType>());
@@ -428,8 +428,8 @@ TEST(shard_tensor_op_shard_row_test, base) {
   auto dst_mesh_attr = ProcessMeshAttribute::get(ctx, dst_process_mesh);
   auto dst_tensor_dist_attr = TensorDistAttribute::get(
       ctx, dst_mesh_attr, dims_mapping, partial_status);
-  paddle::dialect::ReShardOp reshard_op =
-      builder.Build<paddle::dialect::ReShardOp>(shard_op.out(),
+  paddle::dialect::ReshardOp reshard_op =
+      builder.Build<paddle::dialect::ReshardOp>(shard_op.out(),
                                                 dst_tensor_dist_attr);
 
   EXPECT_TRUE(reshard_op.result(0).type().isa<DistDenseTensorType>());
@@ -511,8 +511,8 @@ TEST(shard_tensor_op_shard_col_test, base) {
   auto dst_mesh_attr = ProcessMeshAttribute::get(ctx, dst_process_mesh);
   auto dst_tensor_dist_attr = TensorDistAttribute::get(
       ctx, dst_mesh_attr, dst_dims_mapping, partial_status);
-  paddle::dialect::ReShardOp reshard_op =
-      builder.Build<paddle::dialect::ReShardOp>(shard_op.out(),
+  paddle::dialect::ReshardOp reshard_op =
+      builder.Build<paddle::dialect::ReshardOp>(shard_op.out(),
                                                 dst_tensor_dist_attr);
 
   EXPECT_TRUE(reshard_op.result(0).type().isa<DistDenseTensorType>());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
- 规范ReshardOp的名字。 （从ReShardOp调整为ReshardOp）
- 完善reshard的python api， 支持pir模式以及传递placement参数。
- reshard增加vjp接口，支持带reshard op的网络跑自动微分流程。

### Other
pcard-67164
