### PR TITLE
[CINN] implement strategy for generate shape op

### DIFF
--- a/paddle/cinn/common/dim_expr_converter.cc
+++ b/paddle/cinn/common/dim_expr_converter.cc
@@ -11,9 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #include "paddle/cinn/common/dim_expr_converter.h"
+#include <unordered_map>
 #include "paddle/cinn/common/ir_util.h"
+#include "paddle/cinn/ir/tensor.h"
 
 namespace cinn::common {
 using namespace symbol;  // NOLINT
@@ -27,7 +28,7 @@ struct DimExprToIrExprVisitor {
 
   ir::Expr operator()(const int64_t& dim) { return ir::Expr(dim); }
 
-  ir::Expr operator()(const std::string& dim_expr) {
+  virtual ir::Expr operator()(const std::string& dim_expr) {
     // The dimension must be greater equal than 1, and due to the extensive use
     // of int32 in CAS, the upper bound here is temporarily INT32_MAX, otherwise
     // there may be a risk of overflow.
@@ -111,8 +112,61 @@ struct DimExprToIrExprVisitor {
 
 }  // namespace
 
+struct DimExprConverterWithSymbolBindings::
+    DimExprToIrExprVisitorWithSymbolBinding : public DimExprToIrExprVisitor {
+  using SymbolBinding = cinn::dialect::SymbolBinding;
+  using ShapeSymbolBinding = cinn::dialect::ShapeSymbolBinding;
+  using DataSymbolBinding = cinn::dialect::DataSymbolBinding;
+
+  const std::vector<ir::Tensor>& inputs_;
+  std::unordered_map<std::string, cinn::dialect::SymbolBinding>
+      symbol_binding_map_;
+
+  ir::Expr operator()(const std::string& dim_expr) override {
+    CHECK(symbol_binding_map_.count(dim_expr));
+    auto symbol_binding = symbol_binding_map_[dim_expr];
+    auto [input_idx, input_dim_idx] = std::visit(
+        [](auto&& symbol_binding) -> std::pair<int64_t, int64_t> {
+          return {symbol_binding.input_tensor_idx,
+                  symbol_binding.input_tensor_dim_idx};
+        },
+        symbol_binding);
+    if (std::holds_alternative<ShapeSymbolBinding>(symbol_binding)) {
+      return inputs_[input_idx]->sym_shape[input_dim_idx]->GetDimExpr();
+    }
+    // for data binding [S0, a, b], inputs[a] is Tensor A, return A(b)
+    return inputs_[input_idx](cinn::ir::Expr(input_dim_idx));
+  }
+
+  DimExprToIrExprVisitorWithSymbolBinding(
+      const std::vector<ir::Tensor>& inputs,
+      const std::vector<SymbolBinding>& symbol_bindings)
+      : inputs_(inputs) {
+    for (const auto& symbol_binding : symbol_bindings) {
+      const auto& symbol_name = std::visit(
+          [](auto&& symbol_binding) -> std::string {
+            return symbol_binding.symbol_name;
+          },
+          symbol_binding);
+      symbol_binding_map_[symbol_name] = symbol_binding;
+    }
+  }
+};
+
 ir::Expr DimExprConverter::ConvertToIrExpr(const DimExpr& dim_expr) const {
   return DimExprToIrExprVisitor().ConvertToIrExpr(dim_expr);
+}
+
+ir::Expr DimExprConverterWithSymbolBindings::ConvertToIrExpr(
+    const DimExpr& dim_expr) const {
+  return visitor_->ConvertToIrExpr(dim_expr);
+}
+
+DimExprConverterWithSymbolBindings::DimExprConverterWithSymbolBindings(
+    const std::vector<ir::Tensor>& inputs,
+    const cinn::dialect::SymbolBindings& symbol_bindings) {
+  visitor_ = std::make_shared<DimExprToIrExprVisitorWithSymbolBinding>(
+      inputs, symbol_bindings);
 }
 
 }  // namespace cinn::common

--- a/paddle/cinn/common/dim_expr_converter.h
+++ b/paddle/cinn/common/dim_expr_converter.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <memory.h>
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/ir/ir.h"
 #include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
 
@@ -21,6 +23,17 @@ namespace cinn::common {
 
 struct DimExprConverter final {
   ir::Expr ConvertToIrExpr(const symbol::DimExpr&) const;
+};
+
+struct DimExprConverterWithSymbolBindings final {
+  ir::Expr ConvertToIrExpr(const symbol::DimExpr&) const;
+  DimExprConverterWithSymbolBindings(
+      const std::vector<ir::Tensor>& inputs,
+      const cinn::dialect::SymbolBindings& symbol_bindings);
+
+ private:
+  struct DimExprToIrExprVisitorWithSymbolBinding;
+  std::shared_ptr<DimExprToIrExprVisitorWithSymbolBinding> visitor_;
 };
 
 }  // namespace cinn::common

--- a/paddle/cinn/frontend/paddle_model_convertor.cc
+++ b/paddle/cinn/frontend/paddle_model_convertor.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "paddle/cinn/frontend/paddle_model_convertor.h"
-
 #include <glog/logging.h>
 
 #include <algorithm>
@@ -25,6 +24,7 @@
 #include "paddle/cinn/frontend/paddle/cpp/program_desc.h"
 #include "paddle/cinn/frontend/paddle/model_parser.h"
 #include "paddle/cinn/frontend/var_type_utils.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/hlir/op/use_ops.h"
 #include "paddle/common/enforce.h"
 
@@ -202,6 +202,8 @@ void SetOpDescAttr(const std::string& attr_name,
     VISITOR_EXPAND(std::vector<int64_t>)
     VISITOR_EXPAND(std::vector<double>)
 #undef VISITOR_EXPAND
+    void operator()(const std::vector<symbol::DimExpr>& v) {}
+    void operator()(const cinn::dialect::SymbolBindings& v) {}
 
    private:
     paddle::cpp::OpDesc* op_desc_;

--- a/paddle/cinn/frontend/syntax.cc
+++ b/paddle/cinn/frontend/syntax.cc
@@ -25,6 +25,7 @@
 
 #include "paddle/cinn/frontend/paddle/model_parser.h"
 #include "paddle/cinn/frontend/paddle_model_to_program.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h"
 #include "paddle/cinn/hlir/framework/node.h"
 #include "paddle/cinn/hlir/framework/op.h"
 #include "paddle/cinn/utils/string.h"
@@ -557,6 +558,12 @@ std::string _Instruction_::debug_string() const {
       s_ << "[" + utils::Join(x, ",") + "]";
     }
     void operator()(const std::vector<std::string>& x) {
+      s_ << "[" + utils::Join(x, ",") + "]";
+    }
+    void operator()(const std::vector<symbol::DimExpr>& x) {
+      s_ << "[" + utils::Join(x, ",") + "]";
+    }
+    void operator()(const cinn::dialect::SymbolBindings& x) {
       s_ << "[" + utils::Join(x, ",") + "]";
     }
   };

--- a/paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h
@@ -18,6 +18,7 @@
 #include <optional>
 #include <vector>
 #include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h"
 #include "paddle/pir/include/core/builder.h"
 #include "paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h"
 
@@ -29,6 +30,9 @@ namespace cinn::dialect {
 std::optional<symbol::DimExpr> ConvertAttributeToDimExpr(
     ::pir::Attribute attribute);
 
+std::optional<std::vector<symbol::DimExpr>> ConvertAttributeToDimExprs(
+    ::pir::Attribute attribute);
+
 symbol::DimExpr SubstituteDimExpr(
     const symbol::DimExpr& dim_expr,
     const std::function<std::optional<symbol::DimExpr>(
@@ -36,7 +40,7 @@ symbol::DimExpr SubstituteDimExpr(
 
 std::function<std::optional<symbol::DimExpr>(const std::string& symbol_name)>
 MakeGetterDimExpr4SymbolName(
-    const GenerateShapeOp::SymbolBindings& symbol_bindings,
+    const SymbolBindings& symbol_bindings,
     const std::function<const symbol::ShapeOrDataDimExprs&(int in_tensor_idx)>&
         DimExpr4InputDim);
 
@@ -51,6 +55,6 @@ bool MakeGenerateShapeOpAttribute(
     const std::vector<pir::Value>& origin_inputs,
     std::vector<pir::Value>* minimal_inputs,
     std::vector<pir::Attribute>* output_dim_expr_attrs,
-    GenerateShapeOp::SymbolBindings* symbol_bindings);
+    SymbolBindings* symbol_bindings);
 
 }  // namespace cinn::dialect

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.cc
@@ -478,24 +478,17 @@ GenerateShapeOp::ConvertAttributeToSymbolBindings(
   }
   return std::move(ret);
 }
-
 bool GenerateShapeOp::InferSymbolicShape(
     pir::InferSymbolicShapeContext* infer_context) {
   const auto attr_dim_exprs = [&] {
-    std::vector<symbol::DimExpr> dim_exprs{};
     pir::Attribute dim_expr_attr = this->attributes().at("output_dim_exprs");
-    PADDLE_ENFORCE(dim_expr_attr.isa<pir::ArrayAttribute>(),
+    auto dim_exprs = ConvertAttributeToDimExprs(dim_expr_attr);
+
+    PADDLE_ENFORCE(dim_exprs.has_value(),
                    ::common::errors::PreconditionNotMet(
-                       "Required dim_expr_attr is ArrayAttribute."));
-    auto array = dim_expr_attr.dyn_cast<pir::ArrayAttribute>();
-    for (int i = 0; i < array.size(); ++i) {
-      const auto& dim_expr = ConvertAttributeToDimExpr(array.at(i));
-      PADDLE_ENFORCE(dim_expr.has_value(),
-                     ::common::errors::PreconditionNotMet(
-                         "Required dim_expr.has_value()==true."));
-      dim_exprs.push_back(dim_expr.value());
-    }
-    return dim_exprs;
+                       "Required dim_exprs.has_value()==true."));
+
+    return dim_exprs.value();
   }();
   const auto symbol_bindings = [&] {
     pir::Attribute symbol_bindings_attr =

--- a/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/manual_op.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <variant>
 #include "paddle/cinn/hlir/dialect/operator/ir/attribute_storage.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h"
 #include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_symbolic_shape.h"
 #include "paddle/phi/core/infermeta_utils.h"
@@ -154,18 +155,11 @@ class IR_API GenerateShapeOp
   static constexpr uint32_t attributes_num = 2;
   static const char *attributes_name[attributes_num];
 
-  struct SymbolBindingBase {
-    std::string symbol_name;
-    int64_t input_tensor_idx;
-    int64_t input_tensor_dim_idx;
-  };
-
-  struct DataSymbolBinding : public SymbolBindingBase {};
-  struct ShapeSymbolBinding : public SymbolBindingBase {};
-
-  using SymbolBinding = std::variant<DataSymbolBinding, ShapeSymbolBinding>;
-
-  using SymbolBindings = std::vector<SymbolBinding>;
+  using SymbolBindingBase = cinn::dialect::SymbolBindingBase;
+  using SymbolBinding = cinn::dialect::SymbolBinding;
+  using ShapeSymbolBinding = cinn::dialect::ShapeSymbolBinding;
+  using DataSymbolBinding = cinn::dialect::DataSymbolBinding;
+  using SymbolBindings = cinn::dialect::SymbolBindings;
 
   static void Build(pir::Builder &builder,             // NOLINT
                     pir::OperationArgument &argument,  // NOLINT

--- a/paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h
+++ b/paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <iostream>
+#include <string>
+#include <variant>
+
+namespace cinn {
+namespace dialect {
+struct SymbolBindingBase {
+  std::string symbol_name;
+  int64_t input_tensor_idx;
+  int64_t input_tensor_dim_idx;
+  bool operator==(const SymbolBindingBase& other) const {
+    return symbol_name == other.symbol_name &&
+           input_tensor_idx == other.input_tensor_idx &&
+           input_tensor_dim_idx == other.input_tensor_dim_idx;
+  }
+};
+
+constexpr char* kDataSymbolBinding = "DataSymbolBinding";
+constexpr char* kShapeSymbolBinding = "ShapeSymbolBinding";
+
+struct DataSymbolBinding : public SymbolBindingBase {
+  const char* binding_type() const { return kDataSymbolBinding; }
+};
+struct ShapeSymbolBinding : public SymbolBindingBase {
+  const char* binding_type() const { return kShapeSymbolBinding; }
+};
+
+using SymbolBinding = std::variant<DataSymbolBinding, ShapeSymbolBinding>;
+
+using SymbolBindings = std::vector<SymbolBinding>;
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const SymbolBinding& symbol_binding) {
+  std::visit(
+      [&](auto&& binding) {
+        os << binding.binding_type() << "[" << binding.symbol_name << ","
+           << binding.input_tensor_idx << "," << binding.input_tensor_dim_idx
+           << "]";
+      },
+      symbol_binding);
+}
+}  // namespace dialect
+}  // namespace cinn

--- a/paddle/cinn/hlir/framework/node.cc
+++ b/paddle/cinn/hlir/framework/node.cc
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "paddle/cinn/hlir/framework/node.h"
-
 #include <algorithm>
 
 #include "paddle/cinn/common/context.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h"
+#include "paddle/cinn/hlir/framework/node.h"
 
 namespace cinn {
 namespace hlir {
@@ -68,6 +67,8 @@ struct PyBindNodeAttrVisitor {
   VISIT_ELEMENTS(double)
   VISIT_ELEMENTS(bool)
   VISIT_ELEMENTS(std::string)
+  VISIT_ELEMENTS(symbol::DimExpr)
+  VISIT_ELEMENTS(cinn::dialect::SymbolBinding)
 };
 
 }  // namespace

--- a/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/trivial_op_impl.cc
@@ -590,21 +590,14 @@ std::vector<ir::Var> GetAllForIters(const ir::Expr& expr) {
 }  // namespace trivial_fusion_detail
 
 std::vector<ir::Expr> OperationFusion(
-    const std::vector<::pir::Operation*>& original_ops,
+    const std::vector<::pir::Operation*>& ops,
     const std::vector<ir::Expr>& op_compute_bodies,
     const std::vector<::pir::Value>& outputs) {
-  PADDLE_ENFORCE(FLAGS_group_schedule_tiling_first,
-                 ::common::errors::PreconditionNotMet(
-                     "TrivialFusion must be used with tiling first, set "
-                     "FLAGS_group_schedule_tiling_first=1"));
-  const auto& ops = trivial_fusion_detail::FilterVector(
-      original_ops, [](const ::pir::Operation* op) {
-        if (op->name() == "cinn_op.generate_shape") {
-          return false;
-        }
-        return true;
-      });
-
+  PADDLE_ENFORCE_EQ(FLAGS_group_schedule_tiling_first,
+                    true,
+                    ::common::errors::PreconditionNotMet(
+                        "TrivialFusion must be used with tiling first, set "
+                        "FLAGS_group_schedule_tiling_first=1"));
   std::vector<cinn::fusion::BackendContent> contents;
   for (int i = 0; i < ops.size(); i++) {
     contents.emplace_back(ops[i], op_compute_bodies[i]);

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -18,7 +18,7 @@
 #include <string>
 #include <unordered_map>
 #include "glog/logging.h"
-
+#include "paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
 #include "paddle/cinn/hlir/framework/op.h"
@@ -489,10 +489,22 @@ utils::AttributeMap CompatibleInfo::ConvertAttributes(
   utils::AttributeMap dst_attrs;
   for (auto& item : src_attrs) {
     VLOG(4) << "deal with " << item.first;
-    if (item.first == ::pir::kStopGradientAttrName ||
-        item.first == ::pir::kOutputDimExprs ||
-        item.first == ::pir::kSymbolBindings) {
+    if (item.first == ::pir::kStopGradientAttrName) {
       continue;
+    } else if (item.first == ::pir::kSymbolBindings) {
+      auto symbol_bindings =
+          cinn::dialect::GenerateShapeOp::ConvertAttributeToSymbolBindings(
+              item.second);
+      PADDLE_ENFORCE(symbol_bindings.has_value(),
+                     ::common::errors::PreconditionNotMet(
+                         "Required symbol_bindings.has_value()==true."));
+      dst_attrs[::pir::kSymbolBindings] = symbol_bindings.value();
+    } else if (item.first == ::pir::kOutputDimExprs) {
+      auto dim_exprs = cinn::dialect::ConvertAttributeToDimExprs(item.second);
+      PADDLE_ENFORCE(dim_exprs.has_value(),
+                     ::common::errors::PreconditionNotMet(
+                         "Required dim_exprs.has_value()==true."));
+      dst_attrs[::pir::kOutputDimExprs] = dim_exprs.value();
     } else if (item.second.isa<paddle::dialect::PlaceAttribute>()) {
       auto is_cpu =
           item.second.dyn_cast<paddle::dialect::PlaceAttribute>().data() ==

--- a/paddle/cinn/hlir/op/custom_call.cc
+++ b/paddle/cinn/hlir/op/custom_call.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/cinn/backends/codegen_device_util.h"
 #include "paddle/cinn/common/cas.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h"
 #include "paddle/cinn/hlir/framework/node.h"
 #include "paddle/cinn/hlir/framework/op.h"
 #include "paddle/cinn/hlir/framework/op_strategy.h"
@@ -25,6 +26,7 @@
 #include "paddle/cinn/hlir/pe/transform.h"
 #include "paddle/cinn/ir/ir_printer.h"
 #include "paddle/cinn/utils/string.h"
+#include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
 
 #ifdef CINN_WITH_CUDNN
 #include <cudnn.h>
@@ -893,6 +895,8 @@ std::vector<ir::Expr> CustomCallArgsForMemset(
     EXPAND_MEMSET_TYPE_UNSUPPORT(std::vector<double>)
     EXPAND_MEMSET_TYPE_UNSUPPORT(std::vector<bool>)
     EXPAND_MEMSET_TYPE_UNSUPPORT(std::vector<std::string>)
+    EXPAND_MEMSET_TYPE_UNSUPPORT(std::vector<symbol::DimExpr>)
+    EXPAND_MEMSET_TYPE_UNSUPPORT(std::vector<cinn::dialect::SymbolBinding>)
 #undef EXPAND_MEMSET_TYPE_UNSUPPORT
   };
 

--- a/paddle/cinn/hlir/op/elementwise.cc
+++ b/paddle/cinn/hlir/op/elementwise.cc
@@ -19,6 +19,7 @@
 #include "absl/types/optional.h"
 #include "paddle/cinn/adt/op_equation_context.h"
 #include "paddle/cinn/common/type.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/hlir/framework/node.h"
 #include "paddle/cinn/hlir/framework/op.h"
 #include "paddle/cinn/hlir/framework/op_strategy.h"
@@ -358,6 +359,15 @@ Expr GetScalarExpr(const framework::NodeAttr::attr_t &attr) {
     void operator()(const std::vector<std::string> &) {
       PADDLE_THROW(
           phi::errors::InvalidArgument("wrong type std::vector<std::string>"));
+    }
+    void operator()(const std::vector<symbol::DimExpr> &) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "wrong type std::vector<symbol::DimExpr>"));
+    }
+    void operator()(const std::vector<cinn::dialect::SymbolBinding> &) {
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "wrong type "
+          "std::vector<cinn::dialect::SymbolBinding>"));
     }
   };
   absl::visit(Visitor{scalar}, attr);
@@ -1271,6 +1281,19 @@ std::shared_ptr<framework::OpStrategy> StrategyForGenerateShapeSymbolic(
     const std::vector<Type> &out_type,
     const std::vector<std::vector<ir::Dim>> &output_shapes,
     const Target &target) {
+  PADDLE_ENFORCE(
+      attrs.attr_store.count("output_dim_exprs"),
+      ::common::errors::InvalidArgument("Expected attribute output_dim_exprs "
+                                        "in strategy for generate shape op"));
+  PADDLE_ENFORCE(
+      attrs.attr_store.count("symbol_bindings"),
+      ::common::errors::InvalidArgument("Expected attribute symbol_bindings "
+                                        "in strategy for generate shape op"));
+  auto output_dim_exprs = absl::get<std::vector<symbol::DimExpr>>(
+      attrs.attr_store.at("output_dim_exprs"));
+  auto symbol_bindings = absl::get<cinn::dialect::SymbolBindings>(
+      attrs.attr_store.at("symbol_bindings"));
+
   framework::CINNCompute generate_shape_compute(
       [=](lang::Args args, lang::RetValue *ret) {
         PADDLE_ENFORCE(!args.empty(),
@@ -1287,16 +1310,8 @@ std::shared_ptr<framework::OpStrategy> StrategyForGenerateShapeSymbolic(
         auto stages = CreateStages({});
 
         std::string tensor_name = pack_args.back().operator std::string();
-        ir::Tensor out(ir::_Tensor_::Make(/*name=*/tensor_name,
-                                          /*dtype=*/common::type_of<int64_t>(),
-                                          /*shape=*/
-                                          {
-                                              Expr(1),
-                                          },
-                                          /*domain=*/
-                                          {
-                                              Expr(1),
-                                          }));
+        ir::Tensor out = pe::GenerateShape(
+            inputs, symbol_bindings, output_dim_exprs, tensor_name);
         std::vector<CINNValue> res;
         stages->InsertLazily(out);
         res.push_back(CINNValue(out));

--- a/paddle/cinn/hlir/pe/elementwise.cc
+++ b/paddle/cinn/hlir/pe/elementwise.cc
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "paddle/cinn/common/cas.h"
+#include "paddle/cinn/common/dim_expr_converter.h"
 #include "paddle/cinn/hlir/op/op_util.h"
 #include "paddle/cinn/ir/op/ir_operators.h"
 #include "paddle/cinn/lang/builtin.h"
@@ -349,6 +350,29 @@ ir::Tensor Tril(const ir::Tensor& A,
         return ir::Select::Make(new_indice[0] >= new_indice[1] - diagonal,
                                 A(indice),
                                 ir::Zero(A->type()));
+      },
+      name);
+  return res;
+}
+
+ir::Tensor GenerateShape(const std::vector<ir::Tensor>& inputs,
+                         const cinn::dialect::SymbolBindings& symbol_bindings,
+                         const std::vector<symbol::DimExpr>& output_dim_exprs,
+                         const std::string& name) {
+  if (output_dim_exprs.size() != 1) {
+    LOG(WARNING) << "pe::GenerateShape will return a meaningless tensor when "
+                    "output_dim_exprs.size() != 1";
+    return Compute(
+        {Expr(1)},
+        [=](const std::vector<Expr>& indice) { return Expr(1); },
+        name);
+  }
+  cinn::common::DimExprConverterWithSymbolBindings converter(inputs,
+                                                             symbol_bindings);
+  auto res = Compute(
+      {Expr(1)},
+      [=, &converter](const std::vector<Expr>& indice) {
+        return converter.ConvertToIrExpr(output_dim_exprs[0]);
       },
       name);
   return res;

--- a/paddle/cinn/hlir/pe/elementwise.h
+++ b/paddle/cinn/hlir/pe/elementwise.h
@@ -17,9 +17,11 @@
 #include <string>
 #include <vector>
 
+#include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/cinn/ir/ir.h"
 #include "paddle/cinn/lang/builtin.h"
 #include "paddle/cinn/lang/compute.h"
+#include "paddle/pir/include/dialect/shape/utils/shape_or_data_expr.h"
 
 namespace cinn {
 namespace hlir {
@@ -153,6 +155,12 @@ ir::Tensor Tril(const ir::Tensor& A,
                 const int diagonal,
                 const std::vector<ir::Dim>& out_shape,
                 const std::string& name = UniqName("T_Elementwise_Tril_out"));
+
+ir::Tensor GenerateShape(
+    const std::vector<ir::Tensor>& inputs,
+    const cinn::dialect::SymbolBindings& symbol_bindings,
+    const std::vector<symbol::DimExpr>& output_dim_exprs,
+    const std::string& name = UniqName("T_Generate_Shape_out"));
 
 // This operator checks if all x and y satisfy the condition: |x - y| <= atol +
 // rtol * |y|

--- a/paddle/cinn/utils/type_defs.h
+++ b/paddle/cinn/utils/type_defs.h
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #pragma once
-
 #include <absl/container/flat_hash_map.h>
 #include <absl/types/variant.h>
-
 #include <string>
 #include <vector>
+#include "paddle/cinn/hlir/dialect/operator/ir/symbol_bindings.h"
+#include "paddle/pir/include/dialect/shape/utils/dim_expr.h"
 
 namespace cinn {
 namespace utils {
@@ -35,7 +35,10 @@ using Attribute = absl::variant<bool,
                                 int64_t,
                                 double,
                                 std::vector<int64_t>,
-                                std::vector<double>>;
+                                std::vector<double>,
+                                // the followings are only for generate shape op
+                                std::vector<symbol::DimExpr>,
+                                cinn::dialect::SymbolBindings>;
 using AttributeMap = absl::flat_hash_map<std::string, Attribute>;
 
 // shape type defs


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
New features


### Description
<!-- Describe what you’ve done -->
主要逻辑在：
paddle/cinn/hlir/op/elementwise.cc
paddle/cinn/hlir/pe/elementwise.cc
paddle/cinn/common/dim_expr_converter.cc
其余部分的改动主要是把`SymbolBinding`相关的结构体从`manul_op.h`中抽出，放到新的文件中