### PR TITLE
[CI][SOT] Remove package `github` installation in CI and update SOT trigger file list

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -84,11 +84,11 @@ if not defined INFERENCE_DEMO_INSTALL_DIR set INFERENCE_DEMO_INSTALL_DIR=%cache_
 if not defined LOG_LEVEL set LOG_LEVEL=normal
 if not defined PRECISION_TEST set PRECISION_TEST=OFF
 if not defined WIN_UNITTEST_LEVEL set WIN_UNITTEST_LEVEL=2
-rem LEVEL 0: For unittests unrelated to CUDA/TRT or unittests without GPU memory, only run on 
+rem LEVEL 0: For unittests unrelated to CUDA/TRT or unittests without GPU memory, only run on
 rem          PR-CI-Windows-Infernece(CUDA 11.2), skip them on PR-CI-Windows(CUDA 12.0)
-rem LEVEL 1: For unittests unrelated to CUDA/TRT, only run on PR-CI-Windows-Infernece(CUDA 11.2), 
+rem LEVEL 1: For unittests unrelated to CUDA/TRT, only run on PR-CI-Windows-Infernece(CUDA 11.2),
 rem          skip them on PR-CI-Windows(CUDA 12.0)
-rem LEVEL 2: run all test 
+rem LEVEL 2: run all test
 if not defined NIGHTLY_MODE set NIGHTLY_MODE=OFF
 if not defined retry_times set retry_times=1
 if not defined PYTHON_ROOT set PYTHON_ROOT=C:\Python38
@@ -376,7 +376,7 @@ if "%WITH_GPU%"=="ON" (
     if "!cuda_version!"=="12.0" (
         set "PATH=C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64;%PATH%"
     )
-) 
+)
 echo %PATH%
 rem CUDA_TOOLKIT_ROOT_DIR in cmake must use / rather than \
 set TENSORRT_ROOT=%TENSORRT_ROOT:\=/%
@@ -384,7 +384,7 @@ set CUDA_TOOLKIT_ROOT_DIR=%CUDA_TOOLKIT_ROOT_DIR:\=/%
 
 rem install ninja if GENERATOR is Ninja
 if %GENERATOR% == "Ninja" (
-    rem Set the default generator for cmake to Ninja 
+    rem Set the default generator for cmake to Ninja
     setx CMAKE_GENERATOR Ninja
     pip install ninja
     if %errorlevel% NEQ 0 (
@@ -503,7 +503,6 @@ echo %task_name%|findstr build >nul && (
 :cmake_impl
 cd /d %work_dir%\%BUILD_DIR%
 rem whether to run cpp test
-python -m pip install github
 python -m pip install PyGithub
 python %work_dir%\tools\check_only_change_python_files.py
 if exist %work_dir%\%BUILD_DIR%\only_change_python_file.txt set WITH_CPP_TEST=OFF

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3850,9 +3850,7 @@ function run_setup(){
         INFERENCE_DEMO_INSTALL_DIR=${INFERENCE_DEMO_INSTALL_DIR:-/root/.cache/inference_demo}
     fi
 
-    pip uninstall -y PyGithub
-    pip install github
-    pip install PyGithub
+    pip install -U PyGithub
     python ${PADDLE_ROOT}/tools/check_only_change_python_files.py
     if [ -f "${PADDLE_ROOT}/build/only_change_python_file.txt" ];then
          export WITH_CPP_TEST=OFF

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -289,7 +289,7 @@ EOF
         -DWITH_PYTHON=${WITH_PYTHON:-ON} \
         -DCUDNN_ROOT=/usr/ \
         -DWITH_TESTING=${WITH_TESTING:-ON} \
-	-DWITH_CPP_TEST=${WITH_CPP_TEST:-ON} \
+        -DWITH_CPP_TEST=${WITH_CPP_TEST:-ON} \
         -DWITH_COVERAGE=${WITH_COVERAGE:-OFF} \
         -DWITH_INCREMENTAL_COVERAGE=${WITH_INCREMENTAL_COVERAGE:-OFF} \
         -DCMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
@@ -3853,9 +3853,9 @@ function run_setup(){
     pip install -U PyGithub
     python ${PADDLE_ROOT}/tools/check_only_change_python_files.py
     if [ -f "${PADDLE_ROOT}/build/only_change_python_file.txt" ];then
-         export WITH_CPP_TEST=OFF
+        export WITH_CPP_TEST=OFF
     else
-	 export WITH_CPP_TEST=ON
+        export WITH_CPP_TEST=ON
     fi
     distibuted_flag=${WITH_DISTRIBUTE:-OFF}
     gloo_flag=${distibuted_flag}

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -960,9 +960,9 @@ function check_run_sot_ci() {
     SOT_FILE_LIST=(
         paddle/pir
         paddle/phi
+        paddle/scripts
         paddle/fluid/eager/to_static
         paddle/fluid/pybind/
-        paddle/scripts/paddle_build.sh
         python/
         test/sot
     )

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -958,11 +958,11 @@ function check_run_sot_ci() {
 
     # git diff
     SOT_FILE_LIST=(
-        paddle/fluid/operators/run_program_op.h
-        paddle/fluid/operators/run_program_op.cu
-        paddle/fluid/operators/run_program_op.cc
+        paddle/pir
+        paddle/phi
         paddle/fluid/eager/to_static
         paddle/fluid/pybind/
+        paddle/scripts/paddle_build.sh
         python/
         test/sot
     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#63189 在 `paddle_build.sh` 添加 `pip install github` 导致 `PR-CI-SOT` 流水线在安装 3.11 依赖（`run_setup`）的时候挂掉，如 https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/10555965/job/26019581

```
2024-04-24 23:24:17 + pip install github
2024-04-24 23:24:18 DEPRECATION: Loading egg at /usr/local/lib/python3.11/dist-packages/pip-23.3.1-py3.11.egg is deprecated. pip 24.3 will enforce this behaviour change. A possible replacement is to use pip for package installation.. Discussion can be found at https://github.com/pypa/pip/issues/12330
2024-04-24 23:24:18 DEPRECATION: Loading egg at /usr/local/lib/python3.11/dist-packages/setuptools-68.2.2-py3.11.egg is deprecated. pip 24.3 will enforce this behaviour change. A possible replacement is to use pip for package installation.. Discussion can be found at https://github.com/pypa/pip/issues/12330
2024-04-24 23:24:20 Collecting github
2024-04-24 23:24:20   Using cached github-1.2.7-py3-none-any.whl.metadata (1.7 kB)
2024-04-24 23:24:22 Collecting aiohttp==3.8.1 (from github)
2024-04-24 23:24:23   Using cached aiohttp-3.8.1.tar.gz (7.3 MB)
2024-04-24 23:24:23   Installing build dependencies: started
2024-04-24 23:24:29   Installing build dependencies: finished with status 'done'
2024-04-24 23:24:29   Getting requirements to build wheel: started
2024-04-24 23:24:30   Getting requirements to build wheel: finished with status 'done'
2024-04-24 23:24:30   Installing backend dependencies: started
2024-04-24 23:24:35   Installing backend dependencies: finished with status 'done'
2024-04-24 23:24:35   Preparing metadata (pyproject.toml): started
2024-04-24 23:24:35   Preparing metadata (pyproject.toml): finished with status 'done'
2024-04-24 23:24:35 Requirement already satisfied: typing-extensions in /usr/local/lib/python3.11/dist-packages (from github) (4.10.0)
2024-04-24 23:24:35 Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.11/dist-packages (from aiohttp==3.8.1->github) (23.2.0)
2024-04-24 23:24:36 Collecting charset-normalizer<3.0,>=2.0 (from aiohttp==3.8.1->github)
2024-04-24 23:24:37   Using cached charset_normalizer-2.1.1-py3-none-any.whl.metadata (11 kB)
2024-04-24 23:24:39 Collecting multidict<7.0,>=4.5 (from aiohttp==3.8.1->github)
2024-04-24 23:24:39   Using cached multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.2 kB)
2024-04-24 23:24:41 Collecting async-timeout<5.0,>=4.0.0a3 (from aiohttp==3.8.1->github)
2024-04-24 23:24:41   Using cached async_timeout-4.0.3-py3-none-any.whl.metadata (4.2 kB)
2024-04-24 23:24:43 Collecting yarl<2.0,>=1.0 (from aiohttp==3.8.1->github)
2024-04-24 23:24:43   Using cached yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (31 kB)
2024-04-24 23:24:45 Collecting frozenlist>=1.1.1 (from aiohttp==3.8.1->github)
2024-04-24 23:24:45   Using cached frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2024-04-24 23:24:47 Collecting aiosignal>=1.1.2 (from aiohttp==3.8.1->github)
2024-04-24 23:24:47   Using cached aiosignal-1.3.1-py3-none-any.whl.metadata (4.0 kB)
2024-04-24 23:24:47 Requirement already satisfied: idna>=2.0 in /usr/lib/python3/dist-packages (from yarl<2.0,>=1.0->aiohttp==3.8.1->github) (2.8)
2024-04-24 23:24:48 Using cached github-1.2.7-py3-none-any.whl (15 kB)
2024-04-24 23:24:48 Using cached aiosignal-1.3.1-py3-none-any.whl (7.6 kB)
2024-04-24 23:24:49 Using cached async_timeout-4.0.3-py3-none-any.whl (5.7 kB)
2024-04-24 23:24:49 Using cached charset_normalizer-2.1.1-py3-none-any.whl (39 kB)
2024-04-24 23:24:50 Using cached frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (272 kB)
2024-04-24 23:24:50 Using cached multidict-6.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (128 kB)
2024-04-24 23:24:51 Using cached yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (328 kB)
2024-04-24 23:24:51 Building wheels for collected packages: aiohttp
2024-04-24 23:24:51   Building wheel for aiohttp (pyproject.toml): started
2024-04-24 23:24:51   Building wheel for aiohttp (pyproject.toml): finished with status 'error'
2024-04-24 23:24:51   error: subprocess-exited-with-error
2024-04-24 23:24:51   
2024-04-24 23:24:51   ?? Building wheel for aiohttp (pyproject.toml) did not run successfully.
2024-04-24 23:24:51   ??? exit code: 1
2024-04-24 23:24:51   ??????> [107 lines of output]
2024-04-24 23:24:51       *********************
2024-04-24 23:24:51       * Accelerated build *
2024-04-24 23:24:51       *********************
2024-04-24 23:24:51       running bdist_wheel
2024-04-24 23:24:51       running build
2024-04-24 23:24:51       running build_py
2024-04-24 23:24:51       creating build
2024-04-24 23:24:51       creating build/lib.linux-x86_64-cpython-311
2024-04-24 23:24:51       creating build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/typedefs.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/resolver.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_response.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/client_reqrep.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_server.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/__init__.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/hdrs.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/payload.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_log.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/base_protocol.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/abc.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_urldispatcher.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_middlewares.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/http.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/client_exceptions.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/http_writer.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_routedef.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_app.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_fileresponse.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/worker.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_protocol.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_ws.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/client_proto.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/http_exceptions.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/log.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/http_websocket.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/test_utils.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/http_parser.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/locks.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/client.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/tracing.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_runner.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/client_ws.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_request.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/cookiejar.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/tcp_helpers.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/formdata.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/web_exceptions.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/multipart.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/pytest_plugin.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/payload_streamer.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/streams.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/connector.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/helpers.py -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       running egg_info
2024-04-24 23:24:51       writing aiohttp.egg-info/PKG-INFO
2024-04-24 23:24:51       writing dependency_links to aiohttp.egg-info/dependency_links.txt
2024-04-24 23:24:51       writing requirements to aiohttp.egg-info/requires.txt
2024-04-24 23:24:51       writing top-level names to aiohttp.egg-info/top_level.txt
2024-04-24 23:24:51       reading manifest file 'aiohttp.egg-info/SOURCES.txt'
2024-04-24 23:24:51       reading manifest template 'MANIFEST.in'
2024-04-24 23:24:51       warning: no files found matching 'aiohttp' anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.pyc' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.pyd' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.so' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.lib' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.dll' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.a' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files matching '*.obj' found anywhere in distribution
2024-04-24 23:24:51       warning: no previously-included files found matching 'aiohttp/*.html'
2024-04-24 23:24:51       no previously-included directories found matching 'docs/_build'
2024-04-24 23:24:51       adding license file 'LICENSE.txt'
2024-04-24 23:24:51       writing manifest file 'aiohttp.egg-info/SOURCES.txt'
2024-04-24 23:24:51       copying aiohttp/_cparser.pxd -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_find_header.c -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_find_header.h -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_find_header.pxd -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_headers.pxi -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_helpers.c -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_helpers.pyi -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_helpers.pyx -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_http_parser.c -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_http_parser.pyx -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_http_writer.c -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_http_writer.pyx -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_websocket.c -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/_websocket.pyx -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       copying aiohttp/py.typed -> build/lib.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       creating build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_cparser.pxd.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_find_header.pxd.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_helpers.pyi.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_helpers.pyx.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_http_parser.pyx.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_http_writer.pyx.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/_websocket.pyx.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       copying aiohttp/.hash/hdrs.py.hash -> build/lib.linux-x86_64-cpython-311/aiohttp/.hash
2024-04-24 23:24:51       running build_ext
2024-04-24 23:24:51       building 'aiohttp._websocket' extension
2024-04-24 23:24:51       creating build/temp.linux-x86_64-cpython-311
2024-04-24 23:24:51       creating build/temp.linux-x86_64-cpython-311/aiohttp
2024-04-24 23:24:51       x86_64-linux-gnu-gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -I/usr/include/python3.11 -c aiohttp/_websocket.c -o build/temp.linux-x86_64-cpython-311/aiohttp/_websocket.o
2024-04-24 23:24:51       aiohttp/_websocket.c:198:12: fatal error: longintrepr.h: No such file or directory
2024-04-24 23:24:51         198 |   #include "longintrepr.h"
2024-04-24 23:24:51             |            ^~~~~~~~~~~~~~~
2024-04-24 23:24:51       compilation terminated.
2024-04-24 23:24:51       error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
2024-04-24 23:24:51       [end of output]
2024-04-24 23:24:51   
2024-04-24 23:24:51   note: This error originates from a subprocess, and is likely not a problem with pip.
2024-04-24 23:24:51   ERROR: Failed building wheel for aiohttp
2024-04-24 23:24:51 Failed to build aiohttp
2024-04-24 23:24:51 ERROR: Could not build wheels for aiohttp, which is required to install pyproject.toml-based projects
2024-04-24 23:24:52 + EXCODE=1
```

这里 Python 3.11 装了 `github`，`github` 依赖 `aiohttp>=3.8.1`，虽然并不是很清楚 resolve 后仍然选择的是最低版本 aiohttp 3.8.1，但就 3.8.1 来看，明显是没有 Python 3.11 的预编译 wheel 包的，触发 build 导致挂掉（这个版本应该也没适配 Python 3.11，挂掉很正常）

PyPI 里 `github` 这个包来自于 <https://github.com/VarMonke/Github-Api-Wrapper>，它与 [`PyGithub`](https://github.com/PyGithub/PyGithub) 是有冲突的，它们同样通过 `import github` 来使用，但使用方式完全不同，我们现有脚本里明显都是使用 `PyGithub` 的，`github` 是没有用的，因此直接删掉就好了

另外，没能成功拦截 #63189 的原因是 SOT CI 只对修改部分文件的情况下才会触发，而 `paddle_build.sh` 并不在其中，因此修改监控文件列表，避免类似问题

PCard-66972