### PR TITLE
Complement GTOne and Broadcastable in ConstraintsManager

### DIFF
--- a/paddle/common/union_find_set.h
+++ b/paddle/common/union_find_set.h
@@ -22,7 +22,7 @@ namespace common {
 template <typename T>
 class UnionFindSet {
  public:
-  T Find(const T& x) const {
+  const T& Find(const T& x) const {
     if (parent_.find(x) == parent_.end()) {
       return x;
     }
@@ -39,19 +39,24 @@ class UnionFindSet {
     parent_[Find(q)] = Find(p);
   }
 
-  std::vector<std::vector<T>> Clusters() const {
+  template <typename DoEachClusterT>
+  void VisitCluster(const DoEachClusterT& DoEachCluster) const {
     std::unordered_map<T, std::vector<T>> clusters_map;
     for (auto it = parent_.begin(); it != parent_.end(); it++) {
       clusters_map[Find(it->first)].emplace_back(it->first);
     }
-    std::vector<std::vector<T>> clusters;
-    for (auto it = clusters_map.begin(); it != clusters_map.end(); it++) {
-      clusters.emplace_back(it->second);
+    for (const auto& [_, clusters] : clusters_map) {
+      DoEachCluster(clusters);
     }
+  }
+
+  std::vector<std::vector<T>> Clusters() const {
+    std::vector<std::vector<T>> clusters;
+    VisitCluster([&](const auto& cluster) { clusters.emplace_back(cluster); });
     return clusters;
   }
 
-  bool IsConnect(const T& p, const T& q) const { return Find(p) == Find(q); }
+  bool HasSameRoot(const T& p, const T& q) const { return Find(p) == Find(q); }
 
   std::unordered_map<T, T>* GetMap() { return &parent_; }
 

--- a/paddle/common/union_find_set.h
+++ b/paddle/common/union_find_set.h
@@ -26,6 +26,17 @@ class UnionFindSet {
     if (parent_.find(x) == parent_.end()) {
       return x;
     }
+    if (parent_.at(x) != x) return Find(parent_.at(x));
+    return parent_.at(x);
+  }
+
+  const T& Find(const T& x) {
+    if (parent_.find(x) == parent_.end()) {
+      return x;
+    }
+    if (parent_[x] != x) {
+      parent_[x] = Find(parent_[x]);
+    }
     return parent_.at(x);
   }
 
@@ -48,12 +59,6 @@ class UnionFindSet {
     for (const auto& [_, clusters] : clusters_map) {
       DoEachCluster(clusters);
     }
-  }
-
-  std::vector<std::vector<T>> Clusters() const {
-    std::vector<std::vector<T>> clusters;
-    VisitCluster([&](const auto& cluster) { clusters.emplace_back(cluster); });
-    return clusters;
   }
 
   bool HasSameRoot(const T& p, const T& q) const { return Find(p) == Find(q); }

--- a/paddle/pir/include/dialect/shape/utils/constraints_manager.h
+++ b/paddle/pir/include/dialect/shape/utils/constraints_manager.h
@@ -35,6 +35,8 @@ class IR_API ConstraintsManager {
 
   void AddBroadcastableCstr(const DimExpr& lhs, const DimExpr& rhs);
 
+  bool IsBroadcastable(const DimExpr& lhs, const DimExpr& rhs) const;
+
   using EqualCallbackFunc = std::function<void(const DimExpr&, const DimExpr&)>;
   void SetEqualCallbackFunc(EqualCallbackFunc equal_callback_func);
 

--- a/paddle/pir/include/dialect/shape/utils/constraints_manager.h
+++ b/paddle/pir/include/dialect/shape/utils/constraints_manager.h
@@ -27,8 +27,6 @@ class IR_API ConstraintsManager {
 
   bool IsEqual(const DimExpr& lhs, const DimExpr& rhs) const;
 
-  std::vector<std::vector<DimExpr>> GetEqualClusters() const;
-
   void AddGTOneCstr(const DimExpr& dim_expr);
 
   bool IsGTOne(const DimExpr& dim_expr) const;
@@ -36,6 +34,9 @@ class IR_API ConstraintsManager {
   void AddBroadcastableCstr(const DimExpr& lhs, const DimExpr& rhs);
 
   bool IsBroadcastable(const DimExpr& lhs, const DimExpr& rhs) const;
+
+  template <typename DoEachClusterT>
+  void VisitEqualClusters(const DoEachClusterT& DoEachCluster) const;
 
   using EqualCallbackFunc = std::function<void(const DimExpr&, const DimExpr&)>;
   void SetEqualCallbackFunc(EqualCallbackFunc equal_callback_func);

--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "paddle/pir/include/dialect/shape/utils/constraints_manager.h"
-#include "paddle/pir/include/dialect/shape/utils/dim_expr_builder.h"
 #include "paddle/pir/include/dialect/shape/utils/dim_expr_util.h"
+
 namespace symbol {
 namespace {
 
@@ -37,8 +37,8 @@ bool CanEqualCStrInsert(const DimExpr& lhs, const DimExpr& rhs) {
 }
 
 template <template <class> class OpT>
-std::pair<DimExpr, DimExpr> FindDifferences(const OpT<DimExpr>& lhs,
-                                            const OpT<DimExpr>& rhs) {
+std::pair<DimExpr, DimExpr> EliminateCommonFactor(const OpT<DimExpr>& lhs,
+                                                  const OpT<DimExpr>& rhs) {
   List<DimExpr> lhs_list = lhs.operands;
   List<DimExpr> rhs_list = rhs.operands;
   List<DimExpr> lhs_diffs, rhs_diffs;
@@ -73,11 +73,11 @@ std::pair<DimExpr, DimExpr> SimplifyEqCstr(const DimExpr& lhs,
   auto DoSimplify = Overloaded{
       [](const Add<DimExpr>& lhs,
          const Add<DimExpr>& rhs) -> std::pair<DimExpr, DimExpr> {
-        return FindDifferences<Add>(lhs, rhs);
+        return EliminateCommonFactor<Add>(lhs, rhs);
       },
       [](const Mul<DimExpr>& lhs,
          const Mul<DimExpr>& rhs) -> std::pair<DimExpr, DimExpr> {
-        return FindDifferences<Mul>(lhs, rhs);
+        return EliminateCommonFactor<Mul>(lhs, rhs);
       },
       [](const auto& lhs, const auto& rhs) -> std::pair<DimExpr, DimExpr> {
         return std::make_pair(DimExpr(lhs), DimExpr(rhs));
@@ -120,11 +120,84 @@ void ConstraintsManager::AddEqCstr(const DimExpr& lhs, const DimExpr& rhs) {
 }
 
 bool ConstraintsManager::IsEqual(const DimExpr& lhs, const DimExpr& rhs) const {
-  return lhs == rhs || equals_.IsConnect(lhs, rhs);
+  return lhs == rhs || equals_.HasSameRoot(lhs, rhs);
 }
 
 std::vector<std::vector<DimExpr>> ConstraintsManager::GetEqualClusters() const {
   return equals_.Clusters();
+}
+
+void ConstraintsManager::AddGTOneCstr(const DimExpr& dim_expr) {
+  gtones_.insert(dim_expr);
+
+  auto InsertEqualCstr = [&](const DimExpr& gtone_dim_expr,
+                             const DimExpr& other_dim_expr) {
+    if (IsGTOne(other_dim_expr)) {
+      AddEqCstr(gtone_dim_expr, other_dim_expr);
+    } else {
+      AddEqCstr(
+          gtone_dim_expr,
+          Broadcast<DimExpr>{List<DimExpr>{gtone_dim_expr, other_dim_expr}});
+    }
+  };
+
+  for (auto broadcastable : broadcastables_) {
+    if (broadcastable->lhs == dim_expr) {
+      InsertEqualCstr(dim_expr, broadcastable->rhs);
+    } else if (broadcastable->rhs == dim_expr) {
+      InsertEqualCstr(dim_expr, broadcastable->lhs);
+    }
+  }
+}
+
+namespace {
+
+bool IsGTOneBaseOnValue(const DimExpr& dim_expr) {
+  auto IsGTOnePredicater =
+      Overloaded{[&](std::int64_t dim_expr) { return dim_expr > 1; },
+                 [&](const Add<DimExpr>& dim_expr) {
+                   for (auto sub_dim_expr : *dim_expr.operands) {
+                     if (sub_dim_expr.isa<std::int64_t>() &&
+                         sub_dim_expr.Get<std::int64_t>() > 1)
+                       return true;
+                   }
+                   return false;
+                 },
+                 [&](const auto& dim_expr) { return false; }};
+
+  std::visit(IsGTOnePredicater, dim_expr.variant());
+}
+
+}  // namespace
+
+bool ConstraintsManager::IsGTOne(const DimExpr& dim_expr) const {
+  return gtones_.count(dim_expr) || IsGTOneBaseOnValue(dim_expr);
+}
+
+void ConstraintsManager::AddBroadcastableCstr(const DimExpr& lhs,
+                                              const DimExpr& rhs) {
+  broadcastables_.push_back(Broadcastable<DimExpr>(lhs, rhs));
+
+  bool lhs_gtone = IsGTOne(lhs);
+  bool rhs_gtone = IsGTOne(rhs);
+  if (lhs_gtone && rhs_gtone) {
+    AddEqCstr(lhs, rhs);
+  } else if (lhs_gtone) {
+    AddEqCstr(lhs, Broadcast<DimExpr>{List<DimExpr>{lhs, rhs}});
+  } else if (rhs_gtone) {
+    AddEqCstr(rhs, Broadcast<DimExpr>{List<DimExpr>{lhs, rhs}});
+  }
+}
+
+bool ConstraintsManager::IsBroadcastable(const DimExpr& lhs,
+                                         const DimExpr& rhs) const {
+  for (auto broadcastable : broadcastables_) {
+    if ((broadcastable->lhs == lhs && broadcastable->rhs == rhs) ||
+        (broadcastable->rhs == lhs && broadcastable->lhs == rhs)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void ConstraintsManager::SetEqualCallbackFunc(

--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -167,11 +167,7 @@ bool IsGTOneBaseOnValue(const DimExpr& dim_expr) {
       if (dim_expr.isa<Broadcast<DimExpr>>() ||
           (dim_expr.isa<std::int64_t>() && dim_expr.Get<std::int64_t>() >= 1))
         flag_exist_gtone = true;
-      if (dim_expr.isa<Reciprocal<DimExpr>>() ||
-          dim_expr.isa<Negative<DimExpr>>() || dim_expr.isa<Mul<DimExpr>>() ||
-          dim_expr.isa<Add<DimExpr>>() || dim_expr.isa<Min<DimExpr>>() ||
-          dim_expr.isa<Max<DimExpr>>())
-        return false;
+      if (!dim_expr.isa<std::string>()) return false;
     }
     return flag_exist_gtone;
   };

--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -167,7 +167,8 @@ bool IsGTOneBaseOnValue(const DimExpr& dim_expr) {
       if (dim_expr.isa<Broadcast<DimExpr>>() ||
           (dim_expr.isa<std::int64_t>() && dim_expr.Get<std::int64_t>() >= 1))
         flag_exist_gtone = true;
-      if (!dim_expr.isa<std::string>()) return false;
+      else if (!dim_expr.isa<std::string>())
+        return false;
     }
     return flag_exist_gtone;
   };
@@ -182,6 +183,8 @@ bool IsGTOneBaseOnValue(const DimExpr& dim_expr) {
                  },
                  [&](const Mul<DimExpr>& dim_expr) {
                    if (AllOperandGTOne(dim_expr.operands)) return true;
+                   if (GTOneWithSomeOperandsGEOne(dim_expr.operands))
+                     return true;
                    return false;
                  },
                  [&](const auto& dim_expr) { return false; }};

--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -165,7 +165,7 @@ bool IsGTOneBaseOnValue(const DimExpr& dim_expr) {
                  },
                  [&](const auto& dim_expr) { return false; }};
 
-  std::visit(IsGTOnePredicater, dim_expr.variant());
+  return std::visit(IsGTOnePredicater, dim_expr.variant());
 }
 
 }  // namespace

--- a/test/cpp/pir/shape_dialect/constraints_manager_test.cc
+++ b/test/cpp/pir/shape_dialect/constraints_manager_test.cc
@@ -19,7 +19,7 @@
 
 namespace symbol::test {
 
-TEST(ConstraintsManager, AddEqCstr) {
+TEST(ConstraintsManager, EqualCstr) {
   ConstraintsManager cstr_mgr;
   DimExprBuilder builder(nullptr);
 
@@ -41,6 +41,21 @@ TEST(ConstraintsManager, AddEqCstr) {
   ASSERT_FALSE(cstr_mgr.IsEqual(add_expr_0, add_expr_1));
   DimExpr mul_expr_2 = builder.Mul(sym_expr_0, int_expr_1);
   ASSERT_TRUE(cstr_mgr.IsEqual(mul_expr_2, mul_expr_1));
+}
+
+TEST(ConstraintsManager, GreatThanOneCstr) {
+  ConstraintsManager cstr_mgr;
+  DimExpr sym_expr_0 = DimExpr("S0");
+  cstr_mgr.AddGTOneCstr(sym_expr_0);
+  ASSERT_TRUE(cstr_mgr.IsGTOne(sym_expr_0));
+}
+
+TEST(ConstraintsManager, BroadcastableCstr) {
+  ConstraintsManager cstr_mgr;
+  DimExpr sym_expr_0 = DimExpr("S0");
+  DimExpr int_expr = DimExpr(5);
+  cstr_mgr.AddBroadcastableCstr(sym_expr_0, int_expr);
+  ASSERT_TRUE(cstr_mgr.IsBroadcastable(sym_expr_0, int_expr));
 }
 
 }  // namespace symbol::test

--- a/test/cpp/pir/shape_dialect/constraints_manager_test.cc
+++ b/test/cpp/pir/shape_dialect/constraints_manager_test.cc
@@ -46,6 +46,9 @@ TEST(ConstraintsManager, EqualCstr) {
 TEST(ConstraintsManager, GreatThanOneCstr) {
   ConstraintsManager cstr_mgr;
   DimExpr sym_expr_0 = DimExpr("S0");
+  DimExpr int_expr = DimExpr(5);
+  ASSERT_TRUE(cstr_mgr.IsGTOne(int_expr + sym_expr_0));
+  ASSERT_TRUE(cstr_mgr.IsGTOne(int_expr * sym_expr_0));
   cstr_mgr.AddGTOneCstr(sym_expr_0);
   ASSERT_TRUE(cstr_mgr.IsGTOne(sym_expr_0));
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996
This PR implements the interfaces related to Broadcastable and GreatThanOne in ConstraintsManager to help DimExpr simplify.