### PR TITLE
cinn(backend): change slice's attribute from Int to Expr

### DIFF
--- a/paddle/cinn/hlir/op/transform.cc
+++ b/paddle/cinn/hlir/op/transform.cc
@@ -1674,10 +1674,6 @@ std::shared_ptr<OpStrategy> StrategyForSliceSymbolic(
   if (attrs.attr_store.find("strides") != attrs.attr_store.end()) {
     strides = absl::get<std::vector<int>>(attrs.attr_store.at("strides"));
   }
-  if (attrs.attr_store.find("decrease_axis") != attrs.attr_store.end()) {
-    decrease_axis =
-        absl::get<std::vector<int>>(attrs.attr_store.at("decrease_axis"));
-  }
 
   CHECK(!starts.empty()) << "The Slice op doesn't find [starts] attribute! It "
                             "it a mandatory attribute, please check.";
@@ -1725,8 +1721,10 @@ std::shared_ptr<OpStrategy> StrategyForSliceSymbolic(
         CHECK(arg_pack[1].is_string());
         std::string tensor_name = arg_pack[1].operator std::string();
 
+        auto starts_expr = ToCinnExprs(starts);
+        auto strides_expr = ToCinnExprs(strides);
         auto out = pe::SliceSymbolic(
-            A, starts, axes, strides, decrease_axis, output_shape, tensor_name);
+            A, starts_expr, axes, strides_expr, output_shape, tensor_name);
         LOG(INFO) << "out: " << out;
         auto stages = CreateStages({out});
         *ret = CINNValuePack{{CINNValue(out), CINNValue(stages)}};

--- a/paddle/cinn/hlir/pe/transform.cc
+++ b/paddle/cinn/hlir/pe/transform.cc
@@ -1123,6 +1123,65 @@ ir::Tensor SliceSymbolic(const ir::Tensor& A,
       output_name);
 }
 
+ir::Tensor SliceSymbolic(const ir::Tensor& A,
+                         const std::vector<Expr>& starts,
+                         const std::vector<int>& axes,
+                         const std::vector<Expr>& strides,
+                         const std::vector<Expr>& output_shape,
+                         const std::string& output_name) {
+  std::vector<Expr> input_shape;
+  for (const auto& shape : A->shape) {
+    input_shape.emplace_back(shape);
+  }
+
+  std::vector<Expr> new_starts = starts;
+  // std::transform(starts.begin(),
+  //                starts.end(),
+  //                std::back_inserter(new_starts),
+  //                [](const int start) { return ir::Expr(start); });
+
+  for (int i = 0; i < axes.size(); i++) {
+    if (input_shape[axes[i]].is_constant()) {
+      if (new_starts[i].as_int64() < -input_shape[axes[i]].as_int64()) {
+        new_starts[i] = ir::Expr(0);
+      } else if (new_starts[i].as_int64() < 0) {
+        new_starts[i] = input_shape[axes[i]].as_int64() + new_starts[i];
+      } else if (new_starts[i].as_int64() > input_shape[axes[i]].as_int64()) {
+        new_starts[i] = input_shape[axes[i]].as_int64() - ir::Expr(1);
+      }
+    } else {
+      if (new_starts[i].as_int64() < 0) {
+        new_starts[i] = ir::Add::Make(input_shape[axes[i]], new_starts[i]);
+      }
+    }
+  }
+
+  // output = input[starts:ends:strides]
+  // Note that when strides < 0, the output reverse:
+  // data=[[1,2,3,4],[5,6,7,8],]
+  // axes=[0,1]
+  // starts=[1,3]
+  // ends=[2,0]
+  // strides=[1,-1]
+  // ==> result=[[8,7,6],]
+  return Compute(
+      output_shape,
+      [=](const std::vector<Expr>& indice) {
+        std::vector<Expr> temp;
+        int indice_i = 0;
+        for (int i = 0; i < input_shape.size(); ++i) {
+          temp.emplace_back(indice[indice_i]);
+          indice_i++;
+        }
+        for (int i = 0; i < axes.size(); i++) {
+          temp[axes[i]] =
+              temp[axes[i]] * Expr(strides[i]) + Expr(new_starts[i]);
+        }
+        return A(temp);
+      },
+      output_name);
+}
+
 ir::Tensor SliceAssign(const ir::Tensor& input,
                        const ir::Tensor& assign,
                        const std::vector<int>& axes,

--- a/paddle/cinn/hlir/pe/transform.h
+++ b/paddle/cinn/hlir/pe/transform.h
@@ -185,10 +185,9 @@ ir::Tensor Slice(const ir::Tensor& A,
                  const std::string& output_name);
 
 ir::Tensor SliceSymbolic(const ir::Tensor& A,
-                         const std::vector<int>& starts,
+                         const std::vector<Expr>& starts,
                          const std::vector<int>& axes,
-                         const std::vector<int>& strides,
-                         const std::vector<int>& decrease_axis,
+                         const std::vector<Expr>& strides,
                          const std::vector<Expr>& output_shape,
                          const std::string& output_name);
 

--- a/test/ir/pir/cinn/symbolic/test_cinn_transform_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_transform_symbolic.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from os.path import dirname
+
+import paddle
+from paddle import nn
+from paddle.static import InputSpec
+
+sys.path.append(dirname(dirname(__file__)))
+import utils
+
+
+class GatherLayer(nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return paddle.slice(x, axes=[0], starts=[0], ends=[2])
+
+
+class TestGatherSymbolic(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.shape = [4, 5, 6]
+        self.x = paddle.randn(self.shape, dtype="float32")
+        self.x.stop_gradient = True
+
+    def check_jit_kernel_info(self, static_fn):
+        utils.check_jit_kernel_number(static_fn, 1)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 1})
+
+    def eval(self, use_cinn):
+        net = GatherLayer()
+        input_spec = [
+            InputSpec(shape=[None, None, 6], dtype='float32'),
+        ]
+        net = utils.apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = net(self.x)
+        if use_cinn:
+            self.check_jit_kernel_info(net.forward)
+        return out
+
+    def test_eval(self):
+        cinn_out = self.eval(use_cinn=True)
+        # dy_out = self.eval(use_cinn=False)
+        # np.testing.assert_allclose(
+        #     cinn_out.numpy(), dy_out.numpy(), atol=1e-6, rtol=1e-6
+        # )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/ir/pir/cinn/symbolic/test_cinn_transform_symbolic.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_transform_symbolic.py
@@ -16,6 +16,8 @@ import sys
 import unittest
 from os.path import dirname
 
+import numpy as np
+
 import paddle
 from paddle import nn
 from paddle.static import InputSpec
@@ -60,10 +62,10 @@ class TestGatherSymbolic(unittest.TestCase):
 
     def test_eval(self):
         cinn_out = self.eval(use_cinn=True)
-        # dy_out = self.eval(use_cinn=False)
-        # np.testing.assert_allclose(
-        #     cinn_out.numpy(), dy_out.numpy(), atol=1e-6, rtol=1e-6
-        # )
+        dy_out = self.eval(use_cinn=False)
+        np.testing.assert_allclose(
+            cinn_out.numpy(), dy_out.numpy(), atol=1e-6, rtol=1e-6
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->


### Description
<!-- Describe what you’ve done -->

ctest -R test_cinn_transform_symbolic -V

device codegen
```
568: __global__
568: void fn_slice__0__COND__FPA__FPA__FPA__FPA_12llMULS1_BPA_GE1ll_BPA_AND_FPA__FPA_12llMULS1_BPA_LE1023ll_BPA__BPA_AND_FPA__FPA_1GE1ll_BPA_AND_FPA_1LE1ll_BPA__BPA__BPA___kernel(const float* __restrict__ var, float* __restrict__ var_0, int64_t S0, int64_t S1)
568: {
568:   if (((int)blockIdx.x < 1ll)) {
568:     if (((int)threadIdx.x < (1ll + (12ll * S1)))) {
568:       if ((((int)blockIdx.x + ((12ll * (S1 * (int)blockIdx.x)) + (int)threadIdx.x)) < (12ll * S1))) {
568:         var_0[(((int)threadIdx.x % 6ll) + (((((int)threadIdx.x / 6ll) / S1) * (6ll * S1)) + (6ll * (((int)threadIdx.x / 6ll) % S1))))] = var[(((int)threadIdx.x % 6ll) + (((((int)threadIdx.x / 6ll) / S1) * (6ll * S1)) + (6ll * (((int)threadIdx.x / 6ll) % S1))))];
568:       };
568:     };
568:   };
568: }

```
