### PR TITLE
[CINN] remove infer symbolic in predictor

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -931,12 +931,6 @@ bool AnalysisPredictor::PrepareExecutor() {
         DecompProgram decomp_object(pir_program_.get());
         decomp_object.decomp_program();
 
-        auto shape_pm = std::make_shared<::pir::PassManager>(
-            ::pir::IrContext::Instance(), 2);
-        ::pir::shape::AddShapeOptimizationPass(shape_pm, *pir_program_.get());
-        VLOG(4) << "[ShapeDialect] Run AddShapeOptimizationPass";
-        shape_pm->Run(pir_program_.get());
-
         cinn::dialect::ir::CheckInferSymbolicIfNeed(pir_program_.get(),
                                                     CreatePassMgr);
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Devs


### Description
<!-- Describe what you’ve done -->
pcard-76996

删除predictor的 infer symbolic逻辑， 在add_cinn_pass中间，需要运行一些前处理的流程，才需要调用 infer symbolic的逻辑，否则会失败