### PR TITLE
[Bug Fix] Bug fix for results of paddle.ones elements are all zero.

### DIFF
--- a/paddle/phi/kernels/gpu/full_kernel.cu
+++ b/paddle/phi/kernels/gpu/full_kernel.cu
@@ -42,7 +42,7 @@ void FullKernel(const Context& dev_ctx,
                 DataType dtype,
                 DenseTensor* out) {
   out->Resize(common::make_ddim(shape.GetData()));
-  int numel = out->numel();
+  int64_t numel = out->numel();
   dev_ctx.template Alloc<T>(out);
 
   if (numel > 0) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

Bug fix for the following cases:

```python 
import paddle
paddle.set_default_dtype("bfloat16")
logps = paddle.ones(shape=[32, 100352, 1024])
print(logps)
```

The results should be a tensor with all elements one, but got result tensor whose elements are all zero.