### PR TITLE
【Hackathon 6th Fundable Projects 2 No.36】 Fix modernize-use-equals-default final

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/op_dialect.cc
@@ -439,7 +439,7 @@ class IdManager {
 
   IdManager() : ids_() {}
 
-  ~IdManager() {
+  ~IdManager() {  // NOLINT
     for (auto id : ids_) {
       delete id;
     }
@@ -465,7 +465,7 @@ class AttributeManager {
 
   AttributeManager() : char_pointers_(), pointers_size_() {}
 
-  ~AttributeManager() {
+  ~AttributeManager() {  // NOLINT
     for (size_t i = 0; i < char_pointers_.size(); i++) {
       for (size_t j = 0; j < pointers_size_[i]; j++) {
         delete char_pointers_[i][j];

--- a/paddle/fluid/pir/transforms/onednn/fc_onednn_enable_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/fc_onednn_enable_pass.cc
@@ -26,7 +26,7 @@ namespace {
 
 class FcOneDNNEnablePattern : public paddle::drr::DrrPatternBase {
  public:
-  FcOneDNNEnablePattern() {}
+  FcOneDNNEnablePattern() = default;
 
   std::string name() const override { return "FcOneDNNEnablePattern"; }
 

--- a/paddle/fluid/pir/transforms/onednn/squeeze_transpose_onednn_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/onednn/squeeze_transpose_onednn_fuse_pass.cc
@@ -25,7 +25,7 @@ namespace {
 
 class SqueezeTransposePattern : public paddle::drr::DrrPatternBase {
  public:
-  SqueezeTransposePattern() {}
+  SqueezeTransposePattern() = default;
 
   std::string name() const override { return "SqueezeTransposePattern"; }
 


### PR DESCRIPTION
### PR Category
Others

### PR Types
Bug fixes

### Description

修复了 2 处 default 使用，剩下部分的回避检查。


相关链接：
https://github.com/PaddlePaddle/Paddle/issues/64128