### PR TITLE
[CINN] fix different fn_name

### DIFF
--- a/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.cc
+++ b/paddle/cinn/hlir/dialect/operator/transforms/lowering_pass/utils.cc
@@ -110,23 +110,26 @@ OpLoweringGroupPtr BuildOpLoweringGroup(pir::Operation* fusion_op_ptr) {
                           : group_op_kind;
     }
   }
+  PADDLE_ENFORCE_GT(fusion_op.attributes().count("group_info"),
+                    0UL,
+                    phi::errors::InvalidArgument(
+                        "fusion_op should have group_info attribute."));
 
-  auto group = std::make_shared<OpLoweringGroup>(ops);
+  const auto attr = fusion_op.attribute("group_info")
+                        .dyn_cast<cinn::dialect::GroupInfoAttribute>()
+                        .data();
 
-  if (fusion_op.attributes().count("group_info")) {
-    auto attr = fusion_op.attribute("group_info")
-                    .dyn_cast<cinn::dialect::GroupInfoAttribute>()
-                    .data();
+  const auto& fn_name = attr.fn_name;
+  auto group = std::make_shared<OpLoweringGroup>(ops, fn_name);
 
-    group_op_kind =
-        static_cast<int>(attr.op_pattern_kind) > static_cast<int>(group_op_kind)
-            ? attr.op_pattern_kind
-            : group_op_kind;
-    group->set_loop_ranges(attr.loop_ranges);
-    group->set_loop_ranges_expr(attr.loop_ranges_expr);
-    group->set_reduce_axis(attr.reduce_axis);
-    group->set_alignment_schedule_info(attr.alignment_schedule_info);
-  }
+  group_op_kind =
+      static_cast<int>(attr.op_pattern_kind) > static_cast<int>(group_op_kind)
+          ? attr.op_pattern_kind
+          : group_op_kind;
+  group->set_loop_ranges(attr.loop_ranges);
+  group->set_loop_ranges_expr(attr.loop_ranges_expr);
+  group->set_reduce_axis(attr.reduce_axis);
+  group->set_alignment_schedule_info(attr.alignment_schedule_info);
   group->set_op_pattern_kind(group_op_kind);
 
   // Rebuild output_ops and input_ops of the group

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.cc
@@ -145,8 +145,9 @@ std::shared_ptr<OpLoweringGroup> OpLoweringGroup::Clone(
     ops_mapper[op] = new_op;
   }
 
+  const auto new_fn_name = this->fn_name_ + "_cloned";
   // Construct Base information for new Group
-  auto new_group = std::make_shared<OpLoweringGroup>(new_ops);
+  auto new_group = std::make_shared<OpLoweringGroup>(new_ops, new_fn_name);
   for (auto* op : this->output_ops_) {
     new_group->output_ops_.insert(ops_mapper.at(op));
   }

--- a/paddle/cinn/hlir/framework/pir/op_lowering_group.h
+++ b/paddle/cinn/hlir/framework/pir/op_lowering_group.h
@@ -42,15 +42,13 @@ class OpLoweringGroup {
   OpLoweringGroup(const OpLoweringGroup&) = delete;
   OpLoweringGroup(OpLoweringGroup&&) = delete;
 
-  explicit OpLoweringGroup(const std::vector<::pir::Operation*>& group_ops)
-      : ops_(group_ops) {
-    fn_name_ = CompatibleInfo::GroupOpsName(ops_);
-  }
+  explicit OpLoweringGroup(const std::vector<::pir::Operation*>& group_ops,
+                           const std::string& fn_name)
+      : ops_(group_ops), fn_name_(fn_name) {}
 
-  explicit OpLoweringGroup(std::initializer_list<::pir::Operation*> group_ops)
-      : ops_(group_ops) {
-    fn_name_ = CompatibleInfo::GroupOpsName(ops_);
-  }
+  explicit OpLoweringGroup(std::initializer_list<::pir::Operation*> group_ops,
+                           const std::string& fn_name)
+      : ops_(group_ops), fn_name_(fn_name) {}
 
   const std::string& FuncName() const { return this->fn_name_; }
   ::pir::Block* GetParentBlock() const;

--- a/test/cpp/pir/cinn/compilation_task_test.cc
+++ b/test/cpp/pir/cinn/compilation_task_test.cc
@@ -24,6 +24,7 @@
 #include "paddle/cinn/hlir/dialect/operator/ir/op_attribute.h"
 #include "paddle/cinn/hlir/dialect/operator/ir/op_dialect.h"
 #include "paddle/cinn/hlir/framework/pir/compilation_task.h"
+#include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/cinn/hlir/framework/pir_compiler.h"
 #include "paddle/cinn/utils/data_util.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
@@ -34,6 +35,7 @@
 
 PD_DECLARE_bool(cinn_bucket_compile);
 
+using cinn::hlir::framework::pir::CompatibleInfo;
 using cinn::hlir::framework::pir::OpLoweringGroup;
 using cinn::hlir::framework::pir::OpLoweringGroupPtr;
 
@@ -50,8 +52,11 @@ ProgramInfo BuildProgram(std::vector<int64_t> input_shape) {
       input_shape, value_one, phi::DataType::FLOAT32, phi::GPUPlace());
 
   std::vector<OpLoweringGroupPtr> groups;
+  const std::string fn_name = CompatibleInfo::GroupOpsName(
+      std::initializer_list<::pir::Operation*>({full_op_x.operation()}));
   groups.emplace_back(std::make_shared<OpLoweringGroup>(
-      std::initializer_list<::pir::Operation*>({full_op_x.operation()})));
+      std::initializer_list<::pir::Operation*>({full_op_x.operation()}),
+      fn_name));
   groups.back()->mut_output_ops().insert(full_op_x.operation());
 
   return {program, groups};

--- a/test/cpp/pir/cinn/symbolic_lower_test.cc
+++ b/test/cpp/pir/cinn/symbolic_lower_test.cc
@@ -24,6 +24,7 @@
 #include "paddle/cinn/hlir/framework/pir/group.h"
 #include "paddle/cinn/hlir/framework/pir/op_lowering_group.h"
 #include "paddle/cinn/hlir/framework/pir/op_lowering_impl.h"
+#include "paddle/cinn/hlir/framework/pir/utils.h"
 #include "paddle/cinn/hlir/framework/pir_compiler.h"
 #include "paddle/common/ddim.h"
 #include "paddle/fluid/framework/new_executor/interpretercore.h"
@@ -39,6 +40,7 @@
 
 PD_DECLARE_bool(cinn_bucket_compile);
 
+using cinn::hlir::framework::pir::CompatibleInfo;
 using cinn::hlir::framework::pir::OpLoweringGroup;
 using cinn::hlir::framework::pir::OpLoweringGroupPtr;
 
@@ -88,9 +90,11 @@ BuildGroupProgramForLowering() {
   builder.Build<paddle::dialect::FetchOp>(group_op->result(0), "out", 0);
 
   std::vector<OpLoweringGroupPtr> groups;
-  groups.emplace_back(
-      std::make_shared<OpLoweringGroup>(std::vector<::pir::Operation*>(
-          {exp.operation(), reshape.operation(), sub.operation()})));
+  groups.emplace_back(std::make_shared<OpLoweringGroup>(
+      std::vector<::pir::Operation*>(
+          {exp.operation(), reshape.operation(), sub.operation()}),
+      CompatibleInfo::GroupOpsName(std::vector<::pir::Operation*>(
+          {exp.operation(), reshape.operation(), sub.operation()}))));
   groups[0]->mut_output_ops().insert(groups[0]->ops().back());
   std::unordered_map<::pir::Value, symbol::ShapeOrDataDimExprs>
       value_to_shape_data;
@@ -176,9 +180,11 @@ BuildBroadcastGroupProgramForLowering() {
   builder.Build<paddle::dialect::FetchOp>(group_op->result(0), "out", 0);
 
   std::vector<OpLoweringGroupPtr> groups;
-  groups.emplace_back(
-      std::make_shared<OpLoweringGroup>(std::vector<::pir::Operation*>(
-          {x_broadcast.operation(), sub.operation()})));
+  groups.emplace_back(std::make_shared<OpLoweringGroup>(
+      std::vector<::pir::Operation*>(
+          {x_broadcast.operation(), sub.operation()}),
+      CompatibleInfo::GroupOpsName(std::vector<::pir::Operation*>(
+          {x_broadcast.operation(), sub.operation()}))));
   groups[0]->mut_output_ops().insert(groups[0]->ops().back());
 
   std::unordered_map<::pir::Value, symbol::ShapeOrDataDimExprs>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
修复开启accuracy_check_pass后，报出的fn_name与LowerGroup的fn_name不一致问题