### PR TITLE
[pybind11] Fixed compiling errors for pybind11 `-Wmissing-field-initializers` under gcc8 and python312

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -22,6 +22,7 @@ set(SOURCE_INCLUDE_DIR ${SOURCE_DIR}/include)
 
 include_directories(${PYBIND_INCLUDE_DIR})
 
+# It can be safely removed in gcc9.1+
 set(PYBIND_PATCH_COMMAND "")
 if(LINUX
    AND WITH_ARM
@@ -36,7 +37,7 @@ if(LINUX
   # 2. Patch twice: the tag version of cache == PYBIND_TAG, but patch has already applied to cache.
   set(PYBIND_PATCH_COMMAND
       git checkout -- . && git checkout ${PYBIND_TAG} && patch -Nd
-      ${SOURCE_INCLUDE_DIR}/pybind11 < ${native_dst})
+      ${SOURCE_INCLUDE_DIR}/pybind11/detail < ${native_dst})
 endif()
 
 ExternalProject_Add(

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -22,6 +22,23 @@ set(SOURCE_INCLUDE_DIR ${SOURCE_DIR}/include)
 
 include_directories(${PYBIND_INCLUDE_DIR})
 
+set(PYBIND_PATCH_COMMAND "")
+if(LINUX
+   AND WITH_ARM
+   AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+  set(PYBIND_TAG v2.12.0)
+  file(TO_NATIVE_PATH
+       ${PADDLE_SOURCE_DIR}/patches/pybind/detail/internals.h.patch native_dst)
+  # Note: [Why calling some `git` commands before `patch`?]
+  # Paddle's CI uses cache to accelerate the make process. However, error might raise when patch codes in two scenarios:
+  # 1. Patch to the wrong version: the tag version of CI's cache falls behind PYBIND_TAG, use `git checkout ${PYBIND_TAG}` to solve this.
+  # 2. Patch twice: the tag version of cache == PYBIND_TAG, but patch has already applied to cache.
+  set(PYBIND_PATCH_COMMAND
+      git checkout -- . && git checkout ${PYBIND_TAG} && patch -Nd
+      ${SOURCE_INCLUDE_DIR}/pybind11 < ${native_dst})
+endif()
+
 ExternalProject_Add(
   extern_pybind
   ${EXTERNAL_PROJECT_LOG_ARGS} ${SHALLOW_CLONE}
@@ -33,6 +50,7 @@ ExternalProject_Add(
   # third-party library version changes cannot be incorporated.
   # reference: https://cmake.org/cmake/help/latest/module/ExternalProject.html
   UPDATE_COMMAND ""
+  PATCH_COMMAND ${PYBIND_PATCH_COMMAND}
   CONFIGURE_COMMAND ""
   # I intentionally preserved an extern_pybind/include/pybind11 directory
   # to site-packages, so that you could discern that you intended to

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -25,7 +25,6 @@ include_directories(${PYBIND_INCLUDE_DIR})
 # It can be safely removed in gcc9.1+
 set(PYBIND_PATCH_COMMAND "")
 if(LINUX
-   AND WITH_ARM
    AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
   set(PYBIND_TAG v2.12.0)

--- a/patches/pybind/detail/internals.h.patch
+++ b/patches/pybind/detail/internals.h.patch
@@ -1,12 +1,12 @@
 diff --git a/include/pybind11/detail/internals.h b/include/pybind11/detail/internals.h
-index c1047e4a..2a655d21 100644
+index c1047e4a..e09a6495 100644
 --- a/include/pybind11/detail/internals.h
 +++ b/include/pybind11/detail/internals.h
 @@ -193,11 +193,18 @@ struct internals {
      PyTypeObject *default_metaclass;
      PyObject *instance_base;
  #if defined(WITH_THREAD)
-+#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && __GNUC__ <= 8
++#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
 +#pragma GCC diagnostic push
 +#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 +#endif
@@ -15,7 +15,7 @@ index c1047e4a..2a655d21 100644
  #    if PYBIND11_INTERNALS_VERSION > 4
      PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
  #    endif // PYBIND11_INTERNALS_VERSION > 4
-+#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && __GNUC__ <= 8
++#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
 +#pragma GCC diagnostic pop
 +#endif
      // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:

--- a/patches/pybind/detail/internals.h.patch
+++ b/patches/pybind/detail/internals.h.patch
@@ -1,8 +1,8 @@
 diff --git a/include/pybind11/detail/internals.h b/include/pybind11/detail/internals.h
-index c1047e4a..00924eae 100644
+index c1047e4a..2a655d21 100644
 --- a/include/pybind11/detail/internals.h
 +++ b/include/pybind11/detail/internals.h
-@@ -193,10 +193,17 @@ struct internals {
+@@ -193,11 +193,18 @@ struct internals {
      PyTypeObject *default_metaclass;
      PyObject *instance_base;
  #if defined(WITH_THREAD)
@@ -14,9 +14,9 @@ index c1047e4a..00924eae 100644
      PYBIND11_TLS_KEY_INIT(tstate)
  #    if PYBIND11_INTERNALS_VERSION > 4
      PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
+ #    endif // PYBIND11_INTERNALS_VERSION > 4
 +#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && __GNUC__ <= 8
 +#pragma GCC diagnostic pop
 +#endif
- #    endif // PYBIND11_INTERNALS_VERSION > 4
      // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
      PyInterpreterState *istate = nullptr;

--- a/patches/pybind/detail/internals.h.patch
+++ b/patches/pybind/detail/internals.h.patch
@@ -1,0 +1,22 @@
+diff --git a/include/pybind11/detail/internals.h b/include/pybind11/detail/internals.h
+index c1047e4a..00924eae 100644
+--- a/include/pybind11/detail/internals.h
++++ b/include/pybind11/detail/internals.h
+@@ -193,10 +193,17 @@ struct internals {
+     PyTypeObject *default_metaclass;
+     PyObject *instance_base;
+ #if defined(WITH_THREAD)
++#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && __GNUC__ <= 8
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
++#endif
+     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
+     PYBIND11_TLS_KEY_INIT(tstate)
+ #    if PYBIND11_INTERNALS_VERSION > 4
+     PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
++#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && __GNUC__ <= 8
++#pragma GCC diagnostic pop
++#endif
+ #    endif // PYBIND11_INTERNALS_VERSION > 4
+     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
+     PyInterpreterState *istate = nullptr;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

修复 #63741 引入的问题

可以在 `registry.baidubce.com/device/paddle-cpu:ubuntu18-aarch64-gcc82-python-all` 镜像下复现

复现步骤
```bash
export PY_VERSION=3.12 CMAKE_BUILD_TYPE=Release WITH_DOC=OFF  WITH_GPU=OFF WITH_DISTRIBUTE=ON WITH_PSCORE=ON WITH_MKL=OFF  WITH_ARM=ON WITH_TESTING=OFF WITH_INFERENCE_API_TEST=OFF WITH_CACHE=ON CMAKE_EXPORT_COMPILE_COMMANDS=ON
# 省略pip install 各种包
bash paddle/scripts/paddle_build.sh build_only
```

```bash
[ 59%] Built target extern_brpc
In file included from /usr/local/include/python3.12/pythread.h:128,
                 from /usr/local/include/python3.12/Python.h:89,
                 from /paddle/paddle/fluid/eager/pylayer/py_layer_node.h:17,
                 from /paddle/paddle/fluid/eager/pylayer/py_layer_node.cc:15:
/usr/local/include/python3.12/cpython/pythread.h:42:31: error: missing initializer for member ‘_Py_tss_t::_key’ [-Werror=missing-field-initializers]
 #define Py_tss_NEEDS_INIT   {0}
                               ^
/paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/../detail/internals.h:82:23: note: in expansion of macro ‘Py_tss_NEEDS_INIT’
                     = Py_tss_NEEDS_INIT;                                                          \
                       ^~~~~~~~~~~~~~~~~
/paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/../detail/internals.h:197:5: note: in expansion of macro ‘PYBIND11_TLS_KEY_INIT’
     PYBIND11_TLS_KEY_INIT(tstate)
     ^~~~~~~~~~~~~~~~~~~~~
/usr/local/include/python3.12/cpython/pythread.h:42:31: error: missing initializer for member ‘_Py_tss_t::_key’ [-Werror=missing-field-initializers]
 #define Py_tss_NEEDS_INIT   {0}
                               ^
/paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/../detail/internals.h:82:23: note: in expansion of macro ‘Py_tss_NEEDS_INIT’
                     = Py_tss_NEEDS_INIT;                                                          \
                       ^~~~~~~~~~~~~~~~~
/paddle/build/third_party/pybind/src/extern_pybind/include/pybind11/detail/../detail/internals.h:199:5: note: in expansion of macro ‘PYBIND11_TLS_KEY_INIT’
     PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
     ^~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
paddle/fluid/eager/pylayer/CMakeFiles/py_layer_node.dir/build.make:75: recipe for target 'paddle/fluid/eager/pylayer/CMakeFiles/py_layer_node.dir/py_layer_node.cc.o' failed
make[2]: *** [paddle/fluid/eager/pylayer/CMakeFiles/py_layer_node.dir/py_layer_node.cc.o] Error 1
CMakeFiles/Makefile2:59652: recipe for target 'paddle/fluid/eager/pylayer/CMakeFiles/py_layer_node.dir/all' failed
make[1]: *** [paddle/fluid/eager/pylayer/CMakeFiles/py_layer_node.dir/all] Error 2
Makefile:135: recipe for target 'all' failed
```

closes #63906