### PR TITLE
[PIR][oneDNN] Add new pass conv2d_bn_onednn_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -627,6 +627,7 @@ const std::vector<std::string> kPirXpuPasses{// Functional pass
 const std::vector<std::string> kPirMkldnnPasses {
   "depthwise_conv_onednn_pass",              //
       "squeeze_transpose_onednn_fuse_pass",  //
+      "conv2d_bn_onednn_fuse_pass",          //
       "conv2d_bias_fuse_pass",               //
       "conv2d_transpose_bias_fuse_pass",     //
       "conv3d_bias_fuse_pass",               //

--- a/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.cc
@@ -1,0 +1,205 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.h"
+
+#include "paddle/fluid/pir/dialect/operator/ir/onednn_op.h"
+#include "paddle/fluid/pir/dialect/operator/ir/pd_op.h"
+#include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
+
+#include "paddle/pir/include/pass/pass.h"
+#include "paddle/pir/include/pass/pass_registry.h"
+
+namespace {
+
+class Conv2dBnOneDNNFusePattern
+    : public pir::OpRewritePattern<paddle::dialect::BatchNorm_Op> {
+ public:
+  using pir::OpRewritePattern<paddle::dialect::BatchNorm_Op>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::dialect::BatchNorm_Op op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    // The prev op should be conv2d op.
+    paddle::dialect::Conv2dOp conv2d_op =
+        pir::GetDefiningOpForInput(op, 0)
+            ->dyn_cast<paddle::dialect::Conv2dOp>();
+    if (!conv2d_op) return false;
+
+    auto conv2d_attributes = conv2d_op->attributes();
+    auto padding_algorithm = conv2d_attributes.at("padding_algorithm")
+                                 .dyn_cast<pir::StrAttribute>()
+                                 .AsString();
+    if (padding_algorithm != "EXPLICIT" && padding_algorithm != "SAME" &&
+        padding_algorithm != "VALID") {
+      return false;
+    }
+    auto data_format = conv2d_attributes.at("data_format")
+                           .dyn_cast<pir::StrAttribute>()
+                           .AsString();
+    if (data_format != "NCHW" && data_format != "AnyLayout" &&
+        data_format != "NHWC") {
+      return false;
+    }
+    auto groups =
+        conv2d_attributes.at("groups").dyn_cast<pir::Int32Attribute>().data();
+    if (groups < 1) {
+      return false;
+    }
+    if (!conv2d_op.out().HasOneUse()) return false;
+    // (bukejiyu): The bn
+    // outputs(mean_out\variance_out\saved_mean\saved_variance)
+    //  cannot be used in conv bn fusion
+    if (!op.mean_out().use_empty()) return false;
+    if (!op.variance_out().use_empty()) return false;
+    if (!op.saved_mean().use_empty()) return false;
+    if (!op.saved_variance().use_empty()) return false;
+
+    pir::Value conv2d_filter = conv2d_op.filter();
+    pir::Value bn_mean = op.mean();
+    pir::Value bn_variance = op.variance();
+    pir::Value bn_scale = op.scale();
+    pir::Value bn_bias = op.bias();
+
+    // --- deal with filter ---
+    auto bn_variance_shape = pir::GetShapeFromValue(bn_variance);
+    float epsilon = op.attribute<pir::FloatAttribute>("epsilon").data();
+    if (epsilon < 0.0f || epsilon > 0.001f) {
+      return false;
+    }
+    paddle::dialect::FullOp full_op =
+        rewriter.Build<paddle::dialect::FullOp>(bn_variance_shape, epsilon);
+    paddle::dialect::AddOp add_op =
+        rewriter.Build<paddle::dialect::AddOp>(bn_variance, full_op.out());
+    paddle::dialect::SqrtOp sqrt_op =
+        rewriter.Build<paddle::dialect::SqrtOp>(add_op.out());
+    paddle::dialect::DivideOp div_op =
+        rewriter.Build<paddle::dialect::DivideOp>(bn_scale, sqrt_op.out());
+    // reshape scale
+    auto conv2d_filter_shape = pir::GetShapeFromValue(conv2d_filter);
+    auto bn_scale_shape = pir::GetShapeFromValue(bn_scale);
+    std::vector<int64_t> bn_scale_new_shape(conv2d_filter_shape.size(), 1);
+    bn_scale_new_shape[0] = bn_scale_shape[0];
+    paddle::dialect::ReshapeOp reshape_scale_op =
+        rewriter.Build<paddle::dialect::ReshapeOp>(div_op.out(),
+                                                   bn_scale_new_shape);
+
+    paddle::onednn::dialect::FusedConv2dOp new_conv2d_op;
+
+    conv2d_attributes["force_fp32_output"] = rewriter.bool_attr(false);
+    conv2d_attributes["fuse_residual_connection"] = rewriter.bool_attr(false);
+    conv2d_attributes["mkldnn_data_type"] = rewriter.str_attr("float32");
+    conv2d_attributes["fuse_activation"] = rewriter.str_attr("");
+    conv2d_attributes["fuse_alpha"] = rewriter.float_attr(0.0f);
+    conv2d_attributes["fuse_beta"] = rewriter.float_attr(0.0f);
+    conv2d_attributes["scale_in"] = rewriter.float_attr(1.0f);
+    conv2d_attributes["scale_out"] = rewriter.float_attr(1.0f);
+    conv2d_attributes["scale_in_eltwise"] = rewriter.float_attr(1.0f);
+    conv2d_attributes["scale_weights"] =
+        rewriter.array_attr({rewriter.float_attr(1.0f)});
+
+    auto conv2d_filter_dtype = pir::GetDataTypeFromValue(conv2d_filter);
+    if (conv2d_filter_dtype.isa<pir::Float16Type>()) {
+      return false;
+    }
+    auto mul_op = rewriter.Build<paddle::dialect::MultiplyOp>(
+        conv2d_filter, reshape_scale_op.out());
+
+    // --- deal with bias ---
+    paddle::dialect::MultiplyOp mul_bias_op =
+        rewriter.Build<paddle::dialect::MultiplyOp>(bn_mean, div_op.out());
+    // new bias --> sub_op.out()
+    paddle::dialect::SubtractOp sub_op =
+        rewriter.Build<paddle::dialect::SubtractOp>(bn_bias, mul_bias_op.out());
+    // fuse new bias to fused_conv2d
+    new_conv2d_op = rewriter.Build<paddle::onednn::dialect::FusedConv2dOp>(
+        conv2d_op.input(),
+        mul_op.out(),
+        sub_op.out(),
+        pir::Value{},
+        conv2d_attributes);
+
+    rewriter.ReplaceAllUsesWith(op.out(), new_conv2d_op.output());
+
+    rewriter.EraseOp(op);
+    rewriter.EraseOp(conv2d_op);
+    return true;
+  }
+};
+
+class BatchNormReplacePattern
+    : public pir::OpRewritePattern<paddle::dialect::BatchNormOp> {
+ public:
+  using pir::OpRewritePattern<paddle::dialect::BatchNormOp>::OpRewritePattern;
+  bool MatchAndRewrite(
+      paddle::dialect::BatchNormOp op,
+      pir::PatternRewriter &rewriter) const override {  // NOLINT
+    auto bn_op =
+        rewriter.Build<paddle::dialect::BatchNorm_Op>(op.x(),
+                                                      op.mean(),
+                                                      op.variance(),
+                                                      op.scale(),
+                                                      op.bias(),
+                                                      op->attributes());
+    rewriter.ReplaceAllUsesWith(op.out(), bn_op.out());
+    rewriter.EraseOp(op);
+    return true;
+  }
+};
+
+class Conv2dBnOneDNNFusePass : public pir::PatternRewritePass {
+ public:
+  Conv2dBnOneDNNFusePass()
+      : pir::PatternRewritePass("conv2d_bn_onednn_fuse_pass", 2) {}
+
+  pir::RewritePatternSet InitializePatterns(pir::IrContext *context) override {
+    pir::RewritePatternSet ps(context);
+    auto conv_bn_onednn_pattern = std::make_unique<Conv2dBnOneDNNFusePattern>(
+        context,
+        1,
+        std::vector<std::string>{
+            paddle::dialect::FullOp::name(),
+            paddle::dialect::AddOp::name(),
+            paddle::dialect::SqrtOp::name(),
+            paddle::dialect::DivideOp::name(),
+            paddle::dialect::ReshapeOp::name(),
+            paddle::dialect::MultiplyOp::name(),
+            paddle::dialect::SubtractOp::name(),
+            paddle::dialect::Conv2dOp::name(),
+            paddle::onednn::dialect::FusedConv2dOp::name(),
+        });
+    auto bn_replace_pattern = std::make_unique<BatchNormReplacePattern>(
+        context,
+        1,
+        std::vector<std::string>{paddle::dialect::BatchNorm_Op::name()});
+
+    // bn->bn_replace
+    ps.Add(std::move(bn_replace_pattern));
+    // conv2d+bn->conv2d
+    ps.Add(std::move(conv_bn_onednn_pattern));
+    return ps;
+  }
+};
+
+}  // namespace
+
+namespace pir {
+
+std::unique_ptr<Pass> CreateConv2dBnOneDNNFusePass() {
+  return std::make_unique<Conv2dBnOneDNNFusePass>();
+}
+
+}  // namespace pir
+
+REGISTER_IR_PASS(conv2d_bn_onednn_fuse_pass, Conv2dBnOneDNNFusePass);

--- a/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.h
+++ b/paddle/fluid/pir/transforms/onednn/conv2d_bn_onednn_fuse_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/pir/include/core/dll_decl.h"
+
+namespace pir {
+
+class Pass;
+
+IR_API std::unique_ptr<Pass> CreateConv2dBnOneDNNFusePass();
+
+}  // namespace pir

--- a/paddle/fluid/pir/transforms/passes.h
+++ b/paddle/fluid/pir/transforms/passes.h
@@ -46,6 +46,7 @@ USE_PIR_PASS(remove_redundant_transpose_pass);
 USE_PIR_PASS(depthwise_conv_onednn_pass);
 USE_PIR_PASS(squeeze_transpose_onednn_fuse_pass);
 USE_PIR_PASS(batch_norm_act_fuse_pass);
+USE_PIR_PASS(conv2d_bn_onednn_fuse_pass);
 USE_PIR_PASS(conv2d_bias_fuse_pass);
 USE_PIR_PASS(conv2d_transpose_bias_fuse_pass);
 USE_PIR_PASS(conv3d_bias_fuse_pass);

--- a/test/ir/pir/fused_pass/onednn/test_conv2d_bn_onednn_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_conv2d_bn_onednn_fuse_pass.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from pass_test import PassTest
+
+import paddle
+
+paddle.enable_static()
+
+
+class TestConv2dBnOneDNNPassPattern(PassTest):
+    r"""
+    x_var   f_var
+      \      /
+       conv2d
+          |
+      BatchNorm
+    """
+
+    def is_program_valid(self, program=None):
+        return True
+
+    def build_ir_program(self):
+        with paddle.pir_utils.IrGuard():
+            main_prog = paddle.static.Program()
+            start_prog = paddle.static.Program()
+            with paddle.pir.core.program_guard(main_prog, start_prog):
+                x = paddle.static.data(
+                    name='x', shape=[3, 1, 28, 28], dtype='float32'
+                )
+                conv2d = paddle.nn.Conv2D(
+                    in_channels=1,
+                    out_channels=32,
+                    kernel_size=3,
+                    padding=1,
+                    data_format='NCHW',
+                    bias_attr=False,
+                )
+                bn = paddle.nn.BatchNorm2D(
+                    num_features=32,
+                    data_format='NCHW',
+                    use_global_stats=True,
+                )
+                out = bn(conv2d(x))
+                out = paddle.assign(out)
+                self.pass_attr_list = [{'conv2d_bn_onednn_fuse_pass': {}}]
+                self.feeds = {
+                    "x": np.random.random((3, 1, 28, 28)).astype("float32")
+                }
+                self.fetch_list = [out]
+                self.valid_op_map = {
+                    "onednn_op.fused_conv2d": 1,
+                    "pd_op.batch_norm": 0,
+                }
+                return [main_prog, start_prog]
+
+    def sample_program(self):
+        pir_program = self.build_ir_program()
+        yield pir_program, False
+
+    def test_check_output(self):
+        self.check_pass_correct()
+
+    def setUp(self):
+        self.places.append(paddle.CPUPlace())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/ir/pir/fused_pass/onednn/test_conv2d_bn_onednn_fuse_pass.py
+++ b/test/ir/pir/fused_pass/onednn/test_conv2d_bn_onednn_fuse_pass.py
@@ -64,7 +64,7 @@ class TestConv2dBnOneDNNPassPattern(PassTest):
                 self.fetch_list = [out]
                 self.valid_op_map = {
                     "onednn_op.fused_conv2d": 1,
-                    "pd_op.batch_norm": 0,
+                    "pd_op.batch_norm_": 0,
                 }
                 return [main_prog, start_prog]
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
In old scheme of fluid pass, `conv_bn_fuse_pass` is utilized when enabling oneDNN, to fuse `BatchNorm` into `Convolution`. However, due to new mechanism of PIR, the `BN` is splited into few small ops (add/mul/div/sqrt) and no longer directly fuse into `conv`, which also blocks future fusion of `conv+elemenwise_add`. Hence we add a new pass `conv2d_bn_onednn_fuse_pass`, in order to give back chances for following passes.

Take model `ppyolov2` as example, more ops are fused into `convs` instead of `elementwise ops`:
Before the PR:
```
--------------------------------
I0520 15:48:33.284662 791971 analysis_predictor.cc:1818] MKLDNN is enabled
I0520 15:48:33.284698 791971 analysis_predictor.cc:1942] Ir optimization is turned off, no ir pass will be executed.
--- Running analysis [ir_graph_build_pass]
I0520 15:48:33.289029 791971 executor.cc:187] Old Executor is Running.
--- Running analysis [ir_analysis_pass]
--- Running analysis [ir_params_sync_among_devices_pass]
--- Running analysis [adjust_cudnn_workspace_size_pass]
--- Running analysis [inference_op_replace_pass]
--- Running analysis [save_optimized_model_pass]
--- Running analysis [ir_graph_to_program_pass]
I0520 15:48:33.437140 791971 analysis_predictor.cc:2032] ======= ir optimization completed =======
I0520 15:48:33.438969 791971 naive_executor.cc:200] ---  skip [feed], feed -> scale_factor
I0520 15:48:33.438977 791971 naive_executor.cc:200] ---  skip [feed], feed -> image
I0520 15:48:33.438982 791971 naive_executor.cc:200] ---  skip [feed], feed -> im_shape
I0520 15:48:33.440759 791971 naive_executor.cc:200] ---  skip [save_infer_model/scale_0.tmp_0], fetch -> fetch
I0520 15:48:33.440766 791971 naive_executor.cc:200] ---  skip [save_infer_model/scale_1.tmp_0], fetch -> fetch
--- Running PIR pass [depthwise_conv_mkldnn_pass]
--- Running PIR pass [squeeze_transpose_onednn_fuse_pass]
--- Running PIR pass [conv2d_bn_fuse_pass]
I0520 15:48:33.470760 791971 print_statistics.cc:57] --- detected [101] subgraphs!
--- Running PIR pass [conv2d_bias_fuse_pass]
--- Running PIR pass [conv2d_transpose_bias_fuse_pass]
--- Running PIR pass [conv3d_bias_fuse_pass]
--- Running PIR pass [batch_norm_act_fuse_pass]
I0520 15:48:33.476953 791971 print_statistics.cc:57] --- detected [3] subgraphs!
--- Running PIR pass [scale_matmul_fuse_pass]
--- Running PIR pass [reshape_transpose_matmul_fuse_pass]
--- Running PIR pass [matmul_transpose_reshape_fuse_pass]
--- Running PIR pass [matmul_elementwise_add_fuse_pass]
--- Running PIR pass [matmul_activation_fuse_pass]
--- Running PIR pass [matmul_add_act_fuse_pass]
--- Running PIR pass [fc_onednn_enable_pass]
--- Running PIR pass [fc_activation_fuse_pass]
--- Running PIR pass [softplus_activation_fuse_pass]
--- Running PIR pass [operator_reshape_onednn_fuse_pass]
--- Running PIR pass [conv_elementwise_add_onednn_fuse_pass]
--- Running PIR pass [conv_activation_mkldnn_fuse_pass]
--- Running PIR pass [conv_concat_activation_mkldnn_fuse_pass]
--- Running PIR pass [elementwise_act_onednn_fuse_pass]
I0520 15:48:33.558969 791971 print_statistics.cc:57] --- detected [201] subgraphs!
```
After the PR:
```
--------------------------------------------
I0522 17:16:46.324308 1063842 analysis_predictor.cc:1825] MKLDNN is enabled
I0522 17:16:46.324334 1063842 analysis_predictor.cc:1949] Ir optimization is turned off, no ir pass will be executed.
--- Running analysis [ir_graph_build_pass]
I0522 17:16:46.329386 1063842 executor.cc:187] Old Executor is Running.
--- Running analysis [ir_analysis_pass]
--- Running analysis [ir_params_sync_among_devices_pass]
--- Running analysis [adjust_cudnn_workspace_size_pass]
--- Running analysis [inference_op_replace_pass]
--- Running analysis [save_optimized_model_pass]
--- Running analysis [ir_graph_to_program_pass]
I0522 17:16:46.490196 1063842 analysis_predictor.cc:2039] ======= ir optimization completed =======
I0522 17:16:46.492125 1063842 naive_executor.cc:200] ---  skip [feed], feed -> scale_factor
I0522 17:16:46.492131 1063842 naive_executor.cc:200] ---  skip [feed], feed -> image
I0522 17:16:46.492133 1063842 naive_executor.cc:200] ---  skip [feed], feed -> im_shape
I0522 17:16:46.494035 1063842 naive_executor.cc:200] ---  skip [save_infer_model/scale_0.tmp_0], fetch -> fetch
I0522 17:16:46.494041 1063842 naive_executor.cc:200] ---  skip [save_infer_model/scale_1.tmp_0], fetch -> fetch
--- Running PIR pass [depthwise_conv_mkldnn_pass]
--- Running PIR pass [squeeze_transpose_onednn_fuse_pass]
--- Running PIR pass [conv2d_bn_onednn_fuse_pass]
I0522 17:16:46.527418 1063842 print_statistics.cc:57] --- detected [101] subgraphs!
--- Running PIR pass [conv2d_bias_fuse_pass]
--- Running PIR pass [conv2d_transpose_bias_fuse_pass]
--- Running PIR pass [conv3d_bias_fuse_pass]
--- Running PIR pass [batch_norm_act_fuse_pass]
I0522 17:16:46.532963 1063842 print_statistics.cc:57] --- detected [3] subgraphs!
--- Running PIR pass [scale_matmul_fuse_pass]
--- Running PIR pass [reshape_transpose_matmul_fuse_pass]
--- Running PIR pass [matmul_transpose_reshape_fuse_pass]
--- Running PIR pass [matmul_elementwise_add_fuse_pass]
--- Running PIR pass [matmul_activation_fuse_pass]
--- Running PIR pass [matmul_add_act_fuse_pass]
--- Running PIR pass [fc_onednn_enable_pass]
--- Running PIR pass [fc_activation_fuse_pass]
--- Running PIR pass [softplus_activation_fuse_pass]
--- Running PIR pass [operator_reshape_onednn_fuse_pass]
--- Running PIR pass [conv_elementwise_add_onednn_fuse_pass]
I0522 17:16:46.550860 1063842 print_statistics.cc:57] --- detected [16] subgraphs!
--- Running PIR pass [conv_activation_mkldnn_fuse_pass]
I0522 17:16:46.583005 1063842 print_statistics.cc:57] --- detected [97] subgraphs!
--- Running PIR pass [conv_concat_activation_mkldnn_fuse_pass]
--- Running PIR pass [elementwise_act_onednn_fuse_pass]
I0522 17:16:46.617475 1063842 print_statistics.cc:57] --- detected [104] subgraphs!
```