### PR TITLE
[XPU] adapt tensor fusion helper to xpu device

### DIFF
--- a/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
+++ b/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
@@ -37,6 +37,7 @@ class HOOK_ACTION:
 alignment = {
     "gpu": 256,
     "npu": 256,
+    "xpu": 256,
 }
 
 align = {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Adapt tensor fusion helper to xpu device to use sharding stage1 in fusion mode(`enable_stage1_overlap` `enable_stage1_tensor_fusion`). Refer to this PR: https://github.com/PaddlePaddle/Paddle/pull/61942

