### PR TITLE
use Accelerate BLAS implementation on Mac

### DIFF
--- a/paddle/fluid/platform/cpu_helper.cc
+++ b/paddle/fluid/platform/cpu_helper.cc
@@ -22,6 +22,8 @@ limitations under the License. */
 
 #ifdef PADDLE_USE_OPENBLAS
 #include <cblas.h>
+#elif PADDLE_USE_ACCELERATE
+#include <Accelerate/Accelerate.h>
 #endif
 
 namespace paddle {
@@ -44,6 +46,9 @@ void SetNumThreads(int num_threads) {
   omp_set_num_threads(real_num_threads);
 #elif defined(PADDLE_USE_REFERENCE_CBLAS)
   // cblas not support multi-thread
+  return;
+#elif defined(PADDLE_USE_ACCELERATE)
+  // not sure about apple's blas
   return;
 #else
   PADDLE_THROW(platform::errors::Unimplemented(

--- a/paddle/phi/kernels/funcs/blas/blas.h
+++ b/paddle/phi/kernels/funcs/blas/blas.h
@@ -26,6 +26,9 @@
 
 #if defined(PADDLE_USE_OPENBLAS) || defined(PADDLE_USE_REFERENCE_CBLAS)
 #include <cblas.h>
+#elif defined(PADDLE_USE_ACCELERATE)
+#include <Accelerate/Accelerate.h>
+#define CBLAS_LAYOUT CBLAS_ORDER
 #endif
 
 namespace phi {

--- a/paddle/phi/kernels/funcs/math_function.cc
+++ b/paddle/phi/kernels/funcs/math_function.cc
@@ -21,6 +21,8 @@ limitations under the License. */
 
 #ifdef PADDLE_USE_OPENBLAS
 #include <cblas.h>
+#elif PADDLE_USE_ACCELERATE
+#include <Accelerate/Accelerate.h>
 #endif
 
 #include <memory>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -245,6 +245,10 @@ if(${len} GREATER_EQUAL 1)
           ${test_name}
           "-Wl,-rpath,$<TARGET_FILE_DIR:${paddle_lib}> -Wl,-rpath,$<TARGET_FILE_DIR:phi> -Wl,-rpath,$<TARGET_FILE_DIR:pir> -Wl,-rpath,$<TARGET_FILE_DIR:common>"
         )
+        if(ACCELERATE_FRAMEWORK)
+          target_link_libraries(${test_name} ${ACCELERATE_FRAMEWORK})
+          message(STATUS "linking to accelerate blas library in ${test_name}")
+        endif()
       endif()
       if(NOT ((NOT WITH_PYTHON) AND ON_INFER))
         target_link_libraries(${test_name} ${PYTHON_LIBRARIES})


### PR DESCRIPTION
### PR Category
Environment Adaptation


### PR Types
New features


### Description
Use [Apple’s implementation of the BLAS](https://developer.apple.com/documentation/accelerate/blas) on Mac.

Benefits:
- possibly resolve long standing issues reported in the community, that PaddlePaddle freeze on some Mac settings.
- Speedup on Mac, since Accelerate Framework is generally faster than openblas on Apple's platform.

### Updates

- 2024-5-23 update:
our nightly build pipeline has been updated, it's possible to use the package with Apple's BLAS by : `pip install --no-cache paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/mac/cpu/develop.html`.
I did a quick test, recognizing 15 random images by using `time paddleocr --image_dir images`, it shows 25% speedup compared with paddlepaddle with openblas on my mac m1. (paddlepaddle using accelerate framework V.S. paddlepaddle using openblas: 1m15.297s V.S. 1m34.525s).

- 2024-5-21 update:
The required CI has turned green, so I think we can go ahead and merge this PR. Meanwhile, we should wait for feedback to see if it resolves the PaddlePaddle freeze on some Mac settings.

- 2024-5-20 update: 
I can successfully build the package on my mac m1 using command: 
```
cmake -S . -B build-ninja -GNinja -DPY_VERSION=3.9 -DWITH_GPU=OFF -DWITH_TESTING=OFF -DWITH_AVX=OFF -DWITH_ARM=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build-ninja
```
and successfully run the script in #63344, but building the package with test cases failed on CI pipeline : PR-CI-Mac-Python3.


please ignore the following

PCard-67164