### PR TITLE
Replace plat::bfloat16 phi::dtype::bfloat16 in paddle/fluid/operators

### DIFF
--- a/paddle/fluid/operators/beam_search_decode_op_xpu.cc
+++ b/paddle/fluid/operators/beam_search_decode_op_xpu.cc
@@ -111,7 +111,6 @@ class BeamSearchDecodeXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(beam_search_decode,
                           XPU,

--- a/paddle/fluid/operators/collective/alltoall_op.cc
+++ b/paddle/fluid/operators/collective/alltoall_op.cc
@@ -65,7 +65,6 @@ Scatter tensors from all participators to all participators.
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(alltoall,
                              ops::AllToAllBaseOp,

--- a/paddle/fluid/operators/collective/alltoall_op.cu.cc
+++ b/paddle/fluid/operators/collective/alltoall_op.cu.cc
@@ -139,7 +139,6 @@ class AllToAllOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(alltoall,
                           GPU,
@@ -148,7 +147,7 @@ PD_REGISTER_STRUCT_KERNEL(alltoall,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/collective/barrier_op.cc
+++ b/paddle/fluid/operators/collective/barrier_op.cc
@@ -41,7 +41,6 @@ Barrier Operator - Barrier among all participators.)DOC");
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(barrier, ops::BarrierOp, ops::BarrierOpMaker);
 

--- a/paddle/fluid/operators/collective/barrier_op.cu.cc
+++ b/paddle/fluid/operators/collective/barrier_op.cu.cc
@@ -92,7 +92,6 @@ class BarrierOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(
     barrier, GPU, ALL_LAYOUT, ops::BarrierOpCUDAKernel, int) {}

--- a/paddle/fluid/operators/collective/c_allgather_op.cc
+++ b/paddle/fluid/operators/collective/c_allgather_op.cc
@@ -68,7 +68,6 @@ reference: https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/us
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_allgather,
                              ops::CAllGatherOp,

--- a/paddle/fluid/operators/collective/c_allgather_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_allgather_op.cu.cc
@@ -122,7 +122,6 @@ class CAllGatherOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allgather,
                           GPU,
@@ -131,7 +130,7 @@ PD_REGISTER_STRUCT_KERNEL(c_allgather,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           uint8_t,

--- a/paddle/fluid/operators/collective/c_allgather_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allgather_op_xpu.cc
@@ -116,7 +116,6 @@ class CAllGatherOpXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allgather,
                           XPU,

--- a/paddle/fluid/operators/collective/c_allreduce_avg_op.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_avg_op.cc
@@ -37,7 +37,6 @@ DECLARE_INPLACE_OP_INFERER(AllreduceAvgInplaceInferer, {"X", "Out"});
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_allreduce_avg,
                              ops::CAllReduceOp,

--- a/paddle/fluid/operators/collective/c_allreduce_avg_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_avg_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_ALLREDUCE_CUDA_KERNEL(CAllReduceAvg, kRedAvg)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_avg,
                           GPU,
@@ -32,4 +31,4 @@ PD_REGISTER_STRUCT_KERNEL(c_allreduce_avg,
                           int,
                           int64_t,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}

--- a/paddle/fluid/operators/collective/c_allreduce_max_op.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_max_op.cc
@@ -41,7 +41,6 @@ DEFINE_C_ALLREDUCE_CPU_KERNEL(CAllReduceMax, kRedMax)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_allreduce_max,
                              ops::CAllReduceOp,

--- a/paddle/fluid/operators/collective/c_allreduce_max_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_max_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_ALLREDUCE_CUDA_KERNEL(CAllReduceMax, kRedMax)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_max,
                           GPU,
@@ -29,7 +28,7 @@ PD_REGISTER_STRUCT_KERNEL(c_allreduce_max,
                           ops::CAllReduceMaxCUDAKernel,
                           float,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           double,
                           int,

--- a/paddle/fluid/operators/collective/c_allreduce_max_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_max_op_xpu.cc
@@ -21,7 +21,7 @@ DEFINE_C_ALLREDUCE_XPU_KERNEL(CAllReduceMax, kRedMax)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_max,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/collective/c_allreduce_min_op.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_min_op.cc
@@ -41,7 +41,6 @@ DEFINE_C_ALLREDUCE_CPU_KERNEL(CAllReduceMin, kRedMin)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_allreduce_min,
                              ops::CAllReduceOp,

--- a/paddle/fluid/operators/collective/c_allreduce_min_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_min_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_ALLREDUCE_CUDA_KERNEL(CAllReduceMin, kRedMin)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_min,
                           GPU,

--- a/paddle/fluid/operators/collective/c_allreduce_min_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_min_op_xpu.cc
@@ -21,7 +21,7 @@ DEFINE_C_ALLREDUCE_XPU_KERNEL(CAllReduceMin, kRedMin)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_min,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/collective/c_allreduce_prod_op.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_prod_op.cc
@@ -41,7 +41,6 @@ DEFINE_C_ALLREDUCE_CPU_KERNEL(CAllReduceProd, kRedProd)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_allreduce_prod,
                              ops::CAllReduceOp,

--- a/paddle/fluid/operators/collective/c_allreduce_prod_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_prod_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_ALLREDUCE_CUDA_KERNEL(CAllReduceProd, kRedProd)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_prod,
                           GPU,

--- a/paddle/fluid/operators/collective/c_allreduce_prod_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_prod_op_xpu.cc
@@ -21,7 +21,7 @@ DEFINE_C_ALLREDUCE_XPU_KERNEL(CAllReduceProd, kRedProd)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_prod,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/collective/c_allreduce_sum_op.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_sum_op.cc
@@ -62,7 +62,6 @@ DEFINE_C_ALLREDUCE_CPU_KERNEL(CAllReduceSum, kRedSum)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_allreduce_sum,
                              ops::CAllReduceOp,

--- a/paddle/fluid/operators/collective/c_allreduce_sum_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_sum_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_ALLREDUCE_CUDA_KERNEL(CAllReduceSum, kRedSum)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_sum,
                           GPU,
@@ -29,7 +28,7 @@ PD_REGISTER_STRUCT_KERNEL(c_allreduce_sum,
                           ops::CAllReduceSumCUDAKernel,
                           float,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           double,
                           int,

--- a/paddle/fluid/operators/collective/c_allreduce_sum_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_sum_op_xpu.cc
@@ -21,7 +21,7 @@ DEFINE_C_ALLREDUCE_XPU_KERNEL(CAllReduceSum, kRedSum)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(c_allreduce_sum,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/collective/c_broadcast_op.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op.cc
@@ -59,7 +59,6 @@ Reference: https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/us
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_broadcast,
                              ops::CBroadcastOp,

--- a/paddle/fluid/operators/collective/c_broadcast_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op.cu.cc
@@ -90,7 +90,6 @@ class CBroadcastOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_broadcast,
                           GPU,
@@ -101,7 +100,7 @@ PD_REGISTER_STRUCT_KERNEL(c_broadcast,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           phi::dtype::float16) {
 }

--- a/paddle/fluid/operators/collective/c_broadcast_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_xpu.cc
@@ -129,7 +129,6 @@ class CBroadcastOpXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_broadcast,
                           XPU,

--- a/paddle/fluid/operators/collective/c_concat_op.cc
+++ b/paddle/fluid/operators/collective/c_concat_op.cc
@@ -105,7 +105,6 @@ AllGather the tensors on different trainers and concat them along the last dimen
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OPERATOR(c_concat,
                   ops::CConcatOp,

--- a/paddle/fluid/operators/collective/c_concat_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_concat_op.cu.cc
@@ -165,7 +165,6 @@ class CConcatOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_concat,
                           GPU,
@@ -176,7 +175,7 @@ PD_REGISTER_STRUCT_KERNEL(c_concat,
                           int,
                           int64_t,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           phi::dtype::float16) {
 }

--- a/paddle/fluid/operators/collective/c_concat_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_concat_op_xpu.cc
@@ -160,7 +160,6 @@ class CConcatOpXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_concat,
                           XPU,
@@ -169,5 +168,5 @@ PD_REGISTER_STRUCT_KERNEL(c_concat,
                           float,
                           int,
                           int64_t,
-                          plat::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}

--- a/paddle/fluid/operators/collective/c_embedding_op.cc
+++ b/paddle/fluid/operators/collective/c_embedding_op.cc
@@ -176,7 +176,7 @@ class CEmbeddingOpGradVarTypeInference : public framework::VarTypeInference {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 REGISTER_OPERATOR(c_embedding,
                   ops::CEmbeddingOp,
                   ops::CEmbeddingOpMaker,

--- a/paddle/fluid/operators/collective/c_reduce_avg_op.cc
+++ b/paddle/fluid/operators/collective/c_reduce_avg_op.cc
@@ -37,7 +37,6 @@ class CReduceAvgOpMaker : public CReduceOpMaker {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_reduce_avg,
                              ops::CReduceOp,

--- a/paddle/fluid/operators/collective/c_reduce_avg_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_avg_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_CUDA_KERNEL(CReduceAvg, kRedAvg);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_reduce_avg,
                           GPU,
@@ -32,4 +31,4 @@ PD_REGISTER_STRUCT_KERNEL(c_reduce_avg,
                           int,
                           int64_t,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}

--- a/paddle/fluid/operators/collective/c_reduce_max_op.cc
+++ b/paddle/fluid/operators/collective/c_reduce_max_op.cc
@@ -39,7 +39,6 @@ DEFINE_C_REDUCE_CPU_KERNEL(CReduceMax, kRedMax)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_reduce_max,
                              ops::CReduceOp,

--- a/paddle/fluid/operators/collective/c_reduce_max_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_max_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_CUDA_KERNEL(CReduceMax, kRedMax);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_reduce_max,
                           GPU,

--- a/paddle/fluid/operators/collective/c_reduce_max_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_max_op_xpu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_XPU_KERNEL(CReduceMax, kRedMax);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(
     c_reduce_max, XPU, ALL_LAYOUT, ops::CReduceMaxXPUKernel, float) {}

--- a/paddle/fluid/operators/collective/c_reduce_min_op.cc
+++ b/paddle/fluid/operators/collective/c_reduce_min_op.cc
@@ -38,7 +38,6 @@ DEFINE_C_REDUCE_CPU_KERNEL(CReduceMin, kRedMin)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_reduce_min,
                              ops::CReduceOp,

--- a/paddle/fluid/operators/collective/c_reduce_min_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_min_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_CUDA_KERNEL(CReduceMin, kRedMin);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_reduce_min,
                           GPU,

--- a/paddle/fluid/operators/collective/c_reduce_min_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_min_op_xpu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_XPU_KERNEL(CReduceMin, kRedMin);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(
     c_reduce_min, XPU, ALL_LAYOUT, ops::CReduceMinXPUKernel, float) {}

--- a/paddle/fluid/operators/collective/c_reduce_prod_op.cc
+++ b/paddle/fluid/operators/collective/c_reduce_prod_op.cc
@@ -39,7 +39,6 @@ DEFINE_C_REDUCE_CPU_KERNEL(CReduceProd, kRedProd)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_reduce_prod,
                              ops::CReduceOp,

--- a/paddle/fluid/operators/collective/c_reduce_prod_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_prod_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_CUDA_KERNEL(CReduceProd, kRedProd);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_reduce_prod,
                           GPU,

--- a/paddle/fluid/operators/collective/c_reduce_prod_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_prod_op_xpu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_XPU_KERNEL(CReduceProd, kRedProd);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(
     c_reduce_prod, XPU, ALL_LAYOUT, ops::CReduceProdXPUKernel, float) {}

--- a/paddle/fluid/operators/collective/c_reduce_sum_op.cc
+++ b/paddle/fluid/operators/collective/c_reduce_sum_op.cc
@@ -39,7 +39,6 @@ DEFINE_C_REDUCE_CPU_KERNEL(CReduceSum, kRedSum)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_reduce_sum,
                              ops::CReduceOp,

--- a/paddle/fluid/operators/collective/c_reduce_sum_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_sum_op.cu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_CUDA_KERNEL(CReduceSum, kRedSum);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_reduce_sum,
                           GPU,
@@ -32,4 +31,4 @@ PD_REGISTER_STRUCT_KERNEL(c_reduce_sum,
                           int,
                           int64_t,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}

--- a/paddle/fluid/operators/collective/c_reduce_sum_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_reduce_sum_op_xpu.cc
@@ -21,7 +21,6 @@ DEFINE_C_REDUCE_XPU_KERNEL(CReduceSum, kRedSum);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(
     c_reduce_sum, XPU, ALL_LAYOUT, ops::CReduceSumXPUKernel, float) {}

--- a/paddle/fluid/operators/collective/c_reducescatter_op.cc
+++ b/paddle/fluid/operators/collective/c_reducescatter_op.cc
@@ -67,7 +67,6 @@ Reference: https://docs.nvidia.com/deeplearning/sdk/nccl-developer-guide/docs/us
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_reducescatter,
                              ops::CReduceScatterOp,

--- a/paddle/fluid/operators/collective/c_reducescatter_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_reducescatter_op.cu.cc
@@ -127,7 +127,6 @@ class CReduceScatterOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_reducescatter,
                           GPU,
@@ -136,7 +135,7 @@ PD_REGISTER_STRUCT_KERNEL(c_reducescatter,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/collective/c_scatter_op.cc
+++ b/paddle/fluid/operators/collective/c_scatter_op.cc
@@ -84,7 +84,6 @@ Scatter the source to all participators.
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_scatter, ops::CScatterOp, ops::CScatterOpMaker);
 

--- a/paddle/fluid/operators/collective/c_scatter_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_scatter_op.cu.cc
@@ -167,7 +167,6 @@ class CScatterOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_scatter,
                           GPU,

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op.cc
@@ -189,7 +189,6 @@ DECLARE_INPLACE_OP_INFERER(CSoftmaxWithCrossEntropyGradInplaceInferer,
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OPERATOR(
     c_softmax_with_cross_entropy,

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
@@ -577,7 +577,6 @@ class CSoftmaxWithCrossEntropyGrad : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_softmax_with_cross_entropy,
                           XPU,

--- a/paddle/fluid/operators/collective/c_split_op.cc
+++ b/paddle/fluid/operators/collective/c_split_op.cc
@@ -113,7 +113,6 @@ Split the tensor evenly according to its rank.
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OPERATOR(c_split,
                   ops::CSplitOp,

--- a/paddle/fluid/operators/collective/c_sync_calc_stream_op.cc
+++ b/paddle/fluid/operators/collective/c_sync_calc_stream_op.cc
@@ -32,7 +32,6 @@ Call calculation stream synchronization.
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_sync_calc_stream,
                              ops::CSyncCalcStreamOp,

--- a/paddle/fluid/operators/collective/c_sync_calc_stream_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_sync_calc_stream_op.cu.cc
@@ -14,7 +14,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/collective/c_sync_calc_stream_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_sync_calc_stream,
                           GPU,
@@ -25,4 +24,4 @@ PD_REGISTER_STRUCT_KERNEL(c_sync_calc_stream,
                           int,
                           int64_t,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}

--- a/paddle/fluid/operators/collective/c_sync_calc_stream_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_sync_calc_stream_op_xpu.cc
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/collective/c_sync_calc_stream_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_sync_calc_stream,
                           XPU,

--- a/paddle/fluid/operators/collective/c_sync_comm_stream_op.cc
+++ b/paddle/fluid/operators/collective/c_sync_comm_stream_op.cc
@@ -48,7 +48,6 @@ Call communication stream synchronization.
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(c_sync_comm_stream,
                              ops::CSyncCommStreamOp,

--- a/paddle/fluid/operators/collective/c_sync_comm_stream_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_sync_comm_stream_op.cu.cc
@@ -14,7 +14,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/collective/c_sync_comm_stream_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(
     c_sync_comm_stream, GPU, ALL_LAYOUT, ops::CSyncCommStreamKernel, float) {}

--- a/paddle/fluid/operators/collective/c_sync_comm_stream_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_sync_comm_stream_op_xpu.cc
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/collective/c_sync_comm_stream_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(c_sync_comm_stream,
                           XPU,

--- a/paddle/fluid/operators/collective/global_gather_op.cc
+++ b/paddle/fluid/operators/collective/global_gather_op.cc
@@ -104,7 +104,7 @@ class GlobalGatherOpGradMaker : public framework::SingleGradOpMaker<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 REGISTER_OPERATOR(global_gather,
                   ops::GlobalGatherOp,
                   ops::GlobalGatherOpMaker,

--- a/paddle/fluid/operators/collective/global_gather_op.cu.cc
+++ b/paddle/fluid/operators/collective/global_gather_op.cu.cc
@@ -337,7 +337,6 @@ class GlobalGatherOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(global_gather,
                           GPU,

--- a/paddle/fluid/operators/collective/global_scatter_op.cc
+++ b/paddle/fluid/operators/collective/global_scatter_op.cc
@@ -108,7 +108,7 @@ class GlobalScatterOpGradMaker : public framework::SingleGradOpMaker<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 REGISTER_OPERATOR(global_scatter,
                   ops::GlobalScatterOp,
                   ops::GlobalScatterOpMaker,

--- a/paddle/fluid/operators/collective/global_scatter_op.cu.cc
+++ b/paddle/fluid/operators/collective/global_scatter_op.cu.cc
@@ -344,7 +344,6 @@ class GlobalScatterOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(global_scatter,
                           GPU,

--- a/paddle/fluid/operators/collective/mp_allreduce_sum_op.cc
+++ b/paddle/fluid/operators/collective/mp_allreduce_sum_op.cc
@@ -79,7 +79,6 @@ DEFINE_C_ALLREDUCE_CPU_KERNEL(MpAllReduceSum, kRedSum);
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OPERATOR(mp_allreduce_sum,
                   ops::MpAllReduceSumOp,

--- a/paddle/fluid/operators/collective/mp_allreduce_sum_op.cu.cc
+++ b/paddle/fluid/operators/collective/mp_allreduce_sum_op.cu.cc
@@ -22,7 +22,7 @@ DEFINE_C_ALLREDUCE_CUDA_KERNEL(MpAllReduceSum, kRedSum)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(mp_allreduce_sum,
                           GPU,
                           ALL_LAYOUT,
@@ -32,7 +32,7 @@ PD_REGISTER_STRUCT_KERNEL(mp_allreduce_sum,
                           int,
                           int64_t,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           phi::dtype::float16) {
 }

--- a/paddle/fluid/operators/collective/mp_allreduce_sum_op_xpu.cc
+++ b/paddle/fluid/operators/collective/mp_allreduce_sum_op_xpu.cc
@@ -21,7 +21,7 @@ DEFINE_C_ALLREDUCE_XPU_KERNEL(CAllReduceSum, kRedSum)
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(mp_allreduce_sum,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/collective/partial_allgather_op.cc
+++ b/paddle/fluid/operators/collective/partial_allgather_op.cc
@@ -75,7 +75,6 @@ DECLARE_INPLACE_OP_INFERER(PartialAllGatherOpInplaceInferer, {"X", "Out"});
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OPERATOR(
     partial_allgather,

--- a/paddle/fluid/operators/collective/partial_allgather_op.cu.cc
+++ b/paddle/fluid/operators/collective/partial_allgather_op.cu.cc
@@ -147,7 +147,6 @@ class PartialAllGatherOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(partial_allgather,
                           GPU,
@@ -156,7 +155,7 @@ PD_REGISTER_STRUCT_KERNEL(partial_allgather,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/collective/partial_recv_op.cc
+++ b/paddle/fluid/operators/collective/partial_recv_op.cc
@@ -123,7 +123,6 @@ Reference: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/p2p.h
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(partial_recv,
                              ops::PartialRecvOp,

--- a/paddle/fluid/operators/collective/partial_recv_op.cu.cc
+++ b/paddle/fluid/operators/collective/partial_recv_op.cu.cc
@@ -172,7 +172,6 @@ class PartialRecvOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(partial_recv,
                           GPU,
@@ -181,7 +180,7 @@ PD_REGISTER_STRUCT_KERNEL(partial_recv,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/collective/partial_send_op.cc
+++ b/paddle/fluid/operators/collective/partial_send_op.cc
@@ -88,7 +88,6 @@ Reference: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/p2p.h
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(partial_send,
                              ops::PartialSendOp,

--- a/paddle/fluid/operators/collective/partial_send_op.cu.cc
+++ b/paddle/fluid/operators/collective/partial_send_op.cu.cc
@@ -168,7 +168,6 @@ class PartialSendCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(partial_send,
                           GPU,
@@ -177,7 +176,7 @@ PD_REGISTER_STRUCT_KERNEL(partial_send,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/collective/recv_v2_op.cc
+++ b/paddle/fluid/operators/collective/recv_v2_op.cc
@@ -110,7 +110,6 @@ Reference: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/p2p.h
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(recv_v2, ops::RecvOpV2, ops::RecvOpV2Maker);
 

--- a/paddle/fluid/operators/collective/recv_v2_op.cu.cc
+++ b/paddle/fluid/operators/collective/recv_v2_op.cu.cc
@@ -291,7 +291,6 @@ class RecvOpV2CUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(recv_v2,
                           GPU,
@@ -300,7 +299,7 @@ PD_REGISTER_STRUCT_KERNEL(recv_v2,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/collective/send_v2_op.cc
+++ b/paddle/fluid/operators/collective/send_v2_op.cc
@@ -82,7 +82,6 @@ Reference: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/p2p.h
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_WITHOUT_GRADIENT(send_v2, ops::SendOpV2, ops::SendOpV2Maker);
 

--- a/paddle/fluid/operators/collective/send_v2_op.cu.cc
+++ b/paddle/fluid/operators/collective/send_v2_op.cu.cc
@@ -266,7 +266,6 @@ class SendOpV2CUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(send_v2,
                           GPU,
@@ -275,7 +274,7 @@ PD_REGISTER_STRUCT_KERNEL(send_v2,
                           float,
                           double,
 #if NCCL_VERSION_CODE >= 21000 && CUDA_VERSION >= 11000
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
 #endif
                           int,
                           int64_t,

--- a/paddle/fluid/operators/controlflow/fetch_v2_op.cc
+++ b/paddle/fluid/operators/controlflow/fetch_v2_op.cc
@@ -245,6 +245,6 @@ PD_REGISTER_STRUCT_KERNEL(fetch_v2,
                           uint8_t,
                           bool,
                           phi::dtype::float16,
-                          plat::bfloat16,
-                          plat::complex<float>,
-                          plat::complex<double>) {}
+                          phi::dtype::bfloat16,
+                          phi::dtype::complex<float>,
+                          phi::dtype::complex<double>) {}

--- a/paddle/fluid/operators/cross_entropy_op.cu
+++ b/paddle/fluid/operators/cross_entropy_op.cu
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/cross_entropy_op.h"
 #include "paddle/phi/common/float16.h"
 
-namespace plat = paddle::platform;
 namespace ops = paddle::operators;
 
 PD_REGISTER_STRUCT_KERNEL(cross_entropy,

--- a/paddle/fluid/operators/flatten_op_xpu.cc
+++ b/paddle/fluid/operators/flatten_op_xpu.cc
@@ -17,7 +17,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/flatten_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_XPU_KERNEL(
     flatten2,

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cu
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cu
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/fused/fused_elemwise_activation_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 PD_REGISTER_STRUCT_KERNEL(fused_elemwise_activation,
                           GPU,

--- a/paddle/fluid/operators/fused/fused_gate_attention_op.cu
+++ b/paddle/fluid/operators/fused/fused_gate_attention_op.cu
@@ -616,7 +616,7 @@ class FusedGateAttentionGradKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 #ifdef PADDLE_WITH_HIP
 PD_REGISTER_STRUCT_KERNEL(fused_gate_attention,
                           GPU,
@@ -624,14 +624,14 @@ PD_REGISTER_STRUCT_KERNEL(fused_gate_attention,
                           ops::FusedGateAttentionOpKernel,
                           float,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}
 PD_REGISTER_STRUCT_KERNEL(fused_gate_attention_grad,
                           GPU,
                           ALL_LAYOUT,
                           ops::FusedGateAttentionGradKernel,
                           float,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}
 #else
 PD_REGISTER_STRUCT_KERNEL(fused_gate_attention,
                           GPU,
@@ -640,7 +640,7 @@ PD_REGISTER_STRUCT_KERNEL(fused_gate_attention,
                           float,
                           double,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}
 PD_REGISTER_STRUCT_KERNEL(fused_gate_attention_grad,
                           GPU,
                           ALL_LAYOUT,
@@ -648,5 +648,5 @@ PD_REGISTER_STRUCT_KERNEL(fused_gate_attention_grad,
                           float,
                           double,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}
 #endif

--- a/paddle/fluid/operators/fused/fused_multi_transformer_int8_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_int8_op.cu
@@ -662,7 +662,7 @@ class FusedMultiTransformerINT8OpKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(fused_multi_transformer_int8,
                           GPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/fused/resnet_basic_block_op_xpu.cc
+++ b/paddle/fluid/operators/fused/resnet_basic_block_op_xpu.cc
@@ -993,7 +993,7 @@ class ResNetBasicBlockGradXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(resnet_basic_block,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/fused/resnet_unit_op.cu
+++ b/paddle/fluid/operators/fused/resnet_unit_op.cu
@@ -418,7 +418,7 @@ class ResNetUnitGradKernel : public framework::OpKernel<T> {
 
 #if CUDNN_VERSION >= 8000
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(
     resnet_unit, GPU, ALL_LAYOUT, ops::ResNetUnitKernel, phi::dtype::float16) {}
 PD_REGISTER_STRUCT_KERNEL(resnet_unit_grad,

--- a/paddle/fluid/operators/fused/resnet_unit_op_xpu.cc
+++ b/paddle/fluid/operators/fused/resnet_unit_op_xpu.cc
@@ -358,7 +358,7 @@ class ResNetUnitGradXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(resnet_unit,
                           XPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/isfinite_op.cu
+++ b/paddle/fluid/operators/isfinite_op.cu
@@ -26,7 +26,9 @@ REGISTER_OP_CUDA_KERNEL(
     ops::OverflowKernel<phi::GPUContext,
                         phi::dtype::float16,
                         ops::InfinityFunctor>,
-    ops::OverflowKernel<phi::GPUContext, plat::bfloat16, ops::InfinityFunctor>);
+    ops::OverflowKernel<phi::GPUContext,
+                        phi::dtype::bfloat16,
+                        ops::InfinityFunctor>);
 
 REGISTER_OP_CUDA_KERNEL(
     isnan,
@@ -34,4 +36,5 @@ REGISTER_OP_CUDA_KERNEL(
     ops::OverflowKernel<phi::GPUContext, float, ops::NANFunctor>,
     ops::OverflowKernel<phi::GPUContext, double, ops::NANFunctor>,
     ops::OverflowKernel<phi::GPUContext, phi::dtype::float16, ops::NANFunctor>,
-    ops::OverflowKernel<phi::GPUContext, plat::bfloat16, ops::NANFunctor>);
+    ops::
+        OverflowKernel<phi::GPUContext, phi::dtype::bfloat16, ops::NANFunctor>);

--- a/paddle/fluid/operators/load_combine_op.cc
+++ b/paddle/fluid/operators/load_combine_op.cc
@@ -89,7 +89,7 @@ PD_REGISTER_STRUCT_KERNEL(load_combine,
                           ops::LoadCombineOpKernel,
                           float,
                           double,
-                          plat::bfloat16,
+                          phi::dtype::bfloat16,
                           int,
                           int8_t,
                           int64_t) {}

--- a/paddle/fluid/operators/lod_reset_op.cc
+++ b/paddle/fluid/operators/lod_reset_op.cc
@@ -235,7 +235,6 @@ DECLARE_NO_NEED_BUFFER_VARS_INFERER(LoDResetGradNoNeedBufferVarInferer, "X");
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 REGISTER_OPERATOR(lod_reset,
                   ops::LoDResetOp,
                   ops::LoDResetOpMaker,

--- a/paddle/fluid/operators/matmul_op_xpu.cc
+++ b/paddle/fluid/operators/matmul_op_xpu.cc
@@ -150,19 +150,19 @@ class MatMulGradXPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OP_XPU_KERNEL(
     matmul,
     ops::MatMulXPUKernel<paddle::platform::XPUDeviceContext, float>,
-    ops::MatMulXPUKernel<paddle::platform::XPUDeviceContext, plat::bfloat16>,
+    ops::MatMulXPUKernel<paddle::platform::XPUDeviceContext,
+                         phi::dtype::bfloat16>,
     ops::MatMulXPUKernel<paddle::platform::XPUDeviceContext,
                          phi::dtype::float16>);
 REGISTER_OP_XPU_KERNEL(
     matmul_grad,
     ops::MatMulGradXPUKernel<paddle::platform::XPUDeviceContext, float>,
     ops::MatMulGradXPUKernel<paddle::platform::XPUDeviceContext,
-                             plat::bfloat16>,
+                             phi::dtype::bfloat16>,
     ops::MatMulGradXPUKernel<paddle::platform::XPUDeviceContext,
                              phi::dtype::float16>);
 #endif

--- a/paddle/fluid/operators/optimizers/sparse_momentum_op.cu
+++ b/paddle/fluid/operators/optimizers/sparse_momentum_op.cu
@@ -17,7 +17,7 @@
 #include "paddle/phi/common/float16.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(sparse_momentum,
                           GPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/partial_concat_op.cu
+++ b/paddle/fluid/operators/partial_concat_op.cu
@@ -16,8 +16,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/partial_concat_op.h"
 #include "paddle/phi/common/float16.h"
 
-namespace plat = paddle::platform;
-
 namespace paddle {
 namespace operators {
 

--- a/paddle/fluid/operators/partial_sum_op.cu
+++ b/paddle/fluid/operators/partial_sum_op.cu
@@ -16,8 +16,6 @@ limitations under the License. */
 #include "paddle/fluid/operators/partial_sum_op.h"
 #include "paddle/phi/common/float16.h"
 
-namespace plat = paddle::platform;
-
 namespace paddle {
 namespace operators {
 

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -700,7 +700,6 @@ DECLARE_NO_NEED_BUFFER_VARS_INFERER(ReshapeDoubleGradOpNoNeedBufferVarInferer,
 }  // namespace operators
 }  // namespace paddle
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
 
 REGISTER_OPERATOR(
     reshape,
@@ -776,7 +775,7 @@ REGISTER_OP_CUDA_KERNEL_FUNCTOR(reshape,
                                 ops::ReshapeKernel,
                                 phi::dtype::float16,
                                 ops::ReshapeKernel,
-                                plat::bfloat16,
+                                phi::dtype::bfloat16,
                                 ops::ReshapeKernel);
 REGISTER_OP_CUDA_KERNEL_FUNCTOR(reshape_grad,
                                 float,
@@ -793,6 +792,6 @@ REGISTER_OP_CUDA_KERNEL_FUNCTOR(reshape_grad,
                                 ops::ReshapeGradKernel,
                                 phi::dtype::float16,
                                 ops::ReshapeGradKernel,
-                                plat::bfloat16,
+                                phi::dtype::bfloat16,
                                 ops::ReshapeGradKernel);
 #endif

--- a/paddle/fluid/operators/share_data_op.cc
+++ b/paddle/fluid/operators/share_data_op.cc
@@ -62,7 +62,7 @@ Return a tensor $Out$ that shares data with the input tensor $X$ and without ten
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 REGISTER_OPERATOR(
     share_data,
     ops::ShareDataOp,

--- a/paddle/fluid/operators/share_data_op.cu
+++ b/paddle/fluid/operators/share_data_op.cu
@@ -15,7 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/share_data_op.h"
 
 namespace ops = paddle::operators;
-namespace plat = paddle::platform;
+
 PD_REGISTER_STRUCT_KERNEL(share_data,
                           GPU,
                           ALL_LAYOUT,

--- a/paddle/fluid/operators/soft_relu_op.cu
+++ b/paddle/fluid/operators/soft_relu_op.cu
@@ -40,7 +40,7 @@ PD_REGISTER_STRUCT_KERNEL(soft_relu,
                           float,
                           double,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}
 PD_REGISTER_STRUCT_KERNEL(soft_relu_grad,
                           GPU,
                           ALL_LAYOUT,
@@ -48,4 +48,4 @@ PD_REGISTER_STRUCT_KERNEL(soft_relu_grad,
                           float,
                           double,
                           phi::dtype::float16,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}

--- a/paddle/fluid/operators/uniform_random_batch_size_like_op.cc
+++ b/paddle/fluid/operators/uniform_random_batch_size_like_op.cc
@@ -194,4 +194,4 @@ PD_REGISTER_STRUCT_KERNEL(uniform_random_batch_size_like,
                           ops::CPUUniformRandomKernel,
                           float,
                           double,
-                          plat::bfloat16) {}
+                          phi::dtype::bfloat16) {}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Replace plat::bfloat16 phi::dtype::bfloat16 in paddle/fluid/operators