### PR TITLE
[XPU] enable Generator::IncrementOffset

### DIFF
--- a/paddle/phi/core/generator.cc
+++ b/paddle/phi/core/generator.cc
@@ -272,7 +272,7 @@ uint64_t Generator::Random64() {
 
 std::pair<uint64_t, uint64_t> Generator::IncrementOffset(uint64_t increment) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
-    defined(PADDLE_WITH_CUSTOM_DEVICE)
+    defined(PADDLE_WITH_CUSTOM_DEVICE) || defined(PADDLE_WITH_XPU)
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t offset = state().offset;
   state().offset = offset + increment;


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
在 https://github.com/PaddlePaddle/Paddle/pull/63644 中会调用`Generator::IncrementOffset`函数，但是这个函数在非XPU下面会直接走到`PADDLE_THROW`上。因此稍微修改了一下条件编译。