### PR TITLE
[CINN] Simplify broadcast while SetShapeOrDataForValue

### DIFF
--- a/paddle/pir/include/dialect/shape/utils/shape_analysis.h
+++ b/paddle/pir/include/dialect/shape/utils/shape_analysis.h
@@ -59,6 +59,9 @@ class IR_API InferSymbolicShapeContext {
   void PrintShapeOrDatas() const;
 
  private:
+  symbol::ShapeOrDataDimExprs SimplifyBroadcastForShapeOrData(
+      const symbol::ShapeOrDataDimExprs& shape_or_data);
+
   void SubstituteDimExpr(const symbol::DimExpr& origin,
                          const symbol::DimExpr& substituted);
 

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -221,7 +221,7 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
     }
   };
 
-  auto ShapeOrDataVisitor = common::Overloaded{
+  shape_or_data.Match(
       [&](const symbol::TensorShapeOrDataDimExprs& tensor_shape_or_data) {
         return symbol::ShapeOrDataDimExprs(
             TensorShapeOrDataVisitor(tensor_shape_or_data));
@@ -234,8 +234,7 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
               TensorShapeOrDataVisitor(tensor_shape_or_data));
         }
         return symbol::ShapeOrDataDimExprs(simplified_tensor_list);
-      }};
-  return std::visit(ShapeOrDataVisitor, shape_or_data.variant());
+      });
 }
 
 namespace {

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -221,7 +221,7 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
     }
   };
 
-  shape_or_data.Match(
+  return shape_or_data.Match(
       [&](const symbol::TensorShapeOrDataDimExprs& tensor_shape_or_data) {
         return symbol::ShapeOrDataDimExprs(
             TensorShapeOrDataVisitor(tensor_shape_or_data));

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -119,8 +119,11 @@ void InferSymbolicShapeContext::SetStaticShapeForValue(Value val) {
 
 void InferSymbolicShapeContext::SetShapeOrDataForValue(
     Value val, const symbol::ShapeOrDataDimExprs& shape_or_data) {
+  const symbol::ShapeOrDataDimExprs& simplified_shape_or_data =
+      SimplifyBroadcastForShapeOrData(shape_or_data);
   const symbol::ShapeOrDataDimExprs& substituted_shape_or_data =
-      symbol::SubstituteShapeOrData(shape_or_data, substitution_pattern_);
+      symbol::SubstituteShapeOrData(simplified_shape_or_data,
+                                    substitution_pattern_);
   if (!val) {
     LOG(WARNING) << "Set shape or data for null value";
     return;
@@ -162,6 +165,76 @@ void InferSymbolicShapeContext::AddBroadcastableCstr(
 bool InferSymbolicShapeContext::IsBroadcastable(
     const symbol::DimExpr& lhs, const symbol::DimExpr& rhs) const {
   return constraints_manager_.IsBroadcastable(lhs, rhs);
+}
+
+symbol::ShapeOrDataDimExprs
+InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
+    const symbol::ShapeOrDataDimExprs& shape_or_data) {
+  auto SimplifyBroadcast =
+      [&](const symbol::Broadcast<symbol::DimExpr>& bc) -> symbol::DimExpr {
+    const symbol::List<symbol::DimExpr>& dim_exprs = bc.operands;
+    symbol::List<symbol::DimExpr> gtone_list;
+    for (const auto& dim_expr : *dim_exprs) {
+      if (IsGreatThanOne(dim_expr)) gtone_list->push_back(dim_expr);
+    }
+    symbol::DimExpr simplified_dim_expr = bc;
+    if (gtone_list->size() == 1) {
+      simplified_dim_expr = gtone_list->at(0);
+    } else if (gtone_list->size() > 1) {
+      for (int i = 1; i <= gtone_list->size(); i++) {
+        AddEqualCstr(gtone_list->at(0), gtone_list->at(i));
+      }
+      simplified_dim_expr = gtone_list->at(0);
+    }
+    return simplified_dim_expr;
+  };
+
+  auto SimplifyInShapeOrData =
+      [&](const symbol::TensorShapeOrDataDimExprs& shape_or_data)
+      -> symbol::TensorShapeOrDataDimExprs {
+    auto SimplifyOneDimExpr =
+        [&](const std::vector<symbol::DimExpr>& original_dim_expr)
+        -> std::vector<symbol::DimExpr> {
+      std::vector<symbol::DimExpr> simplified_dim_exprs{};
+      for (const symbol::DimExpr& dim_expr : original_dim_expr) {
+        // TODO(jiawenxuan): recursively evaluate each dim expr
+        if (dim_expr.isa<symbol::Broadcast<symbol::DimExpr>>()) {
+          const auto& simplified_dim_expr = SimplifyBroadcast(
+              dim_expr.Get<symbol::Broadcast<symbol::DimExpr>>());
+          simplified_dim_exprs.push_back(simplified_dim_expr);
+        } else {
+          simplified_dim_exprs.push_back(dim_expr);
+        }
+      }
+      return simplified_dim_exprs;
+    };
+    std::vector<symbol::DimExpr> simplified_shape =
+        SimplifyOneDimExpr(shape_or_data.shape());
+    if (!shape_or_data.data().has_value()) {
+      return symbol::ShapeOrData<symbol::DimExpr>(simplified_shape);
+    } else {
+      std::vector<symbol::DimExpr> simplified_data =
+          SimplifyOneDimExpr(shape_or_data.data().value());
+      return symbol::ShapeOrData<symbol::DimExpr>(simplified_shape,
+                                                  simplified_data);
+    }
+  };
+
+  auto ShapeOrDataVisitor = common::Overloaded{
+      [&](const symbol::TensorShapeOrDataDimExprs& tensor_shape_or_data) {
+        return symbol::ShapeOrDataDimExprs(
+            SimplifyInShapeOrData(tensor_shape_or_data));
+      },
+      [&](const symbol::TensorListShapeOrDataDimExprs& tensor_list) {
+        symbol::TensorListShapeOrDataDimExprs simplified_tensor_list;
+        for (symbol::TensorShapeOrDataDimExprs tensor_shape_or_data :
+             tensor_list) {
+          simplified_tensor_list.push_back(
+              SimplifyInShapeOrData(tensor_shape_or_data));
+        }
+        return symbol::ShapeOrDataDimExprs(simplified_tensor_list);
+      }};
+  return std::visit(ShapeOrDataVisitor, shape_or_data.variant());
 }
 
 namespace {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996
This pr simplify Broadcast while SetShapeOrDataForValue. If the operands of Broadcast contain the dimexpr which is great than one, the Broadcast will be simplify.
