### PR TITLE
Fix memcpy_d2h kernel backend bug in pd_op_to_kernel_pass

### DIFF
--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -404,11 +404,7 @@ static pir::Value AddPlaceTransferOp(pir::Value in,
   } else if ((src_place.GetType() == phi::AllocationType::GPU ||
               src_place.GetType() == phi::AllocationType::XPU) &&
              (dst_place.GetType() == phi::AllocationType::CPU)) {
-    if (src_place.GetType() == phi::AllocationType::XPU) {
-      copy_kernel_key.set_backend(place2backend(dst_place.GetType()));
-    } else {
-      copy_kernel_key.set_backend(phi::Backend::GPU);
-    }
+    copy_kernel_key.set_backend(src_place.GetType());
 
     std::string copy_kernel_name = "memcpy_d2h";
     if (in.type().isa<AllocatedDenseTensorArrayType>()) {

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -404,7 +404,7 @@ static pir::Value AddPlaceTransferOp(pir::Value in,
   } else if ((src_place.GetType() == phi::AllocationType::GPU ||
               src_place.GetType() == phi::AllocationType::XPU) &&
              (dst_place.GetType() == phi::AllocationType::CPU)) {
-    copy_kernel_key.set_backend(src_place.GetType());
+    copy_kernel_key.set_backend(place2backend(src_place.GetType()));
 
     std::string copy_kernel_name = "memcpy_d2h";
     if (in.type().isa<AllocatedDenseTensorArrayType>()) {

--- a/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
+++ b/paddle/fluid/pir/transforms/pd_op_to_kernel_pass.cc
@@ -404,7 +404,12 @@ static pir::Value AddPlaceTransferOp(pir::Value in,
   } else if ((src_place.GetType() == phi::AllocationType::GPU ||
               src_place.GetType() == phi::AllocationType::XPU) &&
              (dst_place.GetType() == phi::AllocationType::CPU)) {
-    copy_kernel_key.set_backend(place2backend(dst_place.GetType()));
+    if (src_place.GetType() == phi::AllocationType::XPU) {
+      copy_kernel_key.set_backend(place2backend(dst_place.GetType()));
+    } else {
+      copy_kernel_key.set_backend(phi::Backend::GPU);
+    }
+
     std::string copy_kernel_name = "memcpy_d2h";
     if (in.type().isa<AllocatedDenseTensorArrayType>()) {
       copy_kernel_name = "memcpy_d2h_multi_io";


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix memcpy_d2h kernel backend bug in pd_op_to_kernel_pass
Pcard-73145