### PR TITLE
fix int32 overflow in rope rotate_half

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_rope_utils.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_utils.h
@@ -315,13 +315,13 @@ __device__ __forceinline__ void rotate_half(phi::Array<const T*, 3> ins_data,
   T store[VecSize];
   using VecType = phi::AlignedVector<T, VecSize>;
   constexpr int kVectorsPerThread = VecSize / 2;
-  int stride_r = head_dim / 2;
+  int64_t stride_r = head_dim / 2;
 #pragma unroll
   for (int iter = 0; iter < 3; iter++) {
     if (iter >= num_inputs) break;
     // get value_index and rotate_half_index
-    int index_v = index;
-    int index_r =
+    int64_t index_v = index;
+    int64_t index_r =
         (index % head_dim) < stride_r ? (index + stride_r) : (index - stride_r);
     MPType sign_r = (index % head_dim) < stride_r ? static_cast<MPType>(-1)
                                                   : static_cast<MPType>(1);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
修复输入长度超过INT_MAX时，fused_rope执行rotate_half存在int32溢出的问题