### PR TITLE
[pir_save_load] add jit load (train)

### DIFF
--- a/paddle/fluid/pir/serialize_deserialize/include/interface.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/interface.h
@@ -53,13 +53,14 @@ void WriteModule(const pir::Program& program,
  * deserilize program will be stored.
  * @param[in] pir_version  The current version of the PIR program format.
  *
- * @return Void. The function modifies the 'program' object to contain the data
- * read from the file.
+ * @return bool. The function modifies the 'program' object to contain the data
+ * read from the file. return bool indicates whether the program can use to
+ * funtune.
  *
  * @note If 'pir_version' is larger than the version of file, will trigger
  * version compatibility modification rule.
  */
-void ReadModule(const std::string& file_path,
+bool ReadModule(const std::string& file_path,
                 pir::Program* program,
                 const uint64_t& pir_version);
 

--- a/paddle/fluid/pir/serialize_deserialize/src/interface.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/interface.cc
@@ -23,6 +23,7 @@ namespace pir {
 #define BASE_CODE "base_code"
 #define MAGIC "magic"
 #define PIRVERSION "version"
+#define TRAINABLE "trainable"
 #define PIR "pir"
 void WriteModule(const pir::Program& program,
                  const std::string& file_path,
@@ -41,7 +42,8 @@ void WriteModule(const pir::Program& program,
   // write base code
   Json total;
 
-  total[BASE_CODE] = {{MAGIC, PIR}, {PIRVERSION, pir_version}};
+  total[BASE_CODE] = {
+      {MAGIC, PIR}, {PIRVERSION, pir_version}, {TRAINABLE, trainable}};
 
   ProgramWriter writer(pir_version, trainable);
   // write program
@@ -63,7 +65,7 @@ void WriteModule(const pir::Program& program,
   fout.close();
 }
 
-void ReadModule(const std::string& file_path,
+bool ReadModule(const std::string& file_path,
                 pir::Program* program,
                 const uint64_t& pir_version) {
   std::ifstream f(file_path);
@@ -83,6 +85,12 @@ void ReadModule(const std::string& file_path,
 
   ProgramReader reader(pir_version);
   reader.RecoverProgram(&(data[PROGRAM]), program);
+
+  if (data[BASE_CODE].contains(TRAINABLE)) {
+    return data[BASE_CODE][TRAINABLE].get<bool>();
+  } else {
+    return false;
+  }
 }
 
 }  // namespace pir

--- a/python/paddle/jit/pir_translated_layer.py
+++ b/python/paddle/jit/pir_translated_layer.py
@@ -74,8 +74,6 @@ class _PirProgramHolder:
 
         self.support_train = trainable
         self._infer_program = program
-        self._forward_program = program
-        self._backward_program = paddle.pir.Program()
 
         self._preprocess()
 
@@ -135,18 +133,6 @@ class _PirProgramHolder:
     @property
     def scope(self):
         return self._inner_scope
-
-    @property
-    def forward_program(self):
-        return self._forward_program
-
-    @property
-    def backward_program(self):
-        return self._backward_program
-
-    @property
-    def train_attr(self):
-        return self._train_attr
 
 
 # [ PirTranslatedLayer : Run program in dygraph mode ]
@@ -353,9 +339,9 @@ def _run_dygraph(instance, input, program_holder):
     if instance._is_test:
         attrs = [
             'forward_global_block',
-            program_holder._infer_program.global_block(),
+            program_holder.infer_program.global_block(),
             'backward_global_block',
-            program_holder.backward_program.global_block(),
+            paddle.pir.Program().global_block(),
             'is_test',
             instance._is_test,
             'program_id',
@@ -389,12 +375,12 @@ def _run_dygraph(instance, input, program_holder):
     else:
         from paddle.jit.dy2static.pir_partial_program import PartialProgramLayer
 
-        inputs = program_holder._input_vars
-        outputs = program_holder._output_vars
-        parameters = (persistable_tensors, program_holder._persistable_vars)
+        inputs = program_holder.input_vars
+        outputs = program_holder.output_vars
+        parameters = (persistable_tensors, program_holder.persistable_vars)
 
         layer = PartialProgramLayer(
-            program_holder._infer_program,
+            program_holder.infer_program,
             inputs,
             outputs,
             parameters,

--- a/python/paddle/jit/pir_translated_layer.py
+++ b/python/paddle/jit/pir_translated_layer.py
@@ -399,8 +399,8 @@ def _run_dygraph(instance, input, program_holder):
             outputs,
             parameters,
         )
-
-        return layer(input_tensors)
+        instance.layer = layer
+        return instance.layer(input_tensors)
 
 
 def _run_static_graph(program_holder, trace_program):

--- a/python/paddle/jit/pir_translated_layer.py
+++ b/python/paddle/jit/pir_translated_layer.py
@@ -36,9 +36,11 @@ from .translated_layer import (
 
 def _load_pir_program(model_file_path):
     program = paddle.static.Program()
-    paddle.base.core.deserialize_pir_program(model_file_path, program, 1)
+    trainable = paddle.base.core.deserialize_pir_program(
+        model_file_path, program, 1
+    )
 
-    return program
+    return program, trainable
 
 
 @switch_to_static_graph
@@ -58,7 +60,7 @@ def _get_pir_persistable_var_names(program):
 
 
 class _PirProgramHolder:
-    def __init__(self, program):
+    def __init__(self, program, trainable):
         super().__init__()
 
         # input, output, persistable,
@@ -70,8 +72,14 @@ class _PirProgramHolder:
         # execution scope
         self._inner_scope = core.Scope()
 
+        self.support_train = trainable
         self._infer_program = program
+        self._forward_program = program
+        self._backward_program = paddle.pir.Program()
+
         self._preprocess()
+
+        self.prepare_train_program = False
 
     def _preprocess(self):
         (
@@ -128,10 +136,22 @@ class _PirProgramHolder:
     def scope(self):
         return self._inner_scope
 
+    @property
+    def forward_program(self):
+        return self._forward_program
 
-# [ PirTranslatedLayer : Run program in imperative mode ]
+    @property
+    def backward_program(self):
+        return self._backward_program
+
+    @property
+    def train_attr(self):
+        return self._train_attr
+
+
+# [ PirTranslatedLayer : Run program in dygraph mode ]
 #
-# DESIGN IDEA: using an special operator `RunProgram`, execute program inside operator.
+# DESIGN IDEA: using an special operator `PirRunProgram`, execute program inside operator.
 #
 # Op's Inputs:
 #   - the input variable of the user feed
@@ -228,9 +248,9 @@ def _construct_program_holders(model_path, model_filename=None):
                     continue
             else:
                 continue
-
+            program, trainable = _load_pir_program(model_file_path)
             program_holder_dict[func_name] = _PirProgramHolder(
-                _load_pir_program(model_file_path)
+                program, trainable
             )
     else:
         for _, _, file_names in os.walk(model_path):
@@ -242,8 +262,9 @@ def _construct_program_holders(model_path, model_filename=None):
                         method_name = 'forward'
                     else:
                         method_name.replace('model', '')
+                    program, trainable = _load_pir_program(model_file_path)
                     program_holder_dict[func_name] = _PirProgramHolder(
-                        _load_pir_program(model_file_path)
+                        program, trainable
                     )
 
     return program_holder_dict
@@ -329,56 +350,60 @@ def _run_dygraph(instance, input, program_holder):
     tmp_scope_vec = [program_holder.scope]
 
     # 2. run program by op
+    if instance._is_test:
+        attrs = [
+            'forward_global_block',
+            program_holder._infer_program.global_block(),
+            'backward_global_block',
+            program_holder.backward_program.global_block(),
+            'is_test',
+            instance._is_test,
+            'program_id',
+            paddle.utils._hash_with_id(program_holder._infer_program, instance),
+            'fx',
+            program_holder.input_vars,
+            'fo',
+            program_holder.output_vars,
+            'fp',
+            program_holder.persistable_vars,
+            'fm',
+            [],
+            'no_need_buffers',
+            [],
+        ]
 
-    forward_program = (
-        program_holder._infer_program
-        if instance._is_test
-        else program_holder.forward_program
-    )
+        _legacy_C_ops.pir_run_program(
+            _valid_vars(input_tensors),
+            _valid_vars(persistable_tensors),
+            _valid_vars(output_tensors),
+            tmp_scope_vec,
+            None,
+            *attrs,
+        )
 
-    backward_program = (
-        paddle.pir.Program()
-        if instance._is_test
-        else program_holder.backward_program
-    )
+        outs = output_tensors
+        if len(output_tensors) == 1:
+            outs = output_tensors[0]
+        return outs
 
-    attrs = [
-        'forward_global_block',
-        forward_program.global_block(),
-        'backward_global_block',
-        backward_program.global_block(),
-        'is_test',
-        instance._is_test,
-        'program_id',
-        paddle.utils._hash_with_id(forward_program, instance),
-        'fx',
-        program_holder.input_vars,
-        'fo',
-        program_holder.output_vars,
-        'fp',
-        program_holder.persistable_vars,
-        'fm',
-        [],
-        'no_need_buffers',
-        [],
-    ]
+    else:
+        from paddle.jit.dy2static.pir_partial_program import PartialProgramLayer
 
-    _legacy_C_ops.pir_run_program(
-        _valid_vars(input_tensors),
-        _valid_vars(persistable_tensors),
-        _valid_vars(output_tensors),
-        tmp_scope_vec,
-        None,
-        *attrs,
-    )
+        inputs = program_holder._input_vars
+        outputs = program_holder._output_vars
+        parameters = (persistable_tensors, program_holder._persistable_vars)
 
-    outs = output_tensors
-    if len(output_tensors) == 1:
-        outs = output_tensors[0]
-    return outs
+        layer = PartialProgramLayer(
+            program_holder._infer_program,
+            inputs,
+            outputs,
+            parameters,
+        )
+
+        return layer(input_tensors)
 
 
-def _run_static_graph(input, program_holder, trace_program):
+def _run_static_graph(program_holder, trace_program):
     paddle.base.framework.switch_main_program(trace_program)
     return program_holder.output_vars
 
@@ -594,7 +619,7 @@ class PirTranslatedLayer(layers.Layer):
                 return _run_dygraph(self, input, program_holder)
             else:
                 return _run_static_graph(
-                    input, program_holder, program_holder.infer_program
+                    program_holder, program_holder.infer_program
                 )
 
         __i_m_p_l__.__name__ = method_name

--- a/test/deprecated/legacy_test/test_io_save_load.py
+++ b/test/deprecated/legacy_test/test_io_save_load.py
@@ -107,12 +107,18 @@ class TestWhenTrainWithNoGrad(unittest.TestCase):
         save_path = os.path.join(self.temp_dir.name, 'train_with_no_grad')
 
         paddle.jit.save(net, save_path)
-        net = paddle.jit.load(save_path)
-        net.eval()
+        net1 = paddle.jit.load(save_path)
+        net1.eval()
 
         with paddle.no_grad():
-            out2 = net(x)
-            self.assertEqual(out, out2)
+            out1 = net1(x)
+            self.assertEqual(out, out1)
+
+        net2 = paddle.jit.load(save_path)
+        net2.train()
+
+        out2 = net2(x)
+        self.assertEqual(out, out2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
pcard-67164

支持jit.load 的train模式。

test_io_save_load.py 中动转静load 旧IR下的梯度没有绑定在x.grad上，或者没有计算出来。
