### PR TITLE
[ci] fix sot ci test commit check error

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -946,7 +946,7 @@ set -ex
 function check_run_sot_ci() {
     set +x
     # use "git commit -m 'message, test=sot'" to force ci to run
-    COMMIT_RUN_CI=$(git log -1 --pretty=format:"%s" | grep -w "test=sot" || true)
+    COMMIT_RUN_CI=$(git log -10 --pretty=format:"%s" | grep -w "test=sot" || true)
     # check pr title
     TITLE_RUN_CI=$(curl -s https://github.com/PaddlePaddle/Paddle/pull/${GIT_PR_ID} | grep "<title>" | grep -i "sot" || true)
     if [[ ${COMMIT_RUN_CI} || ${TITLE_RUN_CI} ]]; then


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

修复在 https://github.com/PaddlePaddle/Paddle/pull/63901#discussion_r1596403253 中暴露的 commit 检查错误

原因是 ci 在运行之前会 `git pull upstream develop` 所以导致 commit 变成如下情况，不能命中我们想要的 commit

```bash
git log -10 --pretty=format:"%s"
Merge branch 'develop' of github.com:PaddlePaddle/Paddle into test_ci
[Prim] reduce_as op support uint8, in8, complex64  and complex128 (#63782)
add reduce_avg op (#64120)
fix
[AutoParallel-PIR] Remove program clone in Pass (#64137)
[Prim][PIR] Decomp supports PIR Distribution (#64072)
[DistDialect] Add pir reshard s to r (#63836)
test=sot
A template demonstrating how to test higher-order autodiff. (#62917)
[PIR save/load]Open more tests (#64121)
```
