### PR TITLE
[CINN]add support for backward shape_optimization_pass

### DIFF
--- a/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
+++ b/paddle/pir/src/dialect/shape/transforms/shape_optimization_pass.cc
@@ -314,6 +314,9 @@ void InferSymExprForAllValues(ModuleOp module_op) {
   auto infer_context = shape_analysis.MutInferSymbolicShapeContext();
   for (uint32_t i = 0; i < module_op->num_regions(); i++) {
     for (auto& block : module_op->region(i)) {
+      for (auto& [_, value] : block.kwargs()) {
+        infer_context->SetSymbolForValueByStaticShape(value);
+      }
       InferSymExprForBlock(block, infer_context);
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation | Others ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Pcard-67164
This PR adds support for backward shape_optimization_pass by adding shape initialization for kwargs.