### PR TITLE
[CINN] Fix bug of fuse_parallel_matmul_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_parallel_matmul_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_parallel_matmul_pass.cc
@@ -53,6 +53,12 @@ class MergeParallelMatmulPattern
       return false;
     }
 
+    auto VectorPrefixEqual = [](const std::vector<std::int64_t>& a,
+                                const std::vector<std::int64_t>& b) {
+      return std::vector<std::int64_t>(a.begin(), a.end() - 1) ==
+             std::vector<std::int64_t>(b.begin(), b.end() - 1);
+    };
+
     auto IsDynamicShape = [&](const std::vector<int64_t>& dims) {
       return std::any_of(
           dims.begin(), dims.end(), [](int64_t dim) { return dim < 0; });
@@ -84,7 +90,7 @@ class MergeParallelMatmulPattern
         if (IsDynamicShape(cur_dim)) {
           continue;
         }
-        if (pre_dim.value() == cur_dim) {
+        if (VectorPrefixEqual(pre_dim.value(), cur_dim)) {
           ret.push_back(it->owner());
         }
       }

--- a/paddle/cinn/hlir/dialect/operator/transforms/fuse_parallel_matmul_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/fuse_parallel_matmul_pass.cc
@@ -53,7 +53,7 @@ class MergeParallelMatmulPattern
       return false;
     }
 
-    auto IsDynameShape = [&](const std::vector<int64_t>& dims) {
+    auto IsDynamicShape = [&](const std::vector<int64_t>& dims) {
       return std::any_of(
           dims.begin(), dims.end(), [](int64_t dim) { return dim < 0; });
     };
@@ -81,7 +81,7 @@ class MergeParallelMatmulPattern
                 .type()
                 .dyn_cast<paddle::dialect::DenseTensorType>()
                 .dims());
-        if (IsDynameShape(cur_dim)) {
+        if (IsDynamicShape(cur_dim)) {
           continue;
         }
         if (pre_dim.value() == cur_dim) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复`fuse_parallel_matmul_pass` block的insert_point失效导致执行报错的问题。