### PR TITLE
[AutoParallel] Standardize the interface of operation dist attr.

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/ir/attribute_storage.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/attribute_storage.h
@@ -125,8 +125,8 @@ class OperationDistAttrStorage : public pir::AttributeStorage {
                               std::vector<pir::Attribute>>;
   OperationDistAttrStorage(ParamKey&& param)  // NOLINT
       : mesh_attr(std::get<0>(param)),
-        operand_attrs(std::get<1>(param)),
-        result_attrs(std::get<2>(param)) {}
+        operands(std::get<1>(param)),
+        results(std::get<2>(param)) {}
 
   ///
   /// \brief Each derived TypeStorage must define a Construct method, which
@@ -156,13 +156,13 @@ class OperationDistAttrStorage : public pir::AttributeStorage {
   /// \brief Each derived TypeStorage needs to overload operator==.
   ///
   bool operator==(const ParamKey& key) const {
-    return mesh_attr == std::get<0>(key) && operand_attrs == std::get<1>(key) &&
-           result_attrs == std::get<2>(key);
+    return mesh_attr == std::get<0>(key) && operands == std::get<1>(key) &&
+           results == std::get<2>(key);
   }
 
   ProcessMeshAttribute mesh_attr;
-  std::vector<pir::Attribute> operand_attrs;
-  std::vector<pir::Attribute> result_attrs;
+  std::vector<pir::Attribute> operands;
+  std::vector<pir::Attribute> results;
 };
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.cc
@@ -78,47 +78,27 @@ TensorDistAttribute TensorDistAttribute::get(
 ProcessMeshAttribute OperationDistAttribute::process_mesh_attr() const {
   return storage()->mesh_attr;
 }
-const std::vector<pir::Attribute>& OperationDistAttribute::operand_attrs()
-    const {
-  return storage()->operand_attrs;
-}
-TensorDistAttribute OperationDistAttribute::operand_dist_attr(
-    uint32_t index) const {
-  return operand_attrs().at(index).dyn_cast<TensorDistAttribute>();
-}
-
-pir::ArrayAttribute OperationDistAttribute::operand_array_attr(
-    uint32_t index) const {
-  return operand_attrs().at(index).dyn_cast<pir::ArrayAttribute>();
+const std::vector<pir::Attribute>& OperationDistAttribute::operands() const {
+  return storage()->operands;
 }
 
 uint32_t OperationDistAttribute::num_operands() const {
-  return operand_attrs().size();
+  return operands().size();
 }
 
-const std::vector<pir::Attribute>& OperationDistAttribute::result_attrs()
-    const {
-  return storage()->result_attrs;
-}
-TensorDistAttribute OperationDistAttribute::result_dist_attr(
-    uint32_t index) const {
-  return result_attrs().at(index).dyn_cast<TensorDistAttribute>();
-}
-
-pir::ArrayAttribute OperationDistAttribute::result_array_attr(
-    uint32_t index) const {
-  return result_attrs().at(index).dyn_cast<pir::ArrayAttribute>();
+const std::vector<pir::Attribute>& OperationDistAttribute::results() const {
+  return storage()->results;
 }
 
 uint32_t OperationDistAttribute::num_results() const {
-  return result_attrs().size();
+  return results().size();
 }
 
 OperationDistAttribute OperationDistAttribute::get(
     pir::IrContext* ctx,
     ProcessMeshAttribute mesh,
-    const std::vector<pir::Attribute>& operand_attrs,
-    const std::vector<pir::Attribute>& result_attrs) {
+    const std::vector<pir::Attribute>& operands,
+    const std::vector<pir::Attribute>& results) {
   auto check_dist_attr = [=](pir::Attribute attr) {
     auto dist_attr = attr.dyn_cast<TensorDistAttribute>();
     auto ids = mesh.process_ids();
@@ -132,8 +112,7 @@ OperationDistAttribute OperationDistAttribute::get(
                             mesh));
     }
   };
-
-  for (auto attr : operand_attrs) {
+  for (auto attr : operands) {
     // NOTE: The operand dist attr maybe empty while the corresponding input is
     // optional.
     if (!attr) continue;
@@ -145,7 +124,7 @@ OperationDistAttribute OperationDistAttribute::get(
       check_dist_attr(attr);
     }
   }
-  return Base::get(ctx, mesh, operand_attrs, result_attrs);
+  return Base::get(ctx, mesh, operands, results);
 }
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_attribute.h
@@ -105,28 +105,26 @@ class OperationDistAttribute : public pir::AttrBase<OperationDistAttribute,
   using Base::Base;
   ProcessMeshAttribute process_mesh_attr() const;
 
-  const std::vector<Attribute>& operand_attrs() const;
-  TensorDistAttribute operand_dist_attr(uint32_t index) const;
-  pir::ArrayAttribute operand_array_attr(uint32_t index) const;
+  const std::vector<Attribute>& operands() const;
+  pir::Attribute operand(uint32_t index) const { return operands().at(index); }
   uint32_t num_operands() const;
 
-  const std::vector<Attribute>& result_attrs() const;
-  TensorDistAttribute result_dist_attr(uint32_t index) const;
-  pir::ArrayAttribute result_array_attr(uint32_t index) const;
+  const std::vector<Attribute>& results() const;
+
+  pir::Attribute result(uint32_t index) const { return results().at(index); }
+
   uint32_t num_results() const;
 
   static OperationDistAttribute get(pir::IrContext* ctx,
                                     ProcessMeshAttribute mesh,
-                                    const std::vector<Attribute>& operand_attrs,
-                                    const std::vector<Attribute>& result_attrs);
+                                    const std::vector<Attribute>& operands,
+                                    const std::vector<Attribute>& results);
 
-  static OperationDistAttribute get(
-      pir::IrContext* ctx,
-      const phi::distributed::ProcessMesh& mesh,
-      const std::vector<Attribute>& operand_attrs,
-      const std::vector<Attribute>& result_attrs) {
-    return get(
-        ctx, ProcessMeshAttribute::get(ctx, mesh), operand_attrs, result_attrs);
+  static OperationDistAttribute get(pir::IrContext* ctx,
+                                    const phi::distributed::ProcessMesh& mesh,
+                                    const std::vector<Attribute>& operands,
+                                    const std::vector<Attribute>& results) {
+    return get(ctx, ProcessMeshAttribute::get(ctx, mesh), operands, results);
   }
 };
 

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_dialect.cc
@@ -102,81 +102,13 @@ void DistDialect::PrintAttribute(pir::Attribute attr, std::ostream &os) const {
               phi::distributed::auto_parallel::str_join(
                   op_dist_attr.process_mesh_attr().process_ids()) +
               "]}";
-    auto num_operand_dist_attrs = op_dist_attr.num_operands();
-    for (uint32_t i = 0; i < num_operand_dist_attrs; ++i) {
-      auto dist_attr = op_dist_attr.operand_dist_attr(i);
-      os << ",operand(" + std::to_string(i) + "):{";
-      if (!dist_attr) {
-        os << "null}";
-        continue;
-      }
-      if (dist_attr.process_mesh_attr() != op_dist_attr.process_mesh_attr()) {
-        os << "mesh_shape:[" +
-                  phi::distributed::auto_parallel::str_join(
-                      dist_attr.process_mesh_attr().shape()) +
-                  "],";
-        os << "process_ids:[" +
-                  phi::distributed::auto_parallel::str_join(
-                      dist_attr.process_mesh_attr().process_ids()) +
-                  "],";
-      }
-      os << "dims_maping:[" +
-                phi::distributed::auto_parallel::str_join(
-                    dist_attr.dims_mapping()) +
-                "]";
-      if (dist_attr.partial_status().size() > 0) {
-        std::vector<std::string> partial_status_strs;
-        for (auto &itr : dist_attr.partial_status()) {
-          std::string s = "partial(" + std::to_string(itr.first) + "," +
-                          phi::ReduceTypeStrings[static_cast<int>(itr.second)] +
-                          ")";
-          partial_status_strs.emplace_back(s);
-        }
-        os << "," +
-                  phi::distributed::auto_parallel::str_join(
-                      partial_status_strs) +
-                  "}";
-      } else {
-        os << "}";
-      }
+    for (uint32_t i = 0; i < op_dist_attr.num_operands(); ++i) {
+      os << ",operand(" + std::to_string(i) + "):{" << op_dist_attr.operand(i)
+         << "}";
     }
-    auto num_result_dist_attrs = op_dist_attr.num_results();
-    for (uint32_t i = 0; i < num_result_dist_attrs; ++i) {
-      auto dist_attr = op_dist_attr.result_dist_attr(i);
-      os << ",result(" + std::to_string(i) + "):{";
-      if (!dist_attr) {
-        os << "null}";
-        continue;
-      }
-      if (dist_attr.process_mesh_attr() != op_dist_attr.process_mesh_attr()) {
-        os << "mesh_shape:[" +
-                  phi::distributed::auto_parallel::str_join(
-                      dist_attr.process_mesh_attr().shape()) +
-                  "],";
-        os << "process_ids:[" +
-                  phi::distributed::auto_parallel::str_join(
-                      dist_attr.process_mesh_attr().process_ids()) +
-                  "],";
-      }
-      os << "dims_maping:[" +
-                phi::distributed::auto_parallel::str_join(
-                    dist_attr.dims_mapping()) +
-                "]";
-      if (dist_attr.partial_status().size() > 0) {
-        std::vector<std::string> partial_status_strs;
-        for (auto &itr : dist_attr.partial_status()) {
-          std::string s = "partial(" + std::to_string(itr.first) + "," +
-                          phi::ReduceTypeStrings[static_cast<int>(itr.second)] +
-                          ")";
-          partial_status_strs.emplace_back(s);
-        }
-        os << "," +
-                  phi::distributed::auto_parallel::str_join(
-                      partial_status_strs) +
-                  "}";
-      } else {
-        os << "}";
-      }
+    for (uint32_t i = 0; i < op_dist_attr.num_results(); ++i) {
+      os << ",result(" + std::to_string(i) + "):{" << op_dist_attr.result(i)
+         << "}";
     }
     os << "}";
   } else {

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/pir/dialect/distributed/ir/dist_tools.h"
+#include "glog/logging.h"
 #include "paddle/common/enforce.h"
 #include "paddle/pir/include/core/operation.h"
 
@@ -76,14 +77,66 @@ phi::distributed::DistMetaTensor CvtToDistMetaTensor(DistDenseTensorType type) {
   return phi::distributed::DistMetaTensor(type.global_ddim(), phi_attr);
 }
 
-TensorDistAttribute CvtToPirDistAttr(
-    const phi::distributed::ArgDistAttr& dist_attr) {
-  auto& attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr, dist_attr);
-  if (attr.process_mesh().empty()) return nullptr;
-  return TensorDistAttribute::get(pir::IrContext::Instance(),
-                                  attr.process_mesh(),
-                                  attr.dims_mapping(),
-                                  attr.partial_status());
+pir::Attribute CvtToPirAttr(const phi::distributed::ArgDistAttr& dist_attr) {
+  auto ctx = pir::IrContext::Instance();
+  if (holds_alternative<phi::distributed::TensorDistAttr>(dist_attr)) {
+    auto& attr = PADDLE_GET_CONST(phi::distributed::TensorDistAttr, dist_attr);
+    return TensorDistAttribute::get(
+        ctx, attr.process_mesh(), attr.dims_mapping(), attr.partial_status());
+  } else {
+    auto& vec = PADDLE_GET_CONST(std::vector<phi::distributed::TensorDistAttr>,
+                                 dist_attr);
+    std::vector<pir::Attribute> array;
+    for (auto& attr : vec) {
+      array.push_back(TensorDistAttribute::get(ctx,
+                                               attr.process_mesh(),
+                                               attr.dims_mapping(),
+                                               attr.partial_status()));
+    }
+    return pir::ArrayAttribute::get(ctx, array);
+  }
+}
+
+pir::Type CvtToPirDistType(pir::Type prim_type, pir::Attribute dist_attr) {
+  if (!prim_type) return nullptr;
+  auto ctx = pir::IrContext::Instance();
+  if (auto dense_tensor_type = prim_type.dyn_cast<pir::DenseTensorType>()) {
+    auto tensor_dist_attr = dist_attr.dyn_cast<TensorDistAttribute>();
+    if (!tensor_dist_attr) {
+      VLOG(0) << "Convert dense tensor type to dist type with attribute {"
+              << dist_attr << "}.";
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Only allowed convert a densor tensor type to dist dense tensor type "
+          "with non-empty TensorDistAttr"));
+    }
+    return DistDenseTensorType::get(ctx, dense_tensor_type, tensor_dist_attr);
+  } else if (auto vec_type = prim_type.dyn_cast<pir::VectorType>()) {
+    auto array_attr = dist_attr.dyn_cast<pir::ArrayAttribute>();
+    if (!array_attr) {
+      VLOG(0) << "Convert vector type to dist type with attribute {"
+              << dist_attr << "}.";
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Only allowed convert a vector type to dist vector type with "
+          "non-empty ArrayAttr"));
+    }
+    PADDLE_ENFORCE_EQ(
+        vec_type.size(),
+        array_attr.size(),
+        common::errors::InvalidArgument(
+            "The vector type size must equal to array attribute size."));
+    std::vector<pir::Type> dist_vec_type;
+    for (size_t idx = 0; idx < vec_type.size(); ++idx) {
+      dist_vec_type.push_back(CvtToPirDistType(vec_type[idx], array_attr[idx]));
+    }
+    return pir::VectorType::get(ctx, dist_vec_type);
+  } else {
+    VLOG(0) << "Convert type{" << prim_type << "} to dist type with attribute {"
+            << dist_attr << "}.";
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Currently only support convert dense_tensor_type r vector type to "
+        "dist."));
+  }
+  return nullptr;
 }
 
 void CopyLeafOpToMesh(pir::Value value, ProcessMeshAttribute mesh_attr) {

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_tools.h
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_tools.h
@@ -28,8 +28,8 @@ void CvtAllInputsToDist(const std::vector<pir::Value>& inputs,
                         ProcessMeshAttribute mesh_attr);
 
 phi::distributed::DistMetaTensor CvtToDistMetaTensor(DistDenseTensorType type);
-TensorDistAttribute CvtToPirDistAttr(
-    const phi::distributed::ArgDistAttr& dist_attr);
+pir::Attribute CvtToPirAttr(const phi::distributed::ArgDistAttr& dist_attr);
+pir::Type CvtToPirDistType(pir::Type prim_type, pir::Attribute dist_attr);
 
 ///
 /// When the following conditions are met:

--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -60,27 +60,11 @@ void BindOperationDistAttribute(py::module *m) {
                                return self.process_mesh_attr().process_mesh();
                              })
       .def("num_operands", &OperationDistAttribute::num_operands)
-      .def(
-          "operand_dist_attrs",
-          [](OperationDistAttribute &self) -> std::vector<TensorDistAttribute> {
-            std::vector<TensorDistAttribute> operand_dist_attrs;
-            for (size_t idx = 0; idx < self.num_operands(); ++idx) {
-              operand_dist_attrs.emplace_back(self.operand_dist_attr(idx));
-            }
-            return operand_dist_attrs;
-          })
-      .def("operand_dist_attr", &OperationDistAttribute::operand_dist_attr)
+      .def("operands", &OperationDistAttribute::operands)
+      .def("operand", &OperationDistAttribute::operand)
       .def("num_results", &OperationDistAttribute::num_results)
-      .def(
-          "result_dist_attrs",
-          [](OperationDistAttribute &self) -> std::vector<TensorDistAttribute> {
-            std::vector<TensorDistAttribute> result_dist_attrs;
-            for (size_t idx = 0; idx < self.num_results(); ++idx) {
-              result_dist_attrs.emplace_back(self.result_dist_attr(idx));
-            }
-            return result_dist_attrs;
-          })
-      .def("result_dist_attr", &OperationDistAttribute::result_dist_attr);
+      .def("results", &OperationDistAttribute::results)
+      .def("result", &OperationDistAttribute::result);
 }
 
 void BindTensorDistAttribute(py::module *m) {
@@ -92,10 +76,6 @@ void BindTensorDistAttribute(py::module *m) {
              std::ostringstream print_stream;
              print_stream << self;
              return print_stream.str();
-           })
-      .def("__eq__",
-           [](TensorDistAttribute &self, const TensorDistAttribute &other) {
-             return self == other;
            })
       .def_property_readonly("process_mesh",
                              [](TensorDistAttribute &self) {
@@ -133,10 +113,10 @@ TensorDistAttribute CreateTensorDistAttribute(
 
 OperationDistAttribute CreateOperationDistAttribute(
     const phi::distributed::ProcessMesh &mesh,
-    const std::vector<pir::Attribute> &operand_attrs,
-    const std::vector<pir::Attribute> &result_attrs) {
+    const std::vector<pir::Attribute> &operands,
+    const std::vector<pir::Attribute> &results) {
   return OperationDistAttribute::get(
-      pir::IrContext::Instance(), mesh, operand_attrs, result_attrs);
+      pir::IrContext::Instance(), mesh, operands, results);
 }
 
 void BindDistUtils(pybind11::module *m) {

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -846,6 +846,26 @@ static PyObject *run_custom_op(PyObject *self,
   }
 }
 
+static PyObject *builtin_combine_op(PyObject *self,
+                                    PyObject *args,
+                                    PyObject *kwargs) {
+  try {
+    VLOG(6) << "Add buitin_combine op into program";
+    VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
+    // Get Value from args
+    PyObject *x_obj = PyTuple_GET_ITEM(args, 0);
+    auto x = CastPyArg2VectorOfValue(x_obj, "builtin_combine", 0);
+    CallStackRecorder callstack_recoder("builtin_combine_op");
+    callstack_recoder.Record();
+    auto static_api_out = paddle::dialect::builtin_combine(x);
+    callstack_recoder.AttachToOps();
+    return ToPyObject(static_api_out);
+  } catch (...) {
+    ThrowExceptionToPython(std::current_exception());
+    return nullptr;
+  }
+}
+
 static PyObject *static_api_fused_gemm_epilogue(PyObject *self,
                                                 PyObject *args,
                                                 PyObject *kwargs) {
@@ -981,6 +1001,10 @@ static PyMethodDef ManualOpsAPI[] = {
      (PyCFunction)(void (*)(void))run_custom_op,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for run_custom_op."},
+    {"builtin_combine",
+     (PyCFunction)(void (*)(void))builtin_combine_op,
+     METH_VARARGS | METH_KEYWORDS,
+     "C++ interface function for builtin_combine_op."},
     {"array_pop",
      (PyCFunction)(void (*)(void))static_api_array_pop,
      METH_VARARGS | METH_KEYWORDS,

--- a/paddle/phi/infermeta/spmd_rules/full_like.cc
+++ b/paddle/phi/infermeta/spmd_rules/full_like.cc
@@ -20,7 +20,9 @@ namespace distributed {
 SpmdInfo FullLikeInferSpmd(const DistMetaTensor& x,
                            const Scalar& y,
                            phi::DataType dtype) {
-  return ElementwiseUnaryInferSpmd(x);
+  TensorDistAttr out_dist_attr = x.dist_attr();
+  out_dist_attr.clean_partial_status();
+  return {{x.dist_attr()}, {out_dist_attr}};
 }
 }  // namespace distributed
 }  // namespace phi

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -24,42 +24,65 @@ register_reshard_funcs()
 partition_skip_op_list = ["builtin.combine"]
 
 
+def reshard_single_value(op, operand, attr):
+    prev_var = operand.source()
+    if prev_var.is_dist() and prev_var.dist_attr() != attr:
+        operand_attr = attr.as_tensor_dist_attr()
+        paddle.pir.set_insertion_point(op)
+        # fold reshard
+        if prev_var.get_defining_op().name() == 'dist_op.reshard':
+            prev_reshard = prev_var.get_defining_op()
+            prev_var = prev_reshard.operand_source(0)
+            if prev_var.dist_attr() == operand_attr:
+                return prev_var
+            reshard_var = paddle._C_ops.reshard_v2(prev_var, operand_attr)
+            return reshard_var
+        # insert reshard
+        reshard_var = paddle._C_ops.reshard_v2(prev_var, operand_attr)
+        return reshard_var
+    return prev_var
+
+
+def reshard_combine_value(op, operand, attr):
+    prev_var = operand.source()
+    assert (
+        prev_var.get_defining_op().name() == 'builtin.combine'
+    ), "TensorList must be defined by builtin.combine op."
+    combine_op = prev_var.get_defining_op()
+    array_attr = attr.as_array_attr()
+    assert len(combine_op.operands()) == len(
+        array_attr
+    ), "The number of combine op operands and the number of dist array_attr are not equal in op"
+    reshard_vars = []
+    for inner_operand, inner_attr in zip(combine_op.operands(), array_attr):
+        reshard_vars.append(reshard_single_value(op, inner_operand, inner_attr))
+    paddle.pir.set_insertion_point(combine_op)
+    return paddle._C_ops.builtin_combine(reshard_vars)
+
+
 def apply_partition_pass(program):
-    new_program = program.clone()
-    with paddle.static.program_guard(new_program):
-        for op in new_program.global_block().ops:
+    with paddle.static.program_guard(program):
+        for op in program.global_block().ops:
             if op.name() in partition_skip_op_list:
                 continue
             assert len(op.operands()) == len(
                 op.dist_attr.operands()
             ), f"The number of operands and the number of op_dist_attr's operands are not equal in op: {op}"
 
-            for var, attr in zip(op.operands(), op.dist_attr.operands()):
-                prev_var = var.source()
-                if prev_var.is_dist() and prev_var.dist_attr() != attr:
-                    operand_attr = attr.as_tensor_dist_attr()
-                    paddle.pir.set_insertion_point(op)
-                    # fold reshard
-                    if prev_var.get_defining_op().name() == 'dist_op.reshard':
-                        prev_reshard = prev_var.get_defining_op()
-                        prev_var = prev_reshard.operand_source(0)
-                        if prev_var.dist_attr() == operand_attr:
-                            var.set_source(prev_var)
-                        else:
-                            reshard_var = paddle._C_ops.reshard_v2(
-                                prev_var, operand_attr
-                            )
-                            var.set_source(reshard_var)
-                        if prev_reshard.result(0).use_empty():
-                            prev_reshard.get_parent_block().remove_op(
-                                prev_reshard
-                            )
-                        continue
-                    # insert reshard
-                    reshard_var = paddle._C_ops.reshard_v2(
-                        prev_var, operand_attr
-                    )
-                    var.set_source(reshard_var)
+            for operand, attr in zip(op.operands(), op.dist_attr.operands()):
+                prev_var = operand.source()
+                if prev_var.is_combine():
+                    operand.set_source(reshard_combine_value(op, operand, attr))
+                else:
+                    operand.set_source(reshard_single_value(op, operand, attr))
+                prev_op = prev_var.get_defining_op()
+                if (
+                    prev_op
+                    and prev_op.num_results() == 1
+                    and prev_var.use_empty()
+                ):
+                    prev_op.erase()
+
             for var, attr in zip(op.results(), op.dist_attr.results()):
                 if (
                     var.initialized()
@@ -76,9 +99,9 @@ def apply_partition_pass(program):
 
         # pruning op and value not belong to cur rank
         cur_rank = paddle.distributed.get_rank()
-        for op in new_program.global_block().ops[::-1]:
+        for op in program.global_block().ops[::-1]:
             if cur_rank not in op.dist_attr.process_mesh.process_ids:
-                new_program.global_block().remove_op(op)
+                program.global_block().remove_op(op)
             else:
                 # set the operand as null when it is not belong to cur rank
                 if (
@@ -89,11 +112,11 @@ def apply_partition_pass(program):
                     .dist_attr()
                     .process_mesh.process_ids
                 ):
-                    op.operand(0).set_source(paddle.pir.fake_value())
+                    op.operand(0).set_source(None)
 
         # merge pd.data ops for
         lr_ops = []
-        for op in new_program.global_block().ops[::-1]:
+        for op in program.global_block().ops[::-1]:
             if (
                 op.name() == 'pd_op.data'
                 and "learning_rate" in op.attrs()["name"]
@@ -105,9 +128,8 @@ def apply_partition_pass(program):
             for op in lr_ops[1:]:
                 lr = op.result(0)
                 lr.replace_all_uses_with(lr_value)
-                new_program.global_block().remove_op(op)
-
-    return new_program
+                program.global_block().remove_op(op)
+    return program
 
 
 def apply_reshard_pass(program):

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/base_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/base_reshard_func.py
@@ -42,6 +42,13 @@ def clean_reshard_funcs():
     _g_reshard_func_list.clear()
 
 
+def is_shard(dist_attr):
+    for v in dist_attr.dims_mapping:
+        if v != -1:
+            return True
+    return False
+
+
 def is_partial(dist_attr):
     if len(dist_attr.partial_status) > 0:
         return True

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/r_to_s_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/r_to_s_reshard_func.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+
+from .base_reshard_func import ReshardFunction, is_replicated, is_shard
+
+
+class RToSReshardFunction(ReshardFunction):
+    def is_suitable(self, src_dist_attr, dst_dist_attr):
+        if not is_replicated(src_dist_attr):
+            return False
+
+        if not is_shard(dst_dist_attr):
+            return False
+
+        in_mesh = src_dist_attr.process_mesh
+        out_mesh = dst_dist_attr.process_mesh
+
+        if in_mesh.ndim != 1:
+            return False
+        if out_mesh.ndim != 1:
+            return False
+        if in_mesh != out_mesh:
+            return False
+        return True
+
+    def reshard(
+        self, program, op, src_dist_attr, dst_dist_attr, remove_op=True
+    ):
+        split_axis = -1
+        mesh_axis = -1
+        for idx, v in enumerate(dst_dist_attr.dims_mapping):
+            if v != -1:
+                split_axis = idx
+                mesh_axis = v
+
+        mesh = src_dist_attr.process_mesh
+        curr_global_rank = paddle.distributed.get_rank()
+        if curr_global_rank in mesh.process_ids:
+            total_nums = op.operand_source(0).shape[split_axis]
+            num_of_pieces = mesh.shape[mesh_axis]
+            piece_len = (total_nums + num_of_pieces - 1) // num_of_pieces
+            rank_relative = mesh.process_ids.index(curr_global_rank)
+            start = rank_relative * piece_len
+            end = start + piece_len
+            if curr_global_rank == mesh.process_ids[-1]:
+                end = total_nums
+
+            paddle.pir.set_insertion_point(op)
+            out_value = paddle.slice(
+                op.operand_source(0), [split_axis], [start], [end]
+            )
+            op.result(0).replace_all_uses_with(out_value)
+            op.get_parent_block().remove_op(op)

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/reshard_func_register.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/reshard_func_register.py
@@ -17,11 +17,13 @@ from .p_to_r_reshard_func import (
     PToRReshardFunction,
     PToRReshardFunctionCrossMesh,
 )
+from .r_to_s_reshard_func import RToSReshardFunction
 from .same_status_reshard_func import SameStatusReshardFunction
 
 
 def register_reshard_funcs():
     register_reshard_func(PToRReshardFunction())
+    register_reshard_func(RToSReshardFunction())
     register_reshard_func(PToRReshardFunctionCrossMesh())
     register_reshard_func(SameStatusReshardFunction())
 

--- a/test/auto_parallel/pir/test_static_pir_program.py
+++ b/test/auto_parallel/pir/test_static_pir_program.py
@@ -115,27 +115,21 @@ class TestBuildFakeProgram(unittest.TestCase):
         self.assertEqual(attrs_op_dist_attr.process_mesh, mesh)
 
         # check op result dist_attr
+        tensor_dist_attr = dist_input_op_dist_attr.result(
+            0
+        ).as_tensor_dist_attr()
+        self.assertEqual(tensor_dist_attr.process_mesh, mesh)
         self.assertEqual(
-            dist_input_op_dist_attr.result_dist_attr(0).process_mesh, mesh
-        )
-        self.assertEqual(
-            dist_input_op_dist_attr.result_dist_attr(0).dims_mapping,
+            tensor_dist_attr.dims_mapping,
             [-1, -1, -1],
         )
+        tensor_dist_attr = dist_w0_op_dist_attr.result(0).as_tensor_dist_attr()
+        self.assertEqual(tensor_dist_attr.process_mesh, mesh)
+        self.assertEqual(tensor_dist_attr.dims_mapping, [0, -1])
 
-        self.assertEqual(
-            dist_w0_op_dist_attr.result_dist_attr(0).process_mesh, mesh
-        )
-        self.assertEqual(
-            dist_w0_op_dist_attr.result_dist_attr(0).dims_mapping, [0, -1]
-        )
-
-        self.assertEqual(
-            dist_w1_op_dist_attr.result_dist_attr(0).process_mesh, mesh
-        )
-        self.assertEqual(
-            dist_w1_op_dist_attr.result_dist_attr(0).dims_mapping, [-1, 0]
-        )
+        tensor_dist_attr = dist_w1_op_dist_attr.result(0).as_tensor_dist_attr()
+        self.assertEqual(tensor_dist_attr.process_mesh, mesh)
+        self.assertEqual(tensor_dist_attr.dims_mapping, [-1, 0])
 
         # check value dist_attr
         self.assertEqual(dist_input.dist_attr().process_mesh, mesh)

--- a/test/auto_parallel/reshard_p_to_r.py
+++ b/test/auto_parallel/reshard_p_to_r.py
@@ -107,8 +107,12 @@ class TestReshardPToR:
                 assert op.dist_attr.num_operands() == 1
                 assert op.dist_attr.num_results() == 1
 
-                op_operand_dist_attr = op.dist_attr.operand_dist_attr(0)
-                op_result_dist_attr = op.dist_attr.result_dist_attr(0)
+                op_operand_dist_attr = op.dist_attr.operand(
+                    0
+                ).as_tensor_dist_attr()
+                op_result_dist_attr = op.dist_attr.result(
+                    0
+                ).as_tensor_dist_attr()
 
                 assert op.dist_attr.process_mesh == self._mesh
                 assert op_operand_dist_attr.process_mesh == self._mesh

--- a/test/auto_parallel/reshard_p_to_r_cross_mesh.py
+++ b/test/auto_parallel/reshard_p_to_r_cross_mesh.py
@@ -113,7 +113,9 @@ class TestReshardPToRCrossMesh:
             if op.name() == 'pd_op.send_v2':
                 assert op.dist_attr.num_operands() == 1
                 assert op.dist_attr.num_results() == 0
-                op_operand_dist_attr = op.dist_attr.operand_dist_attr(0)
+                op_operand_dist_attr = op.dist_attr.operand(
+                    0
+                ).as_tensor_dist_attr()
 
                 assert op.dist_attr.process_mesh == self._in_mesh
                 assert op_operand_dist_attr.process_mesh == self._in_mesh
@@ -127,7 +129,9 @@ class TestReshardPToRCrossMesh:
                 assert op.dist_attr.num_operands() == 0
                 assert op.dist_attr.num_results() == 1
 
-                op_result_dist_attr = op.dist_attr.result_dist_attr(0)
+                op_result_dist_attr = op.dist_attr.result(
+                    0
+                ).as_tensor_dist_attr()
 
                 assert op_result_dist_attr.process_mesh == self._out_mesh
                 assert op_result_dist_attr.dims_mapping == [-1, -1]
@@ -140,8 +144,12 @@ class TestReshardPToRCrossMesh:
                 assert op.dist_attr.num_operands() == 1
                 assert op.dist_attr.num_results() == 1
 
-                op_operand_dist_attr = op.dist_attr.operand_dist_attr(0)
-                op_result_dist_attr = op.dist_attr.result_dist_attr(0)
+                op_operand_dist_attr = op.dist_attr.operand(
+                    0
+                ).as_tensor_dist_attr()
+                op_result_dist_attr = op.dist_attr.result(
+                    0
+                ).as_tensor_dist_attr()
 
                 assert op.dist_attr.process_mesh == self._in_mesh
                 assert op_operand_dist_attr.process_mesh == self._in_mesh

--- a/test/auto_parallel/reshard_r_to_s.py
+++ b/test/auto_parallel/reshard_r_to_s.py
@@ -101,8 +101,6 @@ class TestReshardRToS:
             assert 'pd_op.slice' in new_ops
             assert 'dist_op.reshard' not in new_ops
             assert 'dist_op.reshard' in old_ops
-            print(dist_program)
-            print(main_program)
 
 
 if __name__ == '__main__':

--- a/test/auto_parallel/reshard_r_to_s.py
+++ b/test/auto_parallel/reshard_r_to_s.py
@@ -18,6 +18,9 @@ import numpy as np
 
 import paddle
 import paddle.distributed as dist
+from paddle.distributed.auto_parallel.static.pir_pass import (
+    apply_reshard_pass,
+)
 
 
 class TestReshardRToS:
@@ -57,6 +60,51 @@ class TestReshardRToS:
         assert np.equal(out.shape, input_tensor.shape).all()
         assert np.equal(out._local_shape, out_shape).all()
 
+    def run_pir_test_case(self):
+        paddle.enable_static()
+        if self._backend == "cpu":
+            paddle.set_device("cpu")
+            place = paddle.CPUPlace()
+        elif self._backend == "gpu":
+            place = paddle.CUDAPlace(dist.get_rank())
+
+        BATCH_SIZE = 2
+        SEQ_LEN = 4
+        HIDDEN_SIZE = 8
+        MP_SIZE = 2
+
+        with paddle.pir_utils.IrGuard():
+            main_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program):
+                mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
+                input = paddle.static.data(
+                    name='input', shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
+                )
+                w0 = paddle.pir.core.create_parameter(
+                    dtype="float32",
+                    shape=[HIDDEN_SIZE, HIDDEN_SIZE],
+                    name="w0",
+                    initializer=paddle.nn.initializer.Uniform(),
+                )
+
+                input_tensor = dist.shard_tensor(
+                    w0, self._mesh, [dist.Replicate()]
+                )
+                paddle._C_ops.reshard(
+                    input_tensor, self._mesh, [dist.Shard(self._shard)]
+                )
+            dist_program = apply_reshard_pass(main_program)
+            np.testing.assert_equal(dist_program.num_ops(), 6)
+            old_ops = [op.name() for op in main_program.global_block().ops]
+            new_ops = [op.name() for op in dist_program.global_block().ops]
+
+            assert 'pd_op.slice' in new_ops
+            assert 'dist_op.reshard' not in new_ops
+            assert 'dist_op.reshard' in old_ops
+            print(dist_program)
+            print(main_program)
+
 
 if __name__ == '__main__':
     TestReshardRToS().run_test_case()
+    TestReshardRToS().run_pir_test_case()

--- a/test/cpp/pir/distributed/dist_dialect_test.cc
+++ b/test/cpp/pir/distributed/dist_dialect_test.cc
@@ -270,13 +270,13 @@ TEST(operation_dist_attr_test, base) {
   EXPECT_NE(op_attr, op_attr_2);
   EXPECT_EQ(op_attr.process_mesh_attr(), mesh_attr);
   EXPECT_EQ(op_attr.process_mesh_attr().process_mesh(), process_mesh);
-  EXPECT_EQ(op_attr.operand_attrs(), operand_attrs);
-  EXPECT_EQ(op_attr.operand_dist_attr(0), operand_attrs.at(0));
-  EXPECT_EQ(op_attr.operand_dist_attr(1), operand_attrs.at(1));
+  EXPECT_EQ(op_attr.operands(), operand_attrs);
+  EXPECT_EQ(op_attr.operand(0), operand_attrs.at(0));
+  EXPECT_EQ(op_attr.operand(1), operand_attrs.at(1));
   EXPECT_EQ(op_attr.num_operands(), (uint32_t)2);
 
-  EXPECT_EQ(op_attr.result_attrs(), result_attrs);
-  EXPECT_EQ(op_attr.result_dist_attr(0), result_attrs.at(0));
+  EXPECT_EQ(op_attr.results(), result_attrs);
+  EXPECT_EQ(op_attr.result(0), result_attrs.at(0));
   EXPECT_EQ(op_attr.num_results(), (uint32_t)1);
 }
 

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -109,6 +109,7 @@ STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         'is_dist_dense_tensor_type',
         'dist_attr',
         'update_dist_attr',
+        'is_combine',
         'value_assign',
         'replace_grad_users_with',
         'do_model_average',


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

- 规范化operiton tensor dist的接口及相关使用。
   - OperationDsitAttribute成员函数：（以下函数都会同名pybind到python端） 
       - operands接口，返回vector<Attribute>, 表示操作数的分布式属性。
       - num_operands接口，返回size_t, 表示操作数的个数。
       - operand(size_t index)接口， 返回 Attribute, 表示第index个操作数的分布式属性。
       - results接口，返回vector<Attribute>, 表示输出的分布式属性。
       - num_results接口，返回size_t, 表示输出的个数。
       - result(size_t index)接口， 返回 Attribute, 表示第index个输出的分布式属性。
   - Python端接口变动
       - Attribute增加接口： 
           - as_tensor_dist_attr, 将Attribue对象转换为TensorDistAttribtue对象，如果转换失败，返回None。
           - as_array_attr,  将Attribue对象转换为ArrayAttribtue对象，如果转换失败，返回None。
       - 将ArrayAttribute绑定到python端，支持通过下标访问和通过范围for循环去遍历。 
   
- 修复full_like的inferspmd函数。不需要修改x的dist_attr。
- 重构升级partition pass, 支持op的输入为combine value的场景。
- 增加replicate to shard的reshard策略实现。

### Other
Pcard-67164
