### PR TITLE
Replace memory::Copy in fluid/operators

### DIFF
--- a/paddle/fluid/operators/beam_search_decode_op_xpu.h
+++ b/paddle/fluid/operators/beam_search_decode_op_xpu.h
@@ -50,18 +50,18 @@ int CopyTensorByXPU(const phi::DenseTensor& srcTensor,
   if (flag == 0) {
     T* dstData =
         dstTensor->template mutable_data<T>(paddle::platform::CPUPlace());
-    paddle::memory::Copy(paddle::platform::CPUPlace(),
-                         dstData,
-                         place,
-                         srcData,
-                         srcTensor.numel() * sizeof(T));
+    phi::memory_utils::Copy(paddle::platform::CPUPlace(),
+                            dstData,
+                            place,
+                            srcData,
+                            srcTensor.numel() * sizeof(T));
   } else {
     T* dstData = dstTensor->template mutable_data<T>(place);
-    paddle::memory::Copy(place,
-                         dstData,
-                         paddle::platform::CPUPlace(),
-                         srcData,
-                         srcTensor.numel() * sizeof(T));
+    phi::memory_utils::Copy(place,
+                            dstData,
+                            paddle::platform::CPUPlace(),
+                            srcData,
+                            srcTensor.numel() * sizeof(T));
   }
 
   return xpu::Error_t::SUCCESS;

--- a/paddle/fluid/operators/beam_search_decode_op_xpu.h
+++ b/paddle/fluid/operators/beam_search_decode_op_xpu.h
@@ -14,6 +14,7 @@ limitations under the License. */
 #pragma once
 
 #include "paddle/fluid/operators/beam_search_decode_op_def.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
@@ -18,6 +18,7 @@ limitations under the License. */
 #include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/fluid/platform/device/xpu/bkcl_helper.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/axis_utils.h"
 #include "paddle/phi/kernels/funcs/cross_entropy.h"

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
@@ -248,11 +248,11 @@ struct CSoftmaxWithCrossEntropyProcessGroupFunctor<phi::XPUContext, T> {
         N * 1);
     PADDLE_ENFORCE_XDNN_SUCCESS(ret, "sub");
 
-    memory::Copy(ctx.GetPlace(),
-                 softmax->data(),
-                 ctx.GetPlace(),
-                 softmax_2d.data(),
-                 N * D * sizeof(T));
+    phi::memory_utils::Copy(ctx.GetPlace(),
+                            softmax->data(),
+                            ctx.GetPlace(),
+                            softmax_2d.data(),
+                            N * D * sizeof(T));
   }
 };
 
@@ -513,11 +513,11 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::XPUContext, T> {
         N * 1);
     PADDLE_ENFORCE_XDNN_SUCCESS(ret, "sub");
 
-    memory::Copy(ctx.GetPlace(),
-                 softmax->data(),
-                 ctx.GetPlace(),
-                 softmax_2d.data(),
-                 N * D * sizeof(T));
+    phi::memory_utils::Copy(ctx.GetPlace(),
+                            softmax->data(),
+                            ctx.GetPlace(),
+                            softmax_2d.data(),
+                            N * D * sizeof(T));
   }
 };
 

--- a/paddle/fluid/operators/detection/collect_fpn_proposals_op.cu
+++ b/paddle/fluid/operators/detection/collect_fpn_proposals_op.cu
@@ -111,18 +111,18 @@ class GPUCollectFpnProposalsOpKernel : public framework::OpKernel<T> {
         }
       }
 
-      memory::Copy(place,
-                   concat_rois_data + roi_offset,
-                   place,
-                   roi_in->data<T>(),
-                   roi_in->numel() * sizeof(T),
-                   dev_ctx.stream());
-      memory::Copy(place,
-                   concat_scores_data + score_offset,
-                   place,
-                   score_in->data<T>(),
-                   score_in->numel() * sizeof(T),
-                   dev_ctx.stream());
+      phi::memory_utils::Copy(place,
+                              concat_rois_data + roi_offset,
+                              place,
+                              roi_in->data<T>(),
+                              roi_in->numel() * sizeof(T),
+                              dev_ctx.stream());
+      phi::memory_utils::Copy(place,
+                              concat_scores_data + score_offset,
+                              place,
+                              score_in->data<T>(),
+                              score_in->numel() * sizeof(T),
+                              dev_ctx.stream());
       roi_offset += roi_in->numel();
       score_offset += score_in->numel();
     }
@@ -233,12 +233,12 @@ class GPUCollectFpnProposalsOpKernel : public framework::OpKernel<T> {
     GetLengthLoD<<<blocks, threads, 0, dev_ctx.stream()>>>(
         real_post_num, out_id_data, length_lod_data);
     std::vector<int> length_lod_cpu(lod_size);
-    memory::Copy(platform::CPUPlace(),
-                 length_lod_cpu.data(),
-                 place,
-                 length_lod_data,
-                 sizeof(int) * lod_size,
-                 dev_ctx.stream());
+    phi::memory_utils::Copy(platform::CPUPlace(),
+                            length_lod_cpu.data(),
+                            place,
+                            length_lod_data,
+                            sizeof(int) * lod_size,
+                            dev_ctx.stream());
     dev_ctx.Wait();
 
     std::vector<size_t> offset(1, 0);
@@ -249,12 +249,12 @@ class GPUCollectFpnProposalsOpKernel : public framework::OpKernel<T> {
     if (ctx.HasOutput("RoisNum")) {
       auto* rois_num = ctx.Output<phi::DenseTensor>("RoisNum");
       int* rois_num_data = rois_num->mutable_data<int>({lod_size}, place);
-      memory::Copy(place,
-                   rois_num_data,
-                   place,
-                   length_lod_data,
-                   lod_size * sizeof(int),
-                   dev_ctx.stream());
+      phi::memory_utils::Copy(place,
+                              rois_num_data,
+                              place,
+                              length_lod_data,
+                              lod_size * sizeof(int),
+                              dev_ctx.stream());
     }
 
     framework::LoD lod;

--- a/paddle/fluid/operators/detection/collect_fpn_proposals_op.cu
+++ b/paddle/fluid/operators/detection/collect_fpn_proposals_op.cu
@@ -25,6 +25,7 @@ namespace cub = hipcub;
 #include "paddle/fluid/operators/detection/collect_fpn_proposals_op.h"
 #include "paddle/fluid/platform/for_range.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/mixed_vector.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 #include "paddle/phi/kernels/funcs/gather.cu.h"

--- a/paddle/fluid/operators/detection/generate_proposals_op.cu
+++ b/paddle/fluid/operators/detection/generate_proposals_op.cu
@@ -79,12 +79,12 @@ static std::pair<phi::DenseTensor, phi::DenseTensor> ProposalForOneImage(
                                               keep_index.data<int>());
   int keep_num;
   const auto gpu_place = ctx.GetPlace();
-  memory::Copy(platform::CPUPlace(),
-               &keep_num,
-               gpu_place,
-               keep_num_t.data<int>(),
-               sizeof(int),
-               ctx.stream());
+  phi::memory_utils::Copy(platform::CPUPlace(),
+                          &keep_num,
+                          gpu_place,
+                          keep_num_t.data<int>(),
+                          sizeof(int),
+                          ctx.stream());
   ctx.Wait();
   keep_index.Resize({keep_num});
 
@@ -221,18 +221,18 @@ class CUDAGenerateProposalsKernel : public framework::OpKernel<T> {
       phi::DenseTensor &proposals = box_score_pair.first;
       phi::DenseTensor &scores = box_score_pair.second;
 
-      memory::Copy(place,
-                   rpn_rois_data + num_proposals * 4,
-                   place,
-                   proposals.data<T>(),
-                   sizeof(T) * proposals.numel(),
-                   dev_ctx.stream());
-      memory::Copy(place,
-                   rpn_roi_probs_data + num_proposals,
-                   place,
-                   scores.data<T>(),
-                   sizeof(T) * scores.numel(),
-                   dev_ctx.stream());
+      phi::memory_utils::Copy(place,
+                              rpn_rois_data + num_proposals * 4,
+                              place,
+                              proposals.data<T>(),
+                              sizeof(T) * proposals.numel(),
+                              dev_ctx.stream());
+      phi::memory_utils::Copy(place,
+                              rpn_roi_probs_data + num_proposals,
+                              place,
+                              scores.data<T>(),
+                              sizeof(T) * scores.numel(),
+                              dev_ctx.stream());
       num_proposals += proposals.dims()[0];
       offset.emplace_back(num_proposals);
       tmp_num.push_back(proposals.dims()[0]);
@@ -241,12 +241,12 @@ class CUDAGenerateProposalsKernel : public framework::OpKernel<T> {
       auto *rpn_rois_num = context.Output<phi::DenseTensor>("RpnRoisNum");
       rpn_rois_num->mutable_data<int>({num}, context.GetPlace());
       int *num_data = rpn_rois_num->data<int>();
-      memory::Copy(place,
-                   num_data,
-                   cpu_place,
-                   &tmp_num[0],
-                   sizeof(int) * num,
-                   dev_ctx.stream());
+      phi::memory_utils::Copy(place,
+                              num_data,
+                              cpu_place,
+                              &tmp_num[0],
+                              sizeof(int) * num,
+                              dev_ctx.stream());
       rpn_rois_num->Resize({num});
     }
     framework::LoD lod;

--- a/paddle/fluid/operators/detection/generate_proposals_op.cu
+++ b/paddle/fluid/operators/detection/generate_proposals_op.cu
@@ -21,6 +21,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/memory/memory.h"
 #include "paddle/fluid/operators/detection/bbox_util.cu.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/mixed_vector.h"
 #include "paddle/phi/kernels/funcs/gather.cu.h"
 #include "paddle/phi/kernels/funcs/math_function.h"

--- a/paddle/fluid/operators/fused/fused_dropout_helper.h
+++ b/paddle/fluid/operators/fused/fused_dropout_helper.h
@@ -193,12 +193,12 @@ class FusedDropoutHelper {
         d_bias,
         ctx);
     if (d_residual) {
-      memory::Copy(ctx.GetPlace(),
-                   d_residual,
-                   ctx.GetPlace(),
-                   d_out,
-                   rows_ * cols_ * sizeof(T),
-                   ctx.stream());
+      phi::memory_utils::Copy(ctx.GetPlace(),
+                              d_residual,
+                              ctx.GetPlace(),
+                              d_out,
+                              rows_ * cols_ * sizeof(T),
+                              ctx.stream());
     }
   }
 

--- a/paddle/fluid/operators/fused/fused_dropout_helper.h
+++ b/paddle/fluid/operators/fused/fused_dropout_helper.h
@@ -18,6 +18,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/fused/fused_dropout_act_bias.h"
 #include "paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h"
 #include "paddle/fluid/operators/fused/fused_residual_dropout_bias.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/generator.h"
 #include "paddle/phi/kernels/funcs/dropout_impl_util.h"
 #include "paddle/phi/kernels/funcs/functors.h"

--- a/paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include "paddle/fluid/operators/fused/fused_residual_dropout_bias.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h
@@ -847,12 +847,12 @@ void LaunchLayernormResidualDropoutBias(
   // NOTE(minghaoBD): OutType should be T if drop_out_rate == 1.0
   if (std::abs(dropout_prob - 1.0f) < 1e-5) {
     auto cuda_place = ctx.GetPlace();
-    memory::Copy(cuda_place,
-                 dst,
-                 cuda_place,
-                 residual,
-                 rows * cols * sizeof(T),
-                 ctx.stream());
+    phi::memory_utils::Copy(cuda_place,
+                            dst,
+                            cuda_place,
+                            residual,
+                            rows * cols * sizeof(T),
+                            ctx.stream());
     if (mask_data != nullptr) {
       PADDLE_ENFORCE_GPU_SUCCESS(cudaMemsetAsync(
           mask_data, 0, rows * cols * sizeof(MaskType), ctx.stream()));

--- a/paddle/fluid/operators/fused/fused_residual_dropout_bias.h
+++ b/paddle/fluid/operators/fused/fused_residual_dropout_bias.h
@@ -253,12 +253,12 @@ void LaunchResidualDropoutBias(const uint32_t rows,
     // NOTE(minghaoBD): OutType should be T if dropout_prob == 1.0
     if (residual == dst) return;
     if (residual) {
-      memory::Copy(ctx.GetPlace(),
-                   dst,
-                   ctx.GetPlace(),
-                   residual,
-                   rows * cols * sizeof(T),
-                   ctx.stream());
+      phi::memory_utils::Copy(ctx.GetPlace(),
+                              dst,
+                              ctx.GetPlace(),
+                              residual,
+                              rows * cols * sizeof(T),
+                              ctx.stream());
     } else {
       SetZero<T>(ctx, dst, rows * cols);
     }
@@ -475,12 +475,12 @@ void LaunchResidualDropoutBiasGrad(const T *dout,
         if (dx == nullptr || dx == dout) {                                    \
           return;                                                             \
         }                                                                     \
-        memory::Copy(ctx.GetPlace(),                                          \
-                     dx,                                                      \
-                     ctx.GetPlace(),                                          \
-                     dout,                                                    \
-                     rows *cols * sizeof(T),                                  \
-                     ctx.stream());                                           \
+        phi::memory_utils::Copy(ctx.GetPlace(),                               \
+                                dx,                                           \
+                                ctx.GetPlace(),                               \
+                                dout,                                         \
+                                rows *cols * sizeof(T),                       \
+                                ctx.stream());                                \
       } else {                                                                \
         const uint64_t n = rows * cols;                                       \
         platform::GpuLaunchConfig config =                                    \

--- a/paddle/fluid/operators/fused/fused_residual_dropout_bias.h
+++ b/paddle/fluid/operators/fused/fused_residual_dropout_bias.h
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/fused/fused_dropout_common.h"
 #include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/lookup_table_op.cu
+++ b/paddle/fluid/operators/lookup_table_op.cu
@@ -16,6 +16,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/float16.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace paddle {

--- a/paddle/fluid/operators/lookup_table_op.cu
+++ b/paddle/fluid/operators/lookup_table_op.cu
@@ -175,12 +175,12 @@ class LookupTableGradCUDAKernel : public framework::OpKernel<T> {
 
       // TODO(yuyang18): Strange code here.
       phi::MixVector<int64_t> mixv_new_rows(&new_rows);
-      memory::Copy(gpu_place,
-                   mixv_new_rows.CUDAMutableData(context.GetPlace()),
-                   gpu_place,
-                   ids_data,
-                   ids_num * sizeof(int64_t),
-                   stream);
+      phi::memory_utils::Copy(gpu_place,
+                              mixv_new_rows.CUDAMutableData(context.GetPlace()),
+                              gpu_place,
+                              ids_data,
+                              ids_num * sizeof(int64_t),
+                              stream);
       mixv_new_rows.CopyToCPU();
       d_table->set_rows(new_rows);
 
@@ -202,12 +202,12 @@ class LookupTableGradCUDAKernel : public framework::OpKernel<T> {
                             "output@Grad's shape = [%s].",
                             d_table_value->dims(),
                             d_output_dims_2d));
-      memory::Copy(gpu_place,
-                   d_table_data,
-                   gpu_place,
-                   d_output_data,
-                   d_output->numel() * sizeof(T),
-                   stream);
+      phi::memory_utils::Copy(gpu_place,
+                              d_table_data,
+                              gpu_place,
+                              d_output_data,
+                              d_output->numel() * sizeof(T),
+                              stream);
 
     } else {
       auto ids_t = context.Input<phi::DenseTensor>("Ids");

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -21,6 +21,7 @@
 
 #include "paddle/phi/backends/device_guard.h"
 #include "paddle/phi/backends/device_manager.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -161,11 +161,11 @@ void BufferedReader::ReadAsync(size_t i) {
                 cuda[i].mutable_data(cuda_pinned_place, cpu[i].type());
             auto size = cpu[i].numel() * phi::SizeOf(cpu[i].dtype());
 
-            memory::Copy(cuda_pinned_place,
-                         cuda_pinned_ptrs[i],
-                         cpu[i].place(),
-                         cpu[i].data(),
-                         size);
+            phi::memory_utils::Copy(cuda_pinned_place,
+                                    cuda_pinned_ptrs[i],
+                                    cpu[i].place(),
+                                    cpu[i].data(),
+                                    size);
 
             cuda[i].set_lod(cpu[i].lod());
           } else {
@@ -215,7 +215,7 @@ void BufferedReader::ReadAsync(size_t i) {
           auto size = cpu[i].numel() * phi::SizeOf(cpu[i].dtype());
           if (platform::is_cuda_pinned_place(cpu_place) ||
               platform::is_gpu_place(cpu_place)) {
-            memory::Copy(
+            phi::memory_utils::Copy(
                 place_, gpu_ptr, cpu_place, cpu_ptr, size, stream_.get());
           } else {
             platform::CUDAPinnedPlace cuda_pinned_place;
@@ -223,14 +223,14 @@ void BufferedReader::ReadAsync(size_t i) {
             cuda_pinned_tensor.Resize(cpu[i].dims());
             auto cuda_pinned_ptr = cuda_pinned_tensor.mutable_data(
                 cuda_pinned_place, cpu[i].type());
-            memory::Copy(
+            phi::memory_utils::Copy(
                 cuda_pinned_place, cuda_pinned_ptr, cpu_place, cpu_ptr, size);
-            memory::Copy(place_,
-                         gpu_ptr,
-                         cuda_pinned_place,
-                         cuda_pinned_ptr,
-                         size,
-                         stream_.get());
+            phi::memory_utils::Copy(place_,
+                                    gpu_ptr,
+                                    cuda_pinned_place,
+                                    cuda_pinned_ptr,
+                                    size,
+                                    stream_.get());
 
             platform::GpuStreamSync(stream_.get());
           }
@@ -290,7 +290,7 @@ void BufferedReader::ReadAsync(size_t i) {
               xpu_ptr, tmp, size, XPUMemcpyKind::XPU_HOST_TO_DEVICE));
           delete[] tmp;
         } else {
-          memory::Copy(place_, xpu_ptr, cpu_place, cpu_ptr, size);
+          phi::memory_utils::Copy(place_, xpu_ptr, cpu_place, cpu_ptr, size);
         }
         xpu[i].set_lod(cpu[i].lod());
       }
@@ -339,10 +339,12 @@ void BufferedReader::ReadAsync(size_t i) {
         auto custom_device_ptr = custom_device_ptrs[i];
         auto size = cpu[i].numel() * phi::SizeOf(cpu[i].dtype());
         if ((platform::is_custom_place(cpu_place))) {
-          memory::Copy(place_, custom_device_ptr, cpu_place, cpu_ptr, size);
+          phi::memory_utils::Copy(
+              place_, custom_device_ptr, cpu_place, cpu_ptr, size);
           custom_device_stream_->Synchronize();
         } else {
-          memory::Copy(place_, custom_device_ptr, cpu_place, cpu_ptr, size);
+          phi::memory_utils::Copy(
+              place_, custom_device_ptr, cpu_place, cpu_ptr, size);
         }
         custom_device[i].set_lod(cpu[i].lod());
       }

--- a/paddle/fluid/operators/seed_op.cu
+++ b/paddle/fluid/operators/seed_op.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/operators/seed_op.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace paddle {

--- a/paddle/fluid/operators/seed_op.cu
+++ b/paddle/fluid/operators/seed_op.cu
@@ -40,12 +40,12 @@ class GPUSeedKernel : public framework::OpKernel<T> {
       auto *out_data = out->mutable_data<T>(context.GetPlace());
       auto target_gpu_place = context.GetPlace();
       auto stream = context.cuda_device_context().stream();
-      memory::Copy(target_gpu_place,
-                   out_data,
-                   platform::CPUPlace(),
-                   &seed,
-                   sizeof(int),
-                   stream);
+      phi::memory_utils::Copy(target_gpu_place,
+                              out_data,
+                              platform::CPUPlace(),
+                              &seed,
+                              sizeof(int),
+                              stream);
     }
   }
 };

--- a/paddle/fluid/operators/sequence_ops/sequence_expand_op.cu
+++ b/paddle/fluid/operators/sequence_ops/sequence_expand_op.cu
@@ -17,6 +17,7 @@ limitations under the License. */
 #include "paddle/fluid/memory/memcpy.h"
 #include "paddle/fluid/operators/sequence_ops/sequence_expand_op.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/sequence_ops/sequence_expand_op.cu
+++ b/paddle/fluid/operators/sequence_ops/sequence_expand_op.cu
@@ -123,7 +123,7 @@ static int ExpandByMemoryCopy(const phi::GPUContext& context,
         }
         for (int j = 0; j < repeat_num; j++) {
           for (int k = 0; k < x_seq_len; k++) {
-            memory::Copy(
+            phi::memory_utils::Copy(
                 gpu_place,
                 out_data + (out_start + j * x_seq_len + k) * x_item_length,
                 gpu_place,

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -38,6 +38,7 @@
 #include "paddle/fluid/memory/memcpy.h"
 #include "paddle/fluid/platform/place.h"
 #include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/kernels/cast_kernel.h"

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -320,11 +320,11 @@ class TensorRTEngineOp : public framework::OperatorBase {
                   t,
                   DataType::INT32);
             }
-            paddle::memory::Copy(platform::CPUPlace(),
-                                 int32_host.data(),
-                                 platform::CPUPlace(),
-                                 int32_tensor.data<int>(),
-                                 int32_tensor.numel() * sizeof(int));
+            phi::memory_utils::Copy(platform::CPUPlace(),
+                                    int32_host.data(),
+                                    platform::CPUPlace(),
+                                    int32_tensor.data<int>(),
+                                    int32_tensor.numel() * sizeof(int));
           } else if (platform::is_gpu_place(t.place())) {
 #if defined(PADDLE_WITH_CUDA)
             auto *dev_ctx = pool.Get(t.place());
@@ -335,12 +335,12 @@ class TensorRTEngineOp : public framework::OperatorBase {
                   t,
                   DataType::INT32);
             }
-            paddle::memory::Copy(platform::CPUPlace(),
-                                 int32_host.data(),
-                                 int32_tensor.place(),
-                                 int32_tensor.data<int>(),
-                                 int32_tensor.numel() * sizeof(int),
-                                 nullptr);
+            phi::memory_utils::Copy(platform::CPUPlace(),
+                                    int32_host.data(),
+                                    int32_tensor.place(),
+                                    int32_tensor.data<int>(),
+                                    int32_tensor.numel() * sizeof(int),
+                                    nullptr);
 #endif
           }
           runtime_shape_tensor[name] = int32_host;
@@ -619,12 +619,12 @@ class TensorRTEngineOp : public framework::OperatorBase {
             engine->engine()->bindingIsInput(bind_index)) {
           std::vector<int> shape_v(t.numel());
           if (t.dtype() == phi::DataType::INT32) {
-            paddle::memory::Copy(platform::CPUPlace(),
-                                 shape_v.data(),
-                                 t.place(),
-                                 t.data<int32_t>(),
-                                 t.numel() * sizeof(int),
-                                 nullptr);
+            phi::memory_utils::Copy(platform::CPUPlace(),
+                                    shape_v.data(),
+                                    t.place(),
+                                    t.data<int32_t>(),
+                                    t.numel() * sizeof(int),
+                                    nullptr);
           } else if (t.dtype() == phi::DataType::INT64) {
             std::string x_t = x + "_cast_to_INT32";
             if (scope.FindVar(x_t) == nullptr) {
@@ -636,12 +636,12 @@ class TensorRTEngineOp : public framework::OperatorBase {
                 reinterpret_cast<const phi::GPUContext &>(dev_ctx),
                 t,
                 phi::DataType::INT32);
-            paddle::memory::Copy(platform::CPUPlace(),
-                                 shape_v.data(),
-                                 int32_tensor->place(),
-                                 int32_tensor->data<int32_t>(),
-                                 int32_tensor->numel() * sizeof(int),
-                                 nullptr);
+            phi::memory_utils::Copy(platform::CPUPlace(),
+                                    shape_v.data(),
+                                    int32_tensor->place(),
+                                    int32_tensor->data<int32_t>(),
+                                    int32_tensor->numel() * sizeof(int),
+                                    nullptr);
           }
           trt_context->setTensorAddress(x.c_str(), shape_v.data());
         } else {
@@ -656,12 +656,12 @@ class TensorRTEngineOp : public framework::OperatorBase {
             engine->engine()->bindingIsInput(bind_index)) {
           std::vector<int> shape_v(t.numel());
           if (t.dtype() == phi::DataType::INT32) {
-            paddle::memory::Copy(platform::CPUPlace(),
-                                 shape_v.data(),
-                                 t.place(),
-                                 t.data<int32_t>(),
-                                 t.numel() * sizeof(int),
-                                 nullptr);
+            phi::memory_utils::Copy(platform::CPUPlace(),
+                                    shape_v.data(),
+                                    t.place(),
+                                    t.data<int32_t>(),
+                                    t.numel() * sizeof(int),
+                                    nullptr);
           } else if (t.dtype() == phi::DataType::INT64) {
             std::string x_t = x + "_cast_to_INT32";
             if (scope.FindVar(x_t) == nullptr) {
@@ -673,12 +673,12 @@ class TensorRTEngineOp : public framework::OperatorBase {
                 reinterpret_cast<const phi::GPUContext &>(dev_ctx),
                 t,
                 phi::DataType::INT32);
-            paddle::memory::Copy(platform::CPUPlace(),
-                                 shape_v.data(),
-                                 int32_tensor->place(),
-                                 int32_tensor->data<int32_t>(),
-                                 int32_tensor->numel() * sizeof(int),
-                                 nullptr);
+            phi::memory_utils::Copy(platform::CPUPlace(),
+                                    shape_v.data(),
+                                    int32_tensor->place(),
+                                    int32_tensor->data<int32_t>(),
+                                    int32_tensor->numel() * sizeof(int),
+                                    nullptr);
           }
           trt_context->setInputShapeBinding(bind_index, shape_v.data());
         }

--- a/paddle/fluid/operators/top_k_op_xpu.cc
+++ b/paddle/fluid/operators/top_k_op_xpu.cc
@@ -40,11 +40,11 @@ class TopkXPUKernel : public framework::OpKernel<T> {
     // get k from input tensor
     auto* k_t = ctx.Input<phi::DenseTensor>("K");
     if (k_t) {
-      memory::Copy(platform::CPUPlace(),
-                   static_cast<void*>(&k),
-                   ctx.GetPlace(),
-                   static_cast<const void*>(k_t->data<int>()),
-                   sizeof(int));
+      phi::memory_utils::Copy(platform::CPUPlace(),
+                              static_cast<void*>(&k),
+                              ctx.GetPlace(),
+                              static_cast<const void*>(k_t->data<int>()),
+                              sizeof(int));
       framework::DDim output_dims = output->dims();
       output_dims[output_dims.size() - 1] = k;
       output->Resize(output_dims);

--- a/paddle/fluid/operators/top_k_op_xpu.cc
+++ b/paddle/fluid/operators/top_k_op_xpu.cc
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/top_k_op.h"
 #include "paddle/fluid/platform/device/device_wrapper.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "xpu/refactor/math.h"
 
 namespace paddle {

--- a/paddle/fluid/operators/uniform_random_inplace_op_xpu.cc
+++ b/paddle/fluid/operators/uniform_random_inplace_op_xpu.cc
@@ -63,11 +63,11 @@ class XPUUniformRandomInplaceKernel : public framework::OpKernel<T> {
         data_cpu[pos] = diag_val;
       }
     }
-    memory::Copy(ctx.GetPlace(),
-                 data,
-                 platform::CPUPlace(),
-                 reinterpret_cast<void *>(data_cpu.get()),
-                 size * sizeof(T));
+    phi::memory_utils::Copy(ctx.GetPlace(),
+                            data,
+                            platform::CPUPlace(),
+                            reinterpret_cast<void *>(data_cpu.get()),
+                            size * sizeof(T));
   }
 };
 
@@ -83,11 +83,11 @@ class XPUUniformRandomInplaceGradKernel : public framework::OpKernel<T> {
       for (int64_t i = 0; i < size; ++i) {
         data_cpu[i] = T(0);
       }
-      memory::Copy(ctx.GetPlace(),
-                   data,
-                   platform::CPUPlace(),
-                   reinterpret_cast<void *>(data_cpu.get()),
-                   size * sizeof(T));
+      phi::memory_utils::Copy(ctx.GetPlace(),
+                              data,
+                              platform::CPUPlace(),
+                              reinterpret_cast<void *>(data_cpu.get()),
+                              size * sizeof(T));
     }
   }
 };

--- a/paddle/fluid/operators/uniform_random_inplace_op_xpu.cc
+++ b/paddle/fluid/operators/uniform_random_inplace_op_xpu.cc
@@ -17,6 +17,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/operator.h"
 #include "paddle/fluid/operators/uniform_random_op.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/generator.h"
 
 namespace paddle {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Replace memory::Copy in fluid/operators
替换为phi用法 phi::memory_utils::Copy