### PR TITLE
【pir save load】 modify multi jit program parmeter name. test_jit_layer.py

### DIFF
--- a/paddle/fluid/pir/serialize_deserialize/include/interface.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/interface.h
@@ -128,7 +128,8 @@ void LoadFunction(const std::string& file_path,
                   int64_t seek,
                   const std::vector<int64_t>& shape,
                   bool load_as_fp16,
-                  phi::DenseTensor* out);
+                  phi::DenseTensor* out,
+                  phi::Place place = phi::Place());
 
 /**
  * @brief Save the given tensor into a single file at the specified file path
@@ -146,5 +147,6 @@ void LoadFunction(const std::string& file_path,
 void LoadCombineFunction(const std::string& file_path,
                          const std::vector<std::string>& names,
                          std::vector<phi::DenseTensor*>* out,
-                         bool load_as_fp16);
+                         bool load_as_fp16,
+                         phi::Place place = phi::Place());
 }  // namespace pir

--- a/paddle/fluid/pir/serialize_deserialize/src/save_load_parameters.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/save_load_parameters.cc
@@ -21,20 +21,29 @@ limitations under the License. */
 
 namespace pir {
 
-const phi::DeviceContext* GetDeviceContext(const phi::DenseTensor& x) {
+const phi::DeviceContext* GetDeviceContext(
+    const phi::DenseTensor& x, const phi::Place& place = phi::Place()) {
   phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
   const phi::DeviceContext* dev_ctx = nullptr;
-  auto place = x.place();
-  if (place.GetType() == phi::AllocationType::UNDEFINED) {
+  auto x_place = x.place();
+  if (x_place.GetType() != phi::AllocationType::UNDEFINED) {
+    dev_ctx = pool.Get(x_place);
+    return dev_ctx;
+  } else if (place.GetType() != phi::AllocationType::UNDEFINED) {
+    dev_ctx = pool.Get(place);
+    return dev_ctx;
+  } else {
+    phi::Place compile_place;
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    place = phi::GPUPlace();
+    compile_place = phi::GPUPlace();
 #elif defined(PADDLE_WITH_XPU)
-    place = phi::XPUPlace();
+    compile_place = phi::XPUPlace();
 #else
-    place = phi::CPUPlace();
+    compile_place = phi::CPUPlace();
 #endif
+    dev_ctx = pool.Get(compile_place);
+    return dev_ctx;
   }
-  dev_ctx = pool.Get(place);
   return dev_ctx;
 }
 
@@ -145,7 +154,8 @@ void LoadFunction(const std::string& file_path,
                   int64_t seek,
                   const std::vector<int64_t>& shape,
                   bool load_as_fp16,
-                  phi::DenseTensor* out) {
+                  phi::DenseTensor* out,
+                  phi::Place place) {
   std::ifstream fin(file_path, std::ios::binary);
   PADDLE_ENFORCE_EQ(static_cast<bool>(fin),
                     true,
@@ -156,7 +166,7 @@ void LoadFunction(const std::string& file_path,
   PADDLE_ENFORCE_NOT_NULL(out,
                           phi::errors::InvalidArgument(
                               "The variable to be loaded cannot be found."));
-  const phi::DeviceContext* dev_ctx = GetDeviceContext(*out);
+  const phi::DeviceContext* dev_ctx = GetDeviceContext(*out, place);
 
   if (seek != -1) {
     PADDLE_ENFORCE_GE(seek,
@@ -179,7 +189,8 @@ void LoadFunction(const std::string& file_path,
 void LoadCombineFunction(const std::string& file_path,
                          const std::vector<std::string>& names,
                          std::vector<phi::DenseTensor*>* out,
-                         bool load_as_fp16) {
+                         bool load_as_fp16,
+                         phi::Place place) {
   std::ifstream fin(file_path, std::ios::binary);
   PADDLE_ENFORCE_EQ(static_cast<bool>(fin),
                     true,
@@ -194,7 +205,7 @@ void LoadCombineFunction(const std::string& file_path,
                         "The number of variables to be saved is %d, expect "
                         "it to be greater than 0.",
                         out->size()));
-  const phi::DeviceContext* dev_ctx = GetDeviceContext(*(out->at(0)));
+  const phi::DeviceContext* dev_ctx = GetDeviceContext(*(out->at(0)), place);
   for (size_t i = 0; i < names.size(); i++) {
     auto tensor = out->at(i);
     paddle::framework::DeserializeFromStream(fin, tensor, *dev_ctx);

--- a/paddle/fluid/pybind/io.cc
+++ b/paddle/fluid/pybind/io.cc
@@ -19,13 +19,31 @@ limitations under the License. */
 #include "paddle/fluid/framework/selected_rows_utils.h"
 #include "paddle/fluid/pir/serialize_deserialize/include/interface.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/fluid/pybind/pybind_variant_caster.h"
 #include "paddle/utils/pybind.h"
 
 namespace py = pybind11;
 namespace paddle {
 namespace pybind {
+template <typename PlaceType>
+void LoadCombine(const std::string &file_path,
+                 const std::vector<std::string> &names,
+                 std::vector<phi::DenseTensor *> *out,
+                 bool load_as_fp16,
+                 const PlaceType place) {
+  pir::LoadCombineFunction(file_path, names, out, load_as_fp16, place);
+}
 
+template <typename PlaceType>
+void Load(const std::string &file_path,
+          int64_t seek,
+          const std::vector<int64_t> &shape,
+          bool load_as_fp16,
+          phi::DenseTensor *out,
+          const PlaceType place) {
+  pir::LoadFunction(file_path, seek, shape, load_as_fp16, out, place);
+}
 void BindIO(pybind11::module *m) {
   m->def("save_lod_tensor",
          [](const phi::DenseTensor &tensor, const std::string &str_file_name) {
@@ -128,9 +146,20 @@ void BindIO(pybind11::module *m) {
 
   m->def("save_combine_func", &pir::SaveCombineFunction);
 
-  m->def("load_func", &pir::LoadFunction);
-
-  m->def("load_combine_func", &pir::LoadCombineFunction);
+  m->def("load_func", &Load<paddle::platform::CPUPlace>);
+  m->def("load_func", &Load<paddle::platform::CustomPlace>);
+  m->def("load_func", &Load<paddle::platform::XPUPlace>);
+  m->def("load_func", &Load<paddle::platform::CUDAPinnedPlace>);
+  m->def("load_func", &Load<paddle::platform::CUDAPlace>);
+  m->def("load_func", &Load<paddle::platform::IPUPlace>);
+  m->def("load_func", &Load<paddle::platform::Place>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::CPUPlace>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::CustomPlace>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::XPUPlace>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::CUDAPinnedPlace>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::CUDAPlace>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::IPUPlace>);
+  m->def("load_combine_func", &LoadCombine<paddle::platform::Place>);
 
   m->def("serialize_pir_program",
          &pir::WriteModule,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2154,6 +2154,7 @@ All parameter, weight, gradient are variables in Paddle.
   py::class_<framework::Executor>(m, "Executor")
       .def(py::init<const platform::Place &>())
       .def("close", &Executor::Close)
+      .def("get_place", &Executor::GetPlace)
       .def("run_from_dataset",
            &Executor::RunFromDataset,
            py::call_guard<py::gil_scoped_release>())

--- a/python/paddle/jit/pir_dy2static/parameter_recorder.py
+++ b/python/paddle/jit/pir_dy2static/parameter_recorder.py
@@ -45,6 +45,7 @@ class ParametersRecorder:
                 dtype=dtype,
                 shape=tensor.shape,
                 type=tensor.type,
+                name=tensor.name,
                 initializer=non_used_initializer,
                 trainable=(not tensor.stop_gradient),
             )

--- a/python/paddle/jit/pir_translated_layer.py
+++ b/python/paddle/jit/pir_translated_layer.py
@@ -56,21 +56,18 @@ def _generate_unique_var_name(prefix):
 def _get_pir_persistable_var_names(program):
     persistable_vars = []
     persistable_names = []
-    origin_names = []
     rename_new_old_dict = {}
     for block in program.blocks:
         for var in block.all_parameters():
             if var.persistable:
                 persistable_vars.append(var)
                 origin_name = var.name
-                origin_names.append(origin_name)
                 var.name = _generate_unique_var_name(var.name)
                 rename_new_old_dict[var.name] = origin_name
                 persistable_names.append(var.name)
     return (
         persistable_vars,
         persistable_names,
-        origin_names,
         rename_new_old_dict,
     )
 
@@ -84,7 +81,6 @@ class _PirProgramHolder:
         self._output_vars = []
         self._persistable_vars = []
         self._persistable_names = []
-        self._origin_persistable_names = []
 
         self.support_train = trainable
         # append suffix var name dict
@@ -97,7 +93,6 @@ class _PirProgramHolder:
         (
             self._persistable_vars,
             self._persistable_names,
-            self._origin_persistable_names,
             self._suffix_varname_dict,
         ) = _get_pir_persistable_var_names(self._infer_program)
 
@@ -146,10 +141,6 @@ class _PirProgramHolder:
     def persistable_vars(self):
         return self._persistable_vars
 
-    @property
-    def origin_persistable_names(self):
-        return self._origin_persistable_names
-
 
 # [ PirTranslatedLayer : Run program in dygraph mode ]
 #
@@ -188,8 +179,8 @@ def _load_pir_persistable_vars(model_path, program_holder, params_filename):
     load_var_list = []
     load_densetensor_list = []
     persistable_var = program_holder.persistable_vars
-    origin_persistable_name = program_holder.origin_persistable_names
-    for name, var in sorted(zip(origin_persistable_name, persistable_var)):
+    persistable_name = program_holder.persistable_names
+    for name, var in sorted(zip(persistable_name, persistable_var)):
         if var.persistable:
             # use default shape and dtype
             new_var = framework.EagerParamBase(
@@ -223,6 +214,7 @@ def _load_pir_persistable_vars(model_path, program_holder, params_filename):
             list(load_var_dict.keys()),
             load_densetensor_list,
             False,
+            framework._current_expected_place(),
         )
     else:
         raise ValueError(
@@ -361,7 +353,7 @@ def _run_dygraph(instance, input, program_holder):
 
     persistable_tensors = []
 
-    for var_name in program_holder.origin_persistable_names:
+    for var_name in program_holder.persistable_names:
         dy_var_name = instance._persistable_var_name_dict[var_name]
         if dy_var_name in instance._parameters:
             persistable_tensors.append(instance._parameters[dy_var_name])

--- a/python/paddle/static/pir_io.py
+++ b/python/paddle/static/pir_io.py
@@ -483,7 +483,14 @@ def load_vars_pir(
                         "The directory path and params cannot be None at the same time."
                     )
                 file_path = os.path.join(dirname, v.name)
-                core.load_func(file_path, -1, [], False, var.get_tensor())
+                core.load_func(
+                    file_path,
+                    -1,
+                    [],
+                    False,
+                    var.get_tensor(),
+                    executor._default_executor.get_place(),
+                )
             else:
                 load_var_map[v.name] = var
 
@@ -498,7 +505,11 @@ def load_vars_pir(
                 filename = os.path.join(dirname, filename)
 
             core.load_combine_func(
-                filename, load_var_names, load_var_list, False
+                filename,
+                load_var_names,
+                load_var_list,
+                False,
+                executor._default_executor.get_place(),
             )
             for name, var in zip(load_var_names, load_var_list):
                 set_var(name, np.array(var))

--- a/test/deprecated/legacy_test/test_jit_layer.py
+++ b/test/deprecated/legacy_test/test_jit_layer.py
@@ -134,6 +134,24 @@ class TestMKLOutput(unittest.TestCase):
             out = paddle.unsqueeze(out[0], 0)
             np.testing.assert_equal(out.shape, [1, 498, 80])
 
+    @test_with_dygraph_pir
+    def test_mkl_jit_output(self):
+        with _dygraph_place_guard(place=paddle.CPUPlace()):
+            net = SaveLinear()
+            x = paddle.ones([498, 80])
+            orig_out = net.forward(x)
+            model_path = os.path.join(self.temp_dir.name, 'save_linear')
+            paddle.jit.save(net, model_path, combine_params=True)
+
+            layer = paddle.jit.load(model_path)
+
+            out = layer.forward(x)
+            np.testing.assert_equal(
+                np.mean(orig_out.numpy()), np.mean(out.numpy())
+            )
+            out = paddle.unsqueeze(out, 0)
+            np.testing.assert_equal(out.shape, [1, 498, 80])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/ir/pir/test_save_load_params.py
+++ b/test/ir/pir/test_save_load_params.py
@@ -132,7 +132,14 @@ class TestSimpleParamSaveLoad(unittest.TestCase):
                     paddle.base.core.save_func(v, k, path, True, True)
                     tensor = param_dict[k]
                     tensor.set(np.zeros_like(np.array(tensor)), self.place)
-                    paddle.base.core.load_func(path, -1, [], False, tensor)
+                    paddle.base.core.load_func(
+                        path,
+                        -1,
+                        [],
+                        False,
+                        tensor,
+                        paddle.framework._current_expected_place_(),
+                    )
                     np.testing.assert_array_equal(tensor, v)
 
                 for k, v in opt_dict.items():
@@ -140,7 +147,14 @@ class TestSimpleParamSaveLoad(unittest.TestCase):
                     paddle.base.core.save_func(v, k, path, True, False)
                     tensor = opt_dict[k]
                     tensor.set(np.zeros_like(np.array(tensor)), self.place)
-                    paddle.base.core.load_func(path, -1, [], False, tensor)
+                    paddle.base.core.load_func(
+                        path,
+                        -1,
+                        [],
+                        False,
+                        tensor,
+                        paddle.framework._current_expected_place_(),
+                    )
                     np.testing.assert_array_equal(tensor, v)
 
                 # test save_combine_func and load_combine_func
@@ -157,7 +171,11 @@ class TestSimpleParamSaveLoad(unittest.TestCase):
                     tensor.set(np.zeros_like(np.array(tensor)), self.place)
                     param_new.append(tensor)
                 paddle.base.core.load_combine_func(
-                    path, list(param_dict.keys()), param_new, False
+                    path,
+                    list(param_dict.keys()),
+                    param_new,
+                    False,
+                    paddle.framework._current_expected_place_(),
                 )
                 np.testing.assert_equal(param_new, param_vec)
                 # save to memory
@@ -170,7 +188,11 @@ class TestSimpleParamSaveLoad(unittest.TestCase):
                 )
                 # load as fp16
                 paddle.base.core.load_combine_func(
-                    path, list(param_dict.keys()), param_new, True
+                    path,
+                    list(param_dict.keys()),
+                    param_new,
+                    True,
+                    paddle.framework._current_expected_place_(),
                 )
 
                 # test save_vars


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

others
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
others

### Description
<!-- Describe what you’ve done -->
pcard-67164

修复test_jit_layer.py中单测。 pir 对forward和infer动转静后的parameter名字是不同的，因此combine 的结果没有合并，在加载forward 层的参数时，需要4个， 但是文件有6个导致报错。 解决动转静的parameter 使用动态图的参数命名，保证同一网络的参数的名称相同。

解决了load 需要感知当前tesnor 需要运行的place 问题。不能依赖编译环境进行选择，这会导致gpu 环境下测试cpu 报错。