### PR TITLE
[Dy2St] Mark `VariableRefArray` inner vars as no need buffer to avoid memery leak

### DIFF
--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1291,7 +1291,7 @@ static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
             auto value = op->operand_source(counter);
             if (!op_input_info.no_need_buffer) {
               need_buffer_values.insert(value);
-              if (!IsFakeValue(value) && !value.defining_op() &&
+              if (!IsFakeValue(value) && value.defining_op() &&
                   value.defining_op()->isa<pir::CombineOp>()) {
                 for (const auto &combine_value :
                      value.defining_op()->operands_source()) {

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1291,7 +1291,7 @@ static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
             auto value = op->operand_source(counter);
             if (!op_input_info.no_need_buffer) {
               need_buffer_values.insert(value);
-              if (!IsFakeValue(value) &&
+              if (!IsFakeValue(value) && !value.defining_op() &&
                   value.defining_op()->isa<pir::CombineOp>()) {
                 for (const auto &combine_value :
                      value.defining_op()->operands_source()) {

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1291,7 +1291,8 @@ static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
             auto value = op->operand_source(counter);
             if (!op_input_info.no_need_buffer) {
               need_buffer_values.insert(value);
-              if (value.defining_op()->isa<pir::CombineOp>()) {
+              if (!IsFakeValue(value) &&
+                  value.defining_op()->isa<pir::CombineOp>()) {
                 for (const auto &combine_value :
                      value.defining_op()->operands_source()) {
                   need_buffer_values.insert(combine_value);

--- a/paddle/fluid/pybind/pir.cc
+++ b/paddle/fluid/pybind/pir.cc
@@ -1274,6 +1274,10 @@ static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
   std::unordered_set<::pir::Value> no_need_buffer_values;
   range_block_do(
       whole_block, range, [&need_buffer_values](::pir::Operation *op) {
+        // NOTE(SigureMo): We should process the CombineOp in it's users.
+        if (op->isa<pir::CombineOp>()) {
+          return;
+        }
         if (op->HasInterface<paddle::dialect::OpYamlInfoInterface>() == false) {
           // not a OpYamlInfoInterface, can't have no_need_buffer.
           for (const auto &operand : op->operands_source()) {
@@ -1284,8 +1288,15 @@ static auto GetNoNeedBufferValue(const ::pir::Block *whole_block,
               op->dyn_cast<paddle::dialect::OpYamlInfoInterface>().GetOpInfo();
           int counter = 0;
           for (const auto &op_input_info : std::get<0>(opinfo)) {
+            auto value = op->operand_source(counter);
             if (!op_input_info.no_need_buffer) {
-              need_buffer_values.insert(op->operand_source(counter));
+              need_buffer_values.insert(value);
+              if (value.defining_op()->isa<pir::CombineOp>()) {
+                for (const auto &combine_value :
+                     value.defining_op()->operands_source()) {
+                  need_buffer_values.insert(combine_value);
+                }
+              }
             }
             counter += 1;
           }

--- a/test/dygraph_to_static/test_no_need_buffer.py
+++ b/test/dygraph_to_static/test_no_need_buffer.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_ast_only,
+    test_pir_only,
+)
+
+import paddle
+
+
+# The input of concat_grad is no_need_buffer
+def concat_net(x):
+    y = x + 1
+    z = paddle.concat([y, y], axis=0)
+    return z
+
+
+class TestNoNeedBuffer(Dy2StTestBase):
+    @test_ast_only
+    @test_pir_only
+    def test_no_need_buffer(self):
+        input = paddle.to_tensor([1, 2])
+        input.stop_gradient = False
+        static_fn = paddle.jit.to_static(concat_net)
+        static_res = static_fn(input)
+        dygraph_res = concat_net(input)
+        np.testing.assert_allclose(static_res.numpy(), dygraph_res.numpy())
+
+        _, partial_program_layer = static_fn.get_concrete_program(input)
+        no_need_buffers = partial_program_layer.program.program_attr[
+            "no_need_buffers"
+        ]
+        for no_need_buffer_value in no_need_buffers:
+            defining_op = no_need_buffer_value.get_defining_op()
+            # y = x + 1, it's defining op is `pd_op.scale`
+            if defining_op is not None and defining_op.name() == 'pd_op.scale':
+                break
+        else:
+            raise AssertionError(
+                "middle var `y` should be no_need_buffer value"
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

对于如下代码：

```python
def concat_net(x):
    y = x + 1
    z = x + 2
    out = paddle.concat([y, z], axis=0)
    return out
```

`y` 是一个中间变量（`z` 一样，不赘述），前向的 `concat` 接收 `Combine(y, z)`，反向的 `concat_grad` 同样也接收 `Combine(y, z)`，而 `concat_grad` 的输入是 `no_need_buffer` 的，也就是说前向使用完需要立即释放掉，而不是留在中间变量提供给反向

我们现在已经有了对 `no_need_buffer` 不设置 skip gc 的逻辑，按理说其前向结束就会被 GC 掉，但这里的 `y` 并没有被 gc 掉

这是因为我们前反向拆分时对于 `no_need_buffer` 的分析只将 `concat_grad` 的输入 `Combine(y, z)` 这个 `VariableRefArray` 标记为 `no_need_buffer`，却没有将其内的 `y` 设置为 `no_need_buffer`，这就导致了 `y` 在前向没有释放

因此在前反向拆分时 `no_need_buffer` 处理逻辑中对 `CombineOp` 内元素也进行处理

Pcard-67164