### PR TITLE
Update extension_utils.py to hide console window for pyinstaller nonconsole

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -662,8 +662,12 @@ def find_cuda_home():
         which_cmd = 'where' if IS_WINDOWS else 'which'
         try:
             with open(os.devnull, 'w') as devnull:
+                # STARTUPINFO used to hide the console window
+                si = subprocess.STARTUPINFO()
+                si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                
                 nvcc_path = subprocess.check_output(
-                    [which_cmd, 'nvcc'], stderr=devnull
+                    [which_cmd, 'nvcc'], stderr=devnull, startupinfo=si
                 )
                 nvcc_path = nvcc_path.decode()
                 # Multi CUDA, select the first


### PR DESCRIPTION
### PR Category
User Experience 


### PR Types
Bug fixes


### Description
Used STARTUPINFO to prevent the console window from popping up when using a pyinstaller nonconsole. 

https://stackoverflow.com/questions/7006238/how-do-i-hide-the-console-when-i-use-os-system-or-subprocess-call/7006424#7006424
