### PR TITLE
[PIR][oneDNN] Add fc_activation_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -632,6 +632,7 @@ const std::vector<std::string> kPirMkldnnPasses{
     "matmul_activation_fuse_pass",
     "fc_fuse_pass",
     "fc_onednn_enable_pass",
+    "fc_activation_fuse_pass",
     "self_attention_fuse_pass",
     "softplus_activation_fuse_pass",
     "conv_elementwise_add_onednn_fuse_pass",

--- a/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.cc
@@ -157,7 +157,7 @@ class FusedFcGeluTanhFusePattern : public paddle::drr::DrrPatternBase {
   uint32_t benefit_;
 
  public:
-  FusedFcGeluTanhFusePattern(uint32_t benefit) : benefit_(benefit) {}
+  explicit FusedFcGeluTanhFusePattern(uint32_t benefit) : benefit_(benefit) {}
 
   std::string name() const override { return "FusedFcActivationFusePattern"; }
 
@@ -230,7 +230,7 @@ class FusedFcClipFusePattern : public paddle::drr::DrrPatternBase {
   uint32_t benefit_;
 
  public:
-  FusedFcClipFusePattern(uint32_t benefit) : benefit_(benefit) {}
+  explicit FusedFcClipFusePattern(uint32_t benefit) : benefit_(benefit) {}
 
   std::string name() const override { return "FusedFcActivationFusePattern"; }
 

--- a/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.cc
@@ -1,0 +1,334 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/onednn_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+std::set<std::string> act_ops = {{paddle::dialect::AbsOp::name()},
+                                 {paddle::dialect::GeluOp::name()},
+                                 {paddle::dialect::HardsigmoidOp::name()},
+                                 {paddle::dialect::HardswishOp::name()},
+                                 {paddle::dialect::LeakyReluOp::name()},
+                                 {paddle::dialect::MishOp::name()},
+                                 {paddle::dialect::ReluOp::name()},
+                                 {paddle::dialect::Relu6Op::name()},
+                                 {paddle::dialect::SigmoidOp::name()},
+                                 {paddle::dialect::SqrtOp::name()},
+                                 {paddle::dialect::SwishOp::name()},
+                                 {paddle::dialect::TanhOp::name()}};
+
+std::unordered_map<std::string, std::string> activation_type = {
+    {paddle::dialect::AbsOp::name(), "abs"},
+    {paddle::dialect::GeluOp::name(), "gelu"},
+    {paddle::dialect::HardsigmoidOp::name(), "hard_sigmoid"},
+    {paddle::dialect::HardswishOp::name(), "hard_swish"},
+    {paddle::dialect::LeakyReluOp::name(), "leaky_relu"},
+    {paddle::dialect::MishOp::name(), "mish"},
+    {paddle::dialect::ReluOp::name(), "relu"},
+    {paddle::dialect::Relu6Op::name(), "relu6"},
+    {paddle::dialect::SigmoidOp::name(), "sigmoid"},
+    {paddle::dialect::SqrtOp::name(), "sqrt"},
+    {paddle::dialect::SwishOp::name(), "swish"},
+    {paddle::dialect::TanhOp::name(), "tanh"}};
+
+class FusedFcActivationFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  uint32_t benefit_;
+  std::string act_type_;
+
+ public:
+  FusedFcActivationFusePattern(uint32_t benefit, const std::string &act_type)
+      : benefit_(benefit), act_type_(act_type) {}
+
+  std::string name() const override { return "FusedFcActivationFusePattern"; }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &fc =
+        pat.Op(paddle::onednn::dialect::FcOp::name(),
+               {{"in_num_col_dims", pat.Attr("in_num_col_dims")},
+                {"activation_type", pat.Attr("activation_type")},
+                {"padding_weights", pat.Attr("padding_weights")},
+                {"use_quantizer", pat.Attr("use_quantizer")},
+                {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+                {"scale_in", pat.Attr("scale_in")},
+                {"scale_weights", pat.Attr("scale_weights")},
+                {"scale_out", pat.Attr("scale_out")},
+                {"force_fp32_output", pat.Attr("force_fp32_output")},
+                {"fused_output_scale", pat.Attr("fused_output_scale")},
+                {"fused_reshape2_shape", pat.Attr("fused_reshape2_shape")}});
+
+    std::unordered_map<std::string, paddle::drr::Attribute> act_attrs;
+    if (act_type_ == paddle::dialect::HardsigmoidOp::name()) {
+      act_attrs.emplace("slope", pat.Attr("fuse_alpha"));
+      act_attrs.emplace("offset", pat.Attr("fuse_beta"));
+    } else if (act_type_ == paddle::dialect::LeakyReluOp::name()) {
+      act_attrs.emplace("negative_slope", pat.Attr("fuse_alpha"));
+    } else if (act_type_ == paddle::dialect::GeluOp::name()) {
+      act_attrs.emplace("approximate", pat.Attr("approximate"));
+    }
+
+    const auto &act = pat.Op(act_type_, act_attrs);
+    fc({&pat.Tensor("input"), &pat.Tensor("weight"), &pat.Tensor("bias")},
+       {&pat.Tensor("Out")});
+
+    pat.Tensor("act_out") = act(pat.Tensor("Out"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto act_type = match_ctx.Attr<std::string>("activation_type");
+      if (!(act_type == "" || act_type == "relu")) return false;
+      return true;
+    });
+
+    if (act_type_ == paddle::dialect::GeluOp::name()) {
+      pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+        auto result_gelu = match_ctx.Attr<bool>("approximate");
+        if (result_gelu) return false;
+        return true;
+      });
+    }
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"in_num_col_dims", pat.Attr("in_num_col_dims")},
+        {"activation_type", pat.Attr("activation_type")},
+        {"padding_weights", pat.Attr("padding_weights")},
+        {"use_quantizer", pat.Attr("use_quantizer")},
+        {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+        {"scale_in", pat.Attr("scale_in")},
+        {"scale_weights", pat.Attr("scale_weights")},
+        {"scale_out", pat.Attr("scale_out")},
+        {"force_fp32_output", pat.Attr("force_fp32_output")},
+        {"fused_output_scale", pat.Attr("fused_output_scale")},
+        {"fused_reshape2_shape", pat.Attr("fused_reshape2_shape")}};
+
+    if (act_type_ == paddle::dialect::HardswishOp::name()) {
+      fused_attrs.emplace("fuse_alpha", res.Float32Attr(1.0f / 6.0f));
+      fused_attrs.emplace("fuse_beta", res.Float32Attr(1.0f / 2.0f));
+    } else if (act_type_ == paddle::dialect::HardsigmoidOp::name()) {
+      fused_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
+      fused_attrs.emplace("fuse_beta", pat.Attr("fuse_beta"));
+    } else if (act_type_ == paddle::dialect::LeakyReluOp::name()) {
+      fused_attrs.emplace("fuse_alpha", pat.Attr("fuse_alpha"));
+    } else if (act_type_ == paddle::dialect::SwishOp::name()) {
+      fused_attrs.emplace("fuse_alpha", res.Float32Attr(1.0f));
+    } else if (act_type_ == paddle::dialect::Relu6Op::name()) {
+      fused_attrs.emplace("fuse_beta", res.Float32Attr(6.0f));
+    }
+
+    fused_attrs.insert(std::make_pair("fuse_activation",
+                                      res.StrAttr(activation_type[act_type_])));
+    fused_attrs.insert(std::make_pair("fuse_alpha", res.Float32Attr(0.0f)));
+    fused_attrs.insert(std::make_pair("fuse_beta", res.Float32Attr(0.0f)));
+
+    const auto &fused_fc =
+        res.Op(paddle::onednn::dialect::FcOp::name(), fused_attrs);
+
+    fused_fc({&res.Tensor("input"), &res.Tensor("weight"), &res.Tensor("bias")},
+             {&res.Tensor("act_out")});
+  }
+};
+
+class FusedFcGeluTanhFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  uint32_t benefit_;
+
+ public:
+  FusedFcGeluTanhFusePattern(uint32_t benefit) : benefit_(benefit) {}
+
+  std::string name() const override { return "FusedFcActivationFusePattern"; }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &fc =
+        pat.Op(paddle::onednn::dialect::FcOp::name(),
+               {{"in_num_col_dims", pat.Attr("in_num_col_dims")},
+                {"activation_type", pat.Attr("activation_type")},
+                {"padding_weights", pat.Attr("padding_weights")},
+                {"use_quantizer", pat.Attr("use_quantizer")},
+                {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+                {"scale_in", pat.Attr("scale_in")},
+                {"scale_weights", pat.Attr("scale_weights")},
+                {"scale_out", pat.Attr("scale_out")},
+                {"force_fp32_output", pat.Attr("force_fp32_output")},
+                {"fused_output_scale", pat.Attr("fused_output_scale")},
+                {"fused_reshape2_shape", pat.Attr("fused_reshape2_shape")}});
+
+    const auto &act = pat.Op(paddle::dialect::GeluOp::name(),
+                             {{"approximate", pat.Attr("approximate")}});
+    fc({&pat.Tensor("input"), &pat.Tensor("weight"), &pat.Tensor("bias")},
+       {&pat.Tensor("Out")});
+
+    pat.Tensor("act_out") = act(pat.Tensor("Out"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto act_type = match_ctx.Attr<std::string>("activation_type");
+      if (!(act_type == "" || act_type == "relu")) return false;
+      return true;
+    });
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto result_gelu = match_ctx.Attr<bool>("approximate");
+      if (!result_gelu) return false;
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"in_num_col_dims", pat.Attr("in_num_col_dims")},
+        {"activation_type", pat.Attr("activation_type")},
+        {"padding_weights", pat.Attr("padding_weights")},
+        {"use_quantizer", pat.Attr("use_quantizer")},
+        {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+        {"scale_in", pat.Attr("scale_in")},
+        {"scale_weights", pat.Attr("scale_weights")},
+        {"scale_out", pat.Attr("scale_out")},
+        {"force_fp32_output", pat.Attr("force_fp32_output")},
+        {"fuse_activation", res.StrAttr("gelu_tanh")},
+        {"fuse_alpha", res.Float32Attr(0.0f)},
+        {"fuse_beta", res.Float32Attr(0.0f)},
+        {"fused_output_scale", pat.Attr("fused_output_scale")},
+        {"fused_reshape2_shape", pat.Attr("fused_reshape2_shape")}};
+
+    const auto &fused_fc =
+        res.Op(paddle::onednn::dialect::FcOp::name(), fused_attrs);
+
+    fused_fc({&res.Tensor("input"), &res.Tensor("weight"), &res.Tensor("bias")},
+             {&res.Tensor("act_out")});
+  }
+};
+
+class FusedFcClipFusePattern : public paddle::drr::DrrPatternBase {
+ private:
+  uint32_t benefit_;
+
+ public:
+  FusedFcClipFusePattern(uint32_t benefit) : benefit_(benefit) {}
+
+  std::string name() const override { return "FusedFcActivationFusePattern"; }
+
+  uint32_t benefit() const override { return benefit_; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &fc =
+        pat.Op(paddle::onednn::dialect::FcOp::name(),
+               {{"in_num_col_dims", pat.Attr("in_num_col_dims")},
+                {"activation_type", pat.Attr("activation_type")},
+                {"padding_weights", pat.Attr("padding_weights")},
+                {"use_quantizer", pat.Attr("use_quantizer")},
+                {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+                {"scale_in", pat.Attr("scale_in")},
+                {"scale_weights", pat.Attr("scale_weights")},
+                {"scale_out", pat.Attr("scale_out")},
+                {"force_fp32_output", pat.Attr("force_fp32_output")},
+                {"fused_output_scale", pat.Attr("fused_output_scale")},
+                {"fused_reshape2_shape", pat.Attr("fused_reshape2_shape")}});
+
+    const auto &full1 =
+        pat.Op(paddle::dialect::FullOp::name(),
+               {{"shape", pat.Attr("shape1")}, {"value", pat.Attr("value1")}});
+    const auto &full2 =
+        pat.Op(paddle::dialect::FullOp::name(),
+               {{"shape", pat.Attr("shape2")}, {"value", pat.Attr("value2")}});
+    pat.Tensor("min") = full1();
+    pat.Tensor("max") = full2();
+
+    const auto &act = pat.Op(paddle::dialect::ClipOp::name());
+    fc({&pat.Tensor("input"), &pat.Tensor("weight"), &pat.Tensor("bias")},
+       {&pat.Tensor("Out")});
+
+    pat.Tensor("act_out") =
+        act(pat.Tensor("Out"), pat.Tensor("min"), pat.Tensor("max"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      auto act_type = match_ctx.Attr<std::string>("activation_type");
+      if (!(act_type == "" || act_type == "relu")) return false;
+      return true;
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    std::unordered_map<std::string, paddle::drr::Attribute> fused_attrs{
+        {"in_num_col_dims", pat.Attr("in_num_col_dims")},
+        {"activation_type", pat.Attr("activation_type")},
+        {"padding_weights", pat.Attr("padding_weights")},
+        {"use_quantizer", pat.Attr("use_quantizer")},
+        {"mkldnn_data_type", pat.Attr("mkldnn_data_type")},
+        {"scale_in", pat.Attr("scale_in")},
+        {"scale_weights", pat.Attr("scale_weights")},
+        {"scale_out", pat.Attr("scale_out")},
+        {"force_fp32_output", pat.Attr("force_fp32_output")},
+        {"fuse_activation", res.StrAttr("clip")},
+        {"fuse_alpha", pat.Attr("value1")},
+        {"fuse_beta", pat.Attr("value2")},
+        {"fused_output_scale", pat.Attr("fused_output_scale")},
+        {"fused_reshape2_shape", pat.Attr("fused_reshape2_shape")}};
+
+    const auto &fused_fc =
+        res.Op(paddle::onednn::dialect::FcOp::name(), fused_attrs);
+
+    fused_fc({&res.Tensor("input"), &res.Tensor("weight"), &res.Tensor("bias")},
+             {&res.Tensor("act_out")});
+  }
+};
+
+class FcActivationFusePass : public pir::PatternRewritePass {
+ public:
+  FcActivationFusePass()
+      : pir::PatternRewritePass("fc_activation_fuse_pass", 3) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    int benefit_idx = 1;
+    for (auto act_op : act_ops) {
+      ps.Add(paddle::drr::Create<FusedFcActivationFusePattern>(
+          context, benefit_idx, act_op));
+      benefit_idx++;
+    }
+    ps.Add(paddle::drr::Create<FusedFcGeluTanhFusePattern>(context,
+                                                           benefit_idx++));
+    ps.Add(paddle::drr::Create<FusedFcClipFusePattern>(context, benefit_idx++));
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateFcActivationFusePass() {
+  // onednn_op.fc + pd_op.relu(act) ->  onednn_op.fc
+  return std::make_unique<FcActivationFusePass>();
+}
+}  // namespace pir
+
+REGISTER_IR_PASS(fc_activation_fuse_pass, FcActivationFusePass);

--- a/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/fc_activation_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateFcActivationFusePass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -54,6 +54,7 @@ USE_PIR_PASS(matmul_transpose_reshape_fuse_pass);
 USE_PIR_PASS(matmul_elementwise_add_fuse_pass);
 USE_PIR_PASS(matmul_activation_fuse_pass);
 USE_PIR_PASS(fc_onednn_enable_pass);
+USE_PIR_PASS(fc_activation_fuse_pass);
 USE_PIR_PASS(self_attention_fuse_pass);
 USE_PIR_PASS(softplus_activation_fuse_pass);
 USE_PIR_PASS(conv_elementwise_add_onednn_fuse_pass);

--- a/test/ir/pir/fused_pass/onednn/test_fc_activation_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_fc_activation_fuse_pass.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+
+paddle.enable_static()
+
+activation_type = [
+    "abs",
+    "gelu",
+    "hard_sigmoid",
+    "hard_swish",
+    "leaky_relu",
+    "mish",
+    "relu",
+    "relu6",
+    "sigmoid",
+    "sqrt",
+    "swish",
+    "tanh",
+]
+
+
+class TestFcActivationFusePattern(PassTest):
+    r"""
+    x     w
+     \   /
+     matmul  y
+        \   /
+         add
+          |
+         act
+          |
+         out
+    """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def sample_program(self):
+        x_shape = [3, 2]
+        w_shape = [2, 3]
+        for y_shape in [[3], [1, 3]]:
+            for act_op in activation_type:
+                with paddle.pir_utils.IrGuard():
+                    start_prog = paddle.static.Program()
+                    main_prog = paddle.static.Program()
+                    with paddle.pir.core.program_guard(main_prog, start_prog):
+                        x = paddle.static.data(
+                            name='x', shape=x_shape, dtype='float32'
+                        )
+                        w = paddle.static.data(
+                            name='w', shape=w_shape, dtype='float32'
+                        )
+                        y = paddle.static.data(
+                            name='y', shape=y_shape, dtype='float32'
+                        )
+
+                        add_out = paddle.add(paddle.matmul(x, w), y)
+
+                        if act_op == "abs":
+                            out = paddle.abs(add_out)
+                        elif act_op == "gelu":
+                            out = paddle.nn.functional.gelu(add_out)
+                        elif act_op == "hard_sigmoid":
+                            out = paddle.nn.functional.hardsigmoid(add_out)
+                        elif act_op == "hard_swish":
+                            out = paddle.nn.functional.hardswish(add_out)
+                        elif act_op == "leaky_relu":
+                            out = paddle.nn.functional.leaky_relu(add_out)
+                        elif act_op == "mish":
+                            out = paddle.nn.functional.mish(add_out)
+                        # currently the relu case will be fused by
+                        # fc_fuse_pass, so skip it here
+                        elif act_op == "relu6" or act_op == "relu":
+                            out = paddle.nn.functional.relu6(add_out)
+                        elif act_op == "sigmoid":
+                            out = paddle.nn.functional.sigmoid(add_out)
+                        elif act_op == "sqrt":
+                            out = paddle.sqrt(add_out)
+                        elif act_op == "swish":
+                            out = paddle.nn.functional.swish(add_out)
+                        elif act_op == "tanh":
+                            out = paddle.nn.functional.tanh(add_out)
+
+                        out = paddle.assign(out)
+                        self.pass_attr_list = [
+                            {'fc_fuse_pass': {}},
+                            {'fc_onednn_enable_pass': {}},
+                            {'fc_activation_fuse_pass': {}},
+                        ]
+                        self.feeds = {
+                            "x": np.random.random(x_shape).astype("float32"),
+                            "w": np.random.random(w_shape).astype("float32"),
+                            "y": np.random.random(y_shape).astype("float32"),
+                        }
+                        self.fetch_list = [out]
+                        self.valid_op_map = {
+                            "onednn_op.fc": 1,
+                            "pd_op.fc": 0,
+                            "pd_op.matmul": 0,
+                            "pd_op.add": 0,
+                            "pd_op.relu": 0,
+                            "pd_op.abs": 0,
+                            "pd_op.gelu": 0,
+                            "pd_op.hard_sigmoid": 0,
+                            "pd_op.hard_swish": 0,
+                            "pd_op.leaky_relu": 0,
+                            "pd_op.mish": 0,
+                            "pd_op.relu6": 0,
+                            "pd_op.sigmoid": 0,
+                            "pd_op.sqrt": 0,
+                            "pd_op.swish": 0,
+                            "pd_op.tanh": 0,
+                        }
+
+                        yield [main_prog, start_prog], False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+class TestFcGeluTanhFusePattern(PassTest):
+    r"""
+    x     w
+     \   /
+     matmul  y
+        \   /
+         add
+          |
+      gelu_tanh
+          |
+         out
+    """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                w = paddle.static.data(name='w', shape=[2, 3], dtype='float32')
+                y = paddle.static.data(name='y', shape=[3], dtype='float32')
+                fc_out = paddle.add(paddle.matmul(x, w), y)
+                out = paddle.nn.functional.gelu(fc_out, approximate=True)
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'fc_fuse_pass': {}},
+                    {'fc_onednn_enable_pass': {}},
+                    {'fc_activation_fuse_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                    "w": np.random.random((2, 3)).astype("float32"),
+                    "y": np.random.random(3).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fc": 1,
+                    "pd_op.fc": 0,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                    "pd_op.gelu": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+class TestFcClipFusePattern(PassTest):
+    r"""
+    x     w
+     \   /
+     matmul  y
+        \   /
+         add
+          |
+      gelu_tanh
+          |
+         out
+    """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
+                w = paddle.static.data(name='w', shape=[2, 3], dtype='float32')
+                y = paddle.static.data(name='y', shape=[3], dtype='float32')
+                fc_out = paddle.add(paddle.matmul(x, w), y)
+                out = paddle.clip(fc_out)
+                out = paddle.assign(out)
+                self.pass_attr_list = [
+                    {'fc_fuse_pass': {}},
+                    {'fc_onednn_enable_pass': {}},
+                    {'fc_activation_fuse_pass': {}},
+                ]
+                self.feeds = {
+                    "x": np.random.random((3, 2)).astype("float32"),
+                    "w": np.random.random((2, 3)).astype("float32"),
+                    "y": np.random.random(3).astype("float32"),
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fc": 1,
+                    "pd_op.fc": 0,
+                    "pd_op.matmul": 0,
+                    "pd_op.add": 0,
+                    "pd_op.clip": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        yield self.build_ir_program(), False
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features


### Description
<!-- Describe what you’ve done -->
Based on new pass mechanism, here we add pass "fc_activation_fuse_pass" for PIR.

The new pass is same as "fc_act_mkldnn_fuse_pass" in "/paddle/fluid/framework/ir/mkldnn/fc_act_mkldnn_fuse_pass.cc".