### PR TITLE
[PIR save/load]Open more tests

### DIFF
--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -1217,6 +1217,12 @@ def load(path, **configs):
                         return tensor
                 except:
                     try:
+                        if in_pir_mode():
+                            program = paddle.static.Program()
+                            paddle.core.deserialize_pir_program(
+                                path, program, 1
+                            )
+                            return program
                         with _open_file_buffer(path, "rb") as f:
                             program_desc_str = f.read()
                             program = Program.parse_from_string(

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -154,20 +154,12 @@ def _load_state_dict_from_save_inference_model(model_path, config):
     # 1. load program desc & construct _ProgramHolder
     # TODO(GGBond8488):From a long-term perspective, it is inappropriate for the framework to
     # rely on jit. It is necessary to migrate the dependency from jit to the framework in the future
-    if in_pir_mode():
-        from paddle.jit.pir_translated_layer import (
-            _construct_params_and_buffers,
-            _construct_program_holders,
-        )
+    from paddle.jit.translated_layer import (
+        _construct_params_and_buffers,
+        _construct_program_holders,
+    )
 
-        programs = _construct_program_holders(model_path, config.model_filename)
-    else:
-        from paddle.jit.translated_layer import (
-            _construct_params_and_buffers,
-            _construct_program_holders,
-        )
-
-        programs = _construct_program_holders(model_path, config.model_filename)
+    programs = _construct_program_holders(model_path, config.model_filename)
 
     # 2. load layer parameters & buffers
     with base.dygraph.guard():
@@ -264,18 +256,12 @@ def _build_load_path_and_config(path, config):
     # raise error, avoid confusing behavior
     # TODO(GGBond8488):From a long-term perspective, it is inappropriate for the framework to
     # rely on jit. It is necessary to migrate the dependency from jit to the framework in the future
-    from paddle.jit.pir_translated_layer import (
-        PIR_INFER_MODEL_SUFFIX,
-    )
     from paddle.jit.translated_layer import (
         INFER_MODEL_SUFFIX,
         INFER_PARAMS_SUFFIX,
     )
 
-    if in_pir_mode():
-        prefix_format_path = path + PIR_INFER_MODEL_SUFFIX
-    else:
-        prefix_format_path = path + INFER_MODEL_SUFFIX
+    prefix_format_path = path + INFER_MODEL_SUFFIX
     prefix_format_exist = os.path.exists(prefix_format_path)
     directory_format_exist = os.path.isdir(path)
     if prefix_format_exist and directory_format_exist:
@@ -308,10 +294,7 @@ def _build_load_path_and_config(path, config):
                     "specified file prefix, the ``model_filename`` config does "
                     "not take effect."
                 )
-            if in_pir_mode():
-                config.model_filename = file_prefix + PIR_INFER_MODEL_SUFFIX
-            else:
-                config.model_filename = file_prefix + INFER_MODEL_SUFFIX
+            config.model_filename = file_prefix + INFER_MODEL_SUFFIX
             if config.params_filename is not None:
                 warnings.warn(
                     "When loading the result saved with the "

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -154,12 +154,20 @@ def _load_state_dict_from_save_inference_model(model_path, config):
     # 1. load program desc & construct _ProgramHolder
     # TODO(GGBond8488):From a long-term perspective, it is inappropriate for the framework to
     # rely on jit. It is necessary to migrate the dependency from jit to the framework in the future
-    from paddle.jit.translated_layer import (
-        _construct_params_and_buffers,
-        _construct_program_holders,
-    )
+    if in_pir_mode():
+        from paddle.jit.pir_translated_layer import (
+            _construct_params_and_buffers,
+            _construct_program_holders,
+        )
 
-    programs = _construct_program_holders(model_path, config.model_filename)
+        programs = _construct_program_holders(model_path, config.model_filename)
+    else:
+        from paddle.jit.translated_layer import (
+            _construct_params_and_buffers,
+            _construct_program_holders,
+        )
+
+        programs = _construct_program_holders(model_path, config.model_filename)
 
     # 2. load layer parameters & buffers
     with base.dygraph.guard():
@@ -256,12 +264,18 @@ def _build_load_path_and_config(path, config):
     # raise error, avoid confusing behavior
     # TODO(GGBond8488):From a long-term perspective, it is inappropriate for the framework to
     # rely on jit. It is necessary to migrate the dependency from jit to the framework in the future
+    from paddle.jit.pir_translated_layer import (
+        PIR_INFER_MODEL_SUFFIX,
+    )
     from paddle.jit.translated_layer import (
         INFER_MODEL_SUFFIX,
         INFER_PARAMS_SUFFIX,
     )
 
-    prefix_format_path = path + INFER_MODEL_SUFFIX
+    if in_pir_mode():
+        prefix_format_path = path + PIR_INFER_MODEL_SUFFIX
+    else:
+        prefix_format_path = path + INFER_MODEL_SUFFIX
     prefix_format_exist = os.path.exists(prefix_format_path)
     directory_format_exist = os.path.isdir(path)
     if prefix_format_exist and directory_format_exist:
@@ -294,7 +308,10 @@ def _build_load_path_and_config(path, config):
                     "specified file prefix, the ``model_filename`` config does "
                     "not take effect."
                 )
-            config.model_filename = file_prefix + INFER_MODEL_SUFFIX
+            if in_pir_mode():
+                config.model_filename = file_prefix + PIR_INFER_MODEL_SUFFIX
+            else:
+                config.model_filename = file_prefix + INFER_MODEL_SUFFIX
             if config.params_filename is not None:
                 warnings.warn(
                     "When loading the result saved with the "
@@ -1200,12 +1217,6 @@ def load(path, **configs):
                         return tensor
                 except:
                     try:
-                        if in_pir_mode():
-                            program = paddle.static.Program()
-                            paddle.core.deserialize_pir_program(
-                                path, program, 1
-                            )
-                            return program
                         with _open_file_buffer(path, "rb") as f:
                             program_desc_str = f.read()
                             program = Program.parse_from_string(

--- a/test/deprecated/legacy_test/test_load_state_dict_from_old_format.py
+++ b/test/deprecated/legacy_test/test_load_state_dict_from_old_format.py
@@ -26,7 +26,6 @@ import paddle
 from paddle import base
 from paddle.base import core
 from paddle.framework import in_pir_mode
-from paddle.pir_utils import test_with_pir_api
 
 
 def convolutional_neural_network(img):
@@ -215,7 +214,6 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         for var_name, value in orig_dict.items():
             np.testing.assert_array_equal(value, load_dict[var_name])
 
-    @test_with_pir_api
     def test_load_default(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name, "static_mnist.load_state_dict.default"
@@ -227,7 +225,6 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         new_load_param_dict = paddle.load(self.save_dirname)
         self.check_load_state_dict(orig_param_dict, new_load_param_dict)
 
-    @test_with_pir_api
     def test_load_with_model_filename(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name, "static_mnist.load_state_dict.model_filename"
@@ -241,7 +238,6 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         )
         self.check_load_state_dict(orig_param_dict, new_load_param_dict)
 
-    @test_with_pir_api
     def test_load_with_param_filename(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name, "static_mnist.load_state_dict.param_filename"
@@ -255,7 +251,6 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         )
         self.check_load_state_dict(orig_param_dict, new_load_param_dict)
 
-    @test_with_pir_api
     def test_load_with_model_and_param_filename(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name,

--- a/test/deprecated/legacy_test/test_load_state_dict_from_old_format.py
+++ b/test/deprecated/legacy_test/test_load_state_dict_from_old_format.py
@@ -25,6 +25,8 @@ from test_imperative_base import new_program_scope
 import paddle
 from paddle import base
 from paddle.base import core
+from paddle.framework import in_pir_mode
+from paddle.pir_utils import test_with_pir_api
 
 
 def convolutional_neural_network(img):
@@ -51,8 +53,80 @@ def convolutional_neural_network(img):
     return prediction
 
 
+def simple_img_conv_pool(
+    input,
+    in_channels,
+    out_channels,
+    kernel_size,
+    pool_size,
+    pool_stride,
+    pool_padding=0,
+    pool_type='max',
+    global_pooling=False,
+    conv_stride=1,
+    conv_padding=0,
+    conv_dilation=1,
+    conv_groups=1,
+    param_attr=None,
+    bias_attr=None,
+    act=None,
+    use_cudnn=True,
+):
+    conv = paddle.nn.Conv2D(
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=conv_stride,
+        padding=conv_padding,
+        dilation=conv_dilation,
+        groups=conv_groups,
+        bias_attr=bias_attr,
+    )
+    conv_out = conv(input)
+    if pool_type == 'max':
+        pool_out = paddle.nn.functional.max_pool2d(
+            x=conv_out,
+            kernel_size=pool_size,
+            stride=pool_stride,
+            padding=pool_padding,
+        )
+    else:
+        pool_out = paddle.nn.functional.avg_pool2d(
+            x=conv_out,
+            kernel_size=pool_size,
+            stride=pool_stride,
+            padding=pool_padding,
+        )
+    return pool_out
+
+
+def convolutional_neural_network_pir(img):
+    conv_pool_1 = simple_img_conv_pool(
+        input=img,
+        in_channels=1,
+        out_channels=20,
+        kernel_size=5,
+        pool_size=2,
+        pool_stride=2,
+    )
+    conv_pool_1 = paddle.nn.BatchNorm(20)(conv_pool_1)
+    conv_pool_2 = simple_img_conv_pool(
+        input=conv_pool_1,
+        in_channels=20,
+        out_channels=50,
+        kernel_size=5,
+        pool_size=2,
+        pool_stride=2,
+    )
+    prediction = paddle.static.nn.fc(x=conv_pool_2, size=10, activation='relu')
+    return prediction
+
+
 def static_train_net(img, label):
-    prediction = convolutional_neural_network(img)
+    if in_pir_mode():
+        prediction = convolutional_neural_network_pir(img)
+    else:
+        prediction = convolutional_neural_network(img)
 
     loss = paddle.nn.functional.cross_entropy(
         input=prediction, label=label, reduction='none', use_softmax=False
@@ -80,8 +154,8 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
 
     def train_and_save_model(self):
         with new_program_scope():
-            startup_program = base.default_startup_program()
-            main_program = base.default_main_program()
+            startup_program = paddle.static.default_startup_program()
+            main_program = paddle.static.default_main_program()
 
             img = paddle.static.data(
                 name='img', shape=[None, 1, 28, 28], dtype='float32'
@@ -122,7 +196,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
                         break
 
             static_param_dict = {}
-            for param in base.default_main_program().all_parameters():
+            for param in main_program.global_block().all_parameters():
                 static_param_dict[param.name] = base.executor._fetch_var(
                     param.name
                 )
@@ -132,6 +206,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
                 [img],
                 [prediction],
                 exe,
+                program=main_program,
             )
 
         return static_param_dict
@@ -140,6 +215,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         for var_name, value in orig_dict.items():
             np.testing.assert_array_equal(value, load_dict[var_name])
 
+    @test_with_pir_api
     def test_load_default(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name, "static_mnist.load_state_dict.default"
@@ -151,6 +227,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         new_load_param_dict = paddle.load(self.save_dirname)
         self.check_load_state_dict(orig_param_dict, new_load_param_dict)
 
+    @test_with_pir_api
     def test_load_with_model_filename(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name, "static_mnist.load_state_dict.model_filename"
@@ -164,6 +241,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         )
         self.check_load_state_dict(orig_param_dict, new_load_param_dict)
 
+    @test_with_pir_api
     def test_load_with_param_filename(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name, "static_mnist.load_state_dict.param_filename"
@@ -177,6 +255,7 @@ class TestLoadStateDictFromSaveInferenceModel(unittest.TestCase):
         )
         self.check_load_state_dict(orig_param_dict, new_load_param_dict)
 
+    @test_with_pir_api
     def test_load_with_model_and_param_filename(self):
         self.save_dirname = os.path.join(
             self.temp_dir.name,

--- a/test/deprecated/legacy_test/test_static_save_load_large.py
+++ b/test/deprecated/legacy_test/test_static_save_load_large.py
@@ -22,11 +22,14 @@ from test_imperative_base import new_program_scope
 import paddle
 from paddle import base
 from paddle.base import framework
+from paddle.framework.io_utils import is_pir_fetch_var
+from paddle.pir_utils import test_with_pir_api
 
 LARGE_PARAM = 2**26
 
 
 class TestStaticSaveLoadLargeParameters(unittest.TestCase):
+    @test_with_pir_api
     def test_large_parameters_static_save(self):
         # enable static graph mode
         paddle.enable_static()
@@ -46,6 +49,8 @@ class TestStaticSaveLoadLargeParameters(unittest.TestCase):
             base_map = {}
             for var in prog.list_vars():
                 if isinstance(var, framework.Parameter) or var.persistable:
+                    if is_pir_fetch_var(var):
+                        continue
                     t = np.array(
                         base.global_scope().find_var(var.name).get_tensor()
                     )
@@ -65,6 +70,8 @@ class TestStaticSaveLoadLargeParameters(unittest.TestCase):
 
             for var in load_prog1.list_vars():
                 if isinstance(var, framework.Parameter) or var.persistable:
+                    if is_pir_fetch_var(var):
+                        continue
                     new_t = np.array(
                         base.global_scope().find_var(var.name).get_tensor()
                     )
@@ -76,6 +83,8 @@ class TestStaticSaveLoadLargeParameters(unittest.TestCase):
             paddle.static.set_program_state(load_prog2, program_state)
             for var in load_prog2.list_vars():
                 if isinstance(var, framework.Parameter) or var.persistable:
+                    if is_pir_fetch_var(var):
+                        continue
                     new_t = np.array(
                         base.global_scope().find_var(var.name).get_tensor()
                     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
Open more tests
重写save/load单测中static.nn.xx相关的api组网逻辑，适配pir并开启单测
- test_imperative_load_static_param.py：PIR下使用paddle.nn.XX替换对应的paddle.static.nn.xx接口。由于动态图连续跑两次会出现与静态图parameters命名不符的情况，于是直接删除旧静态图的测试。
- test_load_state_dict_from_old_format.py：使用`test/legacy_test/nets.py` 中的 `simple_img_conv_pool`用到static.nn.conv2d，考虑修改组网会更改函数的参数列表，因此在本测试中重写该函数，使用nn.Conv2D进行组网。单测开启需要适配jit中的部分api接口，将在下个pr中合入。