### PR TITLE
[PIR] Mark more ops as no grad

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -91,6 +91,9 @@ ALLOW_NO_GRAD_OPS = [
     "pd_op.isinf",
     "pd_op.all",
     "pd_op.any",
+    "pd_op.prior_box",
+    "pd_op.share_data",
+    "pd_op.floor_divide",
 ]
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复模型套件上发现的更多没有 grad 的 OP，添加到 `ALLOW_NO_GRAD_OPS` 中

PCard-66972

同 #64149，但 #64149 CI 无论怎么重新触发，不相关的 C++ 单测 `test_api_impl` 都会挂，甚至和 PIR 无关，本 PR 不可能影响，closes #64149