### PR TITLE
add cross mesh r_to_s reshard func for auto parrallel.

### DIFF
--- a/paddle/fluid/pybind/dist_api.cc
+++ b/paddle/fluid/pybind/dist_api.cc
@@ -17,6 +17,7 @@
 
 #include "paddle/fluid/pir/dialect/distributed/ir/dist_api.h"
 #include "paddle/fluid/pir/dialect/distributed/ir/dist_attribute.h"
+#include "paddle/fluid/pir/dialect/distributed/ir/dist_tools.h"
 #include "paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.h"
 #include "paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.h"
 #include "paddle/fluid/pybind/dist_api.h"
@@ -122,6 +123,7 @@ OperationDistAttribute CreateOperationDistAttribute(
 void BindDistUtils(pybind11::module *m) {
   m->def("create_tensor_dist_attribute", CreateTensorDistAttribute);
   m->def("create_op_dist_attribute", CreateOperationDistAttribute);
+  m->def("cvt_to_dist_type", &dialect::CvtToPirDistType);
 }
 
 void BindDistPassAPI(pybind11::module *module) {

--- a/python/paddle/distributed/auto_parallel/static/engine.py
+++ b/python/paddle/distributed/auto_parallel/static/engine.py
@@ -672,12 +672,12 @@ class Engine:
         # TODO(JZ-LIANG) Step 3.1: Partition Pass
         #   insert reshard op if operand tensor's placements if different from what the cumsumer op need.
         #   Partition the computation graph into different pipeline stage if need.
-        dist_program = apply_partition_pass(dist_program)
+        apply_partition_pass(dist_program)
 
         # TODO(hitywt) Step 3.2: Reshard Pass
         #   resolute the reshard op into special collective operation.
         #   collect the communicator created during resolution.
-        dist_program = apply_reshard_pass(dist_program)
+        apply_reshard_pass(dist_program)
 
         # Part 4: Optimization Pass
         # NOTE Only those Optimization Pass that related to Parallelism (need dist attr) should be placed here and all the Pass should be Optional.

--- a/python/paddle/distributed/auto_parallel/static/pir_pass.py
+++ b/python/paddle/distributed/auto_parallel/static/pir_pass.py
@@ -61,99 +61,90 @@ def reshard_combine_value(op, operand, attr):
 
 
 def apply_partition_pass(program):
-    with paddle.static.program_guard(program):
-        for op in program.global_block().ops:
-            if op.name() in partition_skip_op_list:
-                continue
-            assert len(op.operands()) == len(
-                op.dist_attr.operands()
-            ), f"The number of operands and the number of op_dist_attr's operands are not equal in op: {op}"
+    for op in program.global_block().ops:
+        if op.name() in partition_skip_op_list:
+            continue
+        assert len(op.operands()) == len(
+            op.dist_attr.operands()
+        ), f"The number of operands and the number of op_dist_attr's operands are not equal in op: {op}"
 
-            for operand, attr in zip(op.operands(), op.dist_attr.operands()):
-                prev_var = operand.source()
-                if prev_var.is_combine():
-                    operand.set_source(reshard_combine_value(op, operand, attr))
-                else:
-                    operand.set_source(reshard_single_value(op, operand, attr))
-                prev_op = prev_var.get_defining_op()
-                if (
-                    prev_op
-                    and prev_op.num_results() == 1
-                    and prev_var.use_empty()
-                ):
-                    prev_op.erase()
-
-            for var, attr in zip(op.results(), op.dist_attr.results()):
-                if (
-                    var.initialized()
-                    and var.is_dist()
-                    and var.dist_attr() != attr
-                ):
-                    paddle.pir.set_insertion_point_after(op)
-                    old_dist_attr = var.dist_attr()
-                    var.update_dist_attr(attr.as_tensor_dist_attr())
-                    # insert reshard
-                    reshard_var = paddle._C_ops.reshard_v2(var, old_dist_attr)
-                    var.replace_all_uses_with(reshard_var)
-                    reshard_var.get_defining_op().operand(0).set_source(var)
-
-        # pruning op and value not belong to cur rank
-        cur_rank = paddle.distributed.get_rank()
-        for op in program.global_block().ops[::-1]:
-            if cur_rank not in op.dist_attr.process_mesh.process_ids:
-                program.global_block().remove_op(op)
+        for operand, attr in zip(op.operands(), op.dist_attr.operands()):
+            prev_var = operand.source()
+            if prev_var.is_combine():
+                operand.set_source(reshard_combine_value(op, operand, attr))
             else:
-                # set the operand as null when it is not belong to cur rank
-                if (
-                    op.name() == 'dist_op.reshard'
-                    and cur_rank
-                    not in op.operand(0)
-                    .source()
-                    .dist_attr()
-                    .process_mesh.process_ids
-                ):
-                    op.operand(0).set_source(None)
+                operand.set_source(reshard_single_value(op, operand, attr))
+            prev_op = prev_var.get_defining_op()
+            if prev_op and prev_op.num_results() == 1 and prev_var.use_empty():
+                prev_op.erase()
 
-        # merge pd.data ops for
-        lr_ops = []
-        for op in program.global_block().ops[::-1]:
+        for var, attr in zip(op.results(), op.dist_attr.results()):
+            if var.initialized() and var.is_dist() and var.dist_attr() != attr:
+                paddle.pir.set_insertion_point_after(op)
+                old_dist_attr = var.dist_attr()
+                var.update_dist_attr(attr.as_tensor_dist_attr())
+                # insert reshard
+                reshard_var = paddle._C_ops.reshard_v2(var, old_dist_attr)
+                var.replace_all_uses_with(reshard_var)
+                reshard_var.get_defining_op().operand(0).set_source(var)
+
+    # pruning op and value not belong to cur rank
+    cur_rank = paddle.distributed.get_rank()
+    for op in program.global_block().ops[::-1]:
+        if cur_rank not in op.dist_attr.process_mesh.process_ids:
+            op.erase()
+        else:
+            # set the operand as null when it is not belong to cur rank
             if (
-                op.name() == 'pd_op.data'
-                and "learning_rate" in op.attrs()["name"]
+                op.name() == 'dist_op.reshard'
+                and cur_rank
+                not in op.operand(0)
+                .source()
+                .dist_attr()
+                .process_mesh.process_ids
             ):
-                lr_ops.append(op)
+                op.operand(0).set_source(None)
 
-        if len(lr_ops) > 1:
-            lr_value = lr_ops[0].result(0)
-            for op in lr_ops[1:]:
-                lr = op.result(0)
-                lr.replace_all_uses_with(lr_value)
-                program.global_block().remove_op(op)
-    return program
+    # merge pd.data ops for
+    lr_ops = []
+    for op in program.global_block().ops[::-1]:
+        if op.name() == 'pd_op.data' and "learning_rate" in op.attrs()["name"]:
+            lr_ops.append(op)
+
+    if len(lr_ops) > 1:
+        lr_value = lr_ops[0].result(0)
+        for op in lr_ops[1:]:
+            lr = op.result(0)
+            lr.replace_all_uses_with(lr_value)
+            op.erase()
 
 
 def apply_reshard_pass(program):
-    new_program = program.clone()
-    with paddle.base.program_guard(new_program):
-        for op in new_program.global_block().ops:
-            if op.name() == 'dist_op.reshard':
-                var = op.operand_source(0)
-                op_dist_attr = op.dist_attr
-                src_dist_attr = op_dist_attr.operand(0).as_tensor_dist_attr()
-                dst_dist_attr = op_dist_attr.result(0).as_tensor_dist_attr()
-                assert (
-                    not var.initialized() or var.dist_attr() == src_dist_attr
-                ), f"The dist_attr of reshard op's input and operand should be equal, but got {var.dist_attr()} and {src_dist_attr}"
+    for op in program.global_block().ops:
+        if op.name() == 'dist_op.reshard':
+            var = op.operand_source(0)
+            op_dist_attr = op.dist_attr
+            src_dist_attr = op_dist_attr.operand(0).as_tensor_dist_attr()
+            dst_dist_attr = op_dist_attr.result(0).as_tensor_dist_attr()
+            assert (
+                not var.initialized() or var.dist_attr() == src_dist_attr
+            ), f"The dist_attr of reshard op's input and operand should be equal, but got {var.dist_attr()} and {src_dist_attr}"
 
-                reshard_func = choose_reshard_func(src_dist_attr, dst_dist_attr)
-                assert (
-                    reshard_func is not None
-                ), f'There is no reshard function that matches src_dist_attr: {src_dist_attr} and dst_dist_attr: {dst_dist_attr}'
-                reshard_func.reshard(
-                    new_program, op, src_dist_attr, dst_dist_attr
-                )
-
-    return new_program
+            reshard_func = choose_reshard_func(src_dist_attr, dst_dist_attr)
+            assert (
+                reshard_func is not None
+            ), f'There is no reshard function that matches src_dist_attr: {src_dist_attr} and dst_dist_attr: {dst_dist_attr}'
+            paddle.pir.set_insertion_point_after(op)
+            out_value = reshard_func.reshard(
+                src_dist_attr,
+                dst_dist_attr,
+                op.operand_source(0),
+                op.result(0).type(),
+            )
+            if out_value is not None:
+                op.result(0).replace_all_uses_with(out_value)
+            if op.result(0).use_empty():
+                op.erase()
 
 
 # In sequence_parallel, we need to transpose hidden_states
@@ -183,5 +174,5 @@ def eliminate_transpose_by_reshape(program):
                 transpose_var = op.result(0)
                 reshape_var = paddle._C_ops.reshape(var, transpose_var.shape)
                 transpose_var.replace_all_uses_with(reshape_var)
-                program.global_block().remove_op(op)
+                op.erase()
     return program

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/base_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/base_reshard_func.py
@@ -20,7 +20,7 @@ class ReshardFunction:
     def is_suitable(self, dist_tensor, dist_attr):
         raise NotImplementedError
 
-    def reshard(self, program, op, src_tensor, dst_dist_attr):
+    def reshard(self, src_dist_attr, dst_dist_attr, src_value, dst_type):
         raise NotImplementedError
 
 

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_r_reshard_func.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/p_to_r_reshard_func.py
@@ -39,9 +39,7 @@ class PToRReshardFunction(ReshardFunction):
             return False
         return True
 
-    def reshard(
-        self, program, op, src_dist_attr, dst_dist_attr, reshard_op=True
-    ):
+    def reshard(self, src_dist_attr, dst_dist_attr, src_value, dst_type):
         src_mesh = src_dist_attr.process_mesh
         src_reduce_type = src_dist_attr.partial_status[0]
         reduce_mean = False
@@ -49,28 +47,19 @@ class PToRReshardFunction(ReshardFunction):
             src_reduce_type = ReduceOp.SUM
             reduce_mean = True
 
-        op_value = op.result(0)
-        op_type = op_value.type()
-        if reshard_op:
-            paddle.pir.set_insertion_point(op)
-            op_value = op.operand_source(0)
-        else:
-            paddle.pir.set_insertion_point_after(op)
         group = new_process_group(src_mesh.process_ids)
         reduced_value = paddle._pir_ops.c_allreduce_sum_(
-            op_value, group.id, True, False
+            src_value, group.id, True, False
         )
 
         # set dist type and dist attr
-        reduced_value.set_type(op_type)
+        reduced_value.set_type(dst_type)
         reduced_value.get_defining_op().dist_attr = (
             paddle.base.libpaddle.pir.create_op_dist_attribute(
                 src_mesh, [src_dist_attr], [dst_dist_attr]
             )
         )
-        if reshard_op:
-            op.result(0).replace_all_uses_with(reduced_value)
-            program.global_block().remove_op(op)
+        return reduced_value
 
 
 class PToRReshardFunctionCrossMesh(ReshardFunction):
@@ -96,26 +85,30 @@ class PToRReshardFunctionCrossMesh(ReshardFunction):
 
         return True
 
-    def reshard(self, program, op, src_dist_attr, dst_dist_attr):
+    def reshard(self, src_dist_attr, dst_dist_attr, src_value, dst_type):
         same_status_func = SameStatusReshardFunction()
         tmp_dist_attr = paddle.base.libpaddle.pir.create_tensor_dist_attribute(
             dst_dist_attr.process_mesh,
             src_dist_attr.dims_mapping,
             src_dist_attr.partial_status,
         )
-        pre_op, out_dist_attr = same_status_func.reshard(
-            program, op, src_dist_attr, tmp_dist_attr
+        tmp_dst_type = paddle.base.libpaddle.pir.cvt_to_dist_type(
+            src_value.type(), tmp_dist_attr
+        )
+        out_value = same_status_func.reshard(
+            src_dist_attr, tmp_dist_attr, src_value, tmp_dst_type
         )
 
-        if pre_op is None:
-            return None, out_dist_attr
+        if out_value is None:
+            return None
 
         curr_global_rank = paddle.distributed.get_rank()
         if curr_global_rank in dst_dist_attr.process_mesh.process_ids:
             p_to_r_func = PToRReshardFunction()
             assert p_to_r_func.is_suitable(
-                out_dist_attr, dst_dist_attr
-            ), f"Invoke the p to r reshard function is not valid from {pre_op.dist_attr()} to {dst_dist_attr}"
-            p_to_r_func.reshard(
-                program, pre_op, out_dist_attr, dst_dist_attr, False
+                tmp_dist_attr, dst_dist_attr
+            ), f"Invoke the p to r reshard function is not valid from {tmp_dist_attr} to {dst_dist_attr}"
+            return p_to_r_func.reshard(
+                tmp_dist_attr, dst_dist_attr, out_value, dst_type
             )
+        return None

--- a/python/paddle/distributed/auto_parallel/static/reshard_funcs/reshard_func_register.py
+++ b/python/paddle/distributed/auto_parallel/static/reshard_funcs/reshard_func_register.py
@@ -17,14 +17,18 @@ from .p_to_r_reshard_func import (
     PToRReshardFunction,
     PToRReshardFunctionCrossMesh,
 )
-from .r_to_s_reshard_func import RToSReshardFunction
+from .r_to_s_reshard_func import (
+    RToSReshardFunction,
+    RToSReshardFunctionCrossMesh,
+)
 from .same_status_reshard_func import SameStatusReshardFunction
 
 
 def register_reshard_funcs():
     register_reshard_func(PToRReshardFunction())
-    register_reshard_func(RToSReshardFunction())
     register_reshard_func(PToRReshardFunctionCrossMesh())
+    register_reshard_func(RToSReshardFunction())
+    register_reshard_func(RToSReshardFunctionCrossMesh())
     register_reshard_func(SameStatusReshardFunction())
 
 

--- a/test/auto_parallel/pir_reshard_r_to_s_cross_mesh.py
+++ b/test/auto_parallel/pir_reshard_r_to_s_cross_mesh.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import paddle
+import paddle.distributed as dist
+from paddle.distributed.auto_parallel.static.pir_pass import (
+    apply_reshard_pass,
+)
+
+
+class TestReshardRToSCrossMesh:
+    def __init__(self):
+        self._shape = eval(os.getenv("shape"))
+        self._dtype = os.getenv("dtype")
+        self._seeds = eval(os.getenv("seeds"))
+        self._shard = eval(os.getenv("shard"))
+        self._backend = os.getenv("backend")
+        self._in_mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
+        self._out_mesh = dist.ProcessMesh([2, 3], dim_names=["x"])
+
+    def run_test_case(self):
+        paddle.enable_static()
+
+        BATCH_SIZE = 2
+        SEQ_LEN = 4
+        HIDDEN_SIZE = 8
+
+        with paddle.pir_utils.IrGuard():
+            main_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program):
+                input = paddle.static.data(
+                    name='input', shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
+                )
+                input_tensor = dist.shard_tensor(
+                    input, self._in_mesh, [dist.Replicate()]
+                )
+                out = paddle._C_ops.reshard(
+                    input_tensor, self._out_mesh, [dist.Shard(self._shard)]
+                )
+            target_type = out.type()
+
+            old_ops = [op.name() for op in main_program.global_block().ops]
+            assert 'dist_op.reshard' in old_ops
+
+            apply_reshard_pass(main_program)
+        # np.testing.assert_equal(dist_program.num_ops(), 6)
+        new_ops = [op.name() for op in main_program.global_block().ops]
+        assert 'dist_op.reshard' not in new_ops
+        if dist.get_rank() in [0, 1]:
+            assert 'pd_op.send_v2' in new_ops
+        else:
+            assert 'pd_op.recv_v2' in new_ops
+            assert 'pd_op.slice' in new_ops
+        for op in main_program.global_block().ops:
+            if op.name() == 'pd_op.send_v2':
+                assert op.dist_attr.process_mesh == self._in_mesh
+                assert op.operand_source(0).dist_attr() == op.dist_attr.operand(
+                    0
+                )
+
+                operand_dist_attr = op.operand_source(0).dist_attr()
+                assert operand_dist_attr.process_mesh == self._in_mesh
+                assert operand_dist_attr.dims_mapping == [-1, -1, -1]
+                assert operand_dist_attr.partial_status == {}
+            elif op.name() == 'pd_op.recv_v2':
+                assert op.dist_attr.process_mesh == self._out_mesh
+                assert op.result(0).dist_attr() == op.dist_attr.result(0)
+                result_dist_attr = op.result(0).dist_attr()
+                assert result_dist_attr.process_mesh == self._out_mesh
+                assert result_dist_attr.dims_mapping == [-1, -1, -1]
+                assert result_dist_attr.partial_status == {}
+            elif op.name() == 'pd_op.slice':
+                assert op.dist_attr.process_mesh == self._out_mesh
+                assert op.result(0).dist_attr() == op.dist_attr.result(0)
+                assert op.result(0).type() == target_type
+
+
+if __name__ == '__main__':
+    TestReshardRToSCrossMesh().run_test_case()

--- a/test/auto_parallel/pir_reshard_r_to_s_cross_mesh.py
+++ b/test/auto_parallel/pir_reshard_r_to_s_cross_mesh.py
@@ -28,8 +28,8 @@ class TestReshardRToSCrossMesh:
         self._seeds = eval(os.getenv("seeds"))
         self._shard = eval(os.getenv("shard"))
         self._backend = os.getenv("backend")
-        self._in_mesh = dist.ProcessMesh([0, 1], dim_names=["x"])
-        self._out_mesh = dist.ProcessMesh([2, 3], dim_names=["x"])
+        self._in_mesh = dist.ProcessMesh([0, 2], dim_names=["x"])
+        self._out_mesh = dist.ProcessMesh([1, 3], dim_names=["x"])
 
     def run_test_case(self):
         paddle.enable_static()
@@ -59,7 +59,7 @@ class TestReshardRToSCrossMesh:
         # np.testing.assert_equal(dist_program.num_ops(), 6)
         new_ops = [op.name() for op in main_program.global_block().ops]
         assert 'dist_op.reshard' not in new_ops
-        if dist.get_rank() in [0, 1]:
+        if dist.get_rank() in self._in_mesh.process_ids:
             assert 'pd_op.send_v2' in new_ops
         else:
             assert 'pd_op.recv_v2' in new_ops

--- a/test/auto_parallel/reshard_p_to_r.py
+++ b/test/auto_parallel/reshard_p_to_r.py
@@ -88,9 +88,9 @@ class TestReshardPToR:
                 reshard_tensor = paddle._C_ops.reshard(
                     input_tensor, self._mesh, [dist.Replicate()]
                 )
-            dist_program = apply_reshard_pass(main_program)
-        np.testing.assert_equal(dist_program.num_ops(), 4)
-        ops = dist_program.global_block().ops
+            apply_reshard_pass(main_program)
+        np.testing.assert_equal(main_program.num_ops(), 4)
+        ops = main_program.global_block().ops
         np.testing.assert_equal(
             [op.name() for op in ops],
             [

--- a/test/auto_parallel/reshard_p_to_r_cross_mesh.py
+++ b/test/auto_parallel/reshard_p_to_r_cross_mesh.py
@@ -85,11 +85,12 @@ class TestReshardPToRCrossMesh:
                 reshard_tensor = paddle._pir_ops.reshard(
                     input_tensor, self._out_mesh, [dist.Replicate()]
                 )
-            dist_program = apply_reshard_pass(main_program)
 
-        ops = [op.name() for op in dist_program.global_block().ops]
+            apply_reshard_pass(main_program)
+
+        ops = [op.name() for op in main_program.global_block().ops]
         if paddle.distributed.get_rank() == 0:
-            np.testing.assert_equal(dist_program.num_ops(), 4)
+            np.testing.assert_equal(main_program.num_ops(), 4)
             std_ops = [
                 'builtin.parameter',
                 'pd_op.data',
@@ -97,7 +98,7 @@ class TestReshardPToRCrossMesh:
                 'pd_op.send_v2',
             ]
         else:
-            np.testing.assert_equal(dist_program.num_ops(), 5)
+            np.testing.assert_equal(main_program.num_ops(), 5)
             std_ops = [
                 'builtin.parameter',
                 'pd_op.data',
@@ -109,7 +110,7 @@ class TestReshardPToRCrossMesh:
             ops,
             std_ops,
         )
-        for op in dist_program.global_block().ops:
+        for op in main_program.global_block().ops:
             if op.name() == 'pd_op.send_v2':
                 assert op.dist_attr.num_operands() == 1
                 assert op.dist_attr.num_results() == 0

--- a/test/auto_parallel/reshard_r_to_s.py
+++ b/test/auto_parallel/reshard_r_to_s.py
@@ -93,7 +93,8 @@ class TestReshardRToS:
                 paddle._C_ops.reshard(
                     input_tensor, self._mesh, [dist.Shard(self._shard)]
                 )
-            dist_program = apply_reshard_pass(main_program)
+            dist_program = main_program.clone()
+            apply_reshard_pass(dist_program)
             np.testing.assert_equal(dist_program.num_ops(), 6)
             old_ops = [op.name() for op in main_program.global_block().ops]
             new_ops = [op.name() for op in dist_program.global_block().ops]

--- a/test/auto_parallel/test_reshard_r_to_s.py
+++ b/test/auto_parallel/test_reshard_r_to_s.py
@@ -52,5 +52,30 @@ class TestReshardRToS(test_base.CommunicationTestDistBase):
                 )
 
 
+class TestReshardRToSCrossMesh(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(num_of_devices=4, timeout=120)
+        self._default_envs = {
+            "dtype": "float32",
+            "seeds": "2023",
+        }
+        self._changeable_envs = {
+            "shape": ["(10, 20)", "(5, 7)"],
+            "shard": ["0", "1"],
+            "backend": ["cpu", "gpu"],
+        }
+
+    def test_reshard_r_to_s_cross_mesh(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        # self._log_dir.name = "./log"
+        for envs in envs_list:
+            self.run_test_case(
+                "pir_reshard_r_to_s_cross_mesh.py",
+                user_defined_envs=envs,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/auto_parallel/test_reshard_r_to_s.py
+++ b/test/auto_parallel/test_reshard_r_to_s.py
@@ -54,15 +54,15 @@ class TestReshardRToS(test_base.CommunicationTestDistBase):
 
 class TestReshardRToSCrossMesh(test_base.CommunicationTestDistBase):
     def setUp(self):
-        super().setUp(num_of_devices=4, timeout=120)
+        super().setUp(num_of_devices=2, timeout=120)
         self._default_envs = {
             "dtype": "float32",
             "seeds": "2023",
         }
         self._changeable_envs = {
-            "shape": ["(10, 20)", "(5, 7)"],
+            "shape": ["(10, 20)"],
             "shard": ["0", "1"],
-            "backend": ["cpu", "gpu"],
+            "backend": ["cpu"],
         }
 
     def test_reshard_r_to_s_cross_mesh(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Auto Parallel 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

New features 
### Description
<!-- Describe what you’ve done -->
- 增加跨mesh的 r_to_s reshard函数。
- 修改reshard函数的函数签名：dst_value = reshard(self, src_dist_attr, dst_dist_attr, src_value, dst_type): 
    - self为reshard对象自身
    - src_dist_attr， dst_dist_attr表示要示reshard行为的源分布式属性和目标分布式属性
    - src_value表示要被reshard的变量。
    该函数会在当前插入点插入相应的算子，根据src_value得到一个dst_value并返回。 对于一些仅插入sendOp的场景，返回值为None。

    - 该函数仅负责插入，不负责删除。删除任务交给调用方去处理。
- 修改apply_reshard_pass函数，改为原地修改输入的program。

### Other
Pcard-67164