### PR TITLE
【Hackathon 6th No.9】Update ValidateShape to support zero sized tensor flatten -part

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2090,7 +2090,15 @@ static phi::DDim ValidateShape(const std::vector<int64_t> shape,
       output_shape[i] = shape[i];
     } else if (shape[i] == 0) {
       if (static_cast<int>(i) < in_dims.size()) {
-        output_shape[i] = in_dims[static_cast<int>(i)];
+        if (in_size == 0) {
+          // such as [3, 2, 0] -> [0, 0] is [0, 0]; [3, 2, 0] -> [10, 0] is [10,
+          // 0]
+          output_shape[i] = 0;
+        } else {
+          // such as [3, 2, 1] -> [0, 0] is [3, 2]; [3, 2, 1] -> [3, 2, 0] is
+          // [3, 2, 1]
+          output_shape[i] = in_dims[static_cast<int>(i)];
+        }
       } else {
         PADDLE_ENFORCE_EQ(
             in_size,

--- a/test/deprecated/legacy_test/test_flatten_contiguous_range_op.py
+++ b/test/deprecated/legacy_test/test_flatten_contiguous_range_op.py
@@ -580,5 +580,29 @@ class TestFlatten0DTensorOpError(unittest.TestCase):
         self.assertRaises(ValueError, test_ValueError2)
 
 
+class TestFlattenZeroSizedTensorAPI(unittest.TestCase):
+    def test_dygraph(self):
+        paddle.disable_static()
+        data = np.random.randn(2, 3, 0)
+        x = paddle.to_tensor(data)
+        out = paddle.flatten(x)
+        out_np = data.flatten()
+        np.testing.assert_equal(out.numpy(), out_np)
+
+    @test_with_pir_api
+    def test_static(self):
+        paddle.enable_static()
+        data = np.random.randn(2, 3, 0)
+        main_prog = paddle.static.Program()
+        with paddle.static.program_guard(main_prog, paddle.static.Program()):
+            x = paddle.static.data(name="x", shape=[2, 3, 0], dtype='float64')
+            out = paddle.flatten(x)
+
+        exe = paddle.static.Executor(place=paddle.CPUPlace())
+        fetch_out = exe.run(main_prog, feed={"x": data}, fetch_list=[out])[0]
+        out_np = data.flatten()
+        np.testing.assert_equal(fetch_out, out_np)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/community/pull/833#pullrequestreview-1970582142

问题：
![image](https://github.com/PaddlePaddle/Paddle/assets/49900969/3b761e17-cc4b-4c0f-bcf0-364cf8798912)
根据报错信息应该是需要调整unary.cc中的：
static phi::DDim ValidateShape(const std::vector<int64_t> shape, const phi::DDim& in_dims)

如果flatten支持了shape有零的情况，stack也需要支持shape有零的情况
