### PR TITLE
[Cleanup] Remove `typing-extensions` installation at built time

### DIFF
--- a/paddle/fluid/operators/generator/CMakeLists.txt
+++ b/paddle/fluid/operators/generator/CMakeLists.txt
@@ -52,50 +52,16 @@ function(install_py_jinja2)
       OUTPUT_VARIABLE _jinja2_version
       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
-      if(NOT _jinja2_version VERSION_LESS "2.11.3")
-        execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
-                                jinja2==2.11.3)
-      endif()
-      return()
-    endif()
-
     if(_jinja2_version)
       return()
     endif()
   endif()
 
-  if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
-                            jinja2==2.11.3)
-  else()
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U jinja2)
-  endif()
-endfunction()
-
-function(install_py_typing_extensions)
-  if(${PYTHON_VERSION_STRING} VERSION_LESS "3.6.2")
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
-                            typing-extensions>=4.1.1)
-    return()
-  endif()
-
-  execute_process(
-    COMMAND
-      ${PYTHON_EXECUTABLE} "-c"
-      "import re, typing_extensions; print(re.compile('/__init__.py.*').sub('',typing_extensions.__file__))"
-    RESULT_VARIABLE _te_status
-    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  if(NOT _te_status EQUAL 0)
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U
-                            typing-extensions)
-  endif()
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U jinja2)
 endfunction()
 
 install_py_pyyaml()
 install_py_jinja2()
-install_py_typing_extensions()
 
 # parse ops
 set(parsed_op_dir


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

#63690 已将 `typing_extensions` 作为 Paddle 依赖项，在 build 之前会安装 `requirements.txt`，因此无需在 cmake 里再次安装

另外我们早已不支持 Python 3.6，因此移除掉同一文件中对于 `Python<3.6.2` 的逻辑分支

Pcard-76996