### PR TITLE
Test sparse sum op

### DIFF
--- a/paddle/phi/kernels/sparse/gpu/sum_grad_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sum_grad_kernel.cu
@@ -54,7 +54,7 @@ __global__ void SumCsr3DGradCudaKernel(const int64_t* x_crows_data,
                                        const int64_t x_dim1,
                                        T* dx_values_data) {
   // dout_crows_data[index] should be equal to number;
-  CUDA_KERNEL_LOOP_TYPE(index, x_dim0 * (x_dim1 + 1), int64_t) {
+  CUDA_KERNEL_LOOP_TYPE(index, x_dim0 * (x_dim1 + 1) - 1, int64_t) {
     int64_t batch = index / (x_dim1 + 1);
     int64_t number = index % (x_dim1 + 1);
 

--- a/paddle/phi/kernels/sparse/gpu/sum_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sum_kernel.cu
@@ -137,11 +137,16 @@ __global__ void SumCsr3DCudaKernel(const int64_t* x_crows_data,
                                    int64_t* out_crows_data,
                                    int64_t* out_cols_data,
                                    T* out_values_data) {
+  {
+    CUDA_KERNEL_LOOP_TYPE(index, x_dim0 * x_dim1, int64_t) {
+      out_cols_data[index] = 0;
+    }
+  }
+
   CUDA_KERNEL_LOOP_TYPE(index, x_dim0 * (x_dim1 + 1), int64_t) {
     int64_t batch = index / (x_dim1 + 1);
     int64_t number = index % (x_dim1 + 1);
     out_crows_data[index] = number;
-    out_cols_data[index] = 0;
 
     if (number != x_dim1) {
       T sum_value = 0;
@@ -154,6 +159,8 @@ __global__ void SumCsr3DCudaKernel(const int64_t* x_crows_data,
       for (int64_t j = x_crows_data[index]; j < x_crows_data[index + 1]; ++j) {
         sum_value += x_values_data[j + x_values_data_offset];
       }
+
+      // `index - batch` would never exceed x_dim0 * x_dim1.
       out_values_data[index - batch] = sum_value;
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

1. `sum_kernel.cu`
The size of `out_cols_data` is only `x_dim0 * x_dim1`. It is illegal to access memory after x_dim0 * x_dim1. To prevent such illegal access, the loop in `SumCsr3DGradCudaKernel` is splitted into two loops. 

2. `sum_grad_kernel.cu`
The length of `x_crows_data` is only `x_dim0 * (x_dim1 + 1)`. Access to `x_crows_data[x_dim0 * (x_dim1 + 1)]` is in fact illegal. However, `x_crows_data[x_dim0 * (x_dim1 + 1)]` would be 0 to the alignment mechanism of `StreamSafeAllocator`.

Moreover, `dx_values_data` would never be filled when `index = x_dim0 * (x_dim1 + 1) - 1`. Therefore, the last iteration of the loop could be ignored.