### PR TITLE
[PIR] Fix IrGuard bug

### DIFF
--- a/python/paddle/pir_utils.py
+++ b/python/paddle/pir_utils.py
@@ -73,6 +73,7 @@ class IrGuard:
             paddle.enable_static()
         if not self.old_flag:
             paddle.framework.set_flags({"FLAGS_enable_pir_api": True})
+            paddle.framework.set_flags({"FLAGS_enable_pir_in_executor": True})
             paddle.base.framework.global_var._use_pir_api_ = True
             bind_datatype()
             self._switch_to_pir()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix IrGuard bug, which will be change FLAGS_enable_pir_in_executor to 0 when exit guard.
Pcard-67164
