### PR TITLE
[SOT] Fix error on dataclass object debug message

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -19,7 +19,7 @@ import weakref
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from ...profiler import EventGuard
-from ...utils import InnerError, current_tmp_name_records, log, log_do
+from ...utils import current_tmp_name_records, log, log_do
 
 Guard = Callable[[types.FrameType], bool]
 
@@ -49,16 +49,6 @@ class StringifyExpression:
             *[arg.debug_expr for arg in sub_exprs]
         )
         self.free_vars = free_vars
-
-    def __post_init__(self):
-        self.check_expr(self.expr)
-
-    def check_expr(self, expr: str):
-        try:
-            pass
-            # ast.parse(expr) # TODO(xiongkun): too slow
-        except SyntaxError as e:
-            raise InnerError(f"Invalid expression: {expr}") from e
 
     def __hash__(self):
         if self.free_vars:

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -516,6 +516,12 @@ class OpcodeExecutorBase:
         for current_simulator in OpcodeExecutorBase.call_stack:
             code = current_simulator._code
             current_line = current_simulator._current_line
+            file = inspect.getfile(code)
+            if file.startswith("<") and file.endswith(">"):
+                message_lines.append(
+                    f"{indent}  File \"{file}\", line {current_line}"
+                )
+                continue
             lines, start = inspect.getsourcelines(code)
             real_name = code.co_name
             message_lines.append(

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -32,6 +32,7 @@ from ....utils import (
     FallbackError,
     NameGenerator,
     paddle_tensor_methods,
+    printable,
 )
 from ....utils.exceptions import HasNoAttributeError, InnerError
 from ..dispatch_functions import tensor_numel
@@ -604,7 +605,12 @@ class ObjectVariable(VariableBase):
 
     @property
     def main_info(self) -> dict[str, Any]:
-        return {"value": self.value}
+        # NOTE(SigureMo): There are some objects that cannot be printed, such as
+        # uninitialized dataclass, we should fallback to the class name.
+        if printable(self.value):
+            return {"value": self.value}
+        else:
+            return {"value": f"instance {self.value.__class__.__name__}"}
 
     def get_py_value(self, allow_tensor=False) -> Any:
         return self.value

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -75,5 +75,6 @@ from .utils import (  # noqa: F401
     map_if_extend,
     meta_str,
     no_eval_frame,
+    printable,
     tmp_name_guard,
 )

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -385,6 +385,14 @@ def hashable(obj):
         return False
 
 
+def printable(obj):
+    try:
+        str(obj)
+        return True
+    except Exception as e:
+        return False
+
+
 class StepState(Enum):
     COLLECT_INFO = 1
     RUN_SOT = 2

--- a/test/sot/test_dataclass.py
+++ b/test/sot/test_dataclass.py
@@ -21,6 +21,7 @@ from test_case_base import (
 )
 
 import paddle
+from paddle.jit.sot.utils import strict_mode_guard
 
 
 @dataclass
@@ -45,11 +46,13 @@ def return_dataclass_with_post_init(x):
 
 
 class TestDataclass(TestCaseBase):
+    @strict_mode_guard(False)
     @run_in_both_default_and_pir
     def test_dtype_reconstruct(self):
         x = paddle.to_tensor(1)
         self.assert_results(return_dataclass, x)
 
+    @strict_mode_guard(False)
     @run_in_both_default_and_pir
     def test_dtype_reconstruct_with_post_init(self):
         x = paddle.to_tensor(1)

--- a/test/sot/test_dataclass.py
+++ b/test/sot/test_dataclass.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from dataclasses import dataclass
+
+from test_case_base import (
+    TestCaseBase,
+    run_in_both_default_and_pir,
+)
+
+import paddle
+
+
+@dataclass
+class Data:
+    x: paddle.Tensor
+
+
+@dataclass
+class DataWithPostInit:
+    x: paddle.Tensor
+
+    def __post_init__(self):
+        self.x += 1
+
+
+def return_dataclass(x):
+    return Data(x + 1)
+
+
+def return_dataclass_with_post_init(x):
+    return DataWithPostInit(x)
+
+
+class TestDataclass(TestCaseBase):
+    @run_in_both_default_and_pir
+    def test_dtype_reconstruct(self):
+        x = paddle.to_tensor(1)
+        self.assert_results(return_dataclass, x)
+
+    @run_in_both_default_and_pir
+    def test_dtype_reconstruct_with_post_init(self):
+        x = paddle.to_tensor(1)
+        self.assert_results(return_dataclass_with_post_init, x)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

修复模型代码中包含 dataclass SOT 在处理 debug 信息时报错的问题

- dataclass 的 `__init__` 的 code 没有源码，在处理报错时会挂掉，因此跳过 `<xxx>`
- dataclass 模拟过程中 `__new__` 的 object 无法 `print`，调用 `print` 时候会尝试访问相关属性，但是此时还没有调用 `__init__`，访问相关属性时就会挂掉，因此会先尝试调用 `str` 看看是否是 `printable`

PCard-66972