### PR TITLE
Fix Histogram kernel to check range error

### DIFF
--- a/paddle/phi/kernels/cpu/histogram_kernel.cc
+++ b/paddle/phi/kernels/cpu/histogram_kernel.cc
@@ -51,6 +51,21 @@ void HistogramKernel(const Context& dev_ctx,
     output_max = output_max + 1;
   }
 
+  // check if out of range
+  double range =
+      static_cast<double>(output_max) - static_cast<double>(output_min);
+  PADDLE_ENFORCE_LT(
+      range,
+      static_cast<double>(std::numeric_limits<T>::max()),
+      phi::errors::InvalidArgument(
+          "The range of max - min is out of range for target type, "
+          "current kernel type is %s, the range should less than %f "
+          "but now min is %f, max is %f.",
+          typeid(T).name(),
+          std::numeric_limits<T>::max(),
+          output_min,
+          output_max));
+
   PADDLE_ENFORCE_EQ((std::isinf(static_cast<float>(output_min)) ||
                      std::isnan(static_cast<float>(output_max)) ||
                      std::isinf(static_cast<float>(output_min)) ||

--- a/test/legacy_test/test_histogram_op.py
+++ b/test/legacy_test/test_histogram_op.py
@@ -118,6 +118,29 @@ class TestHistogramOpError(unittest.TestCase):
             self.run_network(net_func)
 
     @test_with_pir_api
+    def test_input_range_error(self):
+        """Test range of input is out of bound"""
+
+        def net_func():
+            input_value = paddle.to_tensor(
+                [
+                    -7095538316670326452,
+                    -6102192280439741006,
+                    2040176985344715288,
+                    -6276983991026997920,
+                    -6570715756420355710,
+                    -5998045007776667296,
+                    -6763099356862306438,
+                    3166073479842736625,
+                ],
+                dtype=paddle.int64,
+            )
+            paddle.histogram(input=input_value, bins=1, min=0, max=0)
+
+        with self.assertRaises(ValueError):
+            self.run_network(net_func)
+
+    @test_with_pir_api
     def test_type_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             # The input type must be Variable.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->

Check range in histogrm kernel, details refer to https://github.com/PaddlePaddle/Paddle/issues/64566

pcard-84125

