### PR TITLE
[XPU] add large shape daily test

### DIFF
--- a/test/xpu/get_test_cover_info.py
+++ b/test/xpu/get_test_cover_info.py
@@ -15,6 +15,7 @@
 import fcntl
 import inspect
 import os
+import unittest
 
 import numpy as np
 
@@ -322,6 +323,17 @@ def create_test_class(
     record_op_test(op_name, test_type)
     if not no_grad:
         record_op_test(op_name + '_grad', test_type)
+
+
+def check_run_big_shape_test():
+    def wrapper(cls):
+        run_big_shape_test_flag = os.environ.get("FLAGS_xpu_big_shape_test")
+        return unittest.skipIf(
+            not (run_big_shape_test_flag and run_big_shape_test_flag == "true"),
+            "skip big shape test.",
+        )(cls)
+
+    return wrapper
 
 
 def get_test_cover_info():

--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -142,6 +143,7 @@ class XPUTestSiluOP(XPUOpTestWrapper):
             if os.getenv('XPU_PADDLE_ACT_LUT'):
                 del os.environ['XPU_PADDLE_ACT_LUT']
 
+    @check_run_big_shape_test()
     class TestSiluLargeShape1(XPUTestSilu):
         def init_shape(self):
             self.shape = [8192, 1728]
@@ -1344,6 +1346,7 @@ class XPUTestSinOP(XPUOpTestWrapper):
         def init_config(self):
             self.tmp_x = np.random.uniform(-np.pi, np.pi, [4, 256, 22, 22])
 
+    @check_run_big_shape_test()
     class XPUTestSinLargeShape1(XPUTestSinBase):
         def init_config(self):
             self.tmp_x = np.random.uniform(-np.pi, np.pi, [1, 8192, 1, 128])
@@ -1395,6 +1398,7 @@ class XPUTestCosOP(XPUOpTestWrapper):
         def init_config(self):
             self.tmp_x = np.random.uniform(-np.pi, np.pi, [4, 256, 22, 22])
 
+    @check_run_big_shape_test()
     class XPUTestCosLargeShape1(XPUTestCosBase):
         def init_config(self):
             self.tmp_x = np.random.uniform(-np.pi, np.pi, [1, 8192, 1, 128])

--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -142,6 +142,10 @@ class XPUTestSiluOP(XPUOpTestWrapper):
             if os.getenv('XPU_PADDLE_ACT_LUT'):
                 del os.environ['XPU_PADDLE_ACT_LUT']
 
+    class TestSiluLargeShape1(XPUTestSilu):
+        def init_shape(self):
+            self.shape = [8192, 1728]
+
 
 class TestSiluAPI(unittest.TestCase):
     # test paddle.nn.Silu, paddle.nn.functional.silu
@@ -1340,6 +1344,10 @@ class XPUTestSinOP(XPUOpTestWrapper):
         def init_config(self):
             self.tmp_x = np.random.uniform(-np.pi, np.pi, [4, 256, 22, 22])
 
+    class XPUTestSinLargeShape1(XPUTestSinBase):
+        def init_config(self):
+            self.tmp_x = np.random.uniform(-np.pi, np.pi, [1, 8192, 1, 128])
+
 
 support_types = get_xpu_op_support_types('sin')
 for stype in support_types:
@@ -1386,6 +1394,10 @@ class XPUTestCosOP(XPUOpTestWrapper):
     class XPUTestCos4(XPUTestCosBase):
         def init_config(self):
             self.tmp_x = np.random.uniform(-np.pi, np.pi, [4, 256, 22, 22])
+
+    class XPUTestCosLargeShape1(XPUTestCosBase):
+        def init_config(self):
+            self.tmp_x = np.random.uniform(-np.pi, np.pi, [1, 8192, 1, 128])
 
 
 support_types = get_xpu_op_support_types('cos')

--- a/test/xpu/test_cast_op_xpu.py
+++ b/test/xpu/test_cast_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -100,94 +101,117 @@ class XPUTestCastOp(XPUOpTestWrapper):
         def test_check_output(self):
             self.check_output()
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape1(TestCastOp):
         def init_shape(self):
             self.shape = [1, 8192, 5120]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape2(TestCastOp):
         def init_shape(self):
             self.shape = [1, 8192]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape3(TestCastOp):
         def init_shape(self):
             self.shape = [1, 8192, 1, 128]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape4(TestCastOp):
         def init_shape(self):
             self.shape = [8192]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape5(TestCastOp):
         def init_shape(self):
             self.shape = [31776]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape6(TestCastOp):
         def init_shape(self):
             self.shape = [5120]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape7(TestCastOp):
         def init_shape(self):
             self.shape = [3456]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape8(TestCastOp):
         def init_shape(self):
             self.shape = [1920]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape9(TestCastOp):
         def init_shape(self):
             self.shape = [31776, 5120]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape10(TestCastOp):
         def init_shape(self):
             self.shape = [5120, 1920]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape11(TestCastOp):
         def init_shape(self):
             self.shape = [640, 5120]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape12(TestCastOp):
         def init_shape(self):
             self.shape = [5120, 3456]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape13(TestCastOp):
         def init_shape(self):
             self.shape = [1728, 5120]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape14(TestCastOp):
         def init_shape(self):
             self.shape = [5120, 31776]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape15(TestCastOp):
         def init_shape(self):
             self.shape = [27724]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape16(TestCastOp):
         def init_shape(self):
             self.shape = [32, 5120]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape17(TestCastOp):
         def init_shape(self):
             self.shape = [1728, 32]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape18(TestCastOp):
         def init_shape(self):
             self.shape = [32, 3456]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape19(TestCastOp):
         def init_shape(self):
             self.shape = [32, 3456]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape20(TestCastOp):
         def init_shape(self):
             self.shape = [5120, 32]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape21(TestCastOp):
         def init_shape(self):
             self.shape = [640, 32]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape22(TestCastOp):
         def init_shape(self):
             self.shape = [32, 1920]
 
+    @check_run_big_shape_test()
     class TestCastOpLargeShape23(TestCastOp):
         def init_shape(self):
             self.shape = [19984]

--- a/test/xpu/test_cast_op_xpu.py
+++ b/test/xpu/test_cast_op_xpu.py
@@ -66,7 +66,8 @@ class XPUTestCastOp(XPUOpTestWrapper):
 
     class TestCastOp(XPUOpTest):
         def setUp(self):
-            ipt = np.random.random(size=[10, 10])
+            self.init_shape()
+            ipt = np.random.random(size=self.shape)
             in_typename = self.in_type_str
             out_typename = (
                 'float32'
@@ -93,8 +94,103 @@ class XPUTestCastOp(XPUOpTestWrapper):
             self.op_type = 'cast'
             self.__class__.no_need_check_grad = True
 
+        def init_shape(self):
+            self.shape = [10, 10]
+
         def test_check_output(self):
             self.check_output()
+
+    class TestCastOpLargeShape1(TestCastOp):
+        def init_shape(self):
+            self.shape = [1, 8192, 5120]
+
+    class TestCastOpLargeShape2(TestCastOp):
+        def init_shape(self):
+            self.shape = [1, 8192]
+
+    class TestCastOpLargeShape3(TestCastOp):
+        def init_shape(self):
+            self.shape = [1, 8192, 1, 128]
+
+    class TestCastOpLargeShape4(TestCastOp):
+        def init_shape(self):
+            self.shape = [8192]
+
+    class TestCastOpLargeShape5(TestCastOp):
+        def init_shape(self):
+            self.shape = [31776]
+
+    class TestCastOpLargeShape6(TestCastOp):
+        def init_shape(self):
+            self.shape = [5120]
+
+    class TestCastOpLargeShape7(TestCastOp):
+        def init_shape(self):
+            self.shape = [3456]
+
+    class TestCastOpLargeShape8(TestCastOp):
+        def init_shape(self):
+            self.shape = [1920]
+
+    class TestCastOpLargeShape9(TestCastOp):
+        def init_shape(self):
+            self.shape = [31776, 5120]
+
+    class TestCastOpLargeShape10(TestCastOp):
+        def init_shape(self):
+            self.shape = [5120, 1920]
+
+    class TestCastOpLargeShape11(TestCastOp):
+        def init_shape(self):
+            self.shape = [640, 5120]
+
+    class TestCastOpLargeShape12(TestCastOp):
+        def init_shape(self):
+            self.shape = [5120, 3456]
+
+    class TestCastOpLargeShape13(TestCastOp):
+        def init_shape(self):
+            self.shape = [1728, 5120]
+
+    class TestCastOpLargeShape14(TestCastOp):
+        def init_shape(self):
+            self.shape = [5120, 31776]
+
+    class TestCastOpLargeShape15(TestCastOp):
+        def init_shape(self):
+            self.shape = [27724]
+
+    class TestCastOpLargeShape16(TestCastOp):
+        def init_shape(self):
+            self.shape = [32, 5120]
+
+    class TestCastOpLargeShape17(TestCastOp):
+        def init_shape(self):
+            self.shape = [1728, 32]
+
+    class TestCastOpLargeShape18(TestCastOp):
+        def init_shape(self):
+            self.shape = [32, 3456]
+
+    class TestCastOpLargeShape19(TestCastOp):
+        def init_shape(self):
+            self.shape = [32, 3456]
+
+    class TestCastOpLargeShape20(TestCastOp):
+        def init_shape(self):
+            self.shape = [5120, 32]
+
+    class TestCastOpLargeShape21(TestCastOp):
+        def init_shape(self):
+            self.shape = [640, 32]
+
+    class TestCastOpLargeShape22(TestCastOp):
+        def init_shape(self):
+            self.shape = [32, 1920]
+
+    class TestCastOpLargeShape23(TestCastOp):
+        def init_shape(self):
+            self.shape = [19984]
 
 
 support_types = get_xpu_op_support_types('cast')

--- a/test/xpu/test_concat_op_xpu.py
+++ b/test/xpu/test_concat_op_xpu.py
@@ -18,6 +18,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -144,6 +145,7 @@ class XPUTestConcatOp(XPUOpTestWrapper):
         def test_check_grad(self):
             pass
 
+    @check_run_big_shape_test()
     class TestConcatOpLargeShape1(TestConcatOp):
         def set_inputs(self):
             self.x0 = np.random.random([163840])
@@ -151,6 +153,7 @@ class XPUTestConcatOp(XPUOpTestWrapper):
             self.x2 = np.random.random([2452])
             self.axis = 0
 
+    @check_run_big_shape_test()
     class TestConcatOpLargeShape2(TestConcatOp):
         def set_inputs(self):
             self.x0 = np.random.random([5120])
@@ -158,6 +161,7 @@ class XPUTestConcatOp(XPUOpTestWrapper):
             self.x2 = np.random.random([1762])
             self.axis = 0
 
+    @check_run_big_shape_test()
     class TestConcatOpLargeShape3(TestConcatOp):
         def set_inputs(self):
             self.x0 = np.random.random([3874])

--- a/test/xpu/test_concat_op_xpu.py
+++ b/test/xpu/test_concat_op_xpu.py
@@ -144,6 +144,27 @@ class XPUTestConcatOp(XPUOpTestWrapper):
         def test_check_grad(self):
             pass
 
+    class TestConcatOpLargeShape1(TestConcatOp):
+        def set_inputs(self):
+            self.x0 = np.random.random([163840])
+            self.x1 = np.random.random([5120])
+            self.x2 = np.random.random([2452])
+            self.axis = 0
+
+    class TestConcatOpLargeShape2(TestConcatOp):
+        def set_inputs(self):
+            self.x0 = np.random.random([5120])
+            self.x1 = np.random.random([1])
+            self.x2 = np.random.random([1762])
+            self.axis = 0
+
+    class TestConcatOpLargeShape3(TestConcatOp):
+        def set_inputs(self):
+            self.x0 = np.random.random([3874])
+            self.x1 = np.random.random([3952])
+            self.x2 = np.random.random([4172])
+            self.axis = 0
+
 
 support_types = get_xpu_op_support_types('concat')
 for stype in support_types:

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -261,30 +262,35 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
         def init_axis(self):
             self.axis = 2
 
+    @check_run_big_shape_test()
     class TestElementwiseAddOpLargeShape1(TestElementwiseAddOp):
         def init_input_output(self):
             self.x = np.random.rand(8192, 1920).astype(self.dtype)
             self.y = np.random.rand(1920).astype(self.dtype)
             self.out = self.x + self.y
 
+    @check_run_big_shape_test()
     class TestElementwiseAddOpLargeShape2(TestElementwiseAddOp):
         def init_input_output(self):
             self.x = np.random.rand(1, 8192, 5, 128).astype(self.dtype)
             self.y = np.random.rand(1, 8192, 5, 128).astype(self.dtype)
             self.out = self.x + self.y
 
+    @check_run_big_shape_test()
     class TestElementwiseAddOpLargeShape3(TestElementwiseAddOp):
         def init_input_output(self):
             self.x = np.random.rand(1024, 5120).astype(self.dtype)
             self.y = np.random.rand(5120).astype(self.dtype)
             self.out = self.x + self.y
 
+    @check_run_big_shape_test()
     class TestElementwiseAddOpLargeShape4(TestElementwiseAddOp):
         def init_input_output(self):
             self.x = np.random.rand(8192, 3456).astype(self.dtype)
             self.y = np.random.rand(3456).astype(self.dtype)
             self.out = self.x + self.y
 
+    @check_run_big_shape_test()
     class TestElementwiseAddOpLargeShape5(TestElementwiseAddOp):
         def init_input_output(self):
             self.x = np.random.rand(1, 8192, 31776).astype(self.dtype)

--- a/test/xpu/test_elementwise_add_op_xpu.py
+++ b/test/xpu/test_elementwise_add_op_xpu.py
@@ -261,6 +261,36 @@ class XPUTestElementwiseAddOp(XPUOpTestWrapper):
         def init_axis(self):
             self.axis = 2
 
+    class TestElementwiseAddOpLargeShape1(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = np.random.rand(8192, 1920).astype(self.dtype)
+            self.y = np.random.rand(1920).astype(self.dtype)
+            self.out = self.x + self.y
+
+    class TestElementwiseAddOpLargeShape2(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = np.random.rand(1, 8192, 5, 128).astype(self.dtype)
+            self.y = np.random.rand(1, 8192, 5, 128).astype(self.dtype)
+            self.out = self.x + self.y
+
+    class TestElementwiseAddOpLargeShape3(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = np.random.rand(1024, 5120).astype(self.dtype)
+            self.y = np.random.rand(5120).astype(self.dtype)
+            self.out = self.x + self.y
+
+    class TestElementwiseAddOpLargeShape4(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = np.random.rand(8192, 3456).astype(self.dtype)
+            self.y = np.random.rand(3456).astype(self.dtype)
+            self.out = self.x + self.y
+
+    class TestElementwiseAddOpLargeShape5(TestElementwiseAddOp):
+        def init_input_output(self):
+            self.x = np.random.rand(1, 8192, 31776).astype(self.dtype)
+            self.y = np.random.rand(31776).astype(self.dtype)
+            self.out = self.x + self.y
+
     class TestAddOp(unittest.TestCase):
         def test_name(self):
             with base.program_guard(base.Program()):

--- a/test/xpu/test_elementwise_mul_op_xpu.py
+++ b/test/xpu/test_elementwise_mul_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -212,16 +213,19 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
             self.cal_x = self.x.reshape(1, 1, 10, 10)
             self.axis = 2
 
+    @check_run_big_shape_test()
     class TestElementwiseMulOpLargeShape1(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([8192, 1])
             self.y = self.gen_data_depend_on_dtype([1, 64])
 
+    @check_run_big_shape_test()
     class TestElementwiseMulOpLargeShape2(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([1, 8192, 5, 128])
             self.y = self.gen_data_depend_on_dtype([1, 8192, 1, 128])
 
+    @check_run_big_shape_test()
     class TestElementwiseMulOpLargeShape3(ElementwiseMulOp):
         def init_data(self):
             self.x = self.gen_data_depend_on_dtype([8192, 1728])

--- a/test/xpu/test_elementwise_mul_op_xpu.py
+++ b/test/xpu/test_elementwise_mul_op_xpu.py
@@ -212,6 +212,22 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
             self.cal_x = self.x.reshape(1, 1, 10, 10)
             self.axis = 2
 
+    class TestElementwiseMulOpLargeShape1(ElementwiseMulOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([8192, 1])
+            self.y = self.gen_data_depend_on_dtype([1, 64])
+
+    class TestElementwiseMulOpLargeShape2(ElementwiseMulOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([1, 8192, 5, 128])
+            self.y = self.gen_data_depend_on_dtype([1, 8192, 1, 128])
+
+    class TestElementwiseMulOpLargeShape3(ElementwiseMulOp):
+        def init_data(self):
+            self.x = self.gen_data_depend_on_dtype([8192, 1728])
+            self.y = self.gen_data_depend_on_dtype([8192])
+            self.cal_y = self.y.reshape([8192, 1])
+
 
 support_types = get_xpu_op_support_types('elementwise_mul')
 for stype in support_types:

--- a/test/xpu/test_flash_attention_op_xpu.py
+++ b/test/xpu/test_flash_attention_op_xpu.py
@@ -204,6 +204,15 @@ class TestFlashAttentionAPITest1(TestFlashAttentionAPI):
         self.return_softmax = False
 
 
+class TestFlashAttentionAPITest2(TestFlashAttentionAPI):
+    def setUp(self):
+        self.place = paddle.XPUPlace(0)
+        self.shape = (1, 8192, 5, 128)
+        self.dropout = 0.0
+        self.causal = True
+        self.return_softmax = False
+
+
 # The following three REAL unit tests are disabled because they take a VERY LONG time to run, although they all pass under XHPC v20240105.
 
 # class TestFlashAttentionAPITestEB(TestFlashAttentionAPI):

--- a/test/xpu/test_flash_attention_op_xpu.py
+++ b/test/xpu/test_flash_attention_op_xpu.py
@@ -204,13 +204,13 @@ class TestFlashAttentionAPITest1(TestFlashAttentionAPI):
         self.return_softmax = False
 
 
-class TestFlashAttentionAPITest2(TestFlashAttentionAPI):
-    def setUp(self):
-        self.place = paddle.XPUPlace(0)
-        self.shape = (1, 8192, 5, 128)
-        self.dropout = 0.0
-        self.causal = True
-        self.return_softmax = False
+# class TestFlashAttentionAPITest2(TestFlashAttentionAPI):
+#     def setUp(self):
+#         self.place = paddle.XPUPlace(0)
+#         self.shape = (1, 8192, 5, 128)
+#         self.dropout = 0.0
+#         self.causal = True
+#         self.return_softmax = False
 
 
 # The following three REAL unit tests are disabled because they take a VERY LONG time to run, although they all pass under XHPC v20240105.

--- a/test/xpu/test_layer_norm_op_xpu.py
+++ b/test/xpu/test_layer_norm_op_xpu.py
@@ -184,11 +184,12 @@ class XPUTestLayerNormOp(XPUOpTestWrapper):
             else:
                 self.dtype = np.float32
 
-    class TestXPULayerNormOpLargeShape1(TestXPULayerNormOp):
-        def set_attrs(self):
-            self.shape = [1024, 5120]
-            self.use_bf16_scale_bias = True
-            self.use_fp16_scale_bias = True
+    # @check_run_big_shape_test()
+    # class TestXPULayerNormOpLargeShape1(TestXPULayerNormOp):
+    #     def set_attrs(self):
+    #         self.shape = [1024, 5120]
+    #         self.use_bf16_scale_bias = True
+    #         self.use_fp16_scale_bias = True
 
 
 support_types = get_xpu_op_support_types('layer_norm')

--- a/test/xpu/test_layer_norm_op_xpu.py
+++ b/test/xpu/test_layer_norm_op_xpu.py
@@ -184,6 +184,12 @@ class XPUTestLayerNormOp(XPUOpTestWrapper):
             else:
                 self.dtype = np.float32
 
+    class TestXPULayerNormOpLargeShape1(TestXPULayerNormOp):
+        def set_attrs(self):
+            self.shape = [1024, 5120]
+            self.use_bf16_scale_bias = True
+            self.use_fp16_scale_bias = True
+
 
 support_types = get_xpu_op_support_types('layer_norm')
 for stype in support_types:

--- a/test/xpu/test_matmul_v2_op_xpu.py
+++ b/test/xpu/test_matmul_v2_op_xpu.py
@@ -315,6 +315,45 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = True
             self.trans_y = False
 
+    class TestMatMulOpLargeShape1(TestMatMulV2Op):
+        """
+        Large Shape for EB
+        """
+
+        def config(self):
+            self.x_shape = (8192, 5120)
+            self.y_shape = (5120, 1920)
+            self.trans_x = False
+            self.trans_y = False
+
+    class TestMatMulOpLargeShape2(TestMatMulV2Op):
+        def config(self):
+            self.x_shape = (1024, 5120)
+            self.y_shape = (5120, 32)
+            self.trans_x = False
+            self.trans_y = False
+
+    class TestMatMulOpLargeShape3(TestMatMulV2Op):
+        def config(self):
+            self.x_shape = (8192, 32)
+            self.y_shape = (32, 1920)
+            self.trans_x = False
+            self.trans_y = False
+
+    class TestMatMulOpLargeShape4(TestMatMulV2Op):
+        def config(self):
+            self.x_shape = (8192, 640)
+            self.y_shape = (640, 5120)
+            self.trans_x = False
+            self.trans_y = False
+
+    class TestMatMulOpLargeShape5(TestMatMulV2Op):
+        def config(self):
+            self.x_shape = (640, 32)
+            self.y_shape = (1024, 32)
+            self.trans_x = False
+            self.trans_y = True
+
 
 support_types = get_xpu_op_support_types('matmul_v2')
 for stype in support_types:

--- a/test/xpu/test_matmul_v2_op_xpu.py
+++ b/test/xpu/test_matmul_v2_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -315,6 +316,7 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = True
             self.trans_y = False
 
+    @check_run_big_shape_test()
     class TestMatMulOpLargeShape1(TestMatMulV2Op):
         """
         Large Shape for EB
@@ -326,6 +328,7 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = False
             self.trans_y = False
 
+    @check_run_big_shape_test()
     class TestMatMulOpLargeShape2(TestMatMulV2Op):
         def config(self):
             self.x_shape = (1024, 5120)
@@ -333,6 +336,7 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = False
             self.trans_y = False
 
+    @check_run_big_shape_test()
     class TestMatMulOpLargeShape3(TestMatMulV2Op):
         def config(self):
             self.x_shape = (8192, 32)
@@ -340,6 +344,7 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = False
             self.trans_y = False
 
+    @check_run_big_shape_test()
     class TestMatMulOpLargeShape4(TestMatMulV2Op):
         def config(self):
             self.x_shape = (8192, 640)
@@ -347,6 +352,7 @@ class XPUTestMatmulV2Op(XPUOpTestWrapper):
             self.trans_x = False
             self.trans_y = False
 
+    @check_run_big_shape_test()
     class TestMatMulOpLargeShape5(TestMatMulV2Op):
         def config(self):
             self.x_shape = (640, 32)

--- a/test/xpu/test_range_xpu.py
+++ b/test/xpu/test_range_xpu.py
@@ -83,6 +83,10 @@ class XPUTestRangeOp(XPUOpTestWrapper):
         def init_config(self):
             self.case = (10, -10, -11)
 
+    class TestRangeOpCase5(TestRangeOp):
+        def init_config(self):
+            self.case = (0, 1, 1)
+
 
 support_types = get_xpu_op_support_types("range")
 for stype in support_types:

--- a/test/xpu/test_range_xpu.py
+++ b/test/xpu/test_range_xpu.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License.z
 
 import unittest
 

--- a/test/xpu/test_reduce_sum_op_xpu.py
+++ b/test/xpu/test_reduce_sum_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -135,6 +136,7 @@ class XPUTestReduceSumOp(XPUOpTestWrapper):
             self.reduce_all = True
             self.keep_dim = False
 
+    @check_run_big_shape_test()
     class XPUTestReduceSumLargeShape1(XPUTestReduceSumBase):
         def init_case(self):
             self.shape = (8192,)
@@ -142,6 +144,7 @@ class XPUTestReduceSumOp(XPUOpTestWrapper):
             self.reduce_all = False
             self.keep_dim = False
 
+    @check_run_big_shape_test()
     class XPUTestReduceSumLargeShape2(XPUTestReduceSumBase):
         def init_case(self):
             self.shape = (1, 8192)
@@ -149,6 +152,7 @@ class XPUTestReduceSumOp(XPUOpTestWrapper):
             self.reduce_all = False
             self.keep_dim = False
 
+    @check_run_big_shape_test()
     class XPUTestReduceSumLargeShape3(XPUTestReduceSumBase):
         def init_case(self):
             self.shape = (224, 1)
@@ -156,6 +160,7 @@ class XPUTestReduceSumOp(XPUOpTestWrapper):
             self.reduce_all = False
             self.keep_dim = False
 
+    @check_run_big_shape_test()
     class XPUTestReduceSumLargeShape4(XPUTestReduceSumBase):
         def init_case(self):
             self.shape = (334, 1)
@@ -163,6 +168,7 @@ class XPUTestReduceSumOp(XPUOpTestWrapper):
             self.reduce_all = False
             self.keep_dim = False
 
+    @check_run_big_shape_test()
     class XPUTestReduceSumLargeShape5(XPUTestReduceSumBase):
         def init_case(self):
             self.shape = (338, 1)

--- a/test/xpu/test_reduce_sum_op_xpu.py
+++ b/test/xpu/test_reduce_sum_op_xpu.py
@@ -135,6 +135,41 @@ class XPUTestReduceSumOp(XPUOpTestWrapper):
             self.reduce_all = True
             self.keep_dim = False
 
+    class XPUTestReduceSumLargeShape1(XPUTestReduceSumBase):
+        def init_case(self):
+            self.shape = (8192,)
+            self.axis = (0,)
+            self.reduce_all = False
+            self.keep_dim = False
+
+    class XPUTestReduceSumLargeShape2(XPUTestReduceSumBase):
+        def init_case(self):
+            self.shape = (1, 8192)
+            self.axis = (1,)
+            self.reduce_all = False
+            self.keep_dim = False
+
+    class XPUTestReduceSumLargeShape3(XPUTestReduceSumBase):
+        def init_case(self):
+            self.shape = (224, 1)
+            self.axis = (0,)
+            self.reduce_all = False
+            self.keep_dim = False
+
+    class XPUTestReduceSumLargeShape4(XPUTestReduceSumBase):
+        def init_case(self):
+            self.shape = (334, 1)
+            self.axis = (0,)
+            self.reduce_all = False
+            self.keep_dim = False
+
+    class XPUTestReduceSumLargeShape5(XPUTestReduceSumBase):
+        def init_case(self):
+            self.shape = (338, 1)
+            self.axis = (0,)
+            self.reduce_all = False
+            self.keep_dim = False
+
 
 support_types = get_xpu_op_support_types('reduce_sum')
 for stype in support_types:

--- a/test/xpu/test_reshape2_op_xpu.py
+++ b/test/xpu/test_reshape2_op_xpu.py
@@ -173,6 +173,36 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
             self.infered_shape = (10, 2, 3, -1)
             self.shape = (10, 0, 3, -1)
 
+    class TestReshapeOpLargeShape1(TestReshapeOp):
+        def init_data(self):
+            self.ori_shape = (5120, 32)
+            self.new_shape = (32, 5120)
+            self.infered_shape = (32, 5120)
+
+    class TestReshapeOpLargeShape2(TestReshapeOp):
+        def init_data(self):
+            self.ori_shape = (1, 8192, 5120)
+            self.new_shape = (8192, 5120)
+            self.infered_shape = (8192, 5120)
+
+    class TestReshapeOpLargeShape3(TestReshapeOp):
+        def init_data(self):
+            self.ori_shape = (1, 8192)
+            self.new_shape = (8192,)
+            self.infered_shape = (8192,)
+
+    class TestReshapeOpLargeShape4(TestReshapeOp):
+        def init_data(self):
+            self.ori_shape = (1, 8192, 5, 64, 2)
+            self.new_shape = (1, 8192, 5, 128)
+            self.infered_shape = (1, 8192, 5, 128)
+
+    class TestReshapeOpLargeShape5(TestReshapeOp):
+        def init_data(self):
+            self.ori_shape = (1, 8192, 5, 128)
+            self.new_shape = (1, 8192, 640)
+            self.infered_shape = (1, 8192, 640)
+
 
 support_types = get_xpu_op_support_types("reshape2")
 for stype in support_types:

--- a/test/xpu/test_reshape2_op_xpu.py
+++ b/test/xpu/test_reshape2_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -173,30 +174,35 @@ class XPUTestReshapeOp(XPUOpTestWrapper):
             self.infered_shape = (10, 2, 3, -1)
             self.shape = (10, 0, 3, -1)
 
+    @check_run_big_shape_test()
     class TestReshapeOpLargeShape1(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (5120, 32)
             self.new_shape = (32, 5120)
             self.infered_shape = (32, 5120)
 
+    @check_run_big_shape_test()
     class TestReshapeOpLargeShape2(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192, 5120)
             self.new_shape = (8192, 5120)
             self.infered_shape = (8192, 5120)
 
+    @check_run_big_shape_test()
     class TestReshapeOpLargeShape3(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192)
             self.new_shape = (8192,)
             self.infered_shape = (8192,)
 
+    @check_run_big_shape_test()
     class TestReshapeOpLargeShape4(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192, 5, 64, 2)
             self.new_shape = (1, 8192, 5, 128)
             self.infered_shape = (1, 8192, 5, 128)
 
+    @check_run_big_shape_test()
     class TestReshapeOpLargeShape5(TestReshapeOp):
         def init_data(self):
             self.ori_shape = (1, 8192, 5, 128)

--- a/test/xpu/test_scale_op_xpu.py
+++ b/test/xpu/test_scale_op_xpu.py
@@ -38,6 +38,7 @@ class XPUTestScaleOp(XPUOpTestWrapper):
             self.set_xpu()
             self.op_type = "scale"
             self.place = paddle.XPUPlace(0)
+            self.set_shape()
             self.set_inputs()
             self.set_attrs()
             self.set_output()
@@ -78,6 +79,9 @@ class XPUTestScaleOp(XPUOpTestWrapper):
                 place = paddle.XPUPlace(0)
                 self.check_output_with_place(place)
 
+        def set_shape(self):
+            self.shape = [10, 10]
+
     class TestScaleOp1(TestScaleOp):
         def set_attrs(self):
             self.attrs = {'scale': 3.5}
@@ -97,6 +101,30 @@ class XPUTestScaleOp(XPUOpTestWrapper):
     class TestScaleOp5(TestScaleOp):
         def set_attrs(self):
             self.attrs = {'scale': -0.003}
+
+    class TestScaleOpLargeShape1(TestScaleOp):
+        def set_shape(self):
+            self.shape = [64]
+
+    class TestScaleOpLargeShape2(TestScaleOp):
+        def set_shape(self):
+            self.shape = [8192, 1]
+
+    class TestScaleOpLargeShape3(TestScaleOp):
+        def set_shape(self):
+            self.shape = [1, 8192, 5, 64]
+
+    class TestScaleOpLargeShape4(TestScaleOp):
+        def set_shape(self):
+            self.shape = [8192, 1920]
+
+    class TestScaleOpLargeShape5(TestScaleOp):
+        def set_shape(self):
+            self.shape = [1024, 5120]
+
+    class TestScaleOpLargeShape6(TestScaleOp):
+        def set_shape(self):
+            self.shape = [8192, 3456]
 
 
 class TestScaleApiStatic(unittest.TestCase):

--- a/test/xpu/test_scale_op_xpu.py
+++ b/test/xpu/test_scale_op_xpu.py
@@ -102,29 +102,29 @@ class XPUTestScaleOp(XPUOpTestWrapper):
         def set_attrs(self):
             self.attrs = {'scale': -0.003}
 
-    class TestScaleOpLargeShape1(TestScaleOp):
-        def set_shape(self):
-            self.shape = [64]
+    # class TestScaleOpLargeShape1(TestScaleOp):
+    #     def set_shape(self):
+    #         self.shape = [64]
 
-    class TestScaleOpLargeShape2(TestScaleOp):
-        def set_shape(self):
-            self.shape = [8192, 1]
+    # class TestScaleOpLargeShape2(TestScaleOp):
+    #     def set_shape(self):
+    #         self.shape = [8192, 1]
 
-    class TestScaleOpLargeShape3(TestScaleOp):
-        def set_shape(self):
-            self.shape = [1, 8192, 5, 64]
+    # class TestScaleOpLargeShape3(TestScaleOp):
+    #     def set_shape(self):
+    #         self.shape = [1, 8192, 5, 64]
 
-    class TestScaleOpLargeShape4(TestScaleOp):
-        def set_shape(self):
-            self.shape = [8192, 1920]
+    # class TestScaleOpLargeShape4(TestScaleOp):
+    #     def set_shape(self):
+    #         self.shape = [8192, 1920]
 
-    class TestScaleOpLargeShape5(TestScaleOp):
-        def set_shape(self):
-            self.shape = [1024, 5120]
+    # class TestScaleOpLargeShape5(TestScaleOp):
+    #     def set_shape(self):
+    #         self.shape = [1024, 5120]
 
-    class TestScaleOpLargeShape6(TestScaleOp):
-        def set_shape(self):
-            self.shape = [8192, 3456]
+    # class TestScaleOpLargeShape6(TestScaleOp):
+    #     def set_shape(self):
+    #         self.shape = [8192, 3456]
 
 
 class TestScaleApiStatic(unittest.TestCase):

--- a/test/xpu/test_slice_op_xpu.py
+++ b/test/xpu/test_slice_op_xpu.py
@@ -90,6 +90,24 @@ class XPUTestSliceOp(XPUOpTestWrapper):
             self.infer_flags = [1, 1, 1]
             self.out = self.input[-3:3, 0:100, :, 2:-1]
 
+    class TestCaseLargeShape1(TestSliceOp):
+        def config(self):
+            self.input = np.random.random([8192, 5120])
+            self.starts = [0, 5119]
+            self.ends = [8192, 5120]
+            self.axes = [0, 1]
+            self.infer_flags = [1, 1]
+            self.out = self.input[:, -1:]
+
+    class TestCaseLargeShape2(TestSliceOp):
+        def config(self):
+            self.input = np.random.random([2, 1, 8192, 1, 128])
+            self.starts = [0, 0, 0, 0, 0]
+            self.ends = [2, 1, 1, 1, 128]
+            self.axes = [0, 1, 2, 3, 4]
+            self.infer_flags = [1, 1, 1, 1, 1]
+            self.out = self.input[:, :, -1:, :, :]
+
 
 # 1.2 with attr(decrease)
 class XPUTestSliceOp_decs_dim(XPUOpTestWrapper):

--- a/test/xpu/test_slice_op_xpu.py
+++ b/test/xpu/test_slice_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -90,6 +91,7 @@ class XPUTestSliceOp(XPUOpTestWrapper):
             self.infer_flags = [1, 1, 1]
             self.out = self.input[-3:3, 0:100, :, 2:-1]
 
+    @check_run_big_shape_test()
     class TestCaseLargeShape1(TestSliceOp):
         def config(self):
             self.input = np.random.random([8192, 5120])
@@ -99,6 +101,7 @@ class XPUTestSliceOp(XPUOpTestWrapper):
             self.infer_flags = [1, 1]
             self.out = self.input[:, -1:]
 
+    @check_run_big_shape_test()
     class TestCaseLargeShape2(TestSliceOp):
         def config(self):
             self.input = np.random.random([2, 1, 8192, 1, 128])

--- a/test/xpu/test_split_op_xpu.py
+++ b/test/xpu/test_split_op_xpu.py
@@ -83,6 +83,13 @@ class XPUTestSplitOp(XPUOpTestWrapper):
             self.num = 3
             self.indices_or_sections = 3
 
+    class TestSplitOpLargeShape1(TestSplitOp):
+        def initParameters(self):
+            self.x = np.random.random((1, 8192, 5, 384)).astype(self.dtype)
+            self.axis = 3
+            self.num = 3
+            self.indices_or_sections = 3
+
 
 support_types = get_xpu_op_support_types('split')
 for stype in support_types:

--- a/test/xpu/test_split_op_xpu.py
+++ b/test/xpu/test_split_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -83,6 +84,7 @@ class XPUTestSplitOp(XPUOpTestWrapper):
             self.num = 3
             self.indices_or_sections = 3
 
+    @check_run_big_shape_test()
     class TestSplitOpLargeShape1(TestSplitOp):
         def initParameters(self):
             self.x = np.random.random((1, 8192, 5, 384)).astype(self.dtype)

--- a/test/xpu/test_squared_l2_norm_op_xpu.py
+++ b/test/xpu/test_squared_l2_norm_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -82,76 +83,91 @@ class XPUTestSquaredL2NormOp(XPUOpTestWrapper):
             self.x = np.random.uniform(-0.1, 0.1, (2, 128, 256))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape1(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (5120, 32))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape2(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (32, 1920))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape3(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (640, 32))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape4(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (32, 5120))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape5(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (32, 3456))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape6(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (1728, 32))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape7(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (31776, 5120))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape8(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (5120, 1920))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape9(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (1920,))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape10(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (640, 5120))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape11(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (5120, 3456))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape12(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (3456,))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape13(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (1728, 5120))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape14(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (5120, 31776))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    @check_run_big_shape_test()
     class TestSquaredL2NormOpLargeShape15(TestSquaredL2NormOp):
         def set_inputs(self):
             self.x = np.random.uniform(-0.1, 0.1, (31776,))

--- a/test/xpu/test_squared_l2_norm_op_xpu.py
+++ b/test/xpu/test_squared_l2_norm_op_xpu.py
@@ -82,6 +82,81 @@ class XPUTestSquaredL2NormOp(XPUOpTestWrapper):
             self.x = np.random.uniform(-0.1, 0.1, (2, 128, 256))
             self.x[np.abs(self.x) < self.max_relative_error] = 0.01
 
+    class TestSquaredL2NormOpLargeShape1(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (5120, 32))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape2(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (32, 1920))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape3(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (640, 32))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape4(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (32, 5120))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape5(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (32, 3456))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape6(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (1728, 32))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape7(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (31776, 5120))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape8(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (5120, 1920))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape9(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (1920,))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape10(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (640, 5120))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape11(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (5120, 3456))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape12(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (3456,))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape13(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (1728, 5120))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape14(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (5120, 31776))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
+    class TestSquaredL2NormOpLargeShape15(TestSquaredL2NormOp):
+        def set_inputs(self):
+            self.x = np.random.uniform(-0.1, 0.1, (31776,))
+            self.x[np.abs(self.x) < self.max_relative_error] = 0.01
+
 
 support_types = get_xpu_op_support_types('squared_l2_norm')
 for stype in support_types:

--- a/test/xpu/test_stack_op_xpu.py
+++ b/test/xpu/test_stack_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -114,7 +115,8 @@ class XPUTestStackOp(XPUOpTestWrapper):
             self.axis = 0
             self.dtype = np.int32
 
-    class TestStackOp9(TestStackOp):
+    @check_run_big_shape_test()
+    class TestStackOpLargeShape1(TestStackOp):
         def initParameters(self):
             self.num_inputs = 5
             self.input_dim = (1, 8192, 64)

--- a/test/xpu/test_stack_op_xpu.py
+++ b/test/xpu/test_stack_op_xpu.py
@@ -114,6 +114,12 @@ class XPUTestStackOp(XPUOpTestWrapper):
             self.axis = 0
             self.dtype = np.int32
 
+    class TestStackOp9(TestStackOp):
+        def initParameters(self):
+            self.num_inputs = 5
+            self.input_dim = (1, 8192, 64)
+            self.axis = 2
+
 
 support_types = get_xpu_op_support_types('stack')
 for stype in support_types:

--- a/test/xpu/test_strided_slice_op_xpu.py
+++ b/test/xpu/test_strided_slice_op_xpu.py
@@ -210,6 +210,24 @@ class XPUTestStrideSliceOp(XPUOpTestWrapper):
             self.strides = [1, 1, 1, 2]
             self.infer_flags = [1, 1, 1, 1]
 
+    class XPUTestStrideSliceOpLargeShape1(XPUTestStrideSliceOp):
+        def initTestCase(self):
+            self.shape = (1, 8192, 5, 128)
+            self.axes = [0, 1, 2, 3]
+            self.starts = [0, 0, 0, 0]
+            self.ends = [1, 8192, 5, 128]
+            self.strides = [1, 1, 1, 2]
+            self.infer_flags = [1, 1, 1, 1]
+
+    class XPUTestStrideSliceOpLargeShape2(XPUTestStrideSliceOp):
+        def initTestCase(self):
+            self.shape = (8192, 3456)
+            self.axes = [0, 1]
+            self.starts = [0, 0]
+            self.ends = [8192, 3456]
+            self.strides = [1, 2]
+            self.infer_flags = [1, 1]
+
 
 support_types = get_xpu_op_support_types('strided_slice')
 for stype in support_types:

--- a/test/xpu/test_strided_slice_op_xpu.py
+++ b/test/xpu/test_strided_slice_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -210,6 +211,7 @@ class XPUTestStrideSliceOp(XPUOpTestWrapper):
             self.strides = [1, 1, 1, 2]
             self.infer_flags = [1, 1, 1, 1]
 
+    @check_run_big_shape_test()
     class XPUTestStrideSliceOpLargeShape1(XPUTestStrideSliceOp):
         def initTestCase(self):
             self.shape = (1, 8192, 5, 128)
@@ -219,6 +221,7 @@ class XPUTestStrideSliceOp(XPUOpTestWrapper):
             self.strides = [1, 1, 1, 2]
             self.infer_flags = [1, 1, 1, 1]
 
+    @check_run_big_shape_test()
     class XPUTestStrideSliceOpLargeShape2(XPUTestStrideSliceOp):
         def initTestCase(self):
             self.shape = (8192, 3456)

--- a/test/xpu/test_unsqueeze2_op_xpu.py
+++ b/test/xpu/test_unsqueeze2_op_xpu.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 from get_test_cover_info import (
     XPUOpTestWrapper,
+    check_run_big_shape_test,
     create_test_class,
     get_xpu_op_support_types,
 )
@@ -234,24 +235,28 @@ class XPUTestUnsqueeze2Op(XPUOpTestWrapper):
             self.axes = (3, 1, 1)
             self.new_shape = (10, 1, 1, 2, 5, 1)
 
+    @check_run_big_shape_test()
     class TestUnsqueeze2OpLargeShape1(TestUnsqueeze2Op):
         def init_test_case(self):
             self.ori_shape = (8192,)
             self.axes = (0,)
             self.new_shape = (1, 8192)
 
+    @check_run_big_shape_test()
     class TestUnsqueeze2OpLargeShape2(TestUnsqueeze2Op):
         def init_test_case(self):
             self.ori_shape = (8192, 64)
             self.axes = (1,)
             self.new_shape = (8192, 1, 64)
 
+    @check_run_big_shape_test()
     class TestUnsqueeze2OpLargeShape3(TestUnsqueeze2Op):
         def init_test_case(self):
             self.ori_shape = (1, 8192, 128)
             self.axes = (2,)
             self.new_shape = (1, 8192, 1, 128)
 
+    @check_run_big_shape_test()
     class TestUnsqueeze2OpLargeShape4(TestUnsqueeze2Op):
         def init_test_case(self):
             self.ori_shape = (1, 8192)

--- a/test/xpu/test_unsqueeze2_op_xpu.py
+++ b/test/xpu/test_unsqueeze2_op_xpu.py
@@ -234,6 +234,30 @@ class XPUTestUnsqueeze2Op(XPUOpTestWrapper):
             self.axes = (3, 1, 1)
             self.new_shape = (10, 1, 1, 2, 5, 1)
 
+    class TestUnsqueeze2OpLargeShape1(TestUnsqueeze2Op):
+        def init_test_case(self):
+            self.ori_shape = (8192,)
+            self.axes = (0,)
+            self.new_shape = (1, 8192)
+
+    class TestUnsqueeze2OpLargeShape2(TestUnsqueeze2Op):
+        def init_test_case(self):
+            self.ori_shape = (8192, 64)
+            self.axes = (1,)
+            self.new_shape = (8192, 1, 64)
+
+    class TestUnsqueeze2OpLargeShape3(TestUnsqueeze2Op):
+        def init_test_case(self):
+            self.ori_shape = (1, 8192, 128)
+            self.axes = (2,)
+            self.new_shape = (1, 8192, 1, 128)
+
+    class TestUnsqueeze2OpLargeShape4(TestUnsqueeze2Op):
+        def init_test_case(self):
+            self.ori_shape = (1, 8192)
+            self.axes = (-1,)
+            self.new_shape = (1, 8192, 1)
+
 
 support_types = get_xpu_op_support_types("unsqueeze2")
 for stype in support_types:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
1. Add some large shape daily tests for XPU. Triggered when `FLAGS_xpu_big_shape_test=true` is set.