### PR TITLE
[CINN] Reverse the order of cinn_group_cluster_pass and add_store_in_fusion_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -151,8 +151,8 @@ void ApplyDivideGroupOpToFusionOpPass(
         CreatePassManager) {
   std::shared_ptr<pir::PassManager> pass_manager = CreatePassManager();
   if (FLAGS_group_schedule_tiling_first) {
+    pass_manager->AddPass(cinn::dialect::ir::CreateAddStoreInGroupOpPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateCinnGroupClusterPass());
-    pass_manager->AddPass(cinn::dialect::ir::CreateAddStoreInFusionOpPass());
   } else {
     pass_manager->AddPass(
         cinn::dialect::ir::CreateDivideGroupOpToFusionOpPass());

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.cc
@@ -56,10 +56,10 @@ class AddYieldStoreInFusionOpPattern
   }
 };
 
-class AddStoreInFusionOpPass : public pir::Pass {
+class AddStoreInGroupOpPass : public pir::Pass {
  public:
-  AddStoreInFusionOpPass()
-      : pir::Pass("add_store_in_fusion_op", /*opt_level=*/1) {}
+  AddStoreInGroupOpPass()
+      : pir::Pass("add_store_in_group_op", /*opt_level=*/1) {}
 
   bool Initialize(pir::IrContext* context) override {
     pir::RewritePatternSet ps(context);
@@ -76,14 +76,7 @@ class AddStoreInFusionOpPass : public pir::Pass {
     for (uint32_t i = 0; i < op->num_regions(); ++i) {
       for (auto& block : op->region(i)) {
         for (auto& op : block) {
-          if (op.isa<cinn::dialect::FusionOp>()) {
-            auto fusion_op = op.dyn_cast<cinn::dialect::FusionOp>();
-            if (fusion_op.GetOperators().size() == 2 &&
-                fusion_op.GetOperators()
-                    .front()
-                    ->isa<cinn::dialect::ReshapeOp>()) {
-              continue;
-            }
+          if (op.isa<cinn::dialect::GroupOp>()) {
             auto [_, num_rewrites] =
                 pir::ApplyPatternsGreedily(&op, patterns_, cfg);
             AddStatistics(num_rewrites);
@@ -101,8 +94,8 @@ class AddStoreInFusionOpPass : public pir::Pass {
   pir::FrozenRewritePatternSet patterns_;
 };
 
-std::unique_ptr<pir::Pass> CreateAddStoreInFusionOpPass() {
-  return std::make_unique<AddStoreInFusionOpPass>();
+std::unique_ptr<pir::Pass> CreateAddStoreInGroupOpPass() {
+  return std::make_unique<AddStoreInGroupOpPass>();
 }
 
 }  // namespace ir

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.h
@@ -21,7 +21,7 @@ namespace cinn {
 namespace dialect {
 namespace ir {
 
-std::unique_ptr<pir::Pass> CreateAddStoreInFusionOpPass();
+std::unique_ptr<pir::Pass> CreateAddStoreInGroupOpPass();
 
 }  // namespace ir
 }  // namespace dialect

--- a/paddle/cinn/operator_fusion/pattern_graph.cc
+++ b/paddle/cinn/operator_fusion/pattern_graph.cc
@@ -83,8 +83,7 @@ void PatternGraph<T>::SinkTrivialPattern() {
   GraphTransformer<
       NodePattern,
       T,
-      And<And<NonSinkNodeMatcher, StmtPatternGraphMatcher<TrivialPattern<T>>>,
-          IsNotOutputNodeMatcher>,
+      And<NonSinkNodeMatcher, StmtPatternGraphMatcher<TrivialPattern<T>>>,
       MergeTrivialPatternOperation>(this);
 }
 
@@ -114,17 +113,16 @@ template <typename T>
 void PatternGraph<T>::ReduceTreeGrown() {
   GraphTransformer<NodePattern,
                    T,
-                   And<CanFuseReduceTreeMatcher, IsNotOutputNodeMatcher>,
+                   CanFuseReduceTreeMatcher,
                    MergeReduceTreeOperation>(this);
 }
 
 template <typename T>
 void PatternGraph<T>::ReduceTree_Trivial_Fusion() {
-  GraphTransformer<
-      NodePattern,
-      T,
-      And<CanFuseReduceTreeAndTrivialMatcher, IsNotOutputNodeMatcher>,
-      MergeReduceTreeAndTrivialOperation>(this);
+  GraphTransformer<NodePattern,
+                   T,
+                   CanFuseReduceTreeAndTrivialMatcher,
+                   MergeReduceTreeAndTrivialOperation>(this);
 }
 
 template <typename T>

--- a/paddle/cinn/operator_fusion/pattern_graph.h
+++ b/paddle/cinn/operator_fusion/pattern_graph.h
@@ -363,14 +363,6 @@ struct IsOutputNodeMatcher {
   }
 };
 
-struct IsNotOutputNodeMatcher {
-  template <typename T>
-  bool operator()(const PatternGraph<T>& graph, const PatternNodePtr<T>& node) {
-    bool res = !IsOutputNodeMatcher()(graph, node);
-    return res;
-  }
-};
-
 template <int N>
 struct DownstreamSmallerThan {
   template <typename T>

--- a/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
@@ -74,31 +74,6 @@ ShardableAxesSignature CreateDefaultSignature(pir::Operation* op) {
   return result;
 }
 
-std::optional<ShardableAxesSignature> CreateSignatureForSpecialOps(
-    pir::Operation* op) {
-  if (op->num_results() != 1) {
-    VLOG(4) << "Now we do not support op with multi outputs, create default: "
-            << op->name();
-    return CreateDefaultSignature(op);
-  }
-  if (op->isa<cinn::dialect::ReshapeOp>()) {
-    return CreateDefaultSignature(op);
-  }
-  if (op->name() == "cinn_op.generate_shape") {
-    return CreateDefaultSignature(op);
-  }
-  if (op->name() == "cinn_op.yield_store") {
-    return CreateDefaultSignature(op);
-  }
-  if (op->name() == "cinn_op.reshape") {
-    return CreateDefaultSignature(op);
-  }
-  if (op->name() == "pd_op.reshape") {
-    return CreateDefaultSignature(op);
-  }
-  return std::nullopt;
-}
-
 ShardableAxesSignature CreateSignatureForReduce(pir::Operation* reduce_op) {
   CHECK_EQ(reduce_op->num_operands(), 1);
   CHECK_EQ(reduce_op->num_results(), 1);
@@ -184,6 +159,26 @@ ShardableAxesSignature CreateSignatureForBroadcast(
   result.outputs.emplace_back(ShardableAxes(output_axis_names));
 
   return result;
+}
+
+std::optional<ShardableAxesSignature> CreateSignatureForSpecialOps(
+    pir::Operation* op) {
+  if (op->isa<cinn::dialect::ReshapeOp>()) {
+    return CreateDefaultSignature(op);
+  }
+  if (op->name() == "cinn_op.generate_shape") {
+    return CreateDefaultSignature(op);
+  }
+  if (op->name() == "cinn_op.yield_store") {
+    return CreateSignatureForElementWise(op);
+  }
+  if (op->name() == "cinn_op.reshape") {
+    return CreateDefaultSignature(op);
+  }
+  if (op->name() == "pd_op.reshape") {
+    return CreateDefaultSignature(op);
+  }
+  return std::nullopt;
 }
 
 ShardableAxesSignature ShardableAxesInfoManager::CreateShardableSignature(

--- a/test/cpp/pir/cinn/pir_all_path_test.cc
+++ b/test/cpp/pir/cinn/pir_all_path_test.cc
@@ -74,8 +74,8 @@ static void RunAndCheckResult(::pir::Program* program,
   CHECK_EQ(stage_1_pm.Run(program), true);
 
   pir::PassManager stage_2_pm(ctx);
+  stage_2_pm.AddPass(cinn::dialect::ir::CreateAddStoreInGroupOpPass());
   stage_2_pm.AddPass(cinn::dialect::ir::CreateCinnGroupClusterPass());
-  stage_2_pm.AddPass(cinn::dialect::ir::CreateAddStoreInFusionOpPass());
   stage_2_pm.AddPass(pir::CreateDeadCodeEliminationPass());
   stage_2_pm.AddPass(cinn::dialect::ir::CreateLowerCinnFusionOpPass());
   stage_2_pm.EnableIRPrinting();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

Reverse the order of `cinn_group_cluster_pass` and `add_store_in_fusion_pass`, with the purpose of simplifying fusion process in group cluster pass.

PCard-76996