### PR TITLE
[CINN Unittest] Add Broadcast+Reduce subgraph

### DIFF
--- a/test/ir/pir/cinn/test_cinn_broadcast.py
+++ b/test/ir/pir/cinn/test_cinn_broadcast.py
@@ -54,7 +54,7 @@ class TestCinnCos(unittest.TestCase):
         cinn_out = self.train(use_cinn=True)
         dy_out = self.train(use_cinn=False)
 
-        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-5)
 
 
 if __name__ == '__main__':

--- a/test/ir/pir/cinn/test_cinn_broadcast.py
+++ b/test/ir/pir/cinn/test_cinn_broadcast.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import utils
+
+import paddle
+
+
+class CINNCosSubGraphNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        tmp = x * y
+        tmp1 = paddle.reshape(tmp, [80, 32, 4])
+        tmp2 = paddle.sum(tmp1, axis=2)
+        return tmp2
+
+
+class TestCinnCos(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x = paddle.uniform([80, 128], dtype="float32", min=-0.5, max=0.5)
+        self.x.stop_gradient = True
+        self.y = paddle.uniform([128], dtype="float32", min=-0.5, max=0.5)
+        self.y.stop_gradient = True
+
+    def train(self, use_cinn):
+        net = CINNCosSubGraphNet()
+        net.eval()
+        net = utils.apply_to_static(net, use_cinn)
+        for i in range(1):
+            out = net(self.x, self.y)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-8)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Devs


### Description
<!-- Describe what you’ve done -->
pcard-76996

##### How to run

`FLAGS_print_ir=1 CUDA_VISIBLE_DEVICES=2 GLOG_vmodule=compiler=3 FLAGS_pir_apply_shape_optimization_pass=0 FLAGS_enable_pir_api=1 FLAGS_cinn_new_group_scheduler=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_bucket_compile=True FLAGS_support_reduce_stride_read=1 python test_cinn_broadcast.py`
