### PR TITLE
Adapting VarDesc* Attribute for OpTranslator

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import argparse
 from pathlib import Path
 from typing import Dict, List, Set

--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import argparse
 from pathlib import Path
 from typing import Dict, List, Set

--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -171,7 +171,13 @@ def OpNameNormalizerInitialization(
 
     op_mutable_attributes["reduce_mean"] = set()
     op_mutable_attributes["reduce_mean"].add("axis")
-    op_mutable_attributes["reduce_mean"]["axis"] = []
+    op_mutable_attribute_infos["reduce_mean"] = {}
+    op_mutable_attribute_infos["reduce_mean"]["axis"] = []
+
+    op_mutable_attributes["reduce_mean_grad"] = set()
+    op_mutable_attributes["reduce_mean_grad"].add("axis")
+    op_mutable_attribute_infos["reduce_mean_grad"] = {}
+    op_mutable_attribute_infos["reduce_mean_grad"]["axis"] = []
 
     op_name_normalizer_template = env.get_template("op_compat_info.cc.j2")
     with open(output_source_file, 'wt') as f:

--- a/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
+++ b/paddle/fluid/ir_adaptor/translator/op_compat_gen.py
@@ -169,6 +169,10 @@ def OpNameNormalizerInitialization(
         {"out_grad_in": "Out@GRAD", "out_grad_out": "Out@GRAD"}
     )
 
+    op_mutable_attributes["reduce_mean"] = set()
+    op_mutable_attributes["reduce_mean"].add("axis")
+    op_mutable_attributes["reduce_mean"]["axis"] = []
+
     op_name_normalizer_template = env.get_template("op_compat_info.cc.j2")
     with open(output_source_file, 'wt') as f:
         op_compat_definition = op_name_normalizer_template.render(

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -526,7 +526,7 @@ std::vector<pir::Value> OpTranscriber::GenerateOperationInput(
             1,
             platform::errors::PreconditionNotMet(
                 "The VarDesc has not been defined by a previous Operation."));
-        auto valeue = param_map->at(var->Name()).value;
+        auto value = param_map->at(var->Name()).value;
         op_inputs.push_back(value);
         continue;
       }

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -514,17 +514,19 @@ std::vector<pir::Value> OpTranscriber::GenerateOperationInput(
         mutable_attributes->count(info.name) != 0) {
       if (!op_desc.HasAttr(legacy_input_name) &&
           op_desc.HasAttr(legacy_input_name, true)) {
-        framework::Attribute legacy_attr = op_desc.GetAttr(info.name, true);
+        framework::Attribute legacy_attr =
+            op_desc.GetAttr(legacy_input_name, true);
         VarDesc* var = paddle::get<VarDesc*>(legacy_attr);
-        PADDLE_ENFORCE_NOT_NULL(var,
-                                platform::errors::PreconditionNotMet(
-                                    "legacy_attr is not VarDesc*."));
+        PADDLE_ENFORCE_NOT_NULL(
+            var,
+            platform::errors::PreconditionNotMet(
+                "The type of legacy_attr is not VarDesc*."));
         PADDLE_ENFORCE_GE(
             param_map->count(var->Name()),
-            0,
+            1,
             platform::errors::PreconditionNotMet(
-                "VarDesc* is not defined by the previous Operation."));
-        auto value = param_map->at(var->Name()).value;
+                "The VarDesc has not been defined by a previous Operation."));
+        auto valeue = param_map->at(var->Name()).value;
         op_inputs.push_back(value);
         continue;
       }

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2222,10 +2222,6 @@
     {axis : dim, keepdim : keep_dim}
   extra :
     attrs : [bool use_mkldnn = false]
-  int_array:
-    axis:
-      data_type: int
-      support_tensor: true
 
 - op : mean_all (mean)
   backward : mean_all_grad (mean_grad)

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -2222,6 +2222,10 @@
     {axis : dim, keepdim : keep_dim}
   extra :
     attrs : [bool use_mkldnn = false]
+  int_array:
+    axis:
+      data_type: int
+      support_tensor: true
 
 - op : mean_all (mean)
   backward : mean_all_grad (mean_grad)

--- a/test/legacy_test/test_mean_op.py
+++ b/test/legacy_test/test_mean_op.py
@@ -609,14 +609,11 @@ class TestMeanTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
-)
 class TestMeanWithDimTensor(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
-        self.place = paddle.CUDAPlace(0)
+        self.place = paddle.CPUPlace()
 
     def test_mean_with_dim_tesnor(self):
         old_flag = paddle.base.framework.get_flags(

--- a/test/legacy_test/test_mean_op.py
+++ b/test/legacy_test/test_mean_op.py
@@ -609,6 +609,9 @@ class TestMeanTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestMeanWithDimTensor(unittest.TestCase):
     def setUp(self):
         self.x_shape = [2, 3, 4, 5]

--- a/test/legacy_test/test_mean_op.py
+++ b/test/legacy_test/test_mean_op.py
@@ -609,6 +609,43 @@ class TestMeanTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestMeanWithDimTensor(unittest.TestCase):
+    def setUp(self):
+        self.x_shape = [2, 3, 4, 5]
+        self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
+        self.place = paddle.CUDAPlace(0)
+
+    def test_mean_with_dim_tesnor(self):
+        old_flag = paddle.base.framework.get_flags(
+            "FLAGS_enable_pir_in_executor"
+        )["FLAGS_enable_pir_in_executor"]
+        try:
+            main_program = paddle.static.Program()
+            startup_program = paddle.static.Program()
+            with paddle.static.program_guard(main_program, startup_program):
+                x = paddle.static.data('X', self.x_shape)
+                axis = np.arange(len(self.x_shape)).tolist()
+                dim = paddle.to_tensor(axis)
+                out = paddle.mean(x, dim)
+
+            paddle.framework.set_flags({"FLAGS_enable_pir_in_executor": True})
+            exe = paddle.static.Executor(self.place)
+            exe.run(startup_program)
+            res = exe.run(
+                main_program,
+                feed={'X': self.x},
+                fetch_list=[out],
+            )
+            out_ref = np.mean(self.x)
+            for out in res:
+                np.testing.assert_allclose(out, out_ref, rtol=0.0001)
+        finally:
+            if not old_flag:
+                paddle.framework.set_flags(
+                    {"FLAGS_enable_pir_in_executor": False}
+                )
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
旧IR下`SupportTensor`实现的一种方式是支持`Attribute`的值为`VarDesc*`。该PR为`OpTransltor`适配`VarDesc*`类型的`Attribute`的翻译。利用`mean` op测试该部分功能。