### PR TITLE
API Improvement: fix paddle.median 易用性提升

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -589,7 +589,10 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
                 index_along_axis * x_isnan, axis=axis, keepdim=True
             )
             nan_index_mask = paddle.sum(x_isnan, axis=axis, keepdim=True)
-            out_idx = out_idx * paddle.logical_not(nan_index_mask) + nan_index
+            out_idx = (
+                out_idx * paddle.logical_not(nan_index_mask).astype('int64')
+                + nan_index
+            )
 
     if is_flatten:
         if keepdim:

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -484,7 +484,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             Tensor(shape=[3, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
             [[3],
              [1],
-             [0]]))
+             [0]])
     """
     if not isinstance(x, (Variable, paddle.pir.Value)):
         raise TypeError("In median, the input x should be a Tensor.")

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -589,10 +589,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
                 index_along_axis * x_isnan, axis=axis, keepdim=True
             )
             nan_index_mask = paddle.sum(x_isnan, axis=axis, keepdim=True)
-            out_idx = (
-                out_idx * (~nan_index_mask.astype("bool")).astype("int64")
-                + nan_index
-            )
+            out_idx = out_idx * paddle.logical_not(nan_index_mask) + nan_index
 
     if is_flatten:
         if keepdim:

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -570,7 +570,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             paddle.cast(paddle.isnan(x), dtype=x.dtype) * x,
             axis=axis,
             keepdim=True,
-        )
+        ).astype(x.dtype)
         if need_idx:
             # replace index using the first nan value's index on axis for out_idx
             x_isnan = paddle.isnan(x)

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -423,6 +423,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
         .. code-block:: python
 
             >>> import paddle
+            >>> import numpy as np
 
             >>> x = paddle.arange(12).reshape([3, 4])
             >>> print(x)

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -468,7 +468,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
             >>> x = paddle.to_tensor(np.array([[1,2,3,float('nan')],[1,2,3,4],[float('nan'),1,2,3]])
 
             >>> y6 = paddle.median(x, axis=-1, keepdim=True)
-            >>> print(76)
+            >>> print(y6)
             Tensor(shape=[3, 1], dtype=float64, place=Place(cpu), stop_gradient=True,
             [[nan       ],
              [2.50000000],

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -391,7 +391,7 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
     Compute the median along the specified axis.
 
     Args:
-        x (Tensor): The input Tensor, it's data type can be float32, float64, int32, int64.
+        x (Tensor): The input Tensor, it's data type can be float16, float32, float64, int32, int64.
         axis (int, optional): The axis along which to perform median calculations ``axis`` should be int.
             ``axis`` should be in range [-D, D), where D is the dimensions of ``x`` .
             If ``axis`` is less than 0, it works the same way as :math:`axis + D`.

--- a/test/legacy_test/test_median.py
+++ b/test/legacy_test/test_median.py
@@ -215,6 +215,19 @@ class TestMedianAvg(unittest.TestCase):
             res_np = np.median(x, axis=axis, keepdims=keepdims)
             res_pd = paddle.median(paddle.to_tensor(x), axis, keepdims)
             self.check_numpy_res(res_pd.numpy(False), res_np.astype('float64'))
+            np.testing.assert_equal(res_pd.numpy(False).dtype, np.float32)
+
+    def test_output_dtype(self):
+        supported_dypes = ['float32', 'float64', 'int32', 'int64']
+        for inp_dtype in supported_dypes:
+            x = np.random.randint(low=-100, high=100, size=[2, 4, 5]).astype(
+                inp_dtype
+            )
+            res = paddle.median(paddle.to_tensor(x), mode='avg')
+            if inp_dtype == 'float64':
+                np.testing.assert_equal(res.numpy().dtype, np.float64)
+            else:
+                np.testing.assert_equal(res.numpy().dtype, np.float32)
 
 
 class TestMedianMin(unittest.TestCase):
@@ -292,7 +305,13 @@ class TestMedianMin(unittest.TestCase):
     def test_nan(self):
         paddle.disable_static()
         x = np.array(
-            [[1, 2, 3, float('nan')], [1, 2, 3, 4], [float('nan'), 1, 2, 3]]
+            [
+                [1, 2, 3, float('nan')],
+                [1, 2, 3, 4],
+                [float('nan'), 1, 2, 3],
+                [1, float('nan'), 3, float('nan')],
+                [float('nan'), float('nan'), 3, float('nan')],
+            ]
         )
         lis_tests = [
             [x.astype(dtype), axis, keepdims]
@@ -329,6 +348,16 @@ class TestMedianMin(unittest.TestCase):
                     paddle.to_tensor(x), axis, keepdims, mode='min'
                 )
             np.testing.assert_allclose(res_pd.numpy(False), res_np)
+            np.testing.assert_equal(res_pd.numpy(False).dtype, np.float16)
+
+    def test_output_dtype(self):
+        supported_dypes = ['float32', 'float64', 'int32', 'int64']
+        for inp_dtype in supported_dypes:
+            x = np.random.randint(low=-100, high=100, size=[2, 4, 5]).astype(
+                inp_dtype
+            )
+            res = paddle.median(paddle.to_tensor(x), mode='min')
+            np.testing.assert_equal(res.numpy().dtype, np.dtype(inp_dtype))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 paddle.median 在min分支下不支持输入为除浮点类型以外的类型。
由于paddle.topk不支持bool类型，如果不单独处理bool类型输入，avg和min分支都不能支持，是否需要对bool类型添加支持？