### PR TITLE
[PIR Exe] Check gc early in while instruction

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -59,8 +59,7 @@ IfInstruction::IfInstruction(size_t id,
   SetKernelType(AnalyseOpFuncType(op, place));
   VLOG(6) << "finish process analyse kernel type";
 
-  auto cond_value = if_op.operand_source(0);
-  cond_var_ = value_exec_info->GetVarByValue(cond_value);
+  cond_var_ = value_exec_info->GetVarByValue(if_op.cond());
   for (size_t i = 0; i < if_op.num_results(); ++i) {
     output_vars_.push_back(value_exec_info->GetScope()->GetVar(
         value_exec_info->GetValue2VarName().at(if_op.result(i))));

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
@@ -61,7 +61,7 @@ WhileInstruction::WhileInstruction(
   SetKernelType(AnalyseOpFuncType(op, place));
   VLOG(6) << "finish process analyse kernel type";
 
-  cond_var_ = parent_exe_info->GetVarByValue(while_op.operand_source(0));
+  cond_var_ = parent_exe_info->GetVarByValue(while_op.cond());
   for (size_t i = 1; i < while_op.num_operands(); ++i) {
     inputs_.push_back(
         parent_exe_info->GetVarByValue(while_op.operand_source(i)));
@@ -128,34 +128,30 @@ WhileInstruction::WhileInstruction(
   body_inter_ = std::unique_ptr<PirInterpreter>(new PirInterpreter(
       place, {}, body_block_, body_scope, body_exe_info, execution_config));
 
-  std::set<std::string> body_skip_gc_names_set;
   auto body_block_outputs = GetYiedOpInputs(body_block_);
   for (auto value : body_block_outputs) {
     body_outputs_.push_back(body_inter_->GetNameByValue(value));
-    body_skip_gc_names_.push_back(body_inter_->GetNameByValue(value));
-    body_skip_gc_names_set.insert(body_inter_->GetNameByValue(value));
+    skip_gc_vars.insert(body_inter_->GetNameByValue(value));
   }
   for (auto value : body_outside_inputs) {
     auto name = body_inter_->GetNameByValue(value);
     external_input_names_.insert(name);
-    body_skip_gc_names_.push_back(name);
-    body_skip_gc_names_set.insert(name);
+    skip_gc_vars.insert(name);
   }
   for (const auto& var_name : skip_gc_vars) {
-    body_skip_gc_names_.push_back(var_name);
-    body_skip_gc_names_set.insert(var_name);
+    skip_gc_vars.insert(var_name);
   }
-  body_inter_->SetSkipGcVars(body_skip_gc_names_set);
+  body_inter_->SetSkipGcVars(skip_gc_vars);
 
   if (VLOG_IS_ON(6)) {
     std::stringstream body_outputs;
-    for (auto var_name : body_outputs_) {
+    for (const auto& var_name : body_outputs_) {
       body_outputs << " " << var_name;
     }
     VLOG(6) << "body_outputs include: " << body_outputs.str();
 
     std::stringstream body_skip_gc_names;
-    for (auto var_name : body_skip_gc_names_) {
+    for (const auto& var_name : skip_gc_vars) {
       body_skip_gc_names << " " << var_name;
     }
     VLOG(6) << "body_skip_gc_names include: " << body_skip_gc_names.str();
@@ -250,6 +246,10 @@ void WhileInstruction::SetInputHooks(
   body_inter_->SetInputHooks(hookfuncs);
 }
 
+void WhileInstruction::CheckGCEarly(const CheckGCEarlyHook& check_gc_early) {
+  check_gc_early_ = check_gc_early;
+}
+
 void WhileInstruction::Run() {
 #ifdef PADDLE_WITH_DNNL
   // Executor on being destroyed clears oneDNN cache and resets
@@ -258,6 +258,9 @@ void WhileInstruction::Run() {
   paddle::platform::DontClearMKLDNNCache(body_inter_->GetPlace());
 #endif
   ShareInputsToOutputs();
+
+  check_gc_early_(this);
+
   VLOG(6) << "while instruction start loop ...";
   while (GetCondData(cond_var_->Get<phi::DenseTensor>())) {
     VLOG(6) << "while instruction pass args to body block";

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.cc
@@ -259,7 +259,9 @@ void WhileInstruction::Run() {
 #endif
   ShareInputsToOutputs();
 
-  check_gc_early_(this);
+  if (check_gc_early_) {
+    check_gc_early_(this);
+  }
 
   VLOG(6) << "while instruction start loop ...";
   while (GetCondData(cond_var_->Get<phi::DenseTensor>())) {

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "paddle/fluid/framework/new_executor/instruction/instruction_base.h"
 #include "paddle/fluid/framework/new_executor/interpreter/execution_config.h"
 
@@ -35,6 +37,9 @@ class ValueExecutionInfo;
 ///      'cond', 'output' = body_block('output');
 ///  }
 class WhileInstruction : public InstructionBase {
+ private:
+  using CheckGCEarlyHook = std::function<void(InstructionBase*)>;
+
  public:
   WhileInstruction(size_t id,
                    const platform::Place& place,
@@ -53,6 +58,10 @@ class WhileInstruction : public InstructionBase {
   void SetOutputHooks(const std::vector<PirHookFunc>& hookfuncs);
 
   void SetInputHooks(const std::vector<PirHookFunc>& hookfuncs);
+
+  // CheckGCEarly is designed to recycle unwanted inputs in advance, which can
+  // effectively reduce peak memory in certain scenarios.
+  void CheckGCEarly(const CheckGCEarlyHook& check_gc_early);
 
  private:
   // 'output' = 'input'
@@ -73,12 +82,13 @@ class WhileInstruction : public InstructionBase {
 
   std::unique_ptr<PirInterpreter> body_inter_;
   std::vector<std::string> body_outputs_;
-  std::vector<std::string> body_skip_gc_names_;
   std::set<std::string> external_input_names_;
 
   ::pir::Block* body_block_;
 
   ::pir::Operation* op_;
+
+  CheckGCEarlyHook check_gc_early_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -59,6 +59,7 @@
 #include "paddle/fluid/framework/new_executor/instruction/control_flow/tuple_push_instruction.h"
 #include "paddle/fluid/framework/new_executor/instruction/control_flow/while_instruction.h"
 #include "paddle/fluid/framework/new_executor/instruction/custom_kernel_instruction.h"
+#include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/framework/new_executor/instruction/legacy_kernel_instruction.h"
 #include "paddle/fluid/framework/new_executor/instruction/phi_kernel_instruction.h"
 #include "paddle/fluid/framework/new_executor/pir_adaptor/pir_adaptor_util.h"
@@ -758,6 +759,29 @@ void PirInterpreter::BuildInstruction() {
                                                execution_config_);
         while_instr_ptr->SetOutputHooks(pir_output_hookfuncs_);
         while_instr_ptr->SetInputHooks(pir_input_hookfuncs_);
+
+        while_instr_ptr->CheckGCEarly([this](InstructionBase* instr) {
+          std::unordered_map<pir::Value, std::vector<int>> inputs;
+          GetInputIds(instr->Operation(), *this->value_exe_info_, &inputs);
+          for (const auto& kv : inputs) {
+            if (kv.first ==
+                instr->Operation()->operand_source(0 /*cond var*/)) {
+              // CheckGCEarly should not gc cond var
+              continue;
+            }
+            if (kv.first.isa<pir::BlockArgument>()) {
+              LOG(INFO) << " ---- is block argument";
+              continue;
+            }
+            auto var_id = this->value_exe_info_->GetVarId(kv.first);
+            bool is_ready = this->refs_[var_id]->DynamicRef() == 1;
+            if (is_ready) {
+              this->refs_[var_id]->CheckAndDecrease();
+              this->gc_->Add(this->refs_[var_id]->Var(), instr);
+            }
+          }
+        });
+
         vec_instruction_base_.emplace_back(std::move(while_instr_ptr));
 
         sub_blocks_.insert(

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -757,6 +757,7 @@ void PirInterpreter::BuildInstruction() {
                                                &op,
                                                value_exe_info_.get(),
                                                execution_config_);
+
         while_instr_ptr->SetOutputHooks(pir_output_hookfuncs_);
         while_instr_ptr->SetInputHooks(pir_input_hookfuncs_);
 
@@ -770,12 +771,12 @@ void PirInterpreter::BuildInstruction() {
               continue;
             }
             if (kv.first.isa<pir::BlockArgument>()) {
-              LOG(INFO) << " ---- is block argument";
               continue;
             }
             auto var_id = this->value_exe_info_->GetVarId(kv.first);
             bool is_ready = this->refs_[var_id]->DynamicRef() == 1;
             if (is_ready) {
+              VLOG(4) << "early gc: " << this->GetNameByValue(kv.first);
               this->refs_[var_id]->CheckAndDecrease();
               this->gc_->Add(this->refs_[var_id]->Var(), instr);
             }

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -489,7 +489,7 @@ def return_map_value_list(value, map):
     output = []
     for i in range(len(value)):
         if value[i] in map:
-            output.append(map[value[i]])
+            output.append(return_map_value(value[i], map))
         else:
             output.append(value[i])
     return output

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -560,7 +560,10 @@ def append_backward_ops(
                     )
                     append_full_like(0.0, new_value, value, state, backward_ops)
 
-                input_grad = state.value_to_valuegrad[value][0][0]
+                input_grad = return_map_value(
+                    state.value_to_valuegrad[value][0][0],
+                    bwd_value_to_block_argument_map,
+                )
 
                 inputs_grad.append(input_grad)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-71500

Check gc early in while instruction, which is designed to recycle unwanted inputs in advance, which can effectively reduce peak memory in certain scenarios. For example, reducing around 2GB of memory in llama-7b(bs=4) inference.