### PR TITLE
[PIR] Solve hash collision by using `unordered_set` in CSE

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1673,7 +1673,7 @@ PHI_DEFINE_EXPORTED_bool(
  * Note: If True, will apply CSE optimize pass in Dy2St.
  */
 PHI_DEFINE_EXPORTED_bool(enable_cse_in_dy2st,
-                         true,
+                         false,
                          "Apply CSE optimize pass in Dy2St");
 
 /**

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1673,7 +1673,7 @@ PHI_DEFINE_EXPORTED_bool(
  * Note: If True, will apply CSE optimize pass in Dy2St.
  */
 PHI_DEFINE_EXPORTED_bool(enable_cse_in_dy2st,
-                         false,
+                         true,
                          "Apply CSE optimize pass in Dy2St");
 
 /**

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -157,6 +157,9 @@ struct Expression {
   size_t hash() const { return GetOperationHash(op_); }
 
   bool equal_to(const Expression& other) const {
+    if (hash() != other.hash()) {
+      VLOG(0) << "~~~~~~~~~~~~~~~ Hash not equal! Why call equal_to?";
+    }
     bool is_equal = CheckOperationEqual(op_, other.op());
     // TODO(SigureMo): clean this check before merge
     if (!is_equal) {
@@ -409,6 +412,9 @@ struct ExpressionHash {
 
 struct ExpressionEqual {
   bool operator()(const Expression& lhs, const Expression& rhs) const {
+    if (lhs.hash() != rhs.hash()) {
+      VLOG(0) << "!!!!!!!!!!!!!!!! Hash not equal! Why call equal_to?";
+    }
     return lhs.equal_to(rhs);
   }
 };
@@ -438,10 +444,10 @@ struct ExpressionTable {
   std::optional<Expression> Lookup(Expression expr) {
     VLOG(7) << "[Lookup] op [" << expr.op() << "] " << expr.op()->name()
             << " start";
-    if (!common_exprs_.count(expr)) {
+    auto found_expr_iter = common_exprs_.find(expr);
+    if (found_expr_iter == common_exprs_.end()) {
       return std::nullopt;
     }
-    auto found_expr_iter = common_exprs_.find(expr);
     VLOG(7) << "[Lookup] op [" << expr.op() << "] " << expr.op()->name()
             << " found common subexpression: " << found_expr_iter->op()->name();
     return *found_expr_iter;

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -313,20 +313,20 @@ struct Expression {
       return true;
     }
     if (lhs->name() != rhs->name()) {
-      VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+      VLOG(0) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
               << " vs rhs [" << rhs << "] " << rhs->name() << " name not equal";
       return false;
     }
     for (auto attr_name : lhs->info().GetAttributesName()) {
       if (lhs->attribute(attr_name) != rhs->attribute(attr_name)) {
-        VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+        VLOG(0) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
                 << " vs rhs [" << rhs << "] " << rhs->name()
                 << " attribute not equal: " << attr_name;
         return false;
       }
     }
     if (lhs->num_operands() != rhs->num_operands()) {
-      VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+      VLOG(0) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
               << " vs rhs [" << rhs << "] " << rhs->name()
               << " num_operands not equal";
       return false;
@@ -348,7 +348,7 @@ struct Expression {
     }
     for (size_t i = 0; i < lhs_operands.size(); ++i) {
       if (!CheckValueEqual(lhs_operands[i], rhs_operands[i])) {
-        VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+        VLOG(0) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
                 << " vs rhs [" << rhs << "] " << rhs->name() << " operand " << i
                 << " not equal";
         return false;
@@ -361,13 +361,13 @@ struct Expression {
 
   bool CheckValueEqual(const pir::Value& lhs, const pir::Value& rhs) const {
     if (IsTerminateValue(lhs) != IsTerminateValue(rhs)) {
-      VLOG(7) << "[CheckValueEqual] lhs and rhs has different terminate type";
+      VLOG(0) << "[CheckValueEqual] lhs and rhs has different terminate type";
       return false;
     }
     // Compare two terminate values
     if (IsTerminateValue(lhs) && IsTerminateValue(rhs)) {
       if (lhs != rhs) {
-        VLOG(7) << "[CheckValueEqual] lhs and rhs has different terminate "
+        VLOG(0) << "[CheckValueEqual] lhs and rhs has different terminate "
                    "value";
         return false;
       }
@@ -375,15 +375,15 @@ struct Expression {
     }
     // Compare two non-terminate values
     if (!CheckOperationEqual(lhs.defining_op(), rhs.defining_op())) {
-      VLOG(7) << "[CheckValueEqual] lhs and rhs has different defining op";
+      VLOG(0) << "[CheckValueEqual] lhs and rhs has different defining op";
       return false;
     }
     if (lhs.type() != rhs.type()) {
-      VLOG(7) << "[CheckValueEqual] lhs and rhs has different type";
+      VLOG(0) << "[CheckValueEqual] lhs and rhs has different type";
       return false;
     }
     if (GetOpResultId(lhs) != GetOpResultId(rhs)) {
-      VLOG(7) << "[CheckValueEqual] lhs and rhs has different result id";
+      VLOG(0) << "[CheckValueEqual] lhs and rhs has different result id";
       return false;
     }
     return true;

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -307,6 +307,11 @@ struct Expression {
   bool CheckOperationEqual(pir::Operation* lhs, pir::Operation* rhs) const {
     VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
             << " vs rhs [" << rhs << "] " << rhs->name();
+    if (lhs == rhs) {
+      VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+              << " vs rhs [" << rhs << "] " << rhs->name() << " equal";
+      return true;
+    }
     if (lhs->name() != rhs->name()) {
       VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
               << " vs rhs [" << rhs << "] " << rhs->name() << " name not equal";
@@ -349,6 +354,8 @@ struct Expression {
         return false;
       }
     }
+    VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+            << " vs rhs [" << rhs << "] " << rhs->name() << " equal";
     return true;
   }
 
@@ -357,6 +364,7 @@ struct Expression {
       VLOG(7) << "[CheckValueEqual] lhs and rhs has different terminate type";
       return false;
     }
+    // Compare two terminate values
     if (IsTerminateValue(lhs) && IsTerminateValue(rhs)) {
       if (lhs != rhs) {
         VLOG(7) << "[CheckValueEqual] lhs and rhs has different terminate "
@@ -365,6 +373,7 @@ struct Expression {
       }
       return true;
     }
+    // Compare two non-terminate values
     if (!CheckOperationEqual(lhs.defining_op(), rhs.defining_op())) {
       VLOG(7) << "[CheckValueEqual] lhs and rhs has different defining op";
       return false;
@@ -382,8 +391,8 @@ struct Expression {
 
  private:
   pir::Operation* op_;
-  std::unordered_map<void*, std::pair<size_t, bool>>* op_info_registry_;
-  std::unordered_map<std::pair<void*, void*>, bool>* comparation_cache_;
+  std::unordered_map<void*, std::pair<size_t, bool>>*
+      op_info_registry_;  // owned by ExpressionTable
 };
 
 struct ExpressionHash {

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -157,7 +157,13 @@ struct Expression {
   size_t hash() const { return GetOperationHash(op_); }
 
   bool equal_to(const Expression& other) const {
-    return CheckOperationEqual(op_, other.op());
+    bool is_equal = CheckOperationEqual(op_, other.op());
+    // TODO(SigureMo): clean this check before merge
+    PADDLE_ENFORCE_EQ(
+        is_equal,
+        true,
+        common::errors::PreconditionNotMet("Hash collision detected."));
+    return is_equal;
   }
 
   bool CanBeSafeToReplace() const {

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -158,9 +158,10 @@ struct Expression {
 
   bool equal_to(const Expression& other) const {
     if (hash() != other.hash()) {
-      // NOTE(SigureMo): This is a default behavior of std::unordered_set. But
-      // it always calls equal_to on Windows. So we need to check hash first
-      // to avoid expensive equal_to call.
+      // NOTE(SigureMo): This is a default behavior of std::unordered_set on
+      // Linux. But it is not guaranteed by the standard. On Windows, it always
+      // calls equal_to even if hash is different. So we need to check hash
+      // first to avoid expensive equal_to call.
       return false;
     }
     bool is_equal = CheckOperationEqual(op_, other.op());

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -159,6 +159,12 @@ struct Expression {
   bool equal_to(const Expression& other) const {
     bool is_equal = CheckOperationEqual(op_, other.op());
     // TODO(SigureMo): clean this check before merge
+    if (!is_equal) {
+      VLOG(0) << "Hash collision detected. lhs: " << op_->name() << " [" << op_
+              << "] hash: " << GetOperationHash(op_)
+              << " vs rhs: " << other.op()->name() << " [" << other.op()
+              << "] hash: " << GetOperationHash(other.op());
+    }
     PADDLE_ENFORCE_EQ(
         is_equal,
         true,
@@ -315,6 +321,8 @@ struct Expression {
     if (lhs->name() != rhs->name()) {
       VLOG(0) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
               << " vs rhs [" << rhs << "] " << rhs->name() << " name not equal";
+      VLOG(0) << "lhs hash is " << GetOperationHash(lhs) << ", rhs hash is "
+              << GetOperationHash(rhs);
       return false;
     }
     for (auto attr_name : lhs->info().GetAttributesName()) {

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -165,17 +165,12 @@ struct Expression {
       return false;
     }
     bool is_equal = CheckOperationEqual(op_, other.op());
-    // TODO(SigureMo): clean this check before merge
     if (!is_equal) {
-      VLOG(0) << "Hash collision detected. lhs: " << op_->name() << " [" << op_
+      VLOG(7) << "Hash collision detected. lhs: " << op_->name() << " [" << op_
               << "] hash: " << GetOperationHash(op_)
               << " vs rhs: " << other.op()->name() << " [" << other.op()
               << "] hash: " << GetOperationHash(other.op());
     }
-    PADDLE_ENFORCE_EQ(
-        is_equal,
-        true,
-        common::errors::PreconditionNotMet("Hash collision detected."));
     return is_equal;
   }
 

--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -360,7 +360,7 @@ struct Expression {
   }
 
   bool CheckValueEqual(const pir::Value& lhs, const pir::Value& rhs) const {
-    if (IsTerminateValue(lhs) ^ IsTerminateValue(rhs)) {
+    if (IsTerminateValue(lhs) != IsTerminateValue(rhs)) {
       VLOG(7) << "[CheckValueEqual] lhs and rhs has different terminate type";
       return false;
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

#63960 优化 PR，利用 `unordered_map` 解决潜在的哈希冲突（极小概率，目前没遇到过，但是仍然是需要考虑的）

PCard-66972