### PR TITLE
[XPU] fix kernel fallback for compare_op bf16

### DIFF
--- a/paddle/phi/kernels/legacy/xpu/compare_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/compare_kernel.cc
@@ -83,6 +83,18 @@ DEFINE_XPU_COMPARE_RAW_KERNEL(GreaterEqual,
 
 }  // namespace phi
 
+PD_REGISTER_KERNEL(less_than_raw,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::LessThanRawKernel,
+                   int,
+                   int64_t,
+                   float,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
+}
+
 #define PD_REGISTER_COMPARE_RAW_KERNEL(name, func)        \
   PD_REGISTER_KERNEL(name##_raw,                          \
                      XPU,                                 \
@@ -97,7 +109,6 @@ DEFINE_XPU_COMPARE_RAW_KERNEL(GreaterEqual,
     kernel->OutputAt(0).SetDataType(phi::DataType::BOOL); \
   }
 
-PD_REGISTER_COMPARE_RAW_KERNEL(less_than, LessThan)
 PD_REGISTER_COMPARE_RAW_KERNEL(less_equal, LessEqual)
 PD_REGISTER_COMPARE_RAW_KERNEL(greater_than, GreaterThan)
 PD_REGISTER_COMPARE_RAW_KERNEL(greater_equal, GreaterEqual)

--- a/paddle/phi/kernels/legacy/xpu/compare_kernel.cc
+++ b/paddle/phi/kernels/legacy/xpu/compare_kernel.cc
@@ -83,17 +83,6 @@ DEFINE_XPU_COMPARE_RAW_KERNEL(GreaterEqual,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(less_than_raw,
-                   XPU,
-                   ALL_LAYOUT,
-                   phi::LessThanRawKernel,
-                   int,
-                   int64_t,
-                   float,
-                   phi::dtype::float16) {
-  kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
-}
-
 #define PD_REGISTER_COMPARE_RAW_KERNEL(name, func)        \
   PD_REGISTER_KERNEL(name##_raw,                          \
                      XPU,                                 \
@@ -103,10 +92,12 @@ PD_REGISTER_KERNEL(less_than_raw,
                      int64_t,                             \
                      float,                               \
                      phi::dtype::float16,                 \
+                     phi::dtype::bfloat16,                \
                      bool) {                              \
     kernel->OutputAt(0).SetDataType(phi::DataType::BOOL); \
   }
 
+PD_REGISTER_COMPARE_RAW_KERNEL(less_than, LessThan)
 PD_REGISTER_COMPARE_RAW_KERNEL(less_equal, LessEqual)
 PD_REGISTER_COMPARE_RAW_KERNEL(greater_than, GreaterThan)
 PD_REGISTER_COMPARE_RAW_KERNEL(greater_equal, GreaterEqual)

--- a/paddle/phi/kernels/xpu/compare_kernel.cc
+++ b/paddle/phi/kernels/xpu/compare_kernel.cc
@@ -81,6 +81,18 @@ DEFINE_XPU_COMPARE_KERNEL(GreaterEqual, xpu::broadcast_greater_equal<XPUType>)
 
 }  // namespace phi
 
+PD_REGISTER_KERNEL(less_than,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::LessThanKernel,
+                   int,
+                   int64_t,
+                   float,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
+}
+
 #define PD_REGISTER_COMPARE_KERNEL(name, func)            \
   PD_REGISTER_KERNEL(name,                                \
                      XPU,                                 \
@@ -95,7 +107,6 @@ DEFINE_XPU_COMPARE_KERNEL(GreaterEqual, xpu::broadcast_greater_equal<XPUType>)
     kernel->OutputAt(0).SetDataType(phi::DataType::BOOL); \
   }
 
-PD_REGISTER_COMPARE_KERNEL(less_than, LessThan)
 PD_REGISTER_COMPARE_KERNEL(less_equal, LessEqual)
 PD_REGISTER_COMPARE_KERNEL(greater_than, GreaterThan)
 PD_REGISTER_COMPARE_KERNEL(greater_equal, GreaterEqual)

--- a/paddle/phi/kernels/xpu/compare_kernel.cc
+++ b/paddle/phi/kernels/xpu/compare_kernel.cc
@@ -81,18 +81,6 @@ DEFINE_XPU_COMPARE_KERNEL(GreaterEqual, xpu::broadcast_greater_equal<XPUType>)
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(less_than,
-                   XPU,
-                   ALL_LAYOUT,
-                   phi::LessThanKernel,
-                   int,
-                   int64_t,
-                   float,
-                   phi::dtype::float16,
-                   phi::dtype::bfloat16) {
-  kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
-}
-
 #define PD_REGISTER_COMPARE_KERNEL(name, func)            \
   PD_REGISTER_KERNEL(name,                                \
                      XPU,                                 \
@@ -106,6 +94,8 @@ PD_REGISTER_KERNEL(less_than,
                      bool) {                              \
     kernel->OutputAt(0).SetDataType(phi::DataType::BOOL); \
   }
+
+PD_REGISTER_COMPARE_KERNEL(less_than, LessThan)
 PD_REGISTER_COMPARE_KERNEL(less_equal, LessEqual)
 PD_REGISTER_COMPARE_KERNEL(greater_than, GreaterThan)
 PD_REGISTER_COMPARE_KERNEL(greater_equal, GreaterEqual)

--- a/test/xpu/test_compare_op_xpu.py
+++ b/test/xpu/test_compare_op_xpu.py
@@ -24,13 +24,8 @@ from op_test import convert_float_to_uint16, convert_uint16_to_float
 from op_test_xpu import XPUOpTest
 
 import paddle
-from paddle.base import core
 
 
-@unittest.skipIf(
-    core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
-    "Unsupported on XPU3",
-)
 class TestCompareOpBase(XPUOpTest):
     def setUp(self):
         self.place = paddle.XPUPlace(0)
@@ -107,15 +102,15 @@ class XPUTestLessThanOP(XPUOpTestWrapper):
         def set_data(self):
             self.lbound = -200
             self.hbound = 200
-            self.x_shape = [128, 128, 512]
+            self.x_shape = [16, 64, 512]
             self.y_shape = [1]
 
     class LessThanOpTestCase5(LessThanOpTestCase1):
         def set_data(self):
             self.lbound = -100
             self.hbound = 100
-            self.x_shape = [128, 128, 512]
-            self.y_shape = [128, 128, 512]
+            self.x_shape = [16, 64, 512]
+            self.y_shape = [16, 64, 512]
 
     class LessThanOpTestCase_ZeroDim1(LessThanOpTestCase1):
         def set_data(self):
@@ -187,8 +182,8 @@ class XPUTestLessEqualOp(XPUOpTestWrapper):
         def set_data(self):
             self.lbound = -200
             self.hbound = 200
-            self.x_shape = [128, 128, 512]
-            self.y_shape = [128, 128, 512]
+            self.x_shape = [16, 64, 512]
+            self.y_shape = [16, 64, 512]
 
     class LessEqualOpTestCase_ZeroDim1(LessEqualOpTestCase1):
         def set_data(self):
@@ -232,14 +227,14 @@ class XPUTestGreaterThanOp(XPUOpTestWrapper):
         def set_data(self):
             self.lbound = -200
             self.hbound = 200
-            self.x_shape = [128, 128, 512]
-            self.y_shape = [128, 128, 512]
+            self.x_shape = [16, 64, 512]
+            self.y_shape = [16, 64, 512]
 
     class GreaterThanOpTestCase2(GreaterThanOpTestCase1):
         def set_data(self):
             self.lbound = -100
             self.hbound = 100
-            self.x_shape = [128, 128, 512]
+            self.x_shape = [16, 64, 512]
             self.y_shape = [1]
 
     class GreaterThanOpTestCase3(GreaterThanOpTestCase1):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. fix kernel fallback problem for bf16 comare ops and remove their tests form black list.