### PR TITLE
[CINN] Fix compile bug in cuda 12.3

### DIFF
--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -68,6 +68,18 @@ std::string Predicate2String(ir::Expr predicate) {
   return ss.str();
 }
 
+static std::string CurTailFnName(const std::string &origin_fn_name) {
+  const int MaxStrLength = 16383;
+  if (origin_fn_name.length() <= MaxStrLength) {
+    return origin_fn_name;
+  }
+  VLOG(6) << "Funtion name too long. Curtail and concat hash.";
+  const std::string new_fn_name =
+      origin_fn_name.substr(0, MaxStrLength) +
+      std::to_string(std::hash<std::string>()(origin_fn_name));
+  return new_fn_name;
+}
+
 std::string
 detail::CollectBucketStrategyHostFunctionVisitor::GenDeviceKernelName(
     const std::string &fn_name, ir::Expr predicate) {
@@ -80,7 +92,8 @@ detail::CollectBucketStrategyHostFunctionVisitor::GenDeviceKernelName(
     pos = cond_str.find("-", pos + replacement.length());
   }
   VLOG(3) << "predicate string: " << cond_str;
-  return fn_name + "__COND_" + cond_str + "__kernel";
+  std::string new_fn_name = CurTailFnName(fn_name);
+  return new_fn_name + "__COND_" + cond_str + "__kernel";
 }
 
 void detail::CollectBucketStrategyHostFunctionVisitor::ProcessLoweredFunc(

--- a/paddle/cinn/backends/codegen_device_util.cc
+++ b/paddle/cinn/backends/codegen_device_util.cc
@@ -92,7 +92,9 @@ detail::CollectBucketStrategyHostFunctionVisitor::GenDeviceKernelName(
     pos = cond_str.find("-", pos + replacement.length());
   }
   VLOG(3) << "predicate string: " << cond_str;
-  std::string new_fn_name = CurTailFnName(fn_name);
+  // NOTE(chenxi67): The kernel name is too long to be supported in cuda12.3 so
+  // we need to curtail it.
+  const std::string new_fn_name = CurTailFnName(fn_name);
   return new_fn_name + "__COND_" + cond_str + "__kernel";
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Pcard-67164
模型在CUDA12.3环境下运行报错，原因是CUDA在编译对应kernel string的时候函数签名太长。修改方案：对过长函数签名截断并拼接其哈希值。