### PR TITLE
reset layout when feed new tensor for predictor

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -60,6 +60,11 @@ void Tensor::Reshape(const std::vector<int> &shape) {
           "No tensor called [%s] in the runtime scope", name_));
   auto *tensor = var->GetMutable<phi::DenseTensor>();
   tensor->Resize(common::make_ddim(shape));
+#ifdef PADDLE_WITH_DNNL
+  if (tensor->layout() == phi::DataLayout::ONEDNN) {
+    tensor->set_layout(phi::DataLayout::ANY);
+  }
+#endif
 }
 
 void Tensor::ReshapeStrings(const size_t &shape) {
@@ -207,6 +212,11 @@ void Tensor::CopyFromCpu(const T *data) {
   if (place_ == PlaceType::kCPU) {
     auto *t_data = tensor->mutable_data<T>(paddle::platform::CPUPlace());
     std::memcpy(static_cast<void *>(t_data), data, ele_size);
+#ifdef PADDLE_WITH_DNNL
+    if (tensor->layout() == phi::DataLayout::ONEDNN) {
+      tensor->set_layout(phi::DataLayout::ANY);
+    }
+#endif
   } else if (place_ == PlaceType::kGPU) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
PIR执行器，在使用OneDNN时，如果input不是OneDNN的，会原位修改Tensor为OneDNN Tensor。
Predictor，复用Scope中的Tensor，用于feed预测数据。通过reshape、copy_from_cpu更新input的shape和数据。但没有更新layout和mem_desc。
这导致新的input仍然标记为OneDNN Layout，因此PIR执行器不会对新的input做layout转换，也不会更新mem_desc。输入不同shape的Tensor时，会崩溃。
Pcard-67164