### PR TITLE
[PIR] Use value in Executor `fetch_list` (part1)

### DIFF
--- a/test/amp/test_amp_api.py
+++ b/test/amp/test_amp_api.py
@@ -293,7 +293,7 @@ class TestFp16Guard(AmpTestBase):
 
             x_fp32 = np.random.random(size=[1, 1, 28, 28]).astype("float32")
             (loss_data,) = exe.run(
-                main_program, feed={"X": x_fp32}, fetch_list=[loss.name]
+                main_program, feed={"X": x_fp32}, fetch_list=[loss]
             )
 
             self.assertEqual(

--- a/test/auto_parallel/test_fuse_adamw_pass.py
+++ b/test/auto_parallel/test_fuse_adamw_pass.py
@@ -116,7 +116,7 @@ class TestFuseAdamWPass(unittest.TestCase):
 
         for i in range(5):
             loss_data = exe.run(
-                train_program, feed={"X": x[i]}, fetch_list=[loss.name]
+                train_program, feed={"X": x[i]}, fetch_list=[loss]
             )
         return loss_data
 

--- a/test/collective/collective_global_gather.py
+++ b/test/collective/collective_global_gather.py
@@ -126,7 +126,7 @@ class TestCollectiveGlobalGatherAPI(TestCollectiveAPIRunnerBase):
         (global_expert_count,) = exe.run(
             tmp_main_prog,
             feed={"local_expert_count": local_expert_count},
-            fetch_list=[global_expert_count.name],
+            fetch_list=[global_expert_count],
         )
 
         fwd_expert_count = sum(global_expert_count)

--- a/test/collective/fleet/test_fleet_amp_init.py
+++ b/test/collective/fleet/test_fleet_amp_init.py
@@ -85,7 +85,7 @@ class TestFleetAMPInit(unittest.TestCase):
         step = 1
         for i in range(step):
             cost_val = exe.run(
-                program=main_program, feed=gen_data(), fetch_list=[cost.name]
+                program=main_program, feed=gen_data(), fetch_list=[cost]
             )
 
     def test_fleet_amp_meta_optimizer_init(self):
@@ -135,7 +135,7 @@ class TestFleetAMPInit(unittest.TestCase):
         step = 3
         for i in range(step):
             cost_val = exe.run(
-                program=main_program, feed=gen_data(), fetch_list=[cost.name]
+                program=main_program, feed=gen_data(), fetch_list=[cost]
             )
             print(cost_val)
 

--- a/test/contrib/test_correlation.py
+++ b/test/contrib/test_correlation.py
@@ -129,9 +129,7 @@ class TestCorrelationOp(unittest.TestCase):
 
         place = base.CUDAPlace(0)
         exe = base.Executor(place)
-        res = exe.run(
-            feed={'x1': x1_np, 'x2': x2_np}, fetch_list=[out.name, loss.name]
-        )
+        res = exe.run(feed={'x1': x1_np, 'x2': x2_np}, fetch_list=[out, loss])
 
         np.testing.assert_allclose(res[0], out_np, rtol=1e-05, atol=1e-8)
 

--- a/test/custom_op/test_custom_relu_op_xpu_setup.py
+++ b/test/custom_op/test_custom_relu_op_xpu_setup.py
@@ -54,7 +54,7 @@ def custom_relu_static(
             out_v = exe.run(
                 static.default_main_program(),
                 feed={'X': np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()

--- a/test/deprecated/cpp_extension/test_mixed_extension_setup.py
+++ b/test/deprecated/cpp_extension/test_mixed_extension_setup.py
@@ -43,7 +43,7 @@ def custom_relu_static(
             out_v = exe.run(
                 static.default_main_program(),
                 feed={'X': np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()

--- a/test/deprecated/custom_runtime/test_custom_op_setup.py
+++ b/test/deprecated/custom_runtime/test_custom_op_setup.py
@@ -62,7 +62,7 @@ def custom_relu_static(func, device, dtype, np_x, use_func=True):
             out_v = exe.run(
                 static.default_main_program(),
                 feed={"X": np_x},
-                fetch_list=[out.name],
+                fetch_list=[out],
             )
 
     paddle.disable_static()

--- a/test/deprecated/ir/pir/test_special_op_translator.py
+++ b/test/deprecated/ir/pir/test_special_op_translator.py
@@ -127,7 +127,7 @@ class TestElementwiseOpTranscriber(unittest.TestCase):
                 mean = paddle.mean(out1)
                 paddle.static.append_backward(mean)
 
-                out = exe.run(main_program, {}, fetch_list=[out1.name])
+                out = exe.run(main_program, {}, fetch_list=[out1])
                 np.testing.assert_allclose(
                     out[0],
                     x_data + y_data.reshape(100, 1, 1),
@@ -158,7 +158,7 @@ class TestElementwiseOpTranscriber(unittest.TestCase):
                 mean = paddle.mean(out1)
                 paddle.static.append_backward(mean)
 
-                out = exe.run(main_program, {}, fetch_list=[out1.name])
+                out = exe.run(main_program, {}, fetch_list=[out1])
                 np.testing.assert_allclose(
                     out[0],
                     x_data + y_data.reshape(100, 1, 1),
@@ -325,7 +325,7 @@ class TestReduceOpTranscriber(unittest.TestCase):
                 x = paddle.to_tensor(arr, dtype='int32')
                 out1 = paddle.all(x)
 
-                out = exe.run(main_program, {}, fetch_list=[out1.name])
+                out = exe.run(main_program, {}, fetch_list=[out1])
                 np.testing.assert_array_equal(out[0], np.all(arr))
 
     def test_with_axis(self):
@@ -341,7 +341,7 @@ class TestReduceOpTranscriber(unittest.TestCase):
                 x = paddle.to_tensor(arr, dtype='int32')
                 out1 = paddle.all(x, axis=0)
 
-                out = exe.run(main_program, {}, fetch_list=[out1.name])
+                out = exe.run(main_program, {}, fetch_list=[out1])
                 np.testing.assert_array_equal(out[0], np.all(arr, axis=0))
 
 
@@ -424,7 +424,7 @@ class TestSetValueOp(unittest.TestCase):
             with paddle.static.program_guard(main_program):
                 x = paddle.ones(shape=[2, 3, 4], dtype="float32")
                 x = paddle.static.setitem(x, (0, 0), 6)
-        ret = exe.run(main_program, fetch_list=x.name)
+        ret = exe.run(main_program, fetch_list=[x])
 
         x_data = np.ones([2, 3, 4]).astype("float32")
         x_data[0, 0] = 6
@@ -442,7 +442,7 @@ class TestSetValueOp(unittest.TestCase):
                 x = paddle.ones(shape=[2, 3, 4], dtype="float32")
                 zero = paddle.full([], 0, dtype="int32")
                 x = paddle.static.setitem(x, zero, 6)
-        ret = exe.run(main_program, fetch_list=x.name)
+        ret = exe.run(main_program, fetch_list=[x])
 
         x_data = np.ones([2, 3, 4]).astype("float32")
         x_data[0] = 6

--- a/test/deprecated/ir/pir/test_standalone_pir.py
+++ b/test/deprecated/ir/pir/test_standalone_pir.py
@@ -39,7 +39,7 @@ class TestPir(unittest.TestCase):
                 y = paddle.ones([2, 2], dtype="float32")
 
                 z = x + y
-            out = exe.run(main_program, {}, fetch_list=[z.name])
+            out = exe.run(main_program, {}, fetch_list=[z])
 
         gold_res = np.ones([2, 2], dtype="float32") * 2
 
@@ -65,7 +65,7 @@ class TestCombineOp(unittest.TestCase):
                 y = paddle.ones([2, 2], dtype="float32")
 
                 z = paddle.linalg.multi_dot([x, y])
-            out = exe.run(main_program, {}, fetch_list=[z.name])
+            out = exe.run(main_program, {}, fetch_list=[z])
 
         gold_res = np.ones([2, 2], dtype="float32") * 2
 
@@ -96,7 +96,7 @@ class TestFeedOp(unittest.TestCase):
             out = exe.run(
                 main_program,
                 feed={"x": np_a, "y": np_b},
-                fetch_list=[z.name],
+                fetch_list=[z],
             )
 
         gold_res = np_a + np_b
@@ -124,7 +124,7 @@ class TestSelectedRows(unittest.TestCase):
 
             out = exe.run(
                 main_program,
-                fetch_list=[loss.name],
+                fetch_list=[loss],
             )
 
 
@@ -155,7 +155,7 @@ class TestAddGradOp(unittest.TestCase):
             out = exe.run(
                 main_program,
                 feed={"x": np_a, "y": np_b},
-                fetch_list=[z.name],
+                fetch_list=[z],
             )
 
         gold_res = np_a * np_b
@@ -254,7 +254,7 @@ class TestSplitOp(unittest.TestCase):
             out = exe.run(
                 main_program,
                 feed={"x": np_a},
-                fetch_list=[out0.name],
+                fetch_list=[out0],
             )
 
             np.testing.assert_array_equal(out[0], np_a[0:2])
@@ -280,7 +280,7 @@ class TestPirPrint(unittest.TestCase):
                 z = x + y
                 z = paddle.static.Print(z)
 
-            out = exe.run(main_program, {}, fetch_list=[z.name])
+            out = exe.run(main_program, {}, fetch_list=[z])
 
         gold_res = np.ones([2, 2], dtype="float32") * 2
 

--- a/test/deprecated/ir/test_ir_generate_pass.py
+++ b/test/deprecated/ir/test_ir_generate_pass.py
@@ -282,10 +282,8 @@ class TestGeneratePass(unittest.TestCase):
             "y": np.random.random([10, 10, 10]).astype("float32"),
             "z": np.random.random([10, 10, 10]).astype("float32"),
         }
-        before_out = executor.run(program, feed=feed, fetch_list=[out.name])
-        after_out = executor.run(
-            after_program, feed=feed, fetch_list=[out.name]
-        )
+        before_out = executor.run(program, feed=feed, fetch_list=[out])
+        after_out = executor.run(after_program, feed=feed, fetch_list=[out])
         np.testing.assert_allclose(before_out, after_out, rtol=1e-05)
 
     def test_multi_add_to_sum(self):
@@ -318,10 +316,10 @@ class TestGeneratePass(unittest.TestCase):
             "z": np.random.random([32, 48]).astype("float32"),
         }
         before_out1, before_out2 = executor.run(
-            program, feed=feed, fetch_list=[out1.name, out2.name]
+            program, feed=feed, fetch_list=[out1, out2]
         )
         after_out1, after_out2 = executor.run(
-            after_program, feed=feed, fetch_list=[out1.name, out2.name]
+            after_program, feed=feed, fetch_list=[out1, out2]
         )
         np.testing.assert_allclose(before_out1, after_out1, rtol=1e-05)
         np.testing.assert_allclose(before_out2, after_out2, rtol=1e-05)
@@ -361,10 +359,8 @@ class TestGeneratePass(unittest.TestCase):
         executor = paddle.static.Executor(paddle.CPUPlace())
         executor.run(startup_program)
         feed = {"x": np.random.random([10, 16, 16]).astype("float32")}
-        before_out = executor.run(program, feed=feed, fetch_list=[out.name])
-        after_out = executor.run(
-            after_program, feed=feed, fetch_list=[out.name]
-        )
+        before_out = executor.run(program, feed=feed, fetch_list=[out])
+        after_out = executor.run(after_program, feed=feed, fetch_list=[out])
         np.testing.assert_allclose(before_out, after_out, rtol=1e-05)
 
     def test_generate_simplify_inference(self):
@@ -397,8 +393,6 @@ class TestGeneratePass(unittest.TestCase):
         executor = paddle.static.Executor(paddle.CPUPlace())
         executor.run(startup_program)
         feed = {"x": np.random.random([3, 64, 120]).astype("float32")}
-        before_out = executor.run(program, feed=feed, fetch_list=[out.name])
-        after_out = executor.run(
-            after_program, feed=feed, fetch_list=[out.name]
-        )
+        before_out = executor.run(program, feed=feed, fetch_list=[out])
+        after_out = executor.run(after_program, feed=feed, fetch_list=[out])
         np.testing.assert_allclose(before_out, after_out, rtol=1e-05)

--- a/test/deprecated/legacy_test/check_nan_inf_base.py
+++ b/test/deprecated/legacy_test/check_nan_inf_base.py
@@ -90,7 +90,7 @@ def check(use_cuda):
                 outs = exe.run(
                     main,
                     feed={'x': train_data, 'y': y_label},
-                    fetch_list=[y_predict.name, avg_cost.name, acc_top1.name],
+                    fetch_list=[y_predict, avg_cost, acc_top1],
                 )
                 step += 1
                 print(f'iter={step:.0f},cost={outs[1]},acc1={outs[2]}')

--- a/test/deprecated/legacy_test/dist_fleet_ctr.py
+++ b/test/deprecated/legacy_test/dist_fleet_ctr.py
@@ -198,7 +198,7 @@ class TestDistCTR2x2(FleetDistRunnerBase):
                 batch_idx += 1
                 loss_val = exe.run(
                     program=paddle.static.default_main_program(),
-                    fetch_list=[self.avg_cost.name],
+                    fetch_list=[self.avg_cost],
                 )
                 loss_val = np.mean(loss_val)
                 message = f"TEST ---> batch_idx: {batch_idx} loss: {loss_val}\n"
@@ -231,7 +231,7 @@ class TestDistCTR2x2(FleetDistRunnerBase):
                 while True:
                     loss_val = exe.run(
                         program=base.default_main_program(),
-                        fetch_list=[self.avg_cost.name],
+                        fetch_list=[self.avg_cost],
                     )
                     loss_val = np.mean(loss_val)
                     # TODO(randomly fail)

--- a/test/deprecated/legacy_test/test_calc_gradient.py
+++ b/test/deprecated/legacy_test/test_calc_gradient.py
@@ -59,7 +59,7 @@ class TestDoubleGrad(unittest.TestCase):
         place = base.CPUPlace()
         exe = base.Executor(place)
         exe.run(startup)
-        out = exe.run(main, fetch_list=[grad1.name, grad2.name])
+        out = exe.run(main, fetch_list=[grad1, grad2])
         self.assertEqual(6, out[0][0])
         self.assertEqual(6, out[1][0])
 

--- a/test/deprecated/legacy_test/test_compiled_program.py
+++ b/test/deprecated/legacy_test/test_compiled_program.py
@@ -49,7 +49,7 @@ class TestCompiledProgram(unittest.TestCase):
             (loss_data,) = exe.run(
                 base.default_main_program(),
                 feed={"image": self.img, "label": self.label},
-                fetch_list=[loss.name],
+                fetch_list=[loss],
             )
             self.loss = float(loss_data)
 
@@ -71,7 +71,7 @@ class TestCompiledProgram(unittest.TestCase):
             (loss_data,) = exe.run(
                 compiled_prog,
                 feed={"image": self.img, "label": self.label},
-                fetch_list=[loss.name],
+                fetch_list=[loss],
             )
             np.testing.assert_array_equal(float(loss_data), self.loss)
 

--- a/test/deprecated/legacy_test/test_executor_and_use_program_cache.py
+++ b/test/deprecated/legacy_test/test_executor_and_use_program_cache.py
@@ -52,7 +52,7 @@ class TestExecutor(unittest.TestCase):
                 outs = exe.run(
                     program=main_program,
                     feed={'a': a_np, 'b': b_np},
-                    fetch_list=[output.name],
+                    fetch_list=[output],
                     use_program_cache=use_program_cache,
                 )
                 end = time.time()

--- a/test/deprecated/legacy_test/test_feed_data_check_shape_type.py
+++ b/test/deprecated/legacy_test/test_feed_data_check_shape_type.py
@@ -250,7 +250,7 @@ class TestFeedData(unittest.TestCase):
             fetches = exe.run(
                 train_program,
                 feed={in_data.name: feed_in_data, label.name: feed_label},
-                fetch_list=[loss.name],
+                fetch_list=[loss],
             )
 
 

--- a/test/deprecated/legacy_test/test_fuse_elewise_add_act_pass.py
+++ b/test/deprecated/legacy_test/test_fuse_elewise_add_act_pass.py
@@ -59,7 +59,7 @@ class TestFuseActElewiseAddInplaceGradPass(unittest.TestCase):
             loss_data_fused = exe.run(
                 compiled_prog_fused,
                 feed={"X": x, "Y": y},
-                fetch_list=[loss.name],
+                fetch_list=[loss],
             )
 
         # close fused_pass
@@ -72,7 +72,7 @@ class TestFuseActElewiseAddInplaceGradPass(unittest.TestCase):
         with base.scope_guard(scope):
             exe.run(startup_program)
             loss_data = exe.run(
-                compiled_prog, feed={"X": x, "Y": y}, fetch_list=[loss.name]
+                compiled_prog, feed={"X": x, "Y": y}, fetch_list=[loss]
             )
 
         self.assertEqual(loss_data_fused, loss_data)

--- a/test/deprecated/legacy_test/test_inplace_addto_strategy.py
+++ b/test/deprecated/legacy_test/test_inplace_addto_strategy.py
@@ -104,9 +104,7 @@ class TestInplaceAddto(unittest.TestCase):
                 np.float32
             )
             for i in range(10):
-                res = exe.run(
-                    compiled, feed={'img': img}, fetch_list=[loss.name, w.name]
-                )
+                res = exe.run(compiled, feed={'img': img}, fetch_list=[loss, w])
             return res
 
         res1, w1 = run_program(True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

在 `exe.run` `fetch_list` 直接使用 value 而不是其 name，避免 PIR 下不兼容

PCard-66972