### PR TITLE
【Fix PIR Unittest No.74】Fix some test cast in PIR mode

### DIFF
--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -301,7 +301,7 @@ def pir_check_feed_shape_type(feed, name, target_shape, dtype, num_places=1):
     """
     diff_shape = core.diff_tensor_shape(feed, target_shape, num_places)
     if diff_shape is not None:
-        warnings.warn(
+        raise ValueError(
             'The fed Variable %r should have dimensions = %d, shape = '
             '%r, but received fed shape %r on each device'
             % (name, len(target_shape), target_shape, diff_shape)
@@ -317,7 +317,7 @@ def pir_check_feed_shape_type(feed, name, target_shape, dtype, num_places=1):
             if isinstance(feed._dtype(), core.VarDesc.VarType)
             else feed._dtype()
         )
-        warnings.warn(
+        raise ValueError(
             f'The data type of fed Variable {name!r} must be {var_dtype_format!r}, but received {feed_dtype_format!r}'
         )
     return True

--- a/python/paddle/base/executor.py
+++ b/python/paddle/base/executor.py
@@ -301,7 +301,7 @@ def pir_check_feed_shape_type(feed, name, target_shape, dtype, num_places=1):
     """
     diff_shape = core.diff_tensor_shape(feed, target_shape, num_places)
     if diff_shape is not None:
-        raise ValueError(
+        warnings.warn(
             'The fed Variable %r should have dimensions = %d, shape = '
             '%r, but received fed shape %r on each device'
             % (name, len(target_shape), target_shape, diff_shape)
@@ -317,7 +317,7 @@ def pir_check_feed_shape_type(feed, name, target_shape, dtype, num_places=1):
             if isinstance(feed._dtype(), core.VarDesc.VarType)
             else feed._dtype()
         )
-        raise ValueError(
+        warnings.warn(
             f'The data type of fed Variable {name!r} must be {var_dtype_format!r}, but received {feed_dtype_format!r}'
         )
     return True

--- a/python/paddle/base/reader.py
+++ b/python/paddle/base/reader.py
@@ -23,6 +23,7 @@ import numpy as np
 
 import paddle
 from paddle.base.framework import _set_expected_place
+from paddle.pir.core import datatype_to_vartype
 
 from . import core
 from .data_feeder import BatchedTensorProvider, DataFeeder
@@ -35,6 +36,7 @@ from .framework import (
     default_main_program,
     default_startup_program,
     in_dygraph_mode,
+    in_pir_mode,
     program_guard,
 )
 from .layers.io import (
@@ -840,10 +842,16 @@ class GeneratorLoader(DataLoaderBase):
         self._wait_thread_ends()
         self._var_names = [v.name for v in self._feed_list]
         self._shapes = [v.shape for v in self._feed_list]
-        self._dtypes = [v.dtype for v in self._feed_list]
-        self._need_check_feed = [
-            v.desc.need_check_feed() for v in self._feed_list
-        ]
+        if in_pir_mode():
+            self._dtypes = [
+                datatype_to_vartype[v.dtype] for v in self._feed_list
+            ]
+            self._need_check_feed = [False for v in self._feed_list]
+        else:
+            self._dtypes = [v.dtype for v in self._feed_list]
+            self._need_check_feed = [
+                v.desc.need_check_feed() for v in self._feed_list
+            ]
         self._queue = core.init_lod_tensor_blocking_queue(
             core.Variable(), self._capacity, self._keep_order
         )
@@ -874,7 +882,10 @@ class GeneratorLoader(DataLoaderBase):
             ranks.append(len(feed_data.shape))
             shapes.append(feed_data.shape)
             lod_levels.append(feed_data.lod_level)
-            need_check_feed.append(int(feed_data.desc.need_check_feed()))
+            if in_pir_mode():
+                need_check_feed.append(0)
+            else:
+                need_check_feed.append(int(feed_data.desc.need_check_feed()))
 
         queue_name = data_loader_unique_name_generator(
             'lod_tensor_blocking_queue'

--- a/test/legacy_test/test_py_reader_combination.py
+++ b/test/legacy_test/test_py_reader_combination.py
@@ -119,4 +119,5 @@ class TestPyReaderCombination3(TestPyReaderCombination):
 
 
 if __name__ == '__main__':
+    paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-67164

老静态图通过need_check_feed标记，是否需要检查训练输入的input与desc描述是否一致。
PIR不再支持这种标记，直接在feed时做该检查，如果发现问题则报wraning

关联Issue：https://github.com/PaddlePaddle/Paddle/issues/63740
