### PR TITLE
【Fix PIR Unittest No.66】refine pir unique_name and set_parameter

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -61,7 +61,7 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
     PADDLE_ENFORCE_EQ(param->type(),
                       parameter.type(),
                       phi::errors::InvalidArgument(
-                          "Duplicate parameter with diffrient type."));
+                          "Duplicate parameter %s with diffrient type.", name));
   } else {
     std::unique_ptr<pir::Parameter> param_new(
         new pir::Parameter(nullptr, 0, parameter.type()));
@@ -69,6 +69,18 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
     ApiBuilder::Instance().GetBuilder()->Build<pir::SetParameterOp>(parameter,
                                                                     name);
   }
+}
+
+void updata_parameter(const pir::Value& parameter, const std::string& name) {
+  pir::Parameter* param = ApiBuilder::Instance().GetParameter(name);
+  PADDLE_ENFORCE_NOT_NULL(param,
+                          phi::errors::InvalidArgument(
+                              "Parameter %s not exist, can not updata.", name));
+  std::unique_ptr<pir::Parameter> param_new(
+      new pir::Parameter(nullptr, 0, parameter.type()));
+  ApiBuilder::Instance().SetParameter(name, std::move(param_new));
+  ApiBuilder::Instance().GetBuilder()->Build<pir::SetParameterOp>(parameter,
+                                                                  name);
 }
 
 void shadow_output(const pir::Value& persist_value, const std::string& name) {

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -61,7 +61,7 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
     PADDLE_ENFORCE_EQ(param->type(),
                       parameter.type(),
                       phi::errors::InvalidArgument(
-                          "Duplicate parameter %s with diffrient type.", name));
+                          "Duplicate parameter %s with different type.", name));
   } else {
     std::unique_ptr<pir::Parameter> param_new(
         new pir::Parameter(nullptr, 0, parameter.type()));

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -36,6 +36,8 @@ pir::Value parameter(const std::string& name);
 
 void set_parameter(const pir::Value& parameter, const std::string& name);
 
+void updata_parameter(const pir::Value& parameter, const std::string& name);
+
 void shadow_output(const pir::Value& persist_value, const std::string& name);
 
 pir::Value embedding_grad(const pir::Value& x,

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -81,6 +81,32 @@ static PyObject *static_api_set_parameter(PyObject *self,
   }
 }
 
+static PyObject *static_api_updata_parameter(PyObject *self,
+                                             PyObject *args,
+                                             PyObject *kwargs) {
+  try {
+    VLOG(6) << "Add uodata_parameter op into program";
+    VLOG(8) << "args count: " << (PyTuple_Size(args) / 2);
+
+    // Get Value from args
+    PyObject *parameter_obj = PyTuple_GET_ITEM(args, 0);
+    auto parameter = CastPyArg2Value(parameter_obj, "parameter", 0);
+
+    // Parse Attributes
+    PyObject *name_obj = PyTuple_GET_ITEM(args, 1);
+    std::string name = CastPyArg2String(name_obj, "name", 1);
+    // Call ir static api
+    CallStackRecorder callstack_recoder("uodata_parameter");
+    callstack_recoder.Record();
+    paddle::dialect::updata_parameter(parameter, name);
+    callstack_recoder.AttachToOps();
+    Py_RETURN_NONE;
+  } catch (...) {
+    ThrowExceptionToPython(std::current_exception());
+    return nullptr;
+  }
+}
+
 static PyObject *static_api_set_persistable_value(PyObject *self,
                                                   PyObject *args,
                                                   PyObject *kwargs) {
@@ -949,6 +975,10 @@ static PyMethodDef ManualOpsAPI[] = {
      (PyCFunction)(void (*)(void))static_api_set_parameter,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for set_parameter."},
+    {"updata_parameter",
+     (PyCFunction)(void (*)(void))static_api_updata_parameter,
+     METH_VARARGS | METH_KEYWORDS,
+     "C++ interface function for updata_parameter."},
     {"set_persistable_value",
      (PyCFunction)(void (*)(void))static_api_set_persistable_value,
      METH_VARARGS | METH_KEYWORDS,

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -252,7 +252,7 @@ def _pir_transform(t, dtype):
                 param = op.operand(0).source()
                 cast_param = paddle.cast(param, dtype)
                 cast_param.persistable = True
-                paddle._pir_ops.set_parameter(cast_param, t.name)
+                paddle._pir_ops.updata_parameter(cast_param, t.name)
                 block.remove_op(op)
                 break
     main.set_parameters_from(startup)

--- a/python/paddle/base/layer_helper_base.py
+++ b/python/paddle/base/layer_helper_base.py
@@ -26,6 +26,7 @@ from .framework import (
     default_main_program,
     default_startup_program,
     in_dygraph_mode,
+    in_dynamic_or_pir_mode,
     in_pir_mode,
 )
 from .initializer import _global_bias_initializer, _global_weight_initializer
@@ -377,7 +378,7 @@ class LayerHelperBase:
                 else default_initializer
             )
         if attr.name is None:
-            if in_dygraph_mode():
+            if in_dynamic_or_pir_mode():
                 attr.name = unique_name.generate(".".join([self.name, suffix]))
             else:
                 attr.name = self.main_program._name_generator.generate(

--- a/test/auto_parallel/pir/test_ir_dist_attr.py
+++ b/test/auto_parallel/pir/test_ir_dist_attr.py
@@ -30,7 +30,8 @@ class TestBuildFakeProgram(unittest.TestCase):
     def test_build_api(self):
         with paddle.pir_utils.IrGuard():
             main_program = paddle.base.Program()
-            with paddle.base.program_guard(main_program):
+            start_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program, start_program):
                 mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
                 input = paddle.static.data(
                     name='input', shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
@@ -56,7 +57,8 @@ class TestBuildFakeProgram(unittest.TestCase):
     def test_build_replicated_program(self):
         with paddle.pir_utils.IrGuard():
             main_program = paddle.base.Program()
-            with paddle.base.program_guard(main_program):
+            start_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program, start_program):
                 mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
                 input = paddle.static.data(
                     name='input', shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
@@ -123,7 +125,8 @@ class TestBuildFakeProgram(unittest.TestCase):
     def test_build_col_parallel_program(self):
         with paddle.pir_utils.IrGuard():
             main_program = paddle.base.Program()
-            with paddle.base.program_guard(main_program):
+            start_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program, start_program):
                 mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
                 input = paddle.static.data(
                     name='input', shape=[BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE]
@@ -172,7 +175,8 @@ class TestBuildFakeProgram(unittest.TestCase):
     def test_build_row_parallel_program(self):
         with paddle.pir_utils.IrGuard():
             main_program = paddle.base.Program()
-            with paddle.base.program_guard(main_program):
+            start_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program, start_program):
                 mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
                 input = paddle.static.data(
                     name='input',
@@ -224,7 +228,8 @@ class TestBuildFakeProgram(unittest.TestCase):
     def test_build_with_shard_tensor(self):
         with paddle.pir_utils.IrGuard():
             main_program = paddle.base.Program()
-            with paddle.base.program_guard(main_program):
+            start_program = paddle.base.Program()
+            with paddle.base.program_guard(main_program, start_program):
                 mesh = dist.ProcessMesh([0, 1], dim_names=['mp'])
                 input = paddle.static.data(
                     name='input',

--- a/test/legacy_test/test_imperative_gan.py
+++ b/test/legacy_test/test_imperative_gan.py
@@ -270,4 +270,5 @@ class TestDygraphGAN(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-67164

修复PIR不支持test_imperative_gan.py的问题：
test_imperative_gan利用了静态图，两个main_program共用一个start_program和scope的特性，暴露了PIR的两个问题：
1. PIR的unique_name不应该是用老静态图的main_program。
2. 当Program中出现重复prameter时，应该去重。AMP中需要更新parameter，新增updata_parameter接口。
本PR给予修复。

关联Issue：https://github.com/PaddlePaddle/Paddle/issues/63740
