### PR TITLE
Fix allreduce_matmul_grad overlap bug in new ir

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -144,6 +144,10 @@ void DependencyBuilder::ShareDependencyFrom(const DependencyBuilder& src) {
   is_build_ = true;
 }
 
+const std::string& DependencyBuilder::GetInstructionName(size_t op_idx) const {
+  return (*instructions_)[op_idx].OpBase()->Type();
+}
+
 const std::map<size_t, std::set<size_t>>& DependencyBuilder::OpDownstreamMap()
     const {
   PADDLE_ENFORCE_EQ(
@@ -340,6 +344,13 @@ void DependencyBuilder::AddDependencyForReadOp() {
 void DependencyBuilder::AddDependencyForSequentialRun() {
   size_t dependence_op_idx = ULLONG_MAX;
   for (size_t op_idx = 0; op_idx < op_num_; ++op_idx) {
+    if (this->GetInstructionName(op_idx) == "pd_op.full_int_array") {
+      VLOG(8) << "Skip adding dependency for sequential run: "
+              << dependence_op_idx << "->" << op_idx << " "
+              << this->GetInstructionName(dependence_op_idx) << "->"
+              << this->GetInstructionName(op_idx);
+      continue;
+    }
     if (dependence_op_idx != ULLONG_MAX) {
       AddDownstreamOp(dependence_op_idx, op_idx);
     }
@@ -569,6 +580,11 @@ PirDependencyBuilder::PirDependencyBuilder() : instructions_() {
   is_build_ = false;
   op_downstream_map_ = std::make_shared<std::map<size_t, std::set<size_t>>>();
   op_happens_before_ = std::make_shared<std::vector<std::vector<bool>>>();
+}
+
+const std::string& PirDependencyBuilder::GetInstructionName(
+    size_t op_idx) const {
+  return (instructions_)[op_idx]->Name();
 }
 
 void PirDependencyBuilder::AddDependencyForCommunicationOp() {

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -63,6 +63,8 @@ class DependencyBuilder {
            &((*instructions_)[op2].DeviceContext());
   }
 
+  virtual const std::string& GetInstructionName(size_t op_idx) const;
+
  protected:
   void AddDependencyForCoalesceTensorOp();
   virtual void AddDependencyForCommunicationOp();
@@ -126,6 +128,8 @@ class PirDependencyBuilder : public DependencyBuilder {
     return &((instructions_)[op1]->DeviceContext()) ==
            &((instructions_)[op2]->DeviceContext());
   }
+
+  const std::string& GetInstructionName(size_t op_idx) const override;
 
  private:
   void AddDependencyForCommunicationOp() override;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

```
# For allreduce pattern in the backward phase of column parallel linear:
  dX, dY = matmul_grad(X, Y, dOut)
  dX = c_allreduce_sum(dX)
# Split matmul_grad to 2 matmul:
  dX = matmul(dOut, Y^T)
  dX = c_allreduce_sum(dX)
  dY = matmul(X^T, dOut)

# Then the c_allreduce_sum can overlap with the compute of dY.
```

**问题修复：**

1. 静态图下，pass `allreduce_matmul_grad_overlapping` 优化后，allreduce op execution_stream 应为 auto_parallel_mp
    - 修复前：default. 
    - 原因：原来的代码中有修改成 auto_parallel_mp，但未生效 
    - 修复后：auto_parallel_mp
2. （在修复问题1后）新 IR 下，allreduce 与 matmul 在执行时应该 overlap
    - 修复前：allreduce 与 matmul 顺序执行
![image](https://github.com/PaddlePaddle/Paddle/assets/33742067/0628ce92-4451-4ce7-8934-6e93897935e0)
    - 原因：
      错误地在  matmul  Add Wait Event
    - 修复后：可并行
![image](https://github.com/PaddlePaddle/Paddle/assets/33742067/bcb05d67-f147-47d6-9e97-4067643c27b1)


**性能提升：**
fix后，在GPT 13B，mp2pp4 gbs=4 bf16，吞吐可提高 2%左右

Pcard-73145