### PR TITLE
[CINN] delete redundant ShapeOptimizationPass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_cinn_pass.cc
@@ -112,10 +112,6 @@ void ApplyBuildGroupOpPass(
     const std::function<std::shared_ptr<pir::PassManager>()>&
         CreatePassManager) {
   std::shared_ptr<pir::PassManager> pass_manager = CreatePassManager();
-  bool has_dynamic_shape = HasDynamicShape(*program);
-  if (has_dynamic_shape) {
-    pass_manager->AddPass(pir::CreateShapeOptimizationPass());
-  }
   pass_manager->AddPass(cinn::dialect::ir::CreateFoldManipulationOpsPass());
 
   pass_manager->AddPass(pir::CreateBuildCinnPass());
@@ -130,7 +126,6 @@ void ApplyGroupOpPass(::pir::Program* program,
   pass_manager->AddPass(
       cinn::dialect::ir::CreateAddBroadcastToElementwisePass());
   if (HasDynamicShape(*program)) {
-    pass_manager->AddPass(::pir::CreateShapeOptimizationPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateInsertBroadcastPass());
     pass_manager->AddPass(cinn::dialect::ir::CreateSimplifyDimExprPass());
     pass_manager->AddPass(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Deprecations

### Description
<!-- Describe what you’ve done -->
Pcard-67164
Following the implementation of [[CINN] Reconstruct shape_analysis #63790](https://github.com/PaddlePaddle/Paddle/pull/63790), the GetShapeOrDataForValue function is now operating in a lazy mode for passes. Consequently, the ShapeOptimizationPass, which is responsible for inferring shapes for the entire graph,  is only needed to be executed once(even no need). This pull deletes redundant invocations of the ShapeOptimizationPass.