### PR TITLE
[CINN]fix InferSymbolicShape for assign_value_

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -24,12 +24,14 @@ inline ExprVec GetExprVecFromData(const ShapeOrData &shapeordata) {
     TensorListExprs list =
         shapeordata.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
     for (size_t i = 0; i < list.size(); i++) {
+      CHECK(list[i].data().has_value());
       for (auto expr : list[i].data().value()) {
         result.emplace_back(expr);
       }
     }
     return result;
   } else {
+    CHECK(shapeordata.data().has_value());
     return shapeordata.data().value();
   }
 }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -72,7 +72,7 @@ bool AssignValueOpInferSymbolicShape(
                          .data()
                          .to<int64_t>());
   }
-  if (values.size() > 0) {
+  if (values.size() > 0 && sym_dims.size() == 1) {
     std::vector<symbol::DimExpr> data;
     for (const auto &value : values) {
       data.emplace_back(symbol::DimExpr(value));

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -72,9 +72,11 @@ bool AssignValueOpInferSymbolicShape(
                          .data()
                          .to<int64_t>());
   }
-  if (values.size() == 1) {
-    std::vector<symbol::DimExpr> data{values[0]};
-
+  if (values.size() > 0) {
+    std::vector<symbol::DimExpr> data;
+    for (const auto &value : values) {
+      data.emplace_back(symbol::DimExpr(value));
+    }
     symbol::ShapeOrDataDimExprs shape_data{
         symbol::TensorShapeOrDataDimExprs(sym_dims, data)};
     infer_context->SetShapeOrDataForValue(op->result(0), shape_data);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR fixes InferSymbolicShape for assign_value_ and adds check in GetExprVecFromData.