### PR TITLE
[Inference]add blha_get_max_len op & modify block_multihead_attention op

### DIFF
--- a/paddle/phi/api/yaml/fused_ops.yaml
+++ b/paddle/phi/api/yaml/fused_ops.yaml
@@ -32,17 +32,29 @@
     func : addcmul_xpu
     data_type : x
 
+- op : blha_get_max_len
+  args : (Tensor seq_lens_encoder, Tensor seq_lens_decoder, int bsz)
+  output : Tensor(max_enc_len_this_time), Tensor(max_dec_len_this_time)
+  infer_meta :
+    func : BlhaGetMaxLenInferMeta
+  kernel :
+    func : blha_get_max_len
+    data_type : seq_lens_encoder
+  support_dygraph_mode : true
+
 - op : block_multihead_attention_
-  args : (Tensor qkv, Tensor key_cache, Tensor value_cache, Tensor seq_lens_encoder, Tensor seq_lens_decoder, Tensor seq_lens_this_time, Tensor padding_offsets, Tensor cum_offsets, Tensor cu_seqlens_q, Tensor cu_seqlens_k, Tensor block_tables, Tensor pre_key_cache, Tensor pre_value_cache, Tensor rope_emb, Tensor mask,  Tensor tgt_mask, Tensor cache_k_quant_scales, Tensor cache_v_quant_scales, Tensor cache_k_dequant_scales, Tensor cache_v_dequant_scales, Tensor qkv_out_scale, Tensor qkv_bias, Tensor out_shift, Tensor out_smooth, int max_seq_len, int block_size, bool use_neox_style, bool dynamic_cachekv_quant=false, int quant_round_type=1, float quant_max_bound=127.0, float quant_min_bound=-127.0, float out_scale=-1, str compute_dtype = "default")
+  args : (Tensor qkv, Tensor key_cache, Tensor value_cache, Tensor seq_lens_encoder, Tensor seq_lens_decoder, Tensor seq_lens_this_time, Tensor padding_offsets, Tensor cum_offsets, Tensor cu_seqlens_q, Tensor cu_seqlens_k, Tensor block_tables, Tensor pre_key_cache, Tensor pre_value_cache, Tensor rope_emb, Tensor mask,  Tensor tgt_mask, Tensor cache_k_quant_scales, Tensor cache_v_quant_scales, Tensor cache_k_dequant_scales, Tensor cache_v_dequant_scales, Tensor qkv_out_scale, Tensor qkv_bias, Tensor out_shift, Tensor out_smooth, Tensor max_enc_len_this_time, Tensor max_dec_len_this_time, int max_seq_len, int block_size, bool use_neox_style, bool dynamic_cachekv_quant=false, int quant_round_type=1, float quant_max_bound=127.0, float quant_min_bound=-127.0, float out_scale=-1, str compute_dtype = "default")
   output : Tensor(fmha_out), Tensor(qkv_out), Tensor(key_cache_out), Tensor(value_cache_out)
   infer_meta :
     func : BlockMultiheadAttentionInferMeta
   kernel :
     func : block_multihead_attention
     data_type : qkv
-  optional : pre_key_cache, pre_value_cache, rope_emb, mask, tgt_mask, cache_k_quant_scales, cache_v_quant_scales, cache_k_dequant_scales, cache_v_dequant_scales, qkv_out_scale, qkv_bias, out_shift, out_smooth
+  optional : pre_key_cache, pre_value_cache, rope_emb, mask, tgt_mask, cache_k_quant_scales, cache_v_quant_scales, cache_k_dequant_scales, cache_v_dequant_scales, qkv_out_scale, qkv_bias, out_shift, out_smooth, max_enc_len_this_time, max_dec_len_this_time
   inplace : (qkv -> qkv_out), (key_cache -> key_cache_out), (value_cache -> value_cache_out)
   support_dygraph_mode : true
+  data_transform :
+    skip_transform : max_enc_len_this_time, max_dec_len_this_time
 
 - op : bn_act_xpu
   args : (Tensor x, Tensor mean, Tensor variance, Tensor scale, Tensor bias, float momentum, float epsilon, str data_format, int act_type)

--- a/paddle/phi/api/yaml/fused_ops.yaml
+++ b/paddle/phi/api/yaml/fused_ops.yaml
@@ -33,7 +33,7 @@
     data_type : x
 
 - op : blha_get_max_len
-  args : (Tensor seq_lens_encoder, Tensor seq_lens_decoder, int bsz)
+  args : (Tensor seq_lens_encoder, Tensor seq_lens_decoder, Tensor batch_size)
   output : Tensor(max_enc_len_this_time), Tensor(max_dec_len_this_time)
   infer_meta :
     func : BlhaGetMaxLenInferMeta

--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -232,6 +232,17 @@ void FusedMultiTransformerInferMeta(
   out->set_dims(x.dims());
 }
 
+void BlhaGetMaxLenInferMeta(const MetaTensor& seq_lens_encoder,
+                            const MetaTensor& seq_lens_decoder,
+                            const int bsz,
+                            MetaTensor* max_enc_len_this_time,
+                            MetaTensor* max_dec_len_this_time) {
+  max_enc_len_this_time->set_dims({1});
+  max_enc_len_this_time->set_dtype(phi::DataType::INT32);
+  max_dec_len_this_time->set_dims({1});
+  max_dec_len_this_time->set_dtype(phi::DataType::INT32);
+}
+
 void BlockMultiheadAttentionInferMeta(const MetaTensor& qkv,
                                       const MetaTensor& key_cache,
                                       const MetaTensor& value_cache,
@@ -256,6 +267,8 @@ void BlockMultiheadAttentionInferMeta(const MetaTensor& qkv,
                                       const MetaTensor& qkv_bias,
                                       const MetaTensor& out_shift,
                                       const MetaTensor& out_smooth,
+                                      const MetaTensor& max_enc_len_this_time,
+                                      const MetaTensor& max_dec_len_this_time,
                                       int max_seq_len,
                                       int block_size,
                                       bool use_neox_style,

--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -234,7 +234,7 @@ void FusedMultiTransformerInferMeta(
 
 void BlhaGetMaxLenInferMeta(const MetaTensor& seq_lens_encoder,
                             const MetaTensor& seq_lens_decoder,
-                            const int bsz,
+                            const MetaTensor& batch_size,
                             MetaTensor* max_enc_len_this_time,
                             MetaTensor* max_dec_len_this_time) {
   max_enc_len_this_time->set_dims({1});

--- a/paddle/phi/infermeta/fusion.h
+++ b/paddle/phi/infermeta/fusion.h
@@ -79,7 +79,7 @@ void GroupNormalizeSiluXPUInferMeta(const MetaTensor& x,
 
 void BlhaGetMaxLenInferMeta(const MetaTensor& seq_lens_encoder,
                             const MetaTensor& seq_lens_decoder,
-                            const int bsz,
+                            const MetaTensor& batch_size,
                             MetaTensor* max_enc_len_this_time,
                             MetaTensor* max_dec_len_this_time);
 

--- a/paddle/phi/infermeta/fusion.h
+++ b/paddle/phi/infermeta/fusion.h
@@ -77,6 +77,12 @@ void GroupNormalizeSiluXPUInferMeta(const MetaTensor& x,
                                     float epsilon,
                                     MetaTensor* out);
 
+void BlhaGetMaxLenInferMeta(const MetaTensor& seq_lens_encoder,
+                            const MetaTensor& seq_lens_decoder,
+                            const int bsz,
+                            MetaTensor* max_enc_len_this_time,
+                            MetaTensor* max_dec_len_this_time);
+
 void BlockMultiheadAttentionInferMeta(const MetaTensor& qkv,
                                       const MetaTensor& key_cache,
                                       const MetaTensor& value_cache,
@@ -101,6 +107,8 @@ void BlockMultiheadAttentionInferMeta(const MetaTensor& qkv,
                                       const MetaTensor& qkv_bias,
                                       const MetaTensor& out_shift,
                                       const MetaTensor& out_smooth,
+                                      const MetaTensor& max_enc_len_this_time,
+                                      const MetaTensor& max_dec_len_this_time,
                                       int max_seq_len,
                                       int block_size,
                                       bool use_neox_style,

--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -215,6 +215,7 @@ if(WITH_ROCM)
     "gpu/qr_kernel.cu"
     "gpu/svd_kernel.cu"
     "gpudnn/mha_cudnn_frontend.cu"
+    "fusion/gpu/blha_get_max_len.cu"
     "fusion/gpu/block_multi_head_attention_kernel.cu"
     "fusion/gpu/fused_bn_add_activation_grad_kernel.cu"
     "fusion/gpu/fused_bn_add_activation_kernel.cu"

--- a/paddle/phi/kernels/fusion/gpu/blha_get_max_len.cu
+++ b/paddle/phi/kernels/fusion/gpu/blha_get_max_len.cu
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/flash_attn_kernel.h"
+#include "paddle/phi/kernels/funcs/broadcast_function.h"
+#include "paddle/phi/kernels/funcs/elementwise_functor.h"
+#include "paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention.h"
+#include "paddle/phi/kernels/fusion/gpu/block_attn.h"
+#include "paddle/phi/kernels/gpu/flash_attn_utils.h"
+#include "paddle/phi/kernels/memcpy_kernel.h"
+#include "paddle/utils/none.h"
+
+namespace phi {
+namespace fusion {
+
+void GetMaxLenTensor(const phi::GPUContext& dev_ctx,
+                     const phi::DenseTensor& seq_lens_tensor,
+                     const int batch_size,
+                     DenseTensor* out) {
+  phi::DenseTensor max_len_tensor;
+  max_len_tensor.Resize({{1}});
+  auto* max_len_tensor_data = dev_ctx.template Alloc<int>(
+      &max_len_tensor, max_len_tensor.numel() * sizeof(int));
+  constexpr int blockSize = 128;
+  int max_len_cpu = 0;
+  GetMaxLenKernel<blockSize><<<1, blockSize, 0, dev_ctx.stream()>>>(
+      seq_lens_tensor.data<int>(), max_len_tensor.data<int>(), batch_size);
+  MemcpyD2HKernel(dev_ctx, max_len_tensor, 0, out);
+}
+
+template <typename T, typename Context>
+void BlhaGetMaxLenKernel(const Context& dev_ctx,
+                         const DenseTensor& seq_lens_encoder,
+                         const DenseTensor& seq_lens_decoder,
+                         const int bsz,
+                         DenseTensor* max_enc_len_this_time,
+                         DenseTensor* max_dec_len_this_time) {
+  // decoder
+  max_dec_len_this_time->Resize({{1}});
+  GetMaxLenTensor(dev_ctx, seq_lens_decoder, bsz, max_dec_len_this_time);
+
+  // encoder
+  max_enc_len_this_time->Resize({{1}});
+  GetMaxLenTensor(dev_ctx, seq_lens_encoder, bsz, max_enc_len_this_time);
+}
+}  // namespace fusion
+}  // namespace phi
+
+PD_REGISTER_KERNEL(
+    blha_get_max_len, GPU, ALL_LAYOUT, phi::fusion::BlhaGetMaxLenKernel, int) {}

--- a/paddle/phi/kernels/fusion/gpu/blha_get_max_len.cu
+++ b/paddle/phi/kernels/fusion/gpu/blha_get_max_len.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,16 +28,17 @@ namespace fusion {
 
 void GetMaxLenTensor(const phi::GPUContext& dev_ctx,
                      const phi::DenseTensor& seq_lens_tensor,
-                     const int batch_size,
+                     const phi::DenseTensor& batch_size,
                      DenseTensor* out) {
   phi::DenseTensor max_len_tensor;
   max_len_tensor.Resize({{1}});
   auto* max_len_tensor_data = dev_ctx.template Alloc<int>(
       &max_len_tensor, max_len_tensor.numel() * sizeof(int));
+  const int bsz = batch_size.dims()[0];
   constexpr int blockSize = 128;
   int max_len_cpu = 0;
   GetMaxLenKernel<blockSize><<<1, blockSize, 0, dev_ctx.stream()>>>(
-      seq_lens_tensor.data<int>(), max_len_tensor.data<int>(), batch_size);
+      seq_lens_tensor.data<int>(), max_len_tensor.data<int>(), bsz);
   MemcpyD2HKernel(dev_ctx, max_len_tensor, 0, out);
 }
 
@@ -45,16 +46,16 @@ template <typename T, typename Context>
 void BlhaGetMaxLenKernel(const Context& dev_ctx,
                          const DenseTensor& seq_lens_encoder,
                          const DenseTensor& seq_lens_decoder,
-                         const int bsz,
+                         const phi::DenseTensor& batch_size,
                          DenseTensor* max_enc_len_this_time,
                          DenseTensor* max_dec_len_this_time) {
   // decoder
   max_dec_len_this_time->Resize({{1}});
-  GetMaxLenTensor(dev_ctx, seq_lens_decoder, bsz, max_dec_len_this_time);
+  GetMaxLenTensor(dev_ctx, seq_lens_decoder, batch_size, max_dec_len_this_time);
 
   // encoder
   max_enc_len_this_time->Resize({{1}});
-  GetMaxLenTensor(dev_ctx, seq_lens_encoder, bsz, max_enc_len_this_time);
+  GetMaxLenTensor(dev_ctx, seq_lens_encoder, batch_size, max_enc_len_this_time);
 }
 }  // namespace fusion
 }  // namespace phi

--- a/paddle/phi/kernels/fusion/gpu/blha_get_max_len.cu
+++ b/paddle/phi/kernels/fusion/gpu/blha_get_max_len.cu
@@ -60,5 +60,9 @@ void BlhaGetMaxLenKernel(const Context& dev_ctx,
 }  // namespace fusion
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    blha_get_max_len, GPU, ALL_LAYOUT, phi::fusion::BlhaGetMaxLenKernel, int) {}
+PD_REGISTER_KERNEL(blha_get_max_len,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::fusion::BlhaGetMaxLenKernel,
+                   int,
+                   int64_t) {}

--- a/paddle/phi/kernels/fusion/gpu/block_attn.h
+++ b/paddle/phi/kernels/fusion/gpu/block_attn.h
@@ -2717,23 +2717,6 @@ __global__ void GetMaxLenKernel(const int *seq_lens,
   }
 }
 
-int GetMaxLen(const phi::GPUContext &dev_ctx,
-              const phi::DenseTensor &seq_lens_tensor,
-              phi::DenseTensor *max_len_tensor,
-              const int batch_size) {
-  constexpr int blockSize = 128;
-  int max_len_cpu = 0;
-  GetMaxLenKernel<blockSize><<<1, blockSize, 0, dev_ctx.stream()>>>(
-      seq_lens_tensor.data<int>(), max_len_tensor->data<int>(), batch_size);
-  memory_utils::Copy(phi::CPUPlace(),
-                     &max_len_cpu,
-                     dev_ctx.GetPlace(),
-                     max_len_tensor->data<int>(),
-                     sizeof(int),
-                     dev_ctx.stream());
-  return max_len_cpu;
-}
-
 template <typename T, int VecSize>
 __global__ void InitOutValueKernel(T *output_data,
                                    const int64_t numel,

--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -311,6 +311,10 @@ void DispatchWithDtype(
     max_dec_len_this_time_data =
         GetMaxLen(dev_ctx, seq_lens_decoder, &max_dec_len_tensor, bsz);
   } else {
+    PADDLE_ENFORCE_EQ(max_dec_len_this_time.get().place().GetType(),
+                      phi::AllocationType::CPU,
+                      "max_dec_len_this_time must be on CPU, but Got %s.",
+                      max_dec_len_this_time.get().place());
     max_dec_len_this_time_data = *max_dec_len_this_time.get().data<int>();
   }
 
@@ -323,6 +327,10 @@ void DispatchWithDtype(
     max_enc_len_this_time_data =
         GetMaxLen(dev_ctx, seq_lens_encoder, &max_enc_len_tensor, bsz);
   } else {
+    PADDLE_ENFORCE_EQ(max_enc_len_this_time.get().place().GetType(),
+                      phi::AllocationType::CPU,
+                      "max_enc_len_this_time must be on CPU, but Got %s.",
+                      max_enc_len_this_time.get().place());
     max_enc_len_this_time_data = *max_enc_len_this_time.get().data<int>();
   }
 
@@ -864,12 +872,18 @@ PD_REGISTER_KERNEL(block_multihead_attention,
                    phi::fusion::BlockMultiheadAttentionKernel,
                    phi::dtype::bfloat16,
                    phi::dtype::float16,
-                   int32_t) {}
+                   int32_t) {
+  kernel->InputAt(24).SetBackend(phi::Backend::CPU);
+  kernel->InputAt(25).SetBackend(phi::Backend::CPU);
+}
 #else
 PD_REGISTER_KERNEL(block_multihead_attention,
                    GPU,
                    ALL_LAYOUT,
                    phi::fusion::BlockMultiheadAttentionKernel,
                    phi::dtype::float16,
-                   int32_t) {}
+                   int32_t) {
+  kernel->InputAt(24).SetBackend(phi::Backend::CPU);
+  kernel->InputAt(25).SetBackend(phi::Backend::CPU);
+}
 #endif

--- a/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/block_multi_head_attention_kernel.cu
@@ -311,10 +311,12 @@ void DispatchWithDtype(
     max_dec_len_this_time_data =
         GetMaxLen(dev_ctx, seq_lens_decoder, &max_dec_len_tensor, bsz);
   } else {
-    PADDLE_ENFORCE_EQ(max_dec_len_this_time.get().place().GetType(),
-                      phi::AllocationType::CPU,
-                      "max_dec_len_this_time must be on CPU, but Got %s.",
-                      max_dec_len_this_time.get().place());
+    PADDLE_ENFORCE_EQ(
+        max_dec_len_this_time.get().place().GetType(),
+        phi::AllocationType::CPU,
+        errors::InvalidArgument(
+            "The place of input max_dec_len_this_time must be CPU, but got %s.",
+            max_dec_len_this_time.get().place()));
     max_dec_len_this_time_data = *max_dec_len_this_time.get().data<int>();
   }
 
@@ -327,10 +329,12 @@ void DispatchWithDtype(
     max_enc_len_this_time_data =
         GetMaxLen(dev_ctx, seq_lens_encoder, &max_enc_len_tensor, bsz);
   } else {
-    PADDLE_ENFORCE_EQ(max_enc_len_this_time.get().place().GetType(),
-                      phi::AllocationType::CPU,
-                      "max_enc_len_this_time must be on CPU, but Got %s.",
-                      max_enc_len_this_time.get().place());
+    PADDLE_ENFORCE_EQ(
+        max_enc_len_this_time.get().place().GetType(),
+        phi::AllocationType::CPU,
+        errors::InvalidArgument(
+            "The place of input max_enc_len_this_time must be CPU, but got %s.",
+            max_enc_len_this_time.get().place()));
     max_enc_len_this_time_data = *max_enc_len_this_time.get().data<int>();
   }
 

--- a/python/paddle/incubate/nn/functional/__init__.py
+++ b/python/paddle/incubate/nn/functional/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .blha_get_max_len import blha_get_max_len
 from .block_multihead_attention import block_multihead_attention
 from .fused_dot_product_attention import (
     fused_dot_product_attention,  # noqa: F401
@@ -54,6 +55,7 @@ __all__ = [
     "fused_rms_norm",
     "fused_layer_norm",
     "masked_multihead_attention",
+    "blha_get_max_len",
     "block_multihead_attention",
     "swiglu",
 ]

--- a/python/paddle/incubate/nn/functional/blha_get_max_len.py
+++ b/python/paddle/incubate/nn/functional/blha_get_max_len.py
@@ -35,8 +35,8 @@ def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size):
             >>> import paddle
             >>> paddle.device.set_device('gpu')
 
-            >>> seq_lens_encoder = paddle.cast(paddle.randn(shape=[1]), dtype=paddle.int32)
-            >>> seq_lens_decoder = paddle.cast(paddle.randn(shape=[1]), dtype=paddle.int32)
+            >>> seq_lens_encoder = paddle.cast(paddle.randn(shape=[10]), dtype=paddle.int32)
+            >>> seq_lens_decoder = paddle.cast(paddle.randn(shape=[10]), dtype=paddle.int32)
             >>> bsz = 10
             >>> batch_size = paddle.ones(shape=[bsz])
             >>> max_enc_len_this_time, max_dec_len_this_time = paddle.incubate.nn.functional.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size)

--- a/python/paddle/incubate/nn/functional/blha_get_max_len.py
+++ b/python/paddle/incubate/nn/functional/blha_get_max_len.py
@@ -16,14 +16,14 @@ from paddle import _C_ops
 from paddle.framework import LayerHelper, in_dynamic_mode
 
 
-def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz):
+def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size):
     """
     Apply Fused BlhaGetMaxLen kernel. Typically used before the block_multihead_attention operator.
 
     Args:
         seq_lens_encoder (Tensor): Sentence length of the encoder.
         seq_lens_decoder (Tensor): Sentence length of the decoder.
-        bsz (Int): the batch size.
+        batch_size (Tensor): the batch size.
 
     Returns:
         Tensor|(max_enc_len_this_time, max_dec_len_this_time)
@@ -37,11 +37,14 @@ def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz):
 
             >>> seq_lens_encoder = paddle.cast(paddle.randn(shape=[1]), dtype=paddle.int32)
             >>> seq_lens_decoder = paddle.cast(paddle.randn(shape=[1]), dtype=paddle.int32)
-            >>> bsz = 1
-            >>> max_enc_len_this_time, max_dec_len_this_time = paddle.incubate.nn.functional.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz)
+            >>> bsz = 10
+            >>> batch_size = paddle.ones(shape=[bsz])
+            >>> max_enc_len_this_time, max_dec_len_this_time = paddle.incubate.nn.functional.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size)
     """
     if in_dynamic_mode():
-        return _C_ops.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz)
+        return _C_ops.blha_get_max_len(
+            seq_lens_encoder, seq_lens_decoder, batch_size
+        )
 
     helper = LayerHelper('blha_get_max_len', **locals())
     max_enc_len_this_time = helper.create_variable_for_type_inference(
@@ -54,6 +57,7 @@ def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz):
     inputs = {}
     inputs['seq_lens_encoder'] = seq_lens_encoder
     inputs['seq_lens_decoder'] = seq_lens_decoder
+    inputs['batch_size'] = batch_size
 
     outputs = {
         'max_enc_len_this_time': max_enc_len_this_time,
@@ -63,8 +67,5 @@ def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz):
         type='blha_get_max_len',
         inputs=inputs,
         outputs=outputs,
-        attrs={
-            'bsz': bsz,
-        },
     )
     return max_enc_len_this_time, max_dec_len_this_time

--- a/python/paddle/incubate/nn/functional/blha_get_max_len.py
+++ b/python/paddle/incubate/nn/functional/blha_get_max_len.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle import _C_ops
+from paddle.framework import LayerHelper, in_dynamic_mode
+
+
+def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz):
+    """
+    Apply Fused BlhaGetMaxLen kernel. Typically used before the block_multihead_attention operator.
+
+    Args:
+        seq_lens_encoder (Tensor): Sentence length of the encoder.
+        seq_lens_decoder (Tensor): Sentence length of the decoder.
+        bsz (Int): the batch size.
+
+    Returns:
+        Tensor|(max_enc_len_this_time, max_dec_len_this_time)
+
+    Examples:
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')
+
+            >>> seq_lens_encoder = paddle.cast(paddle.randn(shape=[1]), dtype=paddle.int32)
+            >>> seq_lens_decoder = paddle.cast(paddle.randn(shape=[1]), dtype=paddle.int32)
+            >>> bsz = 1
+            >>> max_enc_len_this_time, max_dec_len_this_time = paddle.incubate.nn.functional.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz)
+    """
+    if in_dynamic_mode():
+        return _C_ops.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, bsz)
+
+    helper = LayerHelper('blha_get_max_len', **locals())
+    max_enc_len_this_time = helper.create_variable_for_type_inference(
+        dtype="int32"
+    )
+    max_dec_len_this_time = helper.create_variable_for_type_inference(
+        dtype="int32"
+    )
+
+    inputs = {}
+    inputs['seq_lens_encoder'] = seq_lens_encoder
+    inputs['seq_lens_decoder'] = seq_lens_decoder
+
+    outputs = {
+        'max_enc_len_this_time': max_enc_len_this_time,
+        'max_dec_len_this_time': max_dec_len_this_time,
+    }
+    helper.append_op(
+        type='blha_get_max_len',
+        inputs=inputs,
+        outputs=outputs,
+        attrs={
+            'bsz': bsz,
+        },
+    )
+    return max_enc_len_this_time, max_dec_len_this_time

--- a/python/paddle/incubate/nn/functional/blha_get_max_len.py
+++ b/python/paddle/incubate/nn/functional/blha_get_max_len.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from paddle import _C_ops
-from paddle.framework import LayerHelper, in_dynamic_mode
+from paddle.framework import LayerHelper, in_dynamic_or_pir_mode
 
 
 def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size):
@@ -41,7 +41,7 @@ def blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size):
             >>> batch_size = paddle.ones(shape=[bsz])
             >>> max_enc_len_this_time, max_dec_len_this_time = paddle.incubate.nn.functional.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size)
     """
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return _C_ops.blha_get_max_len(
             seq_lens_encoder, seq_lens_decoder, batch_size
         )

--- a/python/paddle/incubate/nn/functional/block_multihead_attention.py
+++ b/python/paddle/incubate/nn/functional/block_multihead_attention.py
@@ -78,6 +78,8 @@ def block_multihead_attention(
         qkv_bias (Tensor): The bias of qkv. Its shape is [3 * num_head * head_size].
         out_shift (Tensor): Shift bias of fmha_out, which is the 1st return value. Its shape is [num_head * head_size].
         out_smooth (Tensor): Smooth weight of fmha_out. Its shape is [num_head * head_size].
+        max_enc_len_this_time (Tensor): Sentence length of the encoder this time. Its shape is [1].
+        max_dec_len_this_time (Tensor): Sentence length of the decoder this time. Its shape is [1].
         rope_emb (Tensor): The RoPE embedding. Its shape is [2, batchsize, max_seq_len, 1, head_size // 2].
         mask (Tensor): The mask of qk_matmul in encoder. Its shape is [batchsize, 1, max_seq_len, max_seq_len].
         tgt_mask (Tensor): The mask of qk_matmul in decoder. Its shape is [batchsize, 1, 1, max_seq_len].

--- a/python/paddle/incubate/nn/functional/block_multihead_attention.py
+++ b/python/paddle/incubate/nn/functional/block_multihead_attention.py
@@ -255,6 +255,8 @@ def block_multihead_attention(
             ...     None, # qkv_bias
             ...     None, # out_shift
             ...     None, # out_smooth
+            ...     None, # max_enc_len_this_time
+            ...     None, # max_dec_len_this_time
             ...     None, # rotary_embs
             ...     None, # attn_mask
             ...     None, # tgt_mask

--- a/python/paddle/incubate/nn/functional/block_multihead_attention.py
+++ b/python/paddle/incubate/nn/functional/block_multihead_attention.py
@@ -38,6 +38,8 @@ def block_multihead_attention(
     qkv_bias=None,
     out_shift=None,
     out_smooth=None,
+    max_enc_len_this_time=None,
+    max_dec_len_this_time=None,
     rope_emb=None,
     mask=None,
     tgt_mask=None,
@@ -301,6 +303,8 @@ def block_multihead_attention(
             qkv_bias,
             out_shift,
             out_smooth,
+            max_enc_len_this_time,
+            max_dec_len_this_time,
             max_seq_len,
             block_size,
             use_neox_style,
@@ -353,6 +357,10 @@ def block_multihead_attention(
         inputs["out_shift"] = out_shift
     if out_smooth is not None:
         inputs["out_smooth"] = out_smooth
+    if max_enc_len_this_time is not None:
+        inputs["max_enc_len_this_time"] = max_enc_len_this_time
+    if max_dec_len_this_time is not None:
+        inputs["max_dec_len_this_time"] = max_dec_len_this_time
 
     outputs = {
         'fmha_out': out,

--- a/test/legacy_test/test_blha_get_max_len_op.py
+++ b/test/legacy_test/test_blha_get_max_len_op.py
@@ -21,6 +21,7 @@ from paddle.base import core
 from paddle.incubate.nn.functional import blha_get_max_len
 
 
+@unittest.skipIf(not core.is_compiled_with_cuda())
 class TestBlhaGetMaxLenOp(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()
@@ -42,17 +43,16 @@ class TestBlhaGetMaxLenOp(unittest.TestCase):
         self.batch_size_tensor = paddle.ones([self.batch_size])
 
     def test_all(self):
-        if core.is_compiled_with_cuda():
-            paddle.disable_static()
-            max_enc_len_this_time, max_dec_len_this_time = blha_get_max_len(
-                self.seq_lens_encoder,
-                self.seq_lens_decoder,
-                self.batch_size_tensor,
-            )
-            assert (
-                max_enc_len_this_time.numpy() == self.test_encoder_data_res
-                and max_dec_len_this_time.numpy() == self.test_decoder_data_res
-            )
+        paddle.disable_static()
+        max_enc_len_this_time, max_dec_len_this_time = blha_get_max_len(
+            self.seq_lens_encoder,
+            self.seq_lens_decoder,
+            self.batch_size_tensor,
+        )
+        assert (
+            max_enc_len_this_time.numpy() == self.test_encoder_data_res
+            and max_dec_len_this_time.numpy() == self.test_decoder_data_res
+        )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_blha_get_max_len_op.py
+++ b/test/legacy_test/test_blha_get_max_len_op.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.base import core
 from paddle.incubate.nn.functional import blha_get_max_len
 
 
@@ -41,14 +42,17 @@ class TestBlhaGetMaxLenOp(unittest.TestCase):
         self.batch_size_tensor = paddle.ones([self.batch_size])
 
     def test_all(self):
-        paddle.disable_static()
-        max_enc_len_this_time, max_dec_len_this_time = blha_get_max_len(
-            self.seq_lens_encoder, self.seq_lens_decoder, self.batch_size_tensor
-        )
-        assert (
-            max_enc_len_this_time.numpy() == self.test_encoder_data_res
-            and max_dec_len_this_time.numpy() == self.test_decoder_data_res
-        )
+        if core.is_compiled_with_cuda():
+            paddle.disable_static()
+            max_enc_len_this_time, max_dec_len_this_time = blha_get_max_len(
+                self.seq_lens_encoder,
+                self.seq_lens_decoder,
+                self.batch_size_tensor,
+            )
+            assert (
+                max_enc_len_this_time.numpy() == self.test_encoder_data_res
+                and max_dec_len_this_time.numpy() == self.test_decoder_data_res
+            )
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_blha_get_max_len_op.py
+++ b/test/legacy_test/test_blha_get_max_len_op.py
@@ -21,7 +21,9 @@ from paddle.base import core
 from paddle.incubate.nn.functional import blha_get_max_len
 
 
-@unittest.skipIf(not core.is_compiled_with_cuda())
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "Only support GPU in CUDA mode."
+)
 class TestBlhaGetMaxLenOp(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()

--- a/test/legacy_test/test_blha_get_max_len_op.py
+++ b/test/legacy_test/test_blha_get_max_len_op.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.incubate.nn.functional import blha_get_max_len
+
+
+class TestBlhaGetMaxLenOp(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        self.name = "TestBlhaGetMaxLenOp"
+        self.place = paddle.CUDAPlace(0)
+        self.batch_size = 10
+        self.test_encoder_data = np.random.randint(1, 100, size=self.batch_size)
+        self.test_encoder_data_res = np.max(self.test_encoder_data)
+        self.test_decoder_data = np.random.randint(1, 100, size=self.batch_size)
+        self.test_decoder_data_res = np.max(self.test_decoder_data)
+        self.seq_lens_encoder = paddle.to_tensor(
+            self.test_encoder_data,
+            "int32",
+        )
+        self.seq_lens_decoder = paddle.to_tensor(
+            self.test_decoder_data,
+            "int32",
+        )
+        self.batch_size_tensor = paddle.ones([self.batch_size])
+
+    def test_all(self):
+        paddle.disable_static()
+        max_enc_len_this_time, max_dec_len_this_time = blha_get_max_len(
+            self.seq_lens_encoder, self.seq_lens_decoder, self.batch_size_tensor
+        )
+        assert (
+            max_enc_len_this_time.numpy() == self.test_encoder_data_res
+            and max_dec_len_this_time.numpy() == self.test_decoder_data_res
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_block_multihead_attention.py
+++ b/test/legacy_test/test_block_multihead_attention.py
@@ -392,6 +392,8 @@ class TestBlockMultiHeadAttnEncDec(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -496,6 +498,8 @@ class TestBlockMultiHeadAttnEncDec(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             self.tgt_mask,  # tgt_mask
@@ -690,6 +694,8 @@ class TestBlockMultiHeadAttnRoPE(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             self.rope_emb,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -800,6 +806,8 @@ class TestBlockMultiHeadAttnRoPE(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             self.rope_emb,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -979,6 +987,8 @@ class TestBlockMultiHeadAttnPreCache(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             self.attention_mask,  # attn_mask
             None,  # tgt_mask
@@ -1083,6 +1093,8 @@ class TestBlockMultiHeadAttnPreCache(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             self.attention_mask,  # attn_mask
             None,  # tgt_mask
@@ -1285,6 +1297,8 @@ class TestBlockMultiHeadAttnEncStatic(unittest.TestCase):
                 None,  # qkv_bias
                 None,  # out_shift
                 None,  # out_smooth
+                None,  # max_enc_len_this_time
+                None,  # max_dec_len_this_time
                 None,  # rotary_embs
                 None,  # attn_mask
                 None,  # tgt_mask
@@ -1498,6 +1512,8 @@ class TestBlockMultiHeadAttnEncDecPTQDequant(unittest.TestCase):
             qkv_bias,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -1643,6 +1659,8 @@ class TestBlockMultiHeadAttnEncDecPTQDequant(unittest.TestCase):
             qkv_bias,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -1858,6 +1876,8 @@ class TestBlockMultiHeadAttnEncDecPTQDequantQuantShiftSmooth(unittest.TestCase):
             qkv_bias,  # qkv_bias
             shift,  # out_shift
             smooth,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2021,6 +2041,8 @@ class TestBlockMultiHeadAttnEncDecPTQDequantQuantShiftSmooth(unittest.TestCase):
             qkv_bias,  # qkv_bias
             shift,  # out_shift
             smooth,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2186,6 +2208,8 @@ class TestBlockMultiHeadAttnEncDecQuant(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2298,6 +2322,8 @@ class TestBlockMultiHeadAttnEncDecQuant(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2469,6 +2495,8 @@ class TestBlockMultiHeadAttnEncDecCacheKVDynamicQuant(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2579,6 +2607,8 @@ class TestBlockMultiHeadAttnEncDecCacheKVDynamicQuant(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2762,6 +2792,8 @@ class TestBlockMultiHeadAttnEncDecCacheKVStaticQuant(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask
@@ -2871,6 +2903,8 @@ class TestBlockMultiHeadAttnEncDecCacheKVStaticQuant(unittest.TestCase):
             None,  # qkv_bias
             None,  # out_shift
             None,  # out_smooth
+            None,  # max_enc_len_this_time
+            None,  # max_dec_len_this_time
             None,  # rotary_embs
             None,  # attn_mask
             None,  # tgt_mask


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Pcard-71500

新增算子：blha_get_max_len，输入为seq_lens_encoder、seq_lens_decoder、bsz，输出为max_enc_len_this_time、max_dec_len_this_time

使用示例：

```python
import paddle
paddle.device.set_device('gpu')
seq_lens_encoder = paddle.cast(paddle.randn(shape=[10]), dtype=paddle.int32)
seq_lens_decoder = paddle.cast(paddle.randn(shape=[10]), dtype=paddle.int32)
bsz = 10
batch_size = paddle.ones(shape=[bsz])
max_enc_len_this_time, max_dec_len_this_time = paddle.incubate.nn.functional.blha_get_max_len(seq_lens_encoder, seq_lens_decoder, batch_size)
```

修改block_multihead_attention，新增两个可选参数max_enc_len_this_time和max_dec_len_this_time，在传入时不在kernel内部计算
