### PR TITLE
[AutoParallel-PIR] Remove program clone in Pass

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.cc
@@ -109,27 +109,27 @@ void VerifyDenseBlock(pir::Block* block) {
   }
 }
 
-std::shared_ptr<pir::Program> DistToDensePass(pir::Program* prog) {
+void DistToDensePass(pir::Program* prog) {
   if (FLAGS_print_ir) {
     VLOG(0) << "IR before DistToDense Pass = " << *prog;
   }
 
   pir::IrMapping mapper;
-  auto new_prog = prog->Clone(mapper);
+  // auto new_prog = prog->Clone(mapper);
 
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<OperatorDialect>();
   ctx->GetOrRegisterDialect<DistDialect>();
 
-  ProcessDistBlock(new_prog->block());
-  VLOG(6) << "IR before VerifyDenseBlock Pass = " << *new_prog;
-  VerifyDenseBlock(new_prog->block());
+  ProcessDistBlock(prog->block());
+  VLOG(6) << "IR before VerifyDenseBlock Pass = " << *prog;
+  VerifyDenseBlock(prog->block());
 
   if (FLAGS_print_ir) {
-    VLOG(0) << "IR after DistToDense Pass = " << *new_prog;
+    VLOG(0) << "IR after DistToDense Pass = " << *prog;
   }
 
-  return new_prog;
+  // return prog;
 }
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.h
+++ b/paddle/fluid/pir/dialect/distributed/transforms/dist_to_dense_pass.h
@@ -18,7 +18,7 @@
 namespace paddle {
 namespace dialect {
 
-TEST_API std::shared_ptr<pir::Program> DistToDensePass(pir::Program* prog);
+TEST_API void DistToDensePass(pir::Program* prog);
 
 void ProcessDistBlock(pir::Block* block);
 

--- a/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.cc
@@ -134,7 +134,7 @@ void VerifyDistBlock(pir::Block* block) {
 
 void MixToDistPass(pir::Program* prog) {
   if (FLAGS_print_ir) {
-    std::cout << "IR before MixToDist Pass = " << *prog << std::endl;
+    VLOG(0) << "IR before MixToDist Pass = " << *prog << std::endl;
   }
 
   pir::IrMapping mapper;
@@ -148,7 +148,7 @@ void MixToDistPass(pir::Program* prog) {
   VerifyDistBlock(prog->block());
 
   if (FLAGS_print_ir) {
-    std::cout << "IR after MixToDist Pass = " << *prog << std::endl;
+    VLOG(0) << "IR after MixToDist Pass = " << *prog << std::endl;
   }
 
   // return prog;

--- a/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.cc
@@ -132,26 +132,26 @@ void VerifyDistBlock(pir::Block* block) {
   }
 }
 
-std::shared_ptr<pir::Program> MixToDistPass(pir::Program* prog) {
+void MixToDistPass(pir::Program* prog) {
   if (FLAGS_print_ir) {
     std::cout << "IR before MixToDist Pass = " << *prog << std::endl;
   }
 
   pir::IrMapping mapper;
-  auto new_prog = prog->Clone(mapper);
+  // auto new_prog = prog->Clone(mapper);
 
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<OperatorDialect>();
   ctx->GetOrRegisterDialect<DistDialect>();
 
-  ProcessMixBlock(new_prog->block());
-  VerifyDistBlock(new_prog->block());
+  ProcessMixBlock(prog->block());
+  VerifyDistBlock(prog->block());
 
   if (FLAGS_print_ir) {
-    std::cout << "IR after MixToDist Pass = " << *new_prog << std::endl;
+    std::cout << "IR after MixToDist Pass = " << *prog << std::endl;
   }
 
-  return new_prog;
+  // return prog;
 }
 
 }  // namespace dialect

--- a/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.h
+++ b/paddle/fluid/pir/dialect/distributed/transforms/mix_to_dist_pass.h
@@ -20,7 +20,7 @@ namespace dialect {
 
 // pir::Type ConvertOpTypeToKernelType(pir::Type op_type);
 
-TEST_API std::shared_ptr<pir::Program> MixToDistPass(pir::Program* prog);
+TEST_API void MixToDistPass(pir::Program* prog);
 
 void ProcessMixBlock(pir::Block* block);
 

--- a/test/auto_parallel/pir/test_learning_rate.py
+++ b/test/auto_parallel/pir/test_learning_rate.py
@@ -101,9 +101,7 @@ class TestLearningRate(unittest.TestCase):
         engine = dist_model._engine
         engine._build("train")
         dist_program = engine._fwd_main_progs["train"]
-        dist_program = paddle.base.libpaddle.pir.apply_mix2dist_pass(
-            dist_program
-        )
+        paddle.base.libpaddle.pir.apply_mix2dist_pass(dist_program)
         loss = dist_program.get_output_value_by_name(engine._loss_names[0])
         with paddle.static.program_guard(dist_program):
             params_grads = paddle.autograd.ir_backward.append_backward(loss)

--- a/test/auto_parallel/pir/test_reshard.py
+++ b/test/auto_parallel/pir/test_reshard.py
@@ -53,9 +53,7 @@ class TestToStaticPirProgramTrain(unittest.TestCase):
         engine = dist_model._engine
         engine._build("train")
         dist_program = engine._fwd_main_progs["train"]
-        dist_program = paddle.base.libpaddle.pir.apply_mix2dist_pass(
-            dist_program
-        )
+        paddle.base.libpaddle.pir.apply_mix2dist_pass(dist_program)
         loss = dist_program.get_output_value_by_name(engine._loss_names[0])
         with paddle.static.program_guard(dist_program):
             params_grads = paddle.autograd.ir_backward.append_backward(loss)

--- a/test/auto_parallel/test_pir_mix2dist_pass.py
+++ b/test/auto_parallel/test_pir_mix2dist_pass.py
@@ -42,7 +42,6 @@ class TestBuildFakeProgram(unittest.TestCase):
                 )
 
         paddle.base.libpaddle.pir.apply_mix2dist_pass(main_program)
-        # print(dist_program)
 
 
 if __name__ == "__main__":

--- a/test/auto_parallel/test_pir_mix2dist_pass.py
+++ b/test/auto_parallel/test_pir_mix2dist_pass.py
@@ -41,10 +41,8 @@ class TestBuildFakeProgram(unittest.TestCase):
                     initializer=paddle.nn.initializer.Uniform(),
                 )
 
-        dist_program = paddle.base.libpaddle.pir.apply_mix2dist_pass(
-            main_program
-        )
-        print(dist_program)
+        paddle.base.libpaddle.pir.apply_mix2dist_pass(main_program)
+        # print(dist_program)
 
 
 if __name__ == "__main__":

--- a/test/cpp/pir/distributed/dist_dialect_test.cc
+++ b/test/cpp/pir/distributed/dist_dialect_test.cc
@@ -591,9 +591,8 @@ TEST(mix_to_dist_pass_test, base) {
             (uint32_t)1);
 
   // Apply Pass
-  std::shared_ptr<pir::Program> new_program =
-      paddle::dialect::MixToDistPass(&program);
-  pir::Block* new_block = new_program->block();
+  paddle::dialect::MixToDistPass(&program);
+  pir::Block* new_block = program.block();
   EXPECT_EQ(2, static_cast<int>(new_block->num_ops()));
   std::vector<pir::Operation*> ops;
   for (auto& op : *new_block) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Remove program clone to keep operation relationship between forward and backward which is need by de-composition. 
