### PR TITLE
[PIR] Fix some ops with sub-block print formatting

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -103,7 +103,7 @@ void GroupOp::Print(pir::IrPrinter& printer) {
   auto& os = printer.os;
   auto op = operation();
   printer.PrintOpResult(op);
-  os << " = " << name() << " [id:" << op->id() << "]";
+  os << " = \"" << name() << "\" [id:" << op->id() << "]";
   printer.PrintOpOperands(op);
   os << " -> ";
   printer.PrintOpReturnType(op);
@@ -183,7 +183,7 @@ void FusionOp::Print(pir::IrPrinter& printer) {
   auto& os = printer.os;
   auto op = operation();
   printer.PrintOpResult(op);
-  os << " = " << name() << " [id:" << op->id() << "]";
+  os << " = \"" << name() << "\" [id:" << op->id() << "]";
   printer.PrintOpOperands(op);
   os << " -> ";
   printer.PrintOpReturnType(op);

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -190,7 +190,6 @@ void FusionOp::Print(pir::IrPrinter& printer) {
   os << " {\n";
   printer.AddIndentation();
   for (auto& sub_op : GetOperators()) {
-    // os << printer.indentation();
     printer.PrintOperation(sub_op);
     os << "\n";
   }

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -107,12 +107,14 @@ void GroupOp::Print(pir::IrPrinter& printer) {
   printer.PrintOpOperands(op);
   os << " -> ";
   printer.PrintOpReturnType(op);
-  os << " {";
+  os << " {\n";
+  printer.AddIndentation();
   for (auto& sub_op : GetOperators()) {
-    os << "\n  ";
     printer.PrintOperation(sub_op);
+    os << "\n";
   }
-  os << " \n }";
+  printer.DecreaseIndentation();
+  os << printer.indentation() << "}";
 }
 
 bool GroupOp::InferSymbolicShape(
@@ -185,12 +187,15 @@ void FusionOp::Print(pir::IrPrinter& printer) {
   printer.PrintOpOperands(op);
   os << " -> ";
   printer.PrintOpReturnType(op);
-  os << " {";
+  os << " {\n";
+  printer.AddIndentation();
   for (auto& sub_op : GetOperators()) {
-    os << "\n  ";
+    // os << printer.indentation();
     printer.PrintOperation(sub_op);
+    os << "\n";
   }
-  os << " \n }";
+  printer.DecreaseIndentation();
+  os << printer.indentation() << "}";
 }
 
 void YieldStoreOp::Build(pir::Builder& builder,

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -167,12 +167,12 @@ void IfOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
   printer.PrintOpResult(op);
-  os << " = pd_op.if";
+  os << " = \"" << name() << "\"";
   printer.PrintOpOperands(op);
   printer.PrintAttributeMap(op);
   os << " -> ";
   printer.PrintOpReturnType(op);
-  os << "{\n";
+  os << " {\n";
   printer.AddIndentation();
   for (auto &item : true_block()) {
     printer.PrintOperation(&item);
@@ -427,11 +427,11 @@ void PyLayerOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
   printer.PrintOpResult(op);
-  os << " = pd_op.pylayer";
+  os << " = \"" << name() << "\"";
   printer.PrintOpOperands(op);
   os << " -> ";
   printer.PrintOpReturnType(op);
-  os << "{";
+  os << " {";
   for (auto &item : forward_block()) {
     os << "\n  ";
     printer.PrintOperation(&item);
@@ -534,7 +534,7 @@ void WhileOp::Print(pir::IrPrinter &printer) {
   auto &os = printer.os;
   auto op = operation();
   printer.PrintOpResult(op);
-  os << " = \"" << name() << "\"(cond=";
+  os << " = \"" << name() << "\" (cond=";
   printer.PrintValue(cond());
   os << ", inputs=";
   auto operands = (*this)->operands_source();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

调整和优化含子 block 的 OP 的 print 格式

- 修复 `pd_op.if`、`pd_op.pylayer`、`cinn_op.fusion`、`cinn_op.group` 两侧缺少 `"`
- `cinn_op.fusion`、`cinn_op.group` 复用现有的缩进逻辑，使缩进显示符合预期
- 在需要的地方添加空格

PCard-66972