### PR TITLE
【CINN】Fix bug of CinnGroupOp out of Order

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -490,12 +490,12 @@ std::vector<pir::Value> AnalysisExternalInputs(const Operation* op) {  // NOLINT
   }
   auto group_op =
       const_cast<Operation*>(op)->dyn_cast<cinn::dialect::GroupOp>();
-  auto group_ops = std::unordered_set<::pir::Value>(
+  auto group_ops = std::unordered_set<pir::Operation*>(
       group_op.GetOperators().begin(), group_op.GetOperators().end());
   std::unordered_set<::pir::Value> group_inputs;
   // count all op's input Value
-  for (auto op : group_ops) {
-    for (auto& value : op->operands_source()) {
+  for (auto item : group_ops) {
+    for (auto& value : item->operands_source()) {
       if (!value || !value.type() ||
           group_ops.find(value.defining_op()) != group_ops.end())
         continue;

--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -484,6 +484,23 @@ std::vector<pir::Value> AnalysisOutputs(
   return outputs;
 }
 
+std::vector<pir::Value> AnalysisExternalInputs(
+    const GroupOpsVec& group_ops) {  // NOLINT
+  std::unordered_set<::pir::Value> group_inputs;
+  // count all op's input Value
+  for (auto op : group_ops) {
+    for (auto& value : op->operands_source()) {
+      if (!value || !value.type() ||
+          std::find(group_ops.begin(), group_ops.end(), value.defining_op()) !=
+              group_ops.end())
+        continue;
+      // if the input value owner op is not in OpSet, it's the group's input
+      group_inputs.insert(value);
+    }
+  }
+  return std::vector<pir::Value>(group_inputs.begin(), group_inputs.end());
+}
+
 namespace {
 
 pir::Operation* FindInsertPoint(const GroupOpsVec& group_ops,
@@ -538,18 +555,24 @@ struct IncrementalOrder {
 std::unordered_set<pir::Operation*> GetUpstreamOpsAfterPosition(
     const pir::Operation* position_op,
     const pir::Block* block,
-    const pir::Operation* op,
+    pir::Operation* op,
     std::unordered_set<pir::Operation*>* visited_ops) {
   std::unordered_set<pir::Operation*> ops;
   const auto& IsInBlock = [](const pir::Operation* src_op,
                              const pir::Block* block) {
-    for (auto& op : *block) {
-      if (src_op == &op) return true;
+    for (auto& item : *block) {
+      if (src_op == &item) return true;
     }
     return false;
   };
-
-  for (auto value : op->operands_source()) {
+  std::vector<pir::Value> op_inputs;
+  if (op->isa<cinn::dialect::GroupOp>()) {
+    auto group_op = op->dyn_cast<cinn::dialect::GroupOp>();
+    op_inputs = AnalysisExternalInputs(group_op.GetOperators());
+  } else {
+    op_inputs = op->operands_source();
+  }
+  for (auto value : op_inputs) {
     if (!value || !value.defining_op()) continue;
     pir::Operation* defining_op = value.defining_op();
     if (visited_ops->count(defining_op)) continue;
@@ -580,7 +603,8 @@ void MoveUpstreamOpBeforeGroup(const GroupOpsVec& group_ops,
   }();
 
   for (auto& op : moved_ops) {
-    VLOG(5) << "Move " << op->name() << " before " << insert_point_op->name();
+    VLOG(5) << "Move " << op->id() << " " << op->name() << " before "
+            << insert_point_op->id() << " " << insert_point_op->name();
     op->MoveTo(block, insert_point_op->operator Block::Iterator());
   }
 }

--- a/paddle/fluid/pir/transforms/sub_graph_detector.h
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.h
@@ -71,6 +71,7 @@ class SubgraphDetector {
 };
 
 std::vector<pir::Value> AnalysisOutputs(const GroupOpsVec& group_ops);
+std::vector<pir::Value> AnalysisExternalInputs(const GroupOpsVec& group_ops);
 void ReplaceWithGroupOp(pir::Block* block, const GroupOpsVec& group_ops);
 
 }  // namespace pir


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
 Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-67164

cinn pass中替换插入cinn group op导致op拓扑顺序错误，定位到是递归分析define op时使用op_operands分析，没有考虑到cinn group op的外部输入。本PR修复这一问题，对于cinn group op，遍历op找到ExternelInputValue作为其defining op