### PR TITLE
[CINN] Fix bug of symbol constraint

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
+++ b/paddle/pir/src/dialect/shape/utils/constraints_manager.cc
@@ -236,11 +236,10 @@ void ConstraintsManager::SubstituteInConstraint(const DimExpr& origin,
   substitution_pattern[origin] = substituted;
 
   EqualConstraints substituted_equals;
-  auto substituted_equals_map = substituted_equals.GetMap();
   EqualConstraintsVisitor([&](auto it) {
     DimExpr key = SubstituteDimExpr(it->first, substitution_pattern);
     DimExpr value = SubstituteDimExpr(it->second, substitution_pattern);
-    (*substituted_equals_map)[key] = value;
+    substituted_equals.Union(key, value);
   });
   equals_ = substituted_equals;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复添加符号相等约束时并查集中出现循环引用的Bug。