### PR TITLE
fix reshard of empty tensor and refine local shape calculation

### DIFF
--- a/paddle/phi/api/yaml/generator/dist_api_gen.py
+++ b/paddle/phi/api/yaml/generator/dist_api_gen.py
@@ -49,6 +49,8 @@ MAIN_DIST_BRANCH_TEMPLATE = """
     // 1. InferSpmd (Infer DistAttr of Inputs&Outputs){}
     // 2. Create API Output & Prepare Dist and Dense Output{}
     // 3. Infer DistTensor's Global Shape{}\n
+    // 3.1. Set Output Dist Attr For Default Impl{}\n
+    VLOG(1) << 21111111;
     if (rank_is_in_current_mesh) {{
       // 4. Select Kernel{}
       // 5. Reshard Input{}\n
@@ -58,8 +60,7 @@ MAIN_DIST_BRANCH_TEMPLATE = """
       // 9. DenseTensor Kernel Call{}
       // 10. Fallback{}
     }}\n
-    // 11. Set Output Dist Attr For Default Impl{}\n
-    // 12. Return
+    // 11. Return
     {}
   }}
 """
@@ -489,37 +490,12 @@ NONEED_TO_SET_DIST_ATTR_COMMENT_TEMPLATE = """
 CALCULATE_LOCAL_SHAPE_TEMPLATE = """
 
       // The dist_input_x is a dist tensor, the dims() func return the global dims.
-      auto x_shape = dist_input_x->dims();
-      auto x_numel = dist_input_x->numel();
-      bool visit_negative = false;
-      auto global_shape = {shape};
+      auto out_shape = {out_name}->dims();
       std::vector<{dtype}> local_shape;
-      for (size_t i = 0; i < global_shape.size(); i++) {{
-        auto& out_dist_attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr, spmd_info.second[0]);
+      auto& out_dist_attr = {out_name}->dist_attr();
+      for (int i = 0; i < out_shape.size(); i++) {{
         if (out_dist_attr.dims_mapping()[i] >= 0) {{
-          {dtype} shape_i = global_shape[i];
-          if (shape_i == 0) {{
-            shape_i = x_shape[i];
-          }} else if (shape_i == -1) {{
-            PADDLE_ENFORCE(not visit_negative,
-                           phi::errors::InvalidArgument(
-                               "{op_name} can only have one -1 in the {shape_name}."));
-            visit_negative = true;
-            int64_t non_negative_product = 1;
-            for (size_t j = 0; j < global_shape.size(); j++) {{
-              if (i == j) {{
-                continue;
-              }}
-              int64_t tmp_j = global_shape[j];
-              if (tmp_j == 0) {{
-                tmp_j = x_shape[j];
-              }}
-              non_negative_product *= tmp_j;
-            }}
-            PADDLE_ENFORCE(x_numel % non_negative_product == 0,
-                           phi::errors::InvalidArgument("Cannot infer real shape for -1."));
-            shape_i = x_numel / non_negative_product;
-          }}
+          {dtype} shape_i = out_shape[i];
           int64_t dim = out_dist_attr.dims_mapping()[i];
           int64_t mesh_dim = out_dist_attr.process_mesh().shape()[dim];
           // TODO: Support aliquant condition.
@@ -530,7 +506,7 @@ CALCULATE_LOCAL_SHAPE_TEMPLATE = """
                     "and shard mesh dims is %lld.", i, shape_i, mesh_dim));
           local_shape.push_back(shape_i / mesh_dim);
         }} else {{
-          local_shape.push_back({shape}[i]);
+          local_shape.push_back(out_shape[i]);
         }}
       }}
 """
@@ -1589,9 +1565,7 @@ class DistForwardAPI(ForwardAPI):
             shape_type = self.attrs['attr_info'][shape_name][0]
 
             infer_meta_code = CALCULATE_LOCAL_SHAPE_TEMPLATE.format(
-                shape=f"{shape_name}.GetData()"
-                if shape_type == "IntArray"
-                else f"{shape_name}",
+                out_name=self.dist_output_args[0],
                 dtype="int64_t" if shape_type == "IntArray" else "int",
                 op_name=self.kernel['func'][0],
                 shape_name=shape_name,
@@ -1847,6 +1821,7 @@ class DistForwardAPI(ForwardAPI):
             infer_spmd_code,
             output_creation_code,
             infer_global_shape_code,
+            output_dist_attr_setting,
             kernel_selection_code,
             reshard_input_code,
             prepare_data_code,
@@ -1854,7 +1829,6 @@ class DistForwardAPI(ForwardAPI):
             infer_meta_code,
             kernel_call_code,
             fallback_code,
-            output_dist_attr_setting,
             return_code,
         )
 

--- a/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/p_to_s_reshard_function.cc
@@ -64,7 +64,7 @@ void ReshardPToSWithPadding(DeviceContext* dev_ctx,
     std::swap(axis[0], axis[split_axis]);
     RESHARD_FUNCTOR(dev_ctx, Transpose, dtype, in, axis, &in_reduce_scatter);
   } else {
-    in_reduce_scatter.ShareDataWith(in);
+    in_reduce_scatter.ShareDataNoCheckWith(in);
   }
 
   DenseTensor out_reduce_scatter;

--- a/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
+++ b/paddle/phi/core/distributed/auto_parallel/reshard/s_to_s_reshard_function.cc
@@ -94,7 +94,7 @@ void SToSReshardFunction::Eval(phi::DeviceContext* dev_ctx,
     RESHARD_FUNCTOR(
         dev_ctx, Reshape, dtype, out_transpose, pre_shape_vec, &in_all_to_all);
   } else {
-    in_all_to_all.ShareDataWith(in.value());
+    in_all_to_all.ShareDataNoCheckWith(in.value());
   }
 
   // 2. use all to all to switch data to other ranks

--- a/test/auto_parallel/semi_auto_parallel_for_fused_rope.py
+++ b/test/auto_parallel/semi_auto_parallel_for_fused_rope.py
@@ -61,10 +61,10 @@ class TestFusedRopeApiForSemiAutoParallel(SemiAutoParallelTestBase):
         dist_q = dist.shard_tensor(q, self._mesh, dist.Shard(0))
         dist_q.stop_gradient = False
         dist_out_q, _, _ = fused_rotary_position_embedding(
-            q=dist_q, use_neox_rotary_style=False
+            q=dist_q, use_neox_rotary_style=True
         )
         out_q, _, _ = fused_rotary_position_embedding(
-            q, use_neox_rotary_style=False
+            q, use_neox_rotary_style=True
         )
         self.check_tensor_eq(out_q, dist_out_q)
         self.check_placements(dist_out_q, [dist.Shard(0)])
@@ -85,10 +85,10 @@ class TestFusedRopeApiForSemiAutoParallel(SemiAutoParallelTestBase):
         dist_q.stop_gradient = False
 
         dist_out_q, _, _ = fused_rotary_position_embedding(
-            q=dist_q, use_neox_rotary_style=False, time_major=True
+            q=dist_q, use_neox_rotary_style=True, time_major=True
         )
         out_q, _, _ = fused_rotary_position_embedding(
-            q, use_neox_rotary_style=False, time_major=True
+            q, use_neox_rotary_style=True, time_major=True
         )
         self.check_tensor_eq(out_q, dist_out_q)
         # NOTE: fused_rope have not supported shard on seq_len, so reshard to dist.Replicate

--- a/test/collective/test_communication_api_base.py
+++ b/test/collective/test_communication_api_base.py
@@ -56,9 +56,9 @@ class CommunicationTestDistBase(unittest.TestCase):
             runtime_envs.update(user_defined_envs)
         runtime_envs["CUDA_VISIBLE_DEVICES"] = self._devices
         if self._nnode > 1:
-            start_command = f"{self._python_interp} -u -m paddle.distributed.launch --nnode={self._nnode} --master=127.0.0.1:{self._find_free_port()} --log_dir {self._log_dir.name} --devices {self._devices} {script_file}"
+            start_command = f"{self._python_interp} -u -m paddle.distributed.launch --nnode={self._nnode} --master=127.0.0.1:{self._find_free_port()} --log_dir ./log --devices {self._devices} {script_file}"
         else:
-            start_command = f"{self._python_interp} -u -m paddle.distributed.launch --log_dir {self._log_dir.name} --devices {self._devices} {script_file}"
+            start_command = f"{self._python_interp} -u -m paddle.distributed.launch --log_dir ./log --devices {self._devices} {script_file}"
         start_command_list = start_command.strip().split()
 
         if self._nnode > 1:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
As the title

The following case raise Error as below,
```
a = paddle.rand([16, 32])
dist_a = dist.shard_tensor(a, mesh, [dist.Shard(0)])
b = paddle.rand([16, 32])
dist_b = dist.shard_tensor(b, mesh, [dist.Shard(1)])

a.stop_gradient = False
b.stop_gradient = False
dist_a.stop_gradient = False
dist_a.stop_gradient = False

sum = paddle.add(dist_a, dist_b)

#####
PreconditionNotMetError: Tensor's dimension is out of bound.Tensor's dimension must be equal or less than the size of its memory.But received Tensor's dimension is 1024, memory's size is 0.
  [Hint: Expected numel() * SizeOf(dtype()) <= memory_size(), but received numel() * SizeOf(dtype()):1024 > memory_size():0.] (at /paddle/paddle/phi/core/dense_tensor_impl.cc:55)

I0425 11:07:20.154877 21600 tcp_store.cc:293] receive shutdown event and so quit from MasterDaemon run loop
LAUNCH INFO 2024-04-25 11:07:21,250 Exit code 1
```
This PR fixes that.

Pcard-76459
