### PR TITLE
[Dy2St][PIR] Use old ir guard to ensure PT and legacy IR running correctly

### DIFF
--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -4,8 +4,8 @@ file(
   "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 set(SOT_ENVS SOT_LOG_LEVEL=0 COST_MODEL=False MIN_GRAPH_SIZE=0
-             STRICT_MODE=False FLAGS_enable_pir_api=True)
-set(GC_ENVS FLAGS_eager_delete_tensor_gb=0.0)
+             STRICT_MODE=False)
+set(PIR_ENVS FLAGS_enable_pir_api=True)
 
 if(WIN32 AND NOT WITH_GPU)
   # disable on Windows CPU CI for timeout
@@ -27,7 +27,7 @@ if(NOT WITH_GPU)
 endif()
 
 foreach(TEST_OP ${TEST_OPS})
-  py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${GC_ENVS} ${SOT_ENVS})
+  py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${SOT_ENVS} ${PIR_ENVS})
 endforeach()
 
 set_tests_properties(test_se_resnet PROPERTIES TIMEOUT 900)

--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -4,7 +4,7 @@ file(
   "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 set(SOT_ENVS SOT_LOG_LEVEL=0 COST_MODEL=False MIN_GRAPH_SIZE=0
-             STRICT_MODE=False)
+             STRICT_MODE=False FLAGS_enable_pir_api=True)
 set(GC_ENVS FLAGS_eager_delete_tensor_gb=0.0)
 
 if(WIN32 AND NOT WITH_GPU)

--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -64,11 +64,14 @@ if(WITH_GPU)
 endif()
 
 # Legacy IR only tests for dygraph_to_static
-set(LEGACY_ONLY_TEST_FILES test_legacy_error test_pylayer)
+set(LEGACY_ONLY_TEST_FILES test_legacy_error test_pylayer test_local_cast)
 foreach(ITEST ${LEGACY_ONLY_TEST_FILES})
   if(TEST ${ITEST})
     set_tests_properties(
-      ${ITEST} PROPERTIES ENVIRONMENT "FLAGS_enable_pir_with_pt_in_dy2st=0")
+      ${ITEST}
+      PROPERTIES
+        ENVIRONMENT
+        "FLAGS_enable_pir_with_pt_in_dy2st=0 FLAGS_enable_pir_api=False")
     message(
       STATUS
         "PT Disabled OpTest: set FLAGS_enable_pir_with_pt_in_dy2st to False for ${ITEST}"

--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -67,8 +67,10 @@ set(LEGACY_ONLY_TEST_FILES test_legacy_error test_pylayer test_local_cast)
 foreach(ITEST ${LEGACY_ONLY_TEST_FILES})
   if(TEST ${ITEST})
     set_tests_properties(
-      ${ITEST} PROPERTIES ENVIRONMENT "FLAGS_enable_pir_with_pt_in_dy2st=0"
-                          ENVIRONMENT "FLAGS_enable_pir_api=False")
+      ${ITEST}
+      PROPERTIES
+        ENVIRONMENT
+        "FLAGS_enable_pir_with_pt_in_dy2st=0;FLAGS_enable_pir_api=False")
     message(
       STATUS
         "PT Disabled OpTest: set FLAGS_enable_pir_with_pt_in_dy2st to False for ${ITEST}"

--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -5,7 +5,6 @@ file(
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 set(SOT_ENVS SOT_LOG_LEVEL=0 COST_MODEL=False MIN_GRAPH_SIZE=0
              STRICT_MODE=False)
-set(PIR_ENVS FLAGS_enable_pir_api=True)
 
 if(WIN32 AND NOT WITH_GPU)
   # disable on Windows CPU CI for timeout
@@ -27,7 +26,7 @@ if(NOT WITH_GPU)
 endif()
 
 foreach(TEST_OP ${TEST_OPS})
-  py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${SOT_ENVS} ${PIR_ENVS})
+  py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${SOT_ENVS})
 endforeach()
 
 set_tests_properties(test_se_resnet PROPERTIES TIMEOUT 900)

--- a/test/dygraph_to_static/CMakeLists.txt
+++ b/test/dygraph_to_static/CMakeLists.txt
@@ -68,10 +68,8 @@ set(LEGACY_ONLY_TEST_FILES test_legacy_error test_pylayer test_local_cast)
 foreach(ITEST ${LEGACY_ONLY_TEST_FILES})
   if(TEST ${ITEST})
     set_tests_properties(
-      ${ITEST}
-      PROPERTIES
-        ENVIRONMENT
-        "FLAGS_enable_pir_with_pt_in_dy2st=0 FLAGS_enable_pir_api=False")
+      ${ITEST} PROPERTIES ENVIRONMENT "FLAGS_enable_pir_with_pt_in_dy2st=0"
+                          ENVIRONMENT "FLAGS_enable_pir_api=False")
     message(
       STATUS
         "PT Disabled OpTest: set FLAGS_enable_pir_with_pt_in_dy2st to False for ${ITEST}"

--- a/test/dygraph_to_static/test_partial_program_hook.py
+++ b/test/dygraph_to_static/test_partial_program_hook.py
@@ -63,7 +63,7 @@ class TestPirPartiaProgramLayerHook(Dy2StTestBase):
 
 
 class TestPrimHook(Dy2StTestBase):
-    def setUp(self):
+    def init_test_params(self):
         core._set_prim_all_enabled(False)
 
         def f():
@@ -72,30 +72,33 @@ class TestPrimHook(Dy2StTestBase):
         concrete_program, partial_program = paddle.jit.to_static(
             f, full_graph=True
         ).get_concrete_program()
-        self._hook = program_translator.PrimHooker(
+        hook = program_translator.PrimHooker(
             concrete_program.main_program, None
         )
-        self._forward = partial_program.forward_program
-        self._whole = partial_program._train_program
+        forward = partial_program.forward_program
+        whole = partial_program._train_program
 
-        core._set_prim_all_enabled(True)
-
-    def tearDown(self):
-        core._set_prim_all_enabled(False)
+        return hook, forward, whole
 
     @test_ast_only
     def test_before_append_backward(self):
-        self._hook.before_append_backward(self._forward)
+        hook, forward, whole = self.init_test_params()
+        core._set_prim_all_enabled(True)
+        hook.before_append_backward(forward)
         self.assertNotIn(
-            'dropout', tuple(op.type for op in self._forward.blocks[0].ops)
+            'dropout', tuple(op.type for op in forward.blocks[0].ops)
         )
+        core._set_prim_all_enabled(False)
 
     @test_ast_only
     def test_after_append_backward(self):
-        self._hook.after_append_backward(self._whole, 0)
+        hook, forward, whole = self.init_test_params()
+        core._set_prim_all_enabled(True)
+        hook.after_append_backward(whole, 0)
         self.assertNotIn(
-            'dropout_grad', tuple(op.type for op in self._whole.blocks[0].ops)
+            'dropout_grad', tuple(op.type for op in whole.blocks[0].ops)
         )
+        core._set_prim_all_enabled(False)
 
 
 class TestPirPrimHook(Dy2StTestBase):

--- a/test/sot/test_case_base.py
+++ b/test/sot/test_case_base.py
@@ -106,16 +106,42 @@ class TestCaseBase(unittest.TestCase):
 
 
 # Some decorators for PIR test
+@contextlib.contextmanager
+def pir_dygraph_guard():
+    in_dygraph_mode = paddle.in_dynamic_mode()
+    with paddle.pir_utils.IrGuard():
+        if in_dygraph_mode:
+            paddle.disable_static()
+        yield
+
+
+@contextlib.contextmanager
+def legacy_ir_dygraph_guard():
+    in_dygraph_mode = paddle.in_dynamic_mode()
+    with paddle.pir_utils.OldIrGuard():
+        if in_dygraph_mode:
+            paddle.disable_static()
+        yield
+
+
 def to_pir_test(fn):
     # NOTE(SigureMo): This function should sync with test/dygraph_to_static/dygraph_to_static_utils.py
     @wraps(fn)
     def impl(*args, **kwargs):
-        in_dygraph_mode = paddle.in_dynamic_mode()
-        with paddle.pir_utils.IrGuard():
-            if in_dygraph_mode:
-                paddle.disable_static()
+        with pir_dygraph_guard():
             ir_outs = fn(*args, **kwargs)
         return ir_outs
+
+    return impl
+
+
+def to_pt_test(fn):
+    # NOTE(SigureMo): This function should sync with test/dygraph_to_static/dygraph_to_static_utils.py
+    @wraps(fn)
+    def impl(*args, **kwargs):
+        with legacy_ir_dygraph_guard():
+            pt_outs = fn(*args, **kwargs)
+        return pt_outs
 
     return impl
 
@@ -134,12 +160,12 @@ def run_in_both_default_and_pir(fn):
     @wraps(fn)
     def impl(*args, **kwargs):
         OpcodeExecutorCache().clear()
-        default_fn = fn
         pir_fn = to_pir_test(fn)
-        default_outs = default_fn(*args, **kwargs)
+        pt_fn = to_pt_test(fn)
+        pt_outs = pt_fn(*args, **kwargs)
         OpcodeExecutorCache().clear()
         # The out of test case should be None, which is not used.
         _pir_outs = pir_fn(*args, **kwargs)
-        return default_outs
+        return pt_outs
 
     return impl


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

动转静每种装饰器跑的模式是明确的，确保未来 PIR 理想态切默认后 `to_legacy_ir_test` 和 `to_pir_test` 可以正常工作，因此在这两个模式下切回老 IR 模式

Pcard-67164