### PR TITLE
[kunlun] comm_type XPUContext do not alloc xdnn mem

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -268,7 +268,7 @@ XPUContext::XPUContext(const XPUPlace& place, bool is_comm_context)
   if (is_comm_context) {
     // for communication context init, with gm_size=1 and l3_size=1
     impls_.push_back(std::make_unique<Impl>(place));
-    impls_[0]->Init(1, 1);
+    impls_[0]->Init(0, 0);
   } else if (std::getenv("XPU_CDNN_CLUSTER_PARALLEL") != nullptr) {
     int default_num_stream = 4;
     if (std::getenv("XPU_CDNN_CLUSTER_PARALLEL_STREAM_NUMBER") != nullptr) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Communication Library

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
A comm_type XPUContext still passes non-zero arguments of memory requirements to xdnn:Context initializer, which will bring up an error "param of BufferMgr::set(ptr, size) error, should align to 64" in xdnn. The PR corrects this behavior.