### PR TITLE
Add fuse all_reduce_sum with split to reduce_scatter pass

### DIFF
--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.cc
@@ -1,0 +1,108 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
+ public:
+  std::string name() const override { return "FusedAllReduceSplitPattern"; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
+                                {{"transpose_x", pat.Attr("trans_x")},
+                                 {"transpose_y", pat.Attr("trans_y")}});
+    const auto &c_allreduce_sum_ =
+        pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
+               {{"ring_id", pat.Attr("ring_id")},
+                {"use_calc_stream", pat.Attr("use_calc_stream")}});
+    const auto &assign = pat.Op(paddle::dialect::AssignOp::name());
+    const auto &full = pat.Op(paddle::dialect::FullOp::name());
+    const auto &split_with_num = pat.Op(paddle::dialect::SplitWithNumOp::name(),
+                                        {{"num", pat.Attr("num")}});
+    const auto &builtin_slice =
+        pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
+
+    pat.Tensor("input_grad_partial") =
+        matmul(pat.Tensor("out_grad"), pat.Tensor("weight"));
+    pat.Tensor("input_grad") =
+        c_allreduce_sum_(pat.Tensor("input_grad_partial"));
+    pat.Tensor("input_grad_tmp") = assign(pat.Tensor("input_grad"));
+    pat.Tensor("split_num") = full();
+    pat.Tensor("input_grad_group") =
+        split_with_num(pat.Tensor("input_grad_tmp"), pat.Tensor("split_num"));
+    pat.Tensor("out") = builtin_slice(pat.Tensor("input_grad_group"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      const auto &x_trans = match_ctx.Attr<bool>("trans_x");
+      const auto &y_trans = match_ctx.Attr<bool>("trans_y");
+      auto input_grad_partial_count =
+          match_ctx.Tensor("input_grad_partial").use_count();
+      auto input_grad_count = match_ctx.Tensor("input_grad").use_count();
+      auto input_grad_tmp_count =
+          match_ctx.Tensor("input_grad_tmp").use_count();
+      auto input_grad_group_count =
+          match_ctx.Tensor("input_grad_group").use_count();
+      return (x_trans == false && y_trans == true &&
+              input_grad_partial_count == 1 && input_grad_count == 1 &&
+              input_grad_tmp_count == 1 && input_grad_group_count == 1);
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &c_reducescatter =
+        res.Op(paddle::dialect::CReducescatterOp::name(),
+               {{"ring_id", pat.Attr("ring_id")},
+                {"nranks", pat.Attr("num")},
+                {"use_calc_stream", pat.Attr("use_calc_stream")}});
+
+    c_reducescatter({&res.Tensor("input_grad_partial")}, {&res.Tensor("out")});
+  }
+};
+
+class FuseAllreduceSplitToReducescatterPass : public pir::PatternRewritePass {
+ public:
+  FuseAllreduceSplitToReducescatterPass()
+      : pir::PatternRewritePass("fuse_allreduce_split_to_reducescatter_pass",
+                                2) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern>(context));
+
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateFuseAllreduceSplitToReducescatterPass() {
+  return std::make_unique<FuseAllreduceSplitToReducescatterPass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(fuse_allreduce_split_to_reducescatter_pass,
+                 FuseAllreduceSplitToReducescatterPass);

--- a/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.h
+++ b/paddle/fluid/pir/dialect/distributed/transforms/fuse_allreduce_split_to_reducescatter_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateFuseAllreduceSplitToReducescatterPass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/gpu/fused_linear_param_grad_add_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_linear_param_grad_add_pass.cc
@@ -416,65 +416,6 @@ class FusedMatmulAddGradAddbPattern : public paddle::drr::DrrPatternBase {
         {&res.Tensor("dweight_out"), &res.Tensor("dbias")});
   }
 };
-
-class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
- public:
-  std::string name() const override { return "FusedAllReduceSplitPattern"; }
-
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    paddle::drr::SourcePattern pat = ctx->SourcePattern();
-
-    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
-                                {{"transpose_x", pat.Attr("trans_x")},
-                                 {"transpose_y", pat.Attr("trans_y")}});
-    const auto &c_allreduce_sum_ =
-        pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
-               {{"ring_id", pat.Attr("ring_id")},
-                {"use_calc_stream", pat.Attr("use_calc_stream")}});
-    const auto &assign = pat.Op(paddle::dialect::AssignOp::name());
-    const auto &full = pat.Op(paddle::dialect::FullOp::name());
-    const auto &split_with_num = pat.Op(paddle::dialect::SplitWithNumOp::name(),
-                                        {{"num", pat.Attr("num")}});
-    const auto &builtin_slice =
-        pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
-
-    pat.Tensor("input_grad_partial") =
-        matmul(pat.Tensor("out_grad"), pat.Tensor("weight"));
-    pat.Tensor("input_grad") =
-        c_allreduce_sum_(pat.Tensor("input_grad_partial"));
-    pat.Tensor("input_grad_tmp") = assign(pat.Tensor("input_grad"));
-    pat.Tensor("split_num") = full();
-    pat.Tensor("input_grad_group") =
-        split_with_num(pat.Tensor("input_grad_tmp"), pat.Tensor("split_num"));
-    pat.Tensor("out") = builtin_slice(pat.Tensor("input_grad_group"));
-
-    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
-      const auto &x_trans = match_ctx.Attr<bool>("trans_x");
-      const auto &y_trans = match_ctx.Attr<bool>("trans_y");
-      auto input_grad_partial_count =
-          match_ctx.Tensor("input_grad_partial").use_count();
-      auto input_grad_count = match_ctx.Tensor("input_grad").use_count();
-      auto input_grad_tmp_count =
-          match_ctx.Tensor("input_grad_tmp").use_count();
-      auto input_grad_group_count =
-          match_ctx.Tensor("input_grad_group").use_count();
-      return (x_trans == false && y_trans == true &&
-              input_grad_partial_count == 1 && input_grad_count == 1 &&
-              input_grad_tmp_count == 1 && input_grad_group_count == 1);
-    });
-
-    paddle::drr::ResultPattern res = pat.ResultPattern();
-
-    const auto &c_reducescatter =
-        res.Op(paddle::dialect::CReducescatterOp::name(),
-               {{"ring_id", pat.Attr("ring_id")},
-                {"nranks", pat.Attr("num")},
-                {"use_calc_stream", pat.Attr("use_calc_stream")}});
-
-    c_reducescatter({&res.Tensor("input_grad_partial")}, {&res.Tensor("out")});
-  }
-};
-
 class FusedLinearParamGradAddPass : public pir::PatternRewritePass {
  public:
   FusedLinearParamGradAddPass()
@@ -489,7 +430,6 @@ class FusedLinearParamGradAddPass : public pir::PatternRewritePass {
     ps.Add(paddle::drr::Create<FusedMatmulAddGradAddaPattern>(context));
     ps.Add(paddle::drr::Create<FusedMatmulAddGradAddbPattern>(context));
     ps.Add(paddle::drr::Create<FusedMatmulReshapeMatmulAddPattern>(context));
-    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern>(context));
 
     return ps;
   }

--- a/paddle/fluid/pir/transforms/gpu/fused_linear_param_grad_add_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_linear_param_grad_add_pass.cc
@@ -431,7 +431,7 @@ class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
         pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
                {{"ring_id", pat.Attr("ring_id")},
                 {"use_calc_stream", pat.Attr("use_calc_stream")}});
-    const auto &assign_ = pat.Op(paddle::dialect::Assign_Op::name());
+    const auto &assign = pat.Op(paddle::dialect::AssignOp::name());
     const auto &full = pat.Op(paddle::dialect::FullOp::name());
     const auto &split_with_num = pat.Op(paddle::dialect::SplitWithNumOp::name(),
                                         {{"num", pat.Attr("num")}});
@@ -442,7 +442,7 @@ class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
         matmul(pat.Tensor("out_grad"), pat.Tensor("weight"));
     pat.Tensor("input_grad") =
         c_allreduce_sum_(pat.Tensor("input_grad_partial"));
-    pat.Tensor("input_grad_tmp") = assign_(pat.Tensor("input_grad"));
+    pat.Tensor("input_grad_tmp") = assign(pat.Tensor("input_grad"));
     pat.Tensor("split_num") = full();
     pat.Tensor("input_grad_group") =
         split_with_num(pat.Tensor("input_grad_tmp"), pat.Tensor("split_num"));

--- a/paddle/fluid/pir/transforms/gpu/fused_linear_param_grad_add_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_linear_param_grad_add_pass.cc
@@ -417,6 +417,64 @@ class FusedMatmulAddGradAddbPattern : public paddle::drr::DrrPatternBase {
   }
 };
 
+class FusedAllReduceSplitPattern : public paddle::drr::DrrPatternBase {
+ public:
+  std::string name() const override { return "FusedAllReduceSplitPattern"; }
+
+  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
+    paddle::drr::SourcePattern pat = ctx->SourcePattern();
+
+    const auto &matmul = pat.Op(paddle::dialect::MatmulOp::name(),
+                                {{"transpose_x", pat.Attr("trans_x")},
+                                 {"transpose_y", pat.Attr("trans_y")}});
+    const auto &c_allreduce_sum_ =
+        pat.Op(paddle::dialect::CAllreduceSum_Op::name(),
+               {{"ring_id", pat.Attr("ring_id")},
+                {"use_calc_stream", pat.Attr("use_calc_stream")}});
+    const auto &assign_ = pat.Op(paddle::dialect::Assign_Op::name());
+    const auto &full = pat.Op(paddle::dialect::FullOp::name());
+    const auto &split_with_num = pat.Op(paddle::dialect::SplitWithNumOp::name(),
+                                        {{"num", pat.Attr("num")}});
+    const auto &builtin_slice =
+        pat.Op(pir::SliceOp::name(), {{"index", pat.Attr("index")}});
+
+    pat.Tensor("input_grad_partial") =
+        matmul(pat.Tensor("out_grad"), pat.Tensor("weight"));
+    pat.Tensor("input_grad") =
+        c_allreduce_sum_(pat.Tensor("input_grad_partial"));
+    pat.Tensor("input_grad_tmp") = assign_(pat.Tensor("input_grad"));
+    pat.Tensor("split_num") = full();
+    pat.Tensor("input_grad_group") =
+        split_with_num(pat.Tensor("input_grad_tmp"), pat.Tensor("split_num"));
+    pat.Tensor("out") = builtin_slice(pat.Tensor("input_grad_group"));
+
+    pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
+      const auto &x_trans = match_ctx.Attr<bool>("trans_x");
+      const auto &y_trans = match_ctx.Attr<bool>("trans_y");
+      auto input_grad_partial_count =
+          match_ctx.Tensor("input_grad_partial").use_count();
+      auto input_grad_count = match_ctx.Tensor("input_grad").use_count();
+      auto input_grad_tmp_count =
+          match_ctx.Tensor("input_grad_tmp").use_count();
+      auto input_grad_group_count =
+          match_ctx.Tensor("input_grad_group").use_count();
+      return (x_trans == false && y_trans == true &&
+              input_grad_partial_count == 1 && input_grad_count == 1 &&
+              input_grad_tmp_count == 1 && input_grad_group_count == 1);
+    });
+
+    paddle::drr::ResultPattern res = pat.ResultPattern();
+
+    const auto &c_reducescatter =
+        res.Op(paddle::dialect::CReducescatterOp::name(),
+               {{"ring_id", pat.Attr("ring_id")},
+                {"nranks", pat.Attr("num")},
+                {"use_calc_stream", pat.Attr("use_calc_stream")}});
+
+    c_reducescatter({&res.Tensor("input_grad_partial")}, {&res.Tensor("out")});
+  }
+};
+
 class FusedLinearParamGradAddPass : public pir::PatternRewritePass {
  public:
   FusedLinearParamGradAddPass()
@@ -431,6 +489,7 @@ class FusedLinearParamGradAddPass : public pir::PatternRewritePass {
     ps.Add(paddle::drr::Create<FusedMatmulAddGradAddaPattern>(context));
     ps.Add(paddle::drr::Create<FusedMatmulAddGradAddbPattern>(context));
     ps.Add(paddle::drr::Create<FusedMatmulReshapeMatmulAddPattern>(context));
+    ps.Add(paddle::drr::Create<FusedAllReduceSplitPattern>(context));
 
     return ps;
   }

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -23,6 +23,7 @@ USE_PIR_PASS(fused_gemm_epilogue_pass);
 USE_PIR_PASS(fused_dropout_add_pass);
 USE_PIR_PASS(fused_weight_only_linear_pass);
 USE_PIR_PASS(fused_linear_param_grad_add_pass);
+USE_PIR_PASS(fuse_allreduce_split_to_reducescatter_pass);
 USE_PIR_PASS(inplace_pass);
 USE_PIR_PASS(replace_fetch_with_shadow_output_pass);
 USE_PIR_PASS(identity_op_clean_pass);

--- a/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer_v2.py
@@ -35,6 +35,7 @@ from .utils import (
 PIR_PASS = [
     'fused_gemm_epilogue_pass',
     'fused_linear_param_grad_add_pass',
+    'fuse_allreduce_split_to_reducescatter_pass',
     'fused_dropout_add_pass',
 ]
 

--- a/test/distributed_passes/test_fuse_allreduce_split_to_reducescatter_pass.py
+++ b/test/distributed_passes/test_fuse_allreduce_split_to_reducescatter_pass.py
@@ -18,8 +18,8 @@ import paddle
 
 program_txt = '''
 {
-    (%2) = "builtin.parameter" () {parameter_name:"linear_2.w_0.dist",persistable:[true],stop_gradient:[false]} : () -> builtin.tensor<8192x28672xbf16>
-    (%38) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"linear_2.tmp_0",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
+    (%2) = "builtin.parameter" () {parameter_name:"linear_0.w_0",persistable:[true],stop_gradient:[false]} : () -> builtin.tensor<8192x28672xbf16>
+    (%38) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"linear_0.tmp_0",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
     (%48) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"input",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
     (%50) = "pd_op.matmul" (%48, %2) {event_to_record:"event_7796",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false],transpose_x:false,transpose_y:true} : (builtin.tensor<4096x1x28672xbf16>, builtin.tensor<8192x28672xbf16>) -> builtin.tensor<4096x1x8192xbf16>
     (%57) = "pd_op.c_allreduce_sum_" (%50) {event_to_record:"event_7800",events_to_wait:[],force_record_event:false,persistable:[false],ring_id:(Int32)36,stop_gradient:[false],use_calc_stream:true,use_model_parallel:true} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>

--- a/test/distributed_passes/test_fuse_allreduce_split_to_reducescatter_pass.py
+++ b/test/distributed_passes/test_fuse_allreduce_split_to_reducescatter_pass.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+program_txt = '''
+{
+    (%2) = "builtin.parameter" () {parameter_name:"linear_2.w_0.dist",persistable:[true],stop_gradient:[false]} : () -> builtin.tensor<8192x28672xbf16>
+    (%38) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"linear_2.tmp_0",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
+    (%48) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"input",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
+    (%50) = "pd_op.matmul" (%48, %2) {event_to_record:"event_7796",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false],transpose_x:false,transpose_y:true} : (builtin.tensor<4096x1x28672xbf16>, builtin.tensor<8192x28672xbf16>) -> builtin.tensor<4096x1x8192xbf16>
+    (%57) = "pd_op.c_allreduce_sum_" (%50) {event_to_record:"event_7800",events_to_wait:[],force_record_event:false,persistable:[false],ring_id:(Int32)36,stop_gradient:[false],use_calc_stream:true,use_model_parallel:true} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>
+    (%63) = "pd_op.assign" (%57) {event_to_record:"event_5112",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false]} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>
+    (%64) = "pd_op.full" () {dtype:(pd_op.DataType)int32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)0} : () -> builtin.tensor<1xi32>
+    (%65) = "pd_op.split_with_num" (%63, %64) {event_to_record:"event_7384",events_to_wait:[],force_record_event:false,num:(Int32)2,persistable:[false],stop_gradient:[false]} : (builtin.tensor<4096x1x8192xbf16>, builtin.tensor<1xi32>) -> vec[builtin.tensor<2048x1x8192xbf16>,builtin.tensor<2048x1x8192xbf16>]
+    (%66) = "builtin.slice" (%65) {index:(Int32)0,persistable:[false],stop_gradient:[false]} : (vec[builtin.tensor<2048x1x8192xbf16>,builtin.tensor<2048x1x8192xbf16>]) -> builtin.tensor<2048x1x8192xbf16>
+    (%67) = "pd_op.assign" (%66) {event_to_record:"event_5112",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false]} : (builtin.tensor<2048x1x8192xbf16>) -> builtin.tensor<2048x1x8192xbf16>
+}'''
+
+
+class TestPass(unittest.TestCase):
+    def test_if_with_single_output(self):
+        paddle.pir.register_paddle_dialect()
+        ir_program = paddle.pir.parse_program(program_txt)
+        pm = paddle.pir.PassManager()
+        pm.add_pass('fuse_allreduce_split_to_reducescatter_pass', {})
+        pm.run(ir_program)
+        self.assertEqual(ir_program.global_block().num_ops(), 6)
+        self.assertEqual(
+            ir_program.global_block().ops[-2].name(), "pd_op.c_reducescatter"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/distributed_passes/test_fuse_allreduce_split_to_reducescatter_pass.py
+++ b/test/distributed_passes/test_fuse_allreduce_split_to_reducescatter_pass.py
@@ -21,13 +21,13 @@ program_txt = '''
     (%2) = "builtin.parameter" () {parameter_name:"linear_0.w_0",persistable:[true],stop_gradient:[false]} : () -> builtin.tensor<8192x28672xbf16>
     (%38) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"linear_0.tmp_0",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
     (%48) = "pd_op.data" () {dtype:(pd_op.DataType)bfloat16,name:"input",persistable:[false],place:(pd_op.Place)Place(gpu:0),shape:(pd_op.IntArray)[4096,1,28672],stop_gradient:[false]} : () -> builtin.tensor<4096x1x28672xbf16>
-    (%50) = "pd_op.matmul" (%48, %2) {event_to_record:"event_7796",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false],transpose_x:false,transpose_y:true} : (builtin.tensor<4096x1x28672xbf16>, builtin.tensor<8192x28672xbf16>) -> builtin.tensor<4096x1x8192xbf16>
-    (%57) = "pd_op.c_allreduce_sum_" (%50) {event_to_record:"event_7800",events_to_wait:[],force_record_event:false,persistable:[false],ring_id:(Int32)36,stop_gradient:[false],use_calc_stream:true,use_model_parallel:true} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>
-    (%63) = "pd_op.assign" (%57) {event_to_record:"event_5112",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false]} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>
+    (%50) = "pd_op.matmul" (%48, %2) {persistable:[false],stop_gradient:[false],transpose_x:false,transpose_y:true} : (builtin.tensor<4096x1x28672xbf16>, builtin.tensor<8192x28672xbf16>) -> builtin.tensor<4096x1x8192xbf16>
+    (%57) = "pd_op.c_allreduce_sum_" (%50) {persistable:[false],ring_id:(Int32)36,stop_gradient:[false],use_calc_stream:true,use_model_parallel:true} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>
+    (%63) = "pd_op.assign" (%57) {persistable:[false],stop_gradient:[false]} : (builtin.tensor<4096x1x8192xbf16>) -> builtin.tensor<4096x1x8192xbf16>
     (%64) = "pd_op.full" () {dtype:(pd_op.DataType)int32,place:(pd_op.Place)Place(cpu),shape:(pd_op.IntArray)[1],stop_gradient:[true],value:(Float)0} : () -> builtin.tensor<1xi32>
-    (%65) = "pd_op.split_with_num" (%63, %64) {event_to_record:"event_7384",events_to_wait:[],force_record_event:false,num:(Int32)2,persistable:[false],stop_gradient:[false]} : (builtin.tensor<4096x1x8192xbf16>, builtin.tensor<1xi32>) -> vec[builtin.tensor<2048x1x8192xbf16>,builtin.tensor<2048x1x8192xbf16>]
+    (%65) = "pd_op.split_with_num" (%63, %64) {num:(Int32)2,persistable:[false],stop_gradient:[false]} : (builtin.tensor<4096x1x8192xbf16>, builtin.tensor<1xi32>) -> vec[builtin.tensor<2048x1x8192xbf16>,builtin.tensor<2048x1x8192xbf16>]
     (%66) = "builtin.slice" (%65) {index:(Int32)0,persistable:[false],stop_gradient:[false]} : (vec[builtin.tensor<2048x1x8192xbf16>,builtin.tensor<2048x1x8192xbf16>]) -> builtin.tensor<2048x1x8192xbf16>
-    (%67) = "pd_op.assign" (%66) {event_to_record:"event_5112",events_to_wait:[],force_record_event:false,persistable:[false],stop_gradient:[false]} : (builtin.tensor<2048x1x8192xbf16>) -> builtin.tensor<2048x1x8192xbf16>
+    (%67) = "pd_op.assign" (%66) {persistable:[false],stop_gradient:[false]} : (builtin.tensor<2048x1x8192xbf16>) -> builtin.tensor<2048x1x8192xbf16>
 }'''
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Add fuse all_reduce_sum with split to reduce_scatter pass
Pcard-73145