### PR TITLE
[Not Merge] fix cast error of paddle.median

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -538,12 +538,21 @@ def median(x, axis=None, keepdim=False, mode='avg', name=None):
                 out_idx = paddle.slice(
                     idx, axes=[axis], starts=[kth], ends=[kth + 1]
                 )
-
-    out_tensor = out_tensor + paddle.sum(
-        paddle.cast(paddle.isnan(x), dtype=dtype) * x.astype(dtype),
-        axis=axis,
-        keepdim=True,
-    )
+    if out_tensor.dtype in [
+        paddle.bool,
+        paddle.uint8,
+        paddle.int8,
+        paddle.int16,
+        paddle.int32,
+        paddle.int64,
+    ]:
+        pass
+    else:
+        out_tensor = out_tensor + paddle.sum(
+            paddle.cast(paddle.isnan(x), dtype=dtype) * x.astype(dtype),
+            axis=axis,
+            keepdim=True,
+        )
     if is_flatten:
         if keepdim:
             out_tensor = out_tensor.reshape([1] * dims)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Others


### PR Types
Bug fixes

### Description
card-73263

修复paddle.median新开发“min”模式中的cast error。
example：

import paddle
input = paddle.to_tensor(data=[1, 4, 6])
result = paddle.median(mode='min', x=input, axis=0)  

报错：TypeError: (InvalidType) Type promotion only support calculations between floating-point numbers and between complex and real numbers. But got different data type x: int64, y: float32.(at/paddle/paddle/phi/common/type_promotion.h:159)

min模式中并未对out_tensor做强制cast，但当输入x的dtype为整形时，在后面对nan的处理逻辑中报错如上。为了保持输入输出dtype的一致性，PR并为将out_tensor强制cast为float。而是根据整形数据不可能含有nan，对其做特殊逻辑判断。

