### PR TITLE
[Inference]Fix mixed_precision_pass in faster_rcnn_swin_tiny_fpn_1x_coco model

### DIFF
--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.h
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.h
@@ -80,7 +80,7 @@ class AutoMixedPrecisionPass : public FusePassBase {
   // subgraph id -> pointer to subgraph
   mutable std::vector<Graph*> subgraphes_;
   // var name -> real var node
-  mutable std::unordered_map<std::string, Node*> real_vars_;
+  mutable std::unordered_map<std::string, std::vector<Node*>> real_vars_;
   // subgraph id -> all op nodes in subgraph
   mutable std::vector<std::vector<Node*>> all_op_nodes_;
   // op's unique type -> the op's origin type


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500
修复auto_mixed_precision_pass在控制流场景下修改输出DataType异常问题，控制流场景下有多个sub graph，存在同一个Var被多个Node持有处理的情况，需要统一对这些Node的输出DataType进行处理