### PR TITLE
add custom pinned allocator

### DIFF
--- a/paddle/fluid/framework/dlpack_tensor.cc
+++ b/paddle/fluid/framework/dlpack_tensor.cc
@@ -95,6 +95,11 @@ struct DLDeviceVisitor {
         "platform::CustomPlace is not supported"));
   }
 
+  inline ::DLDevice operator()(const platform::CustomPinnedPlace &place) const {
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "platform::CustomPinnedPlace is not supported"));
+  }
+
   inline ::DLDevice operator()(const platform::CUDAPlace &place) const {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     ::DLDevice device;

--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -53,7 +53,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WITH_CUSTOM_DEVICE)
-  list(APPEND ALLOCATOR_SRCS custom_allocator.cc
+  list(APPEND ALLOCATOR_SRCS custom_allocator.cc custom_pinned_allocator.cc
        stream_safe_custom_device_allocator.cc)
 endif()
 

--- a/paddle/fluid/memory/allocation/custom_pinned_allocator.cc
+++ b/paddle/fluid/memory/allocation/custom_pinned_allocator.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/allocation/custom_pinned_allocator.h"
+
+#include "paddle/fluid/memory/stats.h"
+#include "paddle/fluid/platform/device/device_wrapper.h"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/profiler/mem_tracing.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+bool CustomCPUPinnedAllocator::IsAllocThreadSafe() const { return true; }
+void CustomCPUPinnedAllocator::FreeImpl(phi::Allocation* allocation) {
+  phi::DeviceManager::GetDeviceWithPlace(place_)->MemoryDeallocateHost(
+      allocation->ptr(), allocation->size());
+  VLOG(10) << "CustomPinnedFree " << allocation->ptr();
+  HOST_MEMORY_STAT_UPDATE(Reserved, 0, -allocation->size());
+  platform::RecordMemEvent(allocation->ptr(),
+                           allocation->place(),
+                           allocation->size(),
+                           platform::TracerMemEventType::ReservedFree);
+  delete allocation;
+}
+phi::Allocation* CustomCPUPinnedAllocator::AllocateImpl(size_t size) {
+  void* ptr =
+      phi::DeviceManager::GetDeviceWithPlace(place_)->MemoryAllocateHost(size);
+  if (LIKELY(ptr)) {
+    VLOG(10) << "CustomPinnedAlloc " << size << " " << ptr;
+    HOST_MEMORY_STAT_UPDATE(Reserved, 0, size);
+    platform::RecordMemEvent(ptr,
+                             platform::CUDAPinnedPlace(),
+                             size,
+                             platform::TracerMemEventType::ReservedAllocate);
+    return new Allocation(ptr, size, platform::CUDAPinnedPlace());
+  }
+}
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/custom_pinned_allocator.h
+++ b/paddle/fluid/memory/allocation/custom_pinned_allocator.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include "paddle/fluid/memory/allocation/allocator.h"
+#include "paddle/fluid/platform/place.h"
+namespace paddle {
+namespace memory {
+namespace allocation {
+// Allocator uses `host_memory_allocate`in customdevice
+class CustomCPUPinnedAllocator : public Allocator {
+ public:
+  explicit CustomCPUPinnedAllocator(const platform::CustomPinnedPlace &place)
+      : place_(place) {}
+  bool IsAllocThreadSafe() const override;
+ protected:
+  void FreeImpl(phi::Allocation *allocation) override;
+  phi::Allocation *AllocateImpl(size_t size) override;
+ private:
+  platform::Place place_;
+};
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/system_allocator.cc
+++ b/paddle/fluid/memory/allocation/system_allocator.cc
@@ -346,6 +346,47 @@ void CustomAllocator::Free(void* p, size_t size, size_t index) {
 }
 
 bool CustomAllocator::UseGpu() const { return true; }
+
+void* CustomPinnedAllocator::Alloc(size_t* index, size_t size) {
+  if (size <= 0) return nullptr;
+  void* p;
+  auto place = platform::CustomPinnedPlace(dev_type_);
+  auto device = phi::DeviceManager::GetDeviceWithPlace(place);
+  p = device->MemoryAllocateHost(size);
+  if (LIKELY(p)) {
+    VLOG(4) << "CustomPinnedAllocator::Alloc " << p << " size " << size;
+    *index = 0;
+    plug_pinned_alloc_size += size;
+    HOST_MEMORY_STAT_UPDATE(Reserved, 0, size);
+    platform::RecordMemEvent(
+        p, place, size, platform::TracerMemEventType::ReservedAllocate);
+  } else {
+    return nullptr;
+  }
+  return p;
+}
+void CustomPinnedAllocator::Free(void* p, size_t size, size_t index) {
+  VLOG(4) << "CustomPinnedAllocator::Free " << p << " size " << size;
+  PADDLE_ENFORCE_EQ(index,
+                    0,
+                    platform::errors::InvalidArgument(
+                        "The index should be 0, index is %d", index));
+  PADDLE_ENFORCE_GE(plug_pinned_alloc_size,
+                    size,
+                    platform::errors::InvalidArgument(
+                        "The size of memory (%d) to free exceeds the size of "
+                        "allocated gpu memory (%d)",
+                        size,
+                        plug_pinned_alloc_size));
+  plug_pinned_alloc_size -= size;
+  auto place = platform::CustomPinnedPlace(dev_type_);
+  auto device = phi::DeviceManager::GetDeviceWithPlace(place);
+  device->MemoryDeallocateHost(p, size);
+  HOST_MEMORY_STAT_UPDATE(Reserved, 0, size);
+  platform::RecordMemEvent(
+      p, place, size, platform::TracerMemEventType::ReservedFree);
+}
+bool CustomPinnedAllocator::UseGpu() const { return false; }
 #endif
 
 }  // namespace detail

--- a/paddle/fluid/memory/allocation/system_allocator.h
+++ b/paddle/fluid/memory/allocation/system_allocator.h
@@ -83,6 +83,20 @@ class CustomAllocator : public SystemAllocator {
   std::string dev_type_;
   size_t dev_id_;
 };
+
+class CustomPinnedAllocator : public SystemAllocator {
+ public:
+  explicit CustomPinnedAllocator(const std::string& device_type)
+      : dev_type_(device_type) {}
+
+  virtual void* Alloc(size_t* index, size_t size);
+  virtual void Free(void* p, size_t size, size_t index);
+  virtual bool UseGpu() const;
+
+ private:
+  size_t plug_pinned_alloc_size = 0;
+  std::string dev_type_;
+};
 #endif
 
 }  // namespace detail

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -315,7 +315,30 @@ void BufferedReader::ReadAsync(size_t i) {
                               custom_device.size(),
                               cpu.size()));
       }
+      TensorVec pinned_device{cpu.size()};
+      if (pin_memory_) {
+        platform::CustomPinnedPlace pinned_place(place_.GetDeviceType());
+        platform::CPUPlace cpu_place;
+        std::vector<void *> custom_pinned_ptrs;
+        custom_pinned_ptrs.reserve(cpu.size());
+        for (size_t i = 0; i < cpu.size(); ++i) {
+          if (platform::is_cpu_place(cpu[i].place())) {
+            pinned_device[i].Resize(cpu[i].dims());
+            pinned_device[i].set_layout(cpu[i].layout());
+            custom_pinned_ptrs[i] =
+                pinned_device[i].mutable_data(pinned_place, cpu[i].dtype());
+            auto size = cpu[i].numel() * phi::SizeOf(cpu[i].dtype());
 
+            memory::Copy(cpu_place,
+                         custom_pinned_ptrs[i],
+                         cpu[i].place(),
+                         cpu[i].data(),
+                         size);
+
+            pinned_device[i].set_lod(cpu[i].lod());
+          }
+        }
+      }
       std::vector<void *> custom_device_ptrs;
       custom_device_ptrs.reserve(cpu.size());
       for (size_t i = 0; i < cpu.size(); ++i) {
@@ -335,7 +358,7 @@ void BufferedReader::ReadAsync(size_t i) {
                                          1);
       for (size_t i = 0; i < cpu.size(); ++i) {
         auto cpu_place = cpu[i].place();
-        auto cpu_ptr = cpu[i].data();
+        auto cpu_ptr = auto cpu_ptr = pin_memory_ ? pinned_device[i].data() : cpu[i].data();
         auto custom_device_ptr = custom_device_ptrs[i];
         auto size = cpu[i].numel() * phi::SizeOf(cpu[i].dtype());
         if ((platform::is_custom_place(cpu_place))) {

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -121,6 +121,8 @@ inline std::unique_ptr<DeviceContext> CreateDeviceContext(
                                 custom_ctx->stream());
     }
     dev_ctx->SetAllocator(instance.GetAllocator(p, custom_ctx->stream()).get());
+    phi::CustomPinnedPlace pinned(p.GetDeviceType());
+    dev_ctx->SetPinnedAllocator(instance.GetAllocator(pinned).get());
     dev_ctx->SetGenerator(phi::DefaultCustomDeviceGenerator(p).get());
 #endif
   } else {

--- a/paddle/fluid/platform/place.cc
+++ b/paddle/fluid/platform/place.cc
@@ -49,9 +49,16 @@ bool is_custom_place(const Place &p) {
   return p.GetType() == phi::AllocationType::CUSTOM;
 }
 
+bool is_custom_pinned_place(const Place &p) {
+  return p.GetType() == phi::AllocationType::CUSTOMPINNED;
+}
+
 bool places_are_same_class(const Place &p1, const Place &p2) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   if (is_custom_place(p1) && is_custom_place(p2)) {
+    return p1.GetDeviceType() == p2.GetDeviceType();
+  }
+  if (is_custom_pinned_place(p1) && is_custom_pinned_place(p2)) {
     return p1.GetDeviceType() == p2.GetDeviceType();
   }
 #endif
@@ -78,7 +85,7 @@ std::string PlaceHelper::GetDeviceType(const Place &place) {
     return "gpu";
   } else if (is_xpu_place(place)) {
     return "xpu";
-  } else if (is_custom_place(place)) {
+  } else if (is_custom_place(place) || is_custom_pinned_place(place)) {
     return place.GetDeviceType();
   } else {
     PADDLE_THROW(platform::errors::Fatal(

--- a/paddle/fluid/platform/place.h
+++ b/paddle/fluid/platform/place.h
@@ -32,6 +32,7 @@ using CUDAPinnedPlace = phi::GPUPinnedPlace;
 using XPUPlace = phi::XPUPlace;
 using IPUPlace = phi::IPUPlace;
 using CustomPlace = phi::CustomPlace;
+using CustomPinnedPlace = phi::CustomPinnedPlace;
 
 using PlaceList = std::vector<Place>;
 
@@ -50,6 +51,7 @@ bool is_ipu_place(const Place &);
 TEST_API bool is_cpu_place(const Place &);
 bool is_cuda_pinned_place(const Place &);
 bool is_custom_place(const Place &p);
+bool is_custom_pinned_place(const Place &p);
 bool places_are_same_class(const Place &, const Place &);
 bool is_same_place(const Place &, const Place &);
 
@@ -104,6 +106,16 @@ typename Visitor::result_type VisitPlace(const Place &place,
 #else
       PADDLE_THROW(platform::errors::Unavailable(
           "Paddle is not compiled with CUSTOM. Cannot visit custom device"));
+#endif
+    }
+    case phi::AllocationType::CUSTOMPINNED: {
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+      platform::CustomPinnedPlace p(place.GetDeviceType());
+      return visitor(p);
+#else
+      PADDLE_THROW(
+          platform::errors::Unavailable("Paddle is not compiled with CUSTOM. "
+                                        "Cannot visit custom pinned device"));
 #endif
     }
     default: {

--- a/paddle/phi/common/place.cc
+++ b/paddle/phi/common/place.cc
@@ -39,6 +39,8 @@ const char *AllocationTypeStr(AllocationType type) {
       return "ipu";
     case AllocationType::CUSTOM:
       return "custom_device";
+    case AllocationType::CUSTOMPINNED:
+      return "custom_device_pinned";
     default:
       PD_THROW("Invalid phi device type.");
       return {};
@@ -57,11 +59,16 @@ std::string Place::DebugString() const {
   if (alloc_type_ == AllocationType::CUSTOM) {
     os << phi::CustomRegisteredDeviceMap::Instance().GetGlobalDeviceType(
         device_type_id_);
+  } else if (alloc_type_ == AllocationType::CUSTOMPINNED) {
+    os << phi::CustomRegisteredDeviceMap::Instance().GetGlobalDeviceType(
+              device_type_id_)
+       << "_pinned";
   } else {
     os << AllocationTypeStr(alloc_type_);
   }
   if (alloc_type_ == AllocationType::GPUPINNED ||
-      alloc_type_ == AllocationType::CPU) {
+      alloc_type_ == AllocationType::CPU ||
+      alloc_type_ == AllocationType::CUSTOMPINNED) {
     os << ")";
   } else {
     os << ":" << std::to_string(device) << ")";

--- a/paddle/phi/common/place.h
+++ b/paddle/phi/common/place.h
@@ -35,6 +35,7 @@ enum class AllocationType : int8_t {
   XPU = 4,
   IPU = 7,
   CUSTOM = 9,
+  CUSTOMPINNED = 11,
 };
 
 class TEST_API CustomRegisteredDeviceMap {
@@ -182,6 +183,22 @@ class CustomPlace : public Place {
     if (place.GetType() == AllocationType::CUSTOM) {
       this->Reset(
           AllocationType::CUSTOM, place.GetDeviceId(), place.GetDeviceType());
+    }
+  }
+};
+
+class CustomPinnedPlace : public Place {
+ public:
+  CustomPinnedPlace() : Place(AllocationType::CUSTOMPINNED, 0, "") {}
+  explicit CustomPinnedPlace(const std::string dev_type)
+      : Place(AllocationType::CUSTOMPINNED, 0, dev_type) {}
+
+  CustomPinnedPlace(const CustomPinnedPlace&) = default;
+  CustomPinnedPlace(const Place& place) {  // NOLINT
+    if (place.GetType() == AllocationType::CUSTOMPINNED) {
+      this->Reset(AllocationType::CUSTOMPINNED,
+                  place.GetDeviceId(),
+                  place.GetDeviceType());
     }
   }
 };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
 Others


### Description
Add pinned allocator for custom device, enabling dataloader to use pinned memory for custom device.
