### PR TITLE
[PIR] Fix `ShareData_Op` name in `ALLOW_NO_GRAD_OPS`

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -92,7 +92,7 @@ ALLOW_NO_GRAD_OPS = [
     "pd_op.all",
     "pd_op.any",
     "pd_op.prior_box",
-    "pd_op.share_data",
+    "pd_op.share_data_",
     "pd_op.floor_divide",
 ]
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#64242 添加了 `pd_op.share_data` 到 `ALLOW_NO_GRAD_OPS`，但 #64195 将 `pd_op.share_data` rename 为 `pd_op.share_data_`，两个 PR 并行进行导致了冲突 :joy:，本 PR 进行修复～

cc @chen2016013 

PCard-66972