### PR TITLE
[PIR] Warning once in ir backward

### DIFF
--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -14,8 +14,12 @@
 from __future__ import annotations
 
 import collections
+import logging
+import time
 import warnings
 from collections.abc import Sequence
+from contextlib import contextmanager
+from functools import lru_cache
 from typing import Any
 
 from paddle import pir
@@ -112,6 +116,13 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.sigmoid",
     "pd_op.silu",
 ]
+
+
+@contextmanager
+def timer(name: str):
+    start = time.time()
+    yield
+    print(f"{name} cost {time.time() - start:.4f} s")
 
 
 class ValueWrapper:
@@ -660,3 +671,8 @@ def get_split_op(value):
         if op.name() == "builtin.split":
             return op
     return None
+
+
+@lru_cache
+def warning_once(message: str):
+    logging.warning(message)

--- a/python/paddle/autograd/backward_utils.py
+++ b/python/paddle/autograd/backward_utils.py
@@ -15,10 +15,8 @@ from __future__ import annotations
 
 import collections
 import logging
-import time
 import warnings
 from collections.abc import Sequence
-from contextlib import contextmanager
 from functools import lru_cache
 from typing import Any
 
@@ -116,13 +114,6 @@ ALLOW_DYNAMIC_SHAPE_VJP_OPS = [
     "pd_op.sigmoid",
     "pd_op.silu",
 ]
-
-
-@contextmanager
-def timer(name: str):
-    start = time.time()
-    yield
-    print(f"{name} cost {time.time() - start:.4f} s")
 
 
 class ValueWrapper:

--- a/python/paddle/autograd/ir_backward.py
+++ b/python/paddle/autograd/ir_backward.py
@@ -45,6 +45,7 @@ from paddle.autograd.backward_utils import (
     return_map_value_list,
     some_in_set,
     update_no_grad_set_by_stopgradient,
+    warning_once,
     while_prune_check,
 )
 from paddle.base.libpaddle.pir import (
@@ -906,7 +907,7 @@ def prepare_backward_prune_set(inputs, outputs):
                 for item in get_real_op_inputs(used_op):
                     outputs_fwd_set.add(item)
         else:
-            logging.warning("input provided by inputs has no use")
+            warning_once("input provided by inputs has no use")
 
     inputs_fwd_set = ValueSet()
     for output in outputs:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

`ir_backward` 部分 warning 仅打印一次，避免 warning 把各个 step 日志淹没的问题

PCard-66972