### PR TITLE
[PIR][oneDNN] Avoid repeat warning logs

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -641,7 +641,7 @@ const std::vector<std::string> kPirMkldnnPasses {
       "fc_activation_fuse_pass",             //
 #if !defined(PADDLE_WITH_AVX512F) || !defined(PADDLE_WITH_MKLML) || \
     !defined(PADDLE_WITH_DNNL)
-  // self_attention_fuse_pass is not allowed under this defination
+  // self_attention_fuse_pass is not allowed under this definition
 #else
       "self_attention_fuse_pass",  //
 #endif

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -639,10 +639,8 @@ const std::vector<std::string> kPirMkldnnPasses {
       "matmul_add_act_fuse_pass",            //
       "fc_onednn_enable_pass",               //
       "fc_activation_fuse_pass",             //
-#if !defined(PADDLE_WITH_AVX512F) || !defined(PADDLE_WITH_MKLML) || \
-    !defined(PADDLE_WITH_DNNL)
-  // self_attention_fuse_pass is not allowed under this definition
-#else
+#if defined(PADDLE_WITH_AVX512F) && defined(PADDLE_WITH_MKLML) && \
+    defined(PADDLE_WITH_DNNL)
       "self_attention_fuse_pass",  //
 #endif
       "softplus_activation_fuse_pass",            //

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -624,32 +624,38 @@ const std::vector<std::string> kPirXpuPasses{// Functional pass
                                              "conv2d_bn_xpu_fuse_pass",
                                              "group_norm_silu_xpu_fuse_pass"};
 
-const std::vector<std::string> kPirMkldnnPasses{
-    "depthwise_conv_onednn_pass",
-    "squeeze_transpose_onednn_fuse_pass",
-    "conv2d_bias_fuse_pass",
-    "conv2d_transpose_bias_fuse_pass",
-    "conv3d_bias_fuse_pass",
-    "batch_norm_act_fuse_pass",
-    "scale_matmul_fuse_pass",
-    "reshape_transpose_matmul_fuse_pass",
-    "matmul_transpose_reshape_fuse_pass",
-    "matmul_elementwise_add_fuse_pass",
-    "matmul_activation_fuse_pass",
-    "matmul_add_act_fuse_pass",
-    "fc_onednn_enable_pass",
-    "fc_activation_fuse_pass",
-    "self_attention_fuse_pass",
-    "softplus_activation_fuse_pass",
-    "shuffle_channel_detect_pass",
-    "operator_reshape_onednn_fuse_pass",
-    "conv_elementwise_add_onednn_fuse_pass",
-    "conv_activation_onednn_fuse_pass",
-    "conv_concat_activation_onednn_fuse_pass",
-    "elementwise_act_onednn_fuse_pass",
-    "operator_unsqueeze_onednn_fuse_pass",
-    "operator_scale_onednn_fuse_pass",
-    "onednn_placement_pass"};
+const std::vector<std::string> kPirMkldnnPasses {
+  "depthwise_conv_onednn_pass",              //
+      "squeeze_transpose_onednn_fuse_pass",  //
+      "conv2d_bias_fuse_pass",               //
+      "conv2d_transpose_bias_fuse_pass",     //
+      "conv3d_bias_fuse_pass",               //
+      "batch_norm_act_fuse_pass",            //
+      "scale_matmul_fuse_pass",              //
+      "reshape_transpose_matmul_fuse_pass",  //
+      "matmul_transpose_reshape_fuse_pass",  //
+      "matmul_elementwise_add_fuse_pass",    //
+      "matmul_activation_fuse_pass",         //
+      "matmul_add_act_fuse_pass",            //
+      "fc_onednn_enable_pass",               //
+      "fc_activation_fuse_pass",             //
+#if !defined(PADDLE_WITH_AVX512F) || !defined(PADDLE_WITH_MKLML) || \
+    !defined(PADDLE_WITH_DNNL)
+  // self_attention_fuse_pass is not allowed under this defination
+#else
+      "self_attention_fuse_pass",  //
+#endif
+      "softplus_activation_fuse_pass",            //
+      "shuffle_channel_detect_pass",              //
+      "operator_reshape_onednn_fuse_pass",        //
+      "conv_elementwise_add_onednn_fuse_pass",    //
+      "conv_activation_onednn_fuse_pass",         //
+      "conv_concat_activation_onednn_fuse_pass",  //
+      "elementwise_act_onednn_fuse_pass",         //
+      "operator_unsqueeze_onednn_fuse_pass",      //
+      "operator_scale_onednn_fuse_pass",          //
+      "onednn_placement_pass"                     //
+};
 
 const std::vector<std::string> kPirCpuPasses{};
 

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -57,7 +57,7 @@ USE_PIR_PASS(matmul_activation_fuse_pass);
 USE_PIR_PASS(fc_onednn_enable_pass);
 USE_PIR_PASS(fc_activation_fuse_pass);
 #if !defined(PADDLE_WITH_AVX512F) || !defined(PADDLE_WITH_MKLML)
-// self_attention_fuse_pass is not allowed under this defination
+// self_attention_fuse_pass is not allowed under this definition
 #else
 USE_PIR_PASS(self_attention_fuse_pass);
 #endif

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -56,7 +56,11 @@ USE_PIR_PASS(matmul_elementwise_add_fuse_pass);
 USE_PIR_PASS(matmul_activation_fuse_pass);
 USE_PIR_PASS(fc_onednn_enable_pass);
 USE_PIR_PASS(fc_activation_fuse_pass);
+#if !defined(PADDLE_WITH_AVX512F) || !defined(PADDLE_WITH_MKLML)
+// self_attention_fuse_pass is not allowed under this defination
+#else
 USE_PIR_PASS(self_attention_fuse_pass);
+#endif
 USE_PIR_PASS(softplus_activation_fuse_pass);
 USE_PIR_PASS(shuffle_channel_detect_pass);
 USE_PIR_PASS(operator_reshape_onednn_fuse_pass);

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -56,9 +56,7 @@ USE_PIR_PASS(matmul_elementwise_add_fuse_pass);
 USE_PIR_PASS(matmul_activation_fuse_pass);
 USE_PIR_PASS(fc_onednn_enable_pass);
 USE_PIR_PASS(fc_activation_fuse_pass);
-#if !defined(PADDLE_WITH_AVX512F) || !defined(PADDLE_WITH_MKLML)
-// self_attention_fuse_pass is not allowed under this definition
-#else
+#if defined(PADDLE_WITH_AVX512F) && defined(PADDLE_WITH_MKLML)
 USE_PIR_PASS(self_attention_fuse_pass);
 #endif
 USE_PIR_PASS(softplus_activation_fuse_pass);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
During pattern matching process, the function `CanApplyOn()` will be called when the pattern is called. If we build Paddle on non-AVX512 platform, the pass `self_attention_fuse_pass` will be unavailable. Thus this function is called and output warnings as many times as the number of ops in the graph (a part of example log as below):
```
W0519 15:41:14.948200 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948204 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948207 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948210 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948212 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948215 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948218 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948220 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948223 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948225 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948228 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948231 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948235 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948239 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948242 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948244 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948247 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
W0519 15:41:14.948251 455668 self_attention_fuse_pass.cc:174] No-avx512 or MKL or oneDNN supported!
```
Hence we add macro to avoid such situations, by removing this pass in advance.