### PR TITLE
Replace framework::proto::VarType part

### DIFF
--- a/paddle/fluid/operators/fused/onednn/fusion_lstm_onednn_op.cc
+++ b/paddle/fluid/operators/fused/onednn/fusion_lstm_onednn_op.cc
@@ -398,15 +398,13 @@ class FusionLSTMMKLDNNKernel : public framework::OpKernel<T> {
     std::shared_ptr<dnnl::memory> h0_memory_p, weight_h_memory_p,
         weight_x_memory_p;
 
-    if (framework::TransToProtoVarType(weight_h->dtype()) ==
-        paddle::framework::proto::VarType_Type_FP32) {
+    if (weight_h->dtype() == phi::DataType::FLOAT32) {
       h0_memory_p = handler.template AcquireH0Memory<float>(h0);
       weight_x_memory_p =
           handler.template AcquireWeightXMemory<float>(weight_x);
       weight_h_memory_p =
           handler.template AcquireWeightHMemory<float>(weight_h);
-    } else if (framework::TransToProtoVarType(weight_h->dtype()) ==
-               paddle::framework::proto::VarType_Type_BF16) {
+    } else if (weight_h->dtype() == phi::DataType::BFLOAT16) {
       h0_memory_p = handler.template AcquireH0Memory<phi::dtype::bfloat16>(h0);
       weight_x_memory_p =
           handler.template AcquireWeightXMemory<phi::dtype::bfloat16>(weight_x);

--- a/paddle/fluid/operators/fused/resnet_basic_block_op.cc
+++ b/paddle/fluid/operators/fused/resnet_basic_block_op.cc
@@ -225,26 +225,22 @@ class ResNetBasicBlockOp : public framework::OperatorWithKernel {
 
     // By default, the type of the scale, bias, mean,
     // and var tensors should be float when input tensor's dtype is float16.
-    auto bn_param_type = framework::proto::VarType::FP32;
+    auto bn_param_type = phi::DataType::FLOAT32;
     PADDLE_ENFORCE_EQ(
         bn_param_type,
-        framework::TransToProtoVarType(
-            ctx.Input<phi::DenseTensor>("Scale1")->dtype()),
+        ctx.Input<phi::DenseTensor>("Scale1")->dtype(),
         phi::errors::InvalidArgument("Scale input should be of float type"));
     PADDLE_ENFORCE_EQ(
         bn_param_type,
-        framework::TransToProtoVarType(
-            ctx.Input<phi::DenseTensor>("Bias1")->dtype()),
+        ctx.Input<phi::DenseTensor>("Bias1")->dtype(),
         phi::errors::InvalidArgument("Bias input should be of float type"));
     PADDLE_ENFORCE_EQ(
         bn_param_type,
-        framework::TransToProtoVarType(
-            ctx.Input<phi::DenseTensor>("Scale2")->dtype()),
+        ctx.Input<phi::DenseTensor>("Scale2")->dtype(),
         phi::errors::InvalidArgument("Scale input should be of float type"));
     PADDLE_ENFORCE_EQ(
         bn_param_type,
-        framework::TransToProtoVarType(
-            ctx.Input<phi::DenseTensor>("Bias2")->dtype()),
+        ctx.Input<phi::DenseTensor>("Bias2")->dtype(),
         phi::errors::InvalidArgument("Bias input should be of float type"));
 
     return phi::KernelKey(input_data_type, ctx.GetPlace());

--- a/paddle/fluid/operators/fused/resnet_unit_op.cc
+++ b/paddle/fluid/operators/fused/resnet_unit_op.cc
@@ -206,17 +206,15 @@ class ResNetUnitOp : public framework::OperatorWithKernel {
     auto input_data_type = OperatorWithKernel::IndicateVarDataType(ctx, "X");
     // By default, the type of the scale, bias, mean,
     // and var tensors should be float when input tensor's dtype is float16.
-    auto bn_param_type = framework::proto::VarType::FP32;
+    auto bn_param_type = phi::DataType::FLOAT32;
 
     PADDLE_ENFORCE_EQ(
         bn_param_type,
-        framework::TransToProtoVarType(
-            ctx.Input<phi::DenseTensor>("ScaleX")->dtype()),
+        ctx.Input<phi::DenseTensor>("ScaleX")->dtype(),
         phi::errors::InvalidArgument("Scale input should be of float type"));
     PADDLE_ENFORCE_EQ(
         bn_param_type,
-        framework::TransToProtoVarType(
-            ctx.Input<phi::DenseTensor>("BiasX")->dtype()),
+        ctx.Input<phi::DenseTensor>("BiasX")->dtype(),
         phi::errors::InvalidArgument("Bias input should be of float type"));
     return phi::KernelKey(input_data_type, ctx.GetPlace());
   }

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -80,8 +80,7 @@ struct LoDTensorToArrayFunctor {
     LoDTensorToArrayFunctorImpl<DeviceContext> func;
     func.prev_functor_ = this;
     func.dev_ctx_ = dev_ctx;
-    framework::VisitDataType(framework::TransToProtoVarType(input_.dtype()),
-                             func);
+    phi::VisitDataType(input_.dtype(), func);
   }
 };
 

--- a/paddle/fluid/operators/lookup_table_op.h
+++ b/paddle/fluid/operators/lookup_table_op.h
@@ -90,8 +90,7 @@ class LookupTableKernel : public framework::OpKernel<T> {
       int64_t row_width = table_t.value().dims()[1];
       const auto *table = table_t.value().data<T>();
       auto *output = output_t->mutable_data<T>(context.GetPlace());
-      auto input_data_type =
-          framework::TransToProtoVarType(table_t.value().dtype());
+      auto input_data_type = table_t.value().dtype();
       for (int64_t i = 0; i < ids_numel; ++i) {
         if (padding_idx != kNoPadding && ids[i] == padding_idx) {
           memset(output + i * row_width, 0, row_width * sizeof(T));
@@ -107,9 +106,9 @@ class LookupTableKernel : public framework::OpKernel<T> {
             auto id_index = table_t.GetIndexFromId(ids[i]);
 
             if (id_index != -1) {
-              if (input_data_type == framework::proto::VarType::INT8 ||
-                  input_data_type == framework::proto::VarType::INT16 ||
-                  input_data_type == framework::proto::VarType::BF16) {
+              if (input_data_type == phi::DataType::INT8 ||
+                  input_data_type == phi::DataType::INT16 ||
+                  input_data_type == phi::DataType::BFLOAT16) {
                 memcpy(output + i * row_width,
                        table + id_index * row_width,
                        row_width * sizeof(T));
@@ -140,9 +139,9 @@ class LookupTableKernel : public framework::OpKernel<T> {
                     "the input key should be exists. But received %d.",
                     id_index));
 
-            if (input_data_type == framework::proto::VarType::INT8 ||
-                input_data_type == framework::proto::VarType::INT16 ||
-                input_data_type == framework::proto::VarType::BF16) {
+            if (input_data_type == phi::DataType::INT8 ||
+                input_data_type == phi::DataType::INT16 ||
+                input_data_type == phi::DataType::BFLOAT16) {
               memcpy(output + i * row_width,
                      table + id_index * row_width,
                      row_width * sizeof(T));

--- a/paddle/fluid/operators/optimizers/sparse_momentum_op.h
+++ b/paddle/fluid/operators/optimizers/sparse_momentum_op.h
@@ -304,11 +304,11 @@ class SparseMomentumOpKernel : public framework::OpKernel<T> {
     const bool multi_precision = ctx.Attr<bool>("multi_precision");
     bool use_nesterov = ctx.Attr<bool>("use_nesterov");
     auto index = ctx.Input<phi::DenseTensor>("Index");
-    const auto& index_type = framework::TransToProtoVarType(index->dtype());
+    const auto& index_type = index->dtype();
     if (multi_precision) {
       if (use_nesterov) {
         auto update_method = UseNesterov<MPDType>();
-        if (index_type == framework::proto::VarType::INT32) {
+        if (index_type == phi::DataType::INT32) {
           InnerCompute<MPDType, int, UseNesterov<MPDType>>(
               ctx, multi_precision, update_method);
         } else {
@@ -317,7 +317,7 @@ class SparseMomentumOpKernel : public framework::OpKernel<T> {
         }
       } else {
         auto update_method = NoNesterov<MPDType>();
-        if (index_type == framework::proto::VarType::INT32) {
+        if (index_type == phi::DataType::INT32) {
           InnerCompute<MPDType, int, NoNesterov<MPDType>>(
               ctx, multi_precision, update_method);
         } else {
@@ -328,7 +328,7 @@ class SparseMomentumOpKernel : public framework::OpKernel<T> {
     } else {
       if (use_nesterov) {
         auto update_method = UseNesterov<T>();
-        if (index_type == framework::proto::VarType::INT32) {
+        if (index_type == phi::DataType::INT32) {
           InnerCompute<T, int, UseNesterov<T>>(
               ctx, multi_precision, update_method);
         } else {
@@ -337,7 +337,7 @@ class SparseMomentumOpKernel : public framework::OpKernel<T> {
         }
       } else {
         auto update_method = NoNesterov<T>();
-        if (index_type == framework::proto::VarType::INT32) {
+        if (index_type == phi::DataType::INT32) {
           InnerCompute<T, int, NoNesterov<T>>(
               ctx, multi_precision, update_method);
         } else {
@@ -371,11 +371,10 @@ class SparseMomentumOpKernel : public framework::OpKernel<T> {
       phi::DenseTensor cpu_axis;
       const phi::DenseTensor* axis_tensor = ctx.Input<phi::DenseTensor>("Axis");
       framework::TensorCopy(*axis_tensor, phi::CPUPlace(), &cpu_axis);
-      const auto& axis_type =
-          framework::TransToProtoVarType(axis_tensor->dtype());
-      if (axis_type == framework::proto::VarType::INT32) {
+      const auto& axis_type = axis_tensor->dtype();
+      if (axis_type == phi::DataType::INT32) {
         axis = static_cast<int>(cpu_axis.data<int32_t>()[0]);
-      } else if (axis_type == framework::proto::VarType::INT64) {
+      } else if (axis_type == phi::DataType::INT64) {
         axis = static_cast<int>(cpu_axis.data<int64_t>()[0]);
       }
     } else {

--- a/paddle/fluid/operators/uniform_random_op.h
+++ b/paddle/fluid/operators/uniform_random_op.h
@@ -33,8 +33,7 @@ namespace operators {
 
 inline std::vector<int64_t> GetNewDataFromShapeTensor(
     const phi::DenseTensor* new_data_tensor) {
-  if (framework::TransToProtoVarType(new_data_tensor->dtype()) ==
-      framework::proto::VarType::INT64) {
+  if (new_data_tensor->dtype() == phi::DataType::INT64) {
     auto* new_data = new_data_tensor->data<int64_t>();
     phi::DenseTensor cpu_starts_tensor;
     if (new_data_tensor->place().GetType() == phi::AllocationType::GPU) {
@@ -45,8 +44,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensor(
     std::vector<int64_t> vec_new_data(new_data,
                                       new_data + new_data_tensor->numel());
     return vec_new_data;
-  } else if (framework::TransToProtoVarType(new_data_tensor->dtype()) ==
-             framework::proto::VarType::INT32) {
+  } else if (new_data_tensor->dtype() == phi::DataType::INT32) {
     auto* new_data = new_data_tensor->data<int32_t>();
     std::vector<int64_t> vec_new_data;
     phi::DenseTensor cpu_starts_tensor;
@@ -81,8 +79,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensorList(
             "But received tensor's dim=%s.",
             tensor->dims()));
 
-    if (framework::TransToProtoVarType(tensor->dtype()) ==
-        framework::proto::VarType::INT32) {
+    if (tensor->dtype() == phi::DataType::INT32) {
       if (tensor->place().GetType() == phi::AllocationType::GPU) {
         phi::DenseTensor temp;
         paddle::framework::TensorCopySync(*tensor, phi::CPUPlace(), &temp);
@@ -90,8 +87,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensorList(
       } else {
         vec_new_shape.push_back(static_cast<int64_t>(*tensor->data<int32_t>()));
       }
-    } else if (framework::TransToProtoVarType(tensor->dtype()) ==
-               framework::proto::VarType::INT64) {
+    } else if (tensor->dtype() == phi::DataType::INT64) {
       if (tensor->place().GetType() == phi::AllocationType::GPU) {
         phi::DenseTensor temp;
         paddle::framework::TensorCopySync(*tensor, phi::CPUPlace(), &temp);
@@ -105,8 +101,7 @@ inline std::vector<int64_t> GetNewDataFromShapeTensorList(
           "But got "
           "unsupport dtype: %s.",
           i,
-          paddle::framework::DataTypeToString(
-              framework::TransToProtoVarType(tensor->dtype()))));
+          phi::DataTypeToString(tensor->dtype())));
     }
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
替换部分 framework::proto::VarType 为 phi::DataType 在fluid/operators