### PR TITLE
[SOT][PIR] Skip CINN backend test if paddle not compile with cinn

### DIFF
--- a/test/sot/test_execution_base.py
+++ b/test/sot/test_execution_base.py
@@ -17,6 +17,7 @@ import unittest
 from test_case_base import TestCaseBase
 
 import paddle
+from paddle.framework import use_pir_api
 from paddle.jit.sot import symbolic_translate
 from paddle.static import BuildStrategy
 
@@ -52,6 +53,9 @@ class TestBackend(TestCaseBase):
     def test_backend(self):
         x = paddle.randn([2, 3])
         dy_out = foo(x)
+        # TODO(SigureMo): Find a better way to test the CINN backend.
+        if not paddle.is_compiled_with_cinn() and use_pir_api():
+            return
         sot_out = symbolic_translate(
             foo, build_strategy=BuildStrategy(), backend='CINN'
         )(x)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

PIR 模式下跳过 CINN backend 的测试，因为现在开启 CINN 有 compile with CINN 的判断，如果为 False 则直接报错

Pcard-67164