### PR TITLE
refine optimizer state_dict

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -333,14 +333,18 @@ class Optimizer:
 
         '''
         state_dict = {}
-        for k, v in self._accumulators.items():
-            for para_name, var_tmp in v.items():
-                state_dict[var_tmp.name] = var_tmp
-                # save scale value for xpu
-                if core.is_compiled_with_xpu():
-                    state_dict[
-                        var_tmp.name + ".SCALE_VALUE"
-                    ] = var_tmp.get_tensor().get_xpu_scale_value()
+        if len(self._accumulators) == 0 and len(self._accumulators_holder) > 0:
+            for name, var in self._accumulators_holder.items():
+                state_dict[name] = var
+        else:
+            for k, v in self._accumulators.items():
+                for para_name, var_tmp in v.items():
+                    state_dict[var_tmp.name] = var_tmp
+                    # save scale value for xpu
+                    if core.is_compiled_with_xpu():
+                        state_dict[
+                            var_tmp.name + ".SCALE_VALUE"
+                        ] = var_tmp.get_tensor().get_xpu_scale_value()
         # if has master weight and then save master weight
         if hasattr(self, "_master_weights"):
             if len(self._master_weights) != 0:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
optimizer存在如下问题：
如果用户调用了optimizer.set_state_dict()，但是没有调用optimzier.step()，此时optimizer.state_dict()返回的结果缺少set_state_dict的accumulators信息。

最早这个问题要追溯到 https://github.com/PaddlePaddle/Paddle/pull/20148 ，由于如果用户不调用optimzier.step()，不触发_add_accumulator，optimizer无法准确的创建self._accumulators[name][param.name]。因此，在optimizer.set_state_dict()时，将accumulators暂时存在self._accumulators_holder中，在_add_accumulator时同步到self._accumulators上。

但如果用户调用了optimizer.set_state_dict()，但是没有调用optimzier.step()，self._accumulators为空，数据仍在self._accumulators_holder上。

因此，本PR修改state_dict，如果self._accumulators为空，self._accumulators_holder有值，则将self._accumulators_holder的值给到state_dict。

Pcard-74613