### PR TITLE
[XPU] support record stream for xpu

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -1853,6 +1853,11 @@ const std::shared_ptr<Allocator>& AllocatorFacade::GetAllocator(
   }
   return m->GetAllocator(place, /* A non-zero num to choose allocator_ */ 1);
 }
+
+void AllocatorFacade::RecordStream(std::shared_ptr<phi::Allocation> allocation,
+                                   XPUStream stream) {
+  GetPrivate()->RecordStream(allocation, stream);
+}
 #endif
 
 #ifdef PADDLE_WITH_CUSTOM_DEVICE

--- a/paddle/fluid/memory/allocation/allocator_facade.h
+++ b/paddle/fluid/memory/allocation/allocator_facade.h
@@ -96,6 +96,7 @@ class AllocatorFacade {
 #elif defined(PADDLE_WITH_XPU)
   TEST_API const std::shared_ptr<Allocator>& GetAllocator(
       const platform::Place& place, XPUStream stream);
+  void RecordStream(std::shared_ptr<Allocation> allocation, XPUStream stream);
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/paddle/fluid/memory/malloc.cc
+++ b/paddle/fluid/memory/malloc.cc
@@ -78,6 +78,13 @@ gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation) {
 
 #endif
 
+#ifdef PADDLE_WITH_XPU
+void RecordStream(std::shared_ptr<Allocation> allocation, XPUStream stream) {
+  return allocation::AllocatorFacade::Instance().RecordStream(allocation,
+                                                              stream);
+}
+#endif
+
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
 void RecordStream(std::shared_ptr<Allocation> allocation,
                   phi::stream::stream_t stream) {

--- a/paddle/fluid/memory/malloc.h
+++ b/paddle/fluid/memory/malloc.h
@@ -58,6 +58,9 @@ void EraseStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream);
 
 gpuStream_t GetStream(const std::shared_ptr<Allocation>& allocation);
 #endif
+#ifdef PADDLE_WITH_XPU
+void RecordStream(std::shared_ptr<Allocation> allocation, XPUStream stream);
+#endif
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
 void RecordStream(std::shared_ptr<Allocation> allocation,
                   phi::stream::stream_t stream);

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -501,6 +501,7 @@ void InitMemoryMethod() {
           .GetZeroAllocator(phi::CPUPlace())
           .get();
     };
+    memory_method->record_stream = paddle::memory::RecordStream;
     // XPUs do not have the concept of pinned memory,
     // so the get_pinned_allocator function is not set.
     memory_method->get_new_xpu_event = [](int device_id) {

--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -449,5 +449,9 @@ void XPUContext::StreamWaitStream(int wait_stream, int record_stream) const {
 
 int64_t XPUContext::GetStreamNum() const { return impls_.size(); }
 
+void XPUContext::RecordStream(const DenseTensor& tensor, int i) const {
+  memory_utils::RecordStream(tensor.Holder(), stream(i));
+}
+
 void XPUContext::Init() { impls_[0]->Init(); }
 }  // namespace phi

--- a/paddle/phi/backends/xpu/xpu_context.h
+++ b/paddle/phi/backends/xpu/xpu_context.h
@@ -23,6 +23,7 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/xpu_header.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/common/place.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
 
 namespace Eigen {
@@ -87,6 +88,8 @@ class XPUContext : public DeviceContext,
   Eigen::DefaultDevice* eigen_device() const { return nullptr; }
 
   XPUStream stream(int i = 0) const;
+
+  void RecordStream(const DenseTensor& tensor, int i) const;
 
   static const char* name() { return "XPUContext"; }
 

--- a/paddle/phi/common/memory_utils.cc
+++ b/paddle/phi/common/memory_utils.cc
@@ -133,6 +133,10 @@ const phi::Allocator* GetHostZeroAllocator() {
   return MemoryUtils::Instance().GetHostZeroAllocator();
 }
 
+void RecordStream(std::shared_ptr<Allocation> allocation, XPUStream stream) {
+  return MemoryUtils::Instance().RecordStream(allocation, stream);
+}
+
 // XPUs do not have the concept of pinned memory,
 // so the get_pinned_allocator function is not set.
 std::shared_ptr<std::remove_pointer<XPUEvent>::type> GetXpuEvent(

--- a/paddle/phi/common/memory_utils.h
+++ b/paddle/phi/common/memory_utils.h
@@ -177,6 +177,9 @@ struct MemoryInterface {
   // phi::Allocator* (*get_pinned_allocator)();
   std::shared_ptr<std::remove_pointer<XPUEvent>::type> (*get_new_xpu_event)(
       int device_id);
+
+  void (*record_stream)(std::shared_ptr<Allocation> allocation,
+                        XPUStream stream);
 #endif
 };
 
@@ -398,6 +401,10 @@ class MemoryUtils {
       int device_id) {
     return memory_method_->get_new_xpu_event(device_id);
   }
+
+  void RecordStream(std::shared_ptr<Allocation> allocation, XPUStream stream) {
+    memory_method_->record_stream(allocation, stream);
+  }
 #endif
 
  private:
@@ -484,6 +491,8 @@ const Allocator* GetHostAllocator();
 const Allocator* GetZeroAllocator(int device_id);
 
 const Allocator* GetHostZeroAllocator();
+
+void RecordStream(std::shared_ptr<Allocation> allocation, XPUStream stream);
 
 // XPUs do not have the concept of pinned memory,
 // so the get_pinned_allocator function is not set.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
1. support RecordStream for XPU （used  in fast_paddle）