### PR TITLE
[CINN]Support 0D Tensor and Expr in AST IR

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.h
@@ -203,6 +203,9 @@ class OpLoweringGroup {
   std::unordered_set<::pir::Operation*> output_ops_;
   // op pattern kind.
   OpPatternKind op_pattern_kind_{kElementWise};
+  // FIXME(Aurelius84): Need more elegent way to deal with SymDimExprs
+  // from local and global ShapeAnalysis. It will be removed after
+  // refactoring logic of OpLoweringGroup.
   bool is_broadcast_leaf_{false};
 
   std::vector<std::string> input_names_;

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -1092,9 +1092,6 @@ ir::Tensor OpLowererImpl::GetTensor(const OpLoweringGroupPtr& group,
         sym_shape, CompatibleInfo::ConvertIRType(dtype), input_id);
   } else {
     auto shape = ::common::vectorize<int>(type_info.dims());
-    if (shape.empty()) {
-      shape.push_back(1);
-    }
     return lang::CreatePlaceHolder(
         shape, CompatibleInfo::ConvertIRType(dtype), input_id);
   }

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -250,8 +250,8 @@ ir::Expr CreateReduceExpr(
     const ir::Tensor& new_write_tensor,
     const ir::Tensor& origin_write_tensor) {
   VLOG(4) << "CreateReduceExpr Start.";
-  const std::vector<ir::Expr> indice_expr =
-      std::vector<ir::Expr>(output_iters.begin(), output_iters.end());
+  const std::vector<ir::Expr> indice_expr(output_iters.begin(),
+                                          output_iters.end());
   auto new_init_tensor = ir::Tensor(new_write_tensor->name + "__reduce_init",
                                     new_write_tensor->type(),
                                     new_write_tensor->shape,
@@ -333,8 +333,6 @@ ir::Expr CreateExprWithNewComputeBody(const FusibleOp& fusible_op,
   return std::visit(Visitor(new_compute_body), fusible_op);
 }
 
-bool CheckAllLoopRangeEq(ReduceOp reduce_upper, TrivialOp trivial_down) {}
-
 int GetTensorCounter() {
   static int counter = 1;
   return counter++;
@@ -358,13 +356,15 @@ std::vector<FusibleOp> TransformReduceLoopRange(
 
   const auto create_new_tensor = [&](const ir::Tensor& downstream_load_tensor) {
     VLOG(4) << "Create New Tensor Start";
-    ir::Tensor result = ir::Tensor(
-        downstream_load_tensor->name + "_" + std::to_string(GetTensorCounter()),
-        downstream_load_tensor->type(),
+    const auto shape =
         is_trivial_downstream
             ? FilterWithFakeReduceIter(downstream_output_tensor->shape,
                                        fake_reduce_iter_idx)
-            : downstream_output_tensor->shape,
+            : downstream_output_tensor->shape;
+    ir::Tensor result = ir::Tensor(
+        downstream_load_tensor->name + "_" + std::to_string(GetTensorCounter()),
+        downstream_load_tensor->type(),
+        shape,
         is_trivial_downstream
             ? FilterWithFakeReduceIter(downstream_output_tensor->domain,
                                        fake_reduce_iter_idx)

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.h
@@ -111,8 +111,6 @@ ir::Expr CreateTrivialExpr(const std::vector<ir::Var>& output_iters,
 ir::Expr CreateExprWithNewComputeBody(const FusibleOp& fusible_op,
                                       const ir::Expr& new_compute_body);
 
-bool CheckAllLoopRangeEq(ReduceOp reduce_upper, TrivialOp trivial_down);
-
 FusibleOp CreateFusibleOp(ir::Expr compute_body, OpPatternKind op_pattern);
 
 template <class DownStreamOp>

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -29,6 +29,7 @@
 #include "paddle/cinn/optim/schedule_block_dce.h"
 #include "paddle/cinn/optim/transform_gpu_forloop.h"
 #include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
 
@@ -126,10 +127,12 @@ ir::Expr CopyedReplaceExpr(const Expr& source,
   VLOG(4) << "Replace From : " << cinn::utils::Join(replaced, " ");
   VLOG(4) << "Replace To   : " << cinn::utils::Join(candidates, " ");
 
-  CHECK_EQ(replaced.size(), candidates.size())
-      << "In ReplaceExpr, the size of Vars to be replaced must be equal to "
-         "the "
-         "size of cadidate Exprs! Please check.";
+  PADDLE_ENFORCE_EQ(
+      replaced.size(),
+      candidates.size(),
+      ::common::errors::InvalidArgument(
+          "In ReplaceExpr, the size of Vars to be replaced must be equal to "
+          "the size of cadidate Exprs! Please check."));
   auto copyed_source = ir::ir_utils::IRCopy(source);
   if (replaced.empty()) return copyed_source;
   std::map<Var, Expr, ir::CompVar> replacing_map;

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.cc
@@ -389,10 +389,10 @@ void ReplaceTarget(ir::Expr* e, const ir::Expr& t, const ir::Expr dst) {
 
 ExprTransformer WrapStoreTransformer(const ir::Tensor& tensor,
                                      const std::vector<ir::Expr>& indices) {
-  const auto& f = [=](const ir::Expr& e) -> ir::Expr {
+  const auto& MakeStoreNode = [=](const ir::Expr& e) -> ir::Expr {
     return ir::Store::Make(tensor, e, indices);
   };
-  return ExprTransformer(f);
+  return ExprTransformer(MakeStoreNode);
 }
 
 std::vector<ir::Var> CreateInnerBlockVars(

--- a/paddle/cinn/hlir/framework/pir/trivial_op_util.h
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_util.h
@@ -27,6 +27,7 @@
 #include "paddle/cinn/optim/schedule_block_dce.h"
 #include "paddle/cinn/optim/transform_gpu_forloop.h"
 #include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
 
@@ -51,7 +52,10 @@ std::unordered_map<T, U> MakeMap(const std::vector<T>& keys,
                                  const std::vector<U>& values) {
   std::unordered_map<T, U> result = std::unordered_map<T, U>();
 
-  CHECK(keys.size() == values.size());
+  PADDLE_ENFORCE_EQ(keys.size(),
+                    values.size(),
+                    ::common::errors::InvalidArgument(
+                        "Required keys shall have same size with values."));
   for (int i = 0; i < keys.size(); i++) {
     result[keys[i]] = values[i];
   }

--- a/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.cc
+++ b/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.cc
@@ -24,6 +24,7 @@
 #include "paddle/cinn/ir/group_schedule/tactic/tile_tactic.h"
 #include "paddle/cinn/ir/ir_analyzer/ir_analyzer.h"
 #include "paddle/cinn/ir/op/ir_operators.h"
+#include "paddle/common/enforce.h"
 
 PD_DECLARE_bool(cinn_bucket_compile);
 
@@ -191,7 +192,10 @@ IterativeSpaceInfo DynamicShapeGroupScheduler::ConstructIterSpaceInfo(
           return find_reduce_var;
         },
         /* uniq_target = */ true);
-    CHECK_EQ(reduce_loads.size(), 1);
+    PADDLE_ENFORCE_EQ(reduce_loads.size(),
+                      1,
+                      ::common::errors::PreconditionNotMet(
+                          "Required reduce_loads shall be 1."));
 
     std::vector<ir::Expr> reduce_load_indices =
         reduce_loads.begin()->As<ir::Load>()->indices;
@@ -199,10 +203,16 @@ IterativeSpaceInfo DynamicShapeGroupScheduler::ConstructIterSpaceInfo(
     for (int i = 0; i < reduce_load_indices.size(); ++i) {
       ir::Expr& index = reduce_load_indices[i];
       if (index.is_constant()) continue;
-      CHECK_NOTNULL(index.as_var());
+      PADDLE_ENFORCE_NOT_NULL(index.as_var(),
+                              ::common::errors::PreconditionNotMet(
+                                  "Required index shall be var type."));
       ir::Var iter_var = index.as_var_ref();
       ir::Expr iter_value = iter_var2value.at(iter_var);
-      CHECK(iter_value.as_var() || iter_value.is_constant());
+      PADDLE_ENFORCE_EQ(
+          iter_value.as_var() || iter_value.is_constant(),
+          true,
+          ::common::errors::PreconditionNotMet(
+              "Required iter_value shall be var or constant type."));
       ir::For* for_node;
       if (iter_value.as_var()) {
         for (ir::Expr& loop : loops) {
@@ -213,7 +223,9 @@ IterativeSpaceInfo DynamicShapeGroupScheduler::ConstructIterSpaceInfo(
       } else if (iter_value.is_constant()) {
         for_node = loops.at(loop_idx).As<ir::For>();
       }
-      CHECK_NOTNULL(for_node);
+      PADDLE_ENFORCE_NOT_NULL(for_node,
+                              ::common::errors::PreconditionNotMet(
+                                  "Required for_node shall not be nullptr."));
       bool is_reduce_iter_var = reduce_iter_vars.count(iter_var) > 0;
       if (is_reduce_iter_var) {
         info.rb_space.emplace_back(for_node->extent,

--- a/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.cc
+++ b/paddle/cinn/ir/group_schedule/dy_shape_group_scheduler.cc
@@ -36,8 +36,6 @@ void DynamicShapeGroupScheduler::Init() {
   VLOG(4) << "original group func body: \n"
           << ir_sch_->GetModule().GetExprs()[0];
   InitBuckets();
-  tactics_.emplace_back(CreateLoopReorderAlignmentTactic());
-  VLOG(4) << "CreateLoopReorderAlignmentTactic End";
   tactics_.emplace_back(CreateTileFirstGeneralTactic());
   VLOG(4) << "CreateTileFirstGeneralTactic End";
 }

--- a/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_first_general_tactic.cc
@@ -79,7 +79,7 @@ void TileFirstGeneralTactic::Init(ScheduleContext* context) {
   reduce_current_axis_ =
       IsInnerThreadSpatialLoopGT(context_->config, 1) ? 2 : 1;
   if (context_->config.base_info->is_reduce_all) {
-    reduce_current_axis_ = 1;
+    reduce_current_axis_ = 0;
   }
   // reduce axis have be re-order to last
   vec_flatten_axis_.clear();

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -589,7 +589,8 @@ Var &Var::operator=(const _Var_ *x) {
 Expr Load::Make(Expr tensor, const std::vector<Expr> &origin_indices) {
   CHECK(tensor->type().valid());
   const auto indices = utils::GetCompitableStoreLoadIndices(
-      tensor.as_tensor_ref(), origin_indices) CHECK(!indices.empty());
+      tensor.as_tensor_ref(), origin_indices);
+  CHECK(!indices.empty());
   TryElevateInt32ToInt64(indices);
   for (auto &idx : indices) {
     CHECK(idx.type().ElementOf() == Int(64) ||

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -21,6 +21,7 @@
 #include "paddle/cinn/common/cinn_value.h"
 #include "paddle/cinn/common/ir_util.h"
 #include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/ir_utils.h"
 #include "paddle/cinn/ir/ir_visitor.h"
 #include "paddle/cinn/ir/module.h"
 #include "paddle/cinn/ir/tensor.h"
@@ -379,7 +380,8 @@ Expr Store::Make(Expr tensor, Expr value, const std::vector<Expr> &indices) {
   auto node = make_shared<Store>();
   node->tensor = tensor;
   node->value = value;
-  node->indices = indices;
+  node->indices =
+      utils::GetCompitableStoreLoadIndices(tensor.as_tensor_ref(), indices);
 
   if (tensor->type() != Void()) {
     node->set_type(
@@ -584,9 +586,10 @@ Var &Var::operator=(const _Var_ *x) {
   return *this;
 }
 
-Expr Load::Make(Expr tensor, const std::vector<Expr> &indices) {
+Expr Load::Make(Expr tensor, const std::vector<Expr> &origin_indices) {
   CHECK(tensor->type().valid());
-  CHECK(!indices.empty());
+  const auto indices = utils::GetCompitableStoreLoadIndices(
+      tensor.as_tensor_ref(), origin_indices) CHECK(!indices.empty());
   TryElevateInt32ToInt64(indices);
   for (auto &idx : indices) {
     CHECK(idx.type().ElementOf() == Int(64) ||

--- a/paddle/cinn/ir/ir_utils.h
+++ b/paddle/cinn/ir/ir_utils.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <vector>
+#include "paddle/cinn/ir/tensor.h"
+
+namespace cinn::ir::utils {
+
+// FIXME(Aurelius84): Return [Expr(1)] for 0D Tensor as the shape.
+static inline std::vector<Expr> GetCompitableShape(
+    const std::vector<Expr>& shape) {
+  return shape.empty() ? std::vector<Expr>({Expr(1)}) : shape;
+}
+
+// FIXME(Aurelius84): Actually we can't distingusih 0D Tensor from 1D Tensor
+// with shape [1]. So name it with Maybe prefix.
+static inline bool MaybeZeroRankTensor(const Tensor& tensor) {
+  return tensor.ndims() == 1 && tensor->shape[0].is_constant() &&
+         static_cast<int>(tensor->shape[0].get_constant()) == 1;
+}
+
+// FIXME(Aurelius84): Return [Expr(0)] for 0D Tensor as the indices.
+static inline std::vector<Expr> GetCompitableStoreLoadIndices(
+    const Tensor& tensor, const std::vector<Expr>& indices) {
+  const bool should_fill_zero = indices.empty() && MaybeZeroRankTensor(tensor);
+  return should_fill_zero ? std::vector<Expr>({Expr(0)}) : indices;
+}
+
+}  // namespace cinn::ir::utils

--- a/paddle/cinn/ir/tensor.cc
+++ b/paddle/cinn/ir/tensor.cc
@@ -32,6 +32,7 @@
 #include "paddle/cinn/lang/compute.h"
 #include "paddle/cinn/poly/isl_utils.h"
 #include "paddle/cinn/poly/stage.h"
+#include "paddle/common/enforce.h"
 
 PD_DECLARE_bool(cinn_bucket_compile);
 
@@ -44,7 +45,10 @@ Tensor _Tensor_::Make(const std::string &name,
                       const std::vector<Expr> &domain,
                       FunctionRef fn,
                       const std::vector<Var> &reduce_axis) {
-  CHECK(!name.empty()) << "Tensor name is set empty";
+  PADDLE_ENFORCE_EQ(name.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Required tensor name shall not be empty."));
   auto n = make_shared<_Tensor_>();
   n->name = name;
   n->shape = utils::GetCompitableShape(shape);
@@ -61,7 +65,10 @@ Tensor _Tensor_::Make(const std::string &name,
                       const std::vector<Expr> &shape,
                       const std::vector<Expr> &domain,
                       const std::vector<Var> &reduce_axis) {
-  CHECK(!name.empty()) << "Cannot set empty Tensor name in Tensor::Make";
+  PADDLE_ENFORCE_EQ(name.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Required tensor name shall not be empty."));
   auto n = make_shared<_Tensor_>();
   n->name = name;
   n->shape = utils::GetCompitableShape(shape);
@@ -80,7 +87,14 @@ Tensor _Tensor_::Make(const std::string &name,
                       const std::vector<Dim> &sym_domain,
                       FunctionRef fn,
                       const std::vector<Var> &reduce_axis) {
-  CHECK(!name.empty()) << "Tensor name is set empty";
+  PADDLE_ENFORCE_EQ(name.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Required tensor name shall not be empty."));
+  PADDLE_ENFORCE_EQ(sym_shape.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Required tensor sym_shape shall not be empty."));
   auto n = make_shared<_Tensor_>();
   n->name = name;
   n->sym_shape = sym_shape;
@@ -103,7 +117,14 @@ Tensor _Tensor_::Make(const std::string &name,
                       const std::vector<Dim> &sym_shape,
                       const std::vector<Dim> &sym_domain,
                       const std::vector<Var> &reduce_axis) {
-  CHECK(!name.empty()) << "Cannot set empty Tensor name in Tensor::Make";
+  PADDLE_ENFORCE_EQ(name.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Required tensor name shall not be empty."));
+  PADDLE_ENFORCE_EQ(sym_shape.empty(),
+                    false,
+                    ::common::errors::InvalidArgument(
+                        "Required tensor sym_shape shall not be empty."));
   auto n = make_shared<_Tensor_>();
   n->name = name;
   n->sym_shape = sym_shape;
@@ -152,20 +173,26 @@ std::set<std::string> _Tensor_::GetDependTensorNames() const {
 }
 
 Expr Tensor::operator()(const std::vector<Expr> &indices) const {
-  CHECK(!self()->is_tuple()) << "should extract a specific value from the "
-                                "tuple and operate on that instead";
+  PADDLE_ENFORCE_EQ(self()->is_tuple(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Required tensor shall not be tuple type."));
   auto *node = operator->();
   const auto compitable_indices =
       utils::GetCompitableStoreLoadIndices(*this, indices);
 
-  CHECK_EQ(compitable_indices.size(), ndims())
-      << "number of indices not match the dimension";
-
+  PADDLE_ENFORCE_EQ(compitable_indices.size(),
+                    ndims(),
+                    ::common::errors::PreconditionNotMet(
+                        "number of indices not match the dimension"));
   return Load::Make(*this, compitable_indices);
 }
 
 Expr _Tensor_::inline_expanded(const std::vector<Expr> &indices) {
-  CHECK(is_compute_node());
+  PADDLE_ENFORCE_EQ(is_compute_node(),
+                    true,
+                    ::common::errors::PreconditionNotMet(
+                        "Required tensor shall be compute node."));
   return get_compute_op()->producer_fn(indices);
 }
 
@@ -212,7 +239,6 @@ PlaceholderOp *_Tensor_::get_placeholder_op() const {
 }
 
 void _Tensor_::InitAxis() const {
-  // CHECK(!domain_without_reduce_axis().empty());
   axis_ = cinn::common::GenDefaultAxis(domain_without_reduce_axis().size());
 }
 
@@ -228,7 +254,11 @@ isl::set _Tensor_::GenerateIslDomain() const {
   if (has_expression()) {
     if (axis_.empty()) InitAxis();
     auto domain = domain_with_reduce_axis();
-    CHECK_EQ(axis_with_reduce().size(), domain.size());
+    PADDLE_ENFORCE_EQ(
+        axis_with_reduce().size(),
+        domain.size(),
+        ::common::errors::PreconditionNotMet(
+            "Required axis_with_reduce and domain shall be with same size."));
     auto _axis_with_reduce = axis_with_reduce();
     for (int i = 0; i < domain.size(); i++) {
       auto dim = domain[i];
@@ -339,8 +369,10 @@ Expr *_Tensor_::mutable_body() {
 
 ir::Tensor _Tensor_::InitReduction(poly::StageMap stages,
                                    const Target &target) const {
-  CHECK(contains_reduce_axis())
-      << "InitReduction only works on a reduce tensor";
+  PADDLE_ENFORCE_EQ(contains_reduce_axis(),
+                    true,
+                    ::common::errors::PreconditionNotMet(
+                        "InitReduction only works on a reduce tensor"));
   // return if already exists.
   std::string init_reduce_tensor_name = GenReduceInitTensorNameOf(name);
   if (stages->Lookup(init_reduce_tensor_name))
@@ -426,7 +458,10 @@ ir::Tensor _Tensor_::GetInitTensor(poly::StageMap stages,
 }
 
 Expr _Tensor_::tensor_store_expanded_body() {
-  CHECK(!is_placeholder_node()) << "placeholder should not expand store";
+  PADDLE_ENFORCE_EQ(is_placeholder_node(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Placeholder should not expand store."));
 
   Expr final_body = body();
   if (shape.empty()) return final_body;
@@ -469,8 +504,10 @@ Expr _Tensor_::tensor_store_expanded_body() {
 }
 
 void _Tensor_::Bind(lang::Buffer &buffer) {
-  // CHECK(!inlined()) << "Inlined tensor should bing buffer";
-  CHECK(!buffer->type().is_void());
+  PADDLE_ENFORCE_EQ(buffer->type().is_void(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Required buffer type shall not be void()."));
   if (this->buffer.defined()) {
     // remove the old buffer
     if (this->buffer == buffer.buffer()) return;
@@ -480,9 +517,15 @@ void _Tensor_::Bind(lang::Buffer &buffer) {
   buffer_depended_tensor_names_ = buffer.buffer()->binded_tensor_names();
 
   buffer.buffer()->BindTo(this);
-  CHECK(!buffer->binded_tensor_names().empty());
+  PADDLE_ENFORCE_EQ(buffer->binded_tensor_names().empty(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Reqiured binded_tensor_names shall not be empty."));
   this->buffer = buffer.buffer();
-  CHECK(this->buffer.defined());
+  PADDLE_ENFORCE_EQ(this->buffer.defined(),
+                    true,
+                    ::common::errors::PreconditionNotMet(
+                        "Required buffer shall be defined."));
 }
 
 void _Tensor_::Bind(const Buffer &buffer) {
@@ -547,9 +590,16 @@ bool _Tensor_::HasSameShapeWith(const Tensor &other) const {
 }
 
 Tensor _Tensor_::TupleGet(int offset) const {
-  CHECK(is_tuple());
+  PADDLE_ENFORCE_EQ(is_tuple(),
+                    true,
+                    ::common::errors::PreconditionNotMet(
+                        "Required Tensor shall be tuple type."));
   auto *call = body().As<ir::Call>();
-  CHECK_LT(offset, call->write_args.size());
+  PADDLE_ENFORCE_LT(
+      offset,
+      call->write_args.size(),
+      ::common::errors::PreconditionNotMet(
+          "Required offset shall be less than call->write_args.size()."));
   auto tensor = call->write_args[offset].as_tensor_ref();
   tensor->WithBuffer();
   return tensor;
@@ -566,9 +616,11 @@ std::vector<Expr> _Tensor_::domain_with_reduce_axis() const {
   if (reduce_axis.empty()) return domain;
   auto res = domain;
   for (const Var &axis : reduce_axis) {
-    CHECK(axis->upper_bound.type().is_int(32) ||
-          axis->upper_bound.type().is_int(64))
-        << axis->upper_bound;
+    PADDLE_ENFORCE_EQ(axis->upper_bound.type().is_int(32) ||
+                          axis->upper_bound.type().is_int(64),
+                      true,
+                      ::common::errors::PreconditionNotMet(
+                          "Required upper_bound shall be int32 or int64."));
     res.push_back(axis->upper_bound);
   }
   return res;
@@ -629,7 +681,11 @@ std::set<std::string> _Tensor_::DependingTensorNames() {
 }
 
 const std::vector<Var> &_Tensor_::axis() const {
-  CHECK_EQ(axis_.size(), domain_without_reduce_axis().size());
+  PADDLE_ENFORCE_EQ(axis_.size(),
+                    domain_without_reduce_axis().size(),
+                    ::common::errors::PreconditionNotMet(
+                        "Required axis_ shall have same size with "
+                        "domain_without_reduce_axis."));
   return axis_;
 }
 
@@ -650,7 +706,10 @@ bool _Tensor_::Uses(const Tensor &other) const {
 
 ir::Tensor _Tensor_::Reshape(const std::vector<Expr> &shape,
                              poly::StageMap stages) const {
-  CHECK(!stages[this]->inlined());
+  PADDLE_ENFORCE_EQ(stages[this]->inlined(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Required stage tensor shall not be inlined."));
   auto op = BufferShareOp::Make();
   auto n = make_shared<_Tensor_>();
   auto selft = Tensor(const_cast<ir::_Tensor_ *>(this));
@@ -666,7 +725,11 @@ ir::Tensor _Tensor_::Reshape(const std::vector<Expr> &shape,
       num_elements = num_elements * e.as_int32();
     }
 
-    CHECK_EQ(this_num_elements, num_elements) << "number of elements mismatch.";
+    PADDLE_ENFORCE_EQ(
+        this_num_elements,
+        num_elements,
+        ::common::errors::PreconditionNotMet(
+            "Required this_num_elements shall be equal to num_elements."));
   }
 
   n->name = Context::Global().NewName(name + "_reshape");
@@ -747,7 +810,10 @@ bool _Tensor_::is_reduce_mul() const {
 }
 
 Expr _Tensor_::GetReduceInitVal() const {
-  CHECK(is_reduce_tensor());
+  PADDLE_ENFORCE_EQ(is_reduce_tensor(),
+                    true,
+                    ::common::errors::PreconditionNotMet(
+                        "Required tensor is a reduce type."));
   return body().As<ir::Reduce>()->init;
 }
 
@@ -756,9 +822,18 @@ bool _Tensor_::IsReduceInited(poly::StageMap stages) const {
 }
 
 void _Tensor_::Verify() const {
-  CHECK(!shape.empty());
-  CHECK(!domain.empty());
-  CHECK(!name.empty()) << "Name of tensor should be set";
+  PADDLE_ENFORCE_EQ(shape.empty(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Required shape shall not be empty."));
+  PADDLE_ENFORCE_EQ(domain.empty(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Required domain shall not be empty."));
+  PADDLE_ENFORCE_EQ(name.empty(),
+                    false,
+                    ::common::errors::PreconditionNotMet(
+                        "Required name shall not be empty."));
 }
 
 }  // namespace ir

--- a/paddle/cinn/lang/placeholder.cc
+++ b/paddle/cinn/lang/placeholder.cc
@@ -14,7 +14,9 @@
 
 #include "paddle/cinn/lang/placeholder.h"
 
+#include "paddle/cinn/ir/ir_utils.h"
 #include "paddle/cinn/runtime/intrinsic.h"
+#include "paddle/common/enforce.h"
 
 namespace cinn {
 namespace lang {
@@ -29,12 +31,14 @@ ir::Tensor CreatePlaceHolder(const std::vector<int> &shape,
   for (int s : shape) {
     expr_shape.push_back(Expr(s));
   }
-  return CreatePlaceHolder(expr_shape, type, name);
+  return CreatePlaceHolder(utis::GetCompitableShape(expr_shape), type, name);
 }
 
 ir::Tensor CreatePlaceHolder(const std::vector<ir::Dim> &shape,
                              Type type,
                              const std::string &name) {
+  PADDLE_ENFORCE_GT(
+      shape.size(), 0, "The shape of Placeholder should not be empty.");
   if (type.is_float(32)) {
     return Placeholder<float>(name, shape);
   } else if (type.is_float(64)) {
@@ -65,9 +69,10 @@ ir::Tensor CreatePlaceHolder(const std::vector<ir::Dim> &shape,
   CINN_NOT_IMPLEMENTED
 }
 
-ir::Tensor CreatePlaceHolder(const std::vector<Expr> &shape,
+ir::Tensor CreatePlaceHolder(const std::vector<Expr> &origin_shape,
                              Type type,
                              const std::string &name) {
+  const auto shape = utis::GetCompitableShape(origin_shape);
   if (type.is_float(32)) {
     return Placeholder<float>(name, shape);
   } else if (type.is_float(64)) {

--- a/paddle/cinn/lang/placeholder.cc
+++ b/paddle/cinn/lang/placeholder.cc
@@ -38,8 +38,10 @@ ir::Tensor CreatePlaceHolder(const std::vector<int> &shape,
 ir::Tensor CreatePlaceHolder(const std::vector<ir::Dim> &shape,
                              Type type,
                              const std::string &name) {
-  PADDLE_ENFORCE_GT(
-      shape.size(), 0, "The shape of Placeholder should not be empty.");
+  PADDLE_ENFORCE_GT(shape.size(),
+                    0,
+                    ::common::errors::PreconditionNotMet(
+                        "The shape of Placeholder should not be empty."));
   if (type.is_float(32)) {
     return Placeholder<float>(name, shape);
   } else if (type.is_float(64)) {

--- a/paddle/cinn/lang/placeholder.cc
+++ b/paddle/cinn/lang/placeholder.cc
@@ -31,7 +31,8 @@ ir::Tensor CreatePlaceHolder(const std::vector<int> &shape,
   for (int s : shape) {
     expr_shape.push_back(Expr(s));
   }
-  return CreatePlaceHolder(utis::GetCompitableShape(expr_shape), type, name);
+  return CreatePlaceHolder(
+      ir::utils::GetCompitableShape(expr_shape), type, name);
 }
 
 ir::Tensor CreatePlaceHolder(const std::vector<ir::Dim> &shape,
@@ -72,7 +73,7 @@ ir::Tensor CreatePlaceHolder(const std::vector<ir::Dim> &shape,
 ir::Tensor CreatePlaceHolder(const std::vector<Expr> &origin_shape,
                              Type type,
                              const std::string &name) {
-  const auto shape = utis::GetCompitableShape(origin_shape);
+  const auto shape = ir::utils::GetCompitableShape(origin_shape);
   if (type.is_float(32)) {
     return Placeholder<float>(name, shape);
   } else if (type.is_float(64)) {

--- a/paddle/cinn/operator_fusion/policy/dim_relation.cc
+++ b/paddle/cinn/operator_fusion/policy/dim_relation.cc
@@ -30,7 +30,7 @@ const size_t GetUsageIdx(const pir::Value& v, pir::Operation* op) {
 
 ValueUsage GetValueUsage(const pir::Value& v, const size_t usage_idx) {
   ValueUsage valud_dim;
-  size_t rank = GetRank(v);
+  size_t rank = GetCompitableRank(v);
   for (size_t i = 0; i < rank; ++i) {
     valud_dim.emplace_back(v, i, usage_idx);
   }
@@ -107,8 +107,8 @@ static std::vector<std::pair<size_t, size_t>> GetNonBroadCastDims(
   CHECK(broad_cast_value.has_value());
 
   const auto& [input_value, output_value] = broad_cast_value.value();
-  const int input_rank = GetRank(input_value);
-  const int output_rank = GetRank(output_value);
+  const int input_rank = GetCompitableRank(input_value);
+  const int output_rank = GetCompitableRank(output_value);
   CHECK_GE(output_rank, input_rank);
 
   // Compare axis one by one, from back to front.
@@ -144,7 +144,7 @@ static DimUsageRelation CreateOpRelativenessForBroadcast(pir::Operation* op) {
 static DimUsageRelation CreateOpRelativenessForReduce(pir::Operation* op) {
   const auto& reduce_axis_idx = GetReduceAxisIdx(op);
   DimUsageRelation res;
-  const size_t input_rank = GetRank(op->operand_source(0));
+  const size_t input_rank = GetCompitableRank(op->operand_source(0));
   int out_idx = 0;
   bool keep_dim = GetReduceOpKeepDims(op);
   for (int i = 0; i < input_rank; i++) {

--- a/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
@@ -166,7 +166,7 @@ ShardableAxesSignature CreateSignatureForElementWise(pir::Operation* op) {
   }
   for (int i = 0; i < op->num_results(); ++i) {
     PADDLE_ENFORCE_EQ(rank,
-                      GetCompitableRank(op->operand_source(i)),
+                      GetCompitableRank(op->result(i)),
                       ::common::errors::PreconditionNotMet(
                           "Required all outputs rank shall be equal each other "
                           "in elementwise op."));

--- a/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
@@ -115,7 +115,7 @@ ShardableAxesSignature CreateSignatureForReduce(pir::Operation* reduce_op) {
   bool keep_dim = GetReduceOpKeepDims(reduce_op);
   const auto output_axes = [&]() -> declytype(auto) {
     std::vector<std::string> axes;
-    // In case of reduce all and keep_dim is fale.
+    // In case of reduce all and keep_dim is false.
     if (reduce_axis_idx.size() == input_rank && !keep_dim) {
       axes.emplace_back(ShardableAxesInfoManager::GetUniqueName());
       return axes;

--- a/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
@@ -127,6 +127,7 @@ ShardableAxesSignature CreateSignatureForReduce(pir::Operation* reduce_op) {
         axes.emplace_back(input_axes[i]);
       }
     }
+    return axes;
   }();
 
   result.inputs.emplace_back(input_axes);

--- a/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
+++ b/paddle/cinn/operator_fusion/policy/shardable_axes_base.cc
@@ -107,13 +107,13 @@ ShardableAxesSignature CreateSignatureForReduce(pir::Operation* reduce_op) {
   const size_t input_rank = GetCompitableRank(reduce_op->operand_source(0));
   auto input_axes = CreateNewNamesWithRank(input_rank);
 
-  const auto reduce_axis_idx = [&]() -> declytype(auto) {
+  const auto reduce_axis_idx = [&]() -> decltype(auto) {
     const std::vector<int64_t> axis_idx = GetReduceAxisIdx(reduce_op);
     return std::unordered_set<int64_t>(axis_idx.begin(), axis_idx.end());
   }();
   CHECK_NE(reduce_axis_idx.size(), 0);
   bool keep_dim = GetReduceOpKeepDims(reduce_op);
-  const auto output_axes = [&]() -> declytype(auto) {
+  const auto output_axes = [&]() -> decltype(auto) {
     std::vector<std::string> axes;
     // In case of reduce all and keep_dim is false.
     if (reduce_axis_idx.size() == input_rank && !keep_dim) {

--- a/paddle/cinn/operator_fusion/utils.h
+++ b/paddle/cinn/operator_fusion/utils.h
@@ -44,8 +44,15 @@ static size_t GetRank(pir::Value value) {
   return value.type().dyn_cast<pir::DenseTensorType>().dims().size();
 }
 
+// FIXME(Aurelius84): 0D Tensor is not compitable with other rank.
+// So we need to add a special case for 0D Tensor.
+static size_t GetCompitableRank(pir::Value value) {
+  size_t rank = GetRank(value);
+  return rank == 0 ? 1 : rank;
+}
+
 static std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op) {
-  const size_t input_rank = GetRank(reduce_op->operand_source(0));
+  const size_t input_rank = GetCompitableRank(reduce_op->operand_source(0));
   const auto& attr_val = reduce_op->attributes().at("dim");
   CHECK(attr_val.isa<::pir::ArrayAttribute>());
   const auto& axis_attr = attr_val.dyn_cast<::pir::ArrayAttribute>();
@@ -58,10 +65,6 @@ static std::vector<int64_t> GetReduceAxisIdx(pir::Operation* reduce_op) {
     return all_axis;
   }
   std::vector<int64_t> reduce_axis_idx;
-  if (input_rank == 0) {
-    VLOG(4) << "Reduce op has 0D Tensor input, return empty reduce_axis";
-    return reduce_axis_idx;
-  }
   for (int i = 0; i < axis_attr.size(); ++i) {
     int64_t axis = axis_attr.at(i).dyn_cast<::pir::Int64Attribute>().data();
     if (axis < 0) {

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -263,11 +263,15 @@ bool ShapeConstraintIRAnalysis::IsProductEqual(
 
   symbol::DimExpr lhs_product(1);
   symbol::DimExpr rhs_product(1);
-  for (int i : lhs_dim_idxs) {
-    lhs_product = lhs_product * lhs_shape_data.shape()[i];
+  if (lhs_shape_data.shape().size() > 0) {
+    for (int i : lhs_dim_idxs) {
+      lhs_product = lhs_product * lhs_shape_data.shape()[i];
+    }
   }
-  for (int i : rhs_dim_idxs) {
-    rhs_product = rhs_product * rhs_shape_data.shape()[i];
+  if (rhs_shape_data.shape().size() > 0) {
+    for (int i : rhs_dim_idxs) {
+      rhs_product = rhs_product * rhs_shape_data.shape()[i];
+    }
   }
   return symbol::SimplifyDimExpr(lhs_product) ==
          symbol::SimplifyDimExpr(rhs_product);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

在CINN AST 层面支持了0D Tensor，具体包括：
1. 在ir::Tensor的构造函数统一兼容适配0D shape场景，移除Lowering层的空shape判断
2. 在ir::Tensor的其他构造函数里添加ENFORCE，不允许类似sym_shape为空场景
3. 在ir::Store、ir::Load、Tensor::operator() 处适配0D shape的场景，兼容处理indices
4. 在融合策略处的添加适配逻辑，并在CombindAxes加了调试日志，提升调试体验
5. 将所有涉及CHECK之处升级为PADDL_ENFORCE_XX