### PR TITLE
[PIR] Promote Precision for control flow when open amp

### DIFF
--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -42,6 +42,7 @@ from paddle.common_ops_import import (
     in_dygraph_mode,
 )
 from paddle.framework import use_pir_api
+from paddle.pir.core import _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE
 from paddle.utils import (
     assert_same_structure,
     copy_mutable_vars,
@@ -1382,11 +1383,55 @@ class OutputSelector:
                 return True
             return all(type(out) is type(outs[0]) for out in outs[1:])
 
+        def all_has_same_dtype(outs):
+            if len(outs) <= 1:
+                return True
+            return all(out.dtype == outs[0].dtype for out in outs[1:])
+
         def constant_to_variable_with_block(constant, block_context_manager):
             with block_context_manager():
                 return to_static_variable(constant)
 
+        def promote_precision(out_with_blocks):
+            def get_expected_precision(out_with_blocks):
+                if len(out_with_blocks) <= 1:
+                    return core.DataType.FLOAT32
+                # now only support FLOAT16 to FLOAT32
+                if any(
+                    out.dtype == core.DataType.FLOAT16
+                    for out, _ in out_with_blocks
+                ) and any(
+                    out.dtype == core.DataType.FLOAT32
+                    for out, _ in out_with_blocks
+                ):
+                    return core.DataType.FLOAT32
+                else:
+                    return out_with_blocks[0][0].dtype
+
+            # breakpoint()
+            new_outs = []
+            expected_dtype = get_expected_precision(out_with_blocks)
+            for out, block in out_with_blocks:
+                if expected_dtype != out.dtype:
+                    with block():
+                        out = paddle.cast(
+                            out, _PADDLE_PIR_DTYPE_2_NUMPY_DTYPE[expected_dtype]
+                        )
+                new_outs.append(out)
+            return new_outs
+
         if all(isinstance(out, paddle.pir.Value) for out in outs):
+            if in_pir_mode():
+                amp_attrs = core._get_amp_attrs()
+                amp_level = amp_attrs._amp_level
+                if (amp_level == core.AmpLevel.O2) and (
+                    not all_has_same_dtype(outs)
+                ):
+                    warnings.warn(
+                        f"Return results from different branches in cond has different type: true value is '{outs[0]}' and false value is '{outs[1]}', "
+                        "so we will promote the lower precision to the higher one."
+                    )
+                    return promote_precision(out_with_blocks)
             return outs
 
         if all(arg is None for arg in outs):

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1424,7 +1424,12 @@ class OutputSelector:
             if in_pir_mode():
                 amp_attrs = core._get_amp_attrs()
                 amp_level = amp_attrs._amp_level
-                if (amp_level == core.AmpLevel.O2) and (
+                apply_amp_level_list = [
+                    core.AmpLevel.O0,
+                    core.AmpLevel.O1,
+                    core.AmpLevel.O2,
+                ]
+                if (amp_level in apply_amp_level_list) and (
                     not all_has_same_dtype(outs)
                 ):
                     warnings.warn(

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1408,7 +1408,6 @@ class OutputSelector:
                 else:
                     return out_with_blocks[0][0].dtype
 
-            # breakpoint()
             new_outs = []
             expected_dtype = get_expected_precision(out_with_blocks)
             for out, block in out_with_blocks:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
在动转静amp下，出现了由于算子定义 / 用户自定义名单算子名单等原因，导致控制流下两分支dtype不一致的情况。为保证用户无感，我们应该修复这类情况导致的错误。

类型提升策略和 AMP level 同步：
* 不开 AMP 的情况下，不应该做该类型提升，严格校验 dtype 是否一致；
* 开 AMP 自动向高精度 cast，为低精度变量插 cast op；