### PR TITLE
[PIR] Fix typo `updata` -> `update`

### DIFF
--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.cc
@@ -71,11 +71,11 @@ void set_parameter(const pir::Value& parameter, const std::string& name) {
   }
 }
 
-void updata_parameter(const pir::Value& parameter, const std::string& name) {
+void update_parameter(const pir::Value& parameter, const std::string& name) {
   pir::Parameter* param = ApiBuilder::Instance().GetParameter(name);
   PADDLE_ENFORCE_NOT_NULL(param,
                           phi::errors::InvalidArgument(
-                              "Parameter %s not exist, can not updata.", name));
+                              "Parameter %s not exist, can not update.", name));
   std::unique_ptr<pir::Parameter> param_new(
       new pir::Parameter(nullptr, 0, parameter.type()));
   ApiBuilder::Instance().SetParameter(name, std::move(param_new));

--- a/paddle/fluid/pir/dialect/operator/ir/manual_api.h
+++ b/paddle/fluid/pir/dialect/operator/ir/manual_api.h
@@ -36,7 +36,7 @@ pir::Value parameter(const std::string& name);
 
 void set_parameter(const pir::Value& parameter, const std::string& name);
 
-void updata_parameter(const pir::Value& parameter, const std::string& name);
+void update_parameter(const pir::Value& parameter, const std::string& name);
 
 void shadow_output(const pir::Value& persist_value, const std::string& name);
 

--- a/paddle/fluid/pybind/manual_static_op_function.h
+++ b/paddle/fluid/pybind/manual_static_op_function.h
@@ -81,7 +81,7 @@ static PyObject *static_api_set_parameter(PyObject *self,
   }
 }
 
-static PyObject *static_api_updata_parameter(PyObject *self,
+static PyObject *static_api_update_parameter(PyObject *self,
                                              PyObject *args,
                                              PyObject *kwargs) {
   try {
@@ -98,7 +98,7 @@ static PyObject *static_api_updata_parameter(PyObject *self,
     // Call ir static api
     CallStackRecorder callstack_recoder("uodata_parameter");
     callstack_recoder.Record();
-    paddle::dialect::updata_parameter(parameter, name);
+    paddle::dialect::update_parameter(parameter, name);
     callstack_recoder.AttachToOps();
     Py_RETURN_NONE;
   } catch (...) {
@@ -975,10 +975,10 @@ static PyMethodDef ManualOpsAPI[] = {
      (PyCFunction)(void (*)(void))static_api_set_parameter,
      METH_VARARGS | METH_KEYWORDS,
      "C++ interface function for set_parameter."},
-    {"updata_parameter",
-     (PyCFunction)(void (*)(void))static_api_updata_parameter,
+    {"update_parameter",
+     (PyCFunction)(void (*)(void))static_api_update_parameter,
      METH_VARARGS | METH_KEYWORDS,
-     "C++ interface function for updata_parameter."},
+     "C++ interface function for update_parameter."},
     {"set_persistable_value",
      (PyCFunction)(void (*)(void))static_api_set_persistable_value,
      METH_VARARGS | METH_KEYWORDS,

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -251,7 +251,7 @@ def _pir_transform(t, dtype):
                 param = op.operand(0).source()
                 cast_param = paddle.cast(param, dtype)
                 cast_param.persistable = True
-                paddle._pir_ops.updata_parameter(cast_param, t.name)
+                paddle._pir_ops.update_parameter(cast_param, t.name)
                 block.remove_op(op)
                 break
     main.set_parameters_from(startup)

--- a/test/legacy_test/test_lstm_cudnn_op.py
+++ b/test/legacy_test/test_lstm_cudnn_op.py
@@ -35,7 +35,7 @@ class RandomWeight:
     def __init__(self):
         pass
 
-    def updata_weight(self, hidden_size, input_size, dtype):
+    def update_weight(self, hidden_size, input_size, dtype):
         std = 1.0 / math.sqrt(hidden_size)
         self.hidden_size = hidden_size
         self.input_size = input_size
@@ -432,7 +432,7 @@ class TestCUDNNLstmOp(OpTest):
         input[9][3:][:] = 0
         input[8][4:][:] = 0
 
-        weight.updata_weight(hidden_size, input_size, self.dtype)
+        weight.update_weight(hidden_size, input_size, self.dtype)
         rnn1 = LSTM(
             input_size,
             hidden_size,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Not User Facing

### Description
<!-- Describe what you’ve done -->

修复 typo `updata`

PCard-66972