### PR TITLE
fp16 and bf16 support for CPU GaussianKernel

### DIFF
--- a/paddle/phi/kernels/funcs/norm_distribution.h
+++ b/paddle/phi/kernels/funcs/norm_distribution.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <random>
+#include "paddle/phi/common/data_type.h"
+
+namespace phi {
+
+template <typename T>
+inline void NormalDistribution(T* data,
+                               const int64_t& size,
+                               const float& mean,
+                               const float& std,
+                               std::shared_ptr<std::mt19937_64> engine) {
+  std::normal_distribution<T> dist(static_cast<T>(mean), static_cast<T>(std));
+  for (int64_t i = 0; i < size; ++i) {
+    data[i] = dist(*engine);
+  }
+}
+
+template <>
+inline void NormalDistribution(phi::dtype::float16* data,
+                               const int64_t& size,
+                               const float& mean,
+                               const float& std,
+                               std::shared_ptr<std::mt19937_64> engine) {
+  std::normal_distribution<float> dist(mean, std);
+  for (int64_t i = 0; i < size; ++i) {
+    data[i] = static_cast<phi::dtype::float16>(dist(*engine));
+  }
+}
+
+template <>
+inline void NormalDistribution(phi::dtype::bfloat16* data,
+                               const int64_t& size,
+                               const float& mean,
+                               const float& std,
+                               std::shared_ptr<std::mt19937_64> engine) {
+  std::normal_distribution<float> dist(mean, std);
+  for (int64_t i = 0; i < size; ++i) {
+    data[i] = static_cast<phi::dtype::bfloat16>(dist(*engine));
+  }
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/norm_distribution.h
+++ b/paddle/phi/kernels/funcs/norm_distribution.h
@@ -25,7 +25,7 @@ inline void NormalDistribution(T* data,
                                const float& mean,
                                const float& std,
                                std::shared_ptr<std::mt19937_64> engine) {
-  std::normal_distribution<T> dist(static_cast<T>(mean), static_cast<T>(std));
+  std::normal_distribution<T> dist(mean, std);
   for (int64_t i = 0; i < size; ++i) {
     data[i] = dist(*engine);
   }

--- a/test/deprecated/legacy_test/test_gaussian_random_op.py
+++ b/test/deprecated/legacy_test/test_gaussian_random_op.py
@@ -87,9 +87,7 @@ class TestGaussianRandomFP16Op(OpTest):
         self.std = 2.0
 
     def test_check_output(self):
-        self.check_output_with_place_customized(
-            self.verify_output, place=core.CUDAPlace(0), check_pir=True
-        )
+        self.check_output_customized(self.verify_output, check_pir=True)
 
     def verify_output(self, outs):
         self.assertEqual(outs[0].shape, (123, 92))
@@ -140,9 +138,7 @@ class TestGaussianRandomBF16Op(OpTest):
         self.std = 2.0
 
     def test_check_output(self):
-        self.check_output_with_place_customized(
-            self.verify_output, place=core.CUDAPlace(0), check_pir=True
-        )
+        self.check_output_customized(self.verify_output, check_pir=True)
 
     def verify_output(self, outs):
         outs = convert_uint16_to_float(outs)


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
背景：为了做XPU和GPU的训练对齐，需要把随机数生成这种设备相关的操作都放到CPU上，这样就能保证大家的初值是一样的。排查发现`GaussianKernel`缺少float16和bfloat16的支持，因此参考`UniformKernel`的写法，给它实现出来。