### PR TITLE
[Inference] Prohibiting the use of cudnn to implement the fused_conv2d_add_act kernel in fp32/nchw mode

### DIFF
--- a/paddle/fluid/framework/ir/transfer_layout_pass.cc
+++ b/paddle/fluid/framework/ir/transfer_layout_pass.cc
@@ -107,6 +107,18 @@ void TransferLayoutPass::ApplyImpl(ir::Graph *graph) const {
   FusePassBase::Init("fused_conv2d_add_act_layout_transfer", graph);
   auto *scope = param_scope();
 
+  // float16 for all(cutlass cudnn), float32 for cutlass.
+  // why?
+  // In the case of cudnn nhwc fp32, performance degradation will occur
+  bool is_fp16_precision =
+      static_cast<phi::DataType>(Get<int>("model_precision")) ==
+          phi::DataType::FLOAT16 ||
+      Get<bool>("enable_gpu_mixed");
+
+  bool cutlass_enable = Get<bool>("use_cutlass");
+
+  if (!is_fp16_precision && !cutlass_enable) return;
+
   PADDLE_ENFORCE_EQ(graph->IsMainGraph(),
                     true,
                     platform::errors::InvalidArgument(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
pcard-71501
in the case of cudnn nhwc fp32, performance degradation will occur;fix this case