### PR TITLE
[Typing] Remove `TYPE_CHECKING` guard for `typing_extensions` imports

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/mutable_data.py
@@ -14,16 +14,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
-if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec, TypeAlias
+from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
-    P = ParamSpec("P")
-    R = TypeVar("R")
+P = ParamSpec("P")
+R = TypeVar("R")
 
-    MutableDataT = TypeVar("MutableDataT", bound="MutableData")
-    DataGetter: TypeAlias = Callable[[MutableDataT, Any], Any]
+MutableDataT = TypeVar("MutableDataT", bound="MutableData")
+DataGetter: TypeAlias = Callable[[MutableDataT, Any], Any]
 
 InnerMutableDataT = TypeVar(
     "InnerMutableDataT", bound="dict[str, Any] | list[Any]"

--- a/python/paddle/jit/sot/psdb.py
+++ b/python/paddle/jit/sot/psdb.py
@@ -16,15 +16,12 @@ from __future__ import annotations
 
 import builtins
 import types
-from typing import TYPE_CHECKING, Callable
+from typing import Callable, TypeVar
 
-if TYPE_CHECKING:
-    from typing import TypeVar
+from typing_extensions import ParamSpec
 
-    from typing_extensions import ParamSpec
-
-    T = TypeVar("T")
-    P = ParamSpec("P")
+T = TypeVar("T")
+P = ParamSpec("P")
 
 NO_BREAKGRAPH_CODES: set[types.CodeType] = set()
 NO_FALLBACK_CODES: set[types.CodeType] = set()

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -14,18 +14,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import Callable, TypeVar
+
+from typing_extensions import ParamSpec
 
 import paddle
 
 from .opcode_translator import eval_frame_callback
 from .utils import GraphLogger, StepInfoManager, StepState, log_do
 
-if TYPE_CHECKING:
-    from typing_extensions import ParamSpec
-
-    P = ParamSpec("P")
-    R = TypeVar("R")
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

移除 `typing_extensions` import 外的 `if TYPE_CHECKING:`，之前是因为 `typing_extensions` 并非 Paddle 依赖项，只能如此，以免运行时挂掉，但现在 #63690 已将其作为依赖项了，因此这样做是没有必要的了

Pcard-76996