### PR TITLE
fix. allreduce_sum is needed for matmul_v2_grad when the Y@GRAD not a parameter but from reshard

### DIFF
--- a/python/paddle/distributed/auto_parallel/static/operators/common.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/common.py
@@ -363,6 +363,14 @@ def is_parameter_related(varname, block, dist_context=None):
         var = serial_program.global_block()._find_var_recursive(varname)
         if var is None:
             return False
+    # NOTE(liym27): when Y_var is not a parameter, but Y_var is resharded by a parameter.
+    elif "reshard_api" in varname:
+        for op in block.ops:
+            if op.type == "assign" and varname in op.output("Out"):
+                in_varname = op.input("X")[0]
+                var = block._find_var_recursive(in_varname)
+                if var is not None and var.is_parameter:
+                    return True
     return var.is_parameter
 
 

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
@@ -420,6 +420,10 @@ def _right_operand_parameter_matmul_backward(ctx, *args, **kwargs):
     out_grad_names = []
     if is_parameter_related(Y_var.name, main_block):
         out_grad_names = [kwargs['Y@GRAD'][0]]
+    # NOTE(liym27): when Y_var is not a parameter, but Y_var is resharded by a parameter.
+    # This is a temporary handling method that will be abandoned in the future.
+    elif "reshard_api" in Y_var.name:
+        out_grad_names = [kwargs['Y@GRAD'][0]]
 
     if trans_x:
         trans_x_y_dims_mapping(True, False, X_var_dims_mapping, None)

--- a/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
+++ b/python/paddle/distributed/auto_parallel/static/operators/dist_matmul.py
@@ -420,10 +420,6 @@ def _right_operand_parameter_matmul_backward(ctx, *args, **kwargs):
     out_grad_names = []
     if is_parameter_related(Y_var.name, main_block):
         out_grad_names = [kwargs['Y@GRAD'][0]]
-    # NOTE(liym27): when Y_var is not a parameter, but Y_var is resharded by a parameter.
-    # This is a temporary handling method that will be abandoned in the future.
-    elif "reshard_api" in Y_var.name:
-        out_grad_names = [kwargs['Y@GRAD'][0]]
 
     if trans_x:
         trans_x_y_dims_mapping(True, False, X_var_dims_mapping, None)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
In static auto parallel backward, allreduce_sum op should be appended to program in the situation:
```
x = dist.reshard(weight, ...)
y = paddle.matmul(z, x)
```

Pcard-76459