### PR TITLE
pass_state return  ref of pass_state_

### DIFF
--- a/paddle/pir/include/pass/pass.h
+++ b/paddle/pir/include/pass/pass.h
@@ -176,11 +176,11 @@ class IR_API Pass {
     Set<std::string>("__custom_log__", new std::string{custom_log});
   }
 
-  AnalysisManager analysis_manager() { return pass_state().am; }
+  AnalysisManager analysis_manager();
 
-  detail::PassExecutionState& pass_state();
+  std::optional<detail::PassExecutionState>& pass_state();
 
-  void SignalPassFailure() { pass_state().pass_failed = true; }
+  void SignalPassFailure();
 
  private:
   detail::PassInfo pass_info_;

--- a/paddle/pir/src/pass/pass.cc
+++ b/paddle/pir/src/pass/pass.cc
@@ -42,13 +42,23 @@ Pass::~Pass() {
 
 bool Pass::CanApplyOn(Operation* op) const { return op->num_regions() > 0; }
 
-detail::PassExecutionState& Pass::pass_state() {
+std::optional<detail::PassExecutionState>& Pass::pass_state() {
+  return pass_state_;
+}
+
+void Pass::SignalPassFailure() {
   PADDLE_ENFORCE_EQ(pass_state_.has_value(),
                     true,
                     phi::errors::InvalidArgument("pass state has no value"));
-  return *pass_state_;
+  pass_state_->pass_failed = true;
 }
 
+AnalysisManager Pass::analysis_manager() {
+  PADDLE_ENFORCE_EQ(pass_state_.has_value(),
+                    true,
+                    phi::errors::InvalidArgument("pass state has no value"));
+  return pass_state_->am;
+}
 //===----------------------------------------------------------------------===//
 // PatternRewritePass
 //===----------------------------------------------------------------------===//
@@ -155,7 +165,7 @@ bool detail::PassAdaptor::RunPass(Pass* pass,
     if (instrumentor) instrumentor->RunAfterPass(pass, op);
   }
 
-  bool pass_failed = pass->pass_state().pass_failed;
+  bool pass_failed = pass->pass_state()->pass_failed;
 
   if (!pass_failed && verify) {
     bool verify_recursively = !dynamic_cast<PassAdaptor*>(pass);

--- a/test/cpp/pir/pass/pass_manager_test.cc
+++ b/test/cpp/pir/pass/pass_manager_test.cc
@@ -137,14 +137,15 @@ class TestPass : public pir::Pass {
   TestPass() : pir::Pass("TestPass", 1) {}
   void Run(pir::Operation *op) override {
     auto count_op_analysis = analysis_manager().GetAnalysis<CountOpAnalysis>();
-    pass_state().preserved_analyses.Preserve<CountOpAnalysis>();
-    CHECK_EQ(pass_state().preserved_analyses.IsPreserved<CountOpAnalysis>(),
+    pass_state()->preserved_analyses.Preserve<CountOpAnalysis>();
+    CHECK_EQ(pass_state()->preserved_analyses.IsPreserved<CountOpAnalysis>(),
              true);
     auto no_operation_analysis =
         analysis_manager().GetAnalysis<NoOperationAnalysis>();
-    pass_state().preserved_analyses.Preserve<NoOperationAnalysis>();
-    CHECK_EQ(pass_state().preserved_analyses.IsPreserved<NoOperationAnalysis>(),
-             true);
+    pass_state()->preserved_analyses.Preserve<NoOperationAnalysis>();
+    CHECK_EQ(
+        pass_state()->preserved_analyses.IsPreserved<NoOperationAnalysis>(),
+        true);
     CHECK_EQ(count_op_analysis.count, 11);
     no_operation_analysis.scale = 8;
     CHECK_EQ(no_operation_analysis.scale, 8);
@@ -155,12 +156,13 @@ class TestPass : public pir::Pass {
     LOG(INFO) << "In " << pass_info().name << ": " << module_op->name()
               << std::endl;
 
-    pass_state().preserved_analyses.Unpreserve<CountOpAnalysis>();
-    CHECK_EQ(pass_state().preserved_analyses.IsPreserved<CountOpAnalysis>(),
+    pass_state()->preserved_analyses.Unpreserve<CountOpAnalysis>();
+    CHECK_EQ(pass_state()->preserved_analyses.IsPreserved<CountOpAnalysis>(),
              false);
-    pass_state().preserved_analyses.Unpreserve<NoOperationAnalysis>();
-    CHECK_EQ(pass_state().preserved_analyses.IsPreserved<NoOperationAnalysis>(),
-             false);
+    pass_state()->preserved_analyses.Unpreserve<NoOperationAnalysis>();
+    CHECK_EQ(
+        pass_state()->preserved_analyses.IsPreserved<NoOperationAnalysis>(),
+        false);
   }
 
   bool CanApplyOn(pir::Operation *op) const override {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
pcard-71500
When inheriting PatternRewritePass, you need to obtain the original pass_state_ to support the transfer of information between Passes.
继承PatternRewritePass实现传递Analysis信息时，DrrPatternBase子类构造时，存在pass_state_还未初始化。其初始化在InitializePatterns时，落后于DrrPatternBase子类构造，但早于AddPostProcess。故增加返回std::optional\<pir::detail::PassExecutionState\>&
