### PR TITLE
Fix bug of cudaEvent leak in StreamSafeCUDAAllocator

### DIFF
--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
@@ -75,7 +75,7 @@ void StreamSafeCUDAAllocation::EraseStream(gpuStream_t stream) {
 #ifdef PADDLE_WITH_CUDA
   PADDLE_ENFORCE_GPU_SUCCESS(cudaEventDestroy(it->second));
 #else
-  PADDLE_ENFORCE_GPU_SUCCESS(hipEventDestroy(event));
+  PADDLE_ENFORCE_GPU_SUCCESS(hipEventDestroy(it->second));
 #endif
   outstanding_event_map_.erase(it);
 }

--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
@@ -65,13 +65,10 @@ void StreamSafeCUDAAllocation::EraseStream(gpuStream_t stream) {
   VLOG(8) << "Try remove stream " << stream << " for address " << ptr();
   std::lock_guard<SpinLock> lock_guard(outstanding_event_map_lock_);
   auto it = outstanding_event_map_.find(stream);
-  PADDLE_ENFORCE_NE(
-      it,
-      outstanding_event_map_.end(),
-      phi::errors::NotFound(
-          "Cannot find recorded stream %p for allocation address %p.",
-          stream,
-          ptr()));
+  if (it == outstanding_event_map_.end()) {
+    return;
+  }
+
 #ifdef PADDLE_WITH_CUDA
   PADDLE_ENFORCE_GPU_SUCCESS(cudaEventDestroy(it->second));
 #else


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
PR https://github.com/PaddlePaddle/Paddle/pull/58299 在`StreamSafeCUDAAllocator`中引入`EraseStream`操作移除通信库多流场景下record的cudaEvent，该操作在移除cudaEvent后未进行析构引起资源泄漏，从而使一些模型运行过程出现缓慢降速现象。
本PR对其进行修复。

Pcard-76459