### PR TITLE
【Distributed】Delete `scale_and_split_grads` function

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -616,7 +616,7 @@ class PipelineParallel(MetaParallelBase):
             ), "comm buffers should be created"
             for _, buffers in self._chunk_2_comm_buffers.items():
                 for buffer in buffers:
-                    buffer.scale_and_split_grads()
+                    buffer.scale_grads()
 
         if self._enable_timer:
             self.timers("allreduce_shared_weight_gradients").start()
@@ -1151,7 +1151,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
 
             for _, buffers in self._chunk_2_comm_buffers.items():
                 for buffer in buffers:
-                    buffer.scale_and_split_grads()
+                    buffer.scale_grads()
 
     def _backward_step_helper(self, micro_step):
         virtual_pp_rank = self._get_virtual_pp_rank(micro_step, forward=False)
@@ -1854,7 +1854,7 @@ class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
 
         for buffers in self._chunk_2_comm_buffers.values():
             for buffer in buffers:
-                buffer.scale_and_split_grads()
+                buffer.scale_grads()
 
     def forward_backward_pipeline(
         self, data, scaler, forward_only=False, compute_loss=True

--- a/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
+++ b/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
@@ -625,15 +625,6 @@ class FusedCommBuffer:
 
         self._reset_params_checked_in()
 
-    @imperative_base.no_grad
-    def scale_and_split_grads(self):
-        assert self._task is not None, "Task is not initialized. "
-        self._task.wait()
-        scale_factor = 1.0 / self._comm_group.nranks
-        self.grad_storage.scale_(scale_factor)
-
-        self._reset_params_checked_in()
-
 
 def obtain_storage(
     parameters,

--- a/test/deprecated/cpp/inference/test.cmake
+++ b/test/deprecated/cpp/inference/test.cmake
@@ -169,6 +169,14 @@ set(IMG_CLS_RESNET_INSTALL_DIR
 set(IMG_CLS_RESNET_MODEL_DIR
     "${IMG_CLS_RESNET_INSTALL_DIR}/image_classification_resnet.inference.model")
 
+if(NOT EXISTS
+   ${IMG_CLS_RESNET_INSTALL_DIR}/image_classification_resnet.inference.model.tgz
+)
+  inference_download_and_uncompress_without_verify(
+    ${IMG_CLS_RESNET_INSTALL_DIR} ${INFERENCE_URL}
+    "image_classification_resnet.inference.model.tgz")
+endif()
+
 if(WITH_ONNXRUNTIME)
   set(MOBILENETV2_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/MobileNetV2")
   set(MOBILENETV2_MODEL_DIR "${MOBILENETV2_INSTALL_DIR}/MobileNetV2")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Repalce the function `scale_and_split_grads` using `scale_grads`.