### PR TITLE
Fix uncompelete substitution

### DIFF
--- a/paddle/pir/include/dialect/shape/utils/shape_analysis.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_analysis.h
@@ -102,6 +102,10 @@ class IR_API ShapeConstraintIRAnalysis {
       value_to_shape_or_data_;
 
   symbol::ConstraintsManager constraints_manager_;
+
+  using DimExprSubstitutionPattern =
+      std::unordered_map<symbol::DimExpr, symbol::DimExpr>;
+  DimExprSubstitutionPattern substitution_pattern_;
 };
 
 class IR_API ShapeAnalysisManager {

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -268,12 +268,14 @@ namespace {
 
 bool CanSubstituteInShapeAnalysis(const symbol::DimExpr& lhs,
                                   const symbol::DimExpr& rhs) {
-  int lhs_priority = symbol::GetDimExprPriority(lhs);
-  int rhs_priority = symbol::GetDimExprPriority(rhs);
-  if (lhs_priority >= 2 && rhs_priority >= 2) {
-    return 0;
-  }
-  return true;
+  auto CanSubstitutePredictor = symbol::Overloaded{
+      [](std::int64_t lhs, const auto& rhs) { return true; },
+      [](const std::string& lhs, const std::string& rhs) { return true; },
+      [](const std::string& lhs,
+         const symbol::Broadcast<symbol::DimExpr>& rhs) { return true; },
+      [](const auto& lhs, const auto& rhs) { return false; }};
+  return std::visit(CanSubstitutePredictor, lhs.variant(), rhs.variant()) ||
+         std::visit(CanSubstitutePredictor, lhs.variant(), rhs.variant());
 }
 
 }  // namespace
@@ -281,13 +283,19 @@ bool CanSubstituteInShapeAnalysis(const symbol::DimExpr& lhs,
 void ShapeConstraintIRAnalysis::SubstituteDimExpr(
     const symbol::DimExpr& origin, const symbol::DimExpr& substituted) {
   if (!CanSubstituteInShapeAnalysis(origin, substituted)) return;
-  std::unordered_map<symbol::DimExpr, symbol::DimExpr> substitution_pattern;
-  substitution_pattern[origin] = substituted;
+
+  substitution_pattern_[origin] = substituted;
+  for (auto it = substitution_pattern_.begin();
+       it != substitution_pattern_.end();
+       it++) {
+    if (it->second == origin) it->second = substituted;
+  }
+
   for (auto it = value_to_shape_or_data_.begin();
        it != value_to_shape_or_data_.end();
        it++) {
     const symbol::ShapeOrDataDimExprs& substituted_shape_or_data =
-        symbol::SubstituteShapeOrData(it->second, substitution_pattern);
+        symbol::SubstituteShapeOrData(it->second, substitution_pattern_);
     SetShapeOrDataForValue(it->first, substituted_shape_or_data);
   }
 }

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -60,11 +60,13 @@ ShapeConstraintIRAnalysis::GetShapeOrDataForValue(Value val) const {
 
 void ShapeConstraintIRAnalysis::SetShapeOrDataForValue(
     Value val, const symbol::ShapeOrDataDimExprs& shape_or_data) {
+  const symbol::ShapeOrDataDimExprs& substituted_shape_or_data =
+      symbol::SubstituteShapeOrData(shape_or_data, substitution_pattern_);
   auto iter = value_to_shape_or_data_.find(val);
   if (iter == value_to_shape_or_data_.end()) {
-    value_to_shape_or_data_.emplace(val, shape_or_data);
+    value_to_shape_or_data_.emplace(val, substituted_shape_or_data);
   } else {
-    iter->second = shape_or_data;
+    iter->second = substituted_shape_or_data;
   }
 }
 
@@ -275,7 +277,7 @@ bool CanSubstituteInShapeAnalysis(const symbol::DimExpr& lhs,
          const symbol::Broadcast<symbol::DimExpr>& rhs) { return true; },
       [](const auto& lhs, const auto& rhs) { return false; }};
   return std::visit(CanSubstitutePredictor, lhs.variant(), rhs.variant()) ||
-         std::visit(CanSubstitutePredictor, lhs.variant(), rhs.variant());
+         std::visit(CanSubstitutePredictor, rhs.variant(), lhs.variant());
 }
 
 }  // namespace


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996
This PR saves the substitution pattern in the shape analysis, and triggers substitution each time SetShapeOrDataForValue is called.