### PR TITLE
[CINN] Disable CINN DCE pass

### DIFF
--- a/paddle/cinn/hlir/pass/CMakeLists.txt
+++ b/paddle/cinn/hlir/pass/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT WITH_CUDA)
   #cinn_cc_test(test_alterlayout SRCS alterlayout_test.cc DEPS cinncore)
 endif()
 cinn_cc_test(test_dot_merger SRCS test_dot_merger.cc DEPS cinncore)
-cinn_cc_test(test_dce_pass SRCS dce_pass_test.cc DEPS cinncore)
+# cinn_cc_test(test_dce_pass SRCS dce_pass_test.cc DEPS cinncore)
 cinn_cc_test(test_common_subexpression_elimination SRCS
              common_subexpression_elimination_test.cc DEPS cinncore)
 cinn_cc_test(test_constant_folding_pass SRCS constant_folding_pass_test.cc DEPS


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Deprecations


### Description
<!-- Describe what you’ve done -->
pcard-76996

CINN 前端的 pass 体系已经换成 pir，dce_pass_test 在 CINN-GPU 流水线下会报错，由于该 pass 是旧 ir 下的 pass，已没有必要投入人力修复，因此将该单测 disable

