### PR TITLE
【pir_save_load】support pir save of test_custom_relu_model.py

### DIFF
--- a/test/custom_op/test_custom_relu_model.py
+++ b/test/custom_op/test_custom_relu_model.py
@@ -224,31 +224,26 @@ class TestStaticModel(unittest.TestCase):
 
     @test_with_pir_api
     def test_train_eval(self):
-        if paddle.framework.in_pir_mode():
-            for device in self.devices:
-                # for train
-                original_relu_train_out = self.train_model(
-                    device, use_custom_op=False
-                )
-                custom_relu_train_out = self.train_model(
-                    device, use_custom_op=True
-                )
+        for device in self.devices:
+            # for train
+            original_relu_train_out = self.train_model(
+                device, use_custom_op=False
+            )
+            custom_relu_train_out = self.train_model(device, use_custom_op=True)
 
-                np.testing.assert_array_equal(
-                    original_relu_train_out, custom_relu_train_out
-                )
+            np.testing.assert_array_equal(
+                original_relu_train_out, custom_relu_train_out
+            )
 
-                # for eval
-                original_relu_eval_out = self.eval_model(
-                    device, use_custom_op=False
-                )
-                custom_relu_eval_out = self.eval_model(
-                    device, use_custom_op=True
-                )
+            # for eval
+            original_relu_eval_out = self.eval_model(
+                device, use_custom_op=False
+            )
+            custom_relu_eval_out = self.eval_model(device, use_custom_op=True)
 
-                np.testing.assert_array_equal(
-                    original_relu_eval_out, custom_relu_eval_out
-                )
+            np.testing.assert_array_equal(
+                original_relu_eval_out, custom_relu_eval_out
+            )
 
     def train_model(self, device, use_custom_op=False):
         # reset random seed


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
others

### Description
<!-- Describe what you’ve done -->
pcard-67164

支持pir 下保存custom_op
