### PR TITLE
[CINN] Fix bug of generate_shape infer_symbolic_shape

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.cc
+++ b/paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.cc
@@ -369,21 +369,17 @@ MakeGetterDimExpr4SymbolName(
     symbol_name2symbol_bindins[GetSymbolNameBySymbolBinding(symbol_binding)]
         .emplace_back(symbol_binding);
   }
-  const auto& GetDimExpr =
-      [&](const GenerateShapeOp::SymbolBinding& symbol_binding) {
-        return std::visit(
-            [&](const auto& impl) {
-              return GetDimExprBySymbolBindingImpl(impl, DimExpr4InputDim);
-            },
-            symbol_binding);
-      };
-  return [map = std::move(symbol_name2symbol_bindins), GetDimExpr](
+  return [map = std::move(symbol_name2symbol_bindins), DimExpr4InputDim](
              const std::string& symbol_name) -> std::optional<DimExpr> {
     const auto& iter = map.find(symbol_name);
     if (iter == map.end()) return std::nullopt;
     std::optional<DimExpr> ret = std::nullopt;
     for (const auto& symbol_binding : iter->second) {
-      const auto& current = GetDimExpr(symbol_binding);
+      const auto& current = std::visit(
+          [&](const auto& impl) {
+            return GetDimExprBySymbolBindingImpl(impl, DimExpr4InputDim);
+          },
+          symbol_binding);
       if (!current.has_value()) return std::nullopt;
       if (ret.has_value()) {
         // Same names, same DimExprs.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

修复generate_shape算子infer_symbolic_shape接口中lambda在函数传递时发生拷贝析构的Bug。