### PR TITLE
[Prim][PIR] support huber_loss op forward in prim pir

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
+++ b/paddle/fluid/pir/dialect/op_generator/decomp_interface_gen_op_list.py
@@ -56,6 +56,7 @@ decomp_interface_declare_gen_op_list = [
     "squeeze",
     "stack",
     "unsqueeze",
+    "huber_loss",
 ]
 
 # come into effect in generated file op_decomp.cc
@@ -95,6 +96,7 @@ decomp_interface_implementation_gen_op_list = [
     "squeeze",
     "stack",
     "unsqueeze",
+    "huber_loss",
 ]
 
 

--- a/paddle/fluid/primitive/composite/composite.h
+++ b/paddle/fluid/primitive/composite/composite.h
@@ -209,6 +209,20 @@ Tensor pow_decomp(const Tensor& x, const paddle::Scalar& y) {
 }
 
 template <typename T>
+std::tuple<Tensor, Tensor> huber_loss_decomp(const Tensor& input,
+                                             const Tensor& label,
+                                             float delta) {
+  auto delta_full = full<T>(input.shape(), delta, input.dtype());
+  auto val = label - input;
+  auto abs_val = abs<T>(val);
+  auto ans = where<T>(abs_val <= delta_full,
+                      0.5 * val * val,
+                      delta_full * (abs_val - 0.5 * delta_full));
+  return std::make_tuple(cast<T>(ans, input.dtype()),
+                         cast<T>(val, input.dtype()));
+}
+
+template <typename T>
 Tensor one_hot_decomp(const Tensor& x, const Tensor& num_classes) {
   auto num_classes_tensor =
       backend::full_with_tensor<T>(num_classes, 0, x.dtype());

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2069,6 +2069,8 @@ void HuberLossInferMeta(const MetaTensor& input,
   auto out_dims = label_dims;
   residual->set_dims(out_dims);
   out->set_dims(out_dims);
+  out->set_dtype(input.dtype());
+  residual->set_dtype(input.dtype());
   out->share_lod(input);
 }
 

--- a/test/deprecated/legacy_test/test_huber_loss_op.py
+++ b/test/deprecated/legacy_test/test_huber_loss_op.py
@@ -29,7 +29,7 @@ def huber_loss_forward(val, delta):
         return delta * (abs_val - 0.5 * delta)
 
 
-def huber_loss_wraper(x, y, delta):
+def huber_loss_wrapper(x, y, delta):
     a = paddle._C_ops.huber_loss(x, y, delta)
     return a
 
@@ -37,8 +37,10 @@ def huber_loss_wraper(x, y, delta):
 class TestHuberLossOp(OpTest):
     def setUp(self):
         self.op_type = 'huber_loss'
+        self.prim_op_type = "comp"
         self.python_out_sig = ["Out"]
-        self.python_api = huber_loss_wraper
+        self.python_api = huber_loss_wrapper
+        self.public_python_api = huber_loss_wrapper
 
         self.delta = 1.0
         self.init_dtype()
@@ -65,7 +67,7 @@ class TestHuberLossOp(OpTest):
         return (100, 1)
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_prim_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad(['X', 'Y'], 'Out')
@@ -105,8 +107,10 @@ class TestHuberLossFP16Op(TestHuberLossOp):
 class TestHuberLossBF16Op(OpTest):
     def setUp(self):
         self.op_type = 'huber_loss'
+        self.prim_op_type = "comp"
         self.python_out_sig = ["Out"]
-        self.python_api = huber_loss_wraper
+        self.python_api = huber_loss_wrapper
+        self.public_python_api = huber_loss_wrapper
 
         self.delta = 1.0
         self.init_dtype()
@@ -142,7 +146,7 @@ class TestHuberLossBF16Op(OpTest):
         return (100, 1)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        self.check_output_with_place(self.place, check_prim_pir=True)
 
     def test_check_grad_normal(self):
         self.check_grad_with_place(self.place, ['X', 'Y'], 'Out')

--- a/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
+++ b/test/prim/pir_prim/test_prim_sub_graph_dynamic_shape.py
@@ -74,6 +74,10 @@ def index_sample_net(x, index):
     return paddle.index_sample(x, index)
 
 
+def huber_loss_net(x, label):
+    return paddle._C_ops.huber_loss(x, label, 1.0)
+
+
 def bce_loss_net(x, label):
     return paddle._C_ops.bce_loss(x, label)
 
@@ -318,6 +322,23 @@ class TestPrimTwoIndexSample(TestPrimTwo):
         self.y = np.random.random(self.shape_y).astype(self.dtype_y)
         self.net = index_sample_net
         self.necessary_ops = "pd_op.index_sample"
+        self.enable_cinn = False
+        self.tol = 1e-6
+
+
+class TestPrimHuberLoss(TestPrimTwo):
+    def setUp(self):
+        np.random.seed(2023)
+        self.x_shape = [100, 1]
+        self.y_shape = [100, 1]
+        self.dtype_x = "float32"
+        self.dtype_y = "float32"
+        self.init_x_shape = [None, None]
+        self.init_y_shape = [None, None]
+        self.x = np.random.uniform(0, 1.0, self.x_shape).astype(self.dtype_x)
+        self.y = np.random.uniform(0, 1.0, self.y_shape).astype(self.dtype_y)
+        self.net = huber_loss_net
+        self.necessary_ops = "pd_op.huber_loss"
         self.enable_cinn = False
         self.tol = 1e-6
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
[Prim][PIR] support huber_loss op forward in prim pir

huber_loss is a sub op for smooth_l1_loss，so it's also support smooth_l1_loss prim pir forward