### PR TITLE
[XPU] support flash attention for xpu when causal is false

### DIFF
--- a/paddle/phi/kernels/xpu/flash_attn_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_kernel.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/flash_attn_kernel.h"
-
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 #ifdef PADDLE_WITH_XPU_XHPC
@@ -235,6 +235,28 @@ void FlashAttnKernel(const Context& ctx,
   // output: o
   ctx.template Alloc<T>(out);
 
+  // generate seed offset
+  seed_offset->Resize({2});
+  int64_t* seed_offset_data = ctx.template HostAlloc<int64_t>(seed_offset);
+  if (fixed_seed_offset.get_ptr()) {
+    const int64_t* fixed_seed_offset_data =
+        fixed_seed_offset.get_ptr()->data<int64_t>();
+    seed_offset_data[0] = fixed_seed_offset_data[0];
+    seed_offset_data[1] = fixed_seed_offset_data[1];
+  } else {
+    std::pair<uint64_t, uint64_t> seed_offset_pair;
+    uint64_t inc = batch_size * num_heads * 32;
+    if (rng_name != "") {
+      auto gen = phi::GetRandomSeedGenerator(rng_name);
+      seed_offset_pair = gen->IncrementOffset(inc);
+    } else {
+      auto* gen = ctx.GetGenerator();
+      seed_offset_pair = gen->IncrementOffset(inc);
+    }
+    seed_offset_data[0] = static_cast<int64_t>(seed_offset_pair.first);
+    seed_offset_data[1] = static_cast<int64_t>(seed_offset_pair.second);
+  }
+
   // raw pointers
   using XPUType = typename XPUTypeTrait<T>::Type;
   const XPUType* q_data = reinterpret_cast<const XPUType*>(q.data<T>());
@@ -259,24 +281,24 @@ void FlashAttnKernel(const Context& ctx,
   // nullptr);
   int r = baidu::xpu::xfa::mha_varlen_fwd<XPUType, float, tfloat32, int>(
       ctx.x_context(),
-      q_data,                       // q
-      k_data,                       // k
-      v_data,                       // v
-      out_data,                     // out
-      softmax_lse_data,             // softmax_lse
-      qlod,                         // lod_seqlens_q
-      kvlod,                        // lod_seqlens_k
-      seqlen_q,                     // max_seqlen_q
-      seqlen_k,                     // max_seqlen_k
-      num_heads,                    // head_num
-      num_heads_k,                  // head_num_k
-      head_size,                    // head_dim
-      1.0f / std::sqrt(head_size),  // softmax_scale
-      dropout,                      // p_dropout
-      0x45678901,                   // seed
-      causal,                       // is_causal
-      nullptr,                      // attn_mask
-      bias_data                     // bias
+      q_data,                                      // q
+      k_data,                                      // k
+      v_data,                                      // v
+      out_data,                                    // out
+      softmax_lse_data,                            // softmax_lse
+      qlod,                                        // lod_seqlens_q
+      kvlod,                                       // lod_seqlens_k
+      seqlen_q,                                    // max_seqlen_q
+      seqlen_k,                                    // max_seqlen_k
+      num_heads,                                   // head_num
+      num_heads_k,                                 // head_num_k
+      head_size,                                   // head_dim
+      1.0f / std::sqrt(head_size),                 // softmax_scale
+      dropout,                                     // p_dropout
+      static_cast<uint64_t>(seed_offset_data[0]),  // seed
+      causal,                                      // is_causal
+      nullptr,                                     // attn_mask
+      bias_data                                    // bias
   );
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "mha_varlen_fwd");
 #else


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
New features

### Description
support flash attention for xpu when causal is false，and enable pass bias as attn_mask
