### PR TITLE
GEMM_Epilogue bugFix, cutlass does not support alignment less than 8

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
@@ -96,6 +96,9 @@ class MatmulAddPattern : public paddle::drr::DrrPatternBase {
           }
           return y_dims.at(y_dims.size() - 1) == w_dims.at(1);
         }
+        if (w_dims[0] % 8 != 0 || w_dims[1] % 8 != 0) {
+          return false;
+        }
       }
       return false;
     });

--- a/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
@@ -58,6 +58,7 @@ class MatmulAddPattern : public paddle::drr::DrrPatternBase {
     pat.AddConstraint([&](const paddle::drr::MatchContext &match_ctx) {
       auto w_dtype = pir::GetDataTypeFromValue(match_ctx.Tensor("w"));
       if (!w_dtype.isa<pir::Float16Type>() &&
+          !w_dtype.isa<pir::BFloat16Type>() &&
           !w_dtype.isa<pir::Float32Type>() &&
           !w_dtype.isa<pir::Float64Type>()) {
         return false;

--- a/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
@@ -96,7 +96,10 @@ class MatmulAddPattern : public paddle::drr::DrrPatternBase {
           }
           return y_dims.at(y_dims.size() - 1) == w_dims.at(1);
         }
-        if (w_dims[0] % 8 != 0 || w_dims[1] % 8 != 0) {
+        // gemm_epilogue kernel requires gemm's N and K to be 8 aligned.
+        // K and N correspond to w_dims[0] and w_dims[1] respectively.
+        int cutlass_align = 8;
+        if (w_dims[0] % cutlass_align != 0 || w_dims[1] % cutlass_align != 0) {
           return false;
         }
       }

--- a/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/matmul_add_act_fuse_pass.cc
@@ -98,7 +98,7 @@ class MatmulAddPattern : public paddle::drr::DrrPatternBase {
         }
         // gemm_epilogue kernel requires gemm's N and K to be 8 aligned.
         // K and N correspond to w_dims[0] and w_dims[1] respectively.
-        int cutlass_align = 8;
+        constexpr int cutlass_align = 8;
         if (w_dims[0] % cutlass_align != 0 || w_dims[1] % cutlass_align != 0) {
           return false;
         }


### PR DESCRIPTION
### PR Category
Others


### PR Types
Bug fixes


### Description
P-card-71501
bugFix, GEMM_Epilogue kernel does not support alignment less than 8. we filter this condition in pass.
