### PR TITLE
[Dy2St][PIR] `Value.place` should be property

### DIFF
--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -141,6 +141,7 @@ def monkey_patch_value():
         # 1 means cuda place, see paddle/phi/kernels/memcpy_kernel.cc
         return _C_ops.memcpy(self, 1)
 
+    @property
     def place(self):
         """
         Value don't have 'place' interface in static graph mode

--- a/test/dygraph_to_static/test_place.py
+++ b/test/dygraph_to_static/test_place.py
@@ -15,25 +15,30 @@
 import unittest
 import warnings
 
-from dygraph_to_static_utils import (
-    Dy2StTestBase,
-    test_legacy_and_pt_and_pir,
-)
+from dygraph_to_static_utils import Dy2StTestBase, test_pir_only
 
 import paddle
 
 
 class TestPlace(Dy2StTestBase):
-    @test_legacy_and_pt_and_pir
-    def test_place(self):
+    def test_place_legacy(self):
+        # TODO(cleanup-legacy-ir): remove this test case
         paddle.enable_static()
         x = paddle.to_tensor([1, 2, 3, 4])
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             self.assertIsNone(x.place())
             self.assertTrue(len(w) == 1)
-            if paddle.framework.use_pir_api():
-                self.assertIn("Value do not have 'place'", str(w[-1].message))
+
+    @test_pir_only
+    def test_place(self):
+        paddle.enable_static()
+        x = paddle.to_tensor([1, 2, 3, 4])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertIsNone(x.place)
+            self.assertTrue(len(w) == 1)
+            self.assertIn("Value do not have 'place'", str(w[-1].message))
 
 
 if __name__ == '__main__':

--- a/test/dygraph_to_static/test_place.py
+++ b/test/dygraph_to_static/test_place.py
@@ -15,12 +15,17 @@
 import unittest
 import warnings
 
-from dygraph_to_static_utils import Dy2StTestBase, test_pir_only
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+    test_legacy_and_pt,
+    test_pir_only,
+)
 
 import paddle
 
 
 class TestPlace(Dy2StTestBase):
+    @test_legacy_and_pt
     def test_place_legacy(self):
         # TODO(cleanup-legacy-ir): remove this test case
         paddle.enable_static()

--- a/test/legacy_test/test_math_op_patch_pir.py
+++ b/test/legacy_test/test_math_op_patch_pir.py
@@ -408,7 +408,7 @@ class TestMathOpPatchesPir(unittest.TestCase):
             warnings.simplefilter("always")
             with paddle.pir_utils.IrGuard():
                 x = paddle.static.data(name='x', shape=[3, 2, 1])
-                x.place()
+                _ = x.place
                 self.assertTrue(len(w) == 1)
                 self.assertTrue("place" in str(w[-1].message))
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

`Value.place` 应当和动态图对齐，是一个 property，而不是方法

PCard-66972