### PR TITLE
【Fix SP Bug】To Reuse mp_aync_allreduce In SP,  Keep consistent behavior with MP

### DIFF
--- a/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
+++ b/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
@@ -493,14 +493,25 @@ class ColumnSequenceParallelLinear(Layer):
 
     def forward(self, x):
         # sequence parallelism is same as model parallelis, if sequence parallel is true, input shape is [s, b, h],else input shape is [b, s, h]
-        return SPInnerOverlapLinear.apply(
-            x,
-            self.weight,
-            self.bias,
-            self.fuse_matmul_bias,
-            self.mp_fused_linear_param_grad_add,
-            self.model_parallel_group,
-        )
+        # reuse mp_asyn_allreduce to do sequence parallelism overlap
+        if self.mp_asyn_allreduce:
+            output = SPInnerOverlapLinear.apply(
+                x,
+                self.weight,
+                self.bias,
+                self.fuse_matmul_bias,
+                self.mp_fused_linear_param_grad_add,
+                self.model_parallel_group,
+            )
+        else:
+            if self.is_mp:
+                input_parallel = AllGatherOp.apply(x)
+            else:
+                input_parallel = x
+            output = self.linear(
+                input_parallel, self.weight, self.bias, name=self._name
+            )
+        return output
 
 
 class MPScale(PyLayer):

--- a/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
+++ b/python/paddle/distributed/fleet/utils/sequence_parallel_utils.py
@@ -493,8 +493,8 @@ class ColumnSequenceParallelLinear(Layer):
 
     def forward(self, x):
         # sequence parallelism is same as model parallelis, if sequence parallel is true, input shape is [s, b, h],else input shape is [b, s, h]
-        # reuse mp_asyn_allreduce to do sequence parallelism overlap
-        if self.mp_asyn_allreduce:
+        # reuse mp_async_allreduce to do sequence parallelism overlap
+        if self.mp_async_allreduce:
             output = SPInnerOverlapLinear.apply(
                 x,
                 self.weight,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-70444
1、当前SP默认开启了Overlap功能，这与之前MP的行为不一致
2、这个PR的作用是复用mp_async_allreduce开关，当打开mp_aync_allreduce时，SP进行overlap, 不打开时，不进行overlap 