### PR TITLE
[CINN] fix bug: remove redundant conversion in select

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
+++ b/paddle/cinn/hlir/dialect/operator/ir/ops.yaml
@@ -107,16 +107,6 @@
     func : scale
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
-- op : select
-  args : (Tensor condition, Tensor true_value, Tensor false_value )
-  output : Tensor(out)
-  infer_meta :
-    func : WhereInferMeta
-    spmd_rule: WhereInferSpmd
-  kernel :
-    func : where
-  interfaces : paddle::dialect::InferSymbolicShapeInterface
-
 - op : slice
   args : (Tensor x, int64_t[] axes, int64_t[] starts, int64_t[] ends, int64_t[] infer_flags, int64_t[] decrease_axis)
   output : Tensor

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -1073,23 +1073,6 @@ class SigmoidOpPattern
   }
 };
 
-class WhereOpPattern : public pir::OpRewritePattern<paddle::dialect::WhereOp> {
- public:
-  using pir::OpRewritePattern<paddle::dialect::WhereOp>::OpRewritePattern;
-
-  bool MatchAndRewrite(paddle::dialect::WhereOp op,
-                       pir::PatternRewriter &rewriter) const override {
-    auto select_op = rewriter.Build<cinn::dialect::SelectOp>(
-        op->operand_source(0), op->operand_source(1), op->operand_source(2));
-
-    rewriter.ReplaceAllUsesWith(op.result(0), select_op.result(0));
-
-    rewriter.EraseOp(op);
-
-    return true;
-  }
-};
-
 class GatherOpPattern
     : public pir::OpRewritePattern<paddle::dialect::GatherOp> {
  public:
@@ -1154,7 +1137,6 @@ pir::RewritePatternSet PdOpToCinnOpPass::InitializePatterns(
   ps.Add<UnsqueezeOpPattern>(context);
   ps.Add<SigmoidOpPattern>(context);
   ps.Add<GatherOpPattern>(context);
-  ps.Add<WhereOpPattern>(context);
   ps.Add<FlattenOpPattern>(context);
 
   return ps;

--- a/paddle/cinn/hlir/framework/pir/utils.cc
+++ b/paddle/cinn/hlir/framework/pir/utils.cc
@@ -63,6 +63,7 @@ const std::unordered_map<std::string, std::string> CompatibleInfo::OP_NAMES = {
     {"pd_op.unsqueeze", "reshape"},
     {"pd_op.split_with_num", "split"},
     {"pd_op.expand", "broadcast_to"},
+    {"pd_op.where", "select"},
     {"cinn_op.generate_shape", "generate_shape"},
     {"cinn_op.broadcast", "broadcast_to"}};
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-83707 Fix bug: remove redundant conversion in select