### PR TITLE
Fix argsort kernel annotation

### DIFF
--- a/paddle/phi/kernels/argsort_kernel.h
+++ b/paddle/phi/kernels/argsort_kernel.h
@@ -35,7 +35,7 @@ namespace phi {
  *                      else if false, sort by ascending order
  * @param  stable       Indicate whether to use stable sorting algorithm, which
  *                      guarantees that the order of equivalent elements is
- * preserved.
+ *                      preserved.
  * @param  out          The sorted tensor of Argsort op, with the same shape as
  *                      x
  * @param  indices      The indices of a tensor giving the sorted order, with


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix argsort kernel annotation of parameter `stable`