### PR TITLE
[CINN]Fix compilation cache re-use same fn_ptr wrongly

### DIFF
--- a/paddle/cinn/hlir/framework/pir/fusion_info.h
+++ b/paddle/cinn/hlir/framework/pir/fusion_info.h
@@ -58,17 +58,17 @@ class OperationInfo {
   std::vector<AttributeInfo> attr_infos_;
 };
 
-class OpDepsInfo {
+class OpDepInfo {
  public:
-  OpDepsInfo(size_t upstream_index, size_t upstream_hash)
+  OpDepInfo(size_t upstream_index, size_t upstream_hash)
       : upstream_index_(upstream_index), upstream_hash_(upstream_hash) {}
-  bool operator==(const OpDepsInfo &other) {
+  bool operator==(const OpDepInfo &other) {
     return this->upstream_index_ == other.upstream_index_ &&
            this->upstream_hash_ == other.upstream_hash_;
   }
 
   std::size_t hash() const;
-  friend std::ostream &operator<<(std::ostream &os, const OpDepsInfo &info);
+  friend std::ostream &operator<<(std::ostream &os, const OpDepInfo &info);
 
  private:
   size_t upstream_index_;
@@ -78,7 +78,7 @@ class OpDepsInfo {
 class FusionOpInfo {
  public:
   FusionOpInfo(const ::pir::Operation &op,
-               const std::map<size_t, OpDepsInfo> &deps)
+               const std::map<size_t, OpDepInfo> &deps)
       : op_info_(op), inner_deps_(deps) {}
 
   std::size_t hash() const;
@@ -87,7 +87,7 @@ class FusionOpInfo {
  private:
   OperationInfo op_info_;
   // oprand_source id : OperationInfo hash
-  std::map<size_t, OpDepsInfo> inner_deps_;
+  std::map<size_t, OpDepInfo> inner_deps_;
 };
 
 class FusionInfo {
@@ -122,7 +122,7 @@ class FusionInfo {
 std::ostream &operator<<(std::ostream &os, const AttributeInfo &info);
 std::ostream &operator<<(std::ostream &os, const ValueInfo &info);
 std::ostream &operator<<(std::ostream &os, const OperationInfo &info);
-std::ostream &operator<<(std::ostream &os, const OpDepsInfo &info);
+std::ostream &operator<<(std::ostream &os, const OpDepInfo &info);
 std::ostream &operator<<(std::ostream &os, const FusionOpInfo &info);
 std::ostream &operator<<(std::ostream &os, const FusionInfo &info);
 
@@ -152,7 +152,7 @@ namespace std {
 REGISTER_STD_HASH(AttributeInfo);
 REGISTER_STD_HASH(ValueInfo);
 REGISTER_STD_HASH(OperationInfo);
-REGISTER_STD_HASH(OpDepsInfo)
+REGISTER_STD_HASH(OpDepInfo)
 REGISTER_STD_HASH(FusionOpInfo);
 REGISTER_STD_HASH(FusionInfo)
 }  // namespace std

--- a/paddle/cinn/hlir/framework/pir/fusion_info.h
+++ b/paddle/cinn/hlir/framework/pir/fusion_info.h
@@ -58,10 +58,27 @@ class OperationInfo {
   std::vector<AttributeInfo> attr_infos_;
 };
 
+class OpDepsInfo {
+ public:
+  OpDepsInfo(size_t upstream_index, size_t upstream_hash)
+      : upstream_index_(upstream_index), upstream_hash_(upstream_hash) {}
+  bool operator==(const OpDepsInfo &other) {
+    return this->upstream_index_ == other.upstream_index_ &&
+           this->upstream_hash_ == other.upstream_hash_;
+  }
+
+  std::size_t hash() const;
+  friend std::ostream &operator<<(std::ostream &os, const OpDepsInfo &info);
+
+ private:
+  size_t upstream_index_;
+  size_t upstream_hash_;
+};
+
 class FusionOpInfo {
  public:
   FusionOpInfo(const ::pir::Operation &op,
-               const std::unordered_map<size_t, size_t> &deps)
+               const std::map<size_t, OpDepsInfo> &deps)
       : op_info_(op), inner_deps_(deps) {}
 
   std::size_t hash() const;
@@ -70,7 +87,7 @@ class FusionOpInfo {
  private:
   OperationInfo op_info_;
   // oprand_source id : OperationInfo hash
-  std::unordered_map<size_t, size_t> inner_deps_;
+  std::map<size_t, OpDepsInfo> inner_deps_;
 };
 
 class FusionInfo {
@@ -105,6 +122,7 @@ class FusionInfo {
 std::ostream &operator<<(std::ostream &os, const AttributeInfo &info);
 std::ostream &operator<<(std::ostream &os, const ValueInfo &info);
 std::ostream &operator<<(std::ostream &os, const OperationInfo &info);
+std::ostream &operator<<(std::ostream &os, const OpDepsInfo &info);
 std::ostream &operator<<(std::ostream &os, const FusionOpInfo &info);
 std::ostream &operator<<(std::ostream &os, const FusionInfo &info);
 
@@ -134,6 +152,7 @@ namespace std {
 REGISTER_STD_HASH(AttributeInfo);
 REGISTER_STD_HASH(ValueInfo);
 REGISTER_STD_HASH(OperationInfo);
+REGISTER_STD_HASH(OpDepsInfo)
 REGISTER_STD_HASH(FusionOpInfo);
 REGISTER_STD_HASH(FusionInfo)
 }  // namespace std

--- a/paddle/phi/kernels/cpu/accuracy_check_kernel.cc
+++ b/paddle/phi/kernels/cpu/accuracy_check_kernel.cc
@@ -20,7 +20,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 
-static constexpr float kAtolValue = 1e-5;
+static constexpr float kAtolValue = 1e-8;
 static constexpr float kRtolValue = 1e-5;
 
 bool allclose(float a, float b) {
@@ -58,8 +58,9 @@ void AccuracyCheckKernel(const Context& ctx,
     if (!allclose(x_cpu.data<T>()[i], y_cpu.data<T>()[i])) {
       check_result = false;
       VLOG(2) << "Accuracy check failed between" << x_cpu.data<T>()[i]
-              << " and " << y_cpu.data<T>()[i];
-      break;
+              << " and " << y_cpu.data<T>()[i] << " at index= " << i;
+      res_index = i;
+      // break;
     }
   }
 

--- a/paddle/phi/kernels/cpu/accuracy_check_kernel.cc
+++ b/paddle/phi/kernels/cpu/accuracy_check_kernel.cc
@@ -60,7 +60,7 @@ void AccuracyCheckKernel(const Context& ctx,
       VLOG(2) << "Accuracy check failed between" << x_cpu.data<T>()[i]
               << " and " << y_cpu.data<T>()[i] << " at index= " << i;
       res_index = i;
-      // break;
+      break;
     }
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

### 问题背景
在科学计算LDC模型上，关闭缓存，如下kernel有8个:`fn_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_add_elementwise_add_yield_store_elementwise_mul_elementwise_add_elementwise_add_elementwise_add_elementwise_add_elementwise_add_`

开启缓存，如下kernel会复用成1个：`fn_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_mul_elementwise_add_elementwise_add_yield_store_elementwise_mul_elementwise_add_elementwise_add_elementwise_add_elementwise_add_elementwise_add__2`

对应是如下两个子图Case，其实在计算%16时，依赖的上游算子顺序是有差别的，一个是L6+L7+L8，一个是L5+L7+L8.
<img width="1111" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/9301846/6f72d9ad-1379-400b-94b5-46f0d82d2c68">


这几个上游算子，其实从Op层面，他们的ValueInfo、OpInfo完全一样的（即Hash一样），**但内在中间算子依赖的顺序不同，对于生成的函数，可能导致输入Argument Tensor解析&映射的顺序有差异**，会导致下图中两个红框的CodeGen函数代码段有不同的var，若命中缓存，则引起计算错误。
![image](https://github.com/PaddlePaddle/Paddle/assets/9301846/c392b15b-70e3-4625-9ea6-125be63e0efc)


### 解决方案

fusion_info.cc中的FusionOpInfo数据结构里inner_deps_除了要考虑依赖的上游算子hash，也要考虑依赖的上游算子index