### PR TITLE
【Fix PIR Unittest No.194、207、509】Fix some 0D uts in PIR mode (part2)

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -80,6 +80,7 @@ ALLOW_NO_GRAD_OPS = [
     "pd_op.argmax",
     "pd_op.print",
     "pd_op.accuracy",
+    "pd_op.randint",
     "pd_op.uniform",
     "pd_op.gaussian",
     "pd_op.bernoulli",

--- a/test/deprecated/legacy_test/test_assign_op.py
+++ b/test/deprecated/legacy_test/test_assign_op.py
@@ -24,7 +24,6 @@ import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
 from paddle.base.backward import append_backward
-from paddle.framework import in_pir_mode
 from paddle.pir_utils import test_with_pir_api
 
 
@@ -132,7 +131,7 @@ class TestAssignOpWithTensorArray(unittest.TestCase):
             array = paddle.assign(init_array)
             sums = paddle.tensor.array_read(array=init_array, i=i)
             mean = paddle.mean(sums)
-            append_backward(mean)
+            [(_, x_grad)] = append_backward(mean, parameter_list=[x])
 
         place = (
             paddle.CUDAPlace(0)
@@ -143,25 +142,11 @@ class TestAssignOpWithTensorArray(unittest.TestCase):
         feed_x = np.random.random(size=(100, 10)).astype('float32')
         ones = np.ones((100, 10)).astype('float32')
         feed_add = feed_x + ones
-        if in_pir_mode():
-            x_grad = None
-            for op in main_program.global_block().ops:
-                if "grad" not in op.name():
-                    continue
-                if op.operands()[0].source().is_same(x):
-                    x_grad = op.results()[0]
-            assert x_grad is not None, "Can not find x_grad in main_program"
-            res = exe.run(
-                main_program,
-                feed={'x': feed_x},
-                fetch_list=[sums, x_grad],
-            )
-        else:
-            res = exe.run(
-                main_program,
-                feed={'x': feed_x},
-                fetch_list=[sums.name, x.grad_name],
-            )
+        res = exe.run(
+            main_program,
+            feed={'x': feed_x},
+            fetch_list=[sums, x_grad],
+        )
         np.testing.assert_allclose(res[0], feed_add, rtol=1e-05)
         np.testing.assert_allclose(res[1], ones / 1000.0, rtol=1e-05)
         paddle.disable_static()

--- a/test/deprecated/legacy_test/test_zero_dim_complex_api_deprecated.py
+++ b/test/deprecated/legacy_test/test_zero_dim_complex_api_deprecated.py
@@ -1,0 +1,67 @@
+#   Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note:
+# 0D Tensor indicates that the tensor's dimension is 0
+# 0D Tensor's shape is always [], numel is 1
+# which can be created by paddle.rand([])
+
+import unittest
+
+import paddle
+
+unary_apis_with_complex_input = [
+    paddle.real,
+    paddle.imag,
+    paddle.angle,
+    paddle.conj,
+]
+
+
+class TestUnaryElementwiseAPIWithComplexInput(unittest.TestCase):
+    def test_static_unary(self):
+        paddle.enable_static()
+        for api in unary_apis_with_complex_input:
+            main_prog = paddle.static.Program()
+            block = main_prog.global_block()
+            exe = paddle.static.Executor()
+            with paddle.static.program_guard(
+                main_prog, paddle.static.Program()
+            ):
+                x = paddle.complex(paddle.rand([]), paddle.rand([]))
+                x.stop_gradient = False
+                out = api(x)
+
+                [(_, x_grad), (_, out_grad)] = paddle.static.append_backward(
+                    out, parameter_list=[x, out]
+                )
+
+                # 1) Test Program
+                res = exe.run(main_prog, fetch_list=[x, out, x_grad, out_grad])
+                for item in res:
+                    self.assertEqual(item.shape, ())
+
+                # 2) Test CompiledProgram Program
+                compile_prog = paddle.static.CompiledProgram(main_prog)
+                res = exe.run(
+                    compile_prog, fetch_list=[x, out, x_grad, out_grad]
+                )
+                for item in res:
+                    self.assertEqual(item.shape, ())
+
+        paddle.disable_static()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/deprecated/legacy_test/test_zero_dim_no_backward_api_deprecated.py
+++ b/test/deprecated/legacy_test/test_zero_dim_no_backward_api_deprecated.py
@@ -1,0 +1,40 @@
+#   Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note:
+# 0D Tensor indicates that the tensor's dimension is 0
+# 0D Tensor's shape is always [], numel is 1
+# which can be created by paddle.rand([])
+
+import unittest
+
+import paddle
+
+
+class TestNoBackwardAPIStatic(unittest.TestCase):
+    def setUp(self):
+        paddle.enable_static()
+        self.exe = paddle.static.Executor()
+
+    def test_static_embedding(self):
+        ids = paddle.full(shape=[], fill_value=1, dtype='int64')
+        emb = paddle.static.nn.embedding(ids, (20, 3))
+        prog = paddle.static.default_main_program()
+        self.exe.run(paddle.static.default_startup_program())
+        res = self.exe.run(prog, fetch_list=[emb])
+        self.assertEqual(res[0].shape, (3,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_zero_dim_complex_api.py
+++ b/test/legacy_test/test_zero_dim_complex_api.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,15 @@ unary_apis_with_complex_input = [
     paddle.angle,
     paddle.conj,
 ]
+
+
+class AssertShapeEqualMixin:
+    def assertShapeEqual(self, out, target_tuple):
+        if not paddle.framework.in_pir_mode():
+            out_shape = list(out.shape)
+        else:
+            out_shape = out.shape
+        self.assertEqual(out_shape, target_tuple)
 
 
 class TestUnaryElementwiseAPIWithComplexInput(unittest.TestCase):
@@ -60,27 +69,33 @@ class TestUnaryElementwiseAPIWithComplexInput(unittest.TestCase):
                 x = paddle.complex(paddle.rand([]), paddle.rand([]))
                 x.stop_gradient = False
                 out = api(x)
-                paddle.static.append_backward(out)
 
-                fetch_list = [x, out]
-                if block.has_var(x.grad_name):
-                    fetch_list.extend([x.grad_name, out.grad_name])
+                [(_, x_grad), (_, out_grad)] = paddle.static.append_backward(
+                    out, parameter_list=[x, out]
+                )
 
                 # 1) Test Program
-                res = exe.run(main_prog, fetch_list=fetch_list)
+                res = exe.run(main_prog, fetch_list=[x, out, x_grad, out_grad])
                 for item in res:
                     self.assertEqual(item.shape, ())
 
+                # TODO(cleanup-legacy-ir): In PIR mode, CompiledProgram can be
+                # cleanup.
+                if paddle.framework.use_pir_api():
+                    continue
+
                 # 2) Test CompiledProgram Program
                 compile_prog = paddle.static.CompiledProgram(main_prog)
-                res = exe.run(compile_prog, fetch_list=fetch_list)
+                res = exe.run(
+                    compile_prog, fetch_list=[x, out, x_grad, out_grad]
+                )
                 for item in res:
                     self.assertEqual(item.shape, ())
 
         paddle.disable_static()
 
 
-class TestAsReal(unittest.TestCase):
+class TestAsReal(unittest.TestCase, AssertShapeEqualMixin):
     def test_dygraph(self):
         paddle.disable_static()
         x = paddle.rand([]) + 1j * paddle.rand([])
@@ -108,15 +123,13 @@ class TestAsReal(unittest.TestCase):
             x = paddle.complex(paddle.rand([]), paddle.rand([]))
             x.stop_gradient = False
             out = paddle.as_real(x)
-            self.assertEqual(x.shape, ())
-            self.assertEqual(out.shape, (2,))
-            paddle.static.append_backward(out.sum())
+            self.assertShapeEqual(x, [])
+            self.assertShapeEqual(out, [2])
+            [(_, x_grad), (_, out_grad)] = paddle.static.append_backward(
+                out.sum(), parameter_list=[x, out]
+            )
 
-            fetch_list = [x, out]
-            if block.has_var(x.grad_name):
-                fetch_list.extend([x.grad_name, out.grad_name])
-
-            res = exe.run(main_prog, fetch_list=fetch_list)
+            res = exe.run(main_prog, fetch_list=[x, out, x_grad, out_grad])
             self.assertEqual(res[0].shape, ())
             self.assertEqual(res[1].shape, (2,))
             self.assertEqual(res[2].shape, ())
@@ -125,7 +138,7 @@ class TestAsReal(unittest.TestCase):
         paddle.disable_static()
 
 
-class TestAsComplex(unittest.TestCase):
+class TestAsComplex(unittest.TestCase, AssertShapeEqualMixin):
     def test_dygraph(self):
         paddle.disable_static()
         x = paddle.rand([2])
@@ -152,15 +165,13 @@ class TestAsComplex(unittest.TestCase):
             x = paddle.rand([2])
             x.stop_gradient = False
             out = paddle.as_complex(x)
-            self.assertEqual(x.shape, (2,))
-            self.assertEqual(out.shape, ())
-            paddle.static.append_backward(out.sum())
+            self.assertShapeEqual(x, [2])
+            self.assertShapeEqual(out, [])
+            [(_, x_grad), (_, out_grad)] = paddle.static.append_backward(
+                out.sum(), parameter_list=[x, out]
+            )
 
-            fetch_list = [x, out]
-            if block.has_var(x.grad_name):
-                fetch_list.extend([x.grad_name, out.grad_name])
-
-            res = exe.run(main_prog, fetch_list=fetch_list)
+            res = exe.run(main_prog, fetch_list=[x, out, x_grad, out_grad])
             self.assertEqual(res[0].shape, (2,))
             self.assertEqual(res[1].shape, ())
             self.assertEqual(res[2].shape, (2,))

--- a/test/legacy_test/test_zero_dim_complex_api.py
+++ b/test/legacy_test/test_zero_dim_complex_api.py
@@ -74,21 +74,7 @@ class TestUnaryElementwiseAPIWithComplexInput(unittest.TestCase):
                     out, parameter_list=[x, out]
                 )
 
-                # 1) Test Program
                 res = exe.run(main_prog, fetch_list=[x, out, x_grad, out_grad])
-                for item in res:
-                    self.assertEqual(item.shape, ())
-
-                # TODO(cleanup-legacy-ir): In PIR mode, CompiledProgram can be
-                # cleanup.
-                if paddle.framework.use_pir_api():
-                    continue
-
-                # 2) Test CompiledProgram Program
-                compile_prog = paddle.static.CompiledProgram(main_prog)
-                res = exe.run(
-                    compile_prog, fetch_list=[x, out, x_grad, out_grad]
-                )
                 for item in res:
                     self.assertEqual(item.shape, ())
 

--- a/test/legacy_test/test_zero_dim_distribution_loss_api.py
+++ b/test/legacy_test/test_zero_dim_distribution_loss_api.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -293,12 +293,12 @@ class TestLossAPIStatic(unittest.TestCase):
         out1 = F.sigmoid_focal_loss(
             logit, label, normalizer=fg_num_1, reduction='mean'
         )
-        paddle.static.append_backward(out0.sum())
+        [(_, out0_grad), (_, logit_grad)] = paddle.static.append_backward(
+            out0.sum(), parameter_list=[out0, logit]
+        )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(
-            prog, fetch_list=[out0, out1, out0.grad_name, logit.grad_name]
-        )
+        res = self.exe.run(prog, fetch_list=[out0, out1, out0_grad, logit_grad])
         np.testing.assert_allclose(res[0], res[1])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, ())
@@ -315,10 +315,12 @@ class TestLossAPIStatic(unittest.TestCase):
         loss = paddle.nn.functional.cross_entropy(
             input, label, reduction='mean'
         )
-        paddle.static.append_backward(loss)
+        [(_, input_grad)] = paddle.static.append_backward(
+            loss, parameter_list=[input]
+        )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[loss, input.grad_name])
+        res = self.exe.run(prog, fetch_list=[loss, input_grad])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, (3, 5))
 
@@ -329,10 +331,12 @@ class TestLossAPIStatic(unittest.TestCase):
         label = paddle.rand([3, 5])
 
         loss = paddle.nn.functional.l1_loss(input, label, reduction='sum')
-        paddle.static.append_backward(loss)
+        [(_, input_grad)] = paddle.static.append_backward(
+            loss, parameter_list=[input]
+        )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[loss, input.grad_name])
+        res = self.exe.run(prog, fetch_list=[loss, input_grad])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, (3, 5))
 
@@ -347,10 +351,12 @@ class TestLossAPIStatic(unittest.TestCase):
         label.stop_gradient = False
 
         loss = paddle.nn.functional.nll_loss(log_out, label)
-        paddle.static.append_backward(loss)
+        [(_, input_grad)] = paddle.static.append_backward(
+            loss, parameter_list=[input]
+        )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[loss, input.grad_name])
+        res = self.exe.run(prog, fetch_list=[loss, input_grad])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, (5, 3))
 
@@ -363,10 +369,12 @@ class TestLossAPIStatic(unittest.TestCase):
         label.stop_gradient = False
 
         loss = paddle.nn.functional.nll_loss(log_out, label)
-        paddle.static.append_backward(loss)
+        [(_, input_grad)] = paddle.static.append_backward(
+            loss, parameter_list=[input]
+        )
 
         prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[loss, input.grad_name])
+        res = self.exe.run(prog, fetch_list=[loss, input_grad])
         self.assertEqual(res[0].shape, ())
         self.assertEqual(res[1].shape, (5, 3, 2, 4))
 

--- a/test/legacy_test/test_zero_dim_no_backward_api.py
+++ b/test/legacy_test/test_zero_dim_no_backward_api.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 import unittest
 
 import numpy as np
+from decorator_helper import prog_scope
 
 import paddle
 from paddle.pir_utils import test_with_pir_api
@@ -280,6 +281,7 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         self.assertEqual(res.shape, (5, 2, 2))
 
     @test_with_pir_api
+    @prog_scope()
     def test_strided_slice(self):
         starts = [paddle.full([], 0, 'int32'), paddle.full([], 0, 'int32')]
         ends = [paddle.full([], 4, 'int32'), paddle.full([], 4, 'int32')]
@@ -504,14 +506,6 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
         result = [5.0, 6.0]
         for i in range(len(res)):
             self.assertEqual(res[0][i], result[i])
-
-    def test_static_embedding(self):
-        ids = paddle.full(shape=[], fill_value=1, dtype='int64')
-        emb = paddle.static.nn.embedding(ids, (20, 3))
-        prog = paddle.static.default_main_program()
-        self.exe.run(paddle.static.default_startup_program())
-        res = self.exe.run(prog, fetch_list=[emb])
-        self.assertEqual(res[0].shape, (3,))
 
     @test_with_pir_api
     def test_one_hot_label(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

同 #64064 的 final part，确保全部 0D 单测可以在 PIR 模式直接跑

- 194 `test_zero_dim_distribution_loss_api`，单测 case 未适配，改写适配即可
- 207 `test_zero_dim_no_backward_api`，根据 #62652 `paddle.static.embedding` 无需适配，直接拆分到一个 `_deprecated` 单测
- 509 `test_zero_dim_complex_api`，静态图 case 未适配，改写适配即可，其中 `paddle.static.CompiledProgram` PIR 没有，拆出到 `_deprecated`

### Related links

- #63740

PCard-66972