### PR TITLE
clean use for templatedoc decorator

### DIFF
--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -30,19 +30,30 @@ from paddle.framework import (
     in_dynamic_or_pir_mode,
     in_pir_mode,
 )
-from paddle.tensor.layer_function_generator import templatedoc
 
 __all__ = []
 
 
-@templatedoc()
 def clip_by_norm(x, max_norm, name=None):
     """
-    ${comment}
+    ClipByNorm Operator.
+
+    This operator limits the L2 norm of the input $X$ within $max\\_norm$.
+    If the L2 norm of $X$ is less than or equal to $max\\_norm$, $Out$ will be
+    the same as $X$. If the L2 norm of $X$ is greater than $max\\_norm$, $X$ will
+    be linearly scaled to make the L2 norm of $Out$ equal to $max\\_norm$, as
+    shown in the following formula:
+
+    $$
+    Out = \\frac{max\\_norm * X}{norm(X)},
+    $$
+
+    where $norm(X)$ represents the L2 norm of $X$.
 
     Args:
-        x(${x_type}): ${x_comment}
-        max_norm(${max_norm_type}): ${max_norm_comment}
+        x(Variable): (Tensor) The input of clip_by_norm op and data type is float32.
+            The number of dimensions must be between [1, 9].
+        max_norm(float): (float) The maximum norm value.
         name(str, optional): For detailed information, please refer
             to :ref:`api_guide_Name`. Usually name is no need to set and
             None by default.
@@ -50,7 +61,8 @@ def clip_by_norm(x, max_norm, name=None):
     Returns:
         Tensor:
 
-        out(${out_type}): ${out_comment}
+        out(Variable): (Tensor) The output of clip_by_norm op with shape as input(X)
+            The data type is float32.
 
 
     Examples:
@@ -96,17 +108,16 @@ def clip_by_norm(x, max_norm, name=None):
     return out
 
 
-@templatedoc()
 def merge_selected_rows(x, name=None):
     """
-    ${comment}
+    TODO: Documentation of merge_selected_rows op.
 
     Args:
-        x(${x_type}): ${x_comment}
+        x(Variable): (Tensor), input 0 of merge_selected_rows op.
         name(basestring|None): Name of the output.
 
     Returns:
-        out(${out_type}): ${out_comment}
+        out(Variable): (Tensor), output 0 of merge_selected_rows op.
 
     Examples:
 
@@ -135,7 +146,6 @@ def merge_selected_rows(x, name=None):
     return out
 
 
-@templatedoc()
 def get_tensor_from_selected_rows(x, name=None):
     """
     Get tensor data from input with SelectedRows type, and outputs a Tensor.

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -43,7 +43,9 @@ def clip_by_norm(x, max_norm, name=None):
     be linearly scaled to make the L2 norm of :math:`out` equal to :math:`max\_norm`, as
     shown in the following formula:
 
-    :math:`out = \frac{max\_norm * x}{norm(x)}`
+    .. math::
+
+        out = \frac{max\_norm * x}{norm(x)}
 
     where :math:`norm(x)` represents the L2 norm of :math:`x`.
 

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -35,35 +35,29 @@ __all__ = []
 
 
 def clip_by_norm(x, max_norm, name=None):
-    """
-    ClipByNorm Operator.
+    r"""
 
-    This operator limits the L2 norm of the input $X$ within $max\\_norm$.
-    If the L2 norm of $X$ is less than or equal to $max\\_norm$, $Out$ will be
-    the same as $X$. If the L2 norm of $X$ is greater than $max\\_norm$, $X$ will
-    be linearly scaled to make the L2 norm of $Out$ equal to $max\\_norm$, as
+    Limits the L2 norm of the input :math:`x` within :math:`max\_norm`.
+    If the L2 norm of :math:`x` is less than or equal to :math:`max\_norm`, :math:`out` will be
+    the same as :math:`x`. If the L2 norm of :math:`x` is greater than :math:`max\_norm`, :math:`x` will
+    be linearly scaled to make the L2 norm of :math:`out` equal to :math:`max\_norm`, as
     shown in the following formula:
 
-    $$
-    Out = \\frac{max\\_norm * X}{norm(X)},
-    $$
+    :math:`out = \frac{max\_norm * x}{norm(x)}`
 
-    where $norm(X)$ represents the L2 norm of $X$.
+    where :math:`norm(x)` represents the L2 norm of :math:`x`.
 
     Args:
-        x(Variable): (Tensor) The input of clip_by_norm op and data type is float32.
+        x(Tensor): The input of clip_by_norm and data type is float32.
             The number of dimensions must be between [1, 9].
-        max_norm(float): (float) The maximum norm value.
+        max_norm(float): The maximum norm value.
         name(str, optional): For detailed information, please refer
             to :ref:`api_guide_Name`. Usually name is no need to set and
             None by default.
 
     Returns:
-        Tensor:
-
-        out(Variable): (Tensor) The output of clip_by_norm op with shape as input(X)
+        Tensor: The output of clip_by_norm with shape as input.
             The data type is float32.
-
 
     Examples:
 
@@ -110,14 +104,14 @@ def clip_by_norm(x, max_norm, name=None):
 
 def merge_selected_rows(x, name=None):
     """
-    TODO: Documentation of merge_selected_rows op.
+    Merge by adding duplicated rows in the input SelectedRows object.
 
     Args:
-        x(Variable): (Tensor), input 0 of merge_selected_rows op.
+        x(Tensor): The input selected rows to be merge.
         name(basestring|None): Name of the output.
 
     Returns:
-        out(Variable): (Tensor), output 0 of merge_selected_rows op.
+        Tensor, merged output.
 
     Examples:
 

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -3332,12 +3332,10 @@ def py_func(func, x, out, backward_func=None, skip_vars_in_backward_input=None):
 
 
 def row_conv(input, future_context_size, param_attr=None, act=None):
-    """
+    r"""
     :api_attr: Static Graph
 
-    :strong:`Row-convolution operator`
-
-    The row convolution is called lookahead convolution.  This operator was
+    The row convolution is called lookahead convolution. It was
     introduced in the following paper for DeepSpeech2:
     http://www.cs.cmu.edu/~dyogatam/papers/wang+etal.iclrworkshop2016.pdf
 
@@ -3347,46 +3345,41 @@ def row_conv(input, future_context_size, param_attr=None, act=None):
     unidirectional RNNs, bidirectional RNNs are challenging to deploy in an online
     and low-latency setting. The lookahead convolution incorporates information
     from future subsequences in a computationally efficient manner to improve
-    unidirectional recurrent neural networks. The row convolution operator is
+    unidirectional recurrent neural networks. The row convolution is
     different from the 1D sequence convolution, and is computed as follows:
 
-    Given an input sequence $X$ of length $t$ and input dimension $D$,
-    and a filter ($W$) of size $context \times D$,
+    Given an input sequence :math:`X` of length :math:`t` and input dimension :math:`D`,
+    and a filter (:math:`W`) of size :math:`context \times D`,
     the output sequence is convolved as:
 
-    $$
-    out_{i} = \\sum_{j=i}^{i + context - 1} X_{j} \\cdot W_{j-i}
-    $$
+    :math:`out_{i} = \sum_{j=i}^{i + context - 1} X_{j} \cdot W_{j-i}`
+
 
     In the above equation:
 
-    * $Out_{i}$: The i-th row of output variable with shape [1, D].
+    * :math:`Out_{i}`: The i-th row of output variable with shape [1, D].
 
-    * $context$: Future context size.
+    * :math:`context`: Future context size.
 
-    * $X_{j}$: The j-th row of input variable with shape [1, D].
+    * :math:`X_{j}`: The j-th row of input variable with shape [1, D].
 
-    * $W_{j-i}$: The (j-i)-th row of parameters with shape [1, D].
+    * :math`W_{j-i}`: The (j-i)-th row of parameters with shape [1, D].
 
     More details about row_conv please refer to
     the design document
     https://github.com/PaddlePaddle/Paddle/issues/2228#issuecomment-303903645 .
 
     Args:
-        input (Variable): the input(X) is a LodTensor or tensor, LodTensor(X) supports
-            variable time-length input sequences. The underlying tensor
-            in this phi::DenseTensor is a matrix with shape (T x N), where T
-            is the total time steps in this mini-batch and N is the input
-            data dimension. the shape of Tensor input(X) has shape
+        input (Tensor): The input is a Tensor, the shape of Tensor input has shape
             (B x T x N), B is batch size.
         future_context_size (int): Future context size. Please note, the shape
             of convolution kernel is [future_context_size + 1, D].
         param_attr (ParamAttr): Attributes of parameters, including
             name, initializer etc.
-        act (str): Non-linear activation to be applied to output variable.
+        act (str): Non-linear activation to be applied to output Tensor.
 
     Returns:
-        The output(Out) is a LodTensor or Tensor, which has same type and same shape as X.
+        Tensor: The output is a Tensor, which has same type and same shape as input.
 
     Examples:
 

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -3352,7 +3352,9 @@ def row_conv(input, future_context_size, param_attr=None, act=None):
     and a filter (:math:`W`) of size :math:`context \times D`,
     the output sequence is convolved as:
 
-    :math:`out_{i} = \sum_{j=i}^{i + context - 1} X_{j} \cdot W_{j-i}`
+    .. math::
+
+        Out_{i} = \sum_{j=i}^{i + context - 1} X_{j} \cdot W_{j-i}
 
 
     In the above equation:

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -3363,7 +3363,7 @@ def row_conv(input, future_context_size, param_attr=None, act=None):
 
     * :math:`X_{j}`: The j-th row of input variable with shape [1, D].
 
-    * :math`W_{j-i}`: The (j-i)-th row of parameters with shape [1, D].
+    * :math:`W_{j-i}`: The (j-i)-th row of parameters with shape [1, D].
 
     More details about row_conv please refer to
     the design document

--- a/python/paddle/static/nn/loss.py
+++ b/python/paddle/static/nn/loss.py
@@ -18,7 +18,6 @@ from paddle.base.framework import static_only
 
 # TODO: define loss functions of neural network
 from paddle.base.layer_helper import LayerHelper
-from paddle.base.layers.layer_function_generator import templatedoc
 from paddle.base.param_attr import ParamAttr
 from paddle.nn.initializer import Assign
 
@@ -31,7 +30,6 @@ __all__ = []
 # For now, the comments in c++ use types like Tensor, but in python side
 # the type is often "Variable", and arguments may vary.
 @static_only
-@templatedoc(op_type="nce")
 def nce(
     input,
     label,
@@ -49,14 +47,16 @@ def nce(
     """
     :api_attr: Static Graph
 
-    ${comment}
+    Compute and return the noise-contrastive estimation training loss. See `Noise-contrastive estimation: A new estimation principle
+    for unnormalized statistical models <http://www.jmlr.org/proceedings/papers/v9/gutmann10a/gutmann10a.pdf>`_.
+    By default this operator uses a uniform distribution for sampling.
 
     Args:
         input (Tensor): Input tensor, 2-D tensor with shape [batch_size, dim],
             and data type is float32 or float64.
         label (Tensor): Input label, 2-D tensor with shape [batch_size, num_true_class],
             and data type is int64.
-        num_total_classes (int):${num_total_classes_comment}.
+        num_total_classes (int): Total number of classes in all samples.
         sample_weight (Tensor|None): A Tensor of shape [batch_size, 1]
             storing a weight for each sample. The default weight for each
             sample is 1.0.
@@ -66,7 +66,7 @@ def nce(
         bias_attr (ParamAttr|None): To specify the bias parameter attribute.
             Default: None, which means the default bias parameter property is
             used. See usage for details in :ref:`api_paddle_ParamAttr` .
-        num_neg_samples (int): ${num_neg_samples_comment}.
+        num_neg_samples (int): The number of negative classes. The default value is 10.
         name(str|None): For detailed information, please refer to
             :ref:`api_guide_Name` . Usually name is no need to set and None by default.
         sampler (str, optional): The sampler used to sample class from negative classes.

--- a/python/paddle/static/nn/sequence_lod.py
+++ b/python/paddle/static/nn/sequence_lod.py
@@ -17,12 +17,10 @@ from paddle.base.core import VarDesc
 from paddle.base.data_feeder import check_type, check_variable_and_dtype
 from paddle.base.framework import Variable, in_dygraph_mode
 from paddle.base.layer_helper import LayerHelper
-from paddle.base.layers.layer_function_generator import templatedoc
 
 __all__ = []
 
 
-@templatedoc()
 def sequence_conv(
     input,
     num_filters,

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -441,7 +441,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
         y (Tensor): The input tensor, it's data type should be float16, float32, float64.
         rtol (rtoltype, optional): The relative tolerance. Default: :math:`1e-5` .
         atol (atoltype, optional): The absolute tolerance. Default: :math:`1e-8` .
-        equal_nan (equalnantype, optional): (bool), attribute 2 for allclose op. Default: False.
+        equal_nan (bool, optional): Whether to compare nan as equal. Default: False.
         name (str, optional): Name for the operation. For more information, please
             refer to :ref:`api_guide_Name`. Default: None.
 

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -18,7 +18,6 @@ import paddle
 
 from ..base.data_feeder import check_type, check_variable_and_dtype
 from ..common_ops_import import Variable
-from .layer_function_generator import templatedoc
 
 Tensor = paddle.base.framework.core.eager.Tensor
 
@@ -427,7 +426,6 @@ def equal_all(x, y, name=None):
         return out
 
 
-@templatedoc()
 def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
     r"""
     Check if all :math:`x` and :math:`y` satisfy the condition:
@@ -443,7 +441,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
         y (Tensor): The input tensor, it's data type should be float16, float32, float64.
         rtol (rtoltype, optional): The relative tolerance. Default: :math:`1e-5` .
         atol (atoltype, optional): The absolute tolerance. Default: :math:`1e-8` .
-        equal_nan (equalnantype, optional): ${equal_nan_comment}. Default: False.
+        equal_nan (equalnantype, optional): (bool), attribute 2 for allclose op. Default: False.
         name (str, optional): Name for the operation. For more information, please
             refer to :ref:`api_guide_Name`. Default: None.
 
@@ -503,7 +501,6 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
         return out
 
 
-@templatedoc()
 def equal(x, y, name=None):
     """
 
@@ -605,7 +602,6 @@ def equal_(x, y, name=None):
         return _C_ops.equal_(x, y)
 
 
-@templatedoc()
 def greater_equal(x, y, name=None):
     """
     Returns the truth value of :math:`x >= y` elementwise, which is equivalent function to the overloaded operator `>=`.
@@ -697,7 +693,6 @@ def greater_equal_(x, y, name=None):
         return _C_ops.greater_equal_(x, y)
 
 
-@templatedoc()
 def greater_than(x, y, name=None):
     """
     Returns the truth value of :math:`x > y` elementwise, which is equivalent function to the overloaded operator `>`.
@@ -789,7 +784,6 @@ def greater_than_(x, y, name=None):
         return _C_ops.greater_than_(x, y)
 
 
-@templatedoc()
 def less_equal(x, y, name=None):
     """
     Returns the truth value of :math:`x <= y` elementwise, which is equivalent function to the overloaded operator `<=`.
@@ -882,7 +876,6 @@ def less_equal_(x, y, name=None):
         return _C_ops.less_equal_(x, y)
 
 
-@templatedoc()
 def less_than(x, y, name=None):
     """
     Returns the truth value of :math:`x < y` elementwise, which is equivalent function to the overloaded operator `<`.
@@ -975,7 +968,6 @@ def less_than_(x, y, name=None):
         return _C_ops.less_than_(x, y)
 
 
-@templatedoc()
 def not_equal(x, y, name=None):
     """
     Returns the truth value of :math:`x != y` elementwise, which is equivalent function to the overloaded operator `!=`.
@@ -1365,7 +1357,6 @@ def bitwise_not_(x, name=None):
         return _C_ops.bitwise_not_(x)
 
 
-@templatedoc()
 def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
     r"""
     Check if all :math:`x` and :math:`y` satisfy the condition:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -43,7 +43,7 @@ from ..framework import (
     in_pir_mode,
 )
 from .creation import _complex_to_real_dtype
-from .layer_function_generator import generate_layer_fn, templatedoc
+from .layer_function_generator import generate_layer_fn
 from .manipulation import cast, cast_
 from .ops import (  # noqa: F401
     abs,
@@ -1993,7 +1993,6 @@ def count_nonzero(x, axis=None, keepdim=False, name=None):
     return paddle.sum(int_tensor, axis=axis, keepdim=keepdim, name=name)
 
 
-@templatedoc(op_type="sum")
 def add_n(inputs, name=None):
     """
     Sum one or more Tensor of the input.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
ref #63734 
清理无用 templatedoc 装饰器的使用，将 OP 定义中的参数描述添加到现有的 docstring 中,清理后框架不再存在 templatedoc 装饰器的使用
templatedoc 装饰器只会替换其中的 template arguments （支持$替换
@SigureMo 
