### PR TITLE
[pybind] update `py::exception<>::operator()` to `py::set_error`

### DIFF
--- a/paddle/fluid/pybind/exception.cc
+++ b/paddle/fluid/pybind/exception.cc
@@ -42,7 +42,7 @@ void BindException(pybind11::module* m) {
     try {
       if (p) std::rethrow_exception(p);
     } catch (const platform::EOFException& e) {
-      eof(e.what());
+      pybind11::set_error(eof, e.what());
     } catch (const memory::allocation::BadAlloc& e) {
       PyErr_SetString(PyExc_MemoryError, e.what());
     } catch (const platform::EnforceNotMet& e) {
@@ -77,7 +77,7 @@ void BindException(pybind11::module* m) {
           PyErr_SetString(PyExc_TypeError, e.what());
           break;
         default:
-          exc(e.what());
+          pybind11::set_error(exc, e.what());
           break;
       }
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

在 pybind 2.12 中，`py::exception<>::operator()`已经被标记为弃用，使用`py::set_error()`代替

相关链接：
 * https://github.com/pybind/pybind11/pull/4772