### PR TITLE
[SOT] Fix stringify dtype object in guard string

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -177,7 +177,7 @@ def object_equal_stringify_guard(self) -> list[StringifyExpression]:
 
 def stringify_pyobject(obj: object) -> tuple[str, dict[str, Any]]:
     if isinstance(obj, paddle.core.VarDesc.VarType):
-        return f"paddle.core.DataType({obj.value})", {"paddle": paddle}
+        return f"paddle.core.VarDesc.VarType({obj.value})", {"paddle": paddle}
     elif isinstance(obj, paddle.core.DataType):
         return f"paddle.core.DataType({obj.value})", {"paddle": paddle}
     # For builtin values

--- a/python/paddle/jit/sot/opcode_translator/executor/guard.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/guard.py
@@ -18,6 +18,8 @@ import types
 import weakref
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
+import paddle
+
 from ...profiler import EventGuard
 from ...utils import current_tmp_name_records, log, log_do
 
@@ -171,3 +173,12 @@ def object_equal_stringify_guard(self) -> list[StringifyExpression]:
             ),
         )
     ]
+
+
+def stringify_pyobject(obj: object) -> tuple[str, dict[str, Any]]:
+    if isinstance(obj, paddle.core.VarDesc.VarType):
+        return f"paddle.core.DataType({obj.value})", {"paddle": paddle}
+    elif isinstance(obj, paddle.core.DataType):
+        return f"paddle.core.DataType({obj.value})", {"paddle": paddle}
+    # For builtin values
+    return f"{obj!r}", {}

--- a/python/paddle/jit/sot/opcode_translator/executor/tracker.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/tracker.py
@@ -21,7 +21,7 @@ from itertools import chain
 from typing import TYPE_CHECKING
 
 from ...utils import InnerError, NameGenerator
-from .guard import StringifyExpression, union_free_vars
+from .guard import StringifyExpression, stringify_pyobject, union_free_vars
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -242,7 +242,10 @@ class ConstTracker(Tracker):
         codegen.gen_load_const(self.value)
 
     def trace_value_from_frame(self):
-        return StringifyExpression(f"{self.value!r}", [], {})
+        value_str, value_free_vars = stringify_pyobject(self.value)
+        return StringifyExpression(
+            f"{value_str}", [], union_free_vars(value_free_vars)
+        )
 
     def __repr__(self) -> str:
         return f"ConstTracker(value={self.value})"
@@ -365,10 +368,11 @@ class GetItemTracker(Tracker):
 
     def trace_value_from_frame(self):
         container_tracer = self.container.tracker.trace_value_from_frame()
+        key_string, key_free_vars = stringify_pyobject(self.key)
         return StringifyExpression(
-            f"{{}}[{self.key!r}]",
+            f"{{}}[{key_string}]",
             [container_tracer],
-            union_free_vars(container_tracer.free_vars),
+            union_free_vars(container_tracer.free_vars, key_free_vars),
         )
 
     def __repr__(self) -> str:

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -40,6 +40,7 @@ from ..guard import (
     StringifyExpression,
     check_guard,
     object_equal_stringify_guard,
+    stringify_pyobject,
     union_free_vars,
 )
 from ..mutable_data import MutableDictLikeData
@@ -260,11 +261,15 @@ class TensorDtypeVariable(DataVariable):
             tensor_value_tracer = (
                 self.tracker.obj.tracker.trace_value_from_frame()
             )
+            dtype_str, dtype_free_vars = stringify_pyobject(self.value)
             return [
                 StringifyExpression(
-                    f"str(MetaInfo.from_tensor({{}}).dtype) == '{str(self.value)}'",
+                    f"MetaInfo.from_tensor({{}}).dtype == {dtype_str}",
                     [tensor_value_tracer],
-                    {"MetaInfo": MetaInfo},
+                    union_free_vars(
+                        {"MetaInfo": MetaInfo},
+                        dtype_free_vars,
+                    ),
                 )
             ]
         else:

--- a/test/sot/test_dataclass.py
+++ b/test/sot/test_dataclass.py
@@ -15,10 +15,7 @@
 import unittest
 from dataclasses import dataclass
 
-from test_case_base import (
-    TestCaseBase,
-    run_in_both_default_and_pir,
-)
+from test_case_base import TestCaseBase
 
 import paddle
 from paddle.jit.sot.utils import strict_mode_guard
@@ -47,13 +44,11 @@ def return_dataclass_with_post_init(x):
 
 class TestDataclass(TestCaseBase):
     @strict_mode_guard(False)
-    @run_in_both_default_and_pir
     def test_dtype_reconstruct(self):
         x = paddle.to_tensor(1)
         self.assert_results(return_dataclass, x)
 
     @strict_mode_guard(False)
-    @run_in_both_default_and_pir
     def test_dtype_reconstruct_with_post_init(self):
         x = paddle.to_tensor(1)
         self.assert_results(return_dataclass_with_post_init, x)

--- a/test/sot/test_dtype.py
+++ b/test/sot/test_dtype.py
@@ -16,7 +16,6 @@ import unittest
 
 from test_case_base import (
     TestCaseBase,
-    run_in_both_default_and_pir,
     test_instruction_translator_cache_context,
 )
 
@@ -42,8 +41,12 @@ def reconstruct_dtype():
     return y
 
 
+def dtype_guard(x, cast_map):
+    out = paddle.cast(x, cast_map[x.dtype])
+    return out, out.dtype
+
+
 class TestTensorAstype(TestCaseBase):
-    @run_in_both_default_and_pir
     def test_tensor_astype(self):
         x = paddle.ones([2, 3], dtype="float32")
         y = paddle.ones([2, 3], dtype="int32")
@@ -51,7 +54,6 @@ class TestTensorAstype(TestCaseBase):
 
 
 class TestTensorDtypeGuard(TestCaseBase):
-    @run_in_both_default_and_pir
     def test_tensor_dtype_guard(self):
         x = paddle.ones([2, 3], dtype="float32")
         y = paddle.ones([2, 3], dtype="int32")
@@ -65,9 +67,15 @@ class TestTensorDtypeGuard(TestCaseBase):
 
 
 class TestDtypeReconstruct(TestCaseBase):
-    @run_in_both_default_and_pir
     def test_dtype_reconstruct(self):
         self.assert_results(reconstruct_dtype)
+
+
+class TestDtypeGuard(TestCaseBase):
+    def test_dtype_guard(self):
+        dtype_map = {paddle.float32: paddle.float64}
+        x = paddle.ones([2, 3], dtype="float32")
+        self.assert_results(dtype_guard, x, dtype_map)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 dtype 作为 guard string 的情况下，直接使用 `repr` 导致生成的 guard string 出错的问题（问题发生在 `GetItemTracker`），dtype 直接使用 `repr` 是不可以的，应该手写字符串 reconstruct，如 `paddle.core.DataType({dtype.value})`

另外清理一下 `sot` 目录的 `run_in_both_default_and_pir`，因为 `PR-CI-Py3-PIR` 会承担 PIR 模式的检测

PCard-66972