### PR TITLE
[XPU] fix xpu rotary test bug

### DIFF
--- a/paddle/phi/kernels/fusion/xpu/fused_rope_grad_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_grad_kernel.cc
@@ -29,6 +29,7 @@ void FusedRopeGradKernel(const Context& dev_ctx,
                          const paddle::optional<DenseTensor>& dout_v,
                          bool use_neox_rotary_style,
                          bool time_major,
+                         float rotary_emb_base,
                          DenseTensor* dq,
                          DenseTensor* dk,
                          DenseTensor* dv) {

--- a/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_kernel.cc
@@ -30,6 +30,7 @@ void FusedRopeKernel(const Context& dev_ctx,
                      const paddle::optional<DenseTensor>& position_ids,
                      bool use_neox_rotary_style,
                      bool time_major,
+                     float rotary_emb_base,
                      DenseTensor* out_q,
                      DenseTensor* out_k,
                      DenseTensor* out_v) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
rotary was added a new parameter rotary_base in https://github.com/PaddlePaddle/Paddle/pull/63160, resulting in the occurance of error when testing xpu version of rotary operator. However, xpu does not support null-cos & null-sin inputs, yet. i.e. xpu version of rotary (or to say, rope) does not support the functionality of initializing cos and sin within that single operator. To solve this test error quickly, I choose to it in a nasty way by modifying the interface solely. This will not hurt the function integrity of the original xpu operator and the full calculating process will be supported very soon.
