### PR TITLE
[Inference]Fix fused_flash_attn_pass

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/fused_flash_attn_pass.cc
@@ -139,7 +139,7 @@ class FlashAttnPatternQscaleWithMask : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1) {
+      if (mask_add.size() != 4 || mask_add.at(1) != 1 || mask_add.at(0) != -1) {
         return false;
       }
 
@@ -285,7 +285,7 @@ class FlashAttnPatternOutscaleWithMask : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1) {
+      if (mask_add.size() != 4 || mask_add.at(1) != 1 || mask_add.at(0) != -1) {
         return false;
       }
 
@@ -556,7 +556,7 @@ class TransposeSliceFlashAttnPattern : public paddle::drr::DrrPatternBase {
       }
       // mask's shape [bs, 1, seq_len, seq_len]
       auto mask_add = pir::GetShapeFromValue(match_ctx.Tensor("mask"));
-      if (mask_add.size() != 4 || mask_add.at(1) != 1) {
+      if (mask_add.size() != 4 || mask_add.at(1) != 1 || mask_add.at(0) != -1) {
         return false;
       }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-71500
修复rec_mtb_nrtr模型使用fused_flash_attn_pass后，flash_attn算子调用三方库Flash Attention维度错误的问题，修复方式为在mask0维与batchsize大小不一致的时候跳过该pass执行