### PR TITLE
[Inference] prohibit conv in transfer_layout_pass and fix argsort translation

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -947,6 +947,16 @@ pir::Operation* OpTranscriber::operator()(pir::IrContext* ctx,
   return operation;
 }
 
+struct ArgsortOpTranscriber : public OpTranscriber {
+  void HandleNonexistentAttribute(pir::IrContext* ctx,
+                                  pir::AttributeMap* attribute_map,
+                                  const OpAttributeInfo& info) override {
+    if (info.name == "stable") {
+      (*attribute_map)[info.name] = pir::BoolAttribute::get(ctx, false);
+    }
+  }
+};
+
 struct Assign2AssignOpTranscriber : public OpTranscriber {
   pir::OpInfo LookUpOpInfo(pir::IrContext* ctx,
                            const OpDesc& op_desc) override {
@@ -3459,6 +3469,7 @@ OpTranslator::OpTranslator() {
 
   general_handler = OpTranscriber();
   special_handlers["add_n"] = AddNOpTranscriber();
+  special_handlers["argsort"] = ArgsortOpTranscriber();
   special_handlers["assign"] = AssignOpTranscriber();
   special_handlers["assign_value"] = AssignValueOpTranscriber();
   special_handlers["range"] = ArangeOpTranscriber();

--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
@@ -40,12 +40,6 @@ void RewriteByInfermeta(pir::Operation* op, common::DataLayout new_layout) {
 
 template <>
 common::DataLayout PreferLayoutImpl<Conv2dOp>(pir::Operation* op) {
-  // Note(lyk): We exhibit the layout transformation for conv2d
-  // due to issues with its infermeta and kernel not functioning
-  // properly in NHWC layout. However, if the FLAGS_manually_trans_conv_filter
-  // is enabled, the transfer_layout_pass can also operate correctly.
-  return false;
-
   auto data_format_attr = op->attribute<pir::StrAttribute>("data_format");
   if (!data_format_attr) {
     PADDLE_THROW(phi::errors::InvalidArgument(
@@ -54,18 +48,10 @@ common::DataLayout PreferLayoutImpl<Conv2dOp>(pir::Operation* op) {
         data_format_attr));
   }
 
-  auto concrete_op = op->dyn_cast<Conv2dOp>();
-  if (auto in = concrete_op.input()) {
-    if (auto in_type = in.type()) {
-      if (in_type.isa<DenseTensorType>()) {
-        if (auto tensor_type = in_type.dyn_cast<DenseTensorType>()) {
-          if (tensor_type.dtype().isa<pir::Float16Type>()) {
-            return common::DataLayout::NHWC;
-          }
-        }
-      }
-    }
-  }
+  // Note(lyk): We exhibit the layout transformation for conv2d
+  // due to issues with its infermeta and kernel not functioning
+  // properly in NHWC layout. However, if the FLAGS_manually_trans_conv_filter
+  // is enabled, the transfer_layout_pass can also operate correctly.
   return common::StringToDataLayout(data_format_attr.AsString());
 }
 

--- a/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/layout_transformation.cc
@@ -40,6 +40,12 @@ void RewriteByInfermeta(pir::Operation* op, common::DataLayout new_layout) {
 
 template <>
 common::DataLayout PreferLayoutImpl<Conv2dOp>(pir::Operation* op) {
+  // Note(lyk): We exhibit the layout transformation for conv2d
+  // due to issues with its infermeta and kernel not functioning
+  // properly in NHWC layout. However, if the FLAGS_manually_trans_conv_filter
+  // is enabled, the transfer_layout_pass can also operate correctly.
+  return false;
+
   auto data_format_attr = op->attribute<pir::StrAttribute>("data_format");
   if (!data_format_attr) {
     PADDLE_THROW(phi::errors::InvalidArgument(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
This PR fixes two problem:
1. Exception during translation of argsort. This is because #63513 added new attribute and we adpot it in this PR.
2. Skip layout transformation for `conv2d`. This is because its infermeta and kernel not functioning properly in NHWC layout. For the right implementation, see modifications in #64479.

#### Others
Pcard-71500