### PR TITLE
[PIR] mark gaussian OP has side effect

### DIFF
--- a/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/static_ops.yaml
@@ -453,6 +453,7 @@
     data_type : dtype
     backend : place
   interfaces : paddle::dialect::InferSymbolicShapeInterface
+  traits : pir::SideEffectTrait
 
 - op : get_tensor_from_selected_rows
   args : (Tensor x)
@@ -960,6 +961,7 @@
     param: [seed]
   kernel:
     func: seed
+  traits : pir::SideEffectTrait
 
 - op : send_and_recv
   args : (Tensor[] x, str message_name, str[] send_var_name, str[] recv_var_name, int trainer_id = 0, str mode="forward", str[] endpoints={"127.0.0.1:6164"}, str[] next_endpoints={"127.0.0.1:6164"}, str[] previous_endpoints={"127.0.0.1:6164"})
@@ -1034,6 +1036,7 @@
      func: shuffle_batch
      data_type: x
   backward : shuffle_batch_grad
+  traits : pir::SideEffectTrait
 
 - op : shuffle_channel
   args : (Tensor x, int group = 1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#63960 后续 PR，修复 SD 中发现的 gaussian OP 没有标记为包含 SideEffect 的问题，导致 CSE 误删了，之前只标记了一些含关键字 `rand` 的，本 PR 用关键字 `seed` 搜索发现了其他几个可能会因为随机性而造成 sideeffect 的 OP

PCard-66972