### PR TITLE
Opt rope

### DIFF
--- a/paddle/cinn/backends/codegen_c_test.cc
+++ b/paddle/cinn/backends/codegen_c_test.cc
@@ -200,7 +200,10 @@ void matmul(void* _args, int32_t num_args)
     for (int32_t j = 0; j < 50; j += 1) {
       C__reduce_init[((50 * i) + j)] = 0.00000000f;
       for (int32_t k0 = 0; k0 < 20; k0 += 1) {
-        C[((50 * i) + j)] = (C[((50 * i) + j)] + (A[((20 * i) + k0)] * B[((50 * k0) + j)]));
+        float local_var = C[((50 * i) + j)];
+        float local_var_0 = A[((20 * i) + k0)];
+        float local_var_1 = B[((50 * k0) + j)];
+        C[((50 * i) + j)] = (local_var + (local_var_0 * local_var_1));
       };
     };
   };
@@ -320,7 +323,10 @@ void matmul(void* _args, int32_t num_args)
           C_init[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = 0.00000000f;
           for (int32_t k0_outer = 0; k0_outer < 50; k0_outer += 1) {
             for (int32_t k0_inner = 0; k0_inner < 4; k0_inner += 1) {
-              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = fma(A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))], B[((32 * j_outer) + ((500 * k0_inner) + ((2000 * k0_outer) + j_inner)))], C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))]);
+              float local_var_2 = C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))];
+              float local_var_3 = A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))];
+              float local_var_4 = B[((32 * j_outer) + ((500 * k0_inner) + ((2000 * k0_outer) + j_inner)))];
+              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = fma(local_var_3, local_var_4, local_var_2);
             };
           };
         };
@@ -416,7 +422,10 @@ void matmul_with_packing(void* _args, int32_t num_args)
           C__reduce_init[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = 0;
           for (int32_t k0_outer = 0; k0_outer < 50; k0_outer += 1) {
             for (int32_t k0_inner = 0; k0_inner < 4; k0_inner += 1) {
-              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = fma(A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))], PackedB[((6400 * (j_inner / 32)) + ((j_inner & 31) + ((6400 * j_outer) + ((32 * k0_inner) + (128 * k0_outer)))))], C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))]);
+              float local_var_6 = C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))];
+              float local_var_7 = A[((200 * i_inner) + ((6400 * i_outer) + ((4 * k0_outer) + k0_inner)))];
+              float local_var_8 = PackedB[((6400 * j_outer) + ((32 * k0_inner) + ((128 * k0_outer) + j_inner)))];
+              C[((500 * i_inner) + ((16000 * i_outer) + ((32 * j_outer) + j_inner)))] = fma(local_var_7, local_var_8, local_var_6);
             };
           };
         };

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -401,14 +401,6 @@ Expr Store::index() const {
 }
 
 void Store::replace(Expr old_op, Expr new_op) {
-  VLOG(-1) << "========== enter Store replace==============";
-  VLOG(-1) << "========== old_op: " << old_op << "=========";
-  VLOG(-1) << "========== new_op: " << new_op << "=========";
-  VLOG(-1) << "========== value: " << value << "==========";
-  VLOG(-1) << "========== tensor: " << tensor << "========";
-  for (int i = 0; i < indices.size(); i++) {
-    VLOG(-1) << "========== indices: " << indices[i] << "========";
-  }
   if (value == old_op) {
     value = new_op;
   }
@@ -531,8 +523,6 @@ Expr Call::Make(Type type,
 }
 
 void Call::replace(Expr old_op, Expr new_op) {
-  VLOG(-1) << "Replace Call's old op [" << old_op << "] with new_op [" << new_op
-           << "] ";
   for (int i = 0; i < read_args.size(); i++) {
     if (read_args[i] == old_op) {
       read_args[i] = new_op;
@@ -543,12 +533,6 @@ void Call::replace(Expr old_op, Expr new_op) {
       read_args[i] = new_op;
     }
   }
-  // for (auto &expr : node->read_args) {
-  //   IRVisitorRequireReImpl<void, T>::Visit(&expr, &expr);
-  // }
-  // for (auto &expr : node->write_args) {
-  //   IRVisitorRequireReImpl<void, T>::Visit(&expr, &expr);
-  // }
 }
 
 std::vector<Expr *> Call::expr_fields() {

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -400,6 +400,40 @@ Expr Store::index() const {
   return res;
 }
 
+void Store::replace(Expr old_op, Expr new_op) {
+  VLOG(-1) << "========== enter Store replace==============";
+  VLOG(-1) << "========== old_op: " << old_op << "=========";
+  VLOG(-1) << "========== new_op: " << new_op << "=========";
+  VLOG(-1) << "========== value: " << value << "==========";
+  VLOG(-1) << "========== tensor: " << tensor << "========";
+  for (int i = 0; i < indices.size(); i++) {
+    VLOG(-1) << "========== indices: " << indices[i] << "========";
+  }
+  if (value == old_op) {
+    value = new_op;
+  }
+  if (tensor == old_op) {
+    tensor = new_op;
+  }
+  for (int i = 0; i < indices.size(); i++) {
+    if (indices[i] == old_op) {
+      indices[i] = new_op;
+    }
+  }
+}
+
+void Select::replace(Expr old_op, Expr new_op) {
+  if (condition == old_op) {
+    condition = new_op;
+  }
+  if (true_value == old_op) {
+    true_value = new_op;
+  }
+  if (false_value == old_op) {
+    false_value = new_op;
+  }
+}
+
 const std::string &Store::name() const {
   auto *t = tensor.As<ir::_Tensor_>();
   CHECK(t);
@@ -495,6 +529,28 @@ Expr Call::Make(Type type,
   node->attrs = attrs;
   return Expr(node);
 }
+
+void Call::replace(Expr old_op, Expr new_op) {
+  VLOG(-1) << "Replace Call's old op [" << old_op << "] with new_op [" << new_op
+           << "] ";
+  for (int i = 0; i < read_args.size(); i++) {
+    if (read_args[i] == old_op) {
+      read_args[i] = new_op;
+    }
+  }
+  for (int i = 0; i < write_args.size(); i++) {
+    if (read_args[i] == old_op) {
+      read_args[i] = new_op;
+    }
+  }
+  // for (auto &expr : node->read_args) {
+  //   IRVisitorRequireReImpl<void, T>::Visit(&expr, &expr);
+  // }
+  // for (auto &expr : node->write_args) {
+  //   IRVisitorRequireReImpl<void, T>::Visit(&expr, &expr);
+  // }
+}
+
 std::vector<Expr *> Call::expr_fields() {
   std::vector<Expr *> res;
   for (auto &x : read_args) res.push_back(&x);

--- a/paddle/cinn/ir/ir.cc
+++ b/paddle/cinn/ir/ir.cc
@@ -426,6 +426,12 @@ void Select::replace(Expr old_op, Expr new_op) {
   }
 }
 
+void Cast::replace(Expr old_op, Expr new_op) {
+  if (v() == old_op) {
+    v() = new_op;
+  }
+}
+
 const std::string &Store::name() const {
   auto *t = tensor.As<ir::_Tensor_>();
   CHECK(t);

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -86,8 +86,6 @@ struct Add : public BinaryOpNode<Add> {
 
   void Verify() const override;
 
-  // void replace(Expr old_op, Expr new_op);
-
   static const IrNodeTy _node_type_ = IrNodeTy::Add;
 };
 
@@ -100,8 +98,6 @@ struct Sub : public BinaryOpNode<Sub> {
   static Expr Make(Expr a, Expr b);
 
   void Verify() const override;
-
-  // void replace(Expr old_op, Expr new_op);
 
   static const IrNodeTy _node_type_ = IrNodeTy::Sub;
 };
@@ -116,8 +112,6 @@ struct Mul : public BinaryOpNode<Mul> {
 
   void Verify() const override;
 
-  // void replace(Expr old_op, Expr new_op);
-
   static const IrNodeTy _node_type_ = IrNodeTy::Mul;
 };
 
@@ -129,8 +123,6 @@ struct Div : public BinaryOpNode<Div> {
 
   static Expr Make(Expr a, Expr b);
   void Verify() const override;
-
-  // void replace(Expr old_op, Expr new_op);
 
   static const IrNodeTy _node_type_ = IrNodeTy::Div;
 };

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -86,6 +86,8 @@ struct Add : public BinaryOpNode<Add> {
 
   void Verify() const override;
 
+  // void replace(Expr old_op, Expr new_op);
+
   static const IrNodeTy _node_type_ = IrNodeTy::Add;
 };
 
@@ -98,6 +100,8 @@ struct Sub : public BinaryOpNode<Sub> {
   static Expr Make(Expr a, Expr b);
 
   void Verify() const override;
+
+  // void replace(Expr old_op, Expr new_op);
 
   static const IrNodeTy _node_type_ = IrNodeTy::Sub;
 };
@@ -112,6 +116,8 @@ struct Mul : public BinaryOpNode<Mul> {
 
   void Verify() const override;
 
+  // void replace(Expr old_op, Expr new_op);
+
   static const IrNodeTy _node_type_ = IrNodeTy::Mul;
 };
 
@@ -123,6 +129,9 @@ struct Div : public BinaryOpNode<Div> {
 
   static Expr Make(Expr a, Expr b);
   void Verify() const override;
+
+  // void replace(Expr old_op, Expr new_op);
+
   static const IrNodeTy _node_type_ = IrNodeTy::Div;
 };
 
@@ -357,6 +366,8 @@ struct Call : public ExprNode<Call> {
 
   void Verify() const override;
 
+  void replace(Expr old_op, Expr new_op);
+
   inline size_t total_args_count() const {
     return read_args.size() + write_args.size();
   }
@@ -521,6 +532,7 @@ struct Select : public ExprNode<Select> {
     return {&condition, &true_value, &false_value};
   }
 
+  void replace(Expr old_op, Expr new_op);
   static const IrNodeTy _node_type_ = IrNodeTy::Select;
 };
 
@@ -569,6 +581,8 @@ struct Store : public ExprNode<Store>, public LoadStoreAddrMnger {
   void Verify() const override;
 
   const std::string& name() const;
+
+  void replace(Expr old_op, Expr new_op);
 
   Type type() const override;
 

--- a/paddle/cinn/ir/ir.h
+++ b/paddle/cinn/ir/ir.h
@@ -66,6 +66,8 @@ struct Cast : public ExprNode<Cast> {
   Expr& v() { return operand(0); }
   const Expr& v() const { return operand(0); }
 
+  void replace(Expr old_op, Expr new_op);
+
   void Verify() const override;
 
   static const IrNodeTy _node_type_ = IrNodeTy::Cast;

--- a/paddle/cinn/ir/ir_base.cc
+++ b/paddle/cinn/ir/ir_base.cc
@@ -238,6 +238,10 @@ const Expr &IrNode::operand(int i) {
 
 void IrNode::set_type(Type type) { type_ = type; }
 
+void IrNode::replace(Expr old_op, Expr new_op) {
+  PADDLE_THROW(phi::errors::Unimplemented("Not Implemented"));
+}
+
 void IrNode::convert_int32_to_int64() {
   CHECK(type_ == Int(64) || type_ == Int(32) || type_.is_unk())
       << "Current only support convert int32_t to int64_t, but get type is "

--- a/paddle/cinn/ir/ir_base.h
+++ b/paddle/cinn/ir/ir_base.h
@@ -166,6 +166,7 @@ class IrNode : public cinn::common::Object {
   //! Elevate int32 to int64 if needed
   void convert_int32_to_int64();
 
+  virtual void replace(Expr old_op, Expr new_op);
   //! Get i-th operand
   const Expr& operand(int i);
 
@@ -430,6 +431,13 @@ struct BinaryOpNode : public ExprNode<T> {
 
   Type type() const override { return a().type(); }
 
+  void replace(Expr old_op, Expr new_op) {
+    for (int i = 0; i < operands().size(); i++) {
+      if (operands()[i] == old_op) {
+        operands()[i] = new_op;
+      }
+    }
+  }
   std::vector<Expr*> expr_fields() override { return {&a(), &b()}; }
   std::vector<const Expr*> expr_fields() const override { return {&a(), &b()}; }
 

--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -152,18 +152,15 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   Expr substitute_value(0);
   for (int i = 0; i < process_factors.size(); ++i) {
     Var temp_var(common::UniqName(for_node->loop_var->name));
-    // substitute_value = Expr(temp_var) +
     substitute_value = Expr(temp_var) + substitute_value * process_factors[i];
 
     new_loop_vars.push_back(temp_var);
   }
   substitute_value = cinn::common::AutoSimplify(substitute_value);
   Expr new_node = ir::ir_utils::IRCopy(for_node->body);
-  // VLOG(5) << "During Split, origin new_node is:\n" << new_node;
-  // VLOG(5) << "During Split, for_node->loop_var is:\n" << for_node->loop_var;
-  // VLOG(5) << "During Split, substitute_value is:\n" << substitute_value;
+
   ReplaceExpr(&new_node, {for_node->loop_var}, {substitute_value});
-  // VLOG(5) << "During Split, after new_node is:\n" << new_node;
+
   std::vector<Expr> splited_loops;
   splited_loops.resize(process_factors.size());
 

--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -153,7 +153,6 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   for (int i = 0; i < process_factors.size(); ++i) {
     Var temp_var(common::UniqName(for_node->loop_var->name));
     substitute_value = Expr(temp_var) + substitute_value * process_factors[i];
-
     new_loop_vars.push_back(temp_var);
   }
   substitute_value = cinn::common::AutoSimplify(substitute_value);

--- a/paddle/cinn/ir/schedule/impl/loop_transformation.cc
+++ b/paddle/cinn/ir/schedule/impl/loop_transformation.cc
@@ -152,12 +152,18 @@ std::vector<Expr> DyScheduleImpl::Split(const Expr& loop,
   Expr substitute_value(0);
   for (int i = 0; i < process_factors.size(); ++i) {
     Var temp_var(common::UniqName(for_node->loop_var->name));
+    // substitute_value = Expr(temp_var) +
     substitute_value = Expr(temp_var) + substitute_value * process_factors[i];
+
     new_loop_vars.push_back(temp_var);
   }
   substitute_value = cinn::common::AutoSimplify(substitute_value);
   Expr new_node = ir::ir_utils::IRCopy(for_node->body);
+  // VLOG(5) << "During Split, origin new_node is:\n" << new_node;
+  // VLOG(5) << "During Split, for_node->loop_var is:\n" << for_node->loop_var;
+  // VLOG(5) << "During Split, substitute_value is:\n" << substitute_value;
   ReplaceExpr(&new_node, {for_node->loop_var}, {substitute_value});
+  // VLOG(5) << "During Split, after new_node is:\n" << new_node;
   std::vector<Expr> splited_loops;
   splited_loops.resize(process_factors.size());
 

--- a/paddle/cinn/optim/CMakeLists.txt
+++ b/paddle/cinn/optim/CMakeLists.txt
@@ -32,7 +32,8 @@ gather_srcs(
   schedule_block_dce.cc
   eliminate_common_factor_of_local_index.cc
   if_fusion.cc
-  eliminate_common_global_memory_read.cc)
+  eliminate_common_global_memory_read.cc
+  rearrange_load_instruction.cc)
 
 if(WITH_CUDA)
   gather_srcs(cinnapi_src SRCS transform_gpu_forloop.cc)

--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -23,11 +23,13 @@
 #include "paddle/cinn/optim/extern_call_process.h"
 #include "paddle/cinn/optim/fold_cinn_call_arguments.h"
 #include "paddle/cinn/optim/if_fusion.h"
+// #include "paddle/cinn/optim/global_prefetch.h"
 #include "paddle/cinn/optim/insert_debug_log_callee.h"
 #include "paddle/cinn/optim/ir_simplify.h"
 #include "paddle/cinn/optim/lower_function_call_bind_vars.h"
 #include "paddle/cinn/optim/lower_intrin.h"
 #include "paddle/cinn/optim/map_extern_call.h"
+#include "paddle/cinn/optim/rearrange_load_instruction.h"
 #include "paddle/cinn/optim/remove_schedule_block.h"
 #include "paddle/cinn/optim/replace_const_param_to_integer.h"
 #include "paddle/cinn/optim/replace_cross_thread_reduction.h"
@@ -82,6 +84,10 @@ Expr Optimize(Expr e,
   VLOG(10) << "After Optimize Simplify:" << copied;
 
   IfFusion(&copied);
+  VLOG(10) << "After Optimize IfFusion" << copied;
+
+  VLOG(-1) << "After IfFusion and before Rearrange:" << copied;
+  RearrangeLoadInstruction(&copied);
   VLOG(10) << "After Optimize IfFusion" << copied;
 
   if (runtime_debug_info) {

--- a/paddle/cinn/optim/optimize.cc
+++ b/paddle/cinn/optim/optimize.cc
@@ -23,7 +23,6 @@
 #include "paddle/cinn/optim/extern_call_process.h"
 #include "paddle/cinn/optim/fold_cinn_call_arguments.h"
 #include "paddle/cinn/optim/if_fusion.h"
-// #include "paddle/cinn/optim/global_prefetch.h"
 #include "paddle/cinn/optim/insert_debug_log_callee.h"
 #include "paddle/cinn/optim/ir_simplify.h"
 #include "paddle/cinn/optim/lower_function_call_bind_vars.h"
@@ -86,9 +85,8 @@ Expr Optimize(Expr e,
   IfFusion(&copied);
   VLOG(10) << "After Optimize IfFusion" << copied;
 
-  VLOG(-1) << "After IfFusion and before Rearrange:" << copied;
   RearrangeLoadInstruction(&copied);
-  VLOG(10) << "After Optimize IfFusion" << copied;
+  VLOG(10) << "After Optimize Rearrangement" << copied;
 
   if (runtime_debug_info) {
     LOG(WARNING) << "Turn on runtime debug information output";

--- a/paddle/cinn/optim/rearrange_load_instruction.cc
+++ b/paddle/cinn/optim/rearrange_load_instruction.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/optim/rearrange_load_instruction.h"
+
+#include <stack>
+#include "paddle/cinn/ir/ir_mutator.h"
+#include "paddle/cinn/ir/ir_printer.h"
+#include "paddle/cinn/ir/utils/ir_compare.h"
+#include "paddle/cinn/optim/ir_simplify.h"
+
+#define VisitImpl(_TYPE)                                 \
+  void Visit(const ir::_TYPE *op, Expr *expr) override { \
+    auto old_last_op = last_op;                          \
+    last_op = Expr(const_cast<ir::_TYPE *>(op));         \
+    ir::IRMutator<>::Visit(op, expr);                    \
+    last_op = old_last_op;                               \
+  }
+
+namespace cinn {
+namespace optim {
+
+namespace {
+
+struct RearrangeLoadInstructionMutator : public ir::IRMutator<Expr *> {
+  void operator()(Expr *expr) { Visit(expr, expr); }
+
+ private:
+  void Visit(const ir::Load *op, Expr *expr) override {
+    if (is_inner_store) {
+      auto local_var =
+          ir::_Var_::Make(common::UniqName("local_var"), op->type());
+      auto let_op = ir::Let::Make(local_var, const_cast<ir::Load *>(op));
+      let_list.push_back(let_op);
+      VLOG(-1) << "========== op->name: " << op->name();
+      collection_name_map_expr[op->name()] = local_var;
+      // replaceOp(last_op, op);
+      VLOG(-1) << "========== last_op: " << last_op;
+      last_op->replace(Expr(const_cast<ir::Load *>(op)), local_var);
+    }
+  }
+
+  void Visit(const ir::Store *op, Expr *expr) override {
+    auto old_last_op = last_op;
+    last_op = Expr(const_cast<ir::Store *>(op));
+    is_inner_store = true;
+    ir::IRMutator<>::Visit(op, expr);
+    is_inner_store = false;
+    last_op = old_last_op;
+  }
+
+  void Visit(const ir::Block *op, Expr *expr) override {
+    int old_let_size = let_list.size();
+    int old_stmts_size = stmts_list.size();
+
+    for (auto &stmt : op->stmts) {
+      IRVisitorRequireReImpl<void, Expr *>::Visit(
+          &stmt, const_cast<ir::Expr *>(&stmt));
+      stmts_list.push_back(stmt);
+    }
+
+    if (let_list.size() > old_let_size) {
+      replaceBlock(const_cast<ir::Block *>(op), old_let_size, old_stmts_size);
+    }
+  }
+
+  void replaceBlock(ir::Block *op, int old_let_size, int old_stmts_size) {
+    auto old_last_op = last_op;
+    last_op = Expr(const_cast<ir::Block *>(op));
+
+    std::vector<Expr> new_stmts;
+
+    for (int i = old_let_size; i < let_list.size(); i++) {
+      new_stmts.push_back(let_list[i]);
+    }
+
+    for (int i = old_stmts_size; i < stmts_list.size(); i++) {
+      new_stmts.push_back(stmts_list[i]);
+    }
+
+    while (let_list.size() > old_let_size) {
+      let_list.pop_back();
+    }
+
+    while (stmts_list.size() > old_stmts_size) {
+      stmts_list.pop_back();
+    }
+
+    op->stmts = new_stmts;
+
+    last_op = old_last_op;
+  }
+
+  std::unordered_map<std::string, ir::Expr> collection_name_map_expr;
+  std::vector<Expr> let_list;
+  std::vector<Expr> stmts_list;
+  bool is_inner_store = false;
+  Expr last_op = Expr(nullptr);
+
+  VisitImpl(Expr);
+  VisitImpl(ScheduleBlock);
+  VisitImpl(For);
+  VisitImpl(IntImm);
+  VisitImpl(UIntImm);
+  VisitImpl(FloatImm);
+  VisitImpl(StringImm);
+  VisitImpl(Cast);
+  VisitImpl(PolyFor);
+  VisitImpl(Select);
+  VisitImpl(Call);
+  VisitImpl(_Module_);
+  VisitImpl(_Var_);
+  VisitImpl(Alloc);
+  VisitImpl(Free);
+  VisitImpl(_Buffer_);
+  VisitImpl(_Tensor_);
+  VisitImpl(_LoweredFunc_);
+  VisitImpl(Let);
+  VisitImpl(Reduce);
+  VisitImpl(Ramp);
+  VisitImpl(Broadcast);
+  VisitImpl(FracOp);
+  VisitImpl(Product);
+  VisitImpl(Sum);
+  VisitImpl(PrimitiveNode);
+  VisitImpl(IntrinsicOp);
+  VisitImpl(_BufferRange_);
+  VisitImpl(_Dim_);
+
+  VisitImpl(Add);
+  VisitImpl(Sub);
+  VisitImpl(Mul);
+  VisitImpl(Div);
+  VisitImpl(Mod);
+  VisitImpl(EQ);
+  VisitImpl(NE);
+  VisitImpl(LT);
+  VisitImpl(LE);
+  VisitImpl(GT);
+  VisitImpl(GE);
+  VisitImpl(And);
+  VisitImpl(Or);
+  VisitImpl(Not);
+  VisitImpl(Min);
+  VisitImpl(Max);
+  VisitImpl(Minus)
+};
+}  // namespace
+
+void RearrangeLoadInstruction(Expr *expr) {
+  VLOG(4) << "Before RearrangeLoadInstruction: \n" << *expr;
+
+  RearrangeLoadInstructionMutator collector;
+  collector(expr);
+}
+
+}  // namespace optim
+}  // namespace cinn

--- a/paddle/cinn/optim/rearrange_load_instruction.cc
+++ b/paddle/cinn/optim/rearrange_load_instruction.cc
@@ -43,10 +43,7 @@ struct RearrangeLoadInstructionMutator : public ir::IRMutator<Expr *> {
           ir::_Var_::Make(common::UniqName("local_var"), op->type());
       auto let_op = ir::Let::Make(local_var, const_cast<ir::Load *>(op));
       let_list.push_back(let_op);
-      VLOG(-1) << "========== op->name: " << op->name();
       collection_name_map_expr[op->name()] = local_var;
-      // replaceOp(last_op, op);
-      VLOG(-1) << "========== last_op: " << last_op;
       last_op->replace(Expr(const_cast<ir::Load *>(op)), local_var);
     }
   }
@@ -154,13 +151,11 @@ struct RearrangeLoadInstructionMutator : public ir::IRMutator<Expr *> {
   VisitImpl(Not);
   VisitImpl(Min);
   VisitImpl(Max);
-  VisitImpl(Minus)
+  VisitImpl(Minus);
 };
 }  // namespace
 
 void RearrangeLoadInstruction(Expr *expr) {
-  VLOG(4) << "Before RearrangeLoadInstruction: \n" << *expr;
-
   RearrangeLoadInstructionMutator collector;
   collector(expr);
 }

--- a/paddle/cinn/optim/rearrange_load_instruction.cc
+++ b/paddle/cinn/optim/rearrange_load_instruction.cc
@@ -83,6 +83,8 @@ struct RearrangeLoadInstructionMutator : public ir::IRMutator<Expr *> {
     ir::IRMutator<>::Visit(op, expr);
   }
 
+  void Visit(const ir::Select *op, Expr *expr) override {}
+
   void replaceBlock(ir::Block *op, int old_let_size, int old_stmts_size) {
     std::vector<Expr> new_stmts;
 
@@ -120,7 +122,7 @@ struct RearrangeLoadInstructionMutator : public ir::IRMutator<Expr *> {
   // VisitImpl(StringImm);
   VisitImpl(Cast);
   VisitImpl(PolyFor);
-  VisitImpl(Select);
+  // VisitImpl(Select);
   VisitImpl(Call);
   VisitImpl(_Module_);
   VisitImpl(_Var_);

--- a/paddle/cinn/optim/rearrange_load_instruction.h
+++ b/paddle/cinn/optim/rearrange_load_instruction.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "paddle/cinn/ir/ir.h"
+
+namespace cinn {
+namespace optim {
+
+/*
+ * Do fusion with the adjaccnt if-block.
+ */
+void RearrangeLoadInstruction(Expr *expr);
+
+}  // namespace optim
+}  // namespace cinn


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
pcard-82035
Optimize the Rope subgraph with a dynamic shape and get the performance improvement from 221 us to 138 us, about 37% speedup. 

![f4f8e899ad76773d587a63acc651e3ab](https://github.com/PaddlePaddle/Paddle/assets/18052330/fd3c10f4-9c5e-41e1-b057-eba00cfaa35c)
