### PR TITLE
[CINN]add InferSymbolicShape for assign_out_

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3944,13 +3944,16 @@ std::vector<pir::Type> AssignOut_Op::InferMeta(
 
 bool AssignOut_Op::InferSymbolicShape(
     pir::InferSymbolicShapeContext *infer_context) {
-  const symbol::ShapeOrDataDimExprs &operand_shape_or_data =
+  const auto &x_shape =
       infer_context->GetShapeOrDataForValue(operand_source(0));
-  infer_context->SetShapeOrDataForValue(result(0), operand_shape_or_data);
-  // TODO(Hongqing-work): check if inplace would change shape of
-  // operand_source(1)
-  infer_context->SetShapeOrDataForValue(operand_source(1),
-                                        operand_shape_or_data);
+  const auto &inplace_output_shape =
+      infer_context->GetShapeOrDataForValue(operand_source(1));
+  infer_context->SetShapeOrDataForValue(result(0), x_shape);
+  CHECK(x_shape.shape().size() == inplace_output_shape.shape().size());
+  for (size_t i = 0; i < x_shape.shape().size(); ++i) {
+    infer_context->AddEqualCstr(x_shape.shape()[i],
+                                inplace_output_shape.shape()[i]);
+  }
   return true;
 }
 

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.cc
@@ -3942,6 +3942,18 @@ std::vector<pir::Type> AssignOut_Op::InferMeta(
   return argument_outputs;
 }
 
+bool AssignOut_Op::InferSymbolicShape(
+    pir::InferSymbolicShapeContext *infer_context) {
+  const symbol::ShapeOrDataDimExprs &operand_shape_or_data =
+      infer_context->GetShapeOrDataForValue(operand_source(0));
+  infer_context->SetShapeOrDataForValue(result(0), operand_shape_or_data);
+  // TODO(Hongqing-work): check if inplace would change shape of
+  // operand_source(1)
+  infer_context->SetShapeOrDataForValue(operand_source(1),
+                                        operand_shape_or_data);
+  return true;
+}
+
 phi::DataType AssignOut_Op::GetKernelTypeForVar(
     const std::string &var_name,
     const phi::DataType &tensor_dtype,

--- a/paddle/fluid/pir/dialect/operator/ir/manual_op.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_op.h
@@ -658,6 +658,7 @@ class AssignOut_Op
     : public pir::Op<AssignOut_Op,
                      paddle::dialect::OpYamlInfoInterface,
                      paddle::dialect::InferMetaInterface,
+                     paddle::dialect::InferSymbolicShapeInterface,
                      paddle::dialect::VjpInterface,
                      paddle::dialect::GetKernelTypeForVarInterface,
                      paddle::dialect::InplaceTrait,
@@ -688,6 +689,7 @@ class AssignOut_Op
   static std::vector<pir::Type> InferMeta(
       const std::vector<pir::Value> &input_values,
       pir::AttributeMap *p_attributes);
+  bool InferSymbolicShape(pir::InferSymbolicShapeContext *infer_context);
   static std::vector<std::vector<pir::Value>> Vjp(
       pir::Operation *op,
       const std::vector<std::vector<pir::Value>> &inputs_,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds InferSymbolicShape for assign_out_ to fix llama2 inference.