### PR TITLE
Disable custom op log for LLM models

### DIFF
--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -968,7 +968,7 @@ void RegisterOperatorWithMetaInfo(const std::vector<OpMetaInfo>& op_meta_infos,
   auto op_name = OpMetaInfoHelper::GetOpName(base_op_meta);
 
   if (OpInfoMap::Instance().Has(op_name)) {
-    LOG(WARNING) << "Operator (" << op_name << ") has been registered.";
+    VLOG(1) << "Operator (" << op_name << ") has been registered.";
     return;
   }
 
@@ -1293,8 +1293,8 @@ void RegisterOperatorWithMetaInfoMap(
       continue;
     }
     for (const auto& meta_info : pair.second) {
-      LOG(INFO) << "register pir custom op :"
-                << OpMetaInfoHelper::GetOpName(meta_info);
+      VLOG(1) << "register pir custom op :"
+              << OpMetaInfoHelper::GetOpName(meta_info);
       custom_dialect->RegisterCustomOp(meta_info);
     }
 

--- a/paddle/pir/src/core/ir_context.cc
+++ b/paddle/pir/src/core/ir_context.cc
@@ -296,7 +296,7 @@ void IrContext::RegisterOpInfo(Dialect *dialect,
                                VerifyPtr verify_sig,
                                VerifyPtr verify_region) {
   if (impl().IsOpInfoRegistered(name)) {
-    LOG(WARNING) << name << " op already registered.";
+    VLOG(1) << name << " op already registered.";
   } else {
     OpInfo info = OpInfoImpl::Create(dialect,
                                      op_id,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Security

### Description
<!-- Describe what you’ve done -->
LLM inference models use custom op for acceleration. While Paddle log will expose custom op info when running inferenece job, disalbe these WARN or INFO level logs to DEBUG level to avoid disturbing.

pcard-77889
