### PR TITLE
[SOT] Fallback when breakgraph on comprehensive

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -2047,9 +2047,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
             pycode_gen.extend_instrs(
                 origin_instrs[loop_body_start_idx:loop_body_end_idx]
             )
-            # for instr in origin_instrs[loop_body_start_idx:loop_body_end_idx]:
-            #     if instr.opname in ["LIST_APPEND", "MAP_ADD"]:
-            #         raise FallbackError("")
 
             # break should jump to this nop
             nop_for_break = pycode_gen.add_instr("NOP")

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -38,6 +38,7 @@ from ...utils import (
     InnerError,
     SotUndefinedVar,
     get_static_function,
+    is_comprehensive_name,
     log,
     log_do,
 )
@@ -1714,6 +1715,12 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 iterator.idx = backup_iter_idx
             self._graph.remove_global_guarded_variable(iterator)
             self.stack.push(iterator)
+            if is_comprehensive_name(self._code.co_name):
+                # NOTE(SigureMo): The loop body of comprehensive will access the
+                # value out of the loop, so we simply fallback it now.
+                raise FallbackError(
+                    "Comprehensive for loop break graph is not supported."
+                )
             self._break_graph_when_for_loop(iterator, instr)
             return Stop(state="BreakGraph")
 
@@ -2040,6 +2047,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
             pycode_gen.extend_instrs(
                 origin_instrs[loop_body_start_idx:loop_body_end_idx]
             )
+            # for instr in origin_instrs[loop_body_start_idx:loop_body_end_idx]:
+            #     if instr.opname in ["LIST_APPEND", "MAP_ADD"]:
+            #         raise FallbackError("")
 
             # break should jump to this nop
             nop_for_break = pycode_gen.add_instr("NOP")

--- a/python/paddle/jit/sot/utils/__init__.py
+++ b/python/paddle/jit/sot/utils/__init__.py
@@ -64,6 +64,7 @@ from .utils import (  # noqa: F401
     is_break_graph_api,
     is_builtin_fn,
     is_clean_code,
+    is_comprehensive_name,
     is_paddle_api,
     is_strict_mode,
     list_contain_by_id,

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -149,6 +149,10 @@ def no_eval_frame(func):
     return no_eval_frame_func
 
 
+def is_comprehensive_name(name):
+    return name in ["<listcomp>", "<dictcomp>", "<setcomp>", "<genexpr>"]
+
+
 def is_paddle_api(func):
     if isinstance(func, paddle.nn.Layer):  # ignore all the classes
         return False

--- a/test/sot/test_12_for_loop.py
+++ b/test/sot/test_12_for_loop.py
@@ -295,5 +295,18 @@ class TestUndefinedVarInRiskyCodes(TestCaseBase):
         self.assert_results(undefined_var_case_1)
 
 
+def comp_with_fallback(x):
+    paddle.jit.sot.psdb.fallback()
+    y = [len(t) for t in x]
+    return paddle.to_tensor(y)
+
+
+class TestListCompWithFallback(TestCaseBase):
+    @strict_mode_guard(False)
+    def test_list_comp_with_fallback(self):
+        x = [paddle.randn([4, 6])]
+        self.assert_results(comp_with_fallback, x)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

我们在 for-breakgraph 时候抽的代码是只包含 loop-body 的，为了栈平衡加了一个 `None` 占位，也就是假设抽的 loop-body 不会访问栈上 iter 以及更靠近栈底的元素

但 listcomp 是先创建一个空的 list 放在栈上，然后创建其 iter，之后再进行 loop 迭代，loop-body 中会由 `LIST_APPEND` 不断向那个空的 list 添加元素，而这个 list 是在 iter 之前放在栈上的，不满足上述假设，访问时候就会挂掉

因此对于这种情况我们目前先简单地 fallback，因为对于该种情况支持成本较高，但整体可能没有太多收益，因此先简单 fallback 保证正确性

PCard-66972