### PR TITLE
[Inference] delete vars generated by constant_folding_pass in dead_code_elimination_pass

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -490,6 +490,8 @@ bool AnalysisPredictor::Init(
   }
 #endif
 
+  TryShrinkMemory();
+
   inference::DisplayMemoryInfo(place_, "Init predictor");
   return true;
 }
@@ -1012,7 +1014,10 @@ bool AnalysisPredictor::PrepareExecutor() {
       constant_folding_pass->SetNotOwned(pir::Pass::kParamScopeAttr,
                                          sub_scope_);
       basic_pass_pm.AddPass(std::move(constant_folding_pass));
-      basic_pass_pm.AddPass(::pir::CreateDeadCodeEliminationPass());
+      auto dead_code_elimination_pass = ::pir::CreateDeadCodeEliminationPass();
+      dead_code_elimination_pass->SetNotOwned(pir::Pass::kParamScopeAttr,
+                                              sub_scope_);
+      basic_pass_pm.AddPass(std::move(dead_code_elimination_pass));
       basic_pass_pm.AddPass(::pir::CreateReplaceFetchWithShadowOutputPass());
       if (!config_.glog_info_disabled()) {
         basic_pass_pm.EnablePrintStatistics();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-71500
delete vars generated by constant_folding_pass in dead_code_elimination_pass.