### PR TITLE
【Hackathon 6th Fundable Projects 2 No.28】Fix modernize-avoid-c-arrays_3-final

### DIFF
--- a/paddle/fluid/distributed/ps/table/ssd_sparse_table.cc
+++ b/paddle/fluid/distributed/ps/table/ssd_sparse_table.cc
@@ -2615,7 +2615,7 @@ int32_t SSDSparseTable::LoadWithString(
     char* end = nullptr;
     int local_shard_id = i % _avg_local_shard_num;
     auto& shard = _local_shards[local_shard_id];
-    float data_buffer[FLAGS_pserver_load_batch_size *   // NOLINT
+    float data_buffer[FLAGS_pserver_load_batch_size *  // NOLINT
                       feature_value_size];
     float* data_buffer_ptr = data_buffer;
     uint64_t mem_count = 0;

--- a/paddle/fluid/distributed/ps/table/ssd_sparse_table.cc
+++ b/paddle/fluid/distributed/ps/table/ssd_sparse_table.cc
@@ -2615,8 +2615,8 @@ int32_t SSDSparseTable::LoadWithString(
     char* end = nullptr;
     int local_shard_id = i % _avg_local_shard_num;
     auto& shard = _local_shards[local_shard_id];
-    float data_buffer[FLAGS_pserver_load_batch_size *
-                      feature_value_size];  // NOLINT
+    float data_buffer[FLAGS_pserver_load_batch_size *   // NOLINT
+                      feature_value_size];
     float* data_buffer_ptr = data_buffer;
     uint64_t mem_count = 0;
     uint64_t ssd_count = 0;

--- a/paddle/fluid/distributed/test/graph_node_test.cc
+++ b/paddle/fluid/distributed/test/graph_node_test.cc
@@ -225,7 +225,7 @@ void testFeatureNodeSerializeFloat64() {
 // void testCache();
 void testGraphToBuffer();
 
-const char* edges[] = {"37\t45\t0.34",
+const char* edges[] = {"37\t45\t0.34",    // NOLINT
                        "37\t145\t0.31",
                        "37\t112\t0.21",
                        "96\t48\t1.4",
@@ -239,7 +239,7 @@ const char* edges[] = {"37\t45\t0.34",
                        "97\t111\t0.21"};  // NOLINT
 char edge_file_name[] = "edges.txt";      // NOLINT
 
-const char* nodes[] = {"user\t37\ta 0.34\tb 13 14\tc hello\td abc",
+const char* nodes[] = {"user\t37\ta 0.34\tb 13 14\tc hello\td abc",   // NOLINT
                        "user\t96\ta 0.31\tb 15 10\tc 96hello\td abcd",
                        "user\t59\ta 0.11\tb 11 14",
                        "user\t97\ta 0.11\tb 12 11",

--- a/paddle/fluid/distributed/test/graph_node_test.cc
+++ b/paddle/fluid/distributed/test/graph_node_test.cc
@@ -225,7 +225,7 @@ void testFeatureNodeSerializeFloat64() {
 // void testCache();
 void testGraphToBuffer();
 
-const char* edges[] = {"37\t45\t0.34",    // NOLINT
+const char* edges[] = {"37\t45\t0.34",  // NOLINT
                        "37\t145\t0.31",
                        "37\t112\t0.21",
                        "96\t48\t1.4",
@@ -239,7 +239,7 @@ const char* edges[] = {"37\t45\t0.34",    // NOLINT
                        "97\t111\t0.21"};  // NOLINT
 char edge_file_name[] = "edges.txt";      // NOLINT
 
-const char* nodes[] = {"user\t37\ta 0.34\tb 13 14\tc hello\td abc",   // NOLINT
+const char* nodes[] = {"user\t37\ta 0.34\tb 13 14\tc hello\td abc",  // NOLINT
                        "user\t96\ta 0.31\tb 15 10\tc 96hello\td abcd",
                        "user\t59\ta 0.11\tb 11 14",
                        "user\t97\ta 0.11\tb 12 11",

--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -90,8 +90,8 @@ constexpr char kTargetDialectPrefix[] = "pd_op.";  // NOLINT
 #ifdef PADDLE_WITH_DNNL
 constexpr char kOneDNNTargetDialectPrefix[] = "onednn_op.";  // NOLINT
 #endif
-constexpr char kCustomOpDialectPrefix[] = "custom_op.";
-constexpr char kEmptyVarName[] = "@EMPTY@";  // NOLINT
+constexpr char kCustomOpDialectPrefix[] = "custom_op.";  // NOLINT
+constexpr char kEmptyVarName[] = "@EMPTY@";              // NOLINT
 
 static const std::unordered_set<std::string> SpecialNonInplaceOps = {};
 

--- a/paddle/fluid/operators/pscore/listen_and_serv_op.cc
+++ b/paddle/fluid/operators/pscore/listen_and_serv_op.cc
@@ -14,11 +14,12 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
 
-constexpr char kLRDecayBlockId[] = "lr_decay_block_id";                        // NOLINT
-constexpr char kCheckpointBlockId[] = "checkpint_block_id";                    // NOLINT
-constexpr char kPrefetchVarNameToBlockId[] = "prefetch_var_name_to_block_id";  // NOLINT
-constexpr char kOptimizeBlocks[] = "optimize_blocks";                          // NOLINT
-constexpr char kSparseGradToParam[] = "sparse_grad_to_param";                  // NOLINT
+constexpr char kLRDecayBlockId[] = "lr_decay_block_id";      // NOLINT
+constexpr char kCheckpointBlockId[] = "checkpint_block_id";  // NOLINT
+constexpr char kPrefetchVarNameToBlockId[] =
+    "prefetch_var_name_to_block_id";                           // NOLINT
+constexpr char kOptimizeBlocks[] = "optimize_blocks";          // NOLINT
+constexpr char kSparseGradToParam[] = "sparse_grad_to_param";  // NOLINT
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/operators/pscore/listen_and_serv_op.cc
+++ b/paddle/fluid/operators/pscore/listen_and_serv_op.cc
@@ -14,11 +14,11 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
 
-constexpr char kLRDecayBlockId[] = "lr_decay_block_id";
-constexpr char kCheckpointBlockId[] = "checkpint_block_id";
-constexpr char kPrefetchVarNameToBlockId[] = "prefetch_var_name_to_block_id";
-constexpr char kOptimizeBlocks[] = "optimize_blocks";
-constexpr char kSparseGradToParam[] = "sparse_grad_to_param";
+constexpr char kLRDecayBlockId[] = "lr_decay_block_id";                        // NOLINT
+constexpr char kCheckpointBlockId[] = "checkpint_block_id";                    // NOLINT
+constexpr char kPrefetchVarNameToBlockId[] = "prefetch_var_name_to_block_id";  // NOLINT
+constexpr char kOptimizeBlocks[] = "optimize_blocks";                          // NOLINT
+constexpr char kSparseGradToParam[] = "sparse_grad_to_param";                  // NOLINT
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
@@ -28,8 +28,8 @@
 namespace paddle {
 namespace dialect {
 
-const char* ShardTensorOp::attributes_name[1] = {"op_dist_attr"};
-const char* ReshardOp::attributes_name[1] = {"op_dist_attr"};
+const char* ShardTensorOp::attributes_name[1] = {"op_dist_attr"};   // NOLINT
+const char* ReshardOp::attributes_name[1] = {"op_dist_attr"};       // NOLINT
 
 void ShardTensorOp::VerifySig() {
   VLOG(4)

--- a/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
+++ b/paddle/fluid/pir/dialect/distributed/ir/dist_op.cc
@@ -28,8 +28,8 @@
 namespace paddle {
 namespace dialect {
 
-const char* ShardTensorOp::attributes_name[1] = {"op_dist_attr"};   // NOLINT
-const char* ReshardOp::attributes_name[1] = {"op_dist_attr"};       // NOLINT
+const char* ShardTensorOp::attributes_name[1] = {"op_dist_attr"};  // NOLINT
+const char* ReshardOp::attributes_name[1] = {"op_dist_attr"};      // NOLINT
 
 void ShardTensorOp::VerifySig() {
   VLOG(4)

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -39,7 +39,7 @@ paddle::dialect::IfOp, paddle::dialect::WhileOp, paddle::dialect::HasElementsOp,
 
 using pir::TuplePopOp;
 using pir::TuplePushOp;
-constexpr char kStopGradientAttrName[] = "stop_gradient";
+constexpr char kStopGradientAttrName[] = "stop_gradient";  // NOLINT
 namespace paddle {
 namespace dialect {
 
@@ -826,8 +826,8 @@ void HasElementsOp::VerifySig() {
                         "The type of cf.has_elements' output is not correct."));
 }
 
-const char *AssertOp::attributes_name[1] = {"summarize"};
-const char AssertOp::ERROR_INFO_ATTR_NAME[] = "error_info";
+const char *AssertOp::attributes_name[1] = {"summarize"};   // NOLINT
+const char AssertOp::ERROR_INFO_ATTR_NAME[] = "error_info"; // NOLINT
 
 void AssertOp::Build(pir::Builder &builder,             // NOLINT
                      pir::OperationArgument &argument,  // NOLINT

--- a/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/control_flow_op.cc
@@ -826,8 +826,8 @@ void HasElementsOp::VerifySig() {
                         "The type of cf.has_elements' output is not correct."));
 }
 
-const char *AssertOp::attributes_name[1] = {"summarize"};   // NOLINT
-const char AssertOp::ERROR_INFO_ATTR_NAME[] = "error_info"; // NOLINT
+const char *AssertOp::attributes_name[1] = {"summarize"};    // NOLINT
+const char AssertOp::ERROR_INFO_ATTR_NAME[] = "error_info";  // NOLINT
 
 void AssertOp::Build(pir::Builder &builder,             // NOLINT
                      pir::OperationArgument &argument,  // NOLINT


### PR DESCRIPTION
### PR Category
Others

### PR Types
Bug fixes

### Description

修复了一部分修改 C 风格数组的工作。关于 op 的 C 字符数组未修改，使用 ```NOLINT``` 修饰。


相关链接：
https://github.com/PaddlePaddle/Paddle/issues/64128