### PR TITLE
Add nccl async time profiler

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1578,6 +1578,19 @@ PHI_DEFINE_EXPORTED_bool(enable_async_trace,
                          false,
                          "enable collective async trace");
 
+/**
+ * ProcessGroupNCCL related FLAG
+ * Name: enable_async_time_profiler
+ * Since Version:
+ * Value Range: bool, default=false
+ * Example:
+ * Note: enable nccl async time profiler.
+ */
+
+PHI_DEFINE_EXPORTED_bool(enable_async_time_profiler,
+                         false,
+                         "enable collective async time profiler");
+
 PHI_DEFINE_EXPORTED_int32(async_trace_count, 5, "collective async trace count");
 
 PHI_DEFINE_EXPORTED_bool(

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -25,6 +25,8 @@
 #include "paddle/phi/core/distributed/check/static_check.h"
 #include "paddle/phi/core/distributed/comm_context_manager.h"
 #include "paddle/phi/core/distributed/comm_task_manager.h"
+#include "paddle/phi/core/distributed/nccl_async_recorder.h"
+#include "paddle/phi/core/distributed/nccl_async_time_profiler.h"
 #include "paddle/phi/core/distributed/nccl_comm_task.h"
 #include "paddle/phi/core/distributed/nccl_tools.h"
 #include "paddle/phi/core/distributed/utils.h"
@@ -37,6 +39,7 @@ COMMON_DECLARE_bool(nccl_blocking_wait);
 COMMON_DECLARE_bool(use_stream_safe_cuda_allocator);
 COMMON_DECLARE_bool(use_cuda_malloc_async_allocator);
 COMMON_DECLARE_bool(enable_async_trace);
+COMMON_DECLARE_bool(enable_async_time_profiler);
 
 // set this flag to `true` and recompile to enable dynamic checks
 constexpr bool FLAGS_enable_nccl_dynamic_check = false;
@@ -124,7 +127,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     int size,
     int gid,
     int64_t timeout,
-    int nccl_comm_init_option)
+    int nccl_comm_init_option,
+    std::string recorder_name)
     : ProcessGroupWithStream(rank, size, gid),
       store_(store),
       place_to_calc_event_(),
@@ -134,16 +138,24 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       place_to_group_key_(),
       pg_timeout_(timeout),
       nccl_comm_init_option_(nccl_comm_init_option),
+      recorder_name_(recorder_name),
       allocation_stream_pairs() {
   LOG(INFO) << "ProcessGroupNCCL pg_timeout_ " << pg_timeout_;
   LOG(INFO) << "ProcessGroupNCCL nccl_comm_init_option_ "
             << nccl_comm_init_option_;
+  if (FLAGS_enable_async_time_profiler) {
+    phi::distributed::NCCLAsyncTimeProfiler::GetInstance().RegisterTimer(
+        gid_, rank_, recorder_name_);
+  }
 }
 ProcessGroupNCCL::~ProcessGroupNCCL() {
   LOG(INFO) << "ProcessGroupNCCL destruct ";
   if (FLAGS_enable_async_trace) {
     auto& comm_task_manager = phi::distributed::CommTaskManager::GetInstance();
     comm_task_manager.Stop();
+  }
+  if (FLAGS_enable_async_time_profiler) {
+    phi::distributed::NCCLAsyncTimeProfiler::GetInstance().Stop();
   }
 }
 
@@ -163,6 +175,13 @@ void ProcessGroupNCCL::GroupEnd() {
 #else  // PADDLE_WITH_HIP
     PADDLE_ENFORCE_GPU_SUCCESS(hipDeviceSynchronize());
 #endif
+  }
+}
+
+void ProcessGroupNCCL::LogOneStep() {
+  if (FLAGS_enable_async_time_profiler) {
+    LOG(WARNING) << "[LogOneStep]";
+    phi::distributed::NCCLAsyncTimeProfiler::GetInstance().LogOneStep();
   }
 }
 
@@ -844,9 +863,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
 
   auto nccl_comm_ctx = this->GetCommContext(&store_key);
 
-  if (!FLAGS_enable_async_trace) {
+  if (FLAGS_enable_async_time_profiler) {
+    auto recoder = std::make_shared<phi::distributed::NCCLAsyncRecorder>(
+        place, rank_, gid_, nccl_stream, comm_type);
+    recoder->StartRecord();
     fn(nccl_comm_ctx, nccl_stream);
-  } else {
+    recoder->EndRecord();
+    auto& profiler = phi::distributed::NCCLAsyncTimeProfiler::GetInstance();
+    profiler.AddRecorder(std::move(recoder));
+  } else if (FLAGS_enable_async_trace) {
     std::string group_key = place_to_group_key_.at(key);
     auto comm_task =
         std::make_shared<phi::distributed::NCCLCommTask>(place,
@@ -869,6 +894,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
 
     auto& comm_task_manager = phi::distributed::CommTaskManager::GetInstance();
     comm_task_manager.CommTaskEnqueue(std::move(comm_task));
+  } else {
+    fn(nccl_comm_ctx, nccl_stream);
   }
 
   if (!use_calc_stream) {
@@ -975,9 +1002,15 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
 
   auto nccl_comm_ctx = this->GetCommContext(&store_key);
 
-  if (!FLAGS_enable_async_trace) {
+  if (FLAGS_enable_async_time_profiler) {
+    auto recoder = std::make_shared<phi::distributed::NCCLAsyncRecorder>(
+        place, p2p_rank, gid_, nccl_stream, comm_type);
+    recoder->StartRecord();
     fn(nccl_comm_ctx, nccl_stream, p2p_target_rank);
-  } else {
+    recoder->EndRecord();
+    auto& profiler = phi::distributed::NCCLAsyncTimeProfiler::GetInstance();
+    profiler.AddRecorder(std::move(recoder));
+  } else if (FLAGS_enable_async_trace) {
     comm_task->StartRecord();
     fn(nccl_comm_ctx, nccl_stream, p2p_target_rank);
     comm_task->EndRecord();
@@ -985,6 +1018,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Point2Point(
 
     auto& comm_task_manager = phi::distributed::CommTaskManager::GetInstance();
     comm_task_manager.CommTaskEnqueue(std::move(comm_task));
+  } else {
+    fn(nccl_comm_ctx, nccl_stream, p2p_target_rank);
   }
 
   if (!use_calc_stream) {
@@ -1022,9 +1057,10 @@ std::shared_ptr<ProcessGroupNCCL> ProcessGroupNCCL::CreateProcessGroupNCCL(
     int size,
     int gid,
     int64_t timeout,
-    int nccl_comm_init_option) {
+    int nccl_comm_init_option,
+    std::string recorder_name) {
   auto process_group = std::make_shared<ProcessGroupNCCL>(
-      store, rank, size, gid, timeout, nccl_comm_init_option);
+      store, rank, size, gid, timeout, nccl_comm_init_option, recorder_name);
   ProcessGroupIdMap::GetInstance().emplace(gid, process_group);
   return process_group;
 }

--- a/paddle/fluid/distributed/collective/process_group_nccl.cc
+++ b/paddle/fluid/distributed/collective/process_group_nccl.cc
@@ -178,10 +178,10 @@ void ProcessGroupNCCL::GroupEnd() {
   }
 }
 
-void ProcessGroupNCCL::LogOneStep() {
+void ProcessGroupNCCL::LogSingleStep() {
   if (FLAGS_enable_async_time_profiler) {
-    LOG(WARNING) << "[LogOneStep]";
-    phi::distributed::NCCLAsyncTimeProfiler::GetInstance().LogOneStep();
+    LOG(WARNING) << "[LogSingleStep]";
+    phi::distributed::NCCLAsyncTimeProfiler::GetInstance().LogSingleStep();
   }
 }
 

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -188,7 +188,7 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
 
   static void GroupEnd();
 
-  static void LogOneStep();
+  static void LogSingleStep();
 
   ncclComm_t NCCLComm(const Place& place) const;
 

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -16,7 +16,6 @@
 
 #include <chrono>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -267,11 +266,12 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
   int64_t pg_timeout_;
   int nccl_comm_init_option_;
 
+  // using for comm time profiler
+  std::string recorder_name_;
+
   // optimize memory for process_group
   std::vector<std::pair<std::weak_ptr<phi::Allocation>, gpuStream_t>>
       allocation_stream_pairs;
-
-  std::string recorder_name_;
 };
 
 }  //  namespace distributed

--- a/paddle/fluid/distributed/collective/process_group_nccl.h
+++ b/paddle/fluid/distributed/collective/process_group_nccl.h
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -70,6 +71,15 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
     int gid_;
   };
 
+  // struct NCCLGroupTimer {
+  //   friend std::ostream& operator<<(std::ostream& os, const NCCLGroupTimer&
+  //   dt);
+
+  //   void ResetTime() { time = 0.f; }
+  //   int   gid;
+  //   int   rank;
+  //   float time;
+  // };
  public:
   static std::shared_ptr<ProcessGroupNCCL> CreateProcessGroupNCCL(
       const std::shared_ptr<phi::distributed::Store>& store,
@@ -77,14 +87,16 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
       int size,
       int gid,
       int64_t timeout,
-      int nccl_comm_init_option);
+      int nccl_comm_init_option,
+      std::string recorder_name);
 
   ProcessGroupNCCL(const std::shared_ptr<phi::distributed::Store>& store,
                    int rank,
                    int size,
                    int gid,
                    int64_t timeout = 30 * 60 * 1000,
-                   int nccl_comm_init_option = 0);
+                   int nccl_comm_init_option = 0,
+                   std::string recorder_name = "");
   ~ProcessGroupNCCL();
 
   std::string GetBackendName() const override { return "NCCL"; }
@@ -177,6 +189,8 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
 
   static void GroupEnd();
 
+  static void LogOneStep();
+
   ncclComm_t NCCLComm(const Place& place) const;
 
   const bool GetNCCLCommInitOption() { return nccl_comm_init_option_; }
@@ -256,6 +270,8 @@ class ProcessGroupNCCL final : public ProcessGroupWithStream {
   // optimize memory for process_group
   std::vector<std::pair<std::weak_ptr<phi::Allocation>, gpuStream_t>>
       allocation_stream_pairs;
+
+  std::string recorder_name_;
 };
 
 }  //  namespace distributed

--- a/paddle/fluid/pybind/distributed_py.cc
+++ b/paddle/fluid/pybind/distributed_py.cc
@@ -1240,7 +1240,8 @@ void BindDistributed(py::module *m) {
                   py::call_guard<py::gil_scoped_release>())
       .def_static("group_start", distributed::ProcessGroupNCCL::GroupStart)
       .def_static("group_end", distributed::ProcessGroupNCCL::GroupEnd)
-      .def_static("log_one_step", distributed::ProcessGroupNCCL::LogOneStep);
+      .def_static("log_single_step",
+                  distributed::ProcessGroupNCCL::LogSingleStep);
 
 #endif
 

--- a/paddle/fluid/pybind/distributed_py.cc
+++ b/paddle/fluid/pybind/distributed_py.cc
@@ -1236,9 +1236,11 @@ void BindDistributed(py::module *m) {
                   py::arg("group_id") = 0,
                   py::arg("timeout") = 30 * 60 * 1000,
                   py::arg("nccl_comm_init_option") = 0,
+                  py::arg("recorder_name") = "",
                   py::call_guard<py::gil_scoped_release>())
       .def_static("group_start", distributed::ProcessGroupNCCL::GroupStart)
-      .def_static("group_end", distributed::ProcessGroupNCCL::GroupEnd);
+      .def_static("group_end", distributed::ProcessGroupNCCL::GroupEnd)
+      .def_static("log_one_step", distributed::ProcessGroupNCCL::LogOneStep);
 
 #endif
 

--- a/paddle/phi/core/distributed/CMakeLists.txt
+++ b/paddle/phi/core/distributed/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WITH_NCCL OR WITH_RCCL)
   list(APPEND DISTRIBUTED_COMMON_SRCS comm_task_manager.cc)
   list(APPEND DISTRIBUTED_COMMON_SRCS nccl_comm_context.cc nccl_comm_task.cc
        nccl_tools.cc)
+  list(APPEND DISTRIBUTED_COMMON_SRCS nccl_async_time_profiler.cc
+       nccl_async_recorder.cc)
 endif()
 
 if(WITH_GLOO)

--- a/paddle/phi/core/distributed/nccl_async_recorder.cc
+++ b/paddle/phi/core/distributed/nccl_async_recorder.cc
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/distributed/nccl_async_recorder.h"
+#include "paddle/common/macros.h"
+#include "paddle/phi/backends/dynload/nccl.h"
+#include "paddle/phi/backends/gpu/gpu_decls.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
+#include "paddle/phi/core/distributed/nccl_tools.h"
+
+namespace phi {
+namespace distributed {
+
+NCCLAsyncRecorder::NCCLAsyncRecorder(const phi::Place& place,
+                                     int rank,
+                                     int gid,
+                                     gpuStream_t stream,
+                                     CommType comm_type)
+    : place_(place),
+      rank_(rank),
+      gid_(gid),
+      nccl_stream_(stream),
+      comm_type_(comm_type),
+      is_start_(false) {
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventCreate(&nccl_start_event_));
+  CUDA_CHECK(cudaEventCreate(&nccl_end_event_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventCreate(&nccl_start_event_));
+  HIP_CHECK(hipEventCreate(&nccl_end_event_));
+#endif
+}
+
+void NCCLAsyncRecorder::EventDestroy() {
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventDestroy(nccl_start_event_));
+  CUDA_CHECK(cudaEventDestroy(nccl_end_event_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(cudaEventDestroy(nccl_start_event_));
+  HIP_CHECK(cudaEventDestroy(nccl_end_event_));
+#endif
+}
+
+void NCCLAsyncRecorder::StartRecord() {
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventRecord(nccl_start_event_, nccl_stream_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventRecord(nccl_start_event_, nccl_stream_));
+#endif
+}
+
+void NCCLAsyncRecorder::EndRecord() {
+  backends::gpu::GPUDeviceGuard guard(place_.device);
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaEventRecord(nccl_end_event_, nccl_stream_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipEventRecord(nccl_end_event_, nccl_stream_));
+#endif
+}
+
+bool NCCLAsyncRecorder::QueryEnd() const { return EventQuery(nccl_end_event_); }
+
+bool NCCLAsyncRecorder::QueryStart() const {
+  return EventQuery(nccl_start_event_);
+}
+
+void NCCLAsyncRecorder::Start() {
+  if (IsStart()) {
+    return;
+  }
+  // start_time_ = std::chrono::high_resolution_clock::now();
+  is_start_ = true;
+}
+
+float NCCLAsyncRecorder::RecordTime() const {
+  // auto end_time = std::chrono::high_resolution_clock::now();
+  // std::chrono::duration<float, std::milli> duration = end_time - start_time_;
+  // return duration.count();
+
+  float elapsedTime = 0.f;
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(
+      cudaEventElapsedTime(&elapsedTime, nccl_start_event_, nccl_end_event_));
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(
+      hipEventElapsedTime(&elapsedTime, nccl_start_event_, nccl_end_event_));
+#endif
+  return elapsedTime;
+}
+
+bool NCCLAsyncRecorder::EventQuery(gpuEvent_t event) const {
+#ifdef PADDLE_WITH_CUDA
+  CUDA_CHECK(cudaGetLastError());
+  cudaError_t ret = cudaEventQuery(event);
+  if (ret == cudaSuccess) {
+    return true;
+  } else if (ret != cudaErrorNotReady) {
+    CUDA_CHECK(ret);
+  } else {
+    // ignore and clear the error if not ready
+    CUDA_CHECK(cudaGetLastError());
+  }
+#else  // PADDLE_WITH_HIP
+  HIP_CHECK(hipGetLastError());
+  hipError_t ret = hipEventQuery(event);
+  if (ret == hipSuccess) {
+    return true;
+  } else if (ret != hipErrorNotReady) {
+    HIP_CHECK(ret);
+  } else {
+    // ignore and clear the error if not ready
+    HIP_CHECK(hipGetLastError());
+  }
+#endif
+  return false;
+}
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/nccl_async_recorder.cc
+++ b/paddle/phi/core/distributed/nccl_async_recorder.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/core/distributed/nccl_async_recorder.h"
 #include "paddle/common/macros.h"
-#include "paddle/phi/backends/dynload/nccl.h"
 #include "paddle/phi/backends/gpu/gpu_decls.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/core/distributed/nccl_tools.h"
@@ -48,8 +47,8 @@ void NCCLAsyncRecorder::EventDestroy() {
   CUDA_CHECK(cudaEventDestroy(nccl_start_event_));
   CUDA_CHECK(cudaEventDestroy(nccl_end_event_));
 #else  // PADDLE_WITH_HIP
-  HIP_CHECK(cudaEventDestroy(nccl_start_event_));
-  HIP_CHECK(cudaEventDestroy(nccl_end_event_));
+  HIP_CHECK(hipEventDestroy(nccl_start_event_));
+  HIP_CHECK(hipEventDestroy(nccl_end_event_));
 #endif
 }
 

--- a/paddle/phi/core/distributed/nccl_async_recorder.h
+++ b/paddle/phi/core/distributed/nccl_async_recorder.h
@@ -16,10 +16,15 @@
 #include <memory>
 #include <string>
 
-#include "paddle/phi/backends/dynload/nccl.h"
 #include "paddle/phi/backends/gpu/gpu_decls.h"
 #include "paddle/phi/core/distributed/utils.h"
 #include "paddle/phi/core/enforce.h"
+
+#if defined(PADDLE_WITH_RCCL)
+#include "paddle/phi/backends/dynload/rccl.h"
+#else
+#include "paddle/phi/backends/dynload/nccl.h"
+#endif
 
 namespace phi {
 namespace distributed {

--- a/paddle/phi/core/distributed/nccl_async_recorder.h
+++ b/paddle/phi/core/distributed/nccl_async_recorder.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "paddle/phi/backends/dynload/nccl.h"
+#include "paddle/phi/backends/gpu/gpu_decls.h"
+#include "paddle/phi/core/distributed/utils.h"
+#include "paddle/phi/core/enforce.h"
+
+namespace phi {
+namespace distributed {
+
+class NCCLAsyncRecorder {
+ public:
+  NCCLAsyncRecorder(const phi::Place& place,
+                    int rank,
+                    int gid,
+                    gpuStream_t stream,
+                    CommType comm_type);
+  ~NCCLAsyncRecorder() = default;
+
+  float GetTime() const;
+  void StartRecord();
+  void EndRecord();
+  bool QueryEnd() const;
+  bool QueryStart() const;
+  bool IsStart() const { return is_start_; }
+  void Start();
+
+  int GetGid() const { return gid_; }
+
+  float RecordTime() const;
+  bool EventQuery(gpuEvent_t event) const;
+  void EventDestroy();
+
+ private:
+  phi::Place place_;
+  int rank_;
+  int gid_;
+  gpuStream_t nccl_stream_;
+  CommType comm_type_;
+
+  gpuEvent_t nccl_start_event_;
+  gpuEvent_t nccl_end_event_;
+
+  bool is_start_;
+
+  // std::chrono::high_resolution_clock::time_point start_time_;
+
+ private:
+  DISABLE_COPY_AND_ASSIGN(NCCLAsyncRecorder);
+};
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/nccl_async_time_profiler.cc
+++ b/paddle/phi/core/distributed/nccl_async_time_profiler.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+
+#include "paddle/common/macros.h"
+#include "paddle/phi/core/distributed/nccl_async_recorder.h"
+#include "paddle/phi/core/distributed/nccl_async_time_profiler.h"
+
+namespace phi {
+namespace distributed {
+
+NCCLAsyncTimeProfiler::NCCLAsyncTimeProfiler() : terminated_(false), pool_(10) {
+  loop_thread_ = std::thread(
+      &phi::distributed::NCCLAsyncTimeProfiler::RecordTimeLoop, this);
+
+  clear_thread_ =
+      std::thread(&phi::distributed::NCCLAsyncTimeProfiler::ClearLoop, this);
+}
+
+NCCLAsyncTimeProfiler::~NCCLAsyncTimeProfiler() { Stop(); }
+
+void NCCLAsyncTimeProfiler::LogOneStep() {
+  if (!terminated_.load()) {
+    std::unique_lock<std::mutex> lk(clear_list_mutex_);
+    for (auto& p : time_infos_) {
+      LOG(WARNING) << "gid:" << p.first
+                   << "   comm_group:" << p.second.recorder_name
+                   << "   comm_count:" << p.second.comm_count
+                   << "   time:" << p.second.time_sum
+                   << "   rank:" << p.second.rank;
+      p.second.time_sum = 0.f;
+      p.second.comm_count = 0;
+    }
+  }
+}
+
+void NCCLAsyncTimeProfiler::InnerAddRecorder(
+    std::shared_ptr<NCCLAsyncRecorder> recorder) {
+  std::unique_lock<std::mutex> lk(recoders_list_mutex_);
+  recorders_list_.push_back(std::move(recorder));
+  recorders_cv_.notify_one();
+}
+
+void NCCLAsyncTimeProfiler::AddRecorder(
+    std::shared_ptr<NCCLAsyncRecorder> recorder) {
+  if (!terminated_.load()) {
+    pool_.enqueue(
+        &NCCLAsyncTimeProfiler::InnerAddRecorder, this, std::move(recorder));
+  }
+}
+
+void NCCLAsyncTimeProfiler::AddClearRecorder(
+    std::shared_ptr<NCCLAsyncRecorder> recorder) {
+  if (!terminated_.load()) {
+    std::unique_lock<std::mutex> lk(clear_list_mutex_);
+    clear_list_.push_back(std::move(recorder));
+    clear_cv_.notify_one();
+  }
+}
+
+void NCCLAsyncTimeProfiler::Stop() {
+  terminated_.store(true);
+
+  if (clear_thread_.joinable()) {
+    clear_cv_.notify_one();
+    clear_thread_.join();
+  }
+  if (loop_thread_.joinable()) {
+    recorders_cv_.notify_one();
+    loop_thread_.join();
+  }
+}
+
+void NCCLAsyncTimeProfiler::RecordTimeLoop() {
+  while (!terminated_.load()) {
+    std::unique_lock<std::mutex> lk(recoders_list_mutex_);
+    recorders_cv_.wait_for(lk, std::chrono::milliseconds(1000), [&]() -> bool {
+      return !recorders_list_.empty();
+    });
+    for (auto iter = recorders_list_.begin(); iter != recorders_list_.end();) {
+      auto recorder = *iter;
+      if (!recorder->IsStart() && recorder->QueryStart()) {
+        recorder->Start();
+      }
+      if (recorder->IsStart() && recorder->QueryEnd()) {
+        float recorder_time = recorder->RecordTime();
+        time_infos_[recorder->GetGid()].time_sum += recorder_time;
+        time_infos_[recorder->GetGid()].comm_count++;
+        AddClearRecorder(recorder);
+        iter = recorders_list_.erase(iter);
+      } else {
+        ++iter;
+      }
+    }
+    lk.unlock();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    lk.lock();
+  }
+}
+
+void NCCLAsyncTimeProfiler::ClearLoop() {
+  while (!terminated_.load()) {
+    std::unique_lock<std::mutex> lk(clear_list_mutex_);
+    clear_cv_.wait_for(lk, std::chrono::milliseconds(1000), [&]() -> bool {
+      return !clear_list_.empty();
+    });
+    for (auto iter = clear_list_.begin(); iter != clear_list_.end();) {
+      auto recorder = *iter;
+      recorder->EventDestroy();
+      iter = clear_list_.erase(iter);
+    }
+  }
+}
+
+}  // namespace distributed
+}  // namespace phi

--- a/paddle/phi/core/distributed/nccl_async_time_profiler.h
+++ b/paddle/phi/core/distributed/nccl_async_time_profiler.h
@@ -46,7 +46,7 @@ class NCCLAsyncTimeProfiler {
     time_infos_[gid].recorder_name = recorder_name;
   }
   void Stop();
-  void LogOneStep();
+  void LogSingleStep();
 
   void AddRecorder(std::shared_ptr<NCCLAsyncRecorder> recorder);
 
@@ -66,6 +66,7 @@ class NCCLAsyncTimeProfiler {
 
   std::condition_variable recorders_cv_;
   std::condition_variable clear_cv_;
+  std::condition_variable log_cv_;
 
   std::thread loop_thread_;
   std::thread clear_thread_;

--- a/paddle/phi/core/distributed/nccl_async_time_profiler.h
+++ b/paddle/phi/core/distributed/nccl_async_time_profiler.h
@@ -60,7 +60,9 @@ class NCCLAsyncTimeProfiler {
  private:
   std::atomic<bool> terminated_;
   ::ThreadPool pool_;
+  std::future<void> add_record_task_;
 
+  std::mutex buffer_list_mutex_;
   std::mutex recoders_list_mutex_;
   std::mutex clear_list_mutex_;
 
@@ -71,6 +73,7 @@ class NCCLAsyncTimeProfiler {
   std::thread loop_thread_;
   std::thread clear_thread_;
 
+  std::list<std::shared_ptr<NCCLAsyncRecorder>> buffer_list_;
   std::list<std::shared_ptr<NCCLAsyncRecorder>> recorders_list_;
   std::list<std::shared_ptr<NCCLAsyncRecorder>> clear_list_;
 

--- a/paddle/phi/core/distributed/nccl_async_time_profiler.h
+++ b/paddle/phi/core/distributed/nccl_async_time_profiler.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <ThreadPool.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "paddle/phi/core/enforce.h"
+
+namespace phi {
+namespace distributed {
+
+class NCCLAsyncRecorder;
+
+class NCCLAsyncTimeProfiler {
+ public:
+  NCCLAsyncTimeProfiler();
+
+  ~NCCLAsyncTimeProfiler();
+
+  static NCCLAsyncTimeProfiler& GetInstance() {
+    static NCCLAsyncTimeProfiler instance;
+    return instance;
+  }
+
+  void RegisterTimer(int gid, int rank, std::string recorder_name) {
+    time_infos_[gid] = NCCLGroupTimeInfo();
+    time_infos_[gid].rank = rank;
+    time_infos_[gid].recorder_name = recorder_name;
+  }
+  void Stop();
+  void LogOneStep();
+
+  void AddRecorder(std::shared_ptr<NCCLAsyncRecorder> recorder);
+
+ private:
+  void RecordTimeLoop();
+  void ClearLoop();
+
+  void InnerAddRecorder(std::shared_ptr<NCCLAsyncRecorder> recorder);
+  void AddClearRecorder(std::shared_ptr<NCCLAsyncRecorder> recorder);
+
+ private:
+  std::atomic<bool> terminated_;
+  ::ThreadPool pool_;
+
+  std::mutex recoders_list_mutex_;
+  std::mutex clear_list_mutex_;
+
+  std::condition_variable recorders_cv_;
+  std::condition_variable clear_cv_;
+
+  std::thread loop_thread_;
+  std::thread clear_thread_;
+
+  std::list<std::shared_ptr<NCCLAsyncRecorder>> recorders_list_;
+  std::list<std::shared_ptr<NCCLAsyncRecorder>> clear_list_;
+
+  struct NCCLGroupTimeInfo {
+    int gid;
+    int rank;
+    float time_sum = 0.f;
+    int comm_count = 0;
+    std::string recorder_name = "";
+  };
+  std::unordered_map<int, NCCLGroupTimeInfo> time_infos_;
+};
+
+}  // namespace distributed
+}  // namespace phi

--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -148,6 +148,7 @@ def _new_process_group_impl(
     pg_options,
     group_id=0,
     nccl_comm_init_option=0,
+    recorder_name="",
 ):
     pg = None
     genv = _get_global_env()
@@ -162,6 +163,7 @@ def _new_process_group_impl(
             group_id,
             genv.pg_timeout,
             nccl_comm_init_option,
+            recorder_name,
         )
     elif backend == "xccl":
         pg = core.ProcessGroupCustom.create(
@@ -188,6 +190,7 @@ def new_group(
     backend=None,
     timeout=_default_timeout,
     nccl_comm_init_option=0,
+    recorder_name="",
 ):
     """
 
@@ -243,6 +246,7 @@ def new_group(
                 pg_options=None,
                 group_id=gid,
                 nccl_comm_init_option=nccl_comm_init_option,
+                recorder_name=recorder_name,
             )
         else:
             rank = -1

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -519,7 +519,10 @@ class PipelineLayer(nn.Layer):
                                 )
                             )
 
-                        group = paddle.distributed.new_group(ranks=shared_ranks)
+                        group = paddle.distributed.new_group(
+                            ranks=shared_ranks,
+                            recorder_name="pipe_shared_comm",
+                        )
                         if self.global_rank in shared_ranks:
                             assert key in self.shared_layers
                             if key in self.shared_layers:

--- a/test/collective/test_collective_allgather_api.py
+++ b/test/collective/test_collective_allgather_api.py
@@ -163,6 +163,20 @@ class TestCollectiveAllgatherAPI(TestDistBase):
                 need_envs={"FLAGS_enable_async_trace": "True"},
             )
 
+    def test_allgather_nccl_dygraph_with_time_profiler(self):
+        dtypes_to_test = [
+            "float32",
+        ]
+        for dtype in dtypes_to_test:
+            self.check_with_place(
+                "collective_allgather_api_dygraph.py",
+                "allgather",
+                "nccl",
+                static_mode="0",
+                dtype=dtype,
+                need_envs={"FLAGS_enable_async_time_profiler": "True"},
+            )
+
     def test_allgather_gloo_dygraph(self):
         dtypes_to_test = [
             "float16",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
实现在分布式训练中对通信性能的监控。export FLAGS_enable_async_time_profiler=True 以开启性能监控。在每个step结束时，需要在 python端 调用 framework.core.ProcessGroupNCCL.log_one_step() 打印当前step的通信开销，log_one_step方法在打印完日志后会重置当前 step 的记录。
日志打印出来形如：
![e18f48388a33c74318c95149440bca16](https://github.com/PaddlePaddle/Paddle/assets/75946871/c0627505-b7ef-4450-98cd-6c846494b218)

实现方案：
1. nccl初始化时，构造NCCLAsyncTimeProfiler单例，后台启动RecordTimeLoop，用于异步查询NCCLAsyncRecorder中的event是否完成。为了减小临界区，将event和智能指针的析构放在ClearLoop执行。
2. 在通信前后，使用NCCLAsyncRecorder插入cuda record。为了避免将NCCLAsyncRecorder插入NCCLAsyncTimeProfiler中时阻塞主线程，引入线程池，在线程池的线程中将NCCLAsyncRecorder插入NCCLAsyncTimeProfiler。
3. 在NCCLAsyncTimeProfiler中为每个nccl group维护一个info信息，记录每个step的通信次数和时间。
![271c1ecdafe3b3e23a8edef27e231b30](https://github.com/PaddlePaddle/Paddle/assets/75946871/f6a61733-926d-4a16-ae96-48b2a24854be)
