### PR TITLE
fix print for place.device

### DIFF
--- a/paddle/phi/backends/gpu/gpu_resources.cc
+++ b/paddle/phi/backends/gpu/gpu_resources.cc
@@ -278,7 +278,7 @@ void InitDnnHandle(dnnHandle_t* handle, gpuStream_t stream, Place place) {
     auto compile_miopen_version = MIOPEN_VERSION / 10;
     if (local_miopen_version < static_cast<size_t>(compile_miopen_version)) {
       LOG_FIRST_N(WARNING, 1)
-          << "WARNING: device: " << place.device
+          << "WARNING: device: " << static_cast<int>(place.device)
           << ". The installed Paddle is compiled with MIOPEN "
           << compile_miopen_version / 100 << "." << compile_miopen_version % 100
           << ", but MIOPEN version in your machine is "
@@ -297,7 +297,7 @@ void InitDnnHandle(dnnHandle_t* handle, gpuStream_t stream, Place place) {
         (version < 9000) ? (version % 1000) / 100 : (version % 10000) / 100;
     if (version < static_cast<size_t>(CUDNN_VERSION)) {
       LOG_FIRST_N(WARNING, 1)
-          << "WARNING: device: " << place.device
+          << "WARNING: device: " << static_cast<int>(place.device)
           << ". The installed Paddle is compiled with CUDNN " << CUDNN_MAJOR
           << "." << CUDNN_MINOR << ", but CUDNN version in your machine is "
           << local_cudnn_major << "." << local_cudnn_minor


### PR DESCRIPTION
### PR Category
Others

### PR Types
Bug fixes

### Description
在需要打印`place.device`的时候，要先转换类型到int才可以打印出正确的数值。否则就会按照ASCII打印出来控制字符。在该文件中若干处打印都是对的，只有这两处打印缺少了cast。
本PR修复了此问题。