### PR TITLE
【Hackathon 6th Fundable Projects 1 】Add typing_extensions to requirements

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,3 +6,4 @@ decorator
 astor
 opt_einsum==3.3.0
 networkx
+typing_extensions==4.8.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,4 +6,4 @@ decorator
 astor
 opt_einsum==3.3.0
 networkx
-typing_extensions==4.8.0
+typing_extensions


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
为 Paddle 添加类型提示（Type Hints）中需要使用一些类型注解，而目前 Paddle 支持python 3.8 以上的版本，少数类型未被添加到标准库 typing 中，因此需要引入 typing_extensions。

目前 Paddle 只在开发过程中会间接依赖于 typing_extensions:
![240419_14h48m56s_screenshot](https://github.com/PaddlePaddle/Paddle/assets/72954905/6b68a92e-8e20-47a9-879f-4b6e2467b17b)

若是通过 pypi 安装则没有 typing_extensions，因此需要添加该包。