### PR TITLE
[SOT] Update ut `test_06_call_function` to avoid type promotion error

### DIFF
--- a/test/sot/test_06_call_function.py
+++ b/test/sot/test_06_call_function.py
@@ -67,7 +67,8 @@ def fn_with_varargs_and_kwargs(x, *args, **kwargs):
         + args[0]
         + args[1]
         - args[2]
-        + kwargs['a'] * kwargs['b'] / kwargs['c']
+        + kwargs['a'] * kwargs['b']
+        + kwargs['c']
     )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

#63842 修改了动态图和老 IR 的类型提升行为，PIR 没有改，导致了 PIR 下动静不统一

```python
import paddle

def add(x, y):
    return x + y

x = paddle.to_tensor(2, dtype="int32")
y = paddle.to_tensor(1.2, dtype="float32")

add_static = paddle.jit.to_static(add, full_graph=True)
z_dy = add(x, y)
z_st = add_static(x, y)
print(z_dy, z_st)
```

比如上述 case，开启 `FLAGS_enable_pir_api=True` 动静是不统一的，静态图结果并不符合预期

但 PIR 的类型提升短期内不会支持，暂时修改该单测，因为该单测只是为了测函数的各种调用形式的功能，并不测 dtype 类型提升

PCard-66972