### PR TITLE
API Improvement for paddle.nn.functional.group_norm and paddle.nn.GroupNorm

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -661,7 +661,7 @@ int GroupNormPluginDynamic::enqueue(
       if (cPerBlock > input_desc[0].dims.d[1]) {
         cPerBlock = 8;
       }
-      auto d_dim = input_desc[0].dims.d.size();
+      auto d_dim = input_desc[0].dims.nbDims;
       params_.n = input_desc[0].dims.d[0];
       if (d_dim == 3) {
         params_.c = input_desc[0].dims.d[1];

--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -238,7 +238,7 @@ __global__ void groupNormNCHW32ScaleKernelQDQ(
   int32_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
   // nchw32 layout
-  int c_offset = ci / 32 * params.hw * 32 + ci % 32;
+  int c_offset = ci / 32 * params.dhw * 32 + ci % 32;
 
   // Iterate over the activations to compute the sums.
   for (int32_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
@@ -743,7 +743,7 @@ int GroupNormPluginDynamic::enqueue(
       if (cPerBlock > input_desc[0].dims.d[1]) {
         cPerBlock = 8;
       }
-      auto d_dim = input_desc[0].dims.d.size();
+      auto d_dim = input_desc[0].dims.nbDims;
       params_.n = input_desc[0].dims.d[0];
       if (d_dim == 3) {
         params_.c = input_desc[0].dims.d[1];

--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -90,9 +90,9 @@ __global__ void groupNormNCHW32SumKernelQDQ(
   int32_t ci = blockIdx.x * params.cPerBlock + threadIdx.x * 2;
 
   // The first activation loaded by that block.
-  int32_t hwBegin = blockIdx.y * params.hwPerBlock;
+  int32_t dhwBegin = blockIdx.y * params.dhwPerBlock;
   // The last activation loaded by that block.
-  int32_t hwEnd = min(hwBegin + params.hwPerBlock, params.hw);
+  int32_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
   // The sums.
   float sum = 0.F;
@@ -102,13 +102,13 @@ __global__ void groupNormNCHW32SumKernelQDQ(
 
   // nchw32 layout
   // batch offset + channel offset
-  int nc_offset = static_cast<int64_t>(ni) * params.hwc +
-                  ci / 32 * params.hw * 32 + ci % 32;
+  int nc_offset = static_cast<int64_t>(ni) * params.dhwc +
+                  ci / 32 * params.dhw * 32 + ci % 32;
 
   // Iterate over the activations to compute the sums.
-  for (int32_t hwi = hwBegin; hwi < hwEnd; ++hwi) {
+  for (int32_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The offset.
-    int64_t offset = nc_offset + static_cast<int64_t>(hwi) * 32;
+    int64_t offset = nc_offset + static_cast<int64_t>(dhwi) * 32;
 
     // Fetch two channels per thread.
     __half2 h2(0, 0);
@@ -173,7 +173,7 @@ void groupNormNCHW32SumQDQ(const GroupNormNHWCParams<__half> &params,
   // The number of blocks to compute all the channels.
   grid.x = divUp(params.c, params.cPerBlock);
   // The number of blocks to compute all the activations in a given instance.
-  grid.y = divUp(params.hw, params.hwPerBlock);
+  grid.y = divUp(params.dhw, params.dhwPerBlock);
   // The number of instances.
   grid.z = params.n;
 
@@ -226,25 +226,25 @@ __global__ void groupNormNCHW32ScaleKernelQDQ(
   }
 
   // Compute the mean.
-  float mean = sum * params.invHWC;
+  float mean = sum * params.invDHWC;
   // Compute the variance.
-  float var = sumSq * params.invHWC - (mean * mean);
+  float var = sumSq * params.invDHWC - (mean * mean);
   // Compute the inverse of the stddev.
   float invStdDev = rsqrtf(var + params.eps);
 
   // The first activation loaded by that block.
-  int32_t hwBegin = blockIdx.y * params.hwPerBlock;
+  int32_t dhwBegin = blockIdx.y * params.dhwPerBlock;
   // The last activation loaded by that block.
-  int32_t hwEnd = min(hwBegin + params.hwPerBlock, params.hw);
+  int32_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
   // nchw32 layout
   int c_offset = ci / 32 * params.hw * 32 + ci % 32;
 
   // Iterate over the activations to compute the sums.
-  for (int32_t hwi = hwBegin; hwi < hwEnd; ++hwi) {
+  for (int32_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The src/dst offset.
-    int64_t offset = static_cast<int64_t>(ni) * params.hwc + c_offset +
-                     static_cast<int64_t>(hwi) * 32;
+    int64_t offset = static_cast<int64_t>(ni) * params.dhwc + c_offset +
+                     static_cast<int64_t>(dhwi) * 32;
 
     // Fetch two channels per thread.
     __half2 h2(0, 0);
@@ -297,7 +297,7 @@ void groupNormNCHW32ScaleQDQ(const GroupNormNHWCParams<__half> &params,
   // The number of blocks to compute all the channels.
   grid.x = divUp(params.c, params.cPerBlock);
   // The number of blocks to compute all the activations in a given instance.
-  grid.y = divUp(params.hw, params.hwPerBlock);
+  grid.y = divUp(params.dhw, params.dhwPerBlock);
   // The number of instances.
   grid.z = params.n;
 
@@ -642,7 +642,7 @@ int GroupNormPluginDynamic::enqueue(
                  DataLayout::kNCHW);
     } else if (input_desc[0].format == nvinfer1::PluginFormat::kHWC8) {
       int32_t cPerBlock = 320;
-      int32_t maxBlocksPerHW = 1024;
+      int32_t maxBlocksPerDHW = 1024;
       switch (input_desc[0].dims.d[1]) {
         case 960:
         case 1920:
@@ -661,6 +661,25 @@ int GroupNormPluginDynamic::enqueue(
       if (cPerBlock > input_desc[0].dims.d[1]) {
         cPerBlock = 8;
       }
+      auto d_dim = input_desc[0].dims.d.size();
+      params_.n = input_desc[0].dims.d[0];
+      if (d_dim == 3) {
+        params_.c = input_desc[0].dims.d[1];
+        params_.d = 1;
+        params_.h = 1;
+        params_.w = input_desc[0].dims.d[2];
+      } else if (d_dim == 4) {
+        params_.c = input_desc[0].dims.d[1];
+        params_.d = 1;
+        params_.h = input_desc[0].dims.d[2];
+        params_.w = input_desc[0].dims.d[3];
+      } else {
+        // d_dim == 5
+        params_.c = input_desc[0].dims.d[1];
+        params_.d = input_desc[0].dims.d[2];
+        params_.h = input_desc[0].dims.d[3];
+        params_.w = input_desc[0].dims.d[4];
+      }
 
       params_.withSilu = with_silu_;
       params_.dst = static_cast<half *>(outputs[0]);
@@ -669,18 +688,19 @@ int GroupNormPluginDynamic::enqueue(
       params_.beta = reinterpret_cast<half *>(bias_gpu_);
       params_.redBuffer = static_cast<float *>(workspace);
       params_.var_data = nullptr;
-      params_.n = input_desc[0].dims.d[0];
-      params_.h = input_desc[0].dims.d[2];
-      params_.w = input_desc[0].dims.d[3];
-      params_.c = input_desc[0].dims.d[1];
+      // params_.n = input_desc[0].dims.d[0];
+      // params_.h = input_desc[0].dims.d[2];
+      // params_.w = input_desc[0].dims.d[3];
+      // params_.c = input_desc[0].dims.d[1];
       params_.groups = groups_;
-      params_.hw = params_.h * params_.w;
-      const int32_t blocksPerHW = findMaxDivisor(params_.hw, maxBlocksPerHW);
-      params_.hwPerBlock = divUp(params_.hw, blocksPerHW);
+      params_.dhw = params_.d * params_.h * params_.w;
+      const int32_t blocksPerDHW = findMaxDivisor(params_.dhw, maxBlocksPerDHW);
+      params_.dhwPerBlock = divUp(params_.dhw, blocksPerDHW);
       params_.cPerBlock = cPerBlock;
       params_.cPerGroup = params_.c / params_.groups;
-      params_.hwc = params_.hw * params_.c;
-      params_.invHWC = 1.F / static_cast<float>(params_.hw * params_.cPerGroup);
+      params_.dhwc = params_.dhw * params_.c;
+      params_.invDHWC =
+          1.F / static_cast<float>(params_.dhw * params_.cPerGroup);
       params_.groupsPerBlock = cPerBlock / params_.cPerGroup;
       params_.eps = eps_;
       params_.var_data = nullptr;
@@ -704,7 +724,7 @@ int GroupNormPluginDynamic::enqueue(
 
     if (input_desc[0].format == nvinfer1::PluginFormat::kCHW32) {
       int32_t cPerBlock = 320;
-      int32_t maxBlocksPerHW = 1024;
+      int32_t maxBlocksPerDHW = 1024;
       switch (input_desc[0].dims.d[1]) {
         case 960:
         case 1920:
@@ -723,6 +743,25 @@ int GroupNormPluginDynamic::enqueue(
       if (cPerBlock > input_desc[0].dims.d[1]) {
         cPerBlock = 8;
       }
+      auto d_dim = input_desc[0].dims.d.size();
+      params_.n = input_desc[0].dims.d[0];
+      if (d_dim == 3) {
+        params_.c = input_desc[0].dims.d[1];
+        params_.d = 1;
+        params_.h = 1;
+        params_.w = input_desc[0].dims.d[2];
+      } else if (d_dim == 4) {
+        params_.c = input_desc[0].dims.d[1];
+        params_.d = 1;
+        params_.h = input_desc[0].dims.d[2];
+        params_.w = input_desc[0].dims.d[3];
+      } else {
+        // d_dim == 5
+        params_.c = input_desc[0].dims.d[1];
+        params_.d = input_desc[0].dims.d[2];
+        params_.h = input_desc[0].dims.d[3];
+        params_.w = input_desc[0].dims.d[4];
+      }
       params_.withSilu = with_silu_;
       params_.dst = static_cast<half *>(outputs[0]);
       params_.srcX = static_cast<half const *>(inputs[0]);
@@ -730,18 +769,19 @@ int GroupNormPluginDynamic::enqueue(
       params_.gamma = scale_gpu_;
       params_.beta = bias_gpu_;
       params_.redBuffer = static_cast<float *>(workspace);
-      params_.n = input_desc[0].dims.d[0];
-      params_.h = input_desc[0].dims.d[2];
-      params_.w = input_desc[0].dims.d[3];
-      params_.c = input_desc[0].dims.d[1];
+      // params_.n = input_desc[0].dims.d[0];
+      // params_.h = input_desc[0].dims.d[2];
+      // params_.w = input_desc[0].dims.d[3];
+      // params_.c = input_desc[0].dims.d[1];
       params_.groups = groups_;
-      params_.hw = params_.h * params_.w;
-      const int32_t blocksPerHW = findMaxDivisor(params_.hw, maxBlocksPerHW);
-      params_.hwPerBlock = divUp(params_.hw, blocksPerHW);
+      params_.dhw = params_.d * params_.h * params_.w;
+      const int32_t blocksPerDHW = findMaxDivisor(params_.dhw, maxBlocksPerDHW);
+      params_.dhwPerBlock = divUp(params_.dhw, blocksPerDHW);
       params_.cPerBlock = cPerBlock;
       params_.cPerGroup = params_.c / params_.groups;
-      params_.hwc = params_.hw * params_.c;
-      params_.invHWC = 1.F / static_cast<float>(params_.hw * params_.cPerGroup);
+      params_.dhwc = params_.dhw * params_.c;
+      params_.invDHWC =
+          1.F / static_cast<float>(params_.dhw * params_.cPerGroup);
       params_.groupsPerBlock = cPerBlock / params_.cPerGroup;
       CHECK_EQ(cPerBlock % params_.cPerGroup, 0);
       CHECK_EQ(params_.cPerGroup % 2, 0);

--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.h
@@ -29,7 +29,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
-using phi::GroupNormNHWCParams;
+using phi::GroupNormNDHWCParams;
 class GroupNormPlugin : public PluginTensorRT {
  public:
   size_t getSerializationSize() const TRT_NOEXCEPT override {
@@ -289,7 +289,7 @@ class GroupNormPluginDynamic : public DynamicPluginTensorRT {
   float eps_;
   std::vector<int64_t> mean_shape_;
   std::vector<int64_t> variance_shape_;
-  GroupNormNHWCParams<half> params_;
+  GroupNormNDHWCParams<half> params_;
   bool with_silu_;
   bool with_fp16_;
   bool with_int8_;

--- a/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
@@ -137,19 +137,19 @@ __global__ void prelnGroupNormNHWCSumKernel(
   int32_t ci = blockIdx.x * params.cPerBlock + threadIdx.x * 2;
 
   // The first activation loaded by that block.
-  int32_t hwBegin = blockIdx.y * params.hwPerBlock;
+  int32_t dhwBegin = blockIdx.y * params.dhwPerBlock;
   // The last activation loaded by that block.
-  int32_t hwEnd = min(hwBegin + params.hwPerBlock, params.hw);
+  int32_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
   // The sums.
   float sum = 0.F;
   float sumSq = 0.F;
 
   // Iterate over the activations to compute the sums.
-  for (int32_t hwi = hwBegin; hwi < hwEnd; ++hwi) {
+  for (int32_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The offset.
-    int64_t offset = static_cast<int64_t>(ni) * params.hwc +
-                     static_cast<int64_t>(hwi) * params.c + ci;
+    int64_t offset = static_cast<int64_t>(ni) * params.dhwc +
+                     static_cast<int64_t>(dhwi) * params.c + ci;
     // Fetch two channels per thread.
     __half2 h2(0, 0);
     if (ci < params.c) {
@@ -224,13 +224,13 @@ void prelnGroupNormNHWCSum(GroupNormNHWCParams<__half> const &params,
                         "params.c %% params.cPerBlock should be 0, but get %d.",
                         params.c % params.cPerBlock));
   PADDLE_ENFORCE_EQ(
-      params.hw % params.hwPerBlock,
+      params.dhw % params.dhwPerBlock,
       0,
       platform::errors::InvalidArgument(
           "The groupNormNHWCSum of prelnGroupnormAct Plugin got wrong "
           "parameters"
-          "params.hw  %% params.hwPerBlock should be 0, but get %d.",
-          params.hw % params.hwPerBlock));
+          "params.dhw  %% params.dhwPerBlock should be 0, but get %d.",
+          params.dhw % params.dhwPerBlock));
   // Make sure a group does not span multiple blocks.
   PADDLE_ENFORCE_EQ(
       params.cPerBlock % params.cPerGroup,
@@ -245,7 +245,7 @@ void prelnGroupNormNHWCSum(GroupNormNHWCParams<__half> const &params,
   // The number of blocks to compute all the channels.
   grid.x = params.c / params.cPerBlock;
   // The number of blocks to compute all the activations in a given instance.
-  grid.y = divUp(params.hw, params.hwPerBlock);
+  grid.y = divUp(params.dhw, params.dhwPerBlock);
   // The number of instances.
   grid.z = params.n;
 
@@ -299,21 +299,21 @@ __global__ void prelnGroupNormNHWCScaleKernel(
   }
 
   // Compute the mean.
-  float mean = sum * params.invHWC;
+  float mean = sum * params.invDHWC;
   // Compute the variance.
-  float var = sumSq * params.invHWC - (mean * mean);
+  float var = sumSq * params.invDHWC - (mean * mean);
   // Compute the inverse of the stddev.
   float invStdDev = rsqrtf(var + params.eps);
 
   // The first activation loaded by that block.
-  int32_t hwBegin = blockIdx.y * params.hwPerBlock;
+  int32_t dhwBegin = blockIdx.y * params.dhwPerBlock;
   // The last activation loaded by that block.
-  int32_t hwEnd = min(hwBegin + params.hwPerBlock, params.hw);
+  int32_t dhwEnd = min(dhwBegin + params.dhwPerBlock, params.dhw);
 
   // Iterate over the activations to compute the sums.
-  for (int32_t hwi = hwBegin; hwi < hwEnd; ++hwi) {
+  for (int32_t dhwi = dhwBegin; dhwi < dhwEnd; ++dhwi) {
     // The src/dst offset.
-    int64_t offset = (int64_t)ni * params.hwc + hwi * params.c + ci;
+    int64_t offset = (int64_t)ni * params.dhwc + dhwi * params.c + ci;
 
     // Fetch two channels per thread.
     __half2 h2(0, 0);
@@ -370,7 +370,7 @@ void prelnGroupNormNHWCScale(GroupNormNHWCParams<__half> const &params,
   // The number of blocks to compute all the channels.
   grid.x = params.c / params.cPerBlock;
   // The number of blocks to compute all the activations in a given instance.
-  grid.y = divUp(params.hw, params.hwPerBlock);
+  grid.y = divUp(params.dhw, params.dhwPerBlock);
   // The number of instances.
   grid.z = params.n;
 
@@ -413,7 +413,7 @@ int PrelnGroupnormActPluginDynamic::enqueue(
     VLOG(1) << "TRT Plugin DataType selected. prelnGroupnormAct-->fp16";
 
     int32_t cPerBlock = 320;
-    int32_t maxBlocksPerHW = 1024;
+    int32_t maxBlocksPerDHW = 1024;
 
     switch (input_desc[0].dims.d[1]) {
       case 960:
@@ -433,6 +433,25 @@ int PrelnGroupnormActPluginDynamic::enqueue(
     if (cPerBlock > input_desc[0].dims.d[1]) {
       cPerBlock = 8;
     }
+    auto d_dim = input_desc[0].dims.d.size();
+    params_.n = x_dims[0];
+    if (d_dim == 3) {
+      params_.c = x_dims[1];
+      params_.d = 1;
+      params_.h = 1;
+      params_.w = x_dims[2];
+    } else if (d_dim == 4) {
+      params_.c = x_dims[1];
+      params_.d = 1;
+      params_.h = x_dims[2];
+      params_.w = x_dims[3];
+    } else {
+      // d_dim == 5
+      params_.c = x_dims[1];
+      params_.d = x_dims[2];
+      params_.h = x_dims[3];
+      params_.w = x_dims[4];
+    }
     params_.withSilu = with_silu_;
     params_.dst = static_cast<half *>(outputs[1]);
     params_.eleOut = static_cast<half *>(outputs[0]);
@@ -441,18 +460,18 @@ int PrelnGroupnormActPluginDynamic::enqueue(
     params_.gamma = scale_gpu_.get();
     params_.beta = bias_gpu_.get();
     params_.redBuffer = static_cast<float *>(workspace);
-    params_.n = input_desc[0].dims.d[0];
-    params_.h = input_desc[0].dims.d[2];
-    params_.w = input_desc[0].dims.d[3];
-    params_.c = input_desc[0].dims.d[1];
+    // params_.n = input_desc[0].dims.d[0];
+    // params_.h = input_desc[0].dims.d[2];
+    // params_.w = input_desc[0].dims.d[3];
+    // params_.c = input_desc[0].dims.d[1];
     params_.groups = groups_;
-    params_.hw = params_.h * params_.w;
-    const int32_t blocksPerHW = findMaxDivisor(params_.hw, maxBlocksPerHW);
-    params_.hwPerBlock = divUp(params_.hw, blocksPerHW);
+    params_.dhw = params_.d * params_.h * params_.w;
+    const int32_t blocksPerDHW = findMaxDivisor(params_.dhw, maxBlocksPerDHW);
+    params_.dhwPerBlock = divUp(params_.dhw, blocksPerDHW);
     params_.cPerBlock = cPerBlock;
     params_.cPerGroup = params_.c / params_.groups;
-    params_.hwc = params_.hw * params_.c;
-    params_.invHWC = 1.F / static_cast<float>(params_.hw * params_.cPerGroup);
+    params_.dhwc = params_.dhw * params_.c;
+    params_.invDHWC = 1.F / static_cast<float>(params_.dhw * params_.cPerGroup);
     params_.groupsPerBlock = cPerBlock / params_.cPerGroup;
     params_.eps = eps_;
 

--- a/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
@@ -433,7 +433,7 @@ int PrelnGroupnormActPluginDynamic::enqueue(
     if (cPerBlock > input_desc[0].dims.d[1]) {
       cPerBlock = 8;
     }
-    auto d_dim = input_desc[0].dims.d.size();
+    auto d_dim = input_desc[0].dims.nbDims;
     params_.n = input_desc[0].dims.d[0];
     if (d_dim == 3) {
       params_.c = input_desc[0].dims.d[1];

--- a/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.cu
@@ -434,23 +434,23 @@ int PrelnGroupnormActPluginDynamic::enqueue(
       cPerBlock = 8;
     }
     auto d_dim = input_desc[0].dims.d.size();
-    params_.n = x_dims[0];
+    params_.n = input_desc[0].dims.d[0];
     if (d_dim == 3) {
-      params_.c = x_dims[1];
+      params_.c = input_desc[0].dims.d[1];
       params_.d = 1;
       params_.h = 1;
-      params_.w = x_dims[2];
+      params_.w = input_desc[0].dims.d[2];
     } else if (d_dim == 4) {
-      params_.c = x_dims[1];
+      params_.c = input_desc[0].dims.d[1];
       params_.d = 1;
-      params_.h = x_dims[2];
-      params_.w = x_dims[3];
+      params_.h = input_desc[0].dims.d[2];
+      params_.w = input_desc[0].dims.d[3];
     } else {
       // d_dim == 5
-      params_.c = x_dims[1];
-      params_.d = x_dims[2];
-      params_.h = x_dims[3];
-      params_.w = x_dims[4];
+      params_.c = input_desc[0].dims.d[1];
+      params_.d = input_desc[0].dims.d[2];
+      params_.h = input_desc[0].dims.d[3];
+      params_.w = input_desc[0].dims.d[4];
     }
     params_.withSilu = with_silu_;
     params_.dst = static_cast<half *>(outputs[1]);

--- a/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_groupnorm_act_op_plugin.h
@@ -28,7 +28,7 @@ namespace paddle {
 namespace inference {
 namespace tensorrt {
 namespace plugin {
-using phi::GroupNormNHWCParams;
+using phi::GroupNormNDHWCParams;
 class PrelnGroupnormActPluginDynamic : public DynamicPluginTensorRT {
  public:
   PrelnGroupnormActPluginDynamic(const float* scale,
@@ -174,7 +174,7 @@ class PrelnGroupnormActPluginDynamic : public DynamicPluginTensorRT {
   std::vector<float> bias_;
   std::shared_ptr<void> scale_gpu_;
   std::shared_ptr<void> bias_gpu_;
-  GroupNormNHWCParams<__half> params_;
+  GroupNormNDHWCParams<__half> params_;
   int groups_;
   float eps_;
   bool with_silu_;

--- a/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
@@ -440,7 +440,7 @@ int SkipGroupnormActPluginDynamic::enqueue(
     if (cPerBlock > input_desc[0].dims.d[1]) {
       cPerBlock = 8;
     }
-    auto d_dim = input_desc[0].dims.d.size();
+    auto d_dim = input_desc[0].dims.nbDims;
     params_.n = input_desc[0].dims.d[0];
     if (d_dim == 3) {
       params_.c = input_desc[0].dims.d[1];

--- a/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.cu
@@ -441,23 +441,23 @@ int SkipGroupnormActPluginDynamic::enqueue(
       cPerBlock = 8;
     }
     auto d_dim = input_desc[0].dims.d.size();
-    params_.n = x_dims[0];
+    params_.n = input_desc[0].dims.d[0];
     if (d_dim == 3) {
-      params_.c = x_dims[1];
+      params_.c = input_desc[0].dims.d[1];
       params_.d = 1;
       params_.h = 1;
-      params_.w = x_dims[2];
+      params_.w = input_desc[0].dims.d[2];
     } else if (d_dim == 4) {
-      params_.c = x_dims[1];
+      params_.c = input_desc[0].dims.d[1];
       params_.d = 1;
-      params_.h = x_dims[2];
-      params_.w = x_dims[3];
+      params_.h = input_desc[0].dims.d[2];
+      params_.w = input_desc[0].dims.d[3];
     } else {
       // d_dim == 5
-      params_.c = x_dims[1];
-      params_.d = x_dims[2];
-      params_.h = x_dims[3];
-      params_.w = x_dims[4];
+      params_.c = input_desc[0].dims.d[1];
+      params_.d = input_desc[0].dims.d[2];
+      params_.h = input_desc[0].dims.d[3];
+      params_.w = input_desc[0].dims.d[4];
     }
     params_.withSilu = true;
     params_.dst = static_cast<half *>(outputs[0]);

--- a/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_groupnorm_act_op_plugin.h
@@ -28,7 +28,7 @@ namespace paddle {
 namespace inference {
 namespace tensorrt {
 namespace plugin {
-using phi::GroupNormNHWCParams;
+using phi::GroupNormNDHWCParams;
 class SkipGroupnormActPluginDynamic : public DynamicPluginTensorRT {
  public:
   SkipGroupnormActPluginDynamic(const float* scale,
@@ -169,7 +169,7 @@ class SkipGroupnormActPluginDynamic : public DynamicPluginTensorRT {
   std::vector<float> bias_;
   std::shared_ptr<void> scale_gpu_;
   std::shared_ptr<void> bias_gpu_;
-  GroupNormNHWCParams<__half> params_;
+  GroupNormNDHWCParams<__half> params_;
   int groups_;
   float eps_;
   bool with_fp16_;

--- a/paddle/phi/kernels/group_norm_kernel.h
+++ b/paddle/phi/kernels/group_norm_kernel.h
@@ -58,7 +58,7 @@ class GroupNormDirectCUDAFunctor {
 #endif
 
 template <typename T>
-struct GroupNormNHWCParams {
+struct GroupNormNDHWCParams {
   // The output buffer. Layout NDHWC.
   T* dst;
   // The output buffer. Layout NDHWC.
@@ -111,15 +111,15 @@ struct GroupNormNHWCParams {
 };
 
 template <typename T>
-class groupNormNHWCSum {
+class groupNormNDHWCSum {
  public:
-  void operator()(GroupNormNHWCParams<T>* params, const gpuStream_t stream);
+  void operator()(GroupNormNDHWCParams<T>* params, const gpuStream_t stream);
 };
 
 template <typename T>
-class groupNormNHWCScale {
+class groupNormNDHWCScale {
  public:
-  void operator()(const GroupNormNHWCParams<T>& params,
+  void operator()(const GroupNormNDHWCParams<T>& params,
                   const gpuStream_t stream);
 };
 

--- a/paddle/phi/kernels/group_norm_kernel.h
+++ b/paddle/phi/kernels/group_norm_kernel.h
@@ -59,13 +59,13 @@ class GroupNormDirectCUDAFunctor {
 
 template <typename T>
 struct GroupNormNHWCParams {
-  // The output buffer. Layout NHWC.
+  // The output buffer. Layout NDHWC.
   T* dst;
-  // The output buffer. Layout NHWC.
+  // The output buffer. Layout NDHWC.
   T* eleOut;
-  // The input buffer. Layout NHWC.
+  // The input buffer. Layout NDHWC.
   T const* srcX;
-  // The input buffer. Layout NHWC.
+  // The input buffer. Layout NDHWC.
   T const* srcY;
   // The gamma scaling factor.
   void const* gamma;
@@ -79,8 +79,8 @@ struct GroupNormNHWCParams {
 
   // The number of instances in the batch.
   int32_t n;
-  // The height and width of each activation map.
-  int32_t h, w;
+  // The depth, height and width of each activation map.
+  int32_t d, h, w;
   // The number of channels.
   int32_t c;
   // The number of groups.
@@ -90,22 +90,22 @@ struct GroupNormNHWCParams {
 
   // Precomputed values and parameters to control the execution of the kernels.
 
-  // The number of activations per instance (h * w) and the number of
+  // The number of activations per instance (d * h * w) and the number of
   // activations per block.
-  int32_t hw, hwPerBlock;
+  int32_t dhw, dhwPerBlock;
   // The number of channels per group and blocks per activation in the C
   // dimension.
   int32_t cPerBlock, cPerGroup;
 
   // The precomputed stride between instances.
-  int32_t hwc;
-  // The inverse of hwc in floats (to compute mean/var).
-  float invHWC;
+  int32_t dhwc;
+  // The inverse of dhwc in floats (to compute mean/var).
+  float invDHWC;
   // The precomputed number of groups per block.
   int32_t groupsPerBlock;
   // epsilon, Constant for numerical stability
   float eps;
-  // for NCHW32 int8 use
+  // for NCDHW32 int8 use
   float dqScaleIn;
   float inv_qScale;
 };

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -661,7 +661,7 @@ def group_norm(
             Default: None.
         bias(Tensor, optional): The bias Tensor of group_norm, with shape: attr:`[num_channels]`.
             Default: None.
-        data_format(str, optional): Specify the input data format. Only NCHW is supported. Default: NCHW.
+        data_format(str, optional): Specify the input data format. Support "NCL", "NCHW", "NCDHW", "NLC", "NHWC" or "NDHWC". Default: "NCHW".
         name(str, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`..
 
     Returns:
@@ -702,8 +702,10 @@ def group_norm(
               [[-1.34163547, -0.44721183],
                [ 0.44721183,  1.34163547]]]])
     """
-    if data_format not in ['NCHW', 'NHWC']:
+    if data_format not in ['NCL', 'NCHW', 'NCDHW', 'NLC', 'NHWC', 'NDHWC']:
         raise ValueError("unsupported data layout:" + data_format)
+
+    data_format = 'NCHW' if data_format[1] == 'C' else 'NHWC'
 
     if in_dynamic_or_pir_mode():
         return _C_ops.group_norm(

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -426,11 +426,11 @@ class GroupNorm(Layer):
             division by zero. Default: 1e-05.
         weight_attr(ParamAttr|bool, optional): The parameter attribute for the learnable
             scale :math:`g`. If it is set to False, no scale will be added to the output units.
-            If it is set to None, the bias is initialized one. Default: None.
+            If it is set to None, the scale is initialized one. Default: None.
         bias_attr(ParamAttr|bool, optional): The parameter attribute for the learnable
             bias :math:`b`. If it is set to False, no bias will be added to the output units.
             If it is set to None, the bias is initialized zero. Default: None.
-        data_format(str, optional): Specify the input data format. Only NCHW is supported. Default: NCHW.
+        data_format(str, optional): Specify the input data format. Support "NCL", "NCHW", "NCDHW", "NLC", "NHWC" or "NDHWC". Default: "NCHW".
         name(str, optional): Name for the GroupNorm, default is None. For more information, please refer to :ref:`api_guide_Name`..
 
     Shape:
@@ -493,8 +493,10 @@ class GroupNorm(Layer):
         self._epsilon = epsilon
         self._num_channels = num_channels
         self._num_groups = num_groups
-        if data_format not in ['NCHW', 'NHWC']:
+        if data_format not in ['NCL', 'NCHW', 'NCDHW', 'NLC', 'NHWC', 'NDHWC']:
             raise ValueError("unsupported data layout:" + data_format)
+
+        data_format = 'NCHW' if data_format[1] == 'C' else 'NHWC'
         self._data_format = data_format
 
         param_shape = [self._num_channels]

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -28,25 +28,58 @@ from testsuite import create_op
 from utils import static_guard
 
 import paddle
+import paddle.nn.functional as F
 from paddle import base
 from paddle.base import core
 
 
 def group_norm_naive(x, scale, bias, epsilon, groups, data_layout):
-    if data_layout == "NHWC":
-        x = np.transpose(x, (0, 3, 1, 2))  # NHWC => NCHW
-    N, C, H, W = x.shape
-    G = groups
-    x = x.reshape((N * G, -1))
-    mean = np.mean(x, axis=1, keepdims=True)
-    var = np.var(x, axis=1, keepdims=True)
-    output = (x - mean) / np.sqrt(var + epsilon)
-    output = output.reshape((N, C, H, W)) * scale.reshape(
-        (-1, 1, 1)
-    ) + bias.reshape((-1, 1, 1))
-    if data_layout == "NHWC":
-        output = np.transpose(output, (0, 2, 3, 1))  # NCHW => NHWC
-    return output, mean.reshape((N, G)), var.reshape((N, G))
+    dim = x.ndim
+    if dim == 3:
+        if data_layout == "NLC":
+            x = np.transpose(x, (0, 2, 1))  # NLC => NCL
+        N, C, L = x.shape
+        G = groups
+        x = x.reshape((N * G, -1))
+        mean = np.mean(x, axis=1, keepdims=True)
+        var = np.var(x, axis=1, keepdims=True)
+        output = (x - mean) / np.sqrt(var + epsilon)
+        output = output.reshape((N, C, L)) * scale.reshape(
+            (-1, 1)
+        ) + bias.reshape((-1, 1))
+        if data_layout == "NLC":
+            output = np.transpose(output, (0, 2, 1))  # NCL => NLC
+        return output, mean.reshape((N, G)), var.reshape((N, G))
+    elif dim == 4:
+        if data_layout == "NHWC":
+            x = np.transpose(x, (0, 3, 1, 2))  # NHWC => NCHW
+        N, C, H, W = x.shape
+        G = groups
+        x = x.reshape((N * G, -1))
+        mean = np.mean(x, axis=1, keepdims=True)
+        var = np.var(x, axis=1, keepdims=True)
+        output = (x - mean) / np.sqrt(var + epsilon)
+        output = output.reshape((N, C, H, W)) * scale.reshape(
+            (-1, 1, 1)
+        ) + bias.reshape((-1, 1, 1))
+        if data_layout == "NHWC":
+            output = np.transpose(output, (0, 2, 3, 1))  # NCHW => NHWC
+        return output, mean.reshape((N, G)), var.reshape((N, G))
+    else:
+        if data_layout == "NDHWC":
+            x = np.transpose(x, (0, 4, 1, 2, 3))  # NDHWC => NCDHW
+        N, C, D, H, W = x.shape
+        G = groups
+        x = x.reshape((N * G, -1))
+        mean = np.mean(x, axis=1, keepdims=True)
+        var = np.var(x, axis=1, keepdims=True)
+        output = (x - mean) / np.sqrt(var + epsilon)
+        output = output.reshape((N, C, D, H, W)) * scale.reshape(
+            (-1, 1, 1, 1)
+        ) + bias.reshape((-1, 1, 1, 1))
+        if data_layout == "NDHWC":
+            output = np.transpose(output, (0, 2, 3, 4, 1))  # NCDHW => NDHWC
+        return output, mean.reshape((N, G)), var.reshape((N, G))
 
 
 class TestGroupNormOpError(unittest.TestCase):
@@ -93,11 +126,15 @@ class TestGroupNormOp(OpTest):
         self.shape = (2, 100, 3, 5)
         self.attrs = {'epsilon': 1e-5, 'groups': 2, 'data_layout': "NCHW"}
         self.compare_between_place = False
+        self.channel_last = False
         self.init_test_case()
 
+        self.data_format = 'NCHW' if self.data_format[1] == 'C' else 'NHWC'
         input = np.random.random(self.shape).astype(self.dtype)
-        if self.data_format == "NHWC":
-            input = np.transpose(input, (0, 2, 3, 1))
+        if self.channel_last:
+            shape = list(self.shape)
+            shape.insert(len(shape), shape.pop(1))
+            input = input.reshape(shape)
         scale = np.random.random([self.shape[1]]).astype(self.dtype)
         bias = np.random.random([self.shape[1]]).astype(self.dtype)
         output, mean, var = group_norm_naive(
@@ -267,11 +304,15 @@ class TestGroupNormBF16Op(OpTest):
         self.shape = (2, 100, 3, 5)
         self.attrs = {'epsilon': 1e-5, 'groups': 10, 'data_layout': "NCHW"}
         self.compare_between_place = False
+        self.channel_last = False
         self.init_test_case()
 
+        self.data_format = 'NCHW' if self.data_format[1] == 'C' else 'NHWC'
         input = np.random.random(self.shape).astype(np.float32)
-        if self.data_format == "NHWC":
-            input = np.transpose(input, (0, 2, 3, 1))
+        if self.channel_last:
+            shape = list(self.shape)
+            shape.insert(len(shape), shape.pop(1))
+            input = input.reshape(shape)
         scale = np.random.random([self.shape[1]]).astype(np.float32)
         bias = np.random.random([self.shape[1]]).astype(np.float32)
         output, mean, var = group_norm_naive(
@@ -318,7 +359,7 @@ class TestGroupNormBF16Op(OpTest):
         self.rev_comp_atol = 1e-2
         self.rev_comp_rtol = 1e-2
         # prim bf16 has diff in windows
-        if sys.platform == "win32" or self.data_format == "NHWC":
+        if sys.platform == "win32" or self.channel_last:
             self.rev_comp_atol = 5e-2
             self.rev_comp_rtol = 5e-2
         place = core.CUDAPlace(0)
@@ -339,14 +380,58 @@ class TestGroupNormOp1(TestGroupNormOp):
         self.attrs['groups'] = 1
 
 
+class TestGroupNormOp1_with_NCL(TestGroupNormOp):
+    def init_test_case(self):
+        self.shape = (2, 100, 3)
+        self.data_format = "NCHW"
+        self.attrs['groups'] = 1
+
+
+class TestGroupNormOp1_with_NCDHW(TestGroupNormOp):
+    def init_test_case(self):
+        self.shape = (2, 100, 3, 2, 2)
+        self.data_format = "NCDHW"
+        self.attrs['groups'] = 1
+
+
 class TestGroupNormFP16Op1(TestGroupNormFP16OP):
     def init_test_case(self):
         self.attrs['groups'] = 1
         self.dtype = np.float16
 
 
+class TestGroupNormFP16Op1_with_NCL(TestGroupNormFP16OP):
+    def init_test_case(self):
+        self.shape = (2, 100, 3)
+        self.data_format = "NCL"
+        self.attrs['groups'] = 1
+        self.dtype = np.float16
+
+
+class TestGroupNormFP16Op1_with_NCDHW(TestGroupNormFP16OP):
+    def init_test_case(self):
+        self.shape = (2, 100, 3, 2, 2)
+        self.data_format = "NCDHW"
+        self.attrs['groups'] = 1
+        self.dtype = np.float16
+
+
 class TestGroupNormBF16Op1(TestGroupNormBF16Op):
     def init_test_case(self):
+        self.attrs['groups'] = 1
+
+
+class TestGroupNormBF16Op1_with_NCL(TestGroupNormBF16Op):
+    def init_test_case(self):
+        self.shape = (2, 100, 3)
+        self.data_format = "NCL"
+        self.attrs['groups'] = 1
+
+
+class TestGroupNormBF16Op1_with_NCDHW(TestGroupNormBF16Op):
+    def init_test_case(self):
+        self.shape = (2, 100, 3, 2, 2)
+        self.data_format = "NCDHW"
         self.attrs['groups'] = 1
 
 
@@ -400,12 +485,30 @@ class TestGroupNormOp1_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.attrs['groups'] = 2
         self.data_format = "NHWC"
+        self.channel_last = True
+
+
+class TestGroupNormOp1_With_NLC(TestGroupNormOp):
+    def init_test_case(self):
+        self.shape = (2, 100, 3)
+        self.attrs['groups'] = 2
+        self.data_format = "NLC"
+        self.channel_last = True
+
+
+class TestGroupNormOp1_With_NDHWC(TestGroupNormOp):
+    def init_test_case(self):
+        self.shape = (2, 100, 3, 2, 2)
+        self.attrs['groups'] = 2
+        self.data_format = "NDHWC"
+        self.channel_last = True
 
 
 class TestGroupNormOp2_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.attrs['groups'] = 4
         self.data_format = "NHWC"
+        self.channel_last = True
 
 
 class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
@@ -416,6 +519,7 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
         self.attrs['epsilon'] = 0.5
         self.shape = (1, 100, 4, 4)
         self.dtype = np.float16
+        self.channel_last = True
 
     def test_check_output(self):
         rtol = 2e-3
@@ -429,6 +533,28 @@ class TestGroupNormFP16Op_With_NHWC(TestGroupNormFP16OP):
             inplace_atol=inplace_atol,
             check_pir=True,
         )
+
+
+class TestGroupNormFP16Op_With_NLC(TestGroupNormFP16Op_With_NHWC):
+    def init_test_case(self):
+        self.no_need_check_inplace = True
+        self.attrs['groups'] = 10
+        self.data_format = "NLC"
+        self.attrs['epsilon'] = 0.5
+        self.shape = (1, 100, 4)
+        self.dtype = np.float16
+        self.channel_last = True
+
+
+class TestGroupNormFP16Op_With_NDHWC(TestGroupNormFP16Op_With_NHWC):
+    def init_test_case(self):
+        self.no_need_check_inplace = True
+        self.attrs['groups'] = 10
+        self.data_format = "NDHWC"
+        self.attrs['epsilon'] = 0.5
+        self.shape = (1, 100, 4)
+        self.dtype = np.float16
+        self.channel_last = True
 
 
 class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
@@ -450,19 +576,12 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
         self.compare_between_place = False
         self.init_test_case()
         input = (
-            np.sin(
-                np.arange(
-                    self.shape[0]
-                    * self.shape[1]
-                    * self.shape[2]
-                    * self.shape[3]
-                )
-            )
+            np.sin(np.arange(np.prod(self.shape)))
             .reshape(self.shape)
             .astype(np.float32)
         )
-        scale = np.ones(self.shape[3]).astype(np.float32)
-        bias = np.sin(np.arange(self.shape[3])).astype(np.float32)
+        scale = np.ones(self.shape[-1]).astype(np.float32)
+        bias = np.sin(np.arange(self.shape[-1])).astype(np.float32)
         output, mean, var = group_norm_naive(
             input,
             scale,
@@ -490,11 +609,24 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
         )
 
 
+class TestGroupNormBF16Op_With_NLC(TestGroupNormBF16Op_With_NHWC):
+    def init_test_case(self):
+        self.shape = (1, 3, 512)
+        self.data_format = "NLC"
+
+
+class TestGroupNormBF16Op_With_NDHWC(TestGroupNormBF16Op_With_NHWC):
+    def init_test_case(self):
+        self.shape = (1, 3, 2, 2, 512)
+        self.data_format = "NDHWC"
+
+
 class TestGroupNormOpBigEps1_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.attrs['groups'] = 1
         self.attrs['epsilon'] = 0.5
         self.data_format = "NHWC"
+        self.channel_last = True
 
 
 class TestGroupNormOpBigEps2_With_NHWC(TestGroupNormOp):
@@ -502,12 +634,14 @@ class TestGroupNormOpBigEps2_With_NHWC(TestGroupNormOp):
         self.attrs['groups'] = 4
         self.attrs['epsilon'] = 0.5
         self.data_format = "NHWC"
+        self.channel_last = True
 
 
 class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.attrs['epsilon'] = 0.5
         self.data_format = "NHWC"
+        self.channel_last = True
 
 
 @skip_check_grad_ci(
@@ -520,6 +654,7 @@ class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
         self.attrs['groups'] = 8
         self.data_format = "NHWC"
         self.compare_between_place = True
+        self.channel_last = True
 
 
 class TestGroupNormAPI_With_NHWC(unittest.TestCase):
@@ -569,6 +704,134 @@ class TestGroupNormAPI_With_NHWC(unittest.TestCase):
             )
             np.testing.assert_allclose(results[0], expect_res1[0], rtol=1e-05)
             np.testing.assert_allclose(results[1], expect_res2[0], rtol=1e-05)
+
+
+class TestGroupNormFunctionalAPI_With_NLC(unittest.TestCase):
+    def test_case1(self):
+        places = [paddle.CPUPlace()]
+        if base.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
+            paddle.disable_static(place)
+            data1_np = np.random.random((2, 3, 4)).astype("float64")
+            data2_np = np.random.random((2, 4, 3)).astype("float64")
+            data1 = paddle.to_tensor(data1_np)
+            data2 = paddle.to_tensor(data2_np)
+            scale = paddle.to_tensor([1, 1, 1, 1], dtype="float64")
+            bias = paddle.to_tensor([0, 0, 0, 0], dtype="float64")
+            out1 = F.group_norm(
+                data1, num_groups=2, weight=scale, bias=bias, data_format="NLC"
+            )
+            out2 = F.group_norm(
+                data2, num_groups=2, weight=scale, bias=bias, data_format="NCL"
+            )
+
+            expect_res1 = group_norm_naive(
+                data1_np,
+                scale,
+                bias,
+                epsilon=1e-5,
+                groups=2,
+                data_layout="NLC",
+            )
+            expect_res2 = group_norm_naive(
+                data2_np,
+                scale,
+                bias,
+                epsilon=1e-5,
+                groups=2,
+                data_layout="NCL",
+            )
+            np.testing.assert_allclose(out1.numpy(), expect_res1[0], rtol=1e-05)
+            np.testing.assert_allclose(out2.numpy(), expect_res2[0], rtol=1e-05)
+
+
+class TestGroupNormFunctionalAPI_With_NHWC(unittest.TestCase):
+    def test_case1(self):
+        places = [paddle.CPUPlace()]
+        if base.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
+            paddle.disable_static(place)
+            data1_np = np.random.random((2, 3, 2, 4)).astype("float64")
+            data2_np = np.random.random((2, 4, 3, 2)).astype("float64")
+            data1 = paddle.to_tensor(data1_np)
+            data2 = paddle.to_tensor(data2_np)
+            scale = paddle.to_tensor([1, 1, 1, 1], dtype="float64")
+            bias = paddle.to_tensor([0, 0, 0, 0], dtype="float64")
+            out1 = F.group_norm(
+                data1, num_groups=2, weight=scale, bias=bias, data_format="NHWC"
+            )
+            out2 = F.group_norm(
+                data2, num_groups=2, weight=scale, bias=bias, data_format="NCHW"
+            )
+
+            expect_res1 = group_norm_naive(
+                data1_np,
+                scale,
+                bias,
+                epsilon=1e-5,
+                groups=2,
+                data_layout="NHWC",
+            )
+            expect_res2 = group_norm_naive(
+                data2_np,
+                scale,
+                bias,
+                epsilon=1e-5,
+                groups=2,
+                data_layout="NCHW",
+            )
+            np.testing.assert_allclose(out1.numpy(), expect_res1[0], rtol=1e-05)
+            np.testing.assert_allclose(out2.numpy(), expect_res2[0], rtol=1e-05)
+
+
+class TestGroupNormAPI_With_NDHWC(unittest.TestCase):
+    def test_case1(self):
+        places = [paddle.CPUPlace()]
+        if base.is_compiled_with_cuda():
+            places.append(paddle.CUDAPlace(0))
+        for place in places:
+            paddle.disable_static(place)
+            data1_np = np.random.random((2, 3, 2, 2, 4)).astype("float64")
+            data2_np = np.random.random((2, 4, 3, 2, 2)).astype("float64")
+            data1 = paddle.to_tensor(data1_np)
+            data2 = paddle.to_tensor(data2_np)
+            scale = paddle.to_tensor([1, 1, 1, 1], dtype="float64")
+            bias = paddle.to_tensor([0, 0, 0, 0], dtype="float64")
+            out1 = F.group_norm(
+                data1,
+                num_groups=2,
+                weight=scale,
+                bias=bias,
+                data_format="NDHWC",
+            )
+            out2 = F.group_norm(
+                data2,
+                num_groups=2,
+                weight=scale,
+                bias=bias,
+                data_format="NCDHW",
+            )
+
+            expect_res1 = group_norm_naive(
+                data1_np,
+                scale,
+                bias,
+                epsilon=1e-5,
+                groups=2,
+                data_layout="NDHWC",
+            )
+            expect_res2 = group_norm_naive(
+                data2_np,
+                scale,
+                bias,
+                epsilon=1e-5,
+                groups=2,
+                data_layout="NCDHW",
+            )
+            np.testing.assert_allclose(out1.numpy(), expect_res1[0], rtol=1e-05)
+            np.testing.assert_allclose(out2.numpy(), expect_res2[0], rtol=1e-05)
 
 
 class TestGroupNormException(unittest.TestCase):

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -638,6 +638,28 @@ class TestGroupNormBF16Op_With_NDHWC(TestGroupNormBF16Op_With_NHWC):
         self.shape = (1, 3, 2, 2, 512)
         self.data_format = "NDHWC"
 
+    def test_check_grad(self):
+        if self.compare_between_place:
+            return
+
+        check_prim_grad = False
+
+        self.rev_comp_atol = 1e-2
+        self.rev_comp_rtol = 1e-2
+        # prim bf16 has diff in windows
+        if sys.platform == "win32" or self.channel_last:
+            self.rev_comp_atol = 5e-2
+            self.rev_comp_rtol = 5e-2
+        place = core.CUDAPlace(0)
+        self.check_grad_with_place(
+            place,
+            ['X', 'Scale', 'Bias'],
+            'Y',
+            check_pir=True,
+            check_prim_pir=check_prim_grad,
+            max_relative_error=0.03,
+        )
+
 
 class TestGroupNormOpBigEps1_With_NHWC(TestGroupNormOp):
     def init_test_case(self):

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -592,6 +592,7 @@ class TestGroupNormBF16Op_With_NHWC(TestGroupNormBF16Op):
         }
         self.compare_between_place = False
         self.init_test_case()
+        self.data_format = 'NCHW' if self.data_format[1] == 'C' else 'NHWC'
         input = (
             np.sin(np.arange(np.prod(self.shape)))
             .reshape(self.shape)

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -303,6 +303,8 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NCL_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
+        if not core.is_compiled_with_cuda():
+            return
         paddle.disable_static()
         shape = (2, 6, 4)
         np.random.seed(10)
@@ -346,6 +348,8 @@ class TestGroupNormAPIV2_With_NCL_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NCDHW_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
+        if not core.is_compiled_with_cuda():
+            return
         paddle.disable_static()
         shape = (2, 6, 4, 2, 2)
         np.random.seed(10)
@@ -389,6 +393,8 @@ class TestGroupNormAPIV2_With_NCDHW_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NLC_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
+        if not core.is_compiled_with_cuda():
+            return
         paddle.disable_static()
         shape = (2, 4, 6)
         np.random.seed(10)
@@ -432,6 +438,8 @@ class TestGroupNormAPIV2_With_NLC_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NHWC_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
+        if not core.is_compiled_with_cuda():
+            return
         paddle.disable_static()
         shape = (2, 4, 2, 6)
         np.random.seed(10)
@@ -475,6 +483,8 @@ class TestGroupNormAPIV2_With_NHWC_fp16(unittest.TestCase):
 
 class TestGroupNormAPIV2_With_NDHWC_fp16(unittest.TestCase):
     def test_numerical_accuracy(self):
+        if not core.is_compiled_with_cuda():
+            return
         paddle.disable_static()
         shape = (2, 4, 2, 2, 6)
         np.random.seed(10)

--- a/test/legacy_test/test_group_norm_op_v2.py
+++ b/test/legacy_test/test_group_norm_op_v2.py
@@ -21,9 +21,15 @@ from paddle import base
 from paddle.base import core
 
 
-def group_norm_naive_for_general_dimension(x, scale, bias, epsilon, groups):
+def group_norm_naive_for_general_dimension(
+    x, scale, bias, epsilon, groups, channel_last=False
+):
     # original version group norm only support 4-D tensor
     # this function generalizes to support differnt dimensions tensor (>= 2-D)
+    if channel_last:
+        shape = list(range(x.ndim))
+        shape.insert(1, shape.pop(-1))
+        x = x.transpose(shape)
     input_shape = x.shape
     N, C = x.shape[0], x.shape[1]
     G = groups
@@ -32,8 +38,12 @@ def group_norm_naive_for_general_dimension(x, scale, bias, epsilon, groups):
     var = np.var(x, axis=1, keepdims=True)
     output = (x - mean) / np.sqrt(var + epsilon)
     output = output.reshape(input_shape) * scale.reshape(
-        (-1, 1, 1)
-    ) + bias.reshape((-1, 1, 1))
+        [-1] + [1] * (x.ndim - 2)
+    ) + bias.reshape([-1] + [1] * (x.ndim - 2))
+    if channel_last:
+        shape = list(range(output.ndim))
+        shape.insert(len(shape), shape.pop(1))
+        output = output.transpose(shape)
     return output
 
 
@@ -71,6 +81,176 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
                 result2 = gn2(data_pd).numpy()
                 self.assertTrue(np.allclose(result1, expect_res1, atol=1e-5))
                 self.assertTrue(np.allclose(result2, expect_res2, atol=1e-5))
+
+
+class TestGroupNormAPIV2_With_NCL(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 6, 4)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NCL'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NCL'
+            )
+            data_pd = paddle.to_tensor(data)
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+            np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
+
+
+class TestGroupNormAPIV2_With_NCDHW(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 6, 4, 2, 2)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NCDHW'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NCDHW'
+            )
+            data_pd = paddle.to_tensor(data)
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+            np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
+
+
+class TestGroupNormAPIV2_With_NLC(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 4, 6)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6, channel_last=True
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2, channel_last=True
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NLC'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NLC'
+            )
+            data_pd = paddle.to_tensor(data)
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+            np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
+
+
+class TestGroupNormAPIV2_With_NHWC(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 4, 2, 6)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6, channel_last=True
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2, channel_last=True
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NHWC'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NHWC'
+            )
+            data_pd = paddle.to_tensor(data)
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+            np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
+
+
+class TestGroupNormAPIV2_With_NDHWC(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 4, 2, 2, 6)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6, channel_last=True
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2, channel_last=True
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NDHWC'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NDHWC'
+            )
+            data_pd = paddle.to_tensor(data)
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(result1, expect_res1, atol=1e-5)
+            np.testing.assert_allclose(result2, expect_res2, atol=1e-5)
 
 
 class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
@@ -119,6 +299,221 @@ class TestGroupNormAPIV2_With_General_Dimensions_fp16(unittest.TestCase):
                 np.testing.assert_allclose(
                     result2, expect_res2, rtol=1e-2, atol=1e-3
                 )
+
+
+class TestGroupNormAPIV2_With_NCL_fp16(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 6, 4)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NCL'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NCL'
+            )
+            paddle.assign(paddle.cast(gn1.weight, 'float16'), gn1.weight)
+            paddle.assign(paddle.cast(gn1.bias, 'float16'), gn1.bias)
+            paddle.assign(paddle.cast(gn2.weight, 'float16'), gn2.weight)
+            paddle.assign(paddle.cast(gn2.bias, 'float16'), gn2.bias)
+
+            data_pd = paddle.to_tensor(data.astype('float16'))
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(
+                result1, expect_res1, rtol=1e-2, atol=1e-3
+            )
+            np.testing.assert_allclose(
+                result2, expect_res2, rtol=1e-2, atol=1e-3
+            )
+
+
+class TestGroupNormAPIV2_With_NCDHW_fp16(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 6, 4, 2, 2)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NCDHW'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NCDHW'
+            )
+            paddle.assign(paddle.cast(gn1.weight, 'float16'), gn1.weight)
+            paddle.assign(paddle.cast(gn1.bias, 'float16'), gn1.bias)
+            paddle.assign(paddle.cast(gn2.weight, 'float16'), gn2.weight)
+            paddle.assign(paddle.cast(gn2.bias, 'float16'), gn2.bias)
+
+            data_pd = paddle.to_tensor(data.astype('float16'))
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(
+                result1, expect_res1, rtol=1e-2, atol=1e-2
+            )
+            np.testing.assert_allclose(
+                result2, expect_res2, rtol=1e-2, atol=1e-2
+            )
+
+
+class TestGroupNormAPIV2_With_NLC_fp16(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 4, 6)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6, channel_last=True
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2, channel_last=True
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NLC'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NLC'
+            )
+            paddle.assign(paddle.cast(gn1.weight, 'float16'), gn1.weight)
+            paddle.assign(paddle.cast(gn1.bias, 'float16'), gn1.bias)
+            paddle.assign(paddle.cast(gn2.weight, 'float16'), gn2.weight)
+            paddle.assign(paddle.cast(gn2.bias, 'float16'), gn2.bias)
+
+            data_pd = paddle.to_tensor(data.astype('float16'))
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(
+                result1, expect_res1, rtol=1e-2, atol=1e-3
+            )
+            np.testing.assert_allclose(
+                result2, expect_res2, rtol=1e-2, atol=1e-3
+            )
+
+
+class TestGroupNormAPIV2_With_NHWC_fp16(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 4, 2, 6)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6, channel_last=True
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2, channel_last=True
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NHWC'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NHWC'
+            )
+            paddle.assign(paddle.cast(gn1.weight, 'float16'), gn1.weight)
+            paddle.assign(paddle.cast(gn1.bias, 'float16'), gn1.bias)
+            paddle.assign(paddle.cast(gn2.weight, 'float16'), gn2.weight)
+            paddle.assign(paddle.cast(gn2.bias, 'float16'), gn2.bias)
+
+            data_pd = paddle.to_tensor(data.astype('float16'))
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(
+                result1, expect_res1, rtol=1e-2, atol=1e-3
+            )
+            np.testing.assert_allclose(
+                result2, expect_res2, rtol=1e-2, atol=1e-3
+            )
+
+
+class TestGroupNormAPIV2_With_NDHWC_fp16(unittest.TestCase):
+    def test_numerical_accuracy(self):
+        paddle.disable_static()
+        shape = (2, 4, 2, 2, 6)
+        np.random.seed(10)
+        places = [base.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
+            places.append(base.CUDAPlace(0))
+
+        for place in places:
+            paddle.disable_static(place)
+            scale = np.array([1]).astype("float32")
+            bias = np.array([0]).astype("float32")
+            data = np.random.random(shape).astype("float32")
+            expect_res1 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=6, channel_last=True
+            )
+            expect_res2 = group_norm_naive_for_general_dimension(
+                data, scale, bias, epsilon=1e-5, groups=2, channel_last=True
+            )
+
+            gn1 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=6, data_format='NDHWC'
+            )
+            gn2 = paddle.nn.GroupNorm(
+                num_channels=6, num_groups=2, data_format='NDHWC'
+            )
+            paddle.assign(paddle.cast(gn1.weight, 'float16'), gn1.weight)
+            paddle.assign(paddle.cast(gn1.bias, 'float16'), gn1.bias)
+            paddle.assign(paddle.cast(gn2.weight, 'float16'), gn2.weight)
+            paddle.assign(paddle.cast(gn2.bias, 'float16'), gn2.bias)
+
+            data_pd = paddle.to_tensor(data.astype('float16'))
+            result1 = gn1(data_pd).numpy()
+            result2 = gn2(data_pd).numpy()
+            np.testing.assert_allclose(
+                result1, expect_res1, rtol=1e-2, atol=1e-2
+            )
+            np.testing.assert_allclose(
+                result2, expect_res2, rtol=1e-2, atol=1e-2
+            )
 
 
 class TestGroupNormDimException(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
添加支持 NCL, NLC, NCDHW, NDHWC 的 data_format
https://github.com/PaddlePaddle/Paddle/pull/34773 的修改中应该已将 kernel 增添支持3-D和5-D输入
https://github.com/PaddlePaddle/Paddle/pull/55399 的修改仅针对 NHWC 格式的fp16和bfp16输入做了 kernel 的优化，不支持3-D和5-D输入
因此本pr主要修改的地方是 https://github.com/PaddlePaddle/Paddle/pull/55399 中优化的部分

修复 https://github.com/PaddlePaddle/Paddle/issues/63560