### PR TITLE
[CINN] Refine split_generate_shape_into_shape_ops_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/check_infer_symbolic_pass.cc
@@ -145,7 +145,8 @@ class BlockDimExprsAsserter {
   void AssertDimExprForOutput(pir::Operation* op) {  // NOLINT
     VLOG(5) << "Add assert for result of [ " << op->name() << " ]";
     if (op->num_results() == 0) return;
-    if (!op->HasInterface<paddle::dialect::InferSymbolicShapeInterface>()) {
+    if (!op->HasInterface<paddle::dialect::InferSymbolicShapeInterface>() ||
+        op->HasTrait<pir::SideEffectTrait>()) {
       LOG(INFO) << "skip the checking for [ " << op->name() << " ]";
       return;
     }

--- a/paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.cc
@@ -116,17 +116,6 @@ struct CachedDimExprToValueConverter {
   }
 
   pir::Value ConvertTensorDimToValue(const TensorDimInData& tensor_dim) {
-    auto CastToInt64IfNeed = [&](pir::Value value) {
-      if (value.type()
-              .dyn_cast<paddle::dialect::DenseTensorType>()
-              .dtype()
-              .isa<pir::Int64Type>()) {
-        return value;
-      }
-      return rewriter
-          ->Build<paddle::dialect::CastOp>(value, phi::DataType::INT64)
-          .out();
-    };
     auto FlattenValueIfNeed = [&](pir::Value value) {
       const auto& dims =
           value.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
@@ -141,21 +130,17 @@ struct CachedDimExprToValueConverter {
             .dyn_cast<paddle::dialect::DenseTensorType>()
             .dims()
             .size() == 0) {
-      return CastToInt64IfNeed(
-          rewriter
-              ->Build<paddle::dialect::ReshapeOp>(tensor_dim.value,
-                                                  std::vector<int64_t>{1})
-              .out());
+      return tensor_dim.value;
     }
-    return CastToInt64IfNeed(rewriter
-                                 ->Build<paddle::dialect::SliceOp>(
-                                     FlattenValueIfNeed(tensor_dim.value),
-                                     std::vector<int64_t>{0LL},
-                                     std::vector<int64_t>{tensor_dim.axis},
-                                     std::vector<int64_t>{tensor_dim.axis + 1},
-                                     std::vector<int64_t>{},
-                                     std::vector<int64_t>{})
-                                 .out());
+    return rewriter
+        ->Build<paddle::dialect::SliceOp>(
+            FlattenValueIfNeed(tensor_dim.value),
+            std::vector<int64_t>{0LL},
+            std::vector<int64_t>{tensor_dim.axis},
+            std::vector<int64_t>{tensor_dim.axis + 1},
+            std::vector<int64_t>{},
+            std::vector<int64_t>{})
+        .out();
   }
 
   pir::Value ConvertToValueImpl(
@@ -304,7 +289,43 @@ class SplitGenerateShapeIntoShapeOps
         MakeGetterTensorDim4SymbolName(op);
     if (!TensorDim4SymbolName) return std::nullopt;
     CachedDimExprToValueConverter converter{TensorDim4SymbolName, rewriter};
-    return GetValueOfRewrittenOps(dim_exprs, &converter);
+    std::optional<pir::Value> new_output =
+        GetValueOfRewrittenOps(dim_exprs, &converter);
+    if (!new_output.has_value()) return std::nullopt;
+    const auto& gs_out_type =
+        op->result(0).type().dyn_cast<paddle::dialect::DenseTensorType>();
+    const auto& new_output_type =
+        new_output->type().dyn_cast<paddle::dialect::DenseTensorType>();
+    if (gs_out_type.dtype() != new_output_type.dtype()) {
+      new_output =
+          rewriter
+              ->Build<paddle::dialect::CastOp>(
+                  new_output.value(),
+                  paddle::dialect::TransToPhiDataType(gs_out_type.dtype()))
+              .out();
+    }
+    if (gs_out_type.dims() != new_output_type.dims()) {
+      PADDLE_ENFORCE_EQ(
+          ::common::contain_unknown_dim(gs_out_type.dims()),
+          false,
+          ::common::errors::PreconditionNotMet(
+              "The shape of the output tensor of generate_shape_op should not "
+              "contain unknown dim, but received [%s].",
+              gs_out_type.dims().to_str()));
+      PADDLE_ENFORCE_LE(
+          ::common::product(gs_out_type.dims()),
+          9,
+          ::common::errors::PreconditionNotMet(
+              "The numel of the output tensor of generate_shape_op should be "
+              "less than 9, but received [%s].",
+              ::common::product(gs_out_type.dims())));
+      return rewriter
+          ->Build<paddle::dialect::ReshapeOp>(
+              new_output.value(),
+              ::common::vectorize<int64_t>(gs_out_type.dims()))
+          .out();
+    }
+    return new_output;
   }
 
   TensorDim4SymbolNameT MakeGetterTensorDim4SymbolName(

--- a/paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/split_generate_shape_into_shape_ops_pass.cc
@@ -116,6 +116,17 @@ struct CachedDimExprToValueConverter {
   }
 
   pir::Value ConvertTensorDimToValue(const TensorDimInData& tensor_dim) {
+    auto CastToInt64IfNeed = [&](pir::Value value) {
+      if (value.type()
+              .dyn_cast<paddle::dialect::DenseTensorType>()
+              .dtype()
+              .isa<pir::Int64Type>()) {
+        return value;
+      }
+      return rewriter
+          ->Build<paddle::dialect::CastOp>(value, phi::DataType::INT64)
+          .out();
+    };
     auto FlattenValueIfNeed = [&](pir::Value value) {
       const auto& dims =
           value.type().dyn_cast<paddle::dialect::DenseTensorType>().dims();
@@ -130,17 +141,17 @@ struct CachedDimExprToValueConverter {
             .dyn_cast<paddle::dialect::DenseTensorType>()
             .dims()
             .size() == 0) {
-      return tensor_dim.value;
+      return CastToInt64IfNeed(tensor_dim.value);
     }
-    return rewriter
-        ->Build<paddle::dialect::SliceOp>(
-            FlattenValueIfNeed(tensor_dim.value),
-            std::vector<int64_t>{0LL},
-            std::vector<int64_t>{tensor_dim.axis},
-            std::vector<int64_t>{tensor_dim.axis + 1},
-            std::vector<int64_t>{},
-            std::vector<int64_t>{})
-        .out();
+    return CastToInt64IfNeed(rewriter
+                                 ->Build<paddle::dialect::SliceOp>(
+                                     FlattenValueIfNeed(tensor_dim.value),
+                                     std::vector<int64_t>{0LL},
+                                     std::vector<int64_t>{tensor_dim.axis},
+                                     std::vector<int64_t>{tensor_dim.axis + 1},
+                                     std::vector<int64_t>{},
+                                     std::vector<int64_t>{})
+                                 .out());
   }
 
   pir::Value ConvertToValueImpl(

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.h
@@ -186,7 +186,8 @@ inline ShapeOrData SliceRawInferSymbolicShape(
       out_data.push_back(in_shapeordata.data().value()[i]);
     }
 
-    const std::vector<symbol::DimExpr> shape{std::int64_t(out_data.size())};
+    const ExprVec shape =
+        GetDecreasedDims(ExprVec{out_data.size()}, decrease_axis);
     return symbol::ShapeOrDataDimExprs{
         symbol::TensorShapeOrDataDimExprs(shape, out_data)};
   };


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

1. 优化`split_generate_shape_into_shape_ops_pass`实现逻辑
2. 修复 `check_infer_symbolic_pass` 模型推理Bug
3. 修复slice算子符号推导Bug
