### PR TITLE
[XPU] support add(x_float32, bfloa16_) and add(x_float32, y_float16) for amp_master_grad

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -271,6 +271,7 @@ XPUOpMap& get_kl2_ops() {
       {"elementwise_add",
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
+                     phi::DataType::BFLOAT16,
                      phi::DataType::INT64,
                      phi::DataType::INT32})},
       {"elementwise_div_grad",

--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -271,7 +271,6 @@ XPUOpMap& get_kl2_ops() {
       {"elementwise_add",
        XPUKernelSet({phi::DataType::FLOAT32,
                      phi::DataType::FLOAT16,
-                     phi::DataType::BFLOAT16,
                      phi::DataType::INT64,
                      phi::DataType::INT32})},
       {"elementwise_div_grad",

--- a/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_kernel.cc
@@ -23,6 +23,7 @@
 #include "paddle/phi/backends/xpu/xpu_header.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
@@ -33,18 +34,35 @@ void AddKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const DenseTensor& y,
                DenseTensor* out) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
+  if (x.dtype() == phi::DataType::FLOAT32 &&
+      (y.dtype() == phi::DataType::BFLOAT16 ||
+       y.dtype() == phi::DataType::FLOAT16)) {
+    using Type = DataTypeToCppType<phi::DataType::FLOAT32>::type;
+    using XPUType = typename XPUTypeTrait<Type>::Type;
+    auto f = [](xpu::Context* ctx,
+                const XPUType* x,
+                const XPUType* y,
+                XPUType* z,
+                const std::vector<int>& xshape,
+                const std::vector<int>& yshape) {
+      return xpu::broadcast_add<XPUType>(ctx, x, y, z, xshape, yshape);
+    };
+    auto casted_y = phi::Cast<T>(dev_ctx, y, phi::DataType::FLOAT32);
+    XPUElementwise<Type, XPUType>(dev_ctx, x, casted_y, -1, out, f);
+  } else {
+    using XPUType = typename XPUTypeTrait<T>::Type;
 
-  auto f = [](xpu::Context* ctx,
-              const XPUType* x,
-              const XPUType* y,
-              XPUType* z,
-              const std::vector<int>& xshape,
-              const std::vector<int>& yshape) {
-    return xpu::broadcast_add<XPUType>(ctx, x, y, z, xshape, yshape);
-  };
+    auto f = [](xpu::Context* ctx,
+                const XPUType* x,
+                const XPUType* y,
+                XPUType* z,
+                const std::vector<int>& xshape,
+                const std::vector<int>& yshape) {
+      return xpu::broadcast_add<XPUType>(ctx, x, y, z, xshape, yshape);
+    };
 
-  XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);
+    XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);
+  }
 }
 
 template <typename T, typename Context>

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import copy
 import unittest
 
 import numpy as np
@@ -302,6 +303,33 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
 support_types = get_xpu_op_support_types('elementwise_add')
 for stype in support_types:
     create_test_class(globals(), XPUTestElementwiseAddOp, stype)
+
+
+class TestTensorFloa32Bfloat16OrFloat16Add(unittest.TestCase):
+    def _floa32_bfloat16_or_float16_add(self, y_dtype):
+        paddle.disable_static()
+        test_num = 5
+        val_range = 10000
+        shapes = []
+        for i in range(test_num):
+            shape = [np.random.randint(val_range), np.random.randint(val_range)]
+            shapes.append(shape)
+
+        for i, shape in enumerate(shapes):
+            x = paddle.randn(list(shape), dtype=paddle.float32)
+            x_copy = copy.deepcopy(x)
+            y = paddle.randn(list(shape), dtype=y_dtype)
+            x.add_(y)
+            x_copy.add_(paddle.cast(y, paddle.float32))
+            np.testing.assert_equal(x.numpy(), x_copy.numpy())
+            del x, x_copy
+
+    def test_floa32_bfloat16_add(self):
+        self._floa32_bfloat16_or_float16_add(y_dtype=paddle.bfloat16)
+
+    def test_floa32_float16_add(self):
+        self._floa32_bfloat16_or_float16_add(y_dtype=paddle.float16)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -27,6 +27,7 @@ from op_test_xpu import XPUOpTest
 
 import paddle
 from paddle import base
+from paddle.base import core
 
 paddle.enable_static()
 
@@ -305,6 +306,10 @@ for stype in support_types:
     create_test_class(globals(), XPUTestElementwiseAddOp, stype)
 
 
+@unittest.skipIf(
+    core.get_xpu_device_version(0) != core.XPUVersion.XPU3,
+    "only supported on XPU3",
+)
 class TestTensorFloa32Bfloat16OrFloat16Add(unittest.TestCase):
     def _floa32_bfloat16_or_float16_add(self, y_dtype):
         paddle.disable_static()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
- support add(x_float32, bfloa16_) and add(x_float32, y_float16) for XPU amp_master_grad
- refer to 
  - https://github.com/PaddlePaddle/Paddle/pull/54415
  - [Kernel Selection](https://github.com/PaddlePaddle/community/blob/30a86d3fe24b1bcf465f5186ddfd00ef135c351b/pfcc/paddle-code-reading/kernel_selection/20221130_kernel_selection.md)
- Fixes: https://github.com/PaddlePaddle/Paddle/issues/63846#issuecomment-2076251823