### PR TITLE
[Dy2St] Use `full_graph=True` outside dy2st uts (part2)

### DIFF
--- a/test/ir/inference/test_trt_inference_fp16_io.py
+++ b/test/ir/inference/test_trt_inference_fp16_io.py
@@ -30,7 +30,9 @@ class TestEnableLowPrecisionIO:
         self.temp_dir = tempfile.TemporaryDirectory()
         net = alexnet(True)
         model = to_static(
-            net, input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')]
+            net,
+            input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')],
+            full_graph=True,
         )
         paddle.jit.save(
             model, os.path.join(self.temp_dir.name, 'alexnet/inference')

--- a/test/ir/inference/test_trt_inference_predictor.py
+++ b/test/ir/inference/test_trt_inference_predictor.py
@@ -132,9 +132,9 @@ class BackendPaddle:
                     max_batch_size=max_batch_size,
                     min_subgraph_size=self.args.subgraph_size,
                     use_static=False,
-                    use_calib_mode=False
-                    if self.args.precision == 'int8'
-                    else False,
+                    use_calib_mode=(
+                        False if self.args.precision == 'int8' else False
+                    ),
                 )
                 if self.args.enable_dynamic_shape:
                     if os.path.exists(shape_range_file):
@@ -387,7 +387,9 @@ class TestInferencePredictor(unittest.TestCase):
             )
         ]
 
-        static_model = paddle.jit.to_static(net, input_spec=input_spec)
+        static_model = paddle.jit.to_static(
+            net, input_spec=input_spec, full_graph=True
+        )
         paddle.jit.save(static_model, self.path)
 
     def testInferencePredictor(self):

--- a/test/ir/inference/test_xpu_convert_mixed_precision.py
+++ b/test/ir/inference/test_xpu_convert_mixed_precision.py
@@ -32,7 +32,9 @@ class ConvertMixedPrecision(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         model = resnet50(True)
         net = to_static(
-            model, input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')]
+            model,
+            input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')],
+            full_graph=True,
         )
         paddle.jit.save(
             net, os.path.join(self.temp_dir.name, 'resnet50/inference')

--- a/test/ir/pir/cinn/symbolic/test_decomp_inference_predictor_run.py
+++ b/test/ir/pir/cinn/symbolic/test_decomp_inference_predictor_run.py
@@ -57,6 +57,7 @@ class TestPredictorRunWithTensor(unittest.TestCase):
                     shape=self.shape, dtype='float32', name='input1'
                 ),
             ],
+            full_graph=True,
         )
         paddle.jit.save(
             model,

--- a/test/ir/pir/test_subgraph_exporter.py
+++ b/test/ir/pir/test_subgraph_exporter.py
@@ -97,7 +97,7 @@ class Net(paddle.nn.Layer):
 
 class TestSaveFwdBwdProg(unittest.TestCase):
     def setUp(self):
-        self.net = paddle.jit.to_static(Net())
+        self.net = paddle.jit.to_static(Net(), full_graph=True)
         self.root_dir = os.path.join(get_saving_dir(), "wrapper")
         self.clean()
 

--- a/test/ir/test_convert_to_mixed_precision.py
+++ b/test/ir/test_convert_to_mixed_precision.py
@@ -36,7 +36,9 @@ class TestConvertToMixedPrecision(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         model = resnet50(True)
         net = to_static(
-            model, input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')]
+            model,
+            input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')],
+            full_graph=True,
         )
         paddle.jit.save(
             net, os.path.join(self.temp_dir.name, 'resnet50/inference')

--- a/test/ir/test_inference_datatype.py
+++ b/test/ir/test_inference_datatype.py
@@ -49,6 +49,7 @@ class TestDoubleOnGPU(unittest.TestCase):
             input_spec=[
                 paddle.static.InputSpec(shape=[None, 4], dtype='float64')
             ],
+            full_graph=True,
         )
         paddle.jit.save(
             model,

--- a/test/legacy_test/test_dropout_op.py
+++ b/test/legacy_test/test_dropout_op.py
@@ -1537,7 +1537,9 @@ class PrimNet(paddle.nn.Layer):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 @param.parameterized_class(
@@ -1753,9 +1755,11 @@ class TestCompositeDropout(unittest.TestCase):
                     input_ = paddle.static.data(
                         'x',
                         shape=self.x.shape,
-                        dtype=self.x.dtype
-                        if self.dtype != "bfloat16"
-                        else "float32",
+                        dtype=(
+                            self.x.dtype
+                            if self.dtype != "bfloat16"
+                            else "float32"
+                        ),
                     )
                     input_.stop_gradient = False
                     y = paddle.assign(input_)
@@ -2103,9 +2107,11 @@ class TestPirCompositeDropout(unittest.TestCase):
                     input_ = paddle.static.data(
                         'x',
                         shape=self.x.shape,
-                        dtype=self.x.dtype
-                        if self.dtype != "bfloat16"
-                        else "float32",
+                        dtype=(
+                            self.x.dtype
+                            if self.dtype != "bfloat16"
+                            else "float32"
+                        ),
                     )
                     input_.stop_gradient = False
                     output = paddle.nn.functional.dropout(

--- a/test/legacy_test/test_eager_deletion_recurrent_op.py
+++ b/test/legacy_test/test_eager_deletion_recurrent_op.py
@@ -58,7 +58,7 @@ class TestDy2StRecurrentOpBackward(unittest.TestCase):
         dy_grad = inputs.gradient()
         inputs.clear_gradient()
 
-        net = paddle.jit.to_static(net)
+        net = paddle.jit.to_static(net, full_graph=True)
         outputs, final_states = net(inputs, prev_h)
         outputs.backward()
         st_grad = inputs.gradient()

--- a/test/legacy_test/test_eager_deletion_recurrent_op.py
+++ b/test/legacy_test/test_eager_deletion_recurrent_op.py
@@ -58,7 +58,7 @@ class TestDy2StRecurrentOpBackward(unittest.TestCase):
         dy_grad = inputs.gradient()
         inputs.clear_gradient()
 
-        net = paddle.jit.to_static(net, full_graph=True)
+        net = paddle.jit.to_static(net)
         outputs, final_states = net(inputs, prev_h)
         outputs.backward()
         st_grad = inputs.gradient()

--- a/test/legacy_test/test_group_norm_op.py
+++ b/test/legacy_test/test_group_norm_op.py
@@ -690,7 +690,9 @@ class PrimNet(paddle.nn.Layer):
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 # The original GroupNorm cannot support NHWC format

--- a/test/legacy_test/test_onnx_export.py
+++ b/test/legacy_test/test_onnx_export.py
@@ -60,7 +60,7 @@ class TestExportPrunedGraph(unittest.TestCase):
         model = Logic()
         self.x = paddle.to_tensor(np.array([1]))
         self.y = paddle.to_tensor(np.array([-1]))
-        paddle.jit.to_static(model)
+        paddle.jit.to_static(model, full_graph=True)
         out = model(self.x, self.y, z=True)
         paddle.onnx.export(
             model,

--- a/test/legacy_test/test_stack_op.py
+++ b/test/legacy_test/test_stack_op.py
@@ -399,7 +399,7 @@ class TestStackListOfSingleTensor(unittest.TestCase):
     def test_list_single_tensor(self):
         expect = paddle.stack(self.x)
         paddle.base.core._set_prim_all_enabled(True)
-        st_model = paddle.jit.to_static(paddle.stack)
+        st_model = paddle.jit.to_static(paddle.stack, full_graph=True)
         actual = st_model(self.x)
         np.testing.assert_allclose(expect, actual)
         paddle.enable_static()

--- a/test/legacy_test/test_strided_slice_op.py
+++ b/test/legacy_test/test_strided_slice_op.py
@@ -765,7 +765,7 @@ class TestStridedSliceTensorArray(unittest.TestCase):
 
         self.is_grads_equal_zeros(grads_zeros)
 
-        func = paddle.jit.to_static(net.forward)
+        func = paddle.jit.to_static(net.forward, full_graph=True)
         l2 = func(inps2)
         s2 = l2.numpy()
         l2.sum().backward()
@@ -807,7 +807,7 @@ class TestStridedSliceTensorArray(unittest.TestCase):
                         return array1 + array2 * array2
 
                 net = Simple()
-                func = paddle.jit.to_static(net.forward)
+                func = paddle.jit.to_static(net.forward, full_graph=True)
 
                 inps1 = paddle.to_tensor(
                     np.random.randn(2, 10),

--- a/test/legacy_test/test_tensor_register_hook.py
+++ b/test/legacy_test/test_tensor_register_hook.py
@@ -522,7 +522,6 @@ class TestTensorRegisterHook(unittest.TestCase):
         jit_net = paddle.jit.to_static(
             net,
             input_spec=[paddle.static.InputSpec([None, self.in_size])],
-            full_graph=True,
         )
 
         data = np.random.uniform(size=[self.batch_size, self.in_size]).astype(

--- a/test/legacy_test/test_tensor_register_hook.py
+++ b/test/legacy_test/test_tensor_register_hook.py
@@ -520,7 +520,9 @@ class TestTensorRegisterHook(unittest.TestCase):
     def test_register_hook_in_dy2static_mode(self):
         net = SimpleNetForStatic(self.in_size, self.out_size)
         jit_net = paddle.jit.to_static(
-            net, input_spec=[paddle.static.InputSpec([None, self.in_size])]
+            net,
+            input_spec=[paddle.static.InputSpec([None, self.in_size])],
+            full_graph=True,
         )
 
         data = np.random.uniform(size=[self.batch_size, self.in_size]).astype(

--- a/test/legacy_test/test_translated_layer.py
+++ b/test/legacy_test/test_translated_layer.py
@@ -57,7 +57,8 @@ class LinearNet(nn.Layer):
             paddle.static.InputSpec(
                 shape=[None, IMAGE_SIZE], dtype='float32', name='x'
             )
-        ]
+        ],
+        full_graph=True,
     )
     def forward(self, x):
         return self._linear(x)

--- a/test/prim/process/test_prim_amp.py
+++ b/test/prim/process/test_prim_amp.py
@@ -57,7 +57,9 @@ class TestPrimAMPO1(unittest.TestCase):
         )
 
         if use_prim:
-            net = paddle.jit.to_static(net, build_strategy=False)
+            net = paddle.jit.to_static(
+                net, build_strategy=False, full_graph=True
+            )
         with paddle.amp.auto_cast(level='O1'):
             out = net(self.x)
             loss = paddle.mean(out)
@@ -82,13 +84,17 @@ class TestPrimAMPO1(unittest.TestCase):
             net = PrimeNet()
             core._set_prim_all_enabled(False)
             net.eval()
-            static_net = paddle.jit.to_static(net, build_strategy=False)
+            static_net = paddle.jit.to_static(
+                net, build_strategy=False, full_graph=True
+            )
             res = static_net(self.x)
 
             # set prim all enabled
             core._set_prim_all_enabled(True)
             net.eval()
-            static_net = paddle.jit.to_static(net, build_strategy=False)
+            static_net = paddle.jit.to_static(
+                net, build_strategy=False, full_graph=True
+            )
             with paddle.amp.auto_cast(level='O1'):
                 res_amp = static_net(self.x)
 

--- a/test/sot/test_model_switch_training.py
+++ b/test/sot/test_model_switch_training.py
@@ -59,7 +59,7 @@ class TestModelSwitchTraining(unittest.TestCase):
     def get_static_out(self, input):
         paddle.seed(self.seed)
         self.compile_cache.clear()
-        static_net = paddle.jit.to_static(self.net)
+        static_net = paddle.jit.to_static(self.net, full_graph=False)
         static_net.eval()
         eval_result = static_net(input)
         self.check_mode(is_train=False)

--- a/test/sot/test_segment_linear.py
+++ b/test/sot/test_segment_linear.py
@@ -62,7 +62,7 @@ class TestSegmentLinear(TestCaseBase):
         x = paddle.randn((1, 8, 8))
         net = SimpleNet()
         net = paddle.jit.to_static(
-            net
+            net, full_graph=False
         )  # dont make effect. we need fetch sot PR in paddle.
         loss = net(x)
         loss = loss.sum()

--- a/test/sot/test_sot_cost_model.py
+++ b/test/sot/test_sot_cost_model.py
@@ -102,7 +102,7 @@ class TestCostModel(TestCaseBase):
     def test_net(self):
         x = paddle.rand([10])
         net = Net()
-        net = paddle.jit.to_static(net, enable_fallback=True)
+        net = paddle.jit.to_static(net, full_graph=False)
         for i in range(30):
             x = net(x)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #64058，part2

- #60437

PCard-66972