### PR TITLE
[Dy2St] Use `full_graph=True` outside dy2st uts (part3)

### DIFF
--- a/test/deprecated/prim/prim/vjp/static/test_comp_cast_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_cast_grad.py
@@ -25,7 +25,9 @@ from paddle.base import core, framework
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_div_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_div_grad.py
@@ -24,7 +24,9 @@ from paddle.base import core
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_gather_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_gather_grad.py
@@ -26,7 +26,9 @@ np.random.seed(2023)
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_reshape_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_reshape_grad.py
@@ -24,7 +24,9 @@ from paddle.base import core, framework
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_sqrt_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_sqrt_grad.py
@@ -29,7 +29,9 @@ import paddle
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_sub_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_sub_grad.py
@@ -24,7 +24,9 @@ from paddle.base import core
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_tanh_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_tanh_grad.py
@@ -29,7 +29,9 @@ import paddle
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/prim/vjp/static/test_comp_transpose_grad.py
+++ b/test/deprecated/prim/prim/vjp/static/test_comp_transpose_grad.py
@@ -24,7 +24,9 @@ from paddle.base import core, framework
 def apply_to_static(net, use_cinn):
     build_strategy = paddle.static.BuildStrategy()
     build_strategy.build_cinn_pass = use_cinn
-    return paddle.jit.to_static(net, build_strategy=build_strategy)
+    return paddle.jit.to_static(
+        net, build_strategy=build_strategy, full_graph=True
+    )
 
 
 class PrimeNet(paddle.nn.Layer):

--- a/test/deprecated/prim/process/test_check_inputs.py
+++ b/test/deprecated/prim/process/test_check_inputs.py
@@ -32,7 +32,7 @@ class TestIntarrayInput(unittest.TestCase):
         core._set_prim_all_enabled(True)
         np_data = np.random.random([3, 4]).astype("float32")
         tensor_data = paddle.to_tensor(np_data)
-        net = paddle.jit.to_static(fn)
+        net = paddle.jit.to_static(fn, full_graph=True)
 
         _ = net(tensor_data, shape=[2, 3, 4]).numpy()
         core._set_prim_all_enabled(False)

--- a/test/deprecated/rnn/test_rnn_nets.py
+++ b/test/deprecated/rnn/test_rnn_nets.py
@@ -374,7 +374,9 @@ def predict_test_util(place, mode, stop_gradient=True):
     rnn.train()
 
     rnn = paddle.jit.to_static(
-        rnn, [paddle.static.InputSpec(shape=[None, None, 16], dtype=x.dtype)]
+        rnn,
+        [paddle.static.InputSpec(shape=[None, None, 16], dtype=x.dtype)],
+        full_graph=True,
     )
     temp_dir = tempfile.TemporaryDirectory()
     save_dirname = os.path.join(temp_dir.name, "./inference/%s_infer" % mode)

--- a/test/deprecated/tokenizer/test_faster_tokenizer_op.py
+++ b/test/deprecated/tokenizer/test_faster_tokenizer_op.py
@@ -408,6 +408,7 @@ class TestBertTokenizerOp(unittest.TestCase):
                     shape=[None], dtype=core.VarDesc.VarType.STRINGS
                 ),  # texts
             ],
+            full_graph=True,
         )
         # Save in static graph model.
         paddle.jit.save(static_model, self.inference_path)

--- a/test/ipu/test_dy2static_fp16_ipu.py
+++ b/test/ipu/test_dy2static_fp16_ipu.py
@@ -64,7 +64,7 @@ class TestBase(IPUD2STest):
             ),
             paddle.static.InputSpec(name="target", shape=[32], dtype="int64"),
         ]
-        model = paddle.jit.to_static(model, input_spec=specs)
+        model = paddle.jit.to_static(model, input_spec=specs, full_graph=True)
         optim = paddle.optimizer.Adam(
             learning_rate=0.01, parameters=model.parameters()
         )

--- a/test/ipu/test_dy2static_ipu.py
+++ b/test/ipu/test_dy2static_ipu.py
@@ -42,7 +42,7 @@ class SimpleLayer(paddle.nn.Layer):
         self.use_reduction = use_reduction
         self.use_identity_loss = use_identity_loss
 
-    @to_static()
+    @to_static(full_graph=True)
     def forward(self, x, target=None):
         x = self.conv(x)
         x = paddle.flatten(x, 1, -1)

--- a/test/ipu/test_print_op_ipu.py
+++ b/test/ipu/test_print_op_ipu.py
@@ -113,7 +113,7 @@ class SimpleLayer(paddle.nn.Layer):
             in_channels=3, out_channels=1, kernel_size=2, stride=1
         )
 
-    @to_static()
+    @to_static(full_graph=True)
     def forward(self, x, target=None):
         x = self.conv(x)
         print(x)

--- a/test/ir/inference/test_inference_predictor_run.py
+++ b/test/ir/inference/test_inference_predictor_run.py
@@ -51,6 +51,7 @@ class TestPredictorRunWithTensor(unittest.TestCase):
                     shape=[None, 4], dtype='float32', name='input1'
                 ),
             ],
+            full_graph=True,
         )
         paddle.jit.save(
             model,

--- a/test/ir/inference/test_save_optimized_model_pass.py
+++ b/test/ir/inference/test_save_optimized_model_pass.py
@@ -30,7 +30,9 @@ class TestSaveOptimizedModelPass:
         self.temp_dir = tempfile.TemporaryDirectory()
         net = alexnet(True)
         model = to_static(
-            net, input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')]
+            net,
+            input_spec=[InputSpec(shape=[None, 3, 224, 224], name='x')],
+            full_graph=True,
         )
         paddle.jit.save(
             model, os.path.join(self.temp_dir.name, 'alexnet/inference')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Others

### Description
<!-- Describe what you’ve done -->

同 #64058，part3

- closes #60437

PCard-66972