### PR TITLE
【DRR】fix drr rewite_pattern to ensure op order

### DIFF
--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -546,7 +546,6 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
         }
       }
       // 2. insert new op at point max(max_input_op_index+1, min_src_idx)
-      // NOTE(liym27):
       if (min_src_idx > max_input_op_index) {
         rewriter.set_insertion_point(min_src_idx_op);
         max_input_op_index = op_2_temp_program_index[min_src_idx_op];

--- a/paddle/fluid/pir/drr/src/rewrite_pattern.cc
+++ b/paddle/fluid/pir/drr/src/rewrite_pattern.cc
@@ -484,6 +484,7 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
     }
   }
 
+  bool is_one_result = result_pattern_graph.owned_op_call().size() == 1;
   // topo order visit result_pattern_graph
   GraphTopo graph_topo_visit(&result_pattern_graph);
   graph_topo_visit.WalkGraphNodesTopoOrder([&](const OpCall& op_call) {
@@ -528,14 +529,42 @@ MatchContextImpl DrrRewritePattern::CreateOperations(
         }
       }
     }
-    if (max_input_op_index == 0UL) {
-      VLOG(6) << "Not found producer op for (" << op_call.name() << ")";
-      pir::Operation* source_pattern_first_op = src_match_ctx.IrOperation(
+
+    if (is_one_result && !source_pattern_graph.owned_op_call().empty()) {
+      // 1. get source pattern min-idx op
+      pir::Operation* min_src_idx_op = src_match_ctx.IrOperation(
           source_pattern_graph.owned_op_call()[0].get());
-      max_input_op_index = op_2_temp_program_index[source_pattern_first_op];
-      rewriter.set_insertion_point(source_pattern_first_op);
+      size_t min_src_idx = op_2_temp_program_index[min_src_idx_op];
+      for (const auto& src_owned_op_call :
+           source_pattern_graph.owned_op_call()) {
+        pir::Operation* src_owned_op =
+            src_match_ctx.IrOperation(src_owned_op_call.get());
+        size_t src_owned_op_idx = op_2_temp_program_index[src_owned_op];
+        if (min_src_idx > src_owned_op_idx) {
+          min_src_idx = src_owned_op_idx;
+          min_src_idx_op = src_owned_op;
+        }
+      }
+      // 2. insert new op at point max(max_input_op_index+1, min_src_idx)
+      // NOTE(liym27):
+      if (min_src_idx > max_input_op_index) {
+        rewriter.set_insertion_point(min_src_idx_op);
+        max_input_op_index = op_2_temp_program_index[min_src_idx_op];
+      } else {
+        rewriter.SetInsertionPointAfter(max_index_op);
+      }
+      VLOG(6) << "(" << op_call.name() << ") insert at idx "
+              << std::max(max_input_op_index + 1, min_src_idx);
     } else {
-      rewriter.SetInsertionPointAfter(max_index_op);
+      if (max_input_op_index == 0UL) {
+        VLOG(6) << "Not found producer op for (" << op_call.name() << ")";
+        pir::Operation* source_pattern_first_op = src_match_ctx.IrOperation(
+            source_pattern_graph.owned_op_call()[0].get());
+        max_input_op_index = op_2_temp_program_index[source_pattern_first_op];
+        rewriter.set_insertion_point(source_pattern_first_op);
+      } else {
+        rewriter.SetInsertionPointAfter(max_index_op);
+      }
     }
 
     pir::Operation* new_op =

--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -139,7 +139,7 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
             }
 
             allreduce_op = block._insert_op_without_sync(
-                index=allreduce_id + 1,
+                index=allreduce_id - 1,
                 type=allreduce_op.type,
                 inputs=allreduce_op_inputs,
                 outputs=allreduce_op_outputs,

--- a/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
+++ b/python/paddle/distributed/passes/allreduce_matmul_grad_overlapping.py
@@ -138,8 +138,14 @@ class AllreduceMatmulGradOverlappingPass(PassBase):
                 name: allreduce_op.output(name) for name in allreduce_op_outputs
             }
 
+            # matmul_v2 + reshape + reshape + matmul_v2 + reshape + ... + original c_allreduce_sum
+            # =>
+            # matmul_v2 + new c_allreduce_sum + reshape + reshape + matmul_v2 + reshape + ... + original c_allreduce_sum
+            #
+            # NOTE(liym27): new c_allreduce_sum must be inserted to "the next of the first matmul_v2", otherwise another
+            # pass fused_linear_param_grad_add will not work.
             allreduce_op = block._insert_op_without_sync(
-                index=allreduce_id - 1,
+                index=matmul_grad_id + 1,
                 type=allreduce_op.type,
                 inputs=allreduce_op_inputs,
                 outputs=allreduce_op_outputs,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
**问题背景：**
静态图新IR下，同时开 `allreduce_matmul_grad_overlapping` pass 与 `fused_linear_param_grad_add`  pass，实际上 `allreduce_matmul_grad_overlapping` 的 allreduce 并没有与 `fused_linear_param_grad_add` overlap。导致开 `allreduce_matmul_grad_overlapping` 并未带来性能提升。
timeline 如图：
<img width="500" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/33742067/6b585d80-de6c-4571-b069-67ddba883b7b">

**原因：**
- 新IR先应用 `allreduce_matmul_grad_overlapping` pass （部分IR如图左侧），
然后再应用 `fused_linear_param_grad_add` pass（部分IR如图右侧），左边红框融合后是右边`fused_linear_param_grad_add`，但该op插入的位置(在黑框 allreduce sum 之前)不符合预期，应该在 `allreduce sum` 之后，这样实际运行时 `fused_linear_param_grad_add` 才能与 `allreduce sum` overlap
<img width="400" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/33742067/29cd36e3-43ed-4dfe-90c6-50a14f68d63c">

- `DrrRewritePattern` 在插入新算子时，默认将新算子置于离 新算子input 的 producer op 最近的位置，而不是 旧算子的原位置，导致**改变了算子的先后顺序**(fused_linear_param_grad_add 与 allreduce sum 先后顺序变了)。本 PR 对此做了修改。
- `allreduce_matmul_grad_overlapping` 插入新的 allreduce 算子时，应严格放在 matmul 的下一个位置，否则会影响 `fused_linear_param_grad_add`.  本PR对此做了修改。

**修改后：**
- 在尽可能不改变算子先后顺序的情况下，插入新算子。修改前后对比如下：
<img width="600" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/33742067/7b88040d-ec84-4982-98b3-fc253c90a816">

- timeline 图
<img width="500" alt="image" src="https://github.com/PaddlePaddle/Paddle/assets/33742067/cae6cb12-56e9-4316-b31f-c87da7a620f5">

**性能提升**
GPT 13B，mp2pp4 gbs=4 bf16，吞吐可提高 1% ~ 1.5%

Pcard-73145