### PR TITLE
refactor operation dist attr to support the input&output is tensor list.

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/attribute_storage.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/attribute_storage.h
@@ -121,12 +121,12 @@ class OperationDistAttrStorage : public pir::AttributeStorage {
   /// \brief Declare ParamKey according to parameter type.
   ///
   using ParamKey = std::tuple<ProcessMeshAttribute,
-                              std::vector<TensorDistAttribute>,
-                              std::vector<TensorDistAttribute>>;
+                              std::vector<pir::Attribute>,
+                              std::vector<pir::Attribute>>;
   OperationDistAttrStorage(ParamKey&& param)  // NOLINT
       : mesh_attr(std::get<0>(param)),
-        operand_dist_attrs(std::get<1>(param)),
-        result_dist_attrs(std::get<2>(param)) {}
+        operand_attrs(std::get<1>(param)),
+        result_attrs(std::get<2>(param)) {}
 
   ///
   /// \brief Each derived TypeStorage must define a Construct method, which
@@ -156,14 +156,13 @@ class OperationDistAttrStorage : public pir::AttributeStorage {
   /// \brief Each derived TypeStorage needs to overload operator==.
   ///
   bool operator==(const ParamKey& key) const {
-    return mesh_attr == std::get<0>(key) &&
-           operand_dist_attrs == std::get<1>(key) &&
-           result_dist_attrs == std::get<2>(key);
+    return mesh_attr == std::get<0>(key) && operand_attrs == std::get<1>(key) &&
+           result_attrs == std::get<2>(key);
   }
 
   ProcessMeshAttribute mesh_attr;
-  std::vector<TensorDistAttribute> operand_dist_attrs;
-  std::vector<TensorDistAttribute> result_dist_attrs;
+  std::vector<pir::Attribute> operand_attrs;
+  std::vector<pir::Attribute> result_attrs;
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.cc
@@ -78,48 +78,68 @@ TensorDistAttribute TensorDistAttribute::get(
 ProcessMeshAttribute OperationDistAttribute::process_mesh_attr() const {
   return storage()->mesh_attr;
 }
-const std::vector<TensorDistAttribute>&
-OperationDistAttribute::operand_dist_attrs() const {
-  return storage()->operand_dist_attrs;
+const std::vector<pir::Attribute>& OperationDistAttribute::operand_attrs()
+    const {
+  return storage()->operand_attrs;
 }
 TensorDistAttribute OperationDistAttribute::operand_dist_attr(
     uint32_t index) const {
-  return operand_dist_attrs().at(index);
-}
-uint32_t OperationDistAttribute::num_operand_dist_attrs() const {
-  return operand_dist_attrs().size();
+  return operand_attrs().at(index).dyn_cast<TensorDistAttribute>();
 }
 
-const std::vector<TensorDistAttribute>&
-OperationDistAttribute::result_dist_attrs() const {
-  return storage()->result_dist_attrs;
+pir::ArrayAttribute OperationDistAttribute::operand_array_attr(
+    uint32_t index) const {
+  return operand_attrs().at(index).dyn_cast<pir::ArrayAttribute>();
+}
+
+uint32_t OperationDistAttribute::num_operands() const {
+  return operand_attrs().size();
+}
+
+const std::vector<pir::Attribute>& OperationDistAttribute::result_attrs()
+    const {
+  return storage()->result_attrs;
 }
 TensorDistAttribute OperationDistAttribute::result_dist_attr(
     uint32_t index) const {
-  return result_dist_attrs().at(index);
+  return result_attrs().at(index).dyn_cast<TensorDistAttribute>();
 }
-uint32_t OperationDistAttribute::num_result_dist_attrs() const {
-  return result_dist_attrs().size();
+
+pir::ArrayAttribute OperationDistAttribute::result_array_attr(
+    uint32_t index) const {
+  return result_attrs().at(index).dyn_cast<pir::ArrayAttribute>();
 }
+
+uint32_t OperationDistAttribute::num_results() const {
+  return result_attrs().size();
+}
+
 OperationDistAttribute OperationDistAttribute::get(
     pir::IrContext* ctx,
     ProcessMeshAttribute mesh,
-    const std::vector<TensorDistAttribute>& operand_dist_attrs,
-    const std::vector<TensorDistAttribute>& result_dist_attrs) {
-  for (const auto& iter : operand_dist_attrs) {
+    const std::vector<pir::Attribute>& operand_attrs,
+    const std::vector<pir::Attribute>& result_attrs) {
+  auto check_dist_attr = [=](pir::Attribute attr) {
+    auto dist_attr = attr.dyn_cast<TensorDistAttribute>();
+    PADDLE_ENFORCE_EQ(mesh,
+                      dist_attr.process_mesh_attr(),
+                      common::errors::PreconditionNotMet(
+                          "operand_dist_attrs element's mesh(%s) not equal "
+                          "to input mesh(%s)"));
+  };
+  for (auto attr : operand_attrs) {
     // NOTE: The operand dist attr maybe empty while the corresponding input is
     // optional.
-    if (iter) {
-      PADDLE_ENFORCE_EQ(mesh,
-                        iter.process_mesh_attr(),
-                        common::errors::PreconditionNotMet(
-                            "operand_dist_attrs element's mesh(%s) not equal "
-                            "to input mesh(%s)",
-                            iter.process_mesh_attr(),
-                            mesh));
+    if (!attr) continue;
+    if (auto array_attr = attr.dyn_cast<pir::ArrayAttribute>()) {
+      for (size_t i = 0; i < array_attr.size(); ++i) {
+        check_dist_attr(array_attr[i]);
+      }
+    } else {
+      check_dist_attr(attr);
     }
   }
-  return Base::get(ctx, mesh, operand_dist_attrs, result_dist_attrs);
+  return Base::get(ctx, mesh, operand_attrs, result_attrs);
 }
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.h
@@ -17,6 +17,7 @@
 #include "paddle/phi/common/reduce_type.h"
 #include "paddle/phi/core/distributed/auto_parallel/process_mesh.h"
 #include "paddle/pir/include/core/attribute.h"
+#include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/builtin_attribute_storage.h"
 #include "paddle/pir/include/core/utils.h"
 #include "paddle/utils/flat_hash_map.h"
@@ -104,29 +105,28 @@ class OperationDistAttribute : public pir::AttrBase<OperationDistAttribute,
   using Base::Base;
   ProcessMeshAttribute process_mesh_attr() const;
 
-  const std::vector<TensorDistAttribute>& operand_dist_attrs() const;
+  const std::vector<Attribute>& operand_attrs() const;
   TensorDistAttribute operand_dist_attr(uint32_t index) const;
-  uint32_t num_operand_dist_attrs() const;
+  pir::ArrayAttribute operand_array_attr(uint32_t index) const;
+  uint32_t num_operands() const;
 
-  const std::vector<TensorDistAttribute>& result_dist_attrs() const;
+  const std::vector<Attribute>& result_attrs() const;
   TensorDistAttribute result_dist_attr(uint32_t index) const;
-  uint32_t num_result_dist_attrs() const;
+  pir::ArrayAttribute result_array_attr(uint32_t index) const;
+  uint32_t num_results() const;
 
-  static OperationDistAttribute get(
-      pir::IrContext* ctx,
-      ProcessMeshAttribute mesh,
-      const std::vector<TensorDistAttribute>& operand_dist_attrs,
-      const std::vector<TensorDistAttribute>& result_dist_attrs);
+  static OperationDistAttribute get(pir::IrContext* ctx,
+                                    ProcessMeshAttribute mesh,
+                                    const std::vector<Attribute>& operand_attrs,
+                                    const std::vector<Attribute>& result_attrs);
 
   static OperationDistAttribute get(
       pir::IrContext* ctx,
       const phi::distributed::ProcessMesh& mesh,
-      const std::vector<TensorDistAttribute>& operand_dist_attrs,
-      const std::vector<TensorDistAttribute>& result_dist_attrs) {
-    return get(ctx,
-               ProcessMeshAttribute::get(ctx, mesh),
-               operand_dist_attrs,
-               result_dist_attrs);
+      const std::vector<Attribute>& operand_attrs,
+      const std::vector<Attribute>& result_attrs) {
+    return get(
+        ctx, ProcessMeshAttribute::get(ctx, mesh), operand_attrs, result_attrs);
   }
 };
 

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -98,7 +98,7 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
               phi::distributed::auto_parallel::str_join(
                   op_dist_attr.process_mesh_attr().process_ids()) +
               "]}";
-    auto num_operand_dist_attrs = op_dist_attr.num_operand_dist_attrs();
+    auto num_operand_dist_attrs = op_dist_attr.num_operands();
     for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.operand_dist_attr(i);
       os << ",operand(" + std::to_string(i) + "):{";
@@ -132,7 +132,7 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
         os << "}";
       }
     }
-    auto num_result_dist_attrs = op_dist_attr.num_result_dist_attrs();
+    auto num_result_dist_attrs = op_dist_attr.num_results();
     for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
       auto dist_attr = op_dist_attr.result_dist_attr(i);
       os << ",result(" + std::to_string(i) + "):{";

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_interface.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_interface.h
@@ -26,19 +26,24 @@ class IR_API DistTypeInterface
  public:
   struct Concept {
     /// Defined these methods with the interface.
-    explicit Concept(pir::Type (*local_type)(pir::Type),
-                     ProcessMeshAttribute (*process_mesh_attr)(pir::Type),
-                     TensorDistAttribute (*tensor_dist_attr)(pir::Type),
-                     pir::Type (*copy_with_new_mesh)(pir::Type,
-                                                     ProcessMeshAttribute mesh))
+    explicit Concept(
+        pir::Type (*local_type)(pir::Type),
+        ProcessMeshAttribute (*process_mesh_attr)(pir::Type),
+        TensorDistAttribute (*tensor_dist_attr)(pir::Type),
+        pir::Type (*copy_with_new_mesh)(pir::Type, ProcessMeshAttribute mesh),
+        pir::Type (*copy_with_new_dist_attr)(pir::Type,
+                                             TensorDistAttribute dist_attr))
         : local_type(local_type),
           process_mesh_attr(process_mesh_attr),
           tensor_dist_attr(tensor_dist_attr),
-          copy_with_new_mesh(copy_with_new_mesh) {}
+          copy_with_new_mesh(copy_with_new_mesh),
+          copy_with_new_dist_attr(copy_with_new_dist_attr) {}
     pir::Type (*local_type)(pir::Type);
     ProcessMeshAttribute (*process_mesh_attr)(pir::Type);
     TensorDistAttribute (*tensor_dist_attr)(pir::Type);
     pir::Type (*copy_with_new_mesh)(pir::Type, ProcessMeshAttribute mesh);
+    pir::Type (*copy_with_new_dist_attr)(pir::Type,
+                                         TensorDistAttribute dist_attr);
   };
 
   template <class ConcreteType>
@@ -58,11 +63,16 @@ class IR_API DistTypeInterface
       return pir::cast<ConcreteType>(type).CopyWithNewMesh(mesh);
     }
 
+    static Type CopyWithNewDistAttr(Type type, TensorDistAttribute dist_attr) {
+      return pir::cast<ConcreteType>(type).CopyWithNewDistAttr(dist_attr);
+    }
+
     Model()
         : Concept(local_type,
                   process_mesh_attr,
                   tensor_dist_attr,
-                  CopyWithNewMesh) {}
+                  CopyWithNewMesh,
+                  CopyWithNewDistAttr) {}
   };
 
   DistTypeInterface(pir::Type type, Concept *impl)
@@ -80,6 +90,11 @@ class IR_API DistTypeInterface
 
   DistTypeInterface CopyWithNewMesh(ProcessMeshAttribute mesh) {
     return DistTypeInterface(impl_->copy_with_new_mesh(*this, mesh), impl_);
+  }
+
+  DistTypeInterface CopyWithNewDistAttr(TensorDistAttribute dist_attr) {
+    return DistTypeInterface(impl_->copy_with_new_dist_attr(*this, dist_attr),
+                             impl_);
   }
 
  private:

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
@@ -37,11 +37,10 @@ void ShardTensorOp::VerifySig() {
   VLOG(4) << "Verifying inputs:";
   {
     auto input_size = num_operands();
-    PADDLE_ENFORCE_EQ(
-        input_size,
-        1u,
-        common::errors::PreconditionNotMet(
-            "The size %d of inputs must be equal to 1.", input_size));
+    PADDLE_ENFORCE_EQ(input_size,
+                      1u,
+                      common::errors::PreconditionNotMet(
+                          "The size of inputs must be equal to 1."));
     PADDLE_ENFORCE_EQ((*this)
                           ->operand_source(0)
                           .type()
@@ -80,19 +79,18 @@ void ShardTensorOp::VerifySig() {
     auto op_dist_attr =
         this->attribute<paddle::dialect::OperationDistAttribute>(
             "op_dist_attr");
-    PADDLE_ENFORCE_EQ(op_dist_attr.num_operand_dist_attrs(),
+    PADDLE_ENFORCE_EQ(op_dist_attr.num_operands(),
                       0u,
-                      common::errors::PreconditionNotMet(
-                          "The op_dist_attr input size %d must be equal to 0.",
-                          op_dist_attr.num_operand_dist_attrs()));
+                      phi::errors::PreconditionNotMet(
+                          "The op_dist_attr input size must be equal to 0."));
 
-    PADDLE_ENFORCE_EQ(op_dist_attr.num_result_dist_attrs(),
-                      num_results(),
-                      common::errors::PreconditionNotMet(
-                          "The op_dist_attr output size %d must "
-                          "be equal to op output size %d.",
-                          op_dist_attr.num_result_dist_attrs(),
-                          num_results()));
+    PADDLE_ENFORCE_EQ(
+        op_dist_attr.num_results(),
+        num_results(),
+        phi::errors::PreconditionNotMet("The op_dist_attr output size %d must "
+                                        "be equal to op output size %d.",
+                                        op_dist_attr.num_results(),
+                                        num_results()));
   }
   VLOG(4) << "End Verifying for: ShardTensorOp.";
 }
@@ -137,8 +135,8 @@ void ShardTensorOp::Build(pir::Builder& builder,
   pir::Attribute op_dist_attr = OperationDistAttribute::get(
       pir::IrContext::Instance(),
       process_mesh_attr,
-      std::vector<TensorDistAttribute>(),
-      std::vector<TensorDistAttribute>{tensor_dist_attr});
+      std::vector<pir::Attribute>(),
+      std::vector<pir::Attribute>{tensor_dist_attr});
   argument.AddAttribute("op_dist_attr", op_dist_attr);
 
   VLOG(4) << "Builder construction outputs";
@@ -254,19 +252,17 @@ void ReshardOp::VerifySig() {
     auto op_dist_attr =
         this->attribute<paddle::dialect::OperationDistAttribute>(
             "op_dist_attr");
-    PADDLE_ENFORCE_EQ(op_dist_attr.num_operand_dist_attrs(),
-                      1u,
-                      common::errors::PreconditionNotMet(
-                          "The op_dist_attr input size %d must be equal to 1.",
-                          op_dist_attr.num_operand_dist_attrs()));
+    PADDLE_ENFORCE_EQ(
+        op_dist_attr.num_operands(),
+        1u,
+        common::errors::PreconditionNotMet(
+            "The op_dist_attr input size of reshard op must be equal to 1."));
 
-    PADDLE_ENFORCE_EQ(op_dist_attr.num_result_dist_attrs(),
+    PADDLE_ENFORCE_EQ(op_dist_attr.num_results(),
                       num_results(),
-                      common::errors::PreconditionNotMet(
-                          "The op_dist_attr output size %d must "
-                          "be equal to op output size %d.",
-                          op_dist_attr.num_result_dist_attrs(),
-                          num_results()));
+                      phi::errors::PreconditionNotMet(
+                          "The op_dist_attr output size of reshard op must be "
+                          "equal to op output size."));
   }
   VLOG(4) << "End Verifying for: ShardTensorOp.";
 }
@@ -293,8 +289,8 @@ void ReshardOp::Build(pir::Builder& builder,
   pir::Attribute op_dist_attr = OperationDistAttribute::get(
       pir::IrContext::Instance(),
       input_tensor_type.tensor_dist_attr().process_mesh_attr(),
-      std::vector<TensorDistAttribute>{input_tensor_type.tensor_dist_attr()},
-      std::vector<TensorDistAttribute>{tensor_dist_attr});
+      std::vector<pir::Attribute>{input_tensor_type.tensor_dist_attr()},
+      std::vector<pir::Attribute>{tensor_dist_attr});
   argument.AddAttribute("op_dist_attr", op_dist_attr);
 
   VLOG(4) << "Builder construction outputs";

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_type.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_type.h
@@ -64,8 +64,11 @@ class DistDenseTensorType
   DistDenseTensorType CopyWithNewMesh(ProcessMeshAttribute mesh) {
     return get(ir_context(),
                dense_tensor_type(),
-               tensor_dist_attr().CopyWithNewMesh(mesh),
-               local_ddim());
+               tensor_dist_attr().CopyWithNewMesh(mesh));
+  }
+
+  DistDenseTensorType CopyWithNewDistAttr(TensorDistAttribute dist_attr) {
+    return get(ir_context(), dense_tensor_type(), dist_attr);
   }
 
   static DistDenseTensorType get(pir::IrContext* ctx,

--- a/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_verify_gen.py
@@ -19,8 +19,8 @@ void {op_name}::VerifySig() {{
   VLOG(4) << "Verifying inputs:";
   {{
   auto input_size = num_operands();
-  PADDLE_ENFORCE_EQ(input_size == {inputs_size}u, true, phi::errors::InvalidArgument(
-                    "The size %d of inputs must be equal to {inputs_size}.", input_size));{inputs_type_check}
+  PADDLE_ENFORCE_EQ(input_size , {inputs_size}, common::errors::InvalidArgument(
+                    "The size of inputs must be equal to {inputs_size}."));{inputs_type_check}
   }}
   VLOG(4) << "Verifying attributes:";
   {{{attributes_check}
@@ -28,8 +28,8 @@ void {op_name}::VerifySig() {{
   VLOG(4) << "Verifying outputs:";
   {{
   auto output_size = num_results();
-  PADDLE_ENFORCE_EQ(output_size == {outputs_size}u, true, phi::errors::InvalidArgument(
-                    "The size %d of outputs must be equal to {outputs_size}.", output_size));{outputs_type_check}
+  PADDLE_ENFORCE_EQ(output_size, {outputs_size}, common::errors::InvalidArgument(
+                    "The size of outputs must be equal to {outputs_size}."));{outputs_type_check}
   }}
   VLOG(4) << "End Verifying for: {op_name}.";
 }}

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -731,43 +731,66 @@ void BindVjp(pybind11::module *m) {
             fwd_op.dyn_cast<paddle::dialect::VjpInterface>();
         PADDLE_ENFORCE(
             vjp_interface,
-            phi::errors::InvalidArgument(
+            common::errors::InvalidArgument(
                 "The vjp function is not registered in %s op ", fwd_op.name()));
         std::vector<std::vector<pir::Value>> vjp_res = vjp_interface.Vjp(
             &fwd_op, inputs, outputs, out_grads, stop_gradients);
         PADDLE_ENFORCE_EQ(
             stop_gradients.size(),
             vjp_res.size(),
-            phi::errors::InvalidArgument(
-                "The size of stop_gradients should be the same as vjp_res "
-                "size."
-                "But the size of stop_gradients: %d, vjp_res size: %d",
-                stop_gradients.size(),
-                vjp_res.size()));
+            common::errors::InvalidArgument(
+                "The size of  %s stop_gradients should be the same as vjp_res "
+                "size.",
+                fwd_op.name()));
+
         for (size_t i = 0; i < vjp_res.size(); ++i) {
           PADDLE_ENFORCE_EQ(stop_gradients[i].size(),
                             vjp_res[i].size(),
                             phi::errors::InvalidArgument(
                                 "The size of stop_gradients[%d] should be the "
-                                "same as vjp_res[%d] "
-                                "size."
-                                "But the size of stop_gradients[%d]: %d, "
-                                "vjp_res[%d] size: %d",
+                                "same as vjp_res[%d] size.",
                                 i,
-                                i,
-                                i,
-                                stop_gradients[i].size(),
-                                i,
-                                vjp_res[i].size()));
+                                i));
           py::list sub_res;
           for (size_t j = 0; j < vjp_res[i].size(); ++j) {
             if (!vjp_res[i][j]) {
               sub_res.append(nullptr);
             } else {
+              // The grad_type must equal to forward type.
               sub_res.append(vjp_res[i][j]);
             }
           }
           res.append(sub_res);
+        }
+
+        paddle::dialect::OpYamlInfoInterface yaml_interface =
+            fwd_op.dyn_cast<paddle::dialect::OpYamlInfoInterface>();
+        if (yaml_interface) {
+          auto inputs_grad_info = std::get<0>(yaml_interface.GetOpInfo());
+          PADDLE_ENFORCE_EQ(inputs.size(),
+                            inputs_grad_info.size(),
+                            common::errors::InvalidArgument(
+                                "The size of %s inputs should be the "
+                                "same as inputs_grad_info size.",
+                                fwd_op.name()));
+          size_t grad_index = 0;
+          for (size_t idx = 0; idx < inputs.size(); ++idx) {
+            if (!inputs_grad_info[idx].with_grad_semantic) continue;
+            PADDLE_ENFORCE_EQ(inputs[idx].size(),
+                              vjp_res[grad_index].size(),
+                              common::errors::InvalidArgument(
+                                  "The size of inouts[%d] should be the "
+                                  "same as vjp_res[%d] size.",
+                                  idx,
+                                  grad_index));
+            for (size_t j = 0; j < inputs[idx].size(); ++j) {
+              if (vjp_res[grad_index][j]) {
+                // The grad_type must equal to forward type.
+                vjp_res[grad_index][j].set_type(inputs[idx][j].type());
+              }
+            }
+            ++grad_index;
+          }
         }
         return res;
       });

--- a/paddle/pir/src/core/builtin_op.cc
+++ b/paddle/pir/src/core/builtin_op.cc
@@ -68,12 +68,12 @@ Program *ModuleOp::program() {
 Block &ModuleOp::block() {
   PADDLE_ENFORCE_GT(operation()->num_regions(),
                     0,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The region size of ModuleOp must be equal to 1."));
   auto &region = (*this)->region(0);
   PADDLE_ENFORCE_EQ(region.size(),
                     1,
-                    phi::errors::InvalidArgument(
+                    common::errors::InvalidArgument(
                         "The region size of ModuleOp must be equal to 1."));
   return region.front();
 }
@@ -98,10 +98,10 @@ void ModuleOp::Destroy() {
 void ModuleOp::VerifySig() const {
   VLOG(10) << "Verifying inputs, outputs and attributes for: ModuleOp.";
   // Verify inputs:
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      0u,
-      phi::errors::InvalidArgument("The size of inputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_operands(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 0."));
 
   // Verify attributes:
   auto &attributes = this->attributes();
@@ -109,13 +109,14 @@ void ModuleOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       iter != attributes.end() && iter->second.isa<PointerAttribute>(),
       true,
-      phi::errors::InvalidArgument("Type of attribute: program is not right."));
+      common::errors::InvalidArgument(
+          "Type of attribute: program is not right."));
 
   // Verify outputs:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      0u,
-      phi::errors::InvalidArgument("The size of inputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 0."));
 }
 
 const char *ParameterOp::attributes_name[attributes_num] = {  // NOLINT
@@ -144,10 +145,10 @@ std::string ParameterOp::param_name() const {
 void ParameterOp::VerifySig() const {
   VLOG(10) << "Verifying inputs, outputs and attributes for: ParameterOp.";
   // Verify inputs:
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      0u,
-      phi::errors::InvalidArgument("The size of inputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_operands(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 0."));
 
   // Verify if attributes contain attribute name in attributes_name:
   auto &attributes = this->attributes();
@@ -155,14 +156,14 @@ void ParameterOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       iter != attributes.end() && iter->second.isa<StrAttribute>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Type of attribute: parameter_name is not right."));
 
   // Verify outputs type:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      1u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 1."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    1u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 1."));
 }
 
 const char *SetParameterOp::attributes_name[attributes_num] = {  // NOLINT
@@ -179,10 +180,10 @@ void SetParameterOp::Build(Builder &builder,             // NOLINT
 void SetParameterOp::VerifySig() const {
   VLOG(10) << "Verifying inputs, outputs and attributes for: SetParameterOp.";
   // Verify inputs:
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      1,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 1."));
+  PADDLE_ENFORCE_EQ(num_operands(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 1."));
 
   // Verify attributes:
   auto &attributes = this->attributes();
@@ -190,14 +191,14 @@ void SetParameterOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       iter != attributes.end() && iter->second.isa<StrAttribute>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Type of attribute: parameter_name is not right."));
 
   // Verify outputs:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      0u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 0."));
 }
 
 const char *ShadowOutputOp::attributes_name[attributes_num] = {  // NOLINT
@@ -214,10 +215,10 @@ void ShadowOutputOp::Build(Builder &builder,             // NOLINT
 void ShadowOutputOp::VerifySig() const {
   VLOG(10) << "Verifying inputs, outputs and attributes for: ShadowOutputOp.";
   // Verify inputs:
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      1,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 1."));
+  PADDLE_ENFORCE_EQ(num_operands(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 1."));
 
   // Verify attributes:
   auto &attributes = this->attributes();
@@ -225,14 +226,14 @@ void ShadowOutputOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       iter != attributes.end() && iter->second.isa<StrAttribute>(),
       true,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "Type of attribute: output_name is not right."));
 
   // Verify outputs:
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      0u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 0."));
 }
 
 void CombineOp::Build(Builder &builder,
@@ -249,16 +250,16 @@ void CombineOp::Build(Builder &builder,
 
 void CombineOp::VerifySig() const {
   // outputs.size() == 1
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      1u,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 1."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    1u,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 1."));
 
   // output_type == Vector<Type>
   auto output_type = (*this)->result(0).type().dyn_cast<VectorType>();
   PADDLE_ENFORCE_NOT_NULL(
       output_type,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The type of outputs[0] must be equal to VectorType."));
 
   // inputs.size() == outputs[0].size()
@@ -266,7 +267,7 @@ void CombineOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       output_type.size(),
       input_num,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size %d of output must be equal to size %d of inputs.",
           output_type.size(),
           input_num));
@@ -277,12 +278,12 @@ void CombineOp::VerifySig() const {
     PADDLE_ENFORCE_EQ(
         output_type[i],
         type,
-        phi::errors::InvalidArgument("The type %s of outputs[0][%d] must be "
-                                     "equal to type %s of inputs[%d].",
-                                     output_type[i],
-                                     i,
-                                     type,
-                                     i));
+        common::errors::InvalidArgument("The type %s of outputs[0][%d] must be "
+                                        "equal to type %s of inputs[%d].",
+                                        output_type[i],
+                                        i,
+                                        type,
+                                        i));
   }
 }
 
@@ -309,7 +310,7 @@ void SliceOp::PassStopGradients(OperationArgument &argument, int index) {
     if (defining_op && defining_op->isa<CombineOp>()) {
       PADDLE_ENFORCE_EQ(defining_op->HasAttribute(kStopGradientAttrName),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Required CombineOp must have attribute %s",
                             kStopGradientAttrName));
       auto attrs = defining_op->attribute(kStopGradientAttrName)
@@ -332,7 +333,7 @@ void SliceOp::RefreshStopGradients() {
     if (defining_op && defining_op->isa<CombineOp>()) {
       PADDLE_ENFORCE_EQ(defining_op->HasAttribute(kStopGradientAttrName),
                         true,
-                        phi::errors::InvalidArgument(
+                        common::errors::InvalidArgument(
                             "Required CombineOp must have attribute %s",
                             kStopGradientAttrName));
       auto attr = defining_op->attribute(kStopGradientAttrName)
@@ -348,17 +349,16 @@ void SliceOp::RefreshStopGradients() {
 void SliceOp::VerifySig() const {
   // inputs.size() == 1
   auto input_size = num_operands();
-  PADDLE_ENFORCE_EQ(
-      input_size,
-      1,
-      phi::errors::InvalidArgument("The size %d of inputs must be equal to 1.",
-                                   input_size));
+  PADDLE_ENFORCE_EQ(input_size,
+                    1,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 1."));
 
   // inputs[0].type == Vector<Type>
   auto input_type = (*this)->operand(0).type().dyn_cast<pir::VectorType>();
   PADDLE_ENFORCE_NOT_NULL(
       input_type,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The type %s of inputs[0] must be equal to VectorType.", input_type));
 
   auto output_size = num_results();
@@ -366,32 +366,32 @@ void SliceOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       output_size,
       1,
-      phi::errors::InvalidArgument("The size %d of outputs must be equal to 1.",
-                                   output_size));
+      common::errors::InvalidArgument(
+          "The size %d of outputs must be equal to 1.", output_size));
 
   // attributes contains index: Int32
   auto &attributes = this->attributes();
   PADDLE_ENFORCE_NE(
       attributes.count("index"),
       0,
-      phi::errors::InvalidArgument("The attributes must contains index."));
+      common::errors::InvalidArgument("The attributes must contains index."));
   const pir::Attribute &attr = attributes.at("index");
   PADDLE_ENFORCE_EQ(
       attr.isa<pir::Int32Attribute>(),
       true,
-      phi::errors::InvalidArgument("The attribute index must be INT32."));
+      common::errors::InvalidArgument("The attribute index must be INT32."));
   auto index = attr.dyn_cast<pir::Int32Attribute>().data();
 
   // index >= 0 and < inputs[0].size()
   PADDLE_ENFORCE_GE(
       index,
       0,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The index %d must be greater or equal than 0.", index));
   PADDLE_ENFORCE_LT(
       static_cast<size_t>(index),
       input_type.size(),
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The index %d must be less or equal than size %d of inputs[0].",
           index,
           input_type.size()));
@@ -401,7 +401,7 @@ void SliceOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       input_type[index],
       output_type,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The type %s of inputs[%d] must be equal to type %s of outputs[0].",
           input_type[index],
           index,
@@ -429,7 +429,7 @@ void SplitOp::PassStopGradients(OperationArgument &argument) {
       PADDLE_ENFORCE_EQ(
           argument.output_types.size(),
           defining_op->num_operands(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Required SplitOp.output.size() == CombineOp.input.size(), "
               "but received %d != %d",
               argument.output_types.size(),
@@ -473,7 +473,7 @@ void SplitOp::RefreshStopGradients() {
       PADDLE_ENFORCE_EQ(
           (*this)->num_results(),
           defining_op->num_operands(),
-          phi::errors::InvalidArgument(
+          common::errors::InvalidArgument(
               "Required SplitOp.output.size() == CombineOp.input.size(), "
               "but received %d != %d",
               (*this)->num_results(),
@@ -516,16 +516,16 @@ void SplitOp::RefreshStopGradients() {
 
 void SplitOp::VerifySig() const {
   // inputs.size() == 1
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      1u,
-      phi::errors::InvalidArgument("The size of inputs must be equal to 1."));
+  PADDLE_ENFORCE_EQ(num_operands(),
+                    1u,
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 1."));
 
   // input_type == Vector<Type>
   auto input_type = (*this)->operand(0).type().dyn_cast<VectorType>();
   PADDLE_ENFORCE_NOT_NULL(
       input_type,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The type of inputs[0] must be equal to VectorType."));
 
   // inputs[0].size() == outputs.size()
@@ -533,7 +533,7 @@ void SplitOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       input_type.size(),
       output_num,
-      phi::errors::InvalidArgument(
+      common::errors::InvalidArgument(
           "The size %d of output must be equal to size %d of inputs.",
           output_num,
           input_type.size()));
@@ -553,17 +553,18 @@ void ConstantOp::Build(Builder &builder,
 }
 
 void ConstantOp::VerifySig() const {
-  PADDLE_ENFORCE_EQ(
-      num_operands(),
-      0,
-      phi::errors::InvalidArgument("The size of inputs must be equal to 0."));
-  PADDLE_ENFORCE_EQ(
-      num_results(),
-      1,
-      phi::errors::InvalidArgument("The size of outputs must be equal to 1."));
-  PADDLE_ENFORCE_GT(attributes().count("value"),
+  PADDLE_ENFORCE_EQ(num_operands(),
                     0,
-                    phi::errors::InvalidArgument("must has value attribute"));
+                    common::errors::InvalidArgument(
+                        "The size of inputs must be equal to 0."));
+  PADDLE_ENFORCE_EQ(num_results(),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The size of outputs must be equal to 1."));
+  PADDLE_ENFORCE_GT(
+      attributes().count("value"),
+      0,
+      common::errors::InvalidArgument("must has value attribute"));
 }
 
 Attribute ConstantOp::value() const { return attributes().at("value"); }
@@ -573,7 +574,7 @@ void ConstantTensorOp::VerifySig() const {
   PADDLE_ENFORCE_EQ(
       value().isa<pir::TensorNameAttribute>(),
       true,
-      phi::errors::InvalidArgument("Type of value must be str attribute"));
+      common::errors::InvalidArgument("Type of value must be str attribute"));
 }
 
 ConstantTensorOp ConstantTensorOp::dyn_cast(Operation *op) {

--- a/test/auto_parallel/pir/test_static_pir_program.py
+++ b/test/auto_parallel/pir/test_static_pir_program.py
@@ -96,18 +96,18 @@ class TestBuildFakeProgram(unittest.TestCase):
         # #check attrs
 
         self.assertEqual(dist_input_op_dist_attr.process_mesh, mesh)
-        self.assertEqual(dist_input_op_dist_attr.num_operand_dist_attrs(), 0)
-        self.assertEqual(dist_input_op_dist_attr.num_result_dist_attrs(), 1)
+        self.assertEqual(dist_input_op_dist_attr.num_operands(), 0)
+        self.assertEqual(dist_input_op_dist_attr.num_results(), 1)
 
         dist_w0_op_dist_attr = dist_w0.get_defining_op().dist_attr
         self.assertEqual(dist_w0_op_dist_attr.process_mesh, mesh)
-        self.assertEqual(dist_w0_op_dist_attr.num_operand_dist_attrs(), 0)
-        self.assertEqual(dist_w0_op_dist_attr.num_result_dist_attrs(), 1)
+        self.assertEqual(dist_w0_op_dist_attr.num_operands(), 0)
+        self.assertEqual(dist_w0_op_dist_attr.num_results(), 1)
 
         dist_w1_op_dist_attr = dist_w1.get_defining_op().dist_attr
         self.assertEqual(dist_w1_op_dist_attr.process_mesh, mesh)
-        self.assertEqual(dist_w1_op_dist_attr.num_operand_dist_attrs(), 0)
-        self.assertEqual(dist_w1_op_dist_attr.num_result_dist_attrs(), 1)
+        self.assertEqual(dist_w1_op_dist_attr.num_operands(), 0)
+        self.assertEqual(dist_w1_op_dist_attr.num_results(), 1)
 
         attrs_op_dist_attr = (
             dist_input.get_defining_op().attrs().get("op_dist_attr")

--- a/test/auto_parallel/reshard_p_to_r.py
+++ b/test/auto_parallel/reshard_p_to_r.py
@@ -104,8 +104,8 @@ class TestReshardPToR:
         for op in ops:
             if op.name() == 'pd_op.c_allreduce_sum_':
                 # check op dist_attr
-                assert op.dist_attr.num_operand_dist_attrs() == 1
-                assert op.dist_attr.num_result_dist_attrs() == 1
+                assert op.dist_attr.num_operands() == 1
+                assert op.dist_attr.num_results() == 1
 
                 op_operand_dist_attr = op.dist_attr.operand_dist_attr(0)
                 op_result_dist_attr = op.dist_attr.result_dist_attr(0)

--- a/test/auto_parallel/reshard_p_to_r_cross_mesh.py
+++ b/test/auto_parallel/reshard_p_to_r_cross_mesh.py
@@ -101,8 +101,8 @@ class TestReshardPToRCrossMesh:
         )
         for op in dist_program.global_block().ops:
             if op.name() == 'pd_op.send_v2':
-                assert op.dist_attr.num_operand_dist_attrs() == 1
-                assert op.dist_attr.num_result_dist_attrs() == 0
+                assert op.dist_attr.num_operands() == 1
+                assert op.dist_attr.num_results() == 0
                 op_operand_dist_attr = op.dist_attr.operand_dist_attr(0)
 
                 assert op.dist_attr.process_mesh == self._in_mesh
@@ -114,8 +114,8 @@ class TestReshardPToRCrossMesh:
 
             elif op.name() == 'pd_op.recv_v2':
                 # check op dist_attr
-                assert op.dist_attr.num_operand_dist_attrs() == 0
-                assert op.dist_attr.num_result_dist_attrs() == 1
+                assert op.dist_attr.num_operands() == 0
+                assert op.dist_attr.num_results() == 1
 
                 op_result_dist_attr = op.dist_attr.result_dist_attr(0)
 
@@ -127,8 +127,8 @@ class TestReshardPToRCrossMesh:
             elif op.name() == 'pd_op.c_allreduce_sum_':
                 continue
                 # check op dist_attr
-                assert op.dist_attr.num_operand_dist_attrs() == 1
-                assert op.dist_attr.num_result_dist_attrs() == 1
+                assert op.dist_attr.num_operands() == 1
+                assert op.dist_attr.num_results() == 1
 
                 op_operand_dist_attr = op.dist_attr.operand_dist_attr(0)
                 op_result_dist_attr = op.dist_attr.result_dist_attr(0)

--- a/test/cpp/pir/distributed/dist_dialect_test.cc
+++ b/test/cpp/pir/distributed/dist_dialect_test.cc
@@ -239,14 +239,13 @@ TEST(operation_dist_attr_test, base) {
   auto out_tensor_dist_attr =
       TensorDistAttribute::get(ctx, mesh_attr, dims_mapping, partial_status);
 
-  auto operand_dist_attrs =
-      std::vector<TensorDistAttribute>{x_tensor_dist_attr, y_tensor_dist_attr};
-  auto result_dist_attrs =
-      std::vector<TensorDistAttribute>{out_tensor_dist_attr};
+  auto operand_attrs =
+      std::vector<pir::Attribute>{x_tensor_dist_attr, y_tensor_dist_attr};
+  auto result_attrs = std::vector<pir::Attribute>{out_tensor_dist_attr};
   auto op_attr = OperationDistAttribute::get(
-      ctx, process_mesh, operand_dist_attrs, result_dist_attrs);
-  auto op_attr_1 = OperationDistAttribute::get(
-      ctx, mesh_attr, operand_dist_attrs, result_dist_attrs);
+      ctx, process_mesh, operand_attrs, result_attrs);
+  auto op_attr_1 =
+      OperationDistAttribute::get(ctx, mesh_attr, operand_attrs, result_attrs);
 
   // construct another OperationDistAttribute.
   std::vector<std::string> dim_names_2 = {"x", "s"};
@@ -260,26 +259,25 @@ TEST(operation_dist_attr_test, base) {
   auto out_tensor_dist_attr_2 =
       TensorDistAttribute::get(ctx, mesh_attr_2, dims_mapping, partial_status);
 
-  auto operand_dist_attrs_2 = std::vector<TensorDistAttribute>{
-      x_tensor_dist_attr_2, y_tensor_dist_attr_2};
-  auto result_dist_attrs_2 =
-      std::vector<TensorDistAttribute>{out_tensor_dist_attr_2};
+  auto operand_attrs_2 =
+      std::vector<pir::Attribute>{x_tensor_dist_attr_2, y_tensor_dist_attr_2};
+  auto result_attrs_2 = std::vector<pir::Attribute>{out_tensor_dist_attr_2};
   auto op_attr_2 = OperationDistAttribute::get(
-      ctx, mesh_attr_2, operand_dist_attrs_2, result_dist_attrs_2);
+      ctx, mesh_attr_2, operand_attrs_2, result_attrs_2);
 
   // check
   EXPECT_EQ(op_attr, op_attr_1);
   EXPECT_NE(op_attr, op_attr_2);
   EXPECT_EQ(op_attr.process_mesh_attr(), mesh_attr);
   EXPECT_EQ(op_attr.process_mesh_attr().process_mesh(), process_mesh);
-  EXPECT_EQ(op_attr.operand_dist_attrs(), operand_dist_attrs);
-  EXPECT_EQ(op_attr.operand_dist_attr(0), operand_dist_attrs.at(0));
-  EXPECT_EQ(op_attr.operand_dist_attr(1), operand_dist_attrs.at(1));
-  EXPECT_EQ(op_attr.num_operand_dist_attrs(), (uint32_t)2);
+  EXPECT_EQ(op_attr.operand_attrs(), operand_attrs);
+  EXPECT_EQ(op_attr.operand_dist_attr(0), operand_attrs.at(0));
+  EXPECT_EQ(op_attr.operand_dist_attr(1), operand_attrs.at(1));
+  EXPECT_EQ(op_attr.num_operands(), (uint32_t)2);
 
-  EXPECT_EQ(op_attr.result_dist_attrs(), result_dist_attrs);
-  EXPECT_EQ(op_attr.result_dist_attr(0), result_dist_attrs.at(0));
-  EXPECT_EQ(op_attr.num_result_dist_attrs(), (uint32_t)1);
+  EXPECT_EQ(op_attr.result_attrs(), result_attrs);
+  EXPECT_EQ(op_attr.result_dist_attr(0), result_attrs.at(0));
+  EXPECT_EQ(op_attr.num_results(), (uint32_t)1);
 }
 
 TEST(shard_tensor_op_replicate_test, base) {
@@ -325,13 +323,13 @@ TEST(shard_tensor_op_replicate_test, base) {
   EXPECT_EQ(op_out_type.dims_mapping(), dims_mapping);
   EXPECT_EQ(op_out_type.partial_dims().size(), (size_t)0);
 
-  EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_operand_dist_attrs(),
-            (uint32_t)0);
+  EXPECT_EQ(
+      shard_op.attribute<OperationDistAttribute>("op_dist_attr").num_operands(),
+      (uint32_t)0);
 
-  EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
-            (uint32_t)1);
+  EXPECT_EQ(
+      shard_op.attribute<OperationDistAttribute>("op_dist_attr").num_results(),
+      (uint32_t)1);
   EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
                 .process_mesh_attr(),
             mesh_attr);
@@ -359,10 +357,10 @@ TEST(shard_tensor_op_replicate_test, base) {
   EXPECT_EQ(dst_op_out_type.partial_dims().size(), (size_t)0);
 
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_operand_dist_attrs(),
+                .num_operands(),
             (uint32_t)1);
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
+                .num_results(),
             (uint32_t)1);
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
                 .process_mesh_attr(),
@@ -411,12 +409,12 @@ TEST(shard_tensor_op_shard_row_test, base) {
   EXPECT_EQ(op_out_type.dims_mapping(), dims_mapping);
   EXPECT_EQ(op_out_type.partial_dims().size(), (size_t)0);
 
-  EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_operand_dist_attrs(),
-            (uint32_t)0);
-  EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
-            (uint32_t)1);
+  EXPECT_EQ(
+      shard_op.attribute<OperationDistAttribute>("op_dist_attr").num_operands(),
+      (uint32_t)0);
+  EXPECT_EQ(
+      shard_op.attribute<OperationDistAttribute>("op_dist_attr").num_results(),
+      (uint32_t)1);
   EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
                 .process_mesh_attr(),
             mesh_attr);
@@ -442,10 +440,10 @@ TEST(shard_tensor_op_shard_row_test, base) {
   EXPECT_EQ(dst_op_out_type.partial_dims().size(), (size_t)0);
 
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_operand_dist_attrs(),
+                .num_operands(),
             (uint32_t)1);
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
+                .num_results(),
             (uint32_t)1);
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
                 .process_mesh_attr(),
@@ -494,12 +492,12 @@ TEST(shard_tensor_op_shard_col_test, base) {
   EXPECT_EQ(op_out_type.dims_mapping(), dims_mapping);
   EXPECT_EQ(op_out_type.partial_dims().size(), (size_t)0);
 
-  EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_operand_dist_attrs(),
-            (uint32_t)0);
-  EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
-            (uint32_t)1);
+  EXPECT_EQ(
+      shard_op.attribute<OperationDistAttribute>("op_dist_attr").num_operands(),
+      (uint32_t)0);
+  EXPECT_EQ(
+      shard_op.attribute<OperationDistAttribute>("op_dist_attr").num_results(),
+      (uint32_t)1);
   EXPECT_EQ(shard_op.attribute<OperationDistAttribute>("op_dist_attr")
                 .process_mesh_attr(),
             mesh_attr);
@@ -525,10 +523,10 @@ TEST(shard_tensor_op_shard_col_test, base) {
   EXPECT_EQ(dst_op_out_type.partial_dims().size(), (size_t)0);
 
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_operand_dist_attrs(),
+                .num_operands(),
             (uint32_t)1);
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
+                .num_results(),
             (uint32_t)1);
   EXPECT_EQ(reshard_op.attribute<OperationDistAttribute>("op_dist_attr")
                 .process_mesh_attr(),
@@ -580,10 +578,10 @@ TEST(mix_to_dist_pass_test, base) {
       builder.Build<paddle::dialect::ShardTensorOp>(y_data_op.result(0),
                                                     y_attr_map);
   EXPECT_EQ(x_shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
+                .num_results(),
             (uint32_t)1);
   EXPECT_EQ(y_shard_op.attribute<OperationDistAttribute>("op_dist_attr")
-                .num_result_dist_attrs(),
+                .num_results(),
             (uint32_t)1);
 
   // Apply Pass

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -107,6 +107,7 @@ STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         'use_empty',
         'is_dist_dense_tensor_type',
         'dist_attr',
+        'update_dist_attr',
         'value_assign',
         'replace_grad_users_with',
         'do_model_average',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- OperationDistAttr支持输入输出为Tensor列表的情况。
   - 目前的OperationDistAttr是由两个分别表示输入输出的 vector<TensorDistAttr>组成。当算子的输入或输出为list的时候，就会出现问题。以SplitWithNumOp算子为例，它只有一个类型为VectorType的输出，代表该输出的类型是Tensor数组；那么此时，算子的OperationDistAttr是无法表示输出的分布式属性的。
    - 本pr重构升级OperationDistAttr， 将它的两个分别表示输入输出的 vector<TensorDistAttr>，调整为 vector<pir::Attribute>, 里面的每个元素是TensorDistAttr或者ArrayAttribute。由上层调用者去处理。
  * 假设算子A包含了两个输出，且都是Tensor数组，这两个输出数组的长度分别为4和5，那么此时，他的OperationDistAttr的 result_dist_attr的长度应该为2， 下标0是一个ArrayAttribute, 代表第一个输出数组中每个Tensor的分布式属性； 下标1也是一个ArrayAttribute， 代表第二个输出数组中的每个Tensor的分布式属性。

- 修改call_vjp的pybind接口，强约束张量的前反向的类型完全一致。
  - 目前的vjp接口中，反向算子在build时，输出反向张量的分布式属性来自于inferspmd推断得到的结果。该结果和前向张量的分布式属性不一定一致，这会导致在后面算子的组网失败。
  - 本pr中，inferspmd推断得到的分布式属性仅存储在op_dsit_attr中，输出反向张量的分布式属性和前向严格一致。
- 在partition pass中，在输出的分布式属性和op_dist_attr中的分布式属性不一致时，插入reshard op. 
- 修改partition pass, 消除冗余的reshard。（比如两个相邻的reshard功能互逆时，可以同时移除）


### Other
Pcard-67164
