### PR TITLE
Fix get_int_tensor_list

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -905,7 +905,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None, name=None):
             paddle.utils.check_shape(shape)
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):
-                    shape = paddle.utils.get_int_tensor_list(shape, place)
+                    shape = paddle.utils.get_int_tensor_list(shape)
             elif isinstance(shape, paddle.pir.Value):
                 pass
             else:
@@ -2150,9 +2150,7 @@ def empty(shape, dtype=None, name=None):
                 shape = shape.tolist()
             if isinstance(shape, (list, tuple)):
                 if paddle.utils._contain_var(shape):
-                    shape = paddle.utils.get_int_tensor_list(
-                        shape, _current_expected_place()
-                    )
+                    shape = paddle.utils.get_int_tensor_list(shape)
             elif isinstance(shape, paddle.pir.Value):
                 pass
             else:

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -931,9 +931,7 @@ def uniform(shape, dtype=None, min=-1.0, max=1.0, seed=0, name=None):
         check_type(min, 'min', (float, int, paddle.pir.Value), 'uniform/rand')
         check_type(max, 'max', (float, int, paddle.pir.Value), 'uniform/rand')
         if paddle.utils._contain_var(shape):
-            shape = paddle.utils.get_int_tensor_list(
-                shape, _current_expected_place()
-            )
+            shape = paddle.utils.get_int_tensor_list(shape)
         return _C_ops.uniform(
             shape,
             dtype,
@@ -1115,9 +1113,7 @@ def randint(low=0, high=None, shape=[1], dtype=None, name=None):
         check_shape(shape, 'randint')
         check_dtype(dtype, 'dtype', ['int32', 'int64'], 'randint')
         if paddle.utils._contain_var(shape):
-            shape = paddle.utils.get_int_tensor_list(
-                shape, _current_expected_place()
-            )
+            shape = paddle.utils.get_int_tensor_list(shape)
         return _C_ops.randint(
             low, high, shape, dtype, _current_expected_place()
         )
@@ -1336,9 +1332,7 @@ def randint_like(x, low=0, high=None, dtype=None, name=None):
                 'randint_like',
             )
             if paddle.utils._contain_var(shape):
-                shape = paddle.utils.get_int_tensor_list(
-                    shape, _current_expected_place()
-                )
+                shape = paddle.utils.get_int_tensor_list(shape)
             out = _C_ops.randint(
                 low, high, shape, DataType.INT64, _current_expected_place()
             )

--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -27,7 +27,6 @@ from ..base.data_feeder import check_dtype, convert_dtype
 from ..base.framework import (
     Block,
     Variable,
-    _current_expected_place,
     in_dygraph_mode,
 )
 from ..pir import Value
@@ -383,10 +382,7 @@ def _contain_var(list_or_tuple):
     return False
 
 
-def get_int_tensor_list(ele_list, place=None, default_dtype='int64'):
-    if place is None:
-        place = _current_expected_place()
-
+def get_int_tensor_list(ele_list, default_dtype='int64'):
     int_tensor_list = []
     for ele in ele_list:
         if isinstance(ele, paddle.pir.Value):
@@ -397,11 +393,11 @@ def get_int_tensor_list(ele_list, place=None, default_dtype='int64'):
                 ele = paddle.reshape(ele, [])
             int_tensor_list.append(ele)
         else:
-            temp_out = paddle.full(
-                [],
-                ele,
-                convert_np_dtype_to_dtype_(np.dtype(default_dtype)),
-                place,
+            temp_out = paddle.tensor.fill_constant(
+                shape=[],
+                dtype=convert_np_dtype_to_dtype_(np.dtype(default_dtype)),
+                value=ele,
+                force_cpu=True,
             )
             int_tensor_list.append(temp_out)
     return int_tensor_list


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-67164
原来get_int_tensor_list函数存在的问题：
- get_int_tensor_list 内调用的full函数并不接受一个place参数，place对应的是name参数的位置，place并没有被真正用到
- 原来get_int_tensor_list虽然可以执行但是shape作为可变attr时调用的full会产生GPU的tensor，但是作为可变attr在调用kernel又需要拷贝回CPU。

所以在本PR中用fill_constant替换了full，并指定了force_cpu=True，避免多余的拷贝操作