### PR TITLE
[HACKATHON 6th] Specify nvcc host compiler when using clang

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -212,6 +212,11 @@ if(NOT WIN32)
       -Wno-error=unused-function # Warnings in Numpy Header.
       -Wno-error=array-bounds # Warnings in Eigen::array
   )
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(GPU_COMMON_FLAGS -ccbin=${CMAKE_CXX_COMPILER} ${GPU_COMMON_FLAGS})
+  endif()
+
   if(NOT WITH_NV_JETSON
      AND NOT WITH_ARM
      AND NOT WITH_SW


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
nvcc 在编译 CUDA 程序的时候，会调用系统默认的 host compiler 来编译 host code。
本 PR 的更改为，当使用 Clang 编译 Paddle 时，指定 Clang 为 nvcc 的 host compiler，来保持一致性。