### PR TITLE
remove tpm approval requirements in CI

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -42,19 +42,8 @@ api_params_diff=`python ${PADDLE_ROOT}/tools/check_api_compatible.py ${PADDLE_RO
 api_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.api  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.api`
 if [ "$api_spec_diff" != "" -o "${api_params_diff}" != "" ]; then
     echo_line="You must have one RD (XiaoguangHu01, jeff41404, lanxianghit or qingqing01) approval for API change.\n"
-    echo_line="${echo_line} and one TPM approval for API change: \n"
-    echo_line="${echo_line} jzhang533/ZhangJun, sunzhongkai588/SunZhongKai, Ligoml/LiMengLiu for general APIs.\n"
 
     check_approval 1 XiaoguangHu01 jeff41404 lanxianghit qingqing01
-    check_approval 1 jzhang533 sunzhongkai588 Ligoml
-fi
-
-api_doc_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.doc  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.doc`
-if [ "$api_doc_spec_diff" != "" ]; then
-    echo_line="You must have  one TPM approval for API documents change: \n"
-    echo_line="${echo_line} jzhang533/ZhangJun, sunzhongkai588/SunZhongKai, Ligoml/LiMengLiu for general API docs.\n"
-
-    check_approval 1 jzhang533 sunzhongkai588 Ligoml
 fi
 
 api_yaml_diff=`python ${PADDLE_ROOT}/tools/check_api_yaml_same.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec ${BRANCH} ${PADDLE_ROOT}`


### PR DESCRIPTION
### PR Category
Others

### PR Types
Others

### Description
in our dev workflow, strictly requiring one of the tpm to review api change, and api doc change is no longer necessary. 

Rational: 
- encourage individuals to seek reviews based on the open-source social structure rather than rigid org structure.
- ask engineers with relevant context for reviews is more logical.
- lower barrier to land a PR.

please ignore the following

PCard-67164

