### PR TITLE
[CINN] Open the infer_symbol_check in more tests of cinn

### DIFF
--- a/test/ir/pir/cinn/CMakeLists.txt
+++ b/test/ir/pir/cinn/CMakeLists.txt
@@ -18,7 +18,7 @@ if(WITH_GPU)
       COMMAND
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
-        FLAGS_enable_pir_api=1 FLAGS_prim_all=True
+        FLAGS_enable_pir_api=1 FLAGS_prim_all=True FLAGS_check_infer_symbolic=1
         FLAGS_cinn_new_group_scheduler=1 FLAGS_cinn_bucket_compile=1
         FLAGS_group_schedule_tiling_first=1 ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/${cinn_pir_test_name}.py

--- a/test/ir/pir/cinn/inference/CMakeLists.txt
+++ b/test/ir/pir/cinn/inference/CMakeLists.txt
@@ -12,8 +12,9 @@ if(WITH_GPU)
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
         FLAGS_prim_enable_dynamic=True FLAGS_prim_all=True
-        FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True
-        FLAGS_group_schedule_tiling_first=1 ${PYTHON_EXECUTABLE}
+        FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1
+        FLAGS_cinn_bucket_compile=True FLAGS_group_schedule_tiling_first=1
+        ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/${cinn_pir_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     set_tests_properties(${cinn_pir_test_name} PROPERTIES LABELS

--- a/test/ir/pir/cinn/sub_graphs/CMakeLists.txt
+++ b/test/ir/pir/cinn/sub_graphs/CMakeLists.txt
@@ -95,9 +95,9 @@ if(WITH_GPU)
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/python/:$ENV{PYTHONPATH}
         FLAGS_prim_enable_dynamic=1 FLAGS_cinn_new_group_scheduler=1
-        FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=1
-        FLAGS_group_schedule_tiling_first=1 FLAGS_cudnn_deterministic=true
-        ${PYTHON_EXECUTABLE}
+        FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1
+        FLAGS_cinn_bucket_compile=1 FLAGS_group_schedule_tiling_first=1
+        FLAGS_cudnn_deterministic=true ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/${cinn_sub_graph_test_name}.py
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     set_tests_properties(${cinn_sub_graph_test_name} PROPERTIES LABELS


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

在CINN更多单测中开启符号推导正确性检查。