### PR TITLE
[Auto Parallel] Support MoE expert parallelism in dygraph auto parallel

### DIFF
--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -578,7 +578,14 @@ void BindAutoParallel(py::module *m) {
       .def("__str__", &TensorDistAttr::to_string)
       .def(
           "_is_partial", &TensorDistAttr::is_partial, py::arg("mesh_axis") = -1)
+      .def("_set_partial_status",
+           static_cast<void (TensorDistAttr::*)(
+               const std::vector<int64_t> &dims, const phi::ReduceType &type)>(
+               &TensorDistAttr::set_partial_status),
+           py::arg("dims"),
+           py::arg("type") = phi::ReduceType::kRedSum)
       .def("_partial_dims", &TensorDistAttr::partial_dims)
+      .def("_partial_status", &TensorDistAttr::partial_status_for_python)
       .def("_clean_partial_dims", &TensorDistAttr::clean_partial_dims)
       .def("_set_partial_dims",
            [](TensorDistAttr &self, const std::vector<int64_t> &dims) {

--- a/paddle/fluid/pybind/auto_parallel_py.cc
+++ b/paddle/fluid/pybind/auto_parallel_py.cc
@@ -578,14 +578,7 @@ void BindAutoParallel(py::module *m) {
       .def("__str__", &TensorDistAttr::to_string)
       .def(
           "_is_partial", &TensorDistAttr::is_partial, py::arg("mesh_axis") = -1)
-      .def("_set_partial_status",
-           static_cast<void (TensorDistAttr::*)(
-               const std::vector<int64_t> &dims, const phi::ReduceType &type)>(
-               &TensorDistAttr::set_partial_status),
-           py::arg("dims"),
-           py::arg("type") = phi::ReduceType::kRedSum)
       .def("_partial_dims", &TensorDistAttr::partial_dims)
-      .def("_partial_status", &TensorDistAttr::partial_status_for_python)
       .def("_clean_partial_dims", &TensorDistAttr::clean_partial_dims)
       .def("_set_partial_dims",
            [](TensorDistAttr &self, const std::vector<int64_t> &dims) {

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -117,14 +117,28 @@ void ConvertToDistTensor(Tensor* x, const phi::distributed::ProcessMesh* mesh) {
     return;
   }
   if (x->is_dist_tensor()) {
-    PADDLE_ENFORCE_EQ(
-        std::dynamic_pointer_cast<phi::distributed::DistTensor>(x->impl())
-            ->process_mesh(),
-        *mesh,
-        platform::errors::InvalidArgument(
-            "Input %s has different mesh. However all inputs should "
-            "have the same mesh.",
-            x->name()));
+    auto dist_ptr =
+        std::dynamic_pointer_cast<phi::distributed::DistTensor>(x->impl());
+    if (!dist_ptr->skip_check_mesh() && x->dims().size() > 0) {
+      // NOTE(pkuzyc): In MoE expert parallelism, the mesh of the
+      // inputs and outputs of different experts are different, so
+      // skip checking mesh in the following two casees:
+      // 1. The ``skip_check_mesh_`` flag is true. The MoE-related apis
+      // sets this flag to indicate that the difference between tensor's
+      // mesh is allowed.
+      // 2. The tensor is a 0-D tensor. Specifically, in MoE expert
+      // parallelism, the learning rate's mesh is global, but expert
+      // weights' mesh is the subset of the global mesh, this is also
+      // allowed so skip checking the mesh of 0-D tensor.
+      PADDLE_ENFORCE_EQ(
+          std::dynamic_pointer_cast<phi::distributed::DistTensor>(x->impl())
+              ->process_mesh(),
+          *mesh,
+          platform::errors::InvalidArgument(
+              "Input %s has different mesh. However all inputs should "
+              "have the same mesh.",
+              x->name()));
+    }
     return;
   } else {
     PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -1099,6 +1099,8 @@ void BindTensor(pybind11::module &m) {  // NOLINT
              }
              return self;
            })
+      .def("_unsafe_set_skip_check_mesh",
+           &DistTensor::unsafe_set_skip_check_mesh)
       .def("_clear", &DistTensor::clear);
 #endif
 

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -3007,6 +3007,7 @@
   output : Tensor[] {axis<0 ? input.dims()[input.dims().size()+axis]:input.dims()[axis]}
   infer_meta :
     func : UnbindInferMeta
+    spmd_rule : UnbindInferSpmdDynamic
   kernel :
     func : unbind
   backward : unbind_grad

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.cc
@@ -94,18 +94,6 @@ void TensorDistAttr::set_annotated(
   annotated_ = annotated;
 }
 
-const std::map<int64_t, ReduceType> TensorDistAttr::partial_status_for_python()
-    const {
-  std::map<int64_t, ReduceType> partial_status;
-  for (auto& kv : partial_status_) {
-    std::cout << "partial_dim:" << kv.first
-              << " type:" << static_cast<int>(kv.second) << " str_type:"
-              << ReduceTypeStrings[static_cast<size_t>(kv.second)];
-    partial_status[kv.first] = kv.second;
-  }
-  return partial_status;
-}
-
 const std::set<int64_t> TensorDistAttr::partial_dims() const {
   std::set<int64_t> keys;
   for (auto& kv : partial_status_) {

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.h
@@ -101,8 +101,6 @@ class TEST_API TensorDistAttr {
   // return vector of mesh dims on which the this tensor is partial on
   const std::set<int64_t> partial_dims() const;
 
-  const std::map<int64_t, ReduceType> partial_status_for_python() const;
-
   const paddle::flat_hash_map<int64_t, ReduceType>& partial_status() const {
     return partial_status_;
   }

--- a/paddle/phi/core/distributed/auto_parallel/dist_attr.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_attr.h
@@ -101,6 +101,8 @@ class TEST_API TensorDistAttr {
   // return vector of mesh dims on which the this tensor is partial on
   const std::set<int64_t> partial_dims() const;
 
+  const std::map<int64_t, ReduceType> partial_status_for_python() const;
+
   const paddle::flat_hash_map<int64_t, ReduceType>& partial_status() const {
     return partial_status_;
   }
@@ -197,6 +199,10 @@ class TEST_API TensorDistAttr {
   // if mesh_axis is not -1, check only on specific axis.
   bool is_partial(int64_t mesh_axis = -1) const;
 
+  void set_skip_check_mesh(bool skip);
+
+  bool skip_check_mesh() const { return skip_check_mesh_; }
+
  private:
   static std::vector<std::string> fields_;
   ProcessMesh process_mesh_;
@@ -209,6 +215,8 @@ class TEST_API TensorDistAttr {
   // iterate operation (copy and comparison) would more frequency than random
   // element access. <key: dim on mesh, value: reduce type>
   paddle::flat_hash_map<int64_t, ReduceType> partial_status_;
+  // The flag indicates whether to skip checking the process mesh.
+  bool skip_check_mesh_ = false;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const TensorDistAttr& obj) {

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.cc
@@ -304,6 +304,12 @@ void* DistTensor::AllocateFrom(Allocator* allocator,
   return nullptr;
 }
 
+void DistTensor::unsafe_set_skip_check_mesh(bool skip) {
+  VLOG(6) << "You try to set an initialized DistTensor's dist attr. "
+             "Make sure you are aware of where you change its dist attr.";
+  dist_attr_.set_skip_check_mesh(skip);
+}
+
 void DistTensor::clear() {
   if (value_) {
     value_->clear();

--- a/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
+++ b/paddle/phi/core/distributed/auto_parallel/dist_tensor.h
@@ -178,6 +178,15 @@ class DistTensor final
                      size_t requested_size = 0,
                      bool fake_alloc = false) override;
 
+  /// \brief Set the flag indicating whether to skip checking the process mesh.
+  /// \note Currently only used for the MoE apis,
+  /// it receives the inputs with different process meshes and outputs the dist
+  /// tensor with global process mesh.
+  /// \return void
+  void unsafe_set_skip_check_mesh(bool skip);
+
+  bool skip_check_mesh() const { return dist_attr_.skip_check_mesh(); }
+
   void clear();
 
  private:

--- a/paddle/phi/infermeta/spmd_rules/reduction.h
+++ b/paddle/phi/infermeta/spmd_rules/reduction.h
@@ -27,6 +27,11 @@ SpmdInfo ReductionInferSpmd(const DistMetaTensor& x,
                             const std::vector<int64_t>& axis,
                             bool keep_dim);
 
+SpmdInfo ReductionInferSpmdBase(const DistMetaTensor& x,
+                                const std::vector<int64_t>& axis,
+                                bool keep_dim,
+                                int reduce_type);
+
 // This infer spmd function only use in dynamic mode for it uses
 // IntArray as parameter. The IntArray may contain vector of tensor
 // which is not support in static mode. So we separate these two and

--- a/paddle/phi/infermeta/spmd_rules/rules.cc
+++ b/paddle/phi/infermeta/spmd_rules/rules.cc
@@ -446,6 +446,11 @@ PD_REGISTER_SPMD_RULE(swiglu,
 
 // reduction rule
 PD_REGISTER_SPMD_RULE(
+    reduce_base,
+    PD_INFER_SPMD(phi::distributed::ReductionInferSpmdBase),
+    PD_INFER_SPMD(phi::distributed::ReductionInferSpmdReverse));
+
+PD_REGISTER_SPMD_RULE(
     all,
     PD_INFER_SPMD(phi::distributed::ReductionInferSpmd),
     PD_INFER_SPMD(phi::distributed::ReductionInferSpmdReverse));

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -1934,12 +1934,6 @@ class DistModel:
                 self._engine._inputs_spec,
                 self._engine._labels_spec,
             ) = self._engine._prepare_data_spec_from_dataloader(loader)
-            print(
-                "input_spec:",
-                self._engine._inputs_spec,
-                "label_spec:",
-                self._engine._labels_spec,
-            )
         else:
             batch_size = loader.batch_sampler.batch_size
             (
@@ -2221,7 +2215,6 @@ class DistModel:
         feeds = self._make_feeds(feed_list)
         outs = self._engine.run(feeds)
         self.outs = outs
-        # print(outs)
 
         if self._mode == "predict":
             if "outputs" in outs:

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -22,6 +22,7 @@ import paddle
 import paddle.distributed as dist
 from paddle import _C_ops, nn, pir
 from paddle.amp.grad_scaler import OptimizerState
+from paddle.autograd import PyLayer
 from paddle.base import unique_name
 from paddle.base.dygraph.base import switch_to_static_graph
 from paddle.base.framework import (
@@ -35,6 +36,7 @@ from paddle.distributed.auto_parallel.interface import (
     shard_tensor as shard_tensor_static,
 )
 from paddle.distributed.auto_parallel.placement_type import (
+    to_dim_map,
     to_placements,
 )
 from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
@@ -263,6 +265,233 @@ def shard_tensor(
         return shard_tensor_static(tensor, mesh, sharding_specs)
 
 
+class _set_process_mesh(PyLayer):
+    @staticmethod
+    def forward(ctx, dist_tensor, new_process_mesh):
+        ctx.process_mesh = dist_tensor.process_mesh
+        ctx.placements = dist_tensor.placements
+        ctx.input_tensor = dist_tensor
+        if dist_tensor._is_initialized() is True:
+            out = paddle.Tensor(
+                dist_tensor._local_value(),
+                process_mesh=new_process_mesh,
+                placements=dist_tensor.placements,
+                dtype="float32",
+            )
+            out.stop_gradient = False
+        else:
+            out = paddle.Tensor(
+                np.zeros(dist_tensor.shape),
+                process_mesh=new_process_mesh,
+                placements=dist_tensor.placements,
+                dtype="float32",
+            )
+            out.stop_gradient = False
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_tensor):
+        if grad_tensor._is_initialized() is True:
+            return paddle.Tensor(
+                grad_tensor,
+                process_mesh=ctx.process_mesh,
+                placements=ctx.placements,
+                dtype="float32",
+            )
+        else:
+            return paddle.Tensor(
+                paddle.zeros(grad_tensor.shape),
+                process_mesh=ctx.process_mesh,
+                placements=ctx.placements,
+                dtype="float32",
+            )
+
+
+def set_process_mesh(dist_tensor, new_process_mesh):
+    return _set_process_mesh.apply(dist_tensor, new_process_mesh)
+
+
+class _dtensor_from_local(PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        local_tensor_list,
+        local_mesh_list,
+        idx,
+        global_dims,
+        mesh,
+        placements,
+    ):
+        local_tensor = local_tensor_list[idx]
+        if local_tensor.is_dist():
+            local_mesh = local_tensor.process_mesh
+            local_val = local_tensor._local_value()
+            local_placement = local_tensor.placements[0]
+        else:
+            local_val = local_tensor
+            local_mesh = None
+            local_placement = dist.Replicate()
+
+        ctx.global_mesh = copy.deepcopy(mesh)
+        ctx.placements = placements
+        ctx.local_dims = local_tensor.shape
+        ctx.local_mesh_list = copy.deepcopy(local_mesh_list)
+        ctx.local_placement = local_placement
+
+        place = paddle.framework._current_expected_place()
+        place = paddle.framework._get_paddle_place(place)
+
+        global_tensor = paddle.Tensor(
+            local_val,
+            dims=global_dims,
+            process_mesh=mesh,
+            placements=placements,
+            place=place,
+        )
+        global_tensor.stop_gradient = False
+        return global_tensor
+
+    @staticmethod
+    def backward(ctx, grad_tensor):
+        if ctx.local_mesh_list is None:
+            return grad_tensor._local_value()
+        else:
+            place = paddle.framework._current_expected_place()
+            place = paddle.framework._get_paddle_place(place)
+            out = []
+            for i, local_mesh in enumerate(ctx.local_mesh_list):
+                out.append(
+                    paddle.Tensor(
+                        grad_tensor._local_value(),
+                        dims=ctx.local_dims,
+                        process_mesh=local_mesh,
+                        placements=[ctx.local_placement],
+                        place=place,
+                    )
+                )
+                out[-1].get_tensor()._unsafe_set_skip_check_mesh(True)
+            return out
+
+
+def dtensor_from_local_list(
+    local_tensor_list, mesh, placements, local_mesh_dim=-1
+):
+    # assume the each rank has the same tensor shape for now, just use the local shape to calculate the global shape
+    local_tensor_idx = mesh.process_ids.index(dist.get_rank())
+    local_tensor = local_tensor_list[local_tensor_idx]
+    global_dims = list(local_tensor.shape)
+    local_mesh = None
+    if paddle.in_dynamic_mode():
+        if local_tensor.is_dist():
+            local_mesh = local_tensor.process_mesh
+            local_val = local_tensor._local_value()
+        else:
+            local_val = local_tensor
+
+    if local_mesh is not None:
+        assert (
+            len(local_mesh.shape) == 1
+        ), "dtensor_from_local only support 1D local mesh now when the input ``local_tensor`` is a dist_tensor."
+        local_process_ids = local_mesh.process_ids
+
+        if len(local_process_ids) > 1:
+            diff = local_process_ids[1] - local_process_ids[0]
+            global_mesh_shape = mesh.shape
+            for i in range(len(global_mesh_shape) - 1, -1, -1):
+                diff = diff // global_mesh_shape[i]
+                if diff == 0:
+                    local_mesh_dim = i
+                    break
+            assert (
+                local_mesh_dim == len(global_mesh_shape) - 1
+            ), "Only support the local mesh to be the last dimension of global mesh now."
+        local_placement = local_tensor.placements[0]
+        # if local_mesh_dim > -1 and local_placement != placements[local_mesh_dim]:
+        #     raise ValueError("The local placements of the input ``local_tensor`` must be compatible with the input ``mesh``")
+
+    for idx, placement in enumerate(placements):
+        if placement.is_shard():
+            shard_dim = placement.get_dim()
+            local_dim_size = global_dims[shard_dim]
+            global_dims[shard_dim] = local_dim_size * mesh.shape[idx]
+
+    if paddle.in_dynamic_mode():
+        local_mesh_list = []
+        for tensor in local_tensor_list:
+            local_mesh_list.append(copy.deepcopy(tensor.process_mesh))
+            tensor.get_tensor()._unsafe_set_skip_check_mesh(True)
+
+        return _dtensor_from_local.apply(
+            local_tensor_list,
+            local_mesh_list,
+            local_tensor_idx,
+            global_dims,
+            mesh,
+            placements,
+        )
+    else:
+        if local_mesh_dim == -1:
+            raise ValueError("local_mesh_dim must be set.")
+        mesh_shape = mesh.shape
+        process_ids = np.array(mesh.process_ids).reshape(mesh_shape)
+        splitted_process_ids = np.split(
+            process_ids, mesh_shape[local_mesh_dim], axis=local_mesh_dim
+        )
+        # local_process_ids = splitted_process_ids[dist.get_rank()]
+        # local_mesh = dist.ProcessMesh(local_process_ids)
+        local_mesh_list = []
+        for process_ids in splitted_process_ids:
+            local_mesh_list.append(dist.ProcessMesh(process_ids))
+        local_placements = list(placements)
+        local_placements.pop(local_mesh_dim)
+        if local_placements == []:
+            local_placements.append(dist.Replicate())
+        local_dims_mapping = to_dim_map(local_placements, len(global_dims))
+        global_dims_mapping = to_dim_map(placements, len(global_dims))
+
+        main_program = default_main_program()
+        default_dist_ctx = get_default_distributed_context()
+        local_var = local_tensor
+
+        out_var = main_program.current_block().create_var(
+            name=unique_name.generate_with_ignorable_key(
+                ".".join(['dtensor_from_local_api', 'tmp'])
+            ),
+            dtype=local_tensor.dtype,
+            shape=global_dims,
+            type=local_tensor.type,
+            persistable=local_tensor.persistable,
+            stop_gradient=local_tensor.stop_gradient,
+        )
+
+        # NOTE(zhangyichen): The concat op here is only used to record
+        # the inputs and outputs. The actual computation is defined in
+        # `dist_dtensor_from_local_list.py`.
+        trans_op = main_program.current_block().append_op(
+            type='assign',
+            inputs={'X': [local_var]},
+            outputs={'Out': [out_var]},
+        )
+
+        dist_op = DistributedOperator(trans_op)
+        dist_op.dist_attr.process_mesh = mesh
+        dist_op.dist_attr.mark_annotated("process_mesh")
+        dist_op.dist_attr.chunk_id = 0
+
+        input_dist_attr = dist_op.dist_attr.get_input_dist_attr(local_var.name)
+        input_dist_attr.dims_mapping = local_dims_mapping
+        input_dist_attr.mark_annotated("dims_mapping")
+
+        output_dist_attr = dist_op.dist_attr.get_output_dist_attr(out_var.name)
+        output_dist_attr.dims_mapping = global_dims_mapping
+        output_dist_attr.mark_annotated("dims_mapping")
+
+        default_dist_ctx.add_dist_op_for_program(dist_op)
+        mark_as_sharding_propagation_skip_op(trans_op)
+
+        return out_var
+
+
 def dtensor_from_local(local_tensor, mesh, placements):
     # assume the each rank has the same tensor shape for now, just use the local shape to calculate the global shape
     global_dims = list(local_tensor.shape)
@@ -440,6 +669,199 @@ def reshard(dist_tensor, mesh, placements):
         # out_var = trans_op(dist_tensor)
 
         return out_var
+
+
+class _local_tensors_from_dist(PyLayer):
+    @staticmethod
+    def forward(
+        ctx,
+        dist_tensor,
+        local_mesh_list=None,
+        local_placements=None,
+        global_mesh=None,
+        global_placements=None,
+    ):
+        ctx.local_mesh_list = copy.deepcopy(local_mesh_list)
+        ctx.local_placements = local_placements
+        ctx.global_mesh = copy.deepcopy(global_mesh)
+        ctx.global_placements = global_placements
+        ctx.global_shape = dist_tensor.shape
+
+        if global_mesh is None and global_placements is None:
+            return dist_tensor._local_value()
+        else:
+            if global_mesh is None or global_placements is None:
+                raise ValueError(
+                    "the args global_mesh and global_placements should be set together"
+                )
+            ori_mesh = dist_tensor.process_mesh
+            if global_mesh != dist_tensor.process_mesh:
+                raise ValueError(
+                    "the global_mesh should be the same as dist_tensor's process_mesh."
+                )
+            assert check_placements_equal(
+                global_placements, dist_tensor.placements
+            ), "the global_placements should be the same as dist_tensor's placements."
+            local_shape = dist_tensor._local_value().shape
+            for idx, placement in enumerate(local_placements):
+                if placement.is_shard():
+                    shard_dim = placement.get_dim()
+                    local_dim_size = local_shape[shard_dim]
+                    local_shape[shard_dim] = (
+                        local_dim_size * local_mesh_list[0].shape[idx]
+                    )
+
+            place = paddle.framework._current_expected_place()
+            place = paddle.framework._get_paddle_place(place)
+            local_tensor_list = []
+            for i, local_mesh in enumerate(local_mesh_list):
+                local_tensor = paddle.Tensor(
+                    dist_tensor._local_value(),
+                    dims=local_shape,
+                    process_mesh=local_mesh,
+                    placements=local_placements,
+                    place=place,
+                )
+                local_tensor.get_tensor()._unsafe_set_skip_check_mesh(True)
+                local_tensor.stop_gradient = False
+                local_tensor_list.append(local_tensor)
+            return local_tensor_list
+
+    @staticmethod
+    def backward(ctx, *grad_tensor):
+        place = paddle.framework._current_expected_place()
+        place = paddle.framework._get_paddle_place(place)
+        idx = ctx.global_mesh.process_ids.index(dist.get_rank())
+        local_grad = grad_tensor[idx]
+        global_tensor = paddle.Tensor(
+            local_grad._local_value(),
+            dims=ctx.global_shape,
+            process_mesh=ctx.global_mesh,
+            placements=ctx.global_placements,
+            place=place,
+        )
+        return global_tensor
+
+
+def local_tensor_from_dist(
+    dist_tensor, global_mesh=None, local_mesh_dim=None, global_placements=None
+):
+    """
+    Get the local part of the ``dist_tensor`` on the specific ``local_mesh_dim``.
+    """
+    if (
+        global_mesh is not None
+        and local_mesh_dim is not None
+        and global_placements is not None
+    ):
+        mesh_shape = global_mesh.shape
+        process_ids = np.array(global_mesh.process_ids).reshape(mesh_shape)
+        splitted_process_ids = np.split(
+            process_ids, mesh_shape[local_mesh_dim], axis=local_mesh_dim
+        )
+        local_mesh_list = []
+        for process_ids in splitted_process_ids:
+            local_mesh_list.append(dist.ProcessMesh(process_ids))
+        local_placements = list(global_placements)
+        local_placements.pop(local_mesh_dim)
+        if local_placements == []:
+            local_placements.append(dist.Replicate())
+
+        rank = dist.get_rank()
+        local_idx = 0
+        for i, mesh in enumerate(local_mesh_list):
+            if rank in mesh.process_ids:
+                local_idx = i
+                break
+
+    if paddle.framework.in_dynamic_mode():
+        return _local_tensors_from_dist.apply(
+            dist_tensor,
+            local_mesh_list,
+            local_placements,
+            global_mesh,
+            global_placements,
+        )
+    else:
+        assert isinstance(
+            dist_tensor, Variable
+        ), f"in dy2static mode, local_tensor_from_dist's input should be Variable, but got [{dist_tensor}]"
+        if (
+            global_mesh is None
+            or local_mesh_dim is None
+            or global_placements is None
+        ):
+            raise ValueError(
+                "the args global_mesh, local_mesh_dim and global_placements must be set in dy2static."
+            )
+
+        global_shape = dist_tensor.shape
+        global_dims_mapping = to_dim_map(global_placements, dist_tensor.ndim)
+        local_shape = []
+        for i, shape in enumerate(global_shape):
+            if global_dims_mapping[i] == -1:
+                local_shape.append(shape)
+            else:
+                local_shape.append(shape // mesh_shape[global_dims_mapping[i]])
+
+        main_program = default_main_program()
+        default_dist_ctx = get_default_distributed_context()
+
+        out_var_list = []
+        local_dims_mapping = to_dim_map(local_placements, len(local_shape))
+        for i, local_mesh in enumerate(local_mesh_list):
+            out_var = main_program.current_block().create_var(
+                name=unique_name.generate_with_ignorable_key(
+                    ".".join(['local_tensor_from_dist_api', 'tmp'])
+                ),
+                dtype=dist_tensor.dtype,
+                shape=local_shape,
+                type=dist_tensor.type,
+                persistable=dist_tensor.persistable,
+                stop_gradient=dist_tensor.stop_gradient,
+            )
+            out_var.dist_attr = (
+                dist.auto_parallel.static.dist_attribute.TensorDistAttr()
+            )
+            out_var.dist_attr.process_mesh = local_mesh
+            out_var.dist_attr.mark_annotated("process_mesh")
+            out_var.dist_attr.dims_mapping = local_dims_mapping
+            out_var.dist_attr.mark_annotated("dims_mapping")
+            out_var_list.append(out_var)
+
+            trans_op = main_program.current_block().append_op(
+                type='assign',
+                inputs={'X': [dist_tensor]},
+                outputs={'Out': [out_var]},
+                attrs={
+                    'local_mesh_list': local_mesh_list,
+                    'global_mesh': global_mesh,
+                    'local_dims_mapping': local_dims_mapping,
+                    'global_dims_mapping': global_dims_mapping,
+                },
+            )
+
+            dist_op = DistributedOperator(trans_op)
+            dist_op.dist_attr.process_mesh = local_mesh
+            dist_op.dist_attr.mark_annotated("process_mesh")
+            dist_op.dist_attr.chunk_id = 0
+
+            input_dist_attr = dist_op.dist_attr.get_input_dist_attr(
+                dist_tensor.name
+            )
+            input_dist_attr.dims_mapping = global_dims_mapping
+            input_dist_attr.mark_annotated("dims_mapping")
+
+            output_dist_attr = dist_op.dist_attr.get_output_dist_attr(
+                out_var.name
+            )
+            output_dist_attr.dims_mapping = local_dims_mapping
+            output_dist_attr.mark_annotated("dims_mapping")
+
+            default_dist_ctx.add_dist_op_for_program(dist_op)
+            mark_as_sharding_propagation_skip_op(trans_op)
+
+        return out_var_list
 
 
 def shard_layer(
@@ -1694,6 +2116,12 @@ class DistModel:
                 self._engine._inputs_spec,
                 self._engine._labels_spec,
             ) = self._engine._prepare_data_spec_from_dataloader(loader)
+            print(
+                "input_spec:",
+                self._engine._inputs_spec,
+                "label_spec:",
+                self._engine._labels_spec,
+            )
         else:
             batch_size = loader.batch_sampler.batch_size
             (
@@ -1974,6 +2402,8 @@ class DistModel:
 
         feeds = self._make_feeds(feed_list)
         outs = self._engine.run(feeds)
+        self.outs = outs
+        # print(outs)
 
         if self._mode == "predict":
             if "outputs" in outs:

--- a/python/paddle/distributed/auto_parallel/api.py
+++ b/python/paddle/distributed/auto_parallel/api.py
@@ -482,13 +482,6 @@ def local_tensor_list_from_dtensor(
         if local_placements == []:
             local_placements.append(dist.Replicate())
 
-        rank = dist.get_rank()
-        local_idx = 0
-        for i, mesh in enumerate(local_mesh_list):
-            if rank in mesh.process_ids:
-                local_idx = i
-                break
-
     if paddle.framework.in_dynamic_mode():
         return _local_tensors_from_dist.apply(
             dist_tensor,

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -782,9 +782,14 @@ class ClipGradByGlobalNorm(ClipGradBase):
                     else clip_var
                 )
                 if clip_input.process_mesh != g.process_mesh:
-                    clip_input = paddle.distributed.reshard(
-                        clip_input, g.process_mesh, clip_input.placements
-                    )
+                    if set(g.process_mesh.process_ids) < set(
+                        clip_input.process_mesh.process_ids
+                    ):
+                        clip_input = clip_input._local_value()
+                    else:
+                        clip_input = paddle.distributed.reshard(
+                            clip_input, g.process_mesh, clip_input.placements
+                        )
                 new_grad = paddle.multiply(g, clip_input)
                 params_and_grads.append((p, new_grad))
             else:

--- a/python/paddle/nn/clip.py
+++ b/python/paddle/nn/clip.py
@@ -789,10 +789,11 @@ class ClipGradByGlobalNorm(ClipGradBase):
                         clip_input.process_mesh.process_ids
                     ):
                         placements = clip_input.placements
-                        is_replicate = [
-                            placement.is_replicated()
-                            for placement in placements
-                        ].all()
+                        is_replicate = True
+                        for placement in placements:
+                            if not placement.is_replicated():
+                                is_replicate = False
+                                break
                         if is_replicate:
                             clip_input = clip_input._local_value()
                         else:

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -213,6 +213,8 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
                   test_semi_auto_parallel_unshard_dtensor)
   set_tests_properties(test_semi_auto_parallel_unshard_dtensor
                        PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
+  py_test_modules(test_semi_auto_parallel_simple_net_ep MODULES
+                  test_semi_auto_parallel_simple_net_ep)
   # End of unittests WITH multi cards and timeout
 
   # NOTE(zyl): unittests WITH multi cards and WITHOUT timeout

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -215,6 +215,8 @@ if(WITH_DISTRIBUTE AND WITH_GPU)
                        PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 100)
   py_test_modules(test_semi_auto_parallel_simple_net_ep MODULES
                   test_semi_auto_parallel_simple_net_ep)
+  set_tests_properties(test_semi_auto_parallel_simple_net_ep
+                       PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" TIMEOUT 120)
   # End of unittests WITH multi cards and timeout
 
   # NOTE(zyl): unittests WITH multi cards and WITHOUT timeout

--- a/test/auto_parallel/semi_auto_parallel_simple_net_ep.py
+++ b/test/auto_parallel/semi_auto_parallel_simple_net_ep.py
@@ -27,8 +27,8 @@ class Config:
     def __init__(self):
         self.batch_num = 5
         self.batch_size = 4
-        self.input_size = 784
-        self.hidden_size = 32
+        self.input_size = 32
+        self.hidden_size = 16
         self.class_num = 10
         self.run_ep = False
         self.mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
@@ -149,6 +149,7 @@ class TestSimpleNetForEP:
         optimizer = paddle.optimizer.SGD(
             learning_rate=0.01,
             parameters=model.parameters(),
+            grad_clip=paddle.nn.ClipGradByGlobalNorm(clip_norm=1.0),
         )
         return optimizer
 
@@ -196,7 +197,7 @@ class TestSimpleNetForEP:
         return losses
 
     def run_ep(self):
-        self.set_seed(1234)
+        self.set_seed(self._seed)
         config = Config()
         config.run_ep = True
         model, train_dataloader, criterion, optimizer = self.build(config)
@@ -209,7 +210,7 @@ class TestSimpleNetForEP:
         return loss
 
     def run_replicate(self):
-        self.set_seed(1234)
+        self.set_seed(self._seed)
         config = Config()
         config.run_ep = False
         model, train_dataloader, criterion, optimizer = self.build(config)

--- a/test/auto_parallel/semi_auto_parallel_simple_net_ep.py
+++ b/test/auto_parallel/semi_auto_parallel_simple_net_ep.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import random
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+from paddle.io import BatchSampler, DataLoader
+
+
+class Config:
+    def __init__(self):
+        self.batch_num = 5
+        self.batch_size = 4
+        self.input_size = 784
+        self.hidden_size = 32
+        self.class_num = 10
+        self.run_ep = False
+        self.mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
+        self.expert_mesh_list = []
+        self.expert_mesh_list.append(dist.ProcessMesh([0], dim_names=["x"]))
+        self.expert_mesh_list.append(dist.ProcessMesh([1], dim_names=["x"]))
+
+
+class RandomDataset(paddle.io.Dataset):
+    def __init__(self, images, labels, num_samples, return_dict=False):
+        self.images = images
+        self.labels = labels
+        self.num_samples = self.images.shape[0]
+        self.return_dict = return_dict
+
+    def __getitem__(self, idx):
+        if self.return_dict:
+            return {
+                "image": self.images[idx],
+                "label": self.labels[idx],
+            }
+        else:
+            return self.images[idx], self.labels[idx]
+
+    def __len__(self):
+        return self.num_samples
+
+
+class MLP(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.input_size = config.input_size
+        self.hidden_size = config.hidden_size
+        self.class_num = config.class_num
+        self.down_proj = nn.Linear(
+            self.hidden_size, self.class_num, bias_attr=False
+        )
+
+    def redistribute_expert(self, mesh, placements):
+        # place the experts on different devices
+        self.down_proj.weight = dist.shard_tensor(
+            self.down_proj.weight, mesh, placements
+        )
+
+    def forward(self, x):
+        return self.down_proj(x)
+
+
+class DemoLayer(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.gate = nn.Linear(
+            config.input_size, config.hidden_size, bias_attr=False
+        )
+        self.gate.weight = dist.shard_tensor(
+            self.gate.weight, config.mesh, [dist.Replicate()]
+        )
+
+        self.experts = nn.LayerList()
+        self.experts.append(MLP(config))
+        self.experts.append(MLP(config))
+        if config.run_ep:
+            for i, expert in enumerate(self.experts):
+                expert.redistribute_expert(
+                    config.expert_mesh_list[i], [dist.Replicate()]
+                )
+
+    def forward(self, x):
+        h = self.gate(x)
+        if self.config.run_ep:
+            local_val_list = (
+                dist.auto_parallel.api.local_tensor_list_from_dtensor(
+                    h, self.config.mesh, 0, [dist.Shard(0)]
+                )
+            )
+        else:
+            local_val_list = paddle.split(h, num_or_sections=2, axis=0)
+        expert_out_list = []
+        for i, expert in enumerate(self.experts):
+            local_val = local_val_list[i]
+            expert_out_list.append(expert(local_val))
+        if self.config.run_ep:
+            out = dist.auto_parallel.api.dtensor_from_local_list(
+                expert_out_list, self.config.mesh, [dist.Shard(0)], 0
+            )
+        else:
+            out = paddle.stack(expert_out_list, axis=0)
+            out = out.reshape((-1, self.config.class_num))
+        return out
+
+
+class Criterion(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.loss_func = paddle.nn.MSELoss()
+
+    def forward(self, logits, labels):
+        loss = self.loss_func(logits, labels)
+        return loss
+
+
+class TestSimpleNetForEP:
+    def __init__(self):
+        self._dtype = os.getenv("dtype")
+        self._backend = os.getenv("backend")
+        self._seed = eval(os.getenv("seed"))
+
+        paddle.set_device(self._backend)
+
+    def set_seed(self, seed):
+        random.seed(seed)
+        np.random.seed(seed)
+        paddle.seed(seed)
+
+    def create_optimizer(self, model, lr_scheduler=None):
+        optimizer = paddle.optimizer.SGD(
+            learning_rate=0.01,
+            parameters=model.parameters(),
+        )
+        return optimizer
+
+    def create_data_loader(self, config):
+        nsamples = config.batch_size * config.batch_num
+        images = np.random.rand(nsamples, config.input_size).astype('float32')
+        labels = np.random.rand(nsamples, config.class_num).astype('float32')
+        train_dataset = RandomDataset(images, labels, config.batch_size)
+        train_sampler = BatchSampler(
+            train_dataset,
+            batch_size=config.batch_size,
+            shuffle=False,
+            drop_last=True,
+        )
+        train_dataloader = DataLoader(
+            train_dataset,
+            batch_sampler=train_sampler,
+            num_workers=0,
+        )
+        return train_dataloader
+
+    def build(self, config):
+        model = DemoLayer(config)
+        dataloader = self.create_data_loader(config)
+        optimizer = self.create_optimizer(model)
+        criterion = Criterion()
+        return model, dataloader, criterion, optimizer
+
+    def train(self, config, model, train_dataloader, criterion, optimizer):
+        tr_loss = float(0)
+        global_step = 0
+        model.train()
+
+        losses = []
+        for step, inputs in enumerate(train_dataloader()):
+            inputs, labels = inputs
+            logits = model(inputs)
+            tr_loss = criterion(logits, labels)
+
+            tr_loss.backward()
+            optimizer.step()
+            optimizer.clear_grad()
+            losses.append(tr_loss.numpy())
+
+        return losses
+
+    def run_ep(self):
+        self.set_seed(1234)
+        config = Config()
+        config.run_ep = True
+        model, train_dataloader, criterion, optimizer = self.build(config)
+
+        dist_dataloader = dist.shard_dataloader(
+            train_dataloader, config.mesh, shard_dims="x"
+        )
+        loss = self.train(config, model, dist_dataloader, criterion, optimizer)
+
+        return loss
+
+    def run_replicate(self):
+        self.set_seed(1234)
+        config = Config()
+        config.run_ep = False
+        model, train_dataloader, criterion, optimizer = self.build(config)
+
+        loss = self.train(config, model, train_dataloader, criterion, optimizer)
+        return loss
+
+    def test_ep_demo_net(self):
+        ep_loss = self.run_ep()
+        replicate_loss = self.run_replicate()
+        np.testing.assert_allclose(ep_loss, replicate_loss, rtol=1e-6)
+
+    def run_test_case(self):
+        self.test_ep_demo_net()
+
+
+if __name__ == "__main__":
+    TestSimpleNetForEP().run_test_case()

--- a/test/auto_parallel/test_semi_auto_parallel_simple_net_ep.py
+++ b/test/auto_parallel/test_semi_auto_parallel_simple_net_ep.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tempfile
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+class TestSemiAutoParallelStaticDecorate(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(
+            num_of_devices=2,
+            timeout=300,
+        )
+        self._default_envs = {"dtype": "float32", "seed": "2023"}
+        self._changeable_envs = {"backend": ["gpu"]}
+
+    def test_mlp(self):
+        envs_list = test_base.gen_product_envs_list(
+            {"dtype": "float32", "seed": "2023"}, {"backend": ["gpu"]}
+        )
+        for envs in envs_list:
+            ckpt_path_tmp = tempfile.TemporaryDirectory()
+            envs["ckpt_path"] = ckpt_path_tmp.name
+            self.run_test_case(
+                "semi_auto_parallel_simple_net_ep.py",
+                user_defined_envs=envs,
+            )
+            ckpt_path_tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Auto Parallel


### PR Types
New features

### Description
Pcard-76459
Support MoE expert parallelism in dygraph auto parallel. In auto-parallel expert parallelism, experts' weights have different process meshes. This pr implements the expert parallelism as following:
![图片 1](https://github.com/PaddlePaddle/Paddle/assets/32740647/d6a14a74-858d-430b-b660-66b15ed6f485)

**Main changes**
1. Add two apis ``local_tensor_list_from_dtensor`` and ``dtensor_from_local_list`` to transform the tensors between global and local meshes.
2. Fix the problems when the input tensors of a op have different mesh, which is necessary in expert parallelism:
    1). add a ``skip_check_mesh`` flag in ``TensorDistAttr`` to skip checking whether the process mesh are different.
    2). adapt the computing of tensors with local and global process meshes in ``grad_clip``.