### PR TITLE
【pir_save_load】compress builtin parameter

### DIFF
--- a/paddle/fluid/pir/serialize_deserialize/include/ir_deserialize.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/ir_deserialize.h
@@ -47,6 +47,8 @@ class ProgramReader {
                                       Json* operesult_attrs_json);
   pir::Attribute ReadAttribute(Json* attr_json);
   pir::Type ReadType(Json* type_json);
+
+  pir::Operation* ReadParameterOp(Json* op_json);
 };
 
 }  // namespace pir

--- a/paddle/fluid/pir/serialize_deserialize/include/ir_serialize.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/ir_serialize.h
@@ -76,6 +76,9 @@ class ProgramWriter {
   Json WriteAttribute(const std::string& op_attr_name,
                       const pir::Attribute& attr);
   Json WriteType(const pir::Type& type);
+
+  // special op for optimize json file size
+  Json WriteParameterOP(const pir::Operation& op);
 };
 
 }  // namespace pir

--- a/paddle/fluid/pir/serialize_deserialize/include/schema.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/schema.h
@@ -74,10 +74,4 @@ namespace pir {
 // special op compress
 
 #define PARAMETEROP "p"
-#define PARAMETEROP_NAME "n"
-#define PARAMETEROP_ISDISTRUBUTE "d"
-#define PARAMETEROP_ISPARAMETER "p"
-#define PARAMETEROP_NEEDCLIP "c"
-#define PARAMETEROP_STOPGRADIENT "sp"
-#define PARAMETEROP_PERSISTABLE "pt"
 }  // namespace pir

--- a/paddle/fluid/pir/serialize_deserialize/include/schema.h
+++ b/paddle/fluid/pir/serialize_deserialize/include/schema.h
@@ -43,9 +43,11 @@ namespace pir {
 #define BLOCKOPS "ops"
 
 // operation's key:
+// input
 // which is json array with opoperand json object(ID)
 #define OPOPERANDS "I"
 
+// output
 // which is json array with value json object(ID and TYPE_TYPE)
 #define OPRESULTS "O"
 
@@ -68,4 +70,14 @@ namespace pir {
 
 // NULL_TYPE
 #define NULL_TYPE "NULL"
+
+// special op compress
+
+#define PARAMETEROP "p"
+#define PARAMETEROP_NAME "n"
+#define PARAMETEROP_ISDISTRUBUTE "d"
+#define PARAMETEROP_ISPARAMETER "p"
+#define PARAMETEROP_NEEDCLIP "c"
+#define PARAMETEROP_STOPGRADIENT "sp"
+#define PARAMETEROP_PERSISTABLE "pt"
 }  // namespace pir

--- a/paddle/fluid/pir/serialize_deserialize/src/ir_deserialize.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/ir_deserialize.cc
@@ -89,8 +89,48 @@ void ProgramReader::ReadBlock(Json* block_json, pir::Block* block) {
   return;
 }
 
+pir::Operation* ProgramReader::ReadParameterOp(Json* op_json) {
+  // attr is_distributed; is_parameter; need_clip; parameter_name; persistable;
+  // stop_gradient; trainable;
+  std::vector<pir::Value> inputs;
+  Json& opresult_json = op_json->at(OPRESULTS);
+  std::vector<pir::Type> output_types;
+
+  int64_t value_id_ = opresult_json.at(ID).template get<int64_t>();
+  output_types.push_back(ReadType(&(opresult_json.at(TYPE_TYPE))));
+  VLOG(6) << "Finish Read value " << value_id_ << ".";
+
+  Json& attrs_json = op_json->at(ATTRS);
+  pir::AttributeMap attributes;
+  attributes.insert({"is_distributed", ReadAttribute(&attrs_json.at(0))});
+  attributes.insert({"is_parameter", ReadAttribute(&attrs_json.at(1))});
+  attributes.insert({"need_clip", ReadAttribute(&attrs_json.at(2))});
+  attributes.insert({"parameter_name", ReadAttribute(&attrs_json.at(3))});
+
+  if (op_json->contains(OPRESULTS_ATTRS)) {
+    Json& other_attrs_json = op_json->at(OPRESULTS_ATTRS);
+    attributes.insert({"persistable", ReadAttribute(&other_attrs_json.at(0))});
+    attributes.insert(
+        {"stop_gradient", ReadAttribute(&other_attrs_json.at(1))});
+  }
+
+  pir::IrContext* ctx_ = pir::IrContext::Instance();
+  // prepare opinfo
+  pir::OpInfo op_info = ctx_->GetRegisteredOpInfo(pir::ParameterOp::name());
+  // deserialize op
+  pir::Operation* op =
+      Operation::Create(inputs, attributes, output_types, op_info);
+
+  id_value_map[value_id_] = op->result(0);
+  VLOG(4) << "Finish Read Operation " << op->name() << ".";
+  return op;
+}
+
 pir::Operation* ProgramReader::ReadOp(Json* op_json) {
   auto op_name = op_json->at(ID).template get<std::string>();
+  if (op_name == PARAMETEROP) {
+    return ReadParameterOp(op_json);
+  }
   VLOG(4) << "Read op_name = " << op_name << ".";
   // deserialize opoperands (find value)
   Json& operands_json = op_json->at(OPOPERANDS);

--- a/paddle/fluid/pir/serialize_deserialize/src/ir_serialize.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/ir_serialize.cc
@@ -149,29 +149,45 @@ Json ProgramWriter::WriteValue(const pir::Value& value) {
   return var_json;
 }
 
+#define ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE(attr_name)   \
+  static_cast<int32_t>(op.attributes()                      \
+                           .at(attr_name)                   \
+                           .dyn_cast<pir::ArrayAttribute>() \
+                           .at(0)                           \
+                           .dyn_cast<pir::BoolAttribute>()  \
+                           .data())
 Json ProgramWriter::WriteParameterOP(const pir::Operation& op) {
-  // attr is_distributed; is_parameter; need_clip; parameter_name; persistable;
-  // stop_gradient; trainable;
+  // attr_name ; type
+  // is_distributed; array(bool)
+  // is_parameter; array(bool)
+  // need_clip; array(bool)
+  // parameter_name; string
+  // persistable; array(bool)
+  // stop_gradient; array(bool)
+  // trainable; array(bool)
   Json op_json = Json::object();
   op_json[ID] = PARAMETEROP;
   // serialize opoperands
   VLOG(4) << "Begin write Operation " << op.name() << ".";
   op_json[OPRESULTS] = WriteValue(op.result(0));
   Json attrs_json = Json::array();
-  attrs_json.emplace_back(WriteAttribute(PARAMETEROP_ISDISTRUBUTE,
-                                         op.attributes().at("is_distributed")));
-  attrs_json.emplace_back(WriteAttribute(PARAMETEROP_ISPARAMETER,
-                                         op.attributes().at("is_parameter")));
   attrs_json.emplace_back(
-      WriteAttribute(PARAMETEROP_NEEDCLIP, op.attributes().at("need_clip")));
+      ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE("is_distributed"));
   attrs_json.emplace_back(
-      WriteAttribute(PARAMETEROP_NAME, op.attributes().at("parameter_name")));
+      ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE("is_parameter"));
+  attrs_json.emplace_back(ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE("need_clip"));
+  attrs_json.emplace_back(op.attributes()
+                              .at("parameter_name")
+                              .dyn_cast<pir::StrAttribute>()
+                              .AsString());
   op_json[ATTRS] = attrs_json;
   Json other_attrs_json = Json::array();
-  other_attrs_json.emplace_back(WriteAttribute(
-      PARAMETEROP_PERSISTABLE, op.attributes().at("persistable")));
-  other_attrs_json.emplace_back(WriteAttribute(
-      PARAMETEROP_STOPGRADIENT, op.attributes().at("stop_gradient")));
+  other_attrs_json.emplace_back(
+      ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE("persistable"));
+  other_attrs_json.emplace_back(
+      ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE("stop_gradient"));
+  other_attrs_json.emplace_back(
+      ONE_BOOL_ARRAY_ATTRIBUTE_CAST_TEMPLATE("trainable"));
   if (trainable_) {
     op_json[OPRESULTS_ATTRS] = other_attrs_json;
   }

--- a/python/paddle/static/pir_io.py
+++ b/python/paddle/static/pir_io.py
@@ -489,8 +489,8 @@ def load_vars_pir(
                     file_path,
                     -1,
                     [],
-                    var.get_tensor(),
                     False,
+                    var.get_tensor(),
                     executor._default_executor.get_place(),
                 )
             else:

--- a/python/paddle/static/pir_io.py
+++ b/python/paddle/static/pir_io.py
@@ -489,8 +489,8 @@ def load_vars_pir(
                     file_path,
                     -1,
                     [],
-                    False,
                     var.get_tensor(),
+                    False,
                     executor._default_executor.get_place(),
                 )
             else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
others

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
others

### Description
<!-- Describe what you’ve done -->
pcard-67164

由于pir下每一个参数都有一个builtin_parameter op出现，导致save之后的model文件比旧IR文件多了很多内容，此pr对parameterop的各参数进行压缩.
测试单测：test_bert.py (37个参数 + 115个普通op),  压缩率 48%
test_resnet.py (267个参数 + 177个普通op) 压缩率 28%

压缩方法1: 将参数的名称全称压缩为单个字符，test_resnet 275k -> 233k, test_bert: 68k -> 62k
`{"A":[{"AT":{"D":[{"D":false,"id":"a_bool"}],"id":"a_array"},"N":"d"},   
{"AT":{"D":[{"D":true,"id":"a_bool"}],"id":"a_array"},"N":"p"},   
{"AT":{"D":[{"D":true,"id":"a_bool"}],"id":"a_array"},"N":"c"},   
{"AT":{"D":"next_sent_fc.b_0","id":"a_str"},"N":"n"}],   
"O":{"TT":{"D":[{"id":"t_f32"},[2],"NCHW",[],0],"id":"t_dtensor"},"id":1},   
"OA":[{"AT":{"D":[{"D":true,"id":"a_bool"}],"id":"a_array"},"N":"pt"},   
{"AT":{"D":[{"D":false,"id":"a_bool"}],"id":"a_array"},"N":"sp"}],"id":"p"}`

压缩方法2: 将参数只保存其bool值，不记录参数的ID, DATA。 test_resnet 233k-> 145k test_bert: 62k -> 49k
`{"A":[0,1,1,"next_sent_fc.b_0"],"O":{"TT":{"D":[{"id":"t_f32"},[2],"NCHW",[],0],"id":"t_dtensor"},"id":1},"OA":[1,0,1],"id":"p"}`

最大压缩结果：不保存builtin_parameter 的文件是test_resnet 110k. test_bert44k

这些压缩方法相当于将自动序列化反序列化变为手动，如果builtin_parameter 有参数的变化，需要手动对这个模块进行修改。会提高维护复杂度。