### PR TITLE
【Hackathon 6th Fundable Projects 2 No.27】Fix misc-unused-using-decls-final

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -178,7 +178,6 @@ bool ScaleOpInferSymbolicShape(pir::Operation *op,
 
 }  // namespace paddle::dialect
 
-namespace cinn::dialect {
-}  // namespace cinn::dialect
+namespace cinn::dialect {}  // namespace cinn::dialect
 
 #undef OP_SAME_OPERANDS_AND_RESULT

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/same_operands_result.cc
@@ -179,9 +179,6 @@ bool ScaleOpInferSymbolicShape(pir::Operation *op,
 }  // namespace paddle::dialect
 
 namespace cinn::dialect {
-using paddle::dialect::ReverseOpInferSymbolicShape;
-using paddle::dialect::ScaleOpInferSymbolicShape;
-using paddle::dialect::SelectOpInferSymbolicShape;
 }  // namespace cinn::dialect
 
 #undef OP_SAME_OPERANDS_AND_RESULT

--- a/paddle/fluid/pybind/control_flow_api.cc
+++ b/paddle/fluid/pybind/control_flow_api.cc
@@ -52,7 +52,6 @@ using pir::Builder;
 using pir::CombineOp;
 using pir::Operation;
 using pir::Program;
-using pir::Region;
 using pir::StackCreateOp;
 using pir::TuplePopOp;
 using pir::TuplePushOp;

--- a/paddle/fluid/pybind/rpc.cc
+++ b/paddle/fluid/pybind/rpc.cc
@@ -19,7 +19,6 @@
 
 namespace py = pybind11;
 using paddle::distributed::FutureWrapper;
-using paddle::distributed::PythonRpcHandler;
 using paddle::distributed::RpcAgent;
 using paddle::distributed::WorkerInfo;
 namespace paddle {

--- a/paddle/phi/infermeta/spmd_rules/numel.cc
+++ b/paddle/phi/infermeta/spmd_rules/numel.cc
@@ -21,7 +21,6 @@ limitations under the License. */
 
 namespace phi {
 namespace distributed {
-using phi::distributed::auto_parallel::str_join;
 
 SpmdInfo NumelInferSpmd(const DistMetaTensor& x) {
   std::string alphabet = "abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
### PR Category
Others

### PR Types
Bug fixes

### Description

修复了全部 6 处未使用 namespace。

相关链接：
https://github.com/PaddlePaddle/Paddle/issues/64128