### PR TITLE
[Infra] Update codeowners to check dy2st ut only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,10 +67,9 @@ python/paddle/distributed/fleet/launch.py @sneaxiy @raindrops2sea
 python/paddle/distributed/__init__.py @sneaxiy @raindrops2sea
 python/paddle/incubate/autograd/composite_rules.py @cyber-pioneer @xiaoguoguo626807 @Charles-hit @JiabinYang
 python/paddle/incubate/autograd/primitives.py @cyber-pioneer @xiaoguoguo626807 @Charles-hit @JiabinYang
-python/paddle/jit @SigureMo @2742195759 @Aurelius84 @gouzil
 python/requirements.txt @phlrain @jzhang533 @kolinwei
-test/dygraph_to_static @SigureMo @2742195759 @Aurelius84 @gouzil
-test/sot @SigureMo @2742195759 @Aurelius84 @gouzil
+test/dygraph_to_static @SigureMo @Aurelius84 @gouzil
+test/sot @SigureMo @Aurelius84 @gouzil
 tools/parallel_UT_rule.py @zhwesky2010 @wanghuancoder @Aurelius84
-tools/windows/run_unittests.sh @zhwesky2010 @wanghuancoder  @Aurelius84
+tools/windows/run_unittests.sh @zhwesky2010 @wanghuancoder @Aurelius84
 .pre-commit-config.yaml @SigureMo @gouzil


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

修改动转静相关 codeowner，不检查代码，仅检查单测修改

PCard-66972