### PR TITLE
Supports passing Struct (POD) information between Passes

### DIFF
--- a/paddle/pir/include/pass/analysis_manager.h
+++ b/paddle/pir/include/pass/analysis_manager.h
@@ -225,11 +225,18 @@ class AnalysisMap {
   template <
       typename AnalysisT,
       typename OpT,
-      std::enable_if_t<
-          !std::is_constructible<AnalysisT, OpT, AnalysisManager&>::value>* =
-          nullptr>
+      std::enable_if_t<std::is_constructible<AnalysisT, OpT>::value>* = nullptr>
   static auto ConstructAnalysis(AnalysisManager&, OpT op) {
     return std::make_unique<AnalysisModel<AnalysisT>>(op);
+  }
+
+  /// Construct analysis using default constructor
+  template <typename AnalysisT,
+            typename OpT,
+            std::enable_if_t<std::is_default_constructible<AnalysisT>::value>* =
+                nullptr>
+  static auto ConstructAnalysis(AnalysisManager&, OpT op) {
+    return std::make_unique<AnalysisModel<AnalysisT>>();
   }
 
  private:

--- a/test/cpp/pir/pass/pass_manager_test.cc
+++ b/test/cpp/pir/pass/pass_manager_test.cc
@@ -125,6 +125,13 @@ struct CountOpAnalysis {
 IR_DECLARE_EXPLICIT_TEST_TYPE_ID(CountOpAnalysis)
 IR_DEFINE_EXPLICIT_TYPE_ID(CountOpAnalysis)
 
+struct NoOperationAnalysis {
+  int scale = 0;
+};
+
+IR_DECLARE_EXPLICIT_TEST_TYPE_ID(NoOperationAnalysis)
+IR_DEFINE_EXPLICIT_TYPE_ID(NoOperationAnalysis)
+
 class TestPass : public pir::Pass {
  public:
   TestPass() : pir::Pass("TestPass", 1) {}
@@ -133,7 +140,14 @@ class TestPass : public pir::Pass {
     pass_state().preserved_analyses.Preserve<CountOpAnalysis>();
     CHECK_EQ(pass_state().preserved_analyses.IsPreserved<CountOpAnalysis>(),
              true);
+    auto no_operation_analysis =
+        analysis_manager().GetAnalysis<NoOperationAnalysis>();
+    pass_state().preserved_analyses.Preserve<NoOperationAnalysis>();
+    CHECK_EQ(pass_state().preserved_analyses.IsPreserved<NoOperationAnalysis>(),
+             true);
     CHECK_EQ(count_op_analysis.count, 11);
+    no_operation_analysis.scale = 8;
+    CHECK_EQ(no_operation_analysis.scale, 8);
 
     auto module_op = op->dyn_cast<pir::ModuleOp>();
     CHECK_EQ(module_op.operation(), op);
@@ -143,6 +157,9 @@ class TestPass : public pir::Pass {
 
     pass_state().preserved_analyses.Unpreserve<CountOpAnalysis>();
     CHECK_EQ(pass_state().preserved_analyses.IsPreserved<CountOpAnalysis>(),
+             false);
+    pass_state().preserved_analyses.Unpreserve<NoOperationAnalysis>();
+    CHECK_EQ(pass_state().preserved_analyses.IsPreserved<NoOperationAnalysis>(),
              false);
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
pcard-71500
Supports passing Struct (POD) information between Passes