### PR TITLE
Add remove_shadow_feed_pass for inference and op translater support assign_out_

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -118,6 +118,7 @@
 #include "paddle/fluid/pir/transforms/general/dead_code_elimination_pass.h"
 #include "paddle/fluid/pir/transforms/general/inplace_pass.h"
 #include "paddle/fluid/pir/transforms/general/params_sync_among_devices_pass.h"
+#include "paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.h"
 #include "paddle/fluid/pir/transforms/general/replace_fetch_with_shadow_output_pass.h"
 #include "paddle/fluid/pir/transforms/passes.h"
 #include "paddle/fluid/pir/transforms/pd_op_to_kernel_pass.h"
@@ -1011,6 +1012,9 @@ bool AnalysisPredictor::PrepareExecutor() {
 
       ::pir::PassManager lowered_pm(::pir::IrContext::Instance(), 3);
       if (FLAGS_pir_apply_inplace_pass) {
+        auto remove_shadow_feed_pass = ::pir::CreateRemoveShadowFeedPass();
+        remove_shadow_feed_pass->Set("used_for_inference", new bool(true));
+        lowered_pm.AddPass(std::move(remove_shadow_feed_pass));
         lowered_pm.AddPass(::pir::CreateInplacePass());
       }
       if (!config_.glog_info_disabled()) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1011,10 +1011,10 @@ bool AnalysisPredictor::PrepareExecutor() {
           paddle::dialect::PdOpLowerToKernelPass(pir_program_.get(), place_);
 
       ::pir::PassManager lowered_pm(::pir::IrContext::Instance(), 3);
+      auto remove_shadow_feed_pass = ::pir::CreateRemoveShadowFeedPass();
+      remove_shadow_feed_pass->Set("used_for_inference", new bool(true));
+      lowered_pm.AddPass(std::move(remove_shadow_feed_pass));
       if (FLAGS_pir_apply_inplace_pass) {
-        auto remove_shadow_feed_pass = ::pir::CreateRemoveShadowFeedPass();
-        remove_shadow_feed_pass->Set("used_for_inference", new bool(true));
-        lowered_pm.AddPass(std::move(remove_shadow_feed_pass));
         lowered_pm.AddPass(::pir::CreateInplacePass());
       }
       if (!config_.glog_info_disabled()) {

--- a/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
+++ b/paddle/fluid/pir/transforms/general/remove_shadow_feed_pass.cc
@@ -146,44 +146,69 @@ class RemoveShadowFeedPattern
   std::unordered_map<::pir::Value, std::string> kwargs_map_;
 };
 
+class RemoveShadowFeedPatternInference
+    : public pir::OpRewritePattern<paddle::dialect::PhiKernelOp> {
+ public:
+  explicit RemoveShadowFeedPatternInference(pir::IrContext *context)
+      : pir::OpRewritePattern<paddle::dialect::PhiKernelOp>::OpRewritePattern(
+            context) {}
+
+  bool Match(paddle::dialect::PhiKernelOp op) const override {
+    return op.op_name() == "pd_op.shadow_feed";
+  }
+
+  void Rewrite(paddle::dialect::PhiKernelOp op,
+               pir::PatternRewriter &rewriter) const override {  // NOLINT
+    auto in = op.operand_source(0);
+    auto out = op.result(0);
+    in.set_type(out.type());
+    rewriter.ReplaceAllUsesWith(out, in);
+    rewriter.EraseOp(op);
+  }
+};
+
 class RemoveShadowFeedPass : public pir::PatternRewritePass {
  public:
   RemoveShadowFeedPass()
       : pir::PatternRewritePass("remove_shadow_feed_pass", 0) {}
 
   pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
-    PADDLE_ENFORCE_EQ(
-        Has("top_block"),
-        true,
-        phi::errors::InvalidArgument(
-            "Pass initialize failed."
-            "When using RemoveShadowFeedPass, block attribute is required!"
-            "Use Set method to set the place attribute."));
-    PADDLE_ENFORCE_EQ(
-        Has(pir::Pass::kPlaceAttr),
-        true,
-        phi::errors::InvalidArgument(
-            "Pass initialize failed."
-            "When using RemoveShadowFeedPass, place attribute is required!"
-            "Use Set method to set the place attribute."));
-    PADDLE_ENFORCE_EQ(
-        Has(pir::Pass::kParamScopeAttr),
-        true,
-        phi::errors::InvalidArgument(
-            "Pass initialize failed."
-            "When using RemoveShadowFeedPass, scope attribute is required!"
-            "Use Set method to set the scope attribute."));
-    auto block = &Get<const pir::Block>("top_block");
-    auto &place = Get<const phi::Place>(pir::Pass::kPlaceAttr);
-    auto scope =
-        &Get<const paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
-    PADDLE_ENFORCE_NOT_NULL(
-        block, phi::errors::InvalidArgument("block can not be nullptr"));
-    PADDLE_ENFORCE_NOT_NULL(
-        scope, phi::errors::InvalidArgument("scope can not be nullptr"));
-
     pir::RewritePatternSet ps(context);
-    ps.Add<RemoveShadowFeedPattern>(context, block, place, scope);
+    if (Has("used_for_inference") && Get<bool>("used_for_inference")) {
+      ps.Add<RemoveShadowFeedPatternInference>(context);
+    } else {
+      PADDLE_ENFORCE_EQ(
+          Has("top_block"),
+          true,
+          phi::errors::InvalidArgument(
+              "Pass initialize failed."
+              "When using RemoveShadowFeedPass, block attribute is required!"
+              "Use Set method to set the place attribute."));
+      PADDLE_ENFORCE_EQ(
+          Has(pir::Pass::kPlaceAttr),
+          true,
+          phi::errors::InvalidArgument(
+              "Pass initialize failed."
+              "When using RemoveShadowFeedPass, place attribute is required!"
+              "Use Set method to set the place attribute."));
+      PADDLE_ENFORCE_EQ(
+          Has(pir::Pass::kParamScopeAttr),
+          true,
+          phi::errors::InvalidArgument(
+              "Pass initialize failed."
+              "When using RemoveShadowFeedPass, scope attribute is required!"
+              "Use Set method to set the scope attribute."));
+      auto block = &Get<const pir::Block>("top_block");
+      auto &place = Get<const phi::Place>(pir::Pass::kPlaceAttr);
+      auto scope =
+          &Get<const paddle::framework::Scope>(pir::Pass::kParamScopeAttr);
+      PADDLE_ENFORCE_NOT_NULL(
+          block, phi::errors::InvalidArgument("block can not be nullptr"));
+      PADDLE_ENFORCE_NOT_NULL(
+          scope, phi::errors::InvalidArgument("scope can not be nullptr"));
+
+      ps.Add<RemoveShadowFeedPattern>(context, block, place, scope);
+    }
     return ps;
   }
 };
@@ -197,6 +222,3 @@ std::unique_ptr<pir::Pass> CreateRemoveShadowFeedPass() {
 }
 
 }  // namespace pir
-
-// REGISTER_IR_PASS(remove_shadow_feed_pass,
-//                  RemoveShadowFeedPass);

--- a/test/cpp/pir/core/program_translator_test.cc
+++ b/test/cpp/pir/core/program_translator_test.cc
@@ -278,7 +278,7 @@ TEST(OperatorDialectTest, WhileOpProgram) {
               EXPECT_TRUE(op2.isa<paddle::dialect::LessThanOp>());
             }
             if (body_body_id == 3 || body_body_id == 4) {
-              EXPECT_TRUE(op2.isa<paddle::dialect::AssignOp>());
+              EXPECT_TRUE(op2.isa<paddle::dialect::AssignOut_Op>());
             }
             if (body_body_id == 5) {
               EXPECT_TRUE(op2.isa<pir::YieldOp>());
@@ -290,7 +290,7 @@ TEST(OperatorDialectTest, WhileOpProgram) {
           EXPECT_TRUE(op1.isa<paddle::dialect::LessThanOp>());
         }
         if (body_id == 5 || body_id == 6) {
-          EXPECT_TRUE(op1.isa<paddle::dialect::AssignOp>());
+          EXPECT_TRUE(op1.isa<paddle::dialect::AssignOut_Op>());
         }
         if (body_id == 7) {
           EXPECT_TRUE(op1.isa<pir::YieldOp>());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
Pcard-71500

- Add remove_shadow_feed_pass for inference
- op translater support assign to assign_out_