### PR TITLE
fix gpups error when upgrade cuda12.3

### DIFF
--- a/paddle/fluid/framework/fleet/heter_ps/feature_value.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/feature_value.cu
@@ -356,25 +356,25 @@ void AccessorWrapper<GPUAccessor>::CopyForPushImpl(
   int* d_slot_vector = reinterpret_cast<int*>(buf_slot_vector->ptr());
   int* d_mf_dim_vector = reinterpret_cast<int*>(buf_mf_dim_vector->ptr());
   cudaMemcpyAsync(gpu_values,
-             grad_values.data(),
-             grad_values.size() * sizeof(float*),
-             cudaMemcpyHostToDevice,
-             stream);
+                  grad_values.data(),
+                  grad_values.size() * sizeof(float*),
+                  cudaMemcpyHostToDevice,
+                  stream);
   cudaMemcpyAsync(gpu_len,
-             slot_lengths_lod.data(),
-             slot_lengths.size() * sizeof(int64_t),
-             cudaMemcpyHostToDevice,
-             stream);
+                  slot_lengths_lod.data(),
+                  slot_lengths.size() * sizeof(int64_t),
+                  cudaMemcpyHostToDevice,
+                  stream);
   cudaMemcpyAsync(d_slot_vector,
-             slot_vector.data(),
-             slot_lengths_lod.size() * sizeof(int),
-             cudaMemcpyHostToDevice,
-             stream);
+                  slot_vector.data(),
+                  slot_lengths_lod.size() * sizeof(int),
+                  cudaMemcpyHostToDevice,
+                  stream);
   cudaMemcpyAsync(d_mf_dim_vector,
-             slot_mf_dim_vector.data(),
-             slot_lengths_lod.size() * sizeof(int),
-             cudaMemcpyHostToDevice,
-             stream);
+                  slot_mf_dim_vector.data(),
+                  slot_lengths_lod.size() * sizeof(int),
+                  cudaMemcpyHostToDevice,
+                  stream);
   PushCopyWithPool<<<(total_length + 1024 - 1) / 1024, 1024, 0, stream>>>(
       total_grad_values_gpu,
       gpu_values,

--- a/paddle/fluid/framework/fleet/heter_ps/feature_value.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/feature_value.cu
@@ -355,22 +355,26 @@ void AccessorWrapper<GPUAccessor>::CopyForPushImpl(
   int64_t* gpu_len = reinterpret_cast<int64_t*>(buf_length->ptr());
   int* d_slot_vector = reinterpret_cast<int*>(buf_slot_vector->ptr());
   int* d_mf_dim_vector = reinterpret_cast<int*>(buf_mf_dim_vector->ptr());
-  cudaMemcpy(gpu_values,
+  cudaMemcpyAsync(gpu_values,
              grad_values.data(),
              grad_values.size() * sizeof(float*),
-             cudaMemcpyHostToDevice);
-  cudaMemcpy(gpu_len,
+             cudaMemcpyHostToDevice,
+             stream);
+  cudaMemcpyAsync(gpu_len,
              slot_lengths_lod.data(),
              slot_lengths.size() * sizeof(int64_t),
-             cudaMemcpyHostToDevice);
-  cudaMemcpy(d_slot_vector,
+             cudaMemcpyHostToDevice,
+             stream);
+  cudaMemcpyAsync(d_slot_vector,
              slot_vector.data(),
              slot_lengths_lod.size() * sizeof(int),
-             cudaMemcpyHostToDevice);
-  cudaMemcpy(d_mf_dim_vector,
+             cudaMemcpyHostToDevice,
+             stream);
+  cudaMemcpyAsync(d_mf_dim_vector,
              slot_mf_dim_vector.data(),
              slot_lengths_lod.size() * sizeof(int),
-             cudaMemcpyHostToDevice);
+             cudaMemcpyHostToDevice,
+             stream);
   PushCopyWithPool<<<(total_length + 1024 - 1) / 1024, 1024, 0, stream>>>(
       total_grad_values_gpu,
       gpu_values,

--- a/paddle/fluid/framework/fleet/heter_ps/heter_comm_inl.h
+++ b/paddle/fluid/framework/fleet/heter_ps/heter_comm_inl.h
@@ -1631,6 +1631,7 @@ void HeterComm<KeyType, ValType, GradType, GPUAccessor>::pull_merge_sparse(
                 val_type_size);
   }
 
+  AnyDeviceGuard guard2(dev_id);
   auto d_merged_vals = MemoryAlloc(place, uniq_len * val_type_size);
   auto d_merged_vals_ptr = reinterpret_cast<float *>(d_merged_vals->ptr());
   heter_comm_kernel_->dy_mf_fill_dvals(d_shard_vals_ptr,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Parameter Server

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
fix gpups error when upgrade cuda12.3/cudnn9
```
 ExternalError: CUDA error(400), invalid resource handle.
      [Hint: 'cudaErrorInvalidResourceHandle'. This indicates that a resource handle passed to the API call was not valid. Resource handles are opaque types like cudaStream_t and cudaEvent_t.] (at ../paddle/fluid/framework/fleet/heter_ps/heter_comm_inl.h:516)
      [operator < pull_gpups_sparse > error]. (at ../paddle/phi/core/threadpool.h:40)
```

Pcard-81973