### PR TITLE
[Cleanup] Remove Flake8 config in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,9 +21,6 @@ indent_size = 4
 [Dockerfile.*]
 indent_size = 4
 
-[.flake8]
-indent_size = 4
-
 [*.go]
 indent_style = tab
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ insert_final_newline = true
 [*.{c,cc,cxx,cpp,cu,cuh,h,hpp,hxx,kps}]
 indent_size = 2
 
-[*.{py,java,r}]
+[*.{py,pyi,java,r,toml}]
 indent_size = 4
 
 [Dockerfile.*]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

#62782 清理 flake8 时候忘记这里了，这个已经没用了，因此清理掉

另外规范下 `pyi` 和 `toml` 也使用 4 缩进

PCard-66972