### PR TITLE
[CINN] Udpate reduce op convert in pd_to_cinn_pass

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -84,6 +84,9 @@ class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
         op->operand_source(0), axis, keep_dim, dtype);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
+    if (full_int_array_op->use_empty()) {
+      rewriter.EraseOp(full_int_array_op);
+    }
   }
 };
 
@@ -115,6 +118,9 @@ class ReduceMinMaxOpPattern : public pir::OpRewritePattern<SOURCE_OP> {
         rewriter.Build<TARGET_OP>(op->operand_source(0), axis, keep_dim);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
+    if (full_int_array_op->use_empty()) {
+      rewriter.EraseOp(full_int_array_op);
+    }
   }
 };
 
@@ -146,6 +152,9 @@ class ProdOpPattern : public pir::OpRewritePattern<paddle::dialect::ProdOp> {
         op->operand_source(0), axis, keep_dim, reduce_all);
     rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
     rewriter.EraseOp(op);
+    if (full_int_array_op->use_empty()) {
+      rewriter.EraseOp(full_int_array_op);
+    }
   }
 };
 

--- a/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/pd_to_cinn_pass.cc
@@ -33,116 +33,119 @@ namespace dialect {
 namespace ir {
 using CompatibleInfo = cinn::hlir::framework::pir::CompatibleInfo;
 
-class SumOpPattern : public paddle::drr::DrrPatternBase {
+namespace {
+
+template <typename T = int>
+std::vector<T> GetVectorFromIntArrayAttribute(
+    const pir::ArrayAttribute &array_attr) {
+  const auto &vector_attr = array_attr.AsVector();
+
+  std::vector<T> result;
+  if (vector_attr.size() > 0) {
+    PADDLE_ENFORCE_EQ(vector_attr[0].isa<::pir::Int64Attribute>(),
+                      true,
+                      phi::errors::Unimplemented(
+                          "the 0th elementwise MUST be ir::Int64Attribute"));
+    for (size_t i = 0; i < vector_attr.size(); ++i) {
+      result.push_back(vector_attr[i].dyn_cast<::pir::Int64Attribute>().data());
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+class SumOpPattern : public pir::OpRewritePattern<paddle::dialect::SumOp> {
  public:
-  std::string name() const override { return "SumOpPattern"; }
+  using pir::OpRewritePattern<paddle::dialect::SumOp>::OpRewritePattern;
 
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    // Source Pattern
-    paddle::drr::SourcePattern pattern = ctx->SourcePattern();
-    const auto &full_int_array =
-        pattern.Op(paddle::dialect::FullIntArrayOp::name(),
-                   {{"value", pattern.Attr("axis_info")},
-                    {"dtype", pattern.Attr("dtype_2")},
-                    {"place", pattern.Attr("place_2")}});
+  bool Match(paddle::dialect::SumOp op) const override {
+    if (CompatibleInfo::IsDeniedForCinn(*op.operation())) return false;
+    auto *axes_op = op->operand_source(1).defining_op();
+    return axes_op && axes_op->isa<paddle::dialect::FullIntArrayOp>();
+  }
 
-    const auto &sum = pattern.Op(paddle::dialect::SumOp::name(),
-                                 {{"dtype", pattern.Attr("dtype")},
-                                  {"keepdim", pattern.Attr("keep_dim")}});
-    pattern.Tensor("ret") = sum(pattern.Tensor("arg0"), full_int_array());
+  void Rewrite(paddle::dialect::SumOp op,
+               pir::PatternRewriter &rewriter) const override {
+    auto *axes_op = op->operand_source(1).defining_op();
+    auto full_int_array_op =
+        axes_op->dyn_cast<paddle::dialect::FullIntArrayOp>();
 
-    // Result patterns
-    paddle::drr::ResultPattern res = pattern.ResultPattern();
-    const auto &cinn_reduce_sum =
-        res.Op(cinn::dialect::ReduceSumOp::name(),
-               {{"dim", pattern.Attr("axis_info")},
-                {"dtype", pattern.Attr("dtype")},
-                {"keep_dim", pattern.Attr("keep_dim")}});
-    res.Tensor("ret") = cinn_reduce_sum(res.Tensor("arg0"));
+    // get attribute value from full_int_array op
+    const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
+        full_int_array_op.attribute("value").dyn_cast<pir::ArrayAttribute>());
+    const bool keep_dim =
+        op.attribute("keepdim").dyn_cast<::pir::BoolAttribute>().data();
+    const auto &dtype = op.attribute("dtype")
+                            .dyn_cast<paddle::dialect::DataTypeAttribute>()
+                            .data();
+
+    auto cinn_reduce = rewriter.Build<cinn::dialect::ReduceSumOp>(
+        op->operand_source(0), axis, keep_dim, dtype);
+    rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
+    rewriter.EraseOp(op);
   }
 };
 
-class MaxOpPattern : public paddle::drr::DrrPatternBase {
+template <typename SOURCE_OP, typename TARGET_OP>
+class ReduceMinMaxOpPattern : public pir::OpRewritePattern<SOURCE_OP> {
  public:
-  std::string name() const override { return "MaxOpPattern"; }
+  using pir::OpRewritePattern<SOURCE_OP>::OpRewritePattern;
 
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    // Source Pattern
-    paddle::drr::SourcePattern pattern = ctx->SourcePattern();
-    const auto &full_int_array =
-        pattern.Op(paddle::dialect::FullIntArrayOp::name(),
-                   {{"value", pattern.Attr("axis_info")},
-                    {"dtype", pattern.Attr("dtype_2")},
-                    {"place", pattern.Attr("place_2")}});
+  bool Match(SOURCE_OP op) const override {
+    if (CompatibleInfo::IsDeniedForCinn(*op.operation())) return false;
+    auto *axes_op = op->operand_source(1).defining_op();
+    return axes_op && axes_op->template isa<paddle::dialect::FullIntArrayOp>();
+  }
 
-    const auto &pd_max = pattern.Op(paddle::dialect::MaxOp::name(),
-                                    {{"keepdim", pattern.Attr("keep_dim")}});
-    pattern.Tensor("ret") = pd_max(pattern.Tensor("arg0"), full_int_array());
+  void Rewrite(SOURCE_OP op, pir::PatternRewriter &rewriter) const override {
+    auto *axes_op = op->operand_source(1).defining_op();
+    auto full_int_array_op =
+        axes_op->template dyn_cast<paddle::dialect::FullIntArrayOp>();
 
-    // Result patterns
-    paddle::drr::ResultPattern res = pattern.ResultPattern();
-    const auto &cinn_reduce_max =
-        res.Op(cinn::dialect::ReduceMaxOp::name(),
-               {{"dim", pattern.Attr("axis_info")},
-                {"keep_dim", pattern.Attr("keep_dim")}});
-    res.Tensor("ret") = cinn_reduce_max(res.Tensor("arg0"));
+    // get attribute value from full_int_array op
+    const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
+        full_int_array_op.attribute("value")
+            .template dyn_cast<pir::ArrayAttribute>());
+    const bool keep_dim = op.attribute("keepdim")
+                              .template dyn_cast<::pir::BoolAttribute>()
+                              .data();
+
+    auto cinn_reduce =
+        rewriter.Build<TARGET_OP>(op->operand_source(0), axis, keep_dim);
+    rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
+    rewriter.EraseOp(op);
   }
 };
 
-class MinOpPattern : public paddle::drr::DrrPatternBase {
+class ProdOpPattern : public pir::OpRewritePattern<paddle::dialect::ProdOp> {
  public:
-  std::string name() const override { return "MinOpPattern"; }
+  using pir::OpRewritePattern<paddle::dialect::ProdOp>::OpRewritePattern;
 
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    // Source Pattern
-    paddle::drr::SourcePattern pattern = ctx->SourcePattern();
-    const auto &full_int_array =
-        pattern.Op(paddle::dialect::FullIntArrayOp::name(),
-                   {{"value", pattern.Attr("axis_info")},
-                    {"dtype", pattern.Attr("dtype_2")},
-                    {"place", pattern.Attr("place_2")}});
-
-    const auto &pd_max = pattern.Op(paddle::dialect::MinOp::name(),
-                                    {{"keepdim", pattern.Attr("keep_dim")}});
-    pattern.Tensor("ret") = pd_max(pattern.Tensor("arg0"), full_int_array());
-
-    // Result patterns
-    paddle::drr::ResultPattern res = pattern.ResultPattern();
-    const auto &cinn_reduce_max =
-        res.Op(cinn::dialect::ReduceMinOp::name(),
-               {{"dim", pattern.Attr("axis_info")},
-                {"keep_dim", pattern.Attr("keep_dim")}});
-    res.Tensor("ret") = cinn_reduce_max(res.Tensor("arg0"));
+  bool Match(paddle::dialect::ProdOp op) const override {
+    if (CompatibleInfo::IsDeniedForCinn(*op.operation())) return false;
+    auto *axes_op = op->operand_source(1).defining_op();
+    return axes_op && axes_op->isa<paddle::dialect::FullIntArrayOp>();
   }
-};
 
-class ProdOpPattern : public paddle::drr::DrrPatternBase {
- public:
-  std::string name() const override { return "ProdOpPattern"; }
+  void Rewrite(paddle::dialect::ProdOp op,
+               pir::PatternRewriter &rewriter) const override {
+    auto *axes_op = op->operand_source(1).defining_op();
+    auto full_int_array_op =
+        axes_op->dyn_cast<paddle::dialect::FullIntArrayOp>();
 
-  void operator()(paddle::drr::DrrPatternContext *ctx) const override {
-    // Source Pattern
-    paddle::drr::SourcePattern pattern = ctx->SourcePattern();
-    const auto &full_int_array =
-        pattern.Op(paddle::dialect::FullIntArrayOp::name(),
-                   {{"value", pattern.Attr("axis_info")},
-                    {"dtype", pattern.Attr("dtype_2")},
-                    {"place", pattern.Attr("place_2")}});
+    // get attribute value from full_int_array op
+    const std::vector<int64_t> axis = GetVectorFromIntArrayAttribute<int64_t>(
+        full_int_array_op.attribute("value").dyn_cast<pir::ArrayAttribute>());
+    const bool keep_dim =
+        op.attribute("keep_dim").dyn_cast<::pir::BoolAttribute>().data();
+    const bool reduce_all =
+        op.attribute("reduce_all").dyn_cast<::pir::BoolAttribute>().data();
 
-    const auto &pd_max =
-        pattern.Op(paddle::dialect::ProdOp::name(),
-                   {{"keep_dim", pattern.Attr("keep_dim")},
-                    {"reduce_all", pattern.Attr("reduce_all")}});
-    pattern.Tensor("ret") = pd_max(pattern.Tensor("arg0"), full_int_array());
-
-    // Result patterns
-    paddle::drr::ResultPattern res = pattern.ResultPattern();
-    const auto &cinn_reduce_max =
-        res.Op(cinn::dialect::ReduceProdOp::name(),
-               {{"dim", pattern.Attr("axis_info")},
-                {"keep_dim", pattern.Attr("keep_dim")},
-                {"reduce_all", pattern.Attr("reduce_all")}});
-    res.Tensor("ret") = cinn_reduce_max(res.Tensor("arg0"));
+    auto cinn_reduce = rewriter.Build<cinn::dialect::ReduceProdOp>(
+        op->operand_source(0), axis, keep_dim, reduce_all);
+    rewriter.ReplaceAllUsesWith(op.result(0), cinn_reduce.result(0));
+    rewriter.EraseOp(op);
   }
 };
 
@@ -1117,10 +1120,12 @@ pir::RewritePatternSet PdOpToCinnOpPass::InitializePatterns(
   pir::RewritePatternSet ps(context);
   ps.Add<ScaleOpPattern>(
       context);  // NOTE, scale op pattern should before AddBroadcastTo
-  ps.Add(paddle::drr::Create<SumOpPattern>(context));
-  ps.Add(paddle::drr::Create<MaxOpPattern>(context));
-  ps.Add(paddle::drr::Create<MinOpPattern>(context));
-  ps.Add(paddle::drr::Create<ProdOpPattern>(context));
+  ps.Add<SumOpPattern>(context);
+  ps.Add<ReduceMinMaxOpPattern<paddle::dialect::MinOp,
+                               cinn::dialect::ReduceMinOp>>(context);
+  ps.Add<ReduceMinMaxOpPattern<paddle::dialect::MaxOp,
+                               cinn::dialect::ReduceMaxOp>>(context);
+  ps.Add<ProdOpPattern>(context);
   ps.Add<ReshapeOpPattern>(context);
   ps.Add<PowOpPattern>(context);
   ps.Add<ConcatOpPattern>(context);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
Pcard-67164

由于DRR的匹配规则要求source pattern为闭包，导致reduce系列算子在经过CSE后的子图无法匹配成功，因此将reduce系列的op转换改为普通的PatternRewrite写法。