### PR TITLE
[CINN] Fix bug of get tensor value

### DIFF
--- a/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_impl.cc
@@ -1119,10 +1119,15 @@ ir::Tensor OpLowererImpl::GetTensor(const OpLoweringGroupPtr& group,
     }
     auto tensor = lang::CreatePlaceHolder(
         sym_shape, CompatibleInfo::ConvertIRType(dtype), input_id);
-    const auto& tensor_value = details::GetTensorValueFromShapeOrData(
-        group->GetShapeOrDataExprs(value));
-    if (tensor_value.has_value()) {
-      tensor->set_value(*tensor_value);
+    auto IsIntType = [](const ::pir::Type& t) {
+      return t.isa<::pir::Int32Type>() || t.isa<::pir::Int64Type>();
+    };
+    if (IsIntType(dtype) && group->HasShapeOrDataExprs(value)) {
+      const auto& tensor_value = details::GetTensorValueFromShapeOrData(
+          group->GetShapeOrDataExprs(value));
+      if (tensor_value.has_value()) {
+        tensor->set_value(*tensor_value);
+      }
     }
     return tensor;
   } else {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164

在op lower时跳过无用的tensor value信息获取逻辑。