### PR TITLE
[PIR] Use value in Executor `fetch_list` (part2)

### DIFF
--- a/test/deprecated/legacy_test/test_lr_scheduler.py
+++ b/test/deprecated/legacy_test/test_lr_scheduler.py
@@ -124,9 +124,7 @@ class TestReduceOnPlateauDecay:
 
         for epoch in range(20):
             for batch_id in range(1):
-                out, actual_lr = exe.run(
-                    main_prog, fetch_list=[loss.name, lr_var.name]
-                )
+                out, actual_lr = exe.run(main_prog, fetch_list=[loss, lr_var])
                 expected_lr = reduce_lr_on_plateau(
                     kwargs['factor'],
                     kwargs['threshold'],
@@ -144,9 +142,7 @@ class TestReduceOnPlateauDecay:
 
         for epoch in range(10):
             for batch_id in range(1):
-                out, actual_lr = exe.run(
-                    test_prog, fetch_list=[loss.name, lr_var.name]
-                )
+                out, actual_lr = exe.run(test_prog, fetch_list=[loss, lr_var])
                 expected_lr = reduce_lr_on_plateau(
                     kwargs['factor'],
                     kwargs['threshold'],
@@ -343,7 +339,7 @@ class TestCosineAnnealingWarmRestarts(unittest.TestCase):
                 out = exe.run(
                     main_prog,
                     feed={'x': np.random.randn(3, 4, 5).astype('float32')},
-                    fetch_list=lr_var.name,
+                    fetch_list=[lr_var],
                 )
             expected_lr = np.array(
                 cosine_annealing_warm_restarts_lr(epoch, v_l)
@@ -356,7 +352,7 @@ class TestCosineAnnealingWarmRestarts(unittest.TestCase):
                 out = exe.run(
                     test_prog,
                     feed={'x': np.random.randn(3, 4, 5).astype('float32')},
-                    fetch_list=lr_var.name,
+                    fetch_list=[lr_var],
                 )
             expected_lr = np.array(
                 cosine_annealing_warm_restarts_lr(epoch_num=None, v_l=v_l)
@@ -711,7 +707,7 @@ class TestLRScheduler(unittest.TestCase):
                 out = exe.run(
                     main_prog,
                     feed={'x': np.random.randn(3, 4, 5).astype('float32')},
-                    fetch_list=lr_var.name,
+                    fetch_list=[lr_var],
                 )
             self.assertEqual(out, np.array(python_func(num, **kwarg)))
             scheduler.step()
@@ -722,7 +718,7 @@ class TestLRScheduler(unittest.TestCase):
                 out = exe.run(
                     test_prog,
                     feed={'x': np.random.randn(3, 4, 5).astype('float32')},
-                    fetch_list=lr_var.name,
+                    fetch_list=[lr_var],
                 )
             self.assertEqual(out, np.array(python_func(num, **kwarg)))
             scheduler.step()
@@ -736,7 +732,7 @@ class TestLRScheduler(unittest.TestCase):
                     out = exe.run(
                         compiled_train_prog,
                         feed={'x': np.random.randn(3, 4, 5).astype('float32')},
-                        fetch_list=lr_var.name,
+                        fetch_list=[lr_var],
                     )
                 self.assertEqual(out, np.array(python_result))
                 scheduler.step()
@@ -749,7 +745,7 @@ class TestLRScheduler(unittest.TestCase):
                     out = exe.run(
                         compiled_test_prog,
                         feed={'x': np.random.randn(3, 4, 5).astype('float32')},
-                        fetch_list=lr_var.name,
+                        fetch_list=[lr_var],
                     )
                 self.assertEqual(out, np.array(python_result))
                 scheduler.step()

--- a/test/deprecated/legacy_test/test_memory_reuse_exclude_feed_var.py
+++ b/test/deprecated/legacy_test/test_memory_reuse_exclude_feed_var.py
@@ -53,7 +53,7 @@ class TestMemoryReuseExcludeFeedVar(unittest.TestCase):
         feed_dict = [{image.name: image_tensor}]
 
         for _ in range(self.iteration):
-            exe.run(compiled_prog, feed=feed_dict, fetch_list=[loss.name])
+            exe.run(compiled_prog, feed=feed_dict, fetch_list=[loss])
             np.testing.assert_array_equal(np.array(image_tensor), np_image)
 
     def test_main(self):

--- a/test/deprecated/legacy_test/test_metrics.py
+++ b/test/deprecated/legacy_test/test_metrics.py
@@ -221,7 +221,7 @@ class TestAccuracyStatic(TestAccuracyDynamic):
             state_ret = exe.run(
                 compiled_main_prog,
                 feed={'pred': pred, 'label': label},
-                fetch_list=[s.name for s in to_list(state)],
+                fetch_list=to_list(state),
                 return_numpy=True,
             )
             acc.update(*state_ret)

--- a/test/deprecated/legacy_test/test_momentum_op.py
+++ b/test/deprecated/legacy_test/test_momentum_op.py
@@ -1081,7 +1081,7 @@ class TestMultiTensorMomentumStatic(unittest.TestCase):
         out = []
         for idx in range(5):
             (loss_data,) = exe.run(
-                train_program, feed={"X": x}, fetch_list=[loss.name]
+                train_program, feed={"X": x}, fetch_list=[loss]
             )
             out.append(loss_data)
         return out

--- a/test/deprecated/legacy_test/test_nce.py
+++ b/test/deprecated/legacy_test/test_nce.py
@@ -263,7 +263,7 @@ class TestNCECase1SelectedRows(unittest.TestCase):
                     loss_val = exe.run(
                         dense_train_program,
                         feed=feeder.feed(data),
-                        fetch_list=[cost.name],
+                        fetch_list=[cost],
                     )
                     rets.append(np.mean(loss_val))
 
@@ -284,7 +284,7 @@ class TestNCECase1SelectedRows(unittest.TestCase):
                     loss_val = exe.run(
                         sparse_train_program,
                         feed=feeder.feed(data),
-                        fetch_list=[cost.name],
+                        fetch_list=[cost],
                     )
                     rets.append(np.mean(loss_val))
 

--- a/test/deprecated/legacy_test/test_nonzero_api.py
+++ b/test/deprecated/legacy_test/test_nonzero_api.py
@@ -41,7 +41,7 @@ class TestNonZeroAPI(unittest.TestCase):
             exe = base.Executor(base.CPUPlace())
 
             (res,) = exe.run(
-                feed={'x': data}, fetch_list=[z.name], return_numpy=False
+                feed={'x': data}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.array([[0, 0], [1, 1]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
@@ -56,7 +56,7 @@ class TestNonZeroAPI(unittest.TestCase):
             z = paddle.concat(list(y), axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
-                feed={'x': data}, fetch_list=[z.name], return_numpy=False
+                feed={'x': data}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.array([[0], [1]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
@@ -70,7 +70,7 @@ class TestNonZeroAPI(unittest.TestCase):
             y = paddle.nonzero(x)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
-                feed={'x': data}, fetch_list=[y.name], return_numpy=False
+                feed={'x': data}, fetch_list=[y], return_numpy=False
             )
         expect_out = np.array([[0, 0], [1, 1]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
@@ -82,7 +82,7 @@ class TestNonZeroAPI(unittest.TestCase):
             y = paddle.nonzero(x)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
-                feed={'x': data}, fetch_list=[y.name], return_numpy=False
+                feed={'x': data}, fetch_list=[y], return_numpy=False
             )
         expect_out = np.array([[0], [1]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)

--- a/test/deprecated/legacy_test/test_pass_builder.py
+++ b/test/deprecated/legacy_test/test_pass_builder.py
@@ -55,12 +55,12 @@ class TestPassBuilder(unittest.TestCase):
             )
 
             for i in range(5):
-                _ = exe.run(train_cp, fetch_list=[loss.name], feed=feed_dict)
+                _ = exe.run(train_cp, fetch_list=[loss], feed=feed_dict)
                 (test_loss,) = exe.run(
-                    test_cp, fetch_list=[loss.name], feed=feed_dict
+                    test_cp, fetch_list=[loss], feed=feed_dict
                 )
                 (train_loss,) = exe.run(
-                    train_cp, fetch_list=[loss.name], feed=feed_dict
+                    train_cp, fetch_list=[loss], feed=feed_dict
                 )
 
                 avg_test_loss_val = np.array(test_loss).mean()

--- a/test/deprecated/legacy_test/test_program_prune_backward.py
+++ b/test/deprecated/legacy_test/test_program_prune_backward.py
@@ -399,10 +399,10 @@ class TestProgramPruneBackward(unittest.TestCase):
             exe.run(base.default_startup_program())
 
             (loss_data_prune,) = exe.run(
-                test_prog_prune, feed=feed_dict, fetch_list=[loss.name]
+                test_prog_prune, feed=feed_dict, fetch_list=[loss]
             )
             (loss_data_orig,) = exe.run(
-                test_prog_orig, feed=feed_dict, fetch_list=[loss.name]
+                test_prog_orig, feed=feed_dict, fetch_list=[loss]
             )
             self.assertEqual(loss_data_orig, loss_data_prune)
 
@@ -517,7 +517,7 @@ class TestProgramPruneBackward(unittest.TestCase):
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             (loss_data_orig,) = exe.run(
-                test_prog_orig, feed=feed_dict, fetch_list=[loss.name]
+                test_prog_orig, feed=feed_dict, fetch_list=[loss]
             )
 
         with self.program_scope_guard():
@@ -529,7 +529,7 @@ class TestProgramPruneBackward(unittest.TestCase):
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             (loss_data_prune,) = exe.run(
-                test_prog_prune, feed=feed_dict, fetch_list=[loss.name]
+                test_prog_prune, feed=feed_dict, fetch_list=[loss]
             )
 
         self.program_compare(test_prog_orig, test_prog_prune)
@@ -547,7 +547,7 @@ class TestProgramPruneBackward(unittest.TestCase):
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             (loss_data_orig,) = exe.run(
-                test_prog_orig, feed=feed_dict, fetch_list=[loss.name]
+                test_prog_orig, feed=feed_dict, fetch_list=[loss]
             )
 
         with self.program_scope_guard():
@@ -559,7 +559,7 @@ class TestProgramPruneBackward(unittest.TestCase):
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             (loss_data_prune,) = exe.run(
-                test_prog_prune, feed=feed_dict, fetch_list=[loss.name]
+                test_prog_prune, feed=feed_dict, fetch_list=[loss]
             )
 
         self.program_compare(test_prog_orig, test_prog_prune)

--- a/test/deprecated/legacy_test/test_sgd_op.py
+++ b/test/deprecated/legacy_test/test_sgd_op.py
@@ -392,7 +392,7 @@ class TestSGDMultiPrecision2_0(unittest.TestCase):
         out = []
         for idx in range(5):
             (loss_data,) = exe.run(
-                train_program, feed={"X": x}, fetch_list=[loss.name]
+                train_program, feed={"X": x}, fetch_list=[loss]
             )
             out.append(loss_data)
         return out

--- a/test/deprecated/legacy_test/test_tensor_scalar_type_promotion_static.py
+++ b/test/deprecated/legacy_test/test_tensor_scalar_type_promotion_static.py
@@ -54,7 +54,7 @@ class TestTensorScalarTypePromotionStatic(unittest.TestCase):
         else:
             raise ValueError("Unsupported operation.")
 
-        rlt = exe.run(fetch_list=[c_rlt.name, c.name])
+        rlt = exe.run(fetch_list=[c_rlt, c])
 
         self.assertEqual(rlt[0].dtype, rlt[1].dtype)
         np.testing.assert_array_equal(rlt[0], rlt[1])

--- a/test/deprecated/legacy_test/test_where_op.py
+++ b/test/deprecated/legacy_test/test_where_op.py
@@ -763,7 +763,7 @@ class TestWhereDygraphAPI(unittest.TestCase):
             z = paddle.concat(list(y), axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
-                feed={'x': data}, fetch_list=[z.name], return_numpy=False
+                feed={'x': data}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.array([[0, 0], [1, 1]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
@@ -777,7 +777,7 @@ class TestWhereDygraphAPI(unittest.TestCase):
             z = paddle.concat(list(y), axis=1)
             exe = base.Executor(base.CPUPlace())
             (res,) = exe.run(
-                feed={'x': data}, fetch_list=[z.name], return_numpy=False
+                feed={'x': data}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.array([[0], [1]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)

--- a/test/deprecated/quantization/test_graph.py
+++ b/test/deprecated/quantization/test_graph.py
@@ -93,7 +93,7 @@ class TestGraph(unittest.TestCase):
             for _ in range(iters):
                 data = next(train_reader())
                 loss_v = exe.run(
-                    binary, feed=feeder.feed(data), fetch_list=[loss.name]
+                    binary, feed=feeder.feed(data), fetch_list=[loss]
                 )
                 if not for_ci:
                     print('{}: {}'.format('loss', loss_v))

--- a/test/deprecated/standalone_executor/test_standalone_sequentail_run.py
+++ b/test/deprecated/standalone_executor/test_standalone_sequentail_run.py
@@ -52,7 +52,7 @@ class TestStandaloneExecutor(unittest.TestCase):
             ret = exe.run(
                 compiled_program,
                 feed={"data": data},
-                fetch_list=[v.name for v in outs],
+                fetch_list=list(outs),
             )
             return ret
 

--- a/test/ir/inference/test_yolo_box_post.py
+++ b/test/ir/inference/test_yolo_box_post.py
@@ -99,7 +99,7 @@ class TestYoloBoxPost(unittest.TestCase):
             "im_shape": np.array([[608.0, 608.0]], "float32"),
             "im_scale": np.array([[1.0, 1.0]], "float32"),
         }
-        outs = exe.run(program, feed=feed, fetch_list=[out.name, rois_num.name])
+        outs = exe.run(program, feed=feed, fetch_list=[out, rois_num])
 
 
 if __name__ == '__main__':

--- a/test/ir/test_fuse_resnet_unit.py
+++ b/test/ir/test_fuse_resnet_unit.py
@@ -61,8 +61,8 @@ class TestFuseResNetUnit(unittest.TestCase):
             place, after_program, to_fp16_var_names=after_params
         )
         feed = {"x": np.random.randn(1, 64, 64, 8).astype("float16")}
-        before_out = exe.run(program, feed=feed, fetch_list=[out.name])
-        after_out = exe.run(after_program, feed=feed, fetch_list=[out.name])
+        before_out = exe.run(program, feed=feed, fetch_list=[out])
+        after_out = exe.run(after_program, feed=feed, fetch_list=[out])
         np.testing.assert_allclose(
             before_out[0], after_out[0], rtol=1e-05, atol=0.005
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

同 #64235

在 `exe.run` `fetch_list` 直接使用 value 而不是其 name，避免 PIR 下不兼容

PCard-66972