### PR TITLE
[Inference] self_dp_attention and fused_layer_norm_avx_kernel Clang12-Compile fix

### DIFF
--- a/paddle/phi/kernels/fusion/cpu/fused_layer_norm_avx_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_layer_norm_avx_kernel.cc
@@ -156,11 +156,10 @@ void LayerNormFunc(const T* x_data,
         vbeta = _mm512_maskz_loadu_ps(mask, norm_bias_data + col);
       }
       // (vx - vmean) * vgamma * vvar + vbeta
-      __m512 vy;
       vx = _mm512_mask_sub_ps(vx, mask, vx, vmean);
       vx = _mm512_mask_mul_ps(vx, mask, vx, vgamma);
       vx = _mm512_mask_mul_ps(vx, mask, vx, vvar);
-      vy = _mm512_mask_add_ps(vy, mask, vx, vbeta);
+      __m512 vy = _mm512_mask_add_ps(vx, mask, vx, vbeta);
       _mm512_mask_storeu_ps(py + col, mask, vy);
     }
   }

--- a/paddle/phi/kernels/fusion/cpu/self_dp_attention_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/self_dp_attention_kernel.cc
@@ -304,7 +304,7 @@ void update_out_blk(float* output,
       __m512 vabc = _mm512_maskz_loadu_ps(mask, buf + off);
       vout = _mm512_mask_mul_ps(vout, mask, vout, merr);
       vout = _mm512_mask_mul_ps(vout, mask, vout, vfac);
-      __m512 vupt;
+      __m512 vupt = _mm512_set1_ps(0.0f);
       vupt = _mm512_mask_add_ps(vupt, mask, vout, vabc);
       _mm512_mask_storeu_ps(outbuf + off, mask, vupt);
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Inference


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
pcard-71500
self_dp_attention and fused_layer_norm_avx_kernel Clang12-Compile fix
