### PR TITLE
[CINN ] fix group clutser bug when processing reduce op

### DIFF
--- a/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
@@ -102,14 +102,20 @@ ShardableAxesSignature CreateSignatureForReduce(pir::Operation* reduce_op) {
   bool keep_dim = GetReduceOpKeepDims(reduce_op);
   auto output_axes = std::vector<std::string>();
 
-  for (int i = 0; i < input_rank; i++) {
-    if (std::find(reduce_axis_idx.begin(), reduce_axis_idx.end(), i) !=
-        reduce_axis_idx.end()) {
-      if (keep_dim) {
-        output_axes.emplace_back(ShardableAxesInfoManager::GetUniqueName());
-      }  // else do nothing
-    } else {
-      output_axes.emplace_back(input_axes[i]);
+  if (reduce_axis_idx.empty()) {
+    // When reduce_axis is empty, it means all axes are reduced and the output
+    // should be a new single axis.
+    output_axes.emplace_back(ShardableAxesInfoManager::GetUniqueName());
+  } else {
+    for (int i = 0; i < input_rank; i++) {
+      if (std::find(reduce_axis_idx.begin(), reduce_axis_idx.end(), i) !=
+          reduce_axis_idx.end()) {
+        if (keep_dim) {
+          output_axes.emplace_back(ShardableAxesInfoManager::GetUniqueName());
+        }  // else do nothing
+      } else {
+        output_axes.emplace_back(input_axes[i]);
+      }
     }
   }
 

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -193,12 +193,31 @@ bool ShapeConstraintIRAnalysis::IsProductEqual(
 
   symbol::DimExpr lhs_product(1);
   symbol::DimExpr rhs_product(1);
-  for (int i : lhs_dim_idxs) {
-    lhs_product = lhs_product * lhs_shape_data.shape()[i];
+
+  if (lhs_shape_data.shape().size() >
+      0) {  // Special Process for 0-d shape, to be removed in the future
+    for (int i : lhs_dim_idxs) {
+      PADDLE_ENFORCE_GT(lhs_shape_data.shape().size(),
+                        i,
+                        phi::errors::InvalidArgument(
+                            "Please ensure that the index for comparison is "
+                            "less than the rank of value."));
+      lhs_product = lhs_product * lhs_shape_data.shape()[i];
+    }
   }
-  for (int i : rhs_dim_idxs) {
-    rhs_product = rhs_product * rhs_shape_data.shape()[i];
+
+  if (rhs_shape_data.shape().size() >
+      0) {  // Special Process for 0-d shape, to be removed in the future
+    for (int i : rhs_dim_idxs) {
+      PADDLE_ENFORCE_GT(rhs_shape_data.shape().size(),
+                        i,
+                        phi::errors::InvalidArgument(
+                            "Please ensure that the index for comparison is "
+                            "less than the rank of value."));
+      rhs_product = rhs_product * rhs_shape_data.shape()[i];
+    }
   }
+
   return symbol::SimplifyDimExpr(lhs_product) ==
          symbol::SimplifyDimExpr(rhs_product);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Fix bug: 
1. When reduce op has empty reduce axes (namely all the elements are reduced), the frontend doesn't handle correctly.
2. Currently 0d shape might be inferred by shape analysis, this pr fix the case when the axis of an inferred 0d tensor is compared in `IsProductEqual`

PCard-76996
