### PR TITLE
sigmoid is not fused into fused_conv2d_add_act when using CUDNN

### DIFF
--- a/paddle/fluid/pir/transforms/gpu/conv2d_add_act_fuse_pass.cc
+++ b/paddle/fluid/pir/transforms/gpu/conv2d_add_act_fuse_pass.cc
@@ -35,8 +35,8 @@ class Conv2dAddActFusePassDrrPattern : public paddle::drr::DrrPatternBase {
  private:
   std::string act_name_;
   bool cutlass_pattern_;
-  const std::unordered_set<std::string> conv2d_depthwise_act_set_ = {
-      "relu", "swish", "sigmoid"};
+  const std::unordered_set<std::string> conv2d_depthwise_act_set_ = {"relu",
+                                                                     "swish"};
 
  public:
   static const int CUTLASS_NHWC_ALIGNMENT = 8;
@@ -278,11 +278,9 @@ class Conv2dAdd2ActFusePattern
     if (next_op->isa<paddle::dialect::ReluOp>()) {
       act_name = "relu";
     }
-#if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 8000 && CUDNN_VERSION < 8700
+#if defined(PADDLE_WITH_CUDA) && CUDNN_VERSION >= 8000 && CUDNN_VERSION < 8700
     if (next_op->isa<paddle::dialect::TanhOp>()) {
       act_name = "tanh";
-    } else if (next_op->isa<paddle::dialect::SigmoidOp>()) {
-      act_name = "sigmoid";
     }
 #endif
     if (act_name == "") {
@@ -346,11 +344,10 @@ class Conv2dAddActFusePass : public pir::PatternRewritePass {
                 paddle::dialect::FusedConv2dAddActOp::name()});
 
 // NOTE(liuyuanle): cudnn [8.7, 8.9 now) version has bug when act is
-// sigmoid/tanh. Ref to issue
+// tanh. Ref to issue
 // https://github.com/PaddlePaddle/Paddle/issues/50853
 #if CUDNN_VERSION >= 8000 && CUDNN_VERSION < 8700
-    const std::unordered_set<std::string> cudnn_act_set(
-        {"relu", "sigmoid", "tanh"});
+    const std::unordered_set<std::string> cudnn_act_set({"relu", "tanh"});
 #else
     const std::unordered_set<std::string> cudnn_act_set({"relu"});
 #endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
Pcard-71500
sigmoid is not fused into fused_conv2d_add_act when using CUDNN,because it will cause performance degradation.