### PR TITLE
[PIR] Support invoke op in different op yamls

### DIFF
--- a/paddle/fluid/pir/dialect/op_generator/op_gen.py
+++ b/paddle/fluid/pir/dialect/op_generator/op_gen.py
@@ -1602,8 +1602,11 @@ def AutoCodeGen(
                         )
 
                         build_mutable_attr_is_input = f"static void Build({build_args_with_muta_attr_is_input_for_declare});"
-                if (op_invoke_map is not None) and (
-                    op_invoke_map['func'] in op_info_items
+                # Currently not support invoke op for sparse op.
+                if (
+                    (op_invoke_map is not None)
+                    and (not op_info.is_sparse_op)
+                    and (op_invoke_map['func'] in all_op_info_items)
                 ):
                     op_invoke_class_name = (
                         to_pascal_case(op_invoke_map['func']) + "Op"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
- Support invoke op in different op yamls
