### PR TITLE
[CINN]Support data compute in infer_symbol_shape for some binary elementwise ops

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
@@ -15,37 +15,19 @@
 #include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 
-bool ShouldUseData(pir::Value val) {
-  if (!val.defining_op()) return false;
-  if (val.defining_op()->isa<paddle::dialect::ShapeOp>()) {
-    return true;
-  }
-  return false;
-}
-
 bool InferSymbolicShapeElementWiseBinary(
-    pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis) {
-  const auto &x_shapeordata =
+    pir::Operation *op,
+    pir::ShapeConstraintIRAnalysis *shape_analysis,
+    const std::function<symbol::DimExpr(const symbol::DimExpr &,
+                                        const symbol::DimExpr &)>
+        &DataComputeFunc = nullptr) {
+  const auto &x_shape =
       shape_analysis->GetShapeOrDataForValue(op->operand_source(0));
-  std::vector<symbol::DimExpr> shape_0;
-  // For ElementWiseBinary ops, if the input tensor is from full op, the value
-  // of fullop is useless, only the shape need doing broadcast
-  if (ShouldUseData(op->operand_source(0)) &&
-      x_shapeordata.data().has_value()) {
-    shape_0 = x_shapeordata.data().value();
-  } else {
-    shape_0 = x_shapeordata.shape();
-  }
+  std::vector<symbol::DimExpr> shape_0 = x_shape.shape();
 
-  const auto &y_shapeordata =
+  const auto &y_shape =
       shape_analysis->GetShapeOrDataForValue(op->operand_source(1));
-  std::vector<symbol::DimExpr> shape_1;
-  if (ShouldUseData(op->operand_source(1)) &&
-      y_shapeordata.data().has_value()) {
-    shape_1 = y_shapeordata.data().value();
-  } else {
-    shape_1 = y_shapeordata.shape();
-  }
+  std::vector<symbol::DimExpr> shape_1 = y_shape.shape();
 
   int diff = shape_0.size() - shape_1.size();
   if (diff > 0) {
@@ -75,13 +57,39 @@ bool InferSymbolicShapeElementWiseBinary(
     return shapes;
   }();
 
-  // TODO(lanxianghit): fill data when the operation is on shape computation
-  // std::vector<symbol::DimExpr> data;
-  symbol::ShapeOrDataDimExprs shape_data{
-      symbol::TensorShapeOrDataDimExprs(shapes)};
-  shape_analysis->SetShapeOrDataForValue(op->result(0), shape_data);
-
-  return true;
+  if (x_shape.data() && y_shape.data() && DataComputeFunc) {
+    PADDLE_ENFORCE_LE(
+        x_shape.shape().size(),
+        1,
+        common::errors::InvalidArgument("When compute data, the rank of x "
+                                        "should be 0 or 1, but now recevied %d",
+                                        x_shape.shape().size()));
+    PADDLE_ENFORCE_LE(
+        y_shape.shape().size(),
+        1,
+        common::errors::InvalidArgument("When compute data, the rank of y "
+                                        "should be 0 or 1, but now recevied %d",
+                                        y_shape.shape().size()));
+    PADDLE_ENFORCE_EQ(x_shape.data()->size(),
+                      y_shape.data()->size(),
+                      common::errors::InvalidArgument(
+                          "When compute data, the size of x and y should be "
+                          "equal, but now recevied %d and %d",
+                          x_shape.data()->size(),
+                          y_shape.data()->size()));
+    std::vector<symbol::DimExpr> out_data;
+    for (size_t i = 0; i < x_shape.data()->size(); ++i) {
+      out_data.emplace_back(
+          DataComputeFunc(x_shape.data()->at(i), y_shape.data()->at(i)));
+    }
+    symbol::ShapeOrDataDimExprs shape_data{
+        symbol::TensorShapeOrDataDimExprs(shapes, out_data)};
+    shape_analysis->SetShapeOrDataForValue(op->result(0), shape_data);
+  } else {
+    symbol::ShapeOrDataDimExprs shape_data{
+        symbol::TensorShapeOrDataDimExprs(shapes)};
+    shape_analysis->SetShapeOrDataForValue(op->result(0), shape_data);
+  }
 }
 
 #define OP_ELEMENT_WISE_BINARY(name)                                        \
@@ -91,14 +99,45 @@ bool InferSymbolicShapeElementWiseBinary(
   }
 
 namespace paddle::dialect {
-OP_ELEMENT_WISE_BINARY(Add)
+
+bool AddOpInferSymbolicShape(pir::Operation *op,
+                             pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  return InferSymbolicShapeElementWiseBinary(
+      op,
+      shape_analysis,
+      [](const symbol::DimExpr &x, const symbol::DimExpr &y) { return x + y; });
+}
+
+bool DivideOpInferSymbolicShape(
+    pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  return InferSymbolicShapeElementWiseBinary(
+      op,
+      shape_analysis,
+      [](const symbol::DimExpr &x, const symbol::DimExpr &y) { return x / y; });
+}
+
+bool MultiplyOpInferSymbolicShape(
+    pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  return InferSymbolicShapeElementWiseBinary(
+      op,
+      shape_analysis,
+      [](const symbol::DimExpr &x, const symbol::DimExpr &y) { return x * y; });
+}
+
+bool SubtractOpInferSymbolicShape(
+    pir::Operation *op, pir::ShapeConstraintIRAnalysis *shape_analysis) {
+  return InferSymbolicShapeElementWiseBinary(
+      op,
+      shape_analysis,
+      [](const symbol::DimExpr &x, const symbol::DimExpr &y) { return x - y; });
+}
+
 OP_ELEMENT_WISE_BINARY(Add_)
 OP_ELEMENT_WISE_BINARY(BitwiseAnd)
 OP_ELEMENT_WISE_BINARY(BitwiseAnd_)
 OP_ELEMENT_WISE_BINARY(BitwiseXor)
 OP_ELEMENT_WISE_BINARY(BitwiseXor_)
 OP_ELEMENT_WISE_BINARY(Complex)
-OP_ELEMENT_WISE_BINARY(Divide)
 OP_ELEMENT_WISE_BINARY(Divide_)
 OP_ELEMENT_WISE_BINARY(ElementwisePow)
 OP_ELEMENT_WISE_BINARY(Fmax)
@@ -119,7 +158,6 @@ OP_ELEMENT_WISE_BINARY(LogicalXor)
 OP_ELEMENT_WISE_BINARY(LogicalXor_)
 OP_ELEMENT_WISE_BINARY(Maximum)
 OP_ELEMENT_WISE_BINARY(Minimum)
-OP_ELEMENT_WISE_BINARY(Multiply)
 OP_ELEMENT_WISE_BINARY(MultiplySr)
 OP_ELEMENT_WISE_BINARY(MultiplySr_)
 OP_ELEMENT_WISE_BINARY(Multiply_)
@@ -127,7 +165,6 @@ OP_ELEMENT_WISE_BINARY(NotEqual)
 OP_ELEMENT_WISE_BINARY(NotEqual_)
 OP_ELEMENT_WISE_BINARY(Remainder)
 OP_ELEMENT_WISE_BINARY(Remainder_)
-OP_ELEMENT_WISE_BINARY(Subtract)
 OP_ELEMENT_WISE_BINARY(Subtract_)
 
 }  // namespace paddle::dialect

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/element_wise_binary.cc
@@ -90,6 +90,7 @@ bool InferSymbolicShapeElementWiseBinary(
         symbol::TensorShapeOrDataDimExprs(shapes)};
     shape_analysis->SetShapeOrDataForValue(op->result(0), shape_data);
   }
+  return true;
 }
 
 #define OP_ELEMENT_WISE_BINARY(name)                                        \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

为加、减、乘、除算子添加data区的符号推导处理。