### PR TITLE
[cinn][test] added test cases about precision problem

### DIFF
--- a/test/cinn/precision/testcase_2024-05-07_23-48-49-629021.py
+++ b/test/cinn/precision/testcase_2024-05-07_23-48-49-629021.py
@@ -1,0 +1,153 @@
+
+import os
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = '1'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+
+import unittest
+import numpy as np
+import paddle
+
+
+class CinnMonkeyNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x1):
+        tensor594 = x1
+
+        # tensor594: (128, 64, 32)
+        tensor603 = -tensor594
+        assert tuple(tensor603.shape) == (128, 64, 32)
+        
+        # tensor603: (128, 64, 32)
+        reduced96 = tensor603.sum(axis=(1,), keepdim=True)
+        assert tuple(reduced96.shape) == (128, 1, 32)
+        
+        
+        
+        # tensor594: (128, 64, 32)
+        tensor604 = -tensor594
+        assert tuple(tensor604.shape) == (128, 64, 32)
+        
+        # tensor604: (128, 64, 32)
+        reduced97 = tensor604.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced97.shape) == (128, 64, 1)
+        
+        
+        # tensor594: (128, 64, 32)
+        # reduced96: (128, 1, 32)
+        tensor595 = tensor594 + reduced96
+        assert tuple(tensor595.shape) == (128, 64, 32)
+        
+        # tensor595: (128, 64, 32)
+        tensor606 = -tensor595
+        assert tuple(tensor606.shape) == (128, 64, 32)
+        
+        # tensor606: (128, 64, 32)
+        reduced98 = tensor606.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced98.shape) == (128, 64, 1)
+        
+        # reduced97: (128, 64, 1)
+        tensor596 = -reduced97
+        assert tuple(tensor596.shape) == (128, 64, 1)
+        
+        # tensor596: (128, 64, 1)
+        reduced99 = tensor596.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced99.shape) == (1, 64, 1)
+        
+        # reduced99: (1, 64, 1)
+        expanded58 = paddle.expand(reduced99, shape=(1, 64, 32))
+        assert tuple(expanded58.shape) == (1, 64, 32)
+        
+        # tensor594: (128, 64, 32)
+        tensor597 = -tensor594
+        assert tuple(tensor597.shape) == (128, 64, 32)
+        
+        # expanded58: (1, 64, 32)
+        # reduced98: (128, 64, 1)
+        tensor598 = expanded58 + reduced98
+        assert tuple(tensor598.shape) == (128, 64, 32)
+        
+        
+        # tensor598: (128, 64, 32)
+        tensor610 = -tensor598
+        assert tuple(tensor610.shape) == (128, 64, 32)
+        
+        # tensor610: (128, 64, 32)
+        reduced100 = tensor610.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced100.shape) == (128, 64, 1)
+        
+        # tensor598: (128, 64, 32)
+        # reduced100: (128, 64, 1)
+        tensor599 = tensor598 + reduced100
+        assert tuple(tensor599.shape) == (128, 64, 32)
+        
+        # tensor599: (128, 64, 32)
+        tensor612 = -tensor599
+        assert tuple(tensor612.shape) == (128, 64, 32)
+        
+        # tensor612: (128, 64, 32)
+        reduced101 = tensor612.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced101.shape) == (128, 64, 1)
+        
+        # tensor597: (128, 64, 32)
+        # reduced96: (128, 1, 32)
+        tensor600 = tensor597 + reduced96
+        assert tuple(tensor600.shape) == (128, 64, 32)
+        
+        # tensor600: (128, 64, 32)
+        # reduced101: (128, 64, 1)
+        tensor601 = tensor600 + reduced101
+        assert tuple(tensor601.shape) == (128, 64, 32)
+        
+        # tensor601: (128, 64, 32)
+        tensor615 = -tensor601
+        assert tuple(tensor615.shape) == (128, 64, 32)
+        
+        # tensor615: (128, 64, 32)
+        reduced102 = tensor615.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced102.shape) == (128, 64, 1)
+        return reduced102
+
+
+class TestCinnMonkey(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x1 = paddle.uniform([128, 64, 32], dtype="float32", min=-0.5, max=0.5)
+        self.x1.stop_gradient = True
+
+    def apply_to_static(self, net, use_cinn, input_spec=None):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = use_cinn
+        return paddle.jit.to_static(
+            net,
+            input_spec=input_spec,
+            build_strategy=build_strategy,
+            full_graph=True,
+        )
+
+    def train(self, use_cinn):
+        net = CinnMonkeyNet()
+        net.eval()
+        net = self.apply_to_static(net, use_cinn)
+        out = net(self.x1)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cinn/precision/testcase_2024-05-08_00-25-01-567052.py
+++ b/test/cinn/precision/testcase_2024-05-08_00-25-01-567052.py
@@ -1,0 +1,155 @@
+
+import os
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = '1'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+
+import unittest
+import numpy as np
+import paddle
+
+
+class CinnMonkeyNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x1):
+        tensor7940 = x1
+
+        # tensor7940: (128, 64, 32)
+        tensor7950 = -tensor7940
+        assert tuple(tensor7950.shape) == (128, 64, 32)
+        
+        # tensor7950: (128, 64, 32)
+        reduced1274 = tensor7950.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced1274.shape) == (128, 64, 1)
+        
+        
+        
+        # reduced1274: (128, 64, 1)
+        tensor7951 = -reduced1274
+        assert tuple(tensor7951.shape) == (128, 64, 1)
+        
+        # tensor7951: (128, 64, 1)
+        expanded850 = paddle.expand(tensor7951, shape=(128, 64, 32))
+        assert tuple(expanded850.shape) == (128, 64, 32)
+        
+        
+        # tensor7940: (128, 64, 32)
+        # tensor7940: (128, 64, 32)
+        tensor7941 = tensor7940 + tensor7940
+        assert tuple(tensor7941.shape) == (128, 64, 32)
+        
+        # tensor7941: (128, 64, 32)
+        tensor7953 = -tensor7941
+        assert tuple(tensor7953.shape) == (128, 64, 32)
+        
+        # tensor7953: (128, 64, 32)
+        reduced1275 = tensor7953.sum(axis=(0, 1), keepdim=True)
+        assert tuple(reduced1275.shape) == (1, 1, 32)
+        
+        # reduced1275: (1, 1, 32)
+        # tensor7940: (128, 64, 32)
+        tensor7942 = reduced1275 + tensor7940
+        assert tuple(tensor7942.shape) == (128, 64, 32)
+        
+        # tensor7942: (128, 64, 32)
+        tensor7955 = -tensor7942
+        assert tuple(tensor7955.shape) == (128, 64, 32)
+        
+        # tensor7955: (128, 64, 32)
+        reduced1276 = tensor7955.sum(axis=(0, 1), keepdim=True)
+        assert tuple(reduced1276.shape) == (1, 1, 32)
+        
+        # reduced1276: (1, 1, 32)
+        tensor7943 = -reduced1276
+        assert tuple(tensor7943.shape) == (1, 1, 32)
+        
+        # tensor7943: (1, 1, 32)
+        expanded851 = paddle.expand(tensor7943, shape=(1, 64, 32))
+        assert tuple(expanded851.shape) == (1, 64, 32)
+        
+        # reduced1274: (128, 64, 1)
+        tensor7944 = -reduced1274
+        assert tuple(tensor7944.shape) == (128, 64, 1)
+        
+        # tensor7944: (128, 64, 1)
+        expanded852 = paddle.expand(tensor7944, shape=(128, 64, 32))
+        assert tuple(expanded852.shape) == (128, 64, 32)
+        
+        # expanded850: (128, 64, 32)
+        tensor7945 = -expanded850
+        assert tuple(tensor7945.shape) == (128, 64, 32)
+        
+        # expanded851: (1, 64, 32)
+        tensor7946 = -expanded851
+        assert tuple(tensor7946.shape) == (1, 64, 32)
+        
+        # tensor7946: (1, 64, 32)
+        expanded853 = paddle.expand(tensor7946, shape=(128, 64, 32))
+        assert tuple(expanded853.shape) == (128, 64, 32)
+        
+        
+        # expanded853: (128, 64, 32)
+        tensor7947 = -expanded853
+        assert tuple(tensor7947.shape) == (128, 64, 32)
+        
+        # tensor7947: (128, 64, 32)
+        reduced1277 = tensor7947.sum(axis=(0, 1), keepdim=True)
+        assert tuple(reduced1277.shape) == (1, 1, 32)
+        
+        # reduced1277: (1, 1, 32)
+        # expanded852: (128, 64, 32)
+        tensor7948 = reduced1277 + expanded852
+        assert tuple(tensor7948.shape) == (128, 64, 32)
+        
+        # tensor7948: (128, 64, 32)
+        tensor7962 = -tensor7948
+        assert tuple(tensor7962.shape) == (128, 64, 32)
+        
+        # tensor7962: (128, 64, 32)
+        reduced1278 = tensor7962.sum(axis=(1,), keepdim=True)
+        assert tuple(reduced1278.shape) == (128, 1, 32)
+        return reduced1278
+
+
+class TestCinnMonkey(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x1 = paddle.uniform([128, 64, 32], dtype="float32", min=-0.5, max=0.5)
+        self.x1.stop_gradient = True
+
+    def apply_to_static(self, net, use_cinn, input_spec=None):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = use_cinn
+        return paddle.jit.to_static(
+            net,
+            input_spec=input_spec,
+            build_strategy=build_strategy,
+            full_graph=True,
+        )
+
+    def train(self, use_cinn):
+        net = CinnMonkeyNet()
+        net.eval()
+        net = self.apply_to_static(net, use_cinn)
+        out = net(self.x1)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cinn/precision/testcase_2024-05-08_02-36-56-591889.py
+++ b/test/cinn/precision/testcase_2024-05-08_02-36-56-591889.py
@@ -1,0 +1,173 @@
+
+import os
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = '1'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+
+import unittest
+import numpy as np
+import paddle
+
+
+class CinnMonkeyNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x1):
+        tensor34428 = x1
+
+        # tensor34428: (128, 64, 1)
+        tensor34437 = -tensor34428
+        assert tuple(tensor34437.shape) == (128, 64, 1)
+        
+        # tensor34437: (128, 64, 1)
+        expanded3793 = paddle.expand(tensor34437, shape=(128, 64, 32))
+        assert tuple(expanded3793.shape) == (128, 64, 32)
+        
+        
+        # tensor34428: (128, 64, 1)
+        tensor34438 = -tensor34428
+        assert tuple(tensor34438.shape) == (128, 64, 1)
+        
+        # tensor34438: (128, 64, 1)
+        reduced5555 = tensor34438.sum(axis=(1,), keepdim=True)
+        assert tuple(reduced5555.shape) == (128, 1, 1)
+        
+        # reduced5555: (128, 1, 1)
+        expanded3794 = paddle.expand(reduced5555, shape=(128, 1, 32))
+        assert tuple(expanded3794.shape) == (128, 1, 32)
+        
+        
+        # tensor34428: (128, 64, 1)
+        tensor34439 = -tensor34428
+        assert tuple(tensor34439.shape) == (128, 64, 1)
+        
+        # tensor34439: (128, 64, 1)
+        expanded3795 = paddle.expand(tensor34439, shape=(128, 64, 32))
+        assert tuple(expanded3795.shape) == (128, 64, 32)
+        
+        
+        # expanded3793: (128, 64, 32)
+        tensor34440 = -expanded3793
+        assert tuple(tensor34440.shape) == (128, 64, 32)
+        
+        # tensor34440: (128, 64, 32)
+        reduced5556 = tensor34440.sum(axis=(0, 1), keepdim=True)
+        assert tuple(reduced5556.shape) == (1, 1, 32)
+        
+        # reduced5556: (1, 1, 32)
+        # expanded3794: (128, 1, 32)
+        tensor34429 = reduced5556 + expanded3794
+        assert tuple(tensor34429.shape) == (128, 1, 32)
+        
+        # tensor34429: (128, 1, 32)
+        tensor34442 = -tensor34429
+        assert tuple(tensor34442.shape) == (128, 1, 32)
+        
+        # tensor34442: (128, 1, 32)
+        reduced5557 = tensor34442.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced5557.shape) == (1, 1, 32)
+        
+        # reduced5557: (1, 1, 32)
+        expanded3796 = paddle.expand(reduced5557, shape=(1, 64, 32))
+        assert tuple(expanded3796.shape) == (1, 64, 32)
+        
+        # tensor34428: (128, 64, 1)
+        # expanded3796: (1, 64, 32)
+        tensor34430 = tensor34428 + expanded3796
+        assert tuple(tensor34430.shape) == (128, 64, 32)
+        
+        # tensor34430: (128, 64, 32)
+        tensor34444 = -tensor34430
+        assert tuple(tensor34444.shape) == (128, 64, 32)
+        
+        # tensor34444: (128, 64, 32)
+        reduced5558 = tensor34444.sum(axis=(0, 1), keepdim=True)
+        assert tuple(reduced5558.shape) == (1, 1, 32)
+        
+        # expanded3793: (128, 64, 32)
+        tensor34431 = -expanded3793
+        assert tuple(tensor34431.shape) == (128, 64, 32)
+        
+        # tensor34431: (128, 64, 32)
+        # expanded3795: (128, 64, 32)
+        tensor34432 = tensor34431 + expanded3795
+        assert tuple(tensor34432.shape) == (128, 64, 32)
+        
+        # reduced5558: (1, 1, 32)
+        tensor34433 = -reduced5558
+        assert tuple(tensor34433.shape) == (1, 1, 32)
+        
+        # tensor34433: (1, 1, 32)
+        expanded3797 = paddle.expand(tensor34433, shape=(128, 64, 32))
+        assert tuple(expanded3797.shape) == (128, 64, 32)
+        
+        
+        # expanded3797: (128, 64, 32)
+        # expanded3797: (128, 64, 32)
+        tensor34434 = expanded3797 + expanded3797
+        assert tuple(tensor34434.shape) == (128, 64, 32)
+        
+        # tensor34434: (128, 64, 32)
+        tensor34449 = -tensor34434
+        assert tuple(tensor34449.shape) == (128, 64, 32)
+        
+        # tensor34449: (128, 64, 32)
+        reduced5559 = tensor34449.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced5559.shape) == (128, 64, 1)
+        
+        # reduced5559: (128, 64, 1)
+        # tensor34432: (128, 64, 32)
+        tensor34435 = reduced5559 + tensor34432
+        assert tuple(tensor34435.shape) == (128, 64, 32)
+        
+        # tensor34435: (128, 64, 32)
+        tensor34451 = -tensor34435
+        assert tuple(tensor34451.shape) == (128, 64, 32)
+        
+        # tensor34451: (128, 64, 32)
+        reduced5560 = tensor34451.sum(axis=(1, 2), keepdim=True)
+        assert tuple(reduced5560.shape) == (128, 1, 1)
+        return reduced5560
+
+
+class TestCinnMonkey(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x1 = paddle.uniform([128, 64, 1], dtype="float32", min=-0.5, max=0.5)
+        self.x1.stop_gradient = True
+
+    def apply_to_static(self, net, use_cinn, input_spec=None):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = use_cinn
+        return paddle.jit.to_static(
+            net,
+            input_spec=input_spec,
+            build_strategy=build_strategy,
+            full_graph=True,
+        )
+
+    def train(self, use_cinn):
+        net = CinnMonkeyNet()
+        net.eval()
+        net = self.apply_to_static(net, use_cinn)
+        out = net(self.x1)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cinn/precision/testcase_2024-05-08_03-23-33-590354.py
+++ b/test/cinn/precision/testcase_2024-05-08_03-23-33-590354.py
@@ -1,0 +1,184 @@
+
+import os
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = '1'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+
+import unittest
+import numpy as np
+import paddle
+
+
+class CinnMonkeyNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x1):
+        tensor43863 = x1
+
+        # tensor43863: (128, 64, 32)
+        tensor43873 = -tensor43863
+        assert tuple(tensor43873.shape) == (128, 64, 32)
+        
+        # tensor43873: (128, 64, 32)
+        reduced7078 = tensor43873.sum(axis=(0, 2), keepdim=True)
+        assert tuple(reduced7078.shape) == (1, 64, 1)
+        
+        
+        # reduced7078: (1, 64, 1)
+        tensor43874 = -reduced7078
+        assert tuple(tensor43874.shape) == (1, 64, 1)
+        
+        # tensor43874: (1, 64, 1)
+        expanded4784 = paddle.expand(tensor43874, shape=(128, 64, 1))
+        assert tuple(expanded4784.shape) == (128, 64, 1)
+        
+        
+        # tensor43863: (128, 64, 32)
+        tensor43875 = -tensor43863
+        assert tuple(tensor43875.shape) == (128, 64, 32)
+        
+        # tensor43875: (128, 64, 32)
+        reduced7079 = tensor43875.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced7079.shape) == (128, 64, 1)
+        
+        
+        # tensor43863: (128, 64, 32)
+        tensor43876 = -tensor43863
+        assert tuple(tensor43876.shape) == (128, 64, 32)
+        
+        # tensor43876: (128, 64, 32)
+        reduced7080 = tensor43876.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced7080.shape) == (1, 64, 32)
+        
+        # reduced7078: (1, 64, 1)
+        # reduced7079: (128, 64, 1)
+        tensor43864 = reduced7078 + reduced7079
+        assert tuple(tensor43864.shape) == (128, 64, 1)
+        
+        # tensor43864: (128, 64, 1)
+        tensor43878 = -tensor43864
+        assert tuple(tensor43878.shape) == (128, 64, 1)
+        
+        # tensor43878: (128, 64, 1)
+        expanded4785 = paddle.expand(tensor43878, shape=(128, 64, 32))
+        assert tuple(expanded4785.shape) == (128, 64, 32)
+        
+        # expanded4785: (128, 64, 32)
+        # expanded4784: (128, 64, 1)
+        tensor43865 = expanded4785 + expanded4784
+        assert tuple(tensor43865.shape) == (128, 64, 32)
+        
+        # tensor43865: (128, 64, 32)
+        tensor43880 = -tensor43865
+        assert tuple(tensor43880.shape) == (128, 64, 32)
+        
+        # tensor43880: (128, 64, 32)
+        reduced7081 = tensor43880.sum(axis=(0, 1, 2), keepdim=True)
+        assert tuple(reduced7081.shape) == (1, 1, 1)
+        
+        # tensor43863: (128, 64, 32)
+        # reduced7080: (1, 64, 32)
+        tensor43866 = tensor43863 + reduced7080
+        assert tuple(tensor43866.shape) == (128, 64, 32)
+        
+        
+        # reduced7081: (1, 1, 1)
+        tensor43882 = -reduced7081
+        assert tuple(tensor43882.shape) == (1, 1, 1)
+        
+        # tensor43882: (1, 1, 1)
+        expanded4786 = paddle.expand(tensor43882, shape=(128, 64, 32))
+        assert tuple(expanded4786.shape) == (128, 64, 32)
+        
+        # tensor43866: (128, 64, 32)
+        # expanded4786: (128, 64, 32)
+        tensor43867 = tensor43866 + expanded4786
+        assert tuple(tensor43867.shape) == (128, 64, 32)
+        
+        # tensor43867: (128, 64, 32)
+        tensor43884 = -tensor43867
+        assert tuple(tensor43884.shape) == (128, 64, 32)
+        
+        # tensor43884: (128, 64, 32)
+        reduced7082 = tensor43884.sum(axis=(0, 2), keepdim=True)
+        assert tuple(reduced7082.shape) == (1, 64, 1)
+        
+        # reduced7082: (1, 64, 1)
+        # reduced7081: (1, 1, 1)
+        tensor43868 = reduced7082 + reduced7081
+        assert tuple(tensor43868.shape) == (1, 64, 1)
+        
+        # tensor43868: (1, 64, 1)
+        tensor43886 = -tensor43868
+        assert tuple(tensor43886.shape) == (1, 64, 1)
+        
+        # tensor43886: (1, 64, 1)
+        reduced7083 = tensor43886.sum(axis=(1,), keepdim=True)
+        assert tuple(reduced7083.shape) == (1, 1, 1)
+        
+        # reduced7083: (1, 1, 1)
+        tensor43869 = -reduced7083
+        assert tuple(tensor43869.shape) == (1, 1, 1)
+        
+        # tensor43869: (1, 1, 1)
+        expanded4787 = paddle.expand(tensor43869, shape=(128, 64, 32))
+        assert tuple(expanded4787.shape) == (128, 64, 32)
+        
+        tensor43870 = paddle.ones((128, 1, 32))
+        
+        # expanded4787: (128, 64, 32)
+        # tensor43870: (128, 1, 32)
+        tensor43871 = expanded4787 + tensor43870
+        assert tuple(tensor43871.shape) == (128, 64, 32)
+        
+        # tensor43871: (128, 64, 32)
+        tensor43890 = -tensor43871
+        assert tuple(tensor43890.shape) == (128, 64, 32)
+        
+        # tensor43890: (128, 64, 32)
+        reduced7084 = tensor43890.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced7084.shape) == (1, 64, 32)
+        return reduced7084
+
+
+class TestCinnMonkey(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x1 = paddle.uniform([128, 64, 32], dtype="float32", min=-0.5, max=0.5)
+        self.x1.stop_gradient = True
+
+    def apply_to_static(self, net, use_cinn, input_spec=None):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = use_cinn
+        return paddle.jit.to_static(
+            net,
+            input_spec=input_spec,
+            build_strategy=build_strategy,
+            full_graph=True,
+        )
+
+    def train(self, use_cinn):
+        net = CinnMonkeyNet()
+        net.eval()
+        net = self.apply_to_static(net, use_cinn)
+        out = net(self.x1)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cinn/precision/testcase_2024-05-08_04-32-27-449728.py
+++ b/test/cinn/precision/testcase_2024-05-08_04-32-27-449728.py
@@ -1,0 +1,135 @@
+
+import os
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = '1'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+
+import unittest
+import numpy as np
+import paddle
+
+
+class CinnMonkeyNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x1):
+        tensor57720 = x1
+
+        # tensor57720: (128, 64, 32)
+        tensor57731 = -tensor57720
+        assert tuple(tensor57731.shape) == (128, 64, 32)
+        
+        # tensor57731: (128, 64, 32)
+        reduced9351 = tensor57731.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced9351.shape) == (1, 64, 32)
+        
+        
+        
+        # tensor57720: (128, 64, 32)
+        tensor57721 = -tensor57720
+        assert tuple(tensor57721.shape) == (128, 64, 32)
+        
+        # tensor57721: (128, 64, 32)
+        reduced9352 = tensor57721.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced9352.shape) == (128, 64, 1)
+        
+        # tensor57720: (128, 64, 32)
+        # reduced9352: (128, 64, 1)
+        tensor57722 = tensor57720 + reduced9352
+        assert tuple(tensor57722.shape) == (128, 64, 32)
+        
+        # tensor57722: (128, 64, 32)
+        tensor57734 = -tensor57722
+        assert tuple(tensor57734.shape) == (128, 64, 32)
+        
+        # tensor57734: (128, 64, 32)
+        reduced9353 = tensor57734.sum(axis=(2,), keepdim=True)
+        assert tuple(reduced9353.shape) == (128, 64, 1)
+        
+        # reduced9353: (128, 64, 1)
+        # tensor57720: (128, 64, 32)
+        tensor57723 = reduced9353 + tensor57720
+        assert tuple(tensor57723.shape) == (128, 64, 32)
+        
+        # tensor57723: (128, 64, 32)
+        # reduced9351: (1, 64, 32)
+        tensor57724 = tensor57723 + reduced9351
+        assert tuple(tensor57724.shape) == (128, 64, 32)
+        
+        # tensor57724: (128, 64, 32)
+        tensor57737 = -tensor57724
+        assert tuple(tensor57737.shape) == (128, 64, 32)
+        
+        # tensor57737: (128, 64, 32)
+        reduced9354 = tensor57737.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced9354.shape) == (1, 64, 32)
+        
+        tensor57725 = paddle.ones((128, 1, 32))
+        
+        # tensor57725: (128, 1, 32)
+        # reduced9354: (1, 64, 32)
+        tensor57726 = tensor57725 + reduced9354
+        assert tuple(tensor57726.shape) == (128, 64, 32)
+        
+        tensor57727 = paddle.ones((128, 64, 32))
+        
+        # tensor57726: (128, 64, 32)
+        tensor57728 = -tensor57726
+        assert tuple(tensor57728.shape) == (128, 64, 32)
+        
+        # tensor57728: (128, 64, 32)
+        # tensor57727: (128, 64, 32)
+        tensor57729 = tensor57728 + tensor57727
+        assert tuple(tensor57729.shape) == (128, 64, 32)
+        
+        # tensor57729: (128, 64, 32)
+        tensor57743 = -tensor57729
+        assert tuple(tensor57743.shape) == (128, 64, 32)
+        
+        # tensor57743: (128, 64, 32)
+        reduced9355 = tensor57743.sum(axis=(0,), keepdim=True)
+        assert tuple(reduced9355.shape) == (1, 64, 32)
+        return reduced9355
+
+
+class TestCinnMonkey(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x1 = paddle.uniform([128, 64, 32], dtype="float32", min=-0.5, max=0.5)
+        self.x1.stop_gradient = True
+
+    def apply_to_static(self, net, use_cinn, input_spec=None):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = use_cinn
+        return paddle.jit.to_static(
+            net,
+            input_spec=input_spec,
+            build_strategy=build_strategy,
+            full_graph=True,
+        )
+
+    def train(self, use_cinn):
+        net = CinnMonkeyNet()
+        net.eval()
+        net = self.apply_to_static(net, use_cinn)
+        out = net(self.x1)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cinn/precision/testcase_2024-05-08_07-31-44-263281.py
+++ b/test/cinn/precision/testcase_2024-05-08_07-31-44-263281.py
@@ -1,0 +1,128 @@
+
+import os
+os.environ['FLAGS_cinn_new_group_scheduler'] = '1'
+os.environ['FLAGS_group_schedule_tiling_first'] = '1'
+os.environ['FLAGS_prim_all'] = 'true'
+os.environ['FLAGS_prim_enable_dynamic'] = '1'
+os.environ['FLAGS_print_ir'] = '1'
+os.environ['FLAGS_enable_pir_api'] = '1'
+os.environ['FLAGS_cinn_bucket_compile'] = '1'
+
+import unittest
+import numpy as np
+import paddle
+
+
+class CinnMonkeyNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x1):
+        tensor93540 = x1
+
+        # tensor93540: (128, 64, 1)
+        tensor93549 = -tensor93540
+        assert tuple(tensor93549.shape) == (128, 64, 1)
+        
+        # tensor93549: (128, 64, 1)
+        expanded10156 = paddle.expand(tensor93549, shape=(128, 64, 32))
+        assert tuple(expanded10156.shape) == (128, 64, 32)
+        
+        
+        # expanded10156: (128, 64, 32)
+        tensor93541 = -expanded10156
+        assert tuple(tensor93541.shape) == (128, 64, 32)
+        
+        tensor93542 = paddle.zeros((128, 64, 32))
+        
+        
+        # tensor93540: (128, 64, 1)
+        # tensor93541: (128, 64, 32)
+        tensor93543 = tensor93540 + tensor93541
+        assert tuple(tensor93543.shape) == (128, 64, 32)
+        
+        # tensor93543: (128, 64, 32)
+        tensor93553 = -tensor93543
+        assert tuple(tensor93553.shape) == (128, 64, 32)
+        
+        # tensor93553: (128, 64, 32)
+        reduced15119 = tensor93553.sum(axis=(1,), keepdim=True)
+        assert tuple(reduced15119.shape) == (128, 1, 32)
+        
+        # reduced15119: (128, 1, 32)
+        tensor93544 = -reduced15119
+        assert tuple(tensor93544.shape) == (128, 1, 32)
+        
+        # tensor93544: (128, 1, 32)
+        expanded10157 = paddle.expand(tensor93544, shape=(128, 64, 32))
+        assert tuple(expanded10157.shape) == (128, 64, 32)
+        
+        # expanded10157: (128, 64, 32)
+        # expanded10156: (128, 64, 32)
+        tensor93545 = expanded10157 + expanded10156
+        assert tuple(tensor93545.shape) == (128, 64, 32)
+        
+        # tensor93545: (128, 64, 32)
+        tensor93556 = -tensor93545
+        assert tuple(tensor93556.shape) == (128, 64, 32)
+        
+        # tensor93556: (128, 64, 32)
+        reduced15120 = tensor93556.sum(axis=(0, 1, 2), keepdim=True)
+        assert tuple(reduced15120.shape) == (1, 1, 1)
+        
+        
+        # reduced15120: (1, 1, 1)
+        tensor93557 = -reduced15120
+        assert tuple(tensor93557.shape) == (1, 1, 1)
+        
+        # tensor93557: (1, 1, 1)
+        expanded10158 = paddle.expand(tensor93557, shape=(128, 64, 32))
+        assert tuple(expanded10158.shape) == (128, 64, 32)
+        
+        # expanded10158: (128, 64, 32)
+        tensor93546 = -expanded10158
+        assert tuple(tensor93546.shape) == (128, 64, 32)
+        
+        # reduced15120: (1, 1, 1)
+        # tensor93546: (128, 64, 32)
+        tensor93547 = reduced15120 + tensor93546
+        assert tuple(tensor93547.shape) == (128, 64, 32)
+        return tensor93547
+
+
+class TestCinnMonkey(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2024)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.x1 = paddle.uniform([128, 64, 1], dtype="float32", min=-0.5, max=0.5)
+        self.x1.stop_gradient = True
+
+    def apply_to_static(self, net, use_cinn, input_spec=None):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = use_cinn
+        return paddle.jit.to_static(
+            net,
+            input_spec=input_spec,
+            build_strategy=build_strategy,
+            full_graph=True,
+        )
+
+    def train(self, use_cinn):
+        net = CinnMonkeyNet()
+        net.eval()
+        net = self.apply_to_static(net, use_cinn)
+        out = net(self.x1)
+        return out
+
+    def test_train(self):
+        cinn_out = self.train(use_cinn=True)
+        dy_out = self.train(use_cinn=False)
+
+        # np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-6)
+        np.testing.assert_allclose(cinn_out.numpy(), dy_out.numpy(), atol=1e-1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

 - testcase_2024-05-08_00-25-01-567052.py
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0.1

Mismatched elements: 3712 / 4096 (90.6%)
Max absolute difference: 786432.
Max relative difference: 2.7324716e-06
 x: array([[[-2.039584e+11, -9.214598e+10,  3.794478e+11, ...,
         -4.501165e+10,  3.185473e+11,  3.306163e+11]],
...
 y: array([[[-2.039585e+11, -9.214575e+10,  3.794476e+11, ...,
         -4.501169e+10,  3.185471e+11,  3.306160e+11]],
...

----------------------------------------------------------------------
Ran 1 test in 5.456s

FAILED (failures=1)
```

 - testcase_2024-05-08_03-23-33-590354.py
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0.1

Mismatched elements: 2048 / 2048 (100%)
Max absolute difference: 10485760.
Max relative difference: 2.043608e-06
 x: array([[[5.130993e+12, 5.130993e+12, 5.130993e+12, ..., 5.130993e+12,
         5.130993e+12, 5.130993e+12],
        [5.130993e+12, 5.130993e+12, 5.130993e+12, ..., 5.130993e+12,...
 y: array([[[5.131004e+12, 5.131004e+12, 5.131004e+12, ..., 5.131004e+12,
         5.131004e+12, 5.131004e+12],
        [5.131004e+12, 5.131004e+12, 5.131004e+12, ..., 5.131004e+12,...

----------------------------------------------------------------------
Ran 1 test in 6.700s

FAILED (failures=1)
```

 - testcase_2024-05-08_02-36-56-591889.py
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0.1

Mismatched elements: 128 / 128 (100%)
Max absolute difference: 598016.
Max relative difference: 5.0873628e-06
 x: array([[[-1.175487e+11]],

       [[-1.175487e+11]],...
 y: array([[[-1.175493e+11]],

       [[-1.175493e+11]],...

----------------------------------------------------------------------
Ran 1 test in 5.994s

FAILED (failures=1)
```

 - testcase_2024-05-08_04-32-27-449728.py
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0.1

Mismatched elements: 345 / 2048 (16.8%)
Max absolute difference: 0.53125
Max relative difference: 0.00262743
 x: array([[[ -36417.473 ,  -22028.    ,  -21334.545 , ...,  -56605.53  ,
          -87466.48  ,  -42245.11  ],
        [  36898.902 ,  -17155.645 ,   24385.854 , ...,  -69763.234 ,...
 y: array([[[ -36417.504 ,  -22028.002 ,  -21334.523 , ...,  -56605.504 ,
          -87466.37  ,  -42245.047 ],
        [  36898.95  ,  -17155.654 ,   24385.828 , ...,  -69763.12  ,...

----------------------------------------------------------------------
Ran 1 test in 5.354s

FAILED (failures=1)
```
 - testcase_2024-05-07_23-48-49-629021.py
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0.1

Mismatched elements: 3153 / 8192 (38.5%)
Max absolute difference: 1.
Max relative difference: 0.01736318
 x: array([[[ -340139.75 ],
        [  -60099.516],
        [ -227136.62 ],...
 y: array([[[ -340139.75 ],
        [  -60099.414],
        [ -227136.31 ],...

----------------------------------------------------------------------
Ran 1 test in 6.556s

FAILED (failures=1)
```

- testcase_2024-05-08_07-31-44-263281.py
```
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0.1

Mismatched elements: 262144 / 262144 (100%)
Max absolute difference: 7006.492
Max relative difference: 1.
 x: array([[[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],...
 y: array([[[-7006.492, -7006.492, -7006.492, ..., -7006.492, -7006.492,
         -7006.492],
        [-7006.492, -7006.492, -7006.492, ..., -7006.492, -7006.492,...

----------------------------------------------------------------------
Ran 1 test in 3.852s

FAILED (failures=1)
```