### PR TITLE
[XPU] set the shape of tile's output when the input is 0D

### DIFF
--- a/paddle/phi/kernels/xpu/tile_kernel.cc
+++ b/paddle/phi/kernels/xpu/tile_kernel.cc
@@ -103,7 +103,7 @@ void TileKernel(const Context& dev_ctx,
 
   std::vector<int64_t> temp(repeat_times.size(), 1);
   if (rank == 0 || repeat_times == temp) {
-    out->Resize(x.dims());
+    out->Resize(out_dims);
     dev_ctx.template Alloc<T>(out);
     int64_t count = x.numel() * sizeof(T);
     int r = xpu::copy(dev_ctx.x_context(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device


### PR Types
Improvements


### Description
When use a 0D-tensor as the input to Tile OP, the output on GPU has the new shape while the XPU not.
This PR makes the implementation of Tile on XPU to identical to that on GPU.
