### PR TITLE
fix cinn fail to compile paddle.mean in some situation

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_mapper.cc
+++ b/paddle/cinn/hlir/framework/pir/op_mapper.cc
@@ -120,7 +120,9 @@ void OpMapper::RegisterMapRules() {
   REGISTER_OPERAND_RULE(MinOp, 0);
   REGISTER_OPERAND_RULE(ProdOp, 0);
   REGISTER_ATTR_RULE(ReduceMaxOp, AppendAttrForReduceOp);
+  REGISTER_ATTR_RULE(ReduceMinOp, AppendAttrForReduceOp);
   REGISTER_ATTR_RULE(ReduceSumOp, AppendAttrForReduceOp);
+  REGISTER_ATTR_RULE(ReduceProdOp, AppendAttrForReduceOp);
   REGISTER_ATTR_RULE(BroadcastOp, AppendAttrForBroadcastToOp);
   REGISTER_ATTR_RULE(UniformRandomOp, AppendAttrForUniformOp);
   REGISTER_PD_ATTR_RULE(TransposeOp, AppendAttrForTransposeOp);

--- a/test/ir/pir/cinn/symbolic/test_cinn_reduce_symbolic_demo.py
+++ b/test/ir/pir/cinn/symbolic/test_cinn_reduce_symbolic_demo.py
@@ -26,14 +26,14 @@ import paddle
 from paddle.static import InputSpec
 
 
-def reduce_sum(x):
-    return paddle.sum(x, axis=-1)
+def reduce_mean(x):
+    return paddle.sum(x, axis=[0,1])
 
 
 class CINNSubGraphNet(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
-        self.fn = reduce_sum
+        self.fn = reduce_mean
 
     def forward(self, x):
         out = self.fn(x)
@@ -50,7 +50,7 @@ class TestCinnSubGraphBase(unittest.TestCase):
         self.prepare_data()
 
     def prepare_data(self):
-        self.x_shape = [64, 128]
+        self.x_shape = [16, 32, 64]
         self.x = paddle.randn(self.x_shape, dtype="float32")
         self.x.stop_gradient = False
 
@@ -62,7 +62,7 @@ class TestCinnSubGraphBase(unittest.TestCase):
         paddle.seed(2022)
         net = CINNSubGraphNet()
         input_spec = [
-            InputSpec(shape=[None, 128], dtype='float32'),
+            InputSpec(shape=[None, None, 64], dtype='float32'),
         ]
         net = utils.apply_to_static(net, use_cinn, input_spec)
         net.eval()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
fix `test1` in issue https://github.com/PaddlePaddle/Paddle/issues/63370. With this fix, `test2` no longer cause segment fault, but raise `NotImplementedError: (Unimplemented) Not Implemented (at /home/aistudio/Paddle/paddle/cinn/ir/group_schedule/config/group_tile_config.cc:296)`  
 There is a new test related to this: https://github.com/PaddlePaddle/Paddle/pull/63384