### PR TITLE
【AutoParallel】Remove the Dtype constrain

### DIFF
--- a/paddle/phi/kernels/impl/set_value_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_kernel_impl.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -290,7 +288,7 @@ void SetValueKernel(const Context& dev_ctx,
       shape.size() == 1 && shape[0] == 1 && assign_values.size() == 1) {
     is_full_set_one_value = true;
   }
-  if (is_full_set_one_value && std::is_same<T, float>::value) {
+  if (is_full_set_one_value) {
     dev_ctx.template Alloc<T>(out);
     phi::funcs::set_constant(
         dev_ctx, out, static_cast<float>(assign_values[0]));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-76459
Support other dtype in `set_value_kernel` when setting the whole tensor to one value.