### PR TITLE
[Prim][Dist] enable Flags_prim_enable_dynamic in cpp

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -1532,9 +1532,14 @@ PHI_DEFINE_EXPORTED_bool(print_ir, false, "Whether print ir debug str.");
 PHI_DEFINE_EXPORTED_bool(pir_debug,
                          false,
                          "Whether print more pir debug info.");
-PHI_DEFINE_EXPORTED_bool(prim_skip_dynamic,
-                         true,
-                         "Whether to skip decomposing op with dynamic shape.");
+PHI_DEFINE_EXPORTED_bool(
+    prim_skip_dynamic,
+    true,
+    "Whether to skip decomposing vjp op with dynamic shape.");
+PHI_DEFINE_EXPORTED_bool(
+    prim_enable_dynamic,
+    false,
+    "Whether to enable decomposing composite op with dynamic shape.");
 PHI_DEFINE_EXPORTED_bool(prim_check_ops,
                          false,
                          "Whether to check the decomposed program, to ensure "

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -456,7 +456,7 @@ void DecompProgram::decomp_block(
     bool enable_prim =
         has_decomp_rule(*op) && enable_decomp_by_filter(op->name());
     if (enable_prim && check_decomp_dynamic_shape(op) &&
-        (!Flags_prim_enable_dynamic ||
+        (!FLAGS_prim_enable_dynamic ||
          dynamic_shape_blacklist.find(op->name()) !=
              dynamic_shape_blacklist.end())) {
       enable_prim = false;

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -25,6 +25,7 @@
 #include "paddle/pir/include/core/program.h"
 
 COMMON_DECLARE_bool(prim_check_ops);
+COMMON_DECLARE_bool(prim_enable_dynamic);
 COMMON_DECLARE_string(prim_forward_blacklist);
 
 using paddle::dialect::DenseTensorType;
@@ -455,8 +456,9 @@ void DecompProgram::decomp_block(
     bool enable_prim =
         has_decomp_rule(*op) && enable_decomp_by_filter(op->name());
     if (enable_prim && check_decomp_dynamic_shape(op) &&
-        dynamic_shape_blacklist.find(op->name()) !=
-            dynamic_shape_blacklist.end()) {
+        (!Flags_prim_enable_dynamic ||
+         dynamic_shape_blacklist.find(op->name()) !=
+             dynamic_shape_blacklist.end())) {
       enable_prim = false;
     }
     if (enable_prim) {

--- a/python/paddle/decomposition/decomp.py
+++ b/python/paddle/decomposition/decomp.py
@@ -858,13 +858,21 @@ def decompose_dist_program(pir_program):
             # todo(CZ): to be removed
             if bwd_op_name in ["pd_op.mean_grad", "pd_op.concat_grad"]:
                 continue
+            skip_decomp = False
             if has_decomp_vjp(op):
-                pir.set_insertion_point(op)
-                orig_outs = op.results()
-                decomp_outs = call_decomp_vjp(op)
-                new_outs = _analyse_decomp_results(orig_outs, decomp_outs, op)
-                op.replace_all_uses_with(new_outs)
-                block.remove_op(op)
+                if (
+                    not core._enable_prim_dynamic_shape()
+                ) and _check_prim_dynamic(op):
+                    skip_decomp = True
+                if not skip_decomp:
+                    pir.set_insertion_point(op)
+                    orig_outs = op.results()
+                    decomp_outs = call_decomp_vjp(op)
+                    new_outs = _analyse_decomp_results(
+                        orig_outs, decomp_outs, op
+                    )
+                    op.replace_all_uses_with(new_outs)
+                    block.remove_op(op)
 
 
 def decompose_pir_program(pir_program, param_mapping, grad_var_to_var):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Others


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others


### Description
<!-- Describe what you’ve done -->
Pcard-66975
By default is **distribution**, decomp will skip op with dynamic shape input.
And those op will be decomposed only if **export FLAGS_prim_enable_dynamic=true**.
