### PR TITLE
[CINN] Add shape_ops_fallback_to_phi_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/accuracy_check_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/accuracy_check_pass.cc
@@ -75,10 +75,7 @@ class AddAccuracyCheckPattern
         }
       }
       pir::Operation* pd_op =
-          cinn::dialect::details::RewriteCinnOpToPdOp(op, builder);
-      for (uint32_t i = 0; i < op->num_results(); ++i) {
-        ir_mapping.Add(op->result(i), pd_op->result(i));
-      }
+          cinn::dialect::details::RewriteCinnOpToPdOp(op, ir_mapping, builder);
     };
 
     const auto& ClonePdOp = [&](::pir::Operation* op) -> void {

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -45,6 +45,7 @@
 #include "paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/pir_to_py_code_converter.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/replace_dynamic_expand_pass.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/shape_ops_fallback_to_phi_pass.h"
 #include "paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.h"
 #include "paddle/fluid/pir/transforms/build_cinn_pass.h"
 #include "paddle/fluid/pir/transforms/general/dead_code_elimination_pass.h"
@@ -161,6 +162,10 @@ void ApplyDivideGroupOpToFusionOpPass(
     pass_manager->AddPass(
         cinn::dialect::ir::CreateDivideGroupOpToFusionOpPass());
   }
+
+  pass_manager->AddPass(cinn::dialect::ir::CreateSingleOpFallbackToPhiPass());
+  pass_manager->AddPass(cinn::dialect::ir::CreateShapeOpsFallbackToPhiPass());
+
   pass_manager->Run(program);
 }
 
@@ -181,7 +186,6 @@ void ApplyCinnLowerPass(
     pass_manager->AddPass(std::move(pass.value()));
   }
 
-  pass_manager->AddPass(cinn::dialect::ir::CreateSingleOpFallbackToPhiPass());
   if (FLAGS_enable_cinn_accuracy_check) {
     VLOG(0) << "Enable CINN Accuracy Check Pass";
     pass_manager->AddPass(cinn::dialect::ir::CreateAccuarcyCheckPass());

--- a/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.h
@@ -20,6 +20,7 @@
 #include "paddle/common/enforce.h"
 
 namespace pir {
+class IrMapping;
 class Block;
 class Operation;
 class Builder;
@@ -27,8 +28,8 @@ class Builder;
 
 namespace cinn::dialect::details {
 
-using TRule =
-    std::function<::pir::Operation*(::pir::Operation*, const ::pir::Builder&)>;
+using TRule = std::function<::pir::Operation*(
+    ::pir::Operation*, ::pir::IrMapping&, ::pir::Builder&)>;
 
 class TransformContext {
  private:
@@ -86,6 +87,8 @@ class TransformRegistrar {
 
 void RewriteCinnOpToPdOp(const ::pir::Block& src_block,
                          ::pir::Block* target_block);
-::pir::Operation* RewriteCinnOpToPdOp(::pir::Operation*, const ::pir::Builder&);
+::pir::Operation* RewriteCinnOpToPdOp(::pir::Operation*,
+                                      ::pir::IrMapping&,  // NOLINT
+                                      ::pir::Builder&);   // NOLINT
 
 }  // namespace cinn::dialect::details

--- a/paddle/cinn/hlir/dialect/operator/transforms/shape_ops_fallback_to_phi_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/shape_ops_fallback_to_phi_pass.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/cinn/hlir/dialect/operator/transforms/shape_ops_fallback_to_phi_pass.h"
+
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/cinn/hlir/dialect/operator/transforms/cinn_to_pd_util.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/pir/include/core/dialect.h"
+#include "paddle/pir/include/dialect/control_flow/ir/cf_op.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+
+namespace {
+
+class FusionShapeOpsPattern
+    : public pir::OpRewritePattern<cinn::dialect::FusionOp> {
+ public:
+  explicit FusionShapeOpsPattern(::pir::IrContext* context)
+      : pir::OpRewritePattern<cinn::dialect::FusionOp>(context) {}
+
+  bool Match(cinn::dialect::FusionOp fusion_op) const override {
+    auto& shape_analysis = ::pir::ShapeAnalysisManager::Instance().Get(
+        fusion_op->GetParentProgram());
+    if (fusion_op.num_results() == 1) {
+      const auto& shape =
+          shape_analysis.GetShapeOrDataForValue(fusion_op.result(0));
+      if (shape.data()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void Rewrite(cinn::dialect::FusionOp fusion_op,
+               ::pir::PatternRewriter& rewriter) const override {
+    ::pir::IrMapping ir_mapping;
+    for (auto& op : *fusion_op.block()) {
+      if (op.isa<::pir::YieldOp>()) {
+        for (uint32_t i = 0; i < op.num_operands(); ++i) {
+          rewriter.ReplaceAllUsesWith(
+              fusion_op->result(i),
+              ir_mapping.Lookup<::pir::Value>(op.operand_source(i)));
+        }
+        continue;
+      }
+      for (size_t i = 0; i < op.num_operands(); ++i) {
+        if (!ir_mapping.GetMap<::pir::Value>().count(op.operand_source(i))) {
+          ir_mapping.Add(op.operand_source(i), op.operand_source(i));
+        }
+      }
+      if (op.dialect()->name() == "cinn_op") {
+        auto new_pd_op =
+            details::RewriteCinnOpToPdOp(&op, ir_mapping, rewriter);
+      } else {
+        auto* new_op = op.Clone(ir_mapping, {true, true, true});
+        rewriter.Insert(new_op);
+      }
+    }
+
+    rewriter.EraseOp(fusion_op);
+  }
+};
+
+class ShapeOpsFallbackToPhiPass : public pir::PatternRewritePass {
+ public:
+  ShapeOpsFallbackToPhiPass()
+      : pir::PatternRewritePass("shape_ops_fallback_to_phi_pass", 1) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext* context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add<FusionShapeOpsPattern>(context);
+
+    return ps;
+  }
+
+  bool CanApplyOn(pir::Operation* op) const override {
+    return op->num_regions() > 0;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<::pir::Pass> CreateShapeOpsFallbackToPhiPass() {
+  return std::make_unique<ShapeOpsFallbackToPhiPass>();
+}
+
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/dialect/operator/transforms/shape_ops_fallback_to_phi_pass.h
+++ b/paddle/cinn/hlir/dialect/operator/transforms/shape_ops_fallback_to_phi_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/pass/pass.h"
+
+namespace cinn {
+namespace dialect {
+namespace ir {
+std::unique_ptr<::pir::Pass> CreateShapeOpsFallbackToPhiPass();
+}  // namespace ir
+}  // namespace dialect
+}  // namespace cinn

--- a/test/ir/pir/cinn/inference/CMakeLists.txt
+++ b/test/ir/pir/cinn/inference/CMakeLists.txt
@@ -24,17 +24,4 @@ if(WITH_GPU)
   set_tests_properties(test_llama_forward PROPERTIES TIMEOUT 300)
   set_tests_properties(test_llama_postprocess PROPERTIES TIMEOUT 300)
 
-  add_test(
-    NAME test_llama_postprocess_cinn
-    COMMAND
-      ${CMAKE_COMMAND} -E env
-      PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
-      FLAGS_prim_enable_dynamic=True FLAGS_prim_all=True FLAGS_enable_pir_api=1
-      FLAGS_cinn_bucket_compile=True FLAGS_group_schedule_tiling_first=1
-      FLAGS_pd_unittest_use_cinn=1 FLAGS_pir_apply_shape_optimization_pass=1
-      ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_llama_postprocess.py
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  set_tests_properties(test_llama_postprocess_cinn
-                       PROPERTIES LABELS "RUN_TYPE=CINN" TIMEOUT 300)
-
 endif()

--- a/test/ir/pir/cinn/inference/test_llama_postprocess.py
+++ b/test/ir/pir/cinn/inference/test_llama_postprocess.py
@@ -90,8 +90,8 @@ class TestLlamaPostProcess(unittest.TestCase):
         self.input_ids = paddle.randint(0, 512, [1, 32], dtype="int64")
 
     def check_jit_kernel_info(self, static_fn):
-        utils.check_jit_kernel_number(static_fn, 10)
-        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 10})
+        utils.check_jit_kernel_number(static_fn, 9)
+        utils.check_jit_kernel_structure(static_fn, {utils.JIT_KERNEL_NAME: 9})
 
     def eval(self, use_cinn):
         paddle.seed(2024)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

添加 shape_ops_fallback_to_phi_pass 将用于shape计算的子图 fallback 到 phi kernel执行，避免GPU到CPU的数据拷贝开销。