### PR TITLE
support linux sccache

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -14,6 +14,23 @@ if(NOT WIN32)
     set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PATH})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PATH})
     set(CMAKE_CUDA_COMPILER_LAUNCHER ${CCACHE_PATH})
+  elseif("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    # (Note:zhouwei25) Only Ninja Generator can support sccache now
+    find_program(SCCACHE_PATH sccache)
+
+    if(SCCACHE_PATH)
+      execute_process(COMMAND sccache -V OUTPUT_VARIABLE sccache_version)
+      message(
+        STATUS
+          "sccache is founded, use [${SCCACHE_PATH}] to speed up compile on Windows."
+      )
+
+      set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE_PATH})
+      set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_PATH})
+      # (Note:zhouwei25) sccache for cuda compiler has bug so that it can't be hit
+      # refer to https://github.com/mozilla/sccache/issues/1017, so we fix it
+      set(CMAKE_CUDA_COMPILER_LAUNCHER ${SCCACHE_PATH})
+    endif()
   endif()
 elseif("${CMAKE_GENERATOR}" STREQUAL "Ninja")
   # (Note:zhouwei25) Only Ninja Generator can support sccache now

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -28,6 +28,8 @@ if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
 
     set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE_PATH})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_PATH})
+    # (Note:zhouwei25) sccache for cuda compiler has bug so that it can't be hit
+    # refer to https://github.com/mozilla/sccache/issues/1017, so we fix it
     set(CMAKE_CUDA_COMPILER_LAUNCHER ${SCCACHE_PATH})
   endif()
 endif()

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -14,39 +14,20 @@ if(NOT WIN32)
     set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PATH})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PATH})
     set(CMAKE_CUDA_COMPILER_LAUNCHER ${CCACHE_PATH})
-  elseif("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-    # (Note:zhouwei25) Only Ninja Generator can support sccache now
-    find_program(SCCACHE_PATH sccache)
-
-    if(SCCACHE_PATH)
-      execute_process(COMMAND sccache -V OUTPUT_VARIABLE sccache_version)
-      message(
-        STATUS
-          "sccache is founded, use [${SCCACHE_PATH}] to speed up compile on Windows."
-      )
-
-      set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE_PATH})
-      set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_PATH})
-      # (Note:zhouwei25) sccache for cuda compiler has bug so that it can't be hit
-      # refer to https://github.com/mozilla/sccache/issues/1017, so we fix it
-      set(CMAKE_CUDA_COMPILER_LAUNCHER ${SCCACHE_PATH})
-    endif()
+    return()
   endif()
-elseif("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-  # (Note:zhouwei25) Only Ninja Generator can support sccache now
-  find_program(SCCACHE_PATH sccache)
+endif()
 
+# (Note:zhouwei25) Only Ninja Generator can support sccache now
+if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+  find_program(SCCACHE_PATH sccache)
   if(SCCACHE_PATH)
     execute_process(COMMAND sccache -V OUTPUT_VARIABLE sccache_version)
     message(
-      STATUS
-        "sccache is founded, use [${SCCACHE_PATH}] to speed up compile on Windows."
-    )
+      STATUS "sccache is founded, use [${SCCACHE_PATH}] to speed up compile.")
 
     set(CMAKE_C_COMPILER_LAUNCHER ${SCCACHE_PATH})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${SCCACHE_PATH})
-    # (Note:zhouwei25) sccache for cuda compiler has bug so that it can't be hit
-    # refer to https://github.com/mozilla/sccache/issues/1017, so we fix it
     set(CMAKE_CUDA_COMPILER_LAUNCHER ${SCCACHE_PATH})
   endif()
 endif()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
现在 sccache 只有在 windows 下才会尝试使用，但是实际上 sccache 也支持 linux，并且是分布式的，从功能上可以替代ccache，本 PR 将逻辑修改为了先判断是否在Linux下存在ccache，如果存在则直接使用，否则（包含windows）尝试寻找sccache，在使用Ninja且sccache存在的情况下使用sccache。