### PR TITLE
【AutoParallel】Optimize the method of split program in 'zbpp' to fit 'fused_linear_param_grad'

### DIFF
--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -794,7 +794,14 @@ def _get_backward_op_type(block, op, idx):
                 for i in range(idx, idx + 5):
                     if not is_backward_op(ops[i]):
                         return False
-                    ops_names.append(ops[i].type)
+                    if op[i].type == "matmul_v2":
+                        output_arg_names = op[i].output_arg_names
+                        name = output_arg_names[0].split("@")[0]
+                        if not block._find_var_recursive(name):
+                            return False
+                        var = block._find_var_recursive(name)
+                        if not var.is_parameter:
+                            return False
                 if ops_names == ops_pattern:
                     return True
         return False

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -859,7 +859,7 @@ def _program_for_zero_bubble(program, enable_send_recv_overlap=False):
             elif is_forward_op(op):
                 type_to_ops["forward"].append(op)
             elif is_backward_op(op):
-                types = _get_backward_op_type(block, op)
+                types = _get_backward_op_type(block, op, idx)
                 dealed_op_idx = dealed_op_idx + len(types) - 1
                 for i, type in enumerate(types):
                     type_to_ops[type].append(block.ops[idx + i])

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -794,8 +794,8 @@ def _get_backward_op_type(block, op, idx):
                 for i in range(idx, idx + 5):
                     if not is_backward_op(ops[i]):
                         return False
-                    if op[i].type == "matmul_v2":
-                        output_arg_names = op[i].output_arg_names
+                    if ops[i].type == "matmul_v2":
+                        output_arg_names = ops[i].output_arg_names
                         name = output_arg_names[0].split("@")[0]
                         if not block._find_var_recursive(name):
                             return False

--- a/python/paddle/distributed/passes/pass_utils.py
+++ b/python/paddle/distributed/passes/pass_utils.py
@@ -778,19 +778,48 @@ def _program_for_vpp(
     return list(type_to_program.keys()), list(type_to_program.values())
 
 
-def _get_backward_op_type(block, op):
+def _get_backward_op_type(block, op, idx):
+    # deal the ops pattern: [reshape2, reshape2, matmul_v2, reshape2, elementwise_add]
+    def is_reshape_matmul_pattern(op, idx, ops, ops_len):
+        ops_pattern = [
+            "reshape2",
+            "reshape2",
+            "matmul_v2",
+            "reshape2",
+            "elementwise_add",
+        ]
+        if op.type == "reshape2":
+            if idx + 4 < ops_len:
+                ops_names = []
+                for i in range(idx, idx + 5):
+                    if not is_backward_op(ops[i]):
+                        return False
+                    ops_names.append(ops[i].type)
+                if ops_names == ops_pattern:
+                    return True
+        return False
+
     # For the op doesn't have output such as 'send_v2', it should be backward_b.
     if len(op.output_arg_names) == 0:
-        return "backward_b"
+        return ["backward_b"]
+
+    if is_reshape_matmul_pattern(op, idx, block.ops, len(block.ops)):
+        return [
+            "backward_w",
+            "backward_w",
+            "backward_w",
+            "backward_w",
+            "backward_w",
+        ]
     for name in op.output_arg_names:
         name = name.split("@")[0]
         if not block._find_var_recursive(name):
-            return "backward_b"
+            return ["backward_b"]
         var = block._find_var_recursive(name)
         if not var.is_parameter:
-            return "backward_b"
+            return ["backward_b"]
 
-    return "backward_w"
+    return ["backward_w"]
 
 
 def _program_for_zero_bubble(program, enable_send_recv_overlap=False):
@@ -814,15 +843,20 @@ def _program_for_zero_bubble(program, enable_send_recv_overlap=False):
             type_to_ops[type] = []
         type_to_ops["fetch"] = []
 
-        for op in block.ops:
+        dealed_op_idx = 0
+        for idx, op in enumerate(block.ops):
+            if idx < dealed_op_idx:
+                continue
             if _is_fetch_op(op):
                 type_to_ops["fetch"].append(op)
             elif is_forward_op(op):
                 type_to_ops["forward"].append(op)
             elif is_backward_op(op):
-                type = _get_backward_op_type(block, op)
-                type_to_ops[type].append(op)
-                type_to_ops["backward"].append(op)
+                types = _get_backward_op_type(block, op)
+                dealed_op_idx = dealed_op_idx + len(types) - 1
+                for i, type in enumerate(types):
+                    type_to_ops[type].append(block.ops[idx + i])
+                    type_to_ops["backward"].append(block.ops[idx + i])
             elif is_optimize_op(op):
                 type_to_ops["optimizer"].append(op)
             else:
@@ -831,6 +865,7 @@ def _program_for_zero_bubble(program, enable_send_recv_overlap=False):
                     + str(op.attr('op_role'))
                     + " isn't one of Forward, Backward or Optimizer."
                 )
+            dealed_op_idx = dealed_op_idx + 1
         return type_to_ops
 
     type_to_program = OrderedDict()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Optimize the method of split program in 'zbpp' to fit 'fused_linear_param_grad_pass'.
This PR puts the operator list` [reshape2, reshape2, matmul_v2, reshape2, elementwise_add]` into `backward_w` subporogram because the pass `fused_linear_param_grad_add` can fuse the above operator list.
![image](https://github.com/PaddlePaddle/Paddle/assets/25178174/48951852-7b0f-46d0-983f-b72809b21e31)
The comparison of timelie pictures before and after this PR is as follows:

before this PR:
![image](https://github.com/PaddlePaddle/Paddle/assets/25178174/5b5c81ff-d515-4aea-8523-1fabef5d4fc4)

after this PR:
<img width="1624" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/25178174/0638de18-b046-4c78-8916-b40f616bbfb7">
