### PR TITLE
[Auto Parallel] Add a case when the target shape  is 1 in reshape spmd rule.

### DIFF
--- a/test/auto_parallel/spmd_rules/test_reshape_rule.py
+++ b/test/auto_parallel/spmd_rules/test_reshape_rule.py
@@ -291,6 +291,22 @@ class TestReshapeSPMDRule(unittest.TestCase):
             infered_output_dist_attrs[0].dims_mapping, [1, -1, 0, -1]
         )
 
+        # shape: [1, 2048, 12288] --> [0, 0, 6, 2048]
+        # dims_mapping: [0, -1, 1] --> [0, -1, 1], [0, -1, 1, -1]
+        self.x_dist_tensor_spec.shape = [1, 2048, 12288]
+        self.attrs["shape"] = [0, 0, 6, 2048]
+        self.x_dist_tensor_spec.set_dims_mapping([0, -1, 1])
+        result_dist_attrs = self.rule.infer_forward(
+            self.x_dist_tensor_spec, self.attrs['shape']
+        )
+        infered_input_dist_attrs = result_dist_attrs[0]
+        infered_output_dist_attrs = result_dist_attrs[1]
+
+        self.assertEqual(infered_input_dist_attrs[0].dims_mapping, [0, -1, 1])
+        self.assertEqual(
+            infered_output_dist_attrs[0].dims_mapping, [0, -1, 1, -1]
+        )
+
         # shape: [6, 12, 48, 24] --> [3, 24, 6, -1, -1]
         # raise error
         self.attrs["shape"] = [3, 24, 6, -1, -1]


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
Pcard-76459
Cover the following case in reshape spmd rule:
     shape: [1, 512, 4096] --> [1, 2, 256, 4096],
     input dims_mapping: [0, 1, -1]
     expected output dims_mapping: [0, 1, -1, -1] (not [-1, 1, -1,-1])

In this case, the dim0 in target shape is 1 and it is from dim0 in source shape. make the dim0's transformation be InputDim rather than Singleton so that the sharding status can be propagated.
