### PR TITLE
[Dy2St] Clean some deprecated API usage in dy2st uts

### DIFF
--- a/python/paddle/text/datasets/wmt16.py
+++ b/python/paddle/text/datasets/wmt16.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-"""
+
 
 import os
 import tarfile

--- a/test/dygraph_to_static/bert_dygraph_model.py
+++ b/test/dygraph_to_static/bert_dygraph_model.py
@@ -405,18 +405,20 @@ class PretrainModelLayer(Layer):
         else:
             fc_out = self.out_fc(mask_trans_feat)
 
-        mask_lm_loss = paddle.nn.functional.softmax_with_cross_entropy(
-            logits=fc_out, label=mask_label
+        mask_lm_loss = paddle.nn.functional.cross_entropy(
+            input=fc_out,
+            label=mask_label,
+            reduction="none",
         )
         mean_mask_lm_loss = paddle.mean(mask_lm_loss)
 
         next_sent_fc_out = self.next_sent_fc(next_sent_feat)
 
-        (
-            next_sent_loss,
-            next_sent_softmax,
-        ) = paddle.nn.functional.softmax_with_cross_entropy(
-            logits=next_sent_fc_out, label=labels, return_softmax=True
+        next_sent_softmax = paddle.nn.functional.softmax(next_sent_fc_out)
+        next_sent_loss = paddle.nn.functional.cross_entropy(
+            input=next_sent_fc_out,
+            label=labels,
+            reduction="none",
         )
 
         next_sent_acc = paddle.static.accuracy(

--- a/test/dygraph_to_static/test_ptb_lm.py
+++ b/test/dygraph_to_static/test_ptb_lm.py
@@ -213,8 +213,8 @@ class PtbModel(paddle.nn.Layer):
         projection = paddle.matmul(rnn_out, self.softmax_weight)
         projection = paddle.add(projection, self.softmax_bias)
 
-        loss = paddle.nn.functional.softmax_with_cross_entropy(
-            logits=projection, label=label, soft_label=False
+        loss = paddle.nn.functional.cross_entropy(
+            input=projection, label=label, soft_label=False, reduction="none"
         )
         loss = paddle.reshape(loss, shape=[-1, self.num_steps])
         loss = paddle.mean(loss, axis=[0])

--- a/test/dygraph_to_static/test_transformer.py
+++ b/test/dygraph_to_static/test_transformer.py
@@ -140,7 +140,7 @@ def train_dygraph(args, batch_generator):
                             batch_id,
                             total_avg_cost,
                             total_avg_cost - loss_normalizer,
-                            np.exp([min(total_avg_cost, 100)]),
+                            np.exp([min(total_avg_cost, 100)]).item(),
                         )
                     )
                     avg_batch_time = time.time()
@@ -154,7 +154,7 @@ def train_dygraph(args, batch_generator):
                             batch_id,
                             total_avg_cost,
                             total_avg_cost - loss_normalizer,
-                            np.exp([min(total_avg_cost, 100)]),
+                            np.exp([min(total_avg_cost, 100)]).item(),
                             args.print_step / (time.time() - avg_batch_time),
                         )
                     )

--- a/test/dygraph_to_static/transformer_dygraph_model.py
+++ b/test/dygraph_to_static/transformer_dygraph_model.py
@@ -590,10 +590,11 @@ class CrossEntropyCriterion:
                 epsilon=self.label_smooth_eps,
             )
 
-        cost = paddle.nn.functional.softmax_with_cross_entropy(
-            logits=predict,
+        cost = paddle.nn.functional.cross_entropy(
+            input=predict,
             label=label_out,
             soft_label=True if self.label_smooth_eps else False,
+            reduction="none",
         )
         weighted_cost = cost * weights
         sum_cost = paddle.sum(weighted_cost)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

清理动转静单测目录下部分 deprecated API 的使用，避免大量 warning 干扰日志分析

PCard-66972