### PR TITLE
Replace platform::DeviceContextPool in fluid operators

### DIFF
--- a/paddle/fluid/operators/array_operator.h
+++ b/paddle/fluid/operators/array_operator.h
@@ -45,7 +45,7 @@ class ArrayOp : public framework::OperatorBase {
                                      i_tensor.dims()));
 
     // get device context from pool
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(place);
 
     size_t offset;

--- a/paddle/fluid/operators/array_to_lod_tensor_op.cc
+++ b/paddle/fluid/operators/array_to_lod_tensor_op.cc
@@ -51,7 +51,7 @@ struct ArrayToLoDFunctor {
 
   template <typename Place>
   void operator()(Place place) const {
-    auto &pool = platform::DeviceContextPool::Instance();
+    auto &pool = phi::DeviceContextPool::Instance();
     if (std::is_same<Place, phi::CPUPlace>::value) {
       Apply(static_cast<phi::CPUContext *>(pool.Get(place)));
     } else {

--- a/paddle/fluid/operators/beam_search_decode_op.h
+++ b/paddle/fluid/operators/beam_search_decode_op.h
@@ -39,8 +39,7 @@ struct BeamSearchDecodeFunctor {
       if (step_ids_origin_[0].place().GetType() == phi::AllocationType::GPU) {
         tensor_on_gpu_ = true;
       }
-      platform::DeviceContextPool& pool =
-          platform::DeviceContextPool::Instance();
+      phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
       auto* dev_ctx = pool.Get(step_ids_origin_[0].place());
       // Copy all tensors in the input tensor array
       for (auto& step_id : step_ids_origin_) {
@@ -62,8 +61,7 @@ struct BeamSearchDecodeFunctor {
           phi::AllocationType::GPU) {
         tensor_on_gpu_ = true;
       }
-      platform::DeviceContextPool& pool =
-          platform::DeviceContextPool::Instance();
+      phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
       auto* dev_ctx = pool.Get(step_scores_origin_[0].place());
       // Copy all tensors in the input tensor array
       for (auto& step_score : step_scores_origin_) {

--- a/paddle/fluid/operators/collective/c_allgather_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allgather_op_xpu.cc
@@ -93,7 +93,7 @@ class CAllGatherOpXPUKernel : public framework::OpKernel<T> {
     }
 
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<phi::XPUContext*>(dev_ctx)->x_context()->xpu_stream;
     }
 

--- a/paddle/fluid/operators/collective/c_allreduce_op.h
+++ b/paddle/fluid/operators/collective/c_allreduce_op.h
@@ -237,7 +237,7 @@ class CAllReduceOpXPUKernel : public framework::OpKernel<T> {
       VLOG(3) << "old BKCLCommContext has rid " << rid;
     }
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<phi::XPUContext*>(dev_ctx)->x_context()->xpu_stream;
     }
 
@@ -384,7 +384,7 @@ class CAllReduceOpCUDAKernel : public framework::OpKernel<T> {
     }
     if (ctx.Attr<bool>("use_calc_stream")) {
       // should not use global ctx for calc stream.
-      // auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      // auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       // stream = static_cast<phi::GPUContext*>(dev_ctx)->stream();
       stream = ctx.cuda_device_context().stream();
     }

--- a/paddle/fluid/operators/collective/c_broadcast_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op.cu.cc
@@ -64,11 +64,10 @@ class CBroadcastOpCUDAKernel : public framework::OpKernel<T> {
         VLOG(3) << "rank " << comm->rank() << " invoke Bcast. sent "
                 << x->numel();
         if (out != x) {
-          framework::TensorCopy(
-              *static_cast<const phi::DenseTensor*>(x),
-              place,
-              *platform::DeviceContextPool::Instance().Get(place),
-              static_cast<phi::DenseTensor*>(out));
+          framework::TensorCopy(*static_cast<const phi::DenseTensor*>(x),
+                                place,
+                                *phi::DeviceContextPool::Instance().Get(place),
+                                static_cast<phi::DenseTensor*>(out));
         }
       } else {
         PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclBcast(

--- a/paddle/fluid/operators/collective/c_broadcast_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_xpu.cc
@@ -72,7 +72,7 @@ class CBroadcastOpXPUKernel : public framework::OpKernel<T> {
       VLOG(3) << "old BKCLCommContext has rid " << ring_id;
     }
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<phi::XPUContext*>(dev_ctx)->x_context()->xpu_stream;
     }
     if (comm_ctx) {
@@ -92,11 +92,10 @@ class CBroadcastOpXPUKernel : public framework::OpKernel<T> {
         VLOG(3) << "rank " << comm->rank() << " invoke Bcast. sent "
                 << x->numel();
         if (out != x) {
-          framework::TensorCopy(
-              *static_cast<const phi::DenseTensor*>(x),
-              place,
-              *platform::DeviceContextPool::Instance().Get(place),
-              static_cast<phi::DenseTensor*>(out));
+          framework::TensorCopy(*static_cast<const phi::DenseTensor*>(x),
+                                place,
+                                *phi::DeviceContextPool::Instance().Get(place),
+                                static_cast<phi::DenseTensor*>(out));
         }
       } else {
         auto& dev_ctx = ctx.template device_context<phi::XPUContext>();

--- a/paddle/fluid/operators/collective/c_reduce_op.h
+++ b/paddle/fluid/operators/collective/c_reduce_op.h
@@ -180,7 +180,7 @@ class CReduceOpXPUKernel : public framework::OpKernel<T> {
       VLOG(3) << "old BKCLCommContext has rid " << rid;
     }
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<phi::XPUContext*>(dev_ctx)->x_context()->xpu_stream;
     }
 

--- a/paddle/fluid/operators/collective/c_scatter_op.cu.cc
+++ b/paddle/fluid/operators/collective/c_scatter_op.cu.cc
@@ -113,11 +113,10 @@ class CScatterOpCUDAKernel : public framework::OpKernel<T> {
       if (root_id == comm_ctx->GetRank()) {
         comm_ctx->Broadcast(
             const_cast<phi::DenseTensor*>(x), *x, root_id, stream);
-        framework::TensorCopy(
-            *static_cast<const phi::DenseTensor*>(x),
-            place,
-            *platform::DeviceContextPool::Instance().Get(place),
-            static_cast<phi::DenseTensor*>(&temp));
+        framework::TensorCopy(*static_cast<const phi::DenseTensor*>(x),
+                              place,
+                              *phi::DeviceContextPool::Instance().Get(place),
+                              static_cast<phi::DenseTensor*>(&temp));
       } else {
         comm_ctx->Broadcast(&temp, temp, root_id, stream);
       }
@@ -131,11 +130,10 @@ class CScatterOpCUDAKernel : public framework::OpKernel<T> {
             comm->comm(),
             stream));
 
-        framework::TensorCopy(
-            *static_cast<const phi::DenseTensor*>(x),
-            place,
-            *platform::DeviceContextPool::Instance().Get(place),
-            static_cast<phi::DenseTensor*>(&temp));
+        framework::TensorCopy(*static_cast<const phi::DenseTensor*>(x),
+                              place,
+                              *phi::DeviceContextPool::Instance().Get(place),
+                              static_cast<phi::DenseTensor*>(&temp));
       } else {
         PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::ncclBcast(
             out_ptr, numel, dtype, root_id, comm->comm(), stream));

--- a/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_softmax_with_cross_entropy_op_xpu.cc
@@ -305,7 +305,7 @@ struct CSoftmaxWithCrossEntropyFunctor<phi::XPUContext, T> {
       // NOTE(zhangxiaoci) use global calculate stream so that no sync is
       // required stream = comm->stream();
       stream = static_cast<phi::XPUContext*>(
-                   platform::DeviceContextPool::Instance().Get(place))
+                   phi::DeviceContextPool::Instance().Get(place))
                    ->stream();
       VLOG(3) << "old BKCLCommContext has ring_id " << rid;
     }

--- a/paddle/fluid/operators/collective/c_sync_calc_stream_op.h
+++ b/paddle/fluid/operators/collective/c_sync_calc_stream_op.h
@@ -43,7 +43,7 @@ class CSyncCalcStreamKernel : public framework::OpKernel<T> {
 
     auto place = ctx.GetPlace();
     auto dev_ctx = static_cast<phi::GPUContext*>(
-        platform::DeviceContextPool::Instance().Get(place));
+        phi::DeviceContextPool::Instance().Get(place));
 
     platform::GpuStreamSync(dev_ctx->stream());
 
@@ -55,7 +55,7 @@ class CSyncCalcStreamKernel : public framework::OpKernel<T> {
                           "Sync stream op can run on xpu place only for now."));
 
     auto dev_ctx = static_cast<phi::XPUContext*>(
-        platform::DeviceContextPool::Instance().Get(place));
+        phi::DeviceContextPool::Instance().Get(place));
     dev_ctx->Wait();
 #else
     PADDLE_THROW(phi::errors::PreconditionNotMet(

--- a/paddle/fluid/operators/collective/c_wait_comm_op.cc
+++ b/paddle/fluid/operators/collective/c_wait_comm_op.cc
@@ -52,7 +52,7 @@ class CWaitCommOp : public framework::OperatorBase {
 
     gpuStream_t compute_stream =
         static_cast<phi::GPUContext*>(
-            platform::DeviceContextPool::Instance().Get(place))
+            phi::DeviceContextPool::Instance().Get(place))
             ->stream();
     gpuStream_t comm_stream = nullptr;
     gpuEvent_t event = nullptr;

--- a/paddle/fluid/operators/collective/c_wait_compute_op.cc
+++ b/paddle/fluid/operators/collective/c_wait_compute_op.cc
@@ -52,7 +52,7 @@ class CWaitComputeOp : public framework::OperatorBase {
 
     gpuStream_t compute_stream =
         static_cast<phi::GPUContext*>(
-            platform::DeviceContextPool::Instance().Get(place))
+            phi::DeviceContextPool::Instance().Get(place))
             ->stream();
     gpuStream_t comm_stream = nullptr;
     gpuEvent_t event = nullptr;

--- a/paddle/fluid/operators/controlflow/conditional_block_op.h
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.h
@@ -80,21 +80,21 @@ class ConditionalOp : public framework::OperatorBase {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
       phi::DenseTensor cpu_tensor;
       framework::TensorCopy(*ips[0], phi::CPUPlace(), &cpu_tensor);
-      platform::DeviceContextPool::Instance().Get(ips[0]->place())->Wait();
+      phi::DeviceContextPool::Instance().Get(ips[0]->place())->Wait();
       res = cpu_tensor.data<bool>()[0];
 #endif
     } else if (ips[0]->place().GetType() == phi::AllocationType::XPU) {
 #ifdef PADDLE_WITH_XPU
       phi::DenseTensor cpu_tensor;
       framework::TensorCopy(*ips[0], phi::CPUPlace(), &cpu_tensor);
-      platform::DeviceContextPool::Instance().Get(ips[0]->place())->Wait();
+      phi::DeviceContextPool::Instance().Get(ips[0]->place())->Wait();
       res = cpu_tensor.data<bool>()[0];
 #endif
     } else if (ips[0]->place().GetType() == phi::AllocationType::CUSTOM) {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
       phi::DenseTensor cpu_tensor;
       framework::TensorCopy(*ips[0], phi::CPUPlace(), &cpu_tensor);
-      platform::DeviceContextPool::Instance().Get(ips[0]->place())->Wait();
+      phi::DeviceContextPool::Instance().Get(ips[0]->place())->Wait();
       res = cpu_tensor.data<bool>()[0];
 #endif
     } else {

--- a/paddle/fluid/operators/controlflow/control_flow_op_helper.h
+++ b/paddle/fluid/operators/controlflow/control_flow_op_helper.h
@@ -67,7 +67,7 @@ static void AssignZeroToOutsideTensor(const phi::Place &place,
   outside_tensor->Resize(input_tensor.dims());
   outside_tensor->mutable_data(place, input_tensor.dtype());
   const platform::DeviceContext *dev_ctx =
-      platform::DeviceContextPool::Instance().Get(place);
+      phi::DeviceContextPool::Instance().Get(place);
   phi::funcs::set_constant(*dev_ctx, outside_tensor, 0.0f);
   outside_tensor->set_lod(input_tensor.lod());
 }
@@ -166,7 +166,7 @@ static void AssignLocalGradientToParentScope(
       continue;
     }
     platform::DeviceContext *dev_ctx =
-        platform::DeviceContextPool::Instance().Get(place);
+        phi::DeviceContextPool::Instance().Get(place);
     framework::VisitVarType(*inside_var, AssignFunctor(outside_var, *dev_ctx));
   }
   // Assign zero to the grad_vars that are in outside_grads but not in

--- a/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
+++ b/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
@@ -51,8 +51,7 @@ class WriteToArrayOp : public ArrayOp {
     auto *out_tensor = &out->at(offset);
     out_tensor->set_lod(x_tensor.lod());
     if (x_tensor.memory_size() > 0) {
-      platform::DeviceContextPool &pool =
-          platform::DeviceContextPool::Instance();
+      phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
       auto &dev_ctx = *pool.Get(place);
 
       paddle::framework::TensorCopy(x_tensor, place, dev_ctx, out_tensor);
@@ -158,8 +157,7 @@ class ReadFromArrayOp : public ArrayOp {
     size_t offset = GetOffset(scope, place);
     if (offset < x_array.size()) {
       auto *out_tensor = out->GetMutable<phi::DenseTensor>();
-      platform::DeviceContextPool &pool =
-          platform::DeviceContextPool::Instance();
+      phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
       auto &dev_ctx = *pool.Get(place);
       framework::TensorCopy(x_array[offset], place, dev_ctx, out_tensor);
       out_tensor->set_lod(x_array[offset].lod());

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -87,7 +87,7 @@ class WhileOp : public framework::OperatorBase {
     auto *block = Attr<framework::BlockDesc *>(kStepBlock);
 
     // get device context from pool
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(dev_place);
 
     bool is_test = Attr<bool>("is_test");
@@ -125,7 +125,7 @@ class WhileOp : public framework::OperatorBase {
         scope.FindVar(Output(kStepScopes))->GetMutable<StepScopeVar>();
 
     if (!step_scopes->empty()) {
-      platform::DeviceContextPool::Instance().Get(dev_place)->Wait();
+      phi::DeviceContextPool::Instance().Get(dev_place)->Wait();
       for (auto &s : *step_scopes) {
         if (scope.HasKid(s)) {
           scope.DeleteScope(s);
@@ -332,7 +332,7 @@ class WhileGradOp : public framework::OperatorBase {
         phi::errors::InvalidArgument(
             "WhileGradOp is only callable when is_test is false."));
     // get device context from pool
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(dev_place);
 
     auto *block = Attr<framework::BlockDesc *>(kStepBlock);

--- a/paddle/fluid/operators/custom_device_common_op_registry.cc
+++ b/paddle/fluid/operators/custom_device_common_op_registry.cc
@@ -609,7 +609,7 @@ class CAllReduceOpCustomDeviceKernel : public framework::OpKernel<T> {
 
     std::shared_ptr<phi::stream::Stream> stream;
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                    ->GetStream();
     } else {
@@ -643,7 +643,7 @@ class CBroadcastOpCustomDeviceKernel : public framework::OpKernel<T> {
 
     std::shared_ptr<phi::stream::Stream> stream;
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                    ->GetStream();
     } else {
@@ -701,7 +701,7 @@ class BarrierOpCustomDeviceKernel : public framework::OpKernel<T> {
 
     std::shared_ptr<phi::stream::Stream> stream;
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                    ->GetStream();
     } else {
@@ -1019,7 +1019,7 @@ class GlobalScatterOpCustomDeviceKernel : public framework::OpKernel<T> {
 
       std::shared_ptr<phi::stream::Stream> stream;
       if (ctx.Attr<bool>("use_calc_stream")) {
-        auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
+        auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
         stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                      ->GetStream();
       } else {
@@ -1230,7 +1230,7 @@ class GlobalGatherOpCustomDeviceKernel : public framework::OpKernel<T> {
 
       std::shared_ptr<phi::stream::Stream> stream;
       if (ctx.Attr<bool>("use_calc_stream")) {
-        auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
+        auto dev_ctx = phi::DeviceContextPool::Instance().Get(place);
         stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                      ->GetStream();
       } else {

--- a/paddle/fluid/operators/custom_device_common_op_registry.cc
+++ b/paddle/fluid/operators/custom_device_common_op_registry.cc
@@ -529,7 +529,7 @@ class CSyncCalcStreamCustomDeviceKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto place = ctx.GetPlace();
     auto dev_ctx = static_cast<DeviceContext*>(
-        platform::DeviceContextPool::Instance().Get(place));
+        phi::DeviceContextPool::Instance().Get(place));
     dev_ctx->GetStream()->Synchronize();
   }
 };
@@ -609,7 +609,7 @@ class CAllReduceOpCustomDeviceKernel : public framework::OpKernel<T> {
 
     std::shared_ptr<phi::stream::Stream> stream;
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = paddle::platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                    ->GetStream();
     } else {
@@ -643,7 +643,7 @@ class CBroadcastOpCustomDeviceKernel : public framework::OpKernel<T> {
 
     std::shared_ptr<phi::stream::Stream> stream;
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = paddle::platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                    ->GetStream();
     } else {
@@ -663,11 +663,10 @@ class CBroadcastOpCustomDeviceKernel : public framework::OpKernel<T> {
       VLOG(3) << "rank " << comm->GetRank() << " invoke Bcast. sent "
               << x->numel();
       if (out != x) {
-        framework::TensorCopy(
-            *static_cast<const phi::DenseTensor*>(x),
-            place,
-            *platform::DeviceContextPool::Instance().Get(place),
-            static_cast<phi::DenseTensor*>(out));
+        framework::TensorCopy(*static_cast<const phi::DenseTensor*>(x),
+                              place,
+                              *phi::DeviceContextPool::Instance().Get(place),
+                              static_cast<phi::DenseTensor*>(out));
       }
     } else {
       phi::DeviceManager::CCLBroadcast(place.GetDeviceType(),
@@ -702,7 +701,7 @@ class BarrierOpCustomDeviceKernel : public framework::OpKernel<T> {
 
     std::shared_ptr<phi::stream::Stream> stream;
     if (ctx.Attr<bool>("use_calc_stream")) {
-      auto dev_ctx = paddle::platform::DeviceContextPool::Instance().Get(place);
+      auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
       stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                    ->GetStream();
     } else {
@@ -1020,8 +1019,7 @@ class GlobalScatterOpCustomDeviceKernel : public framework::OpKernel<T> {
 
       std::shared_ptr<phi::stream::Stream> stream;
       if (ctx.Attr<bool>("use_calc_stream")) {
-        auto dev_ctx =
-            paddle::platform::DeviceContextPool::Instance().Get(place);
+        auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
         stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                      ->GetStream();
       } else {
@@ -1232,8 +1230,7 @@ class GlobalGatherOpCustomDeviceKernel : public framework::OpKernel<T> {
 
       std::shared_ptr<phi::stream::Stream> stream;
       if (ctx.Attr<bool>("use_calc_stream")) {
-        auto dev_ctx =
-            paddle::platform::DeviceContextPool::Instance().Get(place);
+        auto dev_ctx = paddle::phi::DeviceContextPool::Instance().Get(place);
         stream = static_cast<paddle::platform::CustomDeviceContext*>(dev_ctx)
                      ->GetStream();
       } else {

--- a/paddle/fluid/operators/ipu/ipu_runtime_op.cc
+++ b/paddle/fluid/operators/ipu/ipu_runtime_op.cc
@@ -31,7 +31,7 @@ class IpuRuntimeOp : public framework::OperatorBase {
  private:
   void RunImpl(const framework::Scope& scope, const phi::Place& place) const {
     auto ipu_backend = platform::ipu::IpuBackend::GetInstance();
-    auto* dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+    auto* dev_ctx = phi::DeviceContextPool::Instance().Get(place);
     framework::RuntimeContext runtime_ctx(inputs_, outputs_, scope);
     framework::ExecutionContext ctx(*this, scope, *dev_ctx, runtime_ctx);
     auto inputs = ctx.MultiInput<phi::DenseTensor>("FeedList");

--- a/paddle/fluid/operators/isfinite_op.h
+++ b/paddle/fluid/operators/isfinite_op.h
@@ -50,7 +50,7 @@ bool TensorIsfinite(const phi::DenseTensor& tensor);
     void apply() const {                                                     \
       auto place = in_.place();                                              \
       auto* ctx = static_cast<phi::device##Context*>(                        \
-          platform::DeviceContextPool::Instance().Get(place));               \
+          phi::DeviceContextPool::Instance().Get(place));                    \
       phi::DenseTensor tmp;                                                  \
       tmp.Resize(in_.dims());                                                \
       out_->Resize({1});                                                     \

--- a/paddle/fluid/operators/load_combine_op.h
+++ b/paddle/fluid/operators/load_combine_op.h
@@ -73,7 +73,7 @@ class LoadCombineOpKernel : public framework::OpKernel<T> {
       std::istream *buffer,
       bool load_as_fp16,
       const std::vector<std::string> &out_var_names) const {
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(place);
     auto out_vars = context.MultiOutputVar("Out");
 

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -61,7 +61,7 @@ struct LoDTensorToArrayFunctor {
 
   template <typename Place>
   void operator()(Place place) const {
-    auto &pool = platform::DeviceContextPool::Instance();
+    auto &pool = phi::DeviceContextPool::Instance();
     auto *dev_ctx = pool.Get(place);
     if (std::is_same<Place, phi::CPUPlace>::value) {
       Apply(static_cast<phi::CPUContext *>(dev_ctx));

--- a/paddle/fluid/operators/memcpy_op.cc
+++ b/paddle/fluid/operators/memcpy_op.cc
@@ -89,7 +89,7 @@ class MemcpyKernel {
         true,
         phi::errors::NotFound("Output(Out) of memcpy_op is not found."));
     auto *out = ctx.OutputVar("Out");
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(ctx.GetPlace());
     auto dst_place_type = ctx.Attr<int>("dst_place_type");
     framework::VisitVarType(*x, MemcpyFunctor(out, dev_ctx, dst_place_type));

--- a/paddle/fluid/operators/pscore/heter_listen_and_serv_op.cc
+++ b/paddle/fluid/operators/pscore/heter_listen_and_serv_op.cc
@@ -125,7 +125,7 @@ void RunServer(
 void HeterListenAndServOp::RunImpl(const framework::Scope &scope,
                                    const phi::Place &dev_place) const {
   // Mark this as PS that it should decide profiling by listening from trainer.
-  platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+  phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
   auto &dev_ctx = *pool.Get(dev_place);
   VLOG(1) << "HeterListenAndServOp::RunImpl On gpu? "
           << platform::is_gpu_place(dev_place);

--- a/paddle/fluid/operators/pscore/send_and_recv_op.cc
+++ b/paddle/fluid/operators/pscore/send_and_recv_op.cc
@@ -41,7 +41,7 @@ class SendAndRecvKernel : public framework::OpKernel<T> {
     auto trainer_id = ctx.Attr<int>("trainer_id");
     auto mode = ctx.Attr<std::string>("mode");
 
-    platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
     auto& context = *pool.Get(place);
 
     distributed::HeterClient* rpc_client =

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -53,8 +53,7 @@ BufferedReader::BufferedReader(
   if (place_.GetType() == phi::AllocationType::GPU && !pin_memory) {
     int dev_idx = place_.device;  // NOLINT
     compute_stream_ =
-        ((phi::GPUContext *)(platform::DeviceContextPool::Instance().Get(
-             place_)))
+        ((phi::GPUContext *)(phi::DeviceContextPool::Instance().Get(place_)))
             ->stream();
     events_.resize(buffer_size);
     for (auto &event : events_) {
@@ -68,8 +67,7 @@ BufferedReader::BufferedReader(
   if (place_.GetType() == phi::AllocationType::XPU) {
     int dev_idx = place_.device;
     compute_stream_ =
-        ((phi::XPUContext *)(platform::DeviceContextPool::Instance().Get(
-             place_)))
+        ((phi::XPUContext *)(phi::DeviceContextPool::Instance().Get(place_)))
             ->stream();
     events_.resize(buffer_size);
     for (auto &event : events_) {
@@ -81,9 +79,10 @@ BufferedReader::BufferedReader(
 
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   if (place_.GetType() == phi::AllocationType::CUSTOM) {
-    auto stream = ((platform::CustomDeviceContext
-                        *)(platform::DeviceContextPool::Instance().Get(place_)))
-                      ->stream();
+    auto stream =
+        ((platform::CustomDeviceContext *)(phi::DeviceContextPool::Instance()
+                                               .Get(place_)))
+            ->stream();
     custom_device_compute_stream_ =
         std::make_shared<phi::stream::Stream>(place_, stream);
 

--- a/paddle/fluid/operators/save_combine_op.h
+++ b/paddle/fluid/operators/save_combine_op.h
@@ -191,7 +191,7 @@ class SaveCombineOpKernel : public framework::OpKernel<T> {
                           inp_var_names.size()));
 
     // get device context from pool
-    platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
     auto& dev_ctx = *pool.Get(place);
 
     if (inp_vars.size() > 0 && inp_vars[0]->IsType<phi::DenseTensor>()) {

--- a/paddle/fluid/operators/save_op.h
+++ b/paddle/fluid/operators/save_op.h
@@ -119,7 +119,7 @@ class SaveOpKernel : public framework::OpKernel<T> {
     VLOG(4) << "save output file_path: " << filename;
 
     // get device context from pool
-    platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
     auto& dev_ctx = *pool.Get(place);
 
     if (input_var->IsType<phi::DenseTensor>()) {

--- a/paddle/fluid/operators/seed_op.cu
+++ b/paddle/fluid/operators/seed_op.cu
@@ -29,8 +29,7 @@ class GPUSeedKernel : public framework::OpKernel<T> {
     auto force_cpu = context.Attr<bool>("force_cpu");
     bool cpu_place = force_cpu || context.GetPlace() == phi::CPUPlace();
     if (cpu_place) {
-      platform::DeviceContextPool &pool =
-          platform::DeviceContextPool::Instance();
+      phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
       auto &dev_ctx = *pool.Get(phi::CPUPlace());
       out->mutable_data<T>(phi::CPUPlace());
       phi::funcs::SetConstant<phi::CPUContext, T> functor;

--- a/paddle/fluid/operators/select_input_op.cc
+++ b/paddle/fluid/operators/select_input_op.cc
@@ -33,7 +33,7 @@ class SelectInputOp : public framework::OperatorBase {
  private:
   void RunImpl(const framework::Scope &scope,
                const phi::Place &dev_place) const override {
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(dev_place);
 
     auto &mask = scope.FindVar(Input("Mask"))->Get<phi::DenseTensor>();

--- a/paddle/fluid/operators/select_output_op.cc
+++ b/paddle/fluid/operators/select_output_op.cc
@@ -45,7 +45,7 @@ class SelectOutputOp : public framework::OperatorBase {
  private:
   void RunImpl(const framework::Scope &scope,
                const phi::Place &dev_place) const override {
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(dev_place);
 
     auto &mask = scope.FindVar(Input("Mask"))->Get<phi::DenseTensor>();

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -309,8 +309,8 @@ class TensorRTEngineOp : public framework::OperatorBase {
              t.dtype() == phi::DataType::INT64) &&
             is_shape_tensor) {
           std::vector<int> int32_host(t.numel());
-          paddle::platform::DeviceContextPool &pool =
-              paddle::platform::DeviceContextPool::Instance();
+          paddle::phi::DeviceContextPool &pool =
+              paddle::phi::DeviceContextPool::Instance();
 
           if (t.place().GetType() == phi::AllocationType::CPU) {
             auto &int32_tensor = t;
@@ -500,7 +500,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
               const phi::Place &dev_place,
               TensorRTEngine *engine) const {
     int runtime_batch = -1;
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(dev_place);
     auto stream = reinterpret_cast<const phi::GPUContext &>(dev_ctx).stream();
     std::vector<std::string> output_maps =

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -309,8 +309,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
              t.dtype() == phi::DataType::INT64) &&
             is_shape_tensor) {
           std::vector<int> int32_host(t.numel());
-          paddle::phi::DeviceContextPool &pool =
-              paddle::phi::DeviceContextPool::Instance();
+          phi::DeviceContextPool &pool = phi::DeviceContextPool::Instance();
 
           if (t.place().GetType() == phi::AllocationType::CPU) {
             auto &int32_tensor = t;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
修改 platform::DeviceContextPool 为 phi::DeviceContextPool 