### PR TITLE
[PIR save/load] Add fetch_targets and open tests

### DIFF
--- a/test/deprecated/legacy_test/test_save_model_without_var.py
+++ b/test/deprecated/legacy_test/test_save_model_without_var.py
@@ -17,9 +17,11 @@ import warnings
 
 import paddle
 from paddle import base
+from paddle.pir_utils import test_with_pir_api
 
 
 class TestSaveModelWithoutVar(unittest.TestCase):
+    @test_with_pir_api
     def test_no_var_save(self):
         data = paddle.static.data(name='data', shape=[-1, 1], dtype='float32')
         data_plus = data + 1


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
pcard-67164
Add fetch_targets and open tests:
- 为load_pir_inference_model添加获取fetch_targets的代码，并返回（此处注意fetch_target内容为fetch op的输入，不是输出，否则会在执行器中再次添加fetch op）
- 开启单测test_save_model_without_var.py， test_static_save_load.py