### PR TITLE
[PIR] Fix `attributes_num` of `SliceArrayOp`

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -394,7 +394,7 @@ class SliceArrayOp
   using Op::Op;
   static const char *name() { return "pd_op.slice_array"; }
   static constexpr const char **attributes_name = nullptr;
-  static constexpr uint32_t attributes_num = 2;
+  static constexpr uint32_t attributes_num = 0;
   static OpInfoTuple GetOpInfo();
 
   void VerifySig();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#60963 将 `SliceArrayOp` attributes 变为输入的时候忘记将 `attributes_num` 一并改为 0 了 :joy:，导致 #63960 暴露了本问题

PCard-66972