### PR TITLE
[PIR] Add FLAG of FLAGS_pir_debug

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1489,6 +1489,10 @@ PHI_DEFINE_EXPORTED_int32(
     "been dropped when you are profiling, try increasing this value.");
 
 PHI_DEFINE_EXPORTED_bool(print_ir, false, "Whether print ir debug str.");
+
+PHI_DEFINE_EXPORTED_bool(pir_debug,
+                         false,
+                         "Whether print more pir debug info.");
 PHI_DEFINE_EXPORTED_bool(prim_skip_dynamic,
                          false,
                          "Whether to skip decomposing op with dynamic shape.");

--- a/paddle/pir/src/core/ir_printer.cc
+++ b/paddle/pir/src/core/ir_printer.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "paddle/common/flags.h"
 #include "paddle/pir/include/core/block.h"
 #include "paddle/pir/include/core/builtin_attribute.h"
 #include "paddle/pir/include/core/builtin_type.h"
@@ -26,6 +27,8 @@
 #include "paddle/pir/include/core/program.h"
 #include "paddle/pir/include/core/utils.h"
 #include "paddle/pir/include/core/value.h"
+
+COMMON_DECLARE_bool(pir_debug);
 
 namespace pir {
 
@@ -181,6 +184,10 @@ void IrPrinter::PrintOperationWithNoRegion(Operation* op) {
   os << " =";
 
   os << " \"" << op->name() << "\"";
+
+  if (FLAGS_pir_debug) {
+    os << " [id:" << op->id() << "]";
+  }
 
   // TODO(lyk): add API to get operands directly
   PrintOpOperands(op);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

添加`FLAGS_pir_debug`用于控制pir program中 operation id信息的打印。

`FLAGS_pir_debug`开启后program打印示例：
```
(%0) = "pd_op.data" [id:16] () {dtype:(pd_op.DataType)int32,name:"x",place:(pd_op.Place)Place(undefined:0),shape:(pd_op.IntArray)[1],stop_gradient:[true]} : () -> builtin.tensor<1xi32>
(%1) = "pd_op.full_int_array" [id:17] () {dtype:(pd_op.DataType)int64,place:(pd_op.Place)Place(cpu),stop_gradient:[true],value:[(Int64)0]} : () -> builtin.tensor<1xi64>
(%2) = "pd_op.prod" [id:18] (%0, %1) {keep_dim:false,reduce_all:true,stop_gradient:[true]} : (builtin.tensor<1xi32>, builtin.tensor<1xi64>) -> builtin.tensor<i32>
() = "builtin.shadow_output" [id:19] (%2) {output_name:"output_0"} : (builtin.tensor<i32>) -> 

```