### PR TITLE
fix FlashAttnOpInferSymbolicShape and FlashAttnInferMeta

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -294,6 +294,14 @@ bool FlashAttnOpInferSymbolicShape(
   shape_analysis->AddEqualCstr(q.shape()[0], v.shape()[0]);
   shape_analysis->AddEqualCstr(k.shape()[1], v.shape()[1]);
 
+  if (op->operand_source(4)) {
+    const symbol::ShapeOrDataDimExprs &attn_mask =
+        shape_analysis->GetShapeOrDataForValue(op->operand_source(4));
+    shape_analysis->AddEqualCstr(attn_mask.shape()[0], q.shape()[0]);
+    shape_analysis->AddEqualCstr(attn_mask.shape()[2], q.shape()[1]);
+    shape_analysis->AddEqualCstr(attn_mask.shape()[3], k.shape()[1]);
+  }
+
   std::vector<symbol::DimExpr> out_shape = q.shape();
 
   out_shape.back() = v.shape().back();

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -291,7 +291,7 @@ bool FlashAttnOpInferSymbolicShape(
                         "[batch_size, seq_len, num_heads, head_dim]"));
 
   shape_analysis->AddEqualCstr(q.shape()[0], k.shape()[0]);
-  shape_analysis->AddEqualCstr(q.shape()[1], v.shape()[1]);
+  shape_analysis->AddEqualCstr(q.shape()[0], v.shape()[0]);
   shape_analysis->AddEqualCstr(k.shape()[1], v.shape()[1]);
 
   std::vector<symbol::DimExpr> out_shape = q.shape();

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -385,10 +385,10 @@ void FlashAttnInferMeta(const MetaTensor& q,
   out->set_dtype(q.dtype());
   out->set_layout(q.layout());
   auto round_multiple = [](int x) { return (x + 127) / 128 * 128; };
-  auto batch_size = q.dims()[0];
-  auto num_heads = q.dims()[2];
-  auto seqlen_q_rounded = round_multiple(q.dims()[1]);
-  auto seqlen_k_rounded = round_multiple(k.dims()[1]);
+  int batch_size = q.dims()[0];
+  int num_heads = q.dims()[2];
+  int seqlen_q_rounded = round_multiple(q.dims()[1]);
+  int seqlen_k_rounded = round_multiple(k.dims()[1]);
   if (softmax) {
     softmax->set_dtype(q.dtype());
     softmax->set_dims(

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -380,6 +380,11 @@ void FlashAttnInferMeta(const MetaTensor& q,
                         MetaTensor* softmax_lse,
                         MetaTensor* seed_offset) {
   auto out_dims = q.dims();
+  PADDLE_ENFORCE_EQ(out_dims.size(),
+                    4,
+                    phi::errors::InvalidArgument(
+                        "flash_attn receive input with dim "
+                        "[batch_size, seq_len, num_heads, head_dim]"));
   out_dims[3] = v.dims()[3];
   out->set_dims(out_dims);
   out->set_dtype(q.dtype());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixed FlashAttnOpInferSymbolicShape and FlashAttnInferMeta by adding shape inferring for softmax, softmax_lse and seed_offset.
