### PR TITLE
Move  paddle/fluid/operators/cudnn_rnn_cache.h to phi

### DIFF
--- a/paddle/fluid/framework/var_type_traits.cc
+++ b/paddle/fluid/framework/var_type_traits.cc
@@ -26,7 +26,7 @@
 #endif
 #include <cudnn.h>
 
-#include "paddle/fluid/operators/cudnn_rnn_cache.h"
+#include "paddle/phi/kernels/funcs/cudnn_rnn_cache.h"
 #include "paddle/phi/kernels/gpudnn/conv_gpudnn_info.h"
 #endif
 #ifdef PADDLE_WITH_HIP
@@ -34,7 +34,7 @@
 #include "paddle/fluid/operators/nccl/nccl_gpu_common.h"   // NOLINT
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"  // NOLINT
 #endif
-#include "paddle/fluid/operators/miopen_rnn_cache.h"
+#include "paddle/phi/kernels/funcs/miopen_rnn_cache.h"
 #endif
 
 #if defined(PADDLE_WITH_XPU_BKCL)

--- a/paddle/fluid/framework/var_type_traits.h
+++ b/paddle/fluid/framework/var_type_traits.h
@@ -54,6 +54,9 @@ class DenseTensor;
 class SelectedRows;
 class SparseCooTensor;
 class SparseCsrTensor;
+namespace funcs {
+class CudnnRNNCache;
+}
 }  // namespace phi
 
 // Users should add forward declarations here
@@ -80,8 +83,6 @@ class Scope;
 }  // namespace framework
 
 namespace operators {
-
-class CudnnRNNCache;
 
 class CUDAGraphWithInOuts;
 
@@ -196,7 +197,7 @@ using VarTypeRegistry = detail::VarTypeRegistryImpl<
     platform::Communicator,
     platform::NCCLCommunicator,
 #endif
-    operators::CudnnRNNCache,
+    phi::funcs::CudnnRNNCache,
 #endif
 #if defined(PADDLE_WITH_XPU_BKCL)
     BKCLUniqueId,

--- a/paddle/phi/kernels/funcs/cudnn_rnn_cache.h
+++ b/paddle/phi/kernels/funcs/cudnn_rnn_cache.h
@@ -16,11 +16,11 @@ limitations under the License. */
 
 #include <vector>
 
-#include "paddle/fluid/framework/tensor.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
+#include "paddle/phi/core/dense_tensor.h"
 
-namespace paddle {
-namespace operators {
+namespace phi {
+namespace funcs {
 
 class CudnnRNNCache {
  public:
@@ -343,5 +343,5 @@ class CudnnRNNCache {
   }
 };
 
-}  // namespace operators
-}  // namespace paddle
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/cudnn_rnn_cache.h
+++ b/paddle/phi/kernels/funcs/cudnn_rnn_cache.h
@@ -16,9 +16,9 @@ limitations under the License. */
 
 #include <vector>
 
+#include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
 #include "paddle/phi/core/dense_tensor.h"
-
 namespace phi {
 namespace funcs {
 
@@ -194,12 +194,12 @@ class CudnnRNNCache {
         phi::dynload::cudnnCreateDropoutDescriptor(&dropout_desc_));
 
     size_t state_size;
+    auto *dev_ctx = phi::DeviceContextPool::Instance().Get(place);
     if (!initialized) {
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::cudnnDropoutGetStatesSize(handle, &state_size));
       dropout_state_->Resize({static_cast<int64_t>(state_size)});
-      uint8_t *dropout_state_data =
-          dropout_state_->mutable_data<uint8_t>(place);
+      uint8_t *dropout_state_data = dev_ctx->Alloc<uint8_t>(dropout_state_);
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::cudnnSetDropoutDescriptor(dropout_desc_,
                                                   handle,
@@ -293,7 +293,7 @@ class CudnnRNNCache {
         handle, rnn_desc_, seq_length_, x_desc_, reserve_size_));
 #endif
     workspace_data_.Resize({static_cast<int64_t>(workspace_size_)});
-    workspace_data_.mutable_data<uint8_t>(place);
+    dev_ctx->Alloc<uint8_t>(&workspace_data_);
   }
 
   void release() {

--- a/paddle/phi/kernels/funcs/miopen_rnn_cache.h
+++ b/paddle/phi/kernels/funcs/miopen_rnn_cache.h
@@ -16,11 +16,11 @@ limitations under the License. */
 
 #include <vector>
 
-#include "paddle/fluid/framework/tensor.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
+#include "paddle/phi/core/dense_tensor.h"
 
-namespace paddle {
-namespace operators {
+namespace phi {
+namespace funcs {
 
 struct CudnnRNNCache {
   CudnnRNNCache() {
@@ -324,5 +324,5 @@ struct CudnnRNNCache {
   }
 };
 
-}  // namespace operators
-}  // namespace paddle
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/miopen_rnn_cache.h
+++ b/paddle/phi/kernels/funcs/miopen_rnn_cache.h
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <vector>
 
+#include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
 #include "paddle/phi/core/dense_tensor.h"
 
@@ -201,12 +202,12 @@ struct CudnnRNNCache {
         phi::dynload::miopenCreateDropoutDescriptor(&dropout_desc_));
 
     size_t state_size;
+    auto *dev_ctx = phi::DeviceContextPool::Instance().Get(place);
     if (!initialized) {
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::miopenDropoutGetStatesSize(handle, &state_size));
       dropout_state_->Resize({static_cast<int64_t>(state_size)});
-      uint8_t *dropout_state_data =
-          dropout_state_->mutable_data<uint8_t>(place);
+      uint8_t *dropout_state_data = dev_ctx->Alloc<uint8_t>(dropout_state_);
       PADDLE_ENFORCE_GPU_SUCCESS(
           phi::dynload::miopenSetDropoutDescriptor(dropout_desc_,
                                                    handle,
@@ -281,7 +282,7 @@ struct CudnnRNNCache {
         handle, rnn_desc_, seq_length_, x_desc_, reserve_size_));
 
     workspace_data_.Resize({static_cast<int64_t>(workspace_size_)});
-    workspace_data_.mutable_data<uint8_t>(place);
+    dev_ctx->Alloc<uint8_t>(&workspace_data_);
   }
 
   void release() {

--- a/test/cpp/fluid/framework/var_type_traits_test.cc
+++ b/test/cpp/fluid/framework/var_type_traits_test.cc
@@ -26,14 +26,14 @@
 #include "paddle/fluid/operators/nccl/nccl_gpu_common.h"
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"
 #endif
-#include "paddle/fluid/operators/cudnn_rnn_cache.h"
+#include "paddle/phi/kernels/funcss/cudnn_rnn_cache.h"
 #endif
 #ifdef PADDLE_WITH_HIP
 #if defined(PADDLE_WITH_RCCL)
 #include "paddle/fluid/operators/nccl/nccl_gpu_common.h"   // NOLINT
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"  // NOLINT
 #endif
-#include "paddle/fluid/operators/miopen_rnn_cache.h"
+#include "paddle/phi/kernels/funcs/miopen_rnn_cache.h"
 #endif
 #if defined(PADDLE_WITH_XPU_BKCL)
 #include "paddle/fluid/platform/device/xpu/bkcl_helper.h"

--- a/test/cpp/fluid/framework/var_type_traits_test.cc
+++ b/test/cpp/fluid/framework/var_type_traits_test.cc
@@ -26,7 +26,7 @@
 #include "paddle/fluid/operators/nccl/nccl_gpu_common.h"
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"
 #endif
-#include "paddle/phi/kernels/funcss/cudnn_rnn_cache.h"
+#include "paddle/phi/kernels/funcs/cudnn_rnn_cache.h"
 #endif
 #ifdef PADDLE_WITH_HIP
 #if defined(PADDLE_WITH_RCCL)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Move  paddle/fluid/operators/cudnn_rnn_cache.h to phi
修改mutable_data为Alloc调用

![image](https://github.com/PaddlePaddle/Paddle/assets/4617245/8a5290d5-4035-4f11-a893-11fa64ee9b88)
