### PR TITLE
[PIR] Fix typo `set_pit_tests_properties` -> `set_pir_tests_properties`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,7 +91,7 @@ function(bash_test_modules TARGET_NAME)
   endif()
 endfunction()
 
-function(set_pit_tests_properties)
+function(set_pir_tests_properties)
   file(STRINGS "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_white_list"
        PIR_OP_TESTS)
   foreach(IR_OP_TEST ${PIR_OP_TESTS})
@@ -299,6 +299,6 @@ if(${len} GREATER_EQUAL 1)
   add_dependencies(build_tests ${test_names})
 endif()
 
-set_pit_tests_properties()
+set_pir_tests_properties()
 
 add_subdirectory(deprecated)

--- a/test/auto_parallel/CMakeLists.txt
+++ b/test/auto_parallel/CMakeLists.txt
@@ -308,4 +308,4 @@ endif()
 py_test_modules(test_job_schedule_profiler_range MODULES
                 test_job_schedule_profiler_range)
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/deprecated/CMakeLists.txt
+++ b/test/deprecated/CMakeLists.txt
@@ -91,7 +91,7 @@ function(bash_test_modules TARGET_NAME)
   endif()
 endfunction()
 
-function(set_pit_tests_properties)
+function(set_pir_tests_properties)
   file(STRINGS "${CMAKE_SOURCE_DIR}/test/white_list/pir_op_test_white_list"
        PIR_OP_TESTS)
   foreach(IR_OP_TEST ${PIR_OP_TESTS})
@@ -164,4 +164,4 @@ if(WITH_TESTING)
 
 endif()
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/deprecated/distribution/CMakeLists.txt
+++ b/test/deprecated/distribution/CMakeLists.txt
@@ -11,4 +11,4 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/deprecated/fft/CMakeLists.txt
+++ b/test/deprecated/fft/CMakeLists.txt
@@ -8,4 +8,4 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/deprecated/legacy_test/CMakeLists.txt
+++ b/test/deprecated/legacy_test/CMakeLists.txt
@@ -888,7 +888,7 @@ py_test_modules(test_stride MODULES test_stride ENVS
                 FLAGS_use_stride_kernel=true)
 
 set_tests_properties(test_linalg_matrix_exp PROPERTIES TIMEOUT 120)
-set_pit_tests_properties()
+set_pir_tests_properties()
 
 set_tests_properties(test_fractional_max_pool2d_op PROPERTIES TIMEOUT 120)
 set_tests_properties(test_fractional_max_pool3d_op PROPERTIES TIMEOUT 120)

--- a/test/distribution/CMakeLists.txt
+++ b/test/distribution/CMakeLists.txt
@@ -8,4 +8,4 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/fft/CMakeLists.txt
+++ b/test/fft/CMakeLists.txt
@@ -8,4 +8,4 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP})
 endforeach()
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -1054,4 +1054,4 @@ if((WITH_ROCM OR WITH_GPU) AND NOT WIN32)
     PROPERTIES ENVIRONMENT "FLAGS_new_executor_micro_batching=False")
 endif()
 
-set_pit_tests_properties()
+set_pir_tests_properties()

--- a/test/mkldnn/CMakeLists.txt
+++ b/test/mkldnn/CMakeLists.txt
@@ -32,4 +32,4 @@ if(WITH_ONEDNN AND NOT WIN32)
 endif()
 # set_tests_properties(test_flags_mkldnn_ops_on_off PROPERTIES TIMEOUT 120)
 
-set_pit_tests_properties()
+set_pir_tests_properties()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

Fix typo `set_pit_tests_properties` -> `set_pir_tests_properties`

PCard-66972