### PR TITLE
[PHI]Fix quantize_linear kernel selection in PHI

### DIFF
--- a/paddle/fluid/operators/ops_signature/quantize_linear_sig.cc
+++ b/paddle/fluid/operators/ops_signature/quantize_linear_sig.cc
@@ -18,7 +18,9 @@ namespace phi {
 
 KernelSignature QuantizeLinearOpArgumentMapping(
     const ArgumentMappingContext& ctx UNUSED) {
-  bool is_test = paddle::any_cast<bool>(ctx.Attr("is_test"));
+  bool is_test = ctx.HasAttr("is_test")
+                     ? paddle::any_cast<bool>(ctx.Attr("is_test"))
+                     : true;
   if (is_test) {
     return KernelSignature(
         "quantize_linear_deprecated_infer",

--- a/paddle/fluid/operators/ops_signature/quantize_linear_sig.cc
+++ b/paddle/fluid/operators/ops_signature/quantize_linear_sig.cc
@@ -18,20 +18,29 @@ namespace phi {
 
 KernelSignature QuantizeLinearOpArgumentMapping(
     const ArgumentMappingContext& ctx UNUSED) {
-  return KernelSignature(
-      "quantize_linear_deprecated",
-      {"X", "Scale", "ZeroPoint", "InAccum", "InState"},
-      {"quant_axis", "bit_length", "round_type", "is_test", "only_observer"},
-      {"Y", "OutState", "OutAccum", "OutScale"});
+  bool is_test = paddle::any_cast<bool>(ctx.Attr("is_test"));
+  if (is_test) {
+    return KernelSignature(
+        "quantize_linear_deprecated_infer",
+        {"X", "Scale", "ZeroPoint"},
+        {"quant_axis", "bit_length", "round_type", "only_observer"},
+        {"Y"});
+  } else {
+    return KernelSignature(
+        "quantize_linear_deprecated_train",
+        {"X", "Scale", "ZeroPoint", "InAccum", "InState"},
+        {"quant_axis", "bit_length", "round_type", "only_observer"},
+        {"Y", "OutState", "OutAccum", "OutScale"});
+  }
 }
 
 KernelSignature DeQuantizeLinearOpArgumentMapping(
     const ArgumentMappingContext& ctx UNUSED) {
   return KernelSignature(
       "dequantize_linear_deprecated",
-      {"X", "Scale", "ZeroPoint", "InAccum", "InState"},
-      {"quant_axis", "bit_length", "round_type", "is_test", "only_observer"},
-      {"Y", "OutState", "OutAccum", "OutScale"});
+      {"X", "Scale", "ZeroPoint"},
+      {"quant_axis", "bit_length", "round_type", "only_observer"},
+      {"Y"});
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/quantize_linear_kernel.cc
+++ b/paddle/phi/kernels/cpu/quantize_linear_kernel.cc
@@ -111,10 +111,16 @@ PD_REGISTER_KERNEL(dequantize_linear,
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 
-PD_REGISTER_KERNEL(quantize_linear_deprecated,
+PD_REGISTER_KERNEL(quantize_linear_deprecated_train,
                    CPU,
                    ALL_LAYOUT,
-                   phi::QuantizeLinearDeprecatedKernel,
+                   phi::QuantizeLinearDeprecatedTrainKernel,
+                   float) {}
+
+PD_REGISTER_KERNEL(quantize_linear_deprecated_infer,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::QuantizeLinearDeprecatedInferKernel,
                    float) {}
 
 PD_REGISTER_KERNEL(dequantize_linear_deprecated,

--- a/paddle/phi/kernels/gpu/quantize_linear_kernel.cu
+++ b/paddle/phi/kernels/gpu/quantize_linear_kernel.cu
@@ -149,10 +149,19 @@ PD_REGISTER_KERNEL(dequantize_linear_deprecated,
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 
-PD_REGISTER_KERNEL(quantize_linear_deprecated,
+PD_REGISTER_KERNEL(quantize_linear_deprecated_train,
                    GPU,
                    ALL_LAYOUT,
-                   phi::QuantizeLinearDeprecatedKernel,
+                   phi::QuantizeLinearDeprecatedTrainKernel,
+                   float,
+                   phi::dtype::float16) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
+}
+
+PD_REGISTER_KERNEL(quantize_linear_deprecated_infer,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::QuantizeLinearDeprecatedInferKernel,
                    float,
                    phi::dtype::float16) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复老IR推理模式下quantize_linear参数过多的问题，将quantize_linear Kernel逻辑拆分，分为训练模式Kernel和推理模式Kernel分别执行