### PR TITLE
fix DenseTensorType to VectorType when dump pir to py code

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.cc
@@ -583,7 +583,7 @@ struct PirToPyCodeConverterHelper {
 
     std::string operator()(AdtTypeId<::pir::VectorType>) {
       std::stringstream ss;
-      const auto& name = ::pir::DenseTensorType::name();
+      const auto& name = ::pir::VectorType::name();
       const auto& vec_type = type.dyn_cast<::pir::VectorType>();
       ss << "self." << name << "(";
       for (int i = 0; i < vec_type.size(); ++i) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes


### Description
pcard-76996

fix DenseTensorType to VectorType when dump pir to py code