### PR TITLE
[CINN]Fix AnalysisExternalInputs invalid pointer problem

### DIFF
--- a/paddle/fluid/pir/transforms/sub_graph_detector.cc
+++ b/paddle/fluid/pir/transforms/sub_graph_detector.cc
@@ -576,7 +576,7 @@ std::unordered_set<pir::Operation*> GetUpstreamOpsAfterPosition(
   const auto& IsInBlock = [](const pir::Operation* src_op,
                              const pir::Block* block) {
     for (auto& item : *block) {
-      if (src_op == &item) return true;
+      if (src_op->id() == item.id()) return true;
     }
     return false;
   };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

从日志上来看，如下行出来的group_ops里的指针是悬空的:
```cpp
auto group_ops = std::unordered_set<pir::Operation*>(
      group_op.GetOperators().begin(), group_op.GetOperators().end());
```
group_op.GetOperators()返回的是一个临时对象，而非引用。两次调用，返回了两个临时对象，基于迭代器构造unordered_set不是同一个对象的begin和end。