### PR TITLE
[PIR] Add Op output type check for CSE

### DIFF
--- a/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
+++ b/paddle/fluid/pir/transforms/general/common_subexpression_elimination_pass.cc
@@ -367,6 +367,21 @@ struct Expression {
         return false;
       }
     }
+
+    if (lhs->num_results() != rhs->num_results()) {
+      VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+              << " vs rhs [" << rhs << "] " << rhs->name()
+              << " num_results not equal";
+      return false;
+    }
+    for (size_t i = 0; i < lhs->num_results(); ++i) {
+      if (lhs->result_type(i) != rhs->result_type(i)) {
+        VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
+                << " vs rhs [" << rhs << "] " << rhs->name() << " result type "
+                << i << " not equal";
+        return false;
+      }
+    }
     VLOG(7) << "[CheckOperationEqual] lhs [" << lhs << "] " << lhs->name()
             << " vs rhs [" << rhs << "] " << rhs->name() << " equal";
     return true;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

CSE 的 equal 判断里添加了对 OP 输出 type 的检查

如下所示，这些 `assign_value` attributes 都是一样的，但是输出 type 不一样，按理说正常组网 infermeta 是不会出现这种情况，这个模型是 PT 转换得来，可能是 PT 或者老 IR 组网的时候哪里有 trick 对输出 type 进行了重新 set

```
    (%1892) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<1xf32>
    (%1893) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<2000xi64>
    (%1894) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<1xf32>
    (%1895) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1xi32>
    (%1896) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x10xf32>
    (%1897) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<1xi64>
    (%1898) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x5xf32>
    (%1899) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x5xf32>
    (%1900) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x5xf32>
    (%1901) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x5xf32>
    (%1902) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x5xf32>
    (%1903) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x9xf32>
    (%1904) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x9xf32>
    (%1905) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x9xf32>
    (%1906) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x9xf32>
    (%1907) = "pd_op.assign_value" () {dtype:(pd_op.DataType)float32,persistable:[false],place:(pd_op.Place)Place(undefined:0),shape:[(Int32)1],stop_gradient:[false],values:[(Double)1.77113e+27]} : () -> builtin.tensor<-1x9xf32>
```

PCard-66972