### PR TITLE
conduct stop_gradient for pylayer output when not_inplace

### DIFF
--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -119,6 +119,9 @@ PyObject* new_tensor_with_impl(paddle::Tensor* tensor) {
     new (&(v->tensor)) paddle::Tensor();
     v->tensor.set_impl(tensor->impl());
     v->tensor.set_name(egr::Controller::Instance().GenerateUniqueName());
+    egr::EagerUtils::autograd_meta(&v->tensor)
+        ->SetStopGradient(
+            egr::EagerUtils::autograd_meta(tensor)->StopGradient());
   } else {
     PADDLE_THROW(platform::errors::Fatal(
         "tp_alloc return null, can not new a PyObject."));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
PyLayer在input作为output时，会被认为inplace。如果需要不被inplace，需要标记mark_not_inplace。此时，PyLayer会复制一份input给output。复制时，需要同时复制stop_gradient。

Pcard-67164