### PR TITLE
[PIR] Fix memory leak when training models containing if control flow

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -207,8 +207,8 @@ void IfInstruction::SetInputHooks(const std::vector<PirHookFunc>& hookfuncs) {
   false_branch_inter_->SetInputHooks(hookfuncs);
 }
 
-void IfInstruction::SetInnerOutputGCHook(const InnerOutputGCHook& hook) {
-  inner_outputs_gc_hook_ = hook;
+void IfInstruction::SetInnerOutputGCFunc(const InnerOutputGCFunc& func) {
+  inner_outputs_gc_ = func;
 }
 
 void IfInstruction::Run() {
@@ -251,11 +251,11 @@ void IfInstruction::Run() {
     true_branch_inter_->Run({}, false);
     CopyBranchOutput(
         true_branch_outputs_, output_vars_, true_branch_inter_->InnerScope());
-    if (inner_outputs_gc_hook_) {
+    if (inner_outputs_gc_) {
       for (auto var_name : true_branch_outputs_) {
         auto* inner_outpuut =
             true_branch_inter_->InnerScope()->FindVar(var_name);
-        inner_outputs_gc_hook_(inner_outpuut, this);
+        inner_outputs_gc_(inner_outpuut, this);
       }
     }
   } else {
@@ -268,11 +268,11 @@ void IfInstruction::Run() {
     false_branch_inter_->Run({}, false);
     CopyBranchOutput(
         false_branch_outputs_, output_vars_, false_branch_inter_->InnerScope());
-    if (inner_outputs_gc_hook_) {
+    if (inner_outputs_gc_) {
       for (auto var_name : false_branch_outputs_) {
         auto* inner_outpuut =
             false_branch_inter_->InnerScope()->FindVar(var_name);
-        inner_outputs_gc_hook_(inner_outpuut, this);
+        inner_outputs_gc_(inner_outpuut, this);
       }
     }
   }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.cc
@@ -253,9 +253,9 @@ void IfInstruction::Run() {
         true_branch_outputs_, output_vars_, true_branch_inter_->InnerScope());
     if (inner_outputs_gc_) {
       for (auto var_name : true_branch_outputs_) {
-        auto* inner_outpuut =
+        auto* inner_output =
             true_branch_inter_->InnerScope()->FindVar(var_name);
-        inner_outputs_gc_(inner_outpuut, this);
+        inner_outputs_gc_(inner_output, this);
       }
     }
   } else {
@@ -270,9 +270,9 @@ void IfInstruction::Run() {
         false_branch_outputs_, output_vars_, false_branch_inter_->InnerScope());
     if (inner_outputs_gc_) {
       for (auto var_name : false_branch_outputs_) {
-        auto* inner_outpuut =
+        auto* inner_output =
             false_branch_inter_->InnerScope()->FindVar(var_name);
-        inner_outputs_gc_(inner_outpuut, this);
+        inner_outputs_gc_(inner_output, this);
       }
     }
   }

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
@@ -29,6 +29,9 @@ class PirInterpreter;
 class ValueExecutionInfo;
 
 class IfInstruction : public InstructionBase {
+ private:
+  using InnerOutputGCHook = std::function<void(Variable*, InstructionBase*)>;
+
  public:
   IfInstruction(size_t id,
                 const platform::Place& place,
@@ -52,6 +55,8 @@ class IfInstruction : public InstructionBase {
 
   void SetInputHooks(const std::vector<PirHookFunc>& hookfuncs);
 
+  void SetInnerOutputGCHook(const InnerOutputGCHook& hook);
+
  private:
   ::pir::Operation* op_;
 
@@ -74,6 +79,8 @@ class IfInstruction : public InstructionBase {
   std::vector<std::string> true_skip_gc_names_;
 
   std::vector<std::string> false_skip_gc_names_;
+
+  InnerOutputGCHook inner_outputs_gc_hook_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
@@ -81,6 +81,9 @@ class IfInstruction : public InstructionBase {
   std::vector<std::string> false_skip_gc_names_;
 
   InnerOutputGCFunc inner_outputs_gc_;
+
+  void InnerOutputGC(const std::vector<std::string>& outputs,
+                     PirInterpreter* inter);
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
+++ b/paddle/fluid/framework/new_executor/instruction/control_flow/if_instruction.h
@@ -30,7 +30,7 @@ class ValueExecutionInfo;
 
 class IfInstruction : public InstructionBase {
  private:
-  using InnerOutputGCHook = std::function<void(Variable*, InstructionBase*)>;
+  using InnerOutputGCFunc = std::function<void(Variable*, InstructionBase*)>;
 
  public:
   IfInstruction(size_t id,
@@ -55,7 +55,7 @@ class IfInstruction : public InstructionBase {
 
   void SetInputHooks(const std::vector<PirHookFunc>& hookfuncs);
 
-  void SetInnerOutputGCHook(const InnerOutputGCHook& hook);
+  void SetInnerOutputGCFunc(const InnerOutputGCFunc& func);
 
  private:
   ::pir::Operation* op_;
@@ -80,7 +80,7 @@ class IfInstruction : public InstructionBase {
 
   std::vector<std::string> false_skip_gc_names_;
 
-  InnerOutputGCHook inner_outputs_gc_hook_;
+  InnerOutputGCFunc inner_outputs_gc_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -732,6 +732,12 @@ void PirInterpreter::BuildInstruction() {
                                             execution_config_);
         if_instr_ptr->SetOutputHooks(pir_output_hookfuncs_);
         if_instr_ptr->SetInputHooks(pir_input_hookfuncs_);
+
+        if_instr_ptr->SetInnerOutputGCHook(
+            [this](Variable* var, InstructionBase* instr) {
+              this->gc_->Add(var, instr);
+            });
+
         vec_instruction_base_.emplace_back(std::move(if_instr_ptr));
 
         sub_blocks_.insert(

--- a/paddle/fluid/framework/new_executor/pir_interpreter.cc
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.cc
@@ -733,7 +733,7 @@ void PirInterpreter::BuildInstruction() {
         if_instr_ptr->SetOutputHooks(pir_output_hookfuncs_);
         if_instr_ptr->SetInputHooks(pir_input_hookfuncs_);
 
-        if_instr_ptr->SetInnerOutputGCHook(
+        if_instr_ptr->SetInnerOutputGCFunc(
             [this](Variable* var, InstructionBase* instr) {
               this->gc_->Add(var, instr);
             });

--- a/paddle/fluid/framework/new_executor/pir_interpreter.h
+++ b/paddle/fluid/framework/new_executor/pir_interpreter.h
@@ -124,6 +124,10 @@ class PirInterpreter : public InterpreterBaseImpl {
     force_events_to_wait_ = force_events_to_wait;
   }
 
+  const std::unordered_set<std::string>& GetParameterVarNames() const {
+    return parameter_var_names_;
+  }
+
  private:
   // build graph
   void UpdateSyncOpNum();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others


### Description
<!-- Describe what you’ve done -->
- 修复 PaddleDetection 中 ppyoloe_plus_crn_l_80e_coco 模型训练在 PIR 下出现的显存泄露问题

#### 问题描述：
ppyoloe_plus_crn_l_80e_coco 模型在 PIR 下训练会出现 memory allocated 随着训练不断增长最后 out of memory 的错误

<details>
<summary>修复前 PIR 训练过程</summary>

```bash
Epoch: [0] [   0/6250] mem_allocated: 1021 MB mem_reserved: 3496 MB
Epoch: [0] [   1/6250] mem_allocated: 1125 MB mem_reserved: 3496 MB
Epoch: [0] [   2/6250] mem_allocated: 1229 MB mem_reserved: 3496 MB
Epoch: [0] [   3/6250] mem_allocated: 1698 MB mem_reserved: 8608 MB
Epoch: [0] [   4/6250] mem_allocated: 1920 MB mem_reserved: 8608 MB
Epoch: [0] [   5/6250] mem_allocated: 2059 MB mem_reserved: 8608 MB
Epoch: [0] [   6/6250] mem_allocated: 2492 MB mem_reserved: 8822 MB
Epoch: [0] [   7/6250] mem_allocated: 2596 MB mem_reserved: 8822 MB
Epoch: [0] [   8/6250] mem_allocated: 2716 MB mem_reserved: 8822 MB
Epoch: [0] [   9/6250] mem_allocated: 2939 MB mem_reserved: 8822 MB
Epoch: [0] [  10/6250] mem_allocated: 3044 MB mem_reserved: 8822 MB
...
Epoch: [0] [  19/6250] mem_allocated: 5268 MB mem_reserved: 10415 MB
----------------------
Error Message Summary:
----------------------
ResourceExhaustedError: 

Out of memory error on GPU 0. Cannot allocate 27.000000MB memory on GPU 0, 10.906372GB memory has been allocated and available memory is only 4.062500MB.
```
</details>

<details>
<summary>修复后 PIR 训练过程</summary>

```bash
Epoch: [0] [   0/6250] mem_allocated: 825 MB mem_reserved: 3497 MB
Epoch: [0] [   1/6250] mem_allocated: 825 MB mem_reserved: 3497 MB
Epoch: [0] [   2/6250] mem_allocated: 825 MB mem_reserved: 3497 MB
Epoch: [0] [   3/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [   4/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [   5/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [   6/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [   7/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [   8/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [   9/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
Epoch: [0] [  10/6250] mem_allocated: 825 MB mem_reserved: 8529 MB
```
</details>

<details>
<summary>旧 IR 训练过程</summary>

```bash
Epoch: [0] [   0/6250] mem_allocated: 825 MB mem_reserved: 3480 MB
Epoch: [0] [   1/6250] mem_allocated: 825 MB mem_reserved: 3480 MB
Epoch: [0] [   2/6250] mem_allocated: 825 MB mem_reserved: 3480 MB
Epoch: [0] [   3/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [   4/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [   5/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [   6/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [   7/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [   8/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [   9/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
Epoch: [0] [  10/6250] mem_allocated: 825 MB mem_reserved: 8517 MB
```
</details>

#### 问题原因
1. if_instruction 中 true 或 false 分支里的计算结果 (inner outputs) 会以共享内存的的方法拷贝给其他 Variable 作为 if_instruction 的输出 (if outputs)，但是这些 inner outputs 没有被 GC，而当 if outputs 被 GC 时，由于 inner outputs 也持有了相同的内存，最终导致这个内存没能正确回收
2. ppyoloe_plus_crn_l_80e_coco 对于 Program 中的同一个 if 控制流，每次迭代执行时都会定义新的 inner outputs，导致随着训练没有被回收的显存越来越多，最后报了 OOM 的错误

#### Solution
- 在完成 if_instruction 后 GC inner outputs，inner outputs 在 if op 的子 block 中不能被 GC，否者会导致 inner outputs 由于没有被引用会在拷贝到 if outputs 前就被 GC 掉了从而报错
