### PR TITLE
[CINN]Add Broadcast DimExpr simplification pattern

### DIFF
--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -959,13 +959,12 @@ struct FoldBroadcast {
 
   DimExpr Rewrite(const DimExpr& expr) {
     const auto& [operands] = expr.Get<Broadcast<DimExpr>>();
-    List<DimExpr> ret_operands = operands;
+    List<DimExpr> ret_operands;
     while (ret_operands->size() > 1) {
       int smaller = SearchInversedPair(ret_operands);
       if (smaller < 1) break;
       ret_operands->erase(ret_operands->begin() + smaller);
     }
-
     if (ret_operands->size() == 1) {
       return ret_operands->at(0);
     } else {
@@ -978,7 +977,6 @@ struct FoldBroadcast {
   // -1 if lhs < rhs
   int Compare(DimExpr lhs, DimExpr rhs) {
     DimExpr dim_expr_to_compare;
-
     auto Comparer =
         common::Overloaded{[&](const Mul<DimExpr>& mul) {
                              for (const auto& expr : *mul.operands) {

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -976,18 +976,20 @@ struct SimplifyBroadcast {
         [&](const Mul<DimExpr>& mul) {
           bool lhs_great_than_rhs = false;
           for (const auto& expr : *mul.operands) {
-            if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
+            if (expr == rhs)
+              lhs_great_than_rhs = true;
+            else if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
               return false;
-            if (expr == rhs) lhs_great_than_rhs = true;
           }
           return lhs_great_than_rhs;
         },
         [&](const Add<DimExpr>& add) {
           bool lhs_great_than_rhs = false;
           for (const auto& expr : *add.operands) {
-            if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
+            if (expr == rhs)
+              lhs_great_than_rhs = true;
+            else if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
               return false;
-            if (expr == rhs) lhs_great_than_rhs = true;
           }
           return lhs_great_than_rhs;
         },

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -974,20 +974,22 @@ struct SimplifyBroadcast {
   bool IsLhsGreatThanRhs(const DimExpr& lhs, const DimExpr& rhs) {
     auto LhsOperandsVisitor = common::Overloaded{
         [&](const Mul<DimExpr>& mul) {
+          bool lhs_great_than_rhs = false;
           for (const auto& expr : *mul.operands) {
             if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
               return false;
-            if (expr == rhs) return true;
+            if (expr == rhs) lhs_great_than_rhs = true;
           }
-          return false;
+          return lhs_great_than_rhs;
         },
         [&](const Add<DimExpr>& add) {
+          bool lhs_great_than_rhs = false;
           for (const auto& expr : *add.operands) {
             if (!expr.isa<std::int64_t>() && !expr.isa<std::string>())
               return false;
-            if (expr == rhs) return true;
+            if (expr == rhs) lhs_great_than_rhs = true;
           }
-          return false;
+          return lhs_great_than_rhs;
         },
         [&](const auto& lhs) { return false; }};
     return std::visit(LhsOperandsVisitor, lhs.variant());

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -160,4 +160,31 @@ TEST(Simplify, ConstantMaxMin) {
   ASSERT_TRUE((simplified_dim_expr2.Has<std::int64_t>()));
   ASSERT_EQ((simplified_dim_expr2.Get<std::int64_t>()), 2);
 }
+
+TEST(Simplify, FoldBroadcast) {
+  DimExpr sym0{"S0"};
+  DimExpr sym1{"S1"};
+  DimExpr mul{Mul<DimExpr>{{sym0, sym1}}};
+  DimExpr broadcast0{Broadcast<DimExpr>{{mul, sym0}}};
+  DimExpr broadcast1{Broadcast<DimExpr>{{sym1, mul}}};
+  DimExpr simplify_broadcast0 = SimplifyDimExpr(broadcast0);
+  DimExpr simplify_broadcast1 = SimplifyDimExpr(broadcast1);
+
+  DimExpr add{Add<DimExpr>{{sym0, sym1}}};
+  DimExpr broadcast2{Broadcast<DimExpr>{{add, sym0}}};
+  DimExpr broadcast3{Broadcast<DimExpr>{{sym1, add}}};
+  DimExpr simplify_broadcast2 = SimplifyDimExpr(broadcast2);
+  DimExpr simplify_broadcast3 = SimplifyDimExpr(broadcast3);
+
+  VLOG(0) << "broadcast2: " << broadcast2;
+  VLOG(0) << "broadcast3: " << broadcast3;
+  VLOG(0) << "simplify_broadcast2: " << simplify_broadcast2;
+  VLOG(0) << "simplify_broadcast3: " << simplify_broadcast3;
+
+  ASSERT_TRUE(simplify_broadcast0 == mul);
+  ASSERT_TRUE(simplify_broadcast1 == mul);
+  ASSERT_TRUE(simplify_broadcast2 == add);
+  ASSERT_TRUE(simplify_broadcast3 == add);
+}
+
 }  // namespace symbol::test

--- a/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
+++ b/test/cpp/pir/shape_dialect/simplify_dim_expr_test.cc
@@ -176,11 +176,6 @@ TEST(Simplify, FoldBroadcast) {
   DimExpr simplify_broadcast2 = SimplifyDimExpr(broadcast2);
   DimExpr simplify_broadcast3 = SimplifyDimExpr(broadcast3);
 
-  VLOG(0) << "broadcast2: " << broadcast2;
-  VLOG(0) << "broadcast3: " << broadcast3;
-  VLOG(0) << "simplify_broadcast2: " << simplify_broadcast2;
-  VLOG(0) << "simplify_broadcast3: " << simplify_broadcast3;
-
   ASSERT_TRUE(simplify_broadcast0 == mul);
   ASSERT_TRUE(simplify_broadcast1 == mul);
   ASSERT_TRUE(simplify_broadcast2 == add);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
pcard-76996
This PR adds a Broadcast DimExpr simplification pattern for Broadcast(A, B)  which A is obvious great than B. 
For example, Broadcast(S0, Add(S0, S1)) => Broadcast(S0, S1).