### PR TITLE
[CINN] Fix bug of capture list in handler_reduce_max_op

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.cc
@@ -37,8 +37,8 @@ pir::Attribute ArrayAttributeToIntArrayAttribute(
 }
 
 const auto& handler_reduce_max_op =
-    [&](::pir::Operation* op,
-        const ::pir::Builder& builder) -> ::pir::Operation* {
+    [](::pir::Operation* op,
+       const ::pir::Builder& builder) -> ::pir::Operation* {
   VLOG(6) << "transform " << op->name() << " from cinn_op to pd_op";
   auto cinn_op = op->dyn_cast<cinn::dialect::ReduceMaxOp>();
   auto attr = cinn_op.attributes();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

CINN


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes


### Description
<!-- Describe what you’ve done -->

The lambda function `handler_reduce_max_op` defined in `cinn_to_pd_util.cc` is global, but its capture list is written in `[&]` which might cause error when compiling. Changing to `[]` will solve this problem.

PCard-76996


