### PR TITLE
[CINN]add guarantee mechanism for shape_optimization_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/add_broadcast_to_elementwise_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_broadcast_to_elementwise_pass.cc
@@ -107,8 +107,6 @@ bool ProcessOp(pir::Operation* op, pir::PatternRewriter* rewriter) {
 
   if (x_dims != y_dims) {
     auto output_shape = GetOutputShape(x_dims, y_dims);
-    pir::ShapeConstraintIRAnalysis& shape_analysis =
-        pir::ShapeAnalysisManager::Instance().Get(op->GetParentProgram());
     std::vector<symbol::DimExpr> out_dim;
     out_dim.reserve(output_shape.size());
     for (auto d : output_shape) {

--- a/paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/add_store_in_fusion_op_pass.cc
@@ -32,8 +32,6 @@ class AddYieldStoreInFusionOpPattern
 
   bool MatchAndRewrite(::pir::YieldOp op,
                        pir::PatternRewriter& rewriter) const override {
-    auto& shape_analysis =
-        pir::ShapeAnalysisManager::Instance().Get(op->GetParentProgram());
     for (auto i = 0; i < op->num_operands(); ++i) {
       if (op->operand_source(i).use_count() == 1) {
         continue;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -404,11 +404,7 @@ bool MatmulOpInferSymbolicShape(pir::Operation *op,
     std::vector<symbol::DimExpr> dims;
     const auto &x_shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(0));
-    if (x_shape_or_data.data().has_value()) {
-      dims = x_shape_or_data.data().value();
-    } else {
-      dims = x_shape_or_data.shape();
-    }
+    dims = x_shape_or_data.shape();
     return dims;
   }();
 
@@ -417,11 +413,7 @@ bool MatmulOpInferSymbolicShape(pir::Operation *op,
     std::vector<symbol::DimExpr> dims;
     const auto y_shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(1));
-    if (y_shape_or_data.data().has_value()) {
-      dims = y_shape_or_data.data().value();
-    } else {
-      dims = y_shape_or_data.shape();
-    }
+    dims = y_shape_or_data.shape();
     return dims;
   }();
 

--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -261,15 +261,6 @@ class ShapeOptimizationPass : public pir::Pass {
 
 }  // namespace
 
-symbol::TensorShapeOrDataDimExprs CreateShapeOrDataByDDim(
-    const pir::DDim& dims) {
-  std::vector<symbol::DimExpr> dim_exprs;
-  for (int i = 0; i < dims.size(); ++i) {
-    dim_exprs.emplace_back(dims.at(i));
-  }
-  return symbol::TensorShapeOrDataDimExprs{dim_exprs};
-}
-
 void InferSymExprForBlock(const Block& block,
                           InferSymbolicShapeContext* infer_context) {
   for (auto& op : block) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds a minimum guarantee mechanism to the shape_optimization_pass. When a specific operator does not have a symbolic shape inference function, it considers using static shape information to allow the use of a new symbol. 
In addition, this PR also fixes a bug in the symbolic shape inference of the Matmul operator.