### PR TITLE
[XPU] avoid malloc redundant memory when creating context in comm manager

### DIFF
--- a/paddle/phi/core/distributed/comm_context_manager.cc
+++ b/paddle/phi/core/distributed/comm_context_manager.cc
@@ -213,6 +213,7 @@ void CommContextManager::CreateBKCLCommContext(
   if (CommContextManager::device_id != -1) {
     std::unique_ptr<phi::XPUContext> dev_ctx(
         new phi::XPUContext(phi::XPUPlace(CommContextManager::device_id)));
+    dev_ctx->x_context()->set_option("XPUAPI_DEFAULT_SIZE", "1");
     dev_ctx->SetAllocator(phi::memory_utils::GetAllocator(
         CommContextManager::device_id, dev_ctx->stream()));
     dev_ctx->SetHostAllocator(phi::memory_utils::GetHostAllocator());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. fix the redundant malloc caused my `XPUAPI_DEFAULT_SIZE` when creating context in comm manager.
2. related PR: https://github.com/PaddlePaddle/Paddle/pull/63817