### PR TITLE
[Prim] Fix composite subtract double grad in broadcast case

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h
@@ -775,14 +775,14 @@ void subtract_double_grad(const Tensor& y,
     } else if (grad_x_grad) {
       if (grad_x_grad.get().dims() != grad_out.dims()) {
         // broad cast grad_x_grad to grad_out
-        auto grad_x_grad_dims = common::vectorize(grad_x_grad.dims());
+        auto grad_x_grad_dims = common::vectorize(grad_x_grad.get().dims());
         auto grad_out_dims = common::vectorize(grad_out.dims());
         auto broadcast_dims = grad_x_grad_dims;
         // reshape to same dims
         bool need_reshape = false;
         if (grad_out_dims.size() > grad_x_grad_dims.size()) {
           need_reshape = true;
-          for (int i = 0; i < grad_out_dims.size() - grad_x_grad_dims.size();
+          for (size_t i = 0; i < grad_out_dims.size() - grad_x_grad_dims.size();
                ++i) {
             broadcast_dims.insert(broadcast_dims.begin(), 1);
           }
@@ -790,7 +790,7 @@ void subtract_double_grad(const Tensor& y,
         // tile if needed
         auto repeat_times = broadcast_dims;
         bool need_tile = false;
-        for (int i = 0; i < broadcast_dims.size(); ++i) {
+        for (size_t i = 0; i < broadcast_dims.size(); ++i) {
           if (grad_out_dims[i] > 1 && broadcast_dims[i] == 1) {
             repeat_times[i] = grad_out_dims[i];
             need_tile = true;
@@ -799,15 +799,15 @@ void subtract_double_grad(const Tensor& y,
           }
         }
         if (need_reshape && need_tile) {
-          set_output<T>(grad_out_grad,
-                        tile<T>(reshape<T>(grad_x_grad.get(), broadcast_dims),
-                                repeat_times));
+          set_output<T>(tile<T>(reshape<T>(grad_x_grad.get(), broadcast_dims),
+                                repeat_times),
+                        grad_out_grad);
         } else if (need_reshape) {
-          set_output<T>(grad_out_grad,
-                        reshape<T>(grad_x_grad.get(), broadcast_dims));
+          set_output<T>(reshape<T>(grad_x_grad.get(), broadcast_dims),
+                        grad_out_grad);
         } else if (need_tile) {
-          set_output<T>(grad_out_grad,
-                        tile<T>(grad_x_grad.get(), repeat_times));
+          set_output<T>(tile<T>(grad_x_grad.get(), repeat_times),
+                        grad_out_grad);
         }
       } else {
         by_pass<T>(grad_x_grad.get(), grad_out_grad);
@@ -815,14 +815,14 @@ void subtract_double_grad(const Tensor& y,
     } else if (grad_y_grad) {
       if (grad_y_grad.get().dims() != grad_out.dims()) {
         // broad cast grad_y_grad to grad_out
-        auto grad_y_grad_dims = common::vectorize(grad_y_grad.dims());
+        auto grad_y_grad_dims = common::vectorize(grad_y_grad.get().dims());
         auto grad_out_dims = common::vectorize(grad_out.dims());
         auto broadcast_dims = grad_y_grad_dims;
         // reshape to same dims
         bool need_reshape = false;
         if (grad_out_dims.size() > grad_y_grad_dims.size()) {
           need_reshape = true;
-          for (int i = 0; i < grad_out_dims.size() - grad_y_grad_dims.size();
+          for (size_t i = 0; i < grad_out_dims.size() - grad_y_grad_dims.size();
                ++i) {
             broadcast_dims.insert(broadcast_dims.begin(), 1);
           }
@@ -830,7 +830,7 @@ void subtract_double_grad(const Tensor& y,
         // tile if needed
         auto repeat_times = broadcast_dims;
         bool need_tile = false;
-        for (int i = 0; i < broadcast_dims.size(); ++i) {
+        for (size_t i = 0; i < broadcast_dims.size(); ++i) {
           if (grad_out_dims[i] > 1 && broadcast_dims[i] == 1) {
             repeat_times[i] = grad_out_dims[i];
             need_tile = true;
@@ -839,15 +839,15 @@ void subtract_double_grad(const Tensor& y,
           }
         }
         if (need_reshape && need_tile) {
-          set_output<T>(grad_out_grad,
-                        tile<T>(reshape<T>(grad_y_grad.get(), broadcast_dims),
-                                repeat_times));
+          set_output<T>(tile<T>(reshape<T>(grad_y_grad.get(), broadcast_dims),
+                                repeat_times),
+                        grad_out_grad);
         } else if (need_reshape) {
-          set_output<T>(grad_out_grad,
-                        reshape<T>(grad_y_grad.get(), broadcast_dims));
+          set_output<T>(reshape<T>(grad_y_grad.get(), broadcast_dims),
+                        grad_out_grad);
         } else if (need_tile) {
-          set_output<T>(grad_out_grad,
-                        tile<T>(grad_y_grad.get(), repeat_times));
+          set_output<T>(tile<T>(grad_y_grad.get(), repeat_times),
+                        grad_out_grad);
         }
       } else {
         by_pass<T>(-grad_y_grad.get(), grad_out_grad);

--- a/test/legacy_test/test_elementwise_nn_grad.py
+++ b/test/legacy_test/test_elementwise_nn_grad.py
@@ -216,6 +216,211 @@ class TestElementwiseSubBroadcastDoubleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestElementwiseSubBroadcastDoubleGradCheck2(unittest.TestCase):
+    def subtract_wrapper(self, x):
+        return paddle.subtract(x[0], x[1])
+
+    @test_with_pir_api
+    @prog_scope()
+    def func(self, place):
+        # the shape of input variable should be clearly specified, not include -1.
+        shape1 = [2, 1, 4, 5]
+        shape2 = [2, 3, 1, 1]
+        eps = 0.005
+        dtype = np.float64
+
+        x = paddle.static.data('x', shape1, dtype)
+        y = paddle.static.data('y', shape2, dtype)
+        x.persistable = True
+        y.persistable = True
+        out = paddle.subtract(x, y)
+        x_arr = np.random.uniform(-1, 1, shape1).astype(dtype)
+        y_arr = np.random.uniform(-1, 1, shape2).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, y], out, x_init=[x_arr, y_arr], place=place, eps=eps
+        )
+        gradient_checker.double_grad_check_for_dygraph(
+            self.subtract_wrapper,
+            [x, y],
+            out,
+            x_init=[x_arr, y_arr],
+            place=place,
+        )
+
+    def test_grad(self):
+        paddle.enable_static()
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        for p in places:
+            self.func(p)
+
+
+class TestElementwiseSubBroadcastDoubleGradCheck3(unittest.TestCase):
+    def subtract_wrapper(self, x):
+        return paddle.subtract(x[0], x[1])
+
+    @test_with_pir_api
+    @prog_scope()
+    def func(self, place):
+        # the shape of input variable should be clearly specified, not include -1.
+        shape1 = [2, 1, 4, 5]
+        shape2 = [1, 1]
+        eps = 0.005
+        dtype = np.float64
+
+        x = paddle.static.data('x', shape1, dtype)
+        y = paddle.static.data('y', shape2, dtype)
+        x.persistable = True
+        y.persistable = True
+        out = paddle.subtract(x, y)
+        x_arr = np.random.uniform(-1, 1, shape1).astype(dtype)
+        y_arr = np.random.uniform(-1, 1, shape2).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, y], out, x_init=[x_arr, y_arr], place=place, eps=eps
+        )
+        gradient_checker.double_grad_check_for_dygraph(
+            self.subtract_wrapper,
+            [x, y],
+            out,
+            x_init=[x_arr, y_arr],
+            place=place,
+        )
+
+    def test_grad(self):
+        paddle.enable_static()
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        for p in places:
+            self.func(p)
+
+
+class TestElementwiseSubBroadcastDoubleGradCheck4(unittest.TestCase):
+    def subtract_wrapper(self, x):
+        return paddle.subtract(x[0], x[1])
+
+    @test_with_pir_api
+    @prog_scope()
+    def func(self, place):
+        # the shape of input variable should be clearly specified, not include -1.
+        shape1 = [2, 1, 4, 5]
+        shape2 = []
+        eps = 0.005
+        dtype = np.float64
+
+        x = paddle.static.data('x', shape1, dtype)
+        y = paddle.static.data('y', shape2, dtype)
+        x.persistable = True
+        y.persistable = True
+        out = paddle.subtract(x, y)
+        x_arr = np.random.uniform(-1, 1, shape1).astype(dtype)
+        y_arr = np.random.uniform(-1, 1, shape2).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, y], out, x_init=[x_arr, y_arr], place=place, eps=eps
+        )
+        gradient_checker.double_grad_check_for_dygraph(
+            self.subtract_wrapper,
+            [x, y],
+            out,
+            x_init=[x_arr, y_arr],
+            place=place,
+        )
+
+    def test_grad(self):
+        paddle.enable_static()
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        for p in places:
+            self.func(p)
+
+
+class TestElementwiseSubBroadcastDoubleGradCheck5(unittest.TestCase):
+    def subtract_wrapper(self, x):
+        return paddle.subtract(x[0], x[1])
+
+    @test_with_pir_api
+    @prog_scope()
+    def func(self, place):
+        # the shape of input variable should be clearly specified, not include -1.
+        shape1 = [2, 1, 4, 5]
+        shape2 = [4, 1]
+        eps = 0.005
+        dtype = np.float64
+
+        x = paddle.static.data('x', shape1, dtype)
+        y = paddle.static.data('y', shape2, dtype)
+        x.persistable = True
+        y.persistable = True
+        out = paddle.subtract(x, y)
+        x_arr = np.random.uniform(-1, 1, shape1).astype(dtype)
+        y_arr = np.random.uniform(-1, 1, shape2).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, y], out, x_init=[x_arr, y_arr], place=place, eps=eps
+        )
+        gradient_checker.double_grad_check_for_dygraph(
+            self.subtract_wrapper,
+            [x, y],
+            out,
+            x_init=[x_arr, y_arr],
+            place=place,
+        )
+
+    def test_grad(self):
+        paddle.enable_static()
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        for p in places:
+            self.func(p)
+
+
+class TestElementwiseSubBroadcastDoubleGradCheck6(unittest.TestCase):
+    def subtract_wrapper(self, x):
+        return paddle.subtract(x[0], x[1])
+
+    @test_with_pir_api
+    @prog_scope()
+    def func(self, place):
+        # the shape of input variable should be clearly specified, not include -1.
+        shape1 = [4, 1, 3]
+        shape2 = [3, 1]
+        eps = 0.005
+        dtype = np.float64
+
+        x = paddle.static.data('x', shape1, dtype)
+        y = paddle.static.data('y', shape2, dtype)
+        x.persistable = True
+        y.persistable = True
+        out = paddle.subtract(x, y)
+        x_arr = np.random.uniform(-1, 1, shape1).astype(dtype)
+        y_arr = np.random.uniform(-1, 1, shape2).astype(dtype)
+
+        gradient_checker.double_grad_check(
+            [x, y], out, x_init=[x_arr, y_arr], place=place, eps=eps
+        )
+        gradient_checker.double_grad_check_for_dygraph(
+            self.subtract_wrapper,
+            [x, y],
+            out,
+            x_init=[x_arr, y_arr],
+            place=place,
+        )
+
+    def test_grad(self):
+        paddle.enable_static()
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(base.CUDAPlace(0))
+        for p in places:
+            self.func(p)
+
+
 class TestElementwiseDivDoubleGradCheck(unittest.TestCase):
     def divide_wrapper(self, x):
         return paddle.divide(x[0], x[1])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-83125

Fix wrong result when meets **broadcast case** for composite `subtract_double_grad`.

``` py
import paddle
import numpy as np
import torch



def compute_grad_grad_out_paddle(x, y, out_grad):
    x = paddle.to_tensor(x)
    x.stop_gradient = False

    y = paddle.to_tensor(y)
    y.stop_gradient = False

    out_grad = paddle.to_tensor(out_grad)
    out_grad.stop_gradient = False

    out = (x - y).tanh()

    x_grad = paddle.grad(out, x, [out_grad], create_graph=True)[0]

    out_grad_grad = paddle.grad(x_grad, out_grad, create_graph=True)[0]

    return out_grad_grad.numpy()


def compute_grad_grad_out_torch(x, y, out_grad):
    x = torch.from_numpy(x).cuda()
    x.requires_grad = True

    y = torch.from_numpy(y).cuda()
    y.requires_grad = True

    out_grad = torch.from_numpy(out_grad).cuda()
    out_grad.requires_grad = True

    out = (x - y).tanh()

    x_grad = torch.autograd.grad(out, x, [out_grad], create_graph=True)[0]

    out_grad_grad = torch.autograd.grad(x_grad.sum(), out_grad, create_graph=True)[0]

    return out_grad_grad.detach().cpu().numpy()


x_shapes = [
    [2, 1, 4, 5],
    [1, 4, 5],
    [1, 4, 5],
    [2, 1, 4, 5],
    [4, 1, 3],
    [4, 1, 3],
]

y_shapes = [
    [2, 3, 1, 1],
    [3, 1, 1],
    [],
    [4, 1],
    [3, 1],
    [1, 3],
]

for x_shape, y_shape in zip(x_shapes, y_shapes):
    x = np.array(np.random.randn(*x_shape), dtype="float32")
    y = np.array(np.random.randn(*y_shape), dtype="float32")
    out_grad = np.ones_like(x - y).astype("float32")
    paddle_result = compute_grad_grad_out_paddle(x, y, out_grad)
    torch_result = compute_grad_grad_out_torch(x, y, out_grad)
    print(np.allclose(paddle_result, torch_result))
```