### PR TITLE
use eager tensor's is_initialized directly

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -105,8 +105,7 @@ def monkey_patch_math_tensor():
         assert (
             numel == 1
         ), "only one element variable can be converted to float."
-        tensor = var.value().get_tensor()
-        assert tensor._is_initialized(), "variable's tensor is not initialized"
+        assert var._is_initialized(), "variable's tensor is not initialized"
         if var.dtype == core.VarDesc.VarType.BF16:
             var = var.astype('float32')
         return float(np.array(var))
@@ -114,8 +113,7 @@ def monkey_patch_math_tensor():
     def _long_(var):
         numel = np.prod(var.shape)
         assert numel == 1, "only one element variable can be converted to long."
-        tensor = var.value().get_tensor()
-        assert tensor._is_initialized(), "variable's tensor is not initialized"
+        assert var._is_initialized(), "variable's tensor is not initialized"
         if var.dtype == core.VarDesc.VarType.BF16:
             var = var.astype('float32')
         return int(np.array(var))
@@ -123,8 +121,7 @@ def monkey_patch_math_tensor():
     def _int_(var):
         numel = np.prod(var.shape)
         assert numel == 1, "only one element variable can be converted to int."
-        tensor = var.value().get_tensor()
-        assert tensor._is_initialized(), "variable's tensor is not initialized"
+        assert var._is_initialized(), "variable's tensor is not initialized"
         if var.dtype == core.VarDesc.VarType.BF16:
             var = var.astype('float32')
         return int(np.array(var))
@@ -143,8 +140,7 @@ def monkey_patch_math_tensor():
         assert (
             numel == 1
         ), "only one element variable can be converted to python index."
-        tensor = var.value().get_tensor()
-        assert tensor._is_initialized(), "variable's tensor is not initialized"
+        assert var._is_initialized(), "variable's tensor is not initialized"
         if var.dtype == core.VarDesc.VarType.BF16:
             var = var.astype('float32')
         return int(np.array(var))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
use eager tensor's is_initialized directly
Pcard-76459