### PR TITLE
[BugFix] fix fused_conv2d_add_act_kernel when its inputs are NHWC

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_conv2d_add_act_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_conv2d_add_act_kernel.cu
@@ -445,7 +445,15 @@ void FusedConv2dAddActKernel(const Context& ctx,
       b_dims[1] = static_cast<int>(bias.dims()[0]);
     }
   } else {
-    b_dims[input_rank - 1] = static_cast<int>(bias.dims()[0]);
+    auto bias_rank = bias.dims().size();
+    if (input_rank == bias_rank) {
+      b_dims[input_rank - 1] = static_cast<int>(bias.dims()[input_rank - 1]);
+    } else {
+      // Note(lyk): remains same before modification, but its correctness is suspucious.
+      // Since it works a long time for some scenarios, we keep this line temporarily. 
+      // But this kernel's implementation should be reviewed.
+      b_dims[input_rank - 1] = static_cast<int>(bias.dims()[0]);
+    }
   }
 
   auto search_func = [&](cudnnConvolutionFwdAlgo_t* cudnn_algo,

--- a/paddle/phi/kernels/fusion/gpu/fused_conv2d_add_act_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_conv2d_add_act_kernel.cu
@@ -449,9 +449,9 @@ void FusedConv2dAddActKernel(const Context& ctx,
     if (input_rank == bias_rank) {
       b_dims[input_rank - 1] = static_cast<int>(bias.dims()[input_rank - 1]);
     } else {
-      // Note(lyk): remains same before modification, but its correctness is suspucious.
-      // Since it works a long time for some scenarios, we keep this line temporarily. 
-      // But this kernel's implementation should be reviewed.
+      // TODO(lyk): remains same before modification, but its correctness is
+      // suspucious. Since it works a long time for some scenarios, we keep this
+      // line temporarily. But this branch still should be reviewed.
       b_dims[input_rank - 1] = static_cast<int>(bias.dims()[0]);
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Fix wrong dimesion setting of bias when layout is NHWC, but only if `bias.rank = input.rank`. For other cases, we remain the existing code cause it worked a long time and we will check its correctness later.

#### Others
Pcard-67164