### PR TITLE
[CINN] Obtain raw reduce axis from group op

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -101,6 +101,14 @@ std::shared_ptr<GroupInfo> OpLowererImpl::GetGroupInfo(
   for (auto& val : group->output_values()) {
     group_info->direct_output_var_names.insert(ValueName(val));
   }
+
+  group->WalkOps([&group_info](::pir::Operation* op) {
+    if (CompatibleInfo::OpKind(*op) == OpPatternKind::kReduction) {
+      group_info->raw_reduce_axis = cinn::fusion::GetReduceAxisIdx(op);
+      group_info->raw_data_rank =
+          cinn::fusion::GetCompitableRank(op->operand_source(0));
+    }
+  });
   return group_info;
 }
 

--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.h
@@ -51,6 +51,8 @@ typedef bool (OpLowererImpl::*ScheduleDetermineFunction)(::pir::Operation*);
 struct GroupInfo {
   std::vector<int64_t> data_space;
   std::vector<int64_t> reduce_axis;
+  int64_t raw_data_rank;
+  std::vector<int64_t> raw_reduce_axis;
   std::set<std::string> reduce_var_names;
   std::set<std::string> shared_var_names;
   std::set<std::string> direct_output_var_names;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -37,14 +37,22 @@ std::shared_ptr<ScheduleConfig::BaseInfo> InitBasicInfo(
   base_info->broadcast_info = group_info->broadcast_info;
   base_info->broadcast_to_elementwise = group_info->broadcast_to_elementwise;
   base_info->data_rank = group_info->data_space.size();
+  base_info->raw_data_rank = group_info->raw_data_rank;
 
   std::set<int64_t> reduce_dim_loc;
-  for (auto dim : group_info->reduce_axis) {
+  for (int64_t dim : group_info->reduce_axis) {
     if (dim < 0) {
       dim += base_info->data_rank;
     }
     base_info->reduce_axis.push_back(dim);
     reduce_dim_loc.insert(dim);
+  }
+
+  for (int64_t dim : group_info->raw_reduce_axis) {
+    if (dim < 0) {
+      dim += base_info->data_rank;
+    }
+    base_info->raw_reduce_axis.push_back(dim);
   }
 
   base_info->spatial_numel = 1;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.h
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.h
@@ -29,7 +29,9 @@ namespace ir {
 struct ScheduleConfig {
   struct BaseInfo {
     std::vector<int64_t> reduce_axis;
+    std::vector<int64_t> raw_reduce_axis;
     int64_t data_rank;
+    int64_t raw_data_rank;
     int64_t reduce_numel;
     int64_t spatial_numel;
     bool has_dynamic_spatial{false};


### PR DESCRIPTION
### PR Category
CINN

### PR Types
New features

### Description
pcard-76996

Extract raw reduce axis from a group op, then store it in `GroupInfo` and `ScheduleConfig`.
