### PR TITLE
[CINN] fix cinn_dynamic_reshape_op_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/dynamic_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/dynamic_reshape_pass.cc
@@ -15,6 +15,7 @@
 #include "paddle/cinn/hlir/dialect/operator/transforms/dynamic_reshape_pass.h"
 
 #include "paddle/cinn/hlir/dialect/operator/ir/cinn_op.h"
+#include "paddle/cinn/hlir/dialect/operator/ir/generate_shape_util.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/manual_op.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
 #include "paddle/pir/include/core/builtin_type_interfaces.h"
@@ -27,34 +28,44 @@ namespace ir {
 bool ReplaceOpWithReshapeOp(pir::Operation* op,
                             pir::ShapeConstraintIRAnalysis* shape_analysis,
                             pir::PatternRewriter& rewriter) {  // NOLINT
+  pir::Value input = op->operand_source(0);
   pir::Value output = op->result(0);
-  // Try to Get more detail output info
-  const auto& GetOutputShape = [&]() -> std::vector<int> {
-    std::vector<int> shape = phi::vectorize<int>(
-        output.type().dyn_cast<pir::DenseTensorType>().dims());
+  const auto& input_shape =
+      shape_analysis->GetShapeOrDataForValue(input).shape();
+  const auto& output_shape =
+      shape_analysis->GetShapeOrDataForValue(output).shape();
 
-    const auto& shape_info =
-        shape_analysis->GetShapeOrDataForValue(op->result(0)).shape();
-    int temp_dim = -1;
+  std::vector<pir::Attribute> output_dim_expr_attrs{};
+  GenerateShapeOp::SymbolBindings symbol_bindings{};
 
-    for (size_t i = 0; i < shape_info.size(); ++i) {
-      if (shape_info[i].isa<int64_t>()) {
-        shape[i] = shape_info[i].Get<int64_t>();
-      } else {
-        shape[i] = temp_dim;
-        temp_dim = 1;
+  unsigned output_dim_idx = 0, input_dim_idx = 0;
+  int64_t local_dim_expr_id = 0;
+  for (; output_dim_idx < output_shape.size(); ++output_dim_idx) {
+    const auto& dim_expr = output_shape.at(output_dim_idx);
+    if (dim_expr.isa<int64_t>()) continue;
+    for (int next_input_dim_idx = input_dim_idx;
+         next_input_dim_idx < input_shape.size();
+         ++next_input_dim_idx) {
+      const auto& input_dim_expr = input_shape.at(next_input_dim_idx);
+      if (dim_expr == input_dim_expr) {
+        std::string sym_name = ToString(dim_expr);
+        if (!dim_expr.isa<std::string>()) {
+          sym_name = "SS" + std::to_string(local_dim_expr_id++);
+        }
+        output_dim_expr_attrs.emplace_back(ConvertDimExprToAttribute(
+            rewriter.ir_context(), ::symbol::DimExpr(sym_name)));
+        symbol_bindings.emplace_back(GenerateShapeOp::ShapeSymbolBinding{
+            sym_name, 0, next_input_dim_idx});
+        input_dim_idx = next_input_dim_idx + 1;
       }
     }
-    return shape;
-  };
+  }
+  auto cinn_generate_shape = rewriter.Build<cinn::dialect::GenerateShapeOp>(
+      std::vector<pir::Value>{input}, output_dim_expr_attrs, symbol_bindings);
+  auto pd_reshape = rewriter.Build<paddle::dialect::ReshapeOp>(
+      op->operand_source(0), cinn_generate_shape.result(0));
 
-  auto cinn_reshape = rewriter.Build<cinn::dialect::ReshapeOp>(
-      op->operand_source(0), GetOutputShape());
-
-  shape_analysis->SetShapeOrDataForValue(
-      cinn_reshape.result(0), shape_analysis->GetShapeOrDataForValue(output));
-
-  rewriter.ReplaceAllUsesWith(output, cinn_reshape.result(0));
+  rewriter.ReplaceAllUsesWith(output, pd_reshape.result(0));
   rewriter.EraseOp(op);
   return true;
 }

--- a/paddle/cinn/hlir/dialect/operator/transforms/dynamic_reshape_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/dynamic_reshape_pass.cc
@@ -42,7 +42,11 @@ bool ReplaceOpWithReshapeOp(pir::Operation* op,
   int64_t local_dim_expr_id = 0;
   for (; output_dim_idx < output_shape.size(); ++output_dim_idx) {
     const auto& dim_expr = output_shape.at(output_dim_idx);
-    if (dim_expr.isa<int64_t>()) continue;
+    if (dim_expr.isa<int64_t>()) {
+      output_dim_expr_attrs.emplace_back(
+          ConvertDimExprToAttribute(rewriter.ir_context(), dim_expr));
+      continue;
+    }
     for (int next_input_dim_idx = input_dim_idx;
          next_input_dim_idx < input_shape.size();
          ++next_input_dim_idx) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixed cinn_dynamic_reshape_op_pass by changing cinn_op.reshape to cinn_op.generate_shape + pd_op.reshape.