### PR TITLE
split test.cmake: add new test_cases.cmake

### DIFF
--- a/test/cpp/inference/CMakeLists.txt
+++ b/test/cpp/inference/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_definitions(-DPADDLE_DLL_EXPORT)
 if(WITH_TESTING)
   include(test.cmake) # some generic cmake function for inference
+  include(test_cases.cmake)
 endif()
 
 add_subdirectory(analysis)

--- a/test/cpp/inference/test.cmake
+++ b/test/cpp/inference/test.cmake
@@ -73,35 +73,6 @@ function(inference_download_and_uncompress_without_verify INSTALL_DIR URL
     INSTALL_COMMAND "")
 endfunction()
 
-set(WORD2VEC_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/word2vec")
-if(NOT EXISTS ${WORD2VEC_INSTALL_DIR}/word2vec.inference.model.tar.gz)
-  inference_download_and_uncompress_without_verify(
-    ${WORD2VEC_INSTALL_DIR} ${INFERENCE_URL} "word2vec.inference.model.tar.gz")
-endif()
-set(WORD2VEC_MODEL_DIR "${WORD2VEC_INSTALL_DIR}/word2vec.inference.model")
-
-set(IMG_CLS_RESNET_INSTALL_DIR
-    "${INFERENCE_DEMO_INSTALL_DIR}/image_classification_resnet")
-if(NOT EXISTS
-   ${IMG_CLS_RESNET_INSTALL_DIR}/image_classification_resnet.inference.model.tgz
-)
-  inference_download_and_uncompress_without_verify(
-    ${IMG_CLS_RESNET_INSTALL_DIR} ${INFERENCE_URL}
-    "image_classification_resnet.inference.model.tgz")
-endif()
-set(IMG_CLS_RESNET_MODEL_DIR
-    "${IMG_CLS_RESNET_INSTALL_DIR}/image_classification_resnet.inference.model")
-
-if(WITH_ONNXRUNTIME)
-  set(MOBILENETV2_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/MobileNetV2")
-  if(NOT EXISTS ${MOBILENETV2_INSTALL_DIR}/MobileNetV2.inference.model.tar.gz)
-    inference_download_and_uncompress_without_verify(
-      ${MOBILENETV2_INSTALL_DIR} ${INFERENCE_URL}
-      "MobileNetV2.inference.model.tar.gz")
-  endif()
-  set(MOBILENETV2_MODEL_DIR "${MOBILENETV2_INSTALL_DIR}/MobileNetV2")
-endif()
-
 function(inference_base_test_build TARGET)
   set(options "")
   set(oneValueArgs "")

--- a/test/cpp/inference/test_cases.cmake
+++ b/test/cpp/inference/test_cases.cmake
@@ -1,0 +1,34 @@
+include(test.cmake) # some generic cmake function for inference
+
+set(WORD2VEC_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/word2vec")
+
+if(NOT EXISTS ${WORD2VEC_INSTALL_DIR}/word2vec.inference.model.tar.gz)
+  inference_download_and_uncompress_without_verify(
+    ${WORD2VEC_INSTALL_DIR} ${INFERENCE_URL} "word2vec.inference.model.tar.gz")
+endif()
+
+set(WORD2VEC_MODEL_DIR "${WORD2VEC_INSTALL_DIR}/word2vec.inference.model")
+
+set(IMG_CLS_RESNET_INSTALL_DIR
+    "${INFERENCE_DEMO_INSTALL_DIR}/image_classification_resnet")
+
+if(NOT EXISTS
+   ${IMG_CLS_RESNET_INSTALL_DIR}/image_classification_resnet.inference.model.tgz
+)
+  inference_download_and_uncompress_without_verify(
+    ${IMG_CLS_RESNET_INSTALL_DIR} ${INFERENCE_URL}
+    "image_classification_resnet.inference.model.tgz")
+endif()
+
+set(IMG_CLS_RESNET_MODEL_DIR
+    "${IMG_CLS_RESNET_INSTALL_DIR}/image_classification_resnet.inference.model")
+
+if(WITH_ONNXRUNTIME)
+  set(MOBILENETV2_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/MobileNetV2")
+  if(NOT EXISTS ${MOBILENETV2_INSTALL_DIR}/MobileNetV2.inference.model.tar.gz)
+    inference_download_and_uncompress_without_verify(
+      ${MOBILENETV2_INSTALL_DIR} ${INFERENCE_URL}
+      "MobileNetV2.inference.model.tar.gz")
+  endif()
+  set(MOBILENETV2_MODEL_DIR "${MOBILENETV2_INSTALL_DIR}/MobileNetV2")
+endif()

--- a/test/quantization/CMakeLists.txt
+++ b/test/quantization/CMakeLists.txt
@@ -1,6 +1,4 @@
-if(ON_INFER)
-  include(../cpp/inference/test.cmake)
-endif()
+include(../cpp/inference/test.cmake)
 file(
   GLOB TEST_OPS
   RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
之前在 https://github.com/PaddlePaddle/Paddle/pull/63887 里面先粗糙绕过了一下某个函数找不到定义的问题。本PR对`test/cpp/inference/test.cmake`进行了拆分，里面只保留纯`function`的部分，这样在外面就可以正常引用。多出来的那些需要进行的“操作”，放到了一个新文件`test/cpp/inference/test_cases.cmake`里面。
