### PR TITLE
fix the bug in sigmoid_cross_entropy_with_logits_grad_kernel

### DIFF
--- a/paddle/phi/kernels/cpu/sigmoid_cross_entropy_with_logits_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/sigmoid_cross_entropy_with_logits_grad_kernel.cc
@@ -47,8 +47,15 @@ void SigmoidCrossEntropyWithLogitsGradKernel(
     if (static_cast<int>(label) == ignore_index) {
       dx_data[idx] = static_cast<T>(0.);
     } else {
-      T simoid_x = static_cast<T>(1) / (static_cast<T>(1) + std::exp(-x));
-      T diff = simoid_x * pos_weight_idx - label;
+      T term1 = (x > 0) ? static_cast<T>(1) : static_cast<T>(0);
+
+      T e_x = std::exp(-std::abs(x));
+      T down = 1 + e_x;
+      T abs_grad = (x >= 0) ? static_cast<T>(1) : static_cast<T>(-1);
+      T up = -e_x * abs_grad * pos_weight_idx;
+      T term3 = up / down;
+
+      T diff = term1 - label + term3;
       dx_data[idx] = dout * diff;
     }
   }

--- a/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
@@ -73,9 +73,14 @@ struct SigmoidBwdPosWeightFunctor {
       dx_data = static_cast<T>(0.);
       counts = 0;
     } else {
-      T simoid_x =
-          static_cast<T>(1) / (static_cast<T>(1) + phi::funcs::real_exp(-x));
-      T diff = simoid_x * pos_weight - label;
+      T term1 = (x > 0) ? static_cast<T>(1) : static_cast<T>(0);
+      T e_x = std::exp(-std::abs(x));
+      T down = 1 + e_x;
+      T abs_grad = (x >= 0) ? static_cast<T>(1) : static_cast<T>(-1);
+      T up = -e_x * abs_grad * pos_weight;
+      T term3 = up / down;
+
+      T diff = term1 - label + term3;
       dx_data = dout * diff;
       counts = 1;
     }

--- a/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
@@ -74,7 +74,7 @@ struct SigmoidBwdPosWeightFunctor {
       counts = 0;
     } else {
       T term1 = (x > 0) ? static_cast<T>(1) : static_cast<T>(0);
-      T e_x = std::exp(-std::abs(x));
+      T e_x = exp(-abs(x));
       T down = 1 + e_x;
       T abs_grad = (x >= 0) ? static_cast<T>(1) : static_cast<T>(-1);
       T up = -e_x * abs_grad * pos_weight;

--- a/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
@@ -74,7 +74,7 @@ struct SigmoidBwdPosWeightFunctor {
       counts = 0;
     } else {
       T term1 = (x > 0) ? static_cast<T>(1) : static_cast<T>(0);
-      T e_x = exp(-abs(x));
+      T e_x = phi::funcs::real_exp(-abs(x));
       T down = 1 + e_x;
       T abs_grad = (x >= 0) ? static_cast<T>(1) : static_cast<T>(-1);
       T up = -e_x * abs_grad * pos_weight;

--- a/test/deprecated/legacy_test/test_sigmoid_cross_entropy_with_logits_grad_with_auto_grad.py
+++ b/test/deprecated/legacy_test/test_sigmoid_cross_entropy_with_logits_grad_with_auto_grad.py
@@ -1,0 +1,92 @@
+#  Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from scipy.special import logit
+
+import paddle
+from paddle import base
+
+
+class TestSigmoidCrossEntropyWithLogitsOpGradWithAutoGrad(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2023)
+        paddle.seed(2023)
+        self.places = [base.CPUPlace()]
+        if base.core.is_compiled_with_cuda():
+            self.places.append(base.CUDAPlace(0))
+        self.batch_size = 64
+        self.num_classes = 20
+
+        self.x = logit(
+            np.random.uniform(0, 1, (self.batch_size, self.num_classes)).astype(
+                "float32"
+            )
+        )
+
+        self.lable = np.random.uniform(
+            0, 1, (self.batch_size, self.num_classes)
+        ).astype("float32")
+
+        self.pos_weight = np.random.uniform(
+            0, 1, (self.batch_size, self.num_classes)
+        ).astype("float32")
+
+    def test_check_grad_with_auto_grad(self):
+        def fn_ref(x, label, weight):
+            out = paddle._C_ops.sigmoid_cross_entropy_with_logits(
+                x, label, weight, False, -100
+            )
+            loss = out.sum()
+            loss.backward()
+            return out, x.grad
+
+        def fn_comp(x, label, weight):
+            zeros = paddle.full((self.batch_size, self.num_classes), 0.0)
+            t1 = paddle.where(x > 0, x, zeros)
+            t2 = x * label
+            t3 = paddle.log(1 + paddle.exp(-paddle.abs(x)))
+            t4 = t1 - t2 + t3 * weight
+            t5 = paddle.full((self.batch_size, self.num_classes), -100.0)
+            out = paddle.where(label == t5, zeros, t4)
+            loss = out.sum()
+            loss.backward()
+            return out, x.grad
+
+        def cal(fn, place):
+            x1 = paddle.to_tensor(self.x, stop_gradient=False, place=place)
+            label1 = paddle.to_tensor(self.lable)
+            pos_weight1 = paddle.to_tensor(self.pos_weight, place=place)
+            res = fn(x1, label1, pos_weight1)
+            return res
+
+        for idx, p in enumerate(self.places):
+            if idx == 0:
+                paddle.set_device('cpu')
+            else:
+                paddle.set_device('gpu')
+
+            ref = cal(fn_ref, p)
+            actual = cal(fn_comp, p)
+
+            for idx in range(len(ref)):
+                np.testing.assert_allclose(
+                    ref[idx].numpy(), actual[idx].numpy(), atol=1e-6, rtol=1e-6
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/deprecated/legacy_test/test_sigmoid_cross_entropy_with_logits_op.py
+++ b/test/deprecated/legacy_test/test_sigmoid_cross_entropy_with_logits_op.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 
-from scipy.special import expit, logit
-
-import paddle
-from paddle import base
-
-sys.path.append("/paddle/build/test/legacy_test/")
 import unittest
 
 import numpy as np
 from op_test import OpTest
+from scipy.special import expit, logit
+
+import paddle
+from paddle import base
 
 
 def loss_wrapper(
@@ -177,7 +174,7 @@ class TestSigmoidCrossEntropyWithLogitsOp4(OpTest):
         self.check_output(check_pir=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_pir=True)
+        self.check_grad(['X'], 'Out', max_relative_error=0.0005, check_pir=True)
 
 
 class TestSigmoidCrossEntropyWithNorm(OpTest):

--- a/test/deprecated/legacy_test/test_sigmoid_cross_entropy_with_logits_op.py
+++ b/test/deprecated/legacy_test/test_sigmoid_cross_entropy_with_logits_op.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
-import numpy as np
-from op_test import OpTest
 from scipy.special import expit, logit
 
 import paddle
 from paddle import base
+
+sys.path.append("/paddle/build/test/legacy_test/")
+import unittest
+
+import numpy as np
+from op_test import OpTest
 
 
 def loss_wrapper(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`sigmoid_cross_entropy_with_logits` op的反向kernel计算实现，与自动微分求导计算出的反向结果不一致。现提交PR进行修复，具体分析以及反向kernel计算方式错误仍能通过单测的分析见下面的Issue：

- https://github.com/PaddlePaddle/Paddle/issues/64226