### PR TITLE
[Dy2St] Use `full_graph=True` outside dy2st uts (part1)

### DIFF
--- a/test/contrib/test_d2s_amp_controlflow.py
+++ b/test/contrib/test_d2s_amp_controlflow.py
@@ -63,7 +63,7 @@ class Net_Sub_Block_FP32(nn.Layer):
 class TestD2SAmpWithControlFlowOp(unittest.TestCase):
     def test_cond_op(self):
         model = Net_Cond()
-        model = paddle.jit.to_static(model)
+        model = paddle.jit.to_static(model, full_graph=True)
         model = paddle.amp.decorate(
             models=model, level='O2', save_dtype="float32"
         )
@@ -72,7 +72,7 @@ class TestD2SAmpWithControlFlowOp(unittest.TestCase):
 
     def test_while_op(self):
         model = Net_While()
-        model = paddle.jit.to_static(model)
+        model = paddle.jit.to_static(model, full_graph=True)
         model = paddle.amp.decorate(
             models=model, level='O2', save_dtype="float32"
         )
@@ -81,7 +81,7 @@ class TestD2SAmpWithControlFlowOp(unittest.TestCase):
 
     def test_sub_block_fp32_op(self):
         model = Net_Sub_Block_FP32()
-        model = paddle.jit.to_static(model)
+        model = paddle.jit.to_static(model, full_graph=True)
         model = paddle.amp.decorate(
             models=model, level='O2', save_dtype="float32"
         )

--- a/test/custom_op/test_custom_relu_model.py
+++ b/test/custom_op/test_custom_relu_model.py
@@ -140,7 +140,9 @@ class TestDygraphModel(unittest.TestCase):
 
         net = Net(self.in_dim, self.out_dim, use_custom_op)
         if dy2stat:
-            net = paddle.jit.to_static(net, input_spec=[self.x_spec])
+            net = paddle.jit.to_static(
+                net, input_spec=[self.x_spec], full_graph=True
+            )
         mse_loss = paddle.nn.MSELoss()
         sgd = paddle.optimizer.SGD(
             learning_rate=0.1, parameters=net.parameters()

--- a/test/custom_op/test_inference_inplace.py
+++ b/test/custom_op/test_inference_inplace.py
@@ -72,6 +72,7 @@ class TestPredictorRunWithTensor(unittest.TestCase):
                     shape=[None, 4], dtype='float32', name='x'
                 ),
             ],
+            full_graph=True,
         )
         paddle.jit.save(
             model,

--- a/test/deprecated/custom_runtime/test_custom_cpu_plugin.py
+++ b/test/deprecated/custom_runtime/test_custom_cpu_plugin.py
@@ -276,7 +276,9 @@ class TestCustomCPUPlugin(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         model = resnet50(True)
         net = to_static(
-            model, input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')]
+            model,
+            input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')],
+            full_graph=True,
         )
         paddle.jit.save(
             net, os.path.join(self.temp_dir.name, 'resnet50/inference')

--- a/test/deprecated/custom_runtime/test_custom_cpu_to_static.py
+++ b/test/deprecated/custom_runtime/test_custom_cpu_to_static.py
@@ -160,7 +160,9 @@ class TestCustomCPUPlugin(unittest.TestCase):
 
         # convert to static model
         build_strategy = paddle.static.BuildStrategy()
-        mnist = paddle.jit.to_static(model, build_strategy=build_strategy)
+        mnist = paddle.jit.to_static(
+            model, build_strategy=build_strategy, full_graph=True
+        )
 
         # data loader
         transform = paddle.vision.transforms.Compose(

--- a/test/deprecated/ir/pir/test_standalone_pir.py
+++ b/test/deprecated/ir/pir/test_standalone_pir.py
@@ -185,7 +185,7 @@ class TestPirBackwardDygraph(unittest.TestCase):
         build_strategy = paddle.static.BuildStrategy()
         build_strategy.enable_inplace = False
 
-        @paddle.jit.to_static(build_strategy=build_strategy)
+        @paddle.jit.to_static(build_strategy=build_strategy, full_graph=True)
         def func(x, y):
             return x * y
 
@@ -210,7 +210,7 @@ class TestPirReshapeBackwardDygraph(unittest.TestCase):
         build_strategy = paddle.static.BuildStrategy()
         build_strategy.enable_inplace = False
 
-        @paddle.jit.to_static(build_strategy=build_strategy)
+        @paddle.jit.to_static(build_strategy=build_strategy, full_graph=True)
         def func(x, y):
             x = x.reshape([-1, 2, 2])
             y = y.reshape([-1, 2, 2])

--- a/test/deprecated/legacy_test/test_apply.py
+++ b/test/deprecated/legacy_test/test_apply.py
@@ -87,11 +87,11 @@ class TestTensorApplyAPI(unittest.TestCase):
             return y
 
         with paddle.jit.api.sot_mode_guard(False):
-            jit_g = paddle.jit.to_static(fn)
+            jit_g = paddle.jit.to_static(fn, full_graph=True)
             out_legacy_ir = jit_g(self.x, self.function)
             with paddle.pir_utils.IrGuard():
                 paddle.disable_static()
-                jit_g = paddle.jit.to_static(fn)
+                jit_g = paddle.jit.to_static(fn, full_graph=True)
                 out_pir = jit_g(self.x, self.function)
         np.testing.assert_allclose(
             self.function(self.x).numpy(), out_legacy_ir.numpy(), rtol=1e-05

--- a/test/deprecated/legacy_test/test_instance_norm_op.py
+++ b/test/deprecated/legacy_test/test_instance_norm_op.py
@@ -196,7 +196,7 @@ class PrimGroupNorm(paddle.nn.Layer):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=False)
+    return paddle.jit.to_static(net, build_strategy=False, full_graph=True)
 
 
 places = [paddle.CPUPlace()]

--- a/test/deprecated/legacy_test/test_instance_norm_op_v2.py
+++ b/test/deprecated/legacy_test/test_instance_norm_op_v2.py
@@ -223,9 +223,9 @@ class TestInstanceNormFP32OP(OpTest):
             atol=self.atol,
             check_prim=self.check_prim,
             check_pir=True,
-            check_prim_pir=False
-            if os.getenv("FLAGS_enable_pir_in_executor")
-            else True,
+            check_prim_pir=(
+                False if os.getenv("FLAGS_enable_pir_in_executor") else True
+            ),
         )
 
     def test_check_grad(self):
@@ -234,9 +234,9 @@ class TestInstanceNormFP32OP(OpTest):
             'Y',
             check_prim=self.check_prim,
             check_pir=True,
-            check_prim_pir=False
-            if os.getenv("FLAGS_enable_pir_in_executor")
-            else True,
+            check_prim_pir=(
+                False if os.getenv("FLAGS_enable_pir_in_executor") else True
+            ),
         )
 
     def init_dtype(self):
@@ -284,9 +284,9 @@ class TestInstanceNormFP16OP(TestInstanceNormFP32OP):
             atol=self.atol,
             check_prim=self.check_prim,
             check_pir=True,
-            check_prim_pir=False
-            if os.getenv("FLAGS_enable_pir_in_executor")
-            else True,
+            check_prim_pir=(
+                False if os.getenv("FLAGS_enable_pir_in_executor") else True
+            ),
         )
 
     def test_check_grad(self):
@@ -298,9 +298,9 @@ class TestInstanceNormFP16OP(TestInstanceNormFP32OP):
             max_relative_error=self.max_relative_error,
             check_prim=self.check_prim,
             check_pir=True,
-            check_prim_pir=False
-            if os.getenv("FLAGS_enable_pir_in_executor")
-            else True,
+            check_prim_pir=(
+                False if os.getenv("FLAGS_enable_pir_in_executor") else True
+            ),
         )
 
 
@@ -364,9 +364,9 @@ class TestInstanceNormBF16OP(OpTest):
             place,
             check_prim=self.check_prim,
             check_pir=True,
-            check_prim_pir=False
-            if os.getenv("FLAGS_enable_pir_in_executor")
-            else True,
+            check_prim_pir=(
+                False if os.getenv("FLAGS_enable_pir_in_executor") else True
+            ),
         )
 
     def test_check_grad(self):
@@ -378,9 +378,9 @@ class TestInstanceNormBF16OP(OpTest):
             user_defined_grads=self.user_defined_grads,
             check_prim=self.check_prim,
             check_pir=True,
-            check_prim_pir=False
-            if os.getenv("FLAGS_enable_pir_in_executor")
-            else True,
+            check_prim_pir=(
+                False if os.getenv("FLAGS_enable_pir_in_executor") else True
+            ),
         )
 
 
@@ -402,7 +402,7 @@ class PrimNet(paddle.nn.Layer):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=False)
+    return paddle.jit.to_static(net, build_strategy=False, full_graph=True)
 
 
 class TestPrimForwardAndBackward(unittest.TestCase):

--- a/test/deprecated/legacy_test/test_jit_layer.py
+++ b/test/deprecated/legacy_test/test_jit_layer.py
@@ -37,7 +37,9 @@ class Net(paddle.nn.Layer):
         self.fc2 = paddle.nn.Linear(4, 4)
         self._bias = 0.4
 
-    @paddle.jit.to_static(input_spec=[InputSpec([None, 4], dtype='float32')])
+    @paddle.jit.to_static(
+        input_spec=[InputSpec([None, 4], dtype='float32')], full_graph=True
+    )
     def forward(self, x):
         out = self.fc1(x)
         out = self.fc2(out)
@@ -45,7 +47,9 @@ class Net(paddle.nn.Layer):
         out = paddle.mean(out)
         return out
 
-    @paddle.jit.to_static(input_spec=[InputSpec([None, 4], dtype='float32')])
+    @paddle.jit.to_static(
+        input_spec=[InputSpec([None, 4], dtype='float32')], full_graph=True
+    )
     def infer(self, input):
         out = self.fc2(input)
         out = out + self._bias
@@ -85,7 +89,8 @@ class SaveLinear(paddle.nn.Layer):
         self.linear = paddle.nn.Linear(80, 80)
 
     @paddle.jit.to_static(
-        input_spec=[InputSpec(shape=[None, 80], dtype='float32')]
+        input_spec=[InputSpec(shape=[None, 80], dtype='float32')],
+        full_graph=True,
     )
     def forward(self, x):
         out = self.linear(x)

--- a/test/deprecated/legacy_test/test_run_program_op.py
+++ b/test/deprecated/legacy_test/test_run_program_op.py
@@ -486,7 +486,7 @@ class TestParametersWithStopGradient(unittest.TestCase):
 
         net = Net()
         if to_static:
-            net = paddle.jit.to_static(net)
+            net = paddle.jit.to_static(net, full_graph=True)
         sgd = paddle.optimizer.SGD(0.01, parameters=net.parameters())
 
         for i in range(self.iter):

--- a/test/deprecated/legacy_test/test_save_inference_model_conditional_op.py
+++ b/test/deprecated/legacy_test/test_save_inference_model_conditional_op.py
@@ -86,6 +86,7 @@ class TestConditionalOp(unittest.TestCase):
             input_spec=[
                 paddle.static.InputSpec(shape=[1, 3, 8, 8], dtype='float32')
             ],
+            full_graph=True,
         )
         root_path = tempfile.TemporaryDirectory()
         model_file = os.path.join(root_path.name, "while_net")
@@ -111,7 +112,9 @@ class TestConditionalOp(unittest.TestCase):
         paddle.disable_static()
         net = ForNet()
         net = paddle.jit.to_static(
-            net, input_spec=[paddle.static.InputSpec(shape=[1], dtype='int32')]
+            net,
+            input_spec=[paddle.static.InputSpec(shape=[1], dtype='int32')],
+            full_graph=True,
         )
         root_path = tempfile.TemporaryDirectory()
         model_file = os.path.join(root_path.name, "for_net")
@@ -137,7 +140,9 @@ class TestConditionalOp(unittest.TestCase):
         paddle.disable_static()
         net = IfElseNet()
         net = paddle.jit.to_static(
-            net, input_spec=[paddle.static.InputSpec(shape=[1], dtype='int32')]
+            net,
+            input_spec=[paddle.static.InputSpec(shape=[1], dtype='int32')],
+            full_graph=True,
         )
         root_path = tempfile.TemporaryDirectory()
         model_file = os.path.join(root_path.name, "if_net")

--- a/test/deprecated/prim/composite_ops/test_composite_batch_norm.py
+++ b/test/deprecated/prim/composite_ops/test_composite_batch_norm.py
@@ -375,7 +375,7 @@ class TestCompositeBatchNorm(unittest.TestCase):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=False)
+    return paddle.jit.to_static(net, build_strategy=False, full_graph=True)
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/composite_ops/test_composite_layer_norm.py
+++ b/test/deprecated/prim/composite_ops/test_composite_layer_norm.py
@@ -272,7 +272,7 @@ class TestCompositelayer_norm(unittest.TestCase):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=False)
+    return paddle.jit.to_static(net, build_strategy=False, full_graph=True)
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/composite_ops/test_composite_softmax.py
+++ b/test/deprecated/prim/composite_ops/test_composite_softmax.py
@@ -129,7 +129,7 @@ class TestCompositeSoftmax(unittest.TestCase):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=False)
+    return paddle.jit.to_static(net, build_strategy=False, full_graph=True)
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_add_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_add_grad.py
@@ -24,7 +24,9 @@ from paddle.base import core
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_add_tanh_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_add_tanh_grad.py
@@ -24,7 +24,9 @@ from paddle.base import core
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #60437，在非动转静目录的单测（非 `dygraph_to_static`）在使用 `to_static` 时，SOT 模式测试由 `dygraph_to_static` 和 `sot` 来承担，非动转静目录原则上都应该显式指定 `full_graph` 是 `True` 还是 `False`，以免使用默认的 SOT 导致 fallback 到动态图

PCard-66972